### PR TITLE
fix(bench): accept negative coordinate arguments

### DIFF
--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -10,7 +10,7 @@
 //!   cargo bn path stats medsci1.mis   # database stats + flag/okBits audit
 //!   cargo bn path bench medsci1.mis   # seeded A* benchmark
 //!   cargo bn path bench --all --json  # all missions, machine-readable
-//!   cargo bn path show medsci1.mis --from " -10,0,5" --to "20,0,30"
+//!   cargo bn path show medsci1.mis --from "-10,0,5" --to "20,0,30"
 //!   cargo bn path cell medsci1.mis --at "20,0,30"
 
 use std::sync::Arc;
@@ -76,26 +76,26 @@ enum PathCommand {
     Show {
         mission: String,
         /// Start position as "x,y,z" (world units, same as debug runtime)
-        #[arg(long)]
-        from: String,
+        #[arg(long, allow_hyphen_values = true, value_parser = parse_vec3)]
+        from: Vector3<f32>,
         /// Goal position as "x,y,z"
-        #[arg(long)]
-        to: String,
+        #[arg(long, allow_hyphen_values = true, value_parser = parse_vec3)]
+        to: Vector3<f32>,
     },
     /// List every cell containing a position, with flags and outgoing links
     Cell {
         mission: String,
         /// Position as "x,y,z"
-        #[arg(long)]
-        at: String,
+        #[arg(long, allow_hyphen_values = true, value_parser = parse_vec3)]
+        at: Vector3<f32>,
     },
     /// Show the walk component containing a position and its frontier links
     /// (how the component connects - or fails to connect - to neighbors)
     Component {
         mission: String,
         /// Position as "x,y,z"
-        #[arg(long)]
-        at: String,
+        #[arg(long, allow_hyphen_values = true, value_parser = parse_vec3)]
+        at: Vector3<f32>,
     },
 }
 
@@ -158,15 +158,15 @@ fn run_path_command(command: PathCommand) -> Result<()> {
         }
         PathCommand::Show { mission, from, to } => {
             let db = load_path_database(&mission)?;
-            dump_path(db, parse_vec3(&from)?, parse_vec3(&to)?);
+            dump_path(db, from, to);
         }
         PathCommand::Cell { mission, at } => {
             let db = load_path_database(&mission)?;
-            dump_cells_at(db, parse_vec3(&at)?);
+            dump_cells_at(db, at);
         }
         PathCommand::Component { mission, at } => {
             let db = load_path_database(&mission)?;
-            dump_component_at(db, parse_vec3(&at)?);
+            dump_component_at(db, at);
         }
     }
 
@@ -888,4 +888,122 @@ fn dump_cells_at(db: PathDatabase, at: Vector3<f32>) {
         "service.cell_from_position would return: {:?}",
         service.cell_from_position(at)
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coordinate_options_accept_space_separated_negative_values() {
+        let invocations: &[&[&str]] = &[
+            &[
+                "bench",
+                "path",
+                "show",
+                "ops4.mis",
+                "--from",
+                "53.5,-8.6,-27.6",
+                "--to",
+                "-9.94,-8.6,-30.0",
+            ],
+            &[
+                "bench",
+                "path",
+                "show",
+                "ops4.mis",
+                "--from",
+                "-9.94,-8.6,-30.0",
+                "--to",
+                "53.5,-8.6,-27.6",
+            ],
+            &[
+                "bench",
+                "path",
+                "cell",
+                "ops4.mis",
+                "--at",
+                "-9.94,-8.6,-30.0",
+            ],
+            &[
+                "bench",
+                "path",
+                "component",
+                "ops4.mis",
+                "--at",
+                "-9.94,-8.6,-30.0",
+            ],
+        ];
+
+        for args in invocations {
+            assert!(
+                Cli::try_parse_from(*args).is_ok(),
+                "failed to parse {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn coordinate_options_keep_accepting_equals_values() {
+        let args = [
+            "bench",
+            "path",
+            "show",
+            "ops4.mis",
+            "--from=53.5,-8.6,-27.6",
+            "--to=-9.94,-8.6,-30.0",
+        ];
+
+        assert!(Cli::try_parse_from(args).is_ok());
+    }
+
+    #[test]
+    fn coordinate_options_reject_malformed_triples() {
+        let invocations: &[&[&str]] = &[
+            &[
+                "bench",
+                "path",
+                "show",
+                "ops4.mis",
+                "--from",
+                "53.5,-8.6",
+                "--to",
+                "-9.94,-8.6,-30.0",
+            ],
+            &[
+                "bench",
+                "path",
+                "show",
+                "ops4.mis",
+                "--from",
+                "53.5,-8.6,-27.6",
+                "--to",
+                "not-a-number,-8.6,-30.0",
+            ],
+            &[
+                "bench",
+                "path",
+                "cell",
+                "ops4.mis",
+                "--at",
+                "-9.94,-8.6,-30.0,4.0",
+            ],
+            &[
+                "bench",
+                "path",
+                "component",
+                "ops4.mis",
+                "--at",
+                "-9.94,,-30.0",
+            ],
+        ];
+
+        for args in invocations {
+            let error = Cli::try_parse_from(*args)
+                .err()
+                .expect("malformed coordinates should fail during CLI parsing");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+            assert!(error.to_string().contains("expected"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- accept space-separated negative-leading coordinates for every `cargo bn path` coordinate option
- parse and validate coordinate triples at clap's argument boundary
- cover `show --from/--to`, `cell --at`, `component --at`, equals syntax, and malformed triples

## Reproduction and result

On base `8977f23681174365daefa2ae1ec870140139d0ac`, the issue's space-separated command was rejected before pathfinding:

```text
$ cargo bn path show ops4.mis --from "53.5,-8.6,-27.6" --to "-9.94,-8.6,-30.0"
error: unexpected argument '-9' found
exit 2
```

Current main failed loudly rather than printing the originally reported silent `no path`, but still rejected the documented space-separated value. Its equals form succeeded with start cell 850, goal cell 305, and 45 waypoints.

With this change, both forms produce that same route:

```text
start cell: Some(850)  goal cell: Some(305)
45 waypoints, path length 88.28, straight-line 63.49, inflation 1.39, total turn 1150 deg
```

Malformed input now fails during CLI parsing, before any mission is loaded:

```text
error: invalid value '53.5,-8.6' for '--from <FROM>': expected 3 components, got 2
exit 2
```

## Root cause and fix

The coordinate options were unvalidated `String` arguments. Clap therefore interpreted a value beginning with `-` as another option, while coordinate parsing happened only after mission loading. The options now explicitly allow hyphen-leading values and use the existing `parse_vec3` function as their clap value parser, passing validated `Vector3<f32>` values to the diagnostics without changing pathfinding.

## Verification

- negative regression run on base: 2 failed, 1 passed (space-separated negative values and early malformed-value validation failed as expected)
- `RUSTFLAGS="-D warnings" cargo test -p bench` — 3 passed
- `RUSTFLAGS="-D warnings" cargo check -p bench` — passed
- `cargo fmt --all -- --check` — passed
- live `path show` with both space-separated and equals forms — identical cells and 45-waypoint result
- live `path cell --at "-9.94,-8.6,-30.0"` and `path component --at "-9.94,-8.6,-30.0"` — passed
- live malformed triple — clap value-validation error, exit 2

The full SDK e2e suite was not run because this is isolated to the standalone benchmark CLI's argv parsing and cannot affect a game runtime.

## Visual proof

`pr-visuals` gate: approved as genuinely non-renderable. This changes only shell-argument parsing and terminal diagnostics in the standalone `cargo bn` benchmark binary; it does not launch the game/debug runtime, alter mission simulation state, or enter a flatscreen/VR rendering path. A debug-runtime GIF or PNG cannot exercise whether clap accepts a particular argv token, so the matched before/after CLI transcript above and parser tests are the direct observable evidence.

Fixes #571
