### PR TITLE
fix(gameplay): keep keypad-controlled doors closed

### DIFF
--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -1,7 +1,7 @@
 use cgmath::{InnerSpace, Vector3, Zero};
-use dark::properties::PropTranslatingDoor;
+use dark::properties::{Link, Links, PropKeypadCode, PropTranslatingDoor};
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, IntoIter, View, World};
 use tracing::trace;
 
 use crate::{physics::PhysicsWorld, time::Time};
@@ -10,6 +10,24 @@ use super::{
     Effect, Message, MessagePayload, Script,
     script_util::{is_entity_locked, play_environmental_sound},
 };
+
+/// Whether a numeric keypad owns this door through an authored SwitchLink.
+///
+/// Retail keypad gates put `PropLocked` and the code on the controller, not on
+/// the linked door. The keypad's successful `TurnOn` is therefore the only
+/// player path that may open a closed target; treating the target as an
+/// ordinary unlocked door lets a direct Frob bypass the code entirely.
+fn has_incoming_keypad_switch(world: &World, door: EntityId) -> bool {
+    let links = world.borrow::<View<Links>>().unwrap();
+    let keypad_codes = world.borrow::<View<PropKeypadCode>>().unwrap();
+
+    (&links, &keypad_codes).iter().any(|(links, _code)| {
+        links.to_links.iter().any(|link| {
+            matches!(link.link, Link::SwitchLink)
+                && link.to_entity_id.is_some_and(|target| target.0 == door)
+        })
+    })
+}
 
 pub struct StdDoor {
     audio_handle: AudioHandle,
@@ -252,7 +270,9 @@ impl Script for StdDoor {
                     // while scripted TurnOn below deliberately bypasses locks.
                     if self.target_is_open(&trans_door) {
                         self.close(entity_id, world, &trans_door)
-                    } else if is_entity_locked(world, entity_id) {
+                    } else if is_entity_locked(world, entity_id)
+                        || has_incoming_keypad_switch(world, entity_id)
+                    {
                         // SS2's existing locked-control feedback; the player
                         // still gets a response without changing door state.
                         Effect::PlaySound {
@@ -288,7 +308,10 @@ mod tests {
     use std::time::Duration;
 
     use cgmath::{Matrix4, vec3};
-    use dark::properties::{KeyCard, PropClassTag, PropKeyDst, PropLocked};
+    use dark::properties::{
+        KeyCard, Link, Links, PropClassTag, PropKeyDst, PropKeypadCode, PropLocked, ToLink,
+        WrappedEntityId,
+    };
 
     use crate::{quest_info::QuestInfo, runtime_props::RuntimePropTransform};
 
@@ -335,6 +358,19 @@ mod tests {
         let mut door = StdDoor::new();
         door.initialize(entity_id, world);
         door
+    }
+
+    fn add_keypad_controller(world: &mut World, door: EntityId) -> EntityId {
+        world.add_entity((
+            PropKeypadCode(15061),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 1091,
+                    to_entity_id: Some(WrappedEntityId(door)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ))
     }
 
     /// A doorway authored permanently open: no travel, state open (#602).
@@ -384,6 +420,29 @@ mod tests {
         let mut door = initialized_door(entity_id, &world);
 
         door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn frob_does_not_open_a_closed_door_controlled_by_a_keypad() {
+        let (mut world, entity_id) = test_world(false, false);
+        let keypad = add_keypad_controller(&mut world, entity_id);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 2.0, 3.0));
+        assert!(!door.is_moving);
+
+        door.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: keypad },
+        );
 
         assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
         assert!(door.is_moving);


### PR DESCRIPTION
## Summary

- recognize numeric-keypad ownership from the authored incoming `SwitchLink`
- reject direct player `Frob` while a keypad-controlled `StdDoor` is closed
- preserve the keypad's legitimate scripted `TurnOn` path and ordinary direct-Frob doors

## Why

Engineering Control door 1091 has no `PropLocked`; retail authors its gate on keypad 1181 (`PropLocked(true)`, `KeypadUnhackable`, code `15061`) and links successful activation to the door. The generic `StdDoor` player-Frob path therefore treated the door as an ordinary unlocked one and let players skip the Cargo Bay 2 / Sanger code objective.

The fix follows that existing in-world topology. It scans live numeric keypads for an authored `SwitchLink` to the closed door, treats that direct player open like a locked-door refusal, and leaves scripted `TurnOn` untouched. There is no mission-id special case or debug-only gate.

## Negative-first

The new unit test builds the same topology: an unlocked `StdDoor` targeted by a numeric keypad's `SwitchLink`.

Before the implementation it failed because direct `Frob` changed the target from `[1,2,3]` to its open endpoint `[1,4,3]`. It now proves both sides:

- direct player `Frob` keeps the closed target still
- `TurnOn` from the keypad opens the same target

## Runtime verification

Fresh `eng1.mis`, 25th Anniversary assets, forced VR, keypad untouched and no collected logs:

- base `main`: the production empty-hand trigger emitted `Frob`; door 1091 moved `[0.2,-0.599506,-169.05] → [3.0,-0.599506,-169.05]`, and bounded movement reached `z=-170.39` inside Engineering Control
- this branch: the same input emitted `Frob`, but the door remained at `[0.2,-0.599506,-169.05]`; bounded movement stopped outside at `z=-168.27`

Campaign: `earth → station → medsci → engineering → hydroponics` · detailed test · 25th Anniversary assets · forced VR · seed `1600004333`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p shock2vr std_door` — 11 passed
- `cargo test -p shock2vr --lib` — 888 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- deterministic before/fix forced-VR mission replays using `/v1/step`, `/v1/screenshot`, production hand trigger, and bounded player movement

`cargo test -p shock2vr` also reaches an unrelated pre-existing compile error in the unchanged `shock2vr/examples/melee_grip.rs` (`Option<MeleePosedArm>` passed where `MeleePosedArm` is expected) on current `origin/main`; the complete lib suite above is green.

Fixes #1078

## Visual verification

![Engineering Control keypad guard](https://gist.githubusercontent.com/tommy-xr/c3ec58a0c1bbc9f6d221840aa4e8c3b2/raw/eng-control-keypad-guard.gif)

<sub>Forced-VR production hand Frob followed by the same bounded forward move: the keypad-owned door stays closed and stops the player outside. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Before the direct Frob reaches Engineering Control; after it remains keypad-gated](https://gist.githubusercontent.com/tommy-xr/c3ec58a0c1bbc9f6d221840aa4e8c3b2/raw/eng-control-before-after.png)