### PR TITLE
docs: add THIRD_PARTY_LICENSES with the SteamVR glove BSD-3 notice

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,40 @@
+# Third-party licenses
+
+Notices for third-party assets and code redistributed in this repository.
+
+## SteamVR Unity Plugin — VR glove hand model
+
+`assets/vr_glove_model.glb` is converted (via FBX2glTF) from `vr_glove_model.fbx`
+in Valve's [SteamVR Unity Plugin](https://github.com/ValveSoftware/steamvr_unity_plugin),
+and the VR hand skin texture is derived from its glove color map. Redistributed
+under the BSD-3-Clause license below.
+
+```
+Copyright (c) Valve Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation andor
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```


### PR DESCRIPTION
The repo ships `assets/vr_glove_model.glb` (converted from Valve's [steamvr_unity_plugin](https://github.com/ValveSoftware/steamvr_unity_plugin) via FBX2glTF) and, as of #1019, a hand skin texture derived from its glove color map. The plugin is BSD-3-Clause; the README credits the source, but clause 2 requires reproducing the copyright notice, conditions, and disclaimer in the distribution's documentation — this adds a root `THIRD_PARTY_LICENSES.md` doing exactly that (license text fetched verbatim from the repo).

Pre-existing gap surfaced by the mandatory license check during the #1019 iteration. New third-party assets should append their notices here.