### PR TITLE
test(e2e): save patrol state from supported pose

### DIFF
--- a/tools/shock2-sdk/test/patrol.e2e.test.ts
+++ b/tools/shock2-sdk/test/patrol.e2e.test.ts
@@ -145,7 +145,8 @@ test(
       mission: "medsci1.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8163),
     });
-    await game.player.teleport({ x: 300, y: 0, z: 300 });
+    // Leave the player at the authored spawn in the sealed cryo recovery room:
+    // it has valid walkable support and is isolated from this patrol route.
     await game.step({ frames: 2 });
 
     const findPatroller = async () => {


### PR DESCRIPTION
## Summary

- keep the patrol save/load scenario at MedSci1's authored player spawn in the sealed cryo recovery room
- stop parking the player at an unsupported off-map debug pose
- retain the production `unsupported_player_pose` save guard and every patrol target/alertness assertion

## Reproduction

Tested current `origin/main` at `750e124bc1e5f1e17cc21a6a5fe6a23ebe5f6548` with the verified 25th Anniversary Remaster root `/Users/bryan/ss2-25th` (`sshock2.kpf` plus remaster `mods/*.kpf`).

The focused scenario failed before the patch at `POST /v1/save` with HTTP 409 and `error_code: unsupported_player_pose`; the reported live position was `[300.0, -1.2, 300.0]`. The guard is correct because that debug teleport has neither authored cells nor walkable support.

MedSci1's authored spawn is the sealed cryo recovery room. It has valid support, is AI-unreachable by design, and is isolated from object 163's patrol route, so it preserves the scenario's intent without weakening save validation.

## Verification

All runtime/E2E commands explicitly used `DARK_ASSET_PATH=/Users/bryan/ss2-25th`.

- focused pre-fix scenario: **failed as expected**, HTTP 409 `unsupported_player_pose`
- focused post-fix scenario: **passed**
- focused reliability: **5/5 passed**
- post-fetch/rebase focused scenario: **passed**
- `npm test`: **26 passed, 277 E2E-gated tests skipped, 0 failed**
- `cargo fmt --all -- --check`: **passed**
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: **passed**
- full `npm run test:e2e`: **294 passed, 2 failed, 7 skipped**; the corrected patrol scenario passed in 16.9s

The two full-suite failures are unchanged baseline failures. Both were rerun on a clean detached worktree at the exact base SHA with the same 25AE root and reproduced identically:

- `creature loot: ... Watts yields the 12451 disc`: reader MFD `-1`, expected `251` (historically tracked as #931)
- `hydro3: collected Korenchkin log opens its double-spaced transcript`: returned the shipped single-line transcript instead of the test's double-spaced expectation

## Visual proof

Approved as non-renderable for the `pr-visuals` gate. This patch changes only one SDK E2E setup command; game/runtime/renderer code and assets are identical across base and fix, and the same production inputs render identical frames. A before/after capture would compare two deliberately different debug camera locations, not a product visual change, and would therefore be misleading rather than evidence of this fix.

Fixes #1040
