### PR TITLE
fix(inventory): size backpack from Strength

### DIFF
--- a/shock2vr/src/inventory/mod.rs
+++ b/shock2vr/src/inventory/mod.rs
@@ -7,14 +7,24 @@
 //! link, so this is also what makes a container's layout stable across a
 //! reload.
 
+use std::collections::HashMap;
+
 use dark::properties::{Link, PropContainDimensions, PropInventoryDimensions};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, ViewMut, World};
+
+use crate::{player_stats::PlayerStats, quest_info::QuestInfo};
 
 pub mod player_inventory_entity;
 pub use player_inventory_entity::*;
 
-/// The player's backpack grid, in cells (`invback.pcx` draws 15x3).
+/// The player's maximum backpack grid, in cells (`invback.pcx` draws 15x3).
 pub const BACKPACK_GRID: (usize, usize) = (15, 3);
+
+/// Strength 1 exposes ten columns; every effective level through 6 adds one.
+pub const BACKPACK_MIN_WIDTH: usize = 10;
+
+/// Effective Strength is capped at 6 for carrying capacity.
+pub const BACKPACK_MAX_STRENGTH: i32 = 6;
 
 /// A container's loot grid, in cells (`contain.pcx` draws 4x4).
 pub const CONTAINER_GRID: (usize, usize) = (4, 4);
@@ -24,22 +34,34 @@ pub const CONTAINER_GRID: (usize, usize) = (4, 4);
 /// item simply has no cell and gets first-fit like an unplaced one.
 const EQUIP_SLOT_BASE: u32 = 1000;
 
+/// Unique, deliberately non-cell ordinals used while a true resize overflow
+/// still belongs to the backpack. The mission normally physicalizes and
+/// detaches those items immediately. Keeping an exceptional modelless item at
+/// a unique pending ordinal avoids both data loss and a duplicate cell claim,
+/// and lets a later grow recover it.
+const PENDING_OVERFLOW_SLOT_BASE: u32 = 0x8000_0000;
+
 /// Which grid `container_entity` is drawn with. The player's backpack is
 /// wider than a container's loot panel, and the ordinal encodes `y * width +
 /// x`, so both sides of the containment link must agree on the width.
 ///
 /// A container's grid is authored as `P$ContainDims`; every container in the
 /// shipped game declares 4x4, which is also the fallback for anything that
-/// does not declare one. The backpack's width is not read from the world yet -
-/// the original derives it from Strength (see the tracking issue), so it stays
-/// at its maximum here.
+/// does not declare one. The backpack is the exception: its usable width is
+/// derived from the persistent character sheet's Strength and Pack-Rat trait.
 pub fn grid_for(world: &World, container_entity: EntityId) -> (usize, usize) {
     let is_backpack = world
         .borrow::<View<PlayerInventoryEntity>>()
         .map(|v| v.get(container_entity).is_ok())
         .unwrap_or(false);
     if is_backpack {
-        return BACKPACK_GRID;
+        return world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|quests| (backpack_width(quests.player_stats()), BACKPACK_GRID.1))
+            // Minimal/debug scenes normally install QuestInfo too. Keep the
+            // old maximum-size behavior as a graceful fallback for any scene
+            // that deliberately has no character sheet.
+            .unwrap_or(BACKPACK_GRID);
     }
     world
         .borrow::<View<PropContainDimensions>>()
@@ -50,6 +72,137 @@ pub fn grid_for(world: &World, container_entity: EntityId) -> (usize, usize) {
         .filter(|(w, h)| *w > 0 && *h > 0)
         .map(|(w, h)| (w as usize, h as usize))
         .unwrap_or(CONTAINER_GRID)
+}
+
+/// The usable backpack width for a character sheet.
+///
+/// Retail treats Pack-Rat as one extra effective Strength for inventory only,
+/// clamps the result to 1..=6, and maps that to 10..=15 columns.
+pub fn backpack_width(stats: &PlayerStats) -> usize {
+    let pack_rat = i32::from(stats.has_os_trait(crate::scripts::gui::TRAIT_PACK_RAT));
+    let effective_strength = (stats.strength + pack_rat).clamp(1, BACKPACK_MAX_STRENGTH);
+    BACKPACK_MIN_WIDTH + (effective_strength - 1) as usize
+}
+
+/// Result of changing the width used to encode a container's cell ordinals.
+/// Overflow remains linked until the mission successfully gives it world
+/// presence, so even a modelless item cannot be silently lost.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WidthRemapOutcome {
+    pub placed: usize,
+    pub overflow: Vec<EntityId>,
+}
+
+/// Re-encode stored `Contains` ordinals after a grid width change.
+///
+/// Existing `(x,y)` coordinates are claimed first. Items falling off the
+/// right edge are then re-placed column-major without disturbing the items
+/// that still fit. A true capacity overflow is returned to the mission, which
+/// mirrors retail by spilling those objects into the world.
+pub fn remap_container_width(
+    world: &mut World,
+    container_entity: EntityId,
+    old_grid: (usize, usize),
+    new_grid: (usize, usize),
+) -> WidthRemapOutcome {
+    if old_grid == new_grid {
+        let placed = Inventory::from_container(world, container_entity, new_grid)
+            .all_items()
+            .count();
+        return WidthRemapOutcome {
+            placed,
+            overflow: Vec::new(),
+        };
+    }
+
+    // Decode every old ordinal before changing any link. Inventory's two-pass
+    // ownership logic also makes malformed duplicate cells deterministic.
+    let old_layout = Inventory::from_container(world, container_entity, old_grid);
+    let mut resized = Inventory::new(new_grid.0, new_grid.1);
+    let mut reflow = Vec::new();
+    let mut accounted_for = std::collections::HashSet::new();
+
+    for item in old_layout.all_items() {
+        accounted_for.insert(item.entity);
+        if !resized.insert_if_fits(item.entity, item.x, item.y, item.width, item.height) {
+            reflow.push(item.clone());
+        }
+    }
+
+    // A prior shrink can leave a modelless overflow linked at a deliberately
+    // non-cell ordinal because it cannot safely be materialized. Such an item
+    // is absent from `old_layout` while the grid is full, but it must join the
+    // deterministic first-fit pass so a later grow can recover it.
+    let mut pending: Vec<(EntityId, u32)> =
+        crate::scripts::script_util::get_all_links_with_data(world, container_entity, |link| {
+            match link {
+                Link::Contains(ordinal) => Some(*ordinal),
+                _ => None,
+            }
+        });
+    pending.sort_by_key(|(entity, ordinal)| (*ordinal, entity.inner()));
+    let v_dims = world.borrow::<View<PropInventoryDimensions>>().unwrap();
+    for (entity, _) in pending {
+        if accounted_for.insert(entity) {
+            let (width, height) = v_dims
+                .get(entity)
+                .map(|dims| (dims.width as usize, dims.height as usize))
+                .unwrap_or((1, 1));
+            reflow.push(ContainedEntityInfo {
+                entity,
+                x: 0,
+                y: 0,
+                width,
+                height,
+            });
+        }
+    }
+    drop(v_dims);
+
+    let mut overflow = Vec::new();
+    for item in reflow {
+        if !resized.insert_first_available(item.entity, item.width, item.height) {
+            overflow.push(item.entity);
+        }
+    }
+
+    let placements: HashMap<EntityId, u32> = resized
+        .all_items()
+        .map(|item| (item.entity, resized.slot_at(item.x, item.y)))
+        .collect();
+    let pending_overflow: HashMap<EntityId, u32> = overflow
+        .iter()
+        .enumerate()
+        .map(|(index, entity)| {
+            (
+                *entity,
+                PENDING_OVERFLOW_SLOT_BASE.saturating_add(index as u32),
+            )
+        })
+        .collect();
+    if let Ok(mut links) = world.borrow::<ViewMut<dark::properties::Links>>()
+        && let Ok(container_links) = (&mut links).get(container_entity)
+    {
+        for link in &mut container_links.to_links {
+            let Some(target) = link.to_entity_id.map(|wrapped| wrapped.0) else {
+                continue;
+            };
+            if matches!(link.link, Link::Contains(_))
+                && let Some(slot) = placements.get(&target)
+            {
+                link.link = Link::Contains(*slot);
+            } else if matches!(link.link, Link::Contains(_))
+                && let Some(slot) = pending_overflow.get(&target)
+            {
+                link.link = Link::Contains(*slot);
+            }
+        }
+    }
+
+    WidthRemapOutcome {
+        placed: placements.len(),
+        overflow,
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -400,5 +553,224 @@ mod tests {
         assert_eq!(inv.first_free_slot(1, 1), Some(inv.slot_at(0, 3)));
         inv.insert_if_fits(ids[1], 0, 3, 1, 1);
         assert_eq!(inv.first_free_slot(1, 1), Some(inv.slot_at(1, 0)));
+    }
+
+    #[test]
+    fn backpack_width_follows_strength_and_pack_rat() {
+        let mut stats = crate::player_stats::PlayerStats::new();
+        assert_eq!(backpack_width(&stats), 10, "Strength 1");
+
+        stats.strength = 4;
+        assert_eq!(backpack_width(&stats), 13, "Strength 4");
+
+        assert!(
+            stats.add_os_trait(crate::scripts::gui::TRAIT_PACK_RAT),
+            "Pack-Rat is an authored O/S trait"
+        );
+        assert_eq!(backpack_width(&stats), 14, "Pack-Rat adds one column");
+
+        stats.strength = 99;
+        assert_eq!(backpack_width(&stats), 15, "effective Strength clamps at 6");
+        stats.strength = -99;
+        assert_eq!(backpack_width(&stats), 10, "effective Strength clamps at 1");
+    }
+
+    #[test]
+    fn player_backpack_grid_reads_the_live_character_sheet() {
+        let mut world = World::new();
+        let backpack = world.add_entity(PlayerInventoryEntity {});
+        world.add_unique(crate::quest_info::QuestInfo::new());
+
+        assert_eq!(grid_for(&world, backpack), (10, 3));
+        world
+            .borrow::<shipyard::UniqueViewMut<crate::quest_info::QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .strength = 5;
+        assert_eq!(grid_for(&world, backpack), (14, 3));
+    }
+
+    fn remap_world(width: usize, height: usize) -> (World, EntityId, Vec<EntityId>) {
+        let mut world = World::new();
+        let item_count = width * height;
+        let items: Vec<_> = (0..item_count).map(|_| world.add_entity(())).collect();
+        let links = items
+            .iter()
+            .enumerate()
+            .map(|(slot, item)| ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(*item)),
+                link: Link::Contains(slot as u32),
+            })
+            .collect();
+        let container = world.add_entity(Links { to_links: links });
+        (world, container, items)
+    }
+
+    fn stored_slot(world: &World, container: EntityId, item: EntityId) -> u32 {
+        world
+            .borrow::<View<Links>>()
+            .unwrap()
+            .get(container)
+            .unwrap()
+            .to_links
+            .iter()
+            .find_map(|link| {
+                (link.to_entity_id.map(|wrapped| wrapped.0) == Some(item))
+                    .then(|| match link.link {
+                        Link::Contains(slot) => Some(slot),
+                        _ => None,
+                    })
+                    .flatten()
+            })
+            .expect("item should retain one Contains link")
+    }
+
+    #[test]
+    fn width_changes_preserve_coordinates_and_repack_right_edge_items() {
+        let (mut world, container, items) = remap_world(11, 3);
+
+        // Make holes in the left side. The rightmost-column items at old
+        // slots 10, 21 and 32 cannot retain x=10 after shrinking to width 10,
+        // so they should fill these holes deterministically.
+        {
+            let mut links = world.borrow::<shipyard::ViewMut<Links>>().unwrap();
+            let links = (&mut links).get(container).unwrap();
+            links
+                .to_links
+                .retain(|link| !matches!(link.link, Link::Contains(0 | 11 | 22)));
+        }
+        let outcome = remap_container_width(&mut world, container, (11, 3), (10, 3));
+        assert!(outcome.overflow.is_empty());
+
+        assert_eq!(
+            stored_slot(&world, container, items[1]),
+            1,
+            "(1,0) stays put"
+        );
+        assert_eq!(
+            stored_slot(&world, container, items[12]),
+            11,
+            "(1,1) re-encodes"
+        );
+        assert_eq!(
+            stored_slot(&world, container, items[23]),
+            21,
+            "(1,2) re-encodes"
+        );
+        assert_eq!(stored_slot(&world, container, items[10]), 0);
+        assert_eq!(stored_slot(&world, container, items[21]), 10);
+        assert_eq!(stored_slot(&world, container, items[32]), 20);
+
+        // Growing must keep every (x,y), which means row 1/2 ordinals change
+        // back to the wider encoding rather than silently moving the icons.
+        let outcome = remap_container_width(&mut world, container, (10, 3), (11, 3));
+        assert!(outcome.overflow.is_empty());
+        assert_eq!(stored_slot(&world, container, items[12]), 12);
+        assert_eq!(stored_slot(&world, container, items[23]), 23);
+    }
+
+    #[test]
+    fn shrinking_replaces_a_multi_cell_item_that_falls_off_the_right() {
+        let mut world = World::new();
+        let fixed = world.add_entity(PropInventoryDimensions {
+            width: 1,
+            height: 3,
+        });
+        let off_right = world.add_entity(PropInventoryDimensions {
+            width: 2,
+            height: 2,
+        });
+        let container = world.add_entity(Links {
+            to_links: vec![
+                ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(fixed)),
+                    link: Link::Contains(0),
+                },
+                ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(off_right)),
+                    link: Link::Contains(9),
+                },
+            ],
+        });
+
+        let outcome = remap_container_width(&mut world, container, (11, 3), (10, 3));
+        assert!(outcome.overflow.is_empty());
+        assert_eq!(stored_slot(&world, container, fixed), 0);
+        assert_eq!(stored_slot(&world, container, off_right), 1);
+
+        let layout = Inventory::from_container(&world, container, (10, 3));
+        assert_eq!(cell_of_item(&layout, fixed), (0, 0));
+        assert_eq!(cell_of_item(&layout, off_right), (1, 0));
+        assert_eq!(
+            layout.all_items().count(),
+            2,
+            "neither item is lost or overlapped"
+        );
+    }
+
+    #[test]
+    fn shrinking_a_full_backpack_reports_true_overflow_without_overlap_or_link_loss() {
+        let (mut world, container, items) = remap_world(11, 3);
+        let outcome = remap_container_width(&mut world, container, (11, 3), (10, 3));
+
+        assert_eq!(outcome.overflow, vec![items[10], items[21], items[32]]);
+        assert_eq!(outcome.placed, 30);
+
+        let placed_slots: std::collections::HashSet<_> = {
+            let links = world.borrow::<View<Links>>().unwrap();
+            let links = links.get(container).unwrap();
+            assert_eq!(
+                links.to_links.len(),
+                33,
+                "overflow remains linked until world spill succeeds"
+            );
+            links
+                .to_links
+                .iter()
+                .filter(|link| {
+                    link.to_entity_id
+                        .is_some_and(|target| !outcome.overflow.contains(&target.0))
+                })
+                .filter_map(|link| match link.link {
+                    Link::Contains(slot) => Some(slot),
+                    _ => None,
+                })
+                .collect()
+        };
+        assert_eq!(placed_slots.len(), 30, "placed items never overlap");
+        assert!(placed_slots.iter().all(|slot| *slot < 30));
+
+        let pending_slots: Vec<_> = outcome
+            .overflow
+            .iter()
+            .map(|entity| stored_slot(&world, container, *entity))
+            .collect();
+        assert_eq!(
+            pending_slots,
+            vec![
+                PENDING_OVERFLOW_SLOT_BASE,
+                PENDING_OVERFLOW_SLOT_BASE + 1,
+                PENDING_OVERFLOW_SLOT_BASE + 2,
+            ],
+            "retained overflow has unique non-cell ordinals"
+        );
+
+        // A modelless item cannot be spilled into the world. If it remains
+        // linked at one of the pending ordinals, a later grow must recover it
+        // without duplication, overlap, or loss.
+        let recovered = remap_container_width(&mut world, container, (10, 3), (11, 3));
+        assert!(recovered.overflow.is_empty());
+        assert_eq!(recovered.placed, 33);
+        let recovered_layout = Inventory::from_container(&world, container, (11, 3));
+        assert_eq!(recovered_layout.all_items().count(), 33);
+        let recovered_slots: std::collections::HashSet<_> = items
+            .iter()
+            .map(|entity| stored_slot(&world, container, *entity))
+            .collect();
+        assert_eq!(recovered_slots.len(), 33);
+        assert!(recovered_slots.iter().all(|slot| *slot < 33));
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3281,6 +3281,68 @@ impl MissionCore {
         moved
     }
 
+    /// Re-encode the backpack's stored cells after effective Strength changes.
+    /// Items that cannot fit even after deterministic reflow are spilled into
+    /// the world, matching retail's `ShockInvResize` -> `ShockInvAddObj` path.
+    fn resize_player_backpack(&mut self, old_width: usize, new_width: usize) {
+        if old_width == new_width {
+            return;
+        }
+        let inventory_entity = match self.world.borrow::<UniqueView<PlayerInfo>>() {
+            Ok(player) => player.inventory_entity_id,
+            Err(_) => return,
+        };
+        let outcome = crate::inventory::remap_container_width(
+            &mut self.world,
+            inventory_entity,
+            (old_width, crate::inventory::BACKPACK_GRID.1),
+            (new_width, crate::inventory::BACKPACK_GRID.1),
+        );
+        for (index, entity_id) in outcome.overflow.into_iter().enumerate() {
+            self.spill_backpack_overflow(entity_id, index);
+        }
+    }
+
+    /// Give one full-pack resize overflow item ordinary world presence beside
+    /// the player. Physicalize before detaching, as the manual throw path does:
+    /// a modelless item remains contained instead of being silently lost.
+    fn spill_backpack_overflow(&mut self, entity_id: EntityId, index: usize) {
+        let player = match self.world.borrow::<UniqueView<PlayerInfo>>() {
+            Ok(player) => player.clone(),
+            Err(_) => return,
+        };
+        self.make_physical(entity_id);
+        if !self.id_to_physics.contains_key(&entity_id) {
+            warn!(
+                "Backpack resize could not spill modelless overflow entity {:?}; preserving its containment link",
+                entity_id
+            );
+            return;
+        }
+
+        self.detach_from_containers(entity_id);
+        let forward = player.rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+        let right = player.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
+        let lane = (index % 5) as f32 - 2.0;
+        let row = (index / 5) as f32;
+        let position = player.pos
+            + forward * (crate::physics::PLAYER_STANDING_RADIUS_WORLD + 0.6 + row * 0.2)
+            + right * lane * 0.25
+            + vec3(0.0, 0.35 + row * 0.1, 0.0);
+        self.set_entity_position_rotation(
+            entity_id,
+            position,
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 1.0),
+        );
+        self.physics.set_velocity(entity_id, forward * 1.5);
+        self.world.add_component(entity_id, PropHasRefs(true));
+        self.script_world.dispatch(Message {
+            payload: MessagePayload::Drop,
+            to: entity_id,
+        });
+    }
+
     /// When an entity is replaced (e.g. a dead power cell recharged into a live
     /// one), any container that held the old entity via a `Contains` link should
     /// keep holding the new one - otherwise the replacement is orphaned in the
@@ -5680,9 +5742,11 @@ impl MissionCore {
 
                 Effect::GrantTourReward { career, year, tour } => {
                     let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    let old_width = crate::inventory::backpack_width(quests.player_stats());
                     let applied = quests
                         .player_stats_mut()
                         .apply_tour_reward(career, year, tour);
+                    let new_width = crate::inventory::backpack_width(quests.player_stats());
                     if applied {
                         info!(
                             "Applied training-tour reward ({:?} year {} tour {}): {:?}",
@@ -5691,6 +5755,10 @@ impl MissionCore {
                             tour,
                             quests.player_stats()
                         );
+                    }
+                    drop(quests);
+                    if applied {
+                        self.resize_player_backpack(old_width, new_width);
                     }
                 }
 
@@ -5724,10 +5792,11 @@ impl MissionCore {
                         .0
                         .clone();
                     if let Some(costs) = costs {
-                        let purchased = {
+                        let (purchased, old_width, new_width) = {
                             let mut quests =
                                 self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
                             let stats = quests.player_stats_mut();
+                            let old_width = crate::inventory::backpack_width(stats);
                             match upgrade_quote(&costs, stats, target) {
                                 Some(cost) if stats.spend_cyber_modules(cost) => {
                                     apply_purchase(stats, target);
@@ -5735,24 +5804,27 @@ impl MissionCore {
                                         "Trainer purchase {:?} (-{} modules, balance {})",
                                         target, cost, stats.cyber_modules
                                     );
-                                    true
+                                    (true, old_width, crate::inventory::backpack_width(stats))
                                 }
                                 Some(cost) => {
                                     info!(
                                         "Trainer purchase {:?} refused: costs {}, balance {}",
                                         target, cost, stats.cyber_modules
                                     );
-                                    false
+                                    (false, old_width, old_width)
                                 }
                                 None => {
                                     info!(
                                         "Trainer purchase {:?} refused: maxed/locked/unavailable",
                                         target
                                     );
-                                    false
+                                    (false, old_width, old_width)
                                 }
                             }
                         };
+                        if purchased {
+                            self.resize_player_backpack(old_width, new_width);
+                        }
                         if purchased && endurance_target {
                             increase_player_max_hit_points(
                                 &self.world,
@@ -5832,68 +5904,70 @@ impl MissionCore {
                         .borrow::<View<dark::properties::PropTemplateId>>()
                         .ok()
                         .and_then(|v| v.get(machine).ok().map(|t| t.template_id));
-                    let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
                     // Without a stable machine id the used state could never
                     // be recorded - refuse rather than vend repeatably.
                     let Some(machine_id) = machine_template_id else {
                         warn!("O/S trait {} refused: machine has no template id", trait_id);
                         continue;
                     };
-                    let used = quests
-                        .read_quest_bit_value(&used_bit_name(machine_id))
-                        .bits()
-                        != 0;
-                    if used {
-                        info!("O/S trait {} refused: machine already used", trait_id);
-                    } else if !quests.player_stats_mut().add_os_trait(trait_id) {
-                        info!("O/S trait {} refused: owned or slots full", trait_id);
-                    } else {
-                        quests.set_quest_bit_value(
-                            &used_bit_name(machine_id),
-                            dark::properties::QuestBitValue::COMPLETE,
-                        );
-                        // Live effects for the implemented subset; the rest
-                        // are storage-only (their consumers don't exist yet).
-                        match trait_id {
-                            TRAIT_NATURALLY_ABLE => {
+                    let (acquired, old_width, new_width) = {
+                        let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                        let old_width = crate::inventory::backpack_width(quests.player_stats());
+                        let used = quests
+                            .read_quest_bit_value(&used_bit_name(machine_id))
+                            .bits()
+                            != 0;
+                        if used {
+                            info!("O/S trait {} refused: machine already used", trait_id);
+                            (false, old_width, old_width)
+                        } else if !quests.player_stats_mut().add_os_trait(trait_id) {
+                            info!("O/S trait {} refused: owned or slots full", trait_id);
+                            (false, old_width, old_width)
+                        } else {
+                            quests.set_quest_bit_value(
+                                &used_bit_name(machine_id),
+                                dark::properties::QuestBitValue::COMPLETE,
+                            );
+                            if trait_id == TRAIT_NATURALLY_ABLE {
                                 quests
                                     .player_stats_mut()
                                     .award_cyber_modules(NATURALLY_ABLE_MODULES);
                             }
-                            TRAIT_TANK => {
-                                // Tank (Trait8): the original raises the
-                                // ceiling AND current HP by the bonus (buying
-                                // at 25/30 yields 30/35), clamped to the new
-                                // max. Loads first re-derive the trait-adjusted
-                                // default, then restore the persisted live pool,
-                                // so the grant cannot double-apply.
-                                drop(quests);
-                                let player_entity = self
-                                    .world
-                                    .borrow::<UniqueView<PlayerInfo>>()
-                                    .unwrap()
-                                    .entity_id;
-                                self.world.run(
-                                    |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
-                                     mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
-                                        let new_max = (&mut v_max)
-                                            .get(player_entity)
-                                            .map(|max| {
-                                                max.hit_points += TANK_HP_BONUS as u32;
-                                                max.hit_points
-                                            })
-                                            .ok();
-                                        if let Ok(hp) = (&mut v_hp).get(player_entity) {
-                                            hp.hit_points += TANK_HP_BONUS;
-                                            if let Some(new_max) = new_max {
-                                                hp.hit_points =
-                                                    hp.hit_points.min(new_max as i32);
-                                            }
+                            let new_width = crate::inventory::backpack_width(quests.player_stats());
+                            (true, old_width, new_width)
+                        }
+                    };
+
+                    if acquired {
+                        self.resize_player_backpack(old_width, new_width);
+                        if trait_id == TRAIT_TANK {
+                            // Tank (Trait8): the original raises the ceiling
+                            // AND current HP by the bonus. Loads first re-derive
+                            // the trait-adjusted default, so this live grant
+                            // cannot double-apply.
+                            let player_entity = self
+                                .world
+                                .borrow::<UniqueView<PlayerInfo>>()
+                                .unwrap()
+                                .entity_id;
+                            self.world.run(
+                                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
+                                 mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
+                                    let new_max = (&mut v_max)
+                                        .get(player_entity)
+                                        .map(|max| {
+                                            max.hit_points += TANK_HP_BONUS as u32;
+                                            max.hit_points
+                                        })
+                                        .ok();
+                                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
+                                        hp.hit_points += TANK_HP_BONUS;
+                                        if let Some(new_max) = new_max {
+                                            hp.hit_points = hp.hit_points.min(new_max as i32);
                                         }
-                                    },
-                                );
-                            }
-                            _ => {}
+                                    }
+                                },
+                            );
                         }
                         info!(
                             "O/S trait acquired: {} ({}){}",
@@ -8995,6 +9069,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             .borrow::<UniqueViewMut<QuestInfo>>()
             .map_err(|_| "scene has no quest info".to_string())?;
         let stats = quests.player_stats_mut();
+        let old_backpack_width = crate::inventory::backpack_width(stats);
 
         let stat_targets = [
             (Stat::Strength, request.strength, "strength"),
@@ -9109,7 +9184,10 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             stats.award_cyber_modules(target.saturating_sub(stats.cyber_modules));
         }
 
+        let new_backpack_width = crate::inventory::backpack_width(stats);
         let result = stats.clone();
+        drop(quests);
+        self.resize_player_backpack(old_backpack_width, new_backpack_width);
         info!("Debug provisioning set player stats: {:?}", result);
         Ok(result)
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1460,6 +1460,19 @@ impl MissionCore {
 
         world.add_unique(quest_info);
 
+        // Current saves record the width that encoded their backpack link
+        // ordinals. Pre-#948 saves omit it and used the former fixed width 15;
+        // migrate both shapes before any restored interaction can add items.
+        let current_backpack_width = world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|quests| crate::inventory::backpack_width(quests.player_stats()))
+            .unwrap_or(crate::inventory::BACKPACK_GRID.0);
+        let backpack_load_remap = held_item_save_data.remap_instantiated_backpack(
+            &mut world,
+            inventory,
+            current_backpack_width,
+        );
+
         crate::scripts::gui::restore_authored_computer_data(
             &mut world,
             &entity_info_rc,
@@ -1715,6 +1728,9 @@ impl MissionCore {
             screen_fade_alpha: 0.0,
             screen_fade_texture,
         };
+        for (index, entity_id) in backpack_load_remap.overflow.into_iter().enumerate() {
+            mission_core.spill_backpack_overflow(entity_id, index);
+        }
         mission_core.process_virtual_hand_effects(asset_cache, held_restore_effects);
         // Re-run each restored held item's Hold script. Only a fresh world
         // grab dispatches Hold (see `restore_held_item_physics` for the same

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -24,7 +24,8 @@
 //! baselines (all careers start from the uniform [`PlayerStats::default`]
 //! baseline for now), and wiring granted psi disciplines into `crate::psi`
 //! known powers. The upgrade UI only sells primary stats with live consumers:
-//! Endurance->maxHP and Cyber Affinity->hacking; see `scripts::gui::trainer`.
+//! Strength->backpack capacity, Endurance->maxHP, and Cyber Affinity->hacking;
+//! see `scripts::gui::trainer`.
 
 use std::collections::BTreeSet;
 

--- a/shock2vr/src/save_load/held_item_save_data.rs
+++ b/shock2vr/src/save_load/held_item_save_data.rs
@@ -20,6 +20,11 @@ pub struct HeldItemSaveData {
     pub entity_in_left_hand: Option<u64>,
     pub entity_in_right_hand: Option<u64>,
     pub inventory_entity: Option<u64>,
+    /// Width used to encode backpack `Contains` ordinals in this save.
+    /// Saves written before #948 omit it and always used the old fixed width
+    /// of 15 columns.
+    #[serde(default)]
+    pub backpack_width: Option<usize>,
 }
 
 impl HeldItemSaveData {
@@ -29,7 +34,32 @@ impl HeldItemSaveData {
             entity_in_left_hand: None,
             entity_in_right_hand: None,
             inventory_entity: None,
+            backpack_width: None,
         }
+    }
+
+    /// Re-encode an instantiated backpack from the width stored by the save to
+    /// the character sheet's current usable width. Missing or invalid metadata
+    /// is a legacy shock2quest save and therefore used the former fixed 15.
+    pub fn remap_instantiated_backpack(
+        &self,
+        world: &mut World,
+        inventory_entity: EntityId,
+        current_width: usize,
+    ) -> crate::inventory::WidthRemapOutcome {
+        let saved_width = self
+            .backpack_width
+            .filter(|width| {
+                (crate::inventory::BACKPACK_MIN_WIDTH..=crate::inventory::BACKPACK_GRID.0)
+                    .contains(width)
+            })
+            .unwrap_or(crate::inventory::BACKPACK_GRID.0);
+        crate::inventory::remap_container_width(
+            world,
+            inventory_entity,
+            (saved_width, crate::inventory::BACKPACK_GRID.1),
+            (current_width, crate::inventory::BACKPACK_GRID.1),
+        )
     }
 
     pub fn instantiate(
@@ -123,6 +153,8 @@ pub(crate) fn backfill_legacy_canonical_template_ids(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+    use shipyard::{Get, View};
 
     fn legacy_entity(name: &str) -> EntitySaveData {
         let old_entity = EntityId::new_from_index_and_gen(12, 1);
@@ -161,5 +193,68 @@ mod tests {
         let mut unmatched = legacy_entity("Mission Specific Object");
         backfill_legacy_canonical_template_ids(&mut unmatched, &HashMap::new());
         assert!(unmatched.canonical_template_ids.is_empty());
+    }
+
+    #[test]
+    fn legacy_fixed_width_backpack_fixture_migrates_row_ordinals() {
+        let mut source = World::new();
+        let old_inventory = source.add_entity(());
+        let old_items: Vec<_> = (0..3).map(|_| source.add_entity(())).collect();
+        let mut held_entities = EntitySaveData::empty();
+        held_entities.all_entities = std::iter::once(old_inventory)
+            .chain(old_items.iter().copied())
+            .map(EntityId::inner)
+            .collect();
+        held_entities.links.insert(
+            old_inventory.inner(),
+            serde_json::to_value(Links {
+                to_links: old_items
+                    .iter()
+                    .zip([0, 15, 30])
+                    .map(|(item, ordinal)| ToLink {
+                        to_template_id: 0,
+                        to_entity_id: Some(WrappedEntityId(*item)),
+                        link: Link::Contains(ordinal),
+                    })
+                    .collect(),
+            })
+            .unwrap(),
+        );
+        let mut fixture = HeldItemSaveData::empty();
+        fixture.held_entities = held_entities;
+        fixture.inventory_entity = Some(old_inventory.inner());
+
+        // This JSON shape is exactly what pre-#948 shock2quest wrote: no
+        // backpack-width metadata, and row ordinals encoded against width 15.
+        let mut legacy_json = serde_json::to_value(fixture).unwrap();
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("backpack_width");
+        let legacy: HeldItemSaveData = serde_json::from_value(legacy_json).unwrap();
+
+        let mut loaded = World::new();
+        let instantiated = legacy.instantiate_with_script_state(&mut loaded);
+        let inventory = instantiated.inventory_entity_id.unwrap();
+        let outcome = legacy.remap_instantiated_backpack(&mut loaded, inventory, 10);
+        assert!(outcome.overflow.is_empty());
+
+        let links = loaded.borrow::<View<Links>>().unwrap();
+        let mut ordinals: Vec<_> = links
+            .get(inventory)
+            .unwrap()
+            .to_links
+            .iter()
+            .filter_map(|link| match link.link {
+                Link::Contains(ordinal) => Some(ordinal),
+                _ => None,
+            })
+            .collect();
+        ordinals.sort_unstable();
+        assert_eq!(
+            ordinals,
+            vec![0, 10, 20],
+            "legacy row coordinates survive the 15-column to 10-column migration"
+        );
     }
 }

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -254,6 +254,7 @@ pub fn to_save_data_with_scripts(
         entity_in_right_hand: player.right_hand_entity_id.map(|ent| ent.inner()),
         held_entities: held_entity_data,
         inventory_entity: Some(player.inventory_entity_id.inner()),
+        backpack_width: Some(crate::inventory::grid_for(world, player.inventory_entity_id).0),
     };
     (world_entity_data, held_metadata)
 }

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -7,7 +7,7 @@ use shipyard::{EntityId, Get, View, World};
 
 use crate::{
     gui::{Gui, GuiComponent, GuiConfig, GuiCursor},
-    inventory::Inventory,
+    inventory::{Inventory, PlayerInventoryEntity, grid_for},
     scripts::{Message, script_util},
 };
 
@@ -81,6 +81,10 @@ const LOOT_GRID_ORIGIN: Vector2<f32> = Vector2::new(15.0, 153.0);
 /// paperdoll owns everything right of x = 527.
 const BACKPACK_GRID_ORIGIN: Vector2<f32> = Vector2::new(4.0, 17.0);
 
+/// `res/iface/BLOCK.PCX` is authored to cover one cell's 34x32 interior,
+/// leaving the separators in `INVBACK.PCX` visible around it.
+const BLOCK_SIZE: Vector2<f32> = Vector2::new(34.0, 32.0);
+
 impl ContainerGui {
     pub fn loot_container() -> ContainerGui {
         ContainerGui {
@@ -148,10 +152,31 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                 .with_size(vec2(self.width, self.height)),
         ];
 
+        // Resolve the usable grid once in panel pixels. Both flat and VR
+        // presentations consume this same component list, so blocked-cell and
+        // item placement cannot diverge at the presentation boundary.
+        let grid = grid_for(world, entity_id);
+        let is_backpack = world
+            .borrow::<View<PlayerInventoryEntity>>()
+            .is_ok_and(|backpacks| backpacks.get(entity_id).is_ok());
+        if is_backpack {
+            for y in 0..self.num_slots_y {
+                for x in grid.0..self.num_slots_x {
+                    components.push(
+                        gui::image("iface/block.pcx")
+                            .with_position(vec2(
+                                self.inv_offset_x + SLOT_PITCH.x * x as f32,
+                                self.inv_offset_y + SLOT_PITCH.y * y as f32,
+                            ))
+                            .with_size(BLOCK_SIZE),
+                    );
+                }
+            }
+        }
+
         // Items keep the cell stored on their containment link; see
         // `Inventory::from_container`.
-        let inventory =
-            Inventory::from_container(world, entity_id, (self.num_slots_x, self.num_slots_y));
+        let inventory = Inventory::from_container(world, entity_id, grid);
 
         let v_inv_dims = world.borrow::<View<PropInventoryDimensions>>().unwrap();
 
@@ -491,6 +516,40 @@ mod tests {
             ContainerGui::loot_container().get_config().world_offset,
             vec3(0.0, 1.0, 0.0)
         );
+    }
+
+    #[test]
+    fn backpack_covers_every_unusable_cell_with_shipped_block_art() {
+        let mut world = World::new();
+        let backpack = world.add_entity((PlayerInventoryEntity {}, Links::empty()));
+        world.add_unique(crate::quest_info::QuestInfo::new());
+
+        let components = ContainerGui::inv_container().get_components(
+            &None,
+            backpack,
+            &world,
+            &ContainerGuiState {},
+        );
+        let blocks: Vec<_> = components
+            .iter()
+            .filter_map(|component| match component {
+                GuiComponent::Image {
+                    texture,
+                    position,
+                    size,
+                    ..
+                } if texture == "iface/block.pcx" => Some((*position, *size)),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            blocks.len(),
+            15,
+            "Strength 1 blocks five columns x three rows"
+        );
+        assert_eq!(blocks[0], (vec2(354.0, 17.0), vec2(34.0, 32.0)));
+        assert_eq!(blocks[14], (vec2(494.0, 85.0), vec2(34.0, 32.0)));
     }
 
     /// Every icon a panel draws for a contained item - the grid buttons and

--- a/shock2vr/src/scripts/gui/trainer.rs
+++ b/shock2vr/src/scripts/gui/trainer.rs
@@ -21,10 +21,11 @@
 //! panel-open/close lifecycle to snapshot against). Costs are Normal
 //! difficulty (no difficulty setting exists yet).
 //!
-//! A stat is only sold when it has a live gameplay consumer. Endurance raises
-//! maximum HP and Cyber Affinity feeds hacking odds; Strength, Psionics, and
-//! Agility stay visible but unavailable until their advertised systems exist.
-//! This prevents a stored-only stat bump from consuming irreplaceable modules.
+//! A stat is only sold when it has a live gameplay consumer. Strength expands
+//! the backpack, Endurance raises maximum HP, and Cyber Affinity feeds hacking
+//! odds; Psionics and Agility stay visible but unavailable until their
+//! advertised systems exist. This prevents a stored-only stat bump from
+//! consuming irreplaceable modules.
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::gamesys::TrainerCostTables;
@@ -70,7 +71,7 @@ pub const ENDURANCE_HP_PER_LEVEL: u32 = 5;
 /// Keep this gate shared by display, immediate feedback, and authoritative
 /// effect handling so a future caller cannot bypass the module-loss guard.
 pub fn stat_upgrade_available(stat: Stat) -> bool {
-    matches!(stat, Stat::Endurance | Stat::CyberAffinity)
+    matches!(stat, Stat::Strength | Stat::Endurance | Stat::CyberAffinity)
 }
 
 /// The cost of buying `target`'s next level given the player's current sheet,
@@ -547,7 +548,12 @@ mod tests {
             upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::CyberAffinity)),
             Some(3)
         );
-        for unsupported in [Stat::Strength, Stat::PsionicAbility, Stat::Agility] {
+        assert_eq!(
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Strength)),
+            Some(3),
+            "Strength is purchasable once backpack capacity consumes it"
+        );
+        for unsupported in [Stat::PsionicAbility, Stat::Agility] {
             assert_eq!(
                 upgrade_quote(&costs, &stats, TrainerTarget::Stat(unsupported)),
                 None,

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -12,7 +12,7 @@
 //! `QuestInfo`, so it survives save/load and deck re-entry), and
 //! `Effect::AcquireOsTrait` applies the pick atomically. Live effects are
 //! implemented for the subset with existing consumers (Tank, Naturally Able,
-//! Pharmo-Friendly, Replicator Expert - see [`live_effect_note`]); everything else stays visible
+//! Pack-Rat, Pharmo-Friendly, Replicator Expert - see [`live_effect_note`]); everything else stays visible
 //! but cannot consume a one-shot machine or trait slot until its effect exists.
 
 use cgmath::{Vector2, Vector3, vec2};
@@ -49,6 +49,7 @@ pub const OS_TRAITS: [(u8, &str); 16] = [
 
 /// Retail trait ids with live gameplay effects here (see the effect handler).
 pub const TRAIT_NATURALLY_ABLE: u8 = 6;
+pub const TRAIT_PACK_RAT: u8 = 3;
 pub const TRAIT_PHARMO_FRIENDLY: u8 = 2;
 pub const TRAIT_TANK: u8 = 8;
 pub const TRAIT_REPLICATOR_EXPERT: u8 = 13;
@@ -399,6 +400,7 @@ pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
     match trait_id {
         TRAIT_TANK => Some("+5 max hit points"),
         TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
+        TRAIT_PACK_RAT => Some("+3 backpack slots"),
         TRAIT_PHARMO_FRIENDLY => Some("20% healing-item bonus"),
         TRAIT_REPLICATOR_EXPERT => Some("20% replicator discount"),
         _ => None,
@@ -486,5 +488,28 @@ mod tests {
             dark::properties::QuestBitValue::UNKNOWN,
             "a refused trait must leave the one-shot machine unused"
         );
+    }
+
+    #[test]
+    fn pack_rat_is_selectable_now_that_backpack_width_consumes_it() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let machine = world.add_entity((dark::properties::PropTemplateId { template_id: 133 },));
+
+        let (state, effect) = TraitGui.handle_msg(
+            machine,
+            &world,
+            &TraitGuiState::default(),
+            &TraitGuiMsg::Pick(TRAIT_PACK_RAT),
+        );
+
+        assert!(matches!(
+            effect,
+            Effect::AcquireOsTrait {
+                trait_id: TRAIT_PACK_RAT,
+                machine: selected_machine,
+            } if selected_machine == machine
+        ));
+        assert_eq!(state.message.as_deref(), Some("Pack-Rat installed."));
     }
 }

--- a/tools/shock2-sdk/test/inventory-strength.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-strength.e2e.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// Strength is load-bearing inventory state: the usable backpack width changes,
+// `Contains` ordinals must be re-encoded to keep (x,y), and the shipped BLOCK
+// art must cover every unavailable cell in both presentations.
+//
+// Negative-first: main exposes all 15 columns at baseline Strength 1, draws no
+// BLOCK art, and stores the four column-major items at 0,15,30,1 rather than
+// the Strength-1 width's 0,10,20,1.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8608);
+
+const isBlock = (element: UiElement) =>
+  element.kind === "image" &&
+  (element.texture ?? "").toLowerCase() === "iface/block.pcx";
+
+async function backpackOrdinals(game: GameServer): Promise<number[]> {
+  const info = await game.info();
+  const backpackId = info.player.inventory_entity_id;
+  assert.ok(backpackId != null, "mission exposes the live backpack entity");
+  const backpack = await game.entities.detail(backpackId);
+  return backpack.outgoing_links
+    .filter((link) => link.link_type.startsWith("Contains"))
+    .map((link) => link.contains_ordinal)
+    .filter((slot): slot is number => slot !== null && slot !== undefined)
+    .sort((a, b) => a - b);
+}
+
+async function clickElement(game: GameServer, element: UiElement) {
+  const [x, y, width, height] = element.screen_rect;
+  await game.input.set("pointer.position", [x + width / 2, y + height / 2]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+}
+
+async function standNear(game: GameServer, id: number) {
+  const [x, y, z] = (await game.entities.detail(id)).position;
+  for (const [dx, dz] of [
+    [0, 1.2],
+    [0, -1.2],
+    [1.2, 0],
+    [-1.2, 0],
+  ]) {
+    await teleportVerified(game, { x: x + dx, y: y + 0.5, z: z + dz });
+    await game.step({ frames: 30 });
+    const player = (await game.info()).player.position;
+    if (Math.hypot(player[0] - x, player[1] - y, player[2] - z) < 3) return;
+  }
+  assert.fail("could not find stable footing near the trait machine");
+}
+
+test(
+  "Strength grows the backpack without moving items and ordinals survive save/load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `inventory_strength_${Date.now()}`;
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal((await game.info()).player.stats?.strength, 1);
+    const items = await Promise.all([
+      game.player.spawnItem("Nanites"),
+      game.player.spawnItem("Nanites"),
+      game.player.spawnItem("Nanites"),
+      game.player.spawnItem("Nanites"),
+    ]);
+    assert.deepEqual(
+      await backpackOrdinals(game),
+      [0, 1, 10, 20],
+      "Strength-1 insertion uses the ten-column encoding",
+    );
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const before = await game.ui.state();
+    assert.ok(before.strip, "use mode exposes the backpack strip");
+    assert.equal(
+      before.strip.elements.filter(isBlock).length,
+      15,
+      "Strength 1 covers five columns x three rows",
+    );
+    const itemRects = items.map((item) =>
+      before.strip!.elements.find((element) => element.entity_id === item.entity_id)?.rect,
+    );
+    assert.equal(
+      itemRects.filter((rect) => rect !== undefined).length,
+      4,
+      "all four provisioned items render in the strip",
+    );
+
+    const raised = await game.player.setStats({ strength: 2 });
+    assert.equal(raised.strength, 2);
+    await game.step({ frames: 3 });
+    assert.deepEqual(
+      await backpackOrdinals(game),
+      [0, 1, 11, 22],
+      "row ordinals re-encode for width 11",
+    );
+    const after = await game.ui.state();
+    assert.ok(after.strip);
+    assert.equal(
+      after.strip.elements.filter(isBlock).length,
+      12,
+      "Strength 2 uncovers exactly one three-cell column",
+    );
+    for (const [index, item] of items.entries()) {
+      const afterRect: UiElement["rect"] | undefined = after.strip.elements.find(
+        (element) => element.entity_id === item.entity_id,
+      )?.rect;
+      assert.deepEqual(afterRect, itemRects[index], "the icon keeps its (x,y)");
+    }
+
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.stats?.strength, 2);
+    assert.deepEqual(
+      await backpackOrdinals(game),
+      [0, 1, 11, 22],
+      "save/load preserves the width-adjusted ordinals",
+    );
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 3 });
+    const loaded = await game.ui.state();
+    assert.ok(loaded.strip);
+    assert.equal(loaded.strip.elements.filter(isBlock).length, 12);
+  },
+);
+
+test(
+  "VR backpack uses the same Strength-1 blocked-cell layout",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+    await game.input.set("head.look", [0, 0]);
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+
+    const ui = await game.ui.state();
+    assert.ok(ui.active_panel, "MoveInventory opens the physical backpack panel");
+    assert.equal(
+      ui.active_panel.elements.filter(isBlock).length,
+      15,
+      "VR consumes the same five blocked columns x three rows",
+    );
+    const blockRects = ui.active_panel.elements.filter(isBlock).map((element) => element.rect);
+    assert.deepEqual(blockRects[0], [354, 17, 34, 32]);
+    const last = blockRects.at(-1);
+    assert.ok(last);
+    assert.ok(Math.abs(last[0] - 494) < 0.001, `last block x: ${last[0]}`);
+    assert.deepEqual(last.slice(1), [85, 34, 32]);
+  },
+);
+
+test(
+  "Pack-Rat is a live trait and adds one three-cell backpack column",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `inventory_pack_rat_${Date.now()}`;
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: basePort + 2,
+    });
+    await game.step({ frames: 5 });
+    await Promise.all([
+      game.player.spawnItem("Nanites"),
+      game.player.spawnItem("Nanites"),
+      game.player.spawnItem("Nanites"),
+    ]);
+    assert.deepEqual(await backpackOrdinals(game), [0, 10, 20]);
+
+    const machines = (await game.entities.list({ filter: "Trait Machine" })).entities;
+    const machine = machines.find((entity) => entity.template_id === 133);
+    assert.ok(machine, "medsci2 exposes its authored Trait Machine");
+    await standNear(game, machine.id);
+    await game.entities.sendMessage(machine.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const traitPanel = (await game.ui.state()).active_panel;
+    assert.ok(traitPanel, "frobbing the machine opens its authored panel");
+    const packRat = traitPanel.elements.find(
+      (element) => element.kind === "button" && element.label === "Pack-Rat",
+    );
+    assert.ok(packRat, "Pack-Rat is offered by the authored machine");
+    await clickElement(game, packRat);
+    await game.step({ frames: 3 });
+
+    assert.deepEqual((await game.info()).player.stats?.os_traits, [3]);
+    assert.deepEqual(
+      await backpackOrdinals(game),
+      [0, 11, 22],
+      "Pack-Rat re-encodes the existing rows for effective Strength 2",
+    );
+    // A machine MFD owns use mode without exposing the top strip. The first
+    // toggle exits that MFD; the second opens ordinary inventory use mode.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 3 });
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 3 });
+    const acquired = await game.ui.state();
+    assert.ok(acquired.strip);
+    assert.equal(
+      acquired.strip.elements.filter(isBlock).length,
+      12,
+      "Pack-Rat uncovers one full three-cell column",
+    );
+
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+    assert.deepEqual((await game.info()).player.stats?.os_traits, [3]);
+    assert.deepEqual(await backpackOrdinals(game), [0, 11, 22]);
+  },
+);

--- a/tools/shock2-sdk/test/trainer.e2e.test.ts
+++ b/tools/shock2-sdk/test/trainer.e2e.test.ts
@@ -11,8 +11,9 @@ import { teleportVerified } from "./helpers/teleport.js";
 // The four medsci1 trainer machines open category upgrade panels: rows list
 // the current level and the cost of the next level from the gamesys cost
 // tables (STATCOST 3/8/15/30/50 etc.). Only stats with live effects may be
-// bought: Endurance raises maximum HP, Cybernetics feeds the hacking path, and
-// storage-only stats refuse without spending modules.
+// bought: Strength expands the backpack, Endurance raises maximum HP,
+// Cybernetics feeds the hacking path, and storage-only stats refuse without
+// spending modules.
 //
 // Negative-first: on the C1 base, frobbing the Stats Trainer hits the
 // intentional SkillTrainerScript no-op stub (#424) - /v1/ui reports no active
@@ -21,7 +22,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8170);
 
 test(
-  "trainer MFD: Endurance 1->4 costs 26 modules and raises max HP persistently",
+  "trainer MFD: Strength expands inventory and Endurance raises max HP persistently",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     const saveName = `trainer_e2e_${Date.now()}`;
@@ -37,11 +38,26 @@ test(
       return s;
     };
 
-    // Provision only the currency; purchases still go through the real MFD,
+    // Provision only currency/items; purchases still go through the real MFD,
     // button messages, effect queue, cost table, and live player properties.
-    const funded = await game.player.setStats({ cyber_modules: 26 });
-    assert.equal(funded.cyber_modules, 26);
+    const funded = await game.player.setStats({ cyber_modules: 29 });
+    assert.equal(funded.cyber_modules, 29);
     assert.equal(funded.endurance, 1, "the regression starts at Endurance 1");
+    await Promise.all([
+      game.player.spawnItem("Nanites"),
+      game.player.spawnItem("Nanites"),
+      game.player.spawnItem("Nanites"),
+    ]);
+    const backpackOrdinals = async () => {
+      const backpackId = (await game.info()).player.inventory_entity_id;
+      assert.ok(backpackId != null);
+      return (await game.entities.detail(backpackId)).outgoing_links
+        .filter((link) => link.link_type.startsWith("Contains"))
+        .map((link) => link.contains_ordinal)
+        .filter((slot): slot is number => slot != null)
+        .sort((a, b) => a - b);
+    };
+    assert.deepEqual(await backpackOrdinals(), [0, 10, 20]);
     const beforePlayer = (await game.info()).player;
     const baseMaxHp = beforePlayer.max_hit_points;
     assert.ok(baseMaxHp != null, "player should have a maximum-HP pool");
@@ -88,7 +104,7 @@ test(
       )}`,
     );
     assert.ok(textEl("unavailable", els), "storage-only stats are marked unavailable");
-    assert.ok(textEl("modules: 26", els), "panel shows the module pool");
+    assert.ok(textEl("modules: 29", els), "panel shows the module pool");
 
     // --- A storage-only stat refuses without taking currency. The same
     // machine then remains usable for a supported purchase. ---
@@ -106,7 +122,7 @@ test(
       await game.input.set("pointer.pressed", 0);
       await game.step({ frames: 2 });
     };
-    await clickElement(rowButton("Strength", els));
+    await clickElement(rowButton("Agility", els));
     await game.step({ frames: 3 });
     assert.deepEqual(await stats(), funded, "refused stat leaves the sheet and modules unchanged");
     assert.equal(
@@ -118,6 +134,25 @@ test(
     assert.ok(
       textEl("Upgrade unavailable", refreshed.active_panel!.elements),
       "the panel explains the refusal",
+    );
+
+    // Strength is now a live purchase: its 1->2 upgrade costs 3 modules and
+    // re-encodes existing row ordinals for the new eleven-column backpack.
+    await clickElement(rowButton("Strength", refreshed.active_panel!.elements));
+    await game.step({ frames: 3 });
+    const afterStrength = await stats();
+    assert.equal(afterStrength.strength, 2);
+    assert.equal(afterStrength.cyber_modules, 26);
+    assert.deepEqual(await backpackOrdinals(), [0, 11, 22]);
+    assert.equal(
+      (await game.info()).player.max_hit_points,
+      baseMaxHp,
+      "Strength does not change live HP",
+    );
+    refreshed = await game.ui.state();
+    assert.ok(
+      textEl("Upgrade complete", refreshed.active_panel!.elements),
+      "the panel confirms the live Strength purchase",
     );
 
     // --- Reproduce issue #813's exact transaction: levels 1->4 cost
@@ -146,6 +181,7 @@ test(
     await game.load(saveName);
     await game.step({ frames: 3 });
     const afterLoad = await stats();
+    assert.equal(afterLoad.strength, 2, "Strength survives save/load");
     assert.equal(afterLoad.endurance, 4, "Endurance survives save/load");
     assert.equal(afterLoad.cyber_modules, 0, "spent balance survives save/load");
     assert.equal(
@@ -157,6 +193,11 @@ test(
     await game.transitionLevel("eng1.mis");
     await game.step({ frames: 3 });
     const afterTransition = await stats();
+    assert.equal(
+      afterTransition.strength,
+      2,
+      "Strength survives a level transition",
+    );
     assert.equal(
       afterTransition.endurance,
       4,


### PR DESCRIPTION
## Summary

- derive the player backpack usable width from effective Strength: `clamp(Strength + Pack-Rat, 1..6) + 9`, producing 10..15 columns and 3 rows
- render shipped `iface/BLOCK.PCX` over every unavailable backpack cell in the shared GUI component layout used by flat and VR
- re-encode containment ordinals after Strength or Pack-Rat changes, preserving fitting coordinates and deterministically re-placing right-edge items without overlap or loss
- enable the now-live Strength trainer purchase and Pack-Rat O/S trait
- migrate pre-#948 saves whose backpack ordinals were encoded at the legacy fixed width of 15

## Resize behavior

Items that still fit keep their exact `(x, y)`. Remaining items are first-fit packed in column-major order. A physical true-overflow item is placed beside the player and detached only after physics creation succeeds. A modelless overflow item retains its Contains link at a unique non-cell pending ordinal, so it is neither duplicated nor lost and can be recovered by a later capacity increase.

Normal gameplay currently only raises Strength and acquires Pack-Rat; it has no path that lowers Strength or removes O/S traits. The shrink and full-overflow paths are defensive coverage for future effects and imported state.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib`: 884 passed, 0 failed
- focused inventory/layout/trait/trainer unit tests: all passed
- serialized legacy-save fixture: 15-wide ordinals 0/15/30 migrate to Strength-1 ordinals 0/10/20
- `npm test`: 302 total, 26 passed, 0 failed, 276 skipped
- focused 25AE SDK scenarios with `DARK_ASSET_PATH=/Users/bryan/ss2-25th`: 4 passed, 0 failed
  - Strength grow, coordinate-preserving ordinal remap, blocked art, save/load
  - VR blocked-cell layout parity
  - authored Pack-Rat machine and persistence
  - authored Strength trainer purchase and persistence
- full explicit 25AE SDK E2E: 302 total, 292 passed, 3 failed, 7 skipped; all new tests and all 23 mission loads passed
- the 3 failures were rerun in isolation on this branch and exact base `e8136855` with the same 25AE path; all three reproduced with identical signatures on base:
  - Watts creature-loot active log mismatch
  - Hydro3 Korenchkin transcript predicate mismatch
  - patroller resume unsupported save pose

25AE sentinel: `/Users/bryan/ss2-25th/sshock2.kpf`, SHA-256 `35597daf68cf3e0c811cd9b9d24a9604d2cffa1d2c793985056b8946c538c6bd`.

## Device

Quest verification was preflighted but could not run because `adb` is not installed (`zsh: command not found: adb`). No device evidence is claimed.

## Visuals

![Strength-scaled backpack remap](https://gist.githubusercontent.com/tommy-xr/3097689e3f24d1aa507105fd1c0a2838/raw/issue-948-strength-remap.gif)

<sub>Strength 1 → 2 unlocks one three-cell backpack column while four real Nanite stacks keep their player-visible cells. Captured headlessly from final head `de1ee6dc` with explicit 25AE assets and deterministic fixed-timestep stepping.</sub>

### Before → after

![Matched base and fix backpack](https://gist.githubusercontent.com/tommy-xr/3097689e3f24d1aa507105fd1c0a2838/raw/issue-948-before-after.png)

<sub>Matched identical requests on exact base `e8136855` (left) and final head `de1ee6dc` (right): base exposes all 15 columns at Strength 1; the fix uses shipped `iface/BLOCK.PCX` art for the five unavailable columns.</sub>

### Flat / VR parity

![Flat and VR backpack parity](https://gist.githubusercontent.com/tommy-xr/3097689e3f24d1aa507105fd1c0a2838/raw/issue-948-flat-vr-parity.png)

<sub>The shared inventory canvas produces the same blocked columns and item cells in the flatscreen strip and VR world panel.</sub>

Fixes #948



