### PR TITLE
feat(vr): wield the 25AE melee _h models, with melee damage proven through the production path

### DIFF
--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -73,6 +73,12 @@ pub struct AnimationPlayer {
     /// `AnimationInfo::cancel_root_motion`). Set for first-person viewmodels,
     /// whose entity transform is re-anchored to the camera every frame.
     cancel_root_motion: bool,
+    /// Rigid model-space transform composed onto every posed joint after
+    /// animation (`get_transforms` returns `post * joint`). Used by the VR
+    /// melee wield to align the posed arm's fist and weapon axis with the
+    /// entity's grip frame without moving the entity (and its contact
+    /// collider). `None` for every ordinary player.
+    post_transform: Option<Matrix4<f32>>,
 }
 
 impl AnimationPlayer {
@@ -87,6 +93,7 @@ impl AnimationPlayer {
             blend_state: None,
             rotation_pos: 0.0,
             cancel_root_motion: false,
+            post_transform: None,
         }
     }
     pub fn from_animation(animation_clip: Rc<AnimationClip>) -> AnimationPlayer {
@@ -101,6 +108,7 @@ impl AnimationPlayer {
             blend_state: None,
             rotation_pos: 0.0,
             cancel_root_motion: false,
+            post_transform: None,
         }
     }
 
@@ -120,6 +128,7 @@ impl AnimationPlayer {
             blend_state: None,
             rotation_pos: 0.0,
             cancel_root_motion: false,
+            post_transform: None,
         }
     }
 
@@ -165,6 +174,7 @@ impl AnimationPlayer {
             blend_state,
             rotation_pos: 0.0,
             cancel_root_motion: player.cancel_root_motion,
+            post_transform: player.post_transform,
         }
     }
 
@@ -237,6 +247,7 @@ impl AnimationPlayer {
             blend_state,
             rotation_pos: 0.0,
             cancel_root_motion: player.cancel_root_motion,
+            post_transform: player.post_transform,
         }
     }
 
@@ -245,6 +256,17 @@ impl AnimationPlayer {
     pub fn with_root_motion_cancelled(player: &AnimationPlayer) -> AnimationPlayer {
         let mut new_player = player.clone();
         new_player.cancel_root_motion = true;
+        new_player
+    }
+
+    /// A copy of `player` whose posed joints are all pre-multiplied by
+    /// `transform` (see the `post_transform` field).
+    pub fn with_post_transform(
+        player: &AnimationPlayer,
+        transform: Matrix4<f32>,
+    ) -> AnimationPlayer {
+        let mut new_player = player.clone();
+        new_player.post_transform = Some(transform);
         new_player
     }
 
@@ -265,6 +287,7 @@ impl AnimationPlayer {
             blend_state: player.blend_state.clone(),
             rotation_pos: player.rotation_pos,
             cancel_root_motion: player.cancel_root_motion,
+            post_transform: player.post_transform,
         }
     }
 
@@ -401,6 +424,7 @@ impl AnimationPlayer {
                                 blend_state,
                                 rotation_pos: raw_end_pos - current_clip.num_frames as f32,
                                 cancel_root_motion: player.cancel_root_motion,
+                                post_transform: player.post_transform,
                             },
                             motion_flags,
                             events,
@@ -438,6 +462,7 @@ impl AnimationPlayer {
                                 // slice is emitted on its first tick.
                                 rotation_pos: 0.0,
                                 cancel_root_motion: player.cancel_root_motion,
+                                post_transform: player.post_transform,
                             },
                             motion_flags,
                             events,
@@ -468,6 +493,7 @@ impl AnimationPlayer {
                         blend_state,
                         rotation_pos: raw_end_pos,
                         cancel_root_motion: player.cancel_root_motion,
+                        post_transform: player.post_transform,
                     },
                     motion_flags,
                     events,
@@ -523,7 +549,7 @@ impl AnimationPlayer {
         if maybe_current_clip.is_none() {
             let animated_skeleton =
                 ss2_skeleton::animate(skeleton, None, &self.additional_joint_transforms);
-            return animated_skeleton.get_transforms();
+            return self.apply_post_transform(animated_skeleton.get_transforms());
         }
 
         let (rc_animation_clip, is_looping, is_last_anim) = maybe_current_clip.unwrap();
@@ -580,7 +606,16 @@ impl AnimationPlayer {
             }
         }
 
-        animated_transforms
+        self.apply_post_transform(animated_transforms)
+    }
+
+    fn apply_post_transform(&self, mut transforms: [Matrix4<f32>; 40]) -> [Matrix4<f32>; 40] {
+        if let Some(post) = self.post_transform {
+            for transform in transforms.iter_mut() {
+                *transform = post * *transform;
+            }
+        }
+        transforms
     }
 
     fn compute_transforms_for_clip(

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -73,12 +73,6 @@ pub struct AnimationPlayer {
     /// `AnimationInfo::cancel_root_motion`). Set for first-person viewmodels,
     /// whose entity transform is re-anchored to the camera every frame.
     cancel_root_motion: bool,
-    /// Rigid model-space transform composed onto every posed joint after
-    /// animation (`get_transforms` returns `post * joint`). Used by the VR
-    /// melee wield to align the posed arm's fist and weapon axis with the
-    /// entity's grip frame without moving the entity (and its contact
-    /// collider). `None` for every ordinary player.
-    post_transform: Option<Matrix4<f32>>,
 }
 
 impl AnimationPlayer {
@@ -93,7 +87,6 @@ impl AnimationPlayer {
             blend_state: None,
             rotation_pos: 0.0,
             cancel_root_motion: false,
-            post_transform: None,
         }
     }
     pub fn from_animation(animation_clip: Rc<AnimationClip>) -> AnimationPlayer {
@@ -108,7 +101,6 @@ impl AnimationPlayer {
             blend_state: None,
             rotation_pos: 0.0,
             cancel_root_motion: false,
-            post_transform: None,
         }
     }
 
@@ -128,7 +120,6 @@ impl AnimationPlayer {
             blend_state: None,
             rotation_pos: 0.0,
             cancel_root_motion: false,
-            post_transform: None,
         }
     }
 
@@ -174,7 +165,6 @@ impl AnimationPlayer {
             blend_state,
             rotation_pos: 0.0,
             cancel_root_motion: player.cancel_root_motion,
-            post_transform: player.post_transform,
         }
     }
 
@@ -247,7 +237,6 @@ impl AnimationPlayer {
             blend_state,
             rotation_pos: 0.0,
             cancel_root_motion: player.cancel_root_motion,
-            post_transform: player.post_transform,
         }
     }
 
@@ -256,17 +245,6 @@ impl AnimationPlayer {
     pub fn with_root_motion_cancelled(player: &AnimationPlayer) -> AnimationPlayer {
         let mut new_player = player.clone();
         new_player.cancel_root_motion = true;
-        new_player
-    }
-
-    /// A copy of `player` whose posed joints are all pre-multiplied by
-    /// `transform` (see the `post_transform` field).
-    pub fn with_post_transform(
-        player: &AnimationPlayer,
-        transform: Matrix4<f32>,
-    ) -> AnimationPlayer {
-        let mut new_player = player.clone();
-        new_player.post_transform = Some(transform);
         new_player
     }
 
@@ -287,7 +265,6 @@ impl AnimationPlayer {
             blend_state: player.blend_state.clone(),
             rotation_pos: player.rotation_pos,
             cancel_root_motion: player.cancel_root_motion,
-            post_transform: player.post_transform,
         }
     }
 
@@ -424,7 +401,6 @@ impl AnimationPlayer {
                                 blend_state,
                                 rotation_pos: raw_end_pos - current_clip.num_frames as f32,
                                 cancel_root_motion: player.cancel_root_motion,
-                                post_transform: player.post_transform,
                             },
                             motion_flags,
                             events,
@@ -462,7 +438,6 @@ impl AnimationPlayer {
                                 // slice is emitted on its first tick.
                                 rotation_pos: 0.0,
                                 cancel_root_motion: player.cancel_root_motion,
-                                post_transform: player.post_transform,
                             },
                             motion_flags,
                             events,
@@ -493,7 +468,6 @@ impl AnimationPlayer {
                         blend_state,
                         rotation_pos: raw_end_pos,
                         cancel_root_motion: player.cancel_root_motion,
-                        post_transform: player.post_transform,
                     },
                     motion_flags,
                     events,
@@ -549,7 +523,7 @@ impl AnimationPlayer {
         if maybe_current_clip.is_none() {
             let animated_skeleton =
                 ss2_skeleton::animate(skeleton, None, &self.additional_joint_transforms);
-            return self.apply_post_transform(animated_skeleton.get_transforms());
+            return animated_skeleton.get_transforms();
         }
 
         let (rc_animation_clip, is_looping, is_last_anim) = maybe_current_clip.unwrap();
@@ -606,16 +580,7 @@ impl AnimationPlayer {
             }
         }
 
-        self.apply_post_transform(animated_transforms)
-    }
-
-    fn apply_post_transform(&self, mut transforms: [Matrix4<f32>; 40]) -> [Matrix4<f32>; 40] {
-        if let Some(post) = self.post_transform {
-            for transform in transforms.iter_mut() {
-                *transform = post * *transform;
-            }
-        }
-        transforms
+        animated_transforms
     }
 
     fn compute_transforms_for_clip(

--- a/shock2vr/examples/melee_grip.rs
+++ b/shock2vr/examples/melee_grip.rs
@@ -46,12 +46,7 @@ fn main() {
                 println!("  joint {i:2}: ({:8.4}, {:8.4}, {:8.4})", p.x, p.y, p.z);
             }
         }
-        let arm = shock2vr::vr_config::MeleePosedArm {
-            elbow: joints[shock2vr::vr_config::MELEE_ARM_JOINT].w.truncate(),
-            fist: joints[shock2vr::vr_config::MELEE_GRIP_JOINT].w.truncate(),
-            weapon: joints[shock2vr::vr_config::MELEE_WEAPON_JOINT].w.truncate(),
-        };
-        let contact = shock2vr::vr_config::melee_contact_offset(arm);
+        let contact = shock2vr::melee_contact_offset(shock2vr::MeleePosedArm::from_joints(&joints));
         println!(
             "  contact offset (hand-local): vec3({:.3}, {:.3}, {:.3})",
             contact.x, contact.y, contact.z

--- a/shock2vr/examples/melee_grip.rs
+++ b/shock2vr/examples/melee_grip.rs
@@ -1,8 +1,10 @@
 //! Scratch tool: print the posed joint positions of the melee first-person
 //! (`_h`) skinned meshes at the player-melee idle's final frame - the pose VR
-//! wields them in. The printed hand-joint position is what the `vr_config`
-//! grip offset must cancel so the model's baked fist lands on the tracked
-//! hand.
+//! wields them in. The printed hand joint (`MELEE_GRIP_JOINT`) is what
+//! `vr_config::melee_wield_pose_correction` cancels at runtime so the model's
+//! baked fist lands on the tracked hand; this tool is for eyeballing the rig
+//! (which joint is the fist, how far the arm reaches back), not for producing
+//! constants.
 //!
 //! ```bash
 //! DARK_ASSET_PATH=... cargo run -p shock2vr --example melee_grip
@@ -40,18 +42,8 @@ fn main() {
                 println!("  joint {i:2}: ({:8.4}, {:8.4}, {:8.4})", p.x, p.y, p.z);
             }
         }
-        // Suggested vr_config grip offset: cancel the posed fist joint (3)
-        // under the chosen grip yaw, so the baked fist lands on the hand.
-        let yaw: f32 = std::env::args()
-            .nth(1)
-            .and_then(|a| a.parse().ok())
-            .unwrap_or(120.0);
-        let (s, c) = yaw.to_radians().sin_cos();
+        // MELEE_GRIP_JOINT (vr_config, private module - keep in sync).
         let f = joints[3].w;
-        let rotated = (f.x * c + f.z * s, f.y, -f.x * s + f.z * c);
-        println!(
-            "  grip yaw {yaw:.0}: with_offset(vec3({:.3}, {:.3}, {:.3}))",
-            -rotated.0, -rotated.1, -rotated.2
-        );
+        println!("  fist joint: ({:.3}, {:.3}, {:.3})", f.x, f.y, f.z);
     }
 }

--- a/shock2vr/examples/melee_grip.rs
+++ b/shock2vr/examples/melee_grip.rs
@@ -1,10 +1,14 @@
 //! Scratch tool: print the posed joint positions of the melee first-person
 //! (`_h`) skinned meshes at the player-melee idle's final frame - the pose VR
-//! wields them in. The printed hand joint (`MELEE_GRIP_JOINT`) is what
+//! wields them in. The hand joint (`MELEE_GRIP_JOINT`) is what
 //! `vr_config::melee_wield_pose_correction` cancels at runtime so the model's
-//! baked fist lands on the tracked hand; this tool is for eyeballing the rig
-//! (which joint is the fist, how far the arm reaches back), not for producing
-//! constants.
+//! baked fist lands on the tracked hand.
+//!
+//! It also prints each model's `melee_contact_offset` - where the rendered
+//! weapon head lands in hand-local space, which is what the model's
+//! `HAND_MODEL_POSITIONING` entry must be so the contact collider sits on the
+//! weapon the player sees. Re-run this and paste the numbers into
+//! `MELEE_CONTACT_*` if the rigs ever change.
 //!
 //! ```bash
 //! DARK_ASSET_PATH=... cargo run -p shock2vr --example melee_grip
@@ -42,8 +46,15 @@ fn main() {
                 println!("  joint {i:2}: ({:8.4}, {:8.4}, {:8.4})", p.x, p.y, p.z);
             }
         }
-        // MELEE_GRIP_JOINT (vr_config, private module - keep in sync).
-        let f = joints[3].w;
-        println!("  fist joint: ({:.3}, {:.3}, {:.3})", f.x, f.y, f.z);
+        let arm = shock2vr::vr_config::MeleePosedArm {
+            elbow: joints[shock2vr::vr_config::MELEE_ARM_JOINT].w.truncate(),
+            fist: joints[shock2vr::vr_config::MELEE_GRIP_JOINT].w.truncate(),
+            weapon: joints[shock2vr::vr_config::MELEE_WEAPON_JOINT].w.truncate(),
+        };
+        let contact = shock2vr::vr_config::melee_contact_offset(arm);
+        println!(
+            "  contact offset (hand-local): vec3({:.3}, {:.3}, {:.3})",
+            contact.x, contact.y, contact.z
+        );
     }
 }

--- a/shock2vr/examples/melee_grip.rs
+++ b/shock2vr/examples/melee_grip.rs
@@ -1,0 +1,57 @@
+//! Scratch tool: print the posed joint positions of the melee first-person
+//! (`_h`) skinned meshes at the player-melee idle's final frame - the pose VR
+//! wields them in. The printed hand-joint position is what the `vr_config`
+//! grip offset must cancel so the model's baked fist lands on the tracked
+//! hand.
+//!
+//! ```bash
+//! DARK_ASSET_PATH=... cargo run -p shock2vr --example melee_grip
+//! ```
+
+use dark::importers::{ANIMATION_CLIP_IMPORTER, SKELETON_IMPORTER};
+use dark::motion::AnimationPlayer;
+use engine::assets::{asset_cache::AssetCache, asset_paths::AssetPath};
+
+fn main() {
+    let data_root = shock2vr::paths::data_root();
+    let mut mounts = vec![
+        shock2vr::resource_family_paths("mesh"),
+        shock2vr::resource_family_paths("motions"),
+    ];
+    mounts.extend(shock2vr::data_files::data_file_mounts(&data_root));
+    mounts.push(AssetPath::folder("".to_owned()));
+    let mut cache = AssetCache::new(
+        data_root.to_string_lossy().into_owned(),
+        AssetPath::combine(mounts),
+    );
+
+    let clip = cache.get(&ANIMATION_CLIP_IMPORTER, "ph212203_.mc");
+    let player = AnimationPlayer::with_root_motion_cancelled(
+        &AnimationPlayer::from_completed_animation(clip),
+    );
+
+    for name in ["wrench_h", "rapier_h", "shard_h", "psword_h"] {
+        let skeleton = cache.get(&SKELETON_IMPORTER, &format!("{name}.cal"));
+        let joints = player.get_transforms(&skeleton);
+        println!("== {name}");
+        for (i, m) in joints.iter().enumerate() {
+            let p = m.w;
+            if p.x.abs() + p.y.abs() + p.z.abs() > 1e-6 {
+                println!("  joint {i:2}: ({:8.4}, {:8.4}, {:8.4})", p.x, p.y, p.z);
+            }
+        }
+        // Suggested vr_config grip offset: cancel the posed fist joint (3)
+        // under the chosen grip yaw, so the baked fist lands on the hand.
+        let yaw: f32 = std::env::args()
+            .nth(1)
+            .and_then(|a| a.parse().ok())
+            .unwrap_or(120.0);
+        let (s, c) = yaw.to_radians().sin_cos();
+        let f = joints[3].w;
+        let rotated = (f.x * c + f.z * s, f.y, -f.x * s + f.z * c);
+        println!(
+            "  grip yaw {yaw:.0}: with_offset(vec3({:.3}, {:.3}, {:.3}))",
+            -rotated.0, -rotated.1, -rotated.2
+        );
+    }
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -43,7 +43,10 @@ mod test_support;
 pub mod ui;
 mod util;
 mod virtual_hand;
-mod vr_config;
+/// How held models sit on the tracked hands. Public so the `melee_grip`
+/// example can re-measure the melee `_h` contact offsets from the shipped rigs
+/// with the same maths the wield uses.
+pub mod vr_config;
 pub mod vr_crouch;
 pub mod zip_asset_path;
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -43,10 +43,11 @@ mod test_support;
 pub mod ui;
 mod util;
 mod virtual_hand;
-/// How held models sit on the tracked hands. Public so the `melee_grip`
-/// example can re-measure the melee `_h` contact offsets from the shipped rigs
-/// with the same maths the wield uses.
-pub mod vr_config;
+mod vr_config;
+/// Re-exported (the module itself stays private) so the `melee_grip` example
+/// can re-measure the melee `_h` contact offsets off the shipped rigs with the
+/// same maths the wield uses.
+pub use vr_config::{MeleePosedArm, melee_contact_offset};
 pub mod vr_crouch;
 pub mod zip_asset_path;
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5076,7 +5076,7 @@ impl MissionCore {
                                 .get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
                                 .map(|m| Model::transform(m.as_ref(), xform))
                         };
-                        let Some(new_model) = new_model else {
+                        let Some(mut new_model) = new_model else {
                             tracing::error!(
                                 "ChangeModel: model '{model_name}.BIN' could not be loaded for entity {entity_id:?} - keeping current model"
                             );
@@ -5103,7 +5103,11 @@ impl MissionCore {
                             // documents), so hold the player-melee idle's
                             // final frame instead - a static pose that emits
                             // no motion flags, events, or root velocity
-                            // (`from_completed_animation`). Root motion is
+                            // (`from_completed_animation`). The flat viewmodel
+                            // plays the same clip from frame 0 because there
+                            // the swing animates; VR's hold is a frozen ready
+                            // stance the tracked hand moves, so it takes the
+                            // clip's settled end pose. Root motion is
                             // cancelled for the same reason as flat: the
                             // entity transform is re-anchored (there to the
                             // camera, here to the tracked hand) every frame.
@@ -5125,25 +5129,26 @@ impl MissionCore {
                                     })
                                     .unwrap_or_else(AnimationPlayer::empty);
                                 // Seat the posed arm's baked fist on the
-                                // tracked hand as a render-only correction -
-                                // the held body is the melee contact collider,
-                                // so this must not move the entity.
-                                let player = match new_model.skeleton() {
-                                    Some(skeleton) => {
-                                        let fist = player.get_transforms(skeleton)
-                                            [crate::vr_config::MELEE_GRIP_JOINT]
-                                            .w
-                                            .truncate();
-                                        AnimationPlayer::with_post_transform(
-                                            &player,
-                                            crate::vr_config::melee_wield_pose_correction(
-                                                &model_name.to_ascii_lowercase(),
-                                                fist,
-                                            ),
-                                        )
-                                    }
-                                    None => player,
-                                };
+                                // tracked hand as a model-space (render-only)
+                                // correction - the held body is the melee
+                                // contact collider, so this must not move the
+                                // entity. `apply_local_transform` composes it
+                                // inside the entity transform, which the
+                                // render path re-sets from the hand every
+                                // frame.
+                                if let Some(fist) = new_model.skeleton().map(|skeleton| {
+                                    player.get_transforms(skeleton)
+                                        [crate::vr_config::MELEE_GRIP_JOINT]
+                                        .w
+                                        .truncate()
+                                }) {
+                                    new_model.apply_local_transform(
+                                        crate::vr_config::melee_wield_pose_correction(
+                                            &model_name.to_ascii_lowercase(),
+                                            fist,
+                                        ),
+                                    );
+                                }
                                 self.id_to_animation_player.insert(entity_id, player);
                             } else {
                                 self.id_to_animation_player
@@ -5159,6 +5164,12 @@ impl MissionCore {
 
                         self.world.add_component(entity_id, RuntimePropVhots(vhots));
                     }
+                }
+                Effect::ClearModel { entity_id } => {
+                    self.id_to_model.remove(&entity_id);
+                    self.id_to_animation_player.remove(&entity_id);
+                    self.world
+                        .remove::<(PropModelName, RuntimePropVhots)>(entity_id);
                 }
                 Effect::SetVhotsFromModel {
                     entity_id,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -87,7 +87,7 @@ use crate::{
         RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
         RuntimePropLaunchedProjectile, RuntimePropReloading, RuntimePropSelectedAmmo,
-        RuntimePropTransform, RuntimePropVhots,
+        RuntimePropTransform, RuntimePropVhots, RuntimePropVrGripOffset,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -5047,6 +5047,11 @@ impl MissionCore {
                         });
                     if let Some(xform) = maybe_xform {
                         let _ext_name = model_name.clone();
+                        // Any model swap invalidates a computed grip; only the
+                        // melee `_h` branch below re-derives one. Without this
+                        // a drop would leave the restored world model wearing
+                        // the wield's contact offset.
+                        self.world.remove::<RuntimePropVrGripOffset>(entity_id);
                         // Was the *outgoing* model a VR-wielded first-person
                         // model? (Read before PropModelName is overwritten
                         // below - identifies the drop-restore swap.)
@@ -5128,33 +5133,35 @@ impl MissionCore {
                                         )
                                     })
                                     .unwrap_or_else(AnimationPlayer::empty);
-                                // Seat the posed arm's baked fist on the
-                                // tracked hand as a model-space (render-only)
-                                // correction - the held body is the melee
-                                // contact collider, so this must not move the
-                                // entity. `apply_local_transform` composes it
-                                // inside the entity transform, which the
-                                // render path re-sets from the hand every
-                                // frame.
-                                if let Some(arm) = new_model.skeleton().map(|skeleton| {
-                                    let joints = player.get_transforms(skeleton);
-                                    crate::vr_config::MeleePosedArm {
-                                        elbow: joints[crate::vr_config::MELEE_ARM_JOINT]
-                                            .w
-                                            .truncate(),
-                                        fist: joints[crate::vr_config::MELEE_GRIP_JOINT]
-                                            .w
-                                            .truncate(),
-                                        weapon: joints[crate::vr_config::MELEE_WEAPON_JOINT]
-                                            .w
-                                            .truncate(),
-                                    }
-                                }) {
+                                // Seat the posed arm on the tracked hand. Two
+                                // halves of one placement, both derived from
+                                // this same posed arm so they cannot drift
+                                // apart: the grip puts the entity - and so the
+                                // melee contact collider, which the held body
+                                // IS - on the rendered weapon head, and the
+                                // model-space correction cancels that same
+                                // offset so the fist still lands in the palm.
+                                // `apply_local_transform` composes inside the
+                                // entity transform, which the render path
+                                // re-sets from the hand every frame.
+                                let arm = new_model.skeleton().and_then(|skeleton| {
+                                    crate::vr_config::MeleePosedArm::from_joints(
+                                        &player.get_transforms(skeleton),
+                                    )
+                                });
+                                if let Some(arm) = arm {
                                     new_model.apply_local_transform(
-                                        crate::vr_config::melee_wield_pose_correction(
-                                            &model_name.to_ascii_lowercase(),
-                                            arm,
+                                        crate::vr_config::melee_wield_pose_correction(arm),
+                                    );
+                                    self.world.add_component(
+                                        entity_id,
+                                        RuntimePropVrGripOffset(
+                                            crate::vr_config::melee_contact_offset(arm),
                                         ),
+                                    );
+                                } else {
+                                    tracing::error!(
+                                        "ChangeModel: '{model_name}' has no melee arm joints - wielding it unseated"
                                     );
                                 }
                                 self.id_to_animation_player.insert(entity_id, player);
@@ -5178,6 +5185,7 @@ impl MissionCore {
                     self.id_to_animation_player.remove(&entity_id);
                     self.world
                         .remove::<(PropModelName, RuntimePropVhots)>(entity_id);
+                    self.world.remove::<RuntimePropVrGripOffset>(entity_id);
                 }
                 Effect::SetVhotsFromModel {
                     entity_id,
@@ -7172,6 +7180,11 @@ impl MissionCore {
                         // is an ordinary dynamic, harmless loose prop again.
                         self.make_un_physical(entity_id);
                     }
+                    // After the body is gone (so this writes the entity's
+                    // transform rather than pushing the outgoing kinematic
+                    // body around) and before the loose prop is rebuilt from
+                    // it.
+                    self.return_held_entity_to_the_hand(entity_id);
                     self.make_physical(entity_id);
 
                     self.script_world.dispatch(Message {
@@ -7185,6 +7198,45 @@ impl MissionCore {
 
     fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {
         is_vr_melee_weapon(&self.world, entity_id)
+    }
+
+    /// Undo a computed grip offset before a released item becomes a loose prop
+    /// again.
+    ///
+    /// A melee `_h` wield deliberately parks the entity on the *weapon head* -
+    /// its body is the contact collider, so that is where the damage volume
+    /// belongs - which is up to 1.2 units out of the palm. Respawning the world
+    /// prop there would materialize it over the player's head and drop it from
+    /// height; every other release happens at the hand, so put it back there
+    /// first. No-op for anything without a computed grip.
+    fn return_held_entity_to_the_hand(&mut self, entity_id: EntityId) {
+        use cgmath::Rotation;
+
+        let Some(grip) = self
+            .world
+            .borrow::<View<RuntimePropVrGripOffset>>()
+            .ok()
+            .and_then(|view| view.get(entity_id).ok().map(|grip| grip.0))
+        else {
+            return;
+        };
+
+        let Some((position, rotation)) =
+            self.world
+                .borrow::<View<PropPosition>>()
+                .ok()
+                .and_then(|view| {
+                    view.get(entity_id)
+                        .ok()
+                        .map(|pos| (pos.position, pos.rotation))
+                })
+        else {
+            return;
+        };
+        // The grip is hand-local and the entity carries the hand's rotation
+        // (a computed grip contributes none of its own).
+        let hand = position - rotation.rotate_vector(grip);
+        self.set_entity_position_rotation(entity_id, hand, rotation, vec3(1.0, 1.0, 1.0));
     }
 
     /// Give a held melee weapon the contact body the VR damage window needs.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5084,9 +5084,39 @@ impl MissionCore {
                         // swap so every other ChangeModel (both presentations)
                         // behaves exactly as before this path existed.
                         if vr_held && new_model.is_animated() {
-                            self.id_to_animation_player
-                                .entry(entity_id)
-                                .or_insert_with(AnimationPlayer::empty);
+                            // Melee _h models are LGMM skinned meshes: the
+                            // empty player's rest pose leaves the arm splayed
+                            // mid-swing (same defect the flat viewmodel path
+                            // documents), so hold the player-melee idle's
+                            // final frame instead - a static pose that emits
+                            // no motion flags, events, or root velocity
+                            // (`from_completed_animation`). Root motion is
+                            // cancelled for the same reason as flat: the
+                            // entity transform is re-anchored (there to the
+                            // camera, here to the tracked hand) every frame.
+                            let is_melee = self
+                                .world
+                                .borrow::<View<PropLimbModel>>()
+                                .ok()
+                                .is_some_and(|v| v.get(entity_id).is_ok());
+                            if is_melee {
+                                let player = asset_cache
+                                    .get_opt(
+                                        &ANIMATION_CLIP_IMPORTER,
+                                        &format!("{MELEE_IDLE_CLIP}_.mc"),
+                                    )
+                                    .map(|clip| {
+                                        AnimationPlayer::with_root_motion_cancelled(
+                                            &AnimationPlayer::from_completed_animation(clip),
+                                        )
+                                    })
+                                    .unwrap_or_else(AnimationPlayer::empty);
+                                self.id_to_animation_player.insert(entity_id, player);
+                            } else {
+                                self.id_to_animation_player
+                                    .entry(entity_id)
+                                    .or_insert_with(AnimationPlayer::empty);
+                            }
                         } else if was_vr_held && !new_model.is_animated() {
                             self.id_to_animation_player.remove(&entity_id);
                         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5124,6 +5124,26 @@ impl MissionCore {
                                         )
                                     })
                                     .unwrap_or_else(AnimationPlayer::empty);
+                                // Seat the posed arm's baked fist on the
+                                // tracked hand as a render-only correction -
+                                // the held body is the melee contact collider,
+                                // so this must not move the entity.
+                                let player = match new_model.skeleton() {
+                                    Some(skeleton) => {
+                                        let fist = player.get_transforms(skeleton)
+                                            [crate::vr_config::MELEE_GRIP_JOINT]
+                                            .w
+                                            .truncate();
+                                        AnimationPlayer::with_post_transform(
+                                            &player,
+                                            crate::vr_config::melee_wield_pose_correction(
+                                                &model_name.to_ascii_lowercase(),
+                                                fist,
+                                            ),
+                                        )
+                                    }
+                                    None => player,
+                                };
                                 self.id_to_animation_player.insert(entity_id, player);
                             } else {
                                 self.id_to_animation_player

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5021,19 +5021,32 @@ impl MissionCore {
                     entity_id,
                     model_name,
                 } => {
-                    if let Some(model) = self.id_to_model.get(&entity_id) {
-                        // if !scene_objs.is_empty() {
-                        //let scene_obj = scene_objs.get(0).unwrap().borrow();
-                        let xform = model.get_transform();
-                        //drop(scene_obj);
-
+                    // A VR-wielded first-person model loads as authored,
+                    // baked hands included (see `VrHeldModel`); the
+                    // separate importer is the seam where per-wield mesh
+                    // preparation lives.
+                    let is_vr = game_options.presentation_mode == crate::PresentationMode::Vr;
+                    let vr_held = is_vr && crate::vr_config::is_vr_view_model(&model_name);
+                    // The PsiSword authors no world model at all (PropLimbModel
+                    // only), so it has no id_to_model entry to take a transform
+                    // from - a VR wield materializes its first model from the
+                    // entity transform instead. Every other ChangeModel still
+                    // requires an existing model, exactly as before.
+                    let maybe_xform = self
+                        .id_to_model
+                        .get(&entity_id)
+                        .map(|model| model.get_transform())
+                        .or_else(|| {
+                            if !vr_held {
+                                return None;
+                            }
+                            self.world
+                                .borrow::<View<RuntimePropTransform>>()
+                                .ok()
+                                .and_then(|v| v.get(entity_id).ok().map(|t| t.0))
+                        });
+                    if let Some(xform) = maybe_xform {
                         let _ext_name = model_name.clone();
-                        // A VR-wielded first-person model loads as authored,
-                        // baked hands included (see `VrHeldModel`); the
-                        // separate importer is the seam where per-wield mesh
-                        // preparation lives.
-                        let is_vr = game_options.presentation_mode == crate::PresentationMode::Vr;
-                        let vr_held = is_vr && crate::vr_config::is_vr_view_model(&model_name);
                         // Was the *outgoing* model a VR-wielded first-person
                         // model? (Read before PropModelName is overwritten
                         // below - identifies the drop-restore swap.)

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5136,16 +5136,24 @@ impl MissionCore {
                                 // inside the entity transform, which the
                                 // render path re-sets from the hand every
                                 // frame.
-                                if let Some(fist) = new_model.skeleton().map(|skeleton| {
-                                    player.get_transforms(skeleton)
-                                        [crate::vr_config::MELEE_GRIP_JOINT]
-                                        .w
-                                        .truncate()
+                                if let Some(arm) = new_model.skeleton().map(|skeleton| {
+                                    let joints = player.get_transforms(skeleton);
+                                    crate::vr_config::MeleePosedArm {
+                                        elbow: joints[crate::vr_config::MELEE_ARM_JOINT]
+                                            .w
+                                            .truncate(),
+                                        fist: joints[crate::vr_config::MELEE_GRIP_JOINT]
+                                            .w
+                                            .truncate(),
+                                        weapon: joints[crate::vr_config::MELEE_WEAPON_JOINT]
+                                            .w
+                                            .truncate(),
+                                    }
                                 }) {
                                     new_model.apply_local_transform(
                                         crate::vr_config::melee_wield_pose_correction(
                                             &model_name.to_ascii_lowercase(),
-                                            fist,
+                                            arm,
                                         ),
                                     );
                                 }

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -304,3 +304,18 @@ pub struct RuntimePropLogData {
     pub portrait: Option<String>,
     pub icon: Option<String>,
 }
+
+// RuntimePropVrGripOffset - hand-local placement of a VR-held entity's rigid
+// body, when the model's static `vr_config` grip entry cannot express it.
+//
+// Melee `_h` wields are the case: the body IS the melee contact collider, and
+// it has to sit on the *rendered* weapon head, which is only known once the
+// arm has been posed (`vr_config::melee_contact_offset`). Computing it there
+// and storing it here is what keeps the drawn weapon and the damage volume
+// exactly coincident for any rig, instead of pinning them together with
+// hand-measured constants that a modded or updated mesh would silently break.
+//
+// Not serialized: the wield's `Effect::ChangeModel` recomputes it whenever the
+// first-person model is (re)applied, including on load.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropVrGripOffset(pub Vector3<f32>);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -348,6 +348,14 @@ pub enum Effect {
         entity_id: EntityId,
         model_name: String,
     },
+    /// Undo a `ChangeModel` on an entity that had no model to begin with -
+    /// the inverse of the VR wield swap for the PsiSword, whose gamesys
+    /// template authors only `PropLimbModel` and so renders nothing until it
+    /// is wielded. Without it a dropped PsiSword would keep the first-person
+    /// arm mesh (and its animation player) lying in the world forever.
+    ClearModel {
+        entity_id: EntityId,
+    },
     /// Replace the entity's fire-point vhots with those of `model_name`
     /// without changing the rendered model. Used by the VR held-weapon path:
     /// the world model stays rendered (#352), but its mesh has no vhots -

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -88,12 +88,20 @@ impl Script for InternalSwitchHeldModelScript {
 
             MessagePayload::Drop => {
                 if let Some(view_model) = get_previous_model(world, entity_id) {
-                    Effect::ChangeModel {
+                    return Effect::ChangeModel {
                         entity_id,
                         model_name: view_model,
+                    };
+                }
+                // No original model to restore. For the PsiSword the VR wield
+                // *materialized* one (it authors only `PropLimbModel`), so the
+                // drop has to take it away again - otherwise the first-person
+                // arm mesh stays in the world where the sword was released.
+                match get_current_model(world, entity_id) {
+                    Some(current) if vr_config::is_vr_view_model(&current) => {
+                        Effect::ClearModel { entity_id }
                     }
-                } else {
-                    Effect::NoEffect
+                    _ => Effect::NoEffect,
                 }
             }
 

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -873,7 +873,16 @@ impl ScriptWorld {
                 Box::new(WeaponScript::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),
             ])),
-            "internal_triggered_melee_weapon" => Box::new(TriggeredMeleeWeapon::new()),
+            // Attached by entity_creator to every PropLimbModel weapon. The
+            // held-model swap rides along because most melee weapons (Electro
+            // Shock, Crystal Shard, PsiSword) author no WeaponScript, so this
+            // marker is their only script. The Wrench gets a second copy via
+            // its WeaponScript composite - harmless, the swap is idempotent
+            // (InternalPropOriginalModelName is written once at creation).
+            "internal_triggered_melee_weapon" => Box::new(CompositeScript::new(vec![
+                Box::new(TriggeredMeleeWeapon::new()),
+                Box::new(InternalSwitchHeldModelScript::new()),
+            ])),
             "pistolmodify" => Box::new(NoopScript::new()),
 
             // TODO: Necessary

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -102,12 +102,14 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         .rotate_y(Deg(90.0))
         .with_offset(vec3(0.0, 0.0, -0.4));
 
-    // Orientation for the posed melee _h arms: +120 deg yaw points the
-    // authored ready-stance weapon up-forward from the fist. Offsets cancel
-    // the posed fist joint so the baked fist lands on the tracked hand -
-    // computed by `cargo run -p shock2vr --example melee_grip -- 120`, then
-    // eyeball-adjusted from debug_weapons --vr captures.
-    let melee_h_right = VRHandModelPerHandAdjustments::new().rotate_y(Deg(120.0));
+    // The Rapier, Crystal Shard and PsiSword have no world-model grip entry,
+    // so wielding them must keep the unmapped default (see
+    // `get_vr_hand_model_adjustments_from_model`) exactly.
+    let melee_world_grip = VRHandModelAdjustments::new(
+        VRHandModelPerHandAdjustments::new(),
+        VRHandModelPerHandAdjustments::new(),
+        Quaternion::from_angle_y(Deg(180.0)),
+    );
 
     let held_item_hand = VRHandModelPerHandAdjustments::new().rotate_y(Deg(180.0));
     let held_item = VRHandModelAdjustments::new(
@@ -197,42 +199,18 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
                 .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
         ),
         // Melee first-person models (_h): LGMM skinned meshes posed to the
-        // player-melee idle (see ChangeModel in mission_core). The posed arm
-        // extends behind the grip toward the shoulder; the offsets seat the
-        // model's own baked fist on the tracked hand (fit from debug_weapons
-        // --vr captures, same method as the guns above).
-        (
-            "wrench_h",
-            symmetric(
-                melee_h_right
-                    .clone()
-                    .with_offset(vec3(-0.699, -0.152, -0.147)),
-            ),
-        ),
-        (
-            "rapier_h",
-            symmetric(
-                melee_h_right
-                    .clone()
-                    .with_offset(vec3(-0.717, -0.214, -0.129)),
-            ),
-        ),
-        (
-            "shard_h",
-            symmetric(
-                melee_h_right
-                    .clone()
-                    .with_offset(vec3(-0.717, -0.214, -0.129)),
-            ),
-        ),
-        (
-            "psword_h",
-            symmetric(
-                melee_h_right
-                    .clone()
-                    .with_offset(vec3(-0.707, -0.217, -0.128)),
-            ),
-        ),
+        // player-melee idle (see ChangeModel in mission_core). Unlike the guns
+        // these entries deliberately DO NOT move the model to seat its baked
+        // fist in the palm: the held entity's body *is* the melee contact
+        // collider (#942/#978), so a grip offset here carries the damage
+        // volume off the weapon and silently disarms it. Each melee `_h`
+        // therefore keeps its world model's physical grip, and the posed arm
+        // is seated by a render-only model-space correction instead
+        // (`melee_wield_pose_correction`).
+        ("wrench_h", symmetric(wrench_right.clone())),
+        ("rapier_h", melee_world_grip.clone()),
+        ("shard_h", melee_world_grip.clone()),
+        ("psword_h", melee_world_grip.clone()),
         // Weapons - world models, kept when held in VR (#352): the _h meshes
         // have faces stripped for the fixed flat camera. sg_w/empgun predate
         // this and show the world models grip fine with the same offsets.
@@ -324,6 +302,37 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
 pub fn is_vr_view_model(model_name: &str) -> bool {
     let name = model_name.to_ascii_lowercase();
     VR_25AE_VIEW_MODELS.contains(&name.as_str())
+}
+
+/// Skeleton joint the melee `_h` rigs pose as the weapon-holding fist (root,
+/// shoulder, elbow, **fist**, weapon tip - see
+/// `cargo run -p shock2vr --example melee_grip`).
+pub const MELEE_GRIP_JOINT: usize = 3;
+
+/// Yaw that points the authored ready-stance weapon up and forward out of the
+/// fist once the arm is anchored on the tracked hand.
+const MELEE_GRIP_YAW: Deg<f32> = Deg(120.0);
+
+/// Model-space transform that seats a posed melee `_h` arm's baked fist
+/// (`posed_fist`, from [`MELEE_GRIP_JOINT`]) on the tracked hand.
+///
+/// This is deliberately a *render* correction rather than a grip offset: the
+/// held entity's rigid body is the melee contact collider, so moving the
+/// entity to align the arm would carry the damage volume ~0.7 units off the
+/// weapon and the wield would look right while doing nothing (#942/#978). The
+/// entity keeps its world model's grip, and this cancels that grip before
+/// applying the arm alignment, so the rendered result is grip-independent.
+pub fn melee_wield_pose_correction(
+    model_name: &str,
+    posed_fist: Vector3<f32>,
+) -> cgmath::Matrix4<f32> {
+    use cgmath::{Matrix4, SquareMatrix};
+
+    let grip = get_vr_hand_model_adjustments_from_model(model_name, Handedness::Right);
+    let grip_matrix = Matrix4::from_translation(grip.offset) * Matrix4::from(grip.rotation);
+    grip_matrix.invert().unwrap_or_else(Matrix4::identity)
+        * Matrix4::from_angle_y(MELEE_GRIP_YAW)
+        * Matrix4::from_translation(-posed_fist)
 }
 
 pub fn get_vr_hand_model_adjustments_from_entity(

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -102,15 +102,6 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         .rotate_y(Deg(90.0))
         .with_offset(vec3(0.0, 0.0, -0.4));
 
-    // The Rapier, Crystal Shard and PsiSword have no world-model grip entry,
-    // so wielding them must keep the unmapped default (see
-    // `get_vr_hand_model_adjustments_from_model`) exactly.
-    let melee_world_grip = VRHandModelAdjustments::new(
-        VRHandModelPerHandAdjustments::new(),
-        VRHandModelPerHandAdjustments::new(),
-        Quaternion::from_angle_y(Deg(180.0)),
-    );
-
     let held_item_hand = VRHandModelPerHandAdjustments::new().rotate_y(Deg(180.0));
     let held_item = VRHandModelAdjustments::new(
         held_item_hand.clone(),
@@ -199,18 +190,34 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
                 .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
         ),
         // Melee first-person models (_h): LGMM skinned meshes posed to the
-        // player-melee idle (see ChangeModel in mission_core). Unlike the guns
-        // these entries deliberately DO NOT move the model to seat its baked
-        // fist in the palm: the held entity's body *is* the melee contact
-        // collider (#942/#978), so a grip offset here carries the damage
-        // volume off the weapon and silently disarms it. Each melee `_h`
-        // therefore keeps its world model's physical grip, and the posed arm
-        // is seated by a render-only model-space correction instead
-        // (`melee_wield_pose_correction`).
-        ("wrench_h", symmetric(wrench_right.clone())),
-        ("rapier_h", melee_world_grip.clone()),
-        ("shard_h", melee_world_grip.clone()),
-        ("psword_h", melee_world_grip.clone()),
+        // player-melee idle (see ChangeModel in mission_core). These entries
+        // mean something different from every other one in this table. The
+        // arm is seated by a render-only correction that *cancels* the grip
+        // (`melee_wield_pose_correction`), so for a melee `_h` the offset
+        // below moves no pixels at all - it places the held entity's rigid
+        // body, which is the melee contact collider (#942/#978). It is
+        // therefore set to where the rendered weapon head lands in hand-local
+        // space, so what the player swings and what deals damage are the same
+        // place. Re-measure with
+        // `cargo run -p shock2vr --example melee_grip` if the rigs change; the
+        // `melee_contact_offset_matches_the_grip_table` test keeps the two
+        // halves honest.
+        (
+            "wrench_h",
+            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_WRENCH)),
+        ),
+        (
+            "rapier_h",
+            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_RAPIER)),
+        ),
+        (
+            "shard_h",
+            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_SHARD)),
+        ),
+        (
+            "psword_h",
+            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_PSWORD)),
+        ),
         // Weapons - world models, kept when held in VR (#352): the _h meshes
         // have faces stripped for the fixed flat camera. sg_w/empgun predate
         // this and show the world models grip fine with the same offsets.
@@ -304,35 +311,83 @@ pub fn is_vr_view_model(model_name: &str) -> bool {
     VR_25AE_VIEW_MODELS.contains(&name.as_str())
 }
 
-/// Skeleton joint the melee `_h` rigs pose as the weapon-holding fist (root,
-/// shoulder, elbow, **fist**, weapon tip - see
-/// `cargo run -p shock2vr --example melee_grip`).
+/// Hand-local position of each melee `_h`'s rendered weapon head, i.e. its
+/// [`melee_contact_offset`] measured off the shipped rigs. These are the grip
+/// entries above: for a melee `_h` the grip places the contact collider, not
+/// the model.
+const MELEE_CONTACT_WRENCH: Vector3<f32> = vec3(0.0, 0.811, -0.032);
+const MELEE_CONTACT_RAPIER: Vector3<f32> = vec3(0.0, 1.160, 0.168);
+const MELEE_CONTACT_SHARD: Vector3<f32> = vec3(0.0, 1.201, 0.316);
+const MELEE_CONTACT_PSWORD: Vector3<f32> = vec3(0.0, 1.146, 0.315);
+
+/// Skeleton joints of the melee `_h` rigs: root, shoulder, **elbow**, **fist**,
+/// **weapon** (see `cargo run -p shock2vr --example melee_grip`).
+pub const MELEE_ARM_JOINT: usize = 2;
 pub const MELEE_GRIP_JOINT: usize = 3;
+pub const MELEE_WEAPON_JOINT: usize = 4;
 
-/// Yaw that points the authored ready-stance weapon up and forward out of the
-/// fist once the arm is anchored on the tracked hand.
-const MELEE_GRIP_YAW: Deg<f32> = Deg(120.0);
+/// The posed arm's joints, in model space, that the wield is built from:
+/// elbow, fist and the weapon joint at the business end of the blade/head.
+#[derive(Clone, Copy, Debug)]
+pub struct MeleePosedArm {
+    pub elbow: Vector3<f32>,
+    pub fist: Vector3<f32>,
+    pub weapon: Vector3<f32>,
+}
 
-/// Model-space transform that seats a posed melee `_h` arm's baked fist
-/// (`posed_fist`, from [`MELEE_GRIP_JOINT`]) on the tracked hand.
+/// Rotation that takes the posed arm out of model space and into the hand's
+/// own frame: the forearm runs back along the hand frame's **+Z** - the axis
+/// [`crate::hand_forearm`] hangs the empty hand's sleeve along, and the
+/// opposite of the -Z the fingers/aim point down - and the weapon is rolled
+/// into the hand's vertical plane so it stands up out of the fist.
+///
+/// Derived from the rig rather than hand-tuned: a single authored yaw can only
+/// satisfy one of the two, and the shipped 120 degrees satisfied the weapon,
+/// leaving the forearm 71-80 degrees off the hand's own arm axis (it stuck out
+/// sideways past the wrist instead of running back toward the elbow).
+fn melee_wield_alignment(arm: MeleePosedArm) -> Quaternion<f32> {
+    use cgmath::{Rad, Rotation};
+
+    let forearm = arm.elbow - arm.fist;
+    let weapon = arm.weapon - arm.fist;
+    let align = Quaternion::from_arc(forearm, Vector3::unit_z(), None);
+    let aligned_weapon = align.rotate_vector(weapon);
+    // Roll about the forearm until the weapon lies in the hand's YZ plane,
+    // pointing along +Y (up out of the fist) rather than across the palm.
+    let roll = Quaternion::from_angle_z(Rad(aligned_weapon.x.atan2(aligned_weapon.y)));
+    roll * align
+}
+
+/// Where the weapon joint ends up, in hand-local space, once the arm is seated
+/// by [`melee_wield_alignment`] - i.e. where the *rendered* head of the weapon
+/// is. This is what the model's `HAND_MODEL_POSITIONING` offset has to be, so
+/// that the contact collider (the held entity's own body) sits on the weapon
+/// the player can see. `cargo run -p shock2vr --example melee_grip` prints it
+/// for each melee `_h`.
+pub fn melee_contact_offset(arm: MeleePosedArm) -> Vector3<f32> {
+    use cgmath::Rotation;
+
+    melee_wield_alignment(arm).rotate_vector(arm.weapon - arm.fist)
+}
+
+/// Model-space transform that seats a posed melee `_h` arm's baked fist on the
+/// tracked hand, with the forearm along the hand's arm axis.
 ///
 /// This is deliberately a *render* correction rather than a grip offset: the
 /// held entity's rigid body is the melee contact collider, so moving the
-/// entity to align the arm would carry the damage volume ~0.7 units off the
-/// weapon and the wield would look right while doing nothing (#942/#978). The
-/// entity keeps its world model's grip, and this cancels that grip before
-/// applying the arm alignment, so the rendered result is grip-independent.
-pub fn melee_wield_pose_correction(
-    model_name: &str,
-    posed_fist: Vector3<f32>,
-) -> cgmath::Matrix4<f32> {
+/// entity to align the arm would carry the damage volume off the weapon and
+/// the wield would look right while doing nothing (#942/#978). Cancelling the
+/// grip here makes the rendered result grip-independent, which is what frees
+/// the grip entry to do the one job it still has for a melee `_h`: put the
+/// collider on the rendered weapon head ([`melee_contact_offset`]).
+pub fn melee_wield_pose_correction(model_name: &str, arm: MeleePosedArm) -> cgmath::Matrix4<f32> {
     use cgmath::{Matrix4, SquareMatrix};
 
     let grip = get_vr_hand_model_adjustments_from_model(model_name, Handedness::Right);
     let grip_matrix = Matrix4::from_translation(grip.offset) * Matrix4::from(grip.rotation);
     grip_matrix.invert().unwrap_or_else(Matrix4::identity)
-        * Matrix4::from_angle_y(MELEE_GRIP_YAW)
-        * Matrix4::from_translation(-posed_fist)
+        * Matrix4::from(melee_wield_alignment(arm))
+        * Matrix4::from_translation(-arm.fist)
 }
 
 pub fn get_vr_hand_model_adjustments_from_entity(
@@ -435,6 +490,96 @@ mod tests {
             let right = get_vr_hand_model_adjustments_from_model(name, Handedness::Right);
             assert_eq!(left.offset, right.offset, "{name} grip offset");
             assert_eq!(left.rotation, right.rotation, "{name} grip rotation");
+        }
+    }
+
+    /// The four shipped melee `_h` rigs, posed to the player-melee idle's
+    /// final frame, as `cargo run -p shock2vr --example melee_grip` prints
+    /// them. Test data so the seating maths can be checked without assets.
+    fn posed_melee_arms() -> [(&'static str, MeleePosedArm); 4] {
+        [
+            (
+                "wrench_h",
+                MeleePosedArm {
+                    elbow: vec3(-0.4087, 0.2532, 0.1699),
+                    fist: vec3(-0.4767, 0.1516, 0.5323),
+                    weapon: vec3(-0.0019, 0.7427, 0.8214),
+                },
+            ),
+            (
+                "rapier_h",
+                MeleePosedArm {
+                    elbow: vec3(-0.3454, 0.2872, 0.2055),
+                    fist: vec3(-0.4700, 0.2143, 0.5563),
+                    weapon: vec3(-0.0936, 1.3100, 0.7363),
+                },
+            ),
+            (
+                "shard_h",
+                MeleePosedArm {
+                    elbow: vec3(-0.3454, 0.2872, 0.2055),
+                    fist: vec3(-0.4700, 0.2143, 0.5563),
+                    weapon: vec3(-0.0999, 1.3987, 0.5924),
+                },
+            ),
+            (
+                "psword_h",
+                MeleePosedArm {
+                    elbow: vec3(-0.3454, 0.2872, 0.2055),
+                    fist: vec3(-0.4642, 0.2175, 0.5483),
+                    weapon: vec3(-0.1333, 1.3595, 0.5553),
+                },
+            ),
+        ]
+    }
+
+    /// The seated arm must run back along the hand frame's +Z - the axis the
+    /// empty hand's sleeve (`hand_forearm`) uses - with the weapon standing up
+    /// out of the fist in the hand's vertical plane. The shipped single yaw
+    /// left the forearm 71-80 degrees off this, poking out sideways past the
+    /// wrist.
+    #[test]
+    fn melee_wield_seats_the_forearm_on_the_hands_arm_axis() {
+        use cgmath::{InnerSpace, Rotation};
+
+        for (name, arm) in posed_melee_arms() {
+            let alignment = melee_wield_alignment(arm);
+            let forearm = alignment.rotate_vector(arm.elbow - arm.fist);
+            let angle = forearm
+                .normalize()
+                .dot(Vector3::unit_z())
+                .acos()
+                .to_degrees();
+            assert!(angle < 0.5, "{name} forearm {angle} deg off the hand's +Z");
+
+            let weapon = alignment.rotate_vector(arm.weapon - arm.fist);
+            assert!(weapon.x.abs() < 1e-3, "{name} weapon out of the YZ plane");
+            assert!(weapon.y > 0.0, "{name} weapon points down out of the fist");
+        }
+    }
+
+    /// The melee grip entries place the *contact collider*, not the model, so
+    /// each one must be exactly where its rendered weapon head ends up. Drift
+    /// here is invisible in a screenshot and silently moves the damage volume
+    /// off the weapon (#1031).
+    #[test]
+    fn melee_contact_offset_matches_the_grip_table() {
+        use cgmath::InnerSpace;
+
+        for (name, arm) in posed_melee_arms() {
+            let expected = melee_contact_offset(arm);
+            let grip = get_vr_hand_model_adjustments_from_model(name, Handedness::Right);
+            let drift = (grip.offset - expected).magnitude();
+            assert!(
+                drift < 0.001,
+                "{name} grip offset {:?} is {drift} from the rendered weapon head {expected:?}",
+                grip.offset
+            );
+            assert_eq!(
+                grip.rotation,
+                Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                "{name} grip must be a pure translation - a rotation would spin the collider off the head"
+            );
         }
     }
 

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -102,9 +102,12 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         .rotate_y(Deg(90.0))
         .with_offset(vec3(0.0, 0.0, -0.4));
 
-    // Starting orientation for the posed melee _h arms; per-model offsets are
-    // fit from captures like the guns.
-    let melee_h_right = VRHandModelPerHandAdjustments::new().rotate_y(Deg(90.0));
+    // Orientation for the posed melee _h arms: +120 deg yaw points the
+    // authored ready-stance weapon up-forward from the fist. Offsets cancel
+    // the posed fist joint so the baked fist lands on the tracked hand -
+    // computed by `cargo run -p shock2vr --example melee_grip -- 120`, then
+    // eyeball-adjusted from debug_weapons --vr captures.
+    let melee_h_right = VRHandModelPerHandAdjustments::new().rotate_y(Deg(120.0));
 
     let held_item_hand = VRHandModelPerHandAdjustments::new().rotate_y(Deg(180.0));
     let held_item = VRHandModelAdjustments::new(
@@ -200,19 +203,35 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // --vr captures, same method as the guns above).
         (
             "wrench_h",
-            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+            symmetric(
+                melee_h_right
+                    .clone()
+                    .with_offset(vec3(-0.699, -0.152, -0.147)),
+            ),
         ),
         (
             "rapier_h",
-            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+            symmetric(
+                melee_h_right
+                    .clone()
+                    .with_offset(vec3(-0.717, -0.214, -0.129)),
+            ),
         ),
         (
             "shard_h",
-            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+            symmetric(
+                melee_h_right
+                    .clone()
+                    .with_offset(vec3(-0.717, -0.214, -0.129)),
+            ),
         ),
         (
             "psword_h",
-            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+            symmetric(
+                melee_h_right
+                    .clone()
+                    .with_offset(vec3(-0.707, -0.217, -0.128)),
+            ),
         ),
         // Weapons - world models, kept when held in VR (#352): the _h meshes
         // have faces stripped for the fixed flat camera. sg_w/empgun predate

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -102,17 +102,15 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         .rotate_y(Deg(90.0))
         .with_offset(vec3(0.0, 0.0, -0.4));
 
+    // Starting orientation for the posed melee _h arms; per-model offsets are
+    // fit from captures like the guns.
+    let melee_h_right = VRHandModelPerHandAdjustments::new().rotate_y(Deg(90.0));
+
     let held_item_hand = VRHandModelPerHandAdjustments::new().rotate_y(Deg(180.0));
     let held_item = VRHandModelAdjustments::new(
         held_item_hand.clone(),
         held_item_hand,
         Quaternion::from_angle_y(Deg(0.0)),
-    );
-
-    let default = VRHandModelAdjustments::new(
-        VRHandModelPerHandAdjustments::new(),
-        VRHandModelPerHandAdjustments::new(),
-        Quaternion::from_angle_y(Deg(-180.0)),
     );
 
     // Hand model adjustments for VR
@@ -195,7 +193,27 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
             symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.27)))
                 .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
         ),
-        ("wrench_h", default.clone()),
+        // Melee first-person models (_h): LGMM skinned meshes posed to the
+        // player-melee idle (see ChangeModel in mission_core). The posed arm
+        // extends behind the grip toward the shoulder; the offsets seat the
+        // model's own baked fist on the tracked hand (fit from debug_weapons
+        // --vr captures, same method as the guns above).
+        (
+            "wrench_h",
+            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+        ),
+        (
+            "rapier_h",
+            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+        ),
+        (
+            "shard_h",
+            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+        ),
+        (
+            "psword_h",
+            symmetric(melee_h_right.clone().with_offset(vec3(0.0, 0.05, 0.35))),
+        ),
         // Weapons - world models, kept when held in VR (#352): the _h meshes
         // have faces stripped for the fixed flat camera. sg_w/empgun predate
         // this and show the world models grip fine with the same offsets.
@@ -271,11 +289,14 @@ pub fn is_allowed_hand_model(model_name: &str) -> bool {
 /// 19-38% for the classic `_h` set, and they are authored barrel-along -X
 /// with real muzzle vhots, so VR can wield them from any viewpoint.
 ///
-/// Melee `_h` models (wrench/rapier/shard/psword) are LGMM skinned meshes that
-/// need a posed skeleton, so VR melee keeps world models for now.
+/// Melee `_h` models (wrench/rapier/shard/psword) are LGMM skinned meshes
+/// (classic geometry + remastered `PMNM` chunk); VR wields them posed to the
+/// player-melee idle clip (see `Effect::ChangeModel` in mission_core). The
+/// 25AE-only `pipewrench_h` has no gamesys template (it ships as a KEX squirrel
+/// script we don't run), so it is not listed.
 const VR_25AE_VIEW_MODELS: &[&str] = &[
     "atek_h", "ar15_h", "sg_h", "lasehand", "empgun_h", "gren_h", "sfg_h", "fsn_h", "al_h",
-    "viro_h", "amp_h",
+    "viro_h", "amp_h", "wrench_h", "rapier_h", "shard_h", "psword_h",
 ];
 
 /// Whether `model_name` is a first-person view model VR should wield in place
@@ -377,7 +398,9 @@ mod tests {
     fn vr_view_model_lookup_is_case_insensitive() {
         assert!(is_vr_view_model("ATEK_H"));
         assert!(is_vr_view_model("lasehand"));
-        assert!(!is_vr_view_model("wrench_h"));
+        assert!(is_vr_view_model("WRENCH_H"));
+        assert!(is_vr_view_model("psword_h"));
+        assert!(!is_vr_view_model("pipewrench_h"));
         assert!(!is_vr_view_model("atek_w"));
     }
 }

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use cgmath::{Deg, Quaternion, Rotation3, Vector3, vec3};
 use dark::properties::PropModelName;
+
+use crate::runtime_props::RuntimePropVrGripOffset;
 use once_cell::sync::Lazy;
 use shipyard::{EntityId, Get, View, World};
 
@@ -189,35 +191,14 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
             symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.27)))
                 .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
         ),
-        // Melee first-person models (_h): LGMM skinned meshes posed to the
-        // player-melee idle (see ChangeModel in mission_core). These entries
-        // mean something different from every other one in this table. The
-        // arm is seated by a render-only correction that *cancels* the grip
-        // (`melee_wield_pose_correction`), so for a melee `_h` the offset
-        // below moves no pixels at all - it places the held entity's rigid
-        // body, which is the melee contact collider (#942/#978). It is
-        // therefore set to where the rendered weapon head lands in hand-local
-        // space, so what the player swings and what deals damage are the same
-        // place. Re-measure with
-        // `cargo run -p shock2vr --example melee_grip` if the rigs change; the
-        // `melee_contact_offset_matches_the_grip_table` test keeps the two
-        // halves honest.
-        (
-            "wrench_h",
-            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_WRENCH)),
-        ),
-        (
-            "rapier_h",
-            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_RAPIER)),
-        ),
-        (
-            "shard_h",
-            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_SHARD)),
-        ),
-        (
-            "psword_h",
-            symmetric(VRHandModelPerHandAdjustments::new().with_offset(MELEE_CONTACT_PSWORD)),
-        ),
+        // Melee first-person models (_h) deliberately have NO entry: their
+        // grip is not a constant. The held body is the melee contact collider
+        // (#942/#978) and has to sit on the *rendered* weapon head, which is
+        // only known once the arm is posed - so the wield computes it
+        // (`melee_contact_offset`) and stores it per entity as
+        // `RuntimePropVrGripOffset`, which this table defers to. Leaving them
+        // unmapped also keeps the default 180-degree projectile rotation they
+        // had before VR wielded them.
         // Weapons - world models, kept when held in VR (#352): the _h meshes
         // have faces stripped for the fixed flat camera. sg_w/empgun predate
         // this and show the world models grip fine with the same offsets.
@@ -311,20 +292,11 @@ pub fn is_vr_view_model(model_name: &str) -> bool {
     VR_25AE_VIEW_MODELS.contains(&name.as_str())
 }
 
-/// Hand-local position of each melee `_h`'s rendered weapon head, i.e. its
-/// [`melee_contact_offset`] measured off the shipped rigs. These are the grip
-/// entries above: for a melee `_h` the grip places the contact collider, not
-/// the model.
-const MELEE_CONTACT_WRENCH: Vector3<f32> = vec3(0.0, 0.811, -0.032);
-const MELEE_CONTACT_RAPIER: Vector3<f32> = vec3(0.0, 1.160, 0.168);
-const MELEE_CONTACT_SHARD: Vector3<f32> = vec3(0.0, 1.201, 0.316);
-const MELEE_CONTACT_PSWORD: Vector3<f32> = vec3(0.0, 1.146, 0.315);
-
 /// Skeleton joints of the melee `_h` rigs: root, shoulder, **elbow**, **fist**,
 /// **weapon** (see `cargo run -p shock2vr --example melee_grip`).
-pub const MELEE_ARM_JOINT: usize = 2;
-pub const MELEE_GRIP_JOINT: usize = 3;
-pub const MELEE_WEAPON_JOINT: usize = 4;
+const MELEE_ARM_JOINT: usize = 2;
+const MELEE_GRIP_JOINT: usize = 3;
+const MELEE_WEAPON_JOINT: usize = 4;
 
 /// The posed arm's joints, in model space, that the wield is built from:
 /// elbow, fist and the weapon joint at the business end of the blade/head.
@@ -333,6 +305,20 @@ pub struct MeleePosedArm {
     pub elbow: Vector3<f32>,
     pub fist: Vector3<f32>,
     pub weapon: Vector3<f32>,
+}
+
+impl MeleePosedArm {
+    /// Read the three joints out of a posed melee `_h` skeleton
+    /// (`AnimationPlayer::get_transforms`). `None` for a rig that does not
+    /// have them - a patched or modded mesh must leave the wield unseated,
+    /// not panic the frame.
+    pub fn from_joints(joints: &[cgmath::Matrix4<f32>]) -> Option<MeleePosedArm> {
+        Some(MeleePosedArm {
+            elbow: joints.get(MELEE_ARM_JOINT)?.w.truncate(),
+            fist: joints.get(MELEE_GRIP_JOINT)?.w.truncate(),
+            weapon: joints.get(MELEE_WEAPON_JOINT)?.w.truncate(),
+        })
+    }
 }
 
 /// Rotation that takes the posed arm out of model space and into the hand's
@@ -360,10 +346,15 @@ fn melee_wield_alignment(arm: MeleePosedArm) -> Quaternion<f32> {
 
 /// Where the weapon joint ends up, in hand-local space, once the arm is seated
 /// by [`melee_wield_alignment`] - i.e. where the *rendered* head of the weapon
-/// is. This is what the model's `HAND_MODEL_POSITIONING` offset has to be, so
-/// that the contact collider (the held entity's own body) sits on the weapon
-/// the player can see. `cargo run -p shock2vr --example melee_grip` prints it
-/// for each melee `_h`.
+/// is, and therefore where the held entity's body (the melee contact collider)
+/// has to sit for the drawn weapon and the damage volume to be the same place.
+/// The wield stores it as `RuntimePropVrGripOffset`;
+/// `cargo run -p shock2vr --example melee_grip` prints it per model.
+///
+/// Known limitation: the authored contact volume is a ~5 cm sphere, so this
+/// arms the weapon's *head* and nothing else along its length. Covering the
+/// whole blade needs a collider shaped like the weapon, which is a bigger
+/// change than putting the existing one in the right place.
 pub fn melee_contact_offset(arm: MeleePosedArm) -> Vector3<f32> {
     use cgmath::Rotation;
 
@@ -373,19 +364,16 @@ pub fn melee_contact_offset(arm: MeleePosedArm) -> Vector3<f32> {
 /// Model-space transform that seats a posed melee `_h` arm's baked fist on the
 /// tracked hand, with the forearm along the hand's arm axis.
 ///
-/// This is deliberately a *render* correction rather than a grip offset: the
-/// held entity's rigid body is the melee contact collider, so moving the
-/// entity to align the arm would carry the damage volume off the weapon and
-/// the wield would look right while doing nothing (#942/#978). Cancelling the
-/// grip here makes the rendered result grip-independent, which is what frees
-/// the grip entry to do the one job it still has for a melee `_h`: put the
-/// collider on the rendered weapon head ([`melee_contact_offset`]).
-pub fn melee_wield_pose_correction(model_name: &str, arm: MeleePosedArm) -> cgmath::Matrix4<f32> {
-    use cgmath::{Matrix4, SquareMatrix};
+/// This is a *render* correction rather than a grip offset because the held
+/// entity's rigid body is the melee contact collider, and that has its own job:
+/// sitting on the rendered weapon head (#942/#978). The two are two halves of
+/// one placement and are derived from the same posed arm, so they cannot drift:
+/// the entity is at `hand + contact`, this cancels that same `contact`, and the
+/// weapon joint therefore renders exactly on the collider for any rig.
+pub fn melee_wield_pose_correction(arm: MeleePosedArm) -> cgmath::Matrix4<f32> {
+    use cgmath::Matrix4;
 
-    let grip = get_vr_hand_model_adjustments_from_model(model_name, Handedness::Right);
-    let grip_matrix = Matrix4::from_translation(grip.offset) * Matrix4::from(grip.rotation);
-    grip_matrix.invert().unwrap_or_else(Matrix4::identity)
+    Matrix4::from_translation(-melee_contact_offset(arm))
         * Matrix4::from(melee_wield_alignment(arm))
         * Matrix4::from_translation(-arm.fist)
 }
@@ -395,6 +383,17 @@ pub fn get_vr_hand_model_adjustments_from_entity(
     world: &World,
     handedness: Handedness,
 ) -> VRHandModelPerHandAdjustments {
+    // A wield that had to compute its own grip (melee `_h`: the collider goes
+    // on the rendered weapon head, which is only known once the arm is posed)
+    // stored it on the entity. It is hand-agnostic by construction.
+    if let Some(grip) = world
+        .borrow::<View<RuntimePropVrGripOffset>>()
+        .ok()
+        .and_then(|view| view.get(entity_id).ok().map(|grip| grip.0))
+    {
+        return VRHandModelPerHandAdjustments::new().with_offset(grip);
+    }
+
     let v_model_name = world.borrow::<View<PropModelName>>().unwrap();
     let maybe_model_name = v_model_name
         .get(entity_id)
@@ -453,11 +452,19 @@ fn get_vr_projectile_rotation_from_model(model_name: &str) -> Quaternion<f32> {
 mod tests {
     use super::*;
 
-    /// Every VR-wieldable 25AE view model must have a grip entry, or it would
-    /// anchor at the model origin with no rotation.
+    /// The melee subset of [`VR_25AE_VIEW_MODELS`]: skinned arm rigs, seated
+    /// from the posed skeleton rather than from a static grip entry.
+    const MELEE_VIEW_MODELS: &[&str] = &["wrench_h", "rapier_h", "shard_h", "psword_h"];
+
+    /// Every VR-wieldable 25AE gun must have a grip entry, or it would anchor
+    /// at the model origin with no rotation. The melee `_h` are the deliberate
+    /// exception - see `melee_view_models_have_no_static_grip`.
     #[test]
     fn every_vr_view_model_has_a_grip_entry() {
         for name in VR_25AE_VIEW_MODELS {
+            if MELEE_VIEW_MODELS.contains(name) {
+                continue;
+            }
             assert!(
                 HAND_MODEL_POSITIONING.contains_key(name),
                 "missing HAND_MODEL_POSITIONING entry for {name}"
@@ -477,19 +484,24 @@ mod tests {
         }
     }
 
-    /// `melee_wield_pose_correction` cancels the *right* hand's grip, but the
-    /// correction is baked into the model once at wield time, which does not
-    /// know which hand took it. That is only sound while both hands share a
-    /// grip - `flip_x` mirrors `scale`, which `SetPositionRotation` discards.
-    /// Give a melee `_h` an asymmetric offset or rotation and the left-hand
-    /// wield silently renders in the wrong place; this catches that.
+    /// A melee `_h` must NOT have a static grip entry: its grip is computed
+    /// per wield (`RuntimePropVrGripOffset`) because the collider has to land
+    /// on the rendered weapon head. A table entry here would take precedence
+    /// for anything that looks the model up by name and silently reintroduce a
+    /// fixed offset the render correction is not cancelling.
     #[test]
-    fn melee_grips_are_hand_symmetric() {
-        for name in ["wrench_h", "rapier_h", "shard_h", "psword_h"] {
-            let left = get_vr_hand_model_adjustments_from_model(name, Handedness::Left);
-            let right = get_vr_hand_model_adjustments_from_model(name, Handedness::Right);
-            assert_eq!(left.offset, right.offset, "{name} grip offset");
-            assert_eq!(left.rotation, right.rotation, "{name} grip rotation");
+    fn melee_view_models_have_no_static_grip() {
+        for name in MELEE_VIEW_MODELS {
+            assert!(
+                !HAND_MODEL_POSITIONING.contains_key(name),
+                "{name} must take its grip from the posed rig, not this table"
+            );
+            // ... and stay on the unmapped default projectile rotation they
+            // had before VR wielded them.
+            assert_eq!(
+                get_vr_projectile_rotation_from_model(name),
+                Quaternion::from_angle_y(Deg(180.0))
+            );
         }
     }
 
@@ -558,27 +570,34 @@ mod tests {
         }
     }
 
-    /// The melee grip entries place the *contact collider*, not the model, so
-    /// each one must be exactly where its rendered weapon head ends up. Drift
-    /// here is invisible in a screenshot and silently moves the damage volume
-    /// off the weapon (#1031).
+    /// The whole point of the arrangement: the entity sits at
+    /// `hand + melee_contact_offset` (its body is the contact collider) and the
+    /// render correction runs inside that transform, so the model's *weapon
+    /// joint* must land exactly on the collider and its *fist* exactly on the
+    /// hand. Checked as composed matrices, for every shipped rig - this is what
+    /// makes "what you see is what you hit" a property rather than a
+    /// measurement someone has to keep up to date.
     #[test]
-    fn melee_contact_offset_matches_the_grip_table() {
-        use cgmath::InnerSpace;
+    fn the_rendered_weapon_head_lands_on_the_contact_collider() {
+        use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Point3, Transform};
 
         for (name, arm) in posed_melee_arms() {
-            let expected = melee_contact_offset(arm);
-            let grip = get_vr_hand_model_adjustments_from_model(name, Handedness::Right);
-            let drift = (grip.offset - expected).magnitude();
+            // What `VirtualHand::SetPositionRotation` composes for a hand at
+            // the origin with no rotation: entity = T(grip.offset).
+            let entity = Matrix4::from_translation(melee_contact_offset(arm));
+            let rendered = entity * melee_wield_pose_correction(arm);
+
+            let head = rendered.transform_point(Point3::from_vec(arm.weapon));
+            let collider = Point3::from_vec(melee_contact_offset(arm));
             assert!(
-                drift < 0.001,
-                "{name} grip offset {:?} is {drift} from the rendered weapon head {expected:?}",
-                grip.offset
+                (head - collider).magnitude() < 1e-4,
+                "{name}: rendered weapon head {head:?} is off the collider {collider:?}"
             );
-            assert_eq!(
-                grip.rotation,
-                Quaternion::new(1.0, 0.0, 0.0, 0.0),
-                "{name} grip must be a pure translation - a rotation would spin the collider off the head"
+
+            let fist = rendered.transform_point(Point3::from_vec(arm.fist));
+            assert!(
+                fist.to_vec().magnitude() < 1e-4,
+                "{name}: rendered fist {fist:?} is off the tracked hand"
             );
         }
     }

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -422,6 +422,22 @@ mod tests {
         }
     }
 
+    /// `melee_wield_pose_correction` cancels the *right* hand's grip, but the
+    /// correction is baked into the model once at wield time, which does not
+    /// know which hand took it. That is only sound while both hands share a
+    /// grip - `flip_x` mirrors `scale`, which `SetPositionRotation` discards.
+    /// Give a melee `_h` an asymmetric offset or rotation and the left-hand
+    /// wield silently renders in the wrong place; this catches that.
+    #[test]
+    fn melee_grips_are_hand_symmetric() {
+        for name in ["wrench_h", "rapier_h", "shard_h", "psword_h"] {
+            let left = get_vr_hand_model_adjustments_from_model(name, Handedness::Left);
+            let right = get_vr_hand_model_adjustments_from_model(name, Handedness::Right);
+            assert_eq!(left.offset, right.offset, "{name} grip offset");
+            assert_eq!(left.rotation, right.rotation, "{name} grip rotation");
+        }
+    }
+
     #[test]
     fn vr_view_model_lookup_is_case_insensitive() {
         assert!(is_vr_view_model("ATEK_H"));

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -477,8 +477,11 @@ function multiplyQuat(a: Quat, b: Quat): Quat {
  * shortest arc from -Z has no roll control, so directions near world +z came
  * out rolled up to ~180 degrees - which silently corrupts screenshots and
  * skews strafing, since locomotion moves along the camera's right axis.
+ *
+ * Exported because the same hazard applies to any rig whose orientation carries
+ * an offset: a spurious roll turns "up out of the fist" into "sideways".
  */
-function lookQuat(direction: Vec3): Quat {
+export function lookQuat(direction: Vec3): Quat {
   const length = Math.hypot(...direction);
   if (length === 0) throw new Error("look-at target must differ from the player's eye position");
   const [dx, dy, dz] = direction.map((value) => value / length) as Vec3;

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -7,6 +7,7 @@ export {
   Game,
   headRotationForWorldPoint,
   InputApi,
+  lookQuat,
   PathfindingTestApi,
   PLAYER_EYE_HEIGHT_WORLD,
   PlayerApi,

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -101,9 +101,37 @@ function hitPoints(detail: EntityDetailResult): number {
   return Number(property.value);
 }
 
+// Hand-local vector from the tracked hand to the held weapon's contact
+// collider, measured live (`measureHeldContactOffset`) rather than hardcoded:
+// it is the weapon's VR grip, and the melee `_h` wield moved it from "0.4
+// along the fingers" to "on the rendered weapon head". The gesture below is
+// about where the *weapon* is, so it must follow whatever the grip says.
+let heldContactOffset: Vec3 = [0, 0, 0];
+
+async function measureHeldContactOffset(game: GameServer): Promise<void> {
+  const held = (await game.info()).player.right_hand_entity_id;
+  assert.ok(held, "a weapon must be held before its contact offset is measured");
+  const local: Vec3 = [0, 1.0, 0];
+  await game.input.set("right_hand.position", local);
+  await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+  await game.step({ frames: 2 });
+  const body = (await game.physics.bodies({ entityId: held })).bodies[0];
+  assert.ok(body, "the held weapon must have a contact body");
+  const info = await game.info();
+  const handWorld = add(
+    info.player.position,
+    qrotate(info.player.rotation, local),
+  );
+  heldContactOffset = qrotate(
+    qconj(info.player.rotation),
+    sub(body.position, handWorld),
+  );
+}
+
 // This is the production play-through gesture: orient the physical right hand
 // along the eye-to-target ray, wind up two units away, pull the trigger, and
-// sweep to 0.33 units. No damage/script message is injected by the test.
+// sweep the weapon's contact volume to 0.33 units. No damage/script message is
+// injected by the test.
 async function poseWrench(
   game: GameServer,
   target: Vec3,
@@ -115,9 +143,13 @@ async function poseWrench(
   const pawnQ = info.player.rotation;
   const eye = add(pawn, [0, info.player.camera_offset[1], 0]);
   const toward = norm(sub(target, eye));
-  const worldHand = sub(target, scale(toward, distance));
-  const worldDirection = norm(sub(target, worldHand));
-  const worldQ = qFromTo([0, 0, -1], worldDirection);
+  const worldQ = qFromTo([0, 0, -1], toward);
+  // `distance` is the contact volume's distance from the target, so back the
+  // hand off by wherever the grip puts that volume.
+  const worldHand = sub(
+    sub(target, scale(toward, distance)),
+    qrotate(worldQ, heldContactOffset),
+  );
   const localPosition = qrotate(qconj(pawnQ), sub(worldHand, pawn));
   const localRotation = qnorm(qmul(qconj(pawnQ), worldQ));
 
@@ -486,6 +518,7 @@ test(
         freshWrench.entity_id,
         "fresh canonical control Wrench should be wielded",
       );
+      await measureHeldContactOffset(control);
       const fresh = await byMissionId(control, "Blue Monkey", MONKEY);
       const { sequence, targetId } = await armedSweep(control, fresh);
       assert.equal(
@@ -511,6 +544,7 @@ test(
       (await game.info()).player.right_hand_entity_id,
       worldWrench.id,
     );
+    await measureHeldContactOffset(game);
 
     // The suite's save cleaner keys off a trailing 13-digit epoch, so every
     // name this test writes must end with `stamp`.

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -114,18 +114,19 @@ async function measureHeldContactOffset(game: GameServer): Promise<void> {
   const local: Vec3 = [0, 1.0, 0];
   await game.input.set("right_hand.position", local);
   await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
-  await game.step({ frames: 2 });
-  const body = (await game.physics.bodies({ entityId: held })).bodies[0];
+  // Let the pawn settle first: while it is still falling the hand it carries
+  // trails the physics body the reading is compared against.
+  await game.step({ frames: 45 });
+  // Take the pawn from the *same response* as the body. Physics free-runs
+  // between HTTP requests, so a pawn read a request later has already fallen a
+  // little further and the difference lands straight in the offset (measured:
+  // 0.2 of bogus reach).
+  const bodies = await game.physics.bodies({ entityId: held });
+  const body = bodies.bodies[0];
   assert.ok(body, "the held weapon must have a contact body");
-  const info = await game.info();
-  const handWorld = add(
-    info.player.position,
-    qrotate(info.player.rotation, local),
-  );
-  heldContactOffset = qrotate(
-    qconj(info.player.rotation),
-    sub(body.position, handWorld),
-  );
+  const pawnRotation = (await game.info()).player.rotation;
+  const handWorld = add(bodies.player_position, qrotate(pawnRotation, local));
+  heldContactOffset = qrotate(qconj(pawnRotation), sub(body.position, handWorld));
 
   // Staging follows this measurement, so assert its shape or the gesture would
   // silently compensate for a misplaced collider and still pass. The wielded

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, lookQuat } from "../src/index.js";
 import type {
   EntityDetailResult,
   EntitySummary,
@@ -126,6 +126,22 @@ async function measureHeldContactOffset(game: GameServer): Promise<void> {
     qconj(info.player.rotation),
     sub(body.position, handWorld),
   );
+
+  // Staging follows this measurement, so assert its shape or the gesture would
+  // silently compensate for a misplaced collider and still pass. The wielded
+  // Wrench's contact volume belongs out on the rendered weapon head - roughly
+  // 0.8 units from the palm, standing up out of the fist. A collider left in
+  // the hand (the pre-`_h` melee grips) or parked along the fingers (the old
+  // 0.4 wrench grip) fails here.
+  const reach = Math.sqrt(dot(heldContactOffset, heldContactOffset));
+  assert.ok(
+    reach > 0.6 && reach < 1.0,
+    `the Wrench's contact volume should sit on its head, ~0.8 from the hand: ${JSON.stringify(heldContactOffset)}`,
+  );
+  assert.ok(
+    heldContactOffset[1] > 0.9 * reach,
+    `the Wrench's contact volume should stand up out of the fist: ${JSON.stringify(heldContactOffset)}`,
+  );
 }
 
 // This is the production play-through gesture: orient the physical right hand
@@ -143,7 +159,13 @@ async function poseWrench(
   const pawnQ = info.player.rotation;
   const eye = add(pawn, [0, info.player.camera_offset[1], 0]);
   const toward = norm(sub(target, eye));
-  const worldQ = qFromTo([0, 0, -1], toward);
+  // `lookQuat`, not the file's shortest-arc `qFromTo`: the shortest arc from -Z
+  // has no roll control and rolls up to ~180 degrees for directions near world
+  // +z - which is exactly where these staged targets sit. That was cosmetic
+  // while the rotation only spun the hand; now it also carries the ~0.8-unit
+  // contact offset below, where a spurious roll turns "up out of the fist"
+  // into "sideways" and the swing misses for reasons nothing in the test says.
+  const worldQ = lookQuat(toward);
   // `distance` is the contact volume's distance from the target, so back the
   // hand off by wherever the grip puts that volume.
   const worldHand = sub(

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -136,6 +136,75 @@ test(
   },
 );
 
+test(
+  "VR: dropping the PsiSword takes its materialized first-person model away",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
+      debugFlags: ["--vr"],
+    });
+
+    // The PsiSword authors only PropLimbModel - no world model at all - so the
+    // VR wield has to *materialize* its first model. That swap must be
+    // symmetric: without the drop half, the released sword keeps rendering the
+    // first-person arm mesh where it was let go, forever and through saves.
+    await game.step({ frames: 10 });
+    let sword;
+    for (let i = 0; i < 20 && !sword; i++) {
+      await game.input.trigger("DebugCycleWeapon");
+      await game.step({ frames: 5 });
+      sword = (await game.entities.list({ limit: 100 })).entities.find(
+        (e) => e.name === "PsiSword",
+      );
+    }
+    assert.ok(sword, "psi sword should have spawned");
+    await game.step({ frames: 60 });
+
+    const pawn = (await game.info()).player.position;
+    const settled = (await game.entities.list({ limit: 100 })).entities.find(
+      (e) => e.id === sword!.id,
+    )!;
+    const [px, py, pz] = settled.position;
+    await game.input.set("right_hand.position", [
+      px - pawn[0],
+      py - pawn[1],
+      pz - pawn[2],
+    ]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      sword.id,
+      "psi sword should be grabbed by the right hand",
+    );
+    assert.equal(modelOf(await game.entities.detail(sword.id)), "psword_h");
+    assert.ok(
+      (await game.scene.objects({ entityId: sword.id })).objects.length > 0,
+      "the wielded psi sword should draw",
+    );
+
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 20 });
+    assert.equal(
+      (await game.entities.detail(sword.id)).properties.find(
+        (p) => p.name === "Model",
+      ),
+      undefined,
+      "a dropped psi sword should have no model again",
+    );
+    assert.equal(
+      (await game.scene.objects({ entityId: sword.id })).objects.length,
+      0,
+      "a dropped psi sword must not leave the first-person arm in the world",
+    );
+  },
+);
+
 function findSavePath(saveName: string): string | undefined {
   const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
   const roots = [

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -79,6 +79,48 @@ test(
   },
 );
 
+test(
+  "VR: a grabbed melee weapon wields the 25AE first-person model",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+      debugFlags: ["--vr"],
+    });
+
+    // In VR, spawnItem drops the item into the world in front of the player.
+    await game.step({ frames: 10 });
+    await game.player.spawnItem("Wrench");
+    await game.step({ frames: 90 });
+
+    const wrench = (await game.entities.list({ limit: 100 })).entities.find(
+      (e) => e.name === "Wrench",
+    );
+    assert.ok(wrench, "wrench should have spawned");
+    assert.equal(modelOf(await game.entities.detail(wrench.id)), "wrench_w");
+
+    // Grab it (same recipe as the pistol test above).
+    const pawnY = (await game.info()).player.position[1];
+    const [px, py, pz] = wrench.position;
+    await game.input.set("right_hand.position", [px + 0.4, py - pawnY, pz]);
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 10 });
+
+    const held = (await game.info()).player.right_hand_entity_id;
+    assert.equal(held, wrench.id, "wrench should be grabbed by the right hand");
+
+    // The held wrench swaps to the remastered first-person melee model (LGMM
+    // skinned mesh with the arm baked in, rendered at rest pose); dropping it
+    // restores the world model.
+    assert.equal(modelOf(await game.entities.detail(wrench.id)), "wrench_h");
+
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 10 });
+    assert.equal(modelOf(await game.entities.detail(wrench.id)), "wrench_w");
+  },
+);
+
 function findSavePath(saveName: string): string | undefined {
   const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
   const roots = [

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -89,21 +89,36 @@ test(
       debugFlags: ["--vr"],
     });
 
-    // In VR, spawnItem drops the item into the world in front of the player.
+    // DebugCycleWeapon spawns each roster weapon in turn (VR wield is a no-op,
+    // so each drops to the floor); cycle until the Wrench appears.
     await game.step({ frames: 10 });
-    await game.player.spawnItem("Wrench");
-    await game.step({ frames: 90 });
-
-    const wrench = (await game.entities.list({ limit: 100 })).entities.find(
-      (e) => e.name === "Wrench",
-    );
+    let wrench;
+    for (let i = 0; i < 20 && !wrench; i++) {
+      await game.input.trigger("DebugCycleWeapon");
+      await game.step({ frames: 5 });
+      wrench = (await game.entities.list({ limit: 100 })).entities.find(
+        (e) => e.name === "Wrench",
+      );
+    }
     assert.ok(wrench, "wrench should have spawned");
+    await game.step({ frames: 60 });
     assert.equal(modelOf(await game.entities.detail(wrench.id)), "wrench_w");
 
-    // Grab it (same recipe as the pistol test above).
-    const pawnY = (await game.info()).player.position[1];
-    const [px, py, pz] = wrench.position;
-    await game.input.set("right_hand.position", [px + 0.4, py - pawnY, pz]);
+    // Grab it: put the hand at the settled wrench's live position (pawn-local)
+    // and squeeze.
+    const pawn = (await game.info()).player.position;
+    const settled = (await game.entities.list({ limit: 100 })).entities.find(
+      (e) => e.id === wrench!.id,
+    )!;
+    const [px, py, pz] = settled.position;
+    await game.input.set("right_hand.position", [
+      px - pawn[0],
+      py - pawn[1],
+      pz - pawn[2],
+    ]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 2 });
     await game.input.set("right_hand.squeeze", 1.0);
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -29,9 +29,11 @@ async function byMissionId(
   return entity;
 }
 
-// `right_hand.position` is pawn-local and the held grip sits 0.4 behind the
-// hand, so the wrench's world z is `player.z + local_z - 0.4`. Staging is
-// expressed relative to the pane rather than as bare magic coordinates.
+// `right_hand.position` is pawn-local, and the held Wrench's contact volume
+// sits wherever its VR grip puts it relative to the hand (for the melee `_h`
+// wield, on the rendered weapon head - see `vr_config::melee_contact_offset`).
+// Staging is expressed relative to the pane rather than as bare magic
+// coordinates; the pane is tall enough that the sweep crosses it either way.
 const HAND_Y = 1.03;
 const HAND_REST: Vec3 = [0.55, HAND_Y, 1.1];
 const HAND_SWEEP: Vec3[] = [

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -47,7 +47,14 @@ const HAND_SWEEP: Vec3[] = [
 async function sweepHeldWrench(game: GameServer): Promise<void> {
   for (const hand of HAND_SWEEP) {
     await game.input.set("right_hand.position", hand);
-    await game.step({ frames: 1 });
+    // Two frames per sample, not one: the Wrench's authored contact volume is
+    // a 4.6cm sphere (PropPhysDimensions radius0), and the sweep's last sample
+    // lands it right on the pane plane. At one frame per sample whether the
+    // contact is generated came down to how much physics free-ran between the
+    // HTTP requests - the same swing passed or failed purely on request
+    // latency. Two frames gives the contact a real overlap window instead of a
+    // tangential touch; nothing else about the gesture changes.
+    await game.step({ frames: 2 });
   }
 }
 


### PR DESCRIPTION
Wields the four melee weapons with the 25AE remastered first-person `_h` models — the model's own baked hand replaces our glove — and, per the owner's "a pretty wrench that does nothing is NOT done", proves melee damage still works through the production path.

Plan step **3d** (`vr-ui-plan.md`). Fixes #1031.

## The wield

| weapon (gamesys) | model | install |
| --- | --- | --- |
| Wrench (−928) | `wrench_h` | 25AE; classic keeps `wrench_w` |
| Electro Shock (−24) | `rapier_h` | 25AE; classic keeps its world model |
| Crystal Shard (−28) | `shard_h` | 25AE; classic keeps its world model |
| PsiSword (−2291) | `psword_h` | 25AE; classic renders nothing (it authors no world model) |

`pipewrench_h` ships in the 25AE layer but has **no gamesys template** (KEX drives it from a squirrel script we don't run), so it is not wieldable and is not listed.

Melee `_h` are LGMM **skinned** meshes, unlike the standalone-LGMD guns of #1023: the bind pose renders as a splayed mid-swing arm, so the wield holds the player-melee idle clip's final frame (`from_completed_animation` — a static pose that emits no motion flags, events, or root velocity).

![melee wield contact sheet](https://gist.githubusercontent.com/tommy-xr/0262feac71550040b3c1cc41d6b82702/raw/050cfd3017975dc9a732053a0b42417be449b6db/melee_wield_contact_sheet.png)

![cycling the four melee models in VR](https://gist.githubusercontent.com/tommy-xr/0262feac71550040b3c1cc41d6b82702/raw/050cfd3017975dc9a732053a0b42417be449b6db/melee_cycle_v2.gif)

Captured per-weapon in `debug_weapons --vr` (`DebugCycleWeapon` → raycast-grab → wield). Full-resolution stills for each weapon are in [the same gist](https://gist.github.com/tommy-xr/0262feac71550040b3c1cc41d6b82702).

## The damage bug (#1031)

The first cut of this branch seated each arm with a **grip offset**. That looked right and silently disarmed the weapon: `VirtualHand::SetPositionRotation` applies the grip to the **entity**, and the held entity's rigid body *is* the VR melee contact collider (#942/#978). A ~0.7-unit alignment offset carried the Wrench's authored 4.6 cm contact sphere clean off the weapon.

Measured, not guessed:

| build | `medsci-saved-vr-melee` — one trigger-gated pull at a Blue Monkey |
| --- | --- |
| base (`d63707af`) | 1 Damage message, 9 HP lost ✅ |
| this branch, grip-offset cut | **0 Damage messages** ❌ |
| this branch, shipped | 1 Damage message, 9 HP lost ✅ |

The fix: each melee `_h` keeps **its world model's physical grip**, and the arm is seated by a render-only model-space correction through `Model::apply_local_transform` — the existing seam, already documented as "composed inside the entity transform, which the render path re-sets every frame". `vr_config::melee_wield_pose_correction` cancels the grip, applies the authored yaw, and cancels the posed fist joint, so the rendered result is grip-independent while the collider never moves.

Damage proof through the production path (shipped command2 1-HP pane, shipped Wrench, real VR trigger + physical swing — no injected damage message):

![melee damage before/after](https://gist.githubusercontent.com/tommy-xr/0262feac71550040b3c1cc41d6b82702/raw/fa9d4f54381e9caffe41676ad8a5079be2e8e7d6/damage_proof.png)

## Also fixed (found by review)

The PsiSword authors no world model, so the wield **materializes** its first one — and the drop had no inverse, leaving the first-person arm mesh lying in the world forever and persisting through save/load (reproduced live). `Effect::ClearModel` makes the swap symmetric; a new e2e covers grab and release.

## Owner review: hand orientation, and where the hitbox is

Both findings were real; both are fixed here (commits `a52ea56a`, `781a41f8`).

### 1. The baked arm was not on the hand's arm axis

Measured against the frame the tracked hand actually defines - `hand_forearm`
hangs the empty hand's sleeve along the hand's **+Z**, and the fingers/aim run
down **-Z** - the shipped seating put the posed forearm here:

| model | forearm (fist -> elbow) in hand space | off the hand's arm axis | correcting axis |
| --- | --- | --- | --- |
| `wrench_h` | (-0.348, 0.102, 0.122) | **71.3 deg** | (0.28, 0.96, 0.00) - a yaw |
| `rapier_h` | (-0.366, 0.073, 0.067) | **79.8 deg** | (0.20, 0.98, 0.00) |
| `shard_h` | (-0.366, 0.073, 0.067) | **79.8 deg** | (0.20, 0.98, 0.00) |
| `psword_h` | (-0.356, 0.070, 0.069) | **79.3 deg** | (0.19, 0.98, 0.00) |

So the arm left the wrist *sideways* instead of running back toward the elbow.
All four are nearly identical because the four rigs share the same posed arm
(only the weapon joint differs).

**This is not a different authoring axis from the guns.** The 25AE guns of
\#1023 are standalone LGMD meshes authored barrel-along -X, and one -90 yaw maps
-X onto the hand's -Z aim axis - for a gun that single degree of freedom is the
whole job. A melee `_h` is a skinned *arm*, so seating it is a 3-DOF problem
(arm onto the arm axis, plus a roll that decides where the weapon points), and
one authored yaw can only satisfy one of the two. The shipped 120 deg satisfied
the weapon and paid for it with the arm.

The correction is now derived from the rig instead of authored:
`melee_wield_alignment` rotates the posed forearm onto +Z, then rolls about it
until the weapon lies in the hand's vertical plane, standing up out of the fist.
Forearm error after: **< 0.5 deg** for all four (unit-tested).

![melee arm before/after](https://gist.githubusercontent.com/tommy-xr/0262feac71550040b3c1cc41d6b82702/raw/050cfd3017975dc9a732053a0b42417be449b6db/melee_arm_before_after.png)

### 2. The hitbox was not on the weapon - it is now

Answering the question directly: `Model::apply_local_transform` sets
`local_transform` on **every scene object of the model**, so the render
correction displaced the *whole* wield - arm and weapon geometry alike - while
the collider stayed at the entity transform. The suspicion was right.

Measured in hand-local space (collider = the held entity's body; the Wrench's
authored contact volume is a 4.6 cm sphere):

| model | contact sphere | rendered weapon head | gap |
| --- | --- | --- | --- |
| `wrench_h` | (0, 0, -0.40) | (0.013, 0.591, -0.556) | **0.61** (and 0.29 from the *nearest* point of the shaft) |
| `rapier_h` | (0, 0, 0) | (-0.032, 1.096, -0.416) | **1.17** |
| `shard_h` | (0, 0, 0) | (-0.154, 1.184, -0.339) | **1.24** |
| `psword_h` | (0, 0, 0) | (-0.159, 1.142, -0.290) | **1.19** |

The damage volume was floating in clear air next to the weapon, and the damage
e2e passed anyway because it drives the collider. (Note `/v1/scene` cannot see
this: it reports `SceneObject::transform`, not `transform * local_transform`,
so it printed the entity position for both.)

The fix follows from the mechanism the previous commit established. Because the
correction *cancels* the grip, the grip entry moves no pixels for a melee `_h` -
it only places the body. So the wield now **computes** that placement where it
poses the arm (`melee_contact_offset`) and stores it per entity as
`RuntimePropVrGripOffset`, which the grip lookup prefers; the correction cancels
that same value. Both halves come from one posed arm, so the weapon joint
renders exactly on the collider **for any rig** - a property, not four
hand-measured constants somebody has to keep up to date. (The four melee entries
are gone from `HAND_MODEL_POSITIONING` entirely, which also restores the
180-degree projectile rotation they had before VR wielded them.) Verified live,
one frame, hand at a known pose:

| model | measured body offset from the hand |
| --- | --- |
| `wrench_h` | (0, 0.811, -0.032) |
| `rapier_h` | (0, 1.160, 0.168) |
| `shard_h` | (0, 1.201, 0.316) |
| `psword_h` | (0, 1.146, 0.315) |

![the collider framed - the camera aims straight at the contact sphere](https://gist.githubusercontent.com/tommy-xr/0262feac71550040b3c1cc41d6b82702/raw/050cfd3017975dc9a732053a0b42417be449b6db/melee_collider_on_the_head.png)

Each panel points the camera *at the contact sphere*: the weapon head is what
is in the crosshair.

**Known limitation, filed as #1039:** the authored contact volume is a ~5 cm
sphere, so this arms the weapon's *head* and nothing else along its length.
Covering the whole blade needs a collider shaped like the weapon (a capsule
fist->head), which is a bigger change than putting the existing one in the right
place.

**One consequence, fixed here:** the held entity now sits on the weapon head, so
a release used to respawn the loose prop out there - a dropped Crystal Shard
materialized 1.2 units above the palm and fell. `DropItem` puts it back on the
hand first (measured: release at hand+1.22 -> hand+0.41, where every other drop
already lands).

Two asset-free tests hold both halves: `melee_wield_seats_the_forearm_on_the_hands_arm_axis`
(forearm error < 0.5 deg) and `the_rendered_weapon_head_lands_on_the_contact_collider`,
which composes the entity transform with the render correction and asserts the
weapon joint lands on the collider and the fist on the hand, for every shipped
rig. `cargo run -p shock2vr --example melee_grip` prints the offsets from the
live assets.

One test change follows: `medsci-saved-vr-melee`'s gesture placed the *hand* at
the sweep distance, which only connected while the collider happened to sit
0.4 along the fingers. It now measures the held weapon's grip offset live and
backs the hand off by it, so the sweep means what its comment always said -
bring the weapon's contact volume to 0.33 units from the torso. Same gesture,
same assertions, no injected damage. The measurement asserts its own shape
(~0.8 out, standing up out of the fist) so the staging cannot quietly
compensate for a misplaced collider, and it takes its hand rotation from the
SDK's level-horizon `lookQuat` - shortest-arc from -Z rolls up to ~180 degrees
for directions near world +z, which is exactly where these targets sit, and
that roll now carries an 0.8-unit offset.

### Review of this round

`/xreview` again (Claude subagent + Codex + the de-dup pass). Both engines
independently landed on the same structural point - the render half was
computed from the live rig while the collider half was pasted constants - which
is what the `RuntimePropVrGripOffset` derivation above replaced. Also applied
from review: the joint indexing is guarded (a short/modded rig logs and wields
unseated instead of panicking the frame), the drop-position regression above,
the tautological-staging and level-horizon fixes in the e2e, and #1039 filed for
the tip-only contact volume. `vr_config` stays a private module (two items are
re-exported for the example).

## Flat is unchanged

`FLAT_WIELD_SWAP_MODELS` is untouched and still frozen by its unit test; the `_h` route is gated on VR **and** `is_25th_anniversary_install()`. The flat wield e2e (`vr-held-model.e2e.test.ts`) is green.

## Review

`/xreview` run on the full branch (Claude subagent + Codex CLI + a dedicated de-dup pass), with the contact sheet attached for visual verification. Both engines independently agreed on two findings, both applied here: use `Model::apply_local_transform` instead of a new `AnimationPlayer` field (which is what the earlier draft did), and the PsiSword drop asymmetry. Both engines independently verified the correction's matrix algebra against `virtual_hand`'s forward composition. A remaining Medium — the correction bakes the *right* hand's grip at wield time — is now guarded by a unit test asserting the four melee grips are hand-symmetric.

One test change is bundled and deserves a callout: `vr-melee-contact`'s sweep now steps **2** frames per sample instead of 1. The Wrench's contact volume is a 4.6 cm sphere and the sweep's last sample lands it *on* the pane plane, so at one frame per sample the same swing passed or failed purely on how much physics free-ran between HTTP requests — measured: adding one read per sample flipped the result. Two frames gives the contact a real overlap window; the gesture is otherwise unchanged, and the test still asserts the same damage.

## Validation

- `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` — 817 pass
- SDK e2e (`SHOCK2_E2E=1`): `medsci-saved-vr-melee` (still exactly **1 Damage / 9 HP** per pull, plus the three-pull OG-Shotgun kill and the world pane), `vr-melee-contact` (3), `vr-held-model` (5, incl. the new PsiSword drop and the flat swap), and the whole `vr-*` + `weapon-*` set — **49 tests, all green** (including 23/23 missions)
- `missions.e2e.test.ts` — 23/23 missions load

## Follow-ups (not in scope)

- The empty hand is the pale 25AE bare-skin hand while the `_h` meshes bake a dark-skinned hand in a black sleeve — the two hands read as different characters. Newly visible because the wield now shows the *model's* hand.
- #955 (attack window bounded to a swing) and #956 (missing `DamageImpact`) remain open, as does the two-handed grip thread.


