### PR TITLE
feat(vr): head-anchored frontend panels with lazy recenter

### DIFF
--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -730,6 +730,9 @@ fn process_events(
     let mut input_context = InputContext::default();
     let head_rotation = camera_rotation(camera_context);
     input_context.head.rotation = head_rotation;
+    // The flat rig has no tracked head: the eye sits directly above the pawn
+    // origin at the fixed camera height, which is exactly the default.
+    input_context.head.position = vec3(0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0);
     let (right_hand_position, right_hand_rotation) =
         hand_pose(camera_context, &hand_context.right_hand_context, 1.0);
     input_context.right_hand.position = right_hand_position;

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -732,7 +732,7 @@ fn process_events(
     input_context.head.rotation = head_rotation;
     // The flat rig has no tracked head: the eye sits directly above the pawn
     // origin at the fixed camera height, which is exactly the default.
-    input_context.head.position = vec3(0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0);
+    input_context.head.position = vec3(0.0, shock2vr::input_context::DEFAULT_HEAD_HEIGHT, 0.0);
     let (right_hand_position, right_hand_rotation) =
         hand_pose(camera_context, &hand_context.right_hand_context, 1.0);
     input_context.right_hand.position = right_hand_position;
@@ -777,7 +777,7 @@ fn process_events(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shock2vr::ui::{frontend_panel, ray_to_canvas};
+    use shock2vr::ui::{PanelPlacement, ray_to_canvas};
 
     /// The frontend canvas the VR panel presents (`main_menu`'s 640x480).
     const CANVAS: cgmath::Vector2<f32> = cgmath::Vector2 { x: 640.0, y: 480.0 };
@@ -797,7 +797,13 @@ mod tests {
         hand: &CameraContext,
     ) -> Option<cgmath::Vector2<f32>> {
         let (position, rotation) = hand_pose(camera, hand, 1.0);
-        let panel = frontend_panel(camera_rotation(camera));
+        // The panel the frontend anchor places from this camera pose - the
+        // one the game actually builds, so this stays a real regression guard.
+        let panel = PanelPlacement::from_head(
+            shock2vr::input_context::Head::default().position,
+            camera_rotation(camera),
+        )
+        .panel();
         let direction = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
         ray_to_canvas(CANVAS, &panel, position, direction)
     }

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -475,6 +475,9 @@ fn main() {
     // pose does not exist yet; one frame of latency is imperceptible for
     // head-anchored UI and is far better than the alternative below.
     let mut last_view_rotation: Option<cgmath::Quaternion<f32>> = None;
+    // Where that same view was, already converted to pawn space (the space the
+    // hands and the world-anchored frontend panel live in).
+    let mut last_view_position: Option<cgmath::Vector3<f32>> = None;
     println!(
         "SHOCK2QUEST_STARTUP mission={} init_ms={:.3}",
         mission,
@@ -783,6 +786,12 @@ fn main() {
 
         let mut input_context = InputContext::default();
         input_context.head.rotation = head_rotation;
+        // The tracked eye, in pawn space. Before the first located view (and
+        // when the head is untracked) this keeps `Head::default`'s fixed eye
+        // height, which is where the camera renders from anyway.
+        if let Some(position) = last_view_position {
+            input_context.head.position = position;
+        }
         input_context.right_hand.rotation = aim_rotation;
         input_context.right_hand.position = right_hand_position;
         input_context.right_hand.trigger_value = right_trigger_value;
@@ -968,6 +977,14 @@ fn main() {
 
         // Remember where the head actually is, for next frame's input context.
         if let Some(view) = views.first() {
+            last_view_position = Some(stage_to_pawn(
+                vec3(
+                    view.pose.position.x,
+                    view.pose.position.y,
+                    view.pose.position.z,
+                ),
+                game.player_center_above_floor(),
+            ));
             last_view_rotation = Some(cgmath::Quaternion::new(
                 view.pose.orientation.w,
                 view.pose.orientation.x,

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -743,9 +743,29 @@ fn main() {
             right_aim_location.pose.orientation.y,
             right_aim_location.pose.orientation.z,
         );
-        // ...so the head gets the actual head, falling back to the aim pose
-        // only on the first frame, before any view has been located.
-        let head_rotation = last_view_rotation.unwrap_or(aim_rotation);
+        // ...so the head gets the actual head. Before any view has been
+        // located (frame 0) the HEAD SPACE pose - located above, this frame -
+        // stands in; the controller aim is only the last resort, when neither
+        // is available. That matters now that the frontend panel is *placed
+        // once* off this pose: anchoring the boot menu to wherever a controller
+        // happened to point would strand it there for the whole screen.
+        let head_pose_rotation = head_location
+            .location_flags
+            .contains(
+                xr::SpaceLocationFlags::ORIENTATION_VALID
+                    | xr::SpaceLocationFlags::ORIENTATION_TRACKED,
+            )
+            .then(|| {
+                cgmath::Quaternion::new(
+                    head_location.pose.orientation.w,
+                    head_location.pose.orientation.x,
+                    head_location.pose.orientation.y,
+                    head_location.pose.orientation.z,
+                )
+            });
+        let head_rotation = last_view_rotation
+            .or(head_pose_rotation)
+            .unwrap_or(aim_rotation);
 
         // Feed the detector before the poses are transformed so this frame's
         // physical stance is available to the crouch request below. Tracked
@@ -786,10 +806,21 @@ fn main() {
 
         let mut input_context = InputContext::default();
         input_context.head.rotation = head_rotation;
-        // The tracked eye, in pawn space. Before the first located view (and
-        // when the head is untracked) this keeps `Head::default`'s fixed eye
-        // height, which is where the camera renders from anyway.
-        if let Some(position) = last_view_position {
+        // The tracked eye, in pawn space. The located head space covers frame
+        // 0, before any view has been located; when the head is untracked
+        // entirely this keeps `Head::default`'s fixed eye height, which is
+        // where the camera renders from anyway.
+        let head_pose_position = tracked_head_position.then(|| {
+            stage_to_pawn(
+                vec3(
+                    head_location.pose.position.x,
+                    head_location.pose.position.y,
+                    head_location.pose.position.z,
+                ),
+                center_above_floor,
+            )
+        });
+        if let Some(position) = last_view_position.or(head_pose_position) {
             input_context.head.position = position;
         }
         input_context.right_hand.rotation = aim_rotation;

--- a/shock2vr/src/input/remote.rs
+++ b/shock2vr/src/input/remote.rs
@@ -39,6 +39,7 @@ pub fn head_rotation_from_yaw_pitch(yaw_deg: f32, pitch_deg: f32) -> Quaternion<
 /// stick does what) since that is the game's convention, not guessable.
 pub fn input_channels_help() -> &'static str {
     "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
+     head.position [x,y,z] (pawn-local), \
      pointer.position [x,y] in [0,1] (origin top-left; null clears), pointer.pressed 0|1, \
      {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
      {left,right}_hand.thumbstick [x,y], \
@@ -57,6 +58,7 @@ pub fn input_channels_help() -> &'static str {
 ///
 /// Recognized channels:
 /// - `head.rotation`                : `[x, y, z, w]` quaternion
+/// - `head.position`                : `[x, y, z]` pawn-local tracked eye position
 /// - `head.look`                    : `[yaw_deg, pitch_deg]` convenience (forward = -Z).
 ///   **Pitch is POSITIVE DOWN** - `+60` looks at the floor, `-60` at the ceiling
 ///   - matching the desktop runtime, where mouse-down increments pitch. The same
@@ -164,6 +166,14 @@ pub fn apply_input_patch(
         "head.rotation" => {
             let q = arr(channel, value, 4)?;
             input.head.rotation = Quaternion::new(q[3], q[0], q[1], q[2]);
+            Ok(())
+        }
+        // Where the head is, in pawn space - the tracked eye a headset would
+        // report. Defaults to the fixed camera eye height above the pawn
+        // origin; world-anchored UI (the VR frontend panels) is placed from it.
+        "head.position" => {
+            let p = arr(channel, value, 3)?;
+            input.head.position = cgmath::vec3(p[0], p[1], p[2]);
             Ok(())
         }
         // Desktop camera convention (yaw=pitch=0 looks toward -X); drives both
@@ -314,9 +324,8 @@ fn canonical_channel(channel: &str) -> Result<(String, bool), String> {
     }
     match channel {
         "head.look" => Ok(("head.rotation".to_owned(), true)),
-        "head.rotation" | "pointer.position" | "pointer.pressed" | "crouch" | "jump" => {
-            Ok((channel.to_owned(), false))
-        }
+        "head.rotation" | "head.position" | "pointer.position" | "pointer.pressed" | "crouch"
+        | "jump" => Ok((channel.to_owned(), false)),
         _ => Err(unknown_channel(channel)),
     }
 }

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -55,12 +55,22 @@ pub struct Pointer2D {
 
 #[derive(Debug, Clone)]
 pub struct Head {
+    /// Where the head is, in pawn space (the same space the hands use), so a
+    /// world-anchored panel can be placed from the player's actual eye rather
+    /// than from a fixed height on the pawn origin.
+    pub position: Vector3<f32>,
     pub rotation: Quaternion<f32>,
 }
+
+/// The seated/standing eye height every runtime falls back to when no tracked
+/// head position is available - the fixed offset the render camera has always
+/// applied on top of the pawn origin.
+pub const DEFAULT_HEAD_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
 
 impl Head {
     pub fn default() -> Head {
         Head {
+            position: Vector3::new(0.0, DEFAULT_HEAD_HEIGHT, 0.0),
             rotation: Quaternion {
                 v: Vector3::zero(),
                 s: 1.0,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -36,7 +36,8 @@ mod systems;
 mod test_support;
 /// Shared 2D canvas UI: layout, the screen-space presentation, and the
 /// world-space (VR) panel. Public so a runtime can check where its simulated
-/// controller ray lands on a frontend panel (`frontend_panel` + `ray_to_canvas`).
+/// controller ray lands on a frontend panel (`FrontendPanelAnchor` +
+/// `ray_to_canvas`).
 pub mod ui;
 mod util;
 mod virtual_hand;

--- a/shock2vr/src/scenes/debug_map.rs
+++ b/shock2vr/src/scenes/debug_map.rs
@@ -218,7 +218,7 @@ impl GameScene for DebugMapScene {
             look_dir = look_dir.normalize();
         }
 
-        // Honest basis, same as `ui::frontend_panel`: local +x the viewer's
+        // Honest basis, same as `ui::PanelPlacement::panel`: local +x the viewer's
         // right, +y up, +Z at the viewer.
         let mut up = vec3(0.0, 1.0, 0.0);
         let mut right = up.cross(look_dir);

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -29,7 +29,7 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, frontend_panel,
+        FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
         pointer_to_canvas, vr_frontend_pointer,
     },
 };
@@ -158,9 +158,10 @@ pub struct GameOverScene {
     /// Where the VR controller ray last met the panel, in canvas pixels. The
     /// VR counterpart of `pointer`, already in canvas space.
     vr_pointer_canvas: Option<Vector2<f32>>,
-    /// Head facing from the latest update, so `render` hangs the panel exactly
+    /// Where the VR panel is anchored: placed from the head on scene entry
+    /// and world-locked after that, so `render` hangs the panel exactly
     /// where `update` hit-tested it.
-    head_rotation: Quaternion<f32>,
+    panel_anchor: FrontendPanelAnchor,
     /// Whether the pointer was pressed last frame (for rising-edge clicks).
     last_pressed: bool,
     /// Screen size from the latest render, so `update` maps the pointer into
@@ -183,7 +184,7 @@ impl GameOverScene {
             save: latest_save(),
             pointer: None,
             vr_pointer_canvas: None,
-            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            panel_anchor: FrontendPanelAnchor::new(),
             // This screen is entered straight out of gameplay - very plausibly
             // with the VR trigger still held from the shot that preceded the
             // death - so it starts "already pressed": the next rising edge
@@ -295,15 +296,21 @@ impl GameScene for GameOverScene {
         let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
         let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
 
-        // The panel hangs off the head's facing, so this is needed for the
-        // render regardless of which presentation drives the pointer.
-        self.head_rotation = input_context.head.rotation;
+        // The panel is placed from the head on scene entry and world-locked
+        // after that; advancing it here keeps the ray and the render agreeing
+        // on where the screen is, in either presentation.
+        let panel = self.panel_anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            time.elapsed,
+        );
 
         let (action, last_pressed, point) =
             if game_options.presentation_mode == PresentationMode::Vr {
                 // VR has no 2D cursor: the pointer is where a controller ray meets
                 // the panel, and the trigger is the button.
-                let (point, pressed) = vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H));
+                let (point, pressed) =
+                    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
                 self.vr_pointer_canvas = point;
                 self.pointer = None;
                 let (action, last_pressed) = resolve_click_at(
@@ -360,7 +367,7 @@ impl GameScene for GameOverScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = frontend_panel(self.head_rotation);
+        let panel = self.panel_anchor.panel();
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
         let objects = canvas.render_world_space(
             asset_cache,
@@ -522,6 +529,12 @@ mod tests {
     }
 
     /// A hand aimed at a canvas point on this screen's VR panel.
+    /// The panel the anchor places on scene entry from the default head pose -
+    /// what `update` would have hit-tested against on the screen's first frame.
+    fn test_panel() -> crate::ui::WorldPanel {
+        crate::ui::test_support::test_panel()
+    }
+
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
         crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
     }
@@ -543,6 +556,7 @@ mod tests {
             let (point, pressed) = vr_frontend_pointer(
                 &vr_input(hand_aimed_at(rects[index].center(), 1.0)),
                 vec2(CANVAS_W, CANVAS_H),
+                &test_panel(),
             );
             let point = point.expect("the ray should land on the panel");
             assert!(rects[index].contains(point));
@@ -559,6 +573,7 @@ mod tests {
         let (point, pressed) = vr_frontend_pointer(
             &vr_input(hand_aimed_at(rects[LOAD_RECT_INDEX].center(), 1.0)),
             vec2(CANVAS_W, CANVAS_H),
+            &test_panel(),
         );
         assert_eq!(
             resolve_click_at(point, pressed, false, &rects, false).0,
@@ -577,6 +592,7 @@ mod tests {
         let (point, pressed) = vr_frontend_pointer(
             &vr_input(hand_aimed_at(rects[QUIT_RECT_INDEX].center(), 1.0)),
             vec2(CANVAS_W, CANVAS_H),
+            &test_panel(),
         );
         assert!(pressed);
         let (action, last) = resolve_click_at(point, pressed, scene.last_pressed, &rects, true);

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -528,13 +528,13 @@ mod tests {
         assert_eq!(action, None);
     }
 
-    /// A hand aimed at a canvas point on this screen's VR panel.
     /// The panel the anchor places on scene entry from the default head pose -
     /// what `update` would have hit-tested against on the screen's first frame.
     fn test_panel() -> crate::ui::WorldPanel {
         crate::ui::test_support::test_panel()
     }
 
+    /// A hand aimed at a canvas point on this screen's VR panel.
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
         crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
     }

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -741,13 +741,13 @@ mod tests {
         }
     }
 
-    /// A hand aimed at a canvas point on this screen's VR panel.
     /// The panel the anchor places on scene entry from the default head pose -
     /// what `update` would have hit-tested against on the screen's first frame.
     fn test_panel() -> crate::ui::WorldPanel {
         crate::ui::test_support::test_panel()
     }
 
+    /// A hand aimed at a canvas point on this screen's VR panel.
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
         crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
     }

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -32,7 +32,7 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, frontend_panel,
+        FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
         pointer_to_canvas, vr_frontend_pointer,
     },
 };
@@ -264,9 +264,10 @@ pub struct LoadGameScene {
     /// Where the VR controller ray last met the panel, in canvas pixels. The
     /// VR counterpart of `pointer`, already in canvas space.
     vr_pointer_canvas: Option<Vector2<f32>>,
-    /// Head facing from the latest update, so `render` hangs the panel exactly
+    /// Where the VR panel is anchored: placed from the head on scene entry
+    /// and world-locked after that, so `render` hangs the panel exactly
     /// where `update` hit-tested it.
-    head_rotation: Quaternion<f32>,
+    panel_anchor: FrontendPanelAnchor,
     /// Whether the pointer was pressed last frame (for rising-edge clicks).
     last_pressed: bool,
     /// Screen size from the latest render, so `update` can map the pointer into
@@ -290,7 +291,7 @@ impl LoadGameScene {
             selected,
             pointer: None,
             vr_pointer_canvas: None,
-            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            panel_anchor: FrontendPanelAnchor::new(),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
             // widgets overlap (the load screen's "Done" center falls inside
@@ -431,15 +432,21 @@ impl GameScene for LoadGameScene {
         self.selected = self.selected.filter(|index| *index < visible);
         let selected = self.selected;
 
-        // The panel hangs off the head's facing, so this is needed for the
-        // render regardless of which presentation drives the pointer.
-        self.head_rotation = input_context.head.rotation;
+        // The panel is placed from the head on scene entry and world-locked
+        // after that; advancing it here keeps the ray and the render agreeing
+        // on where the screen is, in either presentation.
+        let panel = self.panel_anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            time.elapsed,
+        );
 
         let (action, last_pressed, point) =
             if game_options.presentation_mode == PresentationMode::Vr {
                 // VR has no 2D cursor: the pointer is where a controller ray meets
                 // the panel, and the trigger is the button.
-                let (point, pressed) = vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H));
+                let (point, pressed) =
+                    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
                 self.vr_pointer_canvas = point;
                 self.pointer = None;
                 let (action, last_pressed) = resolve_click_at(
@@ -507,7 +514,7 @@ impl GameScene for LoadGameScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = frontend_panel(self.head_rotation);
+        let panel = self.panel_anchor.panel();
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
         let objects = canvas.render_world_space(
             asset_cache,
@@ -735,6 +742,12 @@ mod tests {
     }
 
     /// A hand aimed at a canvas point on this screen's VR panel.
+    /// The panel the anchor places on scene entry from the default head pose -
+    /// what `update` would have hit-tested against on the screen's first frame.
+    fn test_panel() -> crate::ui::WorldPanel {
+        crate::ui::test_support::test_panel()
+    }
+
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
         crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
     }
@@ -752,6 +765,7 @@ mod tests {
         let (point, pressed) = vr_frontend_pointer(
             &vr_input(hand_aimed_at(done, 1.0)),
             vec2(CANVAS_W, CANVAS_H),
+            &test_panel(),
         );
         let point = point.expect("the ray should land on the panel");
         assert!(FALLBACK_RECTS[DONE_RECT_INDEX].contains(point));
@@ -766,8 +780,11 @@ mod tests {
     fn a_vr_ray_can_select_a_save_row_and_load_it() {
         let list = FALLBACK_RECTS[LIST_RECT_INDEX];
         let row = row_rect(list, 2).center();
-        let (point, pressed) =
-            vr_frontend_pointer(&vr_input(hand_aimed_at(row, 1.0)), vec2(CANVAS_W, CANVAS_H));
+        let (point, pressed) = vr_frontend_pointer(
+            &vr_input(hand_aimed_at(row, 1.0)),
+            vec2(CANVAS_W, CANVAS_H),
+            &test_panel(),
+        );
         let point = point.expect("the ray should land on the panel");
         assert_eq!(
             resolve_click_at(Some(point), pressed, false, &FALLBACK_RECTS, 3, false).0,
@@ -779,6 +796,7 @@ mod tests {
         let (point, pressed) = vr_frontend_pointer(
             &vr_input(hand_aimed_at(load, 1.0)),
             vec2(CANVAS_W, CANVAS_H),
+            &test_panel(),
         );
         assert_eq!(
             resolve_click_at(point, pressed, false, &FALLBACK_RECTS, 3, true).0,

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -579,13 +579,13 @@ mod tests {
         assert_eq!(action, Some(MenuAction::Quit));
     }
 
-    /// A hand aimed at a canvas point on this screen's VR panel.
     /// The panel the anchor places on scene entry from the default head pose -
     /// what `update` would have hit-tested against on the menu's first frame.
     fn test_panel() -> WorldPanel {
         crate::ui::test_support::test_panel()
     }
 
+    /// A hand aimed at a canvas point on this screen's VR panel.
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
         crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
     }

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -38,8 +38,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, frontend_panel,
-        pointer_to_canvas, vr_frontend_pointer,
+        FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
+        WorldPanel, pointer_to_canvas, vr_frontend_pointer,
     },
 };
 
@@ -176,8 +176,8 @@ fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
 /// Where a hand is pointing on the menu panel, in canvas pixels, plus whether
 /// its trigger is held. The rule is the frontend's, not this screen's, so it
 /// lives in [`vr_frontend_pointer`].
-fn vr_pointer(input_context: &InputContext) -> (Option<Vector2<f32>>, bool) {
-    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H))
+fn vr_pointer(input_context: &InputContext, panel: &WorldPanel) -> (Option<Vector2<f32>>, bool) {
+    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), panel)
 }
 
 /// Shared click core: both presentations reduce to "a point on the canvas plus
@@ -242,9 +242,10 @@ pub struct MainMenuScene {
     /// Where the VR controller ray last met the panel, in canvas pixels. The
     /// VR counterpart of `pointer`, already in canvas space.
     vr_pointer_canvas: Option<Vector2<f32>>,
-    /// Head facing from the latest update, so `render` hangs the panel exactly
+    /// Where the VR panel is anchored. Placed on scene entry from the head
+    /// pose and world-locked after that, so `render` hangs the panel exactly
     /// where `update` hit-tested it.
-    head_rotation: Quaternion<f32>,
+    panel_anchor: FrontendPanelAnchor,
     /// Whether the pointer was pressed last frame (for rising-edge clicks).
     last_pressed: bool,
     /// Screen size from the latest render, so `update` can map the pointer into
@@ -263,7 +264,7 @@ impl MainMenuScene {
             scene_name: "main_menu".to_owned(),
             pointer: None,
             vr_pointer_canvas: None,
-            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            panel_anchor: FrontendPanelAnchor::new(),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
             // widgets overlap (the load screen's "Done" center falls inside
@@ -338,15 +339,20 @@ impl GameScene for MainMenuScene {
         let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
         let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
 
-        // The panel hangs off the head's facing, so this is needed for the
-        // render regardless of which presentation drives the pointer.
-        self.head_rotation = input_context.head.rotation;
+        // The panel is placed from the head on scene entry and world-locked
+        // after that; advancing it here keeps the ray and the render agreeing
+        // on where the menu is, in either presentation.
+        let panel = self.panel_anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            time.elapsed,
+        );
 
         let (action, last_pressed, point) =
             if game_options.presentation_mode == PresentationMode::Vr {
                 // VR has no 2D cursor: the pointer is where a controller ray meets
                 // the menu panel, and the trigger is the button.
-                let (point, pressed) = vr_pointer(input_context);
+                let (point, pressed) = vr_pointer(input_context, &panel);
                 self.vr_pointer_canvas = point;
                 self.pointer = None;
                 let (action, last_pressed) =
@@ -402,7 +408,7 @@ impl GameScene for MainMenuScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = frontend_panel(self.head_rotation);
+        let panel = self.panel_anchor.panel();
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
         let objects = canvas.render_world_space(
             asset_cache,
@@ -574,6 +580,12 @@ mod tests {
     }
 
     /// A hand aimed at a canvas point on this screen's VR panel.
+    /// The panel the anchor places on scene entry from the default head pose -
+    /// what `update` would have hit-tested against on the menu's first frame.
+    fn test_panel() -> WorldPanel {
+        crate::ui::test_support::test_panel()
+    }
+
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
         crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
     }
@@ -590,7 +602,7 @@ mod tests {
         // Aim at the center of "New Game" (rect 0) and pull the trigger.
         let rects = menu_rects(None);
         let target = rects[0].center();
-        let (point, pressed) = vr_pointer(&vr_input(hand_aimed_at(target, 1.0)));
+        let (point, pressed) = vr_pointer(&vr_input(hand_aimed_at(target, 1.0)), &test_panel());
         let point = point.expect("the ray should land on the panel");
         assert!(
             rects[0].contains(point),
@@ -612,7 +624,7 @@ mod tests {
             left_hand: hand_aimed_at(rects[5].center(), 1.0),
             ..InputContext::default()
         };
-        let (point, pressed) = vr_pointer(&input);
+        let (point, pressed) = vr_pointer(&input, &test_panel());
         let point = point.expect("the left hand should land on the panel");
         assert!(rects[5].contains(point));
         assert_eq!(
@@ -624,7 +636,10 @@ mod tests {
     #[test]
     fn a_light_vr_trigger_is_not_a_press() {
         let rects = menu_rects(None);
-        let (_, pressed) = vr_pointer(&vr_input(hand_aimed_at(rects[0].center(), 0.2)));
+        let (_, pressed) = vr_pointer(
+            &vr_input(hand_aimed_at(rects[0].center(), 0.2)),
+            &test_panel(),
+        );
         assert!(!pressed, "a barely-touched trigger must not click");
     }
 
@@ -639,7 +654,7 @@ mod tests {
             left_hand: away(),
             ..InputContext::default()
         };
-        let (point, pressed) = vr_pointer(&input);
+        let (point, pressed) = vr_pointer(&input, &test_panel());
         assert_eq!(point, None);
         // The trigger is still reported so the held press is consumed rather
         // than becoming a fresh edge when the ray swings back onto a button.

--- a/shock2vr/src/scenes/no_assets.rs
+++ b/shock2vr/src/scenes/no_assets.rs
@@ -36,8 +36,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        BUILTIN_FONT, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
-        frontend_panel,
+        BUILTIN_FONT, FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
+        VR_COMPONENT_Z_STEP,
     },
 };
 
@@ -202,7 +202,7 @@ fn body_text(path: &str) -> String {
 /// See the module docs.
 pub struct NoAssetsScene {
     lines: Vec<String>,
-    head_rotation: Quaternion<f32>,
+    panel_anchor: FrontendPanelAnchor,
     world: World,
 }
 
@@ -210,7 +210,7 @@ impl NoAssetsScene {
     pub fn new(status: &InstallStatus) -> NoAssetsScene {
         NoAssetsScene {
             lines: message_lines(status),
-            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            panel_anchor: FrontendPanelAnchor::new(),
             world: World::new(),
         }
     }
@@ -256,13 +256,17 @@ impl NoAssetsScene {
 impl GameScene for NoAssetsScene {
     fn update(
         &mut self,
-        _time: &Time,
+        time: &Time,
         input_context: &InputContext,
         _asset_cache: &mut AssetCache,
         _game_options: &GameOptions,
         _command_effects: Vec<Effect>,
     ) -> Vec<Effect> {
-        self.head_rotation = input_context.head.rotation;
+        self.panel_anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            time.elapsed,
+        );
         Vec::new()
     }
 
@@ -277,7 +281,7 @@ impl GameScene for NoAssetsScene {
             // the screen size is known.
             return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
         }
-        let panel = frontend_panel(self.head_rotation);
+        let panel = self.panel_anchor.panel();
         let objects = self.build_canvas().render_world_space(
             asset_cache,
             panel.transform(),

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -169,7 +169,7 @@ mod tests {
         let untracked = Hand {
             rotation: Quaternion::zero(),
             // At eye level, where a hand held up in front of the player sits.
-            position: vec3(0.0, crate::ui::FRONTEND_PANEL_EYE_HEIGHT, 0.0),
+            position: crate::input_context::Head::default().position,
             trigger_value: 1.0,
             ..Hand::default()
         };

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -1,7 +1,7 @@
 //! The VR pointer shared by every frontend screen.
 //!
 //! In VR there is no 2D cursor: the "pointer" is where a controller ray meets
-//! the screen's [`frontend_panel`], and the trigger is the button. That rule is
+//! the screen's anchored world panel, and the trigger is the button. That rule is
 //! identical for the main menu, the load screen and the game-over screen, so it
 //! lives here once rather than being re-derived per scene - the same reason
 //! placement lives in one layout pass (see `AGENTS.md` section 3): independent
@@ -11,7 +11,7 @@ use cgmath::{InnerSpace, Quaternion, Rotation, Vector2, Vector3, vec3};
 
 use crate::{
     input_context::{Hand, InputContext},
-    ui::{frontend_panel, ray_to_canvas},
+    ui::{WorldPanel, ray_to_canvas},
 };
 
 /// A VR trigger past this counts as "pressed", matching the hand code's
@@ -44,8 +44,8 @@ fn held(hand: &Hand) -> bool {
 pub fn vr_frontend_pointer(
     input_context: &InputContext,
     canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
 ) -> (Option<Vector2<f32>>, bool) {
-    let panel = frontend_panel(input_context.head.rotation);
     let right = &input_context.right_hand;
     let left = &input_context.left_hand;
 
@@ -67,7 +67,7 @@ pub fn vr_frontend_pointer(
         let Some(direction) = hand_ray(hand.rotation) else {
             continue;
         };
-        if let Some(point) = ray_to_canvas(canvas_size, &panel, hand.position, direction) {
+        if let Some(point) = ray_to_canvas(canvas_size, panel, hand.position, direction) {
             return (Some(point), any_held);
         }
     }
@@ -84,18 +84,30 @@ pub fn vr_frontend_pointer(
 #[cfg(test)]
 pub mod test_support {
     use super::*;
-    use crate::ui::FRONTEND_PANEL_DISTANCE;
+    use crate::ui::{FRONTEND_PANEL_DISTANCE, FrontendPanelAnchor};
+    use std::time::Duration;
 
     /// The head facing the tests aim against: the default camera orientation.
     pub fn test_head() -> Quaternion<f32> {
         Quaternion::new(1.0, 0.0, 0.0, 0.0)
     }
 
+    /// The panel the tests aim at: what a frontend scene's anchor places on
+    /// entry from the default head pose. Built through the real anchor so the
+    /// tests track placement changes instead of re-deriving them.
+    pub fn test_panel() -> WorldPanel {
+        FrontendPanelAnchor::new().update(
+            crate::input_context::Head::default().position,
+            test_head(),
+            Duration::ZERO,
+        )
+    }
+
     /// A hand aimed at a given canvas point, derived from the panel's own basis
     /// rather than world axes - so the tests stay honest whichever way the
     /// panel ends up facing. This is the inverse of [`ray_to_canvas`].
     pub fn hand_aimed_at(canvas_size: Vector2<f32>, point: Vector2<f32>, trigger: f32) -> Hand {
-        let panel = frontend_panel(test_head());
+        let panel = test_panel();
         let u = point.x / canvas_size.x - 0.5;
         let v = 0.5 - point.y / canvas_size.y;
         let right = panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
@@ -119,7 +131,7 @@ pub mod test_support {
     /// `panel.center` makes `ray_to_canvas` bail on distance before it ever
     /// looks at the direction, so the test would pass even aimed at the panel.
     pub fn hand_aimed_away(trigger: f32) -> Hand {
-        let panel = frontend_panel(test_head());
+        let panel = test_panel();
         // The panel's normal points at the viewer, so this stands in front of
         // it and looks the other way.
         let normal = panel.normal();
@@ -161,7 +173,11 @@ mod tests {
             trigger_value: 1.0,
             ..Hand::default()
         };
-        let (point, _) = vr_frontend_pointer(&vr_input(untracked.clone(), untracked), CANVAS);
+        let (point, _) = vr_frontend_pointer(
+            &vr_input(untracked.clone(), untracked),
+            CANVAS,
+            &test_panel(),
+        );
         assert_eq!(
             point, None,
             "an untracked controller must not report a pointer"
@@ -178,6 +194,7 @@ mod tests {
         let (point, pressed) = vr_frontend_pointer(
             &vr_input(untracked, hand_aimed_at(CANVAS, target, 1.0)),
             CANVAS,
+            &test_panel(),
         );
         let point = point.expect("the tracked hand should land on the panel");
         assert!((point.x - target.x).abs() < 1.0 && (point.y - target.y).abs() < 1.0);
@@ -194,7 +211,7 @@ mod tests {
             hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
             hand_aimed_away(1.0),
         );
-        let (point, pressed) = vr_frontend_pointer(&input, CANVAS);
+        let (point, pressed) = vr_frontend_pointer(&input, CANVAS, &test_panel());
         assert!(pressed, "a held trigger must stay reported as held");
         assert_eq!(
             point, None,
@@ -207,6 +224,7 @@ mod tests {
         let (point, pressed) = vr_frontend_pointer(
             &vr_input(hand_aimed_away(1.0), hand_aimed_away(1.0)),
             CANVAS,
+            &test_panel(),
         );
         assert_eq!(point, None);
         assert!(pressed);

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -18,9 +18,7 @@
 
 use std::rc::Rc;
 
-use cgmath::{
-    Deg, InnerSpace, Matrix3, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3,
-};
+use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
 use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
 use engine::{
     Font,
@@ -38,10 +36,7 @@ mod panel_anchor;
 #[cfg(test)]
 pub use frontend_pointer::test_support;
 pub use frontend_pointer::vr_frontend_pointer;
-pub use panel_anchor::{
-    FrontendPanelAnchor, PanelPlacement, RECENTER_DISTANCE, RECENTER_EASE_SECONDS,
-    RECENTER_HOLD_SECONDS, RECENTER_YAW_DEGREES, horizontal_forward, lerp_placement,
-};
+pub use panel_anchor::{FrontendPanelAnchor, PanelPlacement};
 
 /// Font name that resolves to the engine's compiled-in font rather than a
 /// `.FON` asset.
@@ -203,106 +198,17 @@ impl WorldPanel {
 /// The VR menu hangs on a panel 2m ahead of the player at eye level, sized to
 /// the canvas's 4:3 aspect so the art is not stretched.
 ///
-/// "Eye level" is not the scene origin: VR runtimes add a head offset of
-/// `player_eye_height / SCALE_FACTOR` on top of the camera position this scene
-/// returns, so a panel at y=0 hangs below the view and is never seen.
+/// "Eye level" is not the scene origin: VR runtimes add a head offset on top of
+/// the camera position this scene returns, so a panel at y=0 hangs below the
+/// view and is never seen. The panel is hung off the head's tracked position
+/// ([`crate::input_context::Head::position`], which defaults to that same eye
+/// height) rather than off the origin.
 pub const FRONTEND_PANEL_DISTANCE: f32 = 2.0;
-pub const FRONTEND_PANEL_EYE_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
 pub const FRONTEND_PANEL_SIZE: Vector2<f32> = Vector2 { x: 2.0, y: 1.5 };
 
 /// Spacing between stacked canvas layers in world space, so the labels sort in
 /// front of the backdrop instead of z-fighting it.
 pub const VR_COMPONENT_Z_STEP: f32 = 0.001;
-
-/// The panel a frontend screen is drawn on in VR: hung `FRONTEND_PANEL_DISTANCE` in front of the
-/// head and turned to face back at it.
-///
-/// It is anchored to the head's **facing**, not to a fixed world axis. There is
-/// no canonical "forward" to hardcode - the runtimes' yaw-0 camera looks along
-/// +X, not -Z - so a panel pinned to -Z sits off to the side and never enters
-/// the frustum. This mirrors `DebugMapScene`'s construction, which is the
-/// world-space panel that demonstrably renders.
-pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
-    let head = vec3(0.0, FRONTEND_PANEL_EYE_HEIGHT, 0.0);
-    // An untracked pose arrives as the *zero* quaternion, not identity, and
-    // rotating by it silently yields the unrotated vector - so the panel would
-    // pin itself to world -Z and never follow the viewer.
-    let head_rotation = if head_rotation.magnitude2() < 1e-6 {
-        Quaternion::new(1.0, 0.0, 0.0, 0.0)
-    } else {
-        head_rotation.normalize()
-    };
-    // Assumes -Z forward, which is OpenXR's convention. The desktop runtimes'
-    // quaternions happen to agree about the *rendered* view direction (their
-    // `camera_rotation` maps -Z to the direction the view matrix actually
-    // looks), so the panel lands in front of the camera on every runtime.
-    let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
-    let center = head + forward * FRONTEND_PANEL_DISTANCE;
-
-    // Orient the panel by looking from it back to the head. `look_dir` runs
-    // panel -> head, and the basis is honest: local +x is the viewer's right,
-    // local +y is up, and local +Z (the third column, [`WorldPanel::normal`])
-    // points *at* the viewer. A raw element placed with this rotation alone
-    // renders upright; no compensating rotation exists anywhere in the element
-    // path (the only remaining flip is `world_element_transform`'s canvas-y
-    // flip, which every presentation shares).
-    let mut look_dir = head - center;
-    look_dir = if look_dir.magnitude2() < 1e-6 {
-        vec3(0.0, 0.0, 1.0)
-    } else {
-        look_dir.normalize()
-    };
-    let mut up = vec3(0.0, 1.0, 0.0);
-    // The viewer looks along -look_dir, so their right hand points along
-    // (-look_dir) x up == up x look_dir.
-    let mut right = up.cross(look_dir);
-    if right.magnitude2() < 1e-6 {
-        // Looking straight up or down: pick a different up to keep the basis
-        // well-defined.
-        up = vec3(0.0, 0.0, 1.0);
-        right = up.cross(look_dir);
-    }
-    let right = right.normalize();
-    let true_up = look_dir.cross(right).normalize();
-
-    let panel = WorldPanel {
-        center,
-        rotation: Quaternion::from(Matrix3::from_cols(right, true_up, look_dir)),
-        size: FRONTEND_PANEL_SIZE,
-    };
-
-    // Device-comparison probe: `SHOCK2_PANEL_LOG=1` prints the head pose and
-    // the basis this function derived from it, rate-limited. `println!` (not
-    // `tracing`) on purpose - it reaches logcat on Quest, where no tracing
-    // subscriber is installed.
-    if std::env::var_os("SHOCK2_PANEL_LOG").is_some() {
-        use std::sync::atomic::{AtomicU32, Ordering};
-        static CALLS: AtomicU32 = AtomicU32::new(0);
-        if CALLS.fetch_add(1, Ordering::Relaxed) % 90 == 0 {
-            println!(
-                "SHOCK2_PANEL head_quat=({:.4},{:.4},{:.4},{:.4}) forward=({:.4},{:.4},{:.4}) right=({:.4},{:.4},{:.4}) up=({:.4},{:.4},{:.4}) normal=({:.4},{:.4},{:.4})",
-                head_rotation.s,
-                head_rotation.v.x,
-                head_rotation.v.y,
-                head_rotation.v.z,
-                forward.x,
-                forward.y,
-                forward.z,
-                right.x,
-                right.y,
-                right.z,
-                true_up.x,
-                true_up.y,
-                true_up.z,
-                look_dir.x,
-                look_dir.y,
-                look_dir.z,
-            );
-        }
-    }
-
-    panel
-}
 
 /// Intersect a pointing ray with `panel` and return where it lands, in canvas
 /// pixels - the VR counterpart of [`pointer_to_canvas`].

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -34,9 +34,14 @@ use shipyard::EntityId;
 use crate::vr_config::Handedness;
 
 mod frontend_pointer;
+mod panel_anchor;
 #[cfg(test)]
 pub use frontend_pointer::test_support;
 pub use frontend_pointer::vr_frontend_pointer;
+pub use panel_anchor::{
+    FrontendPanelAnchor, PanelPlacement, RECENTER_DISTANCE, RECENTER_EASE_SECONDS,
+    RECENTER_HOLD_SECONDS, RECENTER_YAW_DEGREES, horizontal_forward, lerp_placement,
+};
 
 /// Font name that resolves to the engine's compiled-in font rather than a
 /// `.FON` asset.

--- a/shock2vr/src/ui/panel_anchor.rs
+++ b/shock2vr/src/ui/panel_anchor.rs
@@ -1,0 +1,429 @@
+//! Head-anchored placement for the VR frontend panels.
+//!
+//! A menu glued to the gaze cannot be looked *at*: it moves exactly as fast as
+//! the eye, so nothing on it can be inspected off-center and the world behind
+//! it is permanently occluded. Real headsets place a frontend panel **once**,
+//! world-lock it, and only re-place it when the player has clearly walked or
+//! turned away and stayed away. That is what this module does:
+//!
+//! - **Place on entry** from the head pose, using **yaw only** - the panel is
+//!   gravity-aligned and vertical even if the player enters the menu looking at
+//!   the floor.
+//! - **World-locked** afterward: turning the head moves the panel *in view*.
+//! - **Lazy recenter**: sustained gaze/position divergence (not a glance)
+//!   re-places it, eased rather than teleported.
+//!
+//! The math lives in free functions so it is unit-testable without a runtime;
+//! [`FrontendPanelAnchor`] is the small amount of state a scene keeps.
+
+use std::time::Duration;
+
+use cgmath::{Deg, InnerSpace, Matrix3, Quaternion, Rad, Rotation, Vector3, vec3};
+
+use crate::ui::{FRONTEND_PANEL_DISTANCE, FRONTEND_PANEL_SIZE, WorldPanel};
+
+/// Gaze may drift this far off the panel before a recenter starts counting.
+pub const RECENTER_YAW_DEGREES: f32 = 60.0;
+/// ...or the head may move this far (world units) from where it placed it.
+pub const RECENTER_DISTANCE: f32 = 1.0;
+/// The divergence must be *sustained* this long, so a glance across the room
+/// never drags the menu along.
+pub const RECENTER_HOLD_SECONDS: f32 = 1.0;
+/// How long the re-placement takes. A teleporting panel reads as a glitch;
+/// this is short enough to feel responsive and long enough to be followed.
+pub const RECENTER_EASE_SECONDS: f32 = 0.3;
+
+/// Where a panel was placed: the head position it was hung off, and the
+/// horizontal (yaw-only) direction it was hung along.
+///
+/// Two vectors rather than a `WorldPanel` because these are the quantities that
+/// interpolate meaningfully during a recenter - and because a placement is
+/// gravity-aligned by construction, so there is no roll or pitch to carry.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PanelPlacement {
+    /// The head position at placement time, in pawn space.
+    pub head_position: Vector3<f32>,
+    /// Unit, horizontal (y == 0): the direction the panel hangs along.
+    pub forward: Vector3<f32>,
+}
+
+/// The head's facing flattened onto the horizontal plane.
+///
+/// Yaw only, so a panel built from it is vertical however the head is pitched
+/// or rolled. Two degenerate inputs are handled:
+///
+/// - the **zero quaternion**, which is what a runtime reports for an untracked
+///   pose (rotating by it silently returns the input vector), is treated as
+///   identity;
+/// - a **vertical** forward (looking straight down or up), where the horizontal
+///   projection vanishes. There the head's own **up** axis is used instead:
+///   looking at the floor, the top of your head points where you are facing, so
+///   the panel spawns ahead of the player rather than at an arbitrary yaw.
+pub fn horizontal_forward(head_rotation: Quaternion<f32>) -> Vector3<f32> {
+    let rotation = if head_rotation.magnitude2() < 1e-6 {
+        Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    } else {
+        head_rotation.normalize()
+    };
+
+    let flatten = |v: Vector3<f32>| {
+        let flat = vec3(v.x, 0.0, v.z);
+        (flat.magnitude2() > 1e-6).then(|| flat.normalize())
+    };
+
+    flatten(rotation.rotate_vector(vec3(0.0, 0.0, -1.0)))
+        // Looking straight down/up: the head's up axis carries the yaw.
+        .or_else(|| flatten(rotation.rotate_vector(vec3(0.0, 1.0, 0.0))))
+        // Unreachable for a real rotation (forward and up cannot both be
+        // vertical), but a defined answer beats a NaN basis.
+        .unwrap_or_else(|| vec3(0.0, 0.0, -1.0))
+}
+
+impl PanelPlacement {
+    /// Place a panel from a head pose: at the head, along its yaw.
+    pub fn from_head(head_position: Vector3<f32>, head_rotation: Quaternion<f32>) -> Self {
+        Self {
+            head_position,
+            forward: horizontal_forward(head_rotation),
+        }
+    }
+
+    /// The panel this placement describes.
+    ///
+    /// Same distance, size and honest basis as the gaze-glued
+    /// [`crate::ui::frontend_panel`] - local +x the viewer's right, +y up, +Z
+    /// pointing back at the viewer - but built from a stored placement instead
+    /// of the live head, and gravity-aligned (+y is exactly world up).
+    pub fn panel(&self) -> WorldPanel {
+        let center = self.head_position + self.forward * FRONTEND_PANEL_DISTANCE;
+        // Panel -> head, horizontal, so the panel faces the player squarely.
+        let look_dir = -self.forward;
+        let up = vec3(0.0, 1.0, 0.0);
+        // The viewer looks along -look_dir, so their right is up x look_dir.
+        let right = up.cross(look_dir).normalize();
+        WorldPanel {
+            center,
+            rotation: Quaternion::from(Matrix3::from_cols(right, up, look_dir)),
+            size: FRONTEND_PANEL_SIZE,
+        }
+    }
+
+    /// Signed-magnitude angle between this placement's yaw and a head facing.
+    pub fn yaw_offset_degrees(&self, head_rotation: Quaternion<f32>) -> f32 {
+        let gaze = horizontal_forward(head_rotation);
+        let dot = self.forward.dot(gaze).clamp(-1.0, 1.0);
+        Deg::from(Rad(dot.acos())).0
+    }
+
+    /// Has the player turned or moved far enough that this placement is stale?
+    ///
+    /// Instantaneously stale, that is - the anchor still requires it to hold
+    /// for [`RECENTER_HOLD_SECONDS`] before acting.
+    pub fn is_stale(&self, head_position: Vector3<f32>, head_rotation: Quaternion<f32>) -> bool {
+        self.yaw_offset_degrees(head_rotation) > RECENTER_YAW_DEGREES
+            || (head_position - self.head_position).magnitude() > RECENTER_DISTANCE
+    }
+}
+
+/// Interpolate between two placements. `t` is clamped to `[0, 1]`, so the
+/// endpoints are exactly `from` and `to`.
+pub fn lerp_placement(from: PanelPlacement, to: PanelPlacement, t: f32) -> PanelPlacement {
+    let t = t.clamp(0.0, 1.0);
+    // Smoothstep: no velocity discontinuity at either end, which is what makes
+    // the re-placement read as a move rather than a jump.
+    let s = t * t * (3.0 - 2.0 * t);
+    let head_position = from.head_position + (to.head_position - from.head_position) * s;
+    let blended = from.forward + (to.forward - from.forward) * s;
+    let forward = if blended.magnitude2() < 1e-6 {
+        // Exactly-opposed placements have no shortest arc; commit to the
+        // target rather than producing a zero direction.
+        to.forward
+    } else {
+        let flat = vec3(blended.x, 0.0, blended.z);
+        if flat.magnitude2() < 1e-6 {
+            to.forward
+        } else {
+            flat.normalize()
+        }
+    };
+    PanelPlacement {
+        head_position,
+        forward,
+    }
+}
+
+/// An in-progress eased recenter.
+#[derive(Debug, Clone, Copy)]
+struct Ease {
+    from: PanelPlacement,
+    to: PanelPlacement,
+    /// Seconds elapsed into [`RECENTER_EASE_SECONDS`].
+    elapsed: f32,
+}
+
+/// The stateful half: place on entry, world-lock, lazily recenter.
+///
+/// A frontend scene owns one, feeds it the head pose every update, and both
+/// hit-tests and renders against the panel it returns - so the ray and the art
+/// can never disagree about where the menu is.
+#[derive(Debug, Clone, Default)]
+pub struct FrontendPanelAnchor {
+    placement: Option<PanelPlacement>,
+    ease: Option<Ease>,
+    /// How long the placement has been continuously stale.
+    stale_for: f32,
+}
+
+impl FrontendPanelAnchor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Advance the anchor for a frame and return where the panel now is.
+    ///
+    /// The first call places the panel; later calls leave it alone unless a
+    /// recenter is due or in progress.
+    pub fn update(
+        &mut self,
+        head_position: Vector3<f32>,
+        head_rotation: Quaternion<f32>,
+        dt: Duration,
+    ) -> WorldPanel {
+        let dt = dt.as_secs_f32();
+        let Some(current) = self.placement else {
+            let placed = PanelPlacement::from_head(head_position, head_rotation);
+            self.placement = Some(placed);
+            return placed.panel();
+        };
+
+        if let Some(mut ease) = self.ease {
+            ease.elapsed += dt;
+            let t = ease.elapsed / RECENTER_EASE_SECONDS;
+            let placement = lerp_placement(ease.from, ease.to, t);
+            self.placement = Some(placement);
+            self.ease = (t < 1.0).then_some(ease);
+            return placement.panel();
+        }
+
+        if current.is_stale(head_position, head_rotation) {
+            self.stale_for += dt;
+            if self.stale_for >= RECENTER_HOLD_SECONDS {
+                self.stale_for = 0.0;
+                self.ease = Some(Ease {
+                    from: current,
+                    to: PanelPlacement::from_head(head_position, head_rotation),
+                    elapsed: 0.0,
+                });
+            }
+        } else {
+            // Hysteresis: the clock only counts *sustained* divergence, so a
+            // glance away and back leaves the panel where it was.
+            self.stale_for = 0.0;
+        }
+
+        current.panel()
+    }
+
+    /// Where the panel is, as of the last [`update`](Self::update). `None`
+    /// before the scene's first update.
+    pub fn placement(&self) -> Option<PanelPlacement> {
+        self.placement
+    }
+
+    /// The current panel, or a panel placed from a default head pose if the
+    /// scene has not updated yet (render can run before update on the first
+    /// frame of a scene swap).
+    pub fn panel(&self) -> WorldPanel {
+        self.placement
+            .unwrap_or_else(|| {
+                PanelPlacement::from_head(
+                    vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0),
+                    Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                )
+            })
+            .panel()
+    }
+
+    /// Whether a recenter is currently animating (test/introspection hook).
+    pub fn is_recentering(&self) -> bool {
+        self.ease.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Rotation3, Zero};
+
+    const FRAME: Duration = Duration::from_millis(1000 / 60);
+
+    fn yaw(degrees: f32) -> Quaternion<f32> {
+        Quaternion::from_angle_y(Deg(degrees))
+    }
+
+    fn eye() -> Vector3<f32> {
+        vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0)
+    }
+
+    fn step(anchor: &mut FrontendPanelAnchor, pos: Vector3<f32>, rot: Quaternion<f32>, secs: f32) {
+        let frames = (secs * 60.0).round() as u32;
+        for _ in 0..frames {
+            anchor.update(pos, rot, FRAME);
+        }
+    }
+
+    #[test]
+    fn a_pitched_head_still_places_an_upright_panel() {
+        // Entering the menu while looking at the floor must not hang the panel
+        // at the player's feet, face-down.
+        let pitched = yaw(90.0) * Quaternion::from_angle_x(Deg(-70.0));
+        let placement = PanelPlacement::from_head(eye(), pitched);
+        let panel = placement.panel();
+
+        assert!(
+            (panel.center.y - eye().y).abs() < 1e-4,
+            "panel should hang at eye level, not below it: {:?}",
+            panel.center
+        );
+        let up = panel.rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+        assert!(
+            (up - vec3(0.0, 1.0, 0.0)).magnitude() < 1e-4,
+            "panel up must be gravity up, got {up:?}"
+        );
+        // Yaw preserved: the head faces +X at yaw 90 in this convention.
+        let expected = yaw(90.0).rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!((placement.forward - expected).magnitude() < 1e-3);
+    }
+
+    #[test]
+    fn looking_straight_down_keeps_the_heads_yaw() {
+        // The forward axis is vertical here, so the projection is degenerate
+        // and the fallback decides the answer. It must still be the yaw the
+        // player is facing, not a fixed world axis.
+        let straight_down = yaw(90.0) * Quaternion::from_angle_x(Deg(-90.0));
+        let forward = horizontal_forward(straight_down);
+        let expected = yaw(90.0).rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(
+            (forward - expected).magnitude() < 1e-3,
+            "expected {expected:?}, got {forward:?}"
+        );
+        assert!(forward.y.abs() < 1e-6, "forward must be horizontal");
+    }
+
+    #[test]
+    fn an_untracked_head_is_treated_as_identity() {
+        let forward = horizontal_forward(Quaternion::zero());
+        assert!((forward - vec3(0.0, 0.0, -1.0)).magnitude() < 1e-6);
+    }
+
+    #[test]
+    fn the_panel_is_world_locked_while_the_head_turns() {
+        let mut anchor = FrontendPanelAnchor::new();
+        let placed = anchor.update(eye(), yaw(0.0), FRAME);
+        // A 30 degree turn, held for well past the hold time: inside the
+        // threshold, so the panel must not move at all.
+        step(&mut anchor, eye(), yaw(30.0), 3.0);
+        let after = anchor.panel();
+        assert!((after.center - placed.center).magnitude() < 1e-5);
+        assert!(!anchor.is_recentering());
+    }
+
+    #[test]
+    fn a_brief_glance_past_the_threshold_does_not_recenter() {
+        let mut anchor = FrontendPanelAnchor::new();
+        let placed = anchor.update(eye(), yaw(0.0), FRAME);
+        step(&mut anchor, eye(), yaw(120.0), 0.5); // glance away...
+        step(&mut anchor, eye(), yaw(0.0), 0.5); // ...and back
+        step(&mut anchor, eye(), yaw(120.0), 0.5); // and away again
+        assert!(
+            !anchor.is_recentering(),
+            "the stale clock must reset on the way back"
+        );
+        assert!((anchor.panel().center - placed.center).magnitude() < 1e-5);
+    }
+
+    #[test]
+    fn sustained_turning_away_recenters_into_view() {
+        let mut anchor = FrontendPanelAnchor::new();
+        anchor.update(eye(), yaw(0.0), FRAME);
+        step(&mut anchor, eye(), yaw(120.0), 1.1);
+        assert!(anchor.is_recentering(), "recenter should have started");
+
+        // Mid-ease the panel is between the two placements, not at either.
+        let mid = anchor.placement().unwrap();
+        assert!(mid.yaw_offset_degrees(yaw(120.0)) > 1.0);
+
+        step(&mut anchor, eye(), yaw(120.0), 0.4);
+        assert!(!anchor.is_recentering(), "the ease should have finished");
+        let settled = anchor.placement().unwrap();
+        assert!(
+            settled.yaw_offset_degrees(yaw(120.0)) < 1.0,
+            "the panel should end up in front of the new gaze, off by {}",
+            settled.yaw_offset_degrees(yaw(120.0))
+        );
+    }
+
+    #[test]
+    fn walking_away_recenters_even_facing_the_same_way() {
+        let mut anchor = FrontendPanelAnchor::new();
+        anchor.update(eye(), yaw(0.0), FRAME);
+        let moved = eye() + vec3(3.0, 0.0, 0.0);
+        step(&mut anchor, moved, yaw(0.0), 1.5);
+        step(&mut anchor, moved, yaw(0.0), 0.4);
+        let settled = anchor.placement().unwrap();
+        assert!(
+            (settled.head_position - moved).magnitude() < 1e-3,
+            "the panel should follow the player to {moved:?}, got {:?}",
+            settled.head_position
+        );
+    }
+
+    #[test]
+    fn a_small_step_does_not_recenter() {
+        let mut anchor = FrontendPanelAnchor::new();
+        anchor.update(eye(), yaw(0.0), FRAME);
+        step(&mut anchor, eye() + vec3(0.5, 0.0, 0.0), yaw(0.0), 3.0);
+        assert!(!anchor.is_recentering());
+    }
+
+    #[test]
+    fn the_ease_hits_its_endpoints_exactly() {
+        let a = PanelPlacement::from_head(vec3(0.0, 1.0, 0.0), yaw(0.0));
+        let b = PanelPlacement::from_head(vec3(2.0, 1.0, 3.0), yaw(90.0));
+        let same = |x: PanelPlacement, y: PanelPlacement| {
+            (x.head_position - y.head_position).magnitude() < 1e-5
+                && (x.forward - y.forward).magnitude() < 1e-5
+        };
+        assert!(same(lerp_placement(a, b, 0.0), a));
+        assert!(same(lerp_placement(a, b, 1.0), b));
+        // Clamped, not extrapolated.
+        assert!(same(lerp_placement(a, b, -1.0), a));
+        assert!(same(lerp_placement(a, b, 5.0), b));
+        let mid = lerp_placement(a, b, 0.5);
+        assert!(mid.forward.y.abs() < 1e-6, "the ease must stay horizontal");
+        assert!((mid.forward.magnitude() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn an_exactly_opposed_ease_still_yields_a_direction() {
+        let a = PanelPlacement::from_head(Vector3::zero(), yaw(0.0));
+        let b = PanelPlacement::from_head(Vector3::zero(), yaw(180.0));
+        let mid = lerp_placement(a, b, 0.5);
+        assert!((mid.forward.magnitude() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn the_placed_panel_faces_the_head() {
+        let placement = PanelPlacement::from_head(eye(), yaw(37.0));
+        let panel = placement.panel();
+        let to_head = (eye() - panel.center).normalize();
+        assert!(
+            (panel.normal() - to_head).magnitude() < 1e-4,
+            "the panel normal must point back at the viewer"
+        );
+        assert!(
+            ((panel.center - eye()).magnitude() - FRONTEND_PANEL_DISTANCE).abs() < 1e-4,
+            "the panel must hang at the frontend distance"
+        );
+    }
+}

--- a/shock2vr/src/ui/panel_anchor.rs
+++ b/shock2vr/src/ui/panel_anchor.rs
@@ -18,20 +18,20 @@
 
 use std::time::Duration;
 
-use cgmath::{Deg, InnerSpace, Matrix3, Quaternion, Rad, Rotation, Vector3, vec3};
+use cgmath::{Deg, InnerSpace, Quaternion, Rad, Rotation, Vector3, vec3};
 
 use crate::ui::{FRONTEND_PANEL_DISTANCE, FRONTEND_PANEL_SIZE, WorldPanel};
 
 /// Gaze may drift this far off the panel before a recenter starts counting.
-pub const RECENTER_YAW_DEGREES: f32 = 60.0;
+const RECENTER_YAW_DEGREES: f32 = 60.0;
 /// ...or the head may move this far (world units) from where it placed it.
-pub const RECENTER_DISTANCE: f32 = 1.0;
+const RECENTER_DISTANCE: f32 = 1.0;
 /// The divergence must be *sustained* this long, so a glance across the room
 /// never drags the menu along.
-pub const RECENTER_HOLD_SECONDS: f32 = 1.0;
+const RECENTER_HOLD_SECONDS: f32 = 1.0;
 /// How long the re-placement takes. A teleporting panel reads as a glitch;
 /// this is short enough to feel responsive and long enough to be followed.
-pub const RECENTER_EASE_SECONDS: f32 = 0.3;
+const RECENTER_EASE_SECONDS: f32 = 0.3;
 
 /// Where a panel was placed: the head position it was hung off, and the
 /// horizontal (yaw-only) direction it was hung along.
@@ -56,10 +56,12 @@ pub struct PanelPlacement {
 ///   pose (rotating by it silently returns the input vector), is treated as
 ///   identity;
 /// - a **vertical** forward (looking straight down or up), where the horizontal
-///   projection vanishes. There the head's own **up** axis is used instead:
-///   looking at the floor, the top of your head points where you are facing, so
-///   the panel spawns ahead of the player rather than at an arbitrary yaw.
-pub fn horizontal_forward(head_rotation: Quaternion<f32>) -> Vector3<f32> {
+///   projection vanishes. There the head's own **up** axis carries the yaw -
+///   but only with the right sign: looking at the floor the top of your head
+///   points where you are facing, while looking at the ceiling it points
+///   *behind* you, so the up axis is negated in that case. (Getting this wrong
+///   spawns the panel behind a player who entered the menu looking up.)
+fn horizontal_forward(head_rotation: Quaternion<f32>) -> Vector3<f32> {
     let rotation = if head_rotation.magnitude2() < 1e-6 {
         Quaternion::new(1.0, 0.0, 0.0, 0.0)
     } else {
@@ -71,12 +73,27 @@ pub fn horizontal_forward(head_rotation: Quaternion<f32>) -> Vector3<f32> {
         (flat.magnitude2() > 1e-6).then(|| flat.normalize())
     };
 
-    flatten(rotation.rotate_vector(vec3(0.0, 0.0, -1.0)))
-        // Looking straight down/up: the head's up axis carries the yaw.
-        .or_else(|| flatten(rotation.rotate_vector(vec3(0.0, 1.0, 0.0))))
+    let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+    flatten(forward)
+        .or_else(|| {
+            let up = rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+            flatten(if forward.y > 0.0 { -up } else { up })
+        })
         // Unreachable for a real rotation (forward and up cannot both be
         // vertical), but a defined answer beats a NaN basis.
         .unwrap_or_else(|| vec3(0.0, 0.0, -1.0))
+}
+
+/// The compass angle of a horizontal unit vector, and its inverse. Yaw is the
+/// only degree of freedom a placement has, so interpolating it directly is what
+/// makes a recenter turn the short way round at any angle - blending the
+/// vectors instead collapses to a jump at 180 degrees.
+fn yaw_of(forward: Vector3<f32>) -> f32 {
+    forward.x.atan2(forward.z)
+}
+
+fn forward_of(yaw: f32) -> Vector3<f32> {
+    vec3(yaw.sin(), 0.0, yaw.cos())
 }
 
 impl PanelPlacement {
@@ -90,25 +107,21 @@ impl PanelPlacement {
 
     /// The panel this placement describes.
     ///
-    /// Same distance, size and honest basis as the gaze-glued
-    /// [`crate::ui::frontend_panel`] - local +x the viewer's right, +y up, +Z
-    /// pointing back at the viewer - but built from a stored placement instead
-    /// of the live head, and gravity-aligned (+y is exactly world up).
+    /// The basis is honest - local +x the viewer's right, +y up, +Z pointing
+    /// back at the viewer, so a raw element placed with it renders upright -
+    /// and gravity-aligned, because the placement's forward is horizontal.
     pub fn panel(&self) -> WorldPanel {
-        let center = self.head_position + self.forward * FRONTEND_PANEL_DISTANCE;
-        // Panel -> head, horizontal, so the panel faces the player squarely.
-        let look_dir = -self.forward;
-        let up = vec3(0.0, 1.0, 0.0);
-        // The viewer looks along -look_dir, so their right is up x look_dir.
-        let right = up.cross(look_dir).normalize();
         WorldPanel {
-            center,
-            rotation: Quaternion::from(Matrix3::from_cols(right, up, look_dir)),
+            center: self.head_position + self.forward * FRONTEND_PANEL_DISTANCE,
+            // Panel -> head, so the panel faces the player squarely. The
+            // helper's degenerate-vertical branch cannot fire here: a
+            // placement's forward is horizontal by construction.
+            rotation: crate::util::get_rotation_from_forward_vector(-self.forward),
             size: FRONTEND_PANEL_SIZE,
         }
     }
 
-    /// Signed-magnitude angle between this placement's yaw and a head facing.
+    /// Unsigned angle between this placement's yaw and a head facing.
     pub fn yaw_offset_degrees(&self, head_rotation: Quaternion<f32>) -> f32 {
         let gaze = horizontal_forward(head_rotation);
         let dot = self.forward.dot(gaze).clamp(-1.0, 1.0);
@@ -127,28 +140,22 @@ impl PanelPlacement {
 
 /// Interpolate between two placements. `t` is clamped to `[0, 1]`, so the
 /// endpoints are exactly `from` and `to`.
-pub fn lerp_placement(from: PanelPlacement, to: PanelPlacement, t: f32) -> PanelPlacement {
+fn lerp_placement(from: PanelPlacement, to: PanelPlacement, t: f32) -> PanelPlacement {
     let t = t.clamp(0.0, 1.0);
     // Smoothstep: no velocity discontinuity at either end, which is what makes
     // the re-placement read as a move rather than a jump.
     let s = t * t * (3.0 - 2.0 * t);
     let head_position = from.head_position + (to.head_position - from.head_position) * s;
-    let blended = from.forward + (to.forward - from.forward) * s;
-    let forward = if blended.magnitude2() < 1e-6 {
-        // Exactly-opposed placements have no shortest arc; commit to the
-        // target rather than producing a zero direction.
-        to.forward
-    } else {
-        let flat = vec3(blended.x, 0.0, blended.z);
-        if flat.magnitude2() < 1e-6 {
-            to.forward
-        } else {
-            flat.normalize()
-        }
-    };
+    // Turn along the shortest arc at a constant rate. Blending the direction
+    // vectors instead would stall near the start of a half-turn and snap
+    // through the middle - exactly the teleport the ease exists to avoid.
+    let from_yaw = yaw_of(from.forward);
+    let mut delta = yaw_of(to.forward) - from_yaw;
+    let tau = std::f32::consts::TAU;
+    delta = delta - tau * (delta / tau).round();
     PanelPlacement {
         head_position,
-        forward,
+        forward: forward_of(from_yaw + delta * s),
     }
 }
 
@@ -181,8 +188,8 @@ impl FrontendPanelAnchor {
 
     /// Advance the anchor for a frame and return where the panel now is.
     ///
-    /// The first call places the panel; later calls leave it alone unless a
-    /// recenter is due or in progress.
+    /// The first call with a tracked pose places the panel; later calls leave
+    /// it alone unless a recenter is due or in progress.
     pub fn update(
         &mut self,
         head_position: Vector3<f32>,
@@ -191,6 +198,13 @@ impl FrontendPanelAnchor {
     ) -> WorldPanel {
         let dt = dt.as_secs_f32();
         let Some(current) = self.placement else {
+            // An untracked head arrives as the ZERO quaternion. Placement is
+            // permanent, so locking one in from a pose that carries no facing
+            // would strand the panel along world -Z for the whole screen -
+            // wait for a real pose instead, and show the default meanwhile.
+            if head_rotation.magnitude2() < 1e-6 {
+                return self.panel();
+            }
             let placed = PanelPlacement::from_head(head_position, head_rotation);
             self.placement = Some(placed);
             return placed.panel();
@@ -311,9 +325,43 @@ mod tests {
     }
 
     #[test]
+    fn looking_straight_up_keeps_the_heads_yaw_too() {
+        // The mirror of the case above, and the one that catches a naive
+        // fallback: looking up, the head's up axis points BEHIND the player,
+        // so using it unsigned spawns the panel over their shoulder.
+        let straight_up = yaw(90.0) * Quaternion::from_angle_x(Deg(90.0));
+        let forward = horizontal_forward(straight_up);
+        let expected = yaw(90.0).rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(
+            (forward - expected).magnitude() < 1e-3,
+            "expected {expected:?}, got {forward:?}"
+        );
+    }
+
+    #[test]
     fn an_untracked_head_is_treated_as_identity() {
         let forward = horizontal_forward(Quaternion::zero());
         assert!((forward - vec3(0.0, 0.0, -1.0)).magnitude() < 1e-6);
+    }
+
+    #[test]
+    fn an_untracked_head_does_not_lock_a_placement() {
+        // Placement is permanent, so committing to an untracked pose would
+        // strand the panel along world -Z for the whole screen. The runtimes
+        // can report one on their first frame, which is exactly when the
+        // frontend screens place.
+        let mut anchor = FrontendPanelAnchor::new();
+        anchor.update(eye(), Quaternion::zero(), FRAME);
+        assert!(
+            anchor.placement().is_none(),
+            "an untracked pose must not be locked in"
+        );
+
+        // ...and the first tracked pose places it, off to the side rather than
+        // along the default facing.
+        anchor.update(eye(), yaw(90.0), FRAME);
+        let placed = anchor.placement().expect("a tracked pose should place");
+        assert!(placed.yaw_offset_degrees(yaw(90.0)) < 1e-3);
     }
 
     #[test]
@@ -405,11 +453,32 @@ mod tests {
     }
 
     #[test]
-    fn an_exactly_opposed_ease_still_yields_a_direction() {
-        let a = PanelPlacement::from_head(Vector3::zero(), yaw(0.0));
-        let b = PanelPlacement::from_head(Vector3::zero(), yaw(180.0));
-        let mid = lerp_placement(a, b, 0.5);
-        assert!((mid.forward.magnitude() - 1.0).abs() < 1e-5);
+    fn the_ease_turns_at_an_even_rate_even_through_a_half_turn() {
+        // Blending the direction VECTORS makes a near-180 recenter sit still
+        // and then snap through the middle - the teleport the ease exists to
+        // prevent. Interpolating the yaw keeps every step comparable.
+        for turn in [179.0, 180.0] {
+            let a = PanelPlacement::from_head(Vector3::zero(), yaw(0.0));
+            let b = PanelPlacement::from_head(Vector3::zero(), yaw(turn));
+            let steps = 20;
+            let angles: Vec<f32> = (0..=steps)
+                .map(|i| {
+                    let p = lerp_placement(a, b, i as f32 / steps as f32);
+                    assert!((p.forward.magnitude() - 1.0).abs() < 1e-4);
+                    p.yaw_offset_degrees(yaw(0.0))
+                })
+                .collect();
+            let biggest = angles
+                .windows(2)
+                .map(|w| (w[1] - w[0]).abs())
+                .fold(0.0f32, f32::max);
+            // Smoothstep peaks at 1.5x the mean step; a snap would be ~10x.
+            let mean = turn / steps as f32;
+            assert!(
+                biggest < mean * 2.0,
+                "{turn} degree recenter jumped {biggest} in one step (mean {mean})"
+            );
+        }
     }
 
     #[test]

--- a/tools/shock2-sdk/test/vr-frontend-panel-anchor.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-frontend-panel-anchor.e2e.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+
+// The VR frontend panel is placed ONCE, from the head pose, and then
+// world-locked: turning the head moves it in view instead of dragging it along.
+// Only sustained divergence (>60 degrees of gaze yaw, held ~1s) recenters it.
+//
+// Headless observation: the menu's rollover blip (MROLLOV1) fires when the
+// controller ray enters a widget, so "does aiming at this world position still
+// hit the Load Game button?" is answerable from the audio log. Where the panel
+// is, is therefore measurable without reading pixels.
+//
+// Negative-first: against the previous gaze-glued panel, the first test's
+// "after turning the head, the panel is still at the OLD world position"
+// assertion fails - the panel had already followed the gaze.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const ROLLOVER = "sfx/mrollov1.wav";
+
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+const PANEL_DISTANCE = 2;
+const PANEL_SIZE = { x: 2, y: 1.5 };
+
+/** Normalized canvas center of menu entry `index` (MAINR.BIN's button stack). */
+const menuEntry = (index: number): [number, number] => [
+  (400 + 179 / 2) / CANVAS_W,
+  (20 + index * 76 + 60 / 2) / CANVAS_H,
+];
+
+const NEW_GAME = menuEntry(0);
+const LOAD_GAME = menuEntry(1);
+
+type Vec3 = [number, number, number];
+
+/**
+ * The runtime's head convention: `head.look` yaw 0 gazes along -X.
+ */
+function gaze(yawDegrees: number): Vec3 {
+  const yaw = (yawDegrees * Math.PI) / 180;
+  return [-Math.cos(yaw), 0, -Math.sin(yaw)];
+}
+
+/**
+ * Where a canvas point sits in the world on a panel placed from a head looking
+ * along `yawDegrees` - the same yaw-only, gravity-aligned placement
+ * `FrontendPanelAnchor` makes.
+ */
+function panelPoint(
+  yawDegrees: number,
+  [u, v]: [number, number],
+  origin: Vec3 = [0, PLAYER_EYE_HEIGHT_WORLD, 0],
+): Vec3 {
+  const [gx, , gz] = gaze(yawDegrees);
+  const center: Vec3 = [
+    origin[0] + gx * PANEL_DISTANCE,
+    origin[1],
+    origin[2] + gz * PANEL_DISTANCE,
+  ];
+  // The panel faces back at the head, so the viewer's right is up x (-gaze).
+  const right: Vec3 = [-gz, 0, gx];
+  return [
+    center[0] + right[0] * (u - 0.5) * PANEL_SIZE.x,
+    center[1] + (0.5 - v) * PANEL_SIZE.y,
+    center[2] + right[2] * (u - 0.5) * PANEL_SIZE.x,
+  ];
+}
+
+/** A controller rotation whose -Z ray runs along `direction`. */
+function aimAlong([dx, , dz]: Vec3): [number, number, number, number] {
+  const theta = Math.atan2(-dx, -dz);
+  return [0, Math.sin(theta / 2), 0, Math.cos(theta / 2)];
+}
+
+/**
+ * Aim the right controller at a canvas point on the panel a head at
+ * `panelYaw` would have placed, standing `PANEL_DISTANCE` back along the ray.
+ */
+async function aimAt(
+  game: GameServer,
+  panelYaw: number,
+  point: [number, number],
+  origin?: Vec3,
+): Promise<void> {
+  const direction = gaze(panelYaw);
+  const target = panelPoint(panelYaw, point, origin);
+  await game.input.set("right_hand.rotation", aimAlong(direction));
+  await game.input.set("right_hand.position", [
+    target[0] - direction[0] * PANEL_DISTANCE,
+    target[1],
+    target[2] - direction[2] * PANEL_DISTANCE,
+  ]);
+}
+
+/** Point the controller at nothing, so the next entry is a fresh rollover. */
+async function aimAway(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+  await game.input.set("right_hand.position", [0, PLAYER_EYE_HEIGHT_WORLD, 0]);
+  await game.step({ frames: 5 });
+}
+
+async function lastSequence(game: GameServer): Promise<number> {
+  const { sounds } = await game.audio.recent();
+  return sounds.length === 0 ? 0 : sounds[sounds.length - 1].sequence;
+}
+
+async function rollovers(game: GameServer, since: number): Promise<number> {
+  const { sounds } = await game.audio.recent();
+  return sounds.filter((s) => s.sequence > since && s.sample === ROLLOVER).length;
+}
+
+/** Did aiming there land on a menu entry? */
+async function hovers(
+  game: GameServer,
+  panelYaw: number,
+  point: [number, number],
+  origin?: Vec3,
+): Promise<boolean> {
+  await aimAway(game);
+  const since = await lastSequence(game);
+  await aimAt(game, panelYaw, point, origin);
+  await game.step({ frames: 5 });
+  return (await rollovers(game, since)) > 0;
+}
+
+test(
+  "the VR frontend panel stays where it was placed while the head turns",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "main_menu",
+      port: 8171,
+      debugFlags: ["--vr"],
+    });
+    // Scene entry places the panel from the default head (yaw 0).
+    await game.step({ frames: 10 });
+
+    assert.ok(
+      await hovers(game, 0, LOAD_GAME),
+      "the panel should be placed in front of the entry head pose",
+    );
+
+    // Turn 40 degrees - inside the recenter threshold - and hold it well past
+    // the hold time. The panel must not have moved: the OLD world position
+    // still hovers, and where a gaze-glued panel would now be does not.
+    await game.input.set("head.look", [40, 0]);
+    await game.step({ frames: 180 });
+
+    assert.ok(
+      await hovers(game, 0, NEW_GAME),
+      "the panel must still be at its placement pose after the head turns",
+    );
+    assert.equal(
+      await hovers(game, 40, NEW_GAME),
+      false,
+      "the panel must NOT have followed the gaze",
+    );
+  },
+);
+
+test(
+  "a sustained turn away recenters the VR panel, a glance does not",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "main_menu",
+      port: 8172,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    // A glance well past the yaw threshold, but shorter than the hold time.
+    await game.input.set("head.look", [120, 0]);
+    await game.step({ frames: 30 });
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 30 });
+    assert.ok(
+      await hovers(game, 0, LOAD_GAME),
+      "a half-second glance must not drag the panel along",
+    );
+
+    // Sustained: past the hold time plus the ease.
+    await game.input.set("head.look", [120, 0]);
+    await game.step({ frames: 60 + 30 });
+
+    assert.ok(
+      await hovers(game, 120, LOAD_GAME),
+      "the panel should have re-placed in front of the new gaze",
+    );
+    assert.equal(
+      await hovers(game, 0, LOAD_GAME),
+      false,
+      "and left its original placement",
+    );
+  },
+);
+
+test(
+  "walking away from the VR panel re-places it at the tracked head position",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "main_menu",
+      port: 8173,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    // Facing the same way throughout: only the head's POSITION changes, so
+    // this exercises the distance half of the recenter rule (and proves the
+    // panel is hung off the tracked head, not off the pawn origin).
+    const moved: Vec3 = [0, PLAYER_EYE_HEIGHT_WORLD, 3];
+    await game.input.set("head.position", moved);
+    await game.step({ frames: 60 + 30 });
+
+    assert.ok(
+      await hovers(game, 0, LOAD_GAME, moved),
+      "the panel should follow the head to where it walked",
+    );
+    assert.equal(
+      await hovers(game, 0, LOAD_GAME),
+      false,
+      "and leave the position it was originally placed from",
+    );
+  },
+);


### PR DESCRIPTION
# Head-anchored VR panels: place on entry, gravity-aligned, lazy recenter

Stacked on #997. The VR frontend panels were **gaze-glued** — rebuilt every frame from the head rotation, so the menu was painted on your face (a known VR anti-pattern) and, because the anchor position was a hardcoded `(0, eye_height, 0)`, a roomscale-offset player saw the panel off-axis. This lands the standard VR menu convention.

## Behavior

- **Place on entry**: when a frontend scene opens, the panel is placed once from the *tracked* head pose — position from the head, direction from the gaze **projected onto the horizontal plane** (yaw only: opening the menu while looking at the floor still spawns the panel upright ahead of you), gravity up.
- **World-locked**: the panel stays put as the head turns — it behaves like an object, not a HUD.
- **Lazy recenter**: >60° off gaze yaw or >1.0 wu of head travel, sustained for 1 s (a brief glance does not trigger it), re-places the panel with a 0.3 s smoothstep ease along the shortest yaw arc.

## Implementation

- `InputContext`'s head gains `position` (pawn space): oculus feeds the located head space (fallback: previous view, then controller aim — and a zero-quaternion pose can never lock a placement), desktop uses its fixed eye, debug runtime gains a `head.position [x,y,z]` channel.
- New `shock2vr/src/ui/panel_anchor.rs`: pure placement/staleness/easing math (`PanelPlacement`, unit-tested: yaw-only projection, gravity up, recenter thresholds + hysteresis, ease endpoints, zero-quat) plus the small stateful `FrontendPanelAnchor` owned by the four frontend scenes.
- `vr_frontend_pointer` now takes the scene's anchored panel instead of rebuilding from the head each frame — hit-testing follows the panel automatically, so pointer and render cannot desync.
- The now-dead per-frame `frontend_panel` was retired. Flat presentation untouched.

## Evidence (debug runtime `--vr`, deterministic)

Entry placement — panel centered at the gaze:

![entry](https://gist.githubusercontent.com/tommy-xr/2ec93b64dbba149055ab87edf8eb4211/raw/anchor-01-entry.png)

World-locked — after a 30° head turn the panel stays in the world (before this change it stayed glued dead-center). Frames after 3 s more and after a brief 0.5 s glance to 100° are **pixel-identical (MD5)** to this one — no drift, no premature recenter:

![world locked after 30 degree turn](https://gist.githubusercontent.com/tommy-xr/2ec93b64dbba149055ab87edf8eb4211/raw/anchor-02-yaw30.png)

Lazy recenter — after >60° sustained >1 s, the panel eases back in (caught mid-ease, then settled):

| Mid-ease | Settled |
| --- | --- |
| ![mid ease](https://gist.githubusercontent.com/tommy-xr/2ec93b64dbba149055ab87edf8eb4211/raw/anchor-07-ease-partway.png) | ![recentered](https://gist.githubusercontent.com/tommy-xr/2ec93b64dbba149055ab87edf8eb4211/raw/anchor-06-recentered.png) |

Pointer against the world-locked panel (hover computed from the panel's real placement, then a click transitioned to `earth.mis`), and placement honoring an offset `head.position` on entry:

| Hover on locked panel | Entry with offset head position |
| --- | --- |
| ![hover](https://gist.githubusercontent.com/tommy-xr/2ec93b64dbba149055ab87edf8eb4211/raw/anchor-09-hover-newgame.png) | ![offset entry](https://gist.githubusercontent.com/tommy-xr/2ec93b64dbba149055ab87edf8eb4211/raw/anchor-11-head-position-offset.png) |

## Validation

- `cargo test -p shock2vr` 706 passed; desktop_runtime 5 passed; `RUSTFLAGS="-D warnings"` check clean (shock2vr, desktop, debug); **`cargo apk build` compiles and packages the Quest APK**.
- e2e (SHOCK2_E2E=1): menu-audio (incl. VR ray probe), load-game-screen, player-death, plus a **new anchor e2e test** (world-lock + recenter driven via `head.look`) — 12/12. Negative-tested: on the base, the anchor tests fail (panel followed the gaze; `head.position` unknown).
- Cross-engine review (Claude + Codex) findings fixed: look-up yaw flip, 180° ease snap, Quest frame-0 placement from the controller pose, dead-code cleanup.

## Device verification (Quest 3, release APK `18fdbd4`)

Headset resting untouched on a desk, before/after captured with the pre-PR and PR builds:

![device before/after](https://gist.githubusercontent.com/tommy-xr/2ec93b64dbba149055ab87edf8eb4211/raw/quest-before-after.png)

Measured per eye-half (centre (1032, 1104)): the panel centroid moved from **~570-620 px above centre** (old build: hung high, strongly foreshortened, and with *inverted* stereo disparity because it wasn't placed off the real head) to **~30-95 px of centre**, face-on (+47% lit area), with physically correct disparity. Two captures 11 s apart are identical to 0.1 px (world-locked, no spurious recenter), and a fresh relaunch reproduces the same placement. The residual in-frame tilt is the resting headset's physical roll against a gravity-upright panel — by design.

## Known gaps / follow-ups

- The anchor is per-scene, so the panel re-places at the gaze on each frontend screen swap (menu → load → back). Hoisting one anchor across frontend scenes is a small follow-up if the re-place feels jumpy.
- On-device behavior of the head-space pose path needs a worn-headset pass (desktop/debug verification is complete; the Android build compiles and packages).

