### PR TITLE
feat(quest): enable 25AE high-detail (PMNM) meshes by default on device

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -547,6 +547,15 @@ The project supports experimental flags for gating in-progress features during d
   prop, e.g. shield membranes) are sealed in A* in every mode. Verify AI routing
   with `GET /v1/ai/paths` on the debug runtime.
 
+- **`high_detail_meshes`** / **`no_high_detail_meshes`**: force the 25AE
+  high-detail (`PMNM`) creature meshes on or off, overriding the default (on
+  everywhere since the Quest 3 measurement in #1022; ~0.3 ms extra combined eye
+  time in a 6-creature stress scene, +12 MiB PSS on medsci1). A classic install
+  is unaffected either way - those `.bin`s carry no `PMNM` chunk. `no_...` wins
+  a contradiction. The Quest runtime hardcodes its flag set, so on device the
+  default is the only reachable setting without a rebuild. Tell-tale log line:
+  `high-detail (PMNM) meshes: true|false`.
+
 #### Adding New Experimental Features
 
 1. **Gate the feature in code**:

--- a/dark/src/high_detail.rs
+++ b/dark/src/high_detail.rs
@@ -7,21 +7,25 @@
 //! which made the feature impossible to control on the platform that most needs
 //! to control it.
 //!
-//! Defaults are per-platform, because the tradeoff differs:
+//! Default: on, everywhere.
 //!
-//! - **Desktop: on.** The upgraded creature meshes are ~7x the triangles of the
-//!   originals and cost about 2x the draw calls, which desktop absorbs easily.
-//!   It is also a no-op on a classic install: those assets carry no `PMNM`
-//!   chunk at all (verified across all 1576 `.bin` files), so nothing changes
-//!   for anyone not running the remaster's data.
-//! - **Android/Quest: off.** That same 7x/2x has not been measured on device.
-//!   Turn it on explicitly once it has.
+//! - The upgraded creature meshes are ~7x the triangles of the originals and
+//!   cost about 2x the draw calls, which desktop absorbs easily. It is also a
+//!   no-op on a classic install: those assets carry no `PMNM` chunk at all
+//!   (verified across all 1576 `.bin` files), so nothing changes for anyone
+//!   not running the remaster's data.
+//! - **Quest** shipped off pending a device measurement (#1022). Measured on a
+//!   Quest 3 (release APK, 90 Hz): earth.mis and medsci1.mis hold the same
+//!   FPS/stale-frame profile as with the gate closed, with no meaningful eye
+//!   render time or memory delta, so it is now on by default on device too.
+//!   `no_high_detail_meshes` (see `Game::resolve_high_detail_meshes`) remains
+//!   the opt-out.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// See the module docs for why these differ.
+/// See the module docs for the measurements behind this.
 const fn platform_default() -> bool {
-    !cfg!(target_os = "android")
+    true
 }
 
 static ENABLED: AtomicBool = AtomicBool::new(platform_default());

--- a/dark/src/high_detail.rs
+++ b/dark/src/high_detail.rs
@@ -16,23 +16,23 @@
 //!   not running the remaster's data.
 //! - **Quest** shipped off pending a device measurement (#1022). Measured on a
 //!   Quest 3 (release APK, 90 Hz): earth.mis and medsci1.mis hold the same
-//!   FPS/stale-frame profile as with the gate closed, with no meaningful eye
-//!   render time or memory delta, so it is now on by default on device too.
-//!   `no_high_detail_meshes` (see `Game::resolve_high_detail_meshes`) remains
-//!   the opt-out.
+//!   FPS/stale-frame profile as with the gate closed (~0.3 ms extra combined
+//!   eye time in a 6-creature stress scene, +12 MiB PSS on medsci1), so it is
+//!   now on by default on device too. `no_high_detail_meshes` (see
+//!   `Game::resolve_high_detail_meshes`) forces it off on runtimes that pass
+//!   experimental flags (desktop/debug); the Quest runtime hardcodes its flag
+//!   set, so disabling there is a rebuild.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// See the module docs for the measurements behind this.
-const fn platform_default() -> bool {
-    true
-}
+const DEFAULT_ENABLED: bool = true;
 
-static ENABLED: AtomicBool = AtomicBool::new(platform_default());
+static ENABLED: AtomicBool = AtomicBool::new(DEFAULT_ENABLED);
 
-/// The default for this platform, before any explicit override.
+/// The default, before any explicit override.
 pub fn default_enabled() -> bool {
-    platform_default()
+    DEFAULT_ENABLED
 }
 
 /// Set once at startup, before any model is loaded.

--- a/dark/src/ss2_bin_ai_loader.rs
+++ b/dark/src/ss2_bin_ai_loader.rs
@@ -746,8 +746,9 @@ mod tests {
 /// Build scene objects from an appended `PMNM` high-detail chunk, in its authored
 /// rest pose.
 ///
-/// Opt-in via `SS2_PMNM_MESHES=1`. The vertices are skinned to the same skeleton
-/// the original mesh uses, so these animate normally; the caller supplies the
+/// Gated on [`crate::high_detail::enabled`] (on by default). The vertices are
+/// skinned to the same skeleton the original mesh uses, so these animate
+/// normally; the caller supplies the
 /// bind-pose undo via [`pmnm_bind_matrices`].
 pub fn pmnm_to_scene_objects(
     mesh: &crate::ss2_bin_pmnm::PmnmMesh,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1911,11 +1911,7 @@ mod tests {
     /// On by default on every platform since the Quest measurement (#1022).
     #[test]
     fn defaults_to_enabled_when_unspecified() {
-        assert!(dark::high_detail::default_enabled());
-        assert_eq!(
-            Game::resolve_high_detail_meshes(&features(&[])),
-            dark::high_detail::default_enabled()
-        );
+        assert!(Game::resolve_high_detail_meshes(&features(&[])));
     }
 
     #[test]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -961,10 +961,10 @@ impl Game {
     /// Resolve the high-detail (`PMNM`) mesh setting from the experimental flags,
     /// falling back to the platform default.
     ///
-    /// Two explicit flags rather than one, because the default differs per
-    /// platform: `high_detail_meshes` forces it on (for measuring on Quest, where
-    /// it is off by default), `no_high_detail_meshes` forces it off (to rule it
-    /// out on desktop, where it is on).
+    /// Two explicit flags rather than one so either direction can be forced
+    /// regardless of the default: `high_detail_meshes` forces it on,
+    /// `no_high_detail_meshes` forces it off (the A/B lever that proved #1022
+    /// on desktop and measured it on Quest).
     fn resolve_high_detail_meshes(features: &HashSet<String>) -> bool {
         if features.contains("no_high_detail_meshes") {
             false
@@ -980,7 +980,10 @@ impl Game {
         // Must happen before any model is loaded.
         let high_detail = Self::resolve_high_detail_meshes(&options.experimental_features);
         dark::high_detail::set_enabled(high_detail);
-        info!("high-detail (PMNM) meshes: {high_detail}");
+        // `println!` for the same reason as the install summary below: no
+        // tracing subscriber runs on desktop or Quest, and this line is the
+        // on-device tell-tale that the PMNM gate is open (#1022).
+        println!("high-detail (PMNM) meshes: {high_detail}");
 
         // What data is actually here, decided once and reported before anything
         // mounts it. `println!` rather than `info!`: neither `desktop_runtime`
@@ -1905,8 +1908,10 @@ mod tests {
         list.iter().map(|s| s.to_string()).collect()
     }
 
+    /// On by default on every platform since the Quest measurement (#1022).
     #[test]
-    fn defaults_to_the_platform_default_when_unspecified() {
+    fn defaults_to_enabled_when_unspecified() {
+        assert!(dark::high_detail::default_enabled());
         assert_eq!(
             Game::resolve_high_detail_meshes(&features(&[])),
             dark::high_detail::default_enabled()


### PR DESCRIPTION
Fixes #1022.

## What

The 25AE remastered creature meshes ship as a `PMNM` chunk appended to the classic `.bin`; parsing it was gated off on Android pending a device performance measurement, so the Quest opened the correct remastered files but built only the embedded classic mesh — old mesh *and* old texture (the #1022 symptom). This PR:

- flips `dark::high_detail::platform_default()` to **on everywhere** (desktop was already on; a classic install is unaffected — those `.bin`s carry no `PMNM` chunk),
- makes the gate tell-tale a `println!` so it reaches Quest logcat (no tracing subscriber runs on device or desktop — same rationale as the install-summary line below it),
- keeps `no_high_detail_meshes` as the opt-out on any runtime that can pass experimental flags.

## Quest 3 measurement (release APK, 90 Hz, eye 1680x1760)

Measured with the `oculus-profiling` benchmark, 30 s samples after 10 s warmup, same device/power/refresh across runs:

| Mission | Metric | Gate closed (main) | Gate open (this PR) |
| --- | --- | ---: | ---: |
| earth.mis | FPS mean/min | 90.4 / 90 | 90.5 / 90 |
| earth.mis | stale / torn | 25 / 0 | 17 / 0 |
| earth.mis | VrApi App | 2.63 ms | 2.77 ms |
| earth.mis | PSS | 490.9 MiB | 491.9 MiB |
| medsci1.mis | FPS mean/min | 90.5 / 88 | 90.6 / 87 |
| medsci1.mis | stale / torn | 21 / 1 | 32 / 0 |
| medsci1.mis | VrApi App | 1.87 ms | 1.83 ms |
| medsci1.mis | PSS | 608.1 MiB | 620.1 MiB |

Worst-case creature-dense probe (debug_protocol_droid + 6 spawned og-pipe hybrids alive and animating, `SHOCK2QUEST_PERF` one-second windows): both builds hold 90 fps; combined eye time peaks 0.36+0.20 ms (closed) vs 0.55+0.37 ms (open) — the PMNM cost is ~0.3 ms of an 11.1 ms budget. Memory cost shows up as +12 MiB PSS on medsci1 (creature-heavy deck); frame budget is unaffected.

Device tell-tale after this PR (logcat, previously dropped because it was `info!`):

```
high-detail (PMNM) meshes: true
```

## Verification

- Device A/B captures below: same scene (`debug_protocol_droid`), same install, baseline APK vs this PR's APK.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt --check`, `cargo test -p shock2vr --lib` — green.
- SDK missions e2e (all 23 missions, desktop, 25AE data): green.
- Desktop behavior is unchanged (the default was already on; `no_high_detail_meshes` still forces it off and still wins a contradiction — unit-tested).

## Device evidence (Quest 3, release APK)

![remastered protocol droid on device](https://gist.githubusercontent.com/tommy-xr/e093642f6d64695cb6d24cee8be7b351/raw/enabled-droid.gif)

<sub>This PR's build on device: the remastered droid walking in (`debug_protocol_droid`, captured unattended via the vr-device-loop tooling).</sub>

### Before / after

![before/after](https://gist.githubusercontent.com/tommy-xr/e093642f6d64695cb6d24cee8be7b351/raw/beforeafter.png)

<sub>Same scene, same device, same install. Left: main (gate closed) renders the classic low-poly droid with the legacy `Proto03.gif` texture. Right: this PR renders the 25AE PMNM mesh with its remastered texture.</sub>

## Review

`/xreview` (Claude + Codex, both image-verified the captures): no Critical/High. All agreed findings addressed in the follow-up commit — measured deltas stated in the docs, dead `platform_default()` indirection collapsed, honest opt-out wording (Quest's flag set is hardcoded, so on device the default is the only reachable setting without a rebuild), stale `SS2_PMNM_MESHES` doc fixed, tautological test replaced. Codex's suggestion to drop the now-inert `high_detail_meshes` opt-in was declined: it is the symmetric force-on lever and costs two lines.
