### PR TITLE
refactor(ui): share the frontend menu shell

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1438,7 +1438,7 @@ impl Game {
             // pausable (the player died, a transition started): close rather
             // than strand the player on a panel over a screen that has taken
             // over. The toggle itself is left unhandled - i.e. ignored.
-            self.pause_menu.close();
+            self.close_pause_menu(false);
             return;
         }
 
@@ -1446,7 +1446,7 @@ impl Game {
         // key/button down), so holding the menu button cannot re-toggle.
         if actions.just_triggered(InputAction::TogglePauseMenu) {
             if self.pause_menu.is_open() {
-                self.pause_menu.close();
+                self.close_pause_menu(false);
             } else {
                 self.open_pause_menu();
             }
@@ -1462,14 +1462,25 @@ impl Game {
             &mut self.asset_cache,
             &self.options,
         );
+        self.pause_menu
+            .pump_sfx(&mut self.asset_cache, &mut self.audio_context);
         match action {
-            Some(PauseAction::Resume) => self.pause_menu.close_after_click(),
+            Some(PauseAction::Resume) => self.close_pause_menu(true),
             Some(PauseAction::QuitToMainMenu) => {
-                self.pause_menu.close_after_click();
+                self.close_pause_menu(true);
                 self.handle_global_effect(GlobalEffect::ShowMainMenu);
             }
             None => {}
         }
+    }
+
+    fn close_pause_menu(&mut self, after_click: bool) {
+        if after_click {
+            self.pause_menu.close_after_click();
+        } else {
+            self.pause_menu.close();
+        }
+        self.pause_menu.stop_sfx(&mut self.audio_context);
     }
 
     fn open_pause_menu(&mut self) {

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -21,27 +21,35 @@
 //! paused" rule free: `VirtualHand` is never advanced, so nothing is grabbed,
 //! dropped or fired, and whatever was already held is still held on resume.
 
-use std::collections::HashMap;
-
 use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
-use dark::{
-    importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
-    map::MapRect,
-};
+#[cfg(test)]
+use dark::map::MapRect;
 use engine::{
     assets::asset_cache::AssetCache,
+    audio::AudioContext,
     scene::{SceneObject, color_material, quad},
 };
+use shipyard::EntityId;
 
 use crate::{
     GameOptions, PresentationMode,
-    input_context::{InputContext, Pointer2D},
+    input_context::InputContext,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
-        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, WorldPanel, dev_params_panel,
-        frontend_panel_distance, pointer_to_canvas, vr_frontend_pointer_pass,
+        FrontendMenu, FrontendMenuItem, HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel,
+        dev_params_panel, frontend_panel_distance, hit_menu_item,
     },
 };
+
+#[cfg(test)]
+use crate::{
+    input_context::Pointer2D,
+    ui::{
+        resolve_click_at as shell_resolve_click_at, resolve_flat_click, resolve_menu_labels,
+        resolve_menu_rects, vr_frontend_pointer_pass,
+    },
+};
+#[cfg(test)]
+use std::collections::HashMap;
 
 /// The screen is authored on the original 640x480 `SIM.PCX` canvas.
 const CANVAS_W: f32 = 640.0;
@@ -268,38 +276,29 @@ enum PauseMenuEntry {
     Developer,
 }
 
-struct MenuItem {
-    /// Key into `SIM.STR`.
-    string_key: &'static str,
-    /// Label used when `SIM.STR` is absent or missing the key. These match the
-    /// shipped English strings.
-    fallback_label: &'static str,
-    /// `None` for an entry that exists on the original screen but that the port
-    /// does not implement yet - drawn dimmed, and not clickable.
-    action: Option<PauseMenuEntry>,
-    /// Label drawn instead of the string-table text (and the fallback). Used
-    /// by the Developer entry, which repurposes the inert Options slot - see
-    /// the identical field on the main menu's `MenuItem`.
-    label_override: Option<&'static str>,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PauseMenuTarget {
+    Root(PauseMenuEntry),
+    Developer(dev_params_panel::DevParamsEvent),
 }
 
 // `SIM.PCX` (native 640x480) has a vertical stack of five buttons down the
 // right side. This list is in screen order, top to bottom, so an item's index
 // is also its rect index in `SIMR.BIN`.
-const MENU_ITEMS: &[MenuItem] = &[
-    MenuItem {
+const MENU_ITEMS: &[FrontendMenuItem<PauseMenuEntry>] = &[
+    FrontendMenuItem {
         string_key: "continue",
         fallback_label: "Continue",
         action: Some(PauseMenuEntry::Action(PauseAction::Resume)),
         label_override: None,
     },
-    MenuItem {
+    FrontendMenuItem {
         string_key: "save_game",
         fallback_label: "Save Game",
         action: None,
         label_override: None,
     },
-    MenuItem {
+    FrontendMenuItem {
         string_key: "load_game",
         fallback_label: "Load Game",
         action: None,
@@ -307,13 +306,13 @@ const MENU_ITEMS: &[MenuItem] = &[
     },
     // The Options slot hosts the Developer page while no real options screen
     // exists, matching the main menu's slot.
-    MenuItem {
+    FrontendMenuItem {
         string_key: "options",
         fallback_label: "Options",
         action: Some(PauseMenuEntry::Developer),
         label_override: Some("Developer"),
     },
-    MenuItem {
+    FrontendMenuItem {
         string_key: "quit",
         fallback_label: "Quit to \\nMain Menu",
         action: Some(PauseMenuEntry::Action(PauseAction::QuitToMainMenu)),
@@ -321,48 +320,51 @@ const MENU_ITEMS: &[MenuItem] = &[
     },
 ];
 
+const FALLBACK_RECTS: [Rect; 5] = [
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + 2.0 * FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + 3.0 * FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + 4.0 * FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+];
+
 /// Resolve each menu item's canvas rect from the `SIMR.BIN` layout (falling
 /// back to the vanilla geometry if it's absent). Parallel to [`MENU_ITEMS`].
+#[cfg(test)]
 fn menu_rects(layout: Option<&[MapRect]>) -> Vec<Rect> {
-    MENU_ITEMS
-        .iter()
-        .enumerate()
-        .map(
-            |(index, _)| match layout.and_then(|rects| rects.get(index)) {
-                Some(r) => Rect::new(
-                    r.ul_x as f32,
-                    r.ul_y as f32,
-                    r.width() as f32,
-                    r.height() as f32,
-                ),
-                None => Rect::new(
-                    FALLBACK_BUTTON_X,
-                    FALLBACK_BUTTON_TOP + index as f32 * FALLBACK_BUTTON_PITCH,
-                    FALLBACK_BUTTON_W,
-                    FALLBACK_BUTTON_H,
-                ),
-            },
-        )
-        .collect()
+    resolve_menu_rects(layout, &FALLBACK_RECTS)
 }
 
 /// Resolve each menu item's label from `SIM.STR`, falling back to the shipped
 /// English text when the string table is absent. Parallel to [`MENU_ITEMS`].
+#[cfg(test)]
 fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
-    MENU_ITEMS
-        .iter()
-        .map(|item| {
-            if let Some(label) = item.label_override {
-                return label.to_owned();
-            }
-            strings
-                // The strings importer lowercases its keys.
-                .and_then(|s| s.get(item.string_key))
-                .filter(|label| !label.is_empty())
-                .cloned()
-                .unwrap_or_else(|| item.fallback_label.to_owned())
-        })
-        .collect()
+    resolve_menu_labels(strings, MENU_ITEMS)
 }
 
 /// Split a shipped label into the lines it asks for. `SIM.STR`'s quit entry is
@@ -382,55 +384,33 @@ fn label_lines(label: &str) -> Vec<&str> {
 /// highlight go through this, so the two can never disagree about where an
 /// entry is - or about which entries are live at all.
 fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<PauseMenuEntry> {
-    let mut canvas = UiCanvas::<PauseMenuEntry>::with_events(vec2(CANVAS_W, CANVAS_H));
-    for (item, rect) in MENU_ITEMS.iter().zip(rects) {
-        // Unimplemented entries get no hit region at all, so a click over one
-        // falls through as "nothing was clicked".
-        if let Some(action) = item.action {
-            canvas.button(*rect, "", action);
+    hit_menu_item(point, MENU_ITEMS, rects, |_| true)
+}
+
+fn target_at(
+    page: PauseMenuPage,
+    panel_rects: dev_params_panel::PanelRects,
+    rects: &[Rect],
+    point: Vector2<f32>,
+) -> Option<PauseMenuTarget> {
+    match page {
+        PauseMenuPage::Root => hit(point, rects).map(PauseMenuTarget::Root),
+        PauseMenuPage::Developer => {
+            dev_params_panel::hit(panel_rects, point).map(PauseMenuTarget::Developer)
         }
     }
-    canvas.click_at(point)
 }
 
 /// Shared click core: both presentations reduce to "a point on the canvas plus
 /// a pressed flag", so the rising-edge rule and the hit regions live here once.
+#[cfg(test)]
 fn resolve_click_at(
     point: Option<Vector2<f32>>,
     pressed: bool,
     last_pressed: bool,
     rects: &[Rect],
 ) -> (Option<PauseMenuEntry>, bool) {
-    if !pressed || last_pressed {
-        return (None, pressed);
-    }
-    (point.and_then(|p| hit(p, rects)), pressed)
-}
-
-/// Reduce the flat pointer to "a point on the canvas plus a pressed flag" -
-/// the same shape the VR pointer pass yields, so the page routing above them
-/// is shared. No pointer this frame is not a release: on desktop the cursor
-/// is captured for mouse-look until `wants_pointer` flips it on, so the frame
-/// the menu opens has no pointer at all. Clearing the guard there would
-/// re-arm the click edge under a still-held button, hence `last_pressed`
-/// carries through.
-fn flat_pointer_state(
-    pointer: Option<Pointer2D>,
-    last_pressed: bool,
-    screen_size: Vector2<f32>,
-) -> (Option<Vector2<f32>>, bool) {
-    match pointer {
-        Some(p) => (
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            ),
-            p.pressed,
-        ),
-        None => (None, last_pressed),
-    }
+    shell_resolve_click_at(point, pressed, last_pressed, |point| hit(point, rects))
 }
 
 /// Pure click resolution for the flat pointer on the root page: on a rising
@@ -444,9 +424,14 @@ fn resolve_click(
     screen_size: Vector2<f32>,
     rects: &[Rect],
 ) -> (Option<PauseMenuEntry>, bool, Option<Vector2<f32>>) {
-    let (point, pressed) = flat_pointer_state(pointer, last_pressed, screen_size);
-    let (action, pressed) = resolve_click_at(point, pressed, last_pressed, rects);
-    (action, pressed, point)
+    resolve_flat_click(
+        pointer,
+        last_pressed,
+        screen_size,
+        vec2(CANVAS_W, CANVAS_H),
+        SCALE_MODE,
+        |point| hit(point, rects),
+    )
 }
 
 /// The pause overlay. Closed by default; [`PauseMenu::open`] arms it.
@@ -454,28 +439,11 @@ pub struct PauseMenu {
     open: bool,
     /// Which page the overlay is showing; reset to the root on every open.
     page: PauseMenuPage,
-    /// Pointer from the latest update, used for hover highlighting in render.
-    pointer: Option<Pointer2D>,
-    /// Where the VR controller ray last met the panel, in canvas pixels.
-    vr_pointer_canvas: Option<Vector2<f32>>,
-    /// The pointer pass that hit-tested this frame, kept so `render` draws the
-    /// beams and dot from the very rays `update` resolved the highlight from.
-    vr_pointer: FrontendPointerPass,
-    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
-    /// loaded glove model.
-    vr_pointer_visuals: PointerVisuals,
-    /// Where the VR panel hangs: placed from the head when the menu opens and
-    /// world-locked after that, so `render` draws it where `update` hit-tested.
-    panel_anchor: FrontendPanelAnchor,
+    menu: FrontendMenu<PauseMenuTarget>,
     /// The head pose from the latest update. The panel is world-locked, but the
     /// comfort dim follows the gaze, so it needs the live pose rather than the
     /// placement (see [`world_dim_layer`]).
     head: (Vector3<f32>, Quaternion<f32>),
-    /// Whether the pointer was pressed last frame (for rising-edge clicks).
-    last_pressed: bool,
-    /// Screen size from the latest render, so `update` maps the flat pointer
-    /// into canvas space consistently with how the canvas is drawn.
-    last_screen_size: Vector2<f32>,
     /// Set when a click closed the menu, and cleared once that click is
     /// released. See [`PauseMenu::suspends_scene`].
     closed_under_a_held_press: bool,
@@ -495,17 +463,11 @@ impl PauseMenu {
         Self {
             open: false,
             page: PauseMenuPage::Root,
-            pointer: None,
-            vr_pointer_canvas: None,
-            vr_pointer: FrontendPointerPass::default(),
-            vr_pointer_visuals: PointerVisuals::new(),
-            panel_anchor: FrontendPanelAnchor::new(),
+            menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
             head: (
                 Vector3::new(0.0, 0.0, 0.0),
                 Quaternion::new(0.0, 0.0, 0.0, 0.0),
             ),
-            last_pressed: true,
-            last_screen_size: vec2(CANVAS_W, CANVAS_H),
             closed_under_a_held_press: false,
             panel_rects: dev_params_panel::PanelRects::default(),
         }
@@ -556,15 +518,11 @@ impl PauseMenu {
         // Always land on the root page: reopening straight onto a parameter
         // list the player forgot they left would read as a broken menu.
         self.page = PauseMenuPage::Root;
-        self.panel_anchor = FrontendPanelAnchor::new();
+        self.menu.reset_on_entry();
         // Forget the previous session's head: if `render` runs before the first
         // `update` of this one, a stale pose would hang the dim where the player
         // was standing last time. Untracked takes the panel fallback instead.
         self.head = UNTRACKED_HEAD;
-        self.pointer = None;
-        self.vr_pointer_canvas = None;
-        self.vr_pointer = FrontendPointerPass::default();
-        self.last_pressed = true;
     }
 
     /// Close because an entry was clicked - the press that did it is still
@@ -576,9 +534,19 @@ impl PauseMenu {
 
     pub fn close(&mut self) {
         self.open = false;
-        self.pointer = None;
-        self.vr_pointer_canvas = None;
-        self.vr_pointer = FrontendPointerPass::default();
+        self.menu.clear_pointer();
+    }
+
+    pub fn pump_sfx(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        self.menu.pump_sfx(asset_cache, audio_context);
+    }
+
+    pub fn stop_sfx(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        self.menu.stop_sfx(audio_context);
     }
 
     /// Advance the overlay and report the entry that was clicked, if any.
@@ -600,37 +568,16 @@ impl PauseMenu {
         self.panel_rects = dev_params_panel::rects(asset_cache);
         self.head = (input_context.head.position, input_context.head.rotation);
 
-        // Placed from the head when the menu opens and world-locked after
-        // that; advancing it here keeps the ray and the render agreeing on
-        // where the panel is, in either presentation.
-        let panel = self.panel_anchor.update(
-            input_context.head.position,
-            input_context.head.rotation,
+        let page = self.page;
+        let panel_rects = self.panel_rects;
+        let target = self.menu.update(
             elapsed,
+            input_context,
+            options.presentation_mode,
+            |point| target_at(page, panel_rects, &rects, point),
+            |point| target_at(page, panel_rects, &rects, point),
         );
-
-        // Both presentations reduce to "a point on the canvas plus a pressed
-        // flag"; which page consumes the click is decided after.
-        let (point, pressed) = if options.presentation_mode == PresentationMode::Vr {
-            // VR has no 2D cursor: the pointer is where a controller ray meets
-            // the panel, and the trigger is the button.
-            self.vr_pointer =
-                vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
-            let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
-            self.vr_pointer_canvas = point;
-            self.pointer = None;
-            (point, pressed)
-        } else {
-            self.pointer = input_context.pointer;
-            self.vr_pointer = FrontendPointerPass::default();
-            flat_pointer_state(
-                input_context.pointer,
-                self.last_pressed,
-                self.last_screen_size,
-            )
-        };
-
-        self.consume_pointer(point, pressed, &rects)
+        self.handle_target(target)
     }
 
     /// Route one frame's resolved pointer state to whichever page is showing,
@@ -643,28 +590,29 @@ impl PauseMenu {
     /// press that leaves the Developer page could otherwise land on Quit the
     /// very next frame. Whichever page consumes the click stores the pressed
     /// flag, so the next frame's rising edge is already spent.
+    #[cfg(test)]
     fn consume_pointer(
         &mut self,
         point: Option<Vector2<f32>>,
         pressed: bool,
         rects: &[Rect],
     ) -> Option<PauseAction> {
-        match self.page {
-            PauseMenuPage::Root => {
-                let (entry, last_pressed) =
-                    resolve_click_at(point, pressed, self.last_pressed, rects);
-                self.last_pressed = last_pressed;
-                self.handle_root_entry(entry)
-            }
-            PauseMenuPage::Developer => {
-                // Same rising-edge rule as the root, over the shared panel's
-                // hit regions instead of the entry rects.
-                let event = (pressed && !self.last_pressed)
-                    .then(|| point.and_then(|p| dev_params_panel::hit(self.panel_rects, p)))
-                    .flatten();
-                self.last_pressed = pressed;
-                self.handle_developer_event(event)
-            }
+        let page = self.page;
+        let panel_rects = self.panel_rects;
+        let target = self.menu.resolve_pointer(
+            point,
+            pressed,
+            |point| target_at(page, panel_rects, rects, point),
+            |point| target_at(page, panel_rects, rects, point),
+        );
+        self.handle_target(target)
+    }
+
+    fn handle_target(&mut self, target: Option<PauseMenuTarget>) -> Option<PauseAction> {
+        match target {
+            Some(PauseMenuTarget::Root(entry)) => self.handle_root_entry(Some(entry)),
+            Some(PauseMenuTarget::Developer(event)) => self.handle_developer_event(Some(event)),
+            None => None,
         }
     }
 
@@ -716,8 +664,8 @@ impl PauseMenu {
         if !self.open || options.presentation_mode != PresentationMode::Vr {
             return Vec::new();
         }
-        let panel = self.panel_anchor.panel();
-        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
+        let panel = self.menu.panel();
+        let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
         // First in the list, and therefore first in the overlay group: the
         // comfort dim, which the depth clear below rides on.
         let (dim_position, dim_forward) = dim_pose(self.head.0, self.head.1, &panel);
@@ -726,27 +674,13 @@ impl PauseMenu {
             dim_forward,
             dim_distance(dim_position, &panel),
         )];
-        let canvas_objects = canvas.render_world_space(
-            asset_cache,
-            panel.transform(),
-            self.vr_pointer_canvas,
-            None,
-            VR_COMPONENT_Z_STEP,
-        );
+        let canvas_objects = self.menu.render_world_space(asset_cache, canvas);
         // The controllers and their aim rays, drawn from the same pass that
         // resolved the highlight, so the beams can never promise a hover the
         // menu will not give. The canvas objects already in hand are the layer
         // stack the hit dot has to float clear of - the dim is not one of them,
         // it hangs behind the panel rather than on it.
-        let panel_layers = canvas_objects.len();
         objects.extend(canvas_objects);
-        objects.extend(self.vr_pointer_visuals.render(
-            asset_cache,
-            &self.vr_pointer,
-            vec2(CANVAS_W, CANVAS_H),
-            &panel,
-            panel_layers,
-        ));
         // Everything above was built in the tracked play space (where the head,
         // the hands and therefore the panel anchor live). A frontend *scene*
         // has no pawn, so it renders that space directly; the pause menu hangs
@@ -770,25 +704,17 @@ impl PauseMenu {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        self.last_screen_size = screen_size;
         if !self.open || options.presentation_mode == PresentationMode::Vr {
             return Vec::new();
         }
-        let pointer_canvas = self.pointer.and_then(|p| {
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            )
-        });
+        let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(asset_cache, pointer_canvas);
-        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+        self.menu
+            .render_screen_space(asset_cache, canvas, screen_size)
     }
 
     fn rects(&self, asset_cache: &mut AssetCache) -> Vec<Rect> {
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        menu_rects(layout.as_deref().map(|r| r.as_slice()))
+        self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS)
     }
 
     /// The menu, described once. Screen-space and world-space presentation
@@ -824,8 +750,7 @@ impl PauseMenu {
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
         let rects = self.rects(asset_cache);
-        let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
-        let labels = menu_labels(strings.as_deref());
+        let labels = self.menu.labels(asset_cache, LABELS_FILE, MENU_ITEMS);
         // The highlight resolves through the very same `hit` the click does, so
         // an entry can never light up under a ray that would not activate it.
         let hovered = pointer_canvas.and_then(|p| hit(p, &rects));
@@ -984,7 +909,7 @@ mod tests {
         menu.handle_root_entry(Some(PauseMenuEntry::Developer));
         assert_eq!(menu.page, PauseMenuPage::Developer);
         // Nothing pressed yet, so the next frame is a genuine rising edge.
-        menu.last_pressed = false;
+        menu.menu.set_last_pressed(false);
 
         // Frame 1: press on "Done" - the page turns back to the root.
         assert_eq!(menu.consume_pointer(Some(done), true, &rects), None);
@@ -1014,14 +939,14 @@ mod tests {
         let rects = menu_rects(None);
         let mut menu = PauseMenu::new();
         menu.open();
-        menu.last_pressed = false;
+        menu.menu.set_last_pressed(false);
 
         let developer = rects[OPTIONS_INDEX].center();
         assert_eq!(menu.consume_pointer(Some(developer), true, &rects), None);
         assert_eq!(menu.page, PauseMenuPage::Developer);
         // Still held on the next frame: the edge is already spent, so no
         // panel event is resolved at all.
-        assert!(menu.last_pressed);
+        assert!(menu.menu.last_pressed());
         assert_eq!(menu.consume_pointer(Some(developer), true, &rects), None);
         assert_eq!(menu.page, PauseMenuPage::Developer);
     }
@@ -1181,7 +1106,7 @@ mod tests {
         );
         let (point, pressed) = (pass.point(), pass.pressed);
         assert!(pressed);
-        let (action, last) = resolve_click_at(point, pressed, menu.last_pressed, &rects);
+        let (action, last) = resolve_click_at(point, pressed, true, &rects);
         assert_eq!(action, None, "a carried-over press must not quit the run");
 
         // Releasing and pressing again is a real click.

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -23,12 +23,12 @@ use crate::{
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
-    scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
         FrontendPanelAnchor,
         FrontendPointerPass,
+        FrontendSfx,
         PointerVisuals,
         Rect,
         ScaleMode,

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -11,7 +11,8 @@
 //! driven `GameScene` that emits a `GlobalEffect` on click.
 
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
-use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
+#[cfg(test)]
+use dark::map::MapRect;
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -22,14 +23,19 @@ use shipyard::{EntityId, UniqueViewMut, World};
 use crate::{
     GameOptions, PresentationMode,
     game_scene::GameScene,
-    input_context::{InputContext, Pointer2D},
+    input_context::InputContext,
     mission::{GlobalContext, PlayerLifeState},
     save_load::{SaveFile, latest_save},
     scripts::{Effect, GlobalEffect},
     time::Time,
+    ui::{FrontendMenu, HAlign, Rect, ScaleMode, UiCanvas, VAlign},
+};
+
+#[cfg(test)]
+use crate::{
+    input_context::Pointer2D,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, FrontendSfx, HAlign, PointerVisuals, Rect,
-        ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas,
+        resolve_click_at as shell_resolve_click_at, resolve_flat_click, resolve_menu_rects,
         vr_frontend_pointer_pass,
     },
 };
@@ -80,64 +86,51 @@ const FALLBACK_RECTS: [Rect; 4] = [
 
 /// Resolve the screen's widget rects from `GAMELODR.BIN`, falling back to the
 /// decoded values when it is absent.
-fn screen_rects(layout: Option<&[MapRect]>) -> [Rect; 4] {
-    let mut rects = FALLBACK_RECTS;
-    for (index, rect) in rects.iter_mut().enumerate() {
-        if let Some(r) = layout.and_then(|rects| rects.get(index)) {
-            *rect = Rect::new(
-                r.ul_x as f32,
-                r.ul_y as f32,
-                r.width() as f32,
-                r.height() as f32,
-            );
-        }
-    }
-    rects
+#[cfg(test)]
+fn screen_rects(layout: Option<&[MapRect]>) -> Vec<Rect> {
+    resolve_menu_rects(layout, &FALLBACK_RECTS)
 }
 
 /// Shared click core: both presentations reduce to "a point on the canvas plus
 /// a pressed flag", so the rising-edge rule and the hit regions live here once.
+#[cfg(test)]
 fn resolve_click_at(
     point: Option<Vector2<f32>>,
     pressed: bool,
     last_pressed: bool,
-    rects: &[Rect; 4],
+    rects: &[Rect],
     can_load: bool,
 ) -> (Option<GameOverAction>, bool) {
-    if !pressed || last_pressed {
-        return (None, pressed);
-    }
-    (point.and_then(|c| hit(c, rects, can_load)), pressed)
+    shell_resolve_click_at(point, pressed, last_pressed, |point| {
+        hit(point, rects, can_load)
+    })
 }
 
 /// Pure click resolution: on a rising press edge over an enabled button,
 /// return its action. Also returns the new `last_pressed` for the next frame.
 /// `can_load` disables "Load" when no save exists, so the screen never offers
 /// a recovery it cannot perform.
+#[cfg(test)]
 fn resolve_click(
     pointer: Option<Pointer2D>,
     last_pressed: bool,
     screen_size: Vector2<f32>,
-    rects: &[Rect; 4],
+    rects: &[Rect],
     can_load: bool,
 ) -> (Option<GameOverAction>, bool, Option<Vector2<f32>>) {
-    let Some(p) = pointer else {
-        return (None, false, None);
-    };
-    let canvas_point = pointer_to_canvas(
-        vec2(CANVAS_W, CANVAS_H),
-        p.position,
+    resolve_flat_click(
+        pointer,
+        last_pressed,
         screen_size,
+        vec2(CANVAS_W, CANVAS_H),
         SCALE_MODE,
-    );
-    let (action, pressed) =
-        resolve_click_at(canvas_point, p.pressed, last_pressed, rects, can_load);
-    (action, pressed, canvas_point)
+        |point| hit(point, rects, can_load),
+    )
 }
 
 /// The button at a canvas point, if any. Shared by the click and the rollover
 /// sound so the two always agree on where a button is.
-fn hit(point: Vector2<f32>, rects: &[Rect; 4], can_load: bool) -> Option<GameOverAction> {
+fn hit(point: Vector2<f32>, rects: &[Rect], can_load: bool) -> Option<GameOverAction> {
     if can_load && rects[LOAD_RECT_INDEX].contains(point) {
         Some(GameOverAction::Load)
     } else if rects[QUIT_RECT_INDEX].contains(point) {
@@ -153,29 +146,7 @@ pub struct GameOverScene {
     /// The save offered by "Load", resolved once when the screen opens so the
     /// label and the click agree.
     save: Option<SaveFile>,
-    /// Pointer from the latest update, used for hover highlighting in render.
-    pointer: Option<Pointer2D>,
-    /// Where the VR controller ray last met the panel, in canvas pixels. The
-    /// VR counterpart of `pointer`, already in canvas space.
-    vr_pointer_canvas: Option<Vector2<f32>>,
-    /// The pointer pass that hit-tested this frame, kept so `render` draws the
-    /// beams and dot from the very rays `update` resolved the highlight from.
-    vr_pointer: FrontendPointerPass,
-    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
-    /// loaded glove model.
-    vr_pointer_visuals: PointerVisuals,
-
-    /// Where the VR panel is anchored: placed from the head on scene entry
-    /// and world-locked after that, so `render` hangs the panel exactly
-    /// where `update` hit-tested it.
-    panel_anchor: FrontendPanelAnchor,
-    /// Whether the pointer was pressed last frame (for rising-edge clicks).
-    last_pressed: bool,
-    /// Screen size from the latest render, so `update` maps the pointer into
-    /// canvas space consistently with how the canvas is drawn.
-    last_screen_size: Vector2<f32>,
-    /// The frontend's hum, rollover and select sounds.
-    sfx: FrontendSfx<GameOverAction>,
+    menu: FrontendMenu<GameOverAction>,
 }
 
 impl GameOverScene {
@@ -189,18 +160,7 @@ impl GameOverScene {
             world,
             scene_name: "game_over".to_owned(),
             save: latest_save(),
-            pointer: None,
-            vr_pointer_canvas: None,
-            vr_pointer: FrontendPointerPass::default(),
-            vr_pointer_visuals: PointerVisuals::new(),
-            panel_anchor: FrontendPanelAnchor::new(),
-            // This screen is entered straight out of gameplay - very plausibly
-            // with the VR trigger still held from the shot that preceded the
-            // death - so it starts "already pressed": the next rising edge
-            // requires a real release first, and "Quit" cannot fire itself.
-            last_pressed: true,
-            last_screen_size: vec2(CANVAS_W, CANVAS_H),
-            sfx: FrontendSfx::new(),
+            menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
         }
     }
 }
@@ -220,8 +180,7 @@ impl GameOverScene {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
 
         canvas.text_native(
             rects[HEADER_RECT_INDEX],
@@ -302,53 +261,14 @@ impl GameScene for GameOverScene {
             .filter(|effect| matches!(effect, Effect::GlobalEffect(_)))
             .collect();
 
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
-
-        // The panel is placed from the head on scene entry and world-locked
-        // after that; advancing it here keeps the ray and the render agreeing
-        // on where the screen is, in either presentation.
-        let panel = self.panel_anchor.update(
-            input_context.head.position,
-            input_context.head.rotation,
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
+        let action = self.menu.update(
             time.elapsed,
+            input_context,
+            game_options.presentation_mode,
+            |point| hit(point, &rects, self.save.is_some()),
+            |point| hit(point, &rects, self.save.is_some()),
         );
-
-        let (action, last_pressed, point) =
-            if game_options.presentation_mode == PresentationMode::Vr {
-                // VR has no 2D cursor: the pointer is where a controller ray meets
-                // the panel, and the trigger is the button.
-                self.vr_pointer =
-                    vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
-                let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
-                self.vr_pointer_canvas = point;
-                self.pointer = None;
-                let (action, last_pressed) = resolve_click_at(
-                    point,
-                    pressed,
-                    self.last_pressed,
-                    &rects,
-                    self.save.is_some(),
-                );
-                (action, last_pressed, point)
-            } else {
-                self.pointer = input_context.pointer;
-                self.vr_pointer = FrontendPointerPass::default();
-                resolve_click(
-                    input_context.pointer,
-                    self.last_pressed,
-                    self.last_screen_size,
-                    &rects,
-                    self.save.is_some(),
-                )
-            };
-        self.last_pressed = last_pressed;
-
-        self.sfx
-            .hover(point.and_then(|p| hit(p, &rects, self.save.is_some())));
-        if action.is_some() {
-            self.sfx.click();
-        }
 
         match action {
             Some(GameOverAction::Load) => {
@@ -378,26 +298,8 @@ impl GameScene for GameOverScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = self.panel_anchor.panel();
-        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
-        let mut objects = canvas.render_world_space(
-            asset_cache,
-            panel.transform(),
-            self.vr_pointer_canvas,
-            None,
-            VR_COMPONENT_Z_STEP,
-        );
-        // The controllers and their aim rays, so the player can see where they
-        // are pointing before an entry lights up. The canvas objects already in
-        // hand are the layer stack the hit dot has to float clear of.
-        let panel_layers = objects.len();
-        objects.extend(self.vr_pointer_visuals.render(
-            asset_cache,
-            &self.vr_pointer,
-            vec2(CANVAS_W, CANVAS_H),
-            &panel,
-            panel_layers,
-        ));
+        let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
+        let objects = self.menu.render_world_space(asset_cache, canvas);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -409,23 +311,16 @@ impl GameScene for GameOverScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        self.last_screen_size = screen_size;
         // In VR the screen lives on a world-space panel drawn by `render`; a
         // screen-space copy here would paste the whole canvas over both eyes
         // and hide it.
         if options.presentation_mode == PresentationMode::Vr {
             return Vec::new();
         }
-        let pointer_canvas = self.pointer.and_then(|p| {
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            )
-        });
+        let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(asset_cache, pointer_canvas);
-        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+        self.menu
+            .render_screen_space(asset_cache, canvas, screen_size)
     }
 
     fn handle_effects(
@@ -436,7 +331,7 @@ impl GameScene for GameOverScene {
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Vec<GlobalEffect> {
-        self.sfx.pump(asset_cache, audio_context);
+        self.menu.pump_sfx(asset_cache, audio_context);
         effects
             .into_iter()
             .filter_map(|e| match e {
@@ -447,7 +342,7 @@ impl GameScene for GameOverScene {
     }
 
     fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
-        self.sfx.stop(audio_context);
+        self.menu.stop_sfx(audio_context);
     }
 
     fn wants_pointer(&self) -> bool {
@@ -612,7 +507,6 @@ mod tests {
         // constructor's `last_pressed: true` that reads as a rising edge over
         // whatever the ray happens to cross - up to and including Quit.
         let rects = screen_rects(None);
-        let scene = GameOverScene::new();
         let pass = vr_frontend_pointer_pass(
             &vr_input(hand_aimed_at(rects[QUIT_RECT_INDEX].center(), 1.0)),
             vec2(CANVAS_W, CANVAS_H),
@@ -620,7 +514,7 @@ mod tests {
         );
         let (point, pressed) = (pass.point(), pass.pressed);
         assert!(pressed);
-        let (action, last) = resolve_click_at(point, pressed, scene.last_pressed, &rects, true);
+        let (action, last) = resolve_click_at(point, pressed, true, &rects, true);
         assert_eq!(action, None, "a carried-over press must not activate Quit");
 
         // Releasing and pressing again is a real click.

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -25,12 +25,12 @@ use crate::{
     input_context::{InputContext, Pointer2D},
     mission::{GlobalContext, PlayerLifeState},
     save_load::{SaveFile, latest_save},
-    scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
-        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas, vr_frontend_pointer_pass,
+        FrontendPanelAnchor, FrontendPointerPass, FrontendSfx, HAlign, PointerVisuals, Rect,
+        ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas,
+        vr_frontend_pointer_pass,
     },
 };
 

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -10,10 +10,9 @@
 //! same backdrop and layout, but offering only the single most recent save.
 
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
-use dark::{
-    importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
-    map::MapRect,
-};
+use dark::importers::STRINGS_IMPORTER;
+#[cfg(test)]
+use dark::map::MapRect;
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -25,14 +24,19 @@ use std::collections::HashMap;
 use crate::{
     GameOptions, PresentationMode,
     game_scene::GameScene,
-    input_context::{InputContext, Pointer2D},
+    input_context::InputContext,
     mission::GlobalContext,
     save_load::{SaveFile, all_saves},
     scripts::{Effect, GlobalEffect},
     time::Time,
+    ui::{FrontendMenu, HAlign, Rect, ScaleMode, UiCanvas, VAlign, resolve_menu_label},
+};
+
+#[cfg(test)]
+use crate::{
+    input_context::Pointer2D,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, FrontendSfx, HAlign, PointerVisuals, Rect,
-        ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas,
+        resolve_click_at as shell_resolve_click_at, resolve_flat_click, resolve_menu_rects,
         vr_frontend_pointer_pass,
     },
 };
@@ -125,30 +129,15 @@ enum LoadGameAction {
 
 /// Resolve the screen's widget rects from `GAMELODR.BIN`, falling back to the
 /// decoded values when it is absent.
-fn screen_rects(layout: Option<&[MapRect]>) -> [Rect; 4] {
-    let mut rects = FALLBACK_RECTS;
-    for (index, rect) in rects.iter_mut().enumerate() {
-        if let Some(r) = layout.and_then(|rects| rects.get(index)) {
-            *rect = Rect::new(
-                r.ul_x as f32,
-                r.ul_y as f32,
-                r.width() as f32,
-                r.height() as f32,
-            );
-        }
-    }
-    rects
+#[cfg(test)]
+fn screen_rects(layout: Option<&[MapRect]>) -> Vec<Rect> {
+    resolve_menu_rects(layout, &FALLBACK_RECTS)
 }
 
 /// Look a label up in `GAMELOD.STR`, falling back to the shipped English text
 /// when the table (or the key) is missing, or the value is empty.
 fn label(strings: Option<&HashMap<String, String>>, key: &str, fallback: &str) -> String {
-    strings
-        // The strings importer lowercases its keys.
-        .and_then(|s| s.get(key))
-        .filter(|value| !value.is_empty())
-        .cloned()
-        .unwrap_or_else(|| fallback.to_owned())
+    resolve_menu_label(strings, key, fallback)
 }
 
 /// How many save rows fit in the list rect, stopping at the backdrop's painted
@@ -183,59 +172,47 @@ fn row_text_rect(list: Rect, index: usize) -> Rect {
 
 /// Shared click core: both presentations reduce to "a point on the canvas plus
 /// a pressed flag", so the rising-edge rule and the hit regions live here once.
+#[cfg(test)]
 fn resolve_click_at(
     point: Option<Vector2<f32>>,
     pressed: bool,
     last_pressed: bool,
-    rects: &[Rect; 4],
+    rects: &[Rect],
     visible_saves: usize,
     has_selection: bool,
 ) -> (Option<LoadGameAction>, bool) {
-    if !pressed || last_pressed {
-        return (None, pressed);
-    }
-    (
-        point.and_then(|c| hit(c, rects, visible_saves, has_selection)),
-        pressed,
-    )
+    shell_resolve_click_at(point, pressed, last_pressed, |point| {
+        hit(point, rects, visible_saves, has_selection)
+    })
 }
 
 /// Pure click resolution: on a rising press edge, map the pointer to whatever
 /// it is over - a save row, "Load" (only when a save is selected), or "Done".
 /// Also returns the new `last_pressed` to track for the next frame.
+#[cfg(test)]
 fn resolve_click(
     pointer: Option<Pointer2D>,
     last_pressed: bool,
     screen_size: Vector2<f32>,
-    rects: &[Rect; 4],
+    rects: &[Rect],
     visible_saves: usize,
     has_selection: bool,
 ) -> (Option<LoadGameAction>, bool, Option<Vector2<f32>>) {
-    let Some(p) = pointer else {
-        return (None, false, None);
-    };
-    let canvas_point = pointer_to_canvas(
-        vec2(CANVAS_W, CANVAS_H),
-        p.position,
-        screen_size,
-        SCALE_MODE,
-    );
-    let (action, pressed) = resolve_click_at(
-        canvas_point,
-        p.pressed,
+    resolve_flat_click(
+        pointer,
         last_pressed,
-        rects,
-        visible_saves,
-        has_selection,
-    );
-    (action, pressed, canvas_point)
+        screen_size,
+        vec2(CANVAS_W, CANVAS_H),
+        SCALE_MODE,
+        |point| hit(point, rects, visible_saves, has_selection),
+    )
 }
 
 /// What is at a canvas point: a save row, "Load" (only with a selection), or
 /// "Done". Shared by the click and the rollover sound so the two always agree.
 fn hit(
     point: Vector2<f32>,
-    rects: &[Rect; 4],
+    rects: &[Rect],
     visible_saves: usize,
     has_selection: bool,
 ) -> Option<LoadGameAction> {
@@ -259,29 +236,7 @@ pub struct LoadGameScene {
     saves: Vec<SaveFile>,
     /// Index into [`Self::saves`] of the highlighted row, if any.
     selected: Option<usize>,
-    /// Pointer from the latest update, used for hover highlighting in render.
-    pointer: Option<Pointer2D>,
-    /// Where the VR controller ray last met the panel, in canvas pixels. The
-    /// VR counterpart of `pointer`, already in canvas space.
-    vr_pointer_canvas: Option<Vector2<f32>>,
-    /// The pointer pass that hit-tested this frame, kept so `render` draws the
-    /// beams and dot from the very rays `update` resolved the highlight from.
-    vr_pointer: FrontendPointerPass,
-    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
-    /// loaded glove model.
-    vr_pointer_visuals: PointerVisuals,
-
-    /// Where the VR panel is anchored: placed from the head on scene entry
-    /// and world-locked after that, so `render` hangs the panel exactly
-    /// where `update` hit-tested it.
-    panel_anchor: FrontendPanelAnchor,
-    /// Whether the pointer was pressed last frame (for rising-edge clicks).
-    last_pressed: bool,
-    /// Screen size from the latest render, so `update` can map the pointer into
-    /// canvas space consistently with how the canvas is drawn.
-    last_screen_size: Vector2<f32>,
-    /// The frontend's hum, rollover and select sounds.
-    sfx: FrontendSfx<LoadGameAction>,
+    menu: FrontendMenu<LoadGameAction>,
 }
 
 impl LoadGameScene {
@@ -296,19 +251,7 @@ impl LoadGameScene {
             scene_name: "load_game".to_owned(),
             saves,
             selected,
-            pointer: None,
-            vr_pointer_canvas: None,
-            vr_pointer: FrontendPointerPass::default(),
-            vr_pointer_visuals: PointerVisuals::new(),
-            panel_anchor: FrontendPanelAnchor::new(),
-            // A press held across a scene swap must not read as a click
-            // here: both screens sit on the same 640x480 canvas and their
-            // widgets overlap (the load screen's "Done" center falls inside
-            // the menu's "Quit" rect), so starting "already pressed" makes
-            // the next rising edge require a real release first.
-            last_pressed: true,
-            last_screen_size: vec2(CANVAS_W, CANVAS_H),
-            sfx: FrontendSfx::new(),
+            menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
         }
     }
 }
@@ -328,8 +271,7 @@ impl LoadGameScene {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
         let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
         let strings = strings.as_deref();
 
@@ -426,8 +368,7 @@ impl GameScene for LoadGameScene {
             *world_time = time.clone();
         }
 
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
         let visible = self
             .saves
             .len()
@@ -441,55 +382,15 @@ impl GameScene for LoadGameScene {
         self.selected = self.selected.filter(|index| *index < visible);
         let selected = self.selected;
 
-        // The panel is placed from the head on scene entry and world-locked
-        // after that; advancing it here keeps the ray and the render agreeing
-        // on where the screen is, in either presentation.
-        let panel = self.panel_anchor.update(
-            input_context.head.position,
-            input_context.head.rotation,
+        let action = self.menu.update(
             time.elapsed,
+            input_context,
+            game_options.presentation_mode,
+            |point| hit(point, &rects, visible, selected.is_some()),
+            // Rows are deliberately silent: they highlight on selection
+            // rather than hover, so only visible hover feedback makes noise.
+            |point| hit(point, &rects, 0, selected.is_some()),
         );
-
-        let (action, last_pressed, point) =
-            if game_options.presentation_mode == PresentationMode::Vr {
-                // VR has no 2D cursor: the pointer is where a controller ray meets
-                // the panel, and the trigger is the button.
-                self.vr_pointer =
-                    vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
-                let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
-                self.vr_pointer_canvas = point;
-                self.pointer = None;
-                let (action, last_pressed) = resolve_click_at(
-                    point,
-                    pressed,
-                    self.last_pressed,
-                    &rects,
-                    visible,
-                    selected.is_some(),
-                );
-                (action, last_pressed, point)
-            } else {
-                self.pointer = input_context.pointer;
-                self.vr_pointer = FrontendPointerPass::default();
-                resolve_click(
-                    input_context.pointer,
-                    self.last_pressed,
-                    self.last_screen_size,
-                    &rects,
-                    visible,
-                    selected.is_some(),
-                )
-            };
-        self.last_pressed = last_pressed;
-
-        // Rows are deliberately silent: they highlight on selection rather
-        // than on hover, so a blip over one would have no visible counterpart.
-        // Passing 0 visible rows is what makes `hit` skip them.
-        self.sfx
-            .hover(point.and_then(|p| hit(p, &rects, 0, selected.is_some())));
-        if action.is_some() {
-            self.sfx.click();
-        }
 
         match action {
             Some(LoadGameAction::Select(index)) => {
@@ -525,26 +426,8 @@ impl GameScene for LoadGameScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = self.panel_anchor.panel();
-        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
-        let mut objects = canvas.render_world_space(
-            asset_cache,
-            panel.transform(),
-            self.vr_pointer_canvas,
-            None,
-            VR_COMPONENT_Z_STEP,
-        );
-        // The controllers and their aim rays, so the player can see where they
-        // are pointing before an entry lights up. The canvas objects already in
-        // hand are the layer stack the hit dot has to float clear of.
-        let panel_layers = objects.len();
-        objects.extend(self.vr_pointer_visuals.render(
-            asset_cache,
-            &self.vr_pointer,
-            vec2(CANVAS_W, CANVAS_H),
-            &panel,
-            panel_layers,
-        ));
+        let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
+        let objects = self.menu.render_world_space(asset_cache, canvas);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -556,23 +439,16 @@ impl GameScene for LoadGameScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        self.last_screen_size = screen_size;
         // In VR the screen lives on a world-space panel drawn by `render`; a
         // screen-space copy here would paste the whole canvas over both eyes
         // and hide it.
         if options.presentation_mode == PresentationMode::Vr {
             return Vec::new();
         }
-        let pointer_canvas = self.pointer.and_then(|p| {
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            )
-        });
+        let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(asset_cache, pointer_canvas);
-        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+        self.menu
+            .render_screen_space(asset_cache, canvas, screen_size)
     }
 
     fn handle_effects(
@@ -583,7 +459,7 @@ impl GameScene for LoadGameScene {
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Vec<GlobalEffect> {
-        self.sfx.pump(asset_cache, audio_context);
+        self.menu.pump_sfx(asset_cache, audio_context);
         effects
             .into_iter()
             .filter_map(|e| match e {
@@ -594,7 +470,7 @@ impl GameScene for LoadGameScene {
     }
 
     fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
-        self.sfx.stop(audio_context);
+        self.menu.stop_sfx(audio_context);
     }
 
     fn wants_pointer(&self) -> bool {
@@ -701,10 +577,10 @@ mod tests {
     }
 
     #[test]
-    fn no_pointer_means_no_action() {
+    fn pointer_loss_preserves_a_held_press() {
         let (action, last, _) = resolve_click(None, true, SCREEN, &FALLBACK_RECTS, 3, true);
         assert_eq!(action, None);
-        assert!(!last);
+        assert!(last);
     }
 
     #[test]

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -28,12 +28,12 @@ use crate::{
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
     save_load::{SaveFile, all_saves},
-    scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
-        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas, vr_frontend_pointer_pass,
+        FrontendPanelAnchor, FrontendPointerPass, FrontendSfx, HAlign, PointerVisuals, Rect,
+        ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, pointer_to_canvas,
+        vr_frontend_pointer_pass,
     },
 };
 

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -15,13 +15,9 @@
 //!
 //! See `projects/flatscreen-and-vr-architecture.md` (Slice 3).
 
-use std::collections::HashMap;
-
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
-use dark::{
-    importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
-    map::MapRect,
-};
+#[cfg(test)]
+use dark::map::MapRect;
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -32,17 +28,25 @@ use shipyard::{EntityId, UniqueViewMut, World};
 use crate::{
     GameOptions, PresentationMode,
     game_scene::GameScene,
-    input_context::{InputContext, Pointer2D},
+    input_context::InputContext,
     mission::GlobalContext,
-    scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor, FrontendPointerPass, HAlign, PointerVisuals, Rect, ScaleMode,
-        UiCanvas, VAlign, VR_COMPONENT_Z_STEP, WorldPanel, pointer_to_canvas,
-        vr_frontend_pointer_pass,
+        FrontendMenu, FrontendMenuItem, HAlign, Rect, ScaleMode, UiCanvas, VAlign, hit_menu_item,
     },
 };
+
+#[cfg(test)]
+use crate::{
+    input_context::Pointer2D,
+    ui::{
+        WorldPanel, resolve_click_at as shell_resolve_click_at, resolve_flat_click,
+        resolve_menu_labels, resolve_menu_rects, vr_frontend_pointer_pass,
+    },
+};
+#[cfg(test)]
+use std::collections::HashMap;
 
 /// Mission loaded when the player chooses "New Game".
 const NEW_GAME_MISSION: &str = "earth.mis";
@@ -84,38 +88,20 @@ enum MenuAction {
     Quit,
 }
 
-struct MenuItem {
-    /// Key into `MAIN.STR`.
-    string_key: &'static str,
-    /// Label used when `MAIN.STR` is absent or missing the key. These match the
-    /// shipped English strings.
-    fallback_label: &'static str,
-    /// `None` for an entry that exists on the original screen but that the port
-    /// does not implement yet - drawn dimmed, and not clickable.
-    action: Option<MenuAction>,
-    /// Label drawn instead of the string-table text (and the fallback). Used
-    /// by the Developer entry, which repurposes the inert Options slot: the
-    /// row must read honestly, and a one-word override is deliberately
-    /// cheaper than teaching the shipped `.STR` machinery a new key. Dropping
-    /// the override is the whole retreat path when a real options screen
-    /// lands.
-    label_override: Option<&'static str>,
-}
-
 // MAIN.PCX (native 640x480) has a vertical stack of six buttons down the right
 // side. This list is in screen order, top to bottom, so an item's index is also
 // its rect index in `MAINR.BIN`. Labels are centered in the button rect.
 //
 // (`MAIN.STR` itself lists the keys in reverse screen order; the same reversal
 // holds for `SIM.STR` against the known pause-menu order.)
-const MENU_ITEMS: &[MenuItem] = &[
-    MenuItem {
+const MENU_ITEMS: &[FrontendMenuItem<MenuAction>] = &[
+    FrontendMenuItem {
         string_key: "new_game",
         fallback_label: "New Game",
         action: Some(MenuAction::NewGame),
         label_override: None,
     },
-    MenuItem {
+    FrontendMenuItem {
         string_key: "load_game",
         fallback_label: "Load Game",
         action: Some(MenuAction::LoadGame),
@@ -123,25 +109,25 @@ const MENU_ITEMS: &[MenuItem] = &[
     },
     // The Options slot hosts the Developer screen while no real options
     // screen exists (see `MenuItem::label_override`).
-    MenuItem {
+    FrontendMenuItem {
         string_key: "options",
         fallback_label: "Options",
         action: Some(MenuAction::Developer),
         label_override: Some("Developer"),
     },
-    MenuItem {
+    FrontendMenuItem {
         string_key: "credits",
         fallback_label: "Credits",
         action: None,
         label_override: None,
     },
-    MenuItem {
+    FrontendMenuItem {
         string_key: "intro",
         fallback_label: "Intro",
         action: None,
         label_override: None,
     },
-    MenuItem {
+    FrontendMenuItem {
         string_key: "quit",
         fallback_label: "Quit",
         action: Some(MenuAction::Quit),
@@ -149,136 +135,108 @@ const MENU_ITEMS: &[MenuItem] = &[
     },
 ];
 
+const FALLBACK_RECTS: [Rect; 6] = [
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + 2.0 * FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + 3.0 * FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + 4.0 * FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+    Rect::new(
+        FALLBACK_BUTTON_X,
+        FALLBACK_BUTTON_TOP + 5.0 * FALLBACK_BUTTON_PITCH,
+        FALLBACK_BUTTON_W,
+        FALLBACK_BUTTON_H,
+    ),
+];
+
 /// Resolve each menu item's canvas rect from the `MAINR.BIN` layout (falling
 /// back to the vanilla geometry if it's absent). Parallel to [`MENU_ITEMS`].
+#[cfg(test)]
 fn menu_rects(layout: Option<&[MapRect]>) -> Vec<Rect> {
-    MENU_ITEMS
-        .iter()
-        .enumerate()
-        .map(
-            |(index, _)| match layout.and_then(|rects| rects.get(index)) {
-                Some(r) => Rect::new(
-                    r.ul_x as f32,
-                    r.ul_y as f32,
-                    r.width() as f32,
-                    r.height() as f32,
-                ),
-                None => Rect::new(
-                    FALLBACK_BUTTON_X,
-                    FALLBACK_BUTTON_TOP + index as f32 * FALLBACK_BUTTON_PITCH,
-                    FALLBACK_BUTTON_W,
-                    FALLBACK_BUTTON_H,
-                ),
-            },
-        )
-        .collect()
+    resolve_menu_rects(layout, &FALLBACK_RECTS)
 }
 
 /// Resolve each menu item's label from `MAIN.STR`, falling back to the shipped
 /// English text when the string table is absent. Parallel to [`MENU_ITEMS`].
+#[cfg(test)]
 fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
-    MENU_ITEMS
-        .iter()
-        .map(|item| {
-            if let Some(label) = item.label_override {
-                return label.to_owned();
-            }
-            strings
-                // The strings importer lowercases its keys.
-                .and_then(|s| s.get(item.string_key))
-                .filter(|label| !label.is_empty())
-                .cloned()
-                .unwrap_or_else(|| item.fallback_label.to_owned())
-        })
-        .collect()
+    resolve_menu_labels(strings, MENU_ITEMS)
 }
 
 /// Where the hands are pointing on the menu panel. The rule is the frontend's,
 /// not this screen's, so it lives in [`vr_frontend_pointer_pass`].
-fn vr_pointer(input_context: &InputContext, panel: &WorldPanel) -> FrontendPointerPass {
+#[cfg(test)]
+fn vr_pointer(input_context: &InputContext, panel: &WorldPanel) -> crate::ui::FrontendPointerPass {
     vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), panel)
 }
 
 /// Shared click core: both presentations reduce to "a point on the canvas plus
 /// a pressed flag", so the rising-edge rule and the hit regions live here once.
+#[cfg(test)]
 fn resolve_click_at(
     point: Option<Vector2<f32>>,
     pressed: bool,
     last_pressed: bool,
     rects: &[Rect],
 ) -> (Option<MenuAction>, bool) {
-    if !pressed || last_pressed {
-        return (None, pressed);
-    }
-    (point.and_then(|p| hit(p, rects)), pressed)
+    shell_resolve_click_at(point, pressed, last_pressed, |point| hit(point, rects))
 }
 
 /// The menu entry at a canvas point, if any. Shared by the click and the
 /// rollover sound so the two can never disagree about where an entry is.
 fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<MenuAction> {
-    let mut canvas = UiCanvas::<MenuAction>::with_events(vec2(CANVAS_W, CANVAS_H));
-    for (item, rect) in MENU_ITEMS.iter().zip(rects) {
-        // Unimplemented entries get no hit region at all, so a click over one
-        // falls through as "nothing was clicked".
-        if let Some(action) = item.action {
-            // The backdrop already contains the button art; this button is the
-            // shared canvas hit region for its label.
-            canvas.button(*rect, "", action);
-        }
-    }
-    canvas.click_at(point)
+    hit_menu_item(point, MENU_ITEMS, rects, |_| true)
 }
 
 /// Pure click resolution: on a rising press edge over an implemented item
 /// (`rects` is parallel to [`MENU_ITEMS`]), return its action. Also returns the
 /// new `last_pressed` to track for the next frame.
+#[cfg(test)]
 fn resolve_click(
     pointer: Option<Pointer2D>,
     last_pressed: bool,
     screen_size: Vector2<f32>,
     rects: &[Rect],
 ) -> (Option<MenuAction>, bool, Option<Vector2<f32>>) {
-    match pointer {
-        Some(p) => {
-            let point = pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            );
-            let (action, pressed) = resolve_click_at(point, p.pressed, last_pressed, rects);
-            (action, pressed, point)
-        }
-        None => (None, false, None),
-    }
+    resolve_flat_click(
+        pointer,
+        last_pressed,
+        screen_size,
+        vec2(CANVAS_W, CANVAS_H),
+        SCALE_MODE,
+        |point| hit(point, rects),
+    )
 }
 
 pub struct MainMenuScene {
     world: World,
     scene_name: String,
-    /// Pointer from the latest update, used for hover highlighting in render.
-    pointer: Option<Pointer2D>,
-    /// Where the VR controller ray last met the panel, in canvas pixels. The
-    /// VR counterpart of `pointer`, already in canvas space.
-    vr_pointer_canvas: Option<Vector2<f32>>,
-    /// The pointer pass that hit-tested this frame, kept so `render` draws the
-    /// beams and dot from the very rays `update` resolved the highlight from.
-    vr_pointer: FrontendPointerPass,
-    /// The drawn half of that pointer (hands, beams, dot), holding the lazily
-    /// loaded glove model.
-    vr_pointer_visuals: PointerVisuals,
-
-    /// Where the VR panel is anchored. Placed on scene entry from the head
-    /// pose and world-locked after that, so `render` hangs the panel exactly
-    /// where `update` hit-tested it.
-    panel_anchor: FrontendPanelAnchor,
-    /// Whether the pointer was pressed last frame (for rising-edge clicks).
-    last_pressed: bool,
-    /// Screen size from the latest render, so `update` can map the pointer into
-    /// canvas space consistently with how the canvas is drawn.
-    last_screen_size: Vector2<f32>,
-    /// The frontend's hum, rollover and select sounds.
-    sfx: FrontendSfx<MenuAction>,
+    menu: FrontendMenu<MenuAction>,
 }
 
 impl MainMenuScene {
@@ -288,19 +246,7 @@ impl MainMenuScene {
         Self {
             world,
             scene_name: "main_menu".to_owned(),
-            pointer: None,
-            vr_pointer_canvas: None,
-            vr_pointer: FrontendPointerPass::default(),
-            vr_pointer_visuals: PointerVisuals::new(),
-            panel_anchor: FrontendPanelAnchor::new(),
-            // A press held across a scene swap must not read as a click
-            // here: both screens sit on the same 640x480 canvas and their
-            // widgets overlap (the load screen's "Done" center falls inside
-            // the menu's "Quit" rect), so starting "already pressed" makes
-            // the next rising edge require a real release first.
-            last_pressed: true,
-            last_screen_size: vec2(CANVAS_W, CANVAS_H),
-            sfx: FrontendSfx::new(),
+            menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
         }
     }
 }
@@ -325,10 +271,8 @@ impl MainMenuScene {
         // Menu items, centered in their button and brighter when hovered.
         // Button rects come from the original `MAINR.BIN` layout and labels
         // from `MAIN.STR` (both cached by the asset cache after first load).
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
-        let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
-        let labels = menu_labels(strings.as_deref());
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
+        let labels = self.menu.labels(asset_cache, LABELS_FILE, MENU_ITEMS);
         for ((item, rect), label) in MENU_ITEMS.iter().zip(&rects).zip(&labels) {
             let opacity = if item.action.is_none() {
                 DISABLED_OPACITY
@@ -364,47 +308,14 @@ impl GameScene for MainMenuScene {
             *world_time = time.clone();
         }
 
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
-
-        // The panel is placed from the head on scene entry and world-locked
-        // after that; advancing it here keeps the ray and the render agreeing
-        // on where the menu is, in either presentation.
-        let panel = self.panel_anchor.update(
-            input_context.head.position,
-            input_context.head.rotation,
+        let rects = self.menu.rects(asset_cache, LAYOUT_FILE, &FALLBACK_RECTS);
+        let action = self.menu.update(
             time.elapsed,
+            input_context,
+            game_options.presentation_mode,
+            |point| hit(point, &rects),
+            |point| hit(point, &rects),
         );
-
-        let (action, last_pressed, point) =
-            if game_options.presentation_mode == PresentationMode::Vr {
-                // VR has no 2D cursor: the pointer is where a controller ray meets
-                // the menu panel, and the trigger is the button.
-                self.vr_pointer = vr_pointer(input_context, &panel);
-                let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
-                self.vr_pointer_canvas = point;
-                self.pointer = None;
-                let (action, last_pressed) =
-                    resolve_click_at(point, pressed, self.last_pressed, &rects);
-                (action, last_pressed, point)
-            } else {
-                self.pointer = input_context.pointer;
-                self.vr_pointer = FrontendPointerPass::default();
-                resolve_click(
-                    input_context.pointer,
-                    self.last_pressed,
-                    self.last_screen_size,
-                    &rects,
-                )
-            };
-        self.last_pressed = last_pressed;
-
-        // Hover and click feedback, from the same point that drives the
-        // highlight - so a sound plays exactly when an entry lights up.
-        self.sfx.hover(point.and_then(|p| hit(p, &rects)));
-        if action.is_some() {
-            self.sfx.click();
-        }
 
         match action {
             Some(MenuAction::NewGame) => {
@@ -441,26 +352,8 @@ impl GameScene for MainMenuScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = self.panel_anchor.panel();
-        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
-        let mut objects = canvas.render_world_space(
-            asset_cache,
-            panel.transform(),
-            self.vr_pointer_canvas,
-            None,
-            VR_COMPONENT_Z_STEP,
-        );
-        // The controllers and their aim rays, so the player can see where they
-        // are pointing before an entry lights up. The canvas objects already in
-        // hand are the layer stack the hit dot has to float clear of.
-        let panel_layers = objects.len();
-        objects.extend(self.vr_pointer_visuals.render(
-            asset_cache,
-            &self.vr_pointer,
-            vec2(CANVAS_W, CANVAS_H),
-            &panel,
-            panel_layers,
-        ));
+        let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
+        let objects = self.menu.render_world_space(asset_cache, canvas);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -472,23 +365,16 @@ impl GameScene for MainMenuScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        self.last_screen_size = screen_size;
         // In VR the menu lives on a world-space panel drawn by `render`; a
         // screen-space copy here would paste the whole canvas over both eyes
         // and hide it.
         if options.presentation_mode == PresentationMode::Vr {
             return Vec::new();
         }
-        let pointer_canvas = self.pointer.and_then(|p| {
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            )
-        });
+        let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(asset_cache, pointer_canvas);
-        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+        self.menu
+            .render_screen_space(asset_cache, canvas, screen_size)
     }
 
     fn handle_effects(
@@ -499,7 +385,7 @@ impl GameScene for MainMenuScene {
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Vec<GlobalEffect> {
-        self.sfx.pump(asset_cache, audio_context);
+        self.menu.pump_sfx(asset_cache, audio_context);
         effects
             .into_iter()
             .filter_map(|e| match e {
@@ -510,7 +396,7 @@ impl GameScene for MainMenuScene {
     }
 
     fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
-        self.sfx.stop(audio_context);
+        self.menu.stop_sfx(audio_context);
     }
 
     fn wants_pointer(&self) -> bool {
@@ -604,18 +490,16 @@ mod tests {
             "this test is only meaningful while the rects overlap"
         );
 
-        let mut scene = MainMenuScene::new();
         let held = pointer_at(574.5 / CANVAS_W, 436.0 / CANVAS_H, true);
 
         // First frame after the swap: the press is held, not new.
-        let (action, last, _) = resolve_click(held, scene.last_pressed, SCREEN, &rects);
+        let (action, last, _) = resolve_click(held, true, SCREEN, &rects);
         assert_eq!(action, None, "a carried-over press must not activate Quit");
-        scene.last_pressed = last;
 
         // Releasing and pressing again is a real click.
         let (_, last, _) = resolve_click(
             pointer_at(574.5 / CANVAS_W, 436.0 / CANVAS_H, false),
-            scene.last_pressed,
+            last,
             SCREEN,
             &rects,
         );
@@ -724,10 +608,10 @@ mod tests {
     }
 
     #[test]
-    fn no_pointer_means_no_action() {
+    fn pointer_loss_does_not_rearm_a_held_press() {
         let (action, last, _) = resolve_click(None, true, SCREEN, &menu_rects(None));
         assert_eq!(action, None);
-        assert!(!last);
+        assert!(last, "a missing pointer is not evidence of a release");
     }
 
     #[test]

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -36,7 +36,6 @@ pub mod debug_teleport;
 pub mod debug_turret;
 pub mod debug_weapons;
 pub mod developer;
-pub mod frontend_sfx;
 pub mod game_over;
 pub mod load_game;
 pub mod loading;

--- a/shock2vr/src/ui/frontend_menu.rs
+++ b/shock2vr/src/ui/frontend_menu.rs
@@ -200,11 +200,11 @@ impl<A: Copy + PartialEq> FrontendMenu<A> {
     }
 
     /// Resolve a screen's item labels through the shell that renders them.
-    pub fn labels(
+    pub fn labels<B>(
         &self,
         asset_cache: &mut AssetCache,
         labels_file: &str,
-        items: &[FrontendMenuItem<A>],
+        items: &[FrontendMenuItem<B>],
     ) -> Vec<String> {
         let strings = asset_cache.get_opt(&STRINGS_IMPORTER, labels_file);
         resolve_menu_labels(strings.as_deref(), items)
@@ -243,6 +243,20 @@ impl<A: Copy + PartialEq> FrontendMenu<A> {
         };
         self.pointer_canvas = point;
 
+        self.resolve_pointer(point, pressed, click_hit, hover_hit)
+    }
+
+    /// Consume an already-resolved point/press pair. Reusable overlays call
+    /// this in focused page-turn tests so those tests exercise the same latch
+    /// and sound path as the runtime update.
+    pub fn resolve_pointer(
+        &mut self,
+        point: Option<Vector2<f32>>,
+        pressed: bool,
+        click_hit: impl FnOnce(Vector2<f32>) -> Option<A>,
+        hover_hit: impl FnOnce(Vector2<f32>) -> Option<A>,
+    ) -> Option<A> {
+        self.pointer_canvas = point;
         let (action, pressed) = resolve_click_at(point, pressed, self.last_pressed, click_hit);
         self.last_pressed = pressed;
         self.sfx.hover(point.and_then(hover_hit));
@@ -335,6 +349,16 @@ impl<A: Copy + PartialEq> FrontendMenu<A> {
 
     pub fn stop_sfx(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
         self.sfx.stop(audio_context);
+    }
+
+    #[cfg(test)]
+    pub fn set_last_pressed(&mut self, pressed: bool) {
+        self.last_pressed = pressed;
+    }
+
+    #[cfg(test)]
+    pub fn last_pressed(&self) -> bool {
+        self.last_pressed
     }
 }
 

--- a/shock2vr/src/ui/frontend_menu.rs
+++ b/shock2vr/src/ui/frontend_menu.rs
@@ -1,0 +1,365 @@
+//! Shared lifecycle, input and presentation shell for frontend menus.
+//!
+//! A frontend screen still owns its screen-specific canvas contents and action
+//! handling. This type owns the parts that must not drift between screens:
+//! authored layout/string resolution, flat/VR pointer reduction, rising-edge
+//! clicks, panel placement, pointer visuals, frontend sound, and the two canvas
+//! presentations.
+
+use std::{collections::HashMap, time::Duration};
+
+use cgmath::Vector2;
+use dark::{
+    importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
+    map::MapRect,
+};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext, scene::SceneObject};
+use shipyard::EntityId;
+
+use crate::{
+    PresentationMode,
+    input_context::{InputContext, Pointer2D},
+};
+
+use super::{
+    FrontendPanelAnchor, FrontendPointerPass, PointerVisuals, Rect, ScaleMode, UiCanvas,
+    VR_COMPONENT_Z_STEP, WorldPanel, pointer_to_canvas, vr_frontend_pointer_pass,
+};
+
+use super::frontend_sfx::FrontendSfx;
+
+/// One authored menu entry. Its rect is the same-index entry in the screen's
+/// `*R.BIN` layout and its label comes from the screen's `*.STR` table.
+pub struct FrontendMenuItem<A> {
+    pub string_key: &'static str,
+    pub fallback_label: &'static str,
+    /// `None` draws an inert entry and gives it no hit region.
+    pub action: Option<A>,
+    /// An honest replacement for an authored label (for example the temporary
+    /// Developer entry hosted in the original Options slot).
+    pub label_override: Option<&'static str>,
+}
+
+/// Resolve authored LTRB rectangles, falling back per entry when the layout is
+/// absent or shorter than expected.
+pub fn resolve_menu_rects(layout: Option<&[MapRect]>, fallback: &[Rect]) -> Vec<Rect> {
+    fallback
+        .iter()
+        .enumerate()
+        .map(|(index, fallback)| {
+            layout
+                .and_then(|rects| rects.get(index))
+                .map(|rect| {
+                    Rect::new(
+                        rect.ul_x as f32,
+                        rect.ul_y as f32,
+                        rect.width() as f32,
+                        rect.height() as f32,
+                    )
+                })
+                .unwrap_or(*fallback)
+        })
+        .collect()
+}
+
+/// Resolve a string-table value without allowing a missing/empty localized
+/// entry to blank a widget.
+pub fn resolve_menu_label(
+    strings: Option<&HashMap<String, String>>,
+    key: &str,
+    fallback: &str,
+) -> String {
+    strings
+        // The strings importer lowercases its keys.
+        .and_then(|table| table.get(key))
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+/// Resolve a label parallel to every item in an authored menu.
+pub fn resolve_menu_labels<A>(
+    strings: Option<&HashMap<String, String>>,
+    items: &[FrontendMenuItem<A>],
+) -> Vec<String> {
+    items
+        .iter()
+        .map(|item| {
+            item.label_override.map(str::to_owned).unwrap_or_else(|| {
+                resolve_menu_label(strings, item.string_key, item.fallback_label)
+            })
+        })
+        .collect()
+}
+
+/// Hit-test enabled item actions against their same-index authored rectangles.
+pub fn hit_menu_item<A: Copy>(
+    point: Vector2<f32>,
+    items: &[FrontendMenuItem<A>],
+    rects: &[Rect],
+    enabled: impl Fn(A) -> bool,
+) -> Option<A> {
+    items.iter().zip(rects).find_map(|(item, rect)| {
+        item.action
+            .filter(|action| enabled(*action) && rect.contains(point))
+    })
+}
+
+/// Rising-edge click resolution after either presentation has reduced its
+/// pointer to canvas space.
+pub fn resolve_click_at<A>(
+    point: Option<Vector2<f32>>,
+    pressed: bool,
+    last_pressed: bool,
+    hit: impl FnOnce(Vector2<f32>) -> Option<A>,
+) -> (Option<A>, bool) {
+    if !pressed || last_pressed {
+        return (None, pressed);
+    }
+    (point.and_then(hit), pressed)
+}
+
+/// Flat pointer state in the same `(canvas point, pressed)` shape emitted by
+/// the VR pointer pass. Pointer loss is deliberately not a release: the cursor
+/// can disappear for a frame while capture changes, and clearing the latch
+/// there would turn a held button into a new press when the pointer returns.
+pub fn flat_pointer_state(
+    pointer: Option<Pointer2D>,
+    last_pressed: bool,
+    screen_size: Vector2<f32>,
+    canvas_size: Vector2<f32>,
+    scale_mode: ScaleMode,
+) -> (Option<Vector2<f32>>, bool) {
+    match pointer {
+        Some(pointer) => (
+            pointer_to_canvas(canvas_size, pointer.position, screen_size, scale_mode),
+            pointer.pressed,
+        ),
+        None => (None, last_pressed),
+    }
+}
+
+/// Pure flat click composition, primarily useful to keep screen-level behavior
+/// tests independent from an asset cache or runtime.
+#[cfg(test)]
+pub fn resolve_flat_click<A>(
+    pointer: Option<Pointer2D>,
+    last_pressed: bool,
+    screen_size: Vector2<f32>,
+    canvas_size: Vector2<f32>,
+    scale_mode: ScaleMode,
+    hit: impl FnOnce(Vector2<f32>) -> Option<A>,
+) -> (Option<A>, bool, Option<Vector2<f32>>) {
+    let (point, pressed) =
+        flat_pointer_state(pointer, last_pressed, screen_size, canvas_size, scale_mode);
+    let (action, pressed) = resolve_click_at(point, pressed, last_pressed, hit);
+    (action, pressed, point)
+}
+
+/// Shared state and presentation boundary for one frontend menu.
+pub struct FrontendMenu<A> {
+    canvas_size: Vector2<f32>,
+    scale_mode: ScaleMode,
+    pointer: Option<Pointer2D>,
+    pointer_canvas: Option<Vector2<f32>>,
+    vr_pointer: FrontendPointerPass,
+    vr_pointer_visuals: PointerVisuals,
+    panel_anchor: FrontendPanelAnchor,
+    last_pressed: bool,
+    last_screen_size: Vector2<f32>,
+    sfx: FrontendSfx<A>,
+}
+
+impl<A: Copy + PartialEq> FrontendMenu<A> {
+    pub fn new(canvas_size: Vector2<f32>, scale_mode: ScaleMode) -> Self {
+        Self {
+            canvas_size,
+            scale_mode,
+            pointer: None,
+            pointer_canvas: None,
+            vr_pointer: FrontendPointerPass::default(),
+            vr_pointer_visuals: PointerVisuals::new(),
+            panel_anchor: FrontendPanelAnchor::new(),
+            // Enter every frontend surface already pressed. A held gameplay or
+            // previous-screen input must be released before it can click here.
+            last_pressed: true,
+            last_screen_size: canvas_size,
+            sfx: FrontendSfx::new(),
+        }
+    }
+
+    /// Resolve a screen's layout through the shell that consumes it.
+    pub fn rects(
+        &self,
+        asset_cache: &mut AssetCache,
+        layout_file: &str,
+        fallback: &[Rect],
+    ) -> Vec<Rect> {
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, layout_file);
+        resolve_menu_rects(layout.as_deref().map(|rects| rects.as_slice()), fallback)
+    }
+
+    /// Resolve a screen's item labels through the shell that renders them.
+    pub fn labels(
+        &self,
+        asset_cache: &mut AssetCache,
+        labels_file: &str,
+        items: &[FrontendMenuItem<A>],
+    ) -> Vec<String> {
+        let strings = asset_cache.get_opt(&STRINGS_IMPORTER, labels_file);
+        resolve_menu_labels(strings.as_deref(), items)
+    }
+
+    /// Advance panel placement and resolve one pointer frame. Click, hover,
+    /// highlight and pointer visuals all consume the returned shared point.
+    pub fn update(
+        &mut self,
+        elapsed: Duration,
+        input_context: &InputContext,
+        presentation_mode: PresentationMode,
+        click_hit: impl FnOnce(Vector2<f32>) -> Option<A>,
+        hover_hit: impl FnOnce(Vector2<f32>) -> Option<A>,
+    ) -> Option<A> {
+        let panel = self.panel_anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            elapsed,
+        );
+
+        let (point, pressed) = if presentation_mode == PresentationMode::Vr {
+            self.vr_pointer = vr_frontend_pointer_pass(input_context, self.canvas_size, &panel);
+            self.pointer = None;
+            (self.vr_pointer.point(), self.vr_pointer.pressed)
+        } else {
+            self.pointer = input_context.pointer;
+            self.vr_pointer = FrontendPointerPass::default();
+            flat_pointer_state(
+                input_context.pointer,
+                self.last_pressed,
+                self.last_screen_size,
+                self.canvas_size,
+                self.scale_mode,
+            )
+        };
+        self.pointer_canvas = point;
+
+        let (action, pressed) = resolve_click_at(point, pressed, self.last_pressed, click_hit);
+        self.last_pressed = pressed;
+        self.sfx.hover(point.and_then(hover_hit));
+        if action.is_some() {
+            self.sfx.click();
+        }
+        action
+    }
+
+    /// Clear transient pointer state when an overlay closes.
+    pub fn clear_pointer(&mut self) {
+        self.pointer = None;
+        self.pointer_canvas = None;
+        self.vr_pointer = FrontendPointerPass::default();
+    }
+
+    /// Reset reusable overlay state on entry. Starting pressed prevents the
+    /// input that opened it from activating a widget in the same hold.
+    pub fn reset_on_entry(&mut self) {
+        self.clear_pointer();
+        self.panel_anchor = FrontendPanelAnchor::new();
+        self.last_pressed = true;
+        self.sfx = FrontendSfx::new();
+    }
+
+    pub fn pointer_canvas(&self) -> Option<Vector2<f32>> {
+        self.pointer_canvas
+    }
+
+    /// Update the current target size and map the flat pointer exactly as the
+    /// screen-space presenter maps the canvas.
+    pub fn screen_pointer_canvas(&mut self, screen_size: Vector2<f32>) -> Option<Vector2<f32>> {
+        self.last_screen_size = screen_size;
+        self.pointer.and_then(|pointer| {
+            pointer_to_canvas(
+                self.canvas_size,
+                pointer.position,
+                screen_size,
+                self.scale_mode,
+            )
+        })
+    }
+
+    pub fn panel(&self) -> WorldPanel {
+        self.panel_anchor.panel()
+    }
+
+    /// Present an already-resolved canvas on the shared honest-basis panel and
+    /// append pointer visuals from the same arbitration pass used by update.
+    pub fn render_world_space(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        canvas: UiCanvas,
+    ) -> Vec<SceneObject> {
+        let panel = self.panel();
+        let mut objects = canvas.render_world_space(
+            asset_cache,
+            panel.transform(),
+            self.pointer_canvas,
+            None,
+            VR_COMPONENT_Z_STEP,
+        );
+        let panel_layers = objects.len();
+        objects.extend(self.vr_pointer_visuals.render(
+            asset_cache,
+            &self.vr_pointer,
+            self.canvas_size,
+            &panel,
+            panel_layers,
+        ));
+        objects
+    }
+
+    pub fn render_screen_space(
+        &self,
+        asset_cache: &mut AssetCache,
+        canvas: UiCanvas,
+        screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
+        canvas.render_screen_space(asset_cache, screen_size, self.scale_mode)
+    }
+
+    pub fn pump_sfx(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        self.sfx.pump(asset_cache, audio_context);
+    }
+
+    pub fn stop_sfx(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        self.sfx.stop(audio_context);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::vec2;
+
+    #[test]
+    fn pointer_loss_does_not_rearm_a_held_press() {
+        let canvas = vec2(640.0, 480.0);
+        let screen = vec2(800.0, 600.0);
+        let (action, last_pressed, point) = resolve_flat_click(
+            None,
+            true,
+            screen,
+            canvas,
+            ScaleMode::PreserveAspect,
+            |_| Some(()),
+        );
+        assert_eq!(action, None);
+        assert_eq!(point, None);
+        assert!(
+            last_pressed,
+            "a missing pointer is not evidence of a release"
+        );
+    }
+}

--- a/shock2vr/src/ui/frontend_sfx.rs
+++ b/shock2vr/src/ui/frontend_sfx.rs
@@ -1,4 +1,4 @@
-//! Frontend (menu) sound effects, shared by every 2D screen.
+//! Frontend (menu) sound effects, owned by the shared frontend-menu shell.
 //!
 //! The original frontend is not silent: `res/snd/sfx/` ships the whole set the
 //! menus use - a looping bed (`mloop1`/`mloop2`), a rollover blip played when

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -32,14 +32,23 @@ use shipyard::EntityId;
 use crate::vr_config::Handedness;
 
 pub mod dev_params_panel;
+mod frontend_menu;
 mod frontend_pointer;
+mod frontend_sfx;
 mod panel_anchor;
 mod pointer_visual;
+#[cfg(test)]
+pub use frontend_menu::resolve_flat_click;
+pub use frontend_menu::{
+    FrontendMenu, FrontendMenuItem, flat_pointer_state, hit_menu_item, resolve_click_at,
+    resolve_menu_label, resolve_menu_labels, resolve_menu_rects,
+};
 #[cfg(test)]
 pub use frontend_pointer::test_support;
 pub use frontend_pointer::{
     FrontendPointerPass, FrontendRay, VR_TRIGGER_THRESHOLD, vr_frontend_pointer_pass,
 };
+pub use frontend_sfx::FrontendSfx;
 pub use panel_anchor::{FrontendPanelAnchor, PanelPlacement};
 pub use pointer_visual::PointerVisuals;
 

--- a/tools/shock2-sdk/test/menu-audio.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-audio.e2e.test.ts
@@ -35,6 +35,11 @@ async function playedSince(game: GameServer, since: number): Promise<string[]> {
   return (await played(game)).filter((s) => s.sequence > since).map((s) => s.sample);
 }
 
+async function frontendSoundsSince(game: GameServer, since: number): Promise<string[]> {
+  const frontend = new Set([HUM, ROLLOVER, SELECT]);
+  return (await playedSince(game, since)).filter((sample) => frontend.has(sample));
+}
+
 async function lastSequence(game: GameServer): Promise<number> {
   const sounds = await played(game);
   return sounds.length === 0 ? 0 : sounds[sounds.length - 1].sequence;
@@ -174,6 +179,43 @@ test(
       (await played(game)).filter((s) => s.sample === HUM).length,
       1,
       "and it must not restart under the mission",
+    );
+  },
+);
+
+test(
+  "the pause overlay uses the same hum, rollover and select lifecycle",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_minimal", port: 8125 });
+    await game.step({ frames: 10 });
+
+    // Open over empty backdrop so the bed can be observed separately from a
+    // rollover. Before the shared shell, PauseMenu owned no FrontendSfx at all.
+    await game.input.set("pointer.position", NOTHING);
+    let since = await lastSequence(game);
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 10 });
+    assert.deepEqual(await frontendSoundsSince(game, since), [HUM]);
+    const bed = (await played(game)).find((sound) => sound.sample === HUM);
+    assert.ok(bed, "the pause menu should own a looping bed");
+
+    since = await lastSequence(game);
+    await hover(game, NEW_GAME_ENTRY); // pause row 0 occupies the same canvas slot
+    assert.deepEqual(await frontendSoundsSince(game, since), [ROLLOVER]);
+
+    since = await lastSequence(game);
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 3 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 3 });
+    assert.deepEqual(await frontendSoundsSince(game, since), [SELECT]);
+    assert.equal((await game.info()).paused, false, "Continue should close the overlay");
+
+    const stoppedBed = (await played(game)).find((sound) => sound.sequence === bed.sequence);
+    assert.ok(
+      stoppedBed && stoppedBed.stopped_at_sim_time !== null,
+      "the pause bed must stop when the overlay closes",
     );
   },
 );


### PR DESCRIPTION
## Summary

- introduce FrontendMenu as the shared canvas, pointer-arbitration, anchor, rising-edge, presentation, and SFX shell
- port the main menu, load screen, game-over screen, and pause overlay without moving screen-specific layout or action ownership
- make pointer loss preserve the held latch, and give the pause overlay the same hum/rollover/select lifecycle as the other frontend screens

## Pre-fix reproduction

Current main duplicates the same shell state and render/update flow across all four screens. Main, load, and game-over also convert a missing pointer into released input, unlike pause, so a held press can become a false fresh edge when tracking returns. The negative-first main-menu regression failed on 8977f236 and the shared-shell regression passes here. A pause-audio e2e likewise failed on the base with no HUM event and passes here.

## Verification

- cargo fmt --all -- --check
- RUSTFLAGS=-D warnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime
- RUSTFLAGS=-D warnings cargo test -p shock2vr --lib: 876 passed
- focused shared/main/load/game-over/pause Rust tests: 78 passed
- SDK npm test: 26 passed, 272 gated/skipped
- affected flat/VR SDK e2e selection: 26 passed
- full SDK e2e: 289 passed, 2 failed, 7 skipped; both failures reproduce identically on origin/main (creature-loot reader MFD -1 vs 251, patrol save rejected at unsupported [300,-1.2,300] pose)

## Visual proof

![Pointer loss preserves a held press](https://gist.githubusercontent.com/tommy-xr/d705baf917d83c0af38f27ff72252f6e/raw/pointer-loss-demo.gif)

<sub>Identical fixed-timestep requests on base (left) and fix (right): hold Load, lose pointer tracking, restore tracking while still held, then release and deliberately press again. Base falsely opens Load as soon as tracking returns; the shared shell waits for the real new press.</sub>

### Before → after

![Before and after at the restored-held frame](https://gist.githubusercontent.com/tommy-xr/d705baf917d83c0af38f27ff72252f6e/raw/pointer-loss-before-after.png)

<sub>The same rendered frame after tracking returns: base has already activated Load; the fix remains on Main with Load highlighted because the button is still held.</sub>

### Flat / VR parity across the shared shell

![Main, load, pause, and game-over base/fix parity in flat and VR](https://gist.githubusercontent.com/tommy-xr/d705baf917d83c0af38f27ff72252f6e/raw/frontend-shell-flat-vr-parity.png)

<sub>Main menu, load screen, pause overlay, and game-over screen captured from matched base/fix builds in both presentations. Button placement, labels, hover states, panel geometry, and controller-ray targeting remain aligned. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic 60 Hz fixed timestep).</sub>

No headset pass is required: this changes shared frontend canvas composition and input arbitration only, not Oculus/OpenXR lifecycle, device tracking, or device-only rendering. Both flat and VR presentation/interaction paths are covered by the deterministic debug-runtime harness.

Fixes #1015