### PR TITLE
feat(vr): wield the 25AE first-person weapon models with fitted grips

### DIFF
--- a/dark/examples/mesh_audit.rs
+++ b/dark/examples/mesh_audit.rs
@@ -1,0 +1,66 @@
+//! Scratch tool: report polygon/vertex counts and open (boundary) edges for an
+//! LGMD object `.bin`. A closed solid has every edge shared by exactly two
+//! polygons; a one-sided "viewmodel" mesh leaves many edges used only once.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufReader, Cursor, Read};
+
+fn main() {
+    for path in std::env::args().skip(1) {
+        let mut buf = Vec::new();
+        BufReader::new(File::open(&path).unwrap())
+            .read_to_end(&mut buf)
+            .unwrap();
+        let mut cursor = Cursor::new(buf);
+        let header = dark::ss2_bin_header::read(&mut cursor);
+        let mesh = dark::ss2_bin_obj_loader::read(&mut cursor, &header);
+
+        // Weld positions so an edge shared across sub-objects still matches.
+        let key = |i: u16| {
+            let v = mesh.vertices[i as usize];
+            (
+                (v.x * 4096.0).round() as i64,
+                (v.y * 4096.0).round() as i64,
+                (v.z * 4096.0).round() as i64,
+            )
+        };
+
+        let mut edges: HashMap<(_, _), u32> = HashMap::new();
+        let mut tris = 0usize;
+        for poly in &mesh.polygons {
+            let n = poly.vertex_indices.len();
+            if n < 3 {
+                continue;
+            }
+            tris += n - 2;
+            for i in 0..n {
+                let a = key(poly.vertex_indices[i]);
+                let b = key(poly.vertex_indices[(i + 1) % n]);
+                let e = if a <= b { (a, b) } else { (b, a) };
+                *edges.entry(e).or_insert(0) += 1;
+            }
+        }
+        let open = edges.values().filter(|c| **c == 1).count();
+        let bb = mesh.bounding_box;
+        println!(
+            "  bbox min=({:.3},{:.3},{:.3}) max=({:.3},{:.3},{:.3})",
+            bb.min.x, bb.min.y, bb.min.z, bb.max.x, bb.max.y, bb.max.z
+        );
+        for v in &mesh.vhots {
+            println!(
+                "  vhot {:?} ({:.3},{:.3},{:.3})",
+                v.vhot_type, v.point.x, v.point.y, v.point.z
+            );
+        }
+        println!(
+            "{path}: verts={} polys={} tris={} edges={} open_edges={} ({:.1}%)",
+            mesh.vertices.len(),
+            mesh.polygons.len(),
+            tris,
+            edges.len(),
+            open,
+            100.0 * open as f32 / edges.len().max(1) as f32,
+        );
+    }
+}

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -119,8 +119,7 @@ fn process_vr_held_model(
     };
 
     let islands = ss2_bin_obj_loader::connected_islands(&obj, is_first_person_arm_material);
-    let drop: std::collections::HashSet<usize> =
-        islands.into_iter().skip(1).flatten().collect();
+    let drop: std::collections::HashSet<usize> = islands.into_iter().skip(1).flatten().collect();
 
     let obj = if drop.is_empty() {
         obj

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -100,12 +100,14 @@ pub fn is_first_person_arm_material(name: &str) -> bool {
 /// A first-person weapon model prepared for VR wielding, as its own cache
 /// bucket (see [`FirstPersonHand`] for the type_id trap).
 ///
-/// The 25AE `obj/*_h` models bake in the player's hand and forearm, plus
-/// spare hand islands their reload/fire animations pose into view (e.g. the
-/// pistol's off-hand holding a magazine). In VR the model renders in bind
-/// pose from free viewpoints, so those spare hands float disembodied beside
-/// the gun. Keep the largest arm island (the gripping hand and its sleeve)
-/// and drop the rest; non-arm geometry is untouched.
+/// The mesh renders exactly as authored, baked hand and forearm included. An
+/// earlier revision stripped every arm island but the largest to hide the
+/// spare hands some reload/fire animations pose into view - but "one arm
+/// island = one hand" is false: the pistol (`atek_h`) splits its firing hand
+/// (`ND-arm_atek.psd`) and sleeve (`ND-arm.psd`) into separate islands, so the
+/// strip kept the sleeve and deleted the gripping hand. Spare-hand stripping
+/// is deliberately dropped (a floating spare hand is the lesser evil); it can
+/// return if a reliable classifier turns up.
 pub struct VrHeldModel(pub Model);
 
 fn process_vr_held_model(
@@ -113,29 +115,7 @@ fn process_vr_held_model(
     asset_cache: &mut AssetCache,
     _config: &(),
 ) -> VrHeldModel {
-    let obj = match mesh {
-        SystemShockContentModel::Obj(obj) => obj,
-        other => return VrHeldModel(process_model(other, asset_cache, &())),
-    };
-
-    let islands = ss2_bin_obj_loader::connected_islands(&obj, is_first_person_arm_material);
-    let drop: std::collections::HashSet<usize> = islands.into_iter().skip(1).flatten().collect();
-
-    let obj = if drop.is_empty() {
-        obj
-    } else {
-        let mut filtered = obj.clone();
-        filtered.polygons = obj
-            .polygons
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| !drop.contains(index))
-            .map(|(_, polygon)| polygon.clone())
-            .collect();
-        filtered
-    };
-
-    VrHeldModel(Model::from_obj_bin(obj, asset_cache))
+    VrHeldModel(process_model(mesh, asset_cache, &()))
 }
 
 pub static VR_HELD_MODELS_IMPORTER: Lazy<AssetImporter<SystemShockContentModel, VrHeldModel, ()>> =

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -97,6 +97,51 @@ pub fn is_first_person_arm_material(name: &str) -> bool {
     name.to_ascii_lowercase().starts_with("nd-arm")
 }
 
+/// A first-person weapon model prepared for VR wielding, as its own cache
+/// bucket (see [`FirstPersonHand`] for the type_id trap).
+///
+/// The 25AE `obj/*_h` models bake in the player's hand and forearm, plus
+/// spare hand islands their reload/fire animations pose into view (e.g. the
+/// pistol's off-hand holding a magazine). In VR the model renders in bind
+/// pose from free viewpoints, so those spare hands float disembodied beside
+/// the gun. Keep the largest arm island (the gripping hand and its sleeve)
+/// and drop the rest; non-arm geometry is untouched.
+pub struct VrHeldModel(pub Model);
+
+fn process_vr_held_model(
+    mesh: SystemShockContentModel,
+    asset_cache: &mut AssetCache,
+    _config: &(),
+) -> VrHeldModel {
+    let obj = match mesh {
+        SystemShockContentModel::Obj(obj) => obj,
+        other => return VrHeldModel(process_model(other, asset_cache, &())),
+    };
+
+    let islands = ss2_bin_obj_loader::connected_islands(&obj, is_first_person_arm_material);
+    let drop: std::collections::HashSet<usize> =
+        islands.into_iter().skip(1).flatten().collect();
+
+    let obj = if drop.is_empty() {
+        obj
+    } else {
+        let mut filtered = obj.clone();
+        filtered.polygons = obj
+            .polygons
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !drop.contains(index))
+            .map(|(_, polygon)| polygon.clone())
+            .collect();
+        filtered
+    };
+
+    VrHeldModel(Model::from_obj_bin(obj, asset_cache))
+}
+
+pub static VR_HELD_MODELS_IMPORTER: Lazy<AssetImporter<SystemShockContentModel, VrHeldModel, ()>> =
+    Lazy::new(|| AssetImporter::define(load_model, process_vr_held_model));
+
 /// Newtype so this importer gets its own [`AssetCache`] bucket.
 ///
 /// The cache keys by `importer.type_id()`, which is the *type* of the importer,

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -429,6 +429,30 @@ pub fn split_connected(
     mesh: &SystemShock2ObjectMesh,
     keep: impl Fn(&str) -> bool,
 ) -> Vec<SystemShock2ObjectMesh> {
+    connected_islands(mesh, keep)
+        .into_iter()
+        .map(|polygons| {
+            let wanted = polygons.into_iter().collect::<HashSet<usize>>();
+            let mut island = mesh.clone();
+            island.polygons = mesh
+                .polygons
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| wanted.contains(index))
+                .map(|(_, polygon)| polygon.clone())
+                .collect();
+            island
+        })
+        .collect()
+}
+
+/// Polygon indices of each connected island over the polygons `keep` selects,
+/// ordered largest first (then by earliest polygon, so equal-sized islands are
+/// stable across runs).
+pub fn connected_islands(
+    mesh: &SystemShock2ObjectMesh,
+    keep: impl Fn(&str) -> bool,
+) -> Vec<Vec<usize>> {
     let kept_slots = material_slots(mesh, keep);
 
     // Union-find over vertex indices, joined along every kept polygon's edges.
@@ -485,20 +509,6 @@ pub fn split_connected(
     });
 
     islands
-        .into_iter()
-        .map(|polygons| {
-            let wanted = polygons.into_iter().collect::<HashSet<usize>>();
-            let mut island = mesh.clone();
-            island.polygons = mesh
-                .polygons
-                .iter()
-                .enumerate()
-                .filter(|(index, _)| wanted.contains(index))
-                .map(|(_, polygon)| polygon.clone())
-                .collect();
-            island
-        })
-        .collect()
 }
 
 /// Where one hand sits on a first-person weapon, in model space.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5015,22 +5015,46 @@ impl MissionCore {
                         //drop(scene_obj);
 
                         let _ext_name = model_name.clone();
+                        // A VR-wielded first-person model drops its spare
+                        // baked hand islands (see `VrHeldModel`); everything
+                        // else loads the model as authored.
+                        let vr_held = game_options.presentation_mode
+                            == crate::PresentationMode::Vr
+                            && crate::vr_config::is_vr_view_model(&model_name);
                         // A missing model must never take down the frame (or a
                         // load): keep the current model and complain loudly.
-                        let Some(orig_model) =
-                            asset_cache.get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
-                        else {
+                        let new_model = if vr_held {
+                            asset_cache
+                                .get_opt(
+                                    &dark::importers::VR_HELD_MODELS_IMPORTER,
+                                    &format!("{model_name}.BIN"),
+                                )
+                                .map(|m| Model::transform(&m.as_ref().0, xform))
+                        } else {
+                            asset_cache
+                                .get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
+                                .map(|m| Model::transform(m.as_ref(), xform))
+                        };
+                        let Some(new_model) = new_model else {
                             tracing::error!(
                                 "ChangeModel: model '{model_name}.BIN' could not be loaded for entity {entity_id:?} - keeping current model"
                             );
                             continue;
                         };
 
-                        let orig_model_ref = orig_model.as_ref();
-
-                        let new_model = Model::transform(orig_model_ref, xform);
-
                         let vhots = new_model.vhots();
+                        // An articulated model (e.g. a first-person weapon
+                        // wielded in VR: hand + arm + gun as skeleton
+                        // sub-objects) renders unposed without a player, so
+                        // give it the empty bind pose. An empty player emits
+                        // no motion flags or completion events, and it is a
+                        // no-op if the entity later swaps back to a static
+                        // model.
+                        if new_model.is_animated() {
+                            self.id_to_animation_player
+                                .entry(entity_id)
+                                .or_insert_with(AnimationPlayer::empty);
+                        }
                         self.id_to_model.insert(entity_id, new_model);
                         self.world
                             .add_component(entity_id, PropModelName(model_name));

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1716,6 +1716,19 @@ impl MissionCore {
             screen_fade_texture,
         };
         mission_core.process_virtual_hand_effects(asset_cache, held_restore_effects);
+        // Re-run each restored held item's Hold script. Only a fresh world
+        // grab dispatches Hold (see `restore_held_item_physics` for the same
+        // restore gap), so without this a save/load or level transition loses
+        // whatever Hold set up: the save carries the swapped first-person
+        // PropModelName, but the model was rebuilt through the plain importer
+        // - spare baked hands back - and the cross-mode heal never ran. The
+        // handlers are idempotent for an already-wielded item.
+        for entity_id in [left_hand_entity, right_hand_entity].into_iter().flatten() {
+            mission_core.script_world.dispatch(Message {
+                payload: MessagePayload::Hold,
+                to: entity_id,
+            });
+        }
         engine::platform::service_events();
         mission_core
     }
@@ -5018,8 +5031,23 @@ impl MissionCore {
                         // A VR-wielded first-person model drops its spare
                         // baked hand islands (see `VrHeldModel`); everything
                         // else loads the model as authored.
-                        let vr_held = game_options.presentation_mode == crate::PresentationMode::Vr
-                            && crate::vr_config::is_vr_view_model(&model_name);
+                        let is_vr = game_options.presentation_mode == crate::PresentationMode::Vr;
+                        let vr_held = is_vr && crate::vr_config::is_vr_view_model(&model_name);
+                        // Was the *outgoing* model a VR-wielded first-person
+                        // model? (Read before PropModelName is overwritten
+                        // below - identifies the drop-restore swap.)
+                        let was_vr_held = is_vr
+                            && self
+                                .world
+                                .borrow::<View<PropModelName>>()
+                                .ok()
+                                .and_then(|v_model_name| {
+                                    v_model_name
+                                        .get(entity_id)
+                                        .ok()
+                                        .map(|model| crate::vr_config::is_vr_view_model(&model.0))
+                                })
+                                .unwrap_or(false);
                         // A missing model must never take down the frame (or a
                         // load): keep the current model and complain loudly.
                         let new_model = if vr_held {
@@ -5042,17 +5070,24 @@ impl MissionCore {
                         };
 
                         let vhots = new_model.vhots();
-                        // An articulated model (e.g. a first-person weapon
-                        // wielded in VR: hand + arm + gun as skeleton
-                        // sub-objects) renders unposed without a player, so
-                        // give it the empty bind pose. An empty player emits
-                        // no motion flags or completion events, and it is a
-                        // no-op if the entity later swaps back to a static
-                        // model.
-                        if new_model.is_animated() {
+                        // An articulated VR-wielded first-person model (hand +
+                        // arm + gun as skeleton sub-objects) renders unposed
+                        // without a player, so give it the empty bind pose (it
+                        // emits no motion flags or completion events). The
+                        // player must NOT outlive the wield: the animation
+                        // loop writes every player's root velocity into
+                        // physics each frame, and an empty player's is zero -
+                        // left in place after the drop-restore to the static
+                        // world model it would pin the dropped weapon's
+                        // horizontal velocity to zero. Scoped to the VR wield
+                        // swap so every other ChangeModel (both presentations)
+                        // behaves exactly as before this path existed.
+                        if vr_held && new_model.is_animated() {
                             self.id_to_animation_player
                                 .entry(entity_id)
                                 .or_insert_with(AnimationPlayer::empty);
+                        } else if was_vr_held && !new_model.is_animated() {
+                            self.id_to_animation_player.remove(&entity_id);
                         }
                         self.id_to_model.insert(entity_id, new_model);
                         self.world

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5028,9 +5028,10 @@ impl MissionCore {
                         //drop(scene_obj);
 
                         let _ext_name = model_name.clone();
-                        // A VR-wielded first-person model drops its spare
-                        // baked hand islands (see `VrHeldModel`); everything
-                        // else loads the model as authored.
+                        // A VR-wielded first-person model loads as authored,
+                        // baked hands included (see `VrHeldModel`); the
+                        // separate importer is the seam where per-wield mesh
+                        // preparation lives.
                         let is_vr = game_options.presentation_mode == crate::PresentationMode::Vr;
                         let vr_held = is_vr && crate::vr_config::is_vr_view_model(&model_name);
                         // Was the *outgoing* model a VR-wielded first-person

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5018,8 +5018,7 @@ impl MissionCore {
                         // A VR-wielded first-person model drops its spare
                         // baked hand islands (see `VrHeldModel`); everything
                         // else loads the model as authored.
-                        let vr_held = game_options.presentation_mode
-                            == crate::PresentationMode::Vr
+                        let vr_held = game_options.presentation_mode == crate::PresentationMode::Vr
                             && crate::vr_config::is_vr_view_model(&model_name);
                         // A missing model must never take down the frame (or a
                         // load): keep the current model and complain loudly.

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -22,15 +22,30 @@ impl Script for InternalSwitchHeldModelScript {
     ) -> Effect {
         match msg {
             MessagePayload::Hold => {
-                // The swap to the first-person hand model (_h mesh) is
-                // flat-only: those meshes have their never-visible faces
-                // stripped for the fixed flat camera and look broken from
-                // VR's free viewpoints, so VR keeps the world model (#352).
                 let is_vr = world
                     .borrow::<UniqueView<GlobalPresentationMode>>()
                     .map(|mode| mode.0 == PresentationMode::Vr)
                     .unwrap_or(false);
                 if is_vr {
+                    // On a 25AE install the remastered first-person gun models
+                    // resolve (mods/sshock2ee.kpf outranks the classic
+                    // archives) and are closed meshes, so VR wields them
+                    // directly - ChangeModel also adopts their muzzle vhots.
+                    if crate::is_25th_anniversary_install() {
+                        if let Some(view_model) = get_raw_view_model(world, entity_id)
+                            .filter(|name| vr_config::is_vr_view_model(name))
+                        {
+                            return Effect::ChangeModel {
+                                entity_id,
+                                model_name: view_model,
+                            };
+                        }
+                    }
+
+                    // Otherwise keep the world model: the classic _h meshes
+                    // have their never-visible faces stripped for the fixed
+                    // flat camera and look broken from VR's free viewpoints
+                    // (#352).
                     let mut effects = Vec::new();
 
                     // Self-heal cross-mode saves: a save made in flat while
@@ -87,21 +102,23 @@ impl Script for InternalSwitchHeldModelScript {
     }
 }
 
-fn get_view_model(world: &World, entity_id: EntityId) -> Option<String> {
+/// The entity's authored first-person model name, unfiltered:
+/// `PropPlayerGun.hand_model` for guns, `PropLimbModel` for melee.
+fn get_raw_view_model(world: &World, entity_id: EntityId) -> Option<String> {
     let v_player_gun = world.borrow::<View<PropPlayerGun>>().unwrap();
     let v_melee_weapon = world.borrow::<View<PropLimbModel>>().unwrap();
 
-    let ret = {
-        if let Ok(player_gun) = v_player_gun.get(entity_id) {
-            Some(player_gun.hand_model.clone())
-        } else if let Ok(limb_model) = v_melee_weapon.get(entity_id) {
-            Some(limb_model.0.clone())
-        } else {
-            None
-        }
-    };
+    if let Ok(player_gun) = v_player_gun.get(entity_id) {
+        Some(player_gun.hand_model.clone())
+    } else if let Ok(limb_model) = v_melee_weapon.get(entity_id) {
+        Some(limb_model.0.clone())
+    } else {
+        None
+    }
+}
 
-    ret.filter(|str| vr_config::is_allowed_hand_model(str))
+fn get_view_model(world: &World, entity_id: EntityId) -> Option<String> {
+    get_raw_view_model(world, entity_id).filter(|str| vr_config::is_allowed_hand_model(str))
 }
 
 fn get_current_model(world: &World, entity_id: EntityId) -> Option<String> {

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -597,10 +597,11 @@ pub(crate) fn is_wieldable_weapon(world: &World, entity_id: EntityId) -> bool {
 /// Whether the hand visual (skin + forearm) is drawn for a hand holding
 /// `held_entity`.
 ///
-/// A wielded weapon carries its own first-person model, which is drawn at the
-/// hand's transform and *replaces* the hand - drawing both puts a hand inside
-/// the gun. Anything else - an empty hand, or a held object with no
-/// first-person weapon model - keeps the hand.
+/// A wielded weapon's model is drawn at the hand's transform and *replaces*
+/// the hand - drawing both puts a hand inside the gun. On a 25AE install VR
+/// wields the remastered first-person model (baked hand and forearm included);
+/// otherwise the weapon's world model is drawn. Anything else - an empty hand,
+/// or a held object that is not a wieldable weapon - keeps the hand.
 pub(crate) fn shows_hand_visual(world: &World, held_entity: Option<EntityId>) -> bool {
     match held_entity {
         None => true,

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -129,8 +129,20 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     }
 
     let items = vec![
-        // Weapons - first-person hand models (_h), used when wielded in flat
+        // Weapons - first-person hand models (_h). Used by flat's wield swap
+        // (FLAT_WIELD_SWAP_MODELS) and, on a 25AE install, wielded directly in
+        // VR (VR_25AE_VIEW_MODELS). The whole 25AE set is authored barrel
+        // along -X, so one -90 yaw seats every gun; offsets are hand-fitted
+        // per model to land the grip in the palm.
         ("atek_h", held_weapon.clone()),
+        ("ar15_h", held_weapon.clone()),
+        ("sg_h", held_weapon.clone()),
+        ("empgun_h", held_weapon.clone()),
+        ("gren_h", held_weapon.clone()),
+        ("sfg_h", held_weapon.clone()),
+        ("fsn_h", held_weapon.clone()),
+        ("al_h", held_weapon.clone()),
+        ("viro_h", held_weapon.clone()),
         ("amp_h", held_weapon.clone()),
         (
             "lasehand",
@@ -197,8 +209,36 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     map
 });
 
+/// First-person models the flat wield swap may apply. Frozen to the set that
+/// was allowed before the VR `_h` route grew the grip table, so flat behavior
+/// (which models donate vhots via the swap) is unchanged by VR tuning entries.
+const FLAT_WIELD_SWAP_MODELS: &[&str] = &["atek_h", "amp_h", "lasehand", "wrench_h"];
+
 pub fn is_allowed_hand_model(model_name: &str) -> bool {
-    HAND_MODEL_POSITIONING.contains_key(model_name)
+    let name = model_name.to_ascii_lowercase();
+    FLAT_WIELD_SWAP_MODELS.contains(&name.as_str())
+}
+
+/// The 25th Anniversary Edition's remastered first-person gun models
+/// (`obj/*_h.bin`, LGMD), shipped in `mods/sshock2ee.kpf` which outranks every
+/// classic archive - so on a 25AE install these names always resolve to the
+/// remastered meshes. mesh_audit measures them 0-10.5% open edges versus
+/// 19-38% for the classic `_h` set, and they are authored barrel-along -X
+/// with real muzzle vhots, so VR can wield them from any viewpoint.
+///
+/// Melee `_h` models (wrench/rapier/shard/psword) are LGMM skinned meshes that
+/// need a posed skeleton, so VR melee keeps world models for now.
+const VR_25AE_VIEW_MODELS: &[&str] = &[
+    "atek_h", "ar15_h", "sg_h", "lasehand", "empgun_h", "gren_h", "sfg_h", "fsn_h", "al_h",
+    "viro_h", "amp_h",
+];
+
+/// Whether `model_name` is a first-person view model VR should wield in place
+/// of the world model (only meaningful on a 25AE install, where the remastered
+/// copy is what resolves).
+pub fn is_vr_view_model(model_name: &str) -> bool {
+    let name = model_name.to_ascii_lowercase();
+    VR_25AE_VIEW_MODELS.contains(&name.as_str())
 }
 
 pub fn get_vr_hand_model_adjustments_from_entity(
@@ -258,4 +298,41 @@ fn get_vr_projectile_rotation_from_model(model_name: &str) -> Quaternion<f32> {
     }
 
     maybe_adjustments.unwrap().projectile_rotation
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every VR-wieldable 25AE view model must have a grip entry, or it would
+    /// anchor at the model origin with no rotation.
+    #[test]
+    fn every_vr_view_model_has_a_grip_entry() {
+        for name in VR_25AE_VIEW_MODELS {
+            assert!(
+                HAND_MODEL_POSITIONING.contains_key(name),
+                "missing HAND_MODEL_POSITIONING entry for {name}"
+            );
+        }
+    }
+
+    /// Flat's wield swap is frozen: growing the VR grip table must not change
+    /// which models flat swaps to (and thereby its vhot donors).
+    #[test]
+    fn flat_wield_swap_set_is_frozen() {
+        for name in ["atek_h", "amp_h", "lasehand", "wrench_h"] {
+            assert!(is_allowed_hand_model(name));
+        }
+        for name in ["sg_h", "ar15_h", "empgun_h", "atek_w", "battery"] {
+            assert!(!is_allowed_hand_model(name), "{name} must not swap in flat");
+        }
+    }
+
+    #[test]
+    fn vr_view_model_lookup_is_case_insensitive() {
+        assert!(is_vr_view_model("ATEK_H"));
+        assert!(is_vr_view_model("lasehand"));
+        assert!(!is_vr_view_model("wrench_h"));
+        assert!(!is_vr_view_model("atek_w"));
+    }
 }

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -136,35 +136,19 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // per model to land the grip in the palm.
         (
             "atek_h",
-            symmetric(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.0, 0.12, 0.10)),
-            ),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.10))),
         ),
         (
             "ar15_h",
-            symmetric(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.0, 0.01, 0.17)),
-            ),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.01, 0.17))),
         ),
         (
             "sg_h",
-            symmetric(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.0, 0.04, 0.28)),
-            ),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.04, 0.28))),
         ),
         (
             "empgun_h",
-            symmetric(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.0, 0.01, 0.29)),
-            ),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.01, 0.29))),
         ),
         (
             "gren_h",
@@ -192,11 +176,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ),
         (
             "al_h",
-            symmetric(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.0, 0.09, 0.0)),
-            ),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.09, 0.0))),
         ),
         (
             "viro_h",
@@ -208,20 +188,12 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ),
         (
             "amp_h",
-            symmetric(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.0, 0.0, 0.40)),
-            ),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.0, 0.40))),
         ),
         (
             "lasehand",
-            symmetric(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.0, 0.12, 0.27)),
-            )
-            .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.27)))
+                .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
         ),
         ("wrench_h", default.clone()),
         // Weapons - world models, kept when held in VR (#352): the _h meshes

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -134,21 +134,94 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // VR (VR_25AE_VIEW_MODELS). The whole 25AE set is authored barrel
         // along -X, so one -90 yaw seats every gun; offsets are hand-fitted
         // per model to land the grip in the palm.
-        ("atek_h", held_weapon.clone()),
-        ("ar15_h", held_weapon.clone()),
-        ("sg_h", held_weapon.clone()),
-        ("empgun_h", held_weapon.clone()),
-        ("gren_h", held_weapon.clone()),
-        ("sfg_h", held_weapon.clone()),
-        ("fsn_h", held_weapon.clone()),
-        ("al_h", held_weapon.clone()),
-        ("viro_h", held_weapon.clone()),
-        ("amp_h", held_weapon.clone()),
+        (
+            "atek_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.12, 0.10)),
+            ),
+        ),
+        (
+            "ar15_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.01, 0.17)),
+            ),
+        ),
+        (
+            "sg_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.04, 0.28)),
+            ),
+        ),
+        (
+            "empgun_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.01, 0.29)),
+            ),
+        ),
+        (
+            "gren_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.11, -0.56)),
+            ),
+        ),
+        (
+            "sfg_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.27, -0.21)),
+            ),
+        ),
+        (
+            "fsn_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.27, -0.63)),
+            ),
+        ),
+        (
+            "al_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.09, 0.0)),
+            ),
+        ),
+        (
+            "viro_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.22, -0.90)),
+            ),
+        ),
+        (
+            "amp_h",
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.0, 0.40)),
+            ),
+        ),
         (
             "lasehand",
-            held_weapon
-                .clone()
-                .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.12, 0.27)),
+            )
+            .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
         ),
         ("wrench_h", default.clone()),
         // Weapons - world models, kept when held in VR (#352): the _h meshes

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -3,10 +3,12 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 
-// End-to-end regression tests for held-weapon models (#352): the first-person
-// hand models (_h meshes) have their never-visible faces stripped for the
-// fixed flat camera, so in VR a held weapon keeps its world model, while flat
-// still swaps to the viewmodel for the first-person weapon path.
+// End-to-end regression tests for held-weapon models: on a 25AE install the
+// remastered first-person gun models (obj/*_h.bin in mods/sshock2ee.kpf) are
+// closed meshes, so a VR-grabbed gun swaps to its _h viewmodel; on a classic
+// install the _h meshes have their never-visible faces stripped for the fixed
+// flat camera (#352) and VR keeps the world model. These tests run against the
+// configured DARK_ASSET_PATH, which is a 25AE install.
 //
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
@@ -19,7 +21,7 @@ function modelOf(detail: { properties: { name: string; value: string }[] }): str
 }
 
 test(
-  "VR: a grabbed weapon keeps its world model",
+  "VR: a grabbed weapon wields the 25AE first-person model",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -52,7 +54,12 @@ test(
     const held = (await game.info()).player.right_hand_entity_id;
     assert.equal(held, pistol.id, "pistol should be grabbed by the right hand");
 
-    // The held pistol keeps the world model - no _h viewmodel swap in VR.
+    // The held pistol swaps to the remastered first-person model (25AE
+    // install); dropping it restores the world model.
+    assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_h");
+
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 10 });
     assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_w");
   },
 );

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, findRepoRoot } from "../src/index.js";
 
 // End-to-end regression tests for held-weapon models: on a 25AE install the
 // remastered first-person gun models (obj/*_h.bin in mods/sshock2ee.kpf) are
@@ -61,6 +63,81 @@ test(
     await game.input.set("right_hand.squeeze", 0.0);
     await game.step({ frames: 10 });
     assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_w");
+  },
+);
+
+function findSavePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((root): root is string => Boolean(root));
+  return roots
+    .map((root) => join(root, "saves", `${saveName}.sav`))
+    .find(existsSync);
+}
+
+test(
+  "VR: a load restores a held weapon wielding the first-person model",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    const saveName = `vr_held_restore_${Date.now()}`;
+    let savePath: string | undefined;
+    t.after(() => {
+      if (savePath) rmSync(savePath, { force: true });
+    });
+
+    // Build the save in a flat session, where spawnItem enters the held-items
+    // graph; a VR spawn drops the item into the world instead.
+    {
+      await using game = await GameServer.launch({
+        mission: "earth.mis",
+        port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
+      });
+      await game.step({ frames: 10 });
+
+      const pistol = await game.player.spawnItem("Pistol");
+      await game.save(saveName);
+
+      savePath = findSavePath(saveName);
+      assert.ok(savePath, `save ${saveName} should exist on disk`);
+
+      // Mark the pistol as held in the right hand (the shape a VR session
+      // writes), without simulating a motion-controller grab.
+      const save = JSON.parse(readFileSync(savePath, "utf8"));
+      const held = save.global_data.held_items;
+      const inventoryLinks =
+        held.held_entities.links[String(held.inventory_entity)];
+      inventoryLinks.to_links = inventoryLinks.to_links.filter(
+        (link: { to_entity_id: number | null }) =>
+          link.to_entity_id !== pistol.entity_id,
+      );
+      held.entity_in_right_hand = pistol.entity_id;
+      held.held_entities.properties["P$HasRefs"][String(pistol.entity_id)] =
+        true;
+      writeFileSync(savePath, JSON.stringify(save));
+    }
+
+    // The restore path re-dispatches Hold, so the restored held entity runs
+    // the VR wield swap (25AE first-person model, spare-hand strip included).
+    // Without that dispatch the restored pistol keeps its saved world model.
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8105),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+    // Keep the grip squeezed across the load: VR drops a held item the moment
+    // the squeeze reads released, and the harness's channels default to 0.
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 2 });
+    await game.load(saveName);
+    await game.step({ frames: 10 });
+
+    const heldAfterLoad = (await game.info()).player.right_hand_entity_id;
+    assert.ok(heldAfterLoad, "pistol should be held after load");
+    assert.equal(modelOf(await game.entities.detail(heldAfterLoad)), "atek_h");
   },
 );
 

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -60,6 +60,19 @@ test(
     // install); dropping it restores the world model.
     assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_h");
 
+    // The wield renders the mesh complete, exactly as authored: atek_h draws
+    // 7 scene objects (its material slots, split across sub-objects). The old
+    // spare-hand island strip deleted every `ND-arm_atek.psd` polygon - the
+    // baked *firing* hand - which showed up here as a missing draw (6) and in
+    // the headset as a handless grip. Keeping all hand islands is deliberate:
+    // the real hand outranks hiding a floating spare (PR #1023).
+    const draws = (await game.scene.objects({ entityId: pistol.id })).objects;
+    assert.equal(
+      draws.length,
+      7,
+      "wielded atek_h should draw its full authored mesh, firing hand included",
+    );
+
     await game.input.set("right_hand.squeeze", 0.0);
     await game.step({ frames: 10 });
     assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_w");


### PR DESCRIPTION
## VR wields the 25AE first-person weapon models

On a 25th Anniversary install, a VR-grabbed gun now renders its remastered first-person model (`obj/*_h.bin` from `mods/sshock2ee.kpf`) instead of the world model — grip seated in the hand, muzzle vhots adopted for firing. Classic installs are untouched: the classic `_h` meshes really are one-sided flat-camera shells (#352), so without the 25AE archives VR keeps the world-model path. Flat is unchanged in both cases.

![VR 25AE weapons](https://gist.githubusercontent.com/tommy-xr/d98468648d2ba79e057047de7d468091/raw/weapons_cycle.gif)

<sub>All eleven guns wielded in VR, cycling. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) in `debug_weapons --vr`.</sub>

### Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/d98468648d2ba79e057047de7d468091/raw/beforeafter.png)

### Every weapon, as wielded (owner request: per-weapon evidence)

![contact sheet](https://gist.githubusercontent.com/tommy-xr/d98468648d2ba79e057047de7d468091/raw/contact_sheet.png)

<sub>The small bare hand in each tile is the co-located *reference* hand (left hand parked at the same transform below the grab threshold) marking exactly where the tracked controller is — the grip should land on it. Weapons lying on the floor in some tiles are previously-cycled drops, not part of the wielded model.</sub>

### Pistol firing-hand fix (before → after)

![firing hand before/after](https://gist.githubusercontent.com/tommy-xr/d98468648d2ba79e057047de7d468091/raw/beforeafter_hand_fix.png)

<sub>Same wield, same framing: before, the island strip had deleted every `ND-arm_atek.psd` polygon — the pistol's baked firing hand — leaving a holed hand with the pale reference hand showing through; after, the mesh renders complete.</sub>

### What changed

- **Routing** (`shock2vr/src/scripts/internal_switch_held_model.rs`): on `Hold` in VR, if the install is 25AE and the gun's `hand_model` is in the verified set (`vr_config::VR_25AE_VIEW_MODELS`, 11 models), swap to it via `ChangeModel` — same as flat's wield swap; the model's own muzzle vhots come along. Otherwise the existing world-model + vhot-donor path runs. `Drop` restores the world model (already-existing `InternalPropOriginalModelName` path).
- **Grip fitting** (`shock2vr/src/vr_config.rs`): per-model offsets for all 11, hand-fit against an empty-hand reference at a fixed display pose (~720 px/world-unit calibration at the capture plane). The whole 25AE `_h` set is authored barrel-along **−X**, so one shared −90° yaw seats every gun.
- **All baked hand islands kept** (`dark/src/importers/model_importer.rs`, `VR_HELD_MODELS_IMPORTER`): the VR-held model now renders **exactly as authored, baked hands included**. An earlier revision of this PR stripped every arm-material island but the largest to hide spare reload hands — but "one arm island = one hand" is false: `atek_h` splits its **firing hand** (`ND-arm_atek.psd`, its own island) from its sleeve (`ND-arm.psd`), so the strip kept the sleeve and **deleted the pistol's gripping hand** (the defect the contact sheet showed). Spare-hand stripping is deliberately dropped per owner decision — a floating spare hand is the lesser evil vs deleting the real one; it can return later if a reliable classifier turns up and the floating hands bother anyone in practice. The cache-separated importer stays as the seam for per-wield mesh preparation.
- **Bind-pose fix** (`mission_core.rs` ChangeModel): articulated models (FP meshes are hand+arm+gun skeleton sub-objects) rendered unposed/exploded in the world pass; ChangeModel now installs an empty `AnimationPlayer` (bind pose, emits no motion flags/events) for animated models.
- **Flat frozen** (`vr_config::FLAT_WIELD_SWAP_MODELS`): flat's wield-swap filter no longer derives from the (growing) VR grip table — it stays exactly the pre-change set, covered by a unit test. Flat viewmodel render-verified unchanged (pistol + AR15 screenshots vs base).

### Mesh audit: the 25AE `_h` set is closed (classic is not)

`cargo run -p dark --example mesh_audit` over the 25AE `obj/*_h` guns (open edges = edges used by only one polygon):

| model | tris | open edges | (classic `_h` for comparison) |
|---|---|---|---|
| al_h | 880 | **0.0%** | – |
| viro_h | 1036 | **0.6%** | – |
| empgun_h | 1753 | **0.8%** | – |
| amp_h | 1343 | **1.5%** | classic 5.9% |
| atek_h | 2759 | **3.7%** | classic **19.8%** |
| lasehand | 2256 | **4.1%** | – |
| fsn_h (+H1/H2) | 2106 | **4.2–5.1%** | – |
| sg_h | 1535 | **4.3%** | classic **28.0%** |
| sfg_h | 1357 | **4.9%** | – |
| ar15_h | 2378 | **10.5%** | classic **38.3%** |
| gren_h | 957 | 22.6% (visually fine in VR) | – |

### Heading question: resolved by measurement

The prior handoff flagged an unresolved X-axis-gun heading ambiguity in the `_w` set. The `_h` route dissolves it: every 25AE `_h` model is authored barrel-along −X with a real muzzle vhot, so one rotation fits all. Decisive fire test (VR, pistol wielded, hand at world `[-1.9, 2.244, 0.0]`, barrel along hand −Z): bullet impact at `[-11.496, 2.506, 0.018]` — < 0.2° yaw deviation over 9.6 units, and the impact height exactly equals grip offset (+0.12) + muzzle vhot height (+0.139). The projectile leaves the muzzle vhot straight along the rendered barrel. Classic `_w` fallback behavior is unchanged.

### PMNM / #1022 independence

The eleven gun `_h` models are **standalone remastered LGMD meshes — no `PMNM` chunk** — so this path is independent of the high-detail gate (#1022 / PR #1024) and renders remastered on Quest as-is. The **melee** `_h` models (wrench/rapier/shard/psword/pipewrench) are LGMM skinned meshes shipped as classic geometry + appended PMNM chunk; they need a posed-skeleton render path (the PMNM gate itself landed in PR #1024, now on by default), so **VR melee keeps world models in this PR** (recorded follow-up).

### Two-handed weapons (recorded follow-up — out of scope here)

For the second-grip workstream, the `_h` models posed for a support-hand hold: **sg_h** (baked hand on the pump), **empgun_h** (baked hand on the foregrip), **ar15_h** (baked hand at the magwell). **fsn_h / sfg_h / gren_h** bake no hand at all and are natural two-handers. The idle off-hand currently renders as the ordinary bare hand next to them.

### Known gaps / notes

- Psi Sword (`-2291`) resists the harness raycast-grab in `debug_weapons` (its tile shows the empty fist); its wield path is unchanged by this PR (melee fallback).
- `sfg_h` is a bulky device whose grip handle is occluded from the capture angle; its offset places the authored carry handle at the hand.
- The `dark/examples/mesh_audit.rs` scratch tool stays — it is the evidence for the table above and for future model audits.

### Verification

- `cargo fmt --all --check`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean
- `cargo test -p shock2vr --lib`: 814 passed (3 new vr_config tests: every VR view model has a grip entry; flat swap set frozen; case-insensitive lookup)
- e2e: `vr-held-model` **updated** (was the negative test asserting VR keeps `atek_w`; now asserts the `_h` swap + drop-restore, the flat swap unchanged, and that the wielded `atek_h` draws its **full authored mesh** — 7 scene objects; 6 with the old island strip, red before the keep-all-islands fix) — plus `cross-mode-held-load`, `vr-melee-contact`, `medsci-saved-vr-melee`, all `weapon-*`, `energy-weapon-recharge`, and `missions` (23/23 load): **all green**
- Both presentations render-verified: VR per-weapon sweep above; flat pistol/AR15 viewmodel screenshots identical in framing/behavior to base

