### PR TITLE
fix(vr): fire every VR weapon from its muzzle vhot down its own barrel

### DIFF
--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -33,6 +33,17 @@ const MELEE_DAMAGE: f32 = 6.0;
 /// guns for now; per-weapon loudness is a follow-up.
 const GUNSHOT_NOISE_RADIUS: f32 = 50.0 / SCALE_FACTOR;
 
+/// Rotation taking the projectile's +Z travel axis onto a Dark gun model's
+/// barrel, which is authored along the model's **-X**. Every VR grip entry's
+/// -90 degree yaw exists to point that same axis out of the hand, and every
+/// wieldable model's muzzle vhot sits at its -X extreme (see the
+/// `vr_config` grip table and its `gun_grips_aim_the_barrel_out_of_the_hand`
+/// test), so this one rotation aims every VR weapon - ballistic, energy and
+/// psi alike - down its own rendered barrel.
+fn barrel_axis_from_forward() -> Quaternion<f32> {
+    Quaternion::from_angle_y(Deg(-90.0))
+}
+
 /// The weapon entity's current world position (from its live transform).
 fn weapon_world_position(world: &World, entity_id: EntityId) -> Option<cgmath::Vector3<f32>> {
     let v_transform = world.borrow::<View<RuntimePropTransform>>().ok()?;
@@ -361,6 +372,10 @@ pub(super) fn create_projectile(
         }
     }
 
+    // VR: the weapon is a physical object in the hand, so the shot is defined
+    // entirely by the *rendered* weapon - it leaves the model's muzzle vhot
+    // travelling down the model's barrel. Both are read from the weapon's own
+    // live transform, so no per-weapon aim correction is involved.
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let v_vhots = world.borrow::<View<RuntimePropVhots>>().unwrap();
 
@@ -368,37 +383,29 @@ pub(super) fn create_projectile(
         .get(entity_id)
         .map(|vhots| vhots.0.clone())
         .unwrap_or_default();
-    let vhot = vhots
-        .get(0)
+    // The fire point is the model's first vhot: every wieldable gun/amp model
+    // authors its muzzle there, at the -X tip of the barrel. Documented
+    // fallback for a model that carries no vhot at all (the classic `laser`
+    // and `lasehand` meshes, for instance): the model origin, i.e. the grip -
+    // the shot still leaves along the barrel, just from the hand.
+    let muzzle = vhots
+        .first()
         .map(|v| v.point)
         .unwrap_or(point3(0.0, 0.0, 0.0));
 
     let transform = v_transform.get(entity_id).unwrap();
 
-    let adjustments = vr_config::get_vr_hand_model_adjustments_from_entity(
-        entity_id,
-        world,
-        // TODO: I guess we don't care about handedness for now,
-        // since it only affects the flipping of the weapon... but truly we should consider it.
-        vr_config::Handedness::Left,
-    );
-
-    let rotation = adjustments.rotation;
-    let projectile_rotation: Matrix4<f32> =
-        vr_config::get_projectile_rotation_from_entity(entity_id, world).into();
-    let rot_matrix: Matrix4<f32> = rotation.into();
-    let inv_rot_matrix: Matrix4<f32> = rotation.invert().into();
-
-    // Adjust the vhot position to be in the same coordinate space as the weapon
-    let position = inv_rot_matrix.transform_point(vhot);
-
     Effect::CreateEntity {
         template_id: projectile_template_id,
-        position,
+        position: point3(0.0, 0.0, 0.0),
         // HACK: Not sure why we need to do this, but seems projectile
         // models are rotated 90 degrees
         orientation: Quaternion::from_angle_y(Deg(90.0)),
-        root_transform: transform.0 * rot_matrix * projectile_rotation,
+        // Projectile velocity is `root_transform * (0, 0, magnitude)`, so put
+        // the muzzle at the origin and aim +Z down the barrel.
+        root_transform: transform.0
+            * Matrix4::from_translation(muzzle.to_vec())
+            * Matrix4::from(barrel_axis_from_forward()),
         options: CreateEntityOptions {
             force_visible: true,
             ..CreateEntityOptions::default()
@@ -469,6 +476,87 @@ mod tests {
                         && matches!(msg.payload, MessagePayload::Damage { .. })
             )
         })
+    }
+
+    /// Where a VR shot starts and which way it flies, in world space, from the
+    /// `CreateEntity` the script returns.
+    fn vr_fire_geometry(
+        transform: Matrix4<f32>,
+        vhots: Vec<dark::ss2_bin_obj_loader::Vhot>,
+    ) -> (cgmath::Vector3<f32>, cgmath::Vector3<f32>) {
+        let mut world = World::new();
+        let weapon = world.add_entity((
+            Links::empty(),
+            RuntimePropTransform(transform),
+            RuntimePropVhots(vhots),
+        ));
+
+        let effect = create_projectile(
+            &world,
+            weapon,
+            -1,
+            &dark::properties::ProjectileOptions {
+                order: 0,
+                setting: 0,
+            },
+        );
+        let Effect::CreateEntity {
+            position,
+            root_transform,
+            ..
+        } = effect
+        else {
+            panic!("firing must create the projectile entity");
+        };
+        // Projectile velocity is root_transform * (0, 0, magnitude).
+        let origin = root_transform.transform_point(position).to_vec();
+        let forward = root_transform.transform_vector(vec3(0.0, 0.0, 1.0));
+        (origin, forward.normalize())
+    }
+
+    fn muzzle_vhot(point: cgmath::Point3<f32>) -> dark::ss2_bin_obj_loader::Vhot {
+        dark::ss2_bin_obj_loader::Vhot {
+            vhot_type: dark::ss2_bin_obj_loader::VhotType::Unknown,
+            point,
+        }
+    }
+
+    /// A VR shot leaves the model's muzzle vhot travelling down the barrel
+    /// (the model's -X), for any pose the hand happens to hold the weapon in.
+    #[test]
+    fn a_vr_shot_leaves_the_muzzle_vhot_along_the_barrel() {
+        // A deliberately awkward pose: yawed, pitched and translated, so a
+        // wrong fire axis cannot coincide with the right one.
+        let rotation = Quaternion::from_angle_y(Deg(35.0)) * Quaternion::from_angle_x(Deg(-20.0));
+        let translation = vec3(3.0, 1.5, -4.0);
+        let transform = Matrix4::from_translation(translation) * Matrix4::from(rotation);
+        let vhot = point3(-0.77, -0.03, 0.06);
+
+        let (origin, forward) = vr_fire_geometry(transform, vec![muzzle_vhot(vhot)]);
+
+        let expected_origin = translation + rotation * vhot.to_vec();
+        let expected_forward = rotation * vec3(-1.0, 0.0, 0.0);
+        assert!(
+            (origin - expected_origin).magnitude() < 1e-5,
+            "shot started at {origin:?}, not at the muzzle {expected_origin:?}"
+        );
+        assert!(
+            (forward - expected_forward).magnitude() < 1e-5,
+            "shot flew {forward:?}, not down the barrel {expected_forward:?}"
+        );
+    }
+
+    /// A model with no vhot at all (the classic `laser` / `lasehand` meshes)
+    /// falls back to the model origin, still firing down the barrel.
+    #[test]
+    fn a_vr_shot_from_a_vhotless_model_falls_back_to_the_model_origin() {
+        let rotation = Quaternion::from_angle_y(Deg(-90.0));
+        let transform = Matrix4::from_translation(vec3(1.0, 2.0, 3.0)) * Matrix4::from(rotation);
+
+        let (origin, forward) = vr_fire_geometry(transform, vec![]);
+
+        assert!((origin - vec3(1.0, 2.0, 3.0)).magnitude() < 1e-5);
+        assert!((forward - rotation * vec3(-1.0, 0.0, 0.0)).magnitude() < 1e-5);
     }
 
     #[test]

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -33,13 +33,19 @@ const MELEE_DAMAGE: f32 = 6.0;
 /// guns for now; per-weapon loudness is a follow-up.
 const GUNSHOT_NOISE_RADIUS: f32 = 50.0 / SCALE_FACTOR;
 
-/// Rotation taking the projectile's +Z travel axis onto a Dark gun model's
-/// barrel, which is authored along the model's **-X**. Every VR grip entry's
-/// -90 degree yaw exists to point that same axis out of the hand, and every
-/// wieldable model's muzzle vhot sits at its -X extreme (see the
-/// `vr_config` grip table and its `gun_grips_aim_the_barrel_out_of_the_hand`
-/// test), so this one rotation aims every VR weapon - ballistic, energy and
-/// psi alike - down its own rendered barrel.
+/// Rotation taking the projectile's +Z travel axis onto the barrel of a 25AE
+/// first-person gun model, which is authored along the model's **-X** - that is
+/// where each of those meshes puts its muzzle vhot, and pointing that axis out
+/// of the hand is the whole job of every gun's -90 degree yaw in the
+/// `vr_config` grip table (pinned by its
+/// `gun_grips_aim_the_barrel_out_of_the_hand` test). So this one rotation aims
+/// every VR weapon - ballistic, energy and psi alike - down its own rendered
+/// barrel, with no per-weapon correction.
+///
+/// Caveat, pre-existing and unchanged by this: several *classic-install* world
+/// models (`atek_w`, `ar15_w`, `sg_w`, `gren_w`, `viro_w`, `al_w`) are authored
+/// barrel-along-Z instead, so VR mis-aims them by 90 degrees when the 25AE view
+/// models are unavailable. Tracked in #1034.
 fn barrel_axis_from_forward() -> Quaternion<f32> {
     Quaternion::from_angle_y(Deg(-90.0))
 }
@@ -383,11 +389,18 @@ pub(super) fn create_projectile(
         .get(entity_id)
         .map(|vhots| vhots.0.clone())
         .unwrap_or_default();
-    // The fire point is the model's first vhot: every wieldable gun/amp model
-    // authors its muzzle there, at the -X tip of the barrel. Documented
-    // fallback for a model that carries no vhot at all (the classic `laser`
-    // and `lasehand` meshes, for instance): the model origin, i.e. the grip -
-    // the shot still leaves along the barrel, just from the hand.
+    // The fire point is the model's first vhot, which the 25AE view models that
+    // carry one author at the -X tip of the barrel (atek_h, ar15_h, sg_h,
+    // lasehand, sfg_h, viro_h, amp_h).
+    //
+    // Documented fallback for a model with no vhot at all: the model origin,
+    // i.e. the grip. The shot still leaves along the barrel, just from the
+    // hand. This is not rare - `empgun_h`, `gren_h`, `fsn_h` and `al_h` ship
+    // with zero vhots, as do most classic-install world models - and a shot
+    // starting at the grip can strike the player when the weapon is held in
+    // close to the body (see #1034). Adding clearance is deliberately left to
+    // that issue: it changes where four more weapons fire from, which is a
+    // separate change from making the vhot-carrying weapons faithful.
     let muzzle = vhots
         .first()
         .map(|v| v.point)

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -59,29 +59,16 @@ impl VRHandModelPerHandAdjustments {
 struct VRHandModelAdjustments {
     left_hand: VRHandModelPerHandAdjustments,
     right_hand: VRHandModelPerHandAdjustments,
-    projectile_rotation: Quaternion<f32>,
 }
 
 impl VRHandModelAdjustments {
     pub fn new(
         left_hand: VRHandModelPerHandAdjustments,
         right_hand: VRHandModelPerHandAdjustments,
-        projectile_rotation: Quaternion<f32>,
     ) -> VRHandModelAdjustments {
         VRHandModelAdjustments {
             left_hand,
             right_hand,
-            projectile_rotation,
-        }
-    }
-
-    pub fn with_projectile_rotation(
-        self,
-        projectile_rotation: Quaternion<f32>,
-    ) -> VRHandModelAdjustments {
-        VRHandModelAdjustments {
-            projectile_rotation,
-            ..self
         }
     }
 }
@@ -91,11 +78,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
 
     let held_weapon_right = VRHandModelPerHandAdjustments::new().rotate_y(Deg(-90.0));
     let held_weapon_left = held_weapon_right.clone().flip_x();
-    let held_weapon = VRHandModelAdjustments::new(
-        held_weapon_left,
-        held_weapon_right.clone(),
-        Quaternion::from_angle_y(Deg(0.0)),
-    );
+    let held_weapon = VRHandModelAdjustments::new(held_weapon_left, held_weapon_right.clone());
 
     // The wrench's long axis runs opposite the guns' after the -90 yaw (its
     // model is authored along X where guns are along Y), so it takes +90 and
@@ -105,11 +88,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         .with_offset(vec3(0.0, 0.0, -0.4));
 
     let held_item_hand = VRHandModelPerHandAdjustments::new().rotate_y(Deg(180.0));
-    let held_item = VRHandModelAdjustments::new(
-        held_item_hand.clone(),
-        held_item_hand,
-        Quaternion::from_angle_y(Deg(0.0)),
-    );
+    let held_item = VRHandModelAdjustments::new(held_item_hand.clone(), held_item_hand);
 
     // Hand model adjustments for VR
     // Specify overrides for particular models with how they should be oriented
@@ -117,11 +96,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     // A weapon whose left-hand placement is the right-hand adjustments
     // mirrored (flip_x)
     fn symmetric(right: VRHandModelPerHandAdjustments) -> VRHandModelAdjustments {
-        VRHandModelAdjustments::new(
-            right.clone().flip_x(),
-            right,
-            Quaternion::from_angle_y(Deg(0.0)),
-        )
+        VRHandModelAdjustments::new(right.clone().flip_x(), right)
     }
 
     let items = vec![
@@ -188,17 +163,14 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ),
         (
             "lasehand",
-            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.27)))
-                .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
+            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.27))),
         ),
         // Melee first-person models (_h) deliberately have NO entry: their
         // grip is not a constant. The held body is the melee contact collider
         // (#942/#978) and has to sit on the *rendered* weapon head, which is
         // only known once the arm is posed - so the wield computes it
         // (`melee_contact_offset`) and stores it per entity as
-        // `RuntimePropVrGripOffset`, which this table defers to. Leaving them
-        // unmapped also keeps the default 180-degree projectile rotation they
-        // had before VR wielded them.
+        // `RuntimePropVrGripOffset`, which this table defers to.
         // Weapons - world models, kept when held in VR (#352): the _h meshes
         // have faces stripped for the fixed flat camera. sg_w/empgun predate
         // this and show the world models grip fine with the same offsets.
@@ -226,12 +198,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
                     .with_offset(vec3(-0.21, 0.0, -0.045)),
             ),
         ),
-        (
-            "laser",
-            held_weapon
-                .clone()
-                .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
-        ),
+        ("laser", held_weapon.clone()),
         ("empgun", held_weapon.clone()),
         ("gren_w", held_weapon.clone()),
         ("fsn_w", held_weapon.clone()),
@@ -406,19 +373,6 @@ pub fn get_vr_hand_model_adjustments_from_entity(
     }
 }
 
-pub fn get_projectile_rotation_from_entity(entity_id: EntityId, world: &World) -> Quaternion<f32> {
-    let v_model_name = world.borrow::<View<PropModelName>>().unwrap();
-    let maybe_model_name = v_model_name
-        .get(entity_id)
-        .map(|sz| sz.0.to_ascii_lowercase());
-
-    if let Ok(model_name) = maybe_model_name {
-        get_vr_projectile_rotation_from_model(&model_name)
-    } else {
-        Quaternion::from_angle_y(Deg(180.0))
-    }
-}
-
 pub fn get_vr_hand_model_adjustments_from_model(
     model_name: &str,
     handedness: Handedness,
@@ -438,18 +392,10 @@ pub fn get_vr_hand_model_adjustments_from_model(
     }
 }
 
-fn get_vr_projectile_rotation_from_model(model_name: &str) -> Quaternion<f32> {
-    let maybe_adjustments = HAND_MODEL_POSITIONING.get(model_name);
-
-    if maybe_adjustments.is_none() {
-        return Quaternion::from_angle_y(Deg(180.0));
-    }
-
-    maybe_adjustments.unwrap().projectile_rotation
-}
-
 #[cfg(test)]
 mod tests {
+    use cgmath::InnerSpace;
+
     use super::*;
 
     /// The melee subset of [`VR_25AE_VIEW_MODELS`]: skinned arm rigs, seated
@@ -495,12 +441,6 @@ mod tests {
             assert!(
                 !HAND_MODEL_POSITIONING.contains_key(name),
                 "{name} must take its grip from the posed rig, not this table"
-            );
-            // ... and stay on the unmapped default projectile rotation they
-            // had before VR wielded them.
-            assert_eq!(
-                get_vr_projectile_rotation_from_model(name),
-                Quaternion::from_angle_y(Deg(180.0))
             );
         }
     }
@@ -599,6 +539,38 @@ mod tests {
                 fist.to_vec().magnitude() < 1e-4,
                 "{name}: rendered fist {fist:?} is off the tracked hand"
             );
+        }
+    }
+
+    /// Every model a VR hand can *fire* must seat with its barrel - the
+    /// model's -X axis, where its muzzle vhot sits - pointing out of the hand
+    /// (-Z). `weapon_script::create_projectile` aims the shot down that axis
+    /// for every weapon rather than carrying per-weapon aim corrections, so an
+    /// entry that seats a gun some other way would silently mis-aim it.
+    #[test]
+    fn gun_grips_aim_the_barrel_out_of_the_hand() {
+        // The 25AE view models VR wields, plus the world models it falls back
+        // to on a classic install. The melee `_h` are excluded twice over:
+        // they fire nothing, and they deliberately have no table entry at all
+        // (see `melee_view_models_have_no_static_grip`).
+        let guns = VR_25AE_VIEW_MODELS
+            .iter()
+            .copied()
+            .filter(|name| !MELEE_VIEW_MODELS.contains(name))
+            .chain([
+                "atek_w", "ar15_w", "sg_w", "laser", "empgun", "gren_w", "fsn_w", "sfg_w", "amp_w",
+                "viro_w", "al_w",
+            ]);
+        for name in guns {
+            for handedness in [Handedness::Left, Handedness::Right] {
+                let rotation = get_vr_hand_model_adjustments_from_model(name, handedness).rotation;
+                let barrel = rotation * vec3(-1.0, 0.0, 0.0);
+                let hand_forward = vec3(0.0, 0.0, -1.0);
+                assert!(
+                    (barrel - hand_forward).magnitude() < 1e-4,
+                    "{name} ({handedness:?}) points its barrel at {barrel:?}, not out of the hand"
+                );
+            }
         }
     }
 

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -542,26 +542,30 @@ mod tests {
         }
     }
 
-    /// Every model a VR hand can *fire* must seat with its barrel - the
-    /// model's -X axis, where its muzzle vhot sits - pointing out of the hand
-    /// (-Z). `weapon_script::create_projectile` aims the shot down that axis
-    /// for every weapon rather than carrying per-weapon aim corrections, so an
-    /// entry that seats a gun some other way would silently mis-aim it.
+    /// The 25AE first-person gun models are authored barrel-along -X, and
+    /// `weapon_script::create_projectile` fires every VR weapon down that axis
+    /// rather than carrying per-weapon aim corrections. So each of their grips
+    /// must seat that -X out of the hand (-Z): an entry that seats a gun some
+    /// other way would silently mis-aim it.
+    ///
+    /// Scoped to the 25AE view models on purpose. Several classic world models
+    /// (`atek_w`, `ar15_w`, `sg_w`, `gren_w`, `viro_w`, `al_w`) are authored
+    /// barrel-along Z - their grips satisfy this assertion but their barrels
+    /// do not, which is the pre-existing 90 degree VR mis-aim tracked in #1034.
+    /// Asserting over them would certify that gap as correct.
+    ///
+    /// The melee `_h` are excluded twice over: they fire nothing, and they
+    /// deliberately have no table entry at all (their grip is computed per
+    /// wield - see `melee_view_models_have_no_static_grip`).
     #[test]
     fn gun_grips_aim_the_barrel_out_of_the_hand() {
-        // The 25AE view models VR wields, plus the world models it falls back
-        // to on a classic install. The melee `_h` are excluded twice over:
-        // they fire nothing, and they deliberately have no table entry at all
-        // (see `melee_view_models_have_no_static_grip`).
         let guns = VR_25AE_VIEW_MODELS
             .iter()
             .copied()
-            .filter(|name| !MELEE_VIEW_MODELS.contains(name))
-            .chain([
-                "atek_w", "ar15_w", "sg_w", "laser", "empgun", "gren_w", "fsn_w", "sfg_w", "amp_w",
-                "viro_w", "al_w",
-            ]);
+            .filter(|name| !MELEE_VIEW_MODELS.contains(name));
         for name in guns {
+            // flip_x mirrors only `scale`, so both hands share this rotation -
+            // checking both is what pins that.
             for handedness in [Handedness::Left, Handedness::Right] {
                 let rotation = get_vr_hand_model_adjustments_from_model(name, handedness).rotation;
                 let barrel = rotation * vec3(-1.0, 0.0, 0.0);

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -8,27 +8,27 @@ export const add = (a: Vec3, b: Vec3): Vec3 => [
   a[1] + b[1],
   a[2] + b[2],
 ];
-const sub = (a: Vec3, b: Vec3): Vec3 => [
+export const sub = (a: Vec3, b: Vec3): Vec3 => [
   a[0] - b[0],
   a[1] - b[1],
   a[2] - b[2],
 ];
-const scale = (v: Vec3, amount: number): Vec3 => [
+export const scale = (v: Vec3, amount: number): Vec3 => [
   v[0] * amount,
   v[1] * amount,
   v[2] * amount,
 ];
-const dot = (a: Vec3, b: Vec3): number =>
+export const dot = (a: Vec3, b: Vec3): number =>
   a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-const cross = (a: Vec3, b: Vec3): Vec3 => [
+export const cross = (a: Vec3, b: Vec3): Vec3 => [
   a[1] * b[2] - a[2] * b[1],
   a[2] * b[0] - a[0] * b[2],
   a[0] * b[1] - a[1] * b[0],
 ];
-const normalize = (v: Vec3): Vec3 => scale(v, 1 / Math.sqrt(dot(v, v)));
+export const normalize = (v: Vec3): Vec3 => scale(v, 1 / Math.sqrt(dot(v, v)));
 
-const quatConjugate = ([x, y, z, w]: Quat): Quat => [-x, -y, -z, w];
-const quatMultiply = (
+export const quatConjugate = ([x, y, z, w]: Quat): Quat => [-x, -y, -z, w];
+export const quatMultiply = (
   [ax, ay, az, aw]: Quat,
   [bx, by, bz, bw]: Quat,
 ): Quat => [
@@ -37,7 +37,7 @@ const quatMultiply = (
   aw * bz + ax * by - ay * bx + az * bw,
   aw * bw - ax * bx - ay * by - az * bz,
 ];
-const quatNormalize = (q: Quat): Quat => {
+export const quatNormalize = (q: Quat): Quat => {
   const length = Math.sqrt(q.reduce((sum, value) => sum + value * value, 0));
   return q.map((value) => value / length) as Quat;
 };
@@ -48,7 +48,7 @@ export const quatRotate = (q: Quat, v: Vec3): Vec3 =>
     3,
   ) as Vec3;
 
-function quatFromTo(from: Vec3, to: Vec3): Quat {
+export function quatFromTo(from: Vec3, to: Vec3): Quat {
   const a = normalize(from);
   const b = normalize(to);
   const d = dot(a, b);

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/index.js";
+
+// A VR-wielded weapon must fire from its model's muzzle vhot, travelling along
+// the rendered barrel. Both are checkable numerically: the runtime reports the
+// weapon entity's world transform, and the muzzle vhot is a fixed point in the
+// model, so the expected fire point and axis are known exactly.
+//
+// The laser pistol used to carry a 12 degree `projectile_rotation` fudge in
+// vr_config - a leftover from the era when VR wielded the vhot-less `laser`
+// world model - which skewed BOTH the spawn point and the travel direction off
+// the barrel. Fired from a natural hold the bolt then crossed in front of the
+// player and spanged on their own collider instead of reaching the wall.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8102);
+
+/** Weapon templates cycled by DebugCycleWeapon (mission_core DEBUG_WEAPONS). */
+const LASER_PISTOL = -22;
+const PSI_AMP = -247;
+
+/** dark::SCALE_FACTOR - model units per world unit. */
+const SCALE_FACTOR = 2.5;
+
+/**
+ * The muzzle vhot of each model, in world units (the model's vhot 0, read from
+ * the 25AE `obj/*.bin` and divided by SCALE_FACTOR). Both sit at the model's
+ * -X extreme, which is the authored barrel direction for Dark gun models.
+ */
+const MUZZLE_VHOT: Record<string, Vec3> = {
+  lasehand: [-1.913 / SCALE_FACTOR, -0.0688 / SCALE_FACTOR, 0.16 / SCALE_FACTOR],
+  amp_h: [-1.1072 / SCALE_FACTOR, 0.2719 / SCALE_FACTOR, -0.1199 / SCALE_FACTOR],
+};
+
+type Quat = [number, number, number, number];
+
+const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const scale = (v: Vec3, s: number): Vec3 => [v[0] * s, v[1] * s, v[2] * s];
+const dot = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const len = (v: Vec3): number => Math.sqrt(dot(v, v));
+const norm = (v: Vec3): Vec3 => scale(v, 1 / len(v));
+const cross = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+
+const qconj = ([x, y, z, w]: Quat): Quat => [-x, -y, -z, w];
+const qmul = ([ax, ay, az, aw]: Quat, [bx, by, bz, bw]: Quat): Quat => [
+  aw * bx + ax * bw + ay * bz - az * by,
+  aw * by - ax * bz + ay * bw + az * bx,
+  aw * bz + ax * by - ay * bx + az * bw,
+  aw * bw - ax * bx - ay * by - az * bz,
+];
+const qnorm = (q: Quat): Quat => {
+  const l = Math.sqrt(q.reduce((sum, v) => sum + v * v, 0));
+  return q.map((v) => v / l) as Quat;
+};
+const qrot = (q: Quat, v: Vec3): Vec3 =>
+  qmul(qmul(q, [...v, 0] as Quat), qconj(q)).slice(0, 3) as Vec3;
+function qFromTo(from: Vec3, to: Vec3): Quat {
+  const a = norm(from);
+  const b = norm(to);
+  const d = dot(a, b);
+  if (d < -0.999999) {
+    const axis = Math.abs(a[0]) < 0.9 ? norm(cross(a, [1, 0, 0])) : norm(cross(a, [0, 1, 0]));
+    return [axis[0], axis[1], axis[2], 0];
+  }
+  const c = cross(a, b);
+  return qnorm([c[0], c[1], c[2], 1 + d]);
+}
+
+const angleBetweenDeg = (a: Vec3, b: Vec3): number =>
+  (Math.acos(Math.max(-1, Math.min(1, dot(norm(a), norm(b))))) * 180) / Math.PI;
+
+interface EntityTransform {
+  position: Vec3;
+  rotation: Quat;
+  model: string;
+}
+
+async function entityTransform(game: GameServer, id: number): Promise<EntityTransform> {
+  const detail = await game.entities.detail(id);
+  const model =
+    (detail.properties?.find((p) => p.name === "Model")?.value as string | undefined) ?? "";
+  return {
+    position: detail.position as Vec3,
+    rotation: detail.rotation as Quat,
+    model,
+  };
+}
+
+/** Reach out with the production VR hand and squeeze to pick `target` up. */
+async function grabWithRightHand(game: GameServer, target: Vec3): Promise<void> {
+  const snapshot = await game.info();
+  const pawn = snapshot.player.position as Vec3;
+  const pawnRotation = snapshot.player.rotation as Quat;
+  const eye = add(pawn, [0, snapshot.player.camera_offset[1], 0]);
+  const worldHand = sub(target, scale(norm(sub(target, eye)), 0.3));
+  const inverse = qconj(pawnRotation);
+  await game.input.set("right_hand.position", qrot(inverse, sub(worldHand, pawn)));
+  await game.input.set(
+    "right_hand.rotation",
+    qnorm(qmul(inverse, qFromTo([0, 0, -1], norm(sub(target, worldHand))))),
+  );
+  await game.input.set("right_hand.trigger", 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+}
+
+/**
+ * Hold the weapon at a known pose, pull the trigger, and report where the
+ * projectile appeared and which way it flew, alongside the muzzle/barrel the
+ * rendered weapon says it should have used.
+ */
+async function fireAndTrack(
+  game: GameServer,
+  weaponId: number,
+  handLocalPosition: Vec3,
+  aimDirection: Vec3,
+  projectileMatches: (entity: EntitySummary) => boolean,
+): Promise<{
+  muzzle: Vec3;
+  barrel: Vec3;
+  firstSeen: Vec3;
+  travel: Vec3;
+  distanceTravelled: number;
+}> {
+  await game.input.set("right_hand.position", handLocalPosition);
+  await game.input.set("right_hand.rotation", qFromTo([0, 0, -1], norm(aimDirection)));
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 5 });
+
+  const weapon = await entityTransform(game, weaponId);
+  const vhot = MUZZLE_VHOT[weapon.model];
+  assert.ok(
+    vhot,
+    `VR should wield a view model with a known muzzle vhot, got "${weapon.model}"`,
+  );
+  const muzzle = add(weapon.position, qrot(weapon.rotation, vhot));
+  // Dark gun models are authored with the barrel along the model's -X axis.
+  const barrel = qrot(weapon.rotation, [-1, 0, 0]);
+
+  const before = new Set((await game.entities.list()).entities.map((e) => e.id));
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0);
+
+  const track: Vec3[] = [];
+  for (let frame = 0; frame < 30; frame += 1) {
+    await game.step({ frames: 1 });
+    const shot = (await game.entities.list()).entities.find(
+      (e) => !before.has(e.id) && projectileMatches(e),
+    );
+    if (shot) track.push(shot.position as Vec3);
+  }
+  assert.ok(track.length >= 2, "the trigger pull must spawn a travelling projectile");
+
+  const travel = sub(track[track.length - 1], track[0]);
+  return {
+    muzzle,
+    barrel,
+    firstSeen: track[0],
+    travel,
+    distanceTravelled: len(travel),
+  };
+}
+
+test(
+  "a VR-wielded laser pistol fires from its muzzle vhot along the barrel",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // DebugCycleWeapon drops each weapon in front of the player in VR.
+    let laser: EntitySummary | undefined;
+    for (let cycle = 0; cycle < 12 && !laser; cycle += 1) {
+      await game.input.trigger("DebugCycleWeapon");
+      await game.step({ frames: 10 });
+      laser = (await game.entities.list()).entities.find((e) => e.template_id === LASER_PISTOL);
+    }
+    assert.ok(laser, "DebugCycleWeapon must spawn the Laser Pistol");
+
+    await grabWithRightHand(game, laser.position as Vec3);
+    const held = await game.info();
+    assert.equal(held.player.right_hand_entity_id, laser.id, "the hand must hold the pistol");
+
+    const shot = await fireAndTrack(
+      game,
+      laser.id,
+      // Held out to the side of the body: a bolt that leaves the muzzle along
+      // the barrel reaches the wall, one that veers sideways hits the player.
+      [0, 1, -2],
+      [-1, 0, 0],
+      (e) => e.name === "Laser Shot",
+    );
+
+    const deviation = angleBetweenDeg(shot.travel, shot.barrel);
+    assert.ok(
+      deviation < 1,
+      `the bolt must travel along the rendered barrel, deviated ${deviation.toFixed(2)} degrees`,
+    );
+
+    // The projectile is first observed one frame after the shot, so compare its
+    // back-projection to the muzzle rather than the raw first sample.
+    const origin = sub(shot.firstSeen, scale(norm(shot.travel), len(sub(shot.firstSeen, shot.muzzle))));
+    const originError = len(sub(origin, shot.muzzle));
+    assert.ok(
+      originError < 0.05,
+      `the bolt must leave the muzzle vhot, missed it by ${originError.toFixed(3)} world units`,
+    );
+
+    // A full-range flight: with the 12 degree skew the bolt used to spang on
+    // the player's own collider a fraction of a unit out.
+    assert.ok(
+      shot.distanceTravelled > 5,
+      `the bolt must clear the shooter, only travelled ${shot.distanceTravelled.toFixed(2)}`,
+    );
+  },
+);
+
+test(
+  "a VR-wielded psi amp casts from its muzzle vhot along the barrel",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const amp = (await game.entities.list()).entities.find((e) => e.template_id === PSI_AMP);
+    assert.ok(amp, "debug_psi must place the Psi Amp in the scene");
+
+    await grabWithRightHand(game, amp.position as Vec3);
+    const held = await game.info();
+    assert.equal(held.player.right_hand_entity_id, amp.id, "the hand must hold the amp");
+
+    // A pose that is not axis-aligned, so a wrong fire axis cannot coincide
+    // with the right one.
+    const shot = await fireAndTrack(
+      game,
+      amp.id,
+      [0, 1, -2],
+      [-1, 0.36, 0.84],
+      (e) => e.name.startsWith("Cryo PSI"),
+    );
+
+    const deviation = angleBetweenDeg(shot.travel, shot.barrel);
+    assert.ok(
+      deviation < 1,
+      `the cryo bolt must travel along the barrel, deviated ${deviation.toFixed(2)} degrees`,
+    );
+
+    const origin = sub(shot.firstSeen, scale(norm(shot.travel), len(sub(shot.firstSeen, shot.muzzle))));
+    const originError = len(sub(origin, shot.muzzle));
+    assert.ok(
+      originError < 0.05,
+      `the cryo bolt must leave the muzzle vhot, missed it by ${originError.toFixed(3)} world units`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -3,6 +3,17 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, Vec3 } from "../src/index.js";
+import {
+  add,
+  aimVrHandAt,
+  dot,
+  normalize,
+  quatFromTo,
+  quatRotate,
+  scale,
+  sub,
+} from "./helpers/vr-hand.js";
+import type { Quat } from "./helpers/vr-hand.js";
 
 // A VR-wielded weapon must fire from its model's muzzle vhot, travelling along
 // the rendered barrel. Both are checkable numerically: the runtime reports the
@@ -14,6 +25,9 @@ import type { EntitySummary, Vec3 } from "../src/index.js";
 // world model - which skewed BOTH the spawn point and the travel direction off
 // the barrel. Fired from a natural hold the bolt then crossed in front of the
 // player and spanged on their own collider instead of reaching the wall.
+//
+// Requires a 25th Anniversary install (DARK_ASSET_PATH): the vhots below are
+// the remastered `mods/sshock2ee.kpf` view models', which is what VR wields.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8102);
 
@@ -27,54 +41,24 @@ const SCALE_FACTOR = 2.5;
 /**
  * The muzzle vhot of each model, in world units (the model's vhot 0, read from
  * the 25AE `obj/*.bin` and divided by SCALE_FACTOR). Both sit at the model's
- * -X extreme, which is the authored barrel direction for Dark gun models.
+ * -X extreme, which is the authored barrel direction for these models.
  */
 const MUZZLE_VHOT: Record<string, Vec3> = {
   lasehand: [-1.913 / SCALE_FACTOR, -0.0688 / SCALE_FACTOR, 0.16 / SCALE_FACTOR],
   amp_h: [-1.1072 / SCALE_FACTOR, 0.2719 / SCALE_FACTOR, -0.1199 / SCALE_FACTOR],
 };
 
-type Quat = [number, number, number, number];
-
-const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
-const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
-const scale = (v: Vec3, s: number): Vec3 => [v[0] * s, v[1] * s, v[2] * s];
-const dot = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 const len = (v: Vec3): number => Math.sqrt(dot(v, v));
-const norm = (v: Vec3): Vec3 => scale(v, 1 / len(v));
-const cross = (a: Vec3, b: Vec3): Vec3 => [
-  a[1] * b[2] - a[2] * b[1],
-  a[2] * b[0] - a[0] * b[2],
-  a[0] * b[1] - a[1] * b[0],
-];
 
-const qconj = ([x, y, z, w]: Quat): Quat => [-x, -y, -z, w];
-const qmul = ([ax, ay, az, aw]: Quat, [bx, by, bz, bw]: Quat): Quat => [
-  aw * bx + ax * bw + ay * bz - az * by,
-  aw * by - ax * bz + ay * bw + az * bx,
-  aw * bz + ax * by - ay * bx + az * bw,
-  aw * bw - ax * bx - ay * by - az * bz,
-];
-const qnorm = (q: Quat): Quat => {
-  const l = Math.sqrt(q.reduce((sum, v) => sum + v * v, 0));
-  return q.map((v) => v / l) as Quat;
-};
-const qrot = (q: Quat, v: Vec3): Vec3 =>
-  qmul(qmul(q, [...v, 0] as Quat), qconj(q)).slice(0, 3) as Vec3;
-function qFromTo(from: Vec3, to: Vec3): Quat {
-  const a = norm(from);
-  const b = norm(to);
-  const d = dot(a, b);
-  if (d < -0.999999) {
-    const axis = Math.abs(a[0]) < 0.9 ? norm(cross(a, [1, 0, 0])) : norm(cross(a, [0, 1, 0]));
-    return [axis[0], axis[1], axis[2], 0];
-  }
-  const c = cross(a, b);
-  return qnorm([c[0], c[1], c[2], 1 + d]);
-}
+/**
+ * Stepped frames of flight between the shot and the first position that can be
+ * sampled: the trigger frame spawns and integrates the projectile once, and one
+ * more frame is stepped before the entity list is read.
+ */
+const FLIGHT_FRAMES_BEFORE_FIRST_SAMPLE = 2;
 
 const angleBetweenDeg = (a: Vec3, b: Vec3): number =>
-  (Math.acos(Math.max(-1, Math.min(1, dot(norm(a), norm(b))))) * 180) / Math.PI;
+  (Math.acos(Math.max(-1, Math.min(1, dot(normalize(a), normalize(b))))) * 180) / Math.PI;
 
 interface EntityTransform {
   position: Vec3;
@@ -95,28 +79,21 @@ async function entityTransform(game: GameServer, id: number): Promise<EntityTran
 
 /** Reach out with the production VR hand and squeeze to pick `target` up. */
 async function grabWithRightHand(game: GameServer, target: Vec3): Promise<void> {
-  const snapshot = await game.info();
-  const pawn = snapshot.player.position as Vec3;
-  const pawnRotation = snapshot.player.rotation as Quat;
-  const eye = add(pawn, [0, snapshot.player.camera_offset[1], 0]);
-  const worldHand = sub(target, scale(norm(sub(target, eye)), 0.3));
-  const inverse = qconj(pawnRotation);
-  await game.input.set("right_hand.position", qrot(inverse, sub(worldHand, pawn)));
-  await game.input.set(
-    "right_hand.rotation",
-    qnorm(qmul(inverse, qFromTo([0, 0, -1], norm(sub(target, worldHand))))),
-  );
-  await game.input.set("right_hand.trigger", 0);
-  await game.input.set("right_hand.squeeze", 0);
-  await game.step({ frames: 3 });
+  await aimVrHandAt(game, target, 0.3);
   await game.input.set("right_hand.squeeze", 1);
   await game.step({ frames: 8 });
 }
 
 /**
- * Hold the weapon at a known pose, pull the trigger, and report where the
- * projectile appeared and which way it flew, alongside the muzzle/barrel the
- * rendered weapon says it should have used.
+ * Hold the weapon at a known pose, pull the trigger, and report how the shot
+ * compares to the muzzle and barrel the *rendered* weapon implies.
+ *
+ * The projectile is only observable after it has already flown, so the origin is
+ * measured two ways against the ray it actually flew: how far the muzzle sits
+ * OFF that ray (`lateralError` - a sideways spawn or a skewed heading), and how
+ * far ALONG it the first sample is (`axialDistance`), which must match the
+ * frames of flight that have elapsed - that is what catches a spawn pushed
+ * forward or back down the barrel, which a lateral measure alone cannot see.
  */
 async function fireAndTrack(
   game: GameServer,
@@ -125,31 +102,32 @@ async function fireAndTrack(
   aimDirection: Vec3,
   projectileMatches: (entity: EntitySummary) => boolean,
 ): Promise<{
-  muzzle: Vec3;
-  barrel: Vec3;
-  firstSeen: Vec3;
-  travel: Vec3;
+  barrelDeviationDeg: number;
+  lateralError: number;
+  axialDistance: number;
+  frameStep: number;
   distanceTravelled: number;
 }> {
   await game.input.set("right_hand.position", handLocalPosition);
-  await game.input.set("right_hand.rotation", qFromTo([0, 0, -1], norm(aimDirection)));
+  await game.input.set("right_hand.rotation", quatFromTo([0, 0, -1], normalize(aimDirection)));
   await game.input.set("right_hand.squeeze", 1);
   await game.step({ frames: 5 });
 
   const weapon = await entityTransform(game, weaponId);
   const vhot = MUZZLE_VHOT[weapon.model];
-  assert.ok(
-    vhot,
-    `VR should wield a view model with a known muzzle vhot, got "${weapon.model}"`,
-  );
-  const muzzle = add(weapon.position, qrot(weapon.rotation, vhot));
-  // Dark gun models are authored with the barrel along the model's -X axis.
-  const barrel = qrot(weapon.rotation, [-1, 0, 0]);
+  assert.ok(vhot, `VR should wield a view model with a known muzzle vhot, got "${weapon.model}"`);
+  const muzzle = add(weapon.position, quatRotate(weapon.rotation, vhot));
+  // The 25AE view models are authored with the barrel along the model's -X.
+  const barrel = quatRotate(weapon.rotation, [-1, 0, 0]);
 
   const before = new Set((await game.entities.list()).entities.map((e) => e.id));
   await game.input.set("right_hand.trigger", 1);
   await game.step({ frames: 1 });
   await game.input.set("right_hand.trigger", 0);
+  // The trigger frame spawns the projectile and integrates it once; the first
+  // loop iteration below steps once more before it can be observed. So the
+  // first sample sits FLIGHT_FRAMES_BEFORE_FIRST_SAMPLE frames down the barrel
+  // from where the shot actually started.
 
   const track: Vec3[] = [];
   for (let frame = 0; frame < 30; frame += 1) {
@@ -159,16 +137,43 @@ async function fireAndTrack(
     );
     if (shot) track.push(shot.position as Vec3);
   }
-  assert.ok(track.length >= 2, "the trigger pull must spawn a travelling projectile");
+  assert.ok(track.length >= 3, "the trigger pull must spawn a travelling projectile");
 
   const travel = sub(track[track.length - 1], track[0]);
+  const heading = normalize(travel);
+  const muzzleToFirst = sub(track[0], muzzle);
+  const axialDistance = dot(muzzleToFirst, heading);
+  const lateral = sub(muzzleToFirst, scale(heading, axialDistance));
+
   return {
-    muzzle,
-    barrel,
-    firstSeen: track[0],
-    travel,
+    barrelDeviationDeg: angleBetweenDeg(travel, barrel),
+    lateralError: len(lateral),
+    axialDistance,
+    frameStep: len(sub(track[1], track[0])),
     distanceTravelled: len(travel),
   };
+}
+
+/** Assert a shot left the muzzle vhot travelling down the barrel. */
+function assertLeftTheMuzzle(
+  shot: Awaited<ReturnType<typeof fireAndTrack>>,
+  what: string,
+): void {
+  assert.ok(
+    shot.barrelDeviationDeg < 1,
+    `the ${what} must travel along the rendered barrel, deviated ${shot.barrelDeviationDeg.toFixed(2)} degrees`,
+  );
+  assert.ok(
+    shot.lateralError < 0.05,
+    `the ${what}'s flight path must pass through the muzzle vhot, missing it sideways by ${shot.lateralError.toFixed(3)} world units`,
+  );
+  const expectedAxial = shot.frameStep * FLIGHT_FRAMES_BEFORE_FIRST_SAMPLE;
+  assert.ok(
+    Math.abs(shot.axialDistance - expectedAxial) < shot.frameStep * 0.25,
+    `the ${what} must start at the muzzle: it was ${shot.axialDistance.toFixed(3)} units along the barrel after ` +
+      `${FLIGHT_FRAMES_BEFORE_FIRST_SAMPLE} frames of flight, expected ${expectedAxial.toFixed(3)} ` +
+      `(one frame is ${shot.frameStep.toFixed(3)})`,
+  );
 }
 
 test(
@@ -205,21 +210,7 @@ test(
       (e) => e.name === "Laser Shot",
     );
 
-    const deviation = angleBetweenDeg(shot.travel, shot.barrel);
-    assert.ok(
-      deviation < 1,
-      `the bolt must travel along the rendered barrel, deviated ${deviation.toFixed(2)} degrees`,
-    );
-
-    // The projectile is first observed one frame after the shot, so compare its
-    // back-projection to the muzzle rather than the raw first sample.
-    const origin = sub(shot.firstSeen, scale(norm(shot.travel), len(sub(shot.firstSeen, shot.muzzle))));
-    const originError = len(sub(origin, shot.muzzle));
-    assert.ok(
-      originError < 0.05,
-      `the bolt must leave the muzzle vhot, missed it by ${originError.toFixed(3)} world units`,
-    );
-
+    assertLeftTheMuzzle(shot, "bolt");
     // A full-range flight: with the 12 degree skew the bolt used to spang on
     // the player's own collider a fraction of a unit out.
     assert.ok(
@@ -257,17 +248,6 @@ test(
       (e) => e.name.startsWith("Cryo PSI"),
     );
 
-    const deviation = angleBetweenDeg(shot.travel, shot.barrel);
-    assert.ok(
-      deviation < 1,
-      `the cryo bolt must travel along the barrel, deviated ${deviation.toFixed(2)} degrees`,
-    );
-
-    const origin = sub(shot.firstSeen, scale(norm(shot.travel), len(sub(shot.firstSeen, shot.muzzle))));
-    const originError = len(sub(origin, shot.muzzle));
-    assert.ok(
-      originError < 0.05,
-      `the cryo bolt must leave the muzzle vhot, missed it by ${originError.toFixed(3)} world units`,
-    );
+    assertLeftTheMuzzle(shot, "cryo bolt");
   },
 );


### PR DESCRIPTION
Fixes #1033.

## The bug

In VR the laser pistol's bolt did not come out of the barrel. Held anywhere near the body it crossed in front of the player and spanged on their own collider instead of reaching the target.

Measured headlessly in `debug_weapons --vr` (VR hand grabs the pistol, is posed pointing along -X, fires):

| | before | after |
|---|---|---|
| travel vs. rendered barrel | **12.00 degrees off** | **0.00 degrees** |
| spawn vs. muzzle vhot | **0.16 world units off** | **< 0.01** |
| miss at 11 units of range | **2.5 world units** | 0 |
| fired from a hold at the body | **spangs on the player, 0.43 units out** | flies the full 11 units to the wall |

![VR laser bolt leaving the muzzle](https://gist.githubusercontent.com/tommy-xr/eb7e8a6df1bad5699e39d01d0500b655/raw/vr-projectile-origin.gif)

<sub>AFTER: the VR hand holds the laser pistol in front of the camera in `debug_weapons --vr`, aims down -X and fires; the bolt leaves the visible muzzle and flies the full 11 units into the wall. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before -> after: the bolt vs. the barrel

![before/after bolt path with the weapon in frame](https://gist.githubusercontent.com/tommy-xr/eb7e8a6df1bad5699e39d01d0500b655/raw/vr-projectile-origin-beforeafter.png)

<sub>Same deterministic sequence on both builds - same grab, same hand pose, same trigger frame - with the frames of the bolt's flight blended into one image. Left: the pre-fix bolt starts detached from the gun and angles away. Right: the fixed bolt emerges from the muzzle and recedes along the barrel.</sub>

<sub>**Read this one as "does it come out of the gun", not as an angle.** The camera necessarily looks *down* the barrel, which foreshortens the 12 degrees; a genuinely side-on framing isn't available, because `debug_weapons` only has geometry toward -X and turning to get one fills the frame with void. The panel below is the decisive evidence.</sub>

### Before -> after: where it lands

![before/after impact point on the wall](https://gist.githubusercontent.com/tommy-xr/eb7e8a6df1bad5699e39d01d0500b655/raw/vr-projectile-origin-impact.png)

<sub>The wall at the moment of impact (16 steps after firing), magnified. Dashed yellow marks where the rendered barrel points; the blue circle marks the spang. Before, the impact is ~1.9 world units off that line - the bolt spawns at z 0.22 and drifts +0.17 per step to z 2.18 by the wall. After, z holds at 0.28 from muzzle to wall: no drift at all. The residual y difference between the two (2.14 vs 2.29) is the 0.16-unit muzzle-vhot offset the old code also got wrong.</sub>

## Root cause

`create_projectile`'s VR branch reached the muzzle by applying the hand grip rotation a **second** time and undoing it on the spawn point:

```rust
position       = grip_rotation.invert() * vhot
root_transform = weapon_transform * grip_rotation * projectile_rotation
```

`grip_rotation` is already baked into `weapon_transform` by `virtual_hand`. The construction only landed on the barrel because every gun grip happens to be a -90 degree yaw — and it left `projectile_rotation` as a per-weapon escape hatch. The laser pistol carried 12 degrees of it, from the era when VR wielded the **`laser` world model, which has zero vhots**: the bolt spawned at the grip and the fudge nudged it. Since #1023 VR wields `lasehand`, which does carry a real muzzle vhot at the -X barrel tip, so the fudge became pure error — applied to *both* the spawn point and the direction.

## The fix

One faithful, shared mechanism, no per-weapon special cases: spawn at the model's muzzle vhot, travelling along the model's **-X** — the axis Dark's first-person gun models author their barrel on, where each of them puts its muzzle vhot, and the axis every grip entry's -90 degree yaw exists to point out of the hand.

```rust
root_transform: weapon_transform
    * Matrix4::from_translation(muzzle_vhot)
    * Matrix4::from(barrel_axis_from_forward())   // yaw -90: +Z travel axis -> model -X
```

`projectile_rotation` is **deleted** rather than retuned, so no weapon can carry a private aim correction again, and a `vr_config` test pins every VR-wieldable gun's grip to that convention.

**Documented fallback**: a model with no vhot fires from the model origin (the grip). This covers `empgun_h`, `gren_h`, `fsn_h`, `al_h` (which ship with zero vhots) and the classic world models — unchanged from before, and tracked in #1034.

**Flat is untouched** — it returns earlier, from the crosshair ray. Verified: `world-aim`, `muzzle-flash`, `projectile-trail`, `close-range-projectile`, `slow-projectile-spang`, `ally-line-of-fire` and all `weapon-*` e2e tests pass unchanged.

## The psi amp

The backlog also listed "vr: psi amp cry doesn't come out (maybe reversed?)". **It is not reproducible on current `main`** — I measured the amp firing from its `amp_h` muzzle vhot exactly along the barrel (0.00 degrees deviation) in four hand poses including rolled and off-axis ones, and in both hands. It was almost certainly fixed by #1023, which moved VR from the offset-less `amp_w` world model to `amp_h` with a fitted grip. Rather than leave that to rot, this PR pins it: the psi-amp e2e case is new here and passes on the pre-fix build too.

## Verification

Negative-first, as required:

- **e2e (`tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts`)** — drives the production VR hand (grab, pose, trigger) and asserts, against the weapon's live transform, that the shot's heading is within 1 degree of the rendered barrel, that its flight path passes within 0.05 units of the muzzle vhot laterally, and that its axial distance matches the elapsed frames of flight (so a spawn displaced *along* the barrel is caught too). **Confirmed failing on pre-fix code** at exactly `12.00 degrees`; green after.
- **Rust unit tests** — `a_vr_shot_leaves_the_muzzle_vhot_along_the_barrel` checks the returned `CreateEntity` numerically in an awkward yawed/pitched/translated pose; plus the vhot-less fallback, and the `vr_config` grip-convention test.
- `cargo fmt --all --check`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr --lib` (817 pass), and `missions.e2e.test.ts` (all 23 missions load).

## Review

`/xreview` (Claude + Codex + a dedup pass) found no ship-blocking correctness issue in the production change, and both engines agreed on two test-quality points, both applied: the origin assertion could not detect an along-barrel displacement, and the test duplicated `test/helpers/vr-hand.ts`'s quaternion math for the third time. The Claude reviewer additionally decoded the shipped meshes and showed the doc/test were certifying the -X barrel convention over world models where it is false — corrected in the second commit, and filed as #1034 along with the vhot-less view models and the `vhots.first()` vs. type-sort hazard.


