### PR TITLE
fix(vr): reject item offers to live creatures

### DIFF
--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -274,6 +274,23 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
         !self.require_lootable_creature || creature_is_lootable(world, entity_id)
     }
 
+    /// Keep the offer policy consistent with the loot gate. A living,
+    /// killable creature cannot expose its container, so accepting an item
+    /// here would hide it behind an inaccessible `Contains` link. Claim the
+    /// offer without a transfer; the VR hand's preceding `DropItem` effect
+    /// then leaves the item as an ordinary physical world drop. Corpses,
+    /// invulnerable posed creatures, and plain containers retain the shared
+    /// `DropEntityInfo` fallback by returning `None`.
+    fn on_provide_for_consumption(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        _provided_entity_id: EntityId,
+    ) -> Option<Effect> {
+        (self.require_lootable_creature && !creature_is_lootable(world, entity_id))
+            .then_some(Effect::NoEffect)
+    }
+
     fn handle_msg(
         &self,
         _entity_id: EntityId,
@@ -387,7 +404,7 @@ mod tests {
     use crate::gui::GuiInputInfo;
     use crate::mission::PlayerInfo;
     use cgmath::{Quaternion, point2, vec3};
-    use dark::properties::{FrobFlag, Links, PropFrobInfo, ToLink, WrappedEntityId};
+    use dark::properties::{FrobFlag, Links, PropFrobInfo, PropHitPoints, ToLink, WrappedEntityId};
 
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
@@ -740,6 +757,50 @@ mod tests {
         assert!(
             matches!(event, ContainerGuiMsg::Frob(e) if e == item),
             "clicking a backpack item should Frob (use) it"
+        );
+    }
+
+    /// A live killable creature keeps its loot panel sealed, so accepting an
+    /// offered VR-hand item into the same container would make the item
+    /// inaccessible. Claim the offer as a no-op and let the hand's ordinary
+    /// DropItem effect leave it in the world instead.
+    #[test]
+    fn live_creature_rejects_offered_items() {
+        let mut world = World::new();
+        let live_creature = world.add_entity((PropHitPoints { hit_points: 10 }, Links::empty()));
+        let item = world.add_entity(());
+
+        let effect =
+            ContainerGui::loot_creature().on_provide_for_consumption(live_creature, &world, item);
+
+        assert!(
+            matches!(effect, Some(Effect::NoEffect)),
+            "a live creature must claim and reject the offer, got {:?}",
+            effect
+        );
+    }
+
+    /// Dead creature containers and ordinary containers remain valid deposit
+    /// targets: returning None selects GuiScript's shared DropEntityInfo
+    /// fallback for both.
+    #[test]
+    fn lootable_and_ordinary_containers_accept_offered_items() {
+        let mut world = World::new();
+        let corpse = world.add_entity((PropHitPoints { hit_points: 0 }, Links::empty()));
+        let ordinary_container = world.add_entity(Links::empty());
+        let item = world.add_entity(());
+
+        assert!(
+            ContainerGui::loot_creature()
+                .on_provide_for_consumption(corpse, &world, item)
+                .is_none(),
+            "a dead creature must preserve the normal deposit fallback",
+        );
+        assert!(
+            ContainerGui::loot_container()
+                .on_provide_for_consumption(ordinary_container, &world, item,)
+                .is_none(),
+            "an ordinary container must preserve the normal deposit fallback",
         );
     }
 }

--- a/tools/shock2-sdk/test/earth-vr-live-creature-offer.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-vr-live-creature-offer.e2e.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// Regression for #1064. A VR squeeze release always performs the ordinary
+// world DropItem first, then offers the item to whatever the held-hand ray is
+// over. Generic GUI hosts accept that offer as a container deposit. That is
+// correct for ordinary containers and corpses, but a living killable creature
+// deliberately keeps the same container sealed; accepting the offer used to
+// hide the weapon behind an inaccessible Contains link.
+//
+// This runs against the exact authored Earth Weapons subjects from the
+// campaign repro. Stable mission identities are discovered each launch;
+// runtime entity ids are never hardcoded. Raw teleport is focused setup only:
+// acquisition, the failing release, ray selection, and re-grab all use the
+// production VR hand pose and squeeze edge.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const EARTH_PISTOL = 246;
+const EARTH_TRAINING_DROID = 547;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+function property(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((candidate) => candidate.name === name)?.value;
+}
+
+async function droidContainsPistol(
+  game: GameServer,
+  droidId: number,
+  pistolId: number,
+): Promise<boolean> {
+  return (await game.entities.detail(droidId)).outgoing_links.some(
+    (link) =>
+      link.target_id === pistolId && link.link_type.startsWith("Contains"),
+  );
+}
+
+async function assertPhysicalWorldPistol(
+  game: GameServer,
+  pistolId: number,
+): Promise<void> {
+  assert.equal(
+    property(await game.entities.detail(pistolId), "HasRefs")?.toLowerCase(),
+    "true",
+    "released pistol must remain world-referenced",
+  );
+  const bodies = (await game.physics.bodies({ entityId: pistolId })).bodies;
+  assert.equal(bodies.length, 1, "released pistol must have one physics body");
+  assert.ok(
+    bodies[0].is_enabled && bodies[0].collision_groups.includes("entity"),
+    `released pistol must have an enabled entity body: ${JSON.stringify(bodies[0])}`,
+  );
+}
+
+test(
+  "Earth VR release over a live Training Droid remains a re-grabbable world pistol",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = only(
+      await game.entities.byTemplate(EARTH_PISTOL),
+      "Earth Weapons Pistol 246",
+    );
+    const droid = only(
+      await game.entities.byTemplate(EARTH_TRAINING_DROID),
+      "Earth Training Droid 547",
+    );
+    assert.ok(
+      Number(property(await game.entities.detail(droid.id), "HitPoints")) > 0,
+      "the offer target must be a living killable Training Droid",
+    );
+    assert.equal(
+      await droidContainsPistol(game, droid.id, pistol.id),
+      false,
+      "the droid must not start with the pistol",
+    );
+
+    // Focused setup: stand beside the authored weapon, then acquire it with
+    // the production VR ray+squeeze path.
+    await teleportVerified(game, {
+      x: pistol.position[0] + 1.0,
+      y: pistol.position[1] + 0.5,
+      z: pistol.position[2] + 1.0,
+    });
+    const pistolAim = await game.player.aimAt(pistol.id, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(pistolAim.target_confirmed, true, JSON.stringify(pistolAim));
+    await aimVrHandAt(game, pistolAim.world_point, 0.35, 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol.id,
+      "production squeeze must hold the authored pistol",
+    );
+
+    // Carry the held pistol to the live target and keep the hand ray on its
+    // classified body when opening the grip: this is the exact #1064 edge.
+    await teleportVerified(game, {
+      x: droid.position[0] + 1.2,
+      y: droid.position[1] + 0.5,
+      z: droid.position[2] + 1.2,
+    });
+    const droidAim = await game.player.aimAt(droid.id, {
+      hitbox: "torso",
+      visibility: "required",
+    });
+    assert.equal(droidAim.entity_id, droid.id, JSON.stringify(droidAim));
+    assert.equal(droidAim.visibility.state, "visible", JSON.stringify(droidAim));
+    await aimVrHandAt(game, droidAim.world_point, 0.45, 1);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 8 });
+
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.equal(
+      await droidContainsPistol(game, droid.id, pistol.id),
+      false,
+      "a living creature must reject the offer instead of containing the pistol",
+    );
+    await assertPhysicalWorldPistol(game, pistol.id);
+
+    // Player-observable recovery: select the dropped body through the real
+    // interaction ray, then squeeze it back into the same hand.
+    const dropped = only(
+      await game.entities.byTemplate(EARTH_PISTOL),
+      "released Earth Pistol 246",
+    );
+    const droppedAim = await game.player.aimAt(dropped.id, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(droppedAim.target_confirmed, true, JSON.stringify(droppedAim));
+    await aimVrHandAt(game, droppedAim.world_point, 0.35, 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol.id,
+      "the world pistol must be re-grabbable through production VR input",
+    );
+
+    // Clear-ray release remains the ordinary world-drop control.
+    await game.input.set("right_hand.position", [0.45, -0.15, -0.65]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 8 });
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.equal(await droidContainsPistol(game, droid.id, pistol.id), false);
+    await assertPhysicalWorldPistol(game, pistol.id);
+  },
+);


### PR DESCRIPTION
## Summary

- reject held-item offers to living, killable creature containers, keeping the VR hand's ordinary physical world drop
- preserve deposits into dead/invulnerable creature containers and ordinary containers
- cover the exact Earth Weapons Pistol 246 → live Training Droid 547 release, world presence, ray selection, re-grab, and clear-ray release

## Root cause and semantics

VR squeeze release emits `DropItem` before offering the held item to the entity under the hand ray. Generic GUI fallback turns an unclaimed offer into `DropEntityInfo`. A living creature's `creaturecontainer` deliberately refuses to open, so accepting an offer there hid the item behind an inaccessible `Contains` link.

`ContainerGui::on_provide_for_consumption` now uses the container's existing lootability predicate. A sealed live creature claims the offer as `NoEffect`, leaving the preceding physical drop intact. Lootable creatures and ordinary containers still return `None` and use the shared deposit fallback.

## Verification

- negative-first Rust regression failed before the implementation with `a live creature must claim and reject the offer, got None`
- `cargo test -p shock2vr scripts::gui::container::tests --lib` — 11 passed after rebasing onto current `main`
- `cargo test -p shock2vr --lib` — 879 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `npm run build` in `tools/shock2-sdk`
- focused 25AE `earth.mis --vr` SDK regression — passed after the final fixed-branch rebuild
- standing MedSci2 VR clear-ray release / re-grab / save-load regression — passed
- broad SDK e2e sweep was bounded after 55 passes; 3 failures were isolated and reproduced identically on this fix and parent `05523db1`, so they are unrelated baseline failures: two Eng2 Cargo Bay keycard assertions and Creature Loot's final audio-reader binding assertion

## Campaign

`earth-to-hydro · detailed · 25th Anniversary · vr · seed 1600004333`

Discovered while playtesting on cumulative campaign commit `05523db1`; the review branch is independently rebased onto current `main` and contains only the #1064 fix.

Fixes #1064


<!-- pr-visuals:1065 -->
## Visual verification

![Live-creature offer recovery demo](https://gist.githubusercontent.com/tommy-xr/b2774a329b27bd205c32f4a0fdc1d180/raw/pr1065-pistol-recovery.gif)

<sub>Fixed `earth.mis --vr`: release Pistol 246 over the live Training Droid 547, select the surviving physical world pistol with the production hand ray, then squeeze it back into the same hand. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Base containment bug versus fixed physical pistol](https://gist.githubusercontent.com/tommy-xr/b2774a329b27bd205c32f4a0fdc1d180/raw/pr1065-before-after.png)
<!-- /pr-visuals:1065 -->
