### PR TITLE
fix(vr): fit held melee contact to rendered weapon

### DIFF
--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -1,7 +1,11 @@
 use std::io::{Read, Seek};
 use std::{path::PathBuf, rc::Rc};
 
+use cgmath::{Matrix4, Point3, SquareMatrix, Vector3, Vector4};
 use engine::assets::{asset_cache::AssetCache, asset_importer::AssetImporter};
+use engine::scene::{
+    MAX_SKINNED_JOINTS, SKINNING_PALETTE_SIZE, VertexPositionTextureSkinnedNormal,
+};
 use once_cell::sync::Lazy;
 
 use crate::{
@@ -11,7 +15,7 @@ use crate::{
     ss2_skeleton::Skeleton,
 };
 
-use crate::model::Model;
+use crate::{model::Model, motion::AnimationPlayer};
 
 use super::skeleton_importer::SKELETON_IMPORTER;
 
@@ -108,14 +112,177 @@ pub fn is_first_person_arm_material(name: &str) -> bool {
 /// strip kept the sleeve and deleted the gripping hand. Spare-hand stripping
 /// is deliberately dropped (a floating spare hand is the lesser evil); it can
 /// return if a reliable classifier turns up.
-pub struct VrHeldModel(pub Model);
+pub struct VrHeldModel {
+    pub model: Model,
+    weapon_geometry: Option<VrHeldWeaponGeometry>,
+}
+
+#[derive(Clone)]
+struct VrHeldWeaponGeometry {
+    vertices: Vec<VertexPositionTextureSkinnedNormal>,
+    skeleton: Rc<Skeleton>,
+    bind: Option<[Matrix4<f32>; MAX_SKINNED_JOINTS]>,
+}
+
+/// A cuboid fitted around the posed weapon-only geometry, expressed in the
+/// held entity's local frame.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VrHeldWeaponBounds {
+    pub size: Vector3<f32>,
+    pub center: Vector3<f32>,
+}
+
+impl VrHeldModel {
+    /// Fit a local AABB to the same skinned weapon vertices the renderer uses.
+    /// `local_transform` is the model-space correction applied by the wield,
+    /// so the result and rendered mesh stay in one coordinate system.
+    pub fn posed_weapon_bounds(
+        &self,
+        player: &AnimationPlayer,
+        local_transform: Matrix4<f32>,
+    ) -> Option<VrHeldWeaponBounds> {
+        let geometry = self.weapon_geometry.as_ref()?;
+        let pose = player.get_transforms(&geometry.skeleton);
+        let palette = match &geometry.bind {
+            None => Skeleton::expand_skinning_palette(&pose, &geometry.skeleton),
+            Some(bind) => {
+                let mut palette = [Matrix4::identity(); SKINNING_PALETTE_SIZE];
+                for joint in 0..MAX_SKINNED_JOINTS {
+                    let posed = pose[joint] * bind[joint];
+                    palette[joint] = posed;
+                    palette[MAX_SKINNED_JOINTS + joint] = posed;
+                }
+                palette
+            }
+        };
+
+        bounds_of_skinned_vertices(&geometry.vertices, &palette, local_transform)
+    }
+}
+
+fn is_melee_arm_material(name: &str) -> bool {
+    name.to_ascii_lowercase().contains("melee_arm")
+}
+
+fn rigid_terminal_joint_vertices(
+    vertices: impl IntoIterator<Item = VertexPositionTextureSkinnedNormal>,
+) -> Vec<VertexPositionTextureSkinnedNormal> {
+    let rigid = vertices
+        .into_iter()
+        .filter_map(|vertex| {
+            let mut bindings = vertex
+                .bone_indices
+                .into_iter()
+                .zip(vertex.bone_weights)
+                .filter(|(_, weight)| *weight > 0.0);
+            let (joint, _) = bindings.next()?;
+            (joint < MAX_SKINNED_JOINTS as u32 && bindings.next().is_none())
+                .then_some((joint, vertex))
+        })
+        .collect::<Vec<_>>();
+    let Some(terminal_joint) = rigid.iter().map(|(joint, _)| *joint).max() else {
+        return Vec::new();
+    };
+    rigid
+        .into_iter()
+        .filter_map(|(joint, vertex)| (joint == terminal_joint).then_some(vertex))
+        .collect()
+}
+
+fn weapon_geometry(mesh: &SystemShockContentModel) -> Option<VrHeldWeaponGeometry> {
+    let SystemShockContentModel::Mesh(ai_mesh, skeleton, pmnm) = mesh else {
+        return None;
+    };
+
+    if let Some(pmnm) = pmnm {
+        let runs = pmnm.to_skinned_vertices();
+        let has_named_arm = runs
+            .iter()
+            .any(|(material, _)| is_melee_arm_material(material));
+        let vertices = if has_named_arm {
+            runs.iter()
+                .filter(|(material, _)| !is_melee_arm_material(material))
+                .flat_map(|(_, vertices)| vertices.iter().cloned())
+                .collect::<Vec<_>>()
+        } else {
+            rigid_terminal_joint_vertices(runs.into_iter().flat_map(|(_, vertices)| vertices))
+        };
+        if vertices.is_empty() {
+            return None;
+        }
+        return Some(VrHeldWeaponGeometry {
+            vertices,
+            skeleton: skeleton.clone(),
+            bind: Some(ss2_bin_ai_loader::pmnm_bind_matrices(skeleton)),
+        });
+    }
+
+    // The classic LGMM melee rigs combine hand and weapon under one material.
+    // Their weapon is the rigid geometry on the terminal rendered joint; this
+    // data-derived fallback includes the fist but excludes the forearm instead
+    // of assuming a model name or authored dimension.
+    let vertices = rigid_terminal_joint_vertices(
+        ss2_bin_ai_loader::to_vertices(ai_mesh, skeleton)
+            .0
+            .into_iter()
+            .flat_map(|(_, vertices)| vertices),
+    );
+    (!vertices.is_empty()).then_some(VrHeldWeaponGeometry {
+        vertices,
+        skeleton: skeleton.clone(),
+        bind: None,
+    })
+}
+
+fn bounds_of_skinned_vertices(
+    vertices: &[VertexPositionTextureSkinnedNormal],
+    palette: &[Matrix4<f32>; SKINNING_PALETTE_SIZE],
+    local_transform: Matrix4<f32>,
+) -> Option<VrHeldWeaponBounds> {
+    let mut min = Vector3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut max = Vector3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+
+    for vertex in vertices {
+        let point = Vector4::new(vertex.position.x, vertex.position.y, vertex.position.z, 1.0);
+        let mut skinned = Vector4::new(0.0, 0.0, 0.0, 0.0);
+        let mut total_weight = 0.0;
+        for (joint, weight) in vertex.bone_indices.iter().zip(vertex.bone_weights) {
+            if weight > 0.0 {
+                let matrix = palette.get(*joint as usize)?;
+                skinned += matrix * point * weight;
+                total_weight += weight;
+            }
+        }
+        let skinned = if total_weight > 0.0 { skinned } else { point };
+        let local = local_transform * skinned;
+        let p = Point3::new(local.x, local.y, local.z);
+        if !p.x.is_finite() || !p.y.is_finite() || !p.z.is_finite() {
+            return None;
+        }
+        min.x = min.x.min(p.x);
+        min.y = min.y.min(p.y);
+        min.z = min.z.min(p.z);
+        max.x = max.x.max(p.x);
+        max.y = max.y.max(p.y);
+        max.z = max.z.max(p.z);
+    }
+
+    (min.x.is_finite() && max.x.is_finite()).then_some(VrHeldWeaponBounds {
+        size: max - min,
+        center: (min + max) * 0.5,
+    })
+}
 
 fn process_vr_held_model(
     mesh: SystemShockContentModel,
     asset_cache: &mut AssetCache,
     _config: &(),
 ) -> VrHeldModel {
-    VrHeldModel(process_model(mesh, asset_cache, &()))
+    let weapon_geometry = weapon_geometry(&mesh);
+    VrHeldModel {
+        model: process_model(mesh, asset_cache, &()),
+        weapon_geometry,
+    }
 }
 
 pub static VR_HELD_MODELS_IMPORTER: Lazy<AssetImporter<SystemShockContentModel, VrHeldModel, ()>> =
@@ -169,3 +336,58 @@ fn process_first_person_hands(
 pub static FIRST_PERSON_HANDS_IMPORTER: Lazy<
     AssetImporter<SystemShockContentModel, FirstPersonHands, ()>,
 > = Lazy::new(|| AssetImporter::define(load_model, process_first_person_hands));
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Matrix4, SquareMatrix, vec2, vec3};
+
+    use super::*;
+
+    fn vertex(
+        position: Vector3<f32>,
+        bone_indices: [u32; 4],
+        bone_weights: [f32; 4],
+    ) -> VertexPositionTextureSkinnedNormal {
+        VertexPositionTextureSkinnedNormal {
+            position,
+            uv: vec2(0.0, 0.0),
+            normal: vec3(0.0, 0.0, 1.0),
+            bone_indices,
+            bone_weights,
+        }
+    }
+
+    #[test]
+    fn classic_weapon_fallback_keeps_only_the_terminal_rigid_joint() {
+        let hand = vertex(vec3(0.0, 0.0, 0.0), [2, 0, 0, 0], [1.0, 0.0, 0.0, 0.0]);
+        let weapon = vertex(vec3(0.0, 1.0, 0.0), [3, 0, 0, 0], [1.0, 0.0, 0.0, 0.0]);
+        let stretchy = vertex(vec3(0.0, 0.5, 0.0), [3, 43, 0, 0], [0.5, 0.5, 0.0, 0.0]);
+
+        let fitted = rigid_terminal_joint_vertices([hand, weapon.clone(), stretchy]);
+
+        assert_eq!(fitted.len(), 1);
+        assert_eq!(fitted[0].position, weapon.position);
+    }
+
+    #[test]
+    fn posed_bounds_apply_skinning_and_the_renderers_local_correction() {
+        let vertices = [
+            vertex(vec3(-1.0, 0.0, -0.5), [0, 0, 0, 0], [1.0, 0.0, 0.0, 0.0]),
+            vertex(vec3(1.0, 2.0, 0.5), [0, 0, 0, 0], [1.0, 0.0, 0.0, 0.0]),
+        ];
+        let mut palette = [Matrix4::identity(); SKINNING_PALETTE_SIZE];
+        palette[0] = Matrix4::from_translation(vec3(0.0, 3.0, 0.0));
+        let correction = Matrix4::from_translation(vec3(2.0, -1.0, 4.0));
+
+        let bounds = bounds_of_skinned_vertices(&vertices, &palette, correction).unwrap();
+
+        assert_eq!(bounds.size, vec3(2.0, 2.0, 1.0));
+        assert_eq!(bounds.center, vec3(2.0, 3.0, 4.0));
+    }
+
+    #[test]
+    fn anniversary_melee_arm_material_is_not_weapon_geometry() {
+        assert!(is_melee_arm_material("ND-melee_arm.psd"));
+        assert!(!is_melee_arm_material("ND-wrench.psd"));
+    }
+}

--- a/shock2vr/examples/melee_grip.rs
+++ b/shock2vr/examples/melee_grip.rs
@@ -46,7 +46,9 @@ fn main() {
                 println!("  joint {i:2}: ({:8.4}, {:8.4}, {:8.4})", p.x, p.y, p.z);
             }
         }
-        let contact = shock2vr::melee_contact_offset(shock2vr::MeleePosedArm::from_joints(&joints));
+        let arm = shock2vr::MeleePosedArm::from_joints(&joints)
+            .expect("the shipped melee rigs have elbow, fist, and weapon joints");
+        let contact = shock2vr::melee_contact_offset(arm);
         println!(
             "  contact offset (hand-local): vec3({:.3}, {:.3}, {:.3})",
             contact.x, contact.y, contact.z

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5094,17 +5094,24 @@ impl MissionCore {
                                 .unwrap_or(false);
                         // A missing model must never take down the frame (or a
                         // load): keep the current model and complain loudly.
-                        let new_model = if vr_held {
-                            asset_cache
-                                .get_opt(
-                                    &dark::importers::VR_HELD_MODELS_IMPORTER,
-                                    &format!("{model_name}.BIN"),
-                                )
-                                .map(|m| Model::transform(&m.as_ref().0, xform))
+                        let (new_model, vr_held_source) = if vr_held {
+                            match asset_cache.get_opt(
+                                &dark::importers::VR_HELD_MODELS_IMPORTER,
+                                &format!("{model_name}.BIN"),
+                            ) {
+                                Some(source) => (
+                                    Some(Model::transform(&source.as_ref().model, xform)),
+                                    Some(source),
+                                ),
+                                None => (None, None),
+                            }
                         } else {
-                            asset_cache
-                                .get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
-                                .map(|m| Model::transform(m.as_ref(), xform))
+                            (
+                                asset_cache
+                                    .get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
+                                    .map(|m| Model::transform(m.as_ref(), xform)),
+                                None,
+                            )
                         };
                         let Some(mut new_model) = new_model else {
                             tracing::error!(
@@ -5161,29 +5168,42 @@ impl MissionCore {
                                 // Seat the posed arm on the tracked hand. Two
                                 // halves of one placement, both derived from
                                 // this same posed arm so they cannot drift
-                                // apart: the grip puts the entity - and so the
-                                // melee contact collider, which the held body
-                                // IS - on the rendered weapon head, and the
+                                // apart: the grip puts the entity/body origin
+                                // on the rendered weapon head, and the
                                 // model-space correction cancels that same
                                 // offset so the fist still lands in the palm.
-                                // `apply_local_transform` composes inside the
-                                // entity transform, which the render path
-                                // re-sets from the hand every frame.
+                                // The fitted child collider below extends back
+                                // over the rendered weapon without moving that
+                                // controller-driven body origin.
                                 let arm = new_model.skeleton().and_then(|skeleton| {
                                     crate::vr_config::MeleePosedArm::from_joints(
                                         &player.get_transforms(skeleton),
                                     )
                                 });
                                 if let Some(arm) = arm {
-                                    new_model.apply_local_transform(
-                                        crate::vr_config::melee_wield_pose_correction(arm),
-                                    );
+                                    let correction =
+                                        crate::vr_config::melee_wield_pose_correction(arm);
+                                    new_model.apply_local_transform(correction);
                                     self.world.add_component(
                                         entity_id,
                                         RuntimePropVrGripOffset(
                                             crate::vr_config::melee_contact_offset(arm),
                                         ),
                                     );
+                                    if self.interaction.is_holding(entity_id) {
+                                        match vr_held_source.as_ref().and_then(|source| {
+                                            source.posed_weapon_bounds(&player, correction)
+                                        }) {
+                                            Some(bounds) => self.physics.fit_held_melee_cuboid(
+                                                entity_id,
+                                                bounds.size,
+                                                bounds.center,
+                                            ),
+                                            None => tracing::error!(
+                                                "ChangeModel: '{model_name}' has no fittable weapon geometry - retaining its loose-prop collider"
+                                            ),
+                                        }
+                                    }
                                 } else {
                                     tracing::error!(
                                         "ChangeModel: '{model_name}' has no melee arm joints - wielding it unseated"

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2641,6 +2641,41 @@ impl PhysicsWorld {
         self.set_collision_group(entity_id, CollisionGroup::held_melee());
     }
 
+    /// Replace a held melee body's inherited loose-pickup box with the local
+    /// bounds of the weapon geometry rendered in the hand.
+    ///
+    /// The rigid-body origin stays controller-driven at the authored weapon
+    /// joint; the collider's parent-relative center covers the rest of the
+    /// handle/blade without moving the rendered model or changing the future
+    /// spring-body architecture tracked in #1053.
+    pub fn fit_held_melee_cuboid(
+        &mut self,
+        entity_id: EntityId,
+        size: Vector3<f32>,
+        center: Vector3<f32>,
+    ) {
+        let size = sanitize_collider_size(entity_id, "fit_held_melee_cuboid", size);
+        let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
+            return;
+        };
+        let Some(body) = self.rigid_body_set.get(handle) else {
+            return;
+        };
+        if body.body_type() != RigidBodyType::KinematicPositionBased {
+            return;
+        }
+
+        let collider_handles = body.colliders().to_vec();
+        let shape = SharedShape::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0);
+        let center = vec_to_nvec(center);
+        for collider_handle in collider_handles {
+            if let Some(collider) = self.collider_set.get_mut(collider_handle) {
+                collider.set_shape(shape.clone());
+                collider.set_translation_wrt_parent(center);
+            }
+        }
+    }
+
     /// Resize every cuboid collider attached to a kinematic body. GUI panels
     /// use this when their authored pixel geometry changes while the proxy
     /// entity remains live.
@@ -5633,6 +5668,41 @@ mod tests {
         assert!(
             !collider.solver_groups().test(actor.solver),
             "held melee must not solve impulses against living actors"
+        );
+    }
+
+    /// A held melee body begins life as the loose pickup's model-bounds box.
+    /// Once the rendered first-person weapon has been posed, its fitted bounds
+    /// must replace both that oversized shape and its pickup-space center.
+    #[test]
+    fn held_melee_cuboid_fits_the_rendered_weapon_bounds() {
+        let mut world = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(2).unwrap();
+        let handle = world.add_dynamic(
+            weapon,
+            vec3(0.0, 0.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(1.83, 0.39, 0.20)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        world.set_held_melee(weapon);
+
+        let rendered_size = vec3(0.24, 1.02, 0.18);
+        let rendered_center = vec3(0.0, -0.51, 0.01);
+        world.fit_held_melee_cuboid(weapon, rendered_size, rendered_center);
+
+        assert_eq!(world.cuboid_full_size(handle), Some(rendered_size));
+        let collider = &world.collider_set[world.rigid_body_set[handle].colliders()[0]];
+        assert_eq!(
+            collider.position_wrt_parent().unwrap().translation.vector,
+            vec_to_nvec(rendered_center)
+        );
+        assert_eq!(
+            world.rigid_body_set[handle].body_type(),
+            RigidBodyType::KinematicPositionBased
         );
     }
 

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -318,10 +318,9 @@ fn melee_wield_alignment(arm: MeleePosedArm) -> Quaternion<f32> {
 /// The wield stores it as `RuntimePropVrGripOffset`;
 /// `cargo run -p shock2vr --example melee_grip` prints it per model.
 ///
-/// Known limitation: the authored contact volume is a ~5 cm sphere, so this
-/// arms the weapon's *head* and nothing else along its length. Covering the
-/// whole blade needs a collider shaped like the weapon, which is a bigger
-/// change than putting the existing one in the right place.
+/// The rigid-body origin remains on this weapon joint. `Effect::ChangeModel`
+/// separately fits the body's collider around the rendered weapon vertices,
+/// including the handle/blade extending back from the joint.
 pub fn melee_contact_offset(arm: MeleePosedArm) -> Vector3<f32> {
     use cgmath::Rotation;
 

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -147,7 +147,7 @@ async function measureHeldContactOffset(game: GameServer): Promise<void> {
 
 // This is the production play-through gesture: orient the physical right hand
 // along the eye-to-target ray, wind up two units away, pull the trigger, and
-// sweep the weapon's contact volume to 0.33 units. No damage/script message is
+// sweep the rendered weapon head into the target. No damage/script message is
 // injected by the test.
 async function poseWrench(
   game: GameServer,
@@ -167,8 +167,9 @@ async function poseWrench(
   // contact offset below, where a spurious roll turns "up out of the fist"
   // into "sideways" and the swing misses for reasons nothing in the test says.
   const worldQ = lookQuat(toward);
-  // `distance` is the contact volume's distance from the target, so back the
-  // hand off by wherever the grip puts that volume.
+  // `distance` is the rendered weapon head/body origin's distance from the
+  // target, so back the hand off by wherever the grip puts that origin. The
+  // fitted collider extends back along the visible handle/blade from there.
   const worldHand = sub(
     sub(target, scale(toward, distance)),
     qrotate(worldQ, heldContactOffset),
@@ -255,7 +256,7 @@ async function armedSweep(
   await game.step({ frames: 2 });
 
   const afterTeleport = await game.entities.detail(target.id);
-  const targetPoint =
+  let targetPoint =
     afterTeleport.aim_points?.find((point) => point.classification === "torso")
       ?.position ?? afterTeleport.position;
   await poseWrench(game, targetPoint, 4);
@@ -266,14 +267,18 @@ async function armedSweep(
     (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
   await game.input.set("right_hand.trigger", 1);
   await game.step({ frames: 2 });
-  await poseWrench(game, targetPoint, 0.33);
+  const current = await game.entities.detail(target.id);
+  targetPoint =
+    current.aim_points?.find((point) => point.classification === "torso")
+      ?.position ?? current.position;
+  await poseWrench(game, targetPoint, -0.1, 1);
+  await game.step({ frames: 2 });
   return { sequence, targetId: target.id, targetPoint };
 }
 
-// The #984 report/review's live-torso incremental approach, with one necessary
-// correction: the Wrench's full model bounds can already overlap the actor at
-// a 1.5-unit hand-origin pose. Arm from a measured-clear four-unit pose, then
-// reacquire the moving torso for every 1.5 -> 1.0 -> 0.7 -> 0.4 -> 0.2 step.
+// The #984 report/review's live-torso incremental approach. Arm from a
+// measured-clear four-unit pose, then reacquire the moving torso as the
+// rendered weapon head crosses it.
 async function reviewedIncrementalSweep(
   game: GameServer,
   target: EntitySummary,
@@ -298,7 +303,7 @@ async function reviewedIncrementalSweep(
     (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
   await game.input.set("right_hand.trigger", 1);
   await game.step({ frames: 2 });
-  for (const handDistance of [1.5, 1.0, 0.7, 0.4, 0.2]) {
+  for (const handDistance of [1.5, 1.0, 0.5, 0.15, -0.1]) {
     const current = await game.entities.detail(target.id);
     targetPoint =
       current.aim_points?.find((point) => point.classification === "torso")

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -49,9 +49,8 @@ const HAND_SWEEP: Vec3[] = [
 async function sweepHeldWrench(game: GameServer): Promise<void> {
   for (const hand of HAND_SWEEP) {
     await game.input.set("right_hand.position", hand);
-    // Two frames per sample, not one: the Wrench's authored contact volume is
-    // a 4.6cm sphere (PropPhysDimensions radius0), and the sweep's last sample
-    // lands it right on the pane plane. At one frame per sample whether the
+    // Two frames per sample, not one: the sweep's last sample lands the fitted
+    // weapon box right on the pane plane. At one frame per sample whether the
     // contact is generated came down to how much physics free-ran between the
     // HTTP requests - the same swing passed or failed purely on request
     // latency. Two frames gives the contact a real overlap window instead of a


### PR DESCRIPTION
Fixes #1049

## What changed

- retain the CPU-side weapon-only vertices for VR held melee models
- skin those vertices with the same completed melee-idle pose and local correction used by rendering
- replace the held loose-pickup cuboid with that posed local AABB while leaving the controller-driven rigid-body origin, collision groups, and damage gating unchanged
- use authored `melee_arm` material separation for 25AE PMNM meshes and a data-derived terminal rigid-joint fallback for low-detail LGMM meshes
- update the campaign melee scenario to reacquire a moving torso and sweep the rendered wrench head instead of relying on the oversized legacy slab

This does not alter flat melee/raycast behavior, the contact-edge semantics tracked in #1048, or the spring-body architecture tracked in #1053.

## Reproduction and measurements

On exact base `e8136855`, the held Wrench kept its loose world-model cuboid:

- full extents: `[1.8252745, 0.3863572, 0.2]`
- rigid-body/contact origin, palm-local: `[~0, 0.81078674, -0.03243]`

With this fix, the cuboid fitted from the rendered 25AE `wrench_h` weapon geometry is:

- full extents: `[0.13508987, 0.8600706, 0.22805762]`
- collider center relative to the held body: `[0.010378718, -0.43099326, 0.06692332]`
- rigid-body/contact origin remains palm-local: `[~0, 0.81078674, -0.03243]`
- collider center, palm-local: approximately `[0.010378721, 0.37979348, 0.03449332]`

An ordinary trigger-gated physical swing still emits exactly one authored `Damage` message and removes 9 HP.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p dark --lib` (117 passed)
- `cargo test -p shock2vr --lib` (877 passed)
- negative-first `held_melee_cuboid_fits_the_rendered_weapon_bounds`
- 25AE high-detail `vr-held-model` (5 passed)
- 25AE low-detail `no_high_detail_meshes` held-melee scenario (passed)
- `vr-melee-contact` (3 passed: live contact damage, save/load, hand ownership)
- saved MedSci campaign Wrench scenario (passed: fresh, save/load, and cross-deck canonical 9 damage)
- complete SDK e2e: 299 tests, 289 passed, 3 failed, 7 skipped; all VR melee and flat melee scenarios passed

The three complete-suite failures reproduce identically on exact base `e8136855` in an isolated run (8 tests: 5 passed, 3 failed): creature-loot reader binding, Hydro3 transcript spacing, and a patrol test that asks save to accept the unsupported player pose `[300, -1.2, 300]`. No changed file participates in those paths.

## Device

Quest verification could not run because this environment has no `adb` executable (`adb: command not found`). No headset, APK, Guardian, or automation state was touched.

## Visual evidence

![VR Wrench live contact cuboid through an identical wrist sweep](https://gist.githubusercontent.com/tommy-xr/80c6a1af3496155c779da47ed6c55fde/raw/wrench-contact-volume.gif)

<sub>The rendered 25AE `wrench_h` and the actual live Rapier cuboid (red) move through the same deterministic 20° wrist sweep. Captured headlessly at 20 fps with the VR debug runtime (`/v1/step` + `/v1/screenshot`).</sub>

### Before → after

![Before and after: loose-model slab versus posed Wrench fit](https://gist.githubusercontent.com/tommy-xr/80c6a1af3496155c779da47ed6c55fde/raw/before-after.png)

<sub>Exact product refs: base `e8136855`, fix `f8dea11e`; the same temporary PR #1045 live-Rapier overlay instrumentation was applied to both capture worktrees only. Identical sequence: launch `debug_weapons --vr` with 25AE assets, step 10 frames, spawn Wrench template `-928`, set the same head/hands, equip + enable the overlay, step 60 frames, then capture; animation frames are separated by exactly 3 sim frames. The measured body origin is identical on both sides.</sub>
