### PR TITLE
feat(vr): player damage feedback with a hurt grunt and a hit vignette

### DIFF
--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -71,6 +71,9 @@ pub use basic_material::BasicMaterial;
 pub mod color_material;
 pub use color_material::ColorMaterial;
 
+pub mod vignette_material;
+pub use vignette_material::VignetteMaterial;
+
 pub mod debug_normal_material;
 pub use debug_normal_material::{
     DebugNormalMaterial, DebugNormalSkinnedMaterial, create as create_debug_normal_material,

--- a/engine/src/scene/vignette_material.rs
+++ b/engine/src/scene/vignette_material.rs
@@ -1,0 +1,198 @@
+extern crate gl;
+use crate::engine::EngineRenderContext;
+use crate::scene::Material;
+use crate::shader_program::ShaderProgram;
+
+use c_string::*;
+use cgmath::prelude::*;
+use cgmath::{Matrix4, Vector3};
+use once_cell::sync::OnceCell;
+use std::any::Any;
+
+/// A flat quad that is transparent in the middle and tinted at the rim.
+///
+/// The falloff is computed per-fragment from the quad's own UVs rather than
+/// baked into a texture, because the layer this material exists for is a
+/// *view-locked* quad: it is sized by an angular ratio, so where the rim lands
+/// is a property of the geometry, and the two radii below are the only knobs.
+/// A texture would have to be regenerated whenever those radii changed, and a
+/// textured world-space material in this engine either alpha-*cuts* (see
+/// `basic_material`'s `discard`) or is screen-space only - neither of which can
+/// draw a soft ramp in the world.
+const VERTEX_SHADER_SOURCE: &str = r#"
+        layout (location = 0) in vec3 inPos;
+        layout (location = 1) in vec2 inTex;
+
+        uniform mat4 world;
+        uniform mat4 view;
+        uniform mat4 projection;
+
+        out vec2 texCoord;
+
+        void main() {
+            texCoord = inTex;
+            gl_Position = projection * view * world * vec4(inPos, 1.0);
+        }
+"#;
+
+/// `radius` is 0 at the quad's centre and 1 at the middle of each edge (so it
+/// keeps going past 1 into the corners, which stay fully tinted).
+const FRAGMENT_SHADER_SOURCE: &str = r#"
+        out vec4 fragColor;
+
+        in vec2 texCoord;
+
+        uniform vec3 color;
+        uniform float intensity;
+        uniform float innerRadius;
+        uniform float outerRadius;
+
+        void main() {
+            float radius = length(texCoord - vec2(0.5, 0.5)) * 2.0;
+            float span = max(outerRadius - innerRadius, 0.0001);
+            float t = clamp((radius - innerRadius) / span, 0.0, 1.0);
+            // Smoothstep, so the rim has no visible banding edge where it
+            // meets the clear centre.
+            float ramp = t * t * (3.0 - 2.0 * t);
+            fragColor = vec4(color, ramp * intensity);
+        }
+"#;
+
+struct Uniforms {
+    world_loc: i32,
+    view_loc: i32,
+    projection_loc: i32,
+    color_loc: i32,
+    intensity_loc: i32,
+    inner_radius_loc: i32,
+    outer_radius_loc: i32,
+}
+
+static SHADER_PROGRAM: OnceCell<(ShaderProgram, Uniforms)> = OnceCell::new();
+
+pub struct VignetteMaterial {
+    has_initialized: bool,
+    color: Vector3<f32>,
+    /// Peak opacity at the rim, 0..1.
+    intensity: f32,
+    /// Radius (in the units described on [`FRAGMENT_SHADER_SOURCE`]) where the
+    /// tint starts, and where it reaches full [`intensity`](Self::intensity).
+    inner_radius: f32,
+    outer_radius: f32,
+}
+
+impl Material for VignetteMaterial {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn has_initialized(&self) -> bool {
+        self.has_initialized
+    }
+
+    fn initialize(&mut self, is_opengl_es: bool) {
+        let _ = SHADER_PROGRAM.get_or_init(|| {
+            let vertex_shader = crate::shader::build(
+                VERTEX_SHADER_SOURCE,
+                crate::shader::ShaderType::Vertex,
+                is_opengl_es,
+            );
+
+            let fragment_shader = crate::shader::build(
+                FRAGMENT_SHADER_SOURCE,
+                crate::shader::ShaderType::Fragment,
+                is_opengl_es,
+            );
+
+            unsafe {
+                let shader = crate::shader_program::link(&vertex_shader, &fragment_shader);
+                let uniforms = Uniforms {
+                    world_loc: gl::GetUniformLocation(shader.gl_id, c_str!("world").as_ptr()),
+                    view_loc: gl::GetUniformLocation(shader.gl_id, c_str!("view").as_ptr()),
+                    projection_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("projection").as_ptr(),
+                    ),
+                    color_loc: gl::GetUniformLocation(shader.gl_id, c_str!("color").as_ptr()),
+                    intensity_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("intensity").as_ptr(),
+                    ),
+                    inner_radius_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("innerRadius").as_ptr(),
+                    ),
+                    outer_radius_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("outerRadius").as_ptr(),
+                    ),
+                };
+                (shader, uniforms)
+            }
+        });
+
+        self.has_initialized = true;
+    }
+
+    /// Always translucent - a vignette that wrote colour into the opaque pass
+    /// would paint a solid rectangle over the world. The reported value is the
+    /// transparency at the *rim*, which is what an observer (`/v1/scene`,
+    /// a reviewer) means by "how strong is the effect".
+    fn transparency(&self) -> Option<f32> {
+        Some((1.0 - self.intensity).clamp(0.0, 1.0))
+    }
+
+    fn draw_opaque(
+        &self,
+        _render_context: &EngineRenderContext,
+        _view_matrix: &Matrix4<f32>,
+        _world_matrix: &Matrix4<f32>,
+        _skinning_data: &[Matrix4<f32>],
+        _lights: &crate::scene::light::LightArray,
+    ) -> bool {
+        false
+    }
+
+    fn draw_transparent(
+        &self,
+        render_context: &EngineRenderContext,
+        view_matrix: &Matrix4<f32>,
+        world_matrix: &Matrix4<f32>,
+        _skinning_data: &[Matrix4<f32>],
+        _lights: &crate::scene::light::LightArray,
+    ) -> bool {
+        let (shader_program, uniforms) = SHADER_PROGRAM.get().expect("shader not compiled");
+        unsafe {
+            gl::UseProgram(shader_program.gl_id);
+
+            let projection = render_context.projection_matrix;
+            gl::UniformMatrix4fv(uniforms.world_loc, 1, gl::FALSE, world_matrix.as_ptr());
+            gl::UniformMatrix4fv(uniforms.view_loc, 1, gl::FALSE, view_matrix.as_ptr());
+            gl::UniformMatrix4fv(uniforms.projection_loc, 1, gl::FALSE, projection.as_ptr());
+            gl::Uniform3fv(uniforms.color_loc, 1, self.color.as_ptr());
+            gl::Uniform1f(uniforms.intensity_loc, self.intensity);
+            gl::Uniform1f(uniforms.inner_radius_loc, self.inner_radius);
+            gl::Uniform1f(uniforms.outer_radius_loc, self.outer_radius);
+        }
+        true
+    }
+}
+
+pub fn create(
+    color: Vector3<f32>,
+    intensity: f32,
+    inner_radius: f32,
+    outer_radius: f32,
+) -> Box<dyn Material> {
+    Box::new(VignetteMaterial {
+        has_initialized: false,
+        color,
+        intensity: intensity.clamp(0.0, 1.0),
+        inner_radius,
+        outer_radius,
+    })
+}

--- a/shock2vr/src/hit_feedback.rs
+++ b/shock2vr/src/hit_feedback.rs
@@ -55,59 +55,71 @@ const TINT_COLOR: Vector3<f32> = Vector3 {
     z: 0.02,
 };
 
-/// How far in front of the eyes the layer hangs, in metres. Near enough that
-/// nothing in the world can be between it and the eye in practice; the layer
-/// clears depth anyway, so this only has to stay outside the near plane.
-const LAYER_DISTANCE: f32 = 0.6;
+/// How far in front of the eyes the layer hangs, in metres.
+///
+/// Far rather than near, and for one reason: **stereo**. This is one quad
+/// shared by both eyes, hung from the runtime's head pose, so an eye 32 mm off
+/// that pose sees it shifted by `atan(0.032 / distance)`. At half a metre that
+/// is 3.7 degrees of disagreement between the eyes about where the rim is; out
+/// here it is under a degree, the same margin the pause menu's dim relies on.
+/// Depth is not a consideration - the layer clears depth, so nothing in the
+/// world can occlude it at any distance.
+const LAYER_DISTANCE: f32 = 2.5;
 
-/// Half-edge of the layer quad as a multiple of its distance, so coverage is
-/// an angle and not a size: `atan(5.0)` = 78.7 degrees off-axis in every
-/// direction, against a Quest's ~55 degree half-field. This is the same
-/// argument (and the same number) as the pause menu's comfort dim - see
-/// `pause_menu::WORLD_DIM_EXTENT_RATIO`.
-const LAYER_EXTENT_RATIO: f32 = 5.0;
+/// How much bigger than the frustum the quad is cut. The quad is sized to the
+/// picture exactly (see [`hit_layer`]), so a little slack absorbs a head that
+/// turned between the pose the layer was hung from and the pose the frame is
+/// rendered at, and any small disagreement between a host's reported and
+/// actual frustum. It costs nothing but a few pixels of fully-tinted margin.
+const COVERAGE_MARGIN: f32 = 1.25;
 
 /// Where the tint starts and where it reaches full strength, as fractions of
-/// how far the presentation's field of view actually reaches. Everything
-/// inside [`CLEAR_FIELD_FRACTION`] is untouched - that is the part of the
-/// field the player aims and reads with - and the tint is at full strength by
-/// the edge of the picture.
+/// the way from the view axis to the edge of the picture. Everything inside
+/// [`CLEAR_FIELD_FRACTION`] is untouched - that is the part of the field the
+/// player aims and reads with - and the tint is at full strength by the edge.
+///
+/// Being *fractions of the picture* is what makes this render identically in
+/// flat and VR (AGENTS.md section 3) without a per-presentation branch: the
+/// picture's own extents come from the host's projection matrix, so the same
+/// two numbers describe the same visible effect on a 45-degree monitor and on
+/// a headset's much wider asymmetric per-eye frustum.
 const CLEAR_FIELD_FRACTION: f32 = 0.5;
 const FULL_FIELD_FRACTION: f32 = 1.0;
 
-/// A sane fallback half-field, in degrees, for the frames before any
-/// projection has been seen: the ~29 degrees both flat runtimes' 45-degree
-/// 4:3 `perspective` gives.
-pub const DEFAULT_HALF_FIELD_DEG: f32 = 29.0;
-
-/// How far the picture reaches sideways from the view axis, read straight off
-/// the projection the host is rendering with.
+/// How far the picture reaches from the view axis, as the tangents of the
+/// half-angles on each axis: `(horizontal, vertical)`.
 ///
-/// This is why there is **no per-presentation branch in this module**
-/// (AGENTS.md section 3): a rim effect is only a rim effect relative to where
-/// the picture ends, and flat and VR disagree about that by roughly a factor
-/// of two - both flat runtimes build `perspective(Deg(45.0))` while a Quest
-/// eye reaches about 55 degrees. Hardcoding one angle is what the first cut
-/// did, and it made the tint invisible on flat, with the whole ramp past the
-/// edge of the screen. Hardcoding *two* would then have been a lie in the
-/// debug runtime, whose `--vr` mode renders with the flat 45-degree
-/// projection. Asking the projection is right everywhere, including on a
-/// headset whose per-eye frustum is asymmetric.
-///
-/// For any perspective or off-axis frustum, `m[0][0]` is `2n / (r - l)`, so
-/// its reciprocal is the tangent of half the horizontal extent.
-pub fn half_field_deg_from_projection(projection: Matrix4<f32>) -> f32 {
-    let m00 = projection.x.x;
-    if !m00.is_finite() || m00 <= 0.0 {
-        return DEFAULT_HALF_FIELD_DEG;
-    }
-    (1.0 / m00).atan().to_degrees().clamp(5.0, 85.0)
-}
+/// The fallback is what both flat runtimes' `perspective(Deg(45.0))` on a 4:3
+/// target gives, for the frames before any projection has been seen.
+pub const DEFAULT_VIEW_EXTENTS: (f32, f32) = (0.552_28, 0.414_21);
 
-/// Convert a half-angle off the view axis into the shader's radius units,
-/// where 1.0 is the middle of the quad's edge.
-fn radius_at_half_angle(degrees: f32) -> f32 {
-    degrees.to_radians().tan() / LAYER_EXTENT_RATIO
+/// Read [`DEFAULT_VIEW_EXTENTS`]'s quantity off the projection the host is
+/// actually rendering with.
+///
+/// Hardcoding one angle is what the first cut did, and it made the tint
+/// invisible on flat: the ramp was authored for a headset's ~55 degrees and
+/// the whole of it sat past the edge of a 45-degree screen. Hardcoding *two*
+/// (one per presentation) would then have been a lie in the debug runtime,
+/// whose `--vr` mode renders with the flat projection. Asking the projection
+/// is right everywhere.
+///
+/// For any perspective or off-axis frustum, `m[0][0]` is `2n / (r - l)` and
+/// `m[1][1]` is `2n / (t - b)`, so their reciprocals are the tangents of half
+/// the horizontal and vertical extents. Reading **both** matters: a 4:3 screen
+/// reaches 29 degrees sideways but only 22.5 up, and a single radius would
+/// tint a different fraction of the picture on each axis.
+pub fn view_extents_from_projection(projection: Matrix4<f32>) -> (f32, f32) {
+    let extent = |scale: f32, fallback: f32| {
+        if scale.is_finite() && scale > 0.0 {
+            (1.0 / scale).clamp(0.05, 10.0)
+        } else {
+            fallback
+        }
+    };
+    (
+        extent(projection.x.x, DEFAULT_VIEW_EXTENTS.0),
+        extent(projection.y.y, DEFAULT_VIEW_EXTENTS.1),
+    )
 }
 
 /// Peak rim opacity for a hit of `damage` hit points.
@@ -173,16 +185,18 @@ impl HitFeedback {
 
     /// Record a hit of `damage` applied hit points.
     ///
-    /// A second hit while one is still showing restarts the decay, and never
-    /// makes the tint jump *down*: taking a graze mid-fade from a shotgun
-    /// blast must not look like the blast stopped hurting. So the new peak is
-    /// the stronger of the incoming hit and whatever is on screen right now.
+    /// A second hit while one is still showing restarts the decay, and can
+    /// only ever make the tint *stronger or longer*, never weaker or shorter:
+    /// taking a graze mid-fade from a shotgun blast must not look like the
+    /// blast stopped hurting, and must not cut its fade short either. So both
+    /// the peak and the lifetime are the larger of the incoming hit and what
+    /// is already on screen.
     pub fn trigger(&mut self, damage: f32) {
         if damage <= 0.0 {
             return;
         }
         self.peak = peak_opacity(damage).max(self.intensity());
-        self.duration = duration_secs(damage);
+        self.duration = duration_secs(damage).max(self.remaining);
         self.remaining = self.duration;
     }
 
@@ -212,11 +226,11 @@ impl HitFeedback {
     /// `eye_position` and `eye_forward` are in the same space the returned
     /// object is consumed in - `Game` builds them in pawn space and maps the
     /// result with its pawn-to-world transform, exactly as it does for the
-    /// pause panel. `half_field_deg` comes from the host's own projection -
-    /// see [`half_field_deg_from_projection`].
+    /// pause panel. `view_extents` comes from the host's own projection - see
+    /// [`view_extents_from_projection`].
     pub fn render(
         &self,
-        half_field_deg: f32,
+        view_extents: (f32, f32),
         eye_position: Vector3<f32>,
         eye_forward: Vector3<f32>,
     ) -> Option<SceneObject> {
@@ -225,7 +239,7 @@ impl HitFeedback {
             return None;
         }
         Some(hit_layer(
-            half_field_deg,
+            view_extents,
             eye_position,
             eye_forward,
             intensity,
@@ -245,22 +259,31 @@ impl HitFeedback {
 /// also disagree about winding, and a culled half was the original #1020 bug.
 ///
 /// Because it is view-locked, the *same* code serves flat and VR: the eye pose
-/// differs, and the ramp is mapped onto whatever field of view the host is
-/// actually rendering (see [`half_field_deg_from_projection`]). Nothing else
-/// does.
+/// differs, and the quad is cut to whatever picture the host is rendering (see
+/// [`view_extents_from_projection`]). Nothing else does.
+///
+/// The quad is cut to the frustum on **each axis separately** and the ramp is
+/// then a plain circle in the quad's own UVs, which is what makes the tint
+/// cover the same fraction of the picture sideways and vertically on a 4:3
+/// screen (29 degrees across, 22.5 up) as it does on a near-square headset eye.
 fn hit_layer(
-    half_field: f32,
+    view_extents: (f32, f32),
     eye_position: Vector3<f32>,
     eye_forward: Vector3<f32>,
     intensity: f32,
 ) -> SceneObject {
-    let extent = LAYER_DISTANCE * LAYER_EXTENT_RATIO;
+    let (horizontal, vertical) = view_extents;
+    let width = 2.0 * LAYER_DISTANCE * horizontal * COVERAGE_MARGIN;
+    let height = 2.0 * LAYER_DISTANCE * vertical * COVERAGE_MARGIN;
     let mut object = SceneObject::new(
         engine::scene::vignette_material::create(
             TINT_COLOR,
             intensity,
-            radius_at_half_angle(half_field * CLEAR_FIELD_FRACTION),
-            radius_at_half_angle(half_field * FULL_FIELD_FRACTION),
+            // The quad is `COVERAGE_MARGIN` wider than the picture, so the
+            // edge of the picture sits at `1 / COVERAGE_MARGIN` in the shader's
+            // radius units and the fractions scale down to match.
+            CLEAR_FIELD_FRACTION / COVERAGE_MARGIN,
+            FULL_FIELD_FRACTION / COVERAGE_MARGIN,
         ),
         Box::new(engine::scene::quad::create()),
     );
@@ -269,7 +292,7 @@ fn hit_layer(
             // The quad's +Z faces the viewer once it is turned to look back
             // along the gaze.
             * Matrix4::from(crate::util::get_rotation_from_forward_vector(-eye_forward))
-            * Matrix4::from_scale(extent * 2.0),
+            * Matrix4::from_nonuniform_scale(width, height, 1.0),
     );
     // Translucent: writing depth here would let the layer occlude anything
     // drawn after it in the same overlay group.
@@ -289,33 +312,16 @@ fn hit_layer(
 
 /// The eye pose to hang the layer from, in pawn space.
 ///
-/// An untracked head arrives as the ZERO quaternion, which cgmath's
-/// `rotate_vector` silently returns *unrotated* - so it is treated as "no
-/// pose" and the pawn's own default eye stands in, rather than as a valid
-/// forward that would hang the layer off to one side (VR rule 7).
+/// An untracked head has no usable pose (see [`crate::util::tracked_gaze`]);
+/// the pawn's own default eye, looking straight ahead, stands in for it.
 pub fn eye_pose(
     head_position: Vector3<f32>,
     head_rotation: Quaternion<f32>,
 ) -> (Vector3<f32>, Vector3<f32>) {
-    use cgmath::{InnerSpace, Rotation};
-    if head_rotation.magnitude2() < 1e-6 {
-        return (
-            vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0),
-            vec3(0.0, 0.0, -1.0),
-        );
-    }
-    (
-        head_position,
-        head_rotation
-            .normalize()
-            .rotate_vector(vec3(0.0, 0.0, -1.0)),
-    )
-}
-
-/// Only used to document the angular constants in tests.
-#[cfg(test)]
-fn half_angle_at_radius(radius: f32) -> cgmath::Deg<f32> {
-    cgmath::Deg((radius * LAYER_EXTENT_RATIO).atan().to_degrees())
+    crate::util::tracked_gaze(head_position, head_rotation).unwrap_or((
+        vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0),
+        vec3(0.0, 0.0, -1.0),
+    ))
 }
 
 #[cfg(test)]
@@ -329,7 +335,7 @@ mod tests {
         assert_eq!(feedback.intensity(), 0.0);
         assert!(
             feedback
-                .render(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
+                .render(VR_EXTENTS, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
                 .is_none()
         );
     }
@@ -341,7 +347,7 @@ mod tests {
         assert!(feedback.intensity() > 0.0);
         assert!(
             feedback
-                .render(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
+                .render(VR_EXTENTS, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
                 .is_some()
         );
 
@@ -356,7 +362,7 @@ mod tests {
         assert_eq!(feedback.intensity(), 0.0);
         assert!(
             feedback
-                .render(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
+                .render(VR_EXTENTS, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
                 .is_none()
         );
     }
@@ -401,6 +407,24 @@ mod tests {
         );
     }
 
+    /// ...and it must not cut the fade short either: a 1-point graze arriving
+    /// a quarter of the way through a shotgun blast's fade would otherwise
+    /// replace 0.64 s of remaining tint with the graze's own 0.39 s.
+    #[test]
+    fn a_graze_mid_fade_never_shortens_the_fade() {
+        let mut feedback = HitFeedback::new();
+        feedback.trigger(12.0);
+        feedback.update(duration_secs(12.0) * 0.25);
+        let remaining_before = feedback.remaining;
+
+        feedback.trigger(1.0);
+        assert!(
+            feedback.remaining >= remaining_before,
+            "a graze cut the fade from {remaining_before} to {}",
+            feedback.remaining
+        );
+    }
+
     #[test]
     fn clearing_removes_a_tint_in_flight() {
         let mut feedback = HitFeedback::new();
@@ -417,70 +441,101 @@ mod tests {
         assert_eq!(hurt_schema(25.0), "dam_gen_hi");
     }
 
-    /// A Quest eye reaches about this far off-axis; used to stand in for a
-    /// headset in these tests.
-    const VR_HALF_FIELD: f32 = 55.0;
-    /// What both flat runtimes' `perspective(Deg(45.0))` on 4:3 gives.
-    const FLAT_HALF_FIELD: f32 = 29.0;
+    /// What both flat runtimes' `perspective(Deg(45.0))` on a 4:3 target
+    /// gives, and roughly what one Quest eye reaches. Used to stand in for a
+    /// monitor and for a headset.
+    const FLAT_EXTENTS: (f32, f32) = DEFAULT_VIEW_EXTENTS;
+    const VR_EXTENTS: (f32, f32) = (1.428, 1.428);
+
+    /// Where the picture's own edge lands in the shader's radius units.
+    const PICTURE_EDGE_RADIUS: f32 = 1.0 / COVERAGE_MARGIN;
 
     /// The whole comfort argument is that the middle of the field is left
     /// alone. If the ramp ever started at the view axis this would be the
     /// full-screen flash the design rejects.
     ///
     /// And - the bug that shipped in the first cut and was caught by looking at
-    /// a flat screenshot - the ramp has to land *inside the picture*. Sharing
-    /// one absolute angle across both presentations put flat's whole ramp past
-    /// the edge of a 45-degree screen, so a hit rendered as nothing at all.
+    /// a flat screenshot - the ramp has to land *inside the picture*. Authoring
+    /// it as an absolute angle put flat's whole ramp past the edge of a
+    /// 45-degree screen, so a hit rendered as nothing at all.
     #[test]
-    fn the_tint_lands_inside_the_picture_at_any_field_of_view() {
-        for half_field in [FLAT_HALF_FIELD, VR_HALF_FIELD, 75.0] {
-            let inner = radius_at_half_angle(half_field * CLEAR_FIELD_FRACTION);
-            let outer = radius_at_half_angle(half_field * FULL_FIELD_FRACTION);
+    fn the_tint_lands_inside_the_picture() {
+        let inner = CLEAR_FIELD_FRACTION / COVERAGE_MARGIN;
+        let outer = FULL_FIELD_FRACTION / COVERAGE_MARGIN;
+        assert!(inner > 0.0, "the tint must not start on the view axis");
+        assert!(outer > inner, "the ramp must have width");
+        assert!(
+            inner < PICTURE_EDGE_RADIUS * 0.75,
+            "the ramp starts too near the edge of the picture to be seen"
+        );
+        assert!(
+            outer <= PICTURE_EDGE_RADIUS,
+            "the tint never reaches full strength inside the picture"
+        );
+    }
+
+    /// The quad has to cover the picture it is cut for - on both axes, and
+    /// with room for the head to have turned since the pose it was hung from.
+    /// A quad that fell short would leave an untinted band at the edge, which
+    /// is exactly where the effect lives.
+    #[test]
+    fn the_quad_covers_the_whole_picture_on_both_axes() {
+        for extents in [FLAT_EXTENTS, VR_EXTENTS] {
+            let object = hit_layer(extents, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+            let transform = object.get_transform();
+            // The quad spans -0.5..0.5 before its scale, so a corner maps to
+            // the half-extents.
+            let corner = transform * cgmath::vec4(0.5, 0.5, 0.0, 1.0);
+            let picture_half_width = LAYER_DISTANCE * extents.0;
+            let picture_half_height = LAYER_DISTANCE * extents.1;
             assert!(
-                inner > 0.0,
-                "{half_field}: the tint must not start on the view axis"
+                corner.x.abs() > picture_half_width,
+                "{extents:?}: the quad is narrower than the picture"
             );
-            assert!(outer > inner, "{half_field}: the ramp must have width");
             assert!(
-                half_angle_at_radius(inner) < cgmath::Deg(half_field * 0.75),
-                "{half_field}: the ramp starts too near the edge of the picture to be seen"
-            );
-            assert!(
-                half_angle_at_radius(outer) <= cgmath::Deg(half_field + 1.0),
-                "{half_field}: the tint never reaches full strength inside the picture"
+                corner.y.abs() > picture_half_height,
+                "{extents:?}: the quad is shorter than the picture"
             );
         }
     }
 
-    /// Flat and VR must tint the *same fraction* of the picture - that is what
-    /// "renders identically" means for an effect defined in the field of view
-    /// rather than in pixels.
+    /// A 4:3 monitor reaches further sideways than up, so a quad cut to one
+    /// axis would tint a different fraction of the picture on the other. The
+    /// quad is cut per axis precisely so the circular UV ramp lands at the
+    /// same fraction of the way to the edge everywhere.
     #[test]
-    fn every_field_of_view_tints_the_same_fraction_of_the_picture() {
-        let fractions: Vec<f32> = [FLAT_HALF_FIELD, VR_HALF_FIELD]
-            .into_iter()
-            .map(|half_field| {
-                half_angle_at_radius(radius_at_half_angle(half_field * CLEAR_FIELD_FRACTION)).0
-                    / half_field
-            })
-            .collect();
-        assert!((fractions[0] - fractions[1]).abs() < 1e-3, "{fractions:?}");
+    fn the_quad_is_cut_to_the_pictures_own_aspect() {
+        let object = hit_layer(FLAT_EXTENTS, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+        let corner = object.get_transform() * cgmath::vec4(0.5, 0.5, 0.0, 1.0);
+        let quad_aspect = corner.x.abs() / corner.y.abs();
+        let picture_aspect = FLAT_EXTENTS.0 / FLAT_EXTENTS.1;
+        assert!(
+            (quad_aspect - picture_aspect).abs() < 1e-3,
+            "quad aspect {quad_aspect} does not match the picture's {picture_aspect}"
+        );
     }
 
-    /// The flat runtimes' own projection must come back out as the flat field.
+    /// The flat runtimes' own projection must come back out as the flat
+    /// picture, on both axes.
     #[test]
-    fn the_field_is_read_off_the_projection_the_host_renders_with() {
+    fn the_picture_is_read_off_the_projection_the_host_renders_with() {
         let flat = cgmath::perspective(cgmath::Deg(45.0), 800.0 / 600.0, 0.1, 1000.0);
-        assert!((half_field_deg_from_projection(flat) - FLAT_HALF_FIELD).abs() < 1.0);
+        let (horizontal, vertical) = view_extents_from_projection(flat);
+        assert!((horizontal - FLAT_EXTENTS.0).abs() < 0.01);
+        assert!((vertical - FLAT_EXTENTS.1).abs() < 0.01);
+        assert!(
+            horizontal > vertical,
+            "a 4:3 picture is wider than it is tall"
+        );
 
-        // A wide headset frustum reports a wide field...
+        // A wide headset frustum reports a wide picture...
         let wide = cgmath::perspective(cgmath::Deg(90.0), 1.0, 0.1, 1000.0);
-        assert!(half_field_deg_from_projection(wide) > VR_HALF_FIELD * 0.7);
+        assert!(view_extents_from_projection(wide).0 > horizontal * 1.5);
 
         // ...and a degenerate matrix falls back instead of producing NaN.
         assert_eq!(
-            half_field_deg_from_projection(Matrix4::from_scale(0.0)),
-            DEFAULT_HALF_FIELD_DEG
+            view_extents_from_projection(Matrix4::from_scale(0.0)),
+            DEFAULT_VIEW_EXTENTS
         );
     }
 
@@ -488,13 +543,13 @@ mod tests {
     /// about winding covers only part of the view on the Quest.
     #[test]
     fn the_layer_does_not_depend_on_backface_culling() {
-        let object = hit_layer(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+        let object = hit_layer(VR_EXTENTS, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
         assert_eq!(object.backface_culling(), None);
     }
 
     #[test]
     fn the_layer_draws_translucent_and_over_the_world() {
-        let object = hit_layer(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+        let object = hit_layer(VR_EXTENTS, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
         let transparency = object
             .effective_transparency()
             .expect("the tint must draw translucent, not opaque");
@@ -518,7 +573,7 @@ mod tests {
             vec3(0.0, 1.0, 0.0).normalize(),
             vec3(-0.5, -0.5, 0.7).normalize(),
         ] {
-            let object = hit_layer(VR_HALF_FIELD, eye, forward, 0.5);
+            let object = hit_layer(VR_EXTENTS, eye, forward, 0.5);
             let centre = object.get_transform() * cgmath::vec4(0.0, 0.0, 0.0, 1.0);
             let offset = vec3(centre.x, centre.y, centre.z) - eye;
             assert!(
@@ -527,6 +582,31 @@ mod tests {
             );
             assert!((offset.magnitude() - LAYER_DISTANCE).abs() < 1e-3);
         }
+    }
+
+    /// `Game::render` clamps the layer's eye to the same cap the cameras
+    /// clamp theirs to, because the input context reports the *standing* eye
+    /// even while the frame is drawn from a crouched one. Pin that the clamp
+    /// resolves to the flat runtime's crouched eye line, and that it does
+    /// nothing at all while standing.
+    #[test]
+    fn the_layer_eye_is_clamped_to_the_eye_the_camera_renders_from() {
+        let standing = crate::physics::player_eye_cap_above_center(false);
+        let crouched = crate::physics::player_eye_cap_above_center(true);
+        let reported = crate::input_context::DEFAULT_HEAD_HEIGHT;
+
+        assert!(
+            reported.min(standing) == reported,
+            "the clamp must be a no-op standing: reported {reported}, cap {standing}"
+        );
+        assert!(
+            reported.min(crouched) < reported,
+            "crouched, the reported eye must be pulled down to the camera's"
+        );
+        assert!(
+            (crouched - crate::PLAYER_CROUCH_EYE_HEIGHT / dark::SCALE_FACTOR).abs() < 1e-6,
+            "the crouched cap is the flat camera's crouched eye"
+        );
     }
 
     #[test]

--- a/shock2vr/src/hit_feedback.rs
+++ b/shock2vr/src/hit_feedback.rs
@@ -1,0 +1,446 @@
+//! Feedback for the player taking damage: a hurt grunt and a brief red rim
+//! tint around the view.
+//!
+//! Before this, damage to the player was completely silent and invisible -
+//! hit points ticked down in the HUD's bio meter and nothing else happened, so
+//! in VR (which has no bio meter in the corner of the eye) a hybrid could beat
+//! the player to death without a single cue. Issue: "need some feedback when
+//! hit".
+//!
+//! # Where the pieces live
+//!
+//! The *trigger* is one hook in `mission_core`'s `AdjustHitPoints` applier:
+//! every hit-point change in the game flows through it, so a single site
+//! covers melee, projectiles, psi, and anything added later, and it sees the
+//! damage that was actually *applied* rather than what a weapon asked for.
+//!
+//! The *presentation* is [`HitFeedback`], owned by `Game` next to the pause
+//! menu, because both are view-locked layers over whatever scene is running
+//! and both need the tracked head pose that `Game` already keeps.
+//!
+//! # Comfort
+//!
+//! A full-screen red flash is the obvious implementation and the wrong one in
+//! a headset: it fills the fovea, it is exactly the stimulus that reads as
+//! "something is wrong with my eyes" rather than "I was hit", and at
+//! HUD-of-a-shooter intensities it is genuinely unpleasant to wear. So this is
+//! a *rim* tint - clear through the middle of the field, ramping to red toward
+//! the periphery, where motion and colour changes are noticed without being
+//! stared at. It is brief (well under a second), and both how strong it gets
+//! and how long it lasts scale with the size of the hit, so chip damage is a
+//! flicker and a shotgun blast is unmistakable.
+
+use cgmath::{Deg, Matrix4, Quaternion, Vector3, vec3};
+use engine::scene::SceneObject;
+
+/// Damage that produces a full-strength tint. The player's authored pool is 30
+/// hit points (`The Player`, `P$HitPoints`), so this is "a bit over a third of
+/// your health at once" - a shotgun blast, not a hybrid pipe swing.
+const DAMAGE_FOR_FULL_STRENGTH: f32 = 12.0;
+
+/// Rim opacity at the peak of a full-strength hit. Deliberately short of
+/// opaque: this layer sits over the whole periphery, and the player still has
+/// to fight through it.
+const MAX_RIM_OPACITY: f32 = 0.65;
+
+/// How long the tint lasts for the smallest and for a full-strength hit.
+/// Both are brief; the difference is what makes a big hit read as bigger.
+const MIN_DURATION_SECS: f32 = 0.35;
+const MAX_DURATION_SECS: f32 = 0.85;
+
+/// Arterial red. Not orange (reads as fire/heat) and not pink (reads as UI).
+const TINT_COLOR: Vector3<f32> = Vector3 {
+    x: 0.62,
+    y: 0.02,
+    z: 0.02,
+};
+
+/// How far in front of the eyes the layer hangs, in metres. Near enough that
+/// nothing in the world can be between it and the eye in practice; the layer
+/// clears depth anyway, so this only has to stay outside the near plane.
+const LAYER_DISTANCE: f32 = 0.6;
+
+/// Half-edge of the layer quad as a multiple of its distance, so coverage is
+/// an angle and not a size: `atan(5.0)` = 78.7 degrees off-axis in every
+/// direction, against a Quest's ~55 degree half-field. This is the same
+/// argument (and the same number) as the pause menu's comfort dim - see
+/// `pause_menu::WORLD_DIM_EXTENT_RATIO`.
+const LAYER_EXTENT_RATIO: f32 = 5.0;
+
+/// Where the tint starts and where it reaches full strength, as half-angles
+/// off the view axis. Everything inside [`CLEAR_HALF_ANGLE_DEG`] is untouched
+/// - that is the part of the field the player is actually aiming and reading
+/// with. These are shared by both presentations: flat's narrower field of view
+/// simply shows more of the clear centre and less of the rim, which is the
+/// correct behaviour for an effect defined in the player's field of view
+/// rather than in pixels.
+const CLEAR_HALF_ANGLE_DEG: f32 = 26.0;
+const FULL_HALF_ANGLE_DEG: f32 = 52.0;
+
+/// Convert a half-angle off the view axis into the shader's radius units,
+/// where 1.0 is the middle of the quad's edge.
+fn radius_at_half_angle(degrees: f32) -> f32 {
+    degrees.to_radians().tan() / LAYER_EXTENT_RATIO
+}
+
+/// Peak rim opacity for a hit of `damage` hit points.
+pub fn peak_opacity(damage: f32) -> f32 {
+    let scale = (damage / DAMAGE_FOR_FULL_STRENGTH).clamp(0.0, 1.0);
+    // Square-root, so a 1-point graze is still visible (0.29 of full) instead
+    // of being a rounding error, while the top of the range stays reserved for
+    // hits that really are big.
+    MAX_RIM_OPACITY * scale.sqrt()
+}
+
+/// How long the tint lasts for a hit of `damage` hit points.
+pub fn duration_secs(damage: f32) -> f32 {
+    let scale = (damage / DAMAGE_FOR_FULL_STRENGTH).clamp(0.0, 1.0);
+    MIN_DURATION_SECS + (MAX_DURATION_SECS - MIN_DURATION_SECS) * scale
+}
+
+/// The schema the player grunts with, by how hard they were hit.
+///
+/// These are the original game's own player-voice schemas (`SPEECH_PLAYER` ->
+/// `smallouch` / `medouch` / `bigouch`); they carry no environmental-sound
+/// tags, so they are addressed by name the way the retail scripts did rather
+/// than through an `EnvSoundQuery` (verified: `dark_query sound
+/// +creaturetype:player` and `+event:hit` both match nothing). The thresholds
+/// themselves are a port choice - the retail cutoffs were inside compiled
+/// script - chosen against the player's 30-point pool.
+pub fn hurt_schema(damage: f32) -> &'static str {
+    if damage < 5.0 {
+        "smallouch"
+    } else if damage < 12.0 {
+        "medouch"
+    } else {
+        "bigouch"
+    }
+}
+
+/// The decaying state of the hit tint. Pure: it is advanced with a delta time
+/// and asked for its current strength, and knows nothing about rendering.
+#[derive(Debug, Default)]
+pub struct HitFeedback {
+    /// Strength the current hit started at.
+    peak: f32,
+    /// Total and remaining lifetime of the current hit, in seconds.
+    duration: f32,
+    remaining: f32,
+}
+
+impl HitFeedback {
+    pub fn new() -> HitFeedback {
+        HitFeedback::default()
+    }
+
+    /// Record a hit of `damage` applied hit points.
+    ///
+    /// A second hit while one is still showing restarts the decay, and never
+    /// makes the tint jump *down*: taking a graze mid-fade from a shotgun
+    /// blast must not look like the blast stopped hurting. So the new peak is
+    /// the stronger of the incoming hit and whatever is on screen right now.
+    pub fn trigger(&mut self, damage: f32) {
+        if damage <= 0.0 {
+            return;
+        }
+        self.peak = peak_opacity(damage).max(self.intensity());
+        self.duration = duration_secs(damage);
+        self.remaining = self.duration;
+    }
+
+    /// Advance the decay by `delta_time_secs`.
+    pub fn update(&mut self, delta_time_secs: f32) {
+        self.remaining = (self.remaining - delta_time_secs).max(0.0);
+    }
+
+    /// Forget any hit in flight - used when the campaign is replaced, so a
+    /// tint cannot survive into a freshly loaded game.
+    pub fn clear(&mut self) {
+        self.remaining = 0.0;
+        self.peak = 0.0;
+    }
+
+    /// Current rim opacity, 0 when nothing is showing. Linear decay: it
+    /// reaches zero continuously, so the layer never pops off.
+    pub fn intensity(&self) -> f32 {
+        if self.duration <= 0.0 || self.remaining <= 0.0 {
+            return 0.0;
+        }
+        self.peak * (self.remaining / self.duration)
+    }
+
+    /// The layer to draw this frame, if anything is showing.
+    ///
+    /// `eye_position` and `eye_forward` are in the same space the returned
+    /// object is consumed in - `Game` builds them in pawn space and maps the
+    /// result with its pawn-to-world transform, exactly as it does for the
+    /// pause panel.
+    pub fn render(
+        &self,
+        eye_position: Vector3<f32>,
+        eye_forward: Vector3<f32>,
+    ) -> Option<SceneObject> {
+        let intensity = self.intensity();
+        if intensity <= 0.0 {
+            return None;
+        }
+        Some(hit_layer(eye_position, eye_forward, intensity))
+    }
+}
+
+/// One view-locked, double-sided quad carrying the rim tint.
+///
+/// The geometry follows the pause menu's comfort dim (PR #1020) rather than
+/// being a screen-space overlay, and for the reasons documented there: the two
+/// VR hosts disagree about where `render_per_eye` objects land in the scene
+/// list (the debug runtime appends, `oculus_runtime` prepends), so a
+/// screen-space layer that has to sit *over the world* is drawn correctly on
+/// exactly one of them. A world-space quad emitted from `render` is ordered by
+/// us. For the same reason it does not opt into backface culling - the hosts
+/// also disagree about winding, and a culled half was the original #1020 bug.
+///
+/// Because it is view-locked and defined by an angular ratio, the *same* code
+/// serves flat and VR: the eye pose differs, nothing else does.
+fn hit_layer(eye_position: Vector3<f32>, eye_forward: Vector3<f32>, intensity: f32) -> SceneObject {
+    let extent = LAYER_DISTANCE * LAYER_EXTENT_RATIO;
+    let mut object = SceneObject::new(
+        engine::scene::vignette_material::create(
+            TINT_COLOR,
+            intensity,
+            radius_at_half_angle(CLEAR_HALF_ANGLE_DEG),
+            radius_at_half_angle(FULL_HALF_ANGLE_DEG),
+        ),
+        Box::new(engine::scene::quad::create()),
+    );
+    object.set_transform(
+        Matrix4::from_translation(eye_position + eye_forward * LAYER_DISTANCE)
+            // The quad's +Z faces the viewer once it is turned to look back
+            // along the gaze.
+            * Matrix4::from(crate::util::get_rotation_from_forward_vector(-eye_forward))
+            * Matrix4::from_scale(extent * 2.0),
+    );
+    // Translucent: writing depth here would let the layer occlude anything
+    // drawn after it in the same overlay group.
+    object.set_depth_write(false);
+    // The layer must cover the world regardless of what the player is standing
+    // in front of, so it starts an overlay group (see `pause_menu`'s dim - the
+    // renderer treats everything from the first `clear_depth` object onward as
+    // a group drawn after the world's passes). `Game` emits it before the
+    // pause menu's objects, so a hit that lands as the menu opens stays behind
+    // the panel.
+    object.set_clear_depth(true);
+    object.set_debug_tag(Some(crate::util::render_source_tag(
+        crate::util::render_source::HIT_FEEDBACK,
+    )));
+    object
+}
+
+/// The eye pose to hang the layer from, in pawn space.
+///
+/// An untracked head arrives as the ZERO quaternion, which cgmath's
+/// `rotate_vector` silently returns *unrotated* - so it is treated as "no
+/// pose" and the pawn's own default eye stands in, rather than as a valid
+/// forward that would hang the layer off to one side (VR rule 7).
+pub fn eye_pose(
+    head_position: Vector3<f32>,
+    head_rotation: Quaternion<f32>,
+) -> (Vector3<f32>, Vector3<f32>) {
+    use cgmath::{InnerSpace, Rotation};
+    if head_rotation.magnitude2() < 1e-6 {
+        return (
+            vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0),
+            vec3(0.0, 0.0, -1.0),
+        );
+    }
+    (
+        head_position,
+        head_rotation
+            .normalize()
+            .rotate_vector(vec3(0.0, 0.0, -1.0)),
+    )
+}
+
+/// Only used to document the angular constants in tests.
+#[allow(dead_code)]
+fn half_angle_at_radius(radius: f32) -> Deg<f32> {
+    Deg((radius * LAYER_EXTENT_RATIO).atan().to_degrees())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{InnerSpace, Rotation3, Zero};
+
+    #[test]
+    fn nothing_shows_until_something_hits_the_player() {
+        let feedback = HitFeedback::new();
+        assert_eq!(feedback.intensity(), 0.0);
+        assert!(
+            feedback
+                .render(Vector3::zero(), vec3(0.0, 0.0, -1.0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn a_hit_shows_and_then_decays_to_nothing() {
+        let mut feedback = HitFeedback::new();
+        feedback.trigger(6.0);
+        assert!(feedback.intensity() > 0.0);
+        assert!(
+            feedback
+                .render(Vector3::zero(), vec3(0.0, 0.0, -1.0))
+                .is_some()
+        );
+
+        // Halfway through its life it is weaker but still showing.
+        let duration = duration_secs(6.0);
+        feedback.update(duration * 0.5);
+        let midway = feedback.intensity();
+        assert!(midway > 0.0 && midway < peak_opacity(6.0));
+
+        // And it goes away on its own, without anything clearing it.
+        feedback.update(duration);
+        assert_eq!(feedback.intensity(), 0.0);
+        assert!(
+            feedback
+                .render(Vector3::zero(), vec3(0.0, 0.0, -1.0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn a_bigger_hit_is_stronger_and_lasts_longer() {
+        assert!(peak_opacity(12.0) > peak_opacity(2.0));
+        assert!(duration_secs(12.0) > duration_secs(2.0));
+        // ...and neither runs away past the tuned ceiling.
+        assert_eq!(peak_opacity(500.0), MAX_RIM_OPACITY);
+        assert_eq!(duration_secs(500.0), MAX_DURATION_SECS);
+    }
+
+    #[test]
+    fn even_a_single_point_of_damage_is_visible() {
+        // A linear scale would put a 1-point graze at 0.05 opacity, which is
+        // indistinguishable from nothing on a headset panel.
+        assert!(peak_opacity(1.0) > 0.15);
+    }
+
+    #[test]
+    fn healing_and_zero_damage_show_nothing() {
+        let mut feedback = HitFeedback::new();
+        feedback.trigger(0.0);
+        assert_eq!(feedback.intensity(), 0.0);
+        feedback.trigger(-5.0);
+        assert_eq!(feedback.intensity(), 0.0);
+    }
+
+    #[test]
+    fn a_graze_mid_fade_never_makes_the_tint_jump_down() {
+        let mut feedback = HitFeedback::new();
+        feedback.trigger(12.0);
+        feedback.update(duration_secs(12.0) * 0.25);
+        let before = feedback.intensity();
+
+        feedback.trigger(1.0);
+        assert!(
+            feedback.intensity() >= before,
+            "a small hit during a big one's fade dropped the tint from {before} to {}",
+            feedback.intensity()
+        );
+    }
+
+    #[test]
+    fn clearing_removes_a_tint_in_flight() {
+        let mut feedback = HitFeedback::new();
+        feedback.trigger(10.0);
+        assert!(feedback.intensity() > 0.0);
+        feedback.clear();
+        assert_eq!(feedback.intensity(), 0.0);
+    }
+
+    #[test]
+    fn the_hurt_grunt_gets_louder_with_the_hit() {
+        assert_eq!(hurt_schema(1.0), "smallouch");
+        assert_eq!(hurt_schema(8.0), "medouch");
+        assert_eq!(hurt_schema(25.0), "bigouch");
+    }
+
+    /// The whole comfort argument is that the middle of the field is left
+    /// alone. If the ramp ever started at the view axis this would be the
+    /// full-screen flash the design rejects.
+    #[test]
+    fn the_middle_of_the_view_is_left_clear() {
+        let inner = radius_at_half_angle(CLEAR_HALF_ANGLE_DEG);
+        assert!(inner > 0.0, "the tint must not start on the view axis");
+        assert!(
+            half_angle_at_radius(inner) > Deg(20.0),
+            "the clear centre must cover the part of the field the player reads with"
+        );
+        assert!(radius_at_half_angle(FULL_HALF_ANGLE_DEG) > inner);
+    }
+
+    /// #1020's bug in miniature: a layer that relies on the host agreeing
+    /// about winding covers only part of the view on the Quest.
+    #[test]
+    fn the_layer_does_not_depend_on_backface_culling() {
+        let object = hit_layer(Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+        assert_eq!(object.backface_culling(), None);
+    }
+
+    #[test]
+    fn the_layer_draws_translucent_and_over_the_world() {
+        let object = hit_layer(Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+        let transparency = object
+            .effective_transparency()
+            .expect("the tint must draw translucent, not opaque");
+        assert!(transparency > 0.0 && transparency < 1.0);
+        assert!(
+            object.clear_depth,
+            "a layer depth-tested against the world would only tint what is far away"
+        );
+        assert_eq!(
+            object.debug_tag().and_then(|tag| tag.source.clone()),
+            Some(crate::util::render_source::HIT_FEEDBACK.to_owned())
+        );
+    }
+
+    #[test]
+    fn the_layer_hangs_in_front_of_wherever_the_player_is_looking() {
+        let eye = vec3(3.0, 1.5, -2.0);
+        for forward in [
+            vec3(0.0, 0.0, -1.0),
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0).normalize(),
+            vec3(-0.5, -0.5, 0.7).normalize(),
+        ] {
+            let object = hit_layer(eye, forward, 0.5);
+            let centre = object.get_transform() * cgmath::vec4(0.0, 0.0, 0.0, 1.0);
+            let offset = vec3(centre.x, centre.y, centre.z) - eye;
+            assert!(
+                (offset.normalize() - forward).magnitude() < 1e-3,
+                "layer centre {offset:?} is not along the gaze {forward:?}"
+            );
+            assert!((offset.magnitude() - LAYER_DISTANCE).abs() < 1e-3);
+        }
+    }
+
+    #[test]
+    fn an_untracked_head_falls_back_to_the_pawn_eye_instead_of_a_zero_rotation() {
+        let (position, forward) =
+            eye_pose(vec3(9.0, 9.0, 9.0), Quaternion::new(0.0, 0.0, 0.0, 0.0));
+        assert_eq!(
+            position,
+            vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0)
+        );
+        assert_eq!(forward, vec3(0.0, 0.0, -1.0));
+    }
+
+    #[test]
+    fn a_tracked_head_is_used_as_given() {
+        let head = vec3(0.1, 1.7, -0.2);
+        let rotation = Quaternion::from_angle_y(Deg(90.0));
+        let (position, forward) = eye_pose(head, rotation);
+        assert_eq!(position, head);
+        assert!((forward - vec3(-1.0, 0.0, 0.0)).magnitude() < 1e-5);
+    }
+}

--- a/shock2vr/src/hit_feedback.rs
+++ b/shock2vr/src/hit_feedback.rs
@@ -30,7 +30,7 @@
 //! and how long it lasts scale with the size of the hit, so chip damage is a
 //! flicker and a shotgun blast is unmistakable.
 
-use cgmath::{Deg, Matrix4, Quaternion, Vector3, vec3};
+use cgmath::{Matrix4, Quaternion, Vector3, vec3};
 use engine::scene::SceneObject;
 
 /// Damage that produces a full-strength tint. The player's authored pool is 30
@@ -67,15 +67,42 @@ const LAYER_DISTANCE: f32 = 0.6;
 /// `pause_menu::WORLD_DIM_EXTENT_RATIO`.
 const LAYER_EXTENT_RATIO: f32 = 5.0;
 
-/// Where the tint starts and where it reaches full strength, as half-angles
-/// off the view axis. Everything inside [`CLEAR_HALF_ANGLE_DEG`] is untouched
-/// - that is the part of the field the player is actually aiming and reading
-/// with. These are shared by both presentations: flat's narrower field of view
-/// simply shows more of the clear centre and less of the rim, which is the
-/// correct behaviour for an effect defined in the player's field of view
-/// rather than in pixels.
-const CLEAR_HALF_ANGLE_DEG: f32 = 26.0;
-const FULL_HALF_ANGLE_DEG: f32 = 52.0;
+/// Where the tint starts and where it reaches full strength, as fractions of
+/// how far the presentation's field of view actually reaches. Everything
+/// inside [`CLEAR_FIELD_FRACTION`] is untouched - that is the part of the
+/// field the player aims and reads with - and the tint is at full strength by
+/// the edge of the picture.
+const CLEAR_FIELD_FRACTION: f32 = 0.5;
+const FULL_FIELD_FRACTION: f32 = 1.0;
+
+/// A sane fallback half-field, in degrees, for the frames before any
+/// projection has been seen: the ~29 degrees both flat runtimes' 45-degree
+/// 4:3 `perspective` gives.
+pub const DEFAULT_HALF_FIELD_DEG: f32 = 29.0;
+
+/// How far the picture reaches sideways from the view axis, read straight off
+/// the projection the host is rendering with.
+///
+/// This is why there is **no per-presentation branch in this module**
+/// (AGENTS.md section 3): a rim effect is only a rim effect relative to where
+/// the picture ends, and flat and VR disagree about that by roughly a factor
+/// of two - both flat runtimes build `perspective(Deg(45.0))` while a Quest
+/// eye reaches about 55 degrees. Hardcoding one angle is what the first cut
+/// did, and it made the tint invisible on flat, with the whole ramp past the
+/// edge of the screen. Hardcoding *two* would then have been a lie in the
+/// debug runtime, whose `--vr` mode renders with the flat 45-degree
+/// projection. Asking the projection is right everywhere, including on a
+/// headset whose per-eye frustum is asymmetric.
+///
+/// For any perspective or off-axis frustum, `m[0][0]` is `2n / (r - l)`, so
+/// its reciprocal is the tangent of half the horizontal extent.
+pub fn half_field_deg_from_projection(projection: Matrix4<f32>) -> f32 {
+    let m00 = projection.x.x;
+    if !m00.is_finite() || m00 <= 0.0 {
+        return DEFAULT_HALF_FIELD_DEG;
+    }
+    (1.0 / m00).atan().to_degrees().clamp(5.0, 85.0)
+}
 
 /// Convert a half-angle off the view axis into the shader's radius units,
 /// where 1.0 is the middle of the quad's edge.
@@ -100,20 +127,31 @@ pub fn duration_secs(damage: f32) -> f32 {
 
 /// The schema the player grunts with, by how hard they were hit.
 ///
-/// These are the original game's own player-voice schemas (`SPEECH_PLAYER` ->
-/// `smallouch` / `medouch` / `bigouch`); they carry no environmental-sound
-/// tags, so they are addressed by name the way the retail scripts did rather
-/// than through an `EnvSoundQuery` (verified: `dark_query sound
-/// +creaturetype:player` and `+event:hit` both match nothing). The thresholds
-/// themselves are a port choice - the retail cutoffs were inside compiled
+/// These are the shipped gamesys's own player-damage schemas, resolving to the
+/// `dmgenlo*` / `dmgenme*` / `dmgenhi*` samples in `res/snd/PDamage` - the
+/// original game's player pain grunts. They are addressed **by name**, the way
+/// the retail scripts did, because they carry no environmental-sound tags:
+/// `dark_query sound +creaturetype:player` and `+event:hit` both match
+/// nothing, so an `EnvSoundQuery` cannot reach them.
+///
+/// Two traps are recorded here so nobody re-walks them. First, the obvious
+/// candidates - the `SPEECH_PLAYER` schemas `smallouch` / `medouch` /
+/// `bigouch` - are **dead**: they resolve, but to `pdamlo*` / `pdammed*` /
+/// `pdamhi*` samples that ship in no `.kpf`, so wiring them plays silence.
+/// Second, `PDamage` also holds damage-*type* sets (`dam_bullet_*`,
+/// `dam_elec_*`, `dam_rad_*`, ...); the port does not carry a damage type
+/// through `AdjustHitPoints`, so the generic set is the honest choice, and
+/// picking a type-specific one is the natural follow-up once it does.
+///
+/// The thresholds are a port choice - the retail cutoffs lived in compiled
 /// script - chosen against the player's 30-point pool.
 pub fn hurt_schema(damage: f32) -> &'static str {
     if damage < 5.0 {
-        "smallouch"
+        "dam_gen_lo"
     } else if damage < 12.0 {
-        "medouch"
+        "dam_gen_med"
     } else {
-        "bigouch"
+        "dam_gen_hi"
     }
 }
 
@@ -174,9 +212,11 @@ impl HitFeedback {
     /// `eye_position` and `eye_forward` are in the same space the returned
     /// object is consumed in - `Game` builds them in pawn space and maps the
     /// result with its pawn-to-world transform, exactly as it does for the
-    /// pause panel.
+    /// pause panel. `half_field_deg` comes from the host's own projection -
+    /// see [`half_field_deg_from_projection`].
     pub fn render(
         &self,
+        half_field_deg: f32,
         eye_position: Vector3<f32>,
         eye_forward: Vector3<f32>,
     ) -> Option<SceneObject> {
@@ -184,7 +224,12 @@ impl HitFeedback {
         if intensity <= 0.0 {
             return None;
         }
-        Some(hit_layer(eye_position, eye_forward, intensity))
+        Some(hit_layer(
+            half_field_deg,
+            eye_position,
+            eye_forward,
+            intensity,
+        ))
     }
 }
 
@@ -199,16 +244,23 @@ impl HitFeedback {
 /// us. For the same reason it does not opt into backface culling - the hosts
 /// also disagree about winding, and a culled half was the original #1020 bug.
 ///
-/// Because it is view-locked and defined by an angular ratio, the *same* code
-/// serves flat and VR: the eye pose differs, nothing else does.
-fn hit_layer(eye_position: Vector3<f32>, eye_forward: Vector3<f32>, intensity: f32) -> SceneObject {
+/// Because it is view-locked, the *same* code serves flat and VR: the eye pose
+/// differs, and the ramp is mapped onto whatever field of view the host is
+/// actually rendering (see [`half_field_deg_from_projection`]). Nothing else
+/// does.
+fn hit_layer(
+    half_field: f32,
+    eye_position: Vector3<f32>,
+    eye_forward: Vector3<f32>,
+    intensity: f32,
+) -> SceneObject {
     let extent = LAYER_DISTANCE * LAYER_EXTENT_RATIO;
     let mut object = SceneObject::new(
         engine::scene::vignette_material::create(
             TINT_COLOR,
             intensity,
-            radius_at_half_angle(CLEAR_HALF_ANGLE_DEG),
-            radius_at_half_angle(FULL_HALF_ANGLE_DEG),
+            radius_at_half_angle(half_field * CLEAR_FIELD_FRACTION),
+            radius_at_half_angle(half_field * FULL_FIELD_FRACTION),
         ),
         Box::new(engine::scene::quad::create()),
     );
@@ -261,15 +313,15 @@ pub fn eye_pose(
 }
 
 /// Only used to document the angular constants in tests.
-#[allow(dead_code)]
-fn half_angle_at_radius(radius: f32) -> Deg<f32> {
-    Deg((radius * LAYER_EXTENT_RATIO).atan().to_degrees())
+#[cfg(test)]
+fn half_angle_at_radius(radius: f32) -> cgmath::Deg<f32> {
+    cgmath::Deg((radius * LAYER_EXTENT_RATIO).atan().to_degrees())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::{InnerSpace, Rotation3, Zero};
+    use cgmath::{Deg, InnerSpace, Rotation3, Zero};
 
     #[test]
     fn nothing_shows_until_something_hits_the_player() {
@@ -277,7 +329,7 @@ mod tests {
         assert_eq!(feedback.intensity(), 0.0);
         assert!(
             feedback
-                .render(Vector3::zero(), vec3(0.0, 0.0, -1.0))
+                .render(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
                 .is_none()
         );
     }
@@ -289,7 +341,7 @@ mod tests {
         assert!(feedback.intensity() > 0.0);
         assert!(
             feedback
-                .render(Vector3::zero(), vec3(0.0, 0.0, -1.0))
+                .render(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
                 .is_some()
         );
 
@@ -304,7 +356,7 @@ mod tests {
         assert_eq!(feedback.intensity(), 0.0);
         assert!(
             feedback
-                .render(Vector3::zero(), vec3(0.0, 0.0, -1.0))
+                .render(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0),)
                 .is_none()
         );
     }
@@ -360,36 +412,89 @@ mod tests {
 
     #[test]
     fn the_hurt_grunt_gets_louder_with_the_hit() {
-        assert_eq!(hurt_schema(1.0), "smallouch");
-        assert_eq!(hurt_schema(8.0), "medouch");
-        assert_eq!(hurt_schema(25.0), "bigouch");
+        assert_eq!(hurt_schema(1.0), "dam_gen_lo");
+        assert_eq!(hurt_schema(8.0), "dam_gen_med");
+        assert_eq!(hurt_schema(25.0), "dam_gen_hi");
     }
+
+    /// A Quest eye reaches about this far off-axis; used to stand in for a
+    /// headset in these tests.
+    const VR_HALF_FIELD: f32 = 55.0;
+    /// What both flat runtimes' `perspective(Deg(45.0))` on 4:3 gives.
+    const FLAT_HALF_FIELD: f32 = 29.0;
 
     /// The whole comfort argument is that the middle of the field is left
     /// alone. If the ramp ever started at the view axis this would be the
     /// full-screen flash the design rejects.
+    ///
+    /// And - the bug that shipped in the first cut and was caught by looking at
+    /// a flat screenshot - the ramp has to land *inside the picture*. Sharing
+    /// one absolute angle across both presentations put flat's whole ramp past
+    /// the edge of a 45-degree screen, so a hit rendered as nothing at all.
     #[test]
-    fn the_middle_of_the_view_is_left_clear() {
-        let inner = radius_at_half_angle(CLEAR_HALF_ANGLE_DEG);
-        assert!(inner > 0.0, "the tint must not start on the view axis");
-        assert!(
-            half_angle_at_radius(inner) > Deg(20.0),
-            "the clear centre must cover the part of the field the player reads with"
+    fn the_tint_lands_inside_the_picture_at_any_field_of_view() {
+        for half_field in [FLAT_HALF_FIELD, VR_HALF_FIELD, 75.0] {
+            let inner = radius_at_half_angle(half_field * CLEAR_FIELD_FRACTION);
+            let outer = radius_at_half_angle(half_field * FULL_FIELD_FRACTION);
+            assert!(
+                inner > 0.0,
+                "{half_field}: the tint must not start on the view axis"
+            );
+            assert!(outer > inner, "{half_field}: the ramp must have width");
+            assert!(
+                half_angle_at_radius(inner) < cgmath::Deg(half_field * 0.75),
+                "{half_field}: the ramp starts too near the edge of the picture to be seen"
+            );
+            assert!(
+                half_angle_at_radius(outer) <= cgmath::Deg(half_field + 1.0),
+                "{half_field}: the tint never reaches full strength inside the picture"
+            );
+        }
+    }
+
+    /// Flat and VR must tint the *same fraction* of the picture - that is what
+    /// "renders identically" means for an effect defined in the field of view
+    /// rather than in pixels.
+    #[test]
+    fn every_field_of_view_tints_the_same_fraction_of_the_picture() {
+        let fractions: Vec<f32> = [FLAT_HALF_FIELD, VR_HALF_FIELD]
+            .into_iter()
+            .map(|half_field| {
+                half_angle_at_radius(radius_at_half_angle(half_field * CLEAR_FIELD_FRACTION)).0
+                    / half_field
+            })
+            .collect();
+        assert!((fractions[0] - fractions[1]).abs() < 1e-3, "{fractions:?}");
+    }
+
+    /// The flat runtimes' own projection must come back out as the flat field.
+    #[test]
+    fn the_field_is_read_off_the_projection_the_host_renders_with() {
+        let flat = cgmath::perspective(cgmath::Deg(45.0), 800.0 / 600.0, 0.1, 1000.0);
+        assert!((half_field_deg_from_projection(flat) - FLAT_HALF_FIELD).abs() < 1.0);
+
+        // A wide headset frustum reports a wide field...
+        let wide = cgmath::perspective(cgmath::Deg(90.0), 1.0, 0.1, 1000.0);
+        assert!(half_field_deg_from_projection(wide) > VR_HALF_FIELD * 0.7);
+
+        // ...and a degenerate matrix falls back instead of producing NaN.
+        assert_eq!(
+            half_field_deg_from_projection(Matrix4::from_scale(0.0)),
+            DEFAULT_HALF_FIELD_DEG
         );
-        assert!(radius_at_half_angle(FULL_HALF_ANGLE_DEG) > inner);
     }
 
     /// #1020's bug in miniature: a layer that relies on the host agreeing
     /// about winding covers only part of the view on the Quest.
     #[test]
     fn the_layer_does_not_depend_on_backface_culling() {
-        let object = hit_layer(Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+        let object = hit_layer(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
         assert_eq!(object.backface_culling(), None);
     }
 
     #[test]
     fn the_layer_draws_translucent_and_over_the_world() {
-        let object = hit_layer(Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
+        let object = hit_layer(VR_HALF_FIELD, Vector3::zero(), vec3(0.0, 0.0, -1.0), 0.5);
         let transparency = object
             .effective_transparency()
             .expect("the tint must draw translucent, not opaque");
@@ -413,7 +518,7 @@ mod tests {
             vec3(0.0, 1.0, 0.0).normalize(),
             vec3(-0.5, -0.5, 0.7).normalize(),
         ] {
-            let object = hit_layer(eye, forward, 0.5);
+            let object = hit_layer(VR_HALF_FIELD, eye, forward, 0.5);
             let centre = object.get_transform() * cgmath::vec4(0.0, 0.0, 0.0, 1.0);
             let offset = vec3(centre.x, centre.y, centre.z) - eye;
             assert!(

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -454,6 +454,14 @@ pub struct Game {
     /// [`Game::hit_feedback`] hangs its layer from. Kept here rather than
     /// asked of the scene because `render` has no input context.
     head_pose: (Vector3<f32>, Quaternion<f32>),
+
+    /// How wide the host's picture is, in degrees off the view axis, taken
+    /// from the projection it last handed `render_per_eye`. The hit tint is a
+    /// *rim* effect, so it has to know where the picture ends - and only the
+    /// host knows that (a Quest eye is roughly twice a 45-degree flat screen).
+    /// Carried a frame, because `render` runs before `render_per_eye` and the
+    /// projection does not change between them.
+    view_half_field_deg: f32,
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -1230,6 +1238,7 @@ impl Game {
                 vec3(0.0, input_context::DEFAULT_HEAD_HEIGHT, 0.0),
                 Quaternion::new(1.0, 0.0, 0.0, 0.0),
             ),
+            view_half_field_deg: hit_feedback::DEFAULT_HALF_FIELD_DEG,
         }
     }
 
@@ -1818,7 +1827,10 @@ impl Game {
         // in flat and VR - it is view-locked, so only the eye pose differs.
         let (eye_position, eye_forward) =
             hit_feedback::eye_pose(self.head_pose.0, self.head_pose.1);
-        if let Some(mut layer) = self.hit_feedback.render(eye_position, eye_forward) {
+        if let Some(mut layer) =
+            self.hit_feedback
+                .render(self.view_half_field_deg, eye_position, eye_forward)
+        {
             layer.set_transform(pawn_to_world * layer.get_transform());
             scene.push(layer);
         }
@@ -1845,6 +1857,11 @@ impl Game {
         projection: Matrix4<f32>,
         screen_size: Vector2<f32>,
     ) -> Vec<SceneObject> {
+        // Record how wide the host's picture is for the next frame's `render`,
+        // which is where the view-locked hit tint is emitted (see
+        // `hit_feedback::half_field_deg_from_projection`).
+        self.view_half_field_deg = hit_feedback::half_field_deg_from_projection(projection);
+
         // Sample for rendering
         let font = self.asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
         // let text_obj_0_0 =

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audio_log;
 pub mod game_scene;
 pub mod hand_pose;
 pub mod hand_pose_library;
+pub mod hit_feedback;
 pub mod input;
 pub mod input_context;
 pub mod install;
@@ -443,6 +444,16 @@ pub struct Game {
     /// Wall-clock time spent with the simulation suspended, subtracted from the
     /// clock the scene sees. See [`Game::scene_time`].
     time_suspended: std::time::Duration,
+
+    /// The red rim tint shown for a moment after the player takes damage. Like
+    /// the pause menu, it lives here because it is a view-locked layer over
+    /// whichever scene is running. See [`crate::hit_feedback`].
+    hit_feedback: hit_feedback::HitFeedback,
+
+    /// The last head pose a runtime reported, in pawn space - what
+    /// [`Game::hit_feedback`] hangs its layer from. Kept here rather than
+    /// asked of the scene because `render` has no input context.
+    head_pose: (Vector3<f32>, Quaternion<f32>),
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -1214,6 +1225,11 @@ impl Game {
             campaign_completed: false,
             pause_menu: pause_menu::PauseMenu::new(),
             time_suspended: std::time::Duration::ZERO,
+            hit_feedback: hit_feedback::HitFeedback::new(),
+            head_pose: (
+                vec3(0.0, input_context::DEFAULT_HEAD_HEIGHT, 0.0),
+                Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            ),
         }
     }
 
@@ -1232,6 +1248,13 @@ impl Game {
         // (audio log / message trace), so their entries can be stamped
         // without threading `Time` through every record site.
         audio_log::set_sim_time(self.scene_time(time).total.as_secs_f64());
+
+        // The hit tint decays on *wall* time, ahead of every early return in
+        // this function: a hit taken as the player opens the pause menu or
+        // starts a level transition must fade out on its own rather than hang
+        // frozen at full strength until the simulation resumes.
+        self.head_pose = (input_context.head.position, input_context.head.rotation);
+        self.hit_feedback.update(delta_time);
 
         // Drive a background transition: the loading screen animates while the parse
         // runs on its worker thread. Once the parse has finished AND the loading screen
@@ -1681,6 +1704,9 @@ impl Game {
                 self.pending_transition = None;
                 self.set_active_scene(Box::new(DeveloperScene::new()));
             }
+            GlobalEffect::PlayerHit { damage } => {
+                self.hit_feedback.trigger(damage);
+            }
             GlobalEffect::CompleteCampaign => {
                 // Preserve the destroyed head and the rest of the finale state
                 // in the in-memory mission ledger before the cutscene replaces
@@ -1717,6 +1743,10 @@ impl Game {
     fn set_active_scene(&mut self, scene: Box<dyn GameScene>) {
         self.active_game_scene.on_exit(&mut self.audio_context);
         self.active_game_scene = scene;
+        // Whatever hurt the player belongs to the scene being left: a quickload
+        // taken mid-fight must not open on a red rim, and the main menu must
+        // never show one at all.
+        self.hit_feedback.clear();
     }
 
     /// Get hand spotlights for enhanced lighting when experimental flag is enabled
@@ -1778,6 +1808,21 @@ impl Game {
         // aim at it), so it is mapped into world coordinates with the same
         // pawn transform the runtime builds its camera from.
         let pawn_to_world = Matrix4::from_translation(pos) * Matrix4::from(rot);
+
+        // The hit tint, before the pause menu's objects: it is the first
+        // `clear_depth` object when nothing else is up, so it opens the overlay
+        // group and covers the world; and when the menu *is* up it is still
+        // first in that group, so the panel and its dim draw over it rather
+        // than under a red rim. Emitted from `render` (not `render_per_eye`)
+        // for the reason recorded on `hit_feedback::hit_layer`, and identically
+        // in flat and VR - it is view-locked, so only the eye pose differs.
+        let (eye_position, eye_forward) =
+            hit_feedback::eye_pose(self.head_pose.0, self.head_pose.1);
+        if let Some(mut layer) = self.hit_feedback.render(eye_position, eye_forward) {
+            layer.set_transform(pawn_to_world * layer.get_transform());
+            scene.push(layer);
+        }
+
         scene.extend(
             self.pause_menu
                 .render(&mut self.asset_cache, &self.options, pawn_to_world),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -455,13 +455,14 @@ pub struct Game {
     /// asked of the scene because `render` has no input context.
     head_pose: (Vector3<f32>, Quaternion<f32>),
 
-    /// How wide the host's picture is, in degrees off the view axis, taken
-    /// from the projection it last handed `render_per_eye`. The hit tint is a
-    /// *rim* effect, so it has to know where the picture ends - and only the
-    /// host knows that (a Quest eye is roughly twice a 45-degree flat screen).
-    /// Carried a frame, because `render` runs before `render_per_eye` and the
-    /// projection does not change between them.
-    view_half_field_deg: f32,
+    /// How far the host's picture reaches from the view axis on each axis,
+    /// taken from the projection it last handed `render_per_eye`. The hit tint
+    /// is a *rim* effect, so it has to know where the picture ends - and only
+    /// the host knows that (a Quest eye is roughly twice a 45-degree flat
+    /// screen, and much closer to square). Carried a frame, because `render`
+    /// runs before `render_per_eye` and the projection does not change between
+    /// them.
+    view_extents: (f32, f32),
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -1238,7 +1239,7 @@ impl Game {
                 vec3(0.0, input_context::DEFAULT_HEAD_HEIGHT, 0.0),
                 Quaternion::new(1.0, 0.0, 0.0, 0.0),
             ),
-            view_half_field_deg: hit_feedback::DEFAULT_HALF_FIELD_DEG,
+            view_extents: hit_feedback::DEFAULT_VIEW_EXTENTS,
         }
     }
 
@@ -1825,11 +1826,19 @@ impl Game {
         // than under a red rim. Emitted from `render` (not `render_per_eye`)
         // for the reason recorded on `hit_feedback::hit_layer`, and identically
         // in flat and VR - it is view-locked, so only the eye pose differs.
-        let (eye_position, eye_forward) =
+        let (mut eye_position, eye_forward) =
             hit_feedback::eye_pose(self.head_pose.0, self.head_pose.1);
+        // Centre the layer on the eye the frame is actually drawn from, which
+        // is NOT the eye the input context reports: both flat runtimes put the
+        // *standing* eye in `head.position` while rendering from a crouch-aware
+        // one, and the VR runtimes clamp the tracked eye to the collider crown.
+        // Crouched, that is 0.56 units of disagreement - enough to swing the
+        // rim by ~13 degrees and drag the ramp onto the crosshair. The same
+        // clamp the cameras use is a no-op standing.
+        eye_position.y = eye_position.y.min(self.player_eye_cap_above_center());
         if let Some(mut layer) =
             self.hit_feedback
-                .render(self.view_half_field_deg, eye_position, eye_forward)
+                .render(self.view_extents, eye_position, eye_forward)
         {
             layer.set_transform(pawn_to_world * layer.get_transform());
             scene.push(layer);
@@ -1857,10 +1866,10 @@ impl Game {
         projection: Matrix4<f32>,
         screen_size: Vector2<f32>,
     ) -> Vec<SceneObject> {
-        // Record how wide the host's picture is for the next frame's `render`,
-        // which is where the view-locked hit tint is emitted (see
-        // `hit_feedback::half_field_deg_from_projection`).
-        self.view_half_field_deg = hit_feedback::half_field_deg_from_projection(projection);
+        // Record how far the host's picture reaches for the next frame's
+        // `render`, which is where the view-locked hit tint is emitted (see
+        // `hit_feedback::view_extents_from_projection`).
+        self.view_extents = hit_feedback::view_extents_from_projection(projection);
 
         // Sample for rendering
         let font = self.asset_cache.get(&FONT_IMPORTER, "mainfont.fon");

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4011,6 +4011,9 @@ impl MissionCore {
             player_info.entity_id
         };
 
+        // At most one player hurt grunt per drain - see the `AdjustHitPoints`
+        // handler.
+        let mut player_grunted = false;
         let mut effects = VecDeque::from(effects);
         while let Some(effect) = effects.pop_front() {
             match effect {
@@ -4055,17 +4058,29 @@ impl MissionCore {
                         // Deliberately after the death check's `previous > 0`
                         // guard reads `previous`, and skipped for the killing
                         // blow, which the death path owns.
-                        if entity_id == player_entity && hp < previous && hp > 0 {
+                        if entity_id == player_entity && hp < previous {
                             let damage = (previous - hp) as f32;
+                            // The tint fires for the killing blow too - that
+                            // is the hit the player most needs to see land.
                             global_effects.push(GlobalEffect::PlayerHit { damage });
-                            effects.push_back(Effect::PlaySound {
-                                handle: AudioHandle::new(),
-                                name: crate::hit_feedback::hurt_schema(damage).to_owned(),
-                                source: Some(player_entity),
-                                // The player's own voice: at the ears, not at
-                                // a point in the world they are standing on.
-                                spatial: false,
-                            });
+                            // The grunt does not: `begin_player_death` plays
+                            // the death vocalization, and two player voices at
+                            // once is a mess. Nor does a second grunt for a
+                            // second hit drained in the same pass - several
+                            // damage effects can land together (a blast plus a
+                            // follow-up), and the tint coalesces them where
+                            // stacked audio would just be noise.
+                            if hp > 0 && !player_grunted {
+                                player_grunted = true;
+                                effects.push_back(Effect::PlaySound {
+                                    handle: AudioHandle::new(),
+                                    name: crate::hit_feedback::hurt_schema(damage).to_owned(),
+                                    source: Some(player_entity),
+                                    // The player's own voice: at the ears, not
+                                    // at a point in the world they stand on.
+                                    spatial: false,
+                                });
+                            }
                         }
                         if entity_id == player_entity && previous > 0 && hp == 0 {
                             for death_effect in self.begin_player_death() {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4046,6 +4046,27 @@ impl MissionCore {
                             delta,
                             hp
                         );
+                        // Tell the player they were hit. This is the one hook
+                        // for it: every source of damage - AI melee,
+                        // projectiles, psi, falls - lands here, and what it
+                        // reads is the loss that was actually *applied*, so
+                        // armour or a resistance that soaked a hit makes the
+                        // feedback smaller rather than lying about it.
+                        // Deliberately after the death check's `previous > 0`
+                        // guard reads `previous`, and skipped for the killing
+                        // blow, which the death path owns.
+                        if entity_id == player_entity && hp < previous && hp > 0 {
+                            let damage = (previous - hp) as f32;
+                            global_effects.push(GlobalEffect::PlayerHit { damage });
+                            effects.push_back(Effect::PlaySound {
+                                handle: AudioHandle::new(),
+                                name: crate::hit_feedback::hurt_schema(damage).to_owned(),
+                                source: Some(player_entity),
+                                // The player's own voice: at the ears, not at
+                                // a point in the world they are standing on.
+                                spatial: false,
+                            });
+                        }
                         if entity_id == player_entity && previous > 0 && hp == 0 {
                             for death_effect in self.begin_player_death() {
                                 effects.push_back(death_effect);

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -235,18 +235,10 @@ fn dim_pose(
     head_rotation: Quaternion<f32>,
     panel: &WorldPanel,
 ) -> (Vector3<f32>, Vector3<f32>) {
-    if head_rotation.magnitude2() < 1e-6 {
-        return (
-            panel.center + panel.normal() * frontend_panel_distance(),
-            -panel.normal(),
-        );
-    }
-    (
-        head_position,
-        head_rotation
-            .normalize()
-            .rotate_vector(vec3(0.0, 0.0, -1.0)),
-    )
+    crate::util::tracked_gaze(head_position, head_rotation).unwrap_or((
+        panel.center + panel.normal() * frontend_panel_distance(),
+        -panel.normal(),
+    ))
 }
 
 /// What a click on the pause menu asks `Game` to do.

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -72,6 +72,14 @@ pub enum GlobalEffect {
     /// Play the retail ending and enter the campaign's terminal state.
     CompleteCampaign,
 
+    /// The player just lost `damage` hit points. Handled by `Game`, which owns
+    /// the view-locked hit tint (see `crate::hit_feedback`) the same way it
+    /// owns the pause menu - the layer has to sit over whatever scene is
+    /// running, and the tracked head pose it hangs from lives there.
+    PlayerHit {
+        damage: f32,
+    },
+
     // Quit the game (e.g. from the main menu). The runtime is responsible for
     // observing this via `Game::should_quit` and closing its window.
     Quit,

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -310,6 +310,8 @@ pub mod render_source {
     pub const FRONTEND_POINTER: &str = "frontend_pointer";
     /// The pause menu's comfort dim, behind its panel.
     pub const PAUSE_DIM: &str = "pause_dim";
+    /// The red rim tint shown for a moment after the player takes damage.
+    pub const HIT_FEEDBACK: &str = "hit_feedback";
 }
 
 /// A tag that records only which render path produced an object.

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -168,6 +168,34 @@ pub fn get_rotation_from_matrix(matrix: &Matrix4<f32>) -> Quaternion<f32> {
     rot_matrix.into()
 }
 
+/// Where a tracked head is and what it is looking at, or `None` when the head
+/// is not tracked.
+///
+/// An untracked head arrives as the **ZERO quaternion**, and cgmath's
+/// `rotate_vector` silently returns the input *unrotated* for it - so a caller
+/// that skips this check gets a plausible-looking forward pointing at world
+/// -Z, plus a meaningless position, and hangs its layer somewhere arbitrary.
+/// That is VR rule 7 in the `vr-ui-design` skill; it has cost real bugs
+/// (#994, #997), so it is encoded once here rather than at each view-locked
+/// layer. Callers supply their own fallback for the `None` case, because what
+/// stands in for a missing head differs: the pause dim uses its world-locked
+/// panel, the hit tint uses the pawn's default eye.
+pub fn tracked_gaze(
+    head_position: Vector3<f32>,
+    head_rotation: Quaternion<f32>,
+) -> Option<(Vector3<f32>, Vector3<f32>)> {
+    if head_rotation.magnitude2() < 1e-6 {
+        return None;
+    }
+    use cgmath::Rotation;
+    Some((
+        head_position,
+        head_rotation
+            .normalize()
+            .rotate_vector(vec3(0.0, 0.0, -1.0)),
+    ))
+}
+
 pub fn get_rotation_from_forward_vector(forward: Vector3<f32>) -> Quaternion<f32> {
     let mut default_up = Vector3::new(0.0, 1.0, 0.0);
 

--- a/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
@@ -30,12 +30,18 @@ async function tint(game: GameServer) {
 }
 
 /**
- * Damage the player through the production message path. The player entity is
- * discovered from `/v1/info` every run - runtime entity ids are not stable.
+ * The player's runtime entity id, discovered every run - runtime entity ids are
+ * not stable across launches.
  */
-async function hitPlayer(game: GameServer, amount: number): Promise<void> {
+async function playerEntityId(game: GameServer): Promise<number> {
   const { player } = await game.info();
-  await game.entities.sendMessage(player.entity_id, { type: "Damage", amount });
+  assert.ok(player.entity_id !== null, "the mission has no player entity");
+  return player.entity_id;
+}
+
+/** Damage the player through the production message path. */
+async function hitPlayer(game: GameServer, amount: number): Promise<void> {
+  await game.entities.sendMessage(await playerEntityId(game), { type: "Damage", amount });
   // Messages are delivered on the next step; the second frame is the one the
   // tint is measured on, so the decay assertion below has somewhere to go.
   await game.step({ frames: 2 });
@@ -143,8 +149,10 @@ test(
     const lastSequence = before.sounds.at(-1)?.sequence ?? 0;
 
     // Negative damage is how the healing path reaches the same applier.
-    const { player } = await game.info();
-    await game.entities.sendMessage(player.entity_id, { type: "Damage", amount: -5 });
+    await game.entities.sendMessage(await playerEntityId(game), {
+      type: "Damage",
+      amount: -5,
+    });
     await game.step({ frames: 5 });
 
     assert.equal(await tint(game), undefined, "being healed tinted the view");

--- a/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Taking damage used to be silent and invisible: hit points dropped and
+// nothing else happened. `shock2vr/src/hit_feedback.rs` adds a hurt grunt and
+// a brief red rim tint, and this pins the three things that make it feedback
+// rather than a decoration:
+//
+//   1. the tint appears when the player is hit, in BOTH presentations,
+//   2. it goes away on its own,
+//   3. the grunt that plays is a real, resolvable sample - not a schema name
+//      that resolves to a file no install ships (the `smallouch` trap, which
+//      was exactly this bug in the first cut and which no scene-object
+//      assertion would have caught).
+//
+// Negative-first: without the feature, (1) and (3) both fail - `/v1/scene` has
+// no `hit_feedback` object at all and the damage plays no sound whatsoever.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8101);
+
+const HIT_FEEDBACK_SOURCE = "hit_feedback";
+
+/** The tint layer this frame, or undefined when nothing is showing. */
+async function tint(game: GameServer) {
+  const objects = await game.scene.fromSource(HIT_FEEDBACK_SOURCE);
+  assert.ok(objects.length <= 1, `expected at most one tint layer, got ${objects.length}`);
+  return objects[0];
+}
+
+/**
+ * Damage the player through the production message path. The player entity is
+ * discovered from `/v1/info` every run - runtime entity ids are not stable.
+ */
+async function hitPlayer(game: GameServer, amount: number): Promise<void> {
+  const { player } = await game.info();
+  await game.entities.sendMessage(player.entity_id, { type: "Damage", amount });
+  // Messages are delivered on the next step; the second frame is the one the
+  // tint is measured on, so the decay assertion below has somewhere to go.
+  await game.step({ frames: 2 });
+}
+
+for (const presentation of ["flat", "vr"] as const) {
+  test(
+    `a hit tints the view and then clears, in ${presentation}`,
+    { skip: !e2eEnabled, timeout: 600_000 },
+    async () => {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        port: basePort,
+        debugFlags: presentation === "vr" ? ["--vr"] : [],
+      });
+      await game.step({ frames: 60 });
+
+      // Nothing hurts an untouched player.
+      assert.equal(await tint(game), undefined, "the view is tinted before any damage");
+
+      await hitPlayer(game, 10);
+
+      const shown = await tint(game);
+      assert.ok(shown, "taking 10 damage drew no hit tint");
+      // A layer that draws opaque would hide the world; one that draws fully
+      // clear is a no-op that still passes "the object exists".
+      assert.ok(
+        shown.transparency !== null && shown.transparency > 0.05 && shown.transparency < 0.95,
+        `the tint must be translucent, got ${shown.transparency}`,
+      );
+      // The two device traps from PR #1020's dim, which this layer copies: a
+      // culled quad covers only part of the view on the Quest, and a
+      // depth-tested one only tints what is far away.
+      assert.equal(shown.backface_culling, null, "the tint must not opt into culling");
+      assert.equal(shown.clear_depth, true, "the tint must draw over the world");
+      assert.equal(shown.depth_write, false, "the tint must not occlude what draws after it");
+
+      // A bigger hit reads as bigger.
+      await game.step({ frames: 1 });
+      const faded = await tint(game);
+      assert.ok(faded, "the tint vanished after a single frame");
+      assert.ok(
+        faded.transparency! > shown.transparency!,
+        "the tint must fade, not hold",
+      );
+
+      // ...and it clears on its own, with nothing asked to remove it. The
+      // longest a full-strength hit lasts is well under two seconds.
+      await game.step({ duration: "2s" });
+      assert.equal(await tint(game), undefined, "the tint outlasted its decay");
+    },
+  );
+}
+
+test(
+  "a hit plays a player hurt grunt that actually resolves to a shipped sample",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 1,
+    });
+    await game.step({ frames: 60 });
+
+    const before = await game.audio.recent();
+    const lastSequence = before.sounds.at(-1)?.sequence ?? 0;
+
+    await hitPlayer(game, 10);
+    await game.step({ frames: 5 });
+
+    const after = await game.audio.recent();
+    const played = after.sounds.filter((sound) => sound.sequence > lastSequence);
+    assert.ok(
+      played.length > 0,
+      "damaging the player played nothing - the hurt schema resolved to no shipped sample",
+    );
+    // `dam_gen_med` -> one of dmgenme1..3. Asserting the *sample* rather than
+    // the schema is the whole point: the dead `medouch` schema resolved fine
+    // and then loaded no clip.
+    assert.ok(
+      played.some((sound) => /^dmgen/.test(sound.sample)),
+      `expected a dmgen* player-damage grunt, got ${played.map((s) => s.sample).join(", ")}`,
+    );
+    // The player's own voice is at the ears, not at a point in the world.
+    const grunt = played.find((sound) => /^dmgen/.test(sound.sample))!;
+    assert.deepEqual(grunt.position, [0, 0, 0], "the hurt grunt must not be spatialized");
+  },
+);
+
+test(
+  "healing the player is not treated as a hit",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 2,
+    });
+    await game.step({ frames: 60 });
+
+    await hitPlayer(game, 10);
+    await game.step({ duration: "2s" });
+    assert.equal(await tint(game), undefined);
+
+    const before = await game.audio.recent();
+    const lastSequence = before.sounds.at(-1)?.sequence ?? 0;
+
+    // Negative damage is how the healing path reaches the same applier.
+    const { player } = await game.info();
+    await game.entities.sendMessage(player.entity_id, { type: "Damage", amount: -5 });
+    await game.step({ frames: 5 });
+
+    assert.equal(await tint(game), undefined, "being healed tinted the view");
+    const played = (await game.audio.recent()).sounds.filter(
+      (sound) => sound.sequence > lastSequence && /^dmgen/.test(sound.sample),
+    );
+    assert.equal(played.length, 0, "being healed played a hurt grunt");
+  },
+);


### PR DESCRIPTION
Fixes #1036.

![hit vignette](https://gist.githubusercontent.com/tommy-xr/edd7bd9e3ebd058ef73f629c8dc81711/raw/hit-vignette.gif)

<sub>One 10-HP hit: the rim reddens and fades in under a second, with the middle of the field left clear. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Damage scale, and both presentations

![contact sheet](https://gist.githubusercontent.com/tommy-xr/edd7bd9e3ebd058ef73f629c8dc81711/raw/hit-vignette-scale.png)

<sub>Strength and duration scale with the hit. The `--vr` panel is captured from the VR presentation; it matches the flat one because the layer is cut to whatever projection the host renders with, so there is no per-presentation code path.</sub>

![in-world](https://gist.githubusercontent.com/tommy-xr/edd7bd9e3ebd058ef73f629c8dc81711/raw/hit-vignette-medsci1.png)

<sub>The same hit in `medsci1.mis` — the tint sits at the rim over a real level, leaving the crosshair and the middle of the corridor readable.</sub>


Taking damage as the player was completely silent and invisible: hit points ticked down in the flat HUD's bio meter and nothing else happened. In VR there is no bio meter in the corner of the eye at all, so a hybrid could beat you to death without a single cue.

This adds both halves of the feedback — a hurt grunt and a brief red rim tint — and wires them from **one** hook.

## The trigger

One site, in `mission_core`'s `AdjustHitPoints` applier. Every hit-point change in the game flows through it, so melee, projectiles, psi, traps and anything added later are covered without touching a script, and it sees the loss that was *actually applied* rather than what a weapon asked for — armour that soaks a hit makes the feedback smaller instead of lying about it. Healing (a rise) is ignored.

## The sound: the game's own player-damage schemas

`dam_gen_lo` / `dam_gen_med` / `dam_gen_hi`, picked by damage size, resolving to the shipped `dmgenlo*` / `dmgenme*` / `dmgenhi*` samples in `res/snd/PDamage` — the original game's player pain grunts. They are addressed **by name** the way the retail scripts did, because they carry no environmental-sound tags (`cargo dq sound +creaturetype:player` and `+event:hit` both match nothing), so an `EnvSoundQuery` cannot reach them. Non-spatial: it is the player's own voice, at the ears.

Two data traps recorded in the code so nobody re-walks them:

- The obvious candidates — the `SPEECH_PLAYER` schemas `smallouch` / `medouch` / `bigouch` — are **dead**. They resolve fine, and then point at `pdamlo*` / `pdammed*` / `pdamhi*` samples that ship in no `.kpf`. The first cut wired them and played silence (`Unable to load clip: medouch`). This is why the e2e asserts the **resolved sample name**, not that a schema was requested.
- `PDamage` also holds damage-*type* sets (`dam_bullet_*`, `dam_elec_*`, `dam_rad_*`, …). The port does not carry a damage type through `AdjustHitPoints`, so the generic set is the honest choice; picking a type-specific one is the natural follow-up once it does.

## The visual: a rim tint, not a red flash

**Comfort choices** (per the `vr-ui-design` skill):

- **Rim, not full screen.** A full-screen red flash is the obvious implementation and the wrong one in a headset: it fills the fovea and reads as "something is wrong with my eyes" rather than "I was hit". The middle of the field — the part you aim and read with — is left completely clear; the tint ramps in over the outer half toward the periphery, where a colour change is noticed without being stared at.
- **Brief, and proportional.** Peak opacity and lifetime both scale with the size of the hit (0.35 s for a graze, 0.85 s at full strength), so chip damage is a flicker and a shotgun blast is unmistakable. A second hit mid-fade can only make the tint stronger or longer, never weaker or shorter.
- **Hung 2.5 m out.** One quad is shared by both eyes, so an eye 32 mm off the head pose sees it shifted by `atan(0.032 / distance)`: at half a metre that is 3.7° of stereo disagreement about where the rim is, out here it is under a degree — the same margin PR #1020's dim relies on.
- The killing blow tints too (that is the hit you most need to see land), but stays silent — the death path plays its own vocalization, and two player voices at once is a mess.

**How it renders**, following PR #1020's pause dim as the reference: a **view-locked, double-sided quad** in the renderer's clear-depth overlay group, emitted from `Game::render` rather than `render_per_eye`. Same reasoning as #1020 — the two VR hosts disagree about where per-eye objects land in the scene list (the debug runtime appends, `oculus_runtime` prepends), so a screen-space layer that must sit over the world is composited correctly on exactly one of them; inside the group, order is ours. For the same reason it does not opt into backface culling: the hosts also disagree about winding, and a culled half was the original #1020 bug.

**One emit path serves flat and VR.** There is no per-presentation branch: the quad is cut to whatever picture the host is rendering, read off its own projection matrix (`m[0][0]`/`m[1][1]` give the frustum's half-extents), and the tint is placed as *fractions of the way to the edge of the picture*. That is what makes it the same visible effect on a 45° monitor and on a headset's much wider asymmetric per-eye frustum — and it is correct on the debug runtime's `--vr` mode too, which renders VR with the flat projection. Authoring the ramp as an absolute angle instead was the first cut's bug: the whole thing sat past the edge of a 45° screen and a hit rendered as *nothing*. Both axes are read, because a 4:3 screen reaches 29° across but only 22.5° up.

The layer is centred on the eye the frame is actually drawn from, not the one the input context reports — both flat runtimes put the *standing* eye in `head.position` while rendering from a crouch-aware one, which crouched would have swung the rim ~13° off-axis and dragged the ramp onto the crosshair.

## New engine material

`engine/src/scene/vignette_material.rs` — the falloff is per-fragment from the quad's UVs. It could not reuse an existing material: `basic_material` alpha-*cuts* (`if (texColor.a < 0.1) discard`) so it cannot draw a soft ramp, `color_material` is a flat fill with one uniform transparency, and `screen_space_material` is screen-space only, which is the thing the host-ordering argument above rules out.

## Testing

- **17 new unit tests** in `hit_feedback.rs`, negative-first, over the pure logic and the layer's flags/geometry: decay to nothing, proportionality, the never-weaken/never-shorten retrigger rules, healing is not a hit, the untracked-head (zero-quaternion) guard, no backface culling, translucent + clear-depth, the quad covers the picture on both axes and matches its aspect, and the projection-to-extents read (including the degenerate-matrix fallback). Two of them fail against the first cut: `the_tint_lands_inside_the_picture` is exactly the "invisible on flat" bug.
- **New e2e** `tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts`: damages the player through `POST /v1/entities/:id/message` (entity discovered from `/v1/info` every run — runtime ids are not stable) and asserts the tint appears in `/v1/scene` under the `hit_feedback` render source, has the right compositing flags, fades, and clears on its own — **in both flat and `--vr`** — plus that the grunt resolves to a real `dmgen*` sample and is non-spatial, and that healing does neither.
- `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; **833 lib tests**; the SDK unit tests + `tsc`; the **full e2e suite**, including 23/23 missions.
- The e2e suite's only failures are the two standing baseline ones, both reproduced identically on detached `origin/main`: `creature-loot` (#931) and `patrol` → "resumes its live target across alertness and save/load", which turns out to be the test saving from an off-map pose that `24cfeb27`'s save-pose guard now correctly refuses — filed as **#1040**.

## Reviewed

`/xreview` (Claude + Codex). Fixed from their findings: per-axis frustum fit (a single radius tinted a different fraction of each axis), the 0.6 m → 2.5 m stereo-parallax move, the crouched-eye offset, the graze-truncates-the-fade hole, no tint on the killing blow, and unbounded grunt stacking when several damage effects drain together. The zero-quaternion untracked-head guard (VR rule 7) was extracted into `util::tracked_gaze` and is now shared with the pause menu's dim.

Two findings both engines raised are **not** fixed here because they are pre-existing and not fixable from `shock2vr` — filed as **#1037**: the hosts' opposite per-eye concatenation order means this layer (like any overlay) composites differently on the two of them (flat: the viewmodel/HUD draw over the tint, which is the desired layering; Quest: the tint draws over the VR HUD), and `Effect::SetScreenFade` is already miscomposited on the Quest for the same reason.

## Tuning knobs

`MAX_RIM_OPACITY` (0.65) and the `CLEAR_FIELD_FRACTION` / `FULL_FIELD_FRACTION` pair (0.5 / 1.0) are the dials, and like #1020's `WORLD_DIM_STRENGTH` they want a worn check — how heavy a rim reads in a headset is not something a screenshot settles.


