### PR TITLE
feat(game): pause menu skeleton over any gameplay scene

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -699,6 +699,10 @@ pub struct FrameSnapshot {
     /// The debug runtime deliberately stays up - an automation session must not
     /// kill itself - so this is how the quit path is observed headlessly.
     pub quit_requested: bool,
+    /// True while the in-game pause menu is up - the simulation is frozen and
+    /// `/v1/step` advances only rendering, so automation can tell "paused" from
+    /// "stuck".
+    pub paused: bool,
     pub player: PlayerInfo,
     pub entity_count: usize,
     pub debug_features: Vec<String>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1916,6 +1916,7 @@ fn capture_frame_snapshot(
         mission: game.scene_name().to_string(),
         campaign_completed: game.campaign_completed(),
         quit_requested: game.should_quit(),
+        paused: game.is_paused(),
         player: {
             // Real player state from the active world (position, look, and the
             // held/wielded entities), or zeros when the scene has no player.

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -147,6 +147,15 @@ impl DesktopInputMapper {
                 modifier: Modifier::None,
                 action: InputAction::ToggleUseMode,
             },
+            // Escape opens/closes the in-game pause menu, as it does in the
+            // original. It used to close the window outright (a raw glfw
+            // handler in `main.rs`); the pause menu's "Quit to Main Menu" plus
+            // the main menu's "Quit" is now the way out.
+            Binding {
+                key: Key::Escape,
+                modifier: Modifier::None,
+                action: InputAction::TogglePauseMenu,
+            },
             // AI debug: make everything hunt the player (pinned) / calm down
             Binding {
                 key: Key::G,

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -608,9 +608,6 @@ fn process_events(
             // glfw::WindowEvent::Key(Key::Space, _, Action::Press, _) => {
             //     engine::audio::play_audio(audio)
             // }
-            glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _) => {
-                window.set_should_close(true)
-            }
             glfw::WindowEvent::CursorPos(x, y) => {
                 let mouse_update = camera_update_mouse(camera_context, x as f32, y as f32);
                 rot_yaw = 1.0 * mouse_update.delta_x;

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -357,6 +357,12 @@ fn main() {
         .create_action::<bool>("audio_log_reader", "Audio Log Reader", &[])
         .unwrap();
 
+    // The left controller's Menu button. (The right controller's is reserved
+    // by the Quest system UI, so it can never be the app's.)
+    let menu_action = action_set
+        .create_action::<bool>("menu", "Pause Menu", &[])
+        .unwrap();
+
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
     // interaction profile
@@ -458,6 +464,16 @@ fn main() {
                         )
                         .unwrap(),
                 ),
+                xr::Binding::new(
+                    &menu_action,
+                    xr_instance
+                        .string_to_path(
+                            shock2vr::input::InputAction::TogglePauseMenu
+                                .quest_touch_click_path()
+                                .expect("Quest pause-menu binding"),
+                        )
+                        .unwrap(),
+                ),
             ],
         )
         .unwrap();
@@ -529,7 +545,8 @@ fn main() {
 
     // Controller button edges feed the same semantic action dispatcher as the
     // desktop and debug runtimes. X exposes the player-owned backpack panel;
-    // Y opens/closes and replays the player-owned audio-log reader.
+    // Y opens/closes and replays the player-owned audio-log reader; the left
+    // Menu button opens/closes the pause menu.
     // (The debug input server below can inject the same actions remotely.)
     let mut action_state = shock2vr::input::InputActionState::new();
     // Opt-in remote control for on-device automation; `None` unless
@@ -768,6 +785,7 @@ fn main() {
         let crouch_state = crouch_action.state(&session, xr::Path::NULL).unwrap();
         let inventory_state = inventory_action.state(&session, xr::Path::NULL).unwrap();
         let audio_log_state = audio_log_action.state(&session, xr::Path::NULL).unwrap();
+        let menu_state = menu_action.state(&session, xr::Path::NULL).unwrap();
         // Only edge-detect while the action is live: with the session merely
         // VISIBLE (system overlay up), current_state reads false even though
         // the button may still be physically held, and treating that as a
@@ -789,6 +807,12 @@ fn main() {
             audio_log_state.is_active,
             audio_log_state.changed_since_last_sync,
             audio_log_state.current_state,
+        );
+        action_state.sync_discrete_button(
+            shock2vr::input::InputAction::TogglePauseMenu,
+            menu_state.is_active,
+            menu_state.changed_since_last_sync,
+            menu_state.current_state,
         );
 
         let left_trigger_value = left_trigger

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -139,6 +139,17 @@ pub trait GameScene {
         false
     }
 
+    /// Whether the in-game pause menu may open over this scene.
+    ///
+    /// True for scenes that run a simulation the player would want frozen -
+    /// missions and the `debug_*` scenes. Frontend screens (main menu, load,
+    /// game over, loading, cutscenes) are already system UI with their own way
+    /// out, so pausing them is meaningless and would trap the player behind two
+    /// stacked menus; they keep the default.
+    fn is_pausable(&self) -> bool {
+        false
+    }
+
     /// Whether the player's collider is currently crouched (the *actual*
     /// physics state - stand-up can be refused for lack of headroom). Drives
     /// the crouch-aware camera height; non-mission scenes have no player.

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -85,6 +85,13 @@ pub enum InputAction {
     /// `M` key). No-op in VR. See `projects/flat-ui-panels.md` §5.
     ToggleMap,
 
+    /// Toggle the in-game pause menu. Unlike every other action here this one
+    /// is consumed by `Game` itself rather than turned into an `Effect`: the
+    /// pause overlay lives above the active scene (so missions and debug
+    /// scenes alike get it), and while paused the scene's `update` is skipped -
+    /// an effect routed through the scene could never close the menu again.
+    TogglePauseMenu,
+
     /// Open/play the newest unread audio log (the original's
     /// `play_unread_log`), or replay the newest collected log once all are read.
     /// Collecting a disc only files it in the PDA, so this is how it is read.
@@ -128,6 +135,7 @@ impl InputAction {
             InputAction::ToggleUseMode,
             InputAction::ReadLastUnreadLog,
             InputAction::ToggleMap,
+            InputAction::TogglePauseMenu,
         ]
     }
 
@@ -165,6 +173,7 @@ impl InputAction {
             InputAction::ToggleUseMode => "ToggleUseMode",
             InputAction::ReadLastUnreadLog => "ReadLastUnreadLog",
             InputAction::ToggleMap => "ToggleMap",
+            InputAction::TogglePauseMenu => "TogglePauseMenu",
         }
     }
 
@@ -175,6 +184,9 @@ impl InputAction {
         match self {
             InputAction::MoveInventory => Some("/user/hand/left/input/x/click"),
             InputAction::ReadLastUnreadLog => Some("/user/hand/left/input/y/click"),
+            // The right controller's menu button is reserved by the Quest
+            // system UI; the left one is the app's.
+            InputAction::TogglePauseMenu => Some("/user/hand/left/input/menu/click"),
             _ => None,
         }
     }
@@ -242,6 +254,10 @@ mod tests {
         assert_eq!(
             InputAction::ReadLastUnreadLog.quest_touch_click_path(),
             Some("/user/hand/left/input/y/click")
+        );
+        assert_eq!(
+            InputAction::TogglePauseMenu.quest_touch_click_path(),
+            Some("/user/hand/left/input/menu/click")
         );
     }
 

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -146,6 +146,11 @@ impl ActionDispatcher {
                 head_rotation: input_context.head.rotation,
             });
         }
+        // `InputAction::TogglePauseMenu` deliberately produces no effect: the
+        // pause overlay is owned by `Game`, which reads the action directly
+        // before dispatching. Routing it through the scene would make it
+        // undeliverable exactly when it matters, because a paused scene is
+        // not updated at all.
         effects
     }
 }
@@ -304,6 +309,17 @@ mod tests {
 
         let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
         assert!(matches!(effects[0], Effect::ToggleMap));
+    }
+
+    #[test]
+    fn toggle_pause_menu_produces_no_scene_effect() {
+        // `Game` consumes this one itself; if it ever became an effect the
+        // scene would swallow it while paused and the menu could not close.
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::TogglePauseMenu);
+
+        let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
+        assert!(effects.is_empty());
     }
 
     #[test]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -433,6 +433,10 @@ pub struct Game {
     /// gameplay scene - missions and `debug_*` alike - gets pause for free, and
     /// so the paused scene keeps rendering while its update is skipped.
     pause_menu: pause_menu::PauseMenu,
+
+    /// Wall-clock time spent with the simulation suspended, subtracted from the
+    /// clock the scene sees. See [`Game::scene_time`].
+    time_suspended: std::time::Duration,
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -1200,6 +1204,7 @@ impl Game {
             should_quit: false,
             campaign_completed: false,
             pause_menu: pause_menu::PauseMenu::new(),
+            time_suspended: std::time::Duration::ZERO,
         }
     }
 
@@ -1217,7 +1222,7 @@ impl Game {
         // Publish the simulation clock for the diagnostics ring buffers
         // (audio log / message trace), so their entries can be stamped
         // without threading `Time` through every record site.
-        audio_log::set_sim_time(time.total.as_secs_f64());
+        audio_log::set_sim_time(self.scene_time(time).total.as_secs_f64());
 
         // Drive a background transition: the loading screen animates while the parse
         // runs on its worker thread. Once the parse has finished AND the loading screen
@@ -1237,15 +1242,23 @@ impl Game {
         // scene is not updated at all, so a scene-routed effect could never
         // close the menu again.
         self.update_pause_menu(time, input_context, actions);
-        if self.pause_menu.is_open() {
+        if self.pause_menu.suspends_scene() {
             // Paused: the scene is not updated (nothing simulates, and
             // `VirtualHand` is never advanced, so hands are inert but keep
             // whatever they were holding). It is still *rendered* every frame
             // by `render`/`render_per_eye` - in VR the world must never stop
             // drawing.
+            //
+            // Nothing simulated, so nothing aged: bank this frame's wall time
+            // as suspended rather than letting it reach the scene's clock.
+            // Without this a minute spent in the menu expires every AI deadline
+            // and jumps every total-time-driven animation the moment the world
+            // comes back.
+            self.time_suspended += time.elapsed;
             actions.clear_triggered();
             return;
         }
+        let time = &self.scene_time(time);
 
         // Convert triggered actions into effects; triggered actions are
         // consumed here so injected actions (e.g. from the debug runtime)
@@ -1331,6 +1344,17 @@ impl Game {
         }
     }
 
+    /// The clock the active scene sees: wall time with every suspended frame
+    /// taken back out, so simulation time stops while the pause menu is up.
+    /// `elapsed` is untouched - a suspended frame never reaches the scene at
+    /// all, so its delta is never applied.
+    fn scene_time(&self, time: &Time) -> Time {
+        Time {
+            elapsed: time.elapsed,
+            total: time.total.saturating_sub(self.time_suspended),
+        }
+    }
+
     /// Whether the pause menu is allowed to be up right now.
     ///
     /// Frontend screens are already system UI with their own way out; a dead
@@ -1349,7 +1373,7 @@ impl Game {
         self.active_game_scene
             .world()
             .borrow::<UniqueView<PlayerLifeState>>()
-            .map(|state| state.as_str() == "alive")
+            .map(|state| state.is_alive())
             .unwrap_or(true)
     }
 
@@ -1360,6 +1384,8 @@ impl Game {
         input_context: &input_context::InputContext,
         actions: &input::InputActionState,
     ) {
+        self.pause_menu.poll_release(input_context);
+
         if !self.pause_is_allowed() {
             // Also covers a menu that was up when the scene stopped being
             // pausable (the player died, a transition started): close rather
@@ -1390,9 +1416,9 @@ impl Game {
             &self.options,
         );
         match action {
-            Some(PauseAction::Resume) => self.pause_menu.close(),
+            Some(PauseAction::Resume) => self.pause_menu.close_after_click(),
             Some(PauseAction::QuitToMainMenu) => {
-                self.pause_menu.close();
+                self.pause_menu.close_after_click();
                 self.handle_global_effect(GlobalEffect::ShowMainMenu);
             }
             None => {}
@@ -1745,16 +1771,18 @@ impl Game {
         // let text_obj_0_0 =
         //     SceneObject::screen_space_text("0, 0", font.clone(), 16.0, 0.5, 0.0, 0.0);
 
-        // While the flat pause menu is up its backdrop covers the screen, and
-        // the scene's own screen-space UI (viewmodel, HUD, MFD) must not show
-        // through it. Dropping it here rather than relying on draw order is
-        // deliberate: the renderer runs a transparent pass after the opaque
-        // one, so the HUD's translucent meters land on top of the backdrop no
-        // matter which order the objects are handed over in. The 3D world is
-        // unaffected - `render` still emits it every frame.
-        let mut objs = if self.pause_menu.is_open()
-            && self.options.presentation_mode != PresentationMode::Vr
-        {
+        // While the pause menu is up, the scene's own screen-space UI
+        // (viewmodel, HUD, MFD, and the frozen frob highlights and item labels
+        // that this path emits in VR too) must not show through it. Dropping it
+        // here rather than relying on draw order is deliberate: the renderer
+        // runs a transparent pass after the opaque one, so the HUD's
+        // translucent meters land on top of the backdrop no matter which order
+        // the objects are handed over in. It is dropped in BOTH presentations
+        // because the two VR hosts disagree about where per-eye objects land in
+        // the list (the debug runtime appends, the oculus runtime prepends), so
+        // leaving them in would depth-fight the panel on one host only. The 3D
+        // world is unaffected - `render` still emits it every frame.
+        let mut objs = if self.pause_menu.is_open() {
             Vec::new()
         } else {
             self.active_game_scene.render_per_eye(

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -24,6 +24,7 @@ mod mission;
 pub mod palette;
 pub mod pathfinding;
 pub mod paths;
+pub mod pause_menu;
 mod physics;
 pub mod player_stats;
 mod psi;
@@ -136,7 +137,9 @@ use tracing::{Level, info, span, trace, warn};
 
 use crate::{
     game_scene::GameScene,
-    mission::{GlobalContext, Mission, PlayerInfo},
+    input::InputAction,
+    mission::{GlobalContext, Mission, PlayerInfo, PlayerLifeState},
+    pause_menu::PauseAction,
     scripts::Effect,
 };
 use zip_asset_path::ZipAssetPath;
@@ -425,6 +428,11 @@ pub struct Game {
     // Set only once the retail finale chain reaches DIE-SHODAN-DIE and the
     // ending cutscene has become the active scene.
     campaign_completed: bool,
+
+    /// The in-game pause menu. It lives here rather than in a scene so every
+    /// gameplay scene - missions and `debug_*` alike - gets pause for free, and
+    /// so the paused scene keeps rendering while its update is skipped.
+    pause_menu: pause_menu::PauseMenu,
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -841,7 +849,15 @@ impl Game {
     /// runtimes use this to show the OS cursor and feed `InputContext::pointer`
     /// rather than capturing the mouse for look.
     pub fn wants_pointer(&self) -> bool {
-        self.active_game_scene.wants_pointer()
+        // The pause menu is pointer-driven in flat presentation, and it is
+        // drawn over scenes that otherwise capture the mouse for look.
+        self.pause_menu.is_open() || self.active_game_scene.wants_pointer()
+    }
+
+    /// Whether the in-game pause menu is up (and therefore the simulation is
+    /// frozen). Automation reads this to tell "paused" from "stuck".
+    pub fn is_paused(&self) -> bool {
+        self.pause_menu.is_open()
     }
 
     /// Name of the currently active scene (e.g. "medsci1.mis"), tracking
@@ -1183,6 +1199,7 @@ impl Game {
             mission_to_save_data,
             should_quit: false,
             campaign_completed: false,
+            pause_menu: pause_menu::PauseMenu::new(),
         }
     }
 
@@ -1213,6 +1230,21 @@ impl Game {
                 let pending = self.pending_transition.take().unwrap();
                 self.finish_transition(pending);
             }
+        }
+
+        // The pause menu is a Game-level overlay, so its toggle is consumed
+        // here instead of being dispatched into the scene: while paused the
+        // scene is not updated at all, so a scene-routed effect could never
+        // close the menu again.
+        self.update_pause_menu(time, input_context, actions);
+        if self.pause_menu.is_open() {
+            // Paused: the scene is not updated (nothing simulates, and
+            // `VirtualHand` is never advanced, so hands are inert but keep
+            // whatever they were holding). It is still *rendered* every frame
+            // by `render`/`render_per_eye` - in VR the world must never stop
+            // drawing.
+            actions.clear_triggered();
+            return;
         }
 
         // Convert triggered actions into effects; triggered actions are
@@ -1297,6 +1329,92 @@ impl Game {
         for effect in global_effects {
             self.handle_global_effect(effect);
         }
+    }
+
+    /// Whether the pause menu is allowed to be up right now.
+    ///
+    /// Frontend screens are already system UI with their own way out; a dead
+    /// player belongs to the game-over screen, which owns that moment; and a
+    /// level transition in flight owns the scene swap, so pausing over the
+    /// loading screen would only hide it.
+    fn pause_is_allowed(&self) -> bool {
+        self.pending_transition.is_none()
+            && self.active_game_scene.is_pausable()
+            && self.player_is_alive()
+    }
+
+    fn player_is_alive(&self) -> bool {
+        // Scenes without the life-state unique (the debug scenes) have no death
+        // to be in, so they count as alive.
+        self.active_game_scene
+            .world()
+            .borrow::<UniqueView<PlayerLifeState>>()
+            .map(|state| state.as_str() == "alive")
+            .unwrap_or(true)
+    }
+
+    /// Apply the pause toggle and, while open, drive the overlay.
+    fn update_pause_menu(
+        &mut self,
+        time: &Time,
+        input_context: &input_context::InputContext,
+        actions: &input::InputActionState,
+    ) {
+        if !self.pause_is_allowed() {
+            // Also covers a menu that was up when the scene stopped being
+            // pausable (the player died, a transition started): close rather
+            // than strand the player on a panel over a screen that has taken
+            // over. The toggle itself is left unhandled - i.e. ignored.
+            self.pause_menu.close();
+            return;
+        }
+
+        // `just_triggered` is a rising edge by construction (mappers trigger on
+        // key/button down), so holding the menu button cannot re-toggle.
+        if actions.just_triggered(InputAction::TogglePauseMenu) {
+            if self.pause_menu.is_open() {
+                self.pause_menu.close();
+            } else {
+                self.open_pause_menu();
+            }
+        }
+
+        if !self.pause_menu.is_open() {
+            return;
+        }
+
+        let action = self.pause_menu.update(
+            time.elapsed,
+            input_context,
+            &mut self.asset_cache,
+            &self.options,
+        );
+        match action {
+            Some(PauseAction::Resume) => self.pause_menu.close(),
+            Some(PauseAction::QuitToMainMenu) => {
+                self.pause_menu.close();
+                self.handle_global_effect(GlobalEffect::ShowMainMenu);
+            }
+            None => {}
+        }
+    }
+
+    fn open_pause_menu(&mut self) {
+        // Taking over the screen suspends the flat metagame (Tab/MFD) mode, so
+        // the player is not left with a cursor-driven overlay under the pause
+        // panel. Effects reach a scene through `handle_effects`, which stays
+        // callable while the scene's `update` is skipped.
+        let global_effects = self.active_game_scene.handle_effects(
+            vec![Effect::CloseUseMode],
+            &self.global_context,
+            &self.options,
+            &mut self.asset_cache,
+            &mut self.audio_context,
+        );
+        for effect in global_effects {
+            self.handle_global_effect(effect);
+        }
+        self.pause_menu.open();
     }
 
     fn save_to_file(&self, file_name: String) -> Result<(), SaveGameError> {
@@ -1591,9 +1709,19 @@ impl Game {
     }
 
     pub fn render(&mut self) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
-        let (scene, pos, rot) = self
+        let (mut scene, pos, rot) = self
             .active_game_scene
             .render(&mut self.asset_cache, &self.options);
+
+        // The pause panel hangs in front of the still-rendered world. It is
+        // anchored in the tracked play space (like the head and hands that
+        // aim at it), so it is mapped into world coordinates with the same
+        // pawn transform the runtime builds its camera from.
+        let pawn_to_world = Matrix4::from_translation(pos) * Matrix4::from(rot);
+        scene.extend(
+            self.pause_menu
+                .render(&mut self.asset_cache, &self.options, pawn_to_world),
+        );
 
         // let font = File::open(resource_path("res/fonts/mainfont.FON")).unwrap();
         // let mut font_reader = BufReader::new(font);
@@ -1617,13 +1745,34 @@ impl Game {
         // let text_obj_0_0 =
         //     SceneObject::screen_space_text("0, 0", font.clone(), 16.0, 0.5, 0.0, 0.0);
 
-        let objs = self.active_game_scene.render_per_eye(
+        // While the flat pause menu is up its backdrop covers the screen, and
+        // the scene's own screen-space UI (viewmodel, HUD, MFD) must not show
+        // through it. Dropping it here rather than relying on draw order is
+        // deliberate: the renderer runs a transparent pass after the opaque
+        // one, so the HUD's translucent meters land on top of the backdrop no
+        // matter which order the objects are handed over in. The 3D world is
+        // unaffected - `render` still emits it every frame.
+        let mut objs = if self.pause_menu.is_open()
+            && self.options.presentation_mode != PresentationMode::Vr
+        {
+            Vec::new()
+        } else {
+            self.active_game_scene.render_per_eye(
+                &mut self.asset_cache,
+                view,
+                projection,
+                screen_size,
+                &self.options,
+            )
+        };
+
+        // Drawn last so the pause panel sits over the scene's own screen-space
+        // UI (viewmodel, HUD, MFD).
+        objs.extend(self.pause_menu.render_per_eye(
             &mut self.asset_cache,
-            view,
-            projection,
             screen_size,
             &self.options,
-        );
+        ));
 
         let world_position = vec3(0.0, 1.0, 0.0);
         let screen_width = screen_size.x;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -242,7 +242,7 @@ impl PlayerLifeState {
         }
     }
 
-    fn is_alive(&self) -> bool {
+    pub fn is_alive(&self) -> bool {
         matches!(self, PlayerLifeState::Alive)
     }
 }
@@ -3969,6 +3969,21 @@ impl MissionCore {
         }
     }
 
+    /// Drop out of the flat "use" (metagame) mode: put the inventory strip
+    /// away and let go of anything on the cursor. The cursor item was never
+    /// removed from the backpack (the host only hid it from the strip), so
+    /// clearing the cursor is enough - the item is already reachable there
+    /// (projects/flat-ui.md §1.5), and a save or transition mid-drag serializes
+    /// it correctly with no orphan.
+    ///
+    /// Shared by `ToggleUseMode` and `CloseUseMode` so the two exits from use
+    /// mode cannot drift apart.
+    fn leave_use_mode(&mut self) {
+        self.flat_use_mode = false;
+        self.flat_ui.take_cursor_item();
+        self.flat_ui.set_strip(None);
+    }
+
     pub fn handle_effects(
         &mut self,
         effects: Vec<Effect>,
@@ -4107,29 +4122,19 @@ impl MissionCore {
                         // player into shooter mode with it still up.
                         if self.flat_ui.active_panel().is_some() {
                             self.flat_ui.close();
+                        } else if self.flat_use_mode {
+                            self.leave_use_mode();
                         } else {
-                            self.flat_use_mode = !self.flat_use_mode;
+                            self.flat_use_mode = true;
                             // Use mode shows the player's backpack as the
                             // top-docked inventory strip: bind the strip to the
                             // `internal_inventory` entity (whose GuiScript
                             // already emits SetUI every frame).
-                            // Leaving use mode drops any item on the cursor. It was
-                            // never removed from the backpack (the host only hid it
-                            // from the strip), so clearing the cursor is enough -
-                            // the item is already reachable there (projects/flat-ui.md
-                            // §1.5). This also means a save/transition mid-drag
-                            // serializes it correctly, with no orphan.
-                            if !self.flat_use_mode {
-                                self.flat_ui.take_cursor_item();
-                            }
-                            let strip_entity = if self.flat_use_mode {
-                                self.world
-                                    .borrow::<UniqueView<PlayerInfo>>()
-                                    .ok()
-                                    .map(|player| player.inventory_entity_id)
-                            } else {
-                                None
-                            };
+                            let strip_entity = self
+                                .world
+                                .borrow::<UniqueView<PlayerInfo>>()
+                                .ok()
+                                .map(|player| player.inventory_entity_id);
                             self.flat_ui.set_strip(strip_entity);
                         }
                     }
@@ -4144,9 +4149,7 @@ impl MissionCore {
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
                         self.flat_ui.close();
                         if self.flat_use_mode {
-                            self.flat_use_mode = false;
-                            self.flat_ui.take_cursor_item();
-                            self.flat_ui.set_strip(None);
+                            self.leave_use_mode();
                         }
                     }
                 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4135,6 +4135,22 @@ impl MissionCore {
                     }
                 }
 
+                Effect::CloseUseMode => {
+                    // Idempotent counterpart to `ToggleUseMode`, used when
+                    // something outside the mission (the pause menu) takes over
+                    // the screen: put the overlay away and drop back to shooter
+                    // mode, dropping any cursor item back into the backpack it
+                    // was never actually removed from.
+                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                        self.flat_ui.close();
+                        if self.flat_use_mode {
+                            self.flat_use_mode = false;
+                            self.flat_ui.take_cursor_item();
+                            self.flat_ui.set_strip(None);
+                        }
+                    }
+                }
+
                 Effect::OpenPanel { entity } => {
                     // Bind the presentation's single object-panel slot to the
                     // frobbed entity (the original's frob-script -> overlay
@@ -9668,6 +9684,10 @@ fn wildcard_match(text: &str, pattern: &str) -> bool {
 }
 
 impl crate::game_scene::GameScene for MissionCore {
+    fn is_pausable(&self) -> bool {
+        true
+    }
+
     fn update(
         &mut self,
         time: &Time,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -184,6 +184,10 @@ impl Mission {
 
 // Implementation of GameScene trait for Mission
 impl crate::game_scene::GameScene for Mission {
+    fn is_pausable(&self) -> bool {
+        true
+    }
+
     fn update(
         &mut self,
         time: &Time,

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -59,8 +59,10 @@ const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 
 /// Opacity for an entry the port has not implemented yet.
 const DISABLED_OPACITY: f32 = 0.3;
-/// Opacity for an implemented entry the pointer is not over.
-const IDLE_OPACITY: f32 = 0.6;
+/// Opacity for an implemented entry the pointer is not over. Kept well clear
+/// of [`HOVER_OPACITY`]: on a menu where one of the two live entries abandons
+/// the run, "which one am I about to press" has to read at a glance.
+const IDLE_OPACITY: f32 = 0.45;
 /// Opacity for the entry under the pointer.
 const HOVER_OPACITY: f32 = 1.0;
 
@@ -177,8 +179,9 @@ fn label_lines(label: &str) -> Vec<&str> {
         .collect()
 }
 
-/// The menu entry at a canvas point, if any. Shared by the click and the hover
-/// highlight so the two can never disagree about where an entry is.
+/// The menu entry at a canvas point, if any. Both the click and the hover
+/// highlight go through this, so the two can never disagree about where an
+/// entry is - or about which entries are live at all.
 fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<PauseAction> {
     let mut canvas = UiCanvas::<PauseAction>::with_events(vec2(CANVAS_W, CANVAS_H));
     for (item, rect) in MENU_ITEMS.iter().zip(rects) {
@@ -224,7 +227,11 @@ fn resolve_click(
             let (action, pressed) = resolve_click_at(point, p.pressed, last_pressed, rects);
             (action, pressed, point)
         }
-        None => (None, false, None),
+        // No pointer this frame is not a release: on desktop the cursor is
+        // captured for mouse-look until `wants_pointer` flips it on, so the
+        // frame the menu opens has no pointer at all. Clearing the guard here
+        // would re-arm the click edge under a still-held button.
+        None => (None, last_pressed, None),
     }
 }
 
@@ -249,6 +256,9 @@ pub struct PauseMenu {
     /// Screen size from the latest render, so `update` maps the flat pointer
     /// into canvas space consistently with how the canvas is drawn.
     last_screen_size: Vector2<f32>,
+    /// Set when a click closed the menu, and cleared once that click is
+    /// released. See [`PauseMenu::suspends_scene`].
+    closed_under_a_held_press: bool,
 }
 
 impl Default for PauseMenu {
@@ -268,11 +278,40 @@ impl PauseMenu {
             panel_anchor: FrontendPanelAnchor::new(),
             last_pressed: true,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
+            closed_under_a_held_press: false,
         }
     }
 
     pub fn is_open(&self) -> bool {
         self.open
+    }
+
+    /// Whether the active scene must stay frozen this frame.
+    ///
+    /// Wider than [`is_open`](Self::is_open) by one beat: the trigger that
+    /// pressed "Continue" is still down on the frame the menu closes, and
+    /// `VirtualHand` - which was never advanced while paused - would read it as
+    /// a fresh rising edge and fire the held weapon the instant the world came
+    /// back. The scene stays suspended until that press is released, which is
+    /// the same rising-edge rule the menu applies to itself on the way in.
+    pub fn suspends_scene(&self) -> bool {
+        self.open || self.closed_under_a_held_press
+    }
+
+    /// Clear the post-close latch once nothing is pressed any more.
+    pub fn poll_release(&mut self, input_context: &InputContext) {
+        if !self.closed_under_a_held_press {
+            return;
+        }
+        let hand_held = |hand: &crate::input_context::Hand| {
+            hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD
+        };
+        let pressed = hand_held(&input_context.right_hand)
+            || hand_held(&input_context.left_hand)
+            || input_context.pointer.is_some_and(|p| p.pressed);
+        if !pressed {
+            self.closed_under_a_held_press = false;
+        }
     }
 
     /// Open the menu in front of the player.
@@ -290,6 +329,13 @@ impl PauseMenu {
         self.vr_pointer_canvas = None;
         self.vr_pointer = FrontendPointerPass::default();
         self.last_pressed = true;
+    }
+
+    /// Close because an entry was clicked - the press that did it is still
+    /// held, so latch the scene shut until it is released.
+    pub fn close_after_click(&mut self) {
+        self.closed_under_a_held_press = true;
+        self.close();
     }
 
     pub fn close(&mut self) {
@@ -450,25 +496,24 @@ impl PauseMenu {
 
         // The original's opaque full-screen backdrop. In flat presentation this
         // is also the "dim the world" answer: it covers the view exactly as the
-        // original pause screen does. In VR it covers only the panel, and the
-        // world stays visible (and lit) around it - deliberately, since dimming
-        // the whole VR view would need a renderer-wide pass this skeleton does
-        // not add.
+        // original pause screen does. In VR it covers the panel only - but the
+        // panel is large and close enough to fill most of the field of view, so
+        // in practice the world reads as a border around it rather than a
+        // backdrop. Sizing the VR panel deliberately (and dimming what is left
+        // of the world behind it) is follow-up work this skeleton does not do.
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
-        let rects = menu_rects(
-            asset_cache
-                .get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE)
-                .as_deref()
-                .map(|r| r.as_slice()),
-        );
+        let rects = self.rects(asset_cache);
         let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
         let labels = menu_labels(strings.as_deref());
+        // The highlight resolves through the very same `hit` the click does, so
+        // an entry can never light up under a ray that would not activate it.
+        let hovered = pointer_canvas.and_then(|p| hit(p, &rects));
 
         for ((item, rect), label) in MENU_ITEMS.iter().zip(&rects).zip(&labels) {
             let opacity = if item.action.is_none() {
                 DISABLED_OPACITY
-            } else if pointer_canvas.is_some_and(|p| rect.contains(p)) {
+            } else if item.action == hovered {
                 HOVER_OPACITY
             } else {
                 IDLE_OPACITY
@@ -714,6 +759,77 @@ mod tests {
         assert!(!crate::scenes::MainMenuScene::new().is_pausable());
         assert!(!crate::scenes::GameOverScene::new().is_pausable());
         assert!(!crate::scenes::LoadGameScene::new().is_pausable());
+    }
+
+    /// The desktop opening frame: mouse-look still has the cursor captured, so
+    /// `InputContext::pointer` is `None`. Treating that as a release would
+    /// discard `open()`'s guard and let a still-held button click on frame 2.
+    #[test]
+    fn a_frame_without_a_pointer_is_not_a_release() {
+        let rects = menu_rects(None);
+        let (action, last, _) = resolve_click(None, true, SCREEN, &rects);
+        assert_eq!(action, None);
+        assert!(last, "a missing pointer must not clear the press guard");
+    }
+
+    /// The trigger that pressed "Continue" is still down on the frame the menu
+    /// closes; `VirtualHand` was never advanced while paused, so resuming into
+    /// it reads as a fresh rising edge and fires the held weapon.
+    #[test]
+    fn the_scene_stays_suspended_until_the_selecting_press_is_released() {
+        let mut menu = PauseMenu::new();
+        menu.open();
+        assert!(menu.suspends_scene());
+
+        menu.close_after_click();
+        assert!(!menu.is_open());
+        assert!(menu.suspends_scene(), "the click is still held");
+
+        // Still held: a trigger over the threshold keeps the world frozen.
+        let mut held = InputContext::default();
+        held.right_hand.trigger_value = 1.0;
+        menu.poll_release(&held);
+        assert!(menu.suspends_scene());
+
+        // The flat pointer counts too.
+        let clicking = InputContext {
+            pointer: Some(Pointer2D {
+                position: vec2(0.5, 0.5),
+                pressed: true,
+            }),
+            ..InputContext::default()
+        };
+        menu.poll_release(&clicking);
+        assert!(menu.suspends_scene());
+
+        menu.poll_release(&InputContext::default());
+        assert!(!menu.suspends_scene(), "released: the world may run again");
+    }
+
+    /// A toggle-close (the menu button, not a click) has nothing held to wait
+    /// for, so it must not strand the simulation.
+    #[test]
+    fn closing_with_the_toggle_resumes_immediately() {
+        let mut menu = PauseMenu::new();
+        menu.open();
+        menu.close();
+        assert!(!menu.suspends_scene());
+    }
+
+    /// The highlight must come from the same hit test as the click, so a
+    /// dimmed stub can never light up and a live entry can never fail to.
+    #[test]
+    fn only_the_entry_a_click_would_activate_is_highlighted() {
+        let rects = menu_rects(None);
+        assert_eq!(
+            hit(rects[RESUME_INDEX].center(), &rects),
+            Some(PauseAction::Resume)
+        );
+        assert_eq!(hit(rects[SAVE_INDEX].center(), &rects), None);
+        assert_eq!(
+            hit(rects[QUIT_INDEX].center(), &rects),
+            Some(PauseAction::QuitToMainMenu)
+        );
     }
 
     #[test]

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -1,0 +1,719 @@
+//! The in-game pause menu.
+//!
+//! This is the original's "sim" menu - `SIM.PCX` with the five buttons whose
+//! rects live in `SIMR.BIN` and whose labels live in `SIM.STR` - presented on
+//! the same shared [`UiCanvas`] every other frontend screen uses, so flatscreen
+//! and VR draw one canvas (see AGENTS.md §3).
+//!
+//! Unlike [`crate::scenes::MainMenuScene`] and friends it is **not** a
+//! [`GameScene`](crate::game_scene::GameScene): it is an overlay owned by
+//! [`crate::Game`] and drawn on top of whatever gameplay scene is active. That
+//! placement is the whole design:
+//!
+//! - every gameplay scene - missions *and* the `debug_*` scenes - gets pause
+//!   without implementing anything;
+//! - the paused scene keeps **rendering**, only its `update` is skipped. In VR
+//!   the world must never stop drawing (a frozen submit is a comfort and
+//!   compositor problem, see issues #1002/#1003); head tracking and the panel
+//!   stay live because the runtime keeps calling `render`/`render_per_eye`.
+//!
+//! Skipping the scene update is also what makes the "hands are inert while
+//! paused" rule free: `VirtualHand` is never advanced, so nothing is grabbed,
+//! dropped or fired, and whatever was already held is still held on resume.
+
+use std::collections::HashMap;
+
+use cgmath::{Matrix4, Vector2, vec2};
+use dark::{
+    importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
+    map::MapRect,
+};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+
+use crate::{
+    GameOptions, PresentationMode,
+    input_context::{InputContext, Pointer2D},
+    ui::{
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
+        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas, vr_frontend_pointer_pass,
+    },
+};
+
+/// The screen is authored on the original 640x480 `SIM.PCX` canvas.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+const BACKDROP_TEXTURE: &str = "SIM.PCX";
+/// Original widget layout for `SIM.PCX` - LTRB rects for the five buttons,
+/// top to bottom (`UI_LAYOUT_IMPORTER`).
+const LAYOUT_FILE: &str = "SIMR.BIN";
+/// Original label strings for this screen, keyed by [`MenuItem::string_key`].
+const LABELS_FILE: &str = "SIM.STR";
+/// The same display font the main menu uses (`res/intrface/METAFONT.FON`).
+const MENU_FONT: &str = "metafont.fon";
+/// Baseline pitch for a label that asks for more than one line: METAFONT's
+/// 20px cell plus a little leading. Splitting the 76px button rect evenly
+/// instead would push a two-line label off the top and bottom of its art.
+const MENU_LINE_HEIGHT: f32 = 22.0;
+/// The 4:3 art is letterboxed (not stretched) on non-4:3 windows.
+const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
+
+/// Opacity for an entry the port has not implemented yet.
+const DISABLED_OPACITY: f32 = 0.3;
+/// Opacity for an implemented entry the pointer is not over.
+const IDLE_OPACITY: f32 = 0.6;
+/// Opacity for the entry under the pointer.
+const HOVER_OPACITY: f32 = 1.0;
+
+// Fallback button geometry, used only when `SIMR.BIN` is missing: the decoded
+// vanilla values - a column of five 179x76 buttons at x=400 on a 92px pitch.
+const FALLBACK_BUTTON_X: f32 = 400.0;
+const FALLBACK_BUTTON_TOP: f32 = 20.0;
+const FALLBACK_BUTTON_W: f32 = 179.0;
+const FALLBACK_BUTTON_H: f32 = 76.0;
+const FALLBACK_BUTTON_PITCH: f32 = 92.0;
+
+/// What a click on the pause menu asks `Game` to do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PauseAction {
+    /// Close the menu and let the simulation run again.
+    Resume,
+    /// Abandon the run and go back to the main menu.
+    QuitToMainMenu,
+}
+
+struct MenuItem {
+    /// Key into `SIM.STR`.
+    string_key: &'static str,
+    /// Label used when `SIM.STR` is absent or missing the key. These match the
+    /// shipped English strings.
+    fallback_label: &'static str,
+    /// `None` for an entry that exists on the original screen but that the port
+    /// does not implement yet - drawn dimmed, and not clickable.
+    action: Option<PauseAction>,
+}
+
+// `SIM.PCX` (native 640x480) has a vertical stack of five buttons down the
+// right side. This list is in screen order, top to bottom, so an item's index
+// is also its rect index in `SIMR.BIN`.
+const MENU_ITEMS: &[MenuItem] = &[
+    MenuItem {
+        string_key: "continue",
+        fallback_label: "Continue",
+        action: Some(PauseAction::Resume),
+    },
+    MenuItem {
+        string_key: "save_game",
+        fallback_label: "Save Game",
+        action: None,
+    },
+    MenuItem {
+        string_key: "load_game",
+        fallback_label: "Load Game",
+        action: None,
+    },
+    MenuItem {
+        string_key: "options",
+        fallback_label: "Options",
+        action: None,
+    },
+    MenuItem {
+        string_key: "quit",
+        fallback_label: "Quit to \\nMain Menu",
+        action: Some(PauseAction::QuitToMainMenu),
+    },
+];
+
+/// Resolve each menu item's canvas rect from the `SIMR.BIN` layout (falling
+/// back to the vanilla geometry if it's absent). Parallel to [`MENU_ITEMS`].
+fn menu_rects(layout: Option<&[MapRect]>) -> Vec<Rect> {
+    MENU_ITEMS
+        .iter()
+        .enumerate()
+        .map(
+            |(index, _)| match layout.and_then(|rects| rects.get(index)) {
+                Some(r) => Rect::new(
+                    r.ul_x as f32,
+                    r.ul_y as f32,
+                    r.width() as f32,
+                    r.height() as f32,
+                ),
+                None => Rect::new(
+                    FALLBACK_BUTTON_X,
+                    FALLBACK_BUTTON_TOP + index as f32 * FALLBACK_BUTTON_PITCH,
+                    FALLBACK_BUTTON_W,
+                    FALLBACK_BUTTON_H,
+                ),
+            },
+        )
+        .collect()
+}
+
+/// Resolve each menu item's label from `SIM.STR`, falling back to the shipped
+/// English text when the string table is absent. Parallel to [`MENU_ITEMS`].
+fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
+    MENU_ITEMS
+        .iter()
+        .map(|item| {
+            strings
+                // The strings importer lowercases its keys.
+                .and_then(|s| s.get(item.string_key))
+                .filter(|label| !label.is_empty())
+                .cloned()
+                .unwrap_or_else(|| item.fallback_label.to_owned())
+        })
+        .collect()
+}
+
+/// Split a shipped label into the lines it asks for. `SIM.STR`'s quit entry is
+/// authored as `"    Quit to \nMain Menu"` - a literal backslash-n escape the
+/// string importer passes through verbatim - and the canvas has no multi-line
+/// text element, so the break is resolved here, once, in shared layout.
+fn label_lines(label: &str) -> Vec<&str> {
+    label
+        .split("\\n")
+        .flat_map(|part| part.split('\n'))
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect()
+}
+
+/// The menu entry at a canvas point, if any. Shared by the click and the hover
+/// highlight so the two can never disagree about where an entry is.
+fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<PauseAction> {
+    let mut canvas = UiCanvas::<PauseAction>::with_events(vec2(CANVAS_W, CANVAS_H));
+    for (item, rect) in MENU_ITEMS.iter().zip(rects) {
+        // Unimplemented entries get no hit region at all, so a click over one
+        // falls through as "nothing was clicked".
+        if let Some(action) = item.action {
+            canvas.button(*rect, "", action);
+        }
+    }
+    canvas.click_at(point)
+}
+
+/// Shared click core: both presentations reduce to "a point on the canvas plus
+/// a pressed flag", so the rising-edge rule and the hit regions live here once.
+fn resolve_click_at(
+    point: Option<Vector2<f32>>,
+    pressed: bool,
+    last_pressed: bool,
+    rects: &[Rect],
+) -> (Option<PauseAction>, bool) {
+    if !pressed || last_pressed {
+        return (None, pressed);
+    }
+    (point.and_then(|p| hit(p, rects)), pressed)
+}
+
+/// Pure click resolution for the flat pointer: on a rising press edge over an
+/// implemented item, return its action, plus the `last_pressed` to carry.
+fn resolve_click(
+    pointer: Option<Pointer2D>,
+    last_pressed: bool,
+    screen_size: Vector2<f32>,
+    rects: &[Rect],
+) -> (Option<PauseAction>, bool, Option<Vector2<f32>>) {
+    match pointer {
+        Some(p) => {
+            let point = pointer_to_canvas(
+                vec2(CANVAS_W, CANVAS_H),
+                p.position,
+                screen_size,
+                SCALE_MODE,
+            );
+            let (action, pressed) = resolve_click_at(point, p.pressed, last_pressed, rects);
+            (action, pressed, point)
+        }
+        None => (None, false, None),
+    }
+}
+
+/// The pause overlay. Closed by default; [`PauseMenu::open`] arms it.
+pub struct PauseMenu {
+    open: bool,
+    /// Pointer from the latest update, used for hover highlighting in render.
+    pointer: Option<Pointer2D>,
+    /// Where the VR controller ray last met the panel, in canvas pixels.
+    vr_pointer_canvas: Option<Vector2<f32>>,
+    /// The pointer pass that hit-tested this frame, kept so `render` draws the
+    /// beams and dot from the very rays `update` resolved the highlight from.
+    vr_pointer: FrontendPointerPass,
+    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
+    /// loaded glove model.
+    vr_pointer_visuals: PointerVisuals,
+    /// Where the VR panel hangs: placed from the head when the menu opens and
+    /// world-locked after that, so `render` draws it where `update` hit-tested.
+    panel_anchor: FrontendPanelAnchor,
+    /// Whether the pointer was pressed last frame (for rising-edge clicks).
+    last_pressed: bool,
+    /// Screen size from the latest render, so `update` maps the flat pointer
+    /// into canvas space consistently with how the canvas is drawn.
+    last_screen_size: Vector2<f32>,
+}
+
+impl Default for PauseMenu {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PauseMenu {
+    pub fn new() -> Self {
+        Self {
+            open: false,
+            pointer: None,
+            vr_pointer_canvas: None,
+            vr_pointer: FrontendPointerPass::default(),
+            vr_pointer_visuals: PointerVisuals::new(),
+            panel_anchor: FrontendPanelAnchor::new(),
+            last_pressed: true,
+            last_screen_size: vec2(CANVAS_W, CANVAS_H),
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Open the menu in front of the player.
+    ///
+    /// The panel anchor is reset so the menu is placed from the head pose it is
+    /// opened with rather than from wherever the player was standing the last
+    /// time they paused, and `last_pressed` starts `true` so a trigger still
+    /// held from gameplay (the shot that preceded the pause, or the very button
+    /// press that opened the menu) cannot read as a rising edge on the first
+    /// frame - the game-over screen shipped with exactly that bug.
+    pub fn open(&mut self) {
+        self.open = true;
+        self.panel_anchor = FrontendPanelAnchor::new();
+        self.pointer = None;
+        self.vr_pointer_canvas = None;
+        self.vr_pointer = FrontendPointerPass::default();
+        self.last_pressed = true;
+    }
+
+    pub fn close(&mut self) {
+        self.open = false;
+        self.pointer = None;
+        self.vr_pointer_canvas = None;
+        self.vr_pointer = FrontendPointerPass::default();
+    }
+
+    /// Advance the overlay and report the entry that was clicked, if any.
+    /// A no-op returning `None` while closed.
+    pub fn update(
+        &mut self,
+        elapsed: std::time::Duration,
+        input_context: &InputContext,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+    ) -> Option<PauseAction> {
+        if !self.open {
+            return None;
+        }
+
+        let rects = self.rects(asset_cache);
+
+        // Placed from the head when the menu opens and world-locked after
+        // that; advancing it here keeps the ray and the render agreeing on
+        // where the panel is, in either presentation.
+        let panel = self.panel_anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            elapsed,
+        );
+
+        let (action, last_pressed) = if options.presentation_mode == PresentationMode::Vr {
+            // VR has no 2D cursor: the pointer is where a controller ray meets
+            // the panel, and the trigger is the button.
+            self.vr_pointer =
+                vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
+            let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
+            self.vr_pointer_canvas = point;
+            self.pointer = None;
+            resolve_click_at(point, pressed, self.last_pressed, &rects)
+        } else {
+            self.pointer = input_context.pointer;
+            self.vr_pointer = FrontendPointerPass::default();
+            let (action, last_pressed, _) = resolve_click(
+                input_context.pointer,
+                self.last_pressed,
+                self.last_screen_size,
+                &rects,
+            );
+            (action, last_pressed)
+        };
+        self.last_pressed = last_pressed;
+        action
+    }
+
+    /// World-space presentation: the canvas on a panel in front of the player.
+    /// Empty when closed or flat.
+    ///
+    /// `pawn_to_world` maps the tracked play space - which is what
+    /// [`InputContext::head`] and the hands are expressed in, and therefore
+    /// where the panel is anchored and hit-tested - into world coordinates. It
+    /// is the camera transform the runtime builds from the pose returned
+    /// alongside the scene's objects. A frontend screen has no pawn, so it is
+    /// the identity there and the panel lands in the same place either way;
+    /// inside a mission the pawn is wherever the player is standing, and
+    /// without this the panel would hang near the world origin.
+    pub fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+        pawn_to_world: Matrix4<f32>,
+    ) -> Vec<SceneObject> {
+        if !self.open || options.presentation_mode != PresentationMode::Vr {
+            return Vec::new();
+        }
+        let panel = self.panel_anchor.panel();
+        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
+        let mut objects = canvas.render_world_space(
+            asset_cache,
+            panel.transform(),
+            self.vr_pointer_canvas,
+            None,
+            VR_COMPONENT_Z_STEP,
+        );
+        // The controllers and their aim rays, drawn from the same pass that
+        // resolved the highlight, so the beams can never promise a hover the
+        // menu will not give. The canvas objects already in hand are the layer
+        // stack the hit dot has to float clear of.
+        let panel_layers = objects.len();
+        objects.extend(self.vr_pointer_visuals.render(
+            asset_cache,
+            &self.vr_pointer,
+            vec2(CANVAS_W, CANVAS_H),
+            &panel,
+            panel_layers,
+        ));
+        // Everything above was built in the tracked play space (where the head,
+        // the hands and therefore the panel anchor live). A frontend *scene*
+        // has no pawn, so it renders that space directly; the pause menu hangs
+        // over a mission whose pawn is wherever the player is standing, so it
+        // rebases every object into world coordinates here - once, at the
+        // boundary, rather than by anchoring the panel differently.
+        for object in &mut objects {
+            object.set_transform(pawn_to_world * object.get_transform());
+        }
+        objects
+    }
+
+    /// Screen-space presentation. Empty when closed or in VR (where a
+    /// screen-space copy would paste the canvas over both eyes).
+    pub fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        screen_size: Vector2<f32>,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        self.last_screen_size = screen_size;
+        if !self.open || options.presentation_mode == PresentationMode::Vr {
+            return Vec::new();
+        }
+        let pointer_canvas = self.pointer.and_then(|p| {
+            pointer_to_canvas(
+                vec2(CANVAS_W, CANVAS_H),
+                p.position,
+                screen_size,
+                SCALE_MODE,
+            )
+        });
+        let canvas = self.build_canvas(asset_cache, pointer_canvas);
+        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+    }
+
+    fn rects(&self, asset_cache: &mut AssetCache) -> Vec<Rect> {
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        menu_rects(layout.as_deref().map(|r| r.as_slice()))
+    }
+
+    /// The menu, described once. Screen-space and world-space presentation
+    /// differ only in how this canvas is rendered, so the two can never drift
+    /// apart in layout, labels, or which entries look actionable.
+    fn build_canvas(
+        &self,
+        asset_cache: &mut AssetCache,
+        pointer_canvas: Option<Vector2<f32>>,
+    ) -> UiCanvas {
+        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+
+        // The original's opaque full-screen backdrop. In flat presentation this
+        // is also the "dim the world" answer: it covers the view exactly as the
+        // original pause screen does. In VR it covers only the panel, and the
+        // world stays visible (and lit) around it - deliberately, since dimming
+        // the whole VR view would need a renderer-wide pass this skeleton does
+        // not add.
+        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
+
+        let rects = menu_rects(
+            asset_cache
+                .get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE)
+                .as_deref()
+                .map(|r| r.as_slice()),
+        );
+        let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
+        let labels = menu_labels(strings.as_deref());
+
+        for ((item, rect), label) in MENU_ITEMS.iter().zip(&rects).zip(&labels) {
+            let opacity = if item.action.is_none() {
+                DISABLED_OPACITY
+            } else if pointer_canvas.is_some_and(|p| rect.contains(p)) {
+                HOVER_OPACITY
+            } else {
+                IDLE_OPACITY
+            };
+            // A shipped label may ask for a line break ("Quit to \nMain Menu").
+            // Stack its lines at the font's own pitch, as a block centered on
+            // the button, so a two-line entry sits inside the same art a
+            // one-line entry does.
+            let lines = label_lines(label);
+            let block_h = MENU_LINE_HEIGHT * lines.len() as f32;
+            let top = rect.y + (rect.h - block_h) * 0.5;
+            for (index, line) in lines.iter().enumerate() {
+                canvas
+                    .text_native(
+                        Rect::new(
+                            rect.x,
+                            top + index as f32 * MENU_LINE_HEIGHT,
+                            rect.w,
+                            MENU_LINE_HEIGHT,
+                        ),
+                        line,
+                        MENU_FONT,
+                        HAlign::Center,
+                        VAlign::Middle,
+                    )
+                    .opacity(opacity);
+            }
+        }
+        canvas
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The runtimes render 4:3, so PreserveAspect maps normalized coordinates
+    /// straight onto the 640x480 canvas.
+    const SCREEN: Vector2<f32> = Vector2 { x: 800.0, y: 600.0 };
+
+    const RESUME_INDEX: usize = 0;
+    const SAVE_INDEX: usize = 1;
+    const LOAD_INDEX: usize = 2;
+    const OPTIONS_INDEX: usize = 3;
+    const QUIT_INDEX: usize = 4;
+
+    fn pointer_at(rect: Rect, pressed: bool) -> Option<Pointer2D> {
+        let center = rect.center();
+        Some(Pointer2D {
+            position: vec2(center.x / CANVAS_W, center.y / CANVAS_H),
+            pressed,
+        })
+    }
+
+    #[test]
+    fn clicking_resume_and_quit_activates_them() {
+        let rects = menu_rects(None);
+        for (index, expected) in [
+            (RESUME_INDEX, PauseAction::Resume),
+            (QUIT_INDEX, PauseAction::QuitToMainMenu),
+        ] {
+            let (action, last, _) =
+                resolve_click(pointer_at(rects[index], true), false, SCREEN, &rects);
+            assert_eq!(action, Some(expected));
+            assert!(last);
+        }
+    }
+
+    #[test]
+    fn the_stubbed_entries_are_inert() {
+        let rects = menu_rects(None);
+        for index in [SAVE_INDEX, LOAD_INDEX, OPTIONS_INDEX] {
+            let (action, _, _) =
+                resolve_click(pointer_at(rects[index], true), false, SCREEN, &rects);
+            assert_eq!(action, None, "entry {index} is a dimmed stub");
+        }
+    }
+
+    #[test]
+    fn held_press_does_not_re_activate() {
+        let rects = menu_rects(None);
+        let (action, last, _) =
+            resolve_click(pointer_at(rects[RESUME_INDEX], true), true, SCREEN, &rects);
+        assert_eq!(action, None);
+        assert!(last);
+    }
+
+    #[test]
+    fn menu_rects_prefer_the_layout_file() {
+        let layout: Vec<MapRect> = (0..5)
+            .map(|i| MapRect::new(10, i * 80, 110, i * 80 + 60))
+            .collect();
+        let rects = menu_rects(Some(&layout));
+        assert_eq!(rects.len(), MENU_ITEMS.len());
+        assert_eq!(rects[RESUME_INDEX], Rect::new(10.0, 0.0, 100.0, 60.0));
+        assert_eq!(rects[QUIT_INDEX], Rect::new(10.0, 320.0, 100.0, 60.0));
+        // Without a layout: the decoded vanilla SIMR.BIN geometry.
+        assert_eq!(
+            menu_rects(None)[QUIT_INDEX],
+            Rect::new(400.0, 388.0, 179.0, 76.0)
+        );
+    }
+
+    /// The body of the shipped `res/intrface/SIM.STR`, verbatim. Kept here so a
+    /// rename of a key - ours or the data's - fails a test rather than silently
+    /// falling back to the English constants at runtime.
+    const SHIPPED_SIM_STR: &str = concat!(
+        "continue:\"Continue\"\n",
+        "quit:\"    Quit to \\nMain Menu\"\n",
+        "options:\"Options\"\n",
+        "load_game:\"Load Game\"\n",
+        "save_game:\"Save Game\"\n",
+    );
+
+    #[test]
+    fn every_item_key_resolves_against_the_shipped_string_table() {
+        let lines: Vec<String> = SHIPPED_SIM_STR.lines().map(|l| l.to_owned()).collect();
+        let strings = dark::importers::parse_strings(&lines);
+
+        for item in MENU_ITEMS {
+            assert!(
+                strings.contains_key(item.string_key),
+                "SIM.STR has no key '{}'",
+                item.string_key
+            );
+        }
+        // The table must account for all five entries, so a sixth shipped key
+        // would be a prompt to wire up another item.
+        assert_eq!(strings.len(), MENU_ITEMS.len());
+
+        let labels = menu_labels(Some(&strings));
+        assert_eq!(labels[RESUME_INDEX], "Continue");
+        assert_eq!(labels[SAVE_INDEX], "Save Game");
+        assert_eq!(labels[QUIT_INDEX], "Quit to \\nMain Menu");
+    }
+
+    #[test]
+    fn a_shipped_line_break_becomes_two_lines() {
+        // Drawn verbatim this would put a literal "\n" on the button.
+        assert_eq!(
+            label_lines("Quit to \\nMain Menu"),
+            vec!["Quit to", "Main Menu"]
+        );
+        assert_eq!(label_lines("Continue"), vec!["Continue"]);
+    }
+
+    #[test]
+    fn menu_labels_fall_back_without_a_string_table() {
+        let labels = menu_labels(None);
+        assert_eq!(
+            labels,
+            vec![
+                "Continue",
+                "Save Game",
+                "Load Game",
+                "Options",
+                "Quit to \\nMain Menu"
+            ]
+        );
+    }
+
+    fn test_panel() -> crate::ui::WorldPanel {
+        crate::ui::test_support::test_panel()
+    }
+
+    fn vr_input(hand: crate::input_context::Hand) -> InputContext {
+        InputContext {
+            right_hand: hand,
+            ..InputContext::default()
+        }
+    }
+
+    fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
+        crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
+    }
+
+    #[test]
+    fn a_vr_ray_can_press_resume_and_quit() {
+        let rects = menu_rects(None);
+        for (index, expected) in [
+            (RESUME_INDEX, PauseAction::Resume),
+            (QUIT_INDEX, PauseAction::QuitToMainMenu),
+        ] {
+            let pass = vr_frontend_pointer_pass(
+                &vr_input(hand_aimed_at(rects[index].center(), 1.0)),
+                vec2(CANVAS_W, CANVAS_H),
+                &test_panel(),
+            );
+            let (point, pressed) = (pass.point(), pass.pressed);
+            let point = point.expect("the ray should land on the panel");
+            assert!(rects[index].contains(point));
+            assert_eq!(
+                resolve_click_at(Some(point), pressed, false, &rects).0,
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn a_trigger_held_when_the_menu_opens_does_not_click() {
+        // The menu is opened straight out of gameplay - very plausibly with the
+        // trigger still down, and in VR the menu button and the trigger can be
+        // held together. Without `open()`'s `last_pressed: true` that reads as
+        // a rising edge over whatever the ray crosses, up to and including
+        // "Quit to Main Menu".
+        let rects = menu_rects(None);
+        let mut menu = PauseMenu::new();
+        menu.open();
+
+        let pass = vr_frontend_pointer_pass(
+            &vr_input(hand_aimed_at(rects[QUIT_INDEX].center(), 1.0)),
+            vec2(CANVAS_W, CANVAS_H),
+            &test_panel(),
+        );
+        let (point, pressed) = (pass.point(), pass.pressed);
+        assert!(pressed);
+        let (action, last) = resolve_click_at(point, pressed, menu.last_pressed, &rects);
+        assert_eq!(action, None, "a carried-over press must not quit the run");
+
+        // Releasing and pressing again is a real click.
+        let (_, last) = resolve_click_at(point, false, last, &rects);
+        assert_eq!(
+            resolve_click_at(point, true, last, &rects).0,
+            Some(PauseAction::QuitToMainMenu)
+        );
+    }
+
+    #[test]
+    fn a_press_held_across_frames_clicks_once() {
+        let rects = menu_rects(None);
+        let point = Some(rects[RESUME_INDEX].center());
+        let (action, last) = resolve_click_at(point, true, false, &rects);
+        assert_eq!(action, Some(PauseAction::Resume));
+        assert_eq!(resolve_click_at(point, true, last, &rects).0, None);
+    }
+
+    /// The Game-level gate: a frontend screen is already system UI, so the
+    /// pause menu must never open over one (two stacked menus, and the outer
+    /// one owns the pointer).
+    #[test]
+    fn frontend_screens_are_not_pausable() {
+        use crate::game_scene::GameScene;
+        assert!(!crate::scenes::MainMenuScene::new().is_pausable());
+        assert!(!crate::scenes::GameOverScene::new().is_pausable());
+        assert!(!crate::scenes::LoadGameScene::new().is_pausable());
+    }
+
+    #[test]
+    fn a_closed_menu_renders_and_updates_nothing() {
+        let mut menu = PauseMenu::new();
+        assert!(!menu.is_open());
+        menu.open();
+        assert!(menu.is_open());
+        menu.close();
+        assert!(!menu.is_open());
+    }
+}

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -397,6 +397,15 @@ impl PauseMenu {
         for object in &mut objects {
             object.set_transform(pawn_to_world * object.get_transform());
         }
+        // A modal panel the player cannot read is not a pause menu: world-locked
+        // two metres ahead, it lands inside a wall or a console often enough
+        // that depth-testing it against the world is not an option. The
+        // renderer treats everything from the first `clear_depth` object onward
+        // as an overlay group drawn after the world's own passes, and `Game`
+        // appends these last, so the group is exactly the panel and its rays.
+        if let Some(first) = objects.first_mut() {
+            first.set_clear_depth(true);
+        }
         objects
     }
 

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -181,6 +181,10 @@ impl DebugScene {
 }
 
 impl GameScene for DebugScene {
+    fn is_pausable(&self) -> bool {
+        true
+    }
+
     fn update(
         &mut self,
         time: &Time,
@@ -375,6 +379,10 @@ impl<H> HookedDebugScene<H> {
 }
 
 impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
+    fn is_pausable(&self) -> bool {
+        true
+    }
+
     fn update(
         &mut self,
         time: &Time,

--- a/shock2vr/src/scenes/debug_hud.rs
+++ b/shock2vr/src/scenes/debug_hud.rs
@@ -163,6 +163,10 @@ impl Default for DebugHudScene {
 }
 
 impl GameScene for DebugHudScene {
+    fn is_pausable(&self) -> bool {
+        true
+    }
+
     fn update(
         &mut self,
         time: &Time,

--- a/shock2vr/src/scenes/debug_map.rs
+++ b/shock2vr/src/scenes/debug_map.rs
@@ -140,6 +140,10 @@ impl DebugMapScene {
 }
 
 impl GameScene for DebugMapScene {
+    fn is_pausable(&self) -> bool {
+        true
+    }
+
     fn update(
         &mut self,
         time: &Time,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -161,6 +161,12 @@ pub enum Effect {
     /// See `projects/flat-ui.md`.
     ToggleUseMode,
 
+    /// Leave the flat-mode "use" (metagame) mode and dismiss any open MFD
+    /// panel, idempotently. Unlike [`Effect::ToggleUseMode`] this only ever
+    /// closes, so the pause menu can suspend the metagame without having to
+    /// know how many toggles it would take. No-op in VR.
+    CloseUseMode,
+
     /// Open the presentation's object-bound panel slot - a flat MFD or a VR
     /// world quad - emitted by `GuiScript` when its entity is frobbed. This
     /// mirrors the original engine's frob-script overlay flow

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -36,7 +36,9 @@ mod panel_anchor;
 mod pointer_visual;
 #[cfg(test)]
 pub use frontend_pointer::test_support;
-pub use frontend_pointer::{FrontendPointerPass, FrontendRay, vr_frontend_pointer_pass};
+pub use frontend_pointer::{
+    FrontendPointerPass, FrontendRay, VR_TRIGGER_THRESHOLD, vr_frontend_pointer_pass,
+};
 pub use panel_anchor::{FrontendPanelAnchor, PanelPlacement};
 pub use pointer_visual::PointerVisuals;
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -24,6 +24,7 @@ export type InputAction =
   | "Reload"
   | "CyclePsiPower"
   | "ToggleUseMode"
+  | "TogglePauseMenu"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 
@@ -466,6 +467,8 @@ export interface FrameSnapshot {
    * debug runtime stays up regardless, so this is how the quit path is
    * observed headlessly. */
   quit_requested: boolean;
+  /** True while the in-game pause menu is up (the simulation is frozen). */
+  paused: boolean;
   player: PlayerSnapshot;
   entity_count: number;
   debug_features: string[];

--- a/tools/shock2-sdk/test/pause-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/pause-menu.e2e.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// The in-game pause menu is a `Game`-level overlay, not a scene: it draws over
+// whatever gameplay scene is active and skips that scene's update while it is
+// up. These tests pin the three things that make it a pause menu rather than a
+// screen that happens to be showing:
+//
+//   1. the simulation really is frozen (and really does resume),
+//   2. it works over a debug scene as well as a mission - the whole reason it
+//      lives on `Game`,
+//   3. the edge guards: it never opens over a frontend screen or a dead
+//      player, and a press already held when it opens cannot click an entry.
+//
+// Negative-first: before the feature, (1) fails because `TogglePauseMenu` is
+// not an action at all, and against a version that skips the scene update but
+// keeps `Game::render` gated the world stops drawing - which is the VR
+// comfort/compositor bug (#1002/#1003) this design exists to avoid.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8210);
+
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+// SIMR.BIN: five 179x76 buttons at x=400, top 20, on a 92px pitch.
+const entry = (index: number): [number, number] => [
+  (400 + 179 / 2) / CANVAS_W,
+  (20 + index * 92 + 76 / 2) / CANVAS_H,
+];
+const CONTINUE = entry(0);
+const SAVE_GAME = entry(1);
+const QUIT_TO_MAIN_MENU = entry(4);
+
+/** Walk forward for `frames` and report where the player ended up. */
+async function walk(game: GameServer, frames: number): Promise<[number, number, number]> {
+  await game.input.set("right_hand.thumbstick", [0, 1]);
+  await game.step({ frames });
+  const { position } = await game.info().then((i) => ({ position: i.player.position }));
+  return position as [number, number, number];
+}
+
+/** Click a canvas point with the flat pointer, as a real rising edge. */
+async function click(game: GameServer, [u, v]: [number, number]): Promise<void> {
+  await game.input.set("pointer.position", [u, v]);
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+}
+
+test(
+  "the pause menu freezes the mission and resumes it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 30 });
+
+    assert.ok(
+      (await game.input.actions()).includes("TogglePauseMenu"),
+      "TogglePauseMenu should be in the action vocabulary",
+    );
+
+    // Walking, then paused mid-stride with the stick still held forward.
+    const walking = await walk(game, 60);
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 60 });
+
+    const paused = await game.info();
+    assert.equal(paused.paused, true, "the menu should be up");
+    assert.deepEqual(
+      paused.player.position,
+      walking,
+      "the player must not move while paused, stick held or not",
+    );
+
+    // Still frozen three seconds later - the sim is stopped, not just slow.
+    await game.step({ frames: 180 });
+    const stillPaused = await game.info();
+    assert.deepEqual(stillPaused.player.position, walking, "the sim must stay frozen");
+
+    // A dimmed stub swallows its click: still paused afterwards.
+    await click(game, SAVE_GAME);
+    assert.equal(
+      (await game.info()).paused,
+      true,
+      "Save Game is a dimmed stub and must not resume",
+    );
+
+    // "Continue" resumes, and the sim advances again.
+    await click(game, CONTINUE);
+    const resumed = await game.info();
+    assert.equal(resumed.paused, false, "Continue should resume");
+
+    await game.step({ frames: 60 });
+    const after = await game.info();
+    assert.notDeepEqual(
+      after.player.position,
+      resumed.player.position,
+      "the held stick should move the player again once resumed",
+    );
+  },
+);
+
+test(
+  "Quit to Main Menu leaves the mission, and the menu cannot be paused",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 1,
+    });
+    await game.step({ frames: 30 });
+
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).paused, true);
+
+    await click(game, QUIT_TO_MAIN_MENU);
+    await game.step({ frames: 10 });
+
+    const menu = await game.info();
+    assert.equal(menu.mission, "main_menu", "Quit should land on the main menu");
+    assert.equal(menu.paused, false, "the pause overlay closes with the mission");
+
+    // A frontend screen is already system UI: pausing it would stack two menus
+    // and hand the pointer to the wrong one.
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 20 });
+    assert.equal(
+      (await game.info()).paused,
+      false,
+      "the pause menu must not open over the main menu",
+    );
+  },
+);
+
+test(
+  "a debug scene pauses too - the point of owning this above the scene",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_minimal",
+      port: basePort + 2,
+    });
+    await game.step({ frames: 30 });
+
+    const walking = await walk(game, 60);
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 120 });
+
+    const paused = await game.info();
+    assert.equal(paused.paused, true, "debug scenes are pausable");
+    assert.deepEqual(paused.player.position, walking, "the debug scene must freeze too");
+
+    await click(game, CONTINUE);
+    await game.step({ frames: 60 });
+    const after = await game.info();
+    assert.equal(after.paused, false);
+    assert.notDeepEqual(after.player.position, walking, "and resume");
+  },
+);
+
+test(
+  "a dead player owns the moment - the pause menu stays shut",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 3,
+    });
+    await game.step({ frames: 30 });
+
+    const before = await game.info();
+    assert.ok(before.player.entity_id !== null && before.player.hit_points !== null);
+    await game.entities.sendMessage(before.player.entity_id, {
+      type: "Damage",
+      amount: before.player.hit_points + 100,
+    });
+    await game.step({ frames: 10 });
+    assert.notEqual(
+      (await game.info()).player.life_state,
+      "alive",
+      "the player should be dead or dying",
+    );
+
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 20 });
+    assert.equal(
+      (await game.info()).paused,
+      false,
+      "the death sequence and game-over screen own this moment",
+    );
+  },
+);


### PR DESCRIPTION
The in-game pause menu — the original's "sim" screen (`SIM.PCX` + `SIMR.BIN` rects + `SIM.STR` labels) — on the shared `UiCanvas`, so flatscreen and VR draw one canvas.

![pause menu demo](https://gist.githubusercontent.com/tommy-xr/7d3f556d5229ef35080ad42f66721340/raw/pause-menu.gif)

<sub>medsci1 in VR: walking, paused mid-stride (world keeps drawing, sim frozen), the aim ray sweeping the entries, then "Continue" and the world running again. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Design

**The overlay lives on `Game`, not in a scene.** That placement is the whole design:

- every gameplay scene — missions *and* the `debug_*` scenes — gets pause by opting in with one `GameScene::is_pausable`, implementing nothing else;
- the paused scene keeps **rendering** every frame and only its `update` is skipped, so in VR the world never stops drawing (rule 1 of the `vr-ui-design` skill — a frozen submit is a comfort and compositor problem) and the panel hangs over a live world;
- skipping the update is also what makes "hands are inert while paused" free: `VirtualHand` is never advanced, so nothing is grabbed, dropped or fired, and whatever was held is still held on resume.

`InputAction::TogglePauseMenu` is the trigger. Unlike every other action it deliberately dispatches to **no** `Effect` — while paused the scene is not updated at all, so a scene-routed effect could never close the menu again. `Game` consumes it directly.

The VR panel follows the frontend panel stack: `FrontendPanelAnchor` places it once from the tracked head pose and world-locks it, and hover, click and the drawn beams/hit dot all come from the single `vr_frontend_pointer_pass` (rule 5), so the picture can never promise a hover the menu won't give. The panel is anchored in the tracked play space, like the head and hands that aim at it, so `render` rebases its objects into world coordinates with the pawn transform — once, at the boundary.

| | |
|---|---|
| ![VR hover Continue](https://gist.githubusercontent.com/tommy-xr/7d3f556d5229ef35080ad42f66721340/raw/03_vr_hover_continue.png) | ![flat hover Continue](https://gist.githubusercontent.com/tommy-xr/7d3f556d5229ef35080ad42f66721340/raw/12_flat_hover_continue.png) |
| VR: ray on "Continue", hit dot on the label | Flat: pointer on "Continue" |

Flat/VR parity per AGENTS.md §3: one canvas, one layout in canvas pixels. Every label sits at the same offset inside its button art in both, including the two-line "Quit to / Main Menu" block, and the hover highlight is the same three-step opacity ramp (disabled `0.30` < idle `0.45` < hover `1.00`).

## Bindings

| Runtime | Input | Note |
|---|---|---|
| Desktop | `Esc` | Esc previously closed the window outright (a raw glfw handler). "Quit to Main Menu" + the main menu's "Quit" is now the way out, as in the original. |
| Quest | left controller **Menu** | First discrete `InputAction` bound on device, through the same `sync_discrete_button` edge path as the backpack and audio-log buttons. The right controller's Menu is reserved by the Quest system UI. |
| Debug runtime / SDK | `POST /v1/input/action` `{"action":"TogglePauseMenu"}` | `/v1/info` also gains `paused`, so automation can tell "paused" from "stuck". |

## Edge policy

Each row is a guard with a test.

| Situation | Policy | Where |
|---|---|---|
| Toggle button held down | Rides `just_triggered`, a rising edge by construction — cannot re-toggle | `dispatcher.rs` test |
| Menu opened with the trigger/mouse already down | Opens `last_pressed = true`; the next edge needs a real release first | `a_trigger_held_when_the_menu_opens_does_not_click` |
| A frame with **no** pointer at all (desktop mouse-look still captured on the opening frame) | Not a release — the guard is kept | `a_frame_without_a_pointer_is_not_a_release` |
| The click that selected an entry, still held on the closing frame | Scene stays suspended one beat longer, until it is released — otherwise `VirtualHand` reads it as a fresh edge and fires the held weapon | `the_scene_stays_suspended_until_the_selecting_press_is_released` |
| Closed with the toggle instead of a click | Nothing held to wait for — resumes immediately | `closing_with_the_toggle_resumes_immediately` |
| On a frontend scene (main menu, load, game over, loading) | Ignored — already system UI with its own way out | `frontend_screens_are_not_pausable` + e2e |
| Player dead / dying | Ignored — the death sequence and game-over screen own that moment | e2e |
| Level transition in flight | Ignored — the transition owns the scene swap | `pause_is_allowed` |
| Flat metagame (Tab) mode active | Suspended on open via `Effect::CloseUseMode`, so no cursor overlay sits under the panel | e2e + capture |
| Hands while paused | Inert but grab-preserved — the scene's `update` never runs, so `VirtualHand` never advances | by construction |
| Simulation clock | Suspended frames are banked and subtracted, so AI deadlines and total-time animations don't jump on resume | `Game::scene_time` |

## Skeleton scope / stubbed

- **Save / Load / Options are dimmed, inert stubs.** They exist on the original screen and are drawn at 0.30 opacity with no hit region at all, so a click over one falls through as "nothing was clicked" (covered by `the_stubbed_entries_are_inert`). Wiring them to the existing save/load paths is follow-up work.
- **No world dim in VR.** The flat backdrop is opaque and covers the view exactly as the original does. In VR the backdrop covers the panel only; the panel is large and close enough to fill most of the FOV, so the world reads as a border. Sizing the VR panel deliberately and dimming what's left behind it is follow-up work.
- **No frontend SFX.** The other three frontend screens drive a `FrontendSfx` (hum bed, rollover, select); this one doesn't yet — tracked with the extraction in #1015.
- **Audio is not paused or ducked** — tracked in #1016.
- **The screen shell is a fourth copy** of the main-menu/load/game-over boilerplate. Extracting a shared `FrontendMenu<A>` and porting all four screens is #1015, deliberately kept out of this PR so the pause behavior is reviewable on its own.

## Verification

- `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; `cargo apk check` (Quest).
- `cargo test -p shock2vr --lib` — **794 passed**, 19 of them pause-menu/action tests.
- New `tools/shock2-sdk/test/pause-menu.e2e.test.ts` — 4 scenarios, all green: mission freeze + resume with the stick still held, Quit → main menu (and pause refused there), a debug scene pausing, and a dead player keeping the menu shut. Full SDK e2e suite run.
- Headless captures in both presentations and in a debug scene, with the freeze proven numerically (player position bit-identical across 300 frames / 5 s with the stick held, then advancing after Resume):

| | |
|---|---|
| ![VR paused](https://gist.githubusercontent.com/tommy-xr/7d3f556d5229ef35080ad42f66721340/raw/02_vr_paused.png) | ![flat paused](https://gist.githubusercontent.com/tommy-xr/7d3f556d5229ef35080ad42f66721340/raw/11_flat_paused.png) |
| VR over medsci1 — world still drawing around the panel | Flat — HUD, viewmodel and MFD all suppressed |
| ![debug_minimal paused](https://gist.githubusercontent.com/tommy-xr/7d3f556d5229ef35080ad42f66721340/raw/08_debug_minimal_paused.png) | ![flat resumed](https://gist.githubusercontent.com/tommy-xr/7d3f556d5229ef35080ad42f66721340/raw/13_flat_resumed.png) |
| `debug_minimal` — the point of owning this above the scene | After "Continue": HUD back, no MFD, world running |

Not yet verified on a headset (rule 11: the debug runtime `--vr` is a harness, not a headset). The Quest binding and the on-device panel need a device pass before this can be called done there.
