### PR TITLE
fix(menu): make Quit work on every runtime

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -685,6 +685,10 @@ pub struct FrameSnapshot {
     pub mission: String,
     /// True once the retail finale has entered its terminal ending cutscene.
     pub campaign_completed: bool,
+    /// True once a scene has asked the runtime to quit (the main menu's Quit).
+    /// The debug runtime deliberately stays up - an automation session must not
+    /// kill itself - so this is how the quit path is observed headlessly.
+    pub quit_requested: bool,
     pub player: PlayerInfo,
     pub entity_count: usize,
     pub debug_features: Vec<String>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1890,6 +1890,7 @@ fn capture_frame_snapshot(
         },
         mission: game.scene_name().to_string(),
         campaign_completed: game.campaign_completed(),
+        quit_requested: game.should_quit(),
         player: {
             // Real player state from the active world (position, look, and the
             // held/wielded entities), or zeros when the scene has no player.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -450,6 +450,9 @@ fn main() {
     let mut swapchain = None;
     let mut event_storage = xr::EventDataBuffer::new();
     let mut session_running = false;
+    // Set once a scene has asked to quit and we've asked OpenXR to exit, so the
+    // request is made exactly once (the runtime takes several frames to answer).
+    let mut exit_requested = false;
     let now = Instant::now();
     let engine = engine::android();
     let bundle_storage = engine.get_storage();
@@ -860,6 +863,22 @@ fn main() {
         game.update(&time_context, &input_context, &mut action_state);
         let update_elapsed = update_started.elapsed();
 
+        // A scene asked to quit (the main menu's Quit item). OpenXR owns
+        // teardown: xrRequestExitSession makes the runtime walk us through
+        // STOPPING - where the handler above ends the session - to EXITING,
+        // which breaks 'main_loop. Done here, before xrBeginFrame, so we never
+        // abandon a frame we've already begun.
+        if !exit_requested && game.should_quit() {
+            exit_requested = true;
+            println!("SHOCK2QUEST_XR_EXIT_REQUESTED");
+            if let Err(error) = session.request_exit() {
+                // No orderly path left; leave the loop and finish the activity
+                // rather than lingering on a session nobody can end.
+                println!("SHOCK2QUEST_XR_EXIT_REQUEST_FAILED error={error:?}");
+                break 'main_loop;
+            }
+        }
+
         // Must be called before any rendering is done!
         frame_stream.begin().unwrap();
 
@@ -1204,6 +1223,29 @@ fn main() {
         //     println!();
         // }
         //render_time = Instant::now();
+    }
+
+    // The session is over (EXITING / LOSS_PENDING, or an instance loss). Just
+    // returning is not enough on Android: ndk-glue runs `main` on a thread it
+    // spawned, so the NativeActivity - and the process - would stay up with
+    // nothing rendering, which the headset shows as a black void. Ask Android
+    // to finish the activity, keep servicing its queues while it does, then end
+    // the process.
+    #[cfg(target_os = "android")]
+    {
+        println!("SHOCK2QUEST_XR_SHUTDOWN - finishing the activity");
+        // ndk-glue 0.6 deprecates this in favor of `ndk_context`, which hands
+        // back the JavaVM and the Java activity object - not the
+        // `ANativeActivity` that `finish()` needs. This is still the only way
+        // to reach ANativeActivity_finish from here.
+        #[allow(deprecated)]
+        ndk_glue::native_activity().finish();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            android_pump_events();
+            std::thread::sleep(Duration::from_millis(16));
+        }
+        std::process::exit(0);
     }
 
     // egl_display

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -476,7 +476,14 @@ fn main() {
     // Keep servicing them at milestones inside the synchronous first load,
     // before the per-frame pump below exists.
     #[cfg(target_os = "android")]
-    engine::platform::set_event_pump(Some(android_pump_events));
+    {
+        // `set_event_pump` takes a plain `fn()`; the drain's "was the activity
+        // destroyed" answer is only read at teardown.
+        fn pump_events() {
+            android_pump_events();
+        }
+        engine::platform::set_event_pump(Some(pump_events));
+    }
     let mut game = shock2vr::App::init(options, bundle_storage);
     // The real HMD orientation, from the previous frame's located view.
     // `input_context` is built before `locate_views` runs, so this frame's view
@@ -654,6 +661,24 @@ fn main() {
             // Don't grind up the CPU
             std::thread::sleep(Duration::from_millis(100));
             continue;
+        }
+
+        // A scene asked to quit (the main menu's Quit item). OpenXR owns
+        // teardown: xrRequestExitSession makes the runtime walk us through
+        // STOPPING - where the handler above ends the session - to EXITING,
+        // which breaks 'main_loop. `should_quit` latches, so it is read here,
+        // outside the wait/begin/end frame sequence: the failure path below
+        // leaves the loop, and doing that mid-frame would strand an
+        // xrWaitFrame with no matching xrBeginFrame.
+        if !exit_requested && game.should_quit() {
+            exit_requested = true;
+            println!("SHOCK2QUEST_XR_EXIT_REQUESTED");
+            if let Err(error) = session.request_exit() {
+                // No orderly path left; leave the loop and finish the activity
+                // rather than lingering on a session nobody can end.
+                println!("SHOCK2QUEST_XR_EXIT_REQUEST_FAILED error={error:?}");
+                break 'main_loop;
+            }
         }
         // println!(
         //     " - After polling events: {}",
@@ -862,22 +887,6 @@ fn main() {
         let update_started = Instant::now();
         game.update(&time_context, &input_context, &mut action_state);
         let update_elapsed = update_started.elapsed();
-
-        // A scene asked to quit (the main menu's Quit item). OpenXR owns
-        // teardown: xrRequestExitSession makes the runtime walk us through
-        // STOPPING - where the handler above ends the session - to EXITING,
-        // which breaks 'main_loop. Done here, before xrBeginFrame, so we never
-        // abandon a frame we've already begun.
-        if !exit_requested && game.should_quit() {
-            exit_requested = true;
-            println!("SHOCK2QUEST_XR_EXIT_REQUESTED");
-            if let Err(error) = session.request_exit() {
-                // No orderly path left; leave the loop and finish the activity
-                // rather than lingering on a session nobody can end.
-                println!("SHOCK2QUEST_XR_EXIT_REQUEST_FAILED error={error:?}");
-                break 'main_loop;
-            }
-        }
 
         // Must be called before any rendering is done!
         frame_stream.begin().unwrap();
@@ -1241,10 +1250,18 @@ fn main() {
         #[allow(deprecated)]
         ndk_glue::native_activity().finish();
         let deadline = Instant::now() + Duration::from_secs(1);
-        while Instant::now() < deadline {
-            android_pump_events();
+        while Instant::now() < deadline && !android_pump_events() {
             std::thread::sleep(Duration::from_millis(16));
         }
+        // `process::exit` runs no destructors, so hand the XR objects back
+        // explicitly first - otherwise even the clean exit destroys neither the
+        // session nor the instance, and the runtime service can carry that
+        // state into the next launch.
+        drop(swapchain);
+        drop(frame_stream);
+        drop(frame_wait);
+        drop(session);
+        drop(xr_instance);
         std::process::exit(0);
     }
 
@@ -1356,12 +1373,14 @@ fn end_frame_with_no_layers(
 /// which queue actually has something pending, so every read below is
 /// guaranteed not to block.
 ///
-/// Teardown is deliberately *not* driven from here. The OpenXR session state
-/// machine already exits the main loop on EXITING/LOSS_PENDING after a clean
+/// Returns whether the activity was destroyed during this drain. Teardown is
+/// deliberately *not* driven from that during the main loop: the OpenXR session
+/// state machine already exits it on EXITING/LOSS_PENDING after a clean
 /// `session.end()`; breaking out on ndk-glue's `Destroy` instead would tear
 /// down GL and XR objects after the activity is already gone, with the session
-/// possibly never ended - strictly worse ordering. `Destroy` is logged and the
-/// drain stops for the frame.
+/// possibly never ended - strictly worse ordering. The flag is only read after
+/// the loop, where it ends the post-`finish()` wait as soon as Android has
+/// actually torn the activity down. `Destroy` also stops the drain for the frame.
 ///
 /// The input events are finished as *unhandled* on purpose: gameplay input
 /// arrives through OpenXR actions, and these only need to be consumed so the
@@ -1370,7 +1389,7 @@ fn end_frame_with_no_layers(
 /// must be honored - when it takes the event (IME and friends) it owns it, and
 /// finishing it ourselves would be a double free.
 #[cfg(target_os = "android")]
-fn android_pump_events() {
+fn android_pump_events() -> bool {
     use ndk::looper::{Poll, ThreadLooper};
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -1388,7 +1407,7 @@ fn android_pump_events() {
                 "android_pump_events: no ALooper for this thread - Android queues are NOT being serviced"
             );
         }
-        return;
+        return false;
     };
 
     // Bounded so a flooded queue can never starve rendering; anything left
@@ -1406,7 +1425,7 @@ fn android_pump_events() {
                         // state, so the rest of the lifecycle is informational.
                         if event == ndk_glue::Event::Destroy {
                             println!("android_pump_events: activity destroyed");
-                            return;
+                            return true;
                         }
                     }
                 }
@@ -1438,6 +1457,7 @@ fn android_pump_events() {
             }
         }
     }
+    false
 }
 
 /// Convert a floor-origin STAGE-space position (meters) into the game's pawn

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -180,6 +180,28 @@ fn vr_pointer(input_context: &InputContext, panel: &WorldPanel) -> (Option<Vecto
     vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), panel)
 }
 
+/// What a selected menu entry asks the game to do. Split out of `update` so the
+/// mapping is assertable without a running game - notably Quit, whose effect is
+/// the only thing that makes the runtimes shut down.
+fn effects_for_action(action: Option<MenuAction>) -> Vec<Effect> {
+    match action {
+        Some(MenuAction::NewGame) => {
+            vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
+                level_file: NEW_GAME_MISSION.to_owned(),
+                loc: None,
+                entities_to_trigger: vec![],
+                vitals_transition:
+                    crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
+            })]
+        }
+        Some(MenuAction::LoadGame) => {
+            vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]
+        }
+        Some(MenuAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
+        None => Vec::new(),
+    }
+}
+
 /// Shared click core: both presentations reduce to "a point on the canvas plus
 /// a pressed flag", so the rising-edge rule and the hit regions live here once.
 fn resolve_click_at(
@@ -376,22 +398,7 @@ impl GameScene for MainMenuScene {
             self.sfx.click();
         }
 
-        match action {
-            Some(MenuAction::NewGame) => {
-                vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
-                    level_file: NEW_GAME_MISSION.to_owned(),
-                    loc: None,
-                    entities_to_trigger: vec![],
-                    vitals_transition:
-                        crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
-                })]
-            }
-            Some(MenuAction::LoadGame) => {
-                vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]
-            }
-            Some(MenuAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
-            None => Vec::new(),
-        }
+        effects_for_action(action)
     }
 
     fn render(
@@ -523,6 +530,17 @@ mod tests {
             &menu_rects(None),
         );
         assert_eq!(action, Some(MenuAction::Quit));
+    }
+
+    /// Selecting Quit must ask the game to quit - the runtimes shut down off
+    /// this effect and nothing else.
+    #[test]
+    fn quit_asks_the_game_to_quit() {
+        assert!(matches!(
+            effects_for_action(Some(MenuAction::Quit)).as_slice(),
+            [Effect::GlobalEffect(GlobalEffect::Quit)]
+        ));
+        assert!(effects_for_action(None).is_empty());
     }
 
     #[test]

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -180,28 +180,6 @@ fn vr_pointer(input_context: &InputContext, panel: &WorldPanel) -> (Option<Vecto
     vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H), panel)
 }
 
-/// What a selected menu entry asks the game to do. Split out of `update` so the
-/// mapping is assertable without a running game - notably Quit, whose effect is
-/// the only thing that makes the runtimes shut down.
-fn effects_for_action(action: Option<MenuAction>) -> Vec<Effect> {
-    match action {
-        Some(MenuAction::NewGame) => {
-            vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
-                level_file: NEW_GAME_MISSION.to_owned(),
-                loc: None,
-                entities_to_trigger: vec![],
-                vitals_transition:
-                    crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
-            })]
-        }
-        Some(MenuAction::LoadGame) => {
-            vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]
-        }
-        Some(MenuAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
-        None => Vec::new(),
-    }
-}
-
 /// Shared click core: both presentations reduce to "a point on the canvas plus
 /// a pressed flag", so the rising-edge rule and the hit regions live here once.
 fn resolve_click_at(
@@ -398,7 +376,22 @@ impl GameScene for MainMenuScene {
             self.sfx.click();
         }
 
-        effects_for_action(action)
+        match action {
+            Some(MenuAction::NewGame) => {
+                vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
+                    level_file: NEW_GAME_MISSION.to_owned(),
+                    loc: None,
+                    entities_to_trigger: vec![],
+                    vitals_transition:
+                        crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
+                })]
+            }
+            Some(MenuAction::LoadGame) => {
+                vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]
+            }
+            Some(MenuAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
+            None => Vec::new(),
+        }
     }
 
     fn render(
@@ -530,17 +523,6 @@ mod tests {
             &menu_rects(None),
         );
         assert_eq!(action, Some(MenuAction::Quit));
-    }
-
-    /// Selecting Quit must ask the game to quit - the runtimes shut down off
-    /// this effect and nothing else.
-    #[test]
-    fn quit_asks_the_game_to_quit() {
-        assert!(matches!(
-            effects_for_action(Some(MenuAction::Quit)).as_slice(),
-            [Effect::GlobalEffect(GlobalEffect::Quit)]
-        ));
-        assert!(effects_for_action(None).is_empty());
     }
 
     #[test]

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -458,6 +458,10 @@ export interface FrameSnapshot {
   mission: string;
   /** True once the retail finale has entered its terminal ending cutscene. */
   campaign_completed: boolean;
+  /** True once a scene asked the runtime to quit (the main menu's Quit). The
+   * debug runtime stays up regardless, so this is how the quit path is
+   * observed headlessly. */
+  quit_requested: boolean;
   player: PlayerSnapshot;
   entity_count: number;
   debug_features: string[];

--- a/tools/shock2-sdk/test/helpers/frontend-menu.ts
+++ b/tools/shock2-sdk/test/helpers/frontend-menu.ts
@@ -1,0 +1,36 @@
+import { PLAYER_EYE_HEIGHT_WORLD } from "../../src/index.js";
+
+/** The frontend screens are authored on the original 640x480 UI canvas. */
+export const CANVAS_W = 640;
+export const CANVAS_H = 480;
+
+/** A canvas point normalized to the [0,1] flat `pointer.position` channel. */
+export const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y / CANVAS_H];
+
+/**
+ * The normalized center of a main-menu entry. MAINR.BIN stacks six 179x60
+ * buttons at x=400 on a 76px pitch, in screen order: 0 "New Game",
+ * 1 "Load Game", ... 5 "Quit".
+ */
+export const menuEntry = (index: number): [number, number] =>
+  norm(400 + 179 / 2, 20 + index * 76 + 60 / 2);
+
+// The VR menu is the same canvas on a world-space panel, driven by a controller
+// ray instead of a cursor. The runtime's VR head yaw is +90 degrees (the camera
+// looks along -X), so the panel hangs at x=-2 facing back at the head: canvas +x
+// maps to world -z (the viewer's right) and canvas +y to -y.
+const PANEL_DISTANCE = 2;
+const PANEL_SIZE = { x: 2, y: 1.5 };
+
+/** 90-degree yaw: rotates a hand's -Z ray onto the panel's -X. */
+export const AIM_AT_PANEL: [number, number, number, number] = [0, 0.7071068, 0, 0.7071068];
+
+/**
+ * Pawn-local position of a normalized canvas point on the VR frontend panel. A
+ * hand placed here and rotated by `AIM_AT_PANEL` points straight at that point.
+ */
+export const panelPoint = ([u, v]: [number, number]): [number, number, number] => [
+  -PANEL_DISTANCE,
+  PLAYER_EYE_HEIGHT_WORLD + (0.5 - v) * PANEL_SIZE.y,
+  (0.5 - u) * PANEL_SIZE.x,
+];

--- a/tools/shock2-sdk/test/menu-audio.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-audio.e2e.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import { GameServer } from "../src/index.js";
 import type { PlayedSound } from "../src/types.js";
+import { AIM_AT_PANEL, menuEntry, norm, panelPoint } from "./helpers/frontend-menu.js";
 
 // End-to-end test for the frontend's sound: the original menus are not silent -
 // `res/snd/sfx/` ships a looping bed (mloop1), a rollover blip played when the
@@ -18,15 +19,6 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const HUM = "sfx/mloop1.wav";
 const ROLLOVER = "sfx/mrollov1.wav";
 const SELECT = "sfx/mselect1.wav";
-
-// Canvas-space widget centers on the 640x480 UI canvas, normalized to the
-// [0,1] pointer channel. MAINR.BIN stacks six 179x60 buttons at x=400 on a
-// 76px pitch: button 0 is "New Game", button 1 "Load Game".
-const CANVAS_W = 640;
-const CANVAS_H = 480;
-const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y / CANVAS_H];
-const menuEntry = (index: number): [number, number] =>
-  norm(400 + 179 / 2, 20 + index * 76 + 60 / 2);
 
 const NEW_GAME_ENTRY = menuEntry(0);
 const LOAD_GAME_ENTRY = menuEntry(1);
@@ -112,22 +104,6 @@ test(
 // The VR menu is the same canvas on a world-space panel, driven by a controller
 // ray instead of a cursor - so it must make the same sounds at the same moments
 // (AGENTS.md: "a canvas must render the same way in flatscreen and in VR").
-//
-// The runtime's VR head yaw is +90 degrees (the camera looks along -X), so the
-// panel hangs at x=-2 facing back at the head: canvas +x maps to world -z
-// (the viewer's right) and canvas +y to -y.
-// A hand placed on the button's world position and aimed along -X points at it.
-const PANEL_DISTANCE = 2;
-const PANEL_SIZE = { x: 2, y: 1.5 };
-/** 90-degree yaw: rotates a hand's -Z ray onto the panel's -X. */
-const AIM_AT_PANEL: [number, number, number, number] = [0, 0.7071068, 0, 0.7071068];
-
-/** Pawn-local position of a canvas point on the VR panel. */
-const panelPoint = ([u, v]: [number, number]): [number, number, number] => [
-  -PANEL_DISTANCE,
-  PLAYER_EYE_HEIGHT_WORLD + (0.5 - v) * PANEL_SIZE.y,
-  (0.5 - u) * PANEL_SIZE.x,
-];
 
 test(
   "the VR menu plays the same sounds off the controller ray",

--- a/tools/shock2-sdk/test/menu-quit.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-quit.e2e.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import { GameServer } from "../src/index.js";
+import { AIM_AT_PANEL, menuEntry, panelPoint } from "./helpers/frontend-menu.js";
 
 // End-to-end test for the main menu's Quit entry: clicking it must reach
 // `Game::should_quit`, which is what every runtime shuts down on (the desktop
@@ -15,11 +16,8 @@ import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 // `undefined` and both assertions below fail.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-// MAINR.BIN stacks six 179x60 buttons at x=400 on a 76px pitch, on the 640x480
-// UI canvas; Quit is the last one (index 5), centered at y=430.
-const CANVAS_W = 640;
-const CANVAS_H = 480;
-const QUIT_ENTRY: [number, number] = [(400 + 179 / 2) / CANVAS_W, (20 + 5 * 76 + 30) / CANVAS_H];
+/** Quit is the last of the six main-menu entries. */
+const QUIT_ENTRY = menuEntry(5);
 
 test(
   "clicking Quit in the flat menu requests a quit without killing the runtime",
@@ -56,20 +54,6 @@ test(
 // The VR menu is the same canvas on a world panel, driven by a controller ray -
 // so the Quest's Quit has to travel the same path (AGENTS.md: "a canvas must
 // render the same way in flatscreen and in VR").
-//
-// The runtime's VR head yaw is +90 degrees (the camera looks along -X), so the
-// panel hangs at x=-2 facing the head: canvas +x maps to world -z and +y to -y.
-const PANEL_DISTANCE = 2;
-const PANEL_SIZE = { x: 2, y: 1.5 };
-/** 90-degree yaw: rotates a hand's -Z ray onto the panel's -X. */
-const AIM_AT_PANEL: [number, number, number, number] = [0, 0.7071068, 0, 0.7071068];
-
-/** Pawn-local position of a canvas point on the VR panel. */
-const panelPoint = ([u, v]: [number, number]): [number, number, number] => [
-  -PANEL_DISTANCE,
-  PLAYER_EYE_HEIGHT_WORLD + (0.5 - v) * PANEL_SIZE.y,
-  (0.5 - u) * PANEL_SIZE.x,
-];
 
 test(
   "the VR hand ray can quit from the menu too",

--- a/tools/shock2-sdk/test/menu-quit.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-quit.e2e.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+
+// End-to-end test for the main menu's Quit entry: clicking it must reach
+// `Game::should_quit`, which is what every runtime shuts down on (the desktop
+// closes its window, the Quest asks OpenXR to exit its session).
+//
+// The debug runtime deliberately does NOT quit - an automation session must not
+// kill itself - so it reports the request through `/v1/info`'s `quit_requested`
+// instead, which is what makes the whole path assertable headlessly.
+//
+// Negative-first: without `quit_requested` on the snapshot the field is
+// `undefined` and both assertions below fail.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// MAINR.BIN stacks six 179x60 buttons at x=400 on a 76px pitch, on the 640x480
+// UI canvas; Quit is the last one (index 5), centered at y=430.
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+const QUIT_ENTRY: [number, number] = [(400 + 179 / 2) / CANVAS_W, (20 + 5 * 76 + 30) / CANVAS_H];
+
+test(
+  "clicking Quit in the flat menu requests a quit without killing the runtime",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({ mission: "main_menu", port: 8126 });
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      (await game.info()).quit_requested,
+      false,
+      "nothing has asked to quit yet",
+    );
+
+    // Clicks are rising-edge, so the press has to start on a frame where the
+    // previous one was unpressed.
+    await game.input.set("pointer.position", QUIT_ENTRY);
+    await game.step({ frames: 5 });
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.info()).quit_requested,
+      true,
+      "clicking Quit should ask the game to quit",
+    );
+    // Still serving: the debug runtime is quit-immune on purpose.
+    assert.equal((await game.info()).mission, "main_menu");
+  },
+);
+
+// The VR menu is the same canvas on a world panel, driven by a controller ray -
+// so the Quest's Quit has to travel the same path (AGENTS.md: "a canvas must
+// render the same way in flatscreen and in VR").
+//
+// The runtime's VR head yaw is +90 degrees (the camera looks along -X), so the
+// panel hangs at x=-2 facing the head: canvas +x maps to world -z and +y to -y.
+const PANEL_DISTANCE = 2;
+const PANEL_SIZE = { x: 2, y: 1.5 };
+/** 90-degree yaw: rotates a hand's -Z ray onto the panel's -X. */
+const AIM_AT_PANEL: [number, number, number, number] = [0, 0.7071068, 0, 0.7071068];
+
+/** Pawn-local position of a canvas point on the VR panel. */
+const panelPoint = ([u, v]: [number, number]): [number, number, number] => [
+  -PANEL_DISTANCE,
+  PLAYER_EYE_HEIGHT_WORLD + (0.5 - v) * PANEL_SIZE.y,
+  (0.5 - u) * PANEL_SIZE.x,
+];
+
+test(
+  "the VR hand ray can quit from the menu too",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "main_menu",
+      port: 8127,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    assert.equal((await game.info()).quit_requested, false);
+
+    // Origin at the button's own world position, aimed straight down -X onto it.
+    const [, y, z] = panelPoint(QUIT_ENTRY);
+    await game.input.set("right_hand.rotation", AIM_AT_PANEL);
+    await game.input.set("right_hand.position", [0, y, z]);
+    await game.step({ frames: 10 });
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 3 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.info()).quit_requested,
+      true,
+      "the trigger over Quit should ask the game to quit",
+    );
+    assert.equal((await game.info()).mission, "main_menu");
+  },
+);


### PR DESCRIPTION
The main menu's Quit already produced `Effect::GlobalEffect(GlobalEffect::Quit)` -> `Game::should_quit`, but only the desktop runtime ever observed it. On Quest the item did nothing at all.

## What changed

**Oculus (`runtimes/oculus_runtime/src/lib.rs`)** — the actual fix. Once `game.should_quit()` latches, the loop asks OpenXR to exit (`session.request_exit()`, exactly once) and lets the *existing* session-state machine do the teardown: the runtime drives us READY -> STOPPING (where the handler already calls `session.end()`) -> EXITING, and the EXITING arm already breaks `'main_loop`. The request is issued outside the wait/begin/end frame sequence, so the request-failure fallback (break out and finish anyway) can't strand an `xrWaitFrame` with no matching `xrBeginFrame`.

After the loop: ndk-glue runs `main` on a thread it spawned, so returning is not enough — the NativeActivity and the process would linger with nothing rendering (a black void in the headset). So we finish the activity, keep pumping Android's queues until it reports `Destroy` (1s upper bound), release the XR objects explicitly (`process::exit` runs no destructors), and end the process.

**Debug runtime** — still quit-immune on purpose: an automation session must not kill itself. It now *reports* the request as `quit_requested` on `GET /v1/info` (mirrored in the SDK's `FrameSnapshot`), which is what makes the whole path assertable headlessly.

**Desktop** — no change; verified by reading. `should_quit` -> `window.set_should_close(true)` sits in the single `while !window.should_close()` loop, and `--vr` only switches `PresentationMode`, so both desktop presentations already exit.

## Tests

New `tools/shock2-sdk/test/menu-quit.e2e.test.ts` (gated `SHOCK2_E2E=1`) boots the menu in the debug runtime and clicks Quit twice over: once through the flat pointer channels, once through the VR hand ray (`--vr`), asserting `/v1/info` flips `quit_requested` to true **and** the runtime is still serving. Negative-first: without the `/v1/info` change the field is `undefined` and both tests fail (verified). The duplicated menu/VR-panel geometry the two menu tests shared now lives in `test/helpers/frontend-menu.ts`.

No Rust unit test was added: the `MenuAction::Quit` resolution is already covered by `rising_edge_over_quit_activates_it` / `the_left_hand_can_drive_the_menu_too`, and the effect mapping is a one-line match arm the e2e now exercises end to end.

## Verification

- `cargo fmt --all --check` clean
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean
- `cargo test -p shock2vr --lib` — 740 passed, 0 failed
- `cargo apk check` (android, `-D warnings`) clean
- e2e: `menu-quit` (2) + `menu-audio` (3) — 5 passed, 0 failed
- `/xreview` (Claude + Codex + a de-dup pass): 0 Critical/High. Both engines agreed on two Medium teardown issues (exit requested inside the frame sequence; `process::exit` skipping destructors / not detecting `Destroy`) and on dropping a tautological menu refactor and the test duplication — all four are fixed in the second commit.

**Not device-verified.** No adb device was touched for this change, so the Quest exit path is implemented and compiles but has not run on hardware. It can be verified later with the on-device debug server: trigger the Quit click remotely and watch the process disappear from `adb shell ps`.

No screenshots — nothing visual changed.