### PR TITLE
fix(ui): resolve optional audio-log reader art

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    path::Path,
     rc::Rc,
     sync::Arc,
     time::{Duration, SystemTime},
@@ -118,6 +119,38 @@ pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 /// floor-lying crumple pose doesn't start deeply interpenetrating the level
 /// trimesh (see `spawn_ragdoll`).
 const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
+
+/// Resolve optional media-reader portrait/icon art before it becomes a shared
+/// UI image. STR tables author extension-less PCX-era names, while replacement
+/// layers may provide the same art under a modern encoding (SCP's Earth
+/// `RamsIcon` is PNG). Missing optional art is omitted here; the shared canvas
+/// renderer remains strict for required UI assets such as the reader backdrop.
+fn resolve_optional_log_art_texture(
+    asset_cache: &AssetCache,
+    deck: u32,
+    log: u32,
+    role: &str,
+    authored: Option<String>,
+) -> Option<String> {
+    let authored = authored?;
+    let authored = authored.trim();
+    if authored.is_empty() {
+        return None;
+    }
+    let requested = if Path::new(authored).extension().is_some() {
+        authored.to_owned()
+    } else {
+        format!("{authored}.pcx")
+    };
+    let resolved = dark::util::resolve_texture_name(asset_cache, &requested);
+    if resolved.is_none() {
+        game_log!(
+            WARN,
+            "audio log {deck}/{log} omits missing optional {role} texture '{requested}'"
+        );
+    }
+    resolved
+}
 /// Cold model loads make entity initialization the longest main-thread load
 /// loop, so periodically let the host service its platform queues.
 const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
@@ -3369,8 +3402,20 @@ impl MissionCore {
         let data = crate::runtime_props::RuntimePropLogData {
             name: get("logname"),
             text: get("logtext"),
-            portrait: get("logportrait"),
-            icon: get("logicon"),
+            portrait: resolve_optional_log_art_texture(
+                asset_cache,
+                deck,
+                log,
+                "portrait",
+                get("logportrait"),
+            ),
+            icon: resolve_optional_log_art_texture(
+                asset_cache,
+                deck,
+                log,
+                "deck icon",
+                get("logicon"),
+            ),
         };
         if data.text.as_deref().is_none_or(str::is_empty) {
             return false;
@@ -9279,6 +9324,83 @@ impl crate::game_scene::DebuggableScene for MissionCore {
 
         self.script_world.dispatch(Message { to: id, payload });
         true
+    }
+}
+
+#[cfg(test)]
+mod log_reader_art_tests {
+    use std::{cell::RefCell, collections::HashSet, io::Cursor};
+
+    use engine::assets::asset_paths::{AbstractAssetPath, ReadableAndSeekable};
+
+    use super::*;
+
+    struct FakeAssetPath(HashSet<String>);
+
+    impl AbstractAssetPath for FakeAssetPath {
+        fn exists(&self, _base_path: String, asset_name: String) -> bool {
+            self.0.contains(&asset_name)
+        }
+
+        fn get_reader(
+            &self,
+            _base_path: String,
+            asset_name: String,
+        ) -> Option<RefCell<Box<dyn ReadableAndSeekable>>> {
+            self.exists(String::new(), asset_name)
+                .then(|| RefCell::new(Box::new(Cursor::new(Vec::new())) as _))
+        }
+    }
+
+    fn cache(names: &[&str]) -> AssetCache {
+        AssetCache::new(
+            String::new(),
+            Box::new(FakeAssetPath(
+                names.iter().map(|name| (*name).to_owned()).collect(),
+            )),
+        )
+    }
+
+    #[test]
+    fn optional_log_art_resolves_alternate_encoding_and_omits_missing_keys() {
+        let assets = cache(&["ramsicon.png", "ramsicon.pcx", "bayliss.pcx"]);
+
+        assert_eq!(
+            resolve_optional_log_art_texture(
+                &assets,
+                1,
+                24,
+                "deck icon",
+                Some("RamsIcon".to_owned()),
+            ),
+            Some("ramsicon.png".to_owned()),
+            "the upgraded encoding must win over a same-mount legacy PCX"
+        );
+        assert_eq!(
+            resolve_optional_log_art_texture(
+                &assets,
+                1,
+                24,
+                "portrait",
+                Some("Bayliss".to_owned()),
+            ),
+            Some("bayliss.pcx".to_owned())
+        );
+        assert_eq!(
+            resolve_optional_log_art_texture(
+                &assets,
+                1,
+                24,
+                "deck icon",
+                Some("NotShipped".to_owned()),
+            ),
+            None,
+            "missing optional art must never reach the infallible UI renderer"
+        );
+        assert_eq!(
+            resolve_optional_log_art_texture(&assets, 1, 24, "portrait", Some("  ".to_owned()),),
+            None
+        );
     }
 }
 

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -291,9 +291,11 @@ pub struct RuntimePropMapData {
     pub explored_rects: Vec<dark::map::MapRect>,
 }
 
-// RuntimePropLogData - the resolved presentation strings for an audio log,
+// RuntimePropLogData - the resolved presentation data for an audio log,
 // attached to the player-owned media host when playback opens. The reader
 // panel (`MediaGui`) reads it to render the portrait/deck-icon/name/transcript.
+// Portrait/icon values are concrete, existing texture keys (including their
+// resolved extension), not the extension-less names authored in the STR file.
 // Not serialized: it is a presentation cache derived from the string tables and
 // is re-resolved the next time the reader opens (the log identity persists in
 // `QuestInfo`).

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -177,14 +177,14 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         if let Ok(data) = v_data.get(entity_id) {
             if let Some(portrait) = &data.portrait {
                 components.push(
-                    gui::image(&format!("{}.pcx", portrait.to_ascii_lowercase()))
+                    gui::image(portrait)
                         .with_position(vec2(PORTRAIT_POS.0, PORTRAIT_POS.1))
                         .with_size(vec2(PORTRAIT_SIZE.0, PORTRAIT_SIZE.1)),
                 );
             }
             if let Some(icon) = &data.icon {
                 components.push(
-                    gui::image(&format!("{}.pcx", icon.to_ascii_lowercase()))
+                    gui::image(icon)
                         .with_position(vec2(ICON_POS.0, ICON_POS.1))
                         .with_size(vec2(ICON_SIZE.0, ICON_SIZE.1)),
                 );

--- a/tools/shock2-sdk/test/earth-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-log-reader.e2e.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiPanel } from "../src/types.js";
+import { dataRoot } from "./helpers/crf.js";
+
+// Regression for #1061: SCP overrides Earth log 1/24's deck icon from the
+// base game's RickIcon to RamsIcon. The replacement layers supply the reader
+// art as PNG rather than the PCX-era spelling implied by the string table, so
+// blindly appending `.pcx` made both flat and VR panic in the shared UiCanvas
+// renderer.
+//
+// This test deliberately requires the 25th Anniversary + SCP asset stack: a
+// classic install cannot exercise the overriding string/art encodings. It
+// collects the real Earth object through its production Frob script, invokes
+// the production reader action, renders a frame, then verifies UI, audio and
+// persistent read state in both presentations.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const assets = e2eEnabled ? dataRoot() : null;
+const has25thScp =
+  assets !== null &&
+  existsSync(path.join(assets, "sshock2.kpf")) &&
+  existsSync(path.join(assets, "mods", "scp.kpf"));
+
+const EARTH_TRAINING_LOG = 301;
+
+const panelText = (panel: UiPanel): string =>
+  panel.elements
+    .filter((element) => element.kind === "text" && element.text)
+    .map((element) => element.text)
+    .join(" ");
+
+async function verifyEarthLogReader(
+  presentation: "flat" | "vr",
+  port: number,
+): Promise<void> {
+  await using game = await GameServer.launch({
+    mission: "earth.mis",
+    port,
+    debugFlags: presentation === "vr" ? ["--vr"] : [],
+  });
+  await game.step({ frames: 5 });
+
+  const [disc] = await game.entities.byTemplate(EARTH_TRAINING_LOG);
+  assert.ok(disc, "earth.mis must contain training audio log object 301");
+
+  await game.entities.sendMessage(disc.id, { type: "Frob" });
+  await game.step({ frames: 5 });
+  assert.deepEqual((await game.info()).player.collected_logs, [
+    { deck: 1, log: 24, read: false },
+  ]);
+
+  await game.input.trigger("ReadLastUnreadLog");
+  await game.step({ frames: 5 });
+
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, `${presentation}: the Earth log reader must render`);
+  const transcript = panelText(panel);
+  assert.ok(
+    transcript.includes("message is coming from the audio log"),
+    `${presentation}: reader must expose log 1/24's transcript: ${transcript}`,
+  );
+  assert.ok(
+    transcript.toUpperCase().includes("TRAINER"),
+    `${presentation}: reader must expose log 1/24's header: ${transcript}`,
+  );
+
+  const textures = panel.elements
+    .filter((element) => element.kind === "image")
+    .map((element) => element.texture?.toLowerCase());
+  assert.ok(textures.includes("iface/log.pcx"));
+  assert.ok(textures.includes("bayliss.png"));
+  assert.ok(
+    textures.includes("ramsicon.png"),
+    `${presentation}: SCP's RamsIcon PNG should render (images: ${textures.join(", ")})`,
+  );
+
+  assert.ok(
+    (await game.audio.recent()).sounds.some(
+      (sound) => sound.sample.toLowerCase() === "log0124",
+    ),
+    `${presentation}: reading must play LOG0124`,
+  );
+  assert.deepEqual((await game.info()).player.collected_logs, [
+    { deck: 1, log: 24, read: true },
+  ]);
+
+  const shot = await game.screenshot(`issue-1061-earth-reader-${presentation}.png`);
+  assert.ok(shot.size_bytes > 0, `${presentation}: reader screenshot must contain pixels`);
+}
+
+test(
+  "25AE Earth log 1/24 collects, reads and renders in flat and VR",
+  { skip: !has25thScp, timeout: 600_000 },
+  async () => {
+    await verifyEarthLogReader(
+      "flat",
+      Number(process.env.SHOCK2_E2E_PORT ?? 8861),
+    );
+    await verifyEarthLogReader(
+      "vr",
+      Number(process.env.SHOCK2_E2E_PORT ?? 8862),
+    );
+  },
+);

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -162,12 +162,12 @@ test(
       );
     }
     assert.ok(
-      textures.includes("amanpour.pcx"),
-      "reader should draw the sender portrait from book.crf",
+      textures.includes("amanpour.pcx") || textures.includes("amanpour.png"),
+      "reader should draw the resolved sender portrait from the book family",
     );
     assert.ok(
-      textures.includes("medicon.pcx"),
-      "reader should draw the deck icon from book.crf",
+      textures.includes("medicon.pcx") || textures.includes("medicon.png"),
+      "reader should draw the resolved deck icon from the book family",
     );
     await game.screenshot("log-reader-open.png");
 

--- a/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
@@ -118,8 +118,8 @@ async function assertAmanpourReader(game: GameServer): Promise<UiPanel> {
     .filter((element) => element.kind === "image")
     .map((element) => element.texture?.toLowerCase());
   assert.ok(textures.includes("iface/log.pcx"));
-  assert.ok(textures.includes("amanpour.pcx"));
-  assert.ok(textures.includes("medicon.pcx"));
+  assert.ok(textures.includes("amanpour.pcx") || textures.includes("amanpour.png"));
+  assert.ok(textures.includes("medicon.pcx") || textures.includes("medicon.png"));
   assert.equal((await uiBodies(game)).length, 1, "reader must replace, not overlap, corpse UI");
   return panel;
 }


### PR DESCRIPTION
Fixes #1061

## What changed

- resolve optional media-reader portrait/icon keys before they become shared `UiCanvas` images
- honor replacement encodings through the existing mount-first texture resolver (Earth's authored `RamsIcon` now resolves to the shipped `ramsicon.png`)
- warn and omit only an unresolved optional portrait/icon; required reader/UI assets remain strict
- keep flat and VR on the same resolved `RuntimePropLogData` and canvas

## Regression coverage

- focused Rust unit: alternate encoding wins, legacy PCX still resolves, missing/blank optional keys are omitted
- durable 25AE+SCP Earth object 301 / log 1:24 SDK e2e: production Frob collection, `ReadLastUnreadLog`, rendered transcript/header/art, `LOG0124`, and read state in flat and `--vr`
- existing MedSci flat/persistence and authentic VR corpse-reader regressions remain green with resolved PNG/PCX art

Negative-first: the new Earth e2e failed on the base commit at the first flat reader frame (`/v1/step` 500 after the debug runtime panicked), before passing in both presentations with this change.

## Checks

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` (877 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `npm run build` in `tools/shock2-sdk`
- targeted 25AE Earth flat+VR e2e (passed)
- existing Amanpour flat/persistence + VR reader e2es (passed)

The broader 25AE `log-reader.e2e` run also surfaced an unrelated pre-existing Hydro3 string-layer expectation (`Glory... to` vs resolved `Glory to`); this PR does not change transcript parsing or that assertion.

## Campaign

`earth-to-hydro · detailed · 25th Anniversary · vr · seed 1600004333`

## Visual evidence

![Earth audio-log reader VR world-panel demo](https://gist.githubusercontent.com/tommy-xr/b1e05b205f0f521a00152fb430a7ae70/raw/earth-log-reader-vr-world-panel.gif)

<sub>Earth log 1:24 after production `Frob` + `ReadLastUnreadLog`. Subtle head-look parallax confirms the VR reader is a world panel; its transcript, Bayliss portrait, and Ramsay Center icon render from the same resolved canvas used by flat mode. Captured headlessly on commit `05523db1` via `/v1/step` + `/v1/screenshot` (deterministic fixed-timestep).</sub>

### Reader closed → open (flat and VR)

![Earth audio-log reader closed-to-open comparison in flat and VR](https://gist.githubusercontent.com/tommy-xr/b1e05b205f0f521a00152fb430a7ae70/raw/earth-log-reader-flat-vr-closed-open.png)

<sub>The base revision crashes on its first post-reader render, so this blocker-appropriate comparison intentionally shows the fixed commit’s deterministic reader-closed → reader-open sequence in both presentations; there is no misleading base-build “after” frame.</sub>