### PR TITLE
fix(vr): preserve melee contact impact

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -3613,8 +3613,8 @@ async fn get_recent_audio() -> Json<Value> {
 }
 
 /// HTTP handler for the recently delivered script messages (receiver, payload
-/// variant, and sender where the payload carries one). Pairs with
-/// `/v1/audio/recent` for debugging "why did all of this fire at once".
+/// variant, Damage impact geometry, and sender where the payload carries one).
+/// Pairs with `/v1/audio/recent` for debugging "why did all of this fire at once".
 /// High-frequency payloads (hover, sensor/collision) are filtered out. Reads a
 /// process-wide log, so no game-loop round-trip is needed.
 async fn get_recent_messages() -> Json<Value> {

--- a/shock2vr/src/message_trace.rs
+++ b/shock2vr/src/message_trace.rs
@@ -52,9 +52,21 @@ pub struct TracedMessage {
     pub to: MessageEntity,
     /// Payload variant name (e.g. "TurnOn", "Frob").
     pub payload: String,
+    /// Physical context carried by a `Damage` message, when its source knows
+    /// where and in which direction the blow landed.
+    pub impact: Option<TracedDamageImpact>,
     /// Sender, for the payloads that carry one (`TurnOn`/`TurnOff`/`Alarm`/
     /// `Reset`); null otherwise - `Message` has no universal sender.
     pub from: Option<MessageEntity>,
+}
+
+/// Serializable subset of [`crate::scripts::DamageImpact`] exposed to
+/// headless behavior tests.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct TracedDamageImpact {
+    pub direction: [f32; 3],
+    pub point: [f32; 3],
+    pub bone: Option<u32>,
 }
 
 static RECENT: Mutex<(u64, VecDeque<TracedMessage>)> = Mutex::new((0, VecDeque::new()));
@@ -82,6 +94,21 @@ fn sender_of(payload: &MessagePayload) -> Option<EntityId> {
         | MessagePayload::Reset { from } => Some(*from),
         _ => None,
     }
+}
+
+fn damage_impact_of(payload: &MessagePayload) -> Option<TracedDamageImpact> {
+    let MessagePayload::Damage {
+        impact: Some(impact),
+        ..
+    } = payload
+    else {
+        return None;
+    };
+    Some(TracedDamageImpact {
+        direction: [impact.direction.x, impact.direction.y, impact.direction.z],
+        point: [impact.point.x, impact.point.y, impact.point.z],
+        bone: impact.bone,
+    })
 }
 
 /// Short variant name of a payload, without its (often large) fields.
@@ -115,6 +142,7 @@ pub(crate) fn record(world: &World, sim_time: f64, to: EntityId, payload: &Messa
         frame: frame_of(sim_time),
         to: describe(world, to),
         payload: payload_name(payload),
+        impact: damage_impact_of(payload),
         from: sender_of(payload).map(|from| describe(world, from)),
     };
 
@@ -156,13 +184,42 @@ mod tests {
     }
 
     #[test]
+    fn damage_trace_preserves_impact_geometry() {
+        let payload = MessagePayload::Damage {
+            amount: 9.0,
+            impact: Some(crate::scripts::DamageImpact {
+                direction: vec3(1.0, 0.0, 0.0),
+                point: vec3(2.0, 3.0, 4.0),
+                bone: Some(7),
+            }),
+        };
+
+        assert_eq!(
+            damage_impact_of(&payload),
+            Some(TracedDamageImpact {
+                direction: [1.0, 0.0, 0.0],
+                point: [2.0, 3.0, 4.0],
+                bone: Some(7),
+            })
+        );
+        assert_eq!(
+            damage_impact_of(&MessagePayload::Damage {
+                amount: 3.0,
+                impact: None,
+            }),
+            None
+        );
+    }
+
+    #[test]
     fn high_frequency_payloads_are_filtered() {
         assert!(is_traced(&MessagePayload::Frob));
         assert!(is_traced(&MessagePayload::TurnOn {
             from: EntityId::dead()
         }));
         assert!(!is_traced(&MessagePayload::Collided {
-            with: EntityId::dead()
+            with: EntityId::dead(),
+            contact: None,
         }));
         assert!(!is_traced(&MessagePayload::GUIHover {
             held_entity_id: None,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2199,14 +2199,24 @@ impl MissionCore {
                 physics::CollisionEvent::CollisionStarted {
                     entity1_id,
                     entity2_id,
+                    contact,
                 } => {
                     self.script_world.dispatch(Message {
                         to: entity1_id,
-                        payload: MessagePayload::Collided { with: entity2_id },
+                        payload: MessagePayload::Collided {
+                            with: entity2_id,
+                            contact,
+                        },
                     });
                     self.script_world.dispatch(Message {
                         to: entity2_id,
-                        payload: MessagePayload::Collided { with: entity1_id },
+                        payload: MessagePayload::Collided {
+                            with: entity1_id,
+                            contact: contact.map(|contact| physics::CollisionContact {
+                                point: contact.point,
+                                normal: -contact.normal,
+                            }),
+                        },
                     });
                 }
             }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2159,7 +2159,17 @@ pub enum CollisionEvent {
     CollisionStarted {
         entity1_id: EntityId,
         entity2_id: EntityId,
+        contact: Option<CollisionContact>,
     },
+}
+
+/// World-space geometry for a newly-started physical contact.
+#[derive(Clone, Copy, Debug)]
+pub struct CollisionContact {
+    /// Midpoint between the two touching surfaces.
+    pub point: Vector3<f32>,
+    /// Unit normal pointing from `entity1_id` toward `entity2_id`.
+    pub normal: Vector3<f32>,
 }
 
 /// Predicate selecting *only* sensor colliders - the volumes the player's
@@ -5699,10 +5709,39 @@ mod tests {
                 CollisionEvent::CollisionStarted {
                     entity1_id,
                     entity2_id,
+                    ..
                 } if (*entity1_id == weapon && *entity2_id == actor)
                     || (*entity1_id == actor && *entity2_id == weapon)
             )),
             "held melee must keep reporting authentic actor contact"
+        );
+        let weapon_contact = events.iter().find_map(|event| match event {
+            CollisionEvent::CollisionStarted {
+                entity1_id,
+                entity2_id,
+                contact: Some(contact),
+            } if *entity1_id == weapon && *entity2_id == actor => Some(*contact),
+            CollisionEvent::CollisionStarted {
+                entity1_id,
+                entity2_id,
+                contact: Some(contact),
+            } if *entity1_id == actor && *entity2_id == weapon => Some(CollisionContact {
+                point: contact.point,
+                normal: -contact.normal,
+            }),
+            _ => None,
+        });
+        let weapon_contact = weapon_contact.expect("actor contact should carry its manifold");
+        assert!(
+            weapon_contact.point.x.is_finite()
+                && weapon_contact.point.y.is_finite()
+                && weapon_contact.point.z.is_finite(),
+            "contact point should be finite: {weapon_contact:?}"
+        );
+        assert!(
+            (weapon_contact.normal.magnitude() - 1.0).abs() < 1.0e-4
+                && weapon_contact.normal.x > 0.5,
+            "contact normal should point from the left-side weapon toward the actor: {weapon_contact:?}"
         );
         let actor_velocity = world.get_velocity(actor).unwrap();
         let actor_position = world.get_position(actor_handle).unwrap();

--- a/shock2vr/src/physics/physics_events.rs
+++ b/shock2vr/src/physics/physics_events.rs
@@ -3,6 +3,8 @@ use std::sync::Mutex;
 use rapier3d::prelude::{ColliderSet, ContactPair, EventHandler, Real, RigidBodySet};
 use shipyard::EntityId;
 
+use super::util::{npoint_to_cgvec, nvec_to_cgmath};
+
 pub struct PhysicsEvents {
     queued_events: Mutex<Vec<super::CollisionEvent>>,
 }
@@ -44,10 +46,31 @@ impl EventHandler for PhysicsEvents {
 
             match &event {
                 rapier3d::prelude::CollisionEvent::Started(_, _, _) => {
+                    // Solver contacts already contain the midpoint in world
+                    // space. Pick the deepest active contact and keep its
+                    // manifold normal, which Rapier orients collider1 ->
+                    // collider2. Some synthetic/degenerate contacts may have
+                    // no solver point, so the payload remains optional.
+                    let contact = contact_pair
+                        .manifolds
+                        .iter()
+                        .flat_map(|manifold| {
+                            manifold
+                                .data
+                                .solver_contacts
+                                .iter()
+                                .map(move |contact| (manifold, contact))
+                        })
+                        .min_by(|(_, a), (_, b)| a.dist.total_cmp(&b.dist))
+                        .map(|(manifold, contact)| super::CollisionContact {
+                            point: npoint_to_cgvec(contact.point),
+                            normal: nvec_to_cgmath(manifold.data.normal),
+                        });
                     self.queued_events.lock().unwrap().push(
                         super::CollisionEvent::CollisionStarted {
                             entity1_id: maybe_entity1_id.unwrap(),
                             entity2_id: maybe_entity2_id.unwrap(),
+                            contact,
                         },
                     )
                 }

--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -38,7 +38,7 @@ impl Script for EnergyStation {
                     Effect::NoEffect
                 }
             }
-            MessagePayload::Collided { with } => do_recharge(world, entity_id, with),
+            MessagePayload::Collided { with, .. } => do_recharge(world, entity_id, with),
             // Flat presentation: frobbing the station sends Recharge to every
             // item the player carries at once (there is no
             // hold-one-item-near-the-station step - that is VR-only, handled by

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -45,7 +45,7 @@ impl Script for InternalCollisionType {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with } => {
+            MessagePayload::Collided { with, .. } => {
                 // Only impact-payload entities (projectiles / fragile props
                 // flagged to slay or destroy themselves on contact) deal
                 // collision damage. A plain BOUNCE creature must not: any two

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -73,13 +73,13 @@ impl Script for TriggeredMeleeWeapon {
                 self.hit_entities.clear();
                 Effect::NoEffect
             }
-            MessagePayload::Collided { with }
+            MessagePayload::Collided { with, contact }
                 if self.attack_active && self.hit_entities.insert(*with) =>
             {
                 let Some(amount) = authored_contact_damage(world, entity_id, *with) else {
                     return Effect::NoEffect;
                 };
-                melee_impact(entity_id, *with, world, amount)
+                melee_impact(entity_id, *with, world, amount, *contact)
             }
             _ => Effect::NoEffect,
         }
@@ -108,13 +108,23 @@ fn authored_contact_damage(world: &World, weapon: EntityId, victim: EntityId) ->
     (damage > 0.0).then_some(damage)
 }
 
-fn melee_impact(entity_id: EntityId, with: EntityId, world: &World, amount: f32) -> Effect {
+fn melee_impact(
+    entity_id: EntityId,
+    with: EntityId,
+    world: &World,
+    amount: f32,
+    contact: Option<crate::physics::CollisionContact>,
+) -> Effect {
     let damage_effect = Effect::Send {
         msg: Message {
             to: with,
             payload: MessagePayload::Damage {
                 amount,
-                impact: None,
+                impact: contact.map(|contact| crate::scripts::DamageImpact {
+                    direction: contact.normal,
+                    point: contact.point,
+                    bone: None,
+                }),
             },
         },
     };
@@ -152,7 +162,9 @@ impl Script for MeleeWeapon {
 
         match msg {
             // Legacy literal `wrench` script (Maintenance Tool -2949).
-            MessagePayload::Collided { with } => melee_impact(entity_id, *with, world, 1.0),
+            MessagePayload::Collided { with, contact } => {
+                melee_impact(entity_id, *with, world, 1.0, *contact)
+            }
             _ => Effect::NoEffect,
         }
     }
@@ -235,7 +247,7 @@ mod tests {
                     if msg.to == target
                         && matches!(
                             msg.payload,
-                            MessagePayload::Damage { amount, impact: None }
+                            MessagePayload::Damage { amount, .. }
                                 if (amount - WEAPON_BASH_INTENSITY).abs() < f32::EPSILON
                         )
             )
@@ -271,6 +283,43 @@ mod tests {
         assert!(
             (amount - WEAPON_BASH_INTENSITY).abs() < f32::EPSILON,
             "got {amount}"
+        );
+    }
+
+    /// The physical VR contact must carry the same directional context as the
+    /// flat aim ray so a lethal hit can seed the victim's death ragdoll.
+    #[test]
+    fn a_landed_vr_swing_carries_an_impact_for_the_death_reaction() {
+        let (world, weapon, target) = test_world(PresentationMode::Vr);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+
+        let Effect::Multiple(effects) = collide(&mut script, &world, weapon, target) else {
+            panic!("expected melee impact effects");
+        };
+        let impact = effects.iter().find_map(|effect| match effect {
+            Effect::Send { msg } => match msg.payload {
+                MessagePayload::Damage { impact, .. } => Some(impact),
+                _ => None,
+            },
+            _ => None,
+        });
+        assert!(
+            matches!(
+                impact,
+                Some(Some(crate::scripts::DamageImpact {
+                    direction,
+                    point,
+                    bone: None,
+                })) if direction == vec3(1.0, 0.0, 0.0)
+                    && point == vec3(2.0, 3.0, 4.0)
+            ),
+            "a VR contact damage message must describe its physical impact"
         );
     }
 
@@ -329,7 +378,13 @@ mod tests {
             weapon,
             world,
             &PhysicsWorld::new(),
-            &MessagePayload::Collided { with: target },
+            &MessagePayload::Collided {
+                with: target,
+                contact: Some(crate::physics::CollisionContact {
+                    point: vec3(2.0, 3.0, 4.0),
+                    normal: vec3(1.0, 0.0, 0.0),
+                }),
+            },
         )
     }
 
@@ -414,7 +469,13 @@ mod tests {
             weapon,
             &world,
             &PhysicsWorld::new(),
-            &MessagePayload::Collided { with: target },
+            &MessagePayload::Collided {
+                with: target,
+                contact: Some(crate::physics::CollisionContact {
+                    point: vec3(2.0, 3.0, 4.0),
+                    normal: vec3(1.0, 0.0, 0.0),
+                }),
+            },
         );
 
         assert!(matches!(effect, Effect::NoEffect));

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -197,8 +197,7 @@ use self::{
 
 /// World-space description of the blow behind a `Damage` message, for physics
 /// reactions (ragdoll seeding). None when the source has no meaningful
-/// direction (scripted damage, collisions; radius blasts shove bodies
-/// directly).
+/// direction (scripted damage; radius blasts shove bodies directly).
 #[derive(Clone, Copy, Debug)]
 pub struct DamageImpact {
     /// Unit direction the blow traveled (attacker toward victim).
@@ -229,6 +228,10 @@ pub enum MessagePayload {
     },
     Collided {
         with: EntityId,
+        /// Exact physical contact geometry when this came from Rapier. The
+        /// normal points from the message receiver toward `with`; synthetic
+        /// script collisions have no contact.
+        contact: Option<crate::physics::CollisionContact>,
     },
 
     // Animation event
@@ -615,7 +618,7 @@ impl Script for UnimplementedScript {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with } => {
+            MessagePayload::Collided { with, .. } => {
                 info!("ignoring collision with {:?}", *with);
                 Effect::NoEffect
             }

--- a/shock2vr/src/scripts/tool_consumable.rs
+++ b/shock2vr/src/scripts/tool_consumable.rs
@@ -20,7 +20,7 @@ impl Script for ToolConsumable {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with } => Effect::Send {
+            MessagePayload::Collided { with, .. } => Effect::Send {
                 msg: Message {
                     to: *with,
                     payload: MessagePayload::ProvideForConsumption { entity: entity_id },

--- a/shock2vr/src/scripts/trigger_collide.rs
+++ b/shock2vr/src/scripts/trigger_collide.rs
@@ -23,7 +23,10 @@ impl Script for TriggerCollide {
             MessagePayload::TurnOn { from } => send_to_all_switch_links_and_self(
                 world,
                 entity_id,
-                MessagePayload::Collided { with: *from },
+                MessagePayload::Collided {
+                    with: *from,
+                    contact: None,
+                },
             ),
             _ => Effect::NoEffect,
         }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -691,7 +691,8 @@ export class MessagesApi {
   /**
    * The most recently delivered script messages (oldest first). High-frequency
    * payloads (hover, sensor intersect, collision) are filtered out so the
-   * buffer holds useful event history.
+   * buffer holds useful event history. Damage entries include their physical
+   * impact direction/point when the source supplied them.
    */
   async recent(): Promise<RecentMessagesResult> {
     return this.client.get<RecentMessagesResult>("/v1/messages/recent");

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -772,6 +772,16 @@ export interface TracedMessageEntity {
   template_id: number | null;
 }
 
+/** Physical context carried by a Damage message, when known. */
+export interface TracedDamageImpact {
+  /** Unit direction the blow traveled, attacker toward victim. */
+  direction: Vec3;
+  /** World-space hit point. */
+  point: Vec3;
+  /** Skeleton joint id when damage was forwarded through a creature hitbox. */
+  bone: number | null;
+}
+
 /** One delivered script message (GET /v1/messages/recent). */
 export interface TracedMessage {
   /** Monotonically increasing id - diff against a snapshot to find new ones. */
@@ -783,6 +793,8 @@ export interface TracedMessage {
   to: TracedMessageEntity;
   /** Payload variant name (e.g. "TurnOn", "Frob"). */
   payload: string;
+  /** Physical context for Damage, null for directionless/other messages. */
+  impact: TracedDamageImpact | null;
   /** Sender, for payloads that carry one (TurnOn/TurnOff/Alarm/Reset). */
   from: TracedMessageEntity | null;
 }

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -6,6 +6,7 @@ import type {
   EntityDetailResult,
   EntitySummary,
   PhysicsBodySummary,
+  TracedMessage,
   Vec3,
 } from "../src/index.js";
 import { teleportVerified } from "./helpers/teleport.js";
@@ -229,13 +230,13 @@ async function damageMessagesSince(
   game: GameServer,
   sequence: number,
   targetId: number,
-): Promise<number> {
+): Promise<TracedMessage[]> {
   return (await game.messages.recent()).messages.filter(
     (message) =>
       message.sequence > sequence &&
       message.to.entity_id === targetId &&
       message.payload === "Damage",
-  ).length;
+  );
 }
 
 async function armedSweep(
@@ -424,7 +425,7 @@ async function assertNineDamagePull(
 
   const { sequence, targetId, targetPoint } = await armedSweep(game, target);
   assert.equal(
-    await damageMessagesSince(game, sequence, targetId),
+    (await damageMessagesSince(game, sequence, targetId)).length,
     1,
     `one pull must emit exactly one Damage to ${name}`,
   );
@@ -449,7 +450,7 @@ async function killShotgunWithThreeBoundedPulls(
       target,
     );
     assert.equal(
-      await damageMessagesSince(game, sequence, targetId),
+      (await damageMessagesSince(game, sequence, targetId)).length,
       1,
       `shotgun pull ${hit + 1} must emit exactly one Damage`,
     );
@@ -545,7 +546,7 @@ test(
       const fresh = await byMissionId(control, "Blue Monkey", MONKEY);
       const { sequence, targetId } = await armedSweep(control, fresh);
       assert.equal(
-        await damageMessagesSince(control, sequence, targetId),
+        (await damageMessagesSince(control, sequence, targetId)).length,
         1,
         "fresh Wrench should emit one Damage message",
       );
@@ -623,7 +624,10 @@ test(
 
     const pane = await byMissionId(game, "Window 2", BREAKABLE_PANE);
     const { sequence, targetId, targetPoint } = await armedSweep(game, pane);
-    assert.equal(await damageMessagesSince(game, sequence, targetId), 1);
+    assert.equal(
+      (await damageMessagesSince(game, sequence, targetId)).length,
+      1,
+    );
     assert.equal(
       (
         await game.entities.list({ filter: "Window 2", limit: 30 })
@@ -653,6 +657,76 @@ test(
         Number.isFinite,
       ),
       `dropped Wrench physics must remain finite: ${JSON.stringify(droppedSettled)}`,
+    );
+  },
+);
+
+test(
+  "a lethal VR Wrench contact seeds the death ragdoll along the physical swing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 2,
+      repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
+      debugFlags: ["--vr"],
+      experimental: ["ragdoll"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    const wrench = await game.player.spawnItem(WRENCH_ARCHETYPE);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.input.trigger("EquipWrench");
+    await game.step({ frames: 3 });
+    assert.equal((await game.info()).player.right_hand_entity_id, wrench.entity_id);
+    await measureHeldContactOffset(game);
+
+    const beforeSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(beforeSpawn.entities.map((entity) => entity.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const monster = (
+      await game.entities.list({ filter: "OG-Pipe", limit: 50 })
+    ).entities.find((entity) => !known.has(entity.id));
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+    assert.equal(hitPoints(await game.entities.detail(monster.id)), 12);
+
+    // Leave exactly one authored 9-point Wrench contact as the killing blow.
+    // The setup damage is deliberately directionless and non-lethal.
+    await game.entities.sendMessage(monster.id, { type: "Damage", amount: 3 });
+    await game.step({ frames: 2 });
+    assert.equal(hitPoints(await game.entities.detail(monster.id)), 9);
+
+    const { sequence, targetId } = await reviewedIncrementalSweep(
+      game,
+      monster,
+    );
+    const lethalMessages = await damageMessagesSince(game, sequence, targetId);
+    assert.equal(
+      lethalMessages.length,
+      1,
+      "the lethal pull must be a real Wrench contact",
+    );
+    const impact = lethalMessages[0].impact;
+    assert.ok(impact, "the physical Wrench contact must carry DamageImpact");
+    assert.ok(
+      Math.abs(dot(impact.direction, impact.direction) - 1) < 1e-4,
+      `the contact direction must be unit length: ${JSON.stringify(impact.direction)}`,
+    );
+    let ragdolls = (await game.physics.ragdolls()).ragdolls;
+    for (let frame = 0; frame < 120 && ragdolls.length === 0; frame++) {
+      await game.step({ frames: 1 });
+      ragdolls = (await game.physics.ragdolls()).ragdolls;
+    }
+    assert.equal(ragdolls.length, 1, "the contact kill should hand off to one ragdoll");
+    await game.step({ frames: 3 });
+    const bodies = await game.physics.bodies({ entityId: ragdolls[0].entity_id });
+    const maxAlongImpact = Math.max(
+      ...bodies.bodies.map((body) => dot(body.velocity, impact.direction)),
+    );
+    assert.ok(
+      maxAlongImpact > 1,
+      `a struck limb should move along DamageImpact, max projection=${maxAlongImpact}`,
     );
   },
 );


### PR DESCRIPTION
## Reproduction

On frozen `origin/main` `25c3c67d9a90677702fbad0c71d792a53cff884d`, the production VR Wrench contact path delivered `Damage { impact: None }`. The negative-first Rust test failed because a landed VR swing carried no physical impact, and the exact-base SDK scenario failed with `the physical Wrench contact must carry DamageImpact` after a real Wrench contact killed an OG-Pipe under `--experimental ragdoll`.

## Root cause

Rapier reported contact manifolds, but `CollisionStarted` discarded their geometry before dispatching `Collided`. The VR melee script therefore sent directionless damage. Creature death only seeds a directional ragdoll reaction when `DamageImpact` is present, so lethal physical contacts lost the blow that killed the target.

## Fix

- Preserve the deepest active Rapier solver contact point and manifold normal on `CollisionStarted`.
- Orient the normal from each message receiver toward the other collider.
- Map real melee contact geometry into `DamageImpact`; synthetic collisions remain directionless.
- Expose delivered Damage impact geometry through the existing debug message trace so behavior tests project ragdoll motion against the exact vector the game consumed.

## Verification

Asset root for every runtime/SDK invocation: `DARK_ASSET_PATH=/Users/bryan/ss2-25th` (25AE; `sshock2.kpf` SHA-256 `35597daf68cf3e0c811cd9b9d24a9604d2cffa1d2c793985056b8946c538c6bd`).

- `cargo test -p shock2vr --lib` — 889 passed.
- `cargo test -p shock2vr melee_ -- --nocapture` — 18 passed.
- `cargo test -p shock2vr message_trace -- --nocapture` — 3 passed.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `npm test` — 305 total, 26 passed, 279 E2E-skipped.
- Full `npm run test:e2e` — 305 total, 296 passed, 2 failed, 7 skipped; all 23 mission loads passed. Both failures reproduce unchanged on the exact frozen base: creature-loot active MFD `-1` vs `251`, and the Hydro3 transcript spacing expectation.
- Post-rebase real-runtime matrix — 7/7 passed: flat melee timing, three VR contact/save/ownership scenarios, two ragdoll scenarios, and the new lethal physical-contact reaction.
- Hardened new scenario — 3/3 repeated fix launches passed; exact base failed because the real contact Damage carried no impact.

## Visual evidence

![VR melee contact impact before/after demo](https://gist.githubusercontent.com/tommy-xr/0b451b4a4e5b4d7bddc6c99f98e061d0/raw/vr-melee-impact-demo.gif)

<sub>A real physical VR Wrench kill now carries the Rapier contact through `DamageImpact`, kicking the death ragdoll along the struck direction. Captured headlessly in VR with `--experimental ragdoll` via deterministic fixed-timestep stepping against exact base `25c3c67d` and fix `89273989`.</sub>

### Post-fix still

![Post-fix VR melee contact reaction](https://gist.githubusercontent.com/tommy-xr/0b451b4a4e5b4d7bddc6c99f98e061d0/raw/vr-melee-impact-after.png)

### Before → after

![VR melee impact before and after](https://gist.githubusercontent.com/tommy-xr/0b451b4a4e5b4d7bddc6c99f98e061d0/raw/vr-melee-impact-before-after.png)

Fixes #956