### PR TITLE
fix(scripts): complete the Many ride safely

### DIFF
--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -46,6 +46,35 @@ impl InputContext {
             tracking: None,
         }
     }
+
+    /// Preserve tracked poses and existing VR grip ownership while scripted
+    /// gameplay controls are locked.
+    ///
+    /// A held object is owned by a continuous squeeze in VR. Replacing the
+    /// complete input with `default()` therefore looks exactly like the player
+    /// opened their hand and emits a world drop. Keep that ownership latch for
+    /// hands which were already holding an object, but leave an empty hand's
+    /// squeeze neutral so the lock cannot acquire anything new.
+    pub(crate) fn with_player_controls_suppressed(
+        &self,
+        left_hand_holds_item: bool,
+        right_hand_holds_item: bool,
+    ) -> InputContext {
+        let mut suppressed = self.clone();
+        suppress_hand_controls(&mut suppressed.left_hand, left_hand_holds_item);
+        suppress_hand_controls(&mut suppressed.right_hand, right_hand_holds_item);
+        suppressed.pointer = None;
+        suppressed.crouch = false;
+        suppressed.jump = false;
+        suppressed
+    }
+}
+
+fn suppress_hand_controls(hand: &mut Hand, holds_item: bool) {
+    hand.thumbstick = Vector2::zero();
+    hand.trigger_value = 0.0;
+    hand.squeeze_value = if holds_item { 1.0 } else { 0.0 };
+    hand.a_value = 0.0;
 }
 
 /// A 2D screen-space pointer for flatscreen UI. Position is normalized to
@@ -107,5 +136,57 @@ impl Hand {
             squeeze_value: 0.0,
             a_value: 0.0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, Vector2, Vector3};
+
+    use super::{InputContext, Pointer2D};
+
+    #[test]
+    fn scripted_control_lock_preserves_only_existing_grip_ownership_and_poses() {
+        let mut input = InputContext::default();
+        input.head.position = Vector3::new(1.0, 2.0, 3.0);
+        input.head.rotation = Quaternion::new(0.5, 0.1, 0.2, 0.3);
+        input.left_hand.position = Vector3::new(4.0, 5.0, 6.0);
+        input.left_hand.rotation = Quaternion::new(0.6, 0.2, 0.3, 0.4);
+        input.left_hand.thumbstick = Vector2::new(1.0, -1.0);
+        input.left_hand.trigger_value = 1.0;
+        input.left_hand.squeeze_value = 0.0;
+        input.left_hand.a_value = 1.0;
+        input.right_hand.position = Vector3::new(7.0, 8.0, 9.0);
+        input.right_hand.rotation = Quaternion::new(0.7, 0.3, 0.4, 0.5);
+        input.right_hand.thumbstick = Vector2::new(-1.0, 1.0);
+        input.right_hand.trigger_value = 1.0;
+        input.right_hand.squeeze_value = 1.0;
+        input.right_hand.a_value = 1.0;
+        input.pointer = Some(Pointer2D {
+            position: Vector2::new(0.25, 0.75),
+            pressed: true,
+        });
+        input.crouch = true;
+        input.jump = true;
+
+        let suppressed = input.with_player_controls_suppressed(false, true);
+
+        assert_eq!(suppressed.head.position, input.head.position);
+        assert_eq!(suppressed.head.rotation, input.head.rotation);
+        assert_eq!(suppressed.left_hand.position, input.left_hand.position);
+        assert_eq!(suppressed.left_hand.rotation, input.left_hand.rotation);
+        assert_eq!(suppressed.right_hand.position, input.right_hand.position);
+        assert_eq!(suppressed.right_hand.rotation, input.right_hand.rotation);
+        assert_eq!(suppressed.left_hand.squeeze_value, 0.0);
+        assert_eq!(suppressed.right_hand.squeeze_value, 1.0);
+        assert_eq!(suppressed.left_hand.thumbstick, Vector2::new(0.0, 0.0));
+        assert_eq!(suppressed.right_hand.thumbstick, Vector2::new(0.0, 0.0));
+        assert_eq!(suppressed.left_hand.trigger_value, 0.0);
+        assert_eq!(suppressed.right_hand.trigger_value, 0.0);
+        assert_eq!(suppressed.left_hand.a_value, 0.0);
+        assert_eq!(suppressed.right_hand.a_value, 0.0);
+        assert!(suppressed.pointer.is_none());
+        assert!(!suppressed.crouch);
+        assert!(!suppressed.jump);
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3272,20 +3272,32 @@ impl MissionCore {
         life_state_effects.append(&mut self.update_player_life_state(time.elapsed.as_secs_f32()));
         self.advance_death_camera(time.elapsed.as_secs_f32());
 
-        // A dead player's physical head can still look around in VR, but all
-        // actionable movement, hand, trigger, crouch, and pointer channels are
-        // neutral until reconstruction. Discrete quick-load remains available
-        // because it arrives separately in `command_effects`.
-        let suppressed_input = InputContext::default();
-        let input_context = if self.player_is_alive() && self.player_controls_enabled {
-            input_context
+        // A dead player's actionable channels are neutral until
+        // reconstruction. A scripted control lock is subtler: tracked poses
+        // keep updating, and an item already owned by a VR hand must keep its
+        // grip latch. Otherwise a zeroed squeeze is interpreted as an explicit
+        // DropItem (the eng2 Many ride used to strand the weapon at its
+        // entrance). Empty hands remain neutral and cannot acquire anything.
+        // Discrete quick-load remains available because it arrives separately
+        // in `command_effects`.
+        let suppressed_input = if !self.player_is_alive() {
+            Some(InputContext::default())
+        } else if !self.player_controls_enabled {
+            let (left_held, right_held) = self.interaction.held_entities();
+            Some(
+                input_context
+                    .with_player_controls_suppressed(left_held.is_some(), right_held.is_some()),
+            )
         } else {
-            // The discrete jump is latched separately from the context, so it
-            // has to be dropped here too - otherwise a face button pressed as
-            // the player died would hop the corpse.
-            self.button_jump = false;
-            &suppressed_input
+            None
         };
+        // The discrete jump is latched separately from the context, so it
+        // has to be dropped here too - otherwise a face button pressed as
+        // the player died would hop the corpse.
+        if suppressed_input.is_some() {
+            self.button_jump = false;
+        }
+        let input_context = suppressed_input.as_ref().unwrap_or(input_context);
         // Refill the per-frame AI pathfind budget - only on advancing frames,
         // so paused zero-dt ticks (debug runtime introspection) can't grant
         // extra query slots between stepped frames

--- a/shock2vr/src/scripts/many_ride.rs
+++ b/shock2vr/src/scripts/many_ride.rs
@@ -5,18 +5,20 @@
 //! `ParalyzePlayers`, and the continuously-moving cage platform. A second
 //! white-out releases the player at the end.
 
+use cgmath::{Quaternion, Vector3};
 use dark::properties::{PropDelayTime, PropPosition};
 use serde::{Deserialize, Serialize};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
-use crate::{physics::PhysicsWorld, time::Time};
+use crate::{mission::PlayerInfo, physics::PhysicsWorld, time::Time};
 
 use super::{
-    Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
+    Effect, Message, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
     script_util::{get_first_entity_by_name, send_to_all_switch_links},
 };
 
 const WHITE_OUT_STATE_KEY: &str = "shock2vr.many_ride.white_out";
+const SIT_DOWN_STATE_KEY: &str = "shock2vr.many_ride.sit_down";
 const PARALYZE_STATE_KEY: &str = "shock2vr.many_ride.paralyze_players";
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
@@ -148,13 +150,30 @@ impl Script for WhiteOut {
     }
 }
 
-/// Seat the single supported player at the retail `Seat1` marker and suppress
-/// movement while the adjacent paralyze relay catches up.
-pub struct SitDownRightNow;
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+struct PlayerPose {
+    position: Vector3<f32>,
+    rotation: Quaternion<f32>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct SitDownState {
+    return_pose: Option<PlayerPose>,
+}
+
+/// Temporarily seat the single supported player at retail's `Seat1` marker.
+///
+/// The original sends `GotoSeat` to PlayerScript and later pairs it with
+/// `StandUp`, returning the player from the hallucination to their pre-seat
+/// pose. The port moves the physical pawn to render the ride, so retain that
+/// exact pose here (including across save/load).
+pub struct SitDownRightNow {
+    return_pose: Option<PlayerPose>,
+}
 
 impl SitDownRightNow {
     pub fn new() -> Self {
-        Self
+        Self { return_pose: None }
     }
 }
 
@@ -166,29 +185,81 @@ impl Script for SitDownRightNow {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        if !matches!(msg, MessagePayload::TurnOn { .. }) {
-            return Effect::NoEffect;
+        match msg {
+            MessagePayload::TurnOn { .. } => {
+                let Some(seat) = get_first_entity_by_name(world, "Seat1") else {
+                    return Effect::NoEffect;
+                };
+                let positions = world.borrow::<View<PropPosition>>().unwrap();
+                let Ok(seat_position) = positions.get(seat) else {
+                    return Effect::NoEffect;
+                };
+
+                if self.return_pose.is_none() {
+                    self.return_pose =
+                        world
+                            .borrow::<UniqueView<PlayerInfo>>()
+                            .ok()
+                            .map(|player| PlayerPose {
+                                position: player.pos,
+                                rotation: player.rotation,
+                            });
+                }
+
+                Effect::combine(vec![
+                    Effect::SetPlayerPosition {
+                        position: seat_position.position,
+                        is_teleport: true,
+                        source: dark::properties::TeleportSource::ScriptedTrap,
+                    },
+                    Effect::SetPlayerRotation {
+                        rotation: seat_position.rotation,
+                    },
+                    Effect::SetPlayerControlsEnabled { enabled: false },
+                ])
+            }
+            MessagePayload::StandUp => {
+                let Some(return_pose) = self.return_pose.take() else {
+                    return Effect::SetPlayerControlsEnabled { enabled: true };
+                };
+                Effect::combine(vec![
+                    Effect::SetPlayerPosition {
+                        position: return_pose.position,
+                        is_teleport: true,
+                        source: dark::properties::TeleportSource::ScriptedTrap,
+                    },
+                    Effect::SetPlayerRotation {
+                        rotation: return_pose.rotation,
+                    },
+                    Effect::SetPlayerControlsEnabled { enabled: true },
+                ])
+            }
+            _ => Effect::NoEffect,
         }
+    }
 
-        let Some(seat) = get_first_entity_by_name(world, "Seat1") else {
-            return Effect::NoEffect;
-        };
-        let positions = world.borrow::<View<PropPosition>>().unwrap();
-        let Ok(seat_position) = positions.get(seat) else {
-            return Effect::NoEffect;
-        };
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(SIT_DOWN_STATE_KEY)
+    }
 
-        Effect::combine(vec![
-            Effect::SetPlayerPosition {
-                position: seat_position.position,
-                is_teleport: true,
-                source: dark::properties::TeleportSource::ScriptedTrap,
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &SitDownState {
+                return_pose: self.return_pose,
             },
-            Effect::SetPlayerRotation {
-                rotation: seat_position.rotation,
-            },
-            Effect::SetPlayerControlsEnabled { enabled: false },
-        ])
+            SIT_DOWN_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: SitDownState = state.decode(1, SIT_DOWN_STATE_KEY)?;
+        self.return_pose = restored.return_pose;
+        Ok(())
     }
 }
 
@@ -283,21 +354,31 @@ impl Script for StandUpAgain {
     fn handle_message(
         &mut self,
         _entity_id: EntityId,
-        _world: &World,
+        world: &World,
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        if matches!(msg, MessagePayload::TurnOn { .. }) {
-            Effect::SetPlayerControlsEnabled { enabled: true }
-        } else {
-            Effect::NoEffect
+        if !matches!(msg, MessagePayload::TurnOn { .. }) {
+            return Effect::NoEffect;
         }
+
+        // Retail sends StandUp to PlayerScript, which owns the matching
+        // GotoSeat state. Our single-player equivalent keeps that state on the
+        // unique SitDownNow1 script instance.
+        get_first_entity_by_name(world, "SitDownNow1")
+            .map(|sit_down| Effect::Send {
+                msg: Message {
+                    payload: MessagePayload::StandUp,
+                    to: sit_down,
+                },
+            })
+            .unwrap_or(Effect::SetPlayerControlsEnabled { enabled: true })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{collections::HashMap, time::Duration};
 
     use cgmath::{Quaternion, vec3};
     use dark::properties::{Link, Links, PropSymName, ToLink, WrappedEntityId};
@@ -365,6 +446,17 @@ mod tests {
     #[test]
     fn sit_down_uses_the_single_player_seat_marker() {
         let mut world = World::new();
+        let player_entity = world.add_entity(());
+        let inventory_entity = world.add_entity(());
+        let return_rotation = Quaternion::new(0.5, 0.0, 0.5, 0.0);
+        world.add_unique(PlayerInfo {
+            pos: vec3(1.0, 2.0, 3.0),
+            rotation: return_rotation,
+            entity_id: player_entity,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory_entity,
+        });
         world.add_entity((
             PropSymName("Seat1".to_owned()),
             PropPosition {
@@ -393,6 +485,33 @@ mod tests {
                 effect,
                 Effect::SetPlayerControlsEnabled { enabled: false }
             ))
+        );
+
+        // The pre-seat pose is script-private, versioned state: a save/load
+        // during the ride must still let the paired StandUp return safely.
+        let saved = script.save_state().unwrap();
+        let remap = HashMap::new();
+        let context = ScriptRestoreContext::new(&remap);
+        let mut restored = SitDownRightNow::new();
+        restored.restore_state(&saved, &context).unwrap();
+        let stand_up = Effect::flatten(vec![restored.handle_message(
+            EntityId::dead(),
+            &world,
+            &physics,
+            &MessagePayload::StandUp,
+        )]);
+        assert!(stand_up.iter().any(|effect| matches!(
+            effect,
+            Effect::SetPlayerPosition { position, .. } if *position == vec3(1.0, 2.0, 3.0)
+        )));
+        assert!(stand_up.iter().any(|effect| matches!(
+            effect,
+            Effect::SetPlayerRotation { rotation } if *rotation == return_rotation
+        )));
+        assert!(
+            stand_up
+                .iter()
+                .any(|effect| matches!(effect, Effect::SetPlayerControlsEnabled { enabled: true }))
         );
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -362,6 +362,9 @@ pub enum MessagePayload {
     TurnOff {
         from: EntityId,
     },
+    /// Complete a temporary scripted seat and restore the player's pre-seat
+    /// transform. Retail routes this to PlayerScript after `GotoSeat`.
+    StandUp,
     /// A security device has raised an alarm; the linked ecology switches to
     /// its alert-column population profile.
     Alarm {

--- a/tools/shock2-sdk/test/eng2-many-ride.e2e.test.ts
+++ b/tools/shock2-sdk/test/eng2-many-ride.e2e.test.ts
@@ -15,6 +15,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const TRIPWIRE = 833;
 const SEAT_1 = 870;
 const CAGE_PLATFORM = 976;
+const WRENCH = -928;
 
 async function only(game: GameServer, objectId: number): Promise<EntitySummary> {
   const found = await game.entities.byTemplate(objectId);
@@ -146,6 +147,97 @@ test(
     assert.ok(
       distance(releaseRelativeAfter, releaseRelativeBefore) > 1,
       `StandUpAgain should restore movement after WhiteOut 2; before=${JSON.stringify(releaseRelativeBefore)} after=${JSON.stringify(releaseRelativeAfter)}`,
+    );
+  },
+);
+
+test(
+  "eng2 VR: the Many ride carries an already-held weapon with the player",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8159),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 2 });
+
+    // Provision the retail Wrench into the backpack, then equip it through the
+    // production carried-weapon action while the actual VR grip stays closed.
+    // This establishes the same VirtualHand ownership the Many ride disrupted
+    // in the campaign; direct entity messages cannot prove that state.
+    const wrench = await game.player.spawnItem(WRENCH);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.input.trigger("EquipWrench");
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.entity_id,
+      "the forced-VR regression must begin with the Wrench physically held",
+    );
+
+    const tripwire = await only(game, TRIPWIRE);
+    const [tx, ty, tz] = tripwire.position;
+    await game.player.teleport({ x: tx, y: ty + 0.5, z: tz + 4.8 });
+    await game.step({ frames: 2 });
+    await game.player.teleport({ x: tx, y: ty + 0.5, z: tz });
+
+    // WhiteOut 1 seats and paralyzes the player after two seconds. Suppressing
+    // controls must not turn the held squeeze into a synthetic release, and
+    // the held entity must follow the long scripted relocation to Seat1.
+    await game.step({ frames: 180 });
+    const [player, heldWrench] = await Promise.all([
+      game.player.position(),
+      game.entities.detail(wrench.entity_id),
+    ]);
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.entity_id,
+      "the Many ride must not release a weapon merely because controls are paralyzed",
+    );
+    assert.ok(
+      distance(player, heldWrench.position) < 3,
+      `held Wrench should travel to Seat1 with the player; player=${JSON.stringify(player)} wrench=${JSON.stringify(heldWrench.position)}`,
+    );
+  },
+);
+
+test(
+  "eng2: StandUp returns the player from the temporary Many-ride seat",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8160),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 2 });
+
+    const tripwire = await only(game, TRIPWIRE);
+    const [tx, ty, tz] = tripwire.position;
+    await game.player.teleport({ x: tx, y: ty + 0.5, z: tz + 4.8 });
+    await game.step({ frames: 2 });
+    await game.player.teleport({ x: tx, y: ty + 0.5, z: tz });
+    const preSeatPosition = await game.player.position();
+
+    // Advance past the 80-second second-whiteout branch, its two-second
+    // fade-in, the 200 ms StandUp delay, and the final fade reveal.
+    await game.step({ frames: 5_100 });
+    const returned = await game.player.position();
+    assert.ok(
+      distance(returned, preSeatPosition) < 2,
+      `StandUp should restore the pre-seat Engineering pose; before=${JSON.stringify(preSeatPosition)} after=${JSON.stringify(returned)}`,
+    );
+
+    // The restored pose is ordinary level geometry and controls are live: a
+    // full strafe must move the player instead of leaving them on the isolated
+    // continuously-moving cutscene cage.
+    await game.input.set("right_hand.thumbstick", [1, 0]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.ok(
+      distance(await game.player.position(), returned) > 1,
+      "StandUp should restore controls on the normal Engineering route",
     );
   },
 );


### PR DESCRIPTION
Fixes #1076

## Summary

- keep an existing VR grip latched while scripted player controls are disabled, without allowing an empty hand to acquire anything
- pair the Many ride's `SitDownRightNow` with `StandUpAgain`, restoring the exact pre-seat player pose and controls
- persist that temporary return pose in versioned script state for saves made during the ride
- add negative-first forced-VR regressions for the held Wrench and the authored 80-second return sequence

## Root cause and fidelity

The ride exposed two coupled gaps in the port. Replacing the full `InputContext` with `default()` during paralysis synthesized a squeeze release, so `VirtualHand` emitted `DropItem`. Separately, `StandUpAgain` only re-enabled controls and left the physical pawn on the moving cage.

Retail's `SitDownRightNow` sends `GotoSeat` to `PlayerScript`; the paired `StandUpAgain` sends `StandUp` to that same owner. The port now implements the equivalent single-player state transition. The editor position of `StandUpAgain1` is not treated as a teleport destination.

Script reference: https://thiefmissions.com/telliamed/allscripts.html

## Negative-first evidence

- held-item regression on `origin/main`: `right_hand_entity_id` became `null` instead of Wrench runtime 1695
- return regression on `origin/main`: pre-seat `[0,-11.5,-214.8]`, post-ride `[120.781,-9.865,-79.818]` on the isolated cage route
- no AIPATH route exists from the cage's end sector back to the normal Engineering path, making this a campaign blocker

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr --lib --no-fail-fast` (888 passed)
- `npm test` in `tools/shock2-sdk` (26 passed)
- `SHOCK2_E2E=1 DARK_ASSET_PATH=/Users/bryan/ss2-25th node --test --test-concurrency=1 dist/test/eng2-many-ride.e2e.test.js` (3 passed: flat ride start, forced-VR held Wrench, forced-VR full StandUp return/control)
- deterministic forced-VR before/after capture using the authored `SitDownNow1` and `StandUpAgain1` script endpoints

`cargo test -p shock2vr` also attempts examples and is currently blocked on unchanged `origin/main` code in `examples/melee_grip.rs` (`Option<MeleePosedArm>` passed where `MeleePosedArm` is required); the complete library suite above is green.

## Visual evidence

The same forced-VR request sequence is shown side by side. Both runs equip the
Wrench, send `TurnOn` to the authored `SitDownNow1`, then send `TurnOn` to
`StandUpAgain1`. The base run drops the Wrench and remains on the cage; the fix
returns to the supported Engineering pose with runtime hand ownership intact.

![Many ride before/after animation](https://gist.githubusercontent.com/tommy-xr/1fc77897659553f1e41c901c558c4583/raw/many-ride-before-after.gif)

![Many ride final state before/after](https://gist.githubusercontent.com/tommy-xr/1fc77897659553f1e41c901c558c4583/raw/many-ride-before-after.png)

[Visual evidence gist](https://gist.github.com/tommy-xr/1fc77897659553f1e41c901c558c4583)
