### PR TITLE
docs(skills): codify VR UI & interaction principles as a skill

### DIFF
--- a/.claude/skills/vr-ui-design/SKILL.md
+++ b/.claude/skills/vr-ui-design/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: vr-ui-design
+description: >-
+  Hard-won principles for designing and implementing VR UI and interactions in
+  shock2quest - panels, pointers, pause/system UI, input edges, and the
+  verification discipline that catches VR-only bugs. Load whenever designing or
+  building a VR interaction (menus, panels, HUD, inventory, diegetic UI,
+  controller input), reviewing such a change, or planning a VR UX feature.
+  Complements AGENTS.md section 3 (flat/VR render parity) with the
+  interaction-level rules learned in the frontend-menu campaign (PRs
+  #994-#1009).
+---
+
+# VR UI & interaction principles
+
+Each rule below was paid for with a real bug or device round-trip. A `#N`
+citation is the PR that implemented the rule or the issue that tracks a
+remaining gap - PR/issue and open/closed state are marked where it matters.
+
+## Rendering & lifecycle
+
+1. **Never stop rendering.** Loading, "pause", and session-state changes must
+   keep submitting frames - a frozen compositor is disorienting in-headset,
+   and a render thread that dies or stalls takes Android's lifecycle/input
+   pump down with it, so the watchdog fires an app-wide ANR (#1009). Known
+   gap: a cold load's main-thread GPU build (~2 s) still blocks frame
+   submission at the end of the loading screen - see AGENTS.md's
+   `loading_screen` notes and issue #1011 (open). For any *pause* layer,
+   sim-freeze means dt=0 while frames keep flowing (design intent - the pause
+   skeleton is in flight, not merged).
+2. **Degrade, don't panic, in the frame loop.** Transient OpenXR errors
+   (untracked poses, `ERROR_POSE_INVALID`) are normal for a frame or two after
+   the headset wakes. Honor the view-state flags; submit no layers and retry
+   rather than `.unwrap()`. (#1009; remaining unhardened sites tracked in
+   #1010, open.)
+
+## Panels (system UI: menus, pause, dialogs)
+
+3. **Place on entry, gravity-aligned, world-locked, lazy recenter.** Never
+   gaze-glue a panel (UI painted on the face is an anti-pattern) and never let
+   it roll or pitch with the head. Place once from the *tracked* head pose -
+   position from the head, direction yaw-only - then leave it world-locked;
+   re-place with a short eased turn (0.3 s smoothstep) only after a sustained
+   large deviation (>60 deg / >1 m held ~1 s). Use `FrontendPanelAnchor`
+   (`shock2vr/src/ui/panel_anchor.rs`, introduced by PR #998); do not
+   hand-roll placement - the hardcoded-origin variant was the pre-#998 bug,
+   and the hardcoded-height copy in `debug_map` survives as issue #999 (open).
+4. **The panel basis must be honest.** Local +Z faces the viewer, +X is the
+   viewer's right, content y-flip applied exactly once as a rotation. Any
+   compensating rotation "that makes it render right" is hiding a basis error
+   that will invert on the other runtime. (#994 - the 180-degree saga.)
+
+## Pointing & input
+
+5. **One pointer arbitration, everything reads it.** Hover highlight and
+   click derive from the single shared `vr_frontend_pointer`
+   (`shock2vr/src/ui/frontend_pointer.rs`); PR #1008 (open) renames it to
+   `vr_frontend_pointer_pass` and makes the ray beams and hit dot read the
+   same pass, so the picture can never promise a hover the menu won't give
+   (its negative test forces the two-dots-one-highlight case). Never compute
+   "what am I pointing at" a second time for a visual - see AGENTS.md section
+   3 for why independent paths drift.
+6. **Rising-edge everything, and enter screens "already pressed".** A screen
+   entered while a button is held (dying with trigger down, scene swap under a
+   press) must not treat the held state as a click - initialize
+   `last_pressed = true`. A hand not currently driven must have its button
+   state cleared so a stale press can't latch. (#997 game-over insta-Quit;
+   desktop `--vr` routing in #994.)
+7. **Guard the zero quaternion.** Untracked controllers/head arrive as the
+   ZERO quaternion, and cgmath's `rotate_vector` silently returns the input
+   unrotated - a fixed ray at panel center, a panel pinned to world -Z. Any
+   code consuming a pose must treat near-zero magnitude as "untracked: no
+   pointer / identity / skip", never as a valid pose. (#994, #997.)
+8. **Discrete, non-contextual inputs go through `InputAction`** (AGENTS.md
+   "Adding a New Action") - that's what makes them drivable over HTTP and the
+   on-device debug server with no extra work. **Contextual hand interactions
+   (trigger pull, grab, drop, pointing) are NOT actions** - they stay in
+   `VirtualHand`/`InputContext`, which read game state. Routing a contextual
+   gesture through the action system is a wrong-subsystem bug.
+
+## Design defaults
+
+9. **Diegetic-first for in-game UI, panel-stack for system UI.** In-world
+   interactions (inventory, MFDs, keypads, devices) belong on world surfaces
+   the hands operate; the frontend panel stack is for system UI (main menu,
+   pause, load, game over). Keep the two layers' input ownership crisp
+   (design intent for the pause layer: system UI freezes sim and makes hands
+   pointers-only; diegetic UI runs live).
+10. **Edge-policy table up front.** For any new modal surface, decide in one
+    line each: opening while dead / during a transition / on a frontend scene /
+    with buttons held / with metagame (Tab) mode active. Implement each as a
+    guard with a test.
+
+## Domain behaviors agents consistently get wrong
+
+- **Audio logs are COLLECTED, not inventoried - and collection does NOT play
+  them.** Pickup files the log as collected (readable later); playback is the
+  player's explicit `ReadLastUnreadLog` action. The current VR auto-play on
+  pickup is a documented *stopgap* because VR lacks an action mapper (issue
+  #921) - do not preserve it as "faithful", and do not model logs as
+  carryable objects.
+- **Keycards are COLLECTED, not inventoried.** Frobbing a `PropKeySrc` item
+  emits `AcquireKeyCard`, records the credential in `QuestInfo`'s key-card
+  list (a separate mechanism from quest bits - contrast `FrobQB`), destroys
+  the pickup, and doors consult it implicitly via `can_unlock`. Never put a
+  keycard in the inventory grid or require wielding one at a door. Known gap:
+  the VR *hold/grab* path currently just grabs the card physically instead of
+  collecting it - issue #583 (open) tracks reconciling the pickup paths; the
+  intended spec is that both frob and hold collect.
+- When implementing any pickup, check which model the original game uses
+  (collected flag / credential vs. inventory object) before defaulting to
+  "add to inventory" - `cargo dq` on the template's properties/links usually
+  answers it.
+
+## Verification discipline
+
+11. **`debug_runtime --vr` is a harness, not a headset.** It proves geometry,
+    parity, and interaction logic deterministically - use it for every
+    iteration. But tracked poses, session lifecycle, compositor behavior, and
+    perf only exist on device: anything touching those needs a Quest pass
+    (vr-device-loop skill), with a **fresh install verified by timestamp** -
+    stale APKs have produced false negatives twice.
+12. **Drive the device like the harness - for input.** The on-device debug
+    server (`debug-port.txt` + `adb forward`, PR #996) injects the same input
+    channels as the debug runtime, so on-device interaction (hover, click,
+    head pose) is agent-verifiable without a human in the headset; overridden
+    channels win until released - clear before disconnecting. It has **no
+    `/v1/step` and no `/v1/screenshot`**: the device free-runs (not
+    deterministic), and capture still goes through adb / the vr-device-loop
+    scripts.
+13. **Evidence standards beyond AGENTS.md sections 3-4** (which stay
+    canonical for both-presentation render verification and PR media): read
+    the captured images - byte size is not a content signal (solid frames
+    compress identically); verify hover/hit agreement numerically (label-rect
+    luminance) when correctness of *which* element reacted matters; and for
+    timing-dependent device bugs, prefer deterministic fault injection over
+    waiting for a natural repro (#1009's technique).


### PR DESCRIPTION
Codifies the interaction-level principles learned across the VR menu campaign (#994, #996–#998, #1002, #1003, #1007–#1009) as a loadable skill, so future VR UI/interaction work — including the upcoming inventory/interaction-paradigm design — starts from these rules instead of rediscovering them. Complements AGENTS.md §3/§4, which stay canonical for render parity and PR media; the skill only adds interaction-level rules and points back rather than restating.

**Reviewed by two engines before opening** (Claude Opus subagent + Codex gpt-5.6, both verifying every claim against the actual code). All findings addressed:
- `vr_frontend_pointer` cited by its real name (with #1008's pending rename noted as such) [AGREED]
- Audio-log semantics corrected: collection does **not** play the log; VR auto-play is a documented stopgap (#921), not faithful behavior [AGREED]
- Keycard semantics corrected: frob → `AcquireKeyCard` → `QuestInfo` key-card credential (not a quest bit); the hold-path gap is labeled and cited to open issue #583 [AGREED]
- ANR causal claim aligned with #1009's actual diagnosis (dead render thread kills the event pump, not "blocked main thread")
- Every citation marked PR vs issue with state; design-intent items (pause-layer semantics) labeled as intent, not practice
- Added the InputAction vs contextual `VirtualHand` boundary (Codex: routing a gesture through the wrong subsystem is exactly the mistake a skill-reader would make)
- On-device debug server scoped honestly: input injection only, no /v1/step or /v1/screenshot
- Owner-supplied domain gotchas included: logs and keycards are collected, never inventoried