### PR TITLE
fix(assets): resolve absolute folder mounts

### DIFF
--- a/engine/src/assets/asset_paths.rs
+++ b/engine/src/assets/asset_paths.rs
@@ -2,7 +2,7 @@ use std::{
     cell::RefCell,
     fs::File,
     io::{self, BufReader},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use tracing::{debug, trace};
@@ -95,13 +95,9 @@ pub struct AssetPath {
 
 impl AbstractAssetPath for AssetPath {
     fn exists(&self, base_path: String, asset_name: String) -> bool {
-        let path = base_path.to_owned()
-            + "/"
-            + &self.folder_name.to_owned()
-            + "/"
-            + &asset_name.to_string();
-        let exists = Path::new(&path).exists();
-        trace!("Checking exists [{}]:{}", path, exists);
+        let path = self.resolve_path(&base_path, &asset_name);
+        let exists = path.exists();
+        trace!("Checking exists [{}]:{}", path.display(), exists);
         exists
     }
 
@@ -110,12 +106,8 @@ impl AbstractAssetPath for AssetPath {
         base_path: String,
         asset_name: String,
     ) -> Option<RefCell<Box<dyn ReadableAndSeekable>>> {
-        let path = base_path.to_owned()
-            + "/"
-            + &self.folder_name.to_owned()
-            + "/"
-            + &asset_name.to_string();
-        trace!(" -- reading from path: {}", path);
+        let path = self.resolve_path(&base_path, &asset_name);
+        trace!(" -- reading from path: {}", path.display());
 
         let file = File::open(path).unwrap();
         let reader = BufReader::new(file);
@@ -124,6 +116,15 @@ impl AbstractAssetPath for AssetPath {
 }
 
 impl AssetPath {
+    fn resolve_path(&self, base_path: &str, asset_name: &str) -> PathBuf {
+        let folder = Path::new(&self.folder_name);
+        if folder.is_absolute() {
+            folder.join(asset_name)
+        } else {
+            Path::new(base_path).join(folder).join(asset_name)
+        }
+    }
+
     pub fn combine(asset_paths: Vec<Box<dyn AbstractAssetPath>>) -> Box<dyn AbstractAssetPath> {
         Box::new(MultipleAssetPaths { asset_paths })
     }
@@ -135,7 +136,36 @@ impl AssetPath {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        fs,
+        io::Read,
+        path::PathBuf,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
     use super::*;
+
+    static NEXT_TEMP_DIR: AtomicUsize = AtomicUsize::new(0);
+
+    struct TempAssetTree(PathBuf);
+
+    impl TempAssetTree {
+        fn new(name: &str) -> Self {
+            let sequence = NEXT_TEMP_DIR.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "shock2quest-{name}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TempAssetTree {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
 
     /// A mount that simply owns a fixed set of names.
     struct FakeMount(Vec<&'static str>);
@@ -214,5 +244,43 @@ mod tests {
             paths.resolve_first(String::new(), &candidates(&["txt16/foo.pcx"])),
             None
         );
+    }
+
+    #[test]
+    fn absolute_folder_mount_resolves_without_prefixing_the_base_path() {
+        let root = TempAssetTree::new("absolute-folder-mount");
+        let folder = root.0.join("res/obj");
+        fs::create_dir_all(&folder).unwrap();
+        fs::write(folder.join("override.bin"), b"loose override").unwrap();
+
+        let path = AssetPath::folder(folder.to_string_lossy().into_owned());
+        let base_path = root.0.to_string_lossy().into_owned();
+
+        assert!(path.exists(base_path.clone(), "override.bin".to_owned()));
+        let reader = path
+            .get_reader(base_path, "override.bin".to_owned())
+            .unwrap();
+        let mut contents = String::new();
+        reader.borrow_mut().read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "loose override");
+    }
+
+    #[test]
+    fn relative_folder_mount_resolves_under_the_base_path() {
+        let root = TempAssetTree::new("relative-folder-mount");
+        let folder = root.0.join("res/obj");
+        fs::create_dir_all(&folder).unwrap();
+        fs::write(folder.join("override.bin"), b"relative override").unwrap();
+
+        let path = AssetPath::folder("res/obj".to_owned());
+        let base_path = root.0.to_string_lossy().into_owned();
+
+        assert!(path.exists(base_path.clone(), "override.bin".to_owned()));
+        let reader = path
+            .get_reader(base_path, "override.bin".to_owned())
+            .unwrap();
+        let mut contents = String::new();
+        reader.borrow_mut().read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "relative override");
     }
 }


### PR DESCRIPTION
## Summary

- resolve absolute loose-folder mounts without prefixing the data root a second time
- preserve existing relative and empty-folder mount behavior under the cache base path
- cover both path modes through real filesystem reads

## Reproduction and root cause

On the pre-fix base (`750e124bc1e5f1e17cc21a6a5fe6a23ebe5f6548`), the new negative test failed at `AssetPath::exists` for an absolute folder mount. `exists` and `get_reader` constructed paths with string concatenation:

```text
<absolute base>/<absolute res/obj folder>/<asset>
```

Classic compatibility mounts register `resource_path("res/obj")` and `resource_path("res/mesh")`, which are already absolute whenever `DARK_ASSET_PATH` is absolute. Their loose overrides therefore always missed and fell through to the CRF archives.

`AssetPath` now resolves through `Path`/`PathBuf`: an absolute folder joins the asset directly, while a relative or empty folder remains rooted under `base_path`.

## Verification

- negative-first regression: `absolute_folder_mount_resolves_without_prefixing_the_base_path` failed on the old implementation, then passed after the fix and read the loose file contents
- `relative_folder_mount_resolves_under_the_base_path` passes and reads the relative file contents
- `cargo test -p engine assets::asset_paths::tests -- --nocapture`: 6 passed
- `cargo test -p engine`: 59 passed, 0 failed (post-rebase)
- `cargo fmt --all -- --check`: passed
- `RUSTFLAGS="-D warnings" cargo check -p engine -p shock2vr -p desktop_runtime -p debug_runtime`: passed
- post-rebase focused runtime smoke: `debug_weapons`, deterministic `10 frames -> DebugCycleWeapon -> 10 frames`, Pistol template `-17` discovered and screenshot captured

### Asset roots

- supported-install runtime/E2E evidence: `/Users/bryan/ss2-25th`, sentinel `sshock2.kpf` SHA-256 `35597daf68cf3e0c811cd9b9d24a9604d2cffa1d2c793985056b8946c538c6bd`, full remaster `mods/` stack present. `DARK_ASSET_PATH` was explicitly set for every runtime/SDK run.
- classic compatibility reproduction only: `/Users/bryan/ss2-data-unpacked`, with `shock2.gam`, `res/obj.crf`, and loose `res/obj/atek_w.bin` SHA-256 `bcb50990cec48e19f3191245a16cb23fb20dbb9f2ae3cf2fedd47d189f88d401`. This fixture exercises the classic-only absolute folder mounts and does not substitute for 25AE regression evidence.

### Full SDK E2E

With `DARK_ASSET_PATH=/Users/user/ss2-25th`: 303 tests, 292 passed, 4 failed, 7 skipped; all 23 mission-load smokes passed. Each failure reproduced identically on exact pre-fix base `750e124b` with the same explicit 25AE root:

- creature-loot reader MFD: actual `-1`, expected `251`
- Hydro3 Korenchkin transcript spacing assertion
- saved MedSci Wrench interaction: 0 Damage messages, expected 1
- patrol #410 save rejected at the test's unsupported `[300, -1.2, 300]` player pose

These failures are pre-existing and outside this path-resolution change.

## Visual proof

### Classic compatibility: loose SHTUP pistol override

![Classic loose-folder pistol override](https://gist.githubusercontent.com/tommy-xr/574338773a1d6d2cb79d34655f26d12c/raw/classic-pistol-override.gif)

<sub>Classic compatibility visual evidence only — this is not supported 25AE regression validation. Exact base `750e124bc1e5f1e17cc21a6a5fe6a23ebe5f6548` (CRF fallback) versus fix `9904baf3170e994d86f5aa2ea8690dab08cbe83d`, captured headlessly in flat `debug_weapons` with `DARK_ASSET_PATH=/Users/bryan/ss2-data-unpacked` and the identical deterministic sequence: 10 frames → `DebugCycleWeapon` → 10 frames → screenshot.</sub>

#### Post-fix still

![Post-fix loose SHTUP pistol](https://gist.githubusercontent.com/tommy-xr/574338773a1d6d2cb79d34655f26d12c/raw/classic-pistol-after.png)

#### Before → after

![Classic CRF pistol before and loose SHTUP pistol after](https://gist.githubusercontent.com/tommy-xr/574338773a1d6d2cb79d34655f26d12c/raw/classic-pistol-before-after.png)

<sub>Before: the base duplicates the absolute asset root, misses loose `res/obj/atek_w.bin`, and falls through to the classic CRF pistol. After: the fixed absolute mount reads the loose model and `HRSPist*` textures, visibly rendering the higher-resolution SHTUP pistol.</sub>

Fixes #898

