### PR TITLE
feat(gameplay): show the character-creation debrief as its own screen

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -610,6 +610,9 @@ pub struct UiStateResult {
     /// while the interface is up in VR. Aim a controller at a canvas rect by
     /// mapping it through this.
     pub panel_pose: Option<shock2vr::game_scene::DebugUiPanelPose>,
+    /// The character-creation debrief page currently on screen, verbatim;
+    /// `None` when the debrief screen is not up.
+    pub debrief_text: Option<String>,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1319,6 +1319,9 @@ fn process_command(
             }
         }
         RuntimeCommand::GetUiState { reply } => {
+            // Game-level, so it is reported whether or not the active scene
+            // exposes debug UI state.
+            let debrief_text = game.active_debrief_text().map(str::to_owned);
             let result = game
                 .debug_scene()
                 .map(|scene| {
@@ -1331,6 +1334,7 @@ fn process_command(
                         ammo_cycle: ui.ammo_cycle,
                         pointer: ui.pointer,
                         panel_pose: ui.panel_pose,
+                        debrief_text: debrief_text.clone(),
                     }
                 })
                 .unwrap_or(commands::UiStateResult {
@@ -1341,6 +1345,7 @@ fn process_command(
                     ammo_cycle: None,
                     pointer: None,
                     panel_pose: None,
+                    debrief_text,
                 });
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send ui state - receiver dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -140,6 +140,13 @@ pub trait GameScene {
         false
     }
 
+    /// The character-creation debrief page this scene is showing, if it is the
+    /// debrief screen. Debug introspection only (`/v1/ui`), so a test can
+    /// assert which page came up.
+    fn debrief_text(&self) -> Option<&str> {
+        None
+    }
+
     /// Whether the in-game pause menu may open over this scene.
     ///
     /// True for scenes that run a simulation the player would want frozen -

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1950,8 +1950,16 @@ impl Game {
     /// stand-in chaining into another keeps what the first captured - the empty
     /// world it would capture now is exactly what must not win.
     fn show_over_mission(&mut self, scene: Option<Box<dyn GameScene>>, follow_on: GlobalEffect) {
-        // Any pending transition is abandoned, as for the frontend swaps.
-        self.pending_transition = None;
+        // The same refusal `begin_transition` makes, for the same reason: with a
+        // transition in flight the active scene is the loading screen, and
+        // saving *that* as the outgoing state wipes quest bits, held items and
+        // vitals. Nothing in-game can reach this (the loading scene runs no
+        // scripts), but an external caller can, so refuse rather than corrupt -
+        // the transition already under way is what the player is waiting for.
+        if self.pending_transition.is_some() {
+            warn!("Ignoring a scene standing in for the mission: a level transition is in flight");
+            return;
+        }
         let preserved = match self.preserved_scene_state.take() {
             Some(carried) => carried,
             None => self.save_active_scene(),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -57,7 +57,7 @@ mod wielded_weapon;
 pub mod zip_asset_path;
 
 use scenes::{
-    CutscenePlayerScene, DeveloperScene, GameOverScene, LoadGameScene, MainMenuScene,
+    CutscenePlayerScene, DebriefScene, DeveloperScene, GameOverScene, LoadGameScene, MainMenuScene,
     SceneInitResult, create_initial_scene, load_mission_from_save_data, resolve_ending_cutscene,
 };
 
@@ -173,6 +173,10 @@ use crate::{
     scripts::Effect,
 };
 use zip_asset_path::ZipAssetPath;
+
+/// The character-creation debrief string table (a page per training tour,
+/// keyed `Mission1..Mission27`). Ships with classic and anniversary installs.
+const CHARGEN_STRINGS: &str = "chargen.str";
 
 const AUDIO_EAR_OFFSET: f32 = 1.0;
 
@@ -1543,6 +1547,21 @@ impl Game {
             && self.player_is_alive()
     }
 
+    /// The debrief page for `text_key`, from `res/strings/CHARGEN.STR`.
+    /// `None` when the table or the page is missing or blank.
+    fn debrief_page(&mut self, text_key: &str) -> Option<String> {
+        let strings = self
+            .asset_cache
+            .get_opt(&STRINGS_IMPORTER, CHARGEN_STRINGS)?;
+        crate::player_stats::debrief_text(&strings, text_key)
+    }
+
+    /// The debrief page on screen right now, for debug introspection: the
+    /// active scene is the debrief screen exactly while one is showing.
+    pub fn active_debrief_text(&self) -> Option<&str> {
+        self.active_game_scene.debrief_text()
+    }
+
     fn player_is_alive(&self) -> bool {
         // Scenes without the life-state unique (the debug scenes) have no death
         // to be in, so they count as alive.
@@ -1920,6 +1939,34 @@ impl Game {
 
                 self.campaign_completed = true;
                 self.handle_global_effect(after_ending.after_cutscene(&resolve_ending_cutscene()));
+            }
+            GlobalEffect::ShowDebrief { text_key, then } => {
+                // Any pending transition is abandoned, as for the frontend swaps.
+                self.pending_transition = None;
+                let follow_on = *then;
+                // Capture the scene the page is about to replace, so the
+                // follow-on transition carries the player's career, training
+                // year, inventory and vitals - not the screen's empty world.
+                // Same contract as `PlayCutscene`, which may be the thing that
+                // captured it if a cutscene chains into this.
+                let preserved = match self.preserved_scene_state.take() {
+                    Some(carried) => carried,
+                    None => self.save_active_scene(),
+                };
+                match self.debrief_page(&text_key) {
+                    Some(text) => {
+                        self.set_active_scene(Box::new(DebriefScene::new(text, follow_on)));
+                        // After the swap: `set_active_scene` clears this.
+                        self.preserved_scene_state = Some(preserved);
+                    }
+                    None => {
+                        // A missing or blank page must not strand the player on
+                        // the scene the debrief was replacing.
+                        warn!("No debrief page for '{}' - skipping it", text_key);
+                        self.preserved_scene_state = Some(preserved);
+                        self.handle_global_effect(follow_on);
+                    }
+                }
             }
             GlobalEffect::Quit => {
                 self.should_quit = true;

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1901,35 +1901,17 @@ impl Game {
                 self.hit_feedback.trigger(damage);
             }
             GlobalEffect::PlayCutscene { video, then } => {
-                // Any pending transition is abandoned, as for the frontend swaps.
-                self.pending_transition = None;
                 let follow_on = *then;
-                // Capture the scene the cutscene is about to replace, so a
-                // follow-on transition carries the player's state and not the
-                // cutscene's empty world. A cutscene chaining into another keeps
-                // what the first captured - the empty world it would capture now
-                // is exactly what must not win.
-                let preserved = match self.preserved_scene_state.take() {
-                    Some(carried) => carried,
-                    None => self.save_active_scene(),
-                };
-                match CutscenePlayerScene::new(video, follow_on.clone(), &mut self.audio_context) {
-                    Ok(cutscene) => {
-                        self.set_active_scene(Box::new(cutscene));
-                        // After the swap: `set_active_scene` clears this.
-                        self.preserved_scene_state = Some(preserved);
-                    }
-                    Err(error) => {
-                        // An install missing a movie must not strand the player
-                        // on the scene the cutscene was replacing.
-                        warn!("{error} - skipping it");
-                        // The follow-on still needs what was captured: the scene
-                        // is unchanged here, but in a chain this is the state of
-                        // the gameplay scene an earlier cutscene replaced.
-                        self.preserved_scene_state = Some(preserved);
-                        self.handle_global_effect(follow_on);
-                    }
-                }
+                let cutscene =
+                    CutscenePlayerScene::new(video, follow_on.clone(), &mut self.audio_context)
+                        .map(|cutscene| Box::new(cutscene) as Box<dyn GameScene>)
+                        .map_err(|error| {
+                            // An install missing a movie must not strand the
+                            // player on the scene the cutscene was replacing.
+                            warn!("{error} - skipping it");
+                        })
+                        .ok();
+                self.show_over_mission(cutscene, follow_on);
             }
             GlobalEffect::CompleteCampaign => {
                 // The destroyed head and the rest of the finale state reach the
@@ -1941,35 +1923,51 @@ impl Game {
                 self.handle_global_effect(after_ending.after_cutscene(&resolve_ending_cutscene()));
             }
             GlobalEffect::ShowDebrief { text_key, then } => {
-                // Any pending transition is abandoned, as for the frontend swaps.
-                self.pending_transition = None;
                 let follow_on = *then;
-                // Capture the scene the page is about to replace, so the
-                // follow-on transition carries the player's career, training
-                // year, inventory and vitals - not the screen's empty world.
-                // Same contract as `PlayCutscene`, which may be the thing that
-                // captured it if a cutscene chains into this.
-                let preserved = match self.preserved_scene_state.take() {
-                    Some(carried) => carried,
-                    None => self.save_active_scene(),
-                };
-                match self.debrief_page(&text_key) {
-                    Some(text) => {
-                        self.set_active_scene(Box::new(DebriefScene::new(text, follow_on)));
-                        // After the swap: `set_active_scene` clears this.
-                        self.preserved_scene_state = Some(preserved);
-                    }
-                    None => {
-                        // A missing or blank page must not strand the player on
-                        // the scene the debrief was replacing.
-                        warn!("No debrief page for '{}' - skipping it", text_key);
-                        self.preserved_scene_state = Some(preserved);
-                        self.handle_global_effect(follow_on);
-                    }
+                let page = self.debrief_page(&text_key).map(|text| {
+                    Box::new(DebriefScene::new(text, follow_on.clone())) as Box<dyn GameScene>
+                });
+                if page.is_none() {
+                    // A missing or blank page must not strand the player on the
+                    // scene the debrief was replacing.
+                    warn!("No debrief page for '{}' - skipping it", text_key);
                 }
+                self.show_over_mission(page, follow_on);
             }
             GlobalEffect::Quit => {
                 self.should_quit = true;
+            }
+        }
+    }
+
+    /// Put `scene` on screen in place of the mission until it hands on to
+    /// `follow_on` (a cutscene, the character-creation debrief). `None` means
+    /// the stand-in could not be built, and `follow_on` runs straight away
+    /// rather than stranding the player on the scene it was replacing.
+    ///
+    /// The scene being replaced is saved first, so a `follow_on` transition
+    /// carries the player's state and not the stand-in's empty world. A
+    /// stand-in chaining into another keeps what the first captured - the empty
+    /// world it would capture now is exactly what must not win.
+    fn show_over_mission(&mut self, scene: Option<Box<dyn GameScene>>, follow_on: GlobalEffect) {
+        // Any pending transition is abandoned, as for the frontend swaps.
+        self.pending_transition = None;
+        let preserved = match self.preserved_scene_state.take() {
+            Some(carried) => carried,
+            None => self.save_active_scene(),
+        };
+        match scene {
+            Some(scene) => {
+                self.set_active_scene(scene);
+                // After the swap: `set_active_scene` clears this.
+                self.preserved_scene_state = Some(preserved);
+            }
+            None => {
+                // Re-armed *before* dispatching: the follow-on transition reads
+                // it, and in a chain it is the state of the gameplay scene an
+                // earlier stand-in replaced.
+                self.preserved_scene_state = Some(preserved);
+                self.handle_global_effect(follow_on);
             }
         }
     }
@@ -1979,9 +1977,9 @@ impl Game {
     /// scene swap goes through here so that hook cannot be forgotten.
     fn set_active_scene(&mut self, scene: Box<dyn GameScene>) {
         self.active_game_scene.on_exit(&mut self.audio_context);
-        // Only a cutscene standing in for a scene carries state on its behalf,
-        // and `PlayCutscene` re-arms this straight after the swap. Clearing it
-        // for every other swap means a chain that ends anywhere but a
+        // Only a scene standing in for the mission carries state on its behalf,
+        // and `show_over_mission` re-arms this straight after the swap. Clearing
+        // it for every other swap means a chain that ends anywhere but a
         // transition cannot leak the old scene's state into a later one.
         self.preserved_scene_state = None;
         self.active_game_scene = scene;

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -509,9 +509,53 @@ pub fn tour_reward(career: Career, year: u32, tour: u32) -> Option<&'static Tour
     Some(&REWARDS[career_index(career)][(year - 1) as usize][tour as usize])
 }
 
+/// The debrief page for a completed tour, looked up in a parsed
+/// `res/strings/CHARGEN.STR` table.
+///
+/// Pure so the key casing and the escape handling are testable without an
+/// asset cache: the importer lowercases keys, and the shipped values carry
+/// literal backslash-n escapes ("Get back to Wake Island Station \npronto")
+/// which are unescaped into real line breaks - the same treatment the audio
+/// log reader gives `level<deck>.str`.
+pub fn debrief_text(
+    strings: &std::collections::HashMap<String, String>,
+    text_key: &str,
+) -> Option<String> {
+    strings
+        .get(&text_key.to_ascii_lowercase())
+        .map(|text| text.replace("\\n", "\n"))
+        .filter(|text| !text.trim().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    fn table(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn debrief_text_resolves_the_lowercased_key_and_unescapes_line_breaks() {
+        // Keys as the importer stores them (lowercased); the value is the
+        // shipped Mission7 text, abridged, with its literal escape.
+        let strings = table(&[("mission7", "Get back to Wake Island Station \\npronto.")]);
+        assert_eq!(
+            debrief_text(&strings, "Mission7").as_deref(),
+            Some("Get back to Wake Island Station \npronto.")
+        );
+    }
+
+    #[test]
+    fn debrief_text_is_none_for_a_missing_or_blank_page() {
+        let strings = table(&[("mission1", "   ")]);
+        assert_eq!(debrief_text(&strings, "Mission1"), None);
+        assert_eq!(debrief_text(&strings, "Mission2"), None);
+    }
 
     #[test]
     fn table_is_fully_populated_with_unique_text_keys() {

--- a/shock2vr/src/scenes/debrief.rs
+++ b/shock2vr/src/scenes/debrief.rs
@@ -153,7 +153,10 @@ impl DebriefScene {
             if line.is_empty() {
                 continue;
             }
-            canvas.text_native(
+            // `_fit` rather than plain `text_native`: the wrap already keeps
+            // rows inside the column, so this only catches a single word wider
+            // than the panel, which would otherwise run across the backdrop art.
+            canvas.text_native_fit(
                 Rect::new(TEXT_RECT.x, y, TEXT_RECT.w, BODY_LINE_H),
                 line,
                 BODY_FONT,

--- a/shock2vr/src/scenes/debrief.rs
+++ b/shock2vr/src/scenes/debrief.rs
@@ -91,6 +91,9 @@ pub struct DebriefScene {
     /// tour trigger asked for.
     then: GlobalEffect,
     menu: FrontendMenu<DebriefAction>,
+    /// Latches the "page too tall for the panel" warning, which is otherwise
+    /// decided again on every rendered frame.
+    truncation_warned: bool,
 }
 
 impl DebriefScene {
@@ -101,6 +104,7 @@ impl DebriefScene {
             text,
             then,
             menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
+            truncation_warned: false,
         }
     }
 
@@ -117,7 +121,7 @@ impl DebriefScene {
     /// they cannot drift apart in layout, wrap, or which button looks
     /// actionable.
     fn build_canvas(
-        &self,
+        &mut self,
         asset_cache: &mut AssetCache,
         pointer_canvas: Option<Vector2<f32>>,
     ) -> UiCanvas {
@@ -135,10 +139,13 @@ impl DebriefScene {
             // backdrop art stops at the panel and says so, rather than quietly
             // drawing its last line (the grant) off the screen.
             if y + BODY_LINE_H > TEXT_RECT.y + TEXT_RECT.h {
-                warn!(
-                    "Debrief page is {} rows too tall for the panel - truncated",
-                    lines.len() - index
-                );
+                if !self.truncation_warned {
+                    self.truncation_warned = true;
+                    warn!(
+                        "Debrief page is {} rows too tall for the panel - truncated",
+                        lines.len() - index
+                    );
+                }
                 break;
             }
             // A blank line is a paragraph gap: it spaces the block, it draws
@@ -205,7 +212,8 @@ impl GameScene for DebriefScene {
         options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
+        let pointer_canvas = self.menu.pointer_canvas();
+        let canvas = self.build_canvas(asset_cache, pointer_canvas);
         let objects = self
             .menu
             .render_world_space(asset_cache, canvas, options.presentation_mode);

--- a/shock2vr/src/scenes/debrief.rs
+++ b/shock2vr/src/scenes/debrief.rs
@@ -1,0 +1,406 @@
+//! Character-creation debrief screen.
+//!
+//! The page the original shows as a training tour ends - "Your stint aboard the
+//! UNN Gallo is finished... You've gained +2 Strength." - on its own authored
+//! screen: the `DEBRIEF.PCX` backdrop, its `DEBRIEFR.BIN` widget rect for the
+//! Continue button, and that button's label from `DEBRIEF.STR`. The body text
+//! is the `res/strings/CHARGEN.STR` page the completed tour's reward names.
+//!
+//! Structurally a sibling of [`crate::scenes::GameOverScene`]: a pointer-driven
+//! `GameScene` built on one shared [`UiCanvas`], so flat and VR present the same
+//! layout (AGENTS.md section 3). It stands in for the mission scene the way a
+//! cutscene does, and emits its `then` effect - the level transition the tour
+//! trigger asked for - when Continue is clicked.
+
+use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
+use dark::importers::FONT_IMPORTER;
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    measure_text_width,
+    scene::{SceneObject, light::SpotLight},
+};
+use shipyard::{EntityId, UniqueViewMut, World};
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    input_context::InputContext,
+    mission::GlobalContext,
+    scripts::{Effect, GlobalEffect},
+    time::Time,
+    ui::{FrontendMenu, HAlign, Rect, ScaleMode, UiCanvas, VAlign},
+};
+
+/// The screen is authored on the original 640x480 `DEBRIEF.PCX` canvas.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+const BACKDROP_TEXTURE: &str = "DEBRIEF.PCX";
+/// The screen's widget layout - one LTRB rect (`UI_LAYOUT_IMPORTER`).
+const LAYOUT_FILE: &str = "DEBRIEFR.BIN";
+/// The screen's own string table: a single `Continue` entry.
+const LABELS_FILE: &str = "DEBRIEF.STR";
+const CONTINUE_KEY: &str = "continue";
+const CONTINUE_FALLBACK: &str = "Continue";
+/// Same display font the other frontend screens label their buttons with.
+const MENU_FONT: &str = "metafont.fon";
+/// The small in-game font, for the page body.
+const BODY_FONT: &str = "mainfont.fon";
+/// Glyph-cell height in canvas pixels for the body, and the row pitch.
+/// `mainfont` is ~10 px native; this keeps the page legible at panel distance
+/// while a full 27-line-table page still fits the backdrop's text panel.
+const BODY_FONT_SIZE: f32 = 16.0;
+const BODY_LINE_H: f32 = 19.0;
+/// The 4:3 art is letterboxed (not stretched) on non-4:3 windows.
+const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
+
+/// The backdrop's central text panel, inset off its border. Read off
+/// `DEBRIEF.PCX` (the panel's frame spans x 212..558, y 83..395); the layout
+/// file describes only the button, so this rect is not in it.
+const TEXT_RECT: Rect = Rect::new(224.0, 96.0, 322.0, 288.0);
+
+/// The one thing this screen does.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DebriefAction {
+    Continue,
+}
+
+/// The only index into `DEBRIEFR.BIN`.
+const CONTINUE_RECT_INDEX: usize = 0;
+/// Decoded `DEBRIEFR.BIN` value, used when the layout file is absent.
+const FALLBACK_RECTS: [Rect; 1] = [Rect::new(425.0, 401.0, 210.0, 74.0)];
+
+/// The button at a canvas point, if any. Shared by the click and the rollover
+/// sound so the two always agree on where the button is.
+fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<DebriefAction> {
+    rects[CONTINUE_RECT_INDEX]
+        .contains(point)
+        .then_some(DebriefAction::Continue)
+}
+
+pub struct DebriefScene {
+    world: World,
+    scene_name: String,
+    /// The page being shown, verbatim (authored line breaks intact).
+    text: String,
+    /// What Continue does: the transition (behind any departure cutscenes) the
+    /// tour trigger asked for.
+    then: GlobalEffect,
+    menu: FrontendMenu<DebriefAction>,
+}
+
+impl DebriefScene {
+    pub fn new(text: String, then: GlobalEffect) -> Self {
+        Self {
+            world: super::ui_scene_world(),
+            scene_name: "debrief".to_owned(),
+            text,
+            then,
+            menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
+        }
+    }
+
+    /// What a click does: hand on the effect the tour trigger deferred. The
+    /// screen never decides where the player goes next.
+    fn effects_for(&self, action: Option<DebriefAction>) -> Vec<Effect> {
+        match action {
+            Some(DebriefAction::Continue) => vec![Effect::GlobalEffect(self.then.clone())],
+            None => Vec::new(),
+        }
+    }
+
+    /// The screen, described once. Both presentations render this canvas, so
+    /// they cannot drift apart in layout, wrap, or which button looks
+    /// actionable.
+    fn build_canvas(
+        &self,
+        asset_cache: &mut AssetCache,
+        pointer_canvas: Option<Vector2<f32>>,
+    ) -> UiCanvas {
+        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
+
+        let lines: Vec<String> = {
+            let font = asset_cache.get(&FONT_IMPORTER, BODY_FONT);
+            wrap_page(&**font, &self.text, BODY_FONT_SIZE, TEXT_RECT.w)
+        };
+        for (index, line) in lines.iter().enumerate() {
+            let y = TEXT_RECT.y + index as f32 * BODY_LINE_H;
+            // A blank line is a paragraph gap: it spaces the block, it draws
+            // nothing. Rows past the panel are dropped rather than spilling
+            // over the backdrop art.
+            if line.is_empty() || y + BODY_LINE_H > TEXT_RECT.y + TEXT_RECT.h {
+                continue;
+            }
+            canvas.text(
+                Rect::new(TEXT_RECT.x, y, TEXT_RECT.w, BODY_LINE_H),
+                line,
+                BODY_FONT,
+                BODY_FONT_SIZE,
+                HAlign::Left,
+                VAlign::Middle,
+            );
+        }
+
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
+        let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, LABELS_FILE);
+        let label =
+            crate::ui::resolve_menu_label(strings.as_deref(), CONTINUE_KEY, CONTINUE_FALLBACK);
+        let rect = rects[CONTINUE_RECT_INDEX];
+        let hovered = pointer_canvas.is_some_and(|p| rect.contains(p));
+        canvas
+            .text_native(rect, &label, MENU_FONT, HAlign::Center, VAlign::Middle)
+            .opacity(if hovered { 1.0 } else { 0.6 });
+
+        canvas
+    }
+}
+
+impl GameScene for DebriefScene {
+    fn update(
+        &mut self,
+        time: &Time,
+        input_context: &InputContext,
+        asset_cache: &mut AssetCache,
+        game_options: &GameOptions,
+        command_effects: Vec<Effect>,
+    ) -> Vec<Effect> {
+        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
+            *world_time = time.clone();
+        }
+
+        // Only global effects mean anything here: there is no mission to act on.
+        let mut effects: Vec<Effect> = command_effects
+            .into_iter()
+            .filter(|effect| matches!(effect, Effect::GlobalEffect(_)))
+            .collect();
+
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
+        let action = self.menu.update(
+            time.elapsed,
+            input_context,
+            game_options.presentation_mode,
+            |point| hit(point, &rects),
+            |point| hit(point, &rects),
+        );
+        effects.extend(self.effects_for(action));
+        effects
+    }
+
+    fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
+        let objects = self
+            .menu
+            .render_world_space(asset_cache, canvas, options.presentation_mode);
+        (objects, vec3(0.0, 0.0, 0.0), identity)
+    }
+
+    fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        _view: cgmath::Matrix4<f32>,
+        _projection: cgmath::Matrix4<f32>,
+        screen_size: Vector2<f32>,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
+        let canvas = self.build_canvas(asset_cache, pointer_canvas);
+        self.menu
+            .render_screen_space(asset_cache, canvas, screen_size, options.presentation_mode)
+    }
+
+    fn handle_effects(
+        &mut self,
+        effects: Vec<Effect>,
+        _global_context: &GlobalContext,
+        _game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Vec<GlobalEffect> {
+        self.menu.pump_sfx(asset_cache, audio_context);
+        effects
+            .into_iter()
+            .filter_map(|e| match e {
+                Effect::GlobalEffect(g) => Some(g),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        self.menu.stop_sfx(audio_context);
+    }
+
+    fn wants_pointer(&self) -> bool {
+        true
+    }
+
+    fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {
+        Vec::new()
+    }
+
+    fn world(&self) -> &World {
+        &self.world
+    }
+
+    fn scene_name(&self) -> &str {
+        &self.scene_name
+    }
+
+    /// So `Game` can report the page for `/v1/ui`: a test asserts *which*
+    /// debrief came up, not that glyphs appeared.
+    fn debrief_text(&self) -> Option<&str> {
+        Some(&self.text)
+    }
+}
+
+/// Lay a page out as rows: authored line breaks are honored (a blank line stays
+/// blank, so paragraphs keep their gap) and each authored line is greedily
+/// word-wrapped to `max_width` with real glyph widths.
+fn wrap_page(font: &dyn engine::Font, text: &str, font_size: f32, max_width: f32) -> Vec<String> {
+    let mut lines = Vec::new();
+    for paragraph in text.lines() {
+        let wrapped = wrap_text(font, paragraph, font_size, max_width);
+        if wrapped.is_empty() {
+            lines.push(String::new());
+        } else {
+            lines.extend(wrapped);
+        }
+    }
+    lines
+}
+
+/// Greedy word wrap with real glyph widths. A single word wider than the column
+/// gets its own line rather than being dropped.
+fn wrap_text(font: &dyn engine::Font, text: &str, font_size: f32, max_width: f32) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        let candidate = if current.is_empty() {
+            word.to_owned()
+        } else {
+            format!("{current} {word}")
+        };
+        if measure_text_width(font, &candidate, font_size) <= max_width || current.is_empty() {
+            current = candidate;
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current = word.to_owned();
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fixed-metrics stub: every glyph advances 5 at base height 10.
+    struct FixedFont;
+    impl engine::Font for FixedFont {
+        fn get_texture(&self) -> std::rc::Rc<dyn engine::texture::TextureTrait> {
+            unreachable!("measurement does not touch the texture")
+        }
+        fn get_character_info(&self, _c: char) -> Option<engine::FontCharacterInfo> {
+            Some(engine::FontCharacterInfo {
+                min_uv_x: 0.0,
+                min_uv_y: 0.0,
+                max_uv_x: 1.0,
+                max_uv_y: 1.0,
+                advance: 5.0,
+            })
+        }
+        fn base_height(&self) -> f32 {
+            10.0
+        }
+        fn get_half_pixel(&self) -> f32 {
+            0.0
+        }
+    }
+
+    /// At base height the stub advances 5 per glyph, so a 20-wide column holds
+    /// four characters - and a word longer than that still gets a row.
+    #[test]
+    fn wrap_splits_on_measured_width_and_keeps_wide_words() {
+        assert_eq!(
+            wrap_text(&FixedFont, "aa bb cc", 10.0, 20.0),
+            vec!["aa".to_string(), "bb".to_string(), "cc".to_string()]
+        );
+        assert_eq!(
+            wrap_text(&FixedFont, "aaaaaaa bb", 10.0, 20.0),
+            vec!["aaaaaaa".to_string(), "bb".to_string()]
+        );
+    }
+
+    /// Authored paragraph breaks survive the wrap as blank rows, so the page
+    /// keeps the shape `CHARGEN.STR` authors (date / body / grant).
+    #[test]
+    fn authored_line_breaks_become_their_own_rows() {
+        let rows = wrap_page(&FixedFont, "Feb. 12\n\nYou gained", 10.0, 100.0);
+        assert_eq!(
+            rows,
+            vec![
+                "Feb. 12".to_string(),
+                String::new(),
+                "You gained".to_string()
+            ]
+        );
+    }
+
+    /// Continue is the only widget, and it sits where `DEBRIEFR.BIN` puts it.
+    #[test]
+    fn continue_is_hit_at_the_authored_rect() {
+        let rects = FALLBACK_RECTS.to_vec();
+        assert_eq!(
+            hit(rects[CONTINUE_RECT_INDEX].center(), &rects),
+            Some(DebriefAction::Continue)
+        );
+        assert_eq!(hit(vec2(10.0, 10.0), &rects), None);
+    }
+
+    /// Clicking Continue emits exactly the effect the tour trigger deferred -
+    /// the screen never decides where the player goes next - and nothing at all
+    /// happens until it is clicked.
+    #[test]
+    fn continuing_dispatches_the_follow_on_effect() {
+        let mut scene = DebriefScene::new(
+            "page".to_string(),
+            GlobalEffect::new_game_transition("station.mis".to_string()),
+        );
+        let rects = FALLBACK_RECTS.to_vec();
+        let center = rects[CONTINUE_RECT_INDEX].center();
+
+        assert!(scene.effects_for(None).is_empty());
+
+        // The menu enters already-pressed, so a held input has to be released
+        // before it can click: the first press edge is the second frame.
+        scene
+            .menu
+            .resolve_pointer(Some(center), false, |p| hit(p, &rects), |p| hit(p, &rects));
+        let action =
+            scene
+                .menu
+                .resolve_pointer(Some(center), true, |p| hit(p, &rects), |p| hit(p, &rects));
+        assert_eq!(action, Some(DebriefAction::Continue));
+
+        let effects = scene.effects_for(action);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::GlobalEffect(GlobalEffect::TransitionLevel { .. })]
+        ));
+    }
+
+    #[test]
+    fn world_supports_transition_save_data() {
+        let scene = DebriefScene::new("page".to_string(), GlobalEffect::Quit);
+        let _ = crate::save_load::to_save_data(scene.world());
+    }
+}

--- a/shock2vr/src/scenes/debrief.rs
+++ b/shock2vr/src/scenes/debrief.rs
@@ -21,6 +21,7 @@ use engine::{
     scene::{SceneObject, light::SpotLight},
 };
 use shipyard::{EntityId, UniqueViewMut, World};
+use tracing::warn;
 
 use crate::{
     GameOptions,
@@ -29,7 +30,9 @@ use crate::{
     mission::GlobalContext,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{FrontendMenu, HAlign, Rect, ScaleMode, UiCanvas, VAlign},
+    ui::{
+        FrontendMenu, FrontendMenuItem, HAlign, Rect, ScaleMode, UiCanvas, VAlign, hit_menu_item,
+    },
 };
 
 /// The screen is authored on the original 640x480 `DEBRIEF.PCX` canvas.
@@ -40,16 +43,13 @@ const BACKDROP_TEXTURE: &str = "DEBRIEF.PCX";
 const LAYOUT_FILE: &str = "DEBRIEFR.BIN";
 /// The screen's own string table: a single `Continue` entry.
 const LABELS_FILE: &str = "DEBRIEF.STR";
-const CONTINUE_KEY: &str = "continue";
-const CONTINUE_FALLBACK: &str = "Continue";
 /// Same display font the other frontend screens label their buttons with.
 const MENU_FONT: &str = "metafont.fon";
-/// The small in-game font, for the page body.
+/// The small in-game font, for the page body - drawn at its authored size
+/// (`text_native`, the fidelity-correct default), so the page reads as the same
+/// kind of text the rest of the interface draws.
 const BODY_FONT: &str = "mainfont.fon";
-/// Glyph-cell height in canvas pixels for the body, and the row pitch.
-/// `mainfont` is ~10 px native; this keeps the page legible at panel distance
-/// while a full 27-line-table page still fits the backdrop's text panel.
-const BODY_FONT_SIZE: f32 = 16.0;
+/// Row pitch, matching the load screen's list rows.
 const BODY_LINE_H: f32 = 19.0;
 /// The 4:3 art is letterboxed (not stretched) on non-4:3 windows.
 const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
@@ -65,7 +65,13 @@ enum DebriefAction {
     Continue,
 }
 
-/// The only index into `DEBRIEFR.BIN`.
+/// The screen's one widget, parallel to `DEBRIEFR.BIN`'s one rect.
+const MENU_ITEMS: &[FrontendMenuItem<DebriefAction>] = &[FrontendMenuItem {
+    string_key: "continue",
+    fallback_label: "Continue",
+    action: Some(DebriefAction::Continue),
+    label_override: None,
+}];
 const CONTINUE_RECT_INDEX: usize = 0;
 /// Decoded `DEBRIEFR.BIN` value, used when the layout file is absent.
 const FALLBACK_RECTS: [Rect; 1] = [Rect::new(425.0, 401.0, 210.0, 74.0)];
@@ -73,9 +79,7 @@ const FALLBACK_RECTS: [Rect; 1] = [Rect::new(425.0, 401.0, 210.0, 74.0)];
 /// The button at a canvas point, if any. Shared by the click and the rollover
 /// sound so the two always agree on where the button is.
 fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<DebriefAction> {
-    rects[CONTINUE_RECT_INDEX]
-        .contains(point)
-        .then_some(DebriefAction::Continue)
+    hit_menu_item(point, MENU_ITEMS, rects, |_| true)
 }
 
 pub struct DebriefScene {
@@ -122,34 +126,42 @@ impl DebriefScene {
 
         let lines: Vec<String> = {
             let font = asset_cache.get(&FONT_IMPORTER, BODY_FONT);
-            wrap_page(&**font, &self.text, BODY_FONT_SIZE, TEXT_RECT.w)
+            wrap_page(&**font, &self.text, font.base_height(), TEXT_RECT.w)
         };
         for (index, line) in lines.iter().enumerate() {
             let y = TEXT_RECT.y + index as f32 * BODY_LINE_H;
+            // The shipped pages wrap to at most 10 rows in a 15-row panel, so
+            // this is a guard, not a design: a page that would spill over the
+            // backdrop art stops at the panel and says so, rather than quietly
+            // drawing its last line (the grant) off the screen.
+            if y + BODY_LINE_H > TEXT_RECT.y + TEXT_RECT.h {
+                warn!(
+                    "Debrief page is {} rows too tall for the panel - truncated",
+                    lines.len() - index
+                );
+                break;
+            }
             // A blank line is a paragraph gap: it spaces the block, it draws
-            // nothing. Rows past the panel are dropped rather than spilling
-            // over the backdrop art.
-            if line.is_empty() || y + BODY_LINE_H > TEXT_RECT.y + TEXT_RECT.h {
+            // nothing.
+            if line.is_empty() {
                 continue;
             }
-            canvas.text(
+            canvas.text_native(
                 Rect::new(TEXT_RECT.x, y, TEXT_RECT.w, BODY_LINE_H),
                 line,
                 BODY_FONT,
-                BODY_FONT_SIZE,
                 HAlign::Left,
                 VAlign::Middle,
             );
         }
 
         let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
-        let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, LABELS_FILE);
-        let label =
-            crate::ui::resolve_menu_label(strings.as_deref(), CONTINUE_KEY, CONTINUE_FALLBACK);
+        let labels = self.menu.labels(asset_cache, LABELS_FILE, MENU_ITEMS);
+        let label = &labels[CONTINUE_RECT_INDEX];
         let rect = rects[CONTINUE_RECT_INDEX];
         let hovered = pointer_canvas.is_some_and(|p| rect.contains(p));
         canvas
-            .text_native(rect, &label, MENU_FONT, HAlign::Center, VAlign::Middle)
+            .text_native(rect, label, MENU_FONT, HAlign::Center, VAlign::Middle)
             .opacity(if hovered { 1.0 } else { 0.6 });
 
         canvas

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 
 pub mod cutscene_player;
 pub mod cutscene_skip;
+pub mod debrief;
 pub mod debug_camera;
 pub mod debug_common;
 pub mod debug_gloves;
@@ -46,6 +47,7 @@ pub mod main_menu;
 pub mod no_assets;
 
 pub use cutscene_player::CutscenePlayerScene;
+pub use debrief::DebriefScene;
 pub use debug_camera::DebugCameraScene;
 pub use debug_gloves::DebugGlovesScene;
 pub use debug_hand_poses::DebugHandPosesScene;

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -68,6 +68,33 @@ impl ChooseMissionScript {
         }
     }
 
+    /// The debrief page key for the tour this trigger completes, if any: the
+    /// `Mission1..Mission27` key `player_stats::REWARDS` records beside the
+    /// grants for (career, completed year, tour index). The markers carry no
+    /// text of their own - only `P$CharGenRo` - so the page is selected the way
+    /// the original does, from the same table that decides the stats.
+    fn debrief_key(world: &World, entity_id: EntityId, current_year: u32) -> Option<&'static str> {
+        match Self::grant_reward_effect(world, entity_id, current_year) {
+            Effect::GrantTourReward { career, year, tour } => {
+                crate::player_stats::tour_reward(career, year, tour).map(|reward| reward.text_key)
+            }
+            _ => None,
+        }
+    }
+
+    /// `transition` behind the tour's debrief page, when it has one. The page
+    /// comes first: it reports the tour that just ended, and its Continue is
+    /// what starts the departure.
+    fn behind_debrief(
+        transition: super::GlobalEffect,
+        debrief_key: Option<&str>,
+    ) -> super::GlobalEffect {
+        match debrief_key {
+            Some(key) => transition.after_debrief(key),
+            None => transition,
+        }
+    }
+
     /// The reward effect for completing this tour: the current career (from the
     /// persisted career bit) + the training year being completed (`current_year`,
     /// 1..=3) + the tour index `P$CharGenRo` carried by the tour marker
@@ -142,14 +169,17 @@ impl Script for ChooseMissionScript {
                             .unwrap_or_default()
                     };
 
-                    let transition = Self::behind_departure_cutscenes(
-                        super::GlobalEffect::TransitionLevel {
-                            level_file: "station.mis".to_string(),
-                            loc: None,
-                            entities_to_trigger,
-                            vitals_transition: super::PlayerVitalsTransition::Preserve,
-                        },
-                        new_year,
+                    let transition = Self::behind_debrief(
+                        Self::behind_departure_cutscenes(
+                            super::GlobalEffect::TransitionLevel {
+                                level_file: "station.mis".to_string(),
+                                loc: None,
+                                entities_to_trigger,
+                                vitals_transition: super::PlayerVitalsTransition::Preserve,
+                            },
+                            new_year,
+                        ),
+                        Self::debrief_key(world, entity_id, current_year),
                     );
 
                     Effect::Multiple(vec![
@@ -168,14 +198,17 @@ impl Script for ChooseMissionScript {
                     let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
                     let dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
 
-                    let transition = Self::behind_departure_cutscenes(
-                        super::GlobalEffect::TransitionLevel {
-                            level_file,
-                            loc: dest_loc,
-                            entities_to_trigger: vec![],
-                            vitals_transition: super::PlayerVitalsTransition::Preserve,
-                        },
-                        new_year,
+                    let transition = Self::behind_debrief(
+                        Self::behind_departure_cutscenes(
+                            super::GlobalEffect::TransitionLevel {
+                                level_file,
+                                loc: dest_loc,
+                                entities_to_trigger: vec![],
+                                vitals_transition: super::PlayerVitalsTransition::Preserve,
+                            },
+                            new_year,
+                        ),
+                        Self::debrief_key(world, entity_id, current_year),
                     );
 
                     Effect::Multiple(vec![
@@ -215,6 +248,31 @@ mod tests {
 
         assert!(ChooseMissionScript::departure_cutscenes(1).is_empty());
         assert!(ChooseMissionScript::departure_cutscenes(5).is_empty());
+    }
+
+    /// The debrief page reports the tour that just ended, so it comes first -
+    /// in front of the departure clips, which are in front of the transition.
+    /// A tour with no page leaves the chain exactly as it was.
+    #[test]
+    fn the_tour_page_comes_before_the_departure_clips() {
+        let transition = GlobalEffect::new_game_transition("station.mis".to_string());
+        let departure = ChooseMissionScript::behind_departure_cutscenes(transition.clone(), 2);
+
+        let wrapped = ChooseMissionScript::behind_debrief(departure, Some("Mission1"));
+        let GlobalEffect::ShowDebrief { text_key, then } = wrapped else {
+            panic!("the tour should show its debrief page first");
+        };
+        assert_eq!(text_key, "Mission1");
+        let GlobalEffect::PlayCutscene { video, then } = *then else {
+            panic!("continuing should depart on the tour's clip");
+        };
+        assert_eq!(video, "shuttle1.avi");
+        assert!(matches!(*then, GlobalEffect::TransitionLevel { .. }));
+
+        assert!(matches!(
+            ChooseMissionScript::behind_debrief(transition, None),
+            GlobalEffect::TransitionLevel { .. }
+        ));
     }
 
     /// The clips wrap the transition in the order they are shown, and a year

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -68,18 +68,27 @@ impl ChooseMissionScript {
         }
     }
 
-    /// The debrief page key for the tour this trigger completes, if any: the
-    /// `Mission1..Mission27` key `player_stats::REWARDS` records beside the
-    /// grants for (career, completed year, tour index). The markers carry no
-    /// text of their own - only `P$CharGenRo` - so the page is selected the way
-    /// the original does, from the same table that decides the stats.
-    fn debrief_key(world: &World, entity_id: EntityId, current_year: u32) -> Option<&'static str> {
-        match Self::grant_reward_effect(world, entity_id, current_year) {
-            Effect::GrantTourReward { career, year, tour } => {
-                crate::player_stats::tour_reward(career, year, tour).map(|reward| reward.text_key)
-            }
-            _ => None,
+    /// The debrief page key for the grant this trigger is about to make, if
+    /// any: the `Mission1..Mission27` key `player_stats::REWARDS` records
+    /// beside the grants themselves. The markers carry no text of their own -
+    /// only `P$CharGenRo` - so the page is selected the way the original does,
+    /// from the same table that decides the stats.
+    ///
+    /// `None` for a year already granted, so the page can never claim a stat
+    /// change `apply_tour_reward` is about to refuse (two markers firing in one
+    /// frame both read the pre-effect quest bits).
+    fn debrief_key(world: &World, grant: &Effect) -> Option<&'static str> {
+        let Effect::GrantTourReward { career, year, tour } = grant else {
+            return None;
+        };
+        let already_granted = world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|quest_info| quest_info.player_stats().granted_years.contains(year))
+            .unwrap_or(false);
+        if already_granted {
+            return None;
         }
+        crate::player_stats::tour_reward(*career, *year, *tour).map(|reward| reward.text_key)
     }
 
     /// `transition` behind the tour's debrief page, when it has one. The page
@@ -179,7 +188,7 @@ impl Script for ChooseMissionScript {
                             },
                             new_year,
                         ),
-                        Self::debrief_key(world, entity_id, current_year),
+                        Self::debrief_key(world, &grant_effect),
                     );
 
                     Effect::Multiple(vec![
@@ -208,7 +217,7 @@ impl Script for ChooseMissionScript {
                             },
                             new_year,
                         ),
-                        Self::debrief_key(world, entity_id, current_year),
+                        Self::debrief_key(world, &grant_effect),
                     );
 
                     Effect::Multiple(vec![

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -103,6 +103,20 @@ pub enum GlobalEffect {
         damage: f32,
     },
 
+    /// Show the character-creation debrief page - the `res/strings/CHARGEN.STR`
+    /// entry `text_key` on the original `DEBRIEF.PCX` screen - and dispatch
+    /// `then` when the player continues.
+    ///
+    /// A screen rather than an overlay, so the page owns the moment the way the
+    /// original does. Like [`PlayCutscene`](GlobalEffect::PlayCutscene) it
+    /// replaces the mission scene, so handling it saves that scene: a `then`
+    /// transition has to carry the player's career, training year, inventory
+    /// and vitals, not the empty world of the screen that stood in for it.
+    ShowDebrief {
+        text_key: String,
+        then: Box<GlobalEffect>,
+    },
+
     // Quit the game (e.g. from the main menu). The runtime is responsible for
     // observing this via `Game::should_quit` and closing its window.
     Quit,
@@ -117,6 +131,15 @@ impl GlobalEffect {
     pub fn after_cutscene(self, video: &str) -> Self {
         GlobalEffect::PlayCutscene {
             video: video.to_owned(),
+            then: Box::new(self),
+        }
+    }
+
+    /// Show the debrief page for `text_key` first and dispatch `self` when the
+    /// player continues.
+    pub fn after_debrief(self, text_key: &str) -> Self {
+        GlobalEffect::ShowDebrief {
+            text_key: text_key.to_owned(),
             then: Box::new(self),
         }
     }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -785,6 +785,11 @@ export interface UiState {
    * mapping it through this pose - see `test/helpers/vr-hand.ts`.
    */
   panel_pose: UiPanelPose | null;
+  /**
+   * The character-creation debrief page on screen right now, verbatim; null
+   * when the debrief screen is not up.
+   */
+  debrief_text: string | null;
 }
 
 /** One frame of pointing at the shared UI canvas. */

--- a/tools/shock2-sdk/test/debrief.e2e.test.ts
+++ b/tools/shock2-sdk/test/debrief.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import { isCutsceneScene } from "./helpers/cutscenes.js";
 import { DEBRIEF_CONTINUE, dismissDebrief } from "./helpers/debrief.js";
-import { AIM_AT_PANEL, norm, panelPoint } from "./helpers/frontend-menu.js";
+import { vrClickCanvasPoint } from "./helpers/frontend-menu.js";
 
 // The character-creation debrief: the page the original shows as a training
 // tour ends ("Your stint aboard the UNN Gallo is finished... You've gained +2
@@ -50,19 +50,6 @@ async function completeTourZero(game: GameServer): Promise<void> {
     type: "TurnOn",
   } as unknown as Parameters<typeof game.entities.sendMessage>[1]);
   await game.step({ frames: 30 });
-}
-
-/** Pull the trigger over a canvas point on the VR panel, as a rising edge. */
-async function vrClick(game: GameServer, [x, y]: [number, number]): Promise<void> {
-  const [, py, pz] = panelPoint(norm(x, y));
-  await game.input.set("right_hand.rotation", AIM_AT_PANEL);
-  await game.input.set("right_hand.position", [0, py, pz]);
-  await game.input.set("right_hand.trigger", 0);
-  await game.step({ frames: 3 });
-  await game.input.set("right_hand.trigger", 1);
-  await game.step({ frames: 3 });
-  await game.input.set("right_hand.trigger", 0);
-  await game.step({ frames: 3 });
 }
 
 test(
@@ -134,7 +121,7 @@ test(
     );
 
     // The same canvas rect drives the click in VR, through the controller ray.
-    await vrClick(game, DEBRIEF_CONTINUE);
+    await vrClickCanvasPoint(game, DEBRIEF_CONTINUE);
     const after = (await game.info()).mission;
     assert.ok(
       isCutsceneScene(after) || after.toLowerCase().includes("station"),

--- a/tools/shock2-sdk/test/debrief.e2e.test.ts
+++ b/tools/shock2-sdk/test/debrief.e2e.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { isCutsceneScene } from "./helpers/cutscenes.js";
+import { DEBRIEF_CONTINUE, dismissDebrief } from "./helpers/debrief.js";
+import { AIM_AT_PANEL, norm, panelPoint } from "./helpers/frontend-menu.js";
+
+// The character-creation debrief: the page the original shows as a training
+// tour ends ("Your stint aboard the UNN Gallo is finished... You've gained +2
+// Strength."), on its own authored screen (DEBRIEF.PCX + DEBRIEFR.BIN) rather
+// than as an overlay, with a Continue button that starts the departure.
+//
+// The tour markers in station.mis carry no text - only P$CharGenRo, the tour
+// index - so the string is selected the way the original does: (career, year,
+// tour) picks a Mission1..Mission27 key in res/strings/CHARGEN.STR, which the
+// reward table already records.
+//
+// Negative-first: on the base revision nothing implements the debrief at all
+// (`TourReward::text_key` is read by nobody), so the tour trigger swaps
+// straight to the departure and every assertion here fails - there is no
+// "debrief" scene to land on.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8100);
+
+/** The debrief only lands with a career chosen; chargen sets this bit. */
+const CAREER_BIT = "career_marine";
+/** Marine year 1 tour 0 = CHARGEN.STR "Mission1". */
+const EXPECTED_PAGE = "UNN Gallo";
+const EXPECTED_GRANT = "+2 Strength";
+/**
+ * Complete a training tour: pick a career, then fire a ChooseMission marker
+ * exactly as the tour tripwire does.
+ *
+ * The three markers differ only in `P$CharGenRo` (the tour index) and their
+ * authored position, and runtime entity ids are not stable, so the tour is
+ * pinned by position: tour 0 is the marker at the greatest z (-22.6, -5.6,
+ * 11.2 in the mission file). Both presentations must complete the SAME tour,
+ * or their screenshots show different pages and prove nothing about layout.
+ */
+async function completeTourZero(game: GameServer): Promise<void> {
+  await game.quests.set(CAREER_BIT, "complete");
+  const markers = (await game.transitions()).transitions.filter((t) =>
+    t.dest_level.toLowerCase().includes("medsci1"),
+  );
+  assert.equal(markers.length, 3, "station has three ChooseMission tour markers");
+  const tourZero = markers.reduce((a, b) => (a.position[2] >= b.position[2] ? a : b));
+  // TurnOn is a valid debug message; the SDK's typed union predates it.
+  await game.entities.sendMessage(tourZero.entity_id, {
+    type: "TurnOn",
+  } as unknown as Parameters<typeof game.entities.sendMessage>[1]);
+  await game.step({ frames: 30 });
+}
+
+/** Pull the trigger over a canvas point on the VR panel, as a rising edge. */
+async function vrClick(game: GameServer, [x, y]: [number, number]): Promise<void> {
+  const [, py, pz] = panelPoint(norm(x, y));
+  await game.input.set("right_hand.rotation", AIM_AT_PANEL);
+  await game.input.set("right_hand.position", [0, py, pz]);
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 3 });
+}
+
+test(
+  "flat: finishing a training tour opens the debrief page, and Continue departs",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.ui.state()).debrief_text,
+      null,
+      "no debrief may show before a tour is completed",
+    );
+
+    await completeTourZero(game);
+
+    // The tour hands the screen to the debrief, before the departure - the
+    // level change waits behind the page.
+    assert.equal((await game.info()).mission, "debrief");
+    // The page really is the tour's own CHARGEN.STR entry, not just "some text
+    // drew": a wrong key would still emit glyphs.
+    const page = (await game.ui.state()).debrief_text ?? "";
+    assert.match(page, new RegExp(EXPECTED_PAGE), `wrong debrief page: ${page}`);
+    assert.match(page, new RegExp(EXPECTED_GRANT.replace("+", "\\+")));
+
+    // It is a page, not a timed overlay: it waits for the player.
+    await game.step({ frames: 20 * 60 });
+    assert.equal((await game.info()).mission, "debrief", "the page must wait to be dismissed");
+
+    assert.ok(await dismissDebrief(game), "Continue should be clickable on the page");
+    const after = (await game.info()).mission;
+    assert.ok(
+      isCutsceneScene(after) || after.toLowerCase().includes("station"),
+      `Continue should start the departure, got ${after}`,
+    );
+    assert.equal((await game.ui.state()).debrief_text, null, "and leave the page behind");
+  },
+);
+
+test(
+  "vr: the same tour's page presents on the world panel, and its Continue works",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    await completeTourZero(game);
+
+    assert.equal((await game.info()).mission, "debrief");
+    const page = (await game.ui.state()).debrief_text ?? "";
+    assert.match(page, new RegExp(EXPECTED_PAGE), `wrong debrief page: ${page}`);
+
+    // The screen is on the shared frontend panel in front of the head, not left
+    // at the world origin.
+    const objects = (await game.scene.objects()).objects;
+    const depths = objects.filter((o) => o.source === null).map((o) => -o.position[0]);
+    assert.ok(depths.length > 0, "the VR presentation must draw the page on its panel");
+    assert.ok(
+      Math.min(...depths) > 0.5 && Math.max(...depths) < 6,
+      `the panel should hang in front of the head, got ${JSON.stringify(depths)}`,
+    );
+
+    // The same canvas rect drives the click in VR, through the controller ray.
+    await vrClick(game, DEBRIEF_CONTINUE);
+    const after = (await game.info()).mission;
+    assert.ok(
+      isCutsceneScene(after) || after.toLowerCase().includes("station"),
+      `Continue should start the departure in VR too, got ${after}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { SceneObjectSummary } from "../src/types.js";
-import { AIM_AT_PANEL, menuEntry, norm, panelPoint } from "./helpers/frontend-menu.js";
+import { menuEntry, norm, vrClickCanvasPoint } from "./helpers/frontend-menu.js";
 
 // The Developer screen: the shared dev-params row panel, hosted by a frontend
 // scene reached from the main menu's repurposed Options slot, and by a second
@@ -145,21 +145,6 @@ function panelDepth(objects: SceneObjectSummary[]): number {
   return depths[Math.floor(depths.length / 2)];
 }
 
-/** Pull the trigger over a canvas point on the VR panel, as a rising edge. */
-async function vrClick(game: GameServer, [x, y]: [number, number]): Promise<void> {
-  const [, py, pz] = panelPoint(norm(x, y));
-  await game.input.set("right_hand.rotation", AIM_AT_PANEL);
-  // Aimed straight down -X: the ray meets the panel at the same canvas point
-  // whatever distance the panel is currently tuned to.
-  await game.input.set("right_hand.position", [0, py, pz]);
-  await game.input.set("right_hand.trigger", 0);
-  await game.step({ frames: 3 });
-  await game.input.set("right_hand.trigger", 1);
-  await game.step({ frames: 3 });
-  await game.input.set("right_hand.trigger", 0);
-  await game.step({ frames: 3 });
-}
-
 test(
   "the VR Developer screen's > visibly moves the live panel",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
@@ -171,7 +156,7 @@ test(
     await game.step({ frames: 10 });
 
     // Into the Developer screen via the controller ray.
-    await vrClick(game, [400 + 179 / 2, 20 + 2 * 76 + 30]);
+    await vrClickCanvasPoint(game, [400 + 179 / 2, 20 + 2 * 76 + 30]);
     assert.equal((await game.info()).mission, "developer");
     await game.step({ frames: 5 });
 
@@ -184,7 +169,7 @@ test(
 
     // One click on panel_distance's `>`: the registry moves AND the very
     // panel being pointed at re-renders farther away.
-    await vrClick(game, ROW0_INCREMENT);
+    await vrClickCanvasPoint(game, ROW0_INCREMENT);
     assert.ok(Math.abs((await paramValue(game, "panel_distance")) - 2.1) < 1e-4);
     await game.step({ frames: 2 });
     const after = panelDepth((await game.scene.objects()).objects);
@@ -194,13 +179,13 @@ test(
     );
 
     // Step back down; the panel comes home.
-    await vrClick(game, ROW0_DECREMENT);
+    await vrClickCanvasPoint(game, ROW0_DECREMENT);
     await game.step({ frames: 2 });
     const restored = panelDepth((await game.scene.objects()).objects);
     assert.ok(Math.abs(restored - 2.0) < 0.05, `expected 2.0, got ${restored}`);
 
     // Done returns to the main menu.
-    await vrClick(game, DONE);
+    await vrClickCanvasPoint(game, DONE);
     assert.equal((await game.info()).mission, "main_menu");
   },
 );
@@ -342,18 +327,18 @@ test(
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });
-    await vrClick(game, [400 + 179 / 2, 20 + 2 * 76 + 30]);
+    await vrClickCanvasPoint(game, [400 + 179 / 2, 20 + 2 * 76 + 30]);
     assert.equal((await game.info()).mission, "developer");
 
     // The same canvas points as the flat run, reached by the ray.
-    await vrClick(game, ACTION);
+    await vrClickCanvasPoint(game, ACTION);
     assert.equal((await game.info()).mission, "developer");
     await game.step({ frames: 5 });
     await game.screenshot("dev-scenes-vr.png");
 
-    await vrClick(game, TAB_DEBUG_SCENES);
-    await vrClick(game, sceneRow(DEBUG_MINIMAL_ROW));
-    await vrClick(game, ACTION);
+    await vrClickCanvasPoint(game, TAB_DEBUG_SCENES);
+    await vrClickCanvasPoint(game, sceneRow(DEBUG_MINIMAL_ROW));
+    await vrClickCanvasPoint(game, ACTION);
     assert.equal((await game.info()).mission, "debug_minimal");
   },
 );

--- a/tools/shock2-sdk/test/helpers/debrief.ts
+++ b/tools/shock2-sdk/test/helpers/debrief.ts
@@ -1,5 +1,5 @@
 import type { GameServer } from "../../src/index.js";
-import { norm } from "./frontend-menu.js";
+import { clickCanvasPoint } from "./frontend-menu.js";
 
 // A training tour ends on the debrief screen (DEBRIEF.PCX), which waits for the
 // player before the departure runs. Any test that drives a tour therefore has
@@ -19,12 +19,6 @@ export async function debriefIsUp(game: GameServer): Promise<boolean> {
  */
 export async function dismissDebrief(game: GameServer): Promise<boolean> {
   if (!(await debriefIsUp(game))) return false;
-  await game.input.set("pointer.position", norm(...DEBRIEF_CONTINUE));
-  await game.input.set("pointer.pressed", 0);
-  await game.step({ frames: 3 });
-  await game.input.set("pointer.pressed", 1);
-  await game.step({ frames: 3 });
-  await game.input.set("pointer.pressed", 0);
-  await game.step({ frames: 3 });
+  await clickCanvasPoint(game, DEBRIEF_CONTINUE);
   return true;
 }

--- a/tools/shock2-sdk/test/helpers/debrief.ts
+++ b/tools/shock2-sdk/test/helpers/debrief.ts
@@ -1,0 +1,30 @@
+import type { GameServer } from "../../src/index.js";
+import { norm } from "./frontend-menu.js";
+
+// A training tour ends on the debrief screen (DEBRIEF.PCX), which waits for the
+// player before the departure runs. Any test that drives a tour therefore has
+// to dismiss it, the way a player does.
+
+/** The Continue button's center, from DEBRIEFR.BIN (425,401 210x74). */
+export const DEBRIEF_CONTINUE: [number, number] = [425 + 210 / 2, 401 + 74 / 2];
+
+/** Whether the debrief screen is what is on screen right now. */
+export async function debriefIsUp(game: GameServer): Promise<boolean> {
+  return (await game.info()).mission === "debrief";
+}
+
+/**
+ * Click Continue on the debrief page if it is up, as a real rising edge, and
+ * report whether there was one to dismiss.
+ */
+export async function dismissDebrief(game: GameServer): Promise<boolean> {
+  if (!(await debriefIsUp(game))) return false;
+  await game.input.set("pointer.position", norm(...DEBRIEF_CONTINUE));
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+  return true;
+}

--- a/tools/shock2-sdk/test/helpers/frontend-menu.ts
+++ b/tools/shock2-sdk/test/helpers/frontend-menu.ts
@@ -48,3 +48,35 @@ export const panelPoint = ([u, v]: [number, number]): [number, number, number] =
   PLAYER_EYE_HEIGHT_WORLD + (0.5 - v) * PANEL_SIZE.y,
   (0.5 - u) * PANEL_SIZE.x,
 ];
+
+/** Click a canvas point with the flat pointer, as a real rising edge. */
+export async function clickCanvasPoint(
+  game: GameServer,
+  [x, y]: [number, number],
+): Promise<void> {
+  await game.input.set("pointer.position", norm(x, y));
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+}
+
+/** Pull the trigger over a canvas point on the VR panel, as a rising edge. */
+export async function vrClickCanvasPoint(
+  game: GameServer,
+  [x, y]: [number, number],
+): Promise<void> {
+  const [, py, pz] = panelPoint(norm(x, y));
+  await game.input.set("right_hand.rotation", AIM_AT_PANEL);
+  // Aimed straight down -X: the ray meets the panel at the same canvas point
+  // whatever distance the panel is currently tuned to.
+  await game.input.set("right_hand.position", [0, py, pz]);
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 3 });
+}

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { stepPastCutscenes } from "./helpers/cutscenes.js";
+import { dismissDebrief } from "./helpers/debrief.js";
 
 // End-to-end test for the HONEST character-creation chain the player walks at
 // game start: earth.mis (pick a career) -> station.mis three training tours ->
@@ -113,6 +114,9 @@ async function teleportTo(game: GameServer, [x, y, z]: Vec3): Promise<void> {
 async function tripAndArrive(game: GameServer, at: Vec3, frames: number): Promise<string[]> {
   await teleportTo(game, at);
   await game.step({ frames });
+  // A tour ends on its debrief page, which waits for the player before the
+  // departure runs; a career door has none to dismiss.
+  await dismissDebrief(game);
   return stepPastCutscenes(game);
 }
 


### PR DESCRIPTION
System Shock 2 shows a page of text when a character-creation training tour
ends — "Your stint aboard the UNN Gallo is finished… You've gained +2
Strength." Nothing implemented it here, in either presentation. This adds it,
as its own screen.

## The data discovery

Mission text had no known source in the data, so this started with `cargo dq`
on `station.mis`.

**The chargen markers carry no text.** The three `S$ChooseMission` entities in
`station.mis` (template −327 "Marker") hold exactly six properties:
`DestLevel`, `DestLoc`, `Position`, `Scale`, `Scripts`, and **`P$CharGenRo`** —
the tour index, 0/1/2. No text property, no link to one. So the string is not
authored on the trigger: it is *selected in code* from (career, training year,
tour), which is precisely the 27-entry table `player_stats::REWARDS` already
encodes, each row carrying the `Mission1..Mission27` key of
`res/strings/CHARGEN.STR` in `TourReward::text_key` — a field documented as
"display only … so a future UI can show the message" and, until now, read by
nobody. `CHARGEN.STR` ships in `sshock2.kpf`/`res/strings` on **both** classic
and anniversary installs, so the feature is not 25AE-only.

## A screen, not an overlay

Per review direction, the debrief is an **interstitial**, not a HUD layer — the
original gives this moment a whole page, so it gets one:

- **`DEBRIEF.PCX`** backdrop, **`DEBRIEFR.BIN`** for the Continue button's rect
  (one LTRB rect, `425,401 210x74`, via `dark::importers::UI_LAYOUT_IMPORTER`),
  **`DEBRIEF.STR`** for its label. The body is the tour's `CHARGEN.STR` page,
  word-wrapped on real glyph widths into the backdrop's text panel, drawn at the
  font's authored size (`text_native`) like every other screen's body text.
- **`DebriefScene`** is a sibling of `GameOverScene`: one shared `UiCanvas`
  built once in 640×480 canvas pixels, presented screen-space on flat and on the
  shared frontend world panel in VR, with the same `FrontendMenu` driving the
  pointer, hover and click in both. Neither presentation makes a placement
  decision of its own (AGENTS.md §3).
- **`GlobalEffect::ShowDebrief { text_key, then }`** mirrors `PlayCutscene`: the
  tour trigger hands it the transition it wanted, the page stands in for the
  mission scene, and **Continue** dispatches the follow-on — the departure
  cutscene, then the level change. Both effects now go through one
  `Game::show_over_mission`, which saves the replaced scene (so the follow-on
  carries career, training year, inventory and vitals) and, if the stand-in
  cannot be built, runs the follow-on rather than stranding the player. A
  missing or blank `CHARGEN.STR` page therefore just departs, as before.
- The page is selected from the grant the trigger is *about to make*, and is
  suppressed for a training year already granted — so it can never claim a stat
  change `apply_tour_reward` would refuse.

**`GlobalEffect::ShowMessage` and the message overlay are gone.** They were
introduced by the earlier revision of this PR and nothing else used them; a
screen needs none of the stand-down rules an overlay did (pause menu, loading
screen). Issue #1029's message trap (`P$UseMsg` → `USEMSG.STR`) will want a
transient HUD line — that is a different presentation from this page, and is
better added with its consumer than kept alive here unused.

## What it looks like

![debrief screen demo](https://gist.githubusercontent.com/tommy-xr/984ff207a07d358c134d0fbda9712146/raw/demo.gif)

<sub>The tour ends, the page comes up and waits, Continue lights on hover and departs into the shuttle clip. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![flat vs vr debrief screen](https://gist.githubusercontent.com/tommy-xr/984ff207a07d358c134d0fbda9712146/raw/side_by_side.png)

<sub>The same tour (Marine, year 1, tour 0 -> `Mission1`) in both presentations: same wrap, same rows, Continue in the same place - the VR shot differs only by its pointer ray, because both draw the one canvas.</sub>

There is no before/after pairing: nothing rendered this text on `main`, in
either presentation.

## Verification

- `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr
  -p desktop_runtime -p debug_runtime` clean.
- `cargo test -p shock2vr --lib`: 1176 pass, including the new scene tests
  (Continue's rect and its rising-edge click emitting exactly the deferred
  effect, the wrap and its paragraph rows) and the script test pinning the page
  in front of the departure clips.
- New `tools/shock2-sdk/test/debrief.e2e.test.ts` — negative-first: nothing on
  `main` lands on a `debrief` scene. It completes a tour in `station.mis`,
  asserts the page is that tour's own `CHARGEN.STR` entry (`/v1/ui`
  `debrief_text`), that it *waits* rather than expiring, and that Continue
  departs — in **flat** and in **VR**, through the same canvas rect. The VR
  case also asserts the page is on the panel in front of the head.
- `station-flow.e2e.test.ts` now dismisses the page the way a player does
  (shared `dismissDebrief` helper); all 23 missions still load
  (`missions.e2e.test.ts`).
- Driven end to end on the debug runtime, flat and `--vr`: tour → page →
  Continue → `shuttle1.avi` → `station.mis` with Strength 3 and
  `training_year_2` set, i.e. the preserved-state contract holds.

## Reviewed

`/xreview` — both engines (Claude + Codex) plus a dedicated duplication pass.

**[AGREED] by both engines, fixed:** `show_over_mission` (and, before it,
`PlayCutscene`) would clear a pending transition and then save the *loading*
scene as the outgoing state — wiping quest bits, held items and vitals. It now
refuses exactly as `begin_transition` does, and the transition the player is
waiting for is what lands.

Other findings applied: the `ShowDebrief` arm was a near-verbatim copy of
`PlayCutscene`'s (now one `show_over_mission`); the screen hand-rolled a button
the shared `FrontendMenu` helpers already resolve; the body scaled a bitmap font
1.45× against the repo's fidelity default (now `text_native`); an over-tall page
silently dropped the row naming the grant (now truncated with a one-shot
warning) and an over-wide word could run off the panel (rows are fitted);
`debrief_key` recomputed a grant the caller already had, and now also returns
nothing for an already-granted year. Test-side duplicates — the flat and VR
canvas-click sequences — moved into `helpers/frontend-menu.ts`.

Declined, with reasons: the measured word wrap is the fifth greedy wrapper in
the tree (the other four count characters); converging them belongs in the
shared font layer, not here. Codex wanted the page enqueued only on
`apply_tour_reward`'s own `true`, which would mean emitting it from the effect
applier and so losing the ability to wrap the transition; the pre-effect guard
covers every reachable case (two tour markers cannot fire in one frame in-game),
and the applier stays authoritative for the stats themselves. `CHARGEN.STR` also
carries `MissionPic1..N` → `D001..D006` for the backdrop's empty circular
picture panel; that is a follow-up, not part of "a page of text".
