### PR TITLE
feat(debug): live-tunable dev params registry with a debug HTTP mirror

### DIFF
--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -232,18 +232,19 @@ POST /v1/player/spawn-item - Provision an item template into the inventory
 POST /v1/player/stats     - Provision skills/stats/psi tier/cyber modules
 POST /v1/screenshot       - Capture screenshot
 GET  /v1/dev-params       - List live-tunable dev params (key, label, range, value, default)
-POST /v1/dev-params       - Set a dev param {key, value}; clamped + snapped, 404 on unknown key
+POST /v1/dev-params       - Set a dev param {key, value} (clamped + snapped) or restore its exact default {key, reset: true}; 404 on unknown key
 ```
 
 `/v1/dev-params` mirrors the `shock2vr::dev_params` registry (the live tuning
 knobs the Developer menu will expose - frontend panel distance, pause dim
-strength, eye-height offset). The values are process-global atomics read by
+strength). The values are process-global atomics read by
 their consumers every frame, so the handlers touch the registry directly - no
 `RuntimeCommand` round-trip - and a POST is visible on the next stepped frame:
 
 ```bash
 curl http://127.0.0.1:8080/v1/dev-params
 curl -X POST http://127.0.0.1:8080/v1/dev-params -d '{"key": "panel_distance", "value": 3.0}'
+curl -X POST http://127.0.0.1:8080/v1/dev-params -d '{"key": "panel_distance", "reset": true}'
 ```
 
 The `/v1/control/input` channel vocabulary lives in `shock2vr::input::remote`

--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -231,6 +231,19 @@ POST /v1/control/input    - Set input channel
 POST /v1/player/spawn-item - Provision an item template into the inventory
 POST /v1/player/stats     - Provision skills/stats/psi tier/cyber modules
 POST /v1/screenshot       - Capture screenshot
+GET  /v1/dev-params       - List live-tunable dev params (key, label, range, value, default)
+POST /v1/dev-params       - Set a dev param {key, value}; clamped + snapped, 404 on unknown key
+```
+
+`/v1/dev-params` mirrors the `shock2vr::dev_params` registry (the live tuning
+knobs the Developer menu will expose - frontend panel distance, pause dim
+strength, eye-height offset). The values are process-global atomics read by
+their consumers every frame, so the handlers touch the registry directly - no
+`RuntimeCommand` round-trip - and a POST is visible on the next stepped frame:
+
+```bash
+curl http://127.0.0.1:8080/v1/dev-params
+curl -X POST http://127.0.0.1:8080/v1/dev-params -d '{"key": "panel_distance", "value": 3.0}'
 ```
 
 The `/v1/control/input` channel vocabulary lives in `shock2vr::input::remote`

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -313,6 +313,8 @@ async fn start_http_server(
             axum::routing::post(trigger_input_action),
         )
         .route("/v1/input/actions", get(list_input_actions))
+        .route("/v1/dev-params", get(list_dev_params))
+        .route("/v1/dev-params", axum::routing::post(set_dev_param))
         .route("/v1/audio/recent", get(get_recent_audio))
         .route("/v1/messages/recent", get(get_recent_messages))
         .route("/v1/screenshot", axum::routing::post(take_screenshot))
@@ -368,6 +370,8 @@ async fn start_http_server(
         "  POST /v1/input/action     - Trigger a discrete input action (e.g. PathfindingTestCycle)"
     );
     info!("  GET  /v1/input/actions    - List available input actions");
+    info!("  GET  /v1/dev-params       - List live-tunable dev params (range, value, default)");
+    info!("  POST /v1/dev-params       - Set a dev param {{key, value}} (clamped + snapped, live next frame)");
     info!("  GET  /v1/audio/recent     - Recently played sounds (sample, tags, duration, source)");
     info!("  GET  /v1/messages/recent  - Recently delivered script messages (to/payload/from)");
     info!("  POST /v1/screenshot       - Capture the current framebuffer");
@@ -3518,6 +3522,54 @@ async fn trigger_input_action(
 }
 
 /// HTTP endpoint handler: List available input actions
+/// HTTP handler listing the live-tunable dev params (key, label, kind/range,
+/// current value, default). The registry is process-global atomics
+/// (`shock2vr::dev_params`), so this reads it directly - no game-loop
+/// round-trip, same as `/v1/audio/recent`.
+async fn list_dev_params() -> Json<Value> {
+    let params: Vec<Value> = shock2vr::dev_params::all()
+        .map(|(id, param)| {
+            let shock2vr::dev_params::DevParamKind::Float { min, max, step } = param.kind;
+            json!({
+                "key": param.key,
+                "label": param.label,
+                "kind": "float",
+                "min": min,
+                "max": max,
+                "step": step,
+                "value": shock2vr::dev_params::get(id),
+                "default": param.default,
+            })
+        })
+        .collect();
+    Json(json!({ "params": params }))
+}
+
+#[derive(Deserialize)]
+struct SetDevParamRequest {
+    key: String,
+    value: f32,
+}
+
+/// HTTP handler setting one dev param by key. The value is clamped into the
+/// param's range and snapped to its step grid; the response reports what was
+/// actually applied. Consumers read the registry every frame, so the change is
+/// live on the next stepped frame. Unknown keys are a 404.
+async fn set_dev_param(
+    LenientJson(request): LenientJson<SetDevParamRequest>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    match shock2vr::dev_params::find(&request.key) {
+        Some(id) => {
+            let applied = shock2vr::dev_params::set(id, request.value);
+            Ok(Json(json!({ "key": request.key, "value": applied })))
+        }
+        None => Err((
+            StatusCode::NOT_FOUND,
+            format!("unknown dev param key: {}", request.key),
+        )),
+    }
+}
+
 async fn list_input_actions() -> Json<Value> {
     let actions: Vec<&str> = InputAction::all().iter().map(|a| a.as_str()).collect();
     Json(serde_json::json!({ "actions": actions }))

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -3523,7 +3523,6 @@ async fn trigger_input_action(
     }
 }
 
-/// HTTP endpoint handler: List available input actions
 /// HTTP handler listing the live-tunable dev params (key, label, kind/range,
 /// current value, default). The registry is process-global atomics
 /// (`shock2vr::dev_params`), so this reads it directly - no game-loop
@@ -3550,28 +3549,51 @@ async fn list_dev_params() -> Json<Value> {
 #[derive(Deserialize)]
 struct SetDevParamRequest {
     key: String,
-    value: f32,
+    #[serde(default)]
+    value: Option<f32>,
+    #[serde(default)]
+    reset: bool,
 }
 
-/// HTTP handler setting one dev param by key. The value is clamped into the
-/// param's range and snapped to its step grid; the response reports what was
-/// actually applied. Consumers read the registry every frame, so the change is
-/// live on the next stepped frame. Unknown keys are a 404.
+/// HTTP handler setting one dev param by key. `{key, value}` clamps into the
+/// param's range and snaps to its step grid; `{key, reset: true}` restores
+/// the exact declared default (which a `value` POST cannot always reach - the
+/// snap grid does not round-trip every default). The response reports what
+/// was actually applied. Consumers read the registry every frame, so the
+/// change is live on the next stepped frame. Unknown keys are a 404;
+/// non-finite values, and requests with both or neither of `value`/`reset`,
+/// are a 400.
 async fn set_dev_param(
     LenientJson(request): LenientJson<SetDevParamRequest>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    match shock2vr::dev_params::find(&request.key) {
-        Some(id) => {
-            let applied = shock2vr::dev_params::set(id, request.value);
-            Ok(Json(json!({ "key": request.key, "value": applied })))
-        }
-        None => Err((
+    let Some(id) = shock2vr::dev_params::find(&request.key) else {
+        return Err((
             StatusCode::NOT_FOUND,
             format!("unknown dev param key: {}", request.key),
-        )),
-    }
+        ));
+    };
+    let applied = match (request.value, request.reset) {
+        (Some(value), false) => {
+            if !value.is_finite() {
+                return Err((StatusCode::BAD_REQUEST, "value must be finite".to_string()));
+            }
+            shock2vr::dev_params::set(id, value)
+        }
+        (None, true) => {
+            shock2vr::dev_params::reset(id);
+            shock2vr::dev_params::get(id)
+        }
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "provide exactly one of 'value' or 'reset: true'".to_string(),
+            ));
+        }
+    };
+    Ok(Json(json!({ "key": request.key, "value": applied })))
 }
 
+/// HTTP endpoint handler: List available input actions
 async fn list_input_actions() -> Json<Value> {
     let actions: Vec<&str> = InputAction::all().iter().map(|a| a.as_str()).collect();
     Json(serde_json::json!({ "actions": actions }))

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -371,7 +371,9 @@ async fn start_http_server(
     );
     info!("  GET  /v1/input/actions    - List available input actions");
     info!("  GET  /v1/dev-params       - List live-tunable dev params (range, value, default)");
-    info!("  POST /v1/dev-params       - Set a dev param {{key, value}} (clamped + snapped, live next frame)");
+    info!(
+        "  POST /v1/dev-params       - Set a dev param {{key, value}} (clamped + snapped, live next frame)"
+    );
     info!("  GET  /v1/audio/recent     - Recently played sounds (sample, tags, duration, source)");
     info!("  GET  /v1/messages/recent  - Recently delivered script messages (to/payload/from)");
     info!("  POST /v1/screenshot       - Capture the current framebuffer");

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -119,106 +119,143 @@ pub fn get(id: DevParamId) -> f32 {
 /// (the current value is returned unchanged) so no consumer can ever read
 /// a NaN out of the registry.
 pub fn set(id: DevParamId, value: f32) -> f32 {
-    if !value.is_finite() {
-        return get(id);
-    }
-    let applied = match spec(id).kind {
-        DevParamKind::Float { min, max, step } => {
-            let snapped = if step > 0.0 {
-                min + ((value - min) / step).round() * step
-            } else {
-                value
-            };
-            snapped.clamp(min, max)
-        }
-    };
+    let applied = apply(&spec(id).kind, get(id), value);
     VALUES[id.0].store(applied.to_bits(), Ordering::Relaxed);
     applied
+}
+
+/// The pure constrain step behind [`set`]: what `value` becomes under `kind`
+/// when the parameter currently reads `current`. Split out so the clamp/snap
+/// rules are testable without touching the process-global values (mutating
+/// them from unit tests would race every parallel test that reads a live
+/// parameter).
+fn apply(kind: &DevParamKind, current: f32, value: f32) -> f32 {
+    if !value.is_finite() {
+        return current;
+    }
+    match *kind {
+        DevParamKind::Float { min, max, step } => {
+            if step > 0.0 {
+                // Clamp the grid *index*, not the snapped value: clamping
+                // afterwards would return `max` itself, which is off the
+                // advertised grid whenever the range is not a whole number
+                // of steps (and a future menu's arrows would then walk a
+                // shifted grid).
+                let max_index = ((max - min) / step).floor();
+                let index = ((value - min) / step).round().clamp(0.0, max_index);
+                (min + index * step).clamp(min, max)
+            } else {
+                value.clamp(min, max)
+            }
+        }
+    }
 }
 
 /// Restore a parameter to its declared default, exactly. This stores the
 /// default's own bits rather than routing through [`set`], whose snap grid
 /// does not round-trip every default (e.g. 0.72 on a 0.02 grid lands on
-/// 0.71999997 in f32) - the difference matters to tests (and a future menu
-/// "reset" row) that compare against the default with `==`.
+/// 0.71999997 in f32) - the difference matters to anything that compares
+/// against the default with `==` (the HTTP mirror's reset, a future menu
+/// "reset" row).
 pub fn reset(id: DevParamId) {
     VALUES[id.0].store(spec(id).default.to_bits(), Ordering::Relaxed);
-}
-
-/// Serializes tests that read or write the registry: the values are process
-/// globals, so a mutation test running in parallel with a test that asserts a
-/// default would flake. Writers must restore defaults before dropping the
-/// guard.
-#[cfg(test)]
-pub(crate) fn test_guard() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    LOCK.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // No test here (or anywhere in the crate) mutates the live registry:
+    // the values are process globals read by parallel tests all over the
+    // crate, so a unit-test `set` would be a cross-test race. The constrain
+    // rules are tested through the pure [`apply`]; that `set`/`reset` really
+    // move what consumers render is proven end-to-end by the SDK e2e
+    // (`dev-params.e2e.test.ts`), which watches the VR panel move over HTTP.
+
     /// The registry replaced two consts; anything but these exact defaults
     /// is a behavior change at launch.
     #[test]
     fn defaults_equal_the_consts_they_replaced() {
-        let _guard = test_guard();
         assert_eq!(get(FRONTEND_PANEL_DISTANCE), 2.0);
         assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
     }
 
-    // The mutation tests below hold [`test_guard`] and restore defaults
-    // before releasing it; tests elsewhere in the crate that assert against a
-    // parameter's live value take the same guard so a temporarily non-default
-    // value is never observed.
+    /// Every declared default must be finite and inside its own range, or
+    /// the seeded value would already violate the registry's contract.
+    #[test]
+    fn every_default_is_within_its_declared_range() {
+        for (_, param) in all() {
+            let DevParamKind::Float { min, max, step } = param.kind;
+            assert!(param.default.is_finite());
+            assert!(
+                (min..=max).contains(&param.default),
+                "{}: default {} outside {min}..={max}",
+                param.key,
+                param.default
+            );
+            assert!(step >= 0.0, "{}: negative step", param.key);
+        }
+    }
+
+    const GRID: DevParamKind = DevParamKind::Float {
+        min: 0.5,
+        max: 6.0,
+        step: 0.1,
+    };
 
     #[test]
-    fn set_moves_the_live_value_and_reports_what_it_applied() {
-        let _guard = test_guard();
-        // Negative first: before the set, the default is in effect.
-        assert_eq!(get(FRONTEND_PANEL_DISTANCE), 2.0);
-        let applied = set(FRONTEND_PANEL_DISTANCE, 2.5);
-        assert!((applied - 2.5).abs() < 1e-4);
-        assert!((get(FRONTEND_PANEL_DISTANCE) - 2.5).abs() < 1e-4);
-        reset(FRONTEND_PANEL_DISTANCE);
+    fn apply_passes_an_in_range_on_grid_value_through() {
+        assert!((apply(&GRID, 2.0, 2.5) - 2.5).abs() < 1e-4);
     }
 
     #[test]
-    fn set_clamps_into_the_declared_range() {
-        let _guard = test_guard();
-        assert_eq!(set(FRONTEND_PANEL_DISTANCE, 99.0), 6.0);
-        assert_eq!(set(FRONTEND_PANEL_DISTANCE, -3.0), 0.5);
-        reset(FRONTEND_PANEL_DISTANCE);
+    fn apply_clamps_into_the_declared_range() {
+        assert_eq!(apply(&GRID, 2.0, 99.0), 6.0);
+        assert_eq!(apply(&GRID, 2.0, -3.0), 0.5);
     }
 
     #[test]
-    fn set_snaps_to_the_step_grid() {
-        let _guard = test_guard();
-        // 0.013 is between grid points 0.0 and 0.02 (min 0.0, step 0.02).
-        let applied = set(WORLD_DIM_STRENGTH, 0.013);
+    fn apply_snaps_to_the_step_grid() {
+        let kind = DevParamKind::Float {
+            min: 0.0,
+            max: 1.0,
+            step: 0.02,
+        };
+        // 0.013 is between grid points 0.0 and 0.02.
+        let applied = apply(&kind, 0.72, 0.013);
         assert!((applied - 0.02).abs() < 1e-4, "got {applied}");
-        reset(WORLD_DIM_STRENGTH);
     }
 
-    /// `set(default)` is NOT an exact restore (the snap grid can miss the
-    /// default's bits); `reset` must be.
+    /// A range that is not a whole number of steps must still land on the
+    /// grid at its top end: snapping *then* clamping would return `max`
+    /// itself, off the advertised grid.
     #[test]
-    fn reset_restores_the_exact_default_even_off_grid() {
-        let _guard = test_guard();
-        // 0.72 is default for a 0.02-step grid: set() snaps it to 0.71999997.
-        set(WORLD_DIM_STRENGTH, spec(WORLD_DIM_STRENGTH).default);
-        assert_ne!(get(WORLD_DIM_STRENGTH).to_bits(), 0.72f32.to_bits());
-        reset(WORLD_DIM_STRENGTH);
-        assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
+    fn apply_keeps_an_uneven_ranges_top_end_on_grid() {
+        let kind = DevParamKind::Float {
+            min: 0.0,
+            max: 0.05,
+            step: 0.02,
+        };
+        assert!((apply(&kind, 0.0, 99.0) - 0.04).abs() < 1e-6);
+    }
+
+    /// Why [`reset`] stores the default's own bits instead of routing
+    /// through the snap: the grid cannot represent every default exactly.
+    #[test]
+    fn the_snap_grid_does_not_round_trip_every_default() {
+        let kind = DevParamKind::Float {
+            min: 0.0,
+            max: 1.0,
+            step: 0.02,
+        };
+        assert_ne!(apply(&kind, 0.72, 0.72).to_bits(), 0.72f32.to_bits());
     }
 
     #[test]
-    fn a_non_finite_set_is_refused() {
-        let _guard = test_guard();
-        assert_eq!(set(WORLD_DIM_STRENGTH, f32::NAN), 0.72);
-        assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
-        assert_eq!(set(WORLD_DIM_STRENGTH, f32::INFINITY), 0.72);
+    fn a_non_finite_value_is_refused() {
+        assert_eq!(apply(&GRID, 2.0, f32::NAN), 2.0);
+        assert_eq!(apply(&GRID, 2.0, f32::INFINITY), 2.0);
+        assert_eq!(apply(&GRID, 2.0, f32::NEG_INFINITY), 2.0);
     }
 
     #[test]

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -1,0 +1,203 @@
+//! Live-tunable developer parameters.
+//!
+//! A small registry of runtime tuning knobs that used to be module-private
+//! `const`s (and so cost a rebuild - and on the Quest, a redeploy - per
+//! nudge). Each parameter is declared once in the [`dev_params!`] invocation
+//! below; consumers read it through [`get`] every frame, so a [`set`] is
+//! visible on the next frame with no plumbing.
+//!
+//! Storage is a static table plus one `AtomicU32` of `f32` bits per parameter:
+//! lock-free, safe from any thread, and needing no `&mut Game`. That is what
+//! lets the debug runtime's `GET`/`POST /v1/dev-params` handlers read and
+//! write the registry directly (no `RuntimeCommand` round-trip), and what will
+//! let the Developer menu screen do the same from the game thread.
+//!
+//! Ground rule: **if the consumer does not read the parameter every frame, it
+//! does not belong in this table yet.** Values latched at construction time
+//! (feature gates, collider dimensions, anything baked into a scene object)
+//! would need a poke/rebuild path this registry deliberately does not have.
+
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// How a parameter's value is interpreted and constrained.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DevParamKind {
+    /// A float clamped to `min..=max`; [`set`] snaps to the nearest multiple
+    /// of `step` from `min` (the grid the future menu's `<`/`>` arrows walk).
+    Float { min: f32, max: f32, step: f32 },
+    // `Bool` and `Enum(&'static [&'static str])` go here when a param needs
+    // them - stored in the same f32 bits as 0.0/1.0 and the variant index.
+}
+
+/// One registered parameter: a stable string key (HTTP + future persistence),
+/// a human-readable label (the future menu row), its kind, and its default.
+#[derive(Debug)]
+pub struct DevParam {
+    pub key: &'static str,
+    pub label: &'static str,
+    pub kind: DevParamKind,
+    pub default: f32,
+}
+
+/// Index into [`PARAMS`]; obtained from the generated consts or [`find`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DevParamId(usize);
+
+/// Declares the parameter table. One line per parameter generates its
+/// [`PARAMS`] entry *and* its `pub const` id, so the two cannot drift.
+macro_rules! dev_params {
+    ($($(#[$doc:meta])* $id:ident = float($key:literal, $label:literal, $default:expr, $min:expr, $max:expr, $step:expr)),+ $(,)?) => {
+        /// Every registered parameter, in declaration order (index == id).
+        pub static PARAMS: &[DevParam] = &[
+            $(DevParam {
+                key: $key,
+                label: $label,
+                kind: DevParamKind::Float { min: $min, max: $max, step: $step },
+                default: $default,
+            }),+
+        ];
+
+        #[allow(non_camel_case_types, clippy::upper_case_acronyms, dead_code)]
+        enum __DevParamIndex { $($id),+ }
+
+        $($(#[$doc])* pub const $id: DevParamId = DevParamId(__DevParamIndex::$id as usize);)+
+    };
+}
+
+dev_params! {
+    /// How far ahead of the head the VR frontend/pause panel hangs, in world
+    /// units. Default matches the old `ui::FRONTEND_PANEL_DISTANCE` const.
+    FRONTEND_PANEL_DISTANCE = float("panel_distance", "Panel distance", 2.0, 0.5, 6.0, 0.1),
+    /// How dark the world goes behind the pause panel in VR: 0 leaves it
+    /// untouched, 1 blacks it out. Default matches the old
+    /// `pause_menu::WORLD_DIM_STRENGTH` const.
+    WORLD_DIM_STRENGTH = float("dim_strength", "Pause dim", 0.72, 0.0, 1.0, 0.02),
+    /// Extra eye height, in real-world meters, added on top of the stance's
+    /// base eye height. Default 0 = the unmodified `PLAYER_EYE_HEIGHT`.
+    EYE_HEIGHT_OFFSET = float("eye_offset", "Eye height offset (m)", 0.0, -0.5, 0.5, 0.02),
+}
+
+/// Current values, as `f32` bits. `Lazy` because `f32::to_bits` in a `static`
+/// initializer wants a newer const story than the table needs; the first read
+/// simply seeds every slot with its default.
+static VALUES: Lazy<Vec<AtomicU32>> = Lazy::new(|| {
+    PARAMS
+        .iter()
+        .map(|p| AtomicU32::new(p.default.to_bits()))
+        .collect()
+});
+
+/// Every parameter with its id, in declaration order.
+pub fn all() -> impl Iterator<Item = (DevParamId, &'static DevParam)> {
+    PARAMS.iter().enumerate().map(|(i, p)| (DevParamId(i), p))
+}
+
+/// The static description of one parameter.
+pub fn spec(id: DevParamId) -> &'static DevParam {
+    &PARAMS[id.0]
+}
+
+/// Look a parameter up by its stable string key.
+pub fn find(key: &str) -> Option<DevParamId> {
+    PARAMS.iter().position(|p| p.key == key).map(DevParamId)
+}
+
+/// The parameter's current value.
+pub fn get(id: DevParamId) -> f32 {
+    f32::from_bits(VALUES[id.0].load(Ordering::Relaxed))
+}
+
+/// Set a parameter, clamped into its range and snapped to its step grid.
+/// Returns the value actually applied. A non-finite request is refused
+/// (the current value is returned unchanged) so no consumer can ever read
+/// a NaN out of the registry.
+pub fn set(id: DevParamId, value: f32) -> f32 {
+    if !value.is_finite() {
+        return get(id);
+    }
+    let applied = match spec(id).kind {
+        DevParamKind::Float { min, max, step } => {
+            let snapped = if step > 0.0 {
+                min + ((value - min) / step).round() * step
+            } else {
+                value
+            };
+            snapped.clamp(min, max)
+        }
+    };
+    VALUES[id.0].store(applied.to_bits(), Ordering::Relaxed);
+    applied
+}
+
+/// Serializes tests that read or write the registry: the values are process
+/// globals, so a mutation test running in parallel with a test that asserts a
+/// default would flake. Writers must restore defaults before dropping the
+/// guard.
+#[cfg(test)]
+pub(crate) fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry replaced three consts; anything but these exact defaults
+    /// is a behavior change at launch.
+    #[test]
+    fn defaults_equal_the_consts_they_replaced() {
+        let _guard = test_guard();
+        assert_eq!(get(FRONTEND_PANEL_DISTANCE), 2.0);
+        assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
+        assert_eq!(get(EYE_HEIGHT_OFFSET), 0.0);
+    }
+
+    // The mutation tests below deliberately touch only EYE_HEIGHT_OFFSET: it
+    // has the fewest reader tests elsewhere in the crate, and each of those
+    // takes [`test_guard`] too, so a temporarily non-default value is never
+    // observed.
+
+    #[test]
+    fn set_moves_the_live_value_and_reports_what_it_applied() {
+        let _guard = test_guard();
+        // Negative first: before the set, the default is in effect.
+        assert_eq!(get(EYE_HEIGHT_OFFSET), 0.0);
+        let applied = set(EYE_HEIGHT_OFFSET, 0.2);
+        assert!((applied - 0.2).abs() < 1e-4);
+        assert!((get(EYE_HEIGHT_OFFSET) - 0.2).abs() < 1e-4);
+        set(EYE_HEIGHT_OFFSET, spec(EYE_HEIGHT_OFFSET).default);
+    }
+
+    #[test]
+    fn set_clamps_into_the_declared_range() {
+        let _guard = test_guard();
+        assert_eq!(set(EYE_HEIGHT_OFFSET, 99.0), 0.5);
+        assert_eq!(set(EYE_HEIGHT_OFFSET, -3.0), -0.5);
+        set(EYE_HEIGHT_OFFSET, spec(EYE_HEIGHT_OFFSET).default);
+    }
+
+    #[test]
+    fn set_snaps_to_the_step_grid() {
+        let _guard = test_guard();
+        // 0.013 is between grid points 0.0 and 0.02 (min -0.5, step 0.02).
+        let applied = set(EYE_HEIGHT_OFFSET, 0.013);
+        assert!((applied - 0.02).abs() < 1e-4, "got {applied}");
+        set(EYE_HEIGHT_OFFSET, spec(EYE_HEIGHT_OFFSET).default);
+    }
+
+    #[test]
+    fn a_non_finite_set_is_refused() {
+        let _guard = test_guard();
+        assert_eq!(set(WORLD_DIM_STRENGTH, f32::NAN), 0.72);
+        assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
+        assert_eq!(set(WORLD_DIM_STRENGTH, f32::INFINITY), 0.72);
+    }
+
+    #[test]
+    fn unknown_keys_do_not_resolve() {
+        assert_eq!(find("no_such_param"), None);
+        assert_eq!(find("panel_distance"), Some(FRONTEND_PANEL_DISTANCE));
+    }
+}

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -12,12 +12,18 @@
 //! write the registry directly (no `RuntimeCommand` round-trip), and what will
 //! let the Developer menu screen do the same from the game thread.
 //!
+//! Reads are individually atomic but deliberately unsynchronized across a
+//! frame: a [`set`] landing mid-frame can be seen by later reads in the same
+//! frame (e.g. a panel hit-test and its render disagreeing by one frame).
+//! That is acceptable for tuning knobs - the next frame is consistent - and
+//! in the stepped debug runtime it never happens at all, because HTTP sets
+//! land between frames.
+//!
 //! Ground rule: **if the consumer does not read the parameter every frame, it
 //! does not belong in this table yet.** Values latched at construction time
 //! (feature gates, collider dimensions, anything baked into a scene object)
 //! would need a poke/rebuild path this registry deliberately does not have.
 
-use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 /// How a parameter's value is interpreted and constrained.
@@ -58,6 +64,12 @@ macro_rules! dev_params {
             }),+
         ];
 
+        /// Current values, as `f32` bits, seeded with the defaults. A sized
+        /// array, not a `&[_]` slice: a borrow of interior-mutable data
+        /// cannot be promoted to `'static` (E0492).
+        static VALUES: [AtomicU32; [$(($default as f32)),+].len()] =
+            [$(AtomicU32::new(($default as f32).to_bits())),+];
+
         #[allow(non_camel_case_types, clippy::upper_case_acronyms, dead_code)]
         enum __DevParamIndex { $($id),+ }
 
@@ -73,20 +85,14 @@ dev_params! {
     /// untouched, 1 blacks it out. Default matches the old
     /// `pause_menu::WORLD_DIM_STRENGTH` const.
     WORLD_DIM_STRENGTH = float("dim_strength", "Pause dim", 0.72, 0.0, 1.0, 0.02),
-    /// Extra eye height, in real-world meters, added on top of the stance's
-    /// base eye height. Default 0 = the unmodified `PLAYER_EYE_HEIGHT`.
-    EYE_HEIGHT_OFFSET = float("eye_offset", "Eye height offset (m)", 0.0, -0.5, 0.5, 0.02),
+    // An eye-height offset was considered for this seed set and deliberately
+    // left out: on the Quest the eye is the *tracked pose* (capped in
+    // `oculus_runtime`), which never reads `player_eye_height_for` - so the
+    // knob would be inert exactly where live tuning matters, while the debug
+    // runtime's `--vr` path (which does read it) would falsely "verify" it.
+    // It returns with the Developer screen once the tracked-stage offset is
+    // wired through the runtime (head and hands together).
 }
-
-/// Current values, as `f32` bits. `Lazy` because `f32::to_bits` in a `static`
-/// initializer wants a newer const story than the table needs; the first read
-/// simply seeds every slot with its default.
-static VALUES: Lazy<Vec<AtomicU32>> = Lazy::new(|| {
-    PARAMS
-        .iter()
-        .map(|p| AtomicU32::new(p.default.to_bits()))
-        .collect()
-});
 
 /// Every parameter with its id, in declaration order.
 pub fn all() -> impl Iterator<Item = (DevParamId, &'static DevParam)> {
@@ -130,6 +136,15 @@ pub fn set(id: DevParamId, value: f32) -> f32 {
     applied
 }
 
+/// Restore a parameter to its declared default, exactly. This stores the
+/// default's own bits rather than routing through [`set`], whose snap grid
+/// does not round-trip every default (e.g. 0.72 on a 0.02 grid lands on
+/// 0.71999997 in f32) - the difference matters to tests (and a future menu
+/// "reset" row) that compare against the default with `==`.
+pub fn reset(id: DevParamId) {
+    VALUES[id.0].store(spec(id).default.to_bits(), Ordering::Relaxed);
+}
+
 /// Serializes tests that read or write the registry: the values are process
 /// globals, so a mutation test running in parallel with a test that asserts a
 /// default would flake. Writers must restore defaults before dropping the
@@ -144,47 +159,58 @@ pub(crate) fn test_guard() -> std::sync::MutexGuard<'static, ()> {
 mod tests {
     use super::*;
 
-    /// The registry replaced three consts; anything but these exact defaults
+    /// The registry replaced two consts; anything but these exact defaults
     /// is a behavior change at launch.
     #[test]
     fn defaults_equal_the_consts_they_replaced() {
         let _guard = test_guard();
         assert_eq!(get(FRONTEND_PANEL_DISTANCE), 2.0);
         assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
-        assert_eq!(get(EYE_HEIGHT_OFFSET), 0.0);
     }
 
-    // The mutation tests below deliberately touch only EYE_HEIGHT_OFFSET: it
-    // has the fewest reader tests elsewhere in the crate, and each of those
-    // takes [`test_guard`] too, so a temporarily non-default value is never
-    // observed.
+    // The mutation tests below hold [`test_guard`] and restore defaults
+    // before releasing it; tests elsewhere in the crate that assert against a
+    // parameter's live value take the same guard so a temporarily non-default
+    // value is never observed.
 
     #[test]
     fn set_moves_the_live_value_and_reports_what_it_applied() {
         let _guard = test_guard();
         // Negative first: before the set, the default is in effect.
-        assert_eq!(get(EYE_HEIGHT_OFFSET), 0.0);
-        let applied = set(EYE_HEIGHT_OFFSET, 0.2);
-        assert!((applied - 0.2).abs() < 1e-4);
-        assert!((get(EYE_HEIGHT_OFFSET) - 0.2).abs() < 1e-4);
-        set(EYE_HEIGHT_OFFSET, spec(EYE_HEIGHT_OFFSET).default);
+        assert_eq!(get(FRONTEND_PANEL_DISTANCE), 2.0);
+        let applied = set(FRONTEND_PANEL_DISTANCE, 2.5);
+        assert!((applied - 2.5).abs() < 1e-4);
+        assert!((get(FRONTEND_PANEL_DISTANCE) - 2.5).abs() < 1e-4);
+        reset(FRONTEND_PANEL_DISTANCE);
     }
 
     #[test]
     fn set_clamps_into_the_declared_range() {
         let _guard = test_guard();
-        assert_eq!(set(EYE_HEIGHT_OFFSET, 99.0), 0.5);
-        assert_eq!(set(EYE_HEIGHT_OFFSET, -3.0), -0.5);
-        set(EYE_HEIGHT_OFFSET, spec(EYE_HEIGHT_OFFSET).default);
+        assert_eq!(set(FRONTEND_PANEL_DISTANCE, 99.0), 6.0);
+        assert_eq!(set(FRONTEND_PANEL_DISTANCE, -3.0), 0.5);
+        reset(FRONTEND_PANEL_DISTANCE);
     }
 
     #[test]
     fn set_snaps_to_the_step_grid() {
         let _guard = test_guard();
-        // 0.013 is between grid points 0.0 and 0.02 (min -0.5, step 0.02).
-        let applied = set(EYE_HEIGHT_OFFSET, 0.013);
+        // 0.013 is between grid points 0.0 and 0.02 (min 0.0, step 0.02).
+        let applied = set(WORLD_DIM_STRENGTH, 0.013);
         assert!((applied - 0.02).abs() < 1e-4, "got {applied}");
-        set(EYE_HEIGHT_OFFSET, spec(EYE_HEIGHT_OFFSET).default);
+        reset(WORLD_DIM_STRENGTH);
+    }
+
+    /// `set(default)` is NOT an exact restore (the snap grid can miss the
+    /// default's bits); `reset` must be.
+    #[test]
+    fn reset_restores_the_exact_default_even_off_grid() {
+        let _guard = test_guard();
+        // 0.72 is default for a 0.02-step grid: set() snaps it to 0.71999997.
+        set(WORLD_DIM_STRENGTH, spec(WORLD_DIM_STRENGTH).default);
+        assert_ne!(get(WORLD_DIM_STRENGTH).to_bits(), 0.72f32.to_bits());
+        reset(WORLD_DIM_STRENGTH);
+        assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
     }
 
     #[test]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -96,14 +96,11 @@ pub const METERS_PER_WORLD_UNIT: f32 = 0.3048 * dark::SCALE_FACTOR;
 /// [`Game::player_eye_height`], which wraps it) so shots stay on the
 /// crosshair.
 pub fn player_eye_height_for(crouched: bool) -> f32 {
-    let base = if crouched {
+    if crouched {
         PLAYER_CROUCH_EYE_HEIGHT
     } else {
         PLAYER_EYE_HEIGHT
-    };
-    // Live-tunable extra eye height, declared in real-world meters; an SS2
-    // unit is a foot, so meters convert at 0.3048. Default 0 = `base` exactly.
-    base + dev_params::get(dev_params::EYE_HEIGHT_OFFSET) / 0.3048
+    }
 }
 
 use std::{
@@ -2170,9 +2167,6 @@ mod app_tests {
     /// real `Game`). They must answer exactly as an uncrouched player does.
     #[test]
     fn the_missing_assets_pose_matches_a_standing_player() {
-        // Eye height now includes the live EYE_HEIGHT_OFFSET dev param;
-        // serialize against tests that mutate it.
-        let _guard = dev_params::test_guard();
         let app = missing_assets_app();
         assert_eq!(
             app.player_center_above_floor(),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -15,6 +15,7 @@ pub mod time;
 pub mod career;
 mod creature;
 pub mod data_files;
+pub mod dev_params;
 mod flat_player_controller;
 mod gui;
 mod hand_forearm;
@@ -95,11 +96,14 @@ pub const METERS_PER_WORLD_UNIT: f32 = 0.3048 * dark::SCALE_FACTOR;
 /// [`Game::player_eye_height`], which wraps it) so shots stay on the
 /// crosshair.
 pub fn player_eye_height_for(crouched: bool) -> f32 {
-    if crouched {
+    let base = if crouched {
         PLAYER_CROUCH_EYE_HEIGHT
     } else {
         PLAYER_EYE_HEIGHT
-    }
+    };
+    // Live-tunable extra eye height, declared in real-world meters; an SS2
+    // unit is a foot, so meters convert at 0.3048. Default 0 = `base` exactly.
+    base + dev_params::get(dev_params::EYE_HEIGHT_OFFSET) / 0.3048
 }
 
 use std::{
@@ -2166,6 +2170,9 @@ mod app_tests {
     /// real `Game`). They must answer exactly as an uncrouched player does.
     #[test]
     fn the_missing_assets_pose_matches_a_standing_player() {
+        // Eye height now includes the live EYE_HEIGHT_OFFSET dev param;
+        // serialize against tests that mutate it.
+        let _guard = dev_params::test_guard();
         let app = missing_assets_app();
         assert_eq!(
             app.player_center_above_floor(),

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -37,9 +37,9 @@ use crate::{
     GameOptions, PresentationMode,
     input_context::{InputContext, Pointer2D},
     ui::{
-        FRONTEND_PANEL_DISTANCE, FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals,
-        Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, WorldPanel, pointer_to_canvas,
-        vr_frontend_pointer_pass,
+        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
+        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, WorldPanel, frontend_panel_distance,
+        pointer_to_canvas, vr_frontend_pointer_pass,
     },
 };
 
@@ -97,7 +97,11 @@ const FALLBACK_BUTTON_PITCH: f32 = 92.0;
 /// out completely. **This is the tuning knob** - the value wants a worn check,
 /// because how heavy a dim reads in a headset is not something a screenshot
 /// settles.
-const WORLD_DIM_STRENGTH: f32 = 0.72;
+///
+/// Live-tunable ([`crate::dev_params::WORLD_DIM_STRENGTH`]); read per frame.
+fn world_dim_strength() -> f32 {
+    crate::dev_params::get(crate::dev_params::WORLD_DIM_STRENGTH)
+}
 /// What the world is dimmed *toward*. Black rather than a tint: any hue here
 /// would grade the whole scene and fight the panel art.
 const WORLD_DIM_COLOR: Vector3<f32> = Vector3 {
@@ -107,10 +111,12 @@ const WORLD_DIM_COLOR: Vector3<f32> = Vector3 {
 };
 /// How far in front of the eyes the dim hangs, in metres, when the player is
 /// standing where they opened the menu. Behind the panel (which is at
-/// [`FRONTEND_PANEL_DISTANCE`]) so the panel's own opaque backdrop occludes it
+/// [`frontend_panel_distance`]) so the panel's own opaque backdrop occludes it
 /// and the menu stays at full brightness. Room-scale movement can push the
 /// panel farther away than this, which is what [`dim_distance`] is for.
-const WORLD_DIM_MIN_DISTANCE: f32 = FRONTEND_PANEL_DISTANCE + 1.0;
+fn world_dim_min_distance() -> f32 {
+    frontend_panel_distance() + 1.0
+}
 /// Clear air kept between the panel's farthest corner and the dim, in metres.
 const WORLD_DIM_PANEL_CLEARANCE: f32 = 1.0;
 /// Half-edge of the dim quad, as a multiple of its distance. This is
@@ -137,7 +143,7 @@ const UNTRACKED_HEAD: (Vector3<f32>, Quaternion<f32>) = (
 /// (a sustained deviation, held ~1 s) brings the panel with them. A dim at a
 /// fixed distance would then be in *front* of the panel and grey out the menu.
 /// So it is pushed past the panel's farthest corner, with clearance - never
-/// nearer than [`WORLD_DIM_MIN_DISTANCE`], and never at the panel's own depth.
+/// nearer than [`world_dim_min_distance`], and never at the panel's own depth.
 fn dim_distance(head_position: Vector3<f32>, panel: &WorldPanel) -> f32 {
     let right = panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0)) * panel.size.x * 0.5;
     let up = panel.rotation.rotate_vector(vec3(0.0, 1.0, 0.0)) * panel.size.y * 0.5;
@@ -145,7 +151,7 @@ fn dim_distance(head_position: Vector3<f32>, panel: &WorldPanel) -> f32 {
         .into_iter()
         .map(|(x, y)| (panel.center + right * x + up * y - head_position).magnitude())
         .fold(0.0_f32, f32::max);
-    (farthest_corner + WORLD_DIM_PANEL_CLEARANCE).max(WORLD_DIM_MIN_DISTANCE)
+    (farthest_corner + WORLD_DIM_PANEL_CLEARANCE).max(world_dim_min_distance())
 }
 
 /// The darkening layer between the paused player and the world.
@@ -191,9 +197,9 @@ fn world_dim_layer(
             * Matrix4::from(crate::util::get_rotation_from_forward_vector(-head_forward))
             * Matrix4::from_scale(extent * 2.0),
     );
-    // The material speaks in transparency (0 = opaque), the constant in "how
+    // The material speaks in transparency (0 = opaque), the strength in "how
     // dark does the world go" - the direction a human tunes in.
-    object.set_transparency(Some(1.0 - WORLD_DIM_STRENGTH));
+    object.set_transparency(Some(1.0 - world_dim_strength()));
     // Translucent, and drawn before the panel: writing depth here would let the
     // dim occlude the menu that draws over it.
     object.set_depth_write(false);
@@ -215,7 +221,7 @@ fn world_dim_layer(
 /// An untracked head arrives as the ZERO quaternion, which `rotate_vector`
 /// silently returns unrotated (and comes with a meaningless position) - so it is
 /// treated as "no pose", and the panel stands in for it. The panel hangs
-/// [`FRONTEND_PANEL_DISTANCE`] along its own normal from the head that placed
+/// [`frontend_panel_distance`] along its own normal from the head that placed
 /// it, with the normal pointing back at that head, so it carries a usable
 /// viewer pose: where the player was when they opened the menu.
 fn dim_pose(
@@ -225,7 +231,7 @@ fn dim_pose(
 ) -> (Vector3<f32>, Vector3<f32>) {
     if head_rotation.magnitude2() < 1e-6 {
         return (
-            panel.center + panel.normal() * FRONTEND_PANEL_DISTANCE,
+            panel.center + panel.normal() * frontend_panel_distance(),
             -panel.normal(),
         );
     }
@@ -1030,7 +1036,7 @@ mod tests {
             .effective_transparency()
             .expect("the dim must draw translucent, not opaque");
         assert!(
-            (transparency - (1.0 - WORLD_DIM_STRENGTH)).abs() < 1e-6,
+            (transparency - (1.0 - world_dim_strength())).abs() < 1e-6,
             "the tuning constant must reach the material: {transparency}"
         );
         assert!(
@@ -1152,7 +1158,7 @@ mod tests {
     #[test]
     fn the_dim_layer_stays_behind_the_panel_even_after_stepping_back() {
         let panel = test_panel();
-        let eye = panel.center + panel.normal() * crate::ui::FRONTEND_PANEL_DISTANCE;
+        let eye = panel.center + panel.normal() * crate::ui::frontend_panel_distance();
 
         for step_back in [0.0, 0.5, 1.0, 2.5, 6.0] {
             // Backing away from the panel along its own normal is the worst case.
@@ -1171,7 +1177,7 @@ mod tests {
                 "after stepping back {step_back} m the dim is at {distance} m, \
                  inside the panel's farthest corner at {farthest_corner} m"
             );
-            assert!(distance >= WORLD_DIM_MIN_DISTANCE);
+            assert!(distance >= world_dim_min_distance());
         }
     }
 
@@ -1183,7 +1189,7 @@ mod tests {
         let eye = panel.center + panel.normal() * 5.0;
         let distance = dim_distance(eye, &panel);
         assert!(
-            distance > WORLD_DIM_MIN_DISTANCE,
+            distance > world_dim_min_distance(),
             "this case should push out"
         );
         let object = world_dim_layer(eye, -panel.normal(), distance);
@@ -1220,7 +1226,7 @@ mod tests {
         );
         // ...and to the viewer position the panel implies, not to the garbage
         // position that came with the untracked pose.
-        let implied_head = panel.center + panel.normal() * crate::ui::FRONTEND_PANEL_DISTANCE;
+        let implied_head = panel.center + panel.normal() * crate::ui::frontend_panel_distance();
         assert!((position - implied_head).magnitude() < 1e-4);
     }
 

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -1029,8 +1029,6 @@ mod tests {
     /// would still pass a "the layer exists" test.
     #[test]
     fn the_dim_layer_darkens_the_world() {
-        // Asserts against the live dev-param value; serialize with its mutation tests.
-        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let (position, forward) = dim_pose(Vector3::zero(), head_looking(0.0, 0.0), &panel);
         let object = world_dim_layer(position, forward, dim_distance(position, &panel));
@@ -1159,8 +1157,6 @@ mod tests {
     /// in front would grey out the menu it exists to make readable.
     #[test]
     fn the_dim_layer_stays_behind_the_panel_even_after_stepping_back() {
-        // Asserts against the live dev-param value; serialize with its mutation tests.
-        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let eye = panel.center + panel.normal() * crate::ui::frontend_panel_distance();
 
@@ -1189,8 +1185,6 @@ mod tests {
     /// shrink the angle it subtends.
     #[test]
     fn pushing_the_dim_out_does_not_cost_coverage() {
-        // Asserts against the live dev-param value; serialize with its mutation tests.
-        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let eye = panel.center + panel.normal() * 5.0;
         let distance = dim_distance(eye, &panel);
@@ -1224,8 +1218,6 @@ mod tests {
     /// wherever the player is actually looking.
     #[test]
     fn an_untracked_head_falls_back_to_the_panel() {
-        // Asserts against the live dev-param value; serialize with its mutation tests.
-        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let (position, forward) = dim_pose(vec3(9.0, 9.0, 9.0), Quaternion::zero(), &panel);
         assert!(

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -1029,6 +1029,8 @@ mod tests {
     /// would still pass a "the layer exists" test.
     #[test]
     fn the_dim_layer_darkens_the_world() {
+        // Asserts against the live dev-param value; serialize with its mutation tests.
+        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let (position, forward) = dim_pose(Vector3::zero(), head_looking(0.0, 0.0), &panel);
         let object = world_dim_layer(position, forward, dim_distance(position, &panel));
@@ -1157,6 +1159,8 @@ mod tests {
     /// in front would grey out the menu it exists to make readable.
     #[test]
     fn the_dim_layer_stays_behind_the_panel_even_after_stepping_back() {
+        // Asserts against the live dev-param value; serialize with its mutation tests.
+        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let eye = panel.center + panel.normal() * crate::ui::frontend_panel_distance();
 
@@ -1185,6 +1189,8 @@ mod tests {
     /// shrink the angle it subtends.
     #[test]
     fn pushing_the_dim_out_does_not_cost_coverage() {
+        // Asserts against the live dev-param value; serialize with its mutation tests.
+        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let eye = panel.center + panel.normal() * 5.0;
         let distance = dim_distance(eye, &panel);
@@ -1218,6 +1224,8 @@ mod tests {
     /// wherever the player is actually looking.
     #[test]
     fn an_untracked_head_falls_back_to_the_panel() {
+        // Asserts against the live dev-param value; serialize with its mutation tests.
+        let _guard = crate::dev_params::test_guard();
         let panel = test_panel();
         let (position, forward) = dim_pose(vec3(9.0, 9.0, 9.0), Quaternion::zero(), &panel);
         assert!(

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -6030,8 +6030,6 @@ mod tests {
     /// the crown would be outside every room whose ceiling the body clears.
     #[test]
     fn standing_eye_is_the_head_sphere_plus_eye_offset_inside_the_collider() {
-        // player_eye_height_for reads the live EYE_HEIGHT_OFFSET dev param.
-        let _guard = crate::dev_params::test_guard();
         let eye = crate::player_eye_height_for(false);
         assert_eq!(
             eye,
@@ -6055,8 +6053,6 @@ mod tests {
     /// resolves to the one-sided ceiling rather than the container.
     #[test]
     fn standing_crosshair_reaches_a_container_under_a_seven_foot_ceiling() {
-        // player_eye_height_for reads the live EYE_HEIGHT_OFFSET dev param.
-        let _guard = crate::dev_params::test_guard();
         // hydro2's corpse alcove: a flat floor with a one-sided level ceiling
         // seven feet above it, which the six-foot standing body clears.
         const ROOM_HEIGHT: f32 = 7.0 / SCALE_FACTOR;

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -6030,6 +6030,8 @@ mod tests {
     /// the crown would be outside every room whose ceiling the body clears.
     #[test]
     fn standing_eye_is_the_head_sphere_plus_eye_offset_inside_the_collider() {
+        // player_eye_height_for reads the live EYE_HEIGHT_OFFSET dev param.
+        let _guard = crate::dev_params::test_guard();
         let eye = crate::player_eye_height_for(false);
         assert_eq!(
             eye,
@@ -6053,6 +6055,8 @@ mod tests {
     /// resolves to the one-sided ceiling rather than the container.
     #[test]
     fn standing_crosshair_reaches_a_container_under_a_seven_foot_ceiling() {
+        // player_eye_height_for reads the live EYE_HEIGHT_OFFSET dev param.
+        let _guard = crate::dev_params::test_guard();
         // hydro2's corpse alcove: a flat floor with a one-sided level ceiling
         // seven feet above it, which the six-foot standing body clears.
         const ROOM_HEIGHT: f32 = 7.0 / SCALE_FACTOR;

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -173,7 +173,7 @@ pub fn vr_frontend_pointer_pass(
 #[cfg(test)]
 pub mod test_support {
     use super::*;
-    use crate::ui::{FRONTEND_PANEL_DISTANCE, FrontendPanelAnchor, canvas_to_panel_world};
+    use crate::ui::{FrontendPanelAnchor, canvas_to_panel_world, frontend_panel_distance};
     use std::time::Duration;
 
     /// The head facing the tests aim against: the default camera orientation.
@@ -203,7 +203,7 @@ pub mod test_support {
         Hand {
             // Stand back on the viewer's side (the panel's normal points at the
             // viewer) and aim at the target.
-            position: target + normal * FRONTEND_PANEL_DISTANCE,
+            position: target + normal * frontend_panel_distance(),
             rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), -normal, None),
             trigger_value: trigger,
             ..Hand::default()
@@ -221,7 +221,7 @@ pub mod test_support {
         // it and looks the other way.
         let normal = panel.normal();
         Hand {
-            position: panel.center + normal * FRONTEND_PANEL_DISTANCE,
+            position: panel.center + normal * frontend_panel_distance(),
             rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), normal, None),
             trigger_value: trigger,
             ..Hand::default()

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -207,7 +207,12 @@ impl WorldPanel {
 /// view and is never seen. The panel is hung off the head's tracked position
 /// ([`crate::input_context::Head::position`], which defaults to that same eye
 /// height) rather than off the origin.
-pub const FRONTEND_PANEL_DISTANCE: f32 = 2.0;
+///
+/// Live-tunable ([`crate::dev_params::FRONTEND_PANEL_DISTANCE`]); read it per
+/// frame rather than latching it.
+pub fn frontend_panel_distance() -> f32 {
+    crate::dev_params::get(crate::dev_params::FRONTEND_PANEL_DISTANCE)
+}
 pub const FRONTEND_PANEL_SIZE: Vector2<f32> = Vector2 { x: 2.0, y: 1.5 };
 
 /// Spacing between stacked canvas layers in world space, so the labels sort in

--- a/shock2vr/src/ui/panel_anchor.rs
+++ b/shock2vr/src/ui/panel_anchor.rs
@@ -483,6 +483,8 @@ mod tests {
 
     #[test]
     fn the_placed_panel_faces_the_head() {
+        // Asserts against the live dev-param value; serialize with its mutation tests.
+        let _guard = crate::dev_params::test_guard();
         let placement = PanelPlacement::from_head(eye(), yaw(37.0));
         let panel = placement.panel();
         let to_head = (eye() - panel.center).normalize();

--- a/shock2vr/src/ui/panel_anchor.rs
+++ b/shock2vr/src/ui/panel_anchor.rs
@@ -483,8 +483,6 @@ mod tests {
 
     #[test]
     fn the_placed_panel_faces_the_head() {
-        // Asserts against the live dev-param value; serialize with its mutation tests.
-        let _guard = crate::dev_params::test_guard();
         let placement = PanelPlacement::from_head(eye(), yaw(37.0));
         let panel = placement.panel();
         let to_head = (eye() - panel.center).normalize();

--- a/shock2vr/src/ui/panel_anchor.rs
+++ b/shock2vr/src/ui/panel_anchor.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use cgmath::{Deg, InnerSpace, Quaternion, Rad, Rotation, Vector3, vec3};
 
-use crate::ui::{FRONTEND_PANEL_DISTANCE, FRONTEND_PANEL_SIZE, WorldPanel};
+use crate::ui::{FRONTEND_PANEL_SIZE, WorldPanel, frontend_panel_distance};
 
 /// Gaze may drift this far off the panel before a recenter starts counting.
 const RECENTER_YAW_DEGREES: f32 = 60.0;
@@ -112,7 +112,7 @@ impl PanelPlacement {
     /// and gravity-aligned, because the placement's forward is horizontal.
     pub fn panel(&self) -> WorldPanel {
         WorldPanel {
-            center: self.head_position + self.forward * FRONTEND_PANEL_DISTANCE,
+            center: self.head_position + self.forward * frontend_panel_distance(),
             // Panel -> head, so the panel faces the player squarely. The
             // helper's degenerate-vertical branch cannot fire here: a
             // placement's forward is horizontal by construction.
@@ -491,7 +491,7 @@ mod tests {
             "the panel normal must point back at the viewer"
         );
         assert!(
-            ((panel.center - eye()).magnitude() - FRONTEND_PANEL_DISTANCE).abs() < 1e-4,
+            ((panel.center - eye()).magnitude() - frontend_panel_distance()).abs() < 1e-4,
             "the panel must hang at the frontend distance"
         );
     }

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -122,6 +122,7 @@ const { sounds } = await game.audio.recent();
 // range/current/default, or set one - clamped + snapped, applied next frame.
 const { params } = await game.devParams.list();
 await game.devParams.set("panel_distance", 3.0);
+await game.devParams.reset("panel_distance"); // exact declared default
 ```
 
 Raycasts default to `world` and `entity`. Supported groups are `world`,

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -117,6 +117,11 @@ await game.raycast({
 // Recently played environmental sounds (resolved schema sample + query tags) -
 // the headless way to assert audio, e.g. weapon impact sounds.
 const { sounds } = await game.audio.recent();
+
+// Live-tunable dev params (shock2vr::dev_params): list every knob with its
+// range/current/default, or set one - clamped + snapped, applied next frame.
+const { params } = await game.devParams.list();
+await game.devParams.set("panel_distance", 3.0);
 ```
 
 Raycasts default to `world` and `entity`. Supported groups are `world`,

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -590,6 +590,18 @@ export class DevParamsApi {
   async set(key: string, value: number): Promise<DevParamSetResult> {
     return this.client.post<DevParamSetResult>("/v1/dev-params", { key, value });
   }
+
+  /**
+   * Restore one param to its exact declared default. A `set(key, default)`
+   * cannot always get there - the snap grid does not round-trip every
+   * default - so reset is its own operation.
+   */
+  async reset(key: string): Promise<DevParamSetResult> {
+    return this.client.post<DevParamSetResult>("/v1/dev-params", {
+      key,
+      reset: true,
+    });
+  }
 }
 
 /** Interactive pathfinding test (visual A* debugging). */

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -3,6 +3,8 @@ import type {
   AnimationState,
   CommandResult,
   DebugEntityMessage,
+  DevParamSetResult,
+  DevParamsListResult,
   EntityDetailResult,
   EntityListResult,
   EntitySummary,
@@ -570,6 +572,26 @@ export class SceneApi {
   }
 }
 
+/** Live-tunable developer parameters (the dev_params registry mirror). */
+export class DevParamsApi {
+  constructor(private readonly client: HttpClient) {}
+
+  /** Every registered param with its range, current value, and default. */
+  async list(): Promise<DevParamsListResult> {
+    return this.client.get<DevParamsListResult>("/v1/dev-params");
+  }
+
+  /**
+   * Set one param by key. The runtime clamps into the param's range and snaps
+   * to its step grid; the result reports the value actually applied. Consumers
+   * read the registry every frame, so the change is live on the next stepped
+   * frame. Unknown keys reject with HTTP 404.
+   */
+  async set(key: string, value: number): Promise<DevParamSetResult> {
+    return this.client.post<DevParamSetResult>("/v1/dev-params", { key, value });
+  }
+}
+
 /** Interactive pathfinding test (visual A* debugging). */
 export class PathfindingTestApi {
   constructor(private readonly client: HttpClient) {}
@@ -700,6 +722,7 @@ export class Game {
   readonly pathfinding: PathfindingApi;
   readonly physics: PhysicsApi;
   readonly scene: SceneApi;
+  readonly devParams: DevParamsApi;
   readonly quests: QuestsApi;
   readonly ui: UiApi;
   readonly audio: AudioApi;
@@ -713,6 +736,7 @@ export class Game {
     this.pathfinding = new PathfindingApi(client);
     this.physics = new PhysicsApi(client);
     this.scene = new SceneApi(client);
+    this.devParams = new DevParamsApi(client);
     this.quests = new QuestsApi(client);
     this.ui = new UiApi(client);
     this.audio = new AudioApi(client);

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -3,6 +3,7 @@ export {
   AimOcclusionError,
   AudioApi,
   CommandError,
+  DevParamsApi,
   EntitiesApi,
   Game,
   headRotationForWorldPoint,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -359,6 +359,28 @@ export interface SceneListResult {
   frame_index: number;
 }
 
+/** One live-tunable developer parameter (GET /v1/dev-params). */
+export interface DevParamSummary {
+  key: string;
+  label: string;
+  kind: "float";
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  default: number;
+}
+
+export interface DevParamsListResult {
+  params: DevParamSummary[];
+}
+
+/** What a POST /v1/dev-params actually applied (after clamp/snap). */
+export interface DevParamSetResult {
+  key: string;
+  value: number;
+}
+
 /** Settle/quality metrics for one ragdoll (GET /v1/ragdoll/metrics). */
 export interface RagdollMetrics {
   entity_id: number;

--- a/tools/shock2-sdk/test/dev-params.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-params.e2e.test.ts
@@ -39,7 +39,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8097,
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });
@@ -79,7 +79,19 @@ test(
     const clamped = await game.devParams.set("panel_distance", 99.0);
     assert.ok(Math.abs(clamped.value - 6.0) < 1e-4);
 
-    // ...and unknown keys are refused, not silently accepted.
+    // Reset restores the exact declared default (bit-identical, not merely
+    // close: set(default) can miss it, since the snap grid does not
+    // round-trip every default), and the panel renders back at it.
+    const reset = await game.devParams.reset("panel_distance");
+    assert.equal(reset.value, panelDistance.default);
+    await game.step({ frames: 2 });
+    const restored = panelDepth((await game.scene.objects()).objects);
+    assert.ok(
+      Math.abs(restored - 2.0) < 0.05,
+      `panel should be back at the 2.0m default after reset, got ${restored}`,
+    );
+
+    // Unknown keys are refused, not silently accepted.
     await assert.rejects(
       game.devParams.set("no_such_param", 1.0),
       /404/,

--- a/tools/shock2-sdk/test/dev-params.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-params.e2e.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { SceneObjectSummary } from "../src/types.js";
+
+// The dev-params registry (`shock2vr::dev_params`) is mirrored over HTTP:
+// GET /v1/dev-params lists every live-tunable knob, POST sets one by key.
+// Consumers read the registry every frame, so a POST applies on the very next
+// stepped frame - which this test proves by measuring where the renderer
+// actually placed the VR main-menu panel before and after changing
+// `panel_distance`.
+//
+// Negative-first: against the pre-registry build (panel distance a `const`),
+// the "panel depth follows the POSTed value" assertion fails - the panel
+// stays at 2.0 no matter what is POSTed (and the endpoint itself 404s).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/**
+ * The gaze-axis depth of the frontend panel, from the scene objects the
+ * renderer was handed. The debug runtime's default VR head looks along -X
+ * from the origin, and the panel hangs perpendicular to the gaze, so every
+ * canvas element of it sits at x = -distance (give or take the millimetric
+ * layer stacking). The only other draws on the main menu are the tagged
+ * pointer visuals (`source: "frontend_pointer"`), which are filtered out.
+ */
+function panelDepth(objects: SceneObjectSummary[]): number {
+  const depths = objects
+    .filter((o) => o.source === null)
+    .map((o) => -o.position[0])
+    .sort((a, b) => a - b);
+  assert.ok(depths.length > 0, "expected untagged panel objects in the scene");
+  return depths[Math.floor(depths.length / 2)];
+}
+
+test(
+  "POSTing a dev param moves the live VR frontend panel",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "main_menu",
+      port: 8097,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    // The registry lists the seeded params with their replaced-const defaults.
+    const { params } = await game.devParams.list();
+    const panelDistance = params.find((p) => p.key === "panel_distance");
+    assert.ok(panelDistance, "panel_distance must be registered");
+    assert.equal(panelDistance.kind, "float");
+    assert.ok(Math.abs(panelDistance.value - 2.0) < 1e-4);
+    assert.ok(Math.abs(panelDistance.default - 2.0) < 1e-4);
+
+    // At the default, the panel hangs 2m ahead of the head.
+    const before = panelDepth((await game.scene.objects()).objects);
+    assert.ok(
+      Math.abs(before - 2.0) < 0.05,
+      `panel should render at the default 2.0m, got ${before}`,
+    );
+    const shotBefore = await game.screenshot("dev-params-panel-2m.png");
+
+    // Live-apply: POST a new distance and the very next frames render there.
+    const applied = await game.devParams.set("panel_distance", 4.0);
+    assert.ok(Math.abs(applied.value - 4.0) < 1e-4);
+    await game.step({ frames: 2 });
+    const after = panelDepth((await game.scene.objects()).objects);
+    assert.ok(
+      Math.abs(after - 4.0) < 0.05,
+      `panel should have moved to the POSTed 4.0m, got ${after}`,
+    );
+    const shotAfter = await game.screenshot("dev-params-panel-4m.png");
+    console.log(
+      `panel depth ${before.toFixed(3)} -> ${after.toFixed(3)}; ` +
+        `screenshots: ${shotBefore.full_path} ${shotAfter.full_path}`,
+    );
+
+    // Out-of-range sets are clamped to the declared max...
+    const clamped = await game.devParams.set("panel_distance", 99.0);
+    assert.ok(Math.abs(clamped.value - 6.0) < 1e-4);
+
+    // ...and unknown keys are refused, not silently accepted.
+    await assert.rejects(
+      game.devParams.set("no_such_param", 1.0),
+      /404/,
+      "an unknown key must reject",
+    );
+  },
+);


### PR DESCRIPTION
Stage 1 of the Developer-menu plan: a small registry of **live-tunable runtime
parameters**, plus a debug-runtime HTTP mirror so agents can sweep tuning values
headlessly. **No UI and no persistence in this PR** — PR2 adds the Developer
screen (in the inert Options slot of the main and pause menus), PR3 optionally
persists tweaked values. **Zero behavior change at defaults.**

## Why

The port's tuning knobs (panel distance, pause dim, ...) live as
module-private `const`s next to their consumer, so every nudge costs a rebuild —
and on the Quest, a redeploy; env vars never reach an Android app, so a menu (or
HTTP, on desktop) is the only live channel. This PR builds the registry that
both will read.

## Design

- **`shock2vr/src/dev_params.rs`** — a `dev_params!` macro declares each
  parameter once (stable key, label, float `min/max/step`, default) and
  generates the static table **and** its id const together, so the two cannot
  drift. Bool/enum kinds are deliberately deferred until a param needs them.
- **Storage** — one `AtomicU32` of `f32` bits per param: lock-free, readable
  from any thread, no `&mut Game`. `set()` clamps into range, snaps to the step
  grid, and refuses non-finite values.
- **Consumers read per frame**, so a `set` is visible on the next frame with
  zero plumbing. Ground rule (commented on the module): if the consumer does
  not read it every frame, it does not belong in the table yet.
- **Two seed params**, defaults identical to the consts they replace:
  | key | replaces | default | range |
  |---|---|---|---|
  | `panel_distance` | `ui::FRONTEND_PANEL_DISTANCE` | 2.0 | 0.5–6.0, step 0.1 |
  | `dim_strength` | `pause_menu::WORLD_DIM_STRENGTH` | 0.72 | 0–1, step 0.02 |

  An **eye-height offset** was drafted for this seed set and deliberately
  dropped: on the Quest the eye is the *tracked pose* (capped in
  `oculus_runtime`), which never reads `player_eye_height_for` — the knob
  would have been inert exactly where live tuning matters, while the debug
  runtime's `--vr` path (which does read that accessor) would have falsely
  "verified" it. An inert knob is worse than no knob. It returns in PR2 once
  the offset is wired through the runtime's tracked stage (head and hands
  together). A comment on the param table records this.
- **`reset(id)`** restores a param's exact default bits — `set(default)`
  does not round-trip every default (0.72 on a 0.02 grid snaps to
  0.71999997), which matters to a future menu "reset" row and to tests.
- **HTTP mirror** — `GET /v1/dev-params` (key, label, kind/range, current,
  default) and `POST /v1/dev-params` with `{key, value}` (clamped + snapped
  set; 404 on unknown key, 400 on a non-finite value) or `{key, reset: true}`
  (exact-default restore). Because the values are process-global atomics, the
  handlers read the registry directly — no `RuntimeCommand`/`oneshot`
  round-trip (the `/v1/audio/recent` pattern). SDK grows
  `game.devParams.{list,set,reset}`.

## Verification

- Unit tests (negative-first): defaults equal the replaced consts and sit
  inside their own declared ranges; clamp to range; snap to step grid (and an
  uneven range's top end stays *on* the grid); the snap grid provably cannot
  round-trip every default (why `reset` stores exact bits); non-finite
  refused; unknown key does not resolve. The constrain rules are tested
  through a pure `apply()` with literal kinds — **no test mutates the live
  registry**, so parallel tests reading a live param can never race a unit
  test (both review engines flagged the earlier guard-based version of this).
- `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr
  -p desktop_runtime -p debug_runtime`; `cargo test -p shock2vr --lib` (820
  passed); SDK `npm test` green.
- New SDK e2e (`dev-params.e2e.test.ts`): launches the VR main menu, measures
  the frontend panel's gaze-axis depth from `/v1/scene` at the default
  (**1.997**), POSTs `panel_distance: 4.0`, and the very next frames render the
  panel at **3.997** — live-apply proven from renderer data, not just the API
  echo. Then `reset` returns the exact default and the panel renders back at
  2.0 m. Also asserts HTTP clamp (99 → 6.0) and the unknown-key 404.
- Adjacent e2e suites re-run green: `vr-frontend-panel-anchor` (3 tests) and
  `pause-menu` (6 tests) — the two consumers this PR touches — plus the
  `missions.e2e` safety net (23/23 load). Flat presentation
  is untouched (screen-space rendering never reads the panel distance; the dim
  is VR-only).

### Live tuning evidence (from the e2e)

Not a visual change at defaults — these show the *tunability*: the same VR main
menu with `panel_distance` at the 2.0 default vs after `POST /v1/dev-params
{"key":"panel_distance","value":4.0}`.

| default (2.0 m) | after POST (4.0 m) |
|---|---|
| ![panel at 2m](https://gist.githubusercontent.com/tommy-xr/1a79f7581aab530cdfc3a9a0638a264e/raw/afe9b10424187ab68205e2c62ee2ff9e9d07860d/dev-params-panel-2m.png) | ![panel at 4m](https://gist.githubusercontent.com/tommy-xr/1a79f7581aab530cdfc3a9a0638a264e/raw/afe9b10424187ab68205e2c62ee2ff9e9d07860d/dev-params-panel-4m.png) |

## Review

Cross-engine review (Claude + Codex CLI, plus a dedicated de-dup pass) ran
twice; all agreed findings are addressed in the branch: the unit-test race on
the process-global values (tests now target the pure constrain step), the
unreachable `reset`, and stale eye-offset prose. The de-dup pass found no
actionable duplication. Known accepted tradeoff, documented on the module: a
mid-frame `set` can be seen by later reads in the same frame — fine for tuning
knobs, and impossible in the stepped debug runtime where HTTP lands between
frames.
