### PR TITLE
test(shock2vr): fix cargo test compilation on main (missing update() arg)

### DIFF
--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -666,6 +666,7 @@ mod tests {
             Vector3::zero(),
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             &input,
+            None,
         );
 
         effects


### PR DESCRIPTION
`cargo test -p shock2vr` fails to compile on `main`: the `held_trigger_payload` test helper calls `VirtualHand::update` with 6 args, but the function takes 7 since `held_by_other_hand: Option<EntityId>` was added (E0061 at `virtual_hand.rs:662`). CI runs `cargo check`, which doesn't build `#[cfg(test)]` code, so it slipped through.

One line: pass `None` (the helper simulates a single hand holding an entity — nothing is held by the other hand).

Verified: `cargo test -p shock2vr --lib` on this branch — 695 passed, 0 failed.

Found while validating the restack of #996/#997/#998 after #994 merged.