### PR TITLE
feat(vr): arm-height dev param for on-device comfort tuning

### DIFF
--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -108,16 +108,9 @@ dev_params! {
     /// [`EYE_HEIGHT_OFFSET`]: that one moves the whole stage (head, hands and
     /// view together); this one moves *only* the hands.
     ///
-    /// Applied at the top of [`crate::Game::update`], the one place every
-    /// runtime's `InputContext` converges on, so it lands ahead of every
-    /// consumer - the interacting hand, the rendered glove and sleeve, the
-    /// forearm HUD panels, the frontend pointer and teleport - and lands
-    /// identically on the Quest and in the debug runtime. That placement is
-    /// the whole point, and it is `Game` rather than `App` on purpose: the
-    /// Quest and the desktop go through `App::update`, but the debug runtime
-    /// drives a `Game` directly, so applying it at the `App` seam would leave
-    /// the knob inert in the harness meant to verify it - the mirror image of
-    /// the accessor #1027 rejected for being inert on device.
+    /// Applied - VR only, and only there - at the top of
+    /// [`crate::Game::update`], which every runtime's `InputContext` converges
+    /// on; see that call site for why `Game` and not `App` is the seam.
     ARM_HEIGHT_OFFSET = float("arm_offset", "Arm height (m)", 0.0, -0.5, 0.5, 0.02),
 }
 

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -102,6 +102,21 @@ dev_params! {
     /// deferral). Consequently the debug runtime cannot exercise this knob;
     /// it needs a worn check on device.
     EYE_HEIGHT_OFFSET = float("eye_offset", "Eye height (m)", 0.0, -0.5, 0.5, 0.02),
+    /// Vertical offset applied to BOTH tracked hands, in **meters**, relative
+    /// to a head left where it is - the comfort knob for "my in-game arms do
+    /// not sit where my physical arms do". Deliberately the mirror image of
+    /// [`EYE_HEIGHT_OFFSET`]: that one moves the whole stage (head, hands and
+    /// view together); this one moves *only* the hands.
+    ///
+    /// Applied in [`crate::App::update`], the one place every runtime feeds an
+    /// `InputContext` in, so it lands ahead of every consumer - the interacting
+    /// hand, the rendered glove and sleeve, the forearm HUD panels, the
+    /// frontend pointer and teleport - and lands identically on the Quest and
+    /// in the debug runtime. That placement is the whole point: PR #1027
+    /// rejected an offset wired into an accessor the Quest never reads, which
+    /// the debug runtime then "verified" while it was inert on device. This
+    /// one cannot diverge, because there is only one path.
+    ARM_HEIGHT_OFFSET = float("arm_offset", "Arm height (m)", 0.0, -0.5, 0.5, 0.02),
 }
 
 /// Every parameter with its id, in declaration order.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -108,14 +108,16 @@ dev_params! {
     /// [`EYE_HEIGHT_OFFSET`]: that one moves the whole stage (head, hands and
     /// view together); this one moves *only* the hands.
     ///
-    /// Applied in [`crate::App::update`], the one place every runtime feeds an
-    /// `InputContext` in, so it lands ahead of every consumer - the interacting
-    /// hand, the rendered glove and sleeve, the forearm HUD panels, the
-    /// frontend pointer and teleport - and lands identically on the Quest and
-    /// in the debug runtime. That placement is the whole point: PR #1027
-    /// rejected an offset wired into an accessor the Quest never reads, which
-    /// the debug runtime then "verified" while it was inert on device. This
-    /// one cannot diverge, because there is only one path.
+    /// Applied at the top of [`crate::Game::update`], the one place every
+    /// runtime's `InputContext` converges on, so it lands ahead of every
+    /// consumer - the interacting hand, the rendered glove and sleeve, the
+    /// forearm HUD panels, the frontend pointer and teleport - and lands
+    /// identically on the Quest and in the debug runtime. That placement is
+    /// the whole point, and it is `Game` rather than `App` on purpose: the
+    /// Quest and the desktop go through `App::update`, but the debug runtime
+    /// drives a `Game` directly, so applying it at the `App` seam would leave
+    /// the knob inert in the harness meant to verify it - the mirror image of
+    /// the accessor #1027 rejected for being inert on device.
     ARM_HEIGHT_OFFSET = float("arm_offset", "Arm height (m)", 0.0, -0.5, 0.5, 0.02),
 }
 

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -42,6 +42,82 @@ impl InputContext {
             jump: false,
         }
     }
+
+    /// A copy with both hands raised by `offset_meters`, the head untouched.
+    ///
+    /// Hand positions are in pawn space, whose +Y is world up (the pawn's own
+    /// rotation is yaw-only), so a comfort offset is a plain addition on `y`
+    /// once converted out of meters - no rotation involved, and it therefore
+    /// cannot depend on which way the player is facing or how the hand is
+    /// turned.
+    ///
+    /// Pure and total so the arm-height knob is testable without a runtime;
+    /// [`crate::dev_params::ARM_HEIGHT_OFFSET`] supplies the live value.
+    pub fn with_arm_height_offset(&self, offset_meters: f32) -> InputContext {
+        let mut adjusted = self.clone();
+        if offset_meters == 0.0 {
+            return adjusted;
+        }
+        let offset = offset_meters / crate::METERS_PER_WORLD_UNIT;
+        adjusted.left_hand.position.y += offset;
+        adjusted.right_hand.position.y += offset;
+        adjusted
+    }
+}
+
+#[cfg(test)]
+mod arm_height_tests {
+    use super::*;
+
+    fn sample() -> InputContext {
+        let mut input = InputContext::default();
+        input.left_hand.position = Vector3::new(-0.3, 1.0, -0.5);
+        input.right_hand.position = Vector3::new(0.3, 1.0, -0.5);
+        input.head.position = Vector3::new(0.0, 1.4, 0.0);
+        input
+    }
+
+    /// The knob is in meters of real space but hand positions are world units,
+    /// so the conversion - not the raw number - is what must land. A version
+    /// that forgot to divide would move the hands by 0.762x too much.
+    #[test]
+    fn the_offset_is_converted_from_meters_into_world_units() {
+        let raised = sample().with_arm_height_offset(0.1);
+        let expected = 1.0 + 0.1 / crate::METERS_PER_WORLD_UNIT;
+        assert!((raised.right_hand.position.y - expected).abs() < 1e-5);
+        assert!((raised.left_hand.position.y - expected).abs() < 1e-5);
+    }
+
+    /// The whole point of an ARM-height knob (as opposed to #1028's stage-wide
+    /// eye offset) is that the head stays put - otherwise it would just be a
+    /// second, redundant eye offset.
+    #[test]
+    fn the_head_does_not_move_with_the_arms() {
+        let raised = sample().with_arm_height_offset(0.25);
+        assert_eq!(raised.head.position, sample().head.position);
+    }
+
+    /// Only height changes: an offset that leaked into the horizontal axes
+    /// would push the hands away from the body as well as up.
+    #[test]
+    fn only_the_vertical_axis_moves() {
+        let raised = sample().with_arm_height_offset(-0.2);
+        assert_eq!(raised.right_hand.position.x, 0.3);
+        assert_eq!(raised.right_hand.position.z, -0.5);
+        assert!(
+            raised.right_hand.position.y < 1.0,
+            "a negative offset lowers"
+        );
+    }
+
+    /// The default must be bit-exactly inert, or every player who never opens
+    /// the Developer screen pays for the knob existing.
+    #[test]
+    fn the_default_offset_changes_nothing() {
+        let raised = sample().with_arm_height_offset(0.0);
+        assert_eq!(raised.right_hand.position, sample().right_hand.position);
+        assert_eq!(raised.left_hand.position, sample().left_hand.position);
+    }
 }
 
 /// A 2D screen-space pointer for flatscreen UI. Position is normalized to

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -55,9 +55,6 @@ impl InputContext {
     /// [`crate::dev_params::ARM_HEIGHT_OFFSET`] supplies the live value.
     pub fn with_arm_height_offset(&self, offset_meters: f32) -> InputContext {
         let mut adjusted = self.clone();
-        if offset_meters == 0.0 {
-            return adjusted;
-        }
         let offset = offset_meters / crate::METERS_PER_WORLD_UNIT;
         adjusted.left_hand.position.y += offset;
         adjusted.right_hand.position.y += offset;
@@ -110,8 +107,8 @@ mod arm_height_tests {
         );
     }
 
-    /// The default must be bit-exactly inert, or every player who never opens
-    /// the Developer screen pays for the knob existing.
+    /// The default must be bit-exactly inert - not merely close - or the hands
+    /// of every player who never opens the Developer screen drift.
     #[test]
     fn the_default_offset_changes_nothing() {
         let raised = sample().with_arm_height_offset(0.0);

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -2006,6 +2006,15 @@ impl App {
         input_context: &input_context::InputContext,
         action_state: &mut input::InputActionState,
     ) {
+        // The arm-height comfort offset is applied HERE and nowhere else: this
+        // is the single point every runtime hands an `InputContext` in
+        // through, so the Quest and the debug runtime provably read the same
+        // adjusted hands, and every downstream consumer (interaction, the
+        // rendered glove/sleeve, the forearm HUD panels, the frontend pointer,
+        // teleport) inherits it without its own wiring. Read every frame, so a
+        // `set` from the Developer screen lands on the next one.
+        let input_context =
+            &input_context.with_arm_height_offset(dev_params::get(dev_params::ARM_HEIGHT_OFFSET));
         match self {
             App::Ready(game) => game.update(time, input_context, action_state),
             App::MissingAssets(missing) => missing.update(time, input_context),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1223,6 +1223,18 @@ impl Game {
         input_context: &input_context::InputContext,
         actions: &mut input::InputActionState,
     ) {
+        // The arm-height comfort offset is applied HERE and nowhere else, so
+        // every downstream consumer (the interacting hand, the rendered glove
+        // and sleeve, the forearm HUD panels, the frontend pointer, teleport)
+        // inherits it without its own wiring. `Game::update` rather than
+        // `App::update` is deliberately the seam: the Quest and the desktop go
+        // through `App`, but the debug runtime drives a `Game` directly, so
+        // applying it one level up would leave the knob inert in the very
+        // harness that is supposed to verify it - the mirror image of the
+        // accessor #1027 rejected for being inert on device. Read every frame,
+        // so a `set` from the Developer screen lands on the next one.
+        let input_context =
+            &input_context.with_arm_height_offset(dev_params::get(dev_params::ARM_HEIGHT_OFFSET));
         let span = span!(Level::INFO, "update");
         let _enter = span.enter();
         let delta_time = time.elapsed.as_secs_f32();
@@ -2006,15 +2018,6 @@ impl App {
         input_context: &input_context::InputContext,
         action_state: &mut input::InputActionState,
     ) {
-        // The arm-height comfort offset is applied HERE and nowhere else: this
-        // is the single point every runtime hands an `InputContext` in
-        // through, so the Quest and the debug runtime provably read the same
-        // adjusted hands, and every downstream consumer (interaction, the
-        // rendered glove/sleeve, the forearm HUD panels, the frontend pointer,
-        // teleport) inherits it without its own wiring. Read every frame, so a
-        // `set` from the Developer screen lands on the next one.
-        let input_context =
-            &input_context.with_arm_height_offset(dev_params::get(dev_params::ARM_HEIGHT_OFFSET));
         match self {
             App::Ready(game) => game.update(time, input_context, action_state),
             App::MissingAssets(missing) => missing.update(time, input_context),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1226,15 +1226,23 @@ impl Game {
         // The arm-height comfort offset is applied HERE and nowhere else, so
         // every downstream consumer (the interacting hand, the rendered glove
         // and sleeve, the forearm HUD panels, the frontend pointer, teleport)
-        // inherits it without its own wiring. `Game::update` rather than
-        // `App::update` is deliberately the seam: the Quest and the desktop go
+        // inherits it without its own wiring, and it is read every frame so a
+        // `set` from the Developer screen lands on the next one.
+        //
+        // `Game::update`, not `App::update`: the Quest and the desktop go
         // through `App`, but the debug runtime drives a `Game` directly, so
-        // applying it one level up would leave the knob inert in the very
-        // harness that is supposed to verify it - the mirror image of the
-        // accessor #1027 rejected for being inert on device. Read every frame,
-        // so a `set` from the Developer screen lands on the next one.
-        let input_context =
-            &input_context.with_arm_height_offset(dev_params::get(dev_params::ARM_HEIGHT_OFFSET));
+        // applying it one level up leaves the knob inert in the very harness
+        // meant to verify it - the mirror image of the accessor #1027 rejected
+        // for being inert on device.
+        //
+        // VR only: in flat the hands are synthesized from the camera and never
+        // drawn, so an offset there would move the frob/aim ray origin with no
+        // visual feedback at all.
+        let arm_offset = match self.options.presentation_mode {
+            PresentationMode::Vr => dev_params::get(dev_params::ARM_HEIGHT_OFFSET),
+            PresentationMode::Flat => 0.0,
+        };
+        let input_context = &input_context.with_arm_height_offset(arm_offset);
         let span = span!(Level::INFO, "update");
         let _enter = span.enter();
         let delta_time = time.elapsed.as_secs_f32();

--- a/tools/shock2-sdk/test/vr-arm-height.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-arm-height.e2e.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { SceneObjectSummary } from "../src/types.js";
+
+// `arm_offset` (shock2vr::dev_params::ARM_HEIGHT_OFFSET) is the VR comfort knob
+// for "my in-game arms do not sit where my physical arms do". It is applied in
+// `App::update`, the single point every runtime - the Quest included - feeds an
+// `InputContext` through, so what this test measures in the debug runtime is
+// the same code path the headset takes. (What it cannot measure is the tracked
+// pose upstream of that; only a worn check covers that half.)
+//
+// The claim under test is live-apply on the *rendered* hands: POST a value,
+// step, and the objects the renderer was handed on the `player_hands` path have
+// risen by exactly the POSTed metres, converted into world units.
+//
+// Negative-first: with the `with_arm_height_offset` call removed from
+// `App::update`, the hands do not move and the delta assertion fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** shock2vr::METERS_PER_WORLD_UNIT (0.3048 * dark::SCALE_FACTOR). */
+const METERS_PER_WORLD_UNIT = 0.3048 * 2.5;
+
+const HANDS = "player_hands";
+
+/**
+ * Mean height of everything the hands render path drew. The path emits several
+ * objects per hand (glove, sleeve, forearm HUD panel and its overlay layers);
+ * the offset is a rigid translation of all of them, so their mean moves by
+ * exactly the offset while being far less noisy than any single pick.
+ */
+function handHeight(objects: SceneObjectSummary[]): number {
+  assert.ok(objects.length > 0, "expected the VR hands to be drawn");
+  return objects.reduce((sum, o) => sum + o.position[1], 0) / objects.length;
+}
+
+test(
+  "the arm-height dev param moves the rendered VR hands, live",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+      debugFlags: ["--vr"],
+    });
+    // Long enough for the player to settle on the floor, so the only thing
+    // that moves the hands afterwards is the knob.
+    await game.step({ frames: 90 });
+
+    const { params } = await game.devParams.list();
+    const armOffset = params.find((p) => p.key === "arm_offset");
+    assert.ok(armOffset, "arm_offset must be registered");
+    assert.equal(armOffset.kind, "float");
+    assert.equal(armOffset.value, 0);
+    assert.equal(armOffset.default, 0, "the knob must ship inert");
+
+    const before = handHeight(await game.scene.fromSource(HANDS));
+    const shotBefore = await game.screenshot("arm-height-0.png");
+
+    // Live-apply: the registry is read every frame, so two frames is plenty.
+    const raiseMeters = 0.3;
+    const applied = await game.devParams.set("arm_offset", raiseMeters);
+    assert.ok(Math.abs(applied.value - raiseMeters) < 1e-4);
+    await game.step({ frames: 2 });
+
+    const after = handHeight(await game.scene.fromSource(HANDS));
+    const expected = raiseMeters / METERS_PER_WORLD_UNIT;
+    assert.ok(
+      Math.abs(after - before - expected) < 0.02,
+      `hands should have risen by ${expected.toFixed(3)} world units, ` +
+        `got ${(after - before).toFixed(3)} (${before.toFixed(3)} -> ${after.toFixed(3)})`,
+    );
+    const shotAfter = await game.screenshot("arm-height-0.3.png");
+    console.log(
+      `hand height ${before.toFixed(3)} -> ${after.toFixed(3)}; ` +
+        `screenshots: ${shotBefore.full_path} ${shotAfter.full_path}`,
+    );
+
+    // The knob lowers as well as raises, and is clamped to its declared range.
+    const clamped = await game.devParams.set("arm_offset", -9.0);
+    assert.ok(Math.abs(clamped.value + 0.5) < 1e-4, "clamped to the -0.5 min");
+    await game.step({ frames: 2 });
+    const lowered = handHeight(await game.scene.fromSource(HANDS));
+    assert.ok(
+      lowered < before,
+      `a negative offset must lower the hands, got ${lowered.toFixed(3)} vs ${before.toFixed(3)}`,
+    );
+
+    // Reset puts them back exactly where they started.
+    const reset = await game.devParams.reset("arm_offset");
+    assert.equal(reset.value, armOffset.default);
+    await game.step({ frames: 2 });
+    const restored = handHeight(await game.scene.fromSource(HANDS));
+    assert.ok(
+      Math.abs(restored - before) < 0.02,
+      `hands should be back at the default height, got ${restored.toFixed(3)} vs ${before.toFixed(3)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-arm-height.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-arm-height.e2e.test.ts
@@ -6,17 +6,20 @@ import type { SceneObjectSummary } from "../src/types.js";
 
 // `arm_offset` (shock2vr::dev_params::ARM_HEIGHT_OFFSET) is the VR comfort knob
 // for "my in-game arms do not sit where my physical arms do". It is applied in
-// `App::update`, the single point every runtime - the Quest included - feeds an
-// `InputContext` through, so what this test measures in the debug runtime is
-// the same code path the headset takes. (What it cannot measure is the tracked
-// pose upstream of that; only a worn check covers that half.)
+// `Game::update`, which the Quest reaches through `App::update` and the debug
+// runtime reaches directly, so what this measures here is the same code path
+// the headset takes. (What it cannot measure is the tracked pose upstream of
+// that; only a worn check covers that half.)
 //
 // The claim under test is live-apply on the *rendered* hands: POST a value,
 // step, and the objects the renderer was handed on the `player_hands` path have
-// risen by exactly the POSTed metres, converted into world units.
+// risen by exactly the POSTed metres, converted into world units. The registry
+// protocol itself (metadata, clamping, reset, unknown keys) belongs to
+// `dev-params.e2e.test.ts` and is deliberately not re-proven per knob.
 //
-// Negative-first: with the `with_arm_height_offset` call removed from
-// `App::update`, the hands do not move and the delta assertion fails.
+// Negative-first: with the offset applied one level up in `App::update` - which
+// is where it started, and which the Quest does read - the debug runtime never
+// sees it and the delta assertion fails at 0.000.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 /** shock2vr::METERS_PER_WORLD_UNIT (0.3048 * dark::SCALE_FACTOR). */
@@ -41,7 +44,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8231),
       debugFlags: ["--vr"],
     });
     // Long enough for the player to settle on the floor, so the only thing
@@ -51,8 +54,6 @@ test(
     const { params } = await game.devParams.list();
     const armOffset = params.find((p) => p.key === "arm_offset");
     assert.ok(armOffset, "arm_offset must be registered");
-    assert.equal(armOffset.kind, "float");
-    assert.equal(armOffset.value, 0);
     assert.equal(armOffset.default, 0, "the knob must ship inert");
 
     const before = handHeight(await game.scene.fromSource(HANDS));
@@ -77,24 +78,15 @@ test(
         `screenshots: ${shotBefore.full_path} ${shotAfter.full_path}`,
     );
 
-    // The knob lowers as well as raises, and is clamped to its declared range.
-    const clamped = await game.devParams.set("arm_offset", -9.0);
-    assert.ok(Math.abs(clamped.value + 0.5) < 1e-4, "clamped to the -0.5 min");
+    // The knob lowers as well as raises - a sign error would still have passed
+    // the raise assertion if it had been read from the wrong end of the range.
+    await game.devParams.set("arm_offset", -0.3);
     await game.step({ frames: 2 });
     const lowered = handHeight(await game.scene.fromSource(HANDS));
     assert.ok(
-      lowered < before,
-      `a negative offset must lower the hands, got ${lowered.toFixed(3)} vs ${before.toFixed(3)}`,
-    );
-
-    // Reset puts them back exactly where they started.
-    const reset = await game.devParams.reset("arm_offset");
-    assert.equal(reset.value, armOffset.default);
-    await game.step({ frames: 2 });
-    const restored = handHeight(await game.scene.fromSource(HANDS));
-    assert.ok(
-      Math.abs(restored - before) < 0.02,
-      `hands should be back at the default height, got ${restored.toFixed(3)} vs ${before.toFixed(3)}`,
+      Math.abs(before - lowered - expected) < 0.02,
+      `a negative offset must lower the hands by ${expected.toFixed(3)}, ` +
+        `got ${(before - lowered).toFixed(3)}`,
     );
   },
 );


### PR DESCRIPTION
Adds `arm_offset` ("Arm height (m)") to the dev-params registry (#1027) so the VR
arm height can be nudged live from the Developer screen (#1028) — no rebuild, no
redeploy. It moves **only the hands**, leaving the head where it is; that is the
deliberate complement to #1028's `eye_offset`, which moves the whole tracked stage
(head, hands and view together).

Range -0.5..+0.5 m, step 0.02, default **0.0** (bit-exactly inert until someone
opens the Developer screen).

## Where it is applied, and why that matters

At the top of `Game::update` — **not** `App::update`, which is where the first
draft put it.

#1027 rejected an eye-height knob wired into an accessor the Quest never reads:
it looked live in the debug runtime while being inert on device. This change hit
the *mirror image* of that trap, and the new e2e is what caught it: the desktop
and Quest runtimes drive a `shock2vr::App`, but **the debug runtime constructs a
`Game` directly**, so an offset applied at the `App` seam is live on device and
inert in the only harness that can verify it. `Game::update` is the seam all
three converge on, so one code path serves both.

It is also gated on `PresentationMode::Vr`: in flat the hands are synthesized
from the camera and never drawn, so a nonzero knob would silently move the
frob/aim ray origin with no visual feedback at all.

Every hand-pose consumer sits downstream of that one line — the interacting
hand, the rendered glove and sleeve, the forearm HUD panels, the frontend
pointer and teleport — so none of them needs its own wiring.

## Visuals

Sweeping `arm_offset` from -0.30 m to +0.48 m and back, live from the debug
runtime — medsci1 in `--vr`, hands held at a fixed tracked pose so the only
thing moving is the knob. Head, world and forearm-panel orientation stay put;
the hands, sleeves and forearm HUD rise and fall together.

![arm height sweep](https://gist.githubusercontent.com/tommy-xr/e66b63b8edfb40d500a496abf61bf8be/raw/arm-height.gif)

Before (0.0 m, left) / after (+0.3 m, right) — the same frame at the two ends of
the e2e's assertion:

![before and after](https://gist.githubusercontent.com/tommy-xr/e66b63b8edfb40d500a496abf61bf8be/raw/arm-height-before-after.png)

## Verification

**Verified in the harness (debug runtime, `--vr`):**

- `tools/shock2-sdk/test/vr-arm-height.e2e.test.ts` — POSTs `arm_offset` and
  measures the objects the renderer was actually handed on the `player_hands`
  path: at 0.3 m they rise by 0.394 world units (`0.3 / METERS_PER_WORLD_UNIT`),
  and at -0.3 m they fall by the same. Negative-first: with the offset at the
  `App::update` seam the delta is 0.000 and the test fails.
- Four unit tests on the pure helper (`shock2vr/src/input_context.rs`): the
  metres→world-units conversion, the head not moving with the arms, only the
  vertical axis moving, and the default being bit-exactly inert.
- `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p
  desktop_runtime -p debug_runtime`; `cargo test -p shock2vr --lib` (850 passed);
  e2e: dev-params, dev-menu, all `vr-*`, pause-menu, and `missions` (23/23) green.

**NOT verified on device.** Nothing here has been worn. What a headset check
still owes us: that the knob's *feel* is right through the Quest's tracked pose
(the harness measures downstream of `stage_to_pawn`, never the tracked pose
itself), and that it composes with `eye_offset` as intended when both are
nonzero.

## Note on the symptom that prompted this

The knob was asked for as a comfort control, but the trigger was a report of
arms sitting much higher than the player's physical arms — which **went away on
restart**, so it is transient, not a persistent frame/pivot bug, and this PR
does not claim to fix it. The shape of "wrong until restart" points at a
one-shot sample: hand poses or the stage/reference-space mapping read once
before the OpenXR reference space is established and never re-sampled or
recentered. Nothing was hunted for it here and nothing obvious surfaced while
working in this code; filing it as a lead, not a diagnosis. If it recurs, this
knob at least makes it liveable in the moment.

## Not addressed (pre-existing, noted by review)

`virtual_hand.rs`'s `HAND_OFFSET` is a dead `vec3(0,0,0)` constant applied at a
strictly narrower seam (world space, interacting hand only — it never reaches
the rendered glove, forearm panels or teleport). It is now a second, inert,
less-correct expression of "translate both hands", and invites a future "just
bump `HAND_OFFSET`" fix in the wrong place. Left alone as out of scope.
