### PR TITLE
fix(vr): resolve the wielded weapon per hand and show live ammo on the forearm

### DIFF
--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -19,8 +19,6 @@ use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
 pub(crate) const PANEL_W: f32 = 260.0;
 pub(crate) const PANEL_H: f32 = 64.0;
 pub(crate) const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
-/// The whole panel, for the backdrop art.
-pub(crate) const PANEL: Rect = Rect::new(0.0, 0.0, PANEL_W, PANEL_H);
 
 /// Round count, centered over the gauge (the AMMOBACK footprint at the panel's
 /// right end).
@@ -139,13 +137,13 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
     }
 }
 
-/// The VR forearm panel's canvas: the AMMOFULL art with the readout composited
-/// on it. The panel *is* the canvas here, so the readout is emitted at panel
-/// origin (0,0) - flat emits the same elements at its own panel origin. Pure
-/// (no asset/GL access), so it is unit-testable like `build_flat_hud_canvas`.
-pub(crate) fn build_forearm_panel_canvas(readout: &AmmoReadout) -> UiCanvas {
+/// The readout as the VR forearm draws it: a panel-sized canvas holding just
+/// the readout, which the forearm lays over its AMMOFULL backdrop quad. The
+/// panel *is* the canvas here, so the elements are emitted at panel origin
+/// (0,0) - flat emits the same ones at its own panel origin. Pure (no
+/// asset/GL access), so it is unit-testable like `build_flat_hud_canvas`.
+pub(crate) fn build_readout_canvas(readout: &AmmoReadout) -> UiCanvas {
     let mut canvas = UiCanvas::new(PANEL_SIZE);
-    canvas.image(PANEL, "AMMOFULL.PCX");
     emit(&mut canvas, vec2(0.0, 0.0), readout);
     canvas
 }
@@ -164,22 +162,22 @@ mod tests {
     }
 
     #[test]
-    fn the_empty_handed_forearm_panel_is_just_the_backdrop() {
-        let canvas = build_forearm_panel_canvas(&AmmoReadout::default());
-        assert_eq!(canvas.element_count(), 1);
+    fn the_empty_handed_forearm_readout_is_empty() {
+        // Nothing to say: the forearm shows its bare AMMOFULL backdrop quad.
+        let canvas = build_readout_canvas(&AmmoReadout::default());
+        assert_eq!(canvas.element_count(), 0);
         assert_eq!(canvas.size(), PANEL_SIZE);
     }
 
     #[test]
     fn a_wielded_gun_adds_its_count_icon_and_type_to_the_forearm() {
-        // Backdrop + count = 2; + icon + type label = 4.
         assert_eq!(
-            build_forearm_panel_canvas(&gun(12, None, None)).element_count(),
-            2
+            build_readout_canvas(&gun(12, None, None)).element_count(),
+            1
         );
         assert_eq!(
-            build_forearm_panel_canvas(&gun(12, Some("STD_I.PCX"), Some("std"))).element_count(),
-            4
+            build_readout_canvas(&gun(12, Some("STD_I.PCX"), Some("std"))).element_count(),
+            3
         );
     }
 
@@ -188,7 +186,7 @@ mod tests {
         // What the panel actually says, so a consumed round shows up here and
         // not just in a screenshot.
         let text_of = |readout| {
-            build_forearm_panel_canvas(&readout)
+            build_readout_canvas(&readout)
                 .elements()
                 .iter()
                 .find_map(|element| match element {
@@ -207,14 +205,14 @@ mod tests {
 
     #[test]
     fn the_psi_amp_shows_its_discipline_on_the_forearm_too() {
-        // Backdrop + tier badge + tier count + discipline name = 4, and the
-        // amp's meaningless clip is suppressed exactly as in flat.
-        let canvas = build_forearm_panel_canvas(&AmmoReadout {
+        // Tier badge + tier count + discipline name = 3, and the amp's
+        // meaningless clip is suppressed exactly as in flat.
+        let canvas = build_readout_canvas(&AmmoReadout {
             psi_power: Some(("Projected Cryokinesis".to_string(), 1)),
             ammo: Some(0),
             ..Default::default()
         });
-        assert_eq!(canvas.element_count(), 4);
+        assert_eq!(canvas.element_count(), 3);
     }
 
     /// Every readout element is authored inside the panel, so the VR forearm

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -1,0 +1,181 @@
+//! The ammo readout's layout - decided ONCE, in AMMOFULL panel pixels.
+//!
+//! The original SS2 ammo gauge is authored inside the 260x64 AMMOFULL.PCX
+//! panel. Flatscreen draws that panel into the 640x480 HUD canvas at
+//! [`crate::hud::flat_hud`]'s ammo origin; VR wears the same panel on the
+//! right forearm, where it *is* the whole canvas. Both presentations emit the
+//! readout from [`emit`] below, so the round count, ammo icon and type label
+//! sit in the same place relative to the panel art in the headset as they do
+//! on screen (AGENTS.md section 3).
+//!
+//! Rects are panel-local: (0,0) is the panel's upper-left corner.
+
+use cgmath::{Vector2, vec2};
+use shipyard::World;
+
+use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
+
+/// The AMMOFULL panel's authored pixel size.
+pub(crate) const PANEL_W: f32 = 260.0;
+pub(crate) const PANEL_H: f32 = 64.0;
+pub(crate) const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
+/// The whole panel, for the backdrop art.
+pub(crate) const PANEL: Rect = Rect::new(0.0, 0.0, PANEL_W, PANEL_H);
+
+/// Round count, centered over the gauge (the AMMOBACK footprint at the panel's
+/// right end).
+pub(crate) const COUNT: Rect = Rect::new(166.0, 22.0, 94.0, 20.0);
+/// Selected ammo type's object icon (P$ObjIcon), just left of the gauge.
+pub(crate) const ICON: Rect = Rect::new(126.0, 16.0, 32.0, 32.0);
+/// Ammo-type label (std/he/ap), below the count.
+pub(crate) const TYPE_LABEL: Rect = Rect::new(166.0, 44.0, 94.0, 16.0);
+/// The ammo-type cycle button (the original's `ammoarw` hotspot).
+pub(crate) const CYCLE_BUTTON: Rect = Rect::new(186.0, 15.0, 12.0, 41.0);
+/// Psi tier badge, in place of the ammo icon while the amp is wielded.
+pub(crate) const PSI_TIER_BADGE: Rect = Rect::new(122.0, 22.0, 32.0, 19.0);
+/// Psi discipline name. Longer than the ammo-type label, so it starts further
+/// left.
+pub(crate) const PSI_POWER_NAME: Rect = Rect::new(106.0, 44.0, 154.0, 16.0);
+
+/// Place a panel-local rect into a canvas whose panel origin is `origin`.
+pub(crate) const fn at(origin: Vector2<f32>, rect: Rect) -> Rect {
+    Rect::new(origin.x + rect.x, origin.y + rect.y, rect.w, rect.h)
+}
+
+/// What the ammo readout says this frame. Presentation-agnostic: both the flat
+/// HUD and the VR forearm panel build one of these from the world.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct AmmoReadout {
+    /// Selected psi power `(discipline, tier)` while the psi amp is wielded.
+    /// The amp has no clip, so this *replaces* the ammo readout.
+    pub psi_power: Option<(String, i32)>,
+    /// Rounds in the wielded weapon's clip.
+    pub ammo: Option<i32>,
+    /// The selected ammo type's object-icon bitmap.
+    pub ammo_icon: Option<String>,
+    /// The selected ammo type's class tag ("std", "he", "ap").
+    pub ammo_type: Option<String>,
+    /// Whether to draw the ammo-type cycle arrow. Flat sets this only in use
+    /// mode, where the pointer can actually click it; VR leaves it off (no
+    /// forearm pointer affordance exists - that is an interaction-design
+    /// decision, not a layout one).
+    pub show_cycle_button: bool,
+}
+
+impl AmmoReadout {
+    /// Read the wielded weapon's readout from the world. `show_cycle_button`
+    /// is the caller's (presentation's) call.
+    pub(crate) fn from_world(world: &World, show_cycle_button: bool) -> Self {
+        Self {
+            psi_power: super::get_wielded_psi_power(world),
+            ammo: super::get_wielded_ammo(world),
+            ammo_icon: super::get_wielded_ammo_icon(world),
+            ammo_type: super::get_wielded_ammo_type(world),
+            show_cycle_button,
+        }
+    }
+
+    /// Nothing to say - no weapon with a clip and no psi power wielded. The
+    /// gauge backdrop is not drawn at all in flat when this is true.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.psi_power.is_none() && self.ammo.is_none()
+    }
+}
+
+/// Emit the readout's elements into `canvas`, with the AMMOFULL panel's
+/// upper-left corner at `origin` in that canvas's pixel space. The backdrop
+/// art is the caller's (flat swaps AMMOBACK/AMMOFULL with use mode); every
+/// *placement* lives here.
+pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoReadout) {
+    // The psi amp shows its selected discipline where a gun shows its clip.
+    if let Some((power_name, tier)) = &readout.psi_power {
+        let tier = *tier;
+        canvas
+            .image(
+                at(origin, PSI_TIER_BADGE),
+                &format!("AmPsi{}1.PCX", tier.clamp(1, 5)),
+            )
+            .text_native(
+                at(origin, COUNT),
+                &format!("{tier}"),
+                "mainfont.fon",
+                HAlign::Center,
+                VAlign::Middle,
+            )
+            .text_native(
+                at(origin, PSI_POWER_NAME),
+                &power_name.to_ascii_uppercase(),
+                "mainfont.fon",
+                HAlign::Center,
+                VAlign::Middle,
+            );
+        return;
+    }
+
+    let Some(rounds) = readout.ammo else {
+        return;
+    };
+    canvas.text_native(
+        at(origin, COUNT),
+        &format!("{rounds}"),
+        "mainfont.fon",
+        HAlign::Center,
+        VAlign::Middle,
+    );
+    if let Some(icon) = &readout.ammo_icon {
+        canvas.image(at(origin, ICON), icon);
+    }
+    if let Some(ammo_type) = &readout.ammo_type {
+        canvas.text_native(
+            at(origin, TYPE_LABEL),
+            &ammo_type.to_ascii_uppercase(),
+            "mainfont.fon",
+            HAlign::Center,
+            VAlign::Middle,
+        );
+    }
+    if readout.show_cycle_button {
+        canvas.image(at(origin, CYCLE_BUTTON), "ammoarw0.pcx");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every readout element is authored inside the panel, so the VR forearm
+    /// - where the panel IS the whole canvas - shows all of them.
+    #[test]
+    fn every_element_sits_inside_the_panel() {
+        for rect in [
+            COUNT,
+            ICON,
+            TYPE_LABEL,
+            CYCLE_BUTTON,
+            PSI_TIER_BADGE,
+            PSI_POWER_NAME,
+        ] {
+            assert!(
+                rect.x >= 0.0 && rect.y >= 0.0,
+                "{rect:?} starts outside the panel"
+            );
+            assert!(
+                rect.x + rect.w <= PANEL_W,
+                "{rect:?} overflows the panel width"
+            );
+            assert!(
+                rect.y + rect.h <= PANEL_H,
+                "{rect:?} overflows the panel height"
+            );
+        }
+    }
+
+    #[test]
+    fn placing_the_panel_offsets_position_but_not_size() {
+        let placed = at(vec2(378.0, 414.0), COUNT);
+        assert_eq!(
+            placed,
+            Rect::new(378.0 + COUNT.x, 414.0 + COUNT.y, COUNT.w, COUNT.h)
+        );
+    }
+}

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -139,9 +139,83 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
     }
 }
 
+/// The VR forearm panel's canvas: the AMMOFULL art with the readout composited
+/// on it. The panel *is* the canvas here, so the readout is emitted at panel
+/// origin (0,0) - flat emits the same elements at its own panel origin. Pure
+/// (no asset/GL access), so it is unit-testable like `build_flat_hud_canvas`.
+pub(crate) fn build_forearm_panel_canvas(readout: &AmmoReadout) -> UiCanvas {
+    let mut canvas = UiCanvas::new(PANEL_SIZE);
+    canvas.image(PANEL, "AMMOFULL.PCX");
+    emit(&mut canvas, vec2(0.0, 0.0), readout);
+    canvas
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn gun(ammo: i32, icon: Option<&str>, ammo_type: Option<&str>) -> AmmoReadout {
+        AmmoReadout {
+            ammo: Some(ammo),
+            ammo_icon: icon.map(str::to_string),
+            ammo_type: ammo_type.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn the_empty_handed_forearm_panel_is_just_the_backdrop() {
+        let canvas = build_forearm_panel_canvas(&AmmoReadout::default());
+        assert_eq!(canvas.element_count(), 1);
+        assert_eq!(canvas.size(), PANEL_SIZE);
+    }
+
+    #[test]
+    fn a_wielded_gun_adds_its_count_icon_and_type_to_the_forearm() {
+        // Backdrop + count = 2; + icon + type label = 4.
+        assert_eq!(
+            build_forearm_panel_canvas(&gun(12, None, None)).element_count(),
+            2
+        );
+        assert_eq!(
+            build_forearm_panel_canvas(&gun(12, Some("STD_I.PCX"), Some("std"))).element_count(),
+            4
+        );
+    }
+
+    #[test]
+    fn the_forearm_count_tracks_the_clip() {
+        // What the panel actually says, so a consumed round shows up here and
+        // not just in a screenshot.
+        let text_of = |readout| {
+            build_forearm_panel_canvas(&readout)
+                .elements()
+                .iter()
+                .find_map(|element| match element {
+                    crate::ui::UiElement::Text { text, position, .. }
+                        if *position == vec2(COUNT.x, COUNT.y) =>
+                    {
+                        Some(text.clone())
+                    }
+                    _ => None,
+                })
+        };
+        assert_eq!(text_of(gun(12, None, None)).as_deref(), Some("12"));
+        assert_eq!(text_of(gun(11, None, None)).as_deref(), Some("11"));
+        assert_eq!(text_of(AmmoReadout::default()), None);
+    }
+
+    #[test]
+    fn the_psi_amp_shows_its_discipline_on_the_forearm_too() {
+        // Backdrop + tier badge + tier count + discipline name = 4, and the
+        // amp's meaningless clip is suppressed exactly as in flat.
+        let canvas = build_forearm_panel_canvas(&AmmoReadout {
+            psi_power: Some(("Projected Cryokinesis".to_string(), 1)),
+            ammo: Some(0),
+            ..Default::default()
+        });
+        assert_eq!(canvas.element_count(), 4);
+    }
 
     /// Every readout element is authored inside the panel, so the VR forearm
     /// - where the panel IS the whole canvas - shows all of them.

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -6,13 +6,14 @@
 //! resolution and rendered to a screen-space overlay. Built only in
 //! `PresentationMode::Flat`. See `projects/flatscreen-and-vr-architecture.md`.
 
-use cgmath::vec2;
+use cgmath::{Vector2, vec2};
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use shipyard::World;
 
+use super::ammo_panel::{self, AmmoReadout};
 use super::{
-    get_health_percentage, get_psi_percentage, get_wielded_ammo, get_wielded_ammo_icon,
-    get_wielded_ammo_type, get_wielded_psi_charge, get_wielded_psi_power,
+    get_health_percentage, get_psi_percentage, get_wielded_ammo, get_wielded_psi_charge,
+    get_wielded_psi_power,
 };
 use crate::runtime_props::{PsiChargePhase, RuntimePropPsiCharge};
 use crate::ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign};
@@ -76,25 +77,17 @@ const METERS_FULL_W: f32 = 260.0;
 const AMMO_FULL_MODE_DX: f32 = 166.0;
 const AMMO_FULL_X: f32 = AMMO_X - AMMO_FULL_MODE_DX; // 378
 const AMMO_FULL_GAUGE: Rect = Rect::new(AMMO_FULL_X, AMMO_Y, METERS_FULL_W, AMMO_H);
+/// Where the AMMOFULL panel's upper-left corner lands on the 640x480 HUD
+/// canvas. Everything *inside* the panel (round count, ammo icon and label,
+/// psi discipline, the cycle button) is laid out once in [`ammo_panel`] in
+/// panel pixels and placed relative to this - the VR forearm draws the same
+/// panel with its own origin.
+const AMMO_PANEL_ORIGIN: Vector2<f32> = vec2(AMMO_FULL_X, AMMO_Y);
 /// The AMMOFULL ammo-type cycle button (the original's cycle hotspot, ammoarw
 /// art). Clicking it cycles the wielded weapon's ammo type. Exposed so the
 /// flat pointer host can hit-test the same rect it is drawn at.
 pub(crate) const AMMO_CYCLE_BUTTON: Rect =
-    Rect::new(AMMO_FULL_X + 186.0, AMMO_Y + 15.0, 12.0, 41.0);
-const AMMO_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 22.0, AMMO_W, 20.0); // centered over the gauge
-// Selected ammo-type indicator: the projectile's object icon (P$ObjIcon) just
-// left of the gauge, with its type label (std/he/ap) below the round count.
-const AMMO_ICON: Rect = Rect::new(AMMO_X - 40.0, AMMO_Y + 16.0, 32.0, 32.0);
-const AMMO_TYPE_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 44.0, AMMO_W, 16.0);
-
-// Selected psi power display - drawn in the ammo section while the psi amp
-// is wielded (replacing the meaningless clip readout): the tier badge
-// (AmPsi<tier>1.PCX, 32x19 art), the psi point cost as the count, and the
-// discipline name below.
-const PSI_TIER_BADGE: Rect = Rect::new(AMMO_X - 44.0, AMMO_Y + 22.0, 32.0, 19.0);
-// The discipline names ("Projected Cryokinesis") are long, so the label rect
-// extends left of the gauge and uses a smaller size than the ammo-type label.
-const PSI_POWER_NAME: Rect = Rect::new(AMMO_X - 60.0, AMMO_Y + 44.0, AMMO_W + 60.0, 16.0);
+    ammo_panel::at(AMMO_PANEL_ORIGIN, ammo_panel::CYCLE_BUTTON);
 
 // Psi overload meter - drawn center-screen below the crosshair while the psi
 // amp's trigger is held on an overloadable power (and briefly after release,
@@ -115,18 +108,13 @@ const OVERLOAD_METER: Rect = Rect::new(
 /// access), so it is unit-testable. `crosshair` is false in use mode - the
 /// original turns the crosshair overlay off while the cursor is up
 /// (`ShockOverlayMouseMode`, projects/flat-ui.md §2.1).
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_flat_hud_canvas(
     crosshair: bool,
     use_mode: bool,
     health_fraction: f32,
     psi_fraction: f32,
     psi_charge: Option<RuntimePropPsiCharge>,
-    psi_power: Option<(String, i32)>,
-    ammo: Option<i32>,
-    ammo_icon: Option<String>,
-    ammo_type: Option<String>,
-    can_cycle_ammo: bool,
+    ammo_readout: &AmmoReadout,
 ) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(VIRTUAL_W, VIRTUAL_H));
 
@@ -194,59 +182,13 @@ pub(crate) fn build_flat_hud_canvas(
         }
     }
 
-    // Selected psi power (psi amp wielded): the ammo section shows the
-    // discipline instead of a clip - tier badge, psi cost as the count, and
-    // the discipline name.
-    if let Some((power_name, tier)) = psi_power {
-        canvas
-            .image(ammo_backdrop, ammo_art)
-            .image(PSI_TIER_BADGE, &format!("AmPsi{}1.PCX", tier.clamp(1, 5)))
-            .text_native(
-                AMMO_TEXT,
-                &format!("{tier}"),
-                "mainfont.fon",
-                HAlign::Center,
-                VAlign::Middle,
-            )
-            .text_native(
-                PSI_POWER_NAME,
-                &power_name.to_ascii_uppercase(),
-                "mainfont.fon",
-                HAlign::Center,
-                VAlign::Middle,
-            );
-        return canvas;
-    }
-
-    // Ammo gauge (only when a weapon with a clip is wielded).
-    if let Some(rounds) = ammo {
-        canvas.image(ammo_backdrop, ammo_art).text_native(
-            AMMO_TEXT,
-            &format!("{rounds}"),
-            "mainfont.fon",
-            HAlign::Center,
-            VAlign::Middle,
-        );
-
-        // Selected ammo-type indicator: the projectile's icon + type label.
-        if let Some(icon) = ammo_icon {
-            canvas.image(AMMO_ICON, &icon);
-        }
-        if let Some(ammo_type) = ammo_type {
-            canvas.text_native(
-                AMMO_TYPE_TEXT,
-                &ammo_type.to_ascii_uppercase(),
-                "mainfont.fon",
-                HAlign::Center,
-                VAlign::Middle,
-            );
-        }
-
-        // AMMOFULL ammo-type cycle button (use mode, multi-ammo weapon): the
-        // clickable ammoarw gadget the flat pointer host wires to CycleAmmo.
-        if use_mode && can_cycle_ammo {
-            canvas.image(AMMO_CYCLE_BUTTON, "ammoarw0.pcx");
-        }
+    // Ammo gauge (a weapon with a clip, or the psi amp's selected discipline
+    // in its place). The backdrop art is flat's to choose - use mode expands
+    // it - but everything drawn inside the panel is placed by the shared
+    // `ammo_panel` layout the VR forearm uses.
+    if !ammo_readout.is_empty() {
+        canvas.image(ammo_backdrop, ammo_art);
+        ammo_panel::emit(&mut canvas, AMMO_PANEL_ORIGIN, ammo_readout);
     }
 
     canvas
@@ -267,12 +209,8 @@ pub(crate) fn create_flat_hud(
         get_health_percentage(world),
         get_psi_percentage(world),
         get_wielded_psi_charge(world),
-        get_wielded_psi_power(world),
-        get_wielded_ammo(world),
-        get_wielded_ammo_icon(world),
-        get_wielded_ammo_type(world),
         // The same predicate the pointer hit-test uses, so drawn == clickable.
-        ammo_cycle_button_visible(world, use_mode),
+        &AmmoReadout::from_world(world, ammo_cycle_button_visible(world, use_mode)),
     );
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
@@ -281,13 +219,7 @@ pub(crate) fn create_flat_hud(
 /// Whether the wielded weapon may cycle ammo (empty, with 2+ selectable
 /// projectile types). Uses the same predicate as `cycle_ammo`.
 pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
-    let Some(player) = world
-        .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
-        .ok()
-    else {
-        return false;
-    };
-    let Some(weapon) = player.left_hand_entity_id else {
+    let Some(weapon) = crate::wielded_weapon::wielded_weapon(world) else {
         return false;
     };
     crate::scripts::script_util::can_cycle_ammo(world, weapon)
@@ -310,11 +242,33 @@ pub(crate) fn ammo_cycle_button_visible(world: &World, use_mode: bool) -> bool {
 mod tests {
     use super::*;
 
+    /// `AmmoReadout` for the common test shapes.
+    fn readout(
+        ammo: Option<i32>,
+        ammo_icon: Option<&str>,
+        ammo_type: Option<&str>,
+        show_cycle_button: bool,
+    ) -> AmmoReadout {
+        AmmoReadout {
+            psi_power: None,
+            ammo,
+            ammo_icon: ammo_icon.map(str::to_string),
+            ammo_type: ammo_type.map(str::to_string),
+            show_cycle_button,
+        }
+    }
+
     #[test]
     fn canvas_has_crosshair_bio_backdrop_bars_and_readouts() {
         // Crosshair + bio backdrop + 2 bars + 2 stat numbers = 6 (no weapon).
-        let canvas =
-            build_flat_hud_canvas(true, false, 1.0, 0.75, None, None, None, None, None, false);
+        let canvas = build_flat_hud_canvas(
+            true,
+            false,
+            1.0,
+            0.75,
+            None,
+            &readout(None, None, None, false),
+        );
         assert_eq!(canvas.element_count(), 6);
     }
 
@@ -327,11 +281,7 @@ mod tests {
             1.0,
             0.75,
             None,
-            None,
-            Some(12),
-            None,
-            None,
-            false,
+            &readout(Some(12), None, None, false),
         );
         assert_eq!(canvas.element_count(), 8);
     }
@@ -345,11 +295,7 @@ mod tests {
             1.0,
             0.75,
             None,
-            None,
-            Some(12),
-            Some("STD_I.PCX".to_string()),
-            Some("std".to_string()),
-            false,
+            &readout(Some(12), Some("STD_I.PCX"), Some("std"), false),
         );
         assert_eq!(canvas.element_count(), 10);
     }
@@ -364,11 +310,11 @@ mod tests {
             1.0,
             0.75,
             None,
-            Some(("Projected Cryokinesis".to_string(), 1)),
-            Some(0),
-            None,
-            None,
-            false,
+            &AmmoReadout {
+                psi_power: Some(("Projected Cryokinesis".to_string(), 1)),
+                ammo: Some(0),
+                ..Default::default()
+            },
         );
         assert_eq!(canvas.element_count(), 10);
     }
@@ -376,18 +322,15 @@ mod tests {
     #[test]
     fn use_mode_expands_readouts_and_adds_the_ammo_cycle_button() {
         // Shooter with a multi-ammo weapon: crosshair + bio + 2 bars + 2
-        // numbers + ammo backdrop + count = 8; NO cycle button.
+        // numbers + ammo backdrop + count = 8; NO cycle button (the caller
+        // gates it on use mode, see `ammo_cycle_button_visible`).
         let shooter = build_flat_hud_canvas(
             true,
             false,
             1.0,
             0.75,
             None,
-            None,
-            Some(12),
-            None,
-            None,
-            true,
+            &readout(Some(12), None, None, false),
         );
         assert_eq!(shooter.element_count(), 8);
         // Use mode (crosshair off) with an empty multi-ammo weapon: the same
@@ -399,11 +342,7 @@ mod tests {
             1.0,
             0.75,
             None,
-            None,
-            Some(0),
-            None,
-            None,
-            true,
+            &readout(Some(0), None, None, true),
         );
         assert_eq!(use_mode.element_count(), 8);
         // The cycle button only appears when the weapon can actually cycle.
@@ -413,11 +352,7 @@ mod tests {
             1.0,
             0.75,
             None,
-            None,
-            Some(0),
-            None,
-            None,
-            false,
+            &readout(Some(0), None, None, false),
         );
         assert_eq!(single_ammo.element_count(), 7);
     }
@@ -428,6 +363,38 @@ mod tests {
         // AMMOFULL gauge and left of the compact AMMOBACK footprint.
         assert!(AMMO_FULL_GAUGE.x <= AMMO_CYCLE_BUTTON.x);
         assert!(AMMO_CYCLE_BUTTON.x + AMMO_CYCLE_BUTTON.w <= AMMO_FULL_GAUGE.x + AMMO_FULL_GAUGE.w);
+    }
+
+    /// The shared panel layout must keep landing where the flat HUD authored
+    /// it: the ammo readout moved into `ammo_panel` in panel-local pixels, and
+    /// these are the absolute canvas rects it replaced.
+    #[test]
+    fn shared_panel_layout_reproduces_the_authored_flat_rects() {
+        let placed = |rect| ammo_panel::at(AMMO_PANEL_ORIGIN, rect);
+        assert_eq!(
+            placed(ammo_panel::CYCLE_BUTTON),
+            Rect::new(564.0, 429.0, 12.0, 41.0)
+        );
+        assert_eq!(
+            placed(ammo_panel::COUNT),
+            Rect::new(544.0, 436.0, 94.0, 20.0)
+        );
+        assert_eq!(
+            placed(ammo_panel::ICON),
+            Rect::new(504.0, 430.0, 32.0, 32.0)
+        );
+        assert_eq!(
+            placed(ammo_panel::TYPE_LABEL),
+            Rect::new(544.0, 458.0, 94.0, 16.0)
+        );
+        assert_eq!(
+            placed(ammo_panel::PSI_TIER_BADGE),
+            Rect::new(500.0, 436.0, 32.0, 19.0)
+        );
+        assert_eq!(
+            placed(ammo_panel::PSI_POWER_NAME),
+            Rect::new(484.0, 458.0, 154.0, 16.0)
+        );
     }
 
     #[test]
@@ -445,16 +412,22 @@ mod tests {
     fn use_mode_hides_the_crosshair() {
         // The original turns the crosshair overlay off while the cursor is
         // up (ShockOverlayMouseMode) - one fewer element than shooter mode.
-        let shooter =
-            build_flat_hud_canvas(true, false, 1.0, 0.75, None, None, None, None, None, false);
-        let use_mode =
-            build_flat_hud_canvas(false, false, 1.0, 0.75, None, None, None, None, None, false);
+        let empty = readout(None, None, None, false);
+        let shooter = build_flat_hud_canvas(true, false, 1.0, 0.75, None, &empty);
+        let use_mode = build_flat_hud_canvas(false, false, 1.0, 0.75, None, &empty);
         assert_eq!(use_mode.element_count(), shooter.element_count() - 1);
     }
 
     #[test]
     fn out_of_range_fractions_do_not_panic() {
         // Fills are clamped inside `UiCanvas::bar`.
-        let _ = build_flat_hud_canvas(true, false, 2.0, -1.0, None, None, None, None, None, false);
+        let _ = build_flat_hud_canvas(
+            true,
+            false,
+            2.0,
+            -1.0,
+            None,
+            &readout(None, None, None, false),
+        );
     }
 }

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -4,5 +4,7 @@ pub use item_outline::*;
 pub(crate) mod virtual_arms;
 pub use virtual_arms::*;
 
+pub(crate) mod ammo_panel;
+
 mod flat_hud;
 pub(crate) use flat_hud::*;

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -445,12 +445,10 @@ fn create_ammo_forearm_panel(
 ) -> Vec<SceneObject> {
     use crate::hud::ammo_panel;
 
-    let mut canvas = crate::ui::UiCanvas::new(ammo_panel::PANEL_SIZE);
-    canvas.image(ammo_panel::PANEL, "AMMOFULL.PCX");
     // No cycle affordance on the forearm: nothing points at this panel yet, and
     // drawing a button nobody can press would be a lie.
     let readout = ammo_panel::AmmoReadout::from_world(world, false);
-    ammo_panel::emit(&mut canvas, cgmath::vec2(0.0, 0.0), &readout);
+    let canvas = ammo_panel::build_forearm_panel_canvas(&readout);
 
     canvas.render_world_space(
         asset_cache,

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -58,14 +58,10 @@ pub fn create_arm_hud_panels(
     );
     scene_objects.append(&mut left_hud_layers);
 
-    // Create right arm HUD (AMMOFULL - for ammo)
-    let right_hud = create_forearm_hud_panel(
-        asset_cache,
-        right_hand_position,
-        right_hand_rotation,
-        Handedness::Right,
-    );
-    scene_objects.push(right_hud);
+    // Create right arm HUD (AMMOFULL) with the live ammo readout on it
+    let mut right_hud_layers =
+        create_ammo_forearm_panel(asset_cache, world, right_hand_position, right_hand_rotation);
+    scene_objects.append(&mut right_hud_layers);
 
     // Part of the player's hand visuals: labelled here rather than at the call
     // sites so the `debug_hud` scene, which emits these without an interaction
@@ -161,16 +157,11 @@ pub(crate) fn get_psi_percentage(world: &World) -> f32 {
 /// `(discipline name, tier)`. `Some` only while the wielded weapon is the
 /// psi amp (class tag `weapontype psiamp`).
 pub(crate) fn get_wielded_psi_power(world: &World) -> Option<(String, i32)> {
-    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
-    let weapon = player_info.left_hand_entity_id?;
+    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
 
     // Is the wielded weapon the psi amp? Resolved via its template's class
     // tags, the same mechanism as `get_wielded_ammo_type`.
-    let template_id = crate::scripts::script_util::entity_class_template_id(world, weapon)?;
-    let class_tags = world
-        .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateClassTags>>()
-        .ok()?;
-    if class_tags.0.get(&template_id)?.get("weapontype")? != "psiamp" {
+    if !crate::wielded_weapon::is_psi_amp(world, weapon) {
         return None;
     }
 
@@ -193,8 +184,7 @@ pub(crate) fn get_wielded_psi_power(world: &World) -> Option<(String, i32)> {
 pub(crate) fn get_wielded_psi_charge(
     world: &World,
 ) -> Option<crate::runtime_props::RuntimePropPsiCharge> {
-    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
-    let weapon = player_info.left_hand_entity_id?;
+    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
     let v_charge = world
         .borrow::<View<crate::runtime_props::RuntimePropPsiCharge>>()
         .ok()?;
@@ -202,12 +192,11 @@ pub(crate) fn get_wielded_psi_charge(
 }
 
 /// Current clip ammo of the wielded weapon, or `None` when unarmed or the held
-/// item has no `PropGunState` (melee / unlimited debug weapons). In flatscreen
-/// mode the wielded weapon is the player's left-hand slot (see
-/// `FlatInteraction::held_entities`).
+/// item has no `PropGunState` (melee / unlimited debug weapons). Which held
+/// entity counts as "the wielded weapon" - in either presentation, in either
+/// hand - is decided by [`crate::wielded_weapon`].
 pub(crate) fn get_wielded_ammo(world: &World) -> Option<i32> {
-    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
-    let weapon = player_info.left_hand_entity_id?;
+    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
     let v_gun_state = world
         .borrow::<View<dark::properties::PropGunState>>()
         .ok()?;
@@ -218,8 +207,7 @@ pub(crate) fn get_wielded_ammo(world: &World) -> Option<i32> {
 /// (its ammo type), or `None` when unarmed or the weapon has no projectile links
 /// (melee). Honors `RuntimePropSelectedAmmo` (absent = the first link).
 pub(crate) fn wielded_selected_projectile_template(world: &World) -> Option<i32> {
-    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
-    let weapon = player_info.left_hand_entity_id?;
+    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
     let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
     if projectiles.is_empty() {
         return None;
@@ -419,4 +407,56 @@ fn create_forearm_hud_panel(
     scene_object.set_transform(transform);
 
     scene_object
+}
+
+/// Where the forearm panel hangs, as a root transform for a unit canvas: the
+/// same placement `create_forearm_hud_panel` gives its quad, so the canvas
+/// presenter draws the panel exactly where the plain quad used to.
+fn forearm_panel_transform(
+    hand_position: Vector3<f32>,
+    hand_rotation: Quaternion<f32>,
+    handedness: Handedness,
+) -> Matrix4<f32> {
+    let forearm_position = hand_position + hand_rotation.rotate_vector(FOREARM_OFFSET);
+    let forearm_yaw_rotation = match handedness {
+        Handedness::Left => Quaternion::from(Euler::new(Deg(0.0), Deg(90.0), Deg(0.0))),
+        Handedness::Right => Quaternion::from(Euler::new(Deg(0.0), Deg(-90.0), Deg(0.0))),
+    };
+    let forearm_tilt_rotation = Quaternion::from(Euler::new(Deg(-90.0), Deg(0.0), Deg(180.0)));
+    let final_rotation = hand_rotation * forearm_yaw_rotation * forearm_tilt_rotation;
+
+    Matrix4::from_translation(forearm_position)
+        * Matrix4::from(final_rotation)
+        * Matrix4::from_nonuniform_scale(HUD_PANEL_WIDTH, HUD_PANEL_HEIGHT, 1.0)
+}
+
+/// The right forearm's AMMOFULL panel, with the live ammo readout composited
+/// on it - the VR counterpart of the flat HUD's ammo gauge.
+///
+/// The panel art IS the 260x64 AMMOFULL canvas, so the readout is drawn by the
+/// shared [`crate::hud::ammo_panel`] layout at panel origin (0,0); flat draws
+/// the identical elements at the panel's origin on its 640x480 canvas
+/// (AGENTS.md section 3 - one layout, two presentations).
+fn create_ammo_forearm_panel(
+    asset_cache: &mut AssetCache,
+    world: &World,
+    hand_position: Vector3<f32>,
+    hand_rotation: Quaternion<f32>,
+) -> Vec<SceneObject> {
+    use crate::hud::ammo_panel;
+
+    let mut canvas = crate::ui::UiCanvas::new(ammo_panel::PANEL_SIZE);
+    canvas.image(ammo_panel::PANEL, "AMMOFULL.PCX");
+    // No cycle affordance on the forearm: nothing points at this panel yet, and
+    // drawing a button nobody can press would be a lie.
+    let readout = ammo_panel::AmmoReadout::from_world(world, false);
+    ammo_panel::emit(&mut canvas, cgmath::vec2(0.0, 0.0), &readout);
+
+    canvas.render_world_space(
+        asset_cache,
+        forearm_panel_transform(hand_position, hand_rotation, Handedness::Right),
+        None,
+        None,
+        OVERLAY_Z_OFFSET,
+    )
 }

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -54,7 +54,6 @@ pub fn create_arm_hud_panels(
         world,
         left_hand_position,
         left_hand_rotation,
-        Handedness::Left,
     );
     scene_objects.append(&mut left_hud_layers);
 
@@ -245,33 +244,23 @@ pub(crate) fn get_wielded_ammo_icon(world: &World) -> Option<String> {
     icons.0.get(&template_id).cloned()
 }
 
-/// Create layered forearm HUD with health and psi bar overlays
+/// Create the left forearm's layered BIOFULL HUD with health and psi bar
+/// overlays. (The right forearm is [`create_ammo_forearm_panel`]'s.)
 fn create_forearm_hud_with_overlays(
     asset_cache: &mut AssetCache,
     world: &World,
     hand_position: Vector3<f32>,
     hand_rotation: Quaternion<f32>,
-    handedness: Handedness,
 ) -> Vec<SceneObject> {
     let mut layers = Vec::new();
 
-    // Only add overlays for left hand (BIOFULL display)
-    if handedness != Handedness::Left {
-        // For right hand, just create basic panel
-        let panel = create_forearm_hud_panel(asset_cache, hand_position, hand_rotation, handedness);
-        layers.push(panel);
-        return layers;
-    }
-
     // Calculate base HUD position and rotation
-    let forearm_position = hand_position + hand_rotation.rotate_vector(FOREARM_OFFSET);
-    let forearm_yaw_rotation = Quaternion::from(Euler::new(Deg(0.0), Deg(90.0), Deg(0.0)));
-    let forearm_tilt_rotation = Quaternion::from(Euler::new(Deg(-90.0), Deg(0.0), Deg(180.0)));
-    let final_rotation = hand_rotation * forearm_yaw_rotation * forearm_tilt_rotation;
+    let (forearm_position, final_rotation) =
+        forearm_pose(hand_position, hand_rotation, Handedness::Left);
 
     // Layer 1: Base BIOFULL panel
     let base_panel =
-        create_forearm_hud_panel(asset_cache, hand_position, hand_rotation, handedness);
+        create_forearm_hud_panel(asset_cache, hand_position, hand_rotation, Handedness::Left);
     layers.push(base_panel);
 
     // Layer 2: Health bar overlay
@@ -357,9 +346,6 @@ fn create_forearm_hud_panel(
     hand_rotation: Quaternion<f32>,
     handedness: Handedness,
 ) -> SceneObject {
-    // Calculate forearm position - offset from hand toward elbow
-    let forearm_position = hand_position + hand_rotation.rotate_vector(FOREARM_OFFSET);
-
     // Load appropriate texture based on handedness
     let texture_options = TextureOptions {
         wrap: false,
@@ -382,61 +368,62 @@ fn create_forearm_hud_panel(
     // Create quad geometry
     let geometry = Box::new(engine::scene::quad::create());
 
-    // Calculate wearable computer orientation
-    // For a forearm-mounted display, we need additional rotations:
-    // 1. Yaw rotation to align with forearm direction
-    // 2. Z rotation to make it lie flat on the forearm like a wrist computer
-    let forearm_yaw_rotation = match handedness {
-        Handedness::Left => Quaternion::from(Euler::new(Deg(0.0), Deg(90.0), Deg(0.0))), // Rotate left panel toward body
-        Handedness::Right => Quaternion::from(Euler::new(Deg(0.0), Deg(-90.0), Deg(0.0))), // Rotate right panel toward body
-    };
-
-    // Z rotation to tilt the panel flat against the forearm (like looking down at a wrist watch)
-    let forearm_tilt_rotation = Quaternion::from(Euler::new(Deg(-90.0), Deg(0.0), Deg(180.0)));
-
-    // Combine all rotations: hand rotation + yaw + tilt
-    let final_rotation = hand_rotation * forearm_yaw_rotation * forearm_tilt_rotation;
-
-    // Calculate transform matrix with proper aspect ratio and wearable orientation
-    let transform = Matrix4::from_translation(forearm_position)
-        * Matrix4::from(final_rotation)
-        * Matrix4::from_nonuniform_scale(HUD_PANEL_WIDTH, HUD_PANEL_HEIGHT, 1.0);
-
-    // Create scene object
+    // Create scene object, placed by the shared forearm pose
     let mut scene_object = SceneObject::new(material, geometry);
-    scene_object.set_transform(transform);
+    scene_object.set_transform(forearm_panel_transform(
+        hand_position,
+        hand_rotation,
+        handedness,
+    ));
 
     scene_object
 }
 
-/// Where the forearm panel hangs, as a root transform for a unit canvas: the
-/// same placement `create_forearm_hud_panel` gives its quad, so the canvas
-/// presenter draws the panel exactly where the plain quad used to.
-fn forearm_panel_transform(
+/// Where a forearm panel hangs: offset from the hand toward the elbow, yawed
+/// toward the body and tilted flat against the arm like a wrist computer.
+/// The single source of forearm placement - the panel quad, its overlays and
+/// the ammo readout canvas all derive from this, so they cannot drift apart.
+fn forearm_pose(
     hand_position: Vector3<f32>,
     hand_rotation: Quaternion<f32>,
     handedness: Handedness,
-) -> Matrix4<f32> {
+) -> (Vector3<f32>, Quaternion<f32>) {
     let forearm_position = hand_position + hand_rotation.rotate_vector(FOREARM_OFFSET);
     let forearm_yaw_rotation = match handedness {
         Handedness::Left => Quaternion::from(Euler::new(Deg(0.0), Deg(90.0), Deg(0.0))),
         Handedness::Right => Quaternion::from(Euler::new(Deg(0.0), Deg(-90.0), Deg(0.0))),
     };
     let forearm_tilt_rotation = Quaternion::from(Euler::new(Deg(-90.0), Deg(0.0), Deg(180.0)));
-    let final_rotation = hand_rotation * forearm_yaw_rotation * forearm_tilt_rotation;
+    (
+        forearm_position,
+        hand_rotation * forearm_yaw_rotation * forearm_tilt_rotation,
+    )
+}
 
-    Matrix4::from_translation(forearm_position)
-        * Matrix4::from(final_rotation)
+/// [`forearm_pose`] as a root transform for a panel-sized canvas, so canvas
+/// elements land exactly on the panel quad.
+fn forearm_panel_transform(
+    hand_position: Vector3<f32>,
+    hand_rotation: Quaternion<f32>,
+    handedness: Handedness,
+) -> Matrix4<f32> {
+    let (position, rotation) = forearm_pose(hand_position, hand_rotation, handedness);
+    Matrix4::from_translation(position)
+        * Matrix4::from(rotation)
         * Matrix4::from_nonuniform_scale(HUD_PANEL_WIDTH, HUD_PANEL_HEIGHT, 1.0)
 }
 
 /// The right forearm's AMMOFULL panel, with the live ammo readout composited
 /// on it - the VR counterpart of the flat HUD's ammo gauge.
 ///
-/// The panel art IS the 260x64 AMMOFULL canvas, so the readout is drawn by the
-/// shared [`crate::hud::ammo_panel`] layout at panel origin (0,0); flat draws
-/// the identical elements at the panel's origin on its 640x480 canvas
-/// (AGENTS.md section 3 - one layout, two presentations).
+/// The backdrop stays the plain panel quad the left forearm uses, so both
+/// forearm panels are lit identically (the canvas presenter draws its elements
+/// fully emissive, which suits a readout but would make this panel glow beside
+/// its BIOFULL twin). The readout itself is a panel-sized canvas laid one
+/// overlay step in front, drawn by the shared [`crate::hud::ammo_panel`]
+/// layout at panel origin (0,0) - flat emits the identical elements at the
+/// panel's origin on its 640x480 canvas (AGENTS.md section 3 - one layout, two
+/// presentations).
 fn create_ammo_forearm_panel(
     asset_cache: &mut AssetCache,
     world: &World,
@@ -445,16 +432,26 @@ fn create_ammo_forearm_panel(
 ) -> Vec<SceneObject> {
     use crate::hud::ammo_panel;
 
+    let mut objects = vec![create_forearm_hud_panel(
+        asset_cache,
+        hand_position,
+        hand_rotation,
+        Handedness::Right,
+    )];
+
     // No cycle affordance on the forearm: nothing points at this panel yet, and
     // drawing a button nobody can press would be a lie.
     let readout = ammo_panel::AmmoReadout::from_world(world, false);
-    let canvas = ammo_panel::build_forearm_panel_canvas(&readout);
+    objects.append(
+        &mut ammo_panel::build_readout_canvas(&readout).render_world_space(
+            asset_cache,
+            forearm_panel_transform(hand_position, hand_rotation, Handedness::Right)
+                * Matrix4::from_translation(vec3(0.0, 0.0, OVERLAY_Z_OFFSET)),
+            None,
+            None,
+            OVERLAY_Z_OFFSET,
+        ),
+    );
 
-    canvas.render_world_space(
-        asset_cache,
-        forearm_panel_transform(hand_position, hand_rotation, Handedness::Right),
-        None,
-        None,
-        OVERLAY_Z_OFFSET,
-    )
+    objects
 }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -45,6 +45,7 @@ mod util;
 mod virtual_hand;
 mod vr_config;
 pub mod vr_crouch;
+mod wielded_weapon;
 pub mod zip_asset_path;
 
 use scenes::{
@@ -548,7 +549,11 @@ impl Game {
         use crate::runtime_props::RuntimePropReloading;
         let world = self.world();
         let info = world.borrow::<shipyard::UniqueView<PlayerInfo>>().ok()?;
-        let reload = info.left_hand_entity_id.and_then(|weapon| {
+        // Reload/ammo/psi readouts describe the WIELDED weapon, which in VR
+        // may be in either hand (`crate::wielded_weapon`); the raw hand slots
+        // are reported separately below.
+        let wielded = crate::wielded_weapon::wielded_weapon(world);
+        let reload = wielded.and_then(|weapon| {
             world
                 .borrow::<shipyard::View<RuntimePropReloading>>()
                 .ok()
@@ -604,7 +609,7 @@ impl Game {
                     .ok()?;
                 powers.0.get(selection.index).map(|p| p.name.clone())
             })(),
-            psi_charge: info.left_hand_entity_id.and_then(|weapon| {
+            psi_charge: wielded.and_then(|weapon| {
                 use crate::runtime_props::{PsiChargePhase, RuntimePropPsiCharge};
                 let v = world
                     .borrow::<shipyard::View<RuntimePropPsiCharge>>()

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4103,25 +4103,15 @@ impl MissionCore {
                 }
 
                 Effect::ReloadWeapon => {
-                    let wielded = self
-                        .world
-                        .borrow::<UniqueView<PlayerInfo>>()
-                        .unwrap()
-                        .left_hand_entity_id;
-
-                    if let Some(weapon) = wielded {
+                    // Whichever hand holds the gun - the input action is not
+                    // hand-specific (see `crate::wielded_weapon`).
+                    if let Some(weapon) = crate::wielded_weapon::wielded_weapon(&self.world) {
                         self.begin_reload(weapon);
                     }
                 }
 
                 Effect::CycleAmmo => {
-                    let wielded = self
-                        .world
-                        .borrow::<UniqueView<PlayerInfo>>()
-                        .unwrap()
-                        .left_hand_entity_id;
-
-                    if let Some(weapon) = wielded {
+                    if let Some(weapon) = crate::wielded_weapon::wielded_weapon(&self.world) {
                         self.cycle_ammo(weapon);
                     }
                 }
@@ -4759,13 +4749,10 @@ impl MissionCore {
                         &self.world,
                         class_template_id,
                     );
-                    let already_wielded = self
-                        .world
-                        .borrow::<UniqueView<PlayerInfo>>()
-                        .ok()
-                        .and_then(|player| player.left_hand_entity_id);
-                    if let Some(entity_id) =
-                        maybe_weapon.filter(|entity| Some(*entity) != already_wielded)
+                    if let Some(entity_id) = maybe_weapon
+                        // Either hand: in VR the weapon may already be held in
+                        // the right one.
+                        .filter(|entity| !crate::wielded_weapon::is_held(&self.world, *entity))
                     {
                         effects.push_front(Effect::GrabEntity {
                             entity_id,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4751,8 +4751,10 @@ impl MissionCore {
                     );
                     if let Some(entity_id) = maybe_weapon
                         // Either hand: in VR the weapon may already be held in
-                        // the right one.
-                        .filter(|entity| !crate::wielded_weapon::is_held(&self.world, *entity))
+                        // the right one. Asked of the interaction controller
+                        // rather than `PlayerInfo`, which only mirrors it once
+                        // per update and so can be stale mid-effect-batch.
+                        .filter(|entity| !self.interaction.is_holding(*entity))
                     {
                         effects.push_front(Effect::GrabEntity {
                             entity_id,

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -1,0 +1,79 @@
+//! Which weapon a weapon action or an ammo readout means.
+//!
+//! `PlayerInfo` carries two hand slots. In flatscreen the controller wields
+//! into the *left* slot and the right is always empty (see
+//! `FlatInteraction::held_entities`), so "the left-hand entity" happened to be
+//! a correct spelling of "the wielded weapon". In VR the slots are literally
+//! the two motion controllers, so a gun held in the right hand was invisible
+//! to reload, ammo cycling, and the ammo HUD - all of which read the left slot
+//! only. This module is the single place that answers the question, for both
+//! presentations.
+//!
+//! **Both-hands precedence.** When both hands hold a weapon, the RIGHT hand
+//! wins. It is the dominant/aiming hand for the default VR player, it is the
+//! hand the forearm ammo panel is worn beside, and - because flat never fills
+//! the right slot - preferring it leaves flatscreen behaviour exactly as it
+//! was. A future hand-specific affordance (e.g. a reload gesture that starts
+//! from one controller) should resolve its own hand with [`weapon_in_hand`]
+//! rather than going through [`wielded_weapon`].
+
+use dark::properties::PropGunState;
+use shipyard::{EntityId, Get, UniqueView, View, World};
+
+use crate::{mission::PlayerInfo, vr_config::Handedness};
+
+/// The entity held in `hand`, weapon or not.
+pub fn held_in_hand(world: &World, hand: Handedness) -> Option<EntityId> {
+    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+    match hand {
+        Handedness::Left => player_info.left_hand_entity_id,
+        Handedness::Right => player_info.right_hand_entity_id,
+    }
+}
+
+/// Whether `entity` is held in either hand.
+pub fn is_held(world: &World, entity: EntityId) -> bool {
+    held_in_hand(world, Handedness::Left) == Some(entity)
+        || held_in_hand(world, Handedness::Right) == Some(entity)
+}
+
+/// The weapon held in `hand`, or `None` when that hand is empty or holds
+/// something with no ammo/charge of its own (a medkit, a melee weapon).
+pub fn weapon_in_hand(world: &World, hand: Handedness) -> Option<EntityId> {
+    let held = held_in_hand(world, hand)?;
+    is_weapon(world, held).then_some(held)
+}
+
+/// The weapon the player is wielding, for actions and readouts that are not
+/// tied to one hand (the Reload/CycleAmmo input actions, the ammo readout).
+/// Right hand first - see the module docs for the precedence rule.
+pub fn wielded_weapon(world: &World) -> Option<EntityId> {
+    weapon_in_hand(world, Handedness::Right).or_else(|| weapon_in_hand(world, Handedness::Left))
+}
+
+/// Whether the held `entity` is a weapon the ammo readout and the reload /
+/// ammo-cycle actions apply to: a gun (it has a `PropGunState` clip) or the
+/// psi amp (whose readout is its selected power, not a clip).
+fn is_weapon(world: &World, entity: EntityId) -> bool {
+    if world
+        .borrow::<View<PropGunState>>()
+        .map(|v| v.get(entity).is_ok())
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    is_psi_amp(world, entity)
+}
+
+/// Whether `entity`'s template carries the `weapontype psiamp` class tag.
+pub(crate) fn is_psi_amp(world: &World, entity: EntityId) -> bool {
+    let Some(template_id) = crate::scripts::script_util::entity_class_template_id(world, entity)
+    else {
+        return false;
+    };
+    world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateClassTags>>()
+        .ok()
+        .and_then(|tags| tags.0.get(&template_id)?.get("weapontype").cloned())
+        .is_some_and(|weapon_type| weapon_type == "psiamp")
+}

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -22,25 +22,14 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{mission::PlayerInfo, vr_config::Handedness};
 
-/// The entity held in `hand`, weapon or not.
-pub fn held_in_hand(world: &World, hand: Handedness) -> Option<EntityId> {
-    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
-    match hand {
-        Handedness::Left => player_info.left_hand_entity_id,
-        Handedness::Right => player_info.right_hand_entity_id,
-    }
-}
-
-/// Whether `entity` is held in either hand.
-pub fn is_held(world: &World, entity: EntityId) -> bool {
-    held_in_hand(world, Handedness::Left) == Some(entity)
-        || held_in_hand(world, Handedness::Right) == Some(entity)
-}
-
 /// The weapon held in `hand`, or `None` when that hand is empty or holds
 /// something with no ammo/charge of its own (a medkit, a melee weapon).
 pub fn weapon_in_hand(world: &World, hand: Handedness) -> Option<EntityId> {
-    let held = held_in_hand(world, hand)?;
+    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+    let held = match hand {
+        Handedness::Left => player_info.left_hand_entity_id,
+        Handedness::Right => player_info.right_hand_entity_id,
+    }?;
     is_weapon(world, held).then_some(held)
 }
 

--- a/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { SceneObjectSummary, Vec3 } from "../src/types.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// End-to-end regression for weapon handedness in VR.
+//
+// `PlayerInfo` has two hand slots. Flatscreen wields into the LEFT one and
+// never fills the right, so reload, ammo cycling and every ammo readout used
+// to read `left_hand_entity_id` directly and were correct by construction. In
+// VR the slots are the two literal motion controllers, so a gun grabbed with
+// the RIGHT hand was invisible to all of it: Reload did nothing, CycleAmmo did
+// nothing, and the right forearm panel stayed a static AMMOFULL quad.
+//
+// Every assertion below runs with the pistol in the RIGHT hand and the left
+// hand empty, which is exactly the case the old left-slot-only code missed -
+// so this test fails wholesale before `shock2vr::wielded_weapon`.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const p = detail.properties.find((x) => x.name === "Ammo");
+  assert.ok(p, "weapon should expose an Ammo property");
+  return Number(p.value);
+}
+
+const distance = (a: Vec3, b: Vec3): number =>
+  Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+
+/**
+ * The draws that landed on one world-space panel.
+ *
+ * A panel is a `UiCanvas` rendered by `render_world_space`, which emits one
+ * scene object per canvas element, all sharing the panel's transform apart
+ * from a millimetre-scale depth step that layers them. So a panel is a tight
+ * cluster of `player_hands` draws, and its size is its element count; the
+ * nearest thing that is not part of it (the arm mesh) is ~0.4 m away.
+ */
+function drawsAt(objects: SceneObjectSummary[], panel: Vec3): SceneObjectSummary[] {
+  return objects.filter((object) => distance(object.position, panel) < 0.02);
+}
+
+/**
+ * Locate the right forearm's ammo panel: the biggest cluster of `player_hands`
+ * draws worn near the right hand (the hand/arm meshes and the left BIOFULL
+ * panel sit elsewhere). Only valid while the readout has something to say -
+ * the point of calling it is to pin the panel's origin, which stays put as
+ * long as the hand pose does.
+ */
+async function locateForearmPanel(game: GameServer, rightHand: Vec3): Promise<Vec3> {
+  const near = (await game.scene.fromSource("player_hands")).filter(
+    (object) => distance(object.position, rightHand) < 1.0,
+  );
+  const best = near
+    .map((object) => object.position)
+    .sort((a, b) => drawsAt(near, b).length - drawsAt(near, a).length)[0];
+  assert.ok(best, "the right forearm should be wearing a panel");
+  return best;
+}
+
+/** How many elements the right forearm's ammo panel drew this frame. */
+async function forearmAmmoDraws(game: GameServer, panel: Vec3): Promise<number> {
+  return drawsAt(await game.scene.fromSource("player_hands"), panel).length;
+}
+
+test(
+  "VR: a weapon in the right hand reloads, cycles ammo and drives the forearm readout",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
+      debugFlags: ["--vr"],
+    });
+
+    // DebugCycleWeapon spawns the pistol; the VR path has no auto-wield, so it
+    // drops to the floor for the hands to pick up.
+    await game.step({ frames: 10 });
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 90 });
+    const pistol = (await game.entities.list({ limit: 200 })).entities.find(
+      (entity) => entity.name === "Pistol",
+    );
+    assert.ok(pistol, "pistol should have spawned");
+
+    // Reserve rounds for the reload. `spawn-item` enters the backpack in both
+    // presentations, so this needs no VR inventory interaction.
+    await game.player.spawnItem("Small Standard Clip");
+    await game.step({ frames: 2 });
+
+    // Grab it with the RIGHT hand, leaving the left (the flat wield slot) empty.
+    // The hand pose is unchanged from here on (only the grip opens and closes),
+    // so the forearm panel's transform - and the cluster of draws that
+    // identifies it - stays put for the rest of the test.
+    const { start: rightHand } = await aimVrHandAt(game, pistol.position, 0.45, 1);
+    await game.step({ frames: 8 });
+    const armed = (await game.info()).player;
+    assert.equal(armed.right_hand_entity_id, pistol.id, "pistol is in the right hand");
+    assert.equal(armed.wielded_entity_id, null, "the left (flat wield) slot stays empty");
+
+    // 1. The readout resolves the right hand's gun.
+    assert.equal(
+      armed.wielded_ammo_type,
+      "std",
+      "the ammo readout sees a right-hand gun (was null: left slot only)",
+    );
+
+    // 2. The forearm panel composites the live readout on the backdrop: round
+    //    count + ammo icon + type label. Before the fix the readout resolved to
+    //    nothing and only the backdrop drew.
+    const panel = await locateForearmPanel(game, rightHand);
+    assert.equal(
+      await forearmAmmoDraws(game, panel),
+      4,
+      "backdrop + round count + ammo icon + type label",
+    );
+
+    // 3. The readout is live: what it reports tracks the clip as rounds are
+    //    consumed (the panel's text content itself is asserted without a GL
+    //    context by `hud::ammo_panel`'s unit tests).
+    const loaded = ammoOf(await game.entities.detail(pistol.id));
+    assert.ok(loaded > 3, "debug pistol starts loaded");
+    for (let i = 0; i < 3; i++) {
+      await game.input.set("right_hand.trigger", 1.0);
+      await game.step({ frames: 1 });
+      await game.input.set("right_hand.trigger", 0.0);
+      await game.step({ frames: 10 });
+    }
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      loaded - 3,
+      "three right-hand shots consumed three rounds",
+    );
+    assert.equal(
+      await forearmAmmoDraws(game, panel),
+      4,
+      "the readout stays on the forearm while firing",
+    );
+
+    // 4. Reload finds the right hand's gun and fills it from the reserve clip.
+    await game.input.trigger("Reload");
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.reloading,
+      true,
+      "Reload starts on the right hand's weapon (was a no-op)",
+    );
+    await game.step({ frames: 150 });
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      loaded,
+      "the reserve clip refilled the right hand's magazine",
+    );
+
+    // 5. CycleAmmo likewise. Cycling needs an empty magazine (a loaded one has
+    //    an established projectile identity), so empty it first.
+    for (let i = 0; i < loaded; i++) {
+      await game.input.set("right_hand.trigger", 1.0);
+      await game.step({ frames: 1 });
+      await game.input.set("right_hand.trigger", 0.0);
+      await game.step({ frames: 10 });
+    }
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0, "magazine emptied");
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 3 });
+    assert.notEqual(
+      (await game.info()).player.wielded_ammo_type,
+      "std",
+      "CycleAmmo advances the right hand's weapon (was a no-op)",
+    );
+
+    // 6. Dropping it puts the forearm back to the bare backdrop.
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).player.right_hand_entity_id, null, "pistol dropped");
+    assert.equal(
+      await forearmAmmoDraws(game, panel),
+      1,
+      "an empty hand leaves the bare AMMOFULL backdrop",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
@@ -167,10 +167,11 @@ test(
     assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0, "magazine emptied");
     await game.input.trigger("CycleAmmo");
     await game.step({ frames: 3 });
-    assert.notEqual(
+    assert.equal(
       (await game.info()).player.wielded_ammo_type,
-      "std",
-      "CycleAmmo advances the right hand's weapon (was a no-op)",
+      // The debug pistol's authored projectile links, in order: std -> ap.
+      "ap",
+      "CycleAmmo advances the right hand's weapon to its next type (was a no-op)",
     );
 
     // 6. Dropping it puts the forearm back to the bare backdrop.


### PR DESCRIPTION
Fixes #1041
Fixes #1042

Two unambiguous VR defects, both of which any future VR reload interaction would have to step over first. (Designing that gesture is explicitly **not** part of this PR.)

## 1. The wielded weapon is resolved per hand

`Effect::ReloadWeapon`, `Effect::CycleAmmo` and every wielded-ammo/psi getter read `PlayerInfo.left_hand_entity_id` directly. Flat wields into the left slot and never fills the right, so that spelling was accidentally correct there; in VR the slots are the two literal motion controllers, so a gun in the **right** hand was invisible to reload, ammo cycling and the ammo HUD alike.

New `shock2vr::wielded_weapon` is the single place that answers the question:

| function | answers |
| --- | --- |
| `held_in_hand(world, hand)` | what is in that hand, weapon or not |
| `is_held(world, entity)` | is this entity in either hand |
| `weapon_in_hand(world, hand)` | the weapon in that hand (a gun with a `PropGunState` clip, or the psi amp) |
| `wielded_weapon(world)` | the weapon for hand-agnostic callers |

**Both-hands precedence: the RIGHT hand wins.** It is the dominant/aiming hand for the default VR player, it is the hand the ammo panel is worn beside, and - because flat never fills the right slot - preferring it leaves flatscreen behaviour bit-for-bit unchanged. A future hand-specific affordance (a reload gesture that starts from one controller) should call `weapon_in_hand` with its own hand rather than going through `wielded_weapon`.

Routed through it: the `ReloadWeapon` / `CycleAmmo` effect handlers, the HUD's `get_wielded_ammo` / `_icon` / `_type` / `get_wielded_psi_power` / psi-charge getters, and `Game::player_state`'s reload/ammo reporting. The raw hand slots are still reported separately by `/v1/info`.

## 2. The right forearm shows the live ammo readout

The right forearm panel was a static `AMMOFULL.PCX` quad while the left/BIOFULL panel got live overlays. It now composites the round count, the selected ammo type's object icon and its type label - and, with the psi amp wielded, the selected discipline and tier - exactly as flat does.

The backdrop stays the plain panel quad both forearms share, with only the readout drawn as a canvas one overlay step in front (the same z-offset the health/psi bars use). That matters: the canvas presenter draws its elements fully emissive, so routing the backdrop through it made the right forearm ~2.3x brighter than its BIOFULL twin and stopped it dimming with the room. `forearm_pose` is now the single source of forearm placement, feeding the panel quad, the bar overlays and the readout canvas alike.

**The layout is shared, not duplicated** (AGENTS.md section 3). `hud::ammo_panel` owns every rect, authored once in AMMOFULL's own 260x64 panel pixels, plus one `emit(canvas, origin, readout)` that places them:

- **flat** calls `emit` with the panel's origin on its 640x480 HUD canvas;
- **VR** calls `emit` at `(0,0)`, because on the forearm the panel *is* the whole canvas.

Neither presentation makes a placement decision of its own - no alignment, no measurement, no per-element branching - so the count sits in the same spot relative to the gauge art in the headset as it does on screen, and anything added to the readout lands in both by construction. The only intentional difference is the ammo-type cycle button, which flat draws in use mode where a pointer can click it and VR leaves off (no forearm pointer affordance exists yet); it is a single documented flag on the readout struct, not a layout fork.

## Tests

- `shock2vr::hud::ammo_panel` unit tests (pure, no GL): every rect is inside the panel, placement offsets position but not size, and `build_readout_canvas` produces nothing when empty-handed, the count (+ icon + type label) with a gun, the discipline set with the psi amp, and a count that tracks the clip (12 -> 11).
- `tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts` - new. Grabs the `debug_weapons` pistol with the **right** motion controller in `--vr` (left slot empty) and asserts the readout resolves it, the forearm panel goes from 1 draw (bare backdrop) to 4 (backdrop + count + icon + type label), three shots consume three rounds, `Reload` refills from a reserve clip, `CycleAmmo` advances the type once the magazine is empty, and dropping the gun clears the readout again.
  **Negative-first**: on the base commit (`d63707af`) this fails at the first readout assertion (`null !== 'std'`).

Validation: `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; `cargo test -p shock2vr --lib` (821 pass); e2e `weapon-*` + `vr-*` + `psi*` + `flat-hud` (30 pass), and `missions` + `inventory*` + `save-load` + `cross-mode-held-load` + `give-item` + `vaporize-inventory` + `flat-ui-plumbing` (41 pass, all 23 missions load).

Reviewed with two independent adversarial reviewers plus a dedicated de-duplication pass. Fixed from their findings: the forearm backdrop material above; one placement source (`forearm_pose`) replacing a copied transform and an unreachable right-hand branch; `EquipCarriedWeapon`'s already-held filter now asks the interaction controller (authoritative; `PlayerInfo` only mirrors it once per update) instead of the resolver, which let `is_held` go away; and the e2e asserts the exact cycled ammo type. Known gap they raised and I did not close: nothing asserts the *rendered text* of the VR readout automatically - the unit tests assert the text a readout produces and the e2e asserts the live world values and the draw structure, with the GIF as the end-to-end evidence.


---

## Media

![VR forearm ammo readout counting down and reloading](https://gist.githubusercontent.com/tommy-xr/9a60b66b1ab61cb52cbbc82cebe56160/raw/5a48348b8270761cc7886c0436e8b88e0bf63f55/vr-ammo-demo.gif)

<sub>Right VR forearm panel in `debug_weapons --vr`, pistol held in the **right** motion controller: three shots take the count 12 -> 11 -> 10 -> 9, then `Reload` refills it to 12. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

Still (full magazine - ammo-type icon, round count, type label):

![forearm ammo readout still](https://gist.githubusercontent.com/tommy-xr/9a60b66b1ab61cb52cbbc82cebe56160/raw/5a48348b8270761cc7886c0436e8b88e0bf63f55/vr-ammo-still.png)

## Before -> after

![before/after](https://gist.githubusercontent.com/tommy-xr/9a60b66b1ab61cb52cbbc82cebe56160/raw/5a48348b8270761cc7886c0436e8b88e0bf63f55/vr-ammo-beforeafter.png)

<sub>Both halves are the **same request sequence, camera and forearm pose**, with the pistol grabbed in the right hand in both. The left half was rendered from a build of the base ref (`main` @ `d63707af`), the right half from this branch. On main the right-hand weapon is never resolved, so the panel stays the bare static AMMOFULL quad and `Reload` is a no-op (the round count stays at 9); on this branch the same panel composites the live readout and `Reload` refills to 12.</sub>

