### PR TITLE
fix(ai): preserve AI across object script overrides

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -20,7 +20,7 @@ use dark::{
     model::Model,
     motion::AnimationPlayer,
     properties::{
-        FrobFlag, InternalPropOriginalModelName, Link, Links, PhysicsModelType, PoseType,
+        FrobFlag, InternalPropOriginalModelName, Link, Links, PhysicsModelType, PoseType, PropAI,
         PropClassTag, PropCollisionType, PropCreature, PropCreaturePose, PropFrobInfo,
         PropHUDSelect, PropHasRefs, PropHitPoints, PropImmobile, PropKeySrc, PropLimbModel,
         PropModelName, PropPhysAttr, PropPhysDimensions, PropPhysState, PropPhysType, PropPosition,
@@ -64,6 +64,13 @@ fn needs_internal_simple_health(
 
 fn needs_internal_triggered_melee(has_limb_model: bool) -> bool {
     has_limb_model
+}
+
+fn needs_internal_ai(has_ai: bool, authored_scripts: &[String]) -> bool {
+    has_ai
+        && !authored_scripts
+            .iter()
+            .any(|script| script.eq_ignore_ascii_case("BaseMonster"))
 }
 
 pub fn create_entity_with_position(
@@ -330,6 +337,17 @@ pub fn create_entity_core(
 
     // Create any internal scripts to power some properties
 
+    // Dark's AI/creature service is independent of object-script inheritance.
+    // Most creatures inherit BaseMonster, which is where this port currently
+    // constructs their concrete AI implementation, but mission actors can
+    // deliberately replace their object scripts. Keep PropAI authoritative so
+    // that override does not also erase animation, damage, and signal-response
+    // handling (medsci1 ThreatenOG is the shipped example).
+    let v_ai = world.borrow::<View<PropAI>>().unwrap();
+    if needs_internal_ai(v_ai.get(entity_id).is_ok(), &processed_scripts) {
+        processed_scripts.push("basemonster".to_owned());
+    }
+
     let v_collision_type = world.borrow::<View<PropCollisionType>>().unwrap();
 
     if v_collision_type.get(entity_id).is_ok() {
@@ -407,6 +425,7 @@ pub fn create_entity_core(
     // Release the property views before add_component below needs the world
     // mutably; nothing after this point reads them.
     drop(v_scripts);
+    drop(v_ai);
     drop(v_collision_type);
     drop(v_creature);
     drop(v_hp);
@@ -1557,6 +1576,28 @@ mod tests {
         assert!(
             !needs_internal_triggered_melee(false),
             "Maintenance Tool -2949's literal Wrench script and guns must not gain player melee"
+        );
+    }
+
+    #[test]
+    fn ai_property_survives_an_object_script_inheritance_override() {
+        let threat_en_og_scripts = vec![
+            "TransientCorpse".to_owned(),
+            "triggerdestroy".to_owned(),
+            "creaturecontainer".to_owned(),
+        ];
+
+        assert!(
+            needs_internal_ai(true, &threat_en_og_scripts),
+            "ThreatenOG's explicit non-inheriting scripts must not remove engine AI"
+        );
+        assert!(
+            !needs_internal_ai(true, &["BaseMonster".to_owned()]),
+            "an inherited BaseMonster already owns AI and must not be duplicated"
+        );
+        assert!(
+            !needs_internal_ai(false, &threat_en_og_scripts),
+            "ordinary scripted objects must not gain monster AI"
         );
     }
 

--- a/tools/shock2-sdk/test/medsci-threaten-og.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-threaten-og.e2e.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const THREATEN_OG = 1383;
+const OG_MOAN_WAYPOINT = 760;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0]!;
+}
+
+function property(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((candidate) => candidate.name === name)?.value;
+}
+
+function horizontalDistance(a: number[], b: number[]): number {
+  return Math.hypot(a[0]! - b[0]!, a[2]! - b[2]!);
+}
+
+// Regression for #1068. ThreatenOG's concrete object script list deliberately
+// disables inheritance, but Dark's creature/AI service is independent of that
+// list. The port used to attach AnimatedMonsterAI only through inherited
+// BaseMonster, leaving this live scripted hybrid in its bind pose, immune to
+// Damage, and permanently blocking the camera-room route.
+test(
+  "medsci1 ThreatenOG keeps AI, damage, and its authored OGMoan movement",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8206),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 10 });
+
+    // Mission-object ids are stable; runtime ids are discovered every launch.
+    const threat = only(
+      await game.entities.byTemplate(THREATEN_OG),
+      "ThreatenOG mission object 1383",
+    );
+    const waypoint = only(
+      await game.entities.byTemplate(OG_MOAN_WAYPOINT),
+      "ogmoantrap mission object 760",
+    );
+    const before = await game.entities.detail(threat.id);
+    const initialHp = Number(property(before, "HitPoints"));
+    const initialWaypointDistance = horizontalDistance(
+      before.position,
+      waypoint.position,
+    );
+
+    assert.equal(initialHp, 12, "the authored hybrid must start alive");
+    assert.equal(
+      property(before, "AIBehavior"),
+      "Idle",
+      "the script override must not remove engine creature AI",
+    );
+    assert.ok(
+      (await game.entities.animation(threat.id))?.clip,
+      "the live creature must start in an authored motion rather than the bind pose",
+    );
+
+    // AI Signal Trap 756 delivers this exact production payload after the
+    // normal Science route. Direct injection isolates the receiver here.
+    await game.entities.sendMessage(threat.id, { type: "Signal", name: "OGMoan" });
+    await game.step({ frames: 2 });
+    assert.equal(
+      property(await game.entities.detail(threat.id), "AIBehavior"),
+      "ScriptedSequence",
+      "OGMoan must start the authored response",
+    );
+
+    // A Wrench hit ultimately uses this Damage message path. Receiving it
+    // proves the actor is still a normal live combat target during the beat.
+    await game.entities.sendMessage(threat.id, { type: "Damage", amount: 1 });
+    await game.step({ frames: 2 });
+    assert.equal(
+      Number(property(await game.entities.detail(threat.id), "HitPoints")),
+      initialHp - 1,
+      "ThreatenOG must retain ordinary creature damage handling",
+    );
+
+    let closestWaypointDistance = initialWaypointDistance;
+    let farthestFromBlockingPose = 0;
+    let observedAnimatedPose = false;
+    for (let halfSecond = 0; halfSecond < 40; halfSecond += 1) {
+      await game.step({ frames: 30 });
+      const current = await game.entities.detail(threat.id);
+      closestWaypointDistance = Math.min(
+        closestWaypointDistance,
+        horizontalDistance(current.position, waypoint.position),
+      );
+      farthestFromBlockingPose = Math.max(
+        farthestFromBlockingPose,
+        horizontalDistance(current.position, before.position),
+      );
+      observedAnimatedPose ||= Boolean((await game.entities.animation(threat.id))?.clip);
+      if (farthestFromBlockingPose > 1.5) break;
+    }
+
+    assert.ok(observedAnimatedPose, "the OGMoan performance must remain animated");
+    assert.ok(
+      closestWaypointDistance < initialWaypointDistance - 1.5,
+      `ThreatenOG must progress toward ogmoantrap; initial=${initialWaypointDistance}, closest=${closestWaypointDistance}`,
+    );
+    assert.ok(
+      farthestFromBlockingPose > 1.5,
+      `ThreatenOG must vacate its standing-route pose; moved=${farthestFromBlockingPose}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- keep Dark's `PropAI` authoritative when a mission object disables object-script inheritance
- attach the existing `BaseMonster` AI dispatcher only when the object does not already carry it
- restore ThreatenOG's animation, `OGMoan` response, movement, and creature Damage handling
- add a focused forced-VR MedSci1 SDK regression that resolves mission objects dynamically and checks AI activation, damage, authored movement, and vacating the blocked route

Fixes #1068

Campaign: `earth-to-hydro · detailed · 25th Anniversary · vr · seed 1600004333`

## Root cause

MedSci1 object 1383 (`ThreatenOG`) deliberately authors `PropScripts { inherits: false }` for `TransientCorpse`, `triggerdestroy`, and `creaturecontainer`. That should replace its object scripts only. In Dark, creature AI remains an engine service.

The port currently constructs `AnimatedMonsterAI` through the inherited `BaseMonster` script. The override therefore removed much more than authored: the live 12-HP OG-Pipe had no animation, no signal receiver, no locomotion, and no owner for creature Damage. It remained a T-posed blocking actor forever.

## Validation

- negative-first 25th Anniversary `medsci1.mis --vr` SDK run failed on the parent at missing `AIBehavior`
- focused unit regression: passed
- focused 25th Anniversary forced-VR MedSci1 SDK e2e: passed
- `cargo test -p shock2vr --lib`: 880 passed
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

The post-fix mission run starts the actor in an authored idle motion, accepts `OGMoan` as `ScriptedSequence`, reduces HP 12→11 through the production Damage payload, and moves the live collider more than 1.5 world units off its original standing-route pose toward `ogmoantrap`.

## Visual evidence

![ThreatenOG diagnostic: baseline static versus fixed OGMoan animation and movement](https://gist.githubusercontent.com/tommy-xr/3ce294d19d4a0a641937736546b11651/raw/threatenog-ogmoan-diagnostic.gif)

<sub>Diagnostic capture: fresh 25th Anniversary `medsci1.mis --vr` launches at `main` `63a002ed` and fixed `69077f6a`, driven with the same deterministic request sequence. Runtime IDs were resolved by stable mission objects 1383 (`ThreatenOG`) and 760 (`ogmoantrap`); the camera/player was teleported only for framing, then the exact production `Signal { name: "OGMoan" }` payload was injected. Captured headlessly via `/v1/step` + `/v1/screenshot` at fixed 60 Hz.</sub>

### Before → after

![ThreatenOG before and after at 2.4 seconds](https://gist.githubusercontent.com/tommy-xr/3ce294d19d4a0a641937736546b11651/raw/threatenog-before-after.png)

<sub>Same camera and simulation time, 2.4 seconds after `OGMoan`: `main` has no AI behavior or animation clip and remains in the full T-pose; the fixed actor is in authored `ogsrun*` motion and has advanced about 1.9 world units toward `ogmoantrap`.</sub>