### PR TITLE
feat(vr): visible aim rays and hit dots for the VR frontend panels

### DIFF
--- a/engine/src/scene/color_material.rs
+++ b/engine/src/scene/color_material.rs
@@ -30,8 +30,10 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
 
         in vec3 vertexColor;
 
+        uniform float transparency;
+
         void main() {
-            fragColor = vec4(vertexColor.rgb, 1.0);
+            fragColor = vec4(vertexColor.rgb, 1.0 - transparency);
         }
 "#;
 
@@ -40,6 +42,7 @@ struct Uniforms {
     view_loc: i32,
     projection_loc: i32,
     color_loc: i32,
+    transparency_loc: i32,
 }
 
 static SHADER_PROGRAM: OnceCell<(ShaderProgram, Uniforms)> = OnceCell::new();
@@ -47,6 +50,15 @@ static SHADER_PROGRAM: OnceCell<(ShaderProgram, Uniforms)> = OnceCell::new();
 pub struct ColorMaterial {
     has_initialized: bool,
     pub color: Vector3<f32>,
+    /// 0.0 = opaque, 1.0 = invisible. Authored opaque; a translucent draw
+    /// comes from a per-object `SceneObject::set_transparency` override.
+    transparency: f32,
+}
+
+impl ColorMaterial {
+    fn is_transparent(&self) -> bool {
+        self.transparency > 0.01
+    }
 }
 
 impl Material for ColorMaterial {
@@ -91,12 +103,29 @@ impl Material for ColorMaterial {
                         c_str!("projection").as_ptr(),
                     ),
                     color_loc: gl::GetUniformLocation(shader.gl_id, c_str!("color").as_ptr()),
+                    transparency_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("transparency").as_ptr(),
+                    ),
                 };
                 (shader, uniforms)
             }
         });
 
         self.has_initialized = true;
+    }
+
+    fn set_transparency_override(&mut self, transparency: Option<f32>) {
+        self.transparency = transparency.map_or(0.0, |value| value.clamp(0.0, 1.0));
+    }
+
+    /// Opaque reports `None`, as it did before this material could blend at
+    /// all: every procedural object in the game uses this material, and
+    /// flipping them all from `null` to `0.0` in `/v1/scene` would change an
+    /// observable API for no gain. A translucent draw comes from a per-object
+    /// override, which the caller reports itself.
+    fn transparency(&self) -> Option<f32> {
+        self.is_transparent().then_some(self.transparency)
     }
 
     fn draw_opaque(
@@ -107,6 +136,36 @@ impl Material for ColorMaterial {
         _skinning_data: &[Matrix4<f32>],
         _lights: &crate::scene::light::LightArray,
     ) -> bool {
+        if self.is_transparent() {
+            return false;
+        }
+        self.draw(render_context, view_matrix, world_matrix);
+        true
+    }
+
+    fn draw_transparent(
+        &self,
+        render_context: &EngineRenderContext,
+        view_matrix: &Matrix4<f32>,
+        world_matrix: &Matrix4<f32>,
+        _skinning_data: &[Matrix4<f32>],
+        _lights: &crate::scene::light::LightArray,
+    ) -> bool {
+        if !self.is_transparent() {
+            return false;
+        }
+        self.draw(render_context, view_matrix, world_matrix);
+        true
+    }
+}
+
+impl ColorMaterial {
+    fn draw(
+        &self,
+        render_context: &EngineRenderContext,
+        view_matrix: &Matrix4<f32>,
+        world_matrix: &Matrix4<f32>,
+    ) {
         let (shader_program, uniforms) = SHADER_PROGRAM.get().expect("shader not compiled");
         let p = shader_program;
         unsafe {
@@ -117,8 +176,8 @@ impl Material for ColorMaterial {
             gl::UniformMatrix4fv(uniforms.view_loc, 1, gl::FALSE, view_matrix.as_ptr());
             gl::UniformMatrix4fv(uniforms.projection_loc, 1, gl::FALSE, projection.as_ptr());
             gl::Uniform3fv(uniforms.color_loc, 1, self.color.as_ptr());
+            gl::Uniform1f(uniforms.transparency_loc, self.transparency);
         }
-        true
     }
 }
 
@@ -126,5 +185,6 @@ pub fn create(color: Vector3<f32>) -> Box<dyn Material> {
     Box::new(ColorMaterial {
         has_initialized: false,
         color,
+        transparency: 0.0,
     })
 }

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -57,7 +57,19 @@ pub struct GloveRenderer {
     retarget: HandPoseRetarget,
     open: Pose,
     fist: Pose,
+    point: Pose,
     materials: Vec<Rc<RefCell<Box<dyn Material>>>>,
+}
+
+/// An authored pose a hand can be shown in when nothing analog is driving it -
+/// the VR frontend pointer, where there is no world to grab and the trigger is
+/// just a button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaticHandPose {
+    /// Relaxed, open hand.
+    Relaxed,
+    /// Index extended, the rest curled.
+    Pointing,
 }
 
 impl GloveRenderer {
@@ -97,6 +109,7 @@ impl GloveRenderer {
             retarget,
             open: hand_pose::open_right_hand(),
             fist: hand_pose::fist_right_hand(),
+            point: hand_pose::point_right_hand(),
             materials,
         })
     }
@@ -136,7 +149,61 @@ impl GloveRenderer {
             }
         };
         let pose = self.open.blend_per_finger(&self.fist, &amounts);
-        self.retarget.apply(&pose, &mut self.model);
+        Self::render_posed(
+            &mut self.model,
+            &self.retarget,
+            &self.materials,
+            &pose,
+            position,
+            rotation,
+            handedness,
+        )
+    }
+
+    /// Build the glove in one of the authored [`StaticHandPose`]s.
+    ///
+    /// The frontend pointer needs this: on a menu there is nothing to grab and
+    /// the trigger is a click, so the analog blend `render_hand` does has
+    /// nothing to say - the hand should read as "pointing at the panel" or
+    /// "not", which is exactly what the authored poses are for.
+    pub fn render_static_hand(
+        &mut self,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+        handedness: Handedness,
+        pose: StaticHandPose,
+    ) -> Vec<SceneObject> {
+        // Borrowing the pose straight out of the field (rather than cloning
+        // its two bone vectors every frame) is why this takes the fields
+        // apart instead of `&mut self`.
+        let pose = match pose {
+            StaticHandPose::Relaxed => &self.open,
+            StaticHandPose::Pointing => &self.point,
+        };
+        Self::render_posed(
+            &mut self.model,
+            &self.retarget,
+            &self.materials,
+            pose,
+            position,
+            rotation,
+            handedness,
+        )
+    }
+
+    /// Bake `pose` into the shared model and place it at the hand's transform.
+    /// The one place the model-to-hand frame conversion lives, so every caller
+    /// gets the same hand at the same place.
+    fn render_posed(
+        model: &mut GlbModel,
+        retarget: &HandPoseRetarget,
+        materials: &[Rc<RefCell<Box<dyn Material>>>],
+        pose: &Pose,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+        handedness: Handedness,
+    ) -> Vec<SceneObject> {
+        retarget.apply(pose, model);
 
         // The right-hand model is mirrored across the hand's local X for the
         // left hand (same trick as vr_config::flip_x for held weapons). The
@@ -157,8 +224,8 @@ impl GloveRenderer {
             * grip
             * Matrix4::from_scale(GLOVE_SCALE);
 
-        let mut objects = self.model.to_scene_objects_with_skinning();
-        for (object, material) in objects.iter_mut().zip(&self.materials) {
+        let mut objects = model.to_scene_objects_with_skinning();
+        for (object, material) in objects.iter_mut().zip(materials) {
             object.material = material.clone();
             object.set_transform(world);
         }

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -29,8 +29,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
-        VR_COMPONENT_Z_STEP, pointer_to_canvas, render_pointer_rays, vr_frontend_pointer_pass,
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
+        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas, vr_frontend_pointer_pass,
     },
 };
 
@@ -161,6 +161,9 @@ pub struct GameOverScene {
     /// The pointer pass that hit-tested this frame, kept so `render` draws the
     /// beams and dot from the very rays `update` resolved the highlight from.
     vr_pointer: FrontendPointerPass,
+    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
+    /// loaded glove model.
+    vr_pointer_visuals: PointerVisuals,
 
     /// Where the VR panel is anchored: placed from the head on scene entry
     /// and world-locked after that, so `render` hangs the panel exactly
@@ -189,6 +192,7 @@ impl GameOverScene {
             pointer: None,
             vr_pointer_canvas: None,
             vr_pointer: FrontendPointerPass::default(),
+            vr_pointer_visuals: PointerVisuals::new(),
             panel_anchor: FrontendPanelAnchor::new(),
             // This screen is entered straight out of gameplay - very plausibly
             // with the VR trigger still held from the shot that preceded the
@@ -387,7 +391,8 @@ impl GameScene for GameOverScene {
         // are pointing before an entry lights up. The canvas objects already in
         // hand are the layer stack the hit dot has to float clear of.
         let panel_layers = objects.len();
-        objects.extend(render_pointer_rays(
+        objects.extend(self.vr_pointer_visuals.render(
+            asset_cache,
             &self.vr_pointer,
             vec2(CANVAS_W, CANVAS_H),
             &panel,

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -29,8 +29,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
-        pointer_to_canvas, vr_frontend_pointer,
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
+        VR_COMPONENT_Z_STEP, pointer_to_canvas, render_pointer_rays, vr_frontend_pointer_pass,
     },
 };
 
@@ -158,6 +158,10 @@ pub struct GameOverScene {
     /// Where the VR controller ray last met the panel, in canvas pixels. The
     /// VR counterpart of `pointer`, already in canvas space.
     vr_pointer_canvas: Option<Vector2<f32>>,
+    /// The pointer pass that hit-tested this frame, kept so `render` draws the
+    /// beams and dot from the very rays `update` resolved the highlight from.
+    vr_pointer: FrontendPointerPass,
+
     /// Where the VR panel is anchored: placed from the head on scene entry
     /// and world-locked after that, so `render` hangs the panel exactly
     /// where `update` hit-tested it.
@@ -184,6 +188,7 @@ impl GameOverScene {
             save: latest_save(),
             pointer: None,
             vr_pointer_canvas: None,
+            vr_pointer: FrontendPointerPass::default(),
             panel_anchor: FrontendPanelAnchor::new(),
             // This screen is entered straight out of gameplay - very plausibly
             // with the VR trigger still held from the shot that preceded the
@@ -309,8 +314,9 @@ impl GameScene for GameOverScene {
             if game_options.presentation_mode == PresentationMode::Vr {
                 // VR has no 2D cursor: the pointer is where a controller ray meets
                 // the panel, and the trigger is the button.
-                let (point, pressed) =
-                    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
+                self.vr_pointer =
+                    vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
+                let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
                 self.vr_pointer_canvas = point;
                 self.pointer = None;
                 let (action, last_pressed) = resolve_click_at(
@@ -323,6 +329,7 @@ impl GameScene for GameOverScene {
                 (action, last_pressed, point)
             } else {
                 self.pointer = input_context.pointer;
+                self.vr_pointer = FrontendPointerPass::default();
                 resolve_click(
                     input_context.pointer,
                     self.last_pressed,
@@ -369,13 +376,23 @@ impl GameScene for GameOverScene {
         // on a world-space panel in front of the player.
         let panel = self.panel_anchor.panel();
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
-        let objects = canvas.render_world_space(
+        let mut objects = canvas.render_world_space(
             asset_cache,
             panel.transform(),
             self.vr_pointer_canvas,
             None,
             VR_COMPONENT_Z_STEP,
         );
+        // The controllers and their aim rays, so the player can see where they
+        // are pointing before an entry lights up. The canvas objects already in
+        // hand are the layer stack the hit dot has to float clear of.
+        let panel_layers = objects.len();
+        objects.extend(render_pointer_rays(
+            &self.vr_pointer,
+            vec2(CANVAS_W, CANVAS_H),
+            &panel,
+            panel_layers,
+        ));
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -553,11 +570,12 @@ mod tests {
             (LOAD_RECT_INDEX, GameOverAction::Load),
             (QUIT_RECT_INDEX, GameOverAction::Quit),
         ] {
-            let (point, pressed) = vr_frontend_pointer(
+            let pass = vr_frontend_pointer_pass(
                 &vr_input(hand_aimed_at(rects[index].center(), 1.0)),
                 vec2(CANVAS_W, CANVAS_H),
                 &test_panel(),
             );
+            let (point, pressed) = (pass.point(), pass.pressed);
             let point = point.expect("the ray should land on the panel");
             assert!(rects[index].contains(point));
             assert_eq!(
@@ -570,11 +588,12 @@ mod tests {
     #[test]
     fn a_vr_ray_over_load_is_inert_without_a_save() {
         let rects = screen_rects(None);
-        let (point, pressed) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(hand_aimed_at(rects[LOAD_RECT_INDEX].center(), 1.0)),
             vec2(CANVAS_W, CANVAS_H),
             &test_panel(),
         );
+        let (point, pressed) = (pass.point(), pass.pressed);
         assert_eq!(
             resolve_click_at(point, pressed, false, &rects, false).0,
             None
@@ -589,11 +608,12 @@ mod tests {
         // whatever the ray happens to cross - up to and including Quit.
         let rects = screen_rects(None);
         let scene = GameOverScene::new();
-        let (point, pressed) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(hand_aimed_at(rects[QUIT_RECT_INDEX].center(), 1.0)),
             vec2(CANVAS_W, CANVAS_H),
             &test_panel(),
         );
+        let (point, pressed) = (pass.point(), pass.pressed);
         assert!(pressed);
         let (action, last) = resolve_click_at(point, pressed, scene.last_pressed, &rects, true);
         assert_eq!(action, None, "a carried-over press must not activate Quit");

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -32,8 +32,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
-        pointer_to_canvas, vr_frontend_pointer,
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
+        VR_COMPONENT_Z_STEP, pointer_to_canvas, render_pointer_rays, vr_frontend_pointer_pass,
     },
 };
 
@@ -264,6 +264,10 @@ pub struct LoadGameScene {
     /// Where the VR controller ray last met the panel, in canvas pixels. The
     /// VR counterpart of `pointer`, already in canvas space.
     vr_pointer_canvas: Option<Vector2<f32>>,
+    /// The pointer pass that hit-tested this frame, kept so `render` draws the
+    /// beams and dot from the very rays `update` resolved the highlight from.
+    vr_pointer: FrontendPointerPass,
+
     /// Where the VR panel is anchored: placed from the head on scene entry
     /// and world-locked after that, so `render` hangs the panel exactly
     /// where `update` hit-tested it.
@@ -291,6 +295,7 @@ impl LoadGameScene {
             selected,
             pointer: None,
             vr_pointer_canvas: None,
+            vr_pointer: FrontendPointerPass::default(),
             panel_anchor: FrontendPanelAnchor::new(),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
@@ -445,8 +450,9 @@ impl GameScene for LoadGameScene {
             if game_options.presentation_mode == PresentationMode::Vr {
                 // VR has no 2D cursor: the pointer is where a controller ray meets
                 // the panel, and the trigger is the button.
-                let (point, pressed) =
-                    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
+                self.vr_pointer =
+                    vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
+                let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
                 self.vr_pointer_canvas = point;
                 self.pointer = None;
                 let (action, last_pressed) = resolve_click_at(
@@ -460,6 +466,7 @@ impl GameScene for LoadGameScene {
                 (action, last_pressed, point)
             } else {
                 self.pointer = input_context.pointer;
+                self.vr_pointer = FrontendPointerPass::default();
                 resolve_click(
                     input_context.pointer,
                     self.last_pressed,
@@ -516,13 +523,23 @@ impl GameScene for LoadGameScene {
         // on a world-space panel in front of the player.
         let panel = self.panel_anchor.panel();
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
-        let objects = canvas.render_world_space(
+        let mut objects = canvas.render_world_space(
             asset_cache,
             panel.transform(),
             self.vr_pointer_canvas,
             None,
             VR_COMPONENT_Z_STEP,
         );
+        // The controllers and their aim rays, so the player can see where they
+        // are pointing before an entry lights up. The canvas objects already in
+        // hand are the layer stack the hit dot has to float clear of.
+        let panel_layers = objects.len();
+        objects.extend(render_pointer_rays(
+            &self.vr_pointer,
+            vec2(CANVAS_W, CANVAS_H),
+            &panel,
+            panel_layers,
+        ));
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -762,11 +779,12 @@ mod tests {
     #[test]
     fn a_vr_ray_can_press_done() {
         let done = FALLBACK_RECTS[DONE_RECT_INDEX].center();
-        let (point, pressed) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(hand_aimed_at(done, 1.0)),
             vec2(CANVAS_W, CANVAS_H),
             &test_panel(),
         );
+        let (point, pressed) = (pass.point(), pass.pressed);
         let point = point.expect("the ray should land on the panel");
         assert!(FALLBACK_RECTS[DONE_RECT_INDEX].contains(point));
         assert!(pressed);
@@ -780,11 +798,12 @@ mod tests {
     fn a_vr_ray_can_select_a_save_row_and_load_it() {
         let list = FALLBACK_RECTS[LIST_RECT_INDEX];
         let row = row_rect(list, 2).center();
-        let (point, pressed) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(hand_aimed_at(row, 1.0)),
             vec2(CANVAS_W, CANVAS_H),
             &test_panel(),
         );
+        let (point, pressed) = (pass.point(), pass.pressed);
         let point = point.expect("the ray should land on the panel");
         assert_eq!(
             resolve_click_at(Some(point), pressed, false, &FALLBACK_RECTS, 3, false).0,
@@ -793,11 +812,12 @@ mod tests {
 
         // With a selection, the same rig over "Load" performs the load.
         let load = FALLBACK_RECTS[LOAD_RECT_INDEX].center();
-        let (point, pressed) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(hand_aimed_at(load, 1.0)),
             vec2(CANVAS_W, CANVAS_H),
             &test_panel(),
         );
+        let (point, pressed) = (pass.point(), pass.pressed);
         assert_eq!(
             resolve_click_at(point, pressed, false, &FALLBACK_RECTS, 3, true).0,
             Some(LoadGameAction::Load)

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -32,8 +32,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
-        VR_COMPONENT_Z_STEP, pointer_to_canvas, render_pointer_rays, vr_frontend_pointer_pass,
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
+        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas, vr_frontend_pointer_pass,
     },
 };
 
@@ -267,6 +267,9 @@ pub struct LoadGameScene {
     /// The pointer pass that hit-tested this frame, kept so `render` draws the
     /// beams and dot from the very rays `update` resolved the highlight from.
     vr_pointer: FrontendPointerPass,
+    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
+    /// loaded glove model.
+    vr_pointer_visuals: PointerVisuals,
 
     /// Where the VR panel is anchored: placed from the head on scene entry
     /// and world-locked after that, so `render` hangs the panel exactly
@@ -296,6 +299,7 @@ impl LoadGameScene {
             pointer: None,
             vr_pointer_canvas: None,
             vr_pointer: FrontendPointerPass::default(),
+            vr_pointer_visuals: PointerVisuals::new(),
             panel_anchor: FrontendPanelAnchor::new(),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
@@ -534,7 +538,8 @@ impl GameScene for LoadGameScene {
         // are pointing before an entry lights up. The canvas objects already in
         // hand are the layer stack the hit dot has to float clear of.
         let panel_layers = objects.len();
-        objects.extend(render_pointer_rays(
+        objects.extend(self.vr_pointer_visuals.render(
+            asset_cache,
             &self.vr_pointer,
             vec2(CANVAS_W, CANVAS_H),
             &panel,

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -38,8 +38,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
-        VR_COMPONENT_Z_STEP, WorldPanel, pointer_to_canvas, render_pointer_rays,
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
+        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, WorldPanel, pointer_to_canvas,
         vr_frontend_pointer_pass,
     },
 };
@@ -245,6 +245,9 @@ pub struct MainMenuScene {
     /// The pointer pass that hit-tested this frame, kept so `render` draws the
     /// beams and dot from the very rays `update` resolved the highlight from.
     vr_pointer: FrontendPointerPass,
+    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
+    /// loaded glove model.
+    vr_pointer_visuals: PointerVisuals,
 
     /// Where the VR panel is anchored. Placed on scene entry from the head
     /// pose and world-locked after that, so `render` hangs the panel exactly
@@ -269,6 +272,7 @@ impl MainMenuScene {
             pointer: None,
             vr_pointer_canvas: None,
             vr_pointer: FrontendPointerPass::default(),
+            vr_pointer_visuals: PointerVisuals::new(),
             panel_anchor: FrontendPanelAnchor::new(),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
@@ -428,7 +432,8 @@ impl GameScene for MainMenuScene {
         // are pointing before an entry lights up. The canvas objects already in
         // hand are the layer stack the hit dot has to float clear of.
         let panel_layers = objects.len();
-        objects.extend(render_pointer_rays(
+        objects.extend(self.vr_pointer_visuals.render(
+            asset_cache,
             &self.vr_pointer,
             vec2(CANVAS_W, CANVAS_H),
             &panel,

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -38,8 +38,9 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
-        WorldPanel, pointer_to_canvas, vr_frontend_pointer,
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
+        VR_COMPONENT_Z_STEP, WorldPanel, pointer_to_canvas, render_pointer_rays,
+        vr_frontend_pointer_pass,
     },
 };
 
@@ -173,11 +174,10 @@ fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
         .collect()
 }
 
-/// Where a hand is pointing on the menu panel, in canvas pixels, plus whether
-/// its trigger is held. The rule is the frontend's, not this screen's, so it
-/// lives in [`vr_frontend_pointer`].
-fn vr_pointer(input_context: &InputContext, panel: &WorldPanel) -> (Option<Vector2<f32>>, bool) {
-    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), panel)
+/// Where the hands are pointing on the menu panel. The rule is the frontend's,
+/// not this screen's, so it lives in [`vr_frontend_pointer_pass`].
+fn vr_pointer(input_context: &InputContext, panel: &WorldPanel) -> FrontendPointerPass {
+    vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), panel)
 }
 
 /// Shared click core: both presentations reduce to "a point on the canvas plus
@@ -242,6 +242,10 @@ pub struct MainMenuScene {
     /// Where the VR controller ray last met the panel, in canvas pixels. The
     /// VR counterpart of `pointer`, already in canvas space.
     vr_pointer_canvas: Option<Vector2<f32>>,
+    /// The pointer pass that hit-tested this frame, kept so `render` draws the
+    /// beams and dot from the very rays `update` resolved the highlight from.
+    vr_pointer: FrontendPointerPass,
+
     /// Where the VR panel is anchored. Placed on scene entry from the head
     /// pose and world-locked after that, so `render` hangs the panel exactly
     /// where `update` hit-tested it.
@@ -264,6 +268,7 @@ impl MainMenuScene {
             scene_name: "main_menu".to_owned(),
             pointer: None,
             vr_pointer_canvas: None,
+            vr_pointer: FrontendPointerPass::default(),
             panel_anchor: FrontendPanelAnchor::new(),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
@@ -352,7 +357,8 @@ impl GameScene for MainMenuScene {
             if game_options.presentation_mode == PresentationMode::Vr {
                 // VR has no 2D cursor: the pointer is where a controller ray meets
                 // the menu panel, and the trigger is the button.
-                let (point, pressed) = vr_pointer(input_context, &panel);
+                self.vr_pointer = vr_pointer(input_context, &panel);
+                let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
                 self.vr_pointer_canvas = point;
                 self.pointer = None;
                 let (action, last_pressed) =
@@ -360,6 +366,7 @@ impl GameScene for MainMenuScene {
                 (action, last_pressed, point)
             } else {
                 self.pointer = input_context.pointer;
+                self.vr_pointer = FrontendPointerPass::default();
                 resolve_click(
                     input_context.pointer,
                     self.last_pressed,
@@ -410,13 +417,23 @@ impl GameScene for MainMenuScene {
         // on a world-space panel in front of the player.
         let panel = self.panel_anchor.panel();
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
-        let objects = canvas.render_world_space(
+        let mut objects = canvas.render_world_space(
             asset_cache,
             panel.transform(),
             self.vr_pointer_canvas,
             None,
             VR_COMPONENT_Z_STEP,
         );
+        // The controllers and their aim rays, so the player can see where they
+        // are pointing before an entry lights up. The canvas objects already in
+        // hand are the layer stack the hit dot has to float clear of.
+        let panel_layers = objects.len();
+        objects.extend(render_pointer_rays(
+            &self.vr_pointer,
+            vec2(CANVAS_W, CANVAS_H),
+            &panel,
+            panel_layers,
+        ));
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -602,7 +619,8 @@ mod tests {
         // Aim at the center of "New Game" (rect 0) and pull the trigger.
         let rects = menu_rects(None);
         let target = rects[0].center();
-        let (point, pressed) = vr_pointer(&vr_input(hand_aimed_at(target, 1.0)), &test_panel());
+        let pass = vr_pointer(&vr_input(hand_aimed_at(target, 1.0)), &test_panel());
+        let (point, pressed) = (pass.point(), pass.pressed);
         let point = point.expect("the ray should land on the panel");
         assert!(
             rects[0].contains(point),
@@ -624,7 +642,8 @@ mod tests {
             left_hand: hand_aimed_at(rects[5].center(), 1.0),
             ..InputContext::default()
         };
-        let (point, pressed) = vr_pointer(&input, &test_panel());
+        let pass = vr_pointer(&input, &test_panel());
+        let (point, pressed) = (pass.point(), pass.pressed);
         let point = point.expect("the left hand should land on the panel");
         assert!(rects[5].contains(point));
         assert_eq!(
@@ -636,10 +655,11 @@ mod tests {
     #[test]
     fn a_light_vr_trigger_is_not_a_press() {
         let rects = menu_rects(None);
-        let (_, pressed) = vr_pointer(
+        let pass = vr_pointer(
             &vr_input(hand_aimed_at(rects[0].center(), 0.2)),
             &test_panel(),
         );
+        let (_, pressed) = (pass.point(), pass.pressed);
         assert!(!pressed, "a barely-touched trigger must not click");
     }
 
@@ -654,7 +674,8 @@ mod tests {
             left_hand: away(),
             ..InputContext::default()
         };
-        let (point, pressed) = vr_pointer(&input, &test_panel());
+        let pass = vr_pointer(&input, &test_panel());
+        let (point, pressed) = (pass.point(), pass.pressed);
         assert_eq!(point, None);
         // The trigger is still reported so the held press is consumed rather
         // than becoming a fresh edge when the ray swings back onto a button.

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -34,48 +34,120 @@ fn held(hand: &Hand) -> bool {
     hand.trigger_value > VR_TRIGGER_THRESHOLD
 }
 
-/// Where a hand is pointing on a frontend screen's panel, in canvas pixels,
-/// plus whether its trigger is held.
+/// One controller's aim ray against a frontend panel: where it starts, where it
+/// points, and where it lands on the canvas (if it lands at all).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FrontendRay {
+    /// The controller's position, in world space.
+    pub origin: Vector3<f32>,
+    /// The direction the controller points (its local -Z), normalized.
+    pub direction: Vector3<f32>,
+    /// Where the ray meets the panel, in canvas pixels, or `None` when it
+    /// misses.
+    pub canvas_hit: Option<Vector2<f32>>,
+}
+
+/// The ray for one hand, or `None` when that controller is not tracked.
+///
+/// The one place a hand becomes a ray: everything that pointing means - the
+/// tracked guard, the -Z aim, the panel intersection - happens here once.
+fn frontend_ray(hand: &Hand, canvas_size: Vector2<f32>, panel: &WorldPanel) -> Option<FrontendRay> {
+    let direction = hand_ray(hand.rotation)?;
+    Some(FrontendRay {
+        origin: hand.position,
+        direction,
+        canvas_hit: ray_to_canvas(canvas_size, panel, hand.position, direction),
+    })
+}
+
+/// One frame of frontend pointing: every tracked controller's ray, *which* of
+/// them the menu is listening to, and whether a trigger is down.
+///
+/// This is the single unit of frontend pointing. The hover highlight, the click
+/// and the drawn hit dot ([`crate::ui::render_pointer_rays`]) all read the same
+/// pass, so the dot cannot appear anywhere but the pixel the menu hit-tested,
+/// and a controller the menu is ignoring cannot draw a dot that says otherwise.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct FrontendPointerPass {
+    /// Every tracked controller's ray, right hand first. An untracked
+    /// controller contributes nothing, so it draws nothing - the same guard
+    /// that keeps it from driving the highlight.
+    pub rays: Vec<FrontendRay>,
+    /// Index into `rays` of the controller actually driving the menu, when one
+    /// of them is on the panel.
+    active: Option<usize>,
+    /// Whether either trigger is held.
+    pub pressed: bool,
+}
+
+impl FrontendPointerPass {
+    /// Where the menu is being pointed, in canvas pixels.
+    pub fn point(&self) -> Option<Vector2<f32>> {
+        self.active.and_then(|index| self.rays[index].canvas_hit)
+    }
+
+    /// Whether `rays[index]` is the ray the menu is listening to.
+    pub fn is_active(&self, index: usize) -> bool {
+        self.active == Some(index)
+    }
+}
+
+/// Resolve one frame of frontend pointing.
 ///
 /// Both controllers are always posed in VR, so "whichever hand hits the panel"
 /// would always resolve to the same one. Instead a hand **with its trigger
 /// held** wins, so either controller can click; ties and idle triggers fall
 /// back to the right hand, which then drives the hover highlight.
-pub fn vr_frontend_pointer(
+pub fn vr_frontend_pointer_pass(
     input_context: &InputContext,
     canvas_size: Vector2<f32>,
     panel: &WorldPanel,
-) -> (Option<Vector2<f32>>, bool) {
-    let right = &input_context.right_hand;
-    let left = &input_context.left_hand;
+) -> FrontendPointerPass {
+    let hands = [&input_context.right_hand, &input_context.left_hand];
 
-    let any_held = held(right) || held(left);
-    let order = if held(left) && !held(right) {
-        [left, right]
+    let mut rays = Vec::with_capacity(hands.len());
+    // Where each hand's ray landed in `rays`, since untracked hands are skipped.
+    let mut ray_of_hand = [None, None];
+    for (slot, hand) in hands.iter().enumerate() {
+        if let Some(ray) = frontend_ray(hand, canvas_size, panel) {
+            ray_of_hand[slot] = Some(rays.len());
+            rays.push(ray);
+        }
+    }
+
+    let any_held = held(hands[0]) || held(hands[1]);
+    let order = if held(hands[1]) && !held(hands[0]) {
+        [1, 0]
     } else {
-        [right, left]
+        [0, 1]
     };
 
-    for hand in order {
+    let mut active = None;
+    for slot in order {
         // While a trigger is down, only the hand holding it may supply the
         // point: otherwise an idle hand resting on the panel would report
         // "not pressed" and clear the held state, so sweeping the pressed hand
         // onto a button would read as a fresh edge and click it.
-        if any_held && !held(hand) {
+        if any_held && !held(hands[slot]) {
             continue;
         }
-        let Some(direction) = hand_ray(hand.rotation) else {
+        let Some(index) = ray_of_hand[slot] else {
             continue;
         };
-        if let Some(point) = ray_to_canvas(canvas_size, panel, hand.position, direction) {
-            return (Some(point), any_held);
+        if rays[index].canvas_hit.is_some() {
+            active = Some(index);
+            break;
         }
     }
 
-    // Nothing points at the screen; report the trigger anyway so a press that
-    // starts off-panel is still consumed as "held" rather than becoming a fresh
-    // edge the moment the ray crosses onto a button.
-    (None, any_held)
+    FrontendPointerPass {
+        rays,
+        active,
+        // Nothing may be pointing at the screen; report the trigger anyway so a
+        // press that starts off-panel is still consumed as "held" rather than
+        // becoming a fresh edge the moment the ray crosses onto a button.
+        pressed: any_held,
+    }
 }
 
 /// Test-only rig for aiming a controller at a canvas point, shared by the
@@ -84,7 +156,7 @@ pub fn vr_frontend_pointer(
 #[cfg(test)]
 pub mod test_support {
     use super::*;
-    use crate::ui::{FRONTEND_PANEL_DISTANCE, FrontendPanelAnchor};
+    use crate::ui::{FRONTEND_PANEL_DISTANCE, FrontendPanelAnchor, canvas_to_panel_world};
     use std::time::Duration;
 
     /// The head facing the tests aim against: the default camera orientation.
@@ -108,12 +180,8 @@ pub mod test_support {
     /// panel ends up facing. This is the inverse of [`ray_to_canvas`].
     pub fn hand_aimed_at(canvas_size: Vector2<f32>, point: Vector2<f32>, trigger: f32) -> Hand {
         let panel = test_panel();
-        let u = point.x / canvas_size.x - 0.5;
-        let v = 0.5 - point.y / canvas_size.y;
-        let right = panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
-        let up = panel.rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
         let normal = panel.normal();
-        let target = panel.center + right * (u * panel.size.x) + up * (v * panel.size.y);
+        let target = canvas_to_panel_world(canvas_size, &panel, point);
 
         Hand {
             // Stand back on the viewer's side (the panel's normal points at the
@@ -173,13 +241,14 @@ mod tests {
             trigger_value: 1.0,
             ..Hand::default()
         };
-        let (point, _) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(untracked.clone(), untracked),
             CANVAS,
             &test_panel(),
         );
         assert_eq!(
-            point, None,
+            pass.point(),
+            None,
             "an untracked controller must not report a pointer"
         );
     }
@@ -191,11 +260,12 @@ mod tests {
             ..Hand::default()
         };
         let target = vec2(320.0, 240.0);
-        let (point, pressed) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(untracked, hand_aimed_at(CANVAS, target, 1.0)),
             CANVAS,
             &test_panel(),
         );
+        let (point, pressed) = (pass.point(), pass.pressed);
         let point = point.expect("the tracked hand should land on the panel");
         assert!((point.x - target.x).abs() < 1.0 && (point.y - target.y).abs() < 1.0);
         assert!(pressed);
@@ -211,7 +281,8 @@ mod tests {
             hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
             hand_aimed_away(1.0),
         );
-        let (point, pressed) = vr_frontend_pointer(&input, CANVAS, &test_panel());
+        let pass = vr_frontend_pointer_pass(&input, CANVAS, &test_panel());
+        let (point, pressed) = (pass.point(), pass.pressed);
         assert!(pressed, "a held trigger must stay reported as held");
         assert_eq!(
             point, None,
@@ -221,11 +292,12 @@ mod tests {
 
     #[test]
     fn aiming_away_yields_no_point_but_keeps_the_trigger() {
-        let (point, pressed) = vr_frontend_pointer(
+        let pass = vr_frontend_pointer_pass(
             &vr_input(hand_aimed_away(1.0), hand_aimed_away(1.0)),
             CANVAS,
             &test_panel(),
         );
+        let (point, pressed) = (pass.point(), pass.pressed);
         assert_eq!(point, None);
         assert!(pressed);
     }

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -12,6 +12,7 @@ use cgmath::{InnerSpace, Quaternion, Rotation, Vector2, Vector3, vec3};
 use crate::{
     input_context::{Hand, InputContext},
     ui::{WorldPanel, ray_to_canvas},
+    vr_config::Handedness,
 };
 
 /// A VR trigger past this counts as "pressed", matching the hand code's
@@ -23,11 +24,12 @@ pub const VR_TRIGGER_THRESHOLD: f32 = 0.5;
 /// An untracked hand reports a zero quaternion rather than an identity one.
 /// Rotating by it collapses the ray to the zero vector, so guarding here keeps
 /// an untracked controller from being treated as a hand aimed anywhere at all.
-fn hand_ray(rotation: Quaternion<f32>) -> Option<Vector3<f32>> {
+fn hand_ray(rotation: Quaternion<f32>) -> Option<(Quaternion<f32>, Vector3<f32>)> {
     if rotation.magnitude2() < 1e-6 {
         return None;
     }
-    Some(rotation.normalize().rotate_vector(vec3(0.0, 0.0, -1.0)))
+    let rotation = rotation.normalize();
+    Some((rotation, rotation.rotate_vector(vec3(0.0, 0.0, -1.0))))
 }
 
 fn held(hand: &Hand) -> bool {
@@ -45,18 +47,32 @@ pub struct FrontendRay {
     /// Where the ray meets the panel, in canvas pixels, or `None` when it
     /// misses.
     pub canvas_hit: Option<Vector2<f32>>,
+    /// Which hand this ray belongs to, so the drawn hand is the right one -
+    /// the glove model is right-handed and mirrored for the left.
+    pub handedness: Handedness,
+    /// The controller's own orientation, normalized. The aim is derived from
+    /// it, but the drawn hand needs the full rotation (roll included), and it
+    /// must be the same one the aim came from or hand and beam disagree.
+    pub rotation: Quaternion<f32>,
 }
 
 /// The ray for one hand, or `None` when that controller is not tracked.
 ///
 /// The one place a hand becomes a ray: everything that pointing means - the
 /// tracked guard, the -Z aim, the panel intersection - happens here once.
-fn frontend_ray(hand: &Hand, canvas_size: Vector2<f32>, panel: &WorldPanel) -> Option<FrontendRay> {
-    let direction = hand_ray(hand.rotation)?;
+fn frontend_ray(
+    hand: &Hand,
+    handedness: Handedness,
+    canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
+) -> Option<FrontendRay> {
+    let (rotation, direction) = hand_ray(hand.rotation)?;
     Some(FrontendRay {
         origin: hand.position,
         direction,
         canvas_hit: ray_to_canvas(canvas_size, panel, hand.position, direction),
+        handedness,
+        rotation,
     })
 }
 
@@ -64,7 +80,7 @@ fn frontend_ray(hand: &Hand, canvas_size: Vector2<f32>, panel: &WorldPanel) -> O
 /// them the menu is listening to, and whether a trigger is down.
 ///
 /// This is the single unit of frontend pointing. The hover highlight, the click
-/// and the drawn hit dot ([`crate::ui::render_pointer_rays`]) all read the same
+/// and the drawn hit dot ([`crate::ui::PointerVisuals`]) all read the same
 /// pass, so the dot cannot appear anywhere but the pixel the menu hit-tested,
 /// and a controller the menu is ignoring cannot draw a dot that says otherwise.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -104,12 +120,13 @@ pub fn vr_frontend_pointer_pass(
     panel: &WorldPanel,
 ) -> FrontendPointerPass {
     let hands = [&input_context.right_hand, &input_context.left_hand];
+    let handedness = [Handedness::Right, Handedness::Left];
 
     let mut rays = Vec::with_capacity(hands.len());
     // Where each hand's ray landed in `rays`, since untracked hands are skipped.
     let mut ray_of_hand = [None, None];
     for (slot, hand) in hands.iter().enumerate() {
-        if let Some(ray) = frontend_ray(hand, canvas_size, panel) {
+        if let Some(ray) = frontend_ray(hand, handedness[slot], canvas_size, panel) {
             ray_of_hand[slot] = Some(rays.len());
             rays.push(ray);
         }

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -38,7 +38,7 @@ mod pointer_visual;
 pub use frontend_pointer::test_support;
 pub use frontend_pointer::{FrontendPointerPass, FrontendRay, vr_frontend_pointer_pass};
 pub use panel_anchor::{FrontendPanelAnchor, PanelPlacement};
-pub use pointer_visual::render_pointer_rays;
+pub use pointer_visual::PointerVisuals;
 
 /// Font name that resolves to the engine's compiled-in font rather than a
 /// `.FON` asset.

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -33,10 +33,12 @@ use crate::vr_config::Handedness;
 
 mod frontend_pointer;
 mod panel_anchor;
+mod pointer_visual;
 #[cfg(test)]
 pub use frontend_pointer::test_support;
-pub use frontend_pointer::vr_frontend_pointer;
+pub use frontend_pointer::{FrontendPointerPass, FrontendRay, vr_frontend_pointer_pass};
 pub use panel_anchor::{FrontendPanelAnchor, PanelPlacement};
+pub use pointer_visual::render_pointer_rays;
 
 /// Font name that resolves to the engine's compiled-in font rather than a
 /// `.FON` asset.
@@ -252,6 +254,26 @@ pub fn ray_to_canvas(
     }
 
     Some(vec2(u * canvas_size.x, v * canvas_size.y))
+}
+
+/// Where a canvas point sits in world space on `panel` - the exact inverse of
+/// [`ray_to_canvas`].
+///
+/// Lets a caller that already hit-tested a ray place something *at the hit*
+/// (the VR pointer's dot) from the hit-test's own answer, instead of
+/// re-intersecting the ray and hoping the two agree.
+pub fn canvas_to_panel_world(
+    canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
+    point: Vector2<f32>,
+) -> Vector3<f32> {
+    // Normalize into the same centered unit square `transform` places, then let
+    // the panel's own transform do the placing - rather than re-deriving its
+    // basis here, where it could drift from what the canvas renders with.
+    let u = point.x / canvas_size.x - 0.5;
+    let v = 0.5 - point.y / canvas_size.y;
+    let placed = panel.transform() * cgmath::vec4(u, v, 0.0, 1.0);
+    vec3(placed.x, placed.y, placed.z)
 }
 
 pub fn canvas_rect_to_screen(

--- a/shock2vr/src/ui/pointer_visual.rs
+++ b/shock2vr/src/ui/pointer_visual.rs
@@ -1,0 +1,311 @@
+//! The visible half of the VR frontend pointer: a proxy at each tracked
+//! controller, a beam along its aim, and a dot where the menu is being pointed.
+//!
+//! Without this a VR menu gives no feedback until an entry happens to light up,
+//! so aiming is guesswork (issue #1001). Everything here is derived from the
+//! [`FrontendPointerPass`] the menu itself hit-tested - the *canvas* hit point,
+//! mapped back through [`canvas_to_panel_world`], and the pass's own choice of
+//! which controller is driving the menu - so the dot marks the pixel the menu
+//! hit-tested, on the controller the menu is listening to, and the two cannot
+//! drift apart.
+
+use cgmath::{InnerSpace, Matrix4, Quaternion, Vector2, Vector3, vec3};
+use engine::scene::{SceneObject, color_material, cube};
+
+use crate::ui::{
+    FrontendPointerPass, FrontendRay, VR_COMPONENT_Z_STEP, WorldPanel, canvas_to_panel_world,
+};
+
+/// How far a beam that misses the panel reaches into space. Long enough to read
+/// as "pointing somewhere", short enough not to spear the whole room.
+pub const POINTER_BEAM_MISS_LENGTH: f32 = 2.0;
+/// Beam cross-section, in metres.
+const POINTER_BEAM_THICKNESS: f32 = 0.006;
+/// Edge length of the hit dot, in metres.
+const POINTER_DOT_SIZE: f32 = 0.03;
+/// Clear air between the panel's frontmost canvas layer and the dot.
+const POINTER_DOT_CLEARANCE: f32 = VR_COMPONENT_Z_STEP * 2.0;
+/// Floor on how squarely a ray may meet the panel before the pull-back below
+/// stops scaling. Without it a ray grazing the panel edge would put its dot
+/// arbitrarily far back down the beam.
+const MIN_APPROACH: f32 = 0.25;
+/// Size of the controller proxy: a stubby box at the hand, aimed down the ray.
+const CONTROLLER_PROXY_SIZE: Vector3<f32> = Vector3 {
+    x: 0.035,
+    y: 0.035,
+    z: 0.09,
+};
+
+const BEAM_COLOR: Vector3<f32> = Vector3 {
+    x: 0.3,
+    y: 0.8,
+    z: 1.0,
+};
+const DOT_COLOR: Vector3<f32> = Vector3 {
+    x: 1.0,
+    y: 1.0,
+    z: 1.0,
+};
+const CONTROLLER_COLOR: Vector3<f32> = Vector3 {
+    x: 0.6,
+    y: 0.6,
+    z: 0.7,
+};
+
+/// How far in front of the panel face the dot floats, given a canvas that
+/// stacked `panel_layers` components on it.
+///
+/// [`crate::ui::UiCanvas::render_world_space`] steps component *i* forward by
+/// `VR_COMPONENT_Z_STEP * i`, so the count of objects it emitted bounds the
+/// stack - taking it from the caller keeps this honest as screens gain widgets,
+/// where a guessed layer count would silently sink the dot behind a label.
+fn dot_lift(panel_layers: usize) -> f32 {
+    VR_COMPONENT_Z_STEP * panel_layers as f32 + POINTER_DOT_CLEARANCE
+}
+
+/// Where one controller's pointer draws, in world space.
+///
+/// Pure geometry, so the placement rule is testable without a renderer.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PointerRayGeometry {
+    /// The controller end of the beam.
+    pub start: Vector3<f32>,
+    /// The far end: just clear of the panel hit when there is one, otherwise
+    /// [`POINTER_BEAM_MISS_LENGTH`] out along the aim.
+    pub end: Vector3<f32>,
+    /// The hit dot, drawn only for the controller the menu is listening to.
+    pub dot: Option<Vector3<f32>>,
+}
+
+/// The beam and dot placement for one ray. `marks_hit` is whether this is the
+/// ray the menu is actually pointing with.
+pub fn pointer_ray_geometry(
+    ray: &FrontendRay,
+    canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
+    panel_layers: usize,
+    marks_hit: bool,
+) -> PointerRayGeometry {
+    // The hit comes back from the canvas point the menu hit-tested, not from a
+    // second intersection of the same ray.
+    let Some(point) = ray.canvas_hit else {
+        return PointerRayGeometry {
+            start: ray.origin,
+            end: ray.origin + ray.direction * POINTER_BEAM_MISS_LENGTH,
+            dot: None,
+        };
+    };
+    let hit = canvas_to_panel_world(canvas_size, panel, point);
+
+    // Stop short *along the beam* rather than pushing the marker out along the
+    // panel normal: back down the ray it still reads as the point being aimed
+    // at from any viewpoint, and the beam can end exactly there - so there is
+    // no gap between beam and dot, and no beam tip buried in the canvas layers.
+    let approach = -ray.direction.dot(panel.normal());
+    let marker = hit - ray.direction * (dot_lift(panel_layers) / approach.max(MIN_APPROACH));
+
+    PointerRayGeometry {
+        start: ray.origin,
+        end: marker,
+        dot: marks_hit.then_some(marker),
+    }
+}
+
+/// A unit cube scaled to `scale` and placed at `center`, oriented by `rotation`.
+fn box_object(
+    center: Vector3<f32>,
+    scale: Vector3<f32>,
+    rotation: Quaternion<f32>,
+    color: Vector3<f32>,
+) -> SceneObject {
+    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
+    object.set_transform(
+        Matrix4::from_translation(center)
+            * Matrix4::from(rotation)
+            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
+    );
+    object
+}
+
+/// The scene objects for a frame of frontend pointing: a proxy and beam for
+/// every tracked controller, plus a dot on the one the menu is listening to.
+///
+/// `panel_layers` is how many objects the panel's canvas already emitted (see
+/// [`dot_lift`]). Shared by every frontend screen that uses the VR pointer, so
+/// a screen cannot end up with a pointer that hit-tests but does not show.
+pub fn render_pointer_rays(
+    pass: &FrontendPointerPass,
+    canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
+    panel_layers: usize,
+) -> Vec<SceneObject> {
+    let mut objects = Vec::new();
+    for (index, ray) in pass.rays.iter().enumerate() {
+        let geometry =
+            pointer_ray_geometry(ray, canvas_size, panel, panel_layers, pass.is_active(index));
+
+        let along = geometry.end - geometry.start;
+        let length = along.magnitude();
+        // A degenerate beam (the hand pushed right up to its own hit point) has
+        // no orientation to speak of, so skip the beam and proxy rather than
+        // build a NaN transform - but still mark the hit, which needs none.
+        if length >= 1e-4 {
+            // `from_arc` is fine at the antiparallel extreme: cgmath falls back
+            // to an arbitrary perpendicular axis, and both the beam and the
+            // proxy are square in cross-section, so the free roll is invisible.
+            let aim = Quaternion::from_arc(vec3(0.0, 0.0, 1.0), along / length, None);
+            objects.push(box_object(
+                geometry.start,
+                CONTROLLER_PROXY_SIZE,
+                aim,
+                CONTROLLER_COLOR,
+            ));
+            objects.push(box_object(
+                geometry.start + along * 0.5,
+                vec3(POINTER_BEAM_THICKNESS, POINTER_BEAM_THICKNESS, length),
+                aim,
+                BEAM_COLOR,
+            ));
+        }
+        if let Some(dot) = geometry.dot {
+            objects.push(box_object(
+                dot,
+                // Flat against the panel, so the dot reads as a mark on the
+                // canvas rather than a cube floating off it.
+                vec3(POINTER_DOT_SIZE, POINTER_DOT_SIZE, VR_COMPONENT_Z_STEP),
+                panel.rotation,
+                DOT_COLOR,
+            ));
+        }
+    }
+    objects
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input_context::{Hand, InputContext};
+    use crate::ui::test_support::{hand_aimed_at, hand_aimed_away, test_panel};
+    use crate::ui::{canvas_to_panel_world, vr_frontend_pointer_pass};
+    use cgmath::{Zero, vec2};
+
+    const CANVAS: Vector2<f32> = Vector2 { x: 640.0, y: 480.0 };
+    /// A stand-in for what a frontend canvas emits; the exact count only shifts
+    /// the dot's clearance.
+    const LAYERS: usize = 18;
+
+    fn pass(right: Hand, left: Hand) -> FrontendPointerPass {
+        let input = InputContext {
+            right_hand: right,
+            left_hand: left,
+            ..InputContext::default()
+        };
+        vr_frontend_pointer_pass(&input, CANVAS, &test_panel())
+    }
+
+    fn geometry(pass: &FrontendPointerPass, index: usize) -> PointerRayGeometry {
+        pointer_ray_geometry(
+            &pass.rays[index],
+            CANVAS,
+            &test_panel(),
+            LAYERS,
+            pass.is_active(index),
+        )
+    }
+
+    #[test]
+    fn a_beam_ends_just_in_front_of_the_point_the_menu_hit_tested() {
+        let target = vec2(500.0, 120.0);
+        let pass = pass(hand_aimed_at(CANVAS, target, 0.0), hand_aimed_away(0.0));
+        let panel = test_panel();
+        let geometry = geometry(&pass, 0);
+
+        let hit = canvas_to_panel_world(CANVAS, &panel, target);
+        let dot = geometry.dot.expect("the active ray must show a hit dot");
+        assert_eq!(
+            geometry.end, dot,
+            "the beam must end at the dot, leaving no gap between them"
+        );
+        // The dot stays *on the ray* - it marks the aimed-at point from any
+        // viewpoint, rather than being shoved sideways off the beam.
+        let off_ray = (dot - hit) - ray_component(dot - hit, pass.rays[0].direction);
+        assert!(off_ray.magnitude() < 1e-4, "the dot must sit on the ray");
+        // ...and it clears the panel's whole canvas layer stack, rather than
+        // z-fighting the very label it is pointing at.
+        assert!(
+            (dot - hit).dot(panel.normal()) >= dot_lift(LAYERS) - 1e-4,
+            "the dot must clear the panel's canvas layers"
+        );
+    }
+
+    fn ray_component(v: Vector3<f32>, direction: Vector3<f32>) -> Vector3<f32> {
+        direction * v.dot(direction)
+    }
+
+    #[test]
+    fn a_beam_that_misses_the_panel_floats_free() {
+        let pass = pass(hand_aimed_away(0.0), hand_aimed_away(0.0));
+        let geometry = geometry(&pass, 0);
+        assert_eq!(geometry.dot, None, "an off-panel ray must show no hit dot");
+        assert!(
+            ((geometry.end - geometry.start).magnitude() - POINTER_BEAM_MISS_LENGTH).abs() < 1e-3
+        );
+    }
+
+    #[test]
+    fn an_untracked_controller_draws_nothing() {
+        // The same zero-quaternion guard that keeps an untracked controller
+        // from driving the highlight must keep it from drawing a beam, or the
+        // menu grows a ray from the world origin nobody is holding.
+        let untracked = Hand {
+            rotation: Quaternion::zero(),
+            ..Hand::default()
+        };
+        let pass = pass(untracked.clone(), untracked);
+        assert!(pass.rays.is_empty());
+        assert!(render_pointer_rays(&pass, CANVAS, &test_panel(), LAYERS).is_empty());
+    }
+
+    #[test]
+    fn only_the_controller_the_menu_is_listening_to_shows_a_dot() {
+        // Both hands on the panel: the menu highlights one entry, so exactly
+        // one dot may appear - two would leave the player unable to tell which
+        // one the menu is actually reading.
+        let pass = pass(
+            hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
+            hand_aimed_at(CANVAS, vec2(100.0, 100.0), 0.0),
+        );
+        assert_eq!(pass.rays.len(), 2);
+        let dots = pass
+            .rays
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| geometry(&pass, *index).dot.is_some())
+            .count();
+        assert_eq!(dots, 1);
+        // Right hand: proxy + beam + dot. Left hand: proxy + beam.
+        assert_eq!(
+            render_pointer_rays(&pass, CANVAS, &test_panel(), LAYERS).len(),
+            5
+        );
+    }
+
+    #[test]
+    fn an_idle_hand_on_the_panel_shows_no_dot_while_the_other_holds_its_trigger() {
+        // The menu ignores the idle hand here (`vr_frontend_pointer_pass`'s
+        // held-hand gate), so drawing its dot would promise a hover the menu
+        // will not give and a click it will not take.
+        let pass = pass(
+            hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
+            hand_aimed_away(1.0),
+        );
+        assert_eq!(pass.point(), None);
+        assert!(pass.pressed);
+        assert!(
+            pass.rays
+                .iter()
+                .enumerate()
+                .all(|(index, _)| geometry(&pass, index).dot.is_none())
+        );
+    }
+}

--- a/shock2vr/src/ui/pointer_visual.rs
+++ b/shock2vr/src/ui/pointer_visual.rs
@@ -1,4 +1,4 @@
-//! The visible half of the VR frontend pointer: a proxy at each tracked
+//! The visible half of the VR frontend pointer: a gloved hand at each tracked
 //! controller, a beam along its aim, and a dot where the menu is being pointed.
 //!
 //! Without this a VR menu gives no feedback until an entry happens to light up,
@@ -10,10 +10,16 @@
 //! drift apart.
 
 use cgmath::{InnerSpace, Matrix4, Quaternion, Vector2, Vector3, vec3};
-use engine::scene::{SceneObject, color_material, cube};
+use engine::{
+    assets::asset_cache::AssetCache,
+    scene::{FrontFaceWinding, SceneObject, color_material, cube},
+};
 
-use crate::ui::{
-    FrontendPointerPass, FrontendRay, VR_COMPONENT_Z_STEP, WorldPanel, canvas_to_panel_world,
+use crate::{
+    hand_glove::{GloveRenderer, StaticHandPose},
+    ui::{
+        FrontendPointerPass, FrontendRay, VR_COMPONENT_Z_STEP, WorldPanel, canvas_to_panel_world,
+    },
 };
 
 /// How far a beam that misses the panel reaches into space. Long enough to read
@@ -29,12 +35,25 @@ const POINTER_DOT_CLEARANCE: f32 = VR_COMPONENT_Z_STEP * 2.0;
 /// stops scaling. Without it a ray grazing the panel edge would put its dot
 /// arbitrarily far back down the beam.
 const MIN_APPROACH: f32 = 0.25;
-/// Size of the controller proxy: a stubby box at the hand, aimed down the ray.
+/// Size of the fallback controller proxy: a stubby box at the hand, aimed down
+/// the ray. Only drawn when the glove model is unavailable.
 const CONTROLLER_PROXY_SIZE: Vector3<f32> = Vector3 {
     x: 0.035,
     y: 0.035,
     z: 0.09,
 };
+
+/// How many pieces the beam is cut into to fade along its length. Enough for
+/// the falloff to read as smoke rather than as stripes, few enough that a menu
+/// frame stays cheap on a Quest (each piece is a draw, per hand, per eye).
+pub const BEAM_SEGMENTS: usize = 6;
+/// Transparency (0 = opaque) of the beam where it leaves the hand...
+const BEAM_NEAR_TRANSPARENCY: f32 = 0.35;
+/// ...and at its far end, just short of invisible.
+const BEAM_FAR_TRANSPARENCY: f32 = 0.95;
+/// Clear space left at the hand end, so the beam emerges from the glove's
+/// fingertips instead of starting inside the palm. Roughly a hand's length.
+const BEAM_HAND_CLEARANCE: f32 = 0.25;
 
 const BEAM_COLOR: Vector3<f32> = Vector3 {
     x: 0.3,
@@ -51,6 +70,32 @@ const CONTROLLER_COLOR: Vector3<f32> = Vector3 {
     y: 0.6,
     z: 0.7,
 };
+
+/// How see-through beam segment `index` of `count` is, hand end first.
+///
+/// Strictly increasing, so the beam is brightest where it leaves the hand and
+/// thins out toward the panel - the hit dot stays the one crisp thing at the
+/// far end.
+pub fn beam_segment_transparency(index: usize, count: usize) -> f32 {
+    debug_assert!(index < count);
+    // Sample each segment at its midpoint, so the first segment is not fully at
+    // the near value nor the last fully at the far one.
+    let t = (index as f32 + 0.5) / count as f32;
+    BEAM_NEAR_TRANSPARENCY + (BEAM_FAR_TRANSPARENCY - BEAM_NEAR_TRANSPARENCY) * t
+}
+
+/// The pose the hand driving `rays[index]` is shown in.
+///
+/// Read off the same pass that decides the hover highlight, the click and the
+/// hit dot, so the hand points exactly when the menu is listening to it - a
+/// hand posed as pointing can never promise a hover the menu will not give.
+pub fn pointer_hand_pose(pass: &FrontendPointerPass, index: usize) -> StaticHandPose {
+    if pass.is_active(index) {
+        StaticHandPose::Pointing
+    } else {
+        StaticHandPose::Relaxed
+    }
+}
 
 /// How far in front of the panel face the dot floats, given a canvas that
 /// stacked `panel_layers` components on it.
@@ -127,13 +172,93 @@ fn box_object(
     object
 }
 
-/// The scene objects for a frame of frontend pointing: a proxy and beam for
-/// every tracked controller, plus a dot on the one the menu is listening to.
+/// The faded beam for one ray, hand end first: [`BEAM_SEGMENTS`] pieces whose
+/// alpha falls off along the length.
 ///
-/// `panel_layers` is how many objects the panel's canvas already emitted (see
-/// [`dot_lift`]). Shared by every frontend screen that uses the VR pointer, so
-/// a screen cannot end up with a pointer that hit-tests but does not show.
-pub fn render_pointer_rays(
+/// Each piece draws in the engine's transparent pass (which masks depth writes
+/// for the whole pass), so the segments blend with each other and with the
+/// panel behind rather than occluding one another with their own boxes. They
+/// also cull backfaces: a double-sided box blends *twice* per pixel, which
+/// turns the authored alpha `a` into `1 - (1 - a)^2` and would make the far end
+/// read as a solid rod instead of fading out.
+fn beam_objects(start: Vector3<f32>, along: Vector3<f32>, length: f32) -> Vec<SceneObject> {
+    // The hand fills the first stretch of the ray. A beam no longer than that
+    // would be entirely inside the glove, so there is nothing to draw - the
+    // hand is already touching what it points at.
+    if length <= BEAM_HAND_CLEARANCE {
+        return Vec::new();
+    }
+    let direction = along / length;
+    let drawn = length - BEAM_HAND_CLEARANCE;
+    let step = drawn / BEAM_SEGMENTS as f32;
+    // `from_arc` is fine at the antiparallel extreme: cgmath falls back to an
+    // arbitrary perpendicular axis, and the beam is square in cross-section, so
+    // the free roll is invisible.
+    let aim = Quaternion::from_arc(vec3(0.0, 0.0, 1.0), direction, None);
+
+    (0..BEAM_SEGMENTS)
+        .map(|index| {
+            let center = start + direction * (BEAM_HAND_CLEARANCE + step * (index as f32 + 0.5));
+            let mut object = box_object(
+                center,
+                vec3(POINTER_BEAM_THICKNESS, POINTER_BEAM_THICKNESS, step),
+                aim,
+                BEAM_COLOR,
+            );
+            object.set_transparency(Some(beam_segment_transparency(index, BEAM_SEGMENTS)));
+            // The cube's outward faces are clockwise as seen from outside.
+            object.set_backface_culling(Some(FrontFaceWinding::Clockwise));
+            object
+        })
+        .collect()
+}
+
+/// The visible half of the frontend pointer, including the glove model it draws
+/// the hands with.
+///
+/// The glove is loaded lazily on first render (it needs the asset cache) and
+/// the outcome is kept either way, so a missing model costs one cache miss
+/// rather than one per frame - the same shape `VrInteraction` uses in game.
+#[derive(Default)]
+pub struct PointerVisuals {
+    /// `None` = not tried yet; `Some(None)` = tried and the model is missing.
+    glove: Option<Option<GloveRenderer>>,
+}
+
+impl PointerVisuals {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The scene objects for a frame of frontend pointing: a hand and beam for
+    /// every tracked controller, plus a dot on the one the menu is listening
+    /// to.
+    ///
+    /// `panel_layers` is how many objects the panel's canvas already emitted
+    /// (see [`dot_lift`]). Shared by every frontend screen that uses the VR
+    /// pointer, so a screen cannot end up with a pointer that hit-tests but
+    /// does not show.
+    pub fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        pass: &FrontendPointerPass,
+        canvas_size: Vector2<f32>,
+        panel: &WorldPanel,
+        panel_layers: usize,
+    ) -> Vec<SceneObject> {
+        let glove = self
+            .glove
+            .get_or_insert_with(|| GloveRenderer::new(asset_cache))
+            .as_mut();
+        render_pointer_rays(glove, pass, canvas_size, panel, panel_layers)
+    }
+}
+
+/// The pointer's objects for one frame. Split out from [`PointerVisuals`] so
+/// the geometry can be exercised without an asset cache (`glove: None` draws
+/// the fallback proxy, exactly as a missing model does at runtime).
+fn render_pointer_rays(
+    mut glove: Option<&mut GloveRenderer>,
     pass: &FrontendPointerPass,
     canvas_size: Vector2<f32>,
     panel: &WorldPanel,
@@ -147,26 +272,31 @@ pub fn render_pointer_rays(
         let along = geometry.end - geometry.start;
         let length = along.magnitude();
         // A degenerate beam (the hand pushed right up to its own hit point) has
-        // no orientation to speak of, so skip the beam and proxy rather than
-        // build a NaN transform - but still mark the hit, which needs none.
+        // no orientation to speak of, so skip the beam rather than build a NaN
+        // transform - but still draw the hand and mark the hit, neither of
+        // which needs one.
         if length >= 1e-4 {
-            // `from_arc` is fine at the antiparallel extreme: cgmath falls back
-            // to an arbitrary perpendicular axis, and both the beam and the
-            // proxy are square in cross-section, so the free roll is invisible.
-            let aim = Quaternion::from_arc(vec3(0.0, 0.0, 1.0), along / length, None);
-            objects.push(box_object(
+            objects.extend(beam_objects(geometry.start, along, length));
+        }
+
+        match glove.as_deref_mut() {
+            Some(glove) => objects.extend(glove.render_static_hand(
+                geometry.start,
+                ray.rotation,
+                ray.handedness,
+                pointer_hand_pose(pass, index),
+            )),
+            // No glove model: keep a proxy so the player can still see where
+            // the controller is, rather than a beam growing out of nothing.
+            None if length >= 1e-4 => objects.push(box_object(
                 geometry.start,
                 CONTROLLER_PROXY_SIZE,
-                aim,
+                Quaternion::from_arc(vec3(0.0, 0.0, 1.0), along / length, None),
                 CONTROLLER_COLOR,
-            ));
-            objects.push(box_object(
-                geometry.start + along * 0.5,
-                vec3(POINTER_BEAM_THICKNESS, POINTER_BEAM_THICKNESS, length),
-                aim,
-                BEAM_COLOR,
-            ));
+            )),
+            None => {}
         }
+
         if let Some(dot) = geometry.dot {
             objects.push(box_object(
                 dot,
@@ -263,7 +393,7 @@ mod tests {
         };
         let pass = pass(untracked.clone(), untracked);
         assert!(pass.rays.is_empty());
-        assert!(render_pointer_rays(&pass, CANVAS, &test_panel(), LAYERS).is_empty());
+        assert!(render_pointer_rays(None, &pass, CANVAS, &test_panel(), LAYERS).is_empty());
     }
 
     #[test]
@@ -283,10 +413,117 @@ mod tests {
             .filter(|(index, _)| geometry(&pass, *index).dot.is_some())
             .count();
         assert_eq!(dots, 1);
-        // Right hand: proxy + beam + dot. Left hand: proxy + beam.
+        // Each hand: a proxy plus its beam segments; the right hand also the
+        // one dot.
         assert_eq!(
-            render_pointer_rays(&pass, CANVAS, &test_panel(), LAYERS).len(),
-            5
+            render_pointer_rays(None, &pass, CANVAS, &test_panel(), LAYERS).len(),
+            2 * (BEAM_SEGMENTS + 1) + 1
+        );
+    }
+
+    #[test]
+    fn the_beam_fades_along_its_length() {
+        // "Smoky": brightest at the hand, thinning toward the panel, so the
+        // crisp dot at the end is the thing the eye lands on. A beam of one
+        // flat alpha (or one that brightened toward the panel) would read as a
+        // solid rod and compete with the dot.
+        let alphas: Vec<f32> = (0..BEAM_SEGMENTS)
+            .map(|index| beam_segment_transparency(index, BEAM_SEGMENTS))
+            .collect();
+        assert!(
+            alphas.windows(2).all(|pair| pair[1] > pair[0]),
+            "beam transparency must increase away from the hand: {alphas:?}"
+        );
+        assert!(
+            alphas.iter().all(|a| (0.0..=1.0).contains(a)),
+            "transparency must stay in range: {alphas:?}"
+        );
+        // Translucent at the hand too, not just at the tip.
+        assert!(alphas[0] > 0.0);
+    }
+
+    #[test]
+    fn every_beam_segment_is_translucent_and_single_sided() {
+        // A double-sided box blends twice per pixel, turning alpha `a` into
+        // `1 - (1 - a)^2` - the far end would read as a solid rod rather than
+        // fading out, so the authored ramp only means what it says with the
+        // inner faces culled.
+        let pass = pass(
+            hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
+            hand_aimed_away(0.0),
+        );
+        let objects = render_pointer_rays(None, &pass, CANVAS, &test_panel(), LAYERS);
+        let translucent: Vec<_> = objects
+            .iter()
+            .filter(|object| object.effective_transparency().is_some_and(|t| t > 0.0))
+            .collect();
+        assert_eq!(translucent.len(), 2 * BEAM_SEGMENTS);
+        assert!(
+            translucent
+                .iter()
+                .all(|object| object.backface_culling().is_some())
+        );
+        // The dot stays opaque - it is the focus point.
+        let dot = objects.last().expect("a dot must be drawn");
+        assert_eq!(dot.effective_transparency(), None);
+    }
+
+    #[test]
+    fn a_hand_right_up_against_the_panel_draws_no_beam_but_still_marks_its_hit() {
+        // The whole beam would be inside the glove, so drawing it just buries a
+        // bright box in the hand. The hit still has to be marked - that is what
+        // the player is reading.
+        let panel = test_panel();
+        let target = vec2(320.0, 240.0);
+        let hit = canvas_to_panel_world(CANVAS, &panel, target);
+        let close = Hand {
+            position: hit + panel.normal() * (BEAM_HAND_CLEARANCE * 0.5),
+            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), -panel.normal(), None),
+            ..Hand::default()
+        };
+        // The other controller is untracked, so only the close hand's objects
+        // are in play.
+        let pass = pass(
+            close,
+            Hand {
+                rotation: Quaternion::zero(),
+                ..Hand::default()
+            },
+        );
+        let objects = render_pointer_rays(None, &pass, CANVAS, &panel, LAYERS);
+        assert!(
+            objects
+                .iter()
+                .all(|object| object.effective_transparency().is_none()),
+            "no translucent beam segment may be drawn inside the hand"
+        );
+        assert!(pass.rays[0].canvas_hit.is_some());
+        assert!(
+            geometry(&pass, 0).dot.is_some(),
+            "the hit must still be marked"
+        );
+    }
+
+    #[test]
+    fn only_the_hand_the_menu_is_listening_to_points() {
+        // Pose is arbitrated by the same pass as the dot: the left hand is on
+        // the panel too, but the menu is not reading it, so posing it as
+        // pointing would promise a hover it will not get.
+        let pass = pass(
+            hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
+            hand_aimed_at(CANVAS, vec2(100.0, 100.0), 0.0),
+        );
+        assert_eq!(pointer_hand_pose(&pass, 0), StaticHandPose::Pointing);
+        assert_eq!(pointer_hand_pose(&pass, 1), StaticHandPose::Relaxed);
+    }
+
+    #[test]
+    fn a_hand_pointing_off_the_panel_stays_relaxed() {
+        let pass = pass(hand_aimed_away(0.0), hand_aimed_away(0.0));
+        assert!(!pass.rays.is_empty());
+        assert!(
+            (0..pass.rays.len())
+                .all(|index| pointer_hand_pose(&pass, index) == StaticHandPose::Relaxed)
         );
     }
 


### PR DESCRIPTION
Fixes #1001

While a VR frontend panel (main menu, load, game-over) was up, nothing represented the controllers — no model, no ray — so you could not see where you were aiming until a hover highlight happened to react.

Each tracked controller now draws the **Steam glove the game already wields in VR** at the hand and a smoky beam along its aim (-Z). The controller the menu is actually listening to gets a bright dot where its beam meets the panel, and its hand takes an **index-extended pointing pose**; every other hand stays relaxed. Off-panel the beam just runs ~2 m into space with no dot, and an untracked controller (zero quaternion) draws nothing at all.

![the hand relaxing off-panel and pointing on-panel](https://gist.githubusercontent.com/tommy-xr/b0ea8d8191247300ee949cd78ca3588b/raw/pointer_pose.gif)

<sub>The right hand sweeping from off-panel onto "New Game": the glove switches from relaxed to pointing exactly when the menu starts listening to it, and the dot and highlight appear together. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## One computation, not two that agree by luck

Pointing is resolved once per frame into a `FrontendPointerPass` — every tracked hand's ray, *which* one drives the menu, and the trigger state — and the hover highlight, the click and the drawn dot all read that one pass. Drawing therefore inherits the hit-test's arbitration for free:

- both hands on the panel → only the hand the menu is reading shows a dot;
- an idle hand resting on the panel while the other holds its trigger → no dot at all, matching the `None` the menu reports;
- the **pointing pose** follows the same arbitration, so a hand posed as pointing can never promise a hover the menu will not give.

Without that, the picture would promise a hover the menu will not give. The dot's world position comes from mapping the *canvas* hit back through `canvas_to_panel_world` (now built on `WorldPanel::transform` itself, the exact inverse of `ray_to_canvas`), so it marks the pixel that was hit-tested rather than a second intersection.

The dot is pulled back **along the beam** rather than pushed out along the panel normal, so it stays on the ray from any viewpoint and the beam ends exactly at it — no gap, and no beam tip buried in the canvas. How far it has to clear is taken from the count of objects the panel's canvas just emitted, since `render_world_space` steps component *i* forward by `VR_COMPONENT_Z_STEP * i`; a guessed layer count would silently sink the dot behind a label as screens gain widgets.

All three frontend screens call the one shared `PointerVisuals::render`, so none can grow a pointer that hit-tests but does not show.

## The beam fades, the dot does not

The beam is cut into segments whose alpha falls off along its length — brightest where it leaves the hand, nearly gone at the far end — with the first hand's-length skipped so it emerges from the fingertips rather than the palm (and skipped entirely when the hand is closer to the panel than that). The hit dot stays fully opaque: it is the focus point the fading beam leads the eye to.

The segments **cull backfaces**. A double-sided box blends twice per pixel, which turns an authored alpha `a` into `1 - (1 - a)^2`; measured on a capture, that made the far end read as a near-solid rod. With the inner faces culled the ramp means what it says — pixel-sampled along the beam, brightness falls ~3.5x from hand to dot.

This needed `ColorMaterial` to grow the transparency the other materials already have, so translucent segments draw in the engine's transparent pass. Opaque colour materials still report **no** transparency at all, so `/v1/scene` is unchanged for every other procedural object in the game.

## Flat presentation is untouched

The VR render path early-returns before any of this and the flat update path clears the pass. A flat main-menu capture from this branch and from its base hash **identically** (`a7826aff…`).

## Evidence

| On-panel: point pose, faded beam, crisp dot | Off-panel: relaxed pose, no dot |
| --- | --- |
| ![right glove pointing at a highlighted New Game](https://gist.githubusercontent.com/tommy-xr/b0ea8d8191247300ee949cd78ca3588b/raw/hover_highlight.png) | ![both gloves relaxed, beam running off into space](https://gist.githubusercontent.com/tommy-xr/b0ea8d8191247300ee949cd78ca3588b/raw/off_panel.png) |
| Right hand on "New Game" (highlighted): index extended, one crisp dot, and the beam visibly thinning as it climbs toward it. The left hand is off-panel and stays relaxed. | Both hands past the panel edge: open gloves, a beam, no dot, no highlight. |

Arbitration is visible in the poses, not just in the dot — swap which hand is on the panel and the poses swap with it:

![left glove pointing with the dot, right glove relaxed](https://gist.githubusercontent.com/tommy-xr/b0ea8d8191247300ee949cd78ca3588b/raw/left_active.png)

<sub>Left hand on the panel, right hand off: the **left** glove now points and carries the dot, and the right glove is back to the relaxed open hand — the mirror of the shot above. Both are read from the one `FrontendPointerPass`.</sub>

## Validation

- `cargo fmt --all --check` clean; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
- `cargo test -p shock2vr --lib` — 741 passed, 0 failed; `cargo test -p engine --lib` — 55 passed.
- New geometry tests were negative-tested first: forcing every ray to mark its hit fails `only_the_controller_the_menu_is_listening_to_shows_a_dot` and `an_idle_hand_on_the_panel_shows_no_dot_while_the_other_holds_its_trigger`; restoring the old normal-lift fails the clearance assertion.
- New polish tests were negative-tested first: flattening the alpha ramp fails `the_beam_fades_along_its_length`, and restoring the old half-length clearance fails `a_hand_right_up_against_the_panel_draws_no_beam_but_still_marks_its_hit`.
- Runtime-verified over HTTP: `GET /v1/scene?transparent=true` reports exactly 12 translucent beam segments (2 hands x 6) with transparencies 0.4 → 0.9.
- e2e subsets (`SHOCK2_E2E=1`): `menu-audio` 3/3, `load-game-screen` 2/2, `vr-frontend-panel-anchor` 3/3, `earth-vr-world-panel-arbitration` 1/1, `vr-loading-panel` 2/2.
- Cross-engine review (Claude + Codex) with the captures attached; its findings on beam cost, the short-beam case, the double-blend fade and the `/v1/scene` transparency shape are all fixed above.

## Changelog

- **2nd pass (visual polish):** the proxy box became the real Steam glove, the active hand took the authored index-extended pointing pose, and the flat beam became a translucent one that fades along its length behind a crisp dot. A grey box remains as the fallback for when the glove model cannot be loaded.

## Follow-up (not in this PR)

The 25AE authored hand set is not wired up yet; this uses the shipping Steam glove and its authored `point_right_hand` pose. Swapping the rig later is confined to `GloveRenderer`.

