### PR TITLE
fix(oculus): survive untracked views on don/resume instead of ANRing

### DIFF
--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -506,9 +506,12 @@ fn main() {
     let mut requested_display_refresh_rate = None;
     let mut ready_reported = false;
     let mut session_focused = false;
-    // Consecutive rejected frame submissions, so only the start of a burst is
-    // logged.
+    // Consecutive rejected frame submissions, and consecutive frames whose
+    // views were not tracked. Both are logged once at the start of a burst and
+    // once on recovery (with the length), so a long outage is still visible in
+    // logcat without printing at the display refresh rate.
     let mut submit_failures: u64 = 0;
+    let mut untracked_view_frames: u64 = 0;
     'main_loop: loop {
         // Drain Android's NativeActivity queues. OpenXR is the real input
         // path - nothing here feeds gameplay - but NativeActivity hands the
@@ -980,7 +983,10 @@ fn main() {
         if !view_flags
             .contains(xr::ViewStateFlags::ORIENTATION_VALID | xr::ViewStateFlags::POSITION_VALID)
         {
-            println!("SHOCK2QUEST_XR_VIEWS_UNTRACKED mission={mission} flags={view_flags:?}");
+            if untracked_view_frames == 0 {
+                println!("SHOCK2QUEST_XR_VIEWS_UNTRACKED mission={mission} flags={view_flags:?}");
+            }
+            untracked_view_frames += 1;
             end_frame_with_no_layers(
                 &mut frame_stream,
                 xr_frame_state.predicted_display_time,
@@ -990,6 +996,12 @@ fn main() {
                 print_frame_report(&mission, session_focused, report);
             }
             continue;
+        }
+        if untracked_view_frames > 0 {
+            println!(
+                "SHOCK2QUEST_XR_VIEWS_TRACKED mission={mission} untracked_frames={untracked_view_frames}"
+            );
+            untracked_view_frames = 0;
         }
 
         // Remember where the head actually is, for next frame's input context.
@@ -1087,6 +1099,11 @@ fn main() {
             }
             submit_failures += 1;
         } else {
+            if submit_failures > 0 {
+                println!(
+                    "SHOCK2QUEST_XR_SUBMIT_RECOVERED mission={mission} failed_frames={submit_failures}"
+                );
+            }
             submit_failures = 0;
         }
         let submit_elapsed = submit_started.elapsed();
@@ -1217,9 +1234,11 @@ fn create_projection_matrix(fov: &xr::Fovf, near_z: f32, far_z: f32) -> cgmath::
     )
 }
 
-/// Close out a frame that has nothing to show - the compositor keeps whatever
-/// it last displayed. Used both when the runtime tells us not to render and
-/// when the located views are not yet tracked.
+/// Close out a frame that has nothing to show: submit no layers, so the runtime
+/// composites nothing this frame (it does NOT hold the previous image). Used
+/// both when the runtime tells us not to render and when the located views are
+/// not yet tracked - in the latter case the alternative is a garbage pose, and
+/// a blank frame or two while tracking comes up is the lesser evil.
 ///
 /// Deliberately non-fatal for the same reason as the projection-layer submit:
 /// a panic on the render thread stops the Android event pump and the app ANRs.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -506,6 +506,9 @@ fn main() {
     let mut requested_display_refresh_rate = None;
     let mut ready_reported = false;
     let mut session_focused = false;
+    // Consecutive rejected frame submissions, so only the start of a burst is
+    // logged.
+    let mut submit_failures: u64 = 0;
     'main_loop: loop {
         // Drain Android's NativeActivity queues. OpenXR is the real input
         // path - nothing here feeds gameplay - but NativeActivity hands the
@@ -819,13 +822,11 @@ fn main() {
 
         if !xr_frame_state.should_render {
             //println!("Skipping frame!");
-            frame_stream
-                .end(
-                    xr_frame_state.predicted_display_time,
-                    environment_blend_mode,
-                    &[],
-                )
-                .unwrap();
+            end_frame_with_no_layers(
+                &mut frame_stream,
+                xr_frame_state.predicted_display_time,
+                environment_blend_mode,
+            );
             if let Some(report) = frame_profiler.record_skipped(elapsed_time, update_elapsed) {
                 print_frame_report(&mission, session_focused, report);
             }
@@ -962,9 +963,34 @@ fn main() {
             swapchain_handles
         });
 
-        let (_, views) = session
+        let (view_flags, views) = session
             .locate_views(VIEW_TYPE, xr_frame_state.predicted_display_time, &stage)
             .unwrap();
+
+        // `should_render` being true does not promise the views are tracked:
+        // for a frame or two after the session begins (donning the headset, or
+        // waking it after it dozed) the runtime still reports the view pose as
+        // invalid, and hands back a ZERO quaternion rather than a unit one.
+        // Feeding that to the projection layer makes xrEndFrame fail with
+        // ERROR_POSE_INVALID - which used to panic the render thread, and a
+        // dead render thread stops draining NativeActivity's input queue, so
+        // Horizon OS raises "shock2quest isn't responding" on the next key
+        // event. Treat an untracked view exactly like a frame we were told not
+        // to render: submit no layers and try again next frame.
+        if !view_flags
+            .contains(xr::ViewStateFlags::ORIENTATION_VALID | xr::ViewStateFlags::POSITION_VALID)
+        {
+            println!("SHOCK2QUEST_XR_VIEWS_UNTRACKED mission={mission} flags={view_flags:?}");
+            end_frame_with_no_layers(
+                &mut frame_stream,
+                xr_frame_state.predicted_display_time,
+                environment_blend_mode,
+            );
+            if let Some(report) = frame_profiler.record_skipped(elapsed_time, update_elapsed) {
+                print_frame_report(&mission, session_focused, report);
+            }
+            continue;
+        }
 
         // Remember where the head actually is, for next frame's input context.
         if let Some(view) = views.first() {
@@ -1034,24 +1060,35 @@ fn main() {
             .swapchain(swap2)
             .image_rect(rect);
         let submit_started = Instant::now();
-        frame_stream
-            .end(
-                xr_frame_state.predicted_display_time,
-                environment_blend_mode,
-                &[
-                    &xr::CompositionLayerProjection::new().space(&stage).views(&[
-                        xr::CompositionLayerProjectionView::new()
-                            .pose(views[0].pose)
-                            .fov(views[0].fov)
-                            .sub_image(sub1),
-                        xr::CompositionLayerProjectionView::new()
-                            .pose(views[1].pose)
-                            .fov(views[1].fov)
-                            .sub_image(sub2),
-                    ]),
-                ],
-            )
-            .unwrap();
+        // Never fatal: a rejected frame costs one dropped image, but a panic
+        // here kills the render thread, and with it the per-frame drain of
+        // NativeActivity's lifecycle/input queues - which is what turns a
+        // one-frame compositor complaint into an app-wide ANR.
+        if let Err(error) = frame_stream.end(
+            xr_frame_state.predicted_display_time,
+            environment_blend_mode,
+            &[
+                &xr::CompositionLayerProjection::new().space(&stage).views(&[
+                    xr::CompositionLayerProjectionView::new()
+                        .pose(views[0].pose)
+                        .fov(views[0].fov)
+                        .sub_image(sub1),
+                    xr::CompositionLayerProjectionView::new()
+                        .pose(views[1].pose)
+                        .fov(views[1].fov)
+                        .sub_image(sub2),
+                ]),
+            ],
+        ) {
+            // Only the start of a burst is logged, so a persistently unhappy
+            // compositor cannot flood logcat at 90 Hz.
+            if submit_failures == 0 {
+                println!("SHOCK2QUEST_XR_SUBMIT_FAILED mission={mission} error={error:?}");
+            }
+            submit_failures += 1;
+        } else {
+            submit_failures = 0;
+        }
         let submit_elapsed = submit_started.elapsed();
 
         let requested_refresh_is_active = display_refresh_rate.is_some_and(|active_hz| {
@@ -1178,6 +1215,22 @@ fn create_projection_matrix(fov: &xr::Fovf, near_z: f32, far_z: f32) -> cgmath::
         c0r0, c1r0, c2r0, c3r0, c0r1, c1r1, c2r1, c3r1, c0r2, c1r2, c2r2, c3r2, c0r3, c1r3, c2r3,
         c3r3,
     )
+}
+
+/// Close out a frame that has nothing to show - the compositor keeps whatever
+/// it last displayed. Used both when the runtime tells us not to render and
+/// when the located views are not yet tracked.
+///
+/// Deliberately non-fatal for the same reason as the projection-layer submit:
+/// a panic on the render thread stops the Android event pump and the app ANRs.
+fn end_frame_with_no_layers(
+    frame_stream: &mut xr::FrameStream<xr::OpenGlEs>,
+    predicted_display_time: xr::Time,
+    environment_blend_mode: xr::EnvironmentBlendMode,
+) {
+    if let Err(error) = frame_stream.end(predicted_display_time, environment_blend_mode, &[]) {
+        println!("SHOCK2QUEST_XR_EMPTY_FRAME_FAILED error={error:?}");
+    }
 }
 
 /// Non-blockingly drain the Android lifecycle and input queues once per frame.


### PR DESCRIPTION
Fixes #1003.

## What was actually happening

The ANR is a **symptom of a native panic**, not of a blocked event pump. Device logcat from a reproducing run (Quest 3, integration build of #996/#997/#998):

```
08-16 09:54:42.071  RustStdoutStderr: SHOCK2QUEST_XR_STATE mission=main_menu state=READY
08-16 09:54:42.126  RustStdoutStderr: thread '<unnamed>' (18992) panicked at runtimes/oculus_runtime/src/lib.rs:1102:14:
08-16 09:54:42.126  RustStdoutStderr: called `Result::unwrap()` on an `Err` value: ERROR_POSE_INVALID
...
08-16 09:55:32.747  WindowManager: ANR in Window{71d5af u0 com.tommybuilds.shock2quest/android.app.NativeActivity}.
                    Reason:Input dispatching timed out (... Waited 5001ms for KeyEvent).
```

`lib.rs:1102` in that build is the `.unwrap()` on **`frame_stream.end(...)`** — the `xrEndFrame` submit — **55 ms after the session went READY**, i.e. on the first frame after donning/waking the headset.

Why: the loop discarded the view-state flags —

```rust
let (_, views) = session.locate_views(VIEW_TYPE, ..., &stage).unwrap();
```

`xrFrameState::shouldRender` being true does **not** promise the views are tracked. For a frame or two after the session begins, Meta's runtime reports the view pose as invalid and hands back a **zero quaternion**. Feeding that to `CompositionLayerProjectionView::pose` makes `xrEndFrame` reject the frame with `XR_ERROR_POSE_INVALID`.

The panic only unwound the render thread, so the process survived — but that thread is the one running `android_pump_events()`, which drains NativeActivity's lifecycle and input queues each frame. With it dead, the next key event went unanswered and Android's watchdog fired. That also explains the reported behavior exactly: the app has to be force-closed, and both triggers (first don after launch, and re-don after doze) are the same event — a session going READY again.

The `/data/anr` trace confirms it from the other side: the Java `main` thread is idle in `epoll_pwait` (nothing blocked), and the Rust render thread is simply **absent** from the process's thread list.

## The fix

1. **Honor the view-state flags.** An untracked view is treated exactly like a frame the runtime told us not to render: submit no layers, try again next frame. This reuses the pre-existing `!should_render` path, extracted as `end_frame_with_no_layers`.
2. **Never panic on frame submission.** A rejected frame costs one dropped image; a dead render thread costs the whole app. Failures are logged once per burst, with the burst length on recovery.

Both new diagnostics (`SHOCK2QUEST_XR_VIEWS_UNTRACKED` / `_TRACKED`, `SHOCK2QUEST_XR_SUBMIT_FAILED` / `_RECOVERED`) log only on transitions, so a long tracking outage cannot flood logcat at 90 Hz.

## Acceptance evidence

The natural race is timing-dependent — 6 runs of the doff/don protocol (`prox_open` + `KEYCODE_SLEEP` → launch → `prox_close` + `KEYCODE_WAKEUP`) did not hit it on either build. So the failure was reproduced **deterministically by fault injection**: a temporary probe build zeroes the view orientation and clears the view flags on one frame, exactly as the runtime does during the untracked window. Both probe builds are identical except for the fix.

| | Before (fix reverted + injection) | After (fix + same injection) |
|---|---|---|
| Injection fires | `SHOCK2QUEST_FAULT_INJECT frame=600 zeroing view orientation` | same |
| Render thread | **panicked**, `ERROR_POSE_INVALID` | survived — `SHOCK2QUEST_XR_VIEWS_UNTRACKED flags=ViewStateFlags(0)` |
| Still rendering after | **no** — `SHOCK2QUEST_PERF` stops | **yes** — 90.0 fps, uninterrupted |
| **ANRs after 3 key events** | **1** — `Input dispatching timed out ... Waited 5002ms for KeyEvent` | **0** |

Before:
```
10:45:03.018 SHOCK2QUEST_FAULT_INJECT frame=600 zeroing view orientation
10:45:03.019 thread '<unnamed>' (3493) panicked at runtimes/oculus_runtime/src/lib.rs:1076:14:
10:45:03.019 called `Result::unwrap()` on an `Err` value: ERROR_POSE_INVALID
10:45:48.958 WindowManager: ANR in Window{537db8 u0 com.tommybuilds.shock2quest/android.app.NativeActivity}.
             Reason:Input dispatching timed out (... Waited 5002ms for KeyEvent).
```

After:
```
10:47:18.307 SHOCK2QUEST_FAULT_INJECT frame=600 zeroing view orientation
10:47:18.307 SHOCK2QUEST_XR_VIEWS_UNTRACKED mission=main_menu flags=ViewStateFlags(0)
10:47:53.830 SHOCK2QUEST_PERF mission=main_menu focused=true samples=90 skipped=0 fps=89.999 ...
             (ANR count: 0)
```

The injection is a throwaway probe and is **not** in this branch.

Regression check on the shipped build: 4 further protocol runs (launch → doff/doze → don), 0 panics, 0 ANRs, main menu holding a steady 90.0 fps.

## Validation

- `RUSTFLAGS="-D warnings" cargo apk check` — clean.
- Release APK built and installed on Quest 3; verified rendering at 90 fps with no injected faults.
- No visual change (this is a crash fix; the only rendering difference is that a frame with untracked views is now blank rather than crashing).

## Notes / follow-ups

- Cross-engine review flagged that this hardens only 2 of the hot loop's `.unwrap()`s. `frame_wait.wait()`, `frame_stream.begin()`, `sync_actions()`, the `locate`/`locate_views` calls and the swapchain acquire/release all still turn a transient runtime error into the same ANR. Kept narrow here deliberately; worth a follow-up issue.
- The synchronous level load (#1002) was the other suspect on the issue. It is **not** the cause of these two ANRs — the panic timestamps land 55 ms after `state=READY`, long after `SHOCK2QUEST_STARTUP` reports the load finished.
