### PR TITLE
fix(vr): stop a player-fired projectile from being consumed on the shooter

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -185,6 +185,10 @@ pub fn create_entity_with_position(
         world.add_component(entity_id, RuntimePropProjectileRayOrigin(origin));
     }
 
+    if additional_options.player_fired_projectile {
+        world.add_component(entity_id, RuntimePropPlayerFiredProjectile);
+    }
+
     if additional_options.launch_projectile {
         world.add_component(entity_id, RuntimePropLaunchedProjectile);
     }
@@ -990,6 +994,20 @@ fn create_physics_representation_with_options(
         .map(|scale| scale.0)
         .unwrap_or_else(|_| vec3(1.0, 1.0, 1.0));
 
+    // The membership every ordinary physical collider below uses. A projectile
+    // the player fired takes the variant that is transparent to the player's
+    // own capsule, so a shot leaving a weapon held in at the body is not
+    // consumed on the shooter - see `CollisionGroup::player_projectile`.
+    let is_player_fired = world
+        .borrow::<View<RuntimePropPlayerFiredProjectile>>()
+        .unwrap()
+        .contains(entity_id);
+    let entity_group = if is_player_fired {
+        CollisionGroup::player_projectile()
+    } else {
+        CollisionGroup::entity()
+    };
+
     let (
         v_pos,
         v_phys_attr,
@@ -1133,7 +1151,7 @@ fn create_physics_representation_with_options(
                     pos.rotation,
                     dimensions.offset0,
                     shape,
-                    CollisionGroup::entity(),
+                    entity_group,
                     false,
                     dynamics_options,
                 ));
@@ -1201,10 +1219,13 @@ fn create_physics_representation_with_options(
             }
             _ => None,
         };
-        let mut frob_group = CollisionGroup::entity();
-        if v_hud_select
-            .get(entity_id)
-            .is_ok_and(|hud_select| hud_select.0)
+        // The pick bias is for fixtures: a player-fired shot keeps its
+        // shooter-transparent group even if it were HUD-selectable.
+        let mut frob_group = entity_group;
+        if !is_player_fired
+            && v_hud_select
+                .get(entity_id)
+                .is_ok_and(|hud_select| hud_select.0)
         {
             frob_group = CollisionGroup::selectable();
         }
@@ -1269,7 +1290,7 @@ fn create_physics_representation_with_options(
                 shape,
                 // TODO: Kinematic experiment
                 //is_sensor,
-                CollisionGroup::entity(),
+                entity_group,
                 false,
                 dynamics_options,
             );
@@ -1470,7 +1491,7 @@ fn create_physics_representation_with_options(
             let group = if is_climbable {
                 CollisionGroup::climbable_entity()
             } else {
-                CollisionGroup::entity()
+                entity_group
             };
 
             // `SPHERE` is Dark's *moving* physics model - a simulated sphere
@@ -1625,6 +1646,9 @@ pub struct CreateEntityOptions {
     /// projectile. Flat firing supplies the camera origin while retaining the
     /// forward spawn clearance needed by slow physics projectiles.
     pub projectile_raycast_origin: Option<Point3<f32>>,
+    /// The player fired this projectile, so its collision ray must skip the
+    /// player's own capsule (see `RuntimePropPlayerFiredProjectile`).
+    pub player_fired_projectile: bool,
     /// Create the authored physics model as a launched dynamic body. Dark's
     /// Tweq emitter calls `launchProjectile`; this keeps frobbable emitted
     /// archetypes from being reduced to kinematic selection colliders.
@@ -1646,6 +1670,7 @@ impl Default for CreateEntityOptions {
             attach_to: None,
             transient_fx: false,
             projectile_raycast_origin: None,
+            player_fired_projectile: false,
             launch_projectile: false,
             shot_modifiers: None,
             flinderize_debris: false,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2264,6 +2264,27 @@ impl CollisionGroup {
         CollisionGroup { collision, solver }
     }
 
+    /// A projectile the *player* fired: an ordinary physical entity that is
+    /// transparent to the player's own capsule.
+    ///
+    /// A slow (physics) projectile leaves the muzzle of a weapon the player is
+    /// holding, and in VR that muzzle is inside the player's own capsule
+    /// whenever the weapon is held in close to the body - a natural chest or
+    /// hip hold. Solid to `PLAYER`, the shot collides on its first step, and a
+    /// `DESTROY_ON_IMPACT` projectile is consumed there and then: the psi bolt
+    /// never leaves the amp, the points are spent, and the player takes their
+    /// own damage. AI and turret projectiles keep `CollisionGroup::entity()`
+    /// and hit the player normally.
+    pub fn player_projectile() -> CollisionGroup {
+        Self::solid(InteractionGroups {
+            memberships: InternalCollisionGroups::ENTITY.bits.into(),
+            filter: (InternalCollisionGroups::ALL_COLLIDABLE.bits
+                & !InternalCollisionGroups::PLAYER.bits)
+                .into(),
+            test_mode: Default::default(),
+        })
+    }
+
     /// Collision behavior for a living creature capsule. It collides exactly
     /// like an ordinary physical entity, but its distinct membership lets
     /// interaction-only fixtures and unsimulated movable debris opt out of

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2275,6 +2275,12 @@ impl CollisionGroup {
     /// never leaves the amp, the points are spent, and the player takes their
     /// own damage. AI and turret projectiles keep `CollisionGroup::entity()`
     /// and hit the player normally.
+    ///
+    /// Rapier's `InteractionGroups` test is an AND across both colliders, so
+    /// clearing `PLAYER` from this side alone is enough - the player capsule's
+    /// own `ALL_COLLIDABLE` filter cannot re-enable the pair. Same idiom as
+    /// `held_melee`. See `RuntimePropPlayerFiredProjectile` for what the
+    /// lifetime-long transparency does and does not cost.
     pub fn player_projectile() -> CollisionGroup {
         Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::ENTITY.bits.into(),
@@ -7424,6 +7430,63 @@ mod tests {
 
     fn identity_quat() -> Quaternion<f32> {
         Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    /// A player-fired projectile is transparent to the shooter's own capsule -
+    /// the muzzle of a weapon held in at the body sits inside it - while
+    /// staying solid to everything it is supposed to hit. With
+    /// `CollisionGroup::entity()` the first assertion fails: the bolt collides
+    /// with the player on its first step and, being DESTROY_ON_IMPACT, never
+    /// leaves the weapon.
+    #[test]
+    fn a_player_fired_projectile_passes_through_the_shooter_but_hits_everything_else() {
+        let mut world = PhysicsWorld::new();
+        let bolt = EntityId::from_inner(1).unwrap();
+        world.add_dynamic(
+            bolt,
+            vec3(0.0, 0.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Sphere(0.1),
+            CollisionGroup::player_projectile(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+
+        let body = world
+            .debug_list_bodies()
+            .into_iter()
+            .find(|body| body.entity_id == Some(bolt.inner() as i32))
+            .unwrap();
+        assert!(
+            !body.blocks_player,
+            "a player-fired shot must pass through the player who fired it"
+        );
+        assert!(
+            body.blocks_actor,
+            "a player-fired shot must still hit creatures"
+        );
+
+        // Rapier's `test` is an AND across both colliders, so clearing PLAYER
+        // from this side alone is what makes the shot transparent.
+        let filter = CollisionGroup::player_projectile().collision.filter.bits();
+        assert_eq!(
+            filter & InternalCollisionGroups::PLAYER.bits,
+            0,
+            "the player's own capsule must not interact with the shot"
+        );
+        for still_solid in [
+            InternalCollisionGroups::WORLD,
+            InternalCollisionGroups::ENTITY,
+            InternalCollisionGroups::ACTOR,
+            InternalCollisionGroups::SELECTABLE,
+        ] {
+            assert_ne!(
+                filter & still_solid.bits,
+                0,
+                "a player-fired shot must still hit {still_solid:?}"
+            );
+        }
     }
 
     #[test]

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -318,6 +318,19 @@ pub struct RuntimePropFlatAim {
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropProjectileRayOrigin(pub Point3<f32>);
 
+/// Marks a fast projectile the *player* fired, so its collision ray skips the
+/// player's own capsule.
+///
+/// Rapier's solid raycast reports a shape containing the ray origin as a hit at
+/// distance 0, so a shot whose ray starts inside the player strikes the shooter
+/// before it can travel. Flat firing starts at the eye - always inside the
+/// capsule - and VR firing starts at the weapon's muzzle, which is inside it
+/// whenever the weapon is held in close to the body (a natural chest/hip hold).
+/// Both are the player shooting; neither may hit the player. AI and turret
+/// projectiles carry no marker and keep hitting the player normally.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropPlayerFiredProjectile;
+
 /// Marks an object created through Dark's `launchProjectile` path. Its
 /// authored physics model owns idle velocity; an empty skeletal animation
 /// must not zero the launch, and save/load must recreate it as a dynamic body.

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -328,6 +328,24 @@ pub struct RuntimePropProjectileRayOrigin(pub Point3<f32>);
 /// whenever the weapon is held in close to the body (a natural chest/hip hold).
 /// Both are the player shooting; neither may hit the player. AI and turret
 /// projectiles carry no marker and keep hitting the player normally.
+///
+/// The marker lasts the projectile's whole flight, not just the frames near the
+/// muzzle, so a player-fired body stays transparent to the shooter for its
+/// entire life: a grenade that rebounds off a wall passes through its thrower
+/// rather than detonating on contact with them. It still detonates on the
+/// surface it hits, and `radius_blast` finds the player by position rather than
+/// by collider, so splash damage reaches them normally. Being permanently
+/// transparent also hides these bodies from the player's own movement queries
+/// (`player_movement_filter`), so the player can walk through their own grenade
+/// at rest - preferred over the alternative of being able to shoot yourself.
+///
+/// Not serialized, like every other runtime prop, and - unlike
+/// `RuntimePropLaunchedProjectile` - deliberately not restored on load either,
+/// matching `RuntimePropProjectileRayOrigin`: in-flight projectile state is
+/// already lossy across a save. The residual case is a save taken during the
+/// frame or two a bolt still overlaps the capsule, which reloads solid to the
+/// player. If that ever proves reachable in practice, mirror the
+/// `launched_projectiles` round-trip in `EntitySaveData`.
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropPlayerFiredProjectile;
 

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -184,7 +184,7 @@ impl Script for InternalFastProjectileScript {
 fn is_player_fired(world: &World, entity_id: EntityId) -> bool {
     world
         .borrow::<View<RuntimePropPlayerFiredProjectile>>()
-        .is_ok_and(|fired| fired.get(entity_id).is_ok())
+        .is_ok_and(|fired| fired.contains(entity_id))
 }
 
 /// Whether a collider is one of this creature's own hitboxes. Read from the

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -12,7 +12,8 @@ use crate::{
     mission::entity_creator::CreateEntityOptions,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::{
-        RuntimePropProjectileRayOrigin, RuntimePropShotModifiers, RuntimePropTransform,
+        RuntimePropPlayerFiredProjectile, RuntimePropProjectileRayOrigin, RuntimePropShotModifiers,
+        RuntimePropTransform,
     },
     scripts::{
         Message,
@@ -66,12 +67,15 @@ impl Script for InternalFastProjectileScript {
             .and_then(|origins| origins.get(entity_id).ok().map(|origin| origin.0));
         let start_point =
             maybe_camera_origin.unwrap_or(current_position - forward * SCALE_FACTOR * 0.25);
-        // A camera-origin ray starts at the player's eye, which is INSIDE the
-        // player's own capsule (the eye is the head sphere). Rapier's solid
-        // raycast reports a shape containing the origin as a hit at
-        // distance 0, so keeping `PLAYER` in the mask would make every flat
-        // shot hit the shooter instead of what the crosshair is on.
-        let can_hit_player = maybe_camera_origin.is_none();
+        // A player-fired shot must never hit the player. Rapier's solid raycast
+        // reports a shape containing the ray origin as a hit at distance 0, and
+        // the ray starts inside the player's own capsule in both presentations:
+        // flat rays start at the eye (the head sphere), and a VR ray starts at
+        // the weapon's muzzle, which is inside the capsule whenever the weapon
+        // is held in close to the body. Keeping `PLAYER` in the mask makes the
+        // shot spang on the shooter before it travels. AI and turret
+        // projectiles carry no marker and can still hit the player.
+        let can_hit_player = !is_player_fired(world, entity_id);
         let maybe_hit_spot = projectile_ray_cast(
             start_point,
             forward,
@@ -173,6 +177,14 @@ impl Script for InternalFastProjectileScript {
     ) -> Effect {
         Effect::NoEffect
     }
+}
+
+/// Whether this projectile came out of a weapon the player fired (every
+/// `weapon_script::create_projectile` shot - flat and VR alike).
+fn is_player_fired(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<RuntimePropPlayerFiredProjectile>>()
+        .is_ok_and(|fired| fired.get(entity_id).is_ok())
 }
 
 /// Whether a collider is one of this creature's own hitboxes. Read from the
@@ -319,9 +331,10 @@ fn projectile_ray_cast(
 
 #[cfg(test)]
 mod tests {
-    use super::{hitbox_belongs_to_entity, projectile_ray_cast};
+    use super::{hitbox_belongs_to_entity, is_player_fired, projectile_ray_cast};
     use crate::creature::{HitBoxType, RuntimePropHitBox};
     use crate::physics::PhysicsWorld;
+    use crate::runtime_props::RuntimePropPlayerFiredProjectile;
     use cgmath::{Quaternion, point3, vec3};
     use dark::SCALE_FACTOR;
     use dark::properties::PropCreature;
@@ -643,6 +656,37 @@ mod tests {
             Some(corpse),
             "a body with no hitboxes is hit on its own collider, as it always was",
         );
+    }
+
+    /// A VR shot carries no camera origin, so before this marker its ray kept
+    /// `PLAYER` in the mask. Held in close to the body - a natural chest or hip
+    /// hold - the muzzle sits inside the player's own capsule, and a solid
+    /// raycast reports the containing shape as a hit at distance 0: the shot
+    /// spanged on the shooter instead of leaving the weapon, spending psi/ammo
+    /// and damaging the player. What excludes the player is now this marker,
+    /// set by `create_projectile` in BOTH presentations, rather than the
+    /// incidental presence of a camera origin.
+    ///
+    /// This asserts only the predicate. The containment itself is not
+    /// reproducible in a bare `PhysicsWorld` - the sibling raycast tests below
+    /// pass with `can_hit_player` either way, so they never covered it - so the
+    /// behavioural regression test is the earth.mis e2e
+    /// (`earth-psi-cryo-self-hit.e2e.test.ts`), which fires the mission's own
+    /// psi amp from a natural hold and requires the bolt to survive.
+    #[test]
+    fn a_projectile_from_create_projectile_is_marked_player_fired() {
+        let mut world = World::new();
+        let projectile = world.add_entity(RuntimePropPlayerFiredProjectile);
+        assert!(is_player_fired(&world, projectile));
+    }
+
+    /// The counterpart gate: an unmarked projectile (AI, turret) still hits the
+    /// player, so the fix cannot be "never hit the player".
+    #[test]
+    fn an_unmarked_projectile_is_not_player_fired() {
+        let mut world = World::new();
+        let ai_projectile = world.add_entity(());
+        assert!(!is_player_fired(&world, ai_projectile));
     }
 
     #[test]

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -707,6 +707,15 @@ pub(super) fn create_muzzle_flash(
     }
 }
 
+/// Spawn a shot from a weapon **the player is firing**.
+///
+/// This is the player's fire path only: the sole production senders of
+/// `TriggerPull` are `virtual_hand` (the VR hand) and `flat_player_controller`,
+/// so every projectile created here belongs to the player. AI and turret shots
+/// never reach this function - `ai_util` emits its own `Effect::CreateEntity`.
+/// That is why the shot is unconditionally marked `player_fired_projectile`
+/// below, which makes it transparent to the player's own capsule; an AI shot,
+/// being unmarked, still hits the player normally.
 pub(super) fn create_projectile(
     world: &World,
     entity_id: EntityId,
@@ -718,7 +727,7 @@ pub(super) fn create_projectile(
     // the projectile just ahead of the camera travelling straight along the
     // crosshair, ignoring the offset/rotated barrel transform. This makes both
     // hitscan bullets and slow physics projectiles (grenades) track the
-    // crosshair. VR/AI weapons have no RuntimePropFlatAim and fall through.
+    // crosshair. A VR weapon has no RuntimePropFlatAim and falls through.
     {
         let v_flat_aim = world.borrow::<View<RuntimePropFlatAim>>().unwrap();
         if let Ok(aim) = v_flat_aim.get(entity_id) {

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -737,6 +737,7 @@ pub(super) fn create_projectile(
                     force_visible: true,
                     projectile_raycast_origin: Some(aim.origin),
                     shot_modifiers: Some(modifiers),
+                    player_fired_projectile: true,
                     ..CreateEntityOptions::default()
                 },
             };
@@ -761,11 +762,11 @@ pub(super) fn create_projectile(
     // Documented fallback for a model with no vhot at all: the model origin,
     // i.e. the grip. The shot still leaves along the barrel, just from the
     // hand. This is not rare - `empgun_h`, `gren_h`, `fsn_h` and `al_h` ship
-    // with zero vhots, as do most classic-install world models - and a shot
-    // starting at the grip can strike the player when the weapon is held in
-    // close to the body (see #1034). Adding clearance is deliberately left to
-    // that issue: it changes where four more weapons fire from, which is a
-    // separate change from making the vhot-carrying weapons faithful.
+    // with zero vhots, as do most classic-install world models. Where the shot
+    // *starts* is still only as good as the model, and #1034 tracks giving the
+    // vhotless ones a better fire point; what is no longer at stake is the shot
+    // dying on the shooter, because a player-fired projectile's ray skips the
+    // player's capsule (`player_fired_projectile` below).
     let muzzle = vhots
         .first()
         .map(|v| v.point)
@@ -787,6 +788,7 @@ pub(super) fn create_projectile(
         options: CreateEntityOptions {
             force_visible: true,
             shot_modifiers: Some(modifiers),
+            player_fired_projectile: true,
             ..CreateEntityOptions::default()
         },
     }

--- a/tools/shock2-sdk/test/earth-psi-cryo-self-hit.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psi-cryo-self-hit.e2e.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Regression test for the VR psi amp firing into the player's own capsule.
+//
+// This deliberately runs in a REAL mission - earth.mis's authored Psionic
+// training room, with the mission's own Psi Amp (object 290) - and at a
+// natural close hold, because that is the combination the existing coverage
+// missed. `vr-muzzle-origin.e2e.test.ts` poses the hand at arm's length in the
+// synthetic `debug_psi` scene, which clears the player capsule, so it passed
+// throughout while a player holding the amp at their chest saw the bolt
+// detonate on themselves: psi spent, HP lost, nothing leaving the amp.
+//
+// The assertions are the two things the player actually experiences - the bolt
+// survives and travels, and the cast costs no health - at a hold close enough
+// to the body that the muzzle is inside the player's capsule.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** In front of the authored psi amp in earth.mis's Psionic training room. */
+const TRAINING_ROOM = { x: 238.0, y: 23.5, z: 189.2 };
+
+/** Barrel yawed so the model's -X points away from the player, not into them. */
+const BARREL_FORWARD = [0, 0.7071068, 0, 0.7071068];
+
+/**
+ * Holds that put the amp's muzzle inside the player's own capsule. These are
+ * ordinary ways to hold a controller - at the chest, in at the body, at the
+ * hip - not contrived poses.
+ */
+const CLOSE_HOLDS: Array<[string, number[]]> = [
+  ["chest", [0.35, 1.1, 0.45]],
+  ["in at the body", [0.2, 1.05, 0.2]],
+  ["hip", [0.35, 0.9, 0.35]],
+];
+
+test(
+  "a VR psi amp held close to the body still casts cryokinesis out of the amp",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8098),
+      debugFlags: ["--vr"],
+    });
+
+    await game.step({ frames: 30 });
+    await game.player.teleport(TRAINING_ROOM);
+    await game.step({ frames: 60 });
+
+    // A VR hand with no grip drops whatever it is handed on the same frame, so
+    // squeeze before taking the amp.
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 5 });
+
+    // The mission's own psi amp, discovered by name - runtime ids are not
+    // stable across runs.
+    const amp = (await game.entities.list({ limit: 2000 })).entities.find(
+      (e) => e.name === "Psi Amp",
+    );
+    assert.ok(amp, "earth.mis Psionic training room should contain a Psi Amp");
+
+    await game.player.give(amp.id);
+    await game.step({ frames: 20 });
+    await game.input.trigger("EquipPsiAmp");
+    await game.step({ frames: 30 });
+
+    let player = (await game.info()).player;
+    assert.equal(
+      player.right_hand_entity_id,
+      amp.id,
+      "the amp should be held in the right hand",
+    );
+    assert.equal(
+      player.selected_psi_power,
+      "Cryokinesis",
+      "a fresh earth.mis character starts with Projected Cryokinesis selected",
+    );
+
+    for (const [label, hold] of CLOSE_HOLDS) {
+      await game.input.set("right_hand.position", hold);
+      await game.input.set("right_hand.rotation", BARREL_FORWARD);
+      await game.step({ frames: 10 });
+
+      const before = (await game.info()).player;
+
+      await game.input.set("right_hand.trigger", 1.0);
+      await game.step({ frames: 1 });
+      await game.input.set("right_hand.trigger", 0.0);
+
+      const boltsAtSpawn = await cryoBolts(game);
+      assert.ok(
+        boltsAtSpawn.length > 0,
+        `casting from a ${label} hold should spawn a Cryo PSI bolt`,
+      );
+
+      // Eight frames is far longer than the one frame the bolt used to survive
+      // when it collided with the shooter, and well short of its lifetime.
+      await game.step({ frames: 8 });
+
+      const boltsInFlight = await cryoBolts(game);
+      assert.ok(
+        boltsInFlight.length > 0,
+        `the bolt cast from a ${label} hold must survive, not detonate on the player`,
+      );
+
+      const spawn = boltsAtSpawn[0]!.position;
+      const flown = boltsInFlight[0]!.position;
+      const travelled = Math.hypot(
+        flown[0]! - spawn[0]!,
+        flown[1]! - spawn[1]!,
+        flown[2]! - spawn[2]!,
+      );
+      assert.ok(
+        travelled > 1.0,
+        `the bolt from a ${label} hold should travel away from the amp (moved ${travelled.toFixed(2)})`,
+      );
+
+      const after = (await game.info()).player;
+      assert.equal(
+        after.hit_points,
+        before.hit_points,
+        `casting from a ${label} hold must not damage the caster`,
+      );
+      assert.equal(
+        after.psi_points,
+        before.psi_points! - 1,
+        `a tier 1 cast from a ${label} hold costs exactly one psi point`,
+      );
+
+      // Let the bolts clear before the next hold.
+      await game.step({ frames: 90 });
+    }
+  },
+);
+
+async function cryoBolts(game: GameServer) {
+  const { entities } = await game.entities.list({ limit: 2000 });
+  return entities.filter((e) => e.name?.startsWith("Cryo PSI"));
+}

--- a/tools/shock2-sdk/test/earth-psi-cryo-self-hit.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psi-cryo-self-hit.e2e.test.ts
@@ -15,7 +15,13 @@ import { GameServer } from "../src/index.js";
 //
 // The assertions are the two things the player actually experiences - the bolt
 // survives and travels, and the cast costs no health - at a hold close enough
-// to the body that the muzzle is inside the player's capsule.
+// to the body that the muzzle is inside the player's capsule. That closeness is
+// asserted rather than assumed: if a future grip change moved the muzzle clear
+// of the capsule this test would stop covering anything, so it fails loudly
+// instead.
+//
+// Verified negatively: on the commit before the fix this fails with
+// "the bolt cast from a chest hold must survive, not detonate on the player".
 //
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
@@ -26,6 +32,14 @@ const TRAINING_ROOM = { x: 238.0, y: 23.5, z: 189.2 };
 
 /** Barrel yawed so the model's -X points away from the player, not into them. */
 const BARREL_FORWARD = [0, 0.7071068, 0, 0.7071068];
+
+/**
+ * The standing player capsule's radius in world units
+ * (`PLAYER_STANDING_RADIUS / SCALE_FACTOR` = 1.2 / 2.5). A bolt spawning within
+ * this of the pawn's vertical axis starts inside the shooter - the whole
+ * condition this test exists to cover.
+ */
+const PLAYER_CAPSULE_RADIUS = 1.2 / 2.5;
 
 /**
  * Holds that put the amp's muzzle inside the player's own capsule. These are
@@ -86,34 +100,54 @@ test(
       await game.input.set("right_hand.rotation", BARREL_FORWARD);
       await game.step({ frames: 10 });
 
+      assert.equal(
+        (await cryoBolts(game)).length,
+        0,
+        `no bolt from an earlier hold may still be alive before the ${label} cast`,
+      );
+
       const before = (await game.info()).player;
 
       await game.input.set("right_hand.trigger", 1.0);
       await game.step({ frames: 1 });
       await game.input.set("right_hand.trigger", 0.0);
 
-      const boltsAtSpawn = await cryoBolts(game);
+      const spawned = await cryoBolts(game);
+      assert.equal(
+        spawned.length,
+        1,
+        `casting from a ${label} hold should spawn exactly one Cryo PSI bolt`,
+      );
+      const bolt = spawned[0]!;
+      const spawn = bolt.position;
+
+      // Precondition: the shot really does start inside the shooter. Without
+      // this the test could quietly stop exercising the bug.
+      const radial = Math.hypot(
+        spawn[0]! - before.position[0]!,
+        spawn[2]! - before.position[2]!,
+      );
       assert.ok(
-        boltsAtSpawn.length > 0,
-        `casting from a ${label} hold should spawn a Cryo PSI bolt`,
+        radial < PLAYER_CAPSULE_RADIUS,
+        `the ${label} hold must put the muzzle inside the player capsule for this test to mean anything (radial ${radial.toFixed(2)} >= ${PLAYER_CAPSULE_RADIUS})`,
       );
 
       // Eight frames is far longer than the one frame the bolt used to survive
       // when it collided with the shooter, and well short of its lifetime.
       await game.step({ frames: 8 });
 
-      const boltsInFlight = await cryoBolts(game);
+      // Track the SAME entity - a different bolt would make the distance
+      // measurement meaningless.
+      const inFlight = (await cryoBolts(game)).find((e) => e.id === bolt.id);
       assert.ok(
-        boltsInFlight.length > 0,
+        inFlight,
         `the bolt cast from a ${label} hold must survive, not detonate on the player`,
       );
 
-      const spawn = boltsAtSpawn[0]!.position;
-      const flown = boltsInFlight[0]!.position;
       const travelled = Math.hypot(
-        flown[0]! - spawn[0]!,
-        flown[1]! - spawn[1]!,
-        flown[2]! - spawn[2]!,
+        inFlight.position[0]! - spawn[0]!,
+        inFlight.position[1]! - spawn[1]!,
+        inFlight.position[2]! - spawn[2]!,
       );
       assert.ok(
         travelled > 1.0,
@@ -132,8 +166,9 @@ test(
         `a tier 1 cast from a ${label} hold costs exactly one psi point`,
       );
 
-      // Let the bolts clear before the next hold.
-      await game.step({ frames: 90 });
+      // Let the bolts clear before the next hold (asserted at the top of the
+      // next iteration).
+      await game.step({ frames: 120 });
     }
   },
 );


### PR DESCRIPTION
## The bug

The owner reported that **psi amp cryokinesis still isn't working** in VR. It is
reproducible in a real mission, and it is not an aiming problem.

In `earth.mis`'s authored Psionic training room, holding the mission's own Psi
Amp (object 290) the way you actually hold a controller — at the chest, in at
the body, at the hip — and pulling the trigger:

- the psi point **is** spent,
- the cryo bolt spawns and is **destroyed on the very next frame**,
- the player **takes their own damage**,
- and nothing is seen leaving the amp — just a white flash in your face.

Measured in `earth.mis --vr`, one cast per hold:

| hold | bolt alive after 8 frames | HP | psi |
|---|---|---|---|
| chest `(0.35, 1.10, 0.45)` | **no — gone in 1 frame** | **30 → 29** | 40 → 39 |
| in at the body `(0.20, 1.05, 0.20)` | **no** | **29 → 28** | 39 → 38 |
| hip `(0.35, 0.90, 0.35)` | **no** | **28 → 27** | 38 → 37 |
| arm fully extended `(0.35, 1.10, 0.80)` | yes | 27 → 27 | 37 → 36 |

The `Damage` message goes to entity id 1 — the player.

![before/after at a natural chest hold](https://gist.githubusercontent.com/tommy-xr/aec686926c08beacadca1217a0343fb4/raw/psi-cryo-beforeafter.png)

<sub>Same deterministic sequence on both builds, same hold, same trigger frame, in `earth.mis`'s psi training room. **Left:** the bolt detonates at the muzzle and whites out the screen — the player has frozen themselves. **Right:** a coherent cryo bolt leaves the amp and travels into the room.</sub>

## Root cause

A projectile leaves the muzzle of a weapon the **player is holding**. In VR that
muzzle is *inside the player's own physics capsule* whenever the weapon is held
in close to the body. The cryo bolt is a slow **physics** projectile
(`PropPhysInitialVelocity` = 20, below the 80 threshold for the raycast path),
so it was created solid to `PLAYER`, collided on its first step, and — being
`DESTROY_ON_IMPACT` — was consumed right there by `InternalCollisionType`,
which also sends the 1.0 damage that shows up on the player.

Only the *fully extended arm* clears the capsule, which is exactly why this
survived review: the psi/VR coverage all poses the hand at arm's length in the
synthetic `debug_psi` scene. #1035 measured 0.00° barrel deviation and an exact
muzzle-vhot spawn and was right about both — the aim was never the problem.

The flat path was never affected: it spawns `FLAT_MUZZLE_CLEARANCE`
(1 × `SCALE_FACTOR`) ahead of the camera, well outside the capsule.

## The fix

Make "the player's own shot cannot hit the player" explicit and shared, instead
of an accident of where the muzzle happens to be.

`create_projectile` marks every shot it creates — **flat and VR alike** — with
`RuntimePropPlayerFiredProjectile`. That marker does two things:

- selects `CollisionGroup::player_projectile()`, whose filter is
  `ALL_COLLIDABLE` minus `PLAYER`, so the physical bolt passes through the
  shooter (Rapier's `InteractionGroups` test is an AND across both colliders, so
  clearing it on the projectile side is sufficient);
- excludes `PLAYER` from the fast (raycast) projectile's mask, replacing the old
  `can_hit_player = maybe_camera_origin.is_none()` heuristic, which only
  protected the flat path because flat happened to be the branch that set a
  camera origin.

AI and turret projectiles are spawned by `ai_util`, never through
`create_projectile`, so they carry no marker and still hit the player —
re-verified in `debug_turret` (player 30 → 28 HP under fire) and by
`hostile-ranged-damage`, `player-hit-feedback`.

This also closes the self-detonation half of #1034 for the four vhotless view
models (`empgun_h`, `gren_h`, `fsn_h`, `al_h`): their shots still leave from the
grip, but they can no longer be consumed on the shooter. Where they leave from
is still that issue's business.

## The cryo bolt leaving the amp in earth.mis

![cryo bolt leaving the psi amp in earth.mis](https://gist.githubusercontent.com/tommy-xr/aec686926c08beacadca1217a0343fb4/raw/psi-cryo-earth.gif)

<sub>`earth.mis --vr`, the authored Psionic training room, the mission's own Psi Amp. The amp is held at the left of frame with the barrel yawed 40° across the view, so the bolt's path is readable rather than foreshortened down the barrel: it bursts from the amp, crosses the room past the Training Droid, and recedes. Captured headlessly (`/v1/step` + `/v1/screenshot`, deterministic fixed timestep).</sub>

Same shot at the **close hold that reproduces the bug**, before and after:

| before | after |
|---|---|
| ![](https://gist.githubusercontent.com/tommy-xr/aec686926c08beacadca1217a0343fb4/raw/psi-cryo-close-before.gif) | ![](https://gist.githubusercontent.com/tommy-xr/aec686926c08beacadca1217a0343fb4/raw/psi-cryo-close-after.gif) |

## Test

`tools/shock2-sdk/test/earth-psi-cryo-self-hit.e2e.test.ts` — deliberately a
**real mission**, not a debug scene: `earth.mis`'s training room, the mission's
own amp, and the three natural close holds. Asserts the bolt spawns, survives 8
frames, travels > 1 unit from the amp, costs exactly one psi point, and costs
**no** health.

Verified negatively: on the parent commit it fails with
`the bolt cast from a chest hold must survive, not detonate on the player`.

It asserts its own **precondition** — that the spawn really is inside the player
capsule (radial distance < `PLAYER_STANDING_RADIUS_WORLD`) — so if a future grip
change moved the muzzle clear, the test fails loudly instead of quietly covering
nothing. It tracks the bolt by entity id across samples and requires no earlier
bolt to be alive before each cast.

`physics::a_player_fired_projectile_passes_through_the_shooter_but_hits_everything_else`
covers the collider half as a unit test — the half the psi bug actually goes
through, since the cryo bolt is a *slow* projectile that keeps its body. It is
genuinely negative: with `CollisionGroup::entity()` it fails on
*"a player-fired shot must pass through the player who fired it"*.

**Worth flagging for a follow-up:** the two pre-existing raycast unit tests in
`internal_fast_projectile` — including
`camera_origin_projectile_shoots_past_the_shooters_own_collider` — pass with
`can_hit_player` set **either way**. A bare `PhysicsWorld` does not reproduce the
capsule containment, so they never covered the property they are named for. That
is a large part of why this class of bug survived.

## Validation

- `cargo fmt --all --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` — 877 passed
- e2e: `psi`, `psi-overload`, `psi-trained`, `psi-sustained`, `vr-muzzle-origin`,
  `close-range-projectile`, `slow-projectile-spang`, `explosion`, `weapon-ammo`,
  `weapon-ammo-type`, `weapon-selection`, `weapon-reload`,
  `hostile-ranged-damage`, `player-hit-feedback`, `blood-spang`, `bullet-hole`,
  `muzzle-flash`, `earth-psionic-training`, `docile-training-droid`,
  `monster-death`, plus the new test — all pass
- `missions.e2e.test.ts` — all 23 missions load

## Known trade-offs

- The marker lasts the projectile's whole flight, so a **rebounding grenade
  passes through its thrower** instead of detonating on contact with them. It
  still detonates on the surface it hits, and `radius_blast` finds the player by
  position rather than by collider, so splash damage is unaffected
  (`explosion` e2e passes). Documented on the component.
- The marker is **not restored on load**, matching `RuntimePropProjectileRayOrigin`
  (in-flight projectile state is already lossy across a save). The residual case
  is a save taken during the frame or two a bolt still overlaps the capsule.
  Documented, with a pointer to the `launched_projectiles` round-trip to mirror
  if it ever proves reachable.

## Review

`/xreview` (Claude + Codex + a dedicated de-dup pass). Both engines independently
confirmed the Rapier `InteractionGroups` AND semantics (clearing `PLAYER` on the
projectile side alone is sufficient), that the `entity_group` substitution is
behaviour-preserving for non-projectiles, and that splash still reaches the
player. Codex filed a High claiming AI shots were being mislabeled player-fired;
that was a **false positive** caused by a stale comment in `create_projectile`
(*"VR/AI weapons ... fall through"*) — `TriggerPull` has exactly two production
senders, both player controllers. The comment is corrected, and AI damage is
re-verified in `debug_turret` and by `hostile-ranged-damage`. The remaining
Medium/Low findings (unit coverage for the new group, e2e precondition + bolt
identity, doc gaps) are all addressed in 002e79a.

Refs #1034
