### PR TITLE
feat(vr): show narration subtitles in both presentations, head-anchored toast in VR

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1777,7 +1777,11 @@ impl Game {
                     .cues(&sample)
                     .or_else(|| self.subtitle_db.cues(&audio_schema));
                 if let Some(cues) = cues {
-                    self.subtitle_overlay.post(&sample, cues.to_vec());
+                    // Keyed by the *schema* name: `resolve_schema` is a random
+                    // draw for multi-sample schemas, so keying on the sample
+                    // would defeat the repeat-while-playing guard when a trap
+                    // re-fires. (Every loaded track today is a 1:1 schema.)
+                    self.subtitle_overlay.post(&audio_schema, cues.to_vec());
                 }
             }
         }
@@ -1788,6 +1792,10 @@ impl Game {
     /// scene swap goes through here so that hook cannot be forgotten.
     fn set_active_scene(&mut self, scene: Box<dyn GameScene>) {
         self.active_game_scene.on_exit(&mut self.audio_context);
+        // A narration's remaining cues belong to the outgoing scene - they
+        // must not keep drawing over the menu, the loading screen, or the
+        // next level.
+        self.subtitle_overlay.clear();
         self.active_game_scene = scene;
     }
 
@@ -1850,9 +1858,9 @@ impl Game {
         // aim at it), so it is mapped into world coordinates with the same
         // pawn transform the runtime builds its camera from.
         let pawn_to_world = Matrix4::from_translation(pos) * Matrix4::from(rot);
-        // The VR subtitle toast, before the pause panel: while the menu is up
-        // the frozen toast stays a world object behind the menu's dim rather
-        // than fighting the panel.
+        // The VR subtitle toast. Suppressed entirely while the pause menu is
+        // up (its clock is frozen anyway): both draw in the renderer's
+        // clear-depth overlay group, and the menu owns that space.
         if !self.pause_menu.is_open() {
             scene.extend(self.subtitle_overlay.render(
                 &mut self.asset_cache,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -33,6 +33,8 @@ pub mod quest_info;
 pub mod research;
 mod runtime_props;
 mod scripts;
+mod subtitle_overlay;
+mod subtitles;
 mod systems;
 #[cfg(test)]
 mod test_support;
@@ -288,6 +290,21 @@ fn build_25th_anniversary_mounts(
         mounts.extend(anniversary_family_mounts(family));
     }
 
+    // Narration subtitles: the KEX cue files (`vbriefs.sub` etc.) and the
+    // localization table their `$` tokens resolve through. Prefixed mounts, so
+    // only those files are exposed - nothing else in `base.kpf` (the KEX
+    // runtime archive) leaks into asset resolution. Classic installs have
+    // neither archive and simply mount nothing (see `subtitles`).
+    for (archive, prefix) in [
+        ("sshock2-subtitles.kpf", "data/res/subtitles/english/"),
+        ("base.kpf", "localization/"),
+    ] {
+        let path = resource_path(archive);
+        if Path::new(&path).exists() {
+            mounts.push(ZipAssetPath::with_prefix(path, prefix));
+        }
+    }
+
     // The gamesys, missions and motiondb - shared with the CLI tools, which
     // need those files without any of the resource families above.
     mounts.extend(data_files::data_file_mounts(paths::data_root()));
@@ -295,6 +312,39 @@ fn build_25th_anniversary_mounts(
     mounts.push(BundleAssetPath::new("".to_owned(), bundle_storage));
     mounts.push(AssetPath::folder("".to_owned()));
     mounts
+}
+
+/// Load the narration subtitle database out of the mounted data.
+///
+/// The cue files and the localization table are mounted only from a 25AE
+/// install's archives (see `build_25th_anniversary_mounts`); a classic install
+/// resolves neither and gets an empty database - faithful to 1999, where these
+/// narrations were audio-only. `vbriefs.sub` carries the earth/station
+/// training and briefing narrations, `vtriggers.sub` the in-mission
+/// Polito/SHODAN voice triggers; both play through `TrapSound`.
+fn load_subtitle_db(asset_cache: &AssetCache) -> subtitles::SubtitleDb {
+    use std::io::Read;
+    let read_text = |name: &str| -> Option<String> {
+        let reader = asset_cache.get_raw_reader(name)?;
+        let mut text = String::new();
+        reader.borrow_mut().read_to_string(&mut text).ok()?;
+        Some(text)
+    };
+    let mut db = subtitles::SubtitleDb::default();
+    let Some(loc_source) = read_text("loc_english.txt") else {
+        return db;
+    };
+    let loc = subtitles::Localization::parse(&loc_source);
+    for sub_file in ["vbriefs.sub", "vtriggers.sub"] {
+        if let Some(source) = read_text(sub_file) {
+            db.add_sub_source(&source, &loc);
+        }
+    }
+    // `println!` like the install summary above: this is the tell-tale for
+    // "why are there no subtitles" and no tracing subscriber runs on the
+    // desktop or Quest.
+    println!("narration subtitles: {} cue tracks", db.len());
+    db
 }
 
 /// Whether a mission file is available to load, in whichever layout is in use.
@@ -438,6 +488,15 @@ pub struct Game {
     /// Wall-clock time spent with the simulation suspended, subtracted from the
     /// clock the scene sees. See [`Game::scene_time`].
     time_suspended: std::time::Duration,
+
+    /// Narration transcripts by sample name (25AE data; empty on classic
+    /// installs). Consulted by `GlobalEffect::ShowSubtitle`.
+    subtitle_db: subtitles::SubtitleDb,
+
+    /// The on-screen text for a playing narration: screen-space lines when
+    /// flat, a head-anchored world panel in VR. Game-level like the pause
+    /// menu, so it rides over any gameplay scene.
+    subtitle_overlay: subtitle_overlay::SubtitleOverlay,
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -1096,6 +1155,10 @@ impl Game {
 
         let _strings = asset_cache.get(&STRINGS_IMPORTER, "objname.str");
 
+        // Narration transcripts, when this install ships them (25AE). Loaded
+        // once - the database is tiny (a few hundred cue tracks).
+        let subtitle_db = load_subtitle_db(&asset_cache);
+
         // vhot logging:
         // let atek_file = File::open(resource_path("res/obj/ar15_w.bin")).unwrap();
         // let mut atek_reader = BufReader::new(atek_file);
@@ -1209,6 +1272,8 @@ impl Game {
             campaign_completed: false,
             pause_menu: pause_menu::PauseMenu::new(),
             time_suspended: std::time::Duration::ZERO,
+            subtitle_db,
+            subtitle_overlay: subtitle_overlay::SubtitleOverlay::new(),
         }
     }
 
@@ -1263,6 +1328,11 @@ impl Game {
             return;
         }
         let time = &self.scene_time(time);
+
+        // The subtitle overlay runs on the scene clock (the suspend path above
+        // returned already), so its lines freeze with the world while paused
+        // instead of expiring under the menu.
+        self.subtitle_overlay.update(time.elapsed, input_context);
 
         // Convert triggered actions into effects; triggered actions are
         // consumed here so injected actions (e.g. from the debug runtime)
@@ -1697,6 +1767,19 @@ impl Game {
             GlobalEffect::Quit => {
                 self.should_quit = true;
             }
+            GlobalEffect::ShowSubtitle { audio_schema } => {
+                // Resolve the schema to a sample exactly the way the sound
+                // system will, then try the transcript under either name (a
+                // plain sample name is its own schema miss).
+                let sample = self.resolve_schema(&audio_schema);
+                let cues = self
+                    .subtitle_db
+                    .cues(&sample)
+                    .or_else(|| self.subtitle_db.cues(&audio_schema));
+                if let Some(cues) = cues {
+                    self.subtitle_overlay.post(&sample, cues.to_vec());
+                }
+            }
         }
     }
 
@@ -1767,6 +1850,16 @@ impl Game {
         // aim at it), so it is mapped into world coordinates with the same
         // pawn transform the runtime builds its camera from.
         let pawn_to_world = Matrix4::from_translation(pos) * Matrix4::from(rot);
+        // The VR subtitle toast, before the pause panel: while the menu is up
+        // the frozen toast stays a world object behind the menu's dim rather
+        // than fighting the panel.
+        if !self.pause_menu.is_open() {
+            scene.extend(self.subtitle_overlay.render(
+                &mut self.asset_cache,
+                &self.options,
+                pawn_to_world,
+            ));
+        }
         scene.extend(
             self.pause_menu
                 .render(&mut self.asset_cache, &self.options, pawn_to_world),
@@ -1816,6 +1909,17 @@ impl Game {
                 &self.options,
             )
         };
+
+        // The flat subtitle lines ride over the scene's own screen-space UI,
+        // and are dropped with it while the pause menu is up (the guard above
+        // already emptied `objs` in that case; keep the toast consistent).
+        if !self.pause_menu.is_open() {
+            objs.extend(self.subtitle_overlay.render_per_eye(
+                &mut self.asset_cache,
+                screen_size,
+                &self.options,
+            ));
+        }
 
         // Drawn last so the pause panel sits over the scene's own screen-space
         // UI (viewmodel, HUD, MFD).

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -331,13 +331,24 @@ fn load_subtitle_db(asset_cache: &AssetCache) -> subtitles::SubtitleDb {
         Some(text)
     };
     let mut db = subtitles::SubtitleDb::default();
-    let Some(loc_source) = read_text("loc_english.txt") else {
-        return db;
-    };
-    let loc = subtitles::Localization::parse(&loc_source);
-    for sub_file in ["vbriefs.sub", "vtriggers.sub"] {
-        if let Some(source) = read_text(sub_file) {
-            db.add_sub_source(&source, &loc);
+    match read_text("loc_english.txt") {
+        Some(loc_source) => {
+            let loc = subtitles::Localization::parse(&loc_source);
+            for sub_file in ["vbriefs.sub", "vtriggers.sub"] {
+                if let Some(source) = read_text(sub_file) {
+                    db.add_sub_source(&source, &loc);
+                }
+            }
+        }
+        None => {
+            // Expected on a classic install; on a 25AE install with the cue
+            // files present it means base.kpf is missing/unreadable - say so
+            // rather than silently dropping every subtitle.
+            if read_text("vbriefs.sub").is_some() {
+                println!(
+                    "narration subtitles: cue files found but localization/loc_english.txt is missing - subtitles disabled"
+                );
+            }
         }
     }
     // `println!` like the install summary above: this is the tell-tale for
@@ -1783,6 +1794,9 @@ impl Game {
                     // re-fires. (Every loaded track today is a 1:1 schema.)
                     self.subtitle_overlay.post(&audio_schema, cues.to_vec());
                 }
+            }
+            GlobalEffect::HideSubtitle { audio_schema } => {
+                self.subtitle_overlay.clear_sample(&audio_schema);
             }
         }
     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -75,6 +75,12 @@ pub enum GlobalEffect {
         audio_schema: String,
     },
 
+    /// Take a narration's subtitle down early because its sound was stopped
+    /// (TrapSound TurnOff). A no-op when that schema's text is not showing.
+    HideSubtitle {
+        audio_schema: String,
+    },
+
     // Quit the game (e.g. from the main menu). The runtime is responsible for
     // observing this via `Game::should_quit` and closing its window.
     Quit,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -66,6 +66,15 @@ pub enum GlobalEffect {
     /// Play the retail ending and enter the campaign's terminal state.
     CompleteCampaign,
 
+    /// Show the subtitle text for a narration voice-over, when the install's
+    /// subtitle database has one (25AE data ships transcripts for the trg/
+    /// brief narrations; classic data has none and this is a no-op). The name
+    /// is the audio *schema* the script asked to play - `Game` resolves it to
+    /// a sample the same way the sound system does and looks that up.
+    ShowSubtitle {
+        audio_schema: String,
+    },
+
     // Quit the game (e.g. from the main menu). The runtime is responsible for
     // observing this via `Game::should_quit` and closing its window.
     Quit,

--- a/shock2vr/src/scripts/trap_sound.rs
+++ b/shock2vr/src/scripts/trap_sound.rs
@@ -4,7 +4,7 @@ use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, GlobalEffect, MessagePayload, Script};
 
 pub struct TrapSound {
     playing_sounds: Vec<AudioHandle>,
@@ -31,14 +31,26 @@ impl Script for TrapSound {
                 let handle = AudioHandle::new();
                 self.playing_sounds.push(handle.clone());
                 if let Ok(sound) = maybe_trip_sound {
-                    Effect::PlaySound {
-                        handle,
-                        name: sound.name.to_owned(),
-                        source: Some(entity_id),
-                        // TrapSound(Amb) narrations are anchored at their
-                        // authored station - a stale montage segment two rooms
-                        // away should be distant, not at the player's ears.
-                        spatial: true,
+                    Effect::Combined {
+                        effects: vec![
+                            Effect::PlaySound {
+                                handle,
+                                name: sound.name.to_owned(),
+                                source: Some(entity_id),
+                                // TrapSound(Amb) narrations are anchored at their
+                                // authored station - a stale montage segment two rooms
+                                // away should be distant, not at the player's ears.
+                                spatial: true,
+                            },
+                            // The narration's transcript, when the install has
+                            // one (see `GlobalEffect::ShowSubtitle`). The 25AE
+                            // subtitle database covers exactly this script's
+                            // voice-overs (the trg/brief narrations); ordinary
+                            // sound traps simply miss the lookup.
+                            Effect::GlobalEffect(GlobalEffect::ShowSubtitle {
+                                audio_schema: sound.name.to_owned(),
+                            }),
+                        ],
                     }
                 } else {
                     Effect::NoEffect
@@ -56,5 +68,38 @@ impl Script for TrapSound {
             }
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shipyard::World;
+
+    #[test]
+    fn turn_on_plays_the_sound_and_requests_its_subtitle() {
+        let mut world = World::new();
+        let entity_id = world.add_entity((PropObjectSound {
+            name: "trg0001".to_owned(),
+        },));
+        let physics = PhysicsWorld::new();
+
+        let effect = TrapSound::new().handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        let flattened = Effect::flatten(vec![effect]);
+        assert!(
+            flattened.iter().any(
+                |effect| matches!(effect, Effect::PlaySound { name, .. } if name == "trg0001")
+            )
+        );
+        assert!(flattened.iter().any(|effect| matches!(
+            effect,
+            Effect::GlobalEffect(GlobalEffect::ShowSubtitle { audio_schema }) if audio_schema == "trg0001"
+        )));
     }
 }

--- a/shock2vr/src/scripts/trap_sound.rs
+++ b/shock2vr/src/scripts/trap_sound.rs
@@ -64,6 +64,15 @@ impl Script for TrapSound {
                     });
                 }
                 self.playing_sounds.clear();
+                // Silencing the narration takes its text down with it -
+                // otherwise the authored "silence all" TurnOff broadcasts
+                // (earth's training inverters) leave silent text on screen.
+                let v_sound = world.borrow::<View<PropObjectSound>>().unwrap();
+                if let Ok(sound) = v_sound.get(entity_id) {
+                    eff.push(Effect::GlobalEffect(GlobalEffect::HideSubtitle {
+                        audio_schema: sound.name.to_owned(),
+                    }));
+                }
                 Effect::Combined { effects: eff }
             }
             _ => Effect::NoEffect,
@@ -100,6 +109,35 @@ mod tests {
         assert!(flattened.iter().any(|effect| matches!(
             effect,
             Effect::GlobalEffect(GlobalEffect::ShowSubtitle { audio_schema }) if audio_schema == "trg0001"
+        )));
+    }
+
+    #[test]
+    fn turn_off_takes_the_subtitle_down_with_the_sound() {
+        let mut world = World::new();
+        let entity_id = world.add_entity((PropObjectSound {
+            name: "trg0001".to_owned(),
+        },));
+        let physics = PhysicsWorld::new();
+        let mut trap = TrapSound::new();
+        trap.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        let effect = trap.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOff { from: entity_id },
+        );
+
+        let flattened = Effect::flatten(vec![effect]);
+        assert!(flattened.iter().any(|effect| matches!(
+            effect,
+            Effect::GlobalEffect(GlobalEffect::HideSubtitle { audio_schema }) if audio_schema == "trg0001"
         )));
     }
 }

--- a/shock2vr/src/subtitle_overlay.rs
+++ b/shock2vr/src/subtitle_overlay.rs
@@ -38,9 +38,11 @@ const CANVAS_W: f32 = 640.0;
 const CANVAS_H: f32 = 480.0;
 /// Text column width; the rest is side margin.
 const TEXT_W: f32 = 520.0;
-/// Where the *bottom* line of text sits. On the VR panel (1.5 m tall at 2 m)
-/// this puts the text ~15 degrees below the view center - subtitle height.
-const TEXT_BOTTOM: f32 = 440.0;
+/// Where the *bottom* line of text sits: above the flat HUD's vitals cluster
+/// (whose art tops out around y=414), so a long line never runs through it.
+/// On the VR panel (1.5 m tall at 2 m) this puts the text ~13 degrees below
+/// the view center - subtitle height.
+const TEXT_BOTTOM: f32 = 408.0;
 /// Glyph-cell height in canvas pixels. `mainfont` is ~10 px native; doubling
 /// it keeps the line count low and the text legible at the panel distance.
 const FONT_SIZE: f32 = 20.0;

--- a/shock2vr/src/subtitle_overlay.rs
+++ b/shock2vr/src/subtitle_overlay.rs
@@ -68,6 +68,13 @@ pub struct SubtitleOverlay {
     /// VR panel placement, reset when a new narration starts so the toast is
     /// hung from the head pose that heard it (vr-ui-design rule 3).
     anchor: FrontendPanelAnchor,
+    /// Set by [`post`](Self::post), consumed by the next
+    /// [`update`](Self::update): effects (and so `post`) run *after* the
+    /// frame's update, where the head pose lives, so the anchor reset is
+    /// deferred to the next update rather than leaving an un-placed anchor
+    /// for `render` to fall back on (which would hang the panel at the
+    /// pawn-origin default for one frame).
+    place_pending: bool,
 }
 
 impl Default for SubtitleOverlay {
@@ -81,7 +88,16 @@ impl SubtitleOverlay {
         Self {
             active: None,
             anchor: FrontendPanelAnchor::new(),
+            place_pending: false,
         }
+    }
+
+    /// Drop whatever is showing. Called on scene swaps: a narration in flight
+    /// when the player takes an elevator, dies, or quits to the menu must not
+    /// keep playing its remaining cues over the next scene.
+    pub fn clear(&mut self) {
+        self.active = None;
+        self.place_pending = false;
     }
 
     /// Start showing a sample's cues.
@@ -94,10 +110,12 @@ impl SubtitleOverlay {
         if cues.is_empty() {
             return;
         }
-        if let Some(active) = &self.active {
-            if active.sample.eq_ignore_ascii_case(sample) {
-                return;
-            }
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|active| active.sample.eq_ignore_ascii_case(sample))
+        {
+            return;
         }
         let total = cues
             .iter()
@@ -110,8 +128,9 @@ impl SubtitleOverlay {
             clock: Duration::ZERO,
             total,
         });
-        // Place the panel fresh from the head pose the narration starts at.
-        self.anchor = FrontendPanelAnchor::new();
+        // Re-place the panel from the head pose the narration starts at - on
+        // the next update, which is where that pose is available.
+        self.place_pending = true;
     }
 
     /// Advance the clock and the VR panel anchor. Call on the *scene* clock:
@@ -125,6 +144,10 @@ impl SubtitleOverlay {
         if active.clock >= active.total {
             self.active = None;
             return;
+        }
+        if self.place_pending {
+            self.anchor = FrontendPanelAnchor::new();
+            self.place_pending = false;
         }
         self.anchor.update(
             input_context.head.position,
@@ -193,6 +216,12 @@ impl SubtitleOverlay {
         if !self.is_visible() || options.presentation_mode != PresentationMode::Vr {
             return Vec::new();
         }
+        // A pending placement means no update has seen the head pose since the
+        // narration started; the anchor's fallback would hang the panel at the
+        // pawn-origin default for this one frame, so draw nothing instead.
+        if self.place_pending || self.anchor.placement().is_none() {
+            return Vec::new();
+        }
         let panel = self.anchor.panel();
         let canvas = self.build_canvas(asset_cache);
         let mut objects = canvas.render_world_space(
@@ -204,6 +233,14 @@ impl SubtitleOverlay {
         );
         for object in &mut objects {
             object.set_transform(pawn_to_world * object.get_transform());
+        }
+        // The toast is an overlay, not a world prop: the renderer starts its
+        // overlay group (depth cleared, drawn after the world's passes) at the
+        // first `clear_depth` object, exactly like the pause menu's dim layer.
+        // Without this the text depth-tests against the world and any wall
+        // nearer than the panel's 2 m swallows it - i.e. most of the ship.
+        if let Some(first) = objects.first_mut() {
+            first.clear_depth = true;
         }
         tag_render_source(&mut objects, render_source::SUBTITLE);
         objects
@@ -309,6 +346,16 @@ mod tests {
         overlay.post("trg0001", vec![cue(0, 5000, "old")]);
         overlay.post("trg0002", vec![cue(0, 1000, "new")]);
         assert_eq!(overlay.visible_lines(), vec!["new"]);
+    }
+
+    #[test]
+    fn clear_drops_the_active_narration() {
+        let mut overlay = SubtitleOverlay::new();
+        overlay.post("trg0001", vec![cue(0, 5000, "line")]);
+        assert!(overlay.is_visible());
+        overlay.clear();
+        assert!(!overlay.is_visible());
+        assert!(overlay.visible_lines().is_empty());
     }
 
     #[test]

--- a/shock2vr/src/subtitle_overlay.rs
+++ b/shock2vr/src/subtitle_overlay.rs
@@ -1,0 +1,347 @@
+//! Transient narration text: the on-screen lines for a playing voice-over.
+//!
+//! One overlay owned by [`crate::Game`], fed by
+//! [`GlobalEffect::ShowSubtitle`](crate::scripts::GlobalEffect) and ticked on
+//! the sim clock (it freezes with the scene under the pause menu). The text
+//! lives on a single shared [`UiCanvas`] - the placement decision (wrapped
+//! lines, bottom-center of the 640x480 canvas) is made exactly once, in canvas
+//! pixels, per AGENTS.md section 3:
+//!
+//! - **Flat** renders that canvas in screen space (aspect-preserving, like
+//!   every other flat screen), so the lines sit at the bottom of the window -
+//!   where the remaster draws its subtitles.
+//! - **VR** renders the *same canvas* on a world panel hung from the shared
+//!   [`FrontendPanelAnchor`]: placed from the head pose when a narration
+//!   starts, yaw-only and gravity-aligned, world-locked while it plays, lazily
+//!   recentered only after a sustained large head deviation (vr-ui-design
+//!   rule 3 - never gaze-glued). The bottom-of-canvas placement lands the text
+//!   slightly below the view center at the panel's 2 m focal distance.
+//!
+//! Both presentations therefore show identical content at the same canvas
+//! position; neither makes any placement decision of its own.
+
+use cgmath::{Matrix4, Vector2, vec2};
+use dark::importers::FONT_IMPORTER;
+use engine::{assets::asset_cache::AssetCache, measure_text_width, scene::SceneObject};
+use std::time::Duration;
+
+use crate::{
+    GameOptions, PresentationMode,
+    input_context::InputContext,
+    subtitles::SubtitleCue,
+    ui::{FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP},
+    util::{render_source, tag_render_source},
+};
+
+/// Authored on the same 640x480 canvas as the original UI art.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+/// Text column width; the rest is side margin.
+const TEXT_W: f32 = 520.0;
+/// Where the *bottom* line of text sits. On the VR panel (1.5 m tall at 2 m)
+/// this puts the text ~15 degrees below the view center - subtitle height.
+const TEXT_BOTTOM: f32 = 440.0;
+/// Glyph-cell height in canvas pixels. `mainfont` is ~10 px native; doubling
+/// it keeps the line count low and the text legible at the panel distance.
+const FONT_SIZE: f32 = 20.0;
+const LINE_H: f32 = 24.0;
+const FONT: &str = "mainfont.fon";
+/// Flat letterboxes like every other flat screen.
+const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
+
+/// The narration currently on screen.
+struct ActiveSubtitle {
+    /// Sample the cues belong to, for the repeat-while-playing guard.
+    sample: String,
+    cues: Vec<SubtitleCue>,
+    /// Sim time since the narration started.
+    clock: Duration,
+    /// When the last cue is done and the overlay goes idle.
+    total: Duration,
+}
+
+/// See the module docs.
+pub struct SubtitleOverlay {
+    active: Option<ActiveSubtitle>,
+    /// VR panel placement, reset when a new narration starts so the toast is
+    /// hung from the head pose that heard it (vr-ui-design rule 3).
+    anchor: FrontendPanelAnchor,
+}
+
+impl Default for SubtitleOverlay {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubtitleOverlay {
+    pub fn new() -> Self {
+        Self {
+            active: None,
+            anchor: FrontendPanelAnchor::new(),
+        }
+    }
+
+    /// Start showing a sample's cues.
+    ///
+    /// Re-posting the sample already on screen is ignored (the data marks
+    /// these narrations `singleton`, and level wiring can fire one trap from
+    /// several switch links in the same instant). A *different* sample
+    /// replaces the current one - last narration wins, like the remaster.
+    pub fn post(&mut self, sample: &str, cues: Vec<SubtitleCue>) {
+        if cues.is_empty() {
+            return;
+        }
+        if let Some(active) = &self.active {
+            if active.sample.eq_ignore_ascii_case(sample) {
+                return;
+            }
+        }
+        let total = cues
+            .iter()
+            .map(SubtitleCue::end)
+            .max()
+            .unwrap_or(Duration::ZERO);
+        self.active = Some(ActiveSubtitle {
+            sample: sample.to_owned(),
+            cues,
+            clock: Duration::ZERO,
+            total,
+        });
+        // Place the panel fresh from the head pose the narration starts at.
+        self.anchor = FrontendPanelAnchor::new();
+    }
+
+    /// Advance the clock and the VR panel anchor. Call on the *scene* clock:
+    /// while the pause menu suspends the scene this must not run, so the text
+    /// freezes with the world instead of expiring under the menu.
+    pub fn update(&mut self, elapsed: Duration, input_context: &InputContext) {
+        let Some(active) = &mut self.active else {
+            return;
+        };
+        active.clock += elapsed;
+        if active.clock >= active.total {
+            self.active = None;
+            return;
+        }
+        self.anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            elapsed,
+        );
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.active.is_some()
+    }
+
+    /// The cue lines on screen right now (a multisub can leave gaps between
+    /// cues, where nothing shows - matching the authored timing).
+    fn visible_lines(&self) -> Vec<&str> {
+        let Some(active) = &self.active else {
+            return Vec::new();
+        };
+        active
+            .cues
+            .iter()
+            .filter(|cue| active.clock >= cue.start && active.clock < cue.end())
+            .map(|cue| cue.text.as_str())
+            .collect()
+    }
+
+    /// The one shared canvas: visible cue text, greedily wrapped with real
+    /// glyph measurement, as bottom-anchored centered rows.
+    fn build_canvas(&self, asset_cache: &mut AssetCache) -> UiCanvas {
+        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+        let lines: Vec<String> = {
+            let font = asset_cache.get(&FONT_IMPORTER, FONT);
+            self.visible_lines()
+                .iter()
+                .flat_map(|text| wrap_text(&**font, text, FONT_SIZE, TEXT_W))
+                .collect()
+        };
+        let top = TEXT_BOTTOM - lines.len() as f32 * LINE_H;
+        for (index, line) in lines.iter().enumerate() {
+            canvas.text(
+                Rect::new(
+                    (CANVAS_W - TEXT_W) / 2.0,
+                    top + index as f32 * LINE_H,
+                    TEXT_W,
+                    LINE_H,
+                ),
+                line,
+                FONT,
+                FONT_SIZE,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+        }
+        canvas
+    }
+
+    /// World-space presentation (VR): the canvas on the anchored panel.
+    /// Empty when idle or flat. `pawn_to_world` rebases the tracked play
+    /// space into world coordinates, exactly like the pause menu.
+    pub fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+        pawn_to_world: Matrix4<f32>,
+    ) -> Vec<SceneObject> {
+        if !self.is_visible() || options.presentation_mode != PresentationMode::Vr {
+            return Vec::new();
+        }
+        let panel = self.anchor.panel();
+        let canvas = self.build_canvas(asset_cache);
+        let mut objects = canvas.render_world_space(
+            asset_cache,
+            panel.transform(),
+            None,
+            None,
+            VR_COMPONENT_Z_STEP,
+        );
+        for object in &mut objects {
+            object.set_transform(pawn_to_world * object.get_transform());
+        }
+        tag_render_source(&mut objects, render_source::SUBTITLE);
+        objects
+    }
+
+    /// Screen-space presentation (flat). Empty when idle or in VR (a
+    /// screen-space copy would paste over both eyes).
+    pub fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        screen_size: Vector2<f32>,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        if !self.is_visible() || options.presentation_mode == PresentationMode::Vr {
+            return Vec::new();
+        }
+        let canvas = self.build_canvas(asset_cache);
+        let mut objects = canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE);
+        tag_render_source(&mut objects, render_source::SUBTITLE);
+        objects
+    }
+}
+
+/// Greedy word wrap with real glyph widths. A single word wider than the
+/// column gets its own line rather than being dropped.
+fn wrap_text(font: &dyn engine::Font, text: &str, font_size: f32, max_width: f32) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        let candidate = if current.is_empty() {
+            word.to_owned()
+        } else {
+            format!("{current} {word}")
+        };
+        if measure_text_width(font, &candidate, font_size) <= max_width || current.is_empty() {
+            current = candidate;
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current = word.to_owned();
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input_context::InputContext;
+
+    fn cue(start_ms: u64, length_ms: u64, text: &str) -> SubtitleCue {
+        SubtitleCue {
+            start: Duration::from_millis(start_ms),
+            length: Some(Duration::from_millis(length_ms)),
+            text: text.to_owned(),
+        }
+    }
+
+    fn tick(overlay: &mut SubtitleOverlay, ms: u64) {
+        overlay.update(Duration::from_millis(ms), &InputContext::default());
+    }
+
+    #[test]
+    fn cues_appear_and_expire_on_their_timings() {
+        let mut overlay = SubtitleOverlay::new();
+        overlay.post(
+            "trg0001",
+            vec![cue(0, 1000, "first"), cue(1500, 1000, "second")],
+        );
+        assert_eq!(overlay.visible_lines(), vec!["first"]);
+        tick(&mut overlay, 1200);
+        assert!(
+            overlay.visible_lines().is_empty(),
+            "the gap between cues shows nothing"
+        );
+        tick(&mut overlay, 500);
+        assert_eq!(overlay.visible_lines(), vec!["second"]);
+        tick(&mut overlay, 1000);
+        assert!(
+            !overlay.is_visible(),
+            "overlay goes idle after the last cue"
+        );
+    }
+
+    #[test]
+    fn reposting_the_playing_sample_does_not_restart_it() {
+        let mut overlay = SubtitleOverlay::new();
+        overlay.post("trg0001", vec![cue(0, 1000, "line")]);
+        tick(&mut overlay, 600);
+        overlay.post("TRG0001", vec![cue(0, 1000, "line")]);
+        tick(&mut overlay, 600);
+        assert!(
+            !overlay.is_visible(),
+            "a duplicate post must not rewind the clock"
+        );
+    }
+
+    #[test]
+    fn a_new_sample_replaces_the_current_one() {
+        let mut overlay = SubtitleOverlay::new();
+        overlay.post("trg0001", vec![cue(0, 5000, "old")]);
+        overlay.post("trg0002", vec![cue(0, 1000, "new")]);
+        assert_eq!(overlay.visible_lines(), vec!["new"]);
+    }
+
+    #[test]
+    fn empty_cues_are_ignored() {
+        let mut overlay = SubtitleOverlay::new();
+        overlay.post("trg0001", Vec::new());
+        assert!(!overlay.is_visible());
+    }
+
+    #[test]
+    fn wrap_splits_on_measured_width_and_keeps_wide_words() {
+        /// Fixed-metrics stub: every glyph advances 5 at base height 10.
+        struct FixedFont;
+        impl engine::Font for FixedFont {
+            fn get_texture(&self) -> std::rc::Rc<dyn engine::texture::TextureTrait> {
+                unreachable!("measurement does not touch the texture")
+            }
+            fn get_character_info(&self, _c: char) -> Option<engine::FontCharacterInfo> {
+                Some(engine::FontCharacterInfo {
+                    min_uv_x: 0.0,
+                    min_uv_y: 0.0,
+                    max_uv_x: 1.0,
+                    max_uv_y: 1.0,
+                    advance: 5.0,
+                })
+            }
+            fn base_height(&self) -> f32 {
+                10.0
+            }
+            fn get_half_pixel(&self) -> f32 {
+                0.0
+            }
+        }
+        // 5px per char at size 10; max 30px = 6 chars per line.
+        let lines = wrap_text(&FixedFont, "aa bb cc unbreakable", 10.0, 30.0);
+        assert_eq!(lines, vec!["aa bb", "cc", "unbreakable"]);
+    }
+}

--- a/shock2vr/src/subtitle_overlay.rs
+++ b/shock2vr/src/subtitle_overlay.rs
@@ -100,6 +100,19 @@ impl SubtitleOverlay {
         self.place_pending = false;
     }
 
+    /// Drop the text for `sample` if it is what's showing - the counterpart of
+    /// a TrapSound TurnOff stopping that narration's audio. Text belonging to
+    /// a different narration stays.
+    pub fn clear_sample(&mut self, sample: &str) {
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|active| active.sample.eq_ignore_ascii_case(sample))
+        {
+            self.clear();
+        }
+    }
+
     /// Start showing a sample's cues.
     ///
     /// Re-posting the sample already on screen is ignored (the data marks
@@ -346,6 +359,16 @@ mod tests {
         overlay.post("trg0001", vec![cue(0, 5000, "old")]);
         overlay.post("trg0002", vec![cue(0, 1000, "new")]);
         assert_eq!(overlay.visible_lines(), vec!["new"]);
+    }
+
+    #[test]
+    fn clear_sample_drops_only_the_matching_narration() {
+        let mut overlay = SubtitleOverlay::new();
+        overlay.post("trg0001", vec![cue(0, 5000, "line")]);
+        overlay.clear_sample("trg0002");
+        assert!(overlay.is_visible(), "another sample's text must stay");
+        overlay.clear_sample("TRG0001");
+        assert!(!overlay.is_visible());
     }
 
     #[test]

--- a/shock2vr/src/subtitles.rs
+++ b/shock2vr/src/subtitles.rs
@@ -1,0 +1,440 @@
+//! Subtitle database for the narration voice-overs (25th Anniversary data).
+//!
+//! The remaster ships transcripts for the classic voice triggers - the
+//! training narrations on earth/station, the Polito/SHODAN story triggers -
+//! as KEX subtitle files (`sshock2-subtitles.kpf`, `*.sub`) whose text lines
+//! are `$key` tokens resolved through the KEX localization table
+//! (`base.kpf:localization/loc_english.txt`). The classic 1999 data has no
+//! transcript for these sounds at all, so on a classic install this database
+//! is simply empty and the narrations stay audio-only, exactly as they were
+//! in 1999.
+//!
+//! A `.sub` file is a brace-structured list of speaker blocks:
+//!
+//! ```text
+//! SUB1
+//! {
+//!     type "convo"
+//!     descr "$name_PA"
+//!     singleton
+//!     multisub trg0001 {
+//!         { time 00 length 3000 text "$trg0001_1" }
+//!         { time 3000 length 2200 text "$trg0001_2" }
+//!     }
+//!     sub trg0002 { text "$trg0002" }
+//! }
+//! ```
+//!
+//! `multisub` entries carry explicit millisecond timings; a bare `sub` shows
+//! its single line for the length of the clip (which we approximate from the
+//! text, see [`SubtitleCue::display_length`]). Cues are keyed by the **sample
+//! name** the sound system plays (`trg0001` -> `trg0001.wav`), matched
+//! case-insensitively.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// The KEX localization table: `$key = "value"` lines, `//` comments and
+/// `[section]` headers.
+#[derive(Debug, Default)]
+pub struct Localization {
+    entries: HashMap<String, String>,
+}
+
+impl Localization {
+    pub fn parse(source: &str) -> Self {
+        let mut entries = HashMap::new();
+        for line in source.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with("//") || line.starts_with('[') {
+                continue;
+            }
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            let key = key.trim();
+            let Some(key) = key.strip_prefix('$') else {
+                continue;
+            };
+            let value = value.trim();
+            // The value is everything between the first and last quote, with
+            // `\"` escapes unescaped.
+            let Some(first) = value.find('"') else {
+                continue;
+            };
+            let Some(last) = value.rfind('"') else {
+                continue;
+            };
+            if last <= first {
+                continue;
+            }
+            let raw = &value[first + 1..last];
+            entries.insert(key.to_lowercase(), raw.replace("\\\"", "\""));
+        }
+        Self { entries }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.entries.get(&key.to_lowercase()).map(String::as_str)
+    }
+
+    /// Resolve a `.sub` text token: `$key` looks up the table (`None` when the
+    /// key is unknown - a raw `$trg0001_1` on screen is worse than no line),
+    /// anything else is literal text.
+    fn resolve(&self, token: &str) -> Option<String> {
+        match token.strip_prefix('$') {
+            Some(key) => self.get(key).map(str::to_owned),
+            None => Some(token.to_owned()),
+        }
+    }
+}
+
+/// One line of a sample's subtitle track.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubtitleCue {
+    /// When the line appears, from the start of the sample.
+    pub start: Duration,
+    /// How long it stays, when the file says (`multisub`). `None` for a bare
+    /// `sub` line, whose duration tracks the clip we cannot measure here.
+    pub length: Option<Duration>,
+    pub text: String,
+}
+
+impl SubtitleCue {
+    /// How long the line is on screen: the authored length, or a reading-time
+    /// estimate for untimed lines (bare `sub` entries).
+    pub fn display_length(&self) -> Duration {
+        self.length.unwrap_or_else(|| {
+            let reading = Duration::from_millis(60 * self.text.chars().count() as u64);
+            reading.max(Duration::from_millis(2500))
+        })
+    }
+
+    pub fn end(&self) -> Duration {
+        self.start + self.display_length()
+    }
+}
+
+/// Subtitle cues per sound sample, lowercased sample name as the key.
+#[derive(Debug, Default)]
+pub struct SubtitleDb {
+    by_sample: HashMap<String, Vec<SubtitleCue>>,
+}
+
+impl SubtitleDb {
+    /// Parse one `.sub` source and merge its cues, resolving text through
+    /// `loc`. Malformed trailing input is ignored rather than an error: a
+    /// subtitle file must never take the game down.
+    pub fn add_sub_source(&mut self, source: &str, loc: &Localization) {
+        let mut tokens = Tokenizer::new(source);
+        while let Some(token) = tokens.next() {
+            match token {
+                Token::Word(word) if word.eq_ignore_ascii_case("sub") => {
+                    self.parse_sub(&mut tokens, loc);
+                }
+                Token::Word(word) if word.eq_ignore_ascii_case("multisub") => {
+                    self.parse_multisub(&mut tokens, loc);
+                }
+                // Header (`SUB1`), block braces, `type`/`descr`/`singleton`
+                // metadata and their values: skipped. Only the cue-bearing
+                // entries matter here.
+                _ => {}
+            }
+        }
+    }
+
+    /// `sub NAME { text "$key" }`
+    fn parse_sub(&mut self, tokens: &mut Tokenizer, loc: &Localization) {
+        let Some(Token::Word(name)) = tokens.next() else {
+            return;
+        };
+        let Some(fields) = parse_fields(tokens) else {
+            return;
+        };
+        let Some(text) = fields.text.as_deref().and_then(|t| loc.resolve(t)) else {
+            return;
+        };
+        self.by_sample.insert(
+            name.to_lowercase(),
+            vec![SubtitleCue {
+                start: Duration::ZERO,
+                length: None,
+                text,
+            }],
+        );
+    }
+
+    /// `multisub NAME { { time N length N text "$key" } ... }`
+    fn parse_multisub(&mut self, tokens: &mut Tokenizer, loc: &Localization) {
+        let Some(Token::Word(name)) = tokens.next() else {
+            return;
+        };
+        if tokens.next() != Some(Token::Open) {
+            return;
+        }
+        let mut cues = Vec::new();
+        loop {
+            match tokens.next() {
+                Some(Token::Open) => {
+                    let Some(fields) = parse_fields_open(tokens) else {
+                        return;
+                    };
+                    if let Some(text) = fields.text.as_deref().and_then(|t| loc.resolve(t)) {
+                        cues.push(SubtitleCue {
+                            start: Duration::from_millis(fields.time.unwrap_or(0)),
+                            length: fields.length.map(Duration::from_millis),
+                            text,
+                        });
+                    }
+                }
+                Some(Token::Close) => break,
+                Some(_) => {}
+                None => return,
+            }
+        }
+        if !cues.is_empty() {
+            cues.sort_by_key(|cue| cue.start);
+            self.by_sample.insert(name.to_lowercase(), cues);
+        }
+    }
+
+    pub fn cues(&self, sample: &str) -> Option<&[SubtitleCue]> {
+        self.by_sample
+            .get(&sample.to_lowercase())
+            .map(Vec::as_slice)
+    }
+
+    /// Number of samples with a transcript (the startup log line).
+    pub fn len(&self) -> usize {
+        self.by_sample.len()
+    }
+}
+
+/// The recognized fields of a cue entry, in any order.
+#[derive(Default)]
+struct CueFields {
+    time: Option<u64>,
+    length: Option<u64>,
+    text: Option<String>,
+}
+
+/// Parse `{ field value ... }` where the opening brace is still pending.
+fn parse_fields(tokens: &mut Tokenizer) -> Option<CueFields> {
+    if tokens.next() != Some(Token::Open) {
+        return None;
+    }
+    parse_fields_open(tokens)
+}
+
+/// Parse field/value pairs until the matching `}`; the `{` has been consumed.
+fn parse_fields_open(tokens: &mut Tokenizer) -> Option<CueFields> {
+    let mut fields = CueFields::default();
+    loop {
+        match tokens.next()? {
+            Token::Close => return Some(fields),
+            Token::Word(word) if word.eq_ignore_ascii_case("time") => {
+                fields.time = tokens.next_number();
+            }
+            Token::Word(word) if word.eq_ignore_ascii_case("length") => {
+                fields.length = tokens.next_number();
+            }
+            Token::Word(word) if word.eq_ignore_ascii_case("text") => {
+                if let Some(Token::Str(text) | Token::Word(text)) = tokens.next() {
+                    fields.text = Some(text);
+                }
+            }
+            // Unknown field or stray value: skip.
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Token {
+    Open,
+    Close,
+    Word(String),
+    Str(String),
+}
+
+struct Tokenizer<'a> {
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+}
+
+impl<'a> Tokenizer<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            chars: source.chars().peekable(),
+        }
+    }
+
+    fn next_number(&mut self) -> Option<u64> {
+        match self.next()? {
+            Token::Word(word) | Token::Str(word) => word.parse().ok(),
+            _ => None,
+        }
+    }
+
+    fn next(&mut self) -> Option<Token> {
+        loop {
+            let c = *self.chars.peek()?;
+            if c.is_whitespace() {
+                self.chars.next();
+                continue;
+            }
+            if c == '/' {
+                // `//` comment to end of line (a lone `/` cannot start
+                // anything meaningful in this format either).
+                for c in self.chars.by_ref() {
+                    if c == '\n' {
+                        break;
+                    }
+                }
+                continue;
+            }
+            break;
+        }
+        let c = self.chars.next()?;
+        match c {
+            '{' => Some(Token::Open),
+            '}' => Some(Token::Close),
+            '"' => {
+                let mut s = String::new();
+                while let Some(c) = self.chars.next() {
+                    match c {
+                        '\\' => {
+                            if let Some(escaped) = self.chars.next() {
+                                s.push(escaped);
+                            }
+                        }
+                        '"' => break,
+                        _ => s.push(c),
+                    }
+                }
+                Some(Token::Str(s))
+            }
+            _ => {
+                let mut word = String::new();
+                word.push(c);
+                while let Some(&c) = self.chars.peek() {
+                    if c.is_whitespace() || c == '{' || c == '}' || c == '"' {
+                        break;
+                    }
+                    word.push(c);
+                    self.chars.next();
+                }
+                Some(Token::Word(word))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LOC: &str = r#"
+// Stringtable strings
+[rmlui]
+$back = "Back"
+$trg0001_1 = "Welcome to the Ramsey Center UNN Recruitment Facility."
+$trg0001_2 = "Please watch your step when leaving the train."
+$trg0002 = "Step into the gravshafts."
+$quoted = "He said \"hello\" twice."
+"#;
+
+    const SUB: &str = r#"SUB1
+{
+	type "convo"
+	descr "$name_PA"
+	singleton
+	multisub trg0001 {
+		{ time 00 length 3000 text "$trg0001_1" }
+		{ time 3000 length 2200 text "$trg0001_2" }
+	}
+	sub trg0002 { text "$trg0002" }
+}
+"#;
+
+    fn db() -> SubtitleDb {
+        let loc = Localization::parse(LOC);
+        let mut db = SubtitleDb::default();
+        db.add_sub_source(SUB, &loc);
+        db
+    }
+
+    #[test]
+    fn localization_parses_keys_comments_and_escapes() {
+        let loc = Localization::parse(LOC);
+        assert_eq!(loc.get("back"), Some("Back"));
+        assert_eq!(
+            loc.get("TRG0001_1").map(|s| s.split(' ').next().unwrap()),
+            Some("Welcome")
+        );
+        assert_eq!(loc.get("quoted"), Some("He said \"hello\" twice."));
+        assert_eq!(loc.get("rmlui"), None, "section headers are not entries");
+    }
+
+    #[test]
+    fn multisub_yields_timed_cues() {
+        let db = db();
+        let cues = db.cues("trg0001").expect("trg0001 parsed");
+        assert_eq!(cues.len(), 2);
+        assert_eq!(cues[0].start, Duration::ZERO);
+        assert_eq!(cues[0].length, Some(Duration::from_millis(3000)));
+        assert_eq!(
+            cues[0].text,
+            "Welcome to the Ramsey Center UNN Recruitment Facility."
+        );
+        assert_eq!(cues[1].start, Duration::from_millis(3000));
+    }
+
+    #[test]
+    fn sample_lookup_is_case_insensitive() {
+        let db = db();
+        assert!(db.cues("TRG0001").is_some());
+    }
+
+    #[test]
+    fn bare_sub_yields_untimed_cue_with_reading_time() {
+        let db = db();
+        let cues = db.cues("trg0002").expect("trg0002 parsed");
+        assert_eq!(cues.len(), 1);
+        assert_eq!(cues[0].length, None);
+        assert!(cues[0].display_length() >= Duration::from_millis(2500));
+    }
+
+    #[test]
+    fn unknown_loc_key_drops_the_cue_not_the_track() {
+        let loc = Localization::parse(LOC);
+        let mut db = SubtitleDb::default();
+        db.add_sub_source(
+            r#"SUB1 {
+                multisub half {
+                    { time 0 length 1000 text "$trg0001_1" }
+                    { time 1000 length 1000 text "$missing_key" }
+                }
+            }"#,
+            &loc,
+        );
+        let cues = db.cues("half").expect("known cue kept");
+        assert_eq!(cues.len(), 1, "a raw $token must never reach the screen");
+    }
+
+    #[test]
+    fn malformed_input_is_ignored_without_panicking() {
+        let loc = Localization::parse(LOC);
+        let mut db = SubtitleDb::default();
+        db.add_sub_source("SUB1 { multisub broken { { time 5 ", &loc);
+        db.add_sub_source("{}}}{{ sub } garbage \"", &loc);
+        assert!(db.cues("broken").is_none());
+    }
+
+    #[test]
+    fn literal_text_without_dollar_is_kept_verbatim() {
+        let loc = Localization::parse("");
+        let mut db = SubtitleDb::default();
+        db.add_sub_source(r#"SUB1 { sub plain { text "Just words" } }"#, &loc);
+        assert_eq!(db.cues("plain").unwrap()[0].text, "Just words");
+    }
+}

--- a/shock2vr/src/subtitles.rs
+++ b/shock2vr/src/subtitles.rs
@@ -36,6 +36,13 @@ use std::time::Duration;
 
 /// The KEX localization table: `$key = "value"` lines, `//` comments and
 /// `[section]` headers.
+///
+/// Section headers are treated as comments, so keys from every section land in
+/// one flat map, last definition wins. That is safe for the subtitle keys
+/// (unique across the file) but NOT for the UI sections, which reuse generic
+/// keys (`$cancel`, `$select`, ...) per section - a future caller resolving
+/// the Nightdive `strings` stubs through this table (see
+/// `mod_layer_may_override`) must add section-qualified lookup first.
 #[derive(Debug, Default)]
 pub struct Localization {
     entries: HashMap<String, String>,

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -310,6 +310,9 @@ pub mod render_source {
     pub const FRONTEND_POINTER: &str = "frontend_pointer";
     /// The pause menu's comfort dim, behind its panel.
     pub const PAUSE_DIM: &str = "pause_dim";
+    /// The narration subtitle text: screen-space lines when flat, the
+    /// head-anchored toast panel in VR (`subtitle_overlay`).
+    pub const SUBTITLE: &str = "subtitle";
 }
 
 /// A tag that records only which render path produced an object.

--- a/tools/shock2-sdk/test/subtitle-overlay.e2e.test.ts
+++ b/tools/shock2-sdk/test/subtitle-overlay.e2e.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Narration subtitles (the earth/station training voice-overs).
+//
+// A TrapSound TurnOn plays its narration AND posts the sample's transcript
+// (25AE data: KEX `.sub` cues resolved through `loc_english.txt`). The text is
+// laid out once on the shared 640x480 canvas (wrapped lines, bottom-center):
+// flat renders that canvas in screen space, VR renders the same canvas on a
+// world panel anchored in front of the head. Scene objects from either path
+// carry the "subtitle" debug source, which is what these tests assert on.
+//
+// Negative-first: without the overlay no scene object ever reports the
+// "subtitle" source, so every assertion below fails on the base revision.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// earth.mis mission-object id of the arrival PA Sound Trap (TrapSoundAmb +
+// EarthText, PropObjectSound "trg0001" - the "Welcome to the Ramsey Center"
+// narration, a 4-cue timed multisub ~12.2s long). Stable across launches as
+// `template_id`; runtime entity ids are rediscovered every run.
+const ARRIVAL_PA_SOUND_TRAP = 449;
+
+async function fireArrivalNarration(game: GameServer): Promise<void> {
+  const [trap] = await game.entities.byTemplate(ARRIVAL_PA_SOUND_TRAP);
+  assert.ok(trap, `expected Sound Trap ${ARRIVAL_PA_SOUND_TRAP} in earth.mis`);
+  await game.entities.sendMessage(trap.id, { type: "TurnOn" });
+  await game.step({ frames: 30 });
+}
+
+test(
+  "flat: a narration shows its subtitle lines and they expire with the cues",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
+    });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.scene.fromSource("subtitle")).length,
+      0,
+      "no subtitle may show before any narration plays",
+    );
+
+    await fireArrivalNarration(game);
+
+    const shown = await game.scene.fromSource("subtitle");
+    assert.ok(
+      shown.length >= 1,
+      "the playing narration must draw its subtitle text",
+    );
+
+    // The narration sound plays alongside the text (text replaces nothing).
+    const narrations = (await game.audio.recent()).sounds.filter((sound) =>
+      sound.sample.startsWith("trg"),
+    );
+    assert.ok(
+      narrations.length >= 1,
+      `the narration audio must still play: ${JSON.stringify(narrations)}`,
+    );
+
+    // The trg0001 track totals ~12.2s of cues; well past that the overlay
+    // must be gone (transient toast, not a sticky HUD element).
+    await game.step({ frames: 13 * 60 });
+    assert.equal(
+      (await game.scene.fromSource("subtitle")).length,
+      0,
+      "subtitle lines must expire when their cues end",
+    );
+  },
+);
+
+test(
+  "vr: the same narration presents the subtitle on a world panel near the head",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    await fireArrivalNarration(game);
+
+    const shown = await game.scene.fromSource("subtitle");
+    assert.ok(
+      shown.length >= 1,
+      "VR must present the playing narration's subtitle",
+    );
+
+    // World-space panel, not a screen-space paste-over: the text hangs at the
+    // frontend panel distance (2m) in front of the player, so its world
+    // position is near the player - unlike flat's screen-space objects, which
+    // sit at the identity transform.
+    const player = await game.player.position();
+    for (const object of shown) {
+      const [x, , z] = object.position;
+      const distance = Math.hypot(x - player.x, z - player.z);
+      assert.ok(
+        distance > 0.5 && distance < 4,
+        `subtitle panel must hang near the player (got ${distance.toFixed(2)} ` +
+          `at ${JSON.stringify(object.position)}, player ${JSON.stringify(player)})`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
![VR narration subtitle toast — the four timed cues of the earth.mis arrival PA playing out on the world panel](https://gist.githubusercontent.com/tommy-xr/c68957e0766281c0e0ade7230f6f8fb6/raw/demo.gif)

<sub>VR presentation: the `trg0001` narration's four timed cues appearing/expiring on the head-anchored world panel (~2x speed). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Flat / VR parity (one shared canvas)

![flat vs VR](https://gist.githubusercontent.com/tommy-xr/c68957e0766281c0e0ade7230f6f8fb6/raw/flat-vs-vr.png)

<sub>The same cue at the same canvas position in both presentations. The VR shot is deliberately taken against a wall well inside the 2 m panel distance — the toast rides the clear-depth overlay group, so near geometry cannot swallow it.</sub>

Implements the VR-UI plan's step 3b: the narration voice-overs (earth/station training PA, the in-mission Polito/SHODAN voice triggers) now show their transcript on screen while they play — in **both** presentations.

## What the research changed

The plan assumed flat already showed these texts and only VR was missing a presentation. It isn't so: the port showed **no** text in either presentation (`earthtext`/`trapmessage` are noop scripts; #916 tracks the missing HUD-line facility). The on-screen training text is a **25th Anniversary subtitle feature**: KEX cue files (`sshock2-subtitles.kpf`, `vbriefs.sub` + `vtriggers.sub`) whose `$key` lines resolve through `base.kpf:localization/loc_english.txt`. The classic 1999 data ships no transcripts at all — so on a classic install this change is a deliberate no-op and narrations stay audio-only, exactly as they were in 1999.

## How it works

- **`subtitles.rs`** — parsers for the KEX `.sub` cue grammar (timed `multisub` entries, untimed `sub` lines) and the `$key = "value"` localization table. 207 cue tracks load on a 25AE install; malformed input degrades to "no cues", never a crash.
- **`trap_sound.rs`** — `TrapSound` (the script all these narrations play through) emits `GlobalEffect::ShowSubtitle { audio_schema }` alongside its `PlaySound`. Ordinary sound traps simply miss the DB lookup; script purity is preserved (pure effect, unit-tested).
- **`subtitle_overlay.rs`** — a Game-level overlay (sibling of `pause_menu`): cue timing on the **scene clock** (freezes under pause), and **one shared 640×480 canvas** deciding placement once — wrapped lines (real glyph measurement), bottom-center, above the HUD vitals cluster (AGENTS.md §3: neither presentation makes any placement decision).
  - **Flat** renders that canvas in screen space (aspect-preserving letterbox, like every flat screen).
  - **VR** renders the *same canvas* on a world panel hung from the shared `FrontendPanelAnchor` (vr-ui-design rule 3): placed once from the head pose the narration starts at, yaw-only/gravity-aligned, **world-locked** while it plays, lazily recentered only after a sustained large deviation — never gaze-glued. At the 2 m panel distance the bottom-of-canvas text lands ~13° below view center, standard subtitle height. The toast rides the renderer's clear-depth overlay group (like the pause dim) so a wall nearer than 2 m can't swallow it.
- **`lib.rs`** — mounts the two extra archives (prefix-scoped, nothing else in `base.kpf` leaks into asset resolution), loads the DB once, resolves schema→sample the same way the sound system does, clears an in-flight narration on scene swaps.

Sound is untouched — the narration audio plays exactly as before, in both presentations.

## Verification

- Unit tests: parser grammar (timings, case-insensitivity, `$key` misses dropped, malformed input), overlay lifetime/dedupe/replacement/clear, TrapSound effect emission (negative-first: all assert behavior that doesn't exist on main).
- SDK e2e `subtitle-overlay.e2e.test.ts` (green): flat run asserts the `subtitle` scene source appears with the narration and expires with the cues; VR run asserts the same narration presents on a world panel within 4 m of the player. `missions.e2e.test.ts`: **all 23 missions load** (the mount change touches the shared load path).
- Both presentations render-verified on earth.mis `trg0001`, including the close-wall occlusion case in VR.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p shock2vr --lib` 825 green; no new clippy findings.
- Cross-engine review (`/xreview`, Claude + Codex + de-dup pass) — the High finding (VR occlusion) and both Mediums (scene-swap leak, one-frame un-placed anchor) are fixed in the review commit.
- Remaining Codex suggestions addressed in a follow-up commit: `TurnOff` now takes the subtitle down with its sound (`HideSubtitle` effect + unit tests), and the loader logs when cue files are present but `loc_english.txt` is missing instead of silently disabling subtitles. A third suggestion (registering the cue files with a `TEXT_IMPORTER`) was verified moot — no such importer exists; the loader reads raw. Re-validated after the fixes: fmt/check `-D warnings` clean, `cargo test -p shock2vr --lib` 827 green, subtitle e2e green in both presentations.

## Known follow-ups (out of scope here)

- station.mis `BriefTrap*` use the still-noop `TrapMessage` script with an *empty* sound prop — their trigger path needs its own investigation (they play nothing today either).
- The generic HUD message line ("Picked up log: …", `linebeep`) remains #916 — this PR deliberately implements only the narration-subtitle funnel.
- The crate now has four greedy word-wrap helpers (this one is the only glyph-measured one) and a fourth fixed-metrics test font stub — consolidation into `ui/`/`test_support` is a clean follow-up.
- `Localization` flattens `[section]` namespaces (safe for subtitle keys, documented); resolving the Nightdive `strings` stubs through it later needs section-qualified lookup first.


