### PR TITLE
fix(ui): show failed load feedback

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1101,11 +1101,10 @@ fn process_command(
         }
         RuntimeCommand::LoadGame { file, reply } => {
             tracing::info!("Loading game from '{}'", file);
-            // Existence is pre-checked in the handler, but a file that exists yet
-            // is truncated / not UTF-8 / an incompatible save schema still panics
-            // inside SaveData::read. Contain it so a corrupt save returns an error
-            // rather than bricking the game-loop thread. load_from_file only swaps
-            // `active_game_scene` as its final step (after all fallible reads), so
+            // Truncated, non-UTF-8 and schema-incompatible saves return a normal
+            // load error. Keep this outer guard for an unexpected panic deeper in
+            // mission reconstruction rather than bricking the game-loop thread.
+            // load_from_file only swaps `active_game_scene` as its final step, so
             // a caught panic leaves the previously-active scene intact.
             let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 game.load_game(file.clone())
@@ -2643,8 +2642,8 @@ async fn load_game(
     match reply_rx.await {
         Ok(result) if result.success => Ok(Json(result)),
         // The save existed but was corrupt / schema-incompatible: the game loop
-        // caught the panic and kept the previous scene, so surface a 500 rather
-        // than a misleading success.
+        // kept the previous scene, so surface a 500 rather than a misleading
+        // success.
         Ok(result) => Err((StatusCode::INTERNAL_SERVER_ERROR, result.message)),
         Err(_) => {
             tracing::error!("Failed to receive load result - sender dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -132,6 +132,13 @@ pub trait GameScene {
     /// run it (a debug-runtime load, a level transition).
     fn on_exit(&mut self, _audio_context: &mut AudioContext<EntityId, String>) {}
 
+    /// Notify the still-active scene that its requested save load failed.
+    ///
+    /// A successful load replaces the scene, so only the failure result needs
+    /// routing back. Frontend scenes that offer loading can turn this into
+    /// player-visible feedback; every other scene deliberately ignores it.
+    fn on_load_failed(&mut self) {}
+
     /// Whether this scene wants a 2D mouse cursor (e.g. a menu). Flat runtimes
     /// show the OS cursor and populate `InputContext::pointer` when true; by
     /// default scenes capture the mouse for look.

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -165,7 +165,7 @@ fn listener_ear_positions(
 
 fn read_save_file(path: &Path) -> io::Result<SaveData> {
     let mut file = File::open(path)?;
-    Ok(SaveData::read(&mut file))
+    SaveData::read(&mut file)
 }
 
 /// Whether the resolved data root is a 25th Anniversary Edition install rather
@@ -1656,6 +1656,7 @@ impl Game {
             GlobalEffect::Load { file_name } => {
                 if let Err(error) = self.load_from_file(file_name.clone()) {
                     warn!("Unable to load save '{}': {}", file_name, error);
+                    self.active_game_scene.on_load_failed();
                 }
             }
             GlobalEffect::TransitionLevel {
@@ -2050,6 +2051,20 @@ mod tests {
         let result = read_save_file(&missing);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn malformed_save_file_returns_an_error_instead_of_panicking() {
+        let directory = crate::test_support::TempDir::new("malformed-save-file");
+        let path = directory.path().join("corrupt.sav");
+        std::fs::write(&path, b"this is not a valid save file").unwrap();
+
+        let outcome = std::panic::catch_unwind(|| read_save_file(&path));
+
+        assert!(
+            matches!(outcome, Ok(Err(_))),
+            "malformed save data must be reported through the load result"
+        );
     }
 
     #[test]

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -8,7 +8,7 @@ use crate::quest_info::QuestInfo;
 use crate::scripts::healing_item::ActiveHealing;
 use cgmath::{Quaternion, Vector3};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, io};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct SaveData {
@@ -25,11 +25,11 @@ impl SaveData {
         writer.write_all(save_data_json.as_bytes()).unwrap();
     }
 
-    pub fn read<T: std::io::Read>(reader: &mut T) -> SaveData {
+    pub fn read<T: std::io::Read>(reader: &mut T) -> io::Result<SaveData> {
         let mut save_data_json = String::new();
-        reader.read_to_string(&mut save_data_json).unwrap();
-        let save_data: SaveData = serde_json::from_str(&save_data_json).unwrap();
-        save_data
+        reader.read_to_string(&mut save_data_json)?;
+        serde_json::from_str(&save_data_json)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
     }
 }
 

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -110,6 +110,8 @@ const ACTIVE_OPACITY: f32 = 1.0;
 /// `GAMELOD.STR` keys, with the shipped English text as a fallback.
 const HEADER_KEY: &str = "initial";
 const HEADER_FALLBACK: &str = "Select a file to load.";
+const FAILED_KEY: &str = "failed";
+const FAILED_FALLBACK: &str = "Load Failed";
 const EMPTY_KEY: &str = "unused";
 const EMPTY_FALLBACK: &str = "< EMPTY >";
 const LOAD_KEY: &str = "load";
@@ -125,6 +127,13 @@ enum LoadGameAction {
     Load,
     /// Return to the main menu.
     Done,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum LoadGameStatus {
+    #[default]
+    Initial,
+    Failed,
 }
 
 /// Resolve the screen's widget rects from `GAMELODR.BIN`, falling back to the
@@ -236,12 +245,18 @@ pub struct LoadGameScene {
     saves: Vec<SaveFile>,
     /// Index into [`Self::saves`] of the highlighted row, if any.
     selected: Option<usize>,
+    /// Result of the latest load attempt. The header is the screen's authored
+    /// status line (`initial` / `failed` in `GAMELOD.STR`).
+    status: LoadGameStatus,
     menu: FrontendMenu<LoadGameAction>,
 }
 
 impl LoadGameScene {
     pub fn new() -> Self {
-        let saves = all_saves();
+        Self::from_saves(all_saves())
+    }
+
+    fn from_saves(saves: Vec<SaveFile>) -> Self {
         // Preselect the most recent save so "Load" is immediately meaningful,
         // matching the recovery the game-over screen offers.
         let selected = (!saves.is_empty()).then_some(0);
@@ -251,7 +266,44 @@ impl LoadGameScene {
             scene_name: "load_game".to_owned(),
             saves,
             selected,
+            status: LoadGameStatus::Initial,
             menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
+        }
+    }
+
+    fn header_label(&self, strings: Option<&HashMap<String, String>>) -> String {
+        match self.status {
+            LoadGameStatus::Initial => label(strings, HEADER_KEY, HEADER_FALLBACK),
+            LoadGameStatus::Failed => label(strings, FAILED_KEY, FAILED_FALLBACK),
+        }
+    }
+
+    fn apply_action(&mut self, action: Option<LoadGameAction>) -> Vec<Effect> {
+        match action {
+            Some(LoadGameAction::Select(index)) => {
+                self.selected = Some(index);
+                // The previous failure belonged to the old selection.
+                self.status = LoadGameStatus::Initial;
+                Vec::new()
+            }
+            Some(LoadGameAction::Load) => {
+                // Clear stale feedback while the retry is dispatched. A
+                // synchronous failure sets it again through `on_load_failed`;
+                // success replaces this scene.
+                self.status = LoadGameStatus::Initial;
+                self.selected
+                    .and_then(|index| self.saves.get(index))
+                    .map(|save| {
+                        vec![Effect::GlobalEffect(GlobalEffect::Load {
+                            file_name: save.path.to_string_lossy().into_owned(),
+                        })]
+                    })
+                    .unwrap_or_default()
+            }
+            Some(LoadGameAction::Done) => {
+                vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)]
+            }
+            None => Vec::new(),
         }
     }
 }
@@ -277,7 +329,7 @@ impl LoadGameScene {
 
         canvas.text_native(
             rects[HEADER_RECT_INDEX],
-            &label(strings, HEADER_KEY, HEADER_FALLBACK),
+            &self.header_label(strings),
             MENU_FONT,
             HAlign::Center,
             VAlign::Middle,
@@ -392,24 +444,7 @@ impl GameScene for LoadGameScene {
             |point| hit(point, &rects, 0, selected.is_some()),
         );
 
-        match action {
-            Some(LoadGameAction::Select(index)) => {
-                self.selected = Some(index);
-                Vec::new()
-            }
-            Some(LoadGameAction::Load) => selected
-                .and_then(|index| self.saves.get(index))
-                .map(|save| {
-                    vec![Effect::GlobalEffect(GlobalEffect::Load {
-                        file_name: save.path.to_string_lossy().into_owned(),
-                    })]
-                })
-                .unwrap_or_default(),
-            Some(LoadGameAction::Done) => {
-                vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)]
-            }
-            None => Vec::new(),
-        }
+        self.apply_action(action)
     }
 
     fn render(
@@ -471,6 +506,10 @@ impl GameScene for LoadGameScene {
 
     fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
         self.menu.stop_sfx(audio_context);
+    }
+
+    fn on_load_failed(&mut self) {
+        self.status = LoadGameStatus::Failed;
     }
 
     fn wants_pointer(&self) -> bool {
@@ -749,6 +788,7 @@ mod tests {
 
         for (key, fallback) in [
             (HEADER_KEY, HEADER_FALLBACK),
+            (FAILED_KEY, FAILED_FALLBACK),
             (EMPTY_KEY, EMPTY_FALLBACK),
             (LOAD_KEY, LOAD_FALLBACK),
             (DONE_KEY, DONE_FALLBACK),
@@ -766,5 +806,55 @@ mod tests {
         // An empty shipped value must not blank the widget.
         let strings = HashMap::from([(DONE_KEY.to_owned(), String::new())]);
         assert_eq!(label(Some(&strings), DONE_KEY, DONE_FALLBACK), "Done");
+    }
+
+    fn scene_with_save() -> LoadGameScene {
+        LoadGameScene::from_saves(vec![SaveFile {
+            name: "corrupt".to_owned(),
+            path: std::path::PathBuf::from("corrupt.sav"),
+            modified: std::time::SystemTime::UNIX_EPOCH,
+        }])
+    }
+
+    #[test]
+    fn failed_load_uses_the_shipped_status_label() {
+        let lines: Vec<String> = SHIPPED_GAMELOD_STR.lines().map(str::to_owned).collect();
+        let strings = dark::importers::parse_strings(&lines);
+        let mut scene = scene_with_save();
+
+        assert_eq!(scene.header_label(Some(&strings)), HEADER_FALLBACK);
+        scene.on_load_failed();
+        assert_eq!(scene.header_label(Some(&strings)), FAILED_FALLBACK);
+    }
+
+    #[test]
+    fn failure_state_clears_for_selection_and_retry_and_is_fresh_on_reentry() {
+        let mut scene = scene_with_save();
+        scene.menu.set_last_pressed(true);
+
+        scene.on_load_failed();
+        assert_eq!(scene.status, LoadGameStatus::Failed);
+        assert!(
+            scene.menu.last_pressed(),
+            "load feedback must not rearm a held press"
+        );
+
+        scene.apply_action(Some(LoadGameAction::Select(0)));
+        assert_eq!(scene.status, LoadGameStatus::Initial);
+
+        scene.on_load_failed();
+        let effects = scene.apply_action(Some(LoadGameAction::Load));
+        assert_eq!(scene.status, LoadGameStatus::Initial);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::GlobalEffect(GlobalEffect::Load { file_name })]
+                if file_name == "corrupt.sav"
+        ));
+
+        // A failed retry reports the same state again, while leaving and
+        // re-entering constructs a new prompt rather than preserving it.
+        scene.on_load_failed();
+        assert_eq!(scene.status, LoadGameStatus::Failed);
+        assert_eq!(scene_with_save().status, LoadGameStatus::Initial);
     }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -312,7 +312,7 @@ pub fn create_initial_scene(
 
     if let Some(save_file_path) = &options.save_file {
         let mut file = OpenOptions::new().read(true).open(save_file_path).unwrap();
-        let save_data = SaveData::read(&mut file);
+        let save_data = SaveData::read(&mut file).unwrap();
         let (mission, mission_to_save_data) = load_mission_from_save_data(
             save_data,
             asset_cache,

--- a/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
+++ b/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { AIM_AT_PANEL, panelPoint } from "./helpers/frontend-menu.js";
 
 // End-to-end test for the main menu -> load-game screen -> back round trip,
 // and for actually restoring a save from the list.
@@ -23,10 +27,14 @@ const CANVAS_W = 640;
 const CANVAS_H = 480;
 const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y / CANVAS_H];
 
-const LOAD_GAME_ENTRY = norm(400 + 179 / 2, 96 + 60 / 2);
-const LOAD_BUTTON = norm(527 + 96 / 2, 161 + 62 / 2);
-const DONE_BUTTON = norm(527 + 95 / 2, 405 + 62 / 2);
-const FIRST_ROW = norm(261 + 202 / 2, 54 + 19 / 2);
+const LOAD_GAME_ENTRY_CANVAS: [number, number] = [400 + 179 / 2, 96 + 60 / 2];
+const LOAD_BUTTON_CANVAS: [number, number] = [527 + 96 / 2, 161 + 62 / 2];
+const DONE_BUTTON_CANVAS: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
+const FIRST_ROW_CANVAS: [number, number] = [261 + 202 / 2, 54 + 19 / 2];
+const LOAD_GAME_ENTRY = norm(...LOAD_GAME_ENTRY_CANVAS);
+const LOAD_BUTTON = norm(...LOAD_BUTTON_CANVAS);
+const DONE_BUTTON = norm(...DONE_BUTTON_CANVAS);
+const FIRST_ROW = norm(...FIRST_ROW_CANVAS);
 
 async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
   await game.input.set("pointer.position", [x, y]);
@@ -36,6 +44,18 @@ async function click(game: GameServer, [x, y]: [number, number]): Promise<void> 
   await game.step({ frames: 2 });
   await game.input.set("pointer.pressed", 0);
   await game.step({ frames: 6 });
+}
+
+async function vrClick(game: GameServer, point: [number, number]): Promise<void> {
+  const [, y, z] = panelPoint(norm(...point));
+  await game.input.set("right_hand.rotation", AIM_AT_PANEL);
+  await game.input.set("right_hand.position", [0, y, z]);
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 3 });
 }
 
 async function entityCount(game: GameServer): Promise<number> {
@@ -110,5 +130,114 @@ test(
       (await entityCount(game)) > 100,
       "loading a save should bring up a populated mission",
     );
+  },
+);
+
+test(
+  "a corrupt save reports Load Failed on the shared flat and VR canvas",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async (t) => {
+    const assetRoot = process.env.DARK_ASSET_PATH;
+    assert.ok(assetRoot, "DARK_ASSET_PATH must explicitly select the 25AE root");
+    const saveName = `issue929_corrupt_${Date.now()}`;
+    const savePath = join(assetRoot, "saves", `${saveName}.sav`);
+    mkdirSync(join(assetRoot, "saves"), { recursive: true });
+    writeFileSync(savePath, "this is not a valid save file");
+    t.after(() => rmSync(savePath, { force: true }));
+
+    const captures = join(tmpdir(), `shock2quest-issue929-${process.pid}`);
+    mkdirSync(captures, { recursive: true });
+
+    let flatFailureObjects = 0;
+    {
+      await using game = await GameServer.launch({ mission: "main_menu", port: 8124 });
+      await game.step({ frames: 5 });
+      await click(game, LOAD_GAME_ENTRY);
+      assert.equal((await game.info()).mission, "load_game");
+
+      await game.input.set("pointer.position", norm(20, 20));
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 3 });
+      const before = await game.screenshot(join(captures, "flat-before.png"));
+
+      await click(game, FIRST_ROW);
+      await click(game, LOAD_BUTTON);
+      await game.input.set("pointer.position", norm(20, 20));
+      await game.step({ frames: 3 });
+      assert.equal(
+        (await game.info()).mission,
+        "load_game",
+        "a malformed save must leave the responsive load screen active",
+      );
+      const after = await game.screenshot(join(captures, "flat-failed.png"));
+      assert.equal(
+        readFileSync(before.full_path).equals(readFileSync(after.full_path)),
+        false,
+        "the failure result must visibly change the canvas",
+      );
+      const flatObjects = (await game.scene.objects()).objects.filter(
+        (object) => object.source === null,
+      );
+      flatFailureObjects = flatObjects.length;
+      assert.ok(flatFailureObjects > 0);
+      assert.ok(
+        flatObjects.every((object) => object.position.every((axis) => axis === 0)),
+        "the flat failure canvas must stay in screen space",
+      );
+
+      // Retry remains a rising-edge action and reports the same failure
+      // without wedging the runtime.
+      await click(game, LOAD_BUTTON);
+      assert.equal((await game.info()).mission, "load_game");
+
+      // Leaving discards the transient status; re-entry starts at the shipped
+      // initial prompt again.
+      await click(game, DONE_BUTTON);
+      await click(game, LOAD_GAME_ENTRY);
+      await game.input.set("pointer.position", norm(20, 20));
+      await game.step({ frames: 3 });
+      const reentered = await game.screenshot(join(captures, "flat-reentered.png"));
+      assert.ok(
+        readFileSync(before.full_path).equals(readFileSync(reentered.full_path)),
+        "a fresh load screen must restore the initial status",
+      );
+    }
+
+    {
+      await using game = await GameServer.launch({
+        mission: "main_menu",
+        port: 8125,
+        debugFlags: ["--vr"],
+      });
+      await game.step({ frames: 5 });
+      await vrClick(game, LOAD_GAME_ENTRY_CANVAS);
+      assert.equal((await game.info()).mission, "load_game");
+      await vrClick(game, FIRST_ROW_CANVAS);
+      await vrClick(game, LOAD_BUTTON_CANVAS);
+
+      // Remove the pointer visuals so object-count parity compares only the
+      // canvas built once by LoadGameScene.
+      await game.input.set("right_hand.rotation", AIM_AT_PANEL);
+      await game.input.set("right_hand.position", [0, 10, 10]);
+      await game.input.set("right_hand.trigger", 0);
+      await game.input.set("left_hand.rotation", AIM_AT_PANEL);
+      await game.input.set("left_hand.position", [0, 10, 10]);
+      await game.input.set("left_hand.trigger", 0);
+      await game.step({ frames: 3 });
+      assert.equal((await game.info()).mission, "load_game");
+      await game.screenshot(join(captures, "vr-failed.png"));
+      const vrObjects = (await game.scene.objects()).objects.filter(
+        (object) => object.source === null,
+      );
+      assert.equal(
+        vrObjects.length,
+        flatFailureObjects,
+        "flat and VR must present the same failure canvas contents",
+      );
+      assert.ok(
+        vrObjects.every((object) => Math.hypot(...object.position) > 0.5),
+        "the VR failure canvas must stay on its world panel",
+      );
+    }
   },
 );


### PR DESCRIPTION
## Summary

- route a failed `GlobalEffect::Load` result back to the still-active load-game scene
- render `GAMELOD.STR`'s shipped `failed` label in `GAMELODR.BIN`'s existing header rect through the shared `UiCanvas`
- return malformed, truncated, non-UTF-8, and schema-incompatible save parsing as `InvalidData` instead of panicking
- keep retry, selection, Done/re-entry, rising-edge input, and flat/VR panel behavior deterministic

## Reproduction and root cause

On exact base `e67b851c`, a listed save that disappears before activation reaches `GlobalEffect::Load`, logs `Unable to load save`, and leaves `LoadGameScene` visually unchanged. A malformed save exposed the adjacent stronger failure: `SaveData::read` unwrapped UTF-8/JSON parsing and panicked the game loop.

`Game::handle_global_effect` discarded the load error after logging it. The active scene therefore had no result to display even though the shipped assets already provide:

- `GAMELOD.STR`: `failed: "Load Failed"`
- `GAMELODR.BIN` rect 0: `[261, 31]–[463, 51]` on the shared 640×480 canvas

The fix adds a narrow failure callback to the active scene. `LoadGameScene` swaps only the text in that authored header rect; both presentation boundaries consume the same resolved canvas.

## Failure-state lifecycle

- failure remains visible for the selected save
- selecting a row clears stale feedback
- retry clears the old status while dispatching; another synchronous failure restores it
- Done exits, and re-entering starts with the shipped initial prompt
- feedback never changes the frontend menu's held-press latch

## Verification

All runtime and SDK launches used explicit 25AE data root `/Users/bryan/ss2-25th` (`sshock2.kpf` plus remaster mods).

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` — 890 passed
- three focused Rust regressions: malformed-save error routing, shipped failure label, selection/retry/re-entry/rising-edge lifecycle
- `npm test` in `tools/shock2-sdk` — 26 passed, 279 opt-in skipped
- focused SDK E2E with real malformed save — flat and `--vr` passed, including canvas object parity and screen/world placement
- full SDK E2E — 305 total: 296 passed, 2 exact-base failures, 7 fixture-gated skips; all 23 mission smoke tests passed
  - exact-base failure: creature-loot reader MFD expected 251, got -1
  - exact-base failure: Hydro3 Korenchkin transcript fixture mismatch

## Visual evidence

![Failed load feedback demo](https://gist.githubusercontent.com/tommy-xr/28cad8f8bb1de63fa6b13e5997e990d3/raw/load-failure-demo.gif)

<sub>A listed save is removed before Load is activated. The shipped status line changes to `Load Failed`; captured headlessly via deterministic `/v1/step` + `/v1/screenshot` requests.</sub>

### Before → after

![Silent base compared with failed-load feedback](https://gist.githubusercontent.com/tommy-xr/28cad8f8bb1de63fa6b13e5997e990d3/raw/load-failure-before-after.png)

The exact-base capture is pixel-identical before and after the failed activation. With the fix, only the status-text region changes.

### Post-fix still

![Load Failed status](https://gist.githubusercontent.com/tommy-xr/28cad8f8bb1de63fa6b13e5997e990d3/raw/load-failed-after.png)

### Flat / VR parity

![Flat and VR shared header rect](https://gist.githubusercontent.com/tommy-xr/28cad8f8bb1de63fa6b13e5997e990d3/raw/load-failure-flat-vr.png)

The cyan outlines show the same authored `GAMELODR.BIN` header rect `[261, 31, 202×20]` after each presentation boundary maps the shared 640×480 canvas. `Load Failed` remains centered inside it in both flat and VR; both VR pointer hands were moved out of view before capture.

Visuals used exact base `e67b851cffc76c161b26794826ad446e977c25c4` and fix `1c295e8359a03b1648b3fa510f1f9df9b2128d78`, with `DARK_ASSET_PATH=/Users/bryan/ss2-25th` for every runtime launch and the identical listed-then-deleted save sequence per base/fix pair.

Fixes #929
