### PR TITLE
fix(render): make overlay composition explicit

### DIFF
--- a/engine/src/gl_engine.rs
+++ b/engine/src/gl_engine.rs
@@ -19,7 +19,7 @@ fn init(is_opengl_es: bool, storage: Arc<dyn crate::file_system::Storage>) -> Op
 
 use crate::engine::Engine;
 use crate::engine::EngineRenderContext;
-use crate::scene::scene::Scene;
+use crate::scene::{RenderLayer, scene::Scene};
 
 impl Engine for OpenGLEngine {
     fn get_storage(&self) -> Arc<dyn crate::file_system::Storage> {
@@ -111,39 +111,29 @@ impl Engine for OpenGLEngine {
             // // );
             // floor.draw(&self, render_context, &view);
 
-            // The scene may end with an overlay group (e.g. the first-person
-            // viewmodel + its attachments + HUD): everything from the first
-            // `clear_depth` object onward. It renders AFTER the world's opaque
-            // and transparent passes, so the depth clear does not wipe the
-            // world's depth mid-frame - otherwise the world's transparent pass
-            // depth-tests against an almost-empty buffer and transparent
-            // surfaces (glass, particles) bleed through walls whenever a
-            // viewmodel is up. With no `clear_depth` object (VR, no weapon)
-            // the overlay group is empty and rendering is unchanged.
-            //
-            // NB: this assumes overlay objects come AFTER the world in the
-            // scene list (desktop/debug append per-eye objects last; the
-            // oculus runtime prepends them instead, which is fine only while
-            // nothing in VR sets `clear_depth`).
-            let objects = scene.objects();
-            let overlay_start = objects
-                .iter()
-                .position(|s| s.clear_depth)
-                .unwrap_or(objects.len());
-            let (world, overlay) = objects.split_at(overlay_start);
+            // Composition is keyed explicitly: debug/desktop append per-eye
+            // objects while Oculus prepends them, but both must render world,
+            // scene effects, scene UI, then system UI. Each non-world layer
+            // starts with one depth clear at its group boundary, never from an
+            // individual object mid-pass.
+            for layer in RenderLayer::ORDERED {
+                if scene.objects_in_layer(layer).next().is_none() {
+                    continue;
+                }
+                if layer.clears_depth() {
+                    gl::Clear(gl::DEPTH_BUFFER_BIT);
+                }
 
-            for group in [world, overlay] {
                 // SINGLE-PASS LIGHTING: Opaque pass with all lighting calculated
-                // in shaders. (The overlay group's first object carries the
-                // depth clear, executed in its draw_opaque.)
-                group
-                    .iter()
+                // in shaders.
+                scene
+                    .objects_in_layer(layer)
                     .for_each(|s| s.draw_opaque(self, render_context, &view, scene.lights()));
 
                 // Transparent pass with all lighting calculated in shaders
                 gl::DepthMask(gl::FALSE);
-                group
-                    .iter()
+                scene
+                    .objects_in_layer(layer)
                     .for_each(|s| s.draw_transparent(self, render_context, &view, scene.lights()));
                 gl::DepthMask(gl::TRUE);
             }

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -24,7 +24,7 @@ mod billboard_material;
 pub use billboard_material::*;
 
 pub mod scene_object;
-pub use scene_object::{FrontFaceWinding, SceneObject, SceneObjectDebugTag};
+pub use scene_object::{FrontFaceWinding, RenderLayer, SceneObject, SceneObjectDebugTag};
 
 pub mod renderable;
 pub use renderable::{

--- a/engine/src/scene/scene.rs
+++ b/engine/src/scene/scene.rs
@@ -1,5 +1,5 @@
-use crate::scene::light::LightArray;
 pub use crate::scene::scene_object::SceneObject;
+use crate::scene::{RenderLayer, light::LightArray};
 
 /// Legacy scene type - simple vector of scene objects
 pub type LegacyScene = Vec<SceneObject>;
@@ -40,6 +40,14 @@ impl Scene {
     /// Get a reference to the scene objects
     pub fn objects(&self) -> &[SceneObject] {
         &self.objects
+    }
+
+    /// Objects in one explicit composition layer, preserving their authored
+    /// order within that layer regardless of how a host concatenated sources.
+    pub fn objects_in_layer(&self, layer: RenderLayer) -> impl Iterator<Item = &SceneObject> {
+        self.objects
+            .iter()
+            .filter(move |object| object.render_layer() == layer)
     }
 
     /// Get a mutable reference to the scene objects
@@ -105,5 +113,49 @@ impl std::ops::Deref for Scene {
 impl std::ops::DerefMut for Scene {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.objects
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scene::{color_material, cube};
+    use cgmath::{Matrix4, Vector3};
+
+    fn object(layer: RenderLayer, marker: f32) -> SceneObject {
+        let mut object = SceneObject::new(
+            color_material::create(Vector3::new(1.0, 1.0, 1.0)),
+            Box::new(cube::create()),
+        );
+        object.set_render_layer(layer);
+        object.set_transform(Matrix4::from_translation(Vector3::new(marker, 0.0, 0.0)));
+        object
+    }
+
+    fn render_markers(scene: &Scene) -> Vec<f32> {
+        RenderLayer::ORDERED
+            .into_iter()
+            .flat_map(|layer| scene.objects_in_layer(layer))
+            .map(|object| object.get_transform().w.x)
+            .collect()
+    }
+
+    #[test]
+    fn explicit_layers_make_host_concatenation_order_irrelevant() {
+        let flat = Scene::from_objects(vec![
+            object(RenderLayer::World, 1.0),
+            object(RenderLayer::SceneOverlay, 2.0),
+            object(RenderLayer::SceneUi, 3.0),
+            object(RenderLayer::SystemOverlay, 4.0),
+        ]);
+        let quest = Scene::from_objects(vec![
+            object(RenderLayer::SceneUi, 3.0),
+            object(RenderLayer::SystemOverlay, 4.0),
+            object(RenderLayer::World, 1.0),
+            object(RenderLayer::SceneOverlay, 2.0),
+        ]);
+
+        assert_eq!(render_markers(&flat), vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(render_markers(&quest), vec![1.0, 2.0, 3.0, 4.0]);
     }
 }

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -36,6 +36,45 @@ pub enum FrontFaceWinding {
     CounterClockwise,
 }
 
+/// The explicit composition layer for a scene object.
+///
+/// Hosts may gather the main scene and per-eye objects in either order. The
+/// renderer therefore consumes this key, rather than vector position, to keep
+/// view-locked effects and UI composited identically on every host.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum RenderLayer {
+    /// Ordinary world geometry, rendered against the frame's initial depth.
+    World,
+    /// View-locked scene effects over the world but behind scene UI.
+    SceneOverlay,
+    /// Viewmodels, HUDs, MFDs, and other scene-owned per-eye UI.
+    SceneUi,
+    /// System-owned UI such as the pause menu and final screen fade.
+    SystemOverlay,
+}
+
+impl RenderLayer {
+    pub const ORDERED: [Self; 4] = [
+        Self::World,
+        Self::SceneOverlay,
+        Self::SceneUi,
+        Self::SystemOverlay,
+    ];
+
+    pub fn clears_depth(self) -> bool {
+        self != Self::World
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::World => "world",
+            Self::SceneOverlay => "scene_overlay",
+            Self::SceneUi => "scene_ui",
+            Self::SystemOverlay => "system_overlay",
+        }
+    }
+}
+
 /// Provenance for a scene object, so tooling can report *what* the renderer was
 /// handed. Never read by the renderer itself; a game layer may filter its own
 /// scene by `source` before submitting it (shock2vr drops the player's hands
@@ -60,11 +99,7 @@ pub struct SceneObject {
     pub local_transform: Matrix4<f32>, //hack...
     pub skinning_data: [Matrix4<f32>; crate::scene::SKINNING_PALETTE_SIZE],
     pub depth_write: bool,
-    /// When true, the depth buffer is cleared *before* drawing this object, so it
-    /// (and anything drawn after it) renders on top of the world while still
-    /// depth-testing normally within itself. Used to draw the flatscreen
-    /// first-person weapon viewmodel without clipping into geometry.
-    pub clear_depth: bool,
+    render_layer: RenderLayer,
     /// Per-object transparency override (0.0 = opaque, 1.0 = invisible).
     /// Materials are shared (`Rc`) across every object using the same model, so
     /// a lasting material-level override would bleed between entities; instead
@@ -247,7 +282,7 @@ impl SceneObject {
             local_transform: Matrix4::identity(),
             skinning_data: [Matrix4::identity(); crate::scene::SKINNING_PALETTE_SIZE],
             depth_write: true,
-            clear_depth: false,
+            render_layer: RenderLayer::World,
             transparency_override: None,
             debug_tag: None,
             backface_culling: None,
@@ -268,11 +303,6 @@ impl SceneObject {
         }
 
         let xform = self.transform * self.local_transform;
-        // Clear the depth buffer first so this (and later objects) draw on top of
-        // the world while still depth-testing normally amongst themselves.
-        if self.clear_depth {
-            unsafe { gl::Clear(gl::DEPTH_BUFFER_BIT) };
-        }
         if !self.depth_write {
             unsafe { gl::DepthMask(gl::FALSE) };
         }
@@ -378,7 +408,7 @@ impl SceneObject {
             local_transform: Matrix4::identity(),
             skinning_data: [Matrix4::identity(); crate::scene::SKINNING_PALETTE_SIZE],
             depth_write: true,
-            clear_depth: false,
+            render_layer: RenderLayer::World,
             transparency_override: None,
             debug_tag: None,
             backface_culling: None,
@@ -393,7 +423,7 @@ impl SceneObject {
             local_transform: self.local_transform,
             skinning_data: self.skinning_data,
             depth_write: self.depth_write,
-            clear_depth: self.clear_depth,
+            render_layer: self.render_layer,
             transparency_override: self.transparency_override,
             debug_tag: self.debug_tag.clone(),
             backface_culling: self.backface_culling,
@@ -404,8 +434,12 @@ impl SceneObject {
         self.depth_write = enabled;
     }
 
-    pub fn set_clear_depth(&mut self, enabled: bool) {
-        self.clear_depth = enabled;
+    pub fn set_render_layer(&mut self, layer: RenderLayer) {
+        self.render_layer = layer;
+    }
+
+    pub fn render_layer(&self) -> RenderLayer {
+        self.render_layer
     }
 
     pub fn set_backface_culling(&mut self, front_face: Option<FrontFaceWinding>) {

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -295,6 +295,10 @@ pub struct SceneObjectSummary {
     /// Transparency in effect for this draw (0.0 = opaque, 1.0 = invisible).
     pub transparency: Option<f32>,
     pub depth_write: bool,
+    /// Explicit renderer composition layer.
+    pub render_layer: String,
+    /// Backwards-compatible indication that this object begins a depth-cleared
+    /// layer. Depth is cleared once by the renderer, not by the object.
     pub clear_depth: bool,
     /// Front-face winding used for culling, or absent when double-sided.
     pub backface_culling: Option<String>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -869,11 +869,14 @@ fn run_game_blocking(
 /// Process a command from the HTTP server
 /// Describe the scene objects submitted to the renderer, for `/v1/scene`.
 fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneObjectSummary> {
+    let mut seen_layers = HashSet::new();
     scene
         .iter()
         .map(|obj| {
             let tag = obj.debug_tag();
             let translation = obj.get_transform().w;
+            let render_layer = obj.render_layer();
+            let first_in_layer = seen_layers.insert(render_layer);
             commands::SceneObjectSummary {
                 entity_id: tag.and_then(|t| t.entity_id),
                 name: tag.and_then(|t| t.name.clone()),
@@ -882,7 +885,8 @@ fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneO
                 position: [translation.x, translation.y, translation.z],
                 transparency: obj.effective_transparency(),
                 depth_write: obj.depth_write,
-                clear_depth: obj.clear_depth,
+                render_layer: render_layer.as_str().to_owned(),
+                clear_depth: render_layer.clears_depth() && first_in_layer,
                 backface_culling: obj.backface_culling().map(|w| format!("{w:?}")),
             }
         })
@@ -1603,6 +1607,7 @@ fn process_command(
                     position: o.position,
                     transparency: o.transparency,
                     depth_write: o.depth_write,
+                    render_layer: o.render_layer.clone(),
                     clear_depth: o.clear_depth,
                     backface_culling: o.backface_culling.clone(),
                 })

--- a/shock2vr/src/hit_feedback.rs
+++ b/shock2vr/src/hit_feedback.rs
@@ -31,7 +31,7 @@
 //! flicker and a shotgun blast is unmistakable.
 
 use cgmath::{Matrix4, Quaternion, Vector3, vec3};
-use engine::scene::SceneObject;
+use engine::scene::{RenderLayer, SceneObject};
 
 /// Damage that produces a full-strength tint. The player's authored pool is 30
 /// hit points (`The Player`, `P$HitPoints`), so this is "a bit over a third of
@@ -297,13 +297,10 @@ fn hit_layer(
     // Translucent: writing depth here would let the layer occlude anything
     // drawn after it in the same overlay group.
     object.set_depth_write(false);
-    // The layer must cover the world regardless of what the player is standing
-    // in front of, so it starts an overlay group (see `pause_menu`'s dim - the
-    // renderer treats everything from the first `clear_depth` object onward as
-    // a group drawn after the world's passes). `Game` emits it before the
-    // pause menu's objects, so a hit that lands as the menu opens stays behind
-    // the panel.
-    object.set_clear_depth(true);
+    // The layer covers the world but stays behind scene-owned UI. The renderer
+    // orders this key explicitly, so host concatenation cannot move the tint
+    // over the HUD on Quest or under the world on flat/debug.
+    object.set_render_layer(RenderLayer::SceneOverlay);
     object.set_debug_tag(Some(crate::util::render_source_tag(
         crate::util::render_source::HIT_FEEDBACK,
     )));
@@ -554,10 +551,7 @@ mod tests {
             .effective_transparency()
             .expect("the tint must draw translucent, not opaque");
         assert!(transparency > 0.0 && transparency < 1.0);
-        assert!(
-            object.clear_depth,
-            "a layer depth-tested against the world would only tint what is far away"
-        );
+        assert_eq!(object.render_layer(), RenderLayer::SceneOverlay);
         assert_eq!(
             object.debug_tag().and_then(|tag| tag.source.clone()),
             Some(crate::util::render_source::HIT_FEEDBACK.to_owned())

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -130,7 +130,7 @@ use engine::{
     audio::{AudioClip, AudioContext},
     file_system::Storage,
     game_log,
-    scene::SceneObject,
+    scene::{RenderLayer, SceneObject},
 };
 
 use mission::entity_populator::{EntityPopulator, MissionEntityPopulator, SaveFileEntityPopulator};
@@ -1835,13 +1835,9 @@ impl Game {
         // pawn transform the runtime builds its camera from.
         let pawn_to_world = Matrix4::from_translation(pos) * Matrix4::from(rot);
 
-        // The hit tint, before the pause menu's objects: it is the first
-        // `clear_depth` object when nothing else is up, so it opens the overlay
-        // group and covers the world; and when the menu *is* up it is still
-        // first in that group, so the panel and its dim draw over it rather
-        // than under a red rim. Emitted from `render` (not `render_per_eye`)
-        // for the reason recorded on `hit_feedback::hit_layer`, and identically
-        // in flat and VR - it is view-locked, so only the eye pose differs.
+        // The hit tint occupies the explicit scene-overlay layer: over the
+        // world, behind scene UI and the pause menu, identically in flat and
+        // VR. It remains view-locked, so only the eye pose differs.
         let (mut eye_position, eye_forward) =
             hit_feedback::eye_pose(self.head_pose.0, self.head_pose.1);
         // Centre the layer on the eye the frame is actually drawn from, which
@@ -1860,10 +1856,13 @@ impl Game {
             scene.push(layer);
         }
 
-        scene.extend(
+        let mut pause_objects =
             self.pause_menu
-                .render(&mut self.asset_cache, &self.options, pawn_to_world),
-        );
+                .render(&mut self.asset_cache, &self.options, pawn_to_world);
+        for object in &mut pause_objects {
+            object.set_render_layer(RenderLayer::SystemOverlay);
+        }
+        scene.extend(pause_objects);
 
         // let font = File::open(resource_path("res/fonts/mainfont.FON")).unwrap();
         // let mut font_reader = BufReader::new(font);
@@ -1914,14 +1913,19 @@ impl Game {
                 &self.options,
             )
         };
+        for object in &mut objs {
+            if object.render_layer() == RenderLayer::World {
+                object.set_render_layer(RenderLayer::SceneUi);
+            }
+        }
 
-        // Drawn last so the pause panel sits over the scene's own screen-space
-        // UI (viewmodel, HUD, MFD).
-        objs.extend(self.pause_menu.render_per_eye(
-            &mut self.asset_cache,
-            screen_size,
-            &self.options,
-        ));
+        let mut pause_objects =
+            self.pause_menu
+                .render_per_eye(&mut self.asset_cache, screen_size, &self.options);
+        for object in &mut pause_objects {
+            object.set_render_layer(RenderLayer::SystemOverlay);
+        }
+        objs.extend(pause_objects);
 
         let world_position = vec3(0.0, 1.0, 0.0);
         let screen_width = screen_size.x;
@@ -2112,10 +2116,16 @@ impl App {
         projection: Matrix4<f32>,
         screen_size: Vector2<f32>,
     ) -> Vec<SceneObject> {
-        match self {
+        let mut objects = match self {
             App::Ready(game) => game.render_per_eye(view, projection, screen_size),
             App::MissingAssets(missing) => missing.render_per_eye(view, projection, screen_size),
+        };
+        for object in &mut objects {
+            if object.render_layer() == RenderLayer::World {
+                object.set_render_layer(RenderLayer::SceneUi);
+            }
         }
+        objects
     }
 
     pub fn finish_render(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -54,7 +54,8 @@ use engine::{
     audio::{AudioChannel, AudioContext, AudioHandle, AudioPlaybackSettings},
     game_log, profile,
     scene::{
-        BillboardMaterial, ParticleSystem, SceneObject, VertexPosition, light::SpotLight, quad,
+        BillboardMaterial, ParticleSystem, RenderLayer, SceneObject, VertexPosition,
+        light::SpotLight, quad,
     },
     texture::{TextureOptions, TextureTrait, init_from_memory2},
     texture_format::{PixelFormat, RawTextureData},
@@ -6692,12 +6693,9 @@ impl MissionCore {
                     let s = tan_world / tan_vm;
                     let squish =
                         view.invert().unwrap() * Matrix4::from_nonuniform_scale(s, s, 1.0) * view;
-                    for (i, obj) in scene_objs.into_iter().enumerate() {
+                    for obj in scene_objs {
                         let mut o = obj.clone();
                         o.set_transform(squish * xform);
-                        if i == 0 {
-                            o.set_clear_depth(true);
-                        }
                         ret.push(o);
                     }
 
@@ -6763,10 +6761,9 @@ impl MissionCore {
                 screen_size,
                 self.screen_fade_alpha,
             );
-            // Some HUD bars use an opaque screen material and write depth at
-            // the same Z as this quad. Clear that UI depth before the final
-            // transparent pass so full white covers those bars as well.
-            fade.set_clear_depth(true);
+            // A final system layer covers scene UI in both hosts. Its depth is
+            // cleared once by the renderer at the explicit group boundary.
+            fade.set_render_layer(RenderLayer::SystemOverlay);
             ret.push(fade);
         }
 

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -27,7 +27,7 @@ use dark::map::MapRect;
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
-    scene::{SceneObject, color_material, quad},
+    scene::{RenderLayer, SceneObject, color_material, quad},
 };
 use shipyard::EntityId;
 
@@ -219,11 +219,9 @@ fn world_dim_layer(
     object.set_depth_write(false);
     // A modal panel the player cannot read is not a pause menu: world-locked
     // two metres ahead, it lands inside a wall or a console often enough that
-    // depth-testing it against the world is not an option. The renderer treats
-    // everything from the first `clear_depth` object onward as an overlay group
-    // drawn after the world's own passes, and `Game` appends the menu's objects
-    // last, so the group is exactly the dim, the panel and its rays.
-    object.set_clear_depth(true);
+    // depth-testing it against the world is not an option. The renderer clears
+    // depth once at this explicit system-layer boundary.
+    object.set_render_layer(RenderLayer::SystemOverlay);
     object.set_debug_tag(Some(crate::util::render_source_tag(
         crate::util::render_source::PAUSE_DIM,
     )));
@@ -690,9 +688,8 @@ impl PauseMenu {
         for object in &mut objects {
             object.set_transform(pawn_to_world * object.get_transform());
         }
-        // The overlay group starts at `world_dim_layer`'s `clear_depth`, which
-        // is why the dim is emitted first: the group is the dim, the panel and
-        // its rays, all drawn over the world.
+        // Game assigns this whole ordered stack to the system-overlay layer:
+        // dim first, then panel and rays, all over the world and scene UI.
         objects
     }
 
@@ -1423,20 +1420,15 @@ mod tests {
         assert!((position - implied_head).magnitude() < 1e-4);
     }
 
-    /// The overlay group starts at the first `clear_depth` object, and
-    /// everything from there on draws over the world. The dim is emitted first,
-    /// so it is the object that has to carry the clear - otherwise the group
-    /// would start at the panel and a wall in the player's face would swallow
-    /// the dim while leaving the menu floating over a bright world.
+    /// The dim belongs to the explicit system-overlay group, so a wall in the
+    /// player's face cannot swallow it while leaving the menu floating over a
+    /// bright world.
     #[test]
     fn the_dim_layer_is_not_depth_tested_against_the_world() {
         let panel = test_panel();
         let (position, forward) = dim_pose(Vector3::zero(), head_looking(0.0, 0.0), &panel);
         let object = world_dim_layer(position, forward, dim_distance(position, &panel));
-        assert!(
-            object.clear_depth,
-            "the dim opens the overlay group; without the clear, the wall the player is standing against swallows it"
-        );
+        assert_eq!(object.render_layer(), RenderLayer::SystemOverlay);
         assert!(
             !object.depth_write,
             "the dim must not write depth: the panel draws after it"

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -347,6 +347,9 @@ export interface SceneObjectSummary {
   /** Transparency in effect for this draw (0 = opaque, 1 = invisible). */
   transparency: number | null;
   depth_write: boolean;
+  /** Explicit renderer composition layer. */
+  render_layer: "world" | "scene_overlay" | "scene_ui" | "system_overlay";
+  /** True only for the first submitted object in a depth-cleared layer. */
   clear_depth: boolean;
   /** Front-face winding used for culling, or null when double-sided. */
   backface_culling: string | null;

--- a/tools/shock2-sdk/test/pause-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/pause-menu.e2e.test.ts
@@ -255,11 +255,10 @@ test(
       dim[0].transparency !== null && dim[0].transparency > 0.02 && dim[0].transparency < 0.98,
       `the dim must actually be translucent, got ${dim[0].transparency}`,
     );
-    // The panel renders over the world unconditionally (#1017's clear-depth
-    // overlay group, explicitly kept). The dim now opens that group, so it has
-    // to carry the clear - otherwise a wall in the player's face would swallow
-    // the dim and leave the menu floating over a bright world.
-    assert.equal(dim[0].clear_depth, true, "the dim opens the overlay group");
+    // The dim is the first system-overlay object, so it reports the renderer's
+    // one depth clear at that layer boundary.
+    assert.equal(dim[0].clear_depth, true, "the dim begins a depth-cleared layer");
+    assert.equal(dim[0].render_layer, "system_overlay");
 
     // Resuming puts the world back exactly as it was.
     await game.input.trigger("TogglePauseMenu");

--- a/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
@@ -76,7 +76,12 @@ for (const presentation of ["flat", "vr"] as const) {
       // culled quad covers only part of the view on the Quest, and a
       // depth-tested one only tints what is far away.
       assert.equal(shown.backface_culling, null, "the tint must not opt into culling");
-      assert.equal(shown.clear_depth, true, "the tint must draw over the world");
+      assert.equal(shown.clear_depth, true, "the tint must begin a depth-cleared layer");
+      assert.equal(
+        shown.render_layer,
+        "scene_overlay",
+        "the tint must stay over the world and behind scene UI",
+      );
       assert.equal(shown.depth_write, false, "the tint must not occlude what draws after it");
 
       // A bigger hit reads as bigger.


### PR DESCRIPTION
Fixes #1037.

## Reproduction

The renderer inferred its overlay group from the first `clear_depth` object in a flat scene vector, but hosts assemble that vector differently: desktop/debug append per-eye objects and Oculus prepends them. On the Quest this places WhiteOut before the world and the hit tint after scene UI. A second per-object depth clear also erased viewmodel depth mid-group, so an overlapping hit tint washed over the weapon.

Matched deterministic reproduction on exact base `63a002edd6da190e6a06315ac2958f1c7da52408` used `eng2.mis`: step 2 frames, spawn/equip Wrench, discover and TurnOn authored mission object 945 (`White Out 1`), damage the player for 5 HP, then step 6 frames. The base frame visibly tints the Wrench red.

## Fix

- Add explicit renderer layers: world, scene overlay, scene UI, and system overlay.
- Render those layers in one fixed order regardless of host concatenation.
- Clear depth exactly once at each populated non-world layer boundary instead of from individual objects.
- Assign hit feedback, per-eye scene UI/viewmodels/HUDs, pause UI, and WhiteOut at the shared game composition boundary.
- Report the explicit layer through `/v1/scene` and the TypeScript SDK; retain `clear_depth` as a boundary-only compatibility field.
- Add an engine regression test that submits the same layers in desktop/debug and Oculus orders and proves identical render order.

## Verification

All runtime/E2E commands used the verified System Shock 2 25th Anniversary root `/Users/bryan/ss2-25th` explicitly through `DARK_ASSET_PATH` (sentinel `sshock2.kpf`; remaster assets in `mods/`).

- `RUSTFLAGS="-D warnings" cargo check -p engine -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p engine --lib` — 57 passed
- `cargo test -p shock2vr --lib` — 885 passed after the final rebase
- focused engine host-order regression — passed
- focused hit-feedback tests — flat and `--vr`, 4 passed
- authored eng2 Many ride / WhiteOut E2E — passed before and after the final rebase
- SDK `npm test` / TypeScript — 26 passed
- full SDK E2E — 302 tests: 291 passed, 4 failed, 7 skipped, 0 cancelled; all 23/23 mission-load smoke tests passed (5,752,902.6 ms)
  - `creature-loot` is the standing #931 baseline failure, already reproduced on the exact base.
  - patrol save/load is the standing #1040 baseline failure, already reproduced on the exact base.
  - Hydro 3's Korenchkin transcript assertion reproduced identically on exact base (the rendered retail text lacks the test's expected ellipsis).
  - the saved-VR-melee Wrench scenario missed one contact in the full run, then passed focused on the fix (1/1, 69.45 s) and exact base (1/1, 69.20 s), consistent with a transient contact-timing flake.
- the one new E2E added by the intervening `origin/main` commit (`medsci1 ThreatenOG`) passed focused after rebase (1/1, 21.52 s)

Local Oculus cross-compilation could not start in this checkout: `cargo apk` is not installed and the configured Android NDK clang path is missing. The rebased PR's Android build check passed in CI (3m33s), alongside macOS, Ubuntu, Windows, and formatting. Warning-strict desktop/runtime package checks are green. Unscoped `cargo test -p shock2vr` also builds the stale `examples/melee_grip.rs`; its pre-existing `Option<MeleePosedArm>` mismatch reproduces unchanged on the exact base SHA, so library tests were run directly.

## Visual proof

![Matched exact-base/fix overlay ordering demo](https://gist.githubusercontent.com/tommy-xr/ec81a39810a706feba0bf892c632395a/raw/overlay-ordering-demo.gif)

<sub>Matched deterministic `eng2.mis` sequence on exact base `63a002e` and fix `6ef2fce`: the base washes the Wrench/HUD red, while explicit composition keeps scene UI and the viewmodel above the player hit tint; both sides converge as the authored WhiteOut remains the final system overlay. Captured headlessly with `DARK_ASSET_PATH=/Users/bryan/ss2-25th` (`sshock2.kpf` + remaster `mods/`) through `/v1/step` + `/v1/screenshot` at fixed 60 Hz.</sub>

### Post-fix still

![Post-fix overlay ordering still](https://gist.githubusercontent.com/tommy-xr/ec81a39810a706feba0bf892c632395a/raw/overlay-ordering-after.png)

### Before → after

![Labeled exact-base and fix overlay comparison](https://gist.githubusercontent.com/tommy-xr/ec81a39810a706feba0bf892c632395a/raw/overlay-ordering-before-after.png)
