### PR TITLE
fix(gameplay): load spaced audio log transcripts

### DIFF
--- a/dark/src/importers/strings_importer.rs
+++ b/dark/src/importers/strings_importer.rs
@@ -44,7 +44,13 @@ pub fn parse_strings(content: &[String]) -> HashMap<String, String> {
     let mut current_value = String::new();
 
     for line_str in inner_content {
-        if let Some(pos) = line_str.find(":\"") {
+        let entry = line_str.split_once(':').and_then(|(key, value)| {
+            value
+                .trim_start()
+                .strip_prefix('"')
+                .map(|value| (key, value))
+        });
+        if let Some((key, value)) = entry {
             if let Some(key) = current_key.take() {
                 map.insert(
                     key.to_ascii_lowercase(),
@@ -53,9 +59,8 @@ pub fn parse_strings(content: &[String]) -> HashMap<String, String> {
                 current_value.clear();
             }
 
-            let (key, value) = line_str.split_at(pos);
             current_key = Some(key.trim().to_string());
-            current_value = value[2..].to_string();
+            current_value = value.to_string();
         } else if current_key.is_some() {
             current_value.push_str("\n");
             current_value.push_str(&line_str);
@@ -76,3 +81,18 @@ pub fn parse_strings(content: &[String]) -> HashMap<String, String> {
 
 pub static STRINGS_IMPORTER: Lazy<AssetImporter<Vec<String>, HashMap<String, String>, ()>> =
     Lazy::new(|| AssetImporter::define(import_strings, process_strings));
+
+#[cfg(test)]
+mod tests {
+    use super::parse_strings;
+
+    #[test]
+    fn accepts_whitespace_between_colon_and_opening_quote() {
+        let strings = parse_strings(&[r#"LogText12:  "Glory to the Many!""#.to_string()]);
+
+        assert_eq!(
+            strings.get("logtext12").map(String::as_str),
+            Some("Glory to the Many!")
+        );
+    }
+}

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -281,3 +281,49 @@ test(
     );
   },
 );
+
+// Hydro 3's Korenchkin entry is authored as `LogText12:  "..."` in
+// LEVEL03.STR, with two spaces between the colon and opening quote. It follows
+// the same Dark string-table grammar as the compact `Key:"..."` form and must
+// remain available after the disc has been consumed into the PDA.
+test(
+  "hydro3: collected Korenchkin log opens its double-spaced transcript",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8252),
+    });
+    await game.step({ frames: 5 });
+
+    const [korenchkin] = await game.entities.byTemplate(382);
+    assert.ok(korenchkin, "hydro3 should contain Korenchkin's log (obj 382)");
+
+    await game.entities.sendMessage(korenchkin.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 3, log: 12, read: false }],
+      "the Hydro 3 log should be filed unread",
+    );
+
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "the collected Hydro 3 log should open in the reader");
+    const transcript = panel.elements
+      .filter((element) => element.kind === "text" && element.text)
+      .map((element) => element.text)
+      .join(" ");
+    assert.ok(
+      transcript.includes("Glory... to the Many"),
+      `the reader should render Korenchkin's transcript (got: ${transcript.slice(0, 160)})`,
+    );
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 3, log: 12, read: true }],
+      "successfully opening the log should mark it read",
+    );
+  },
+);


### PR DESCRIPTION
## Reproduction

On exact base `8977f23681174365daefa2ae1ec870140139d0ac`, Hydro 3's authored Korenchkin audio log (mission object 382, deck 3/log 12) enters `collected_logs` when frobbed, but `ReadLastUnreadLog` cannot resolve it. The runtime leaves the entry unread, opens no reader, and reports:

```text
unable to open audio log reader: no collected log has a localized transcript here
```

The shipped `LEVEL03.STR` entry uses valid whitespace between the delimiter and opening quote:

```text
LogText12:  "Glory..."
```

`parse_strings` only recognized the compact `Key:"value"` spelling, so it silently omitted this transcript. This preserves the issue's player-facing failure even though persistent collection itself was added by #468 after the report was filed.

## Fix

- Accept optional whitespace between a Dark string-table entry's colon and opening quote.
- Keep the existing compact syntax and multiline value behavior unchanged.
- Add a parser regression test for the exact spaced form.
- Add a real Hydro 3 SDK scenario that collects mission object 382, opens its Korenchkin transcript, and verifies its unread-to-read transition.

## Verification

- Negative-first parser test on base: failed (`logtext12` absent); fixed: passed.
- `cargo test -p dark` — 114 unit + 11 integration tests passed.
- `SHOCK2_E2E=1 node --test --test-name-pattern='hydro3: collected Korenchkin' dist/test/log-reader.e2e.test.js` — 1 passed.
- `npm test` — 26 passed, 272 opt-in scenarios skipped.
- `cargo fmt --all -- --check` — passed.
- `RUSTFLAGS='-D warnings' cargo check -p dark -p shock2vr -p desktop_runtime -p debug_runtime` — passed.

## Visual verification

![Audio-log world-to-reader flow](https://gist.githubusercontent.com/tommy-xr/d93693faf6eccc7d2e44d5927d952c18/raw/issue-820-world-to-reader.gif)

<sub>Hydroponics deck 3 audio log 12 is collected, then opens its authored Korenchkin transcript. Captured headlessly with deterministic fixed-timestep stepping.</sub>

### Before → after

![Before and after](https://gist.githubusercontent.com/tommy-xr/d93693faf6eccc7d2e44d5927d952c18/raw/issue-820-before-after.png)

<sub>Matched request sequence on base `8977f236` and fix `0d3eb4a0`: both collect deck 3/log 12, but only the fix resolves and opens the authored transcript.</sub>

Fixes #820
