### PR TITLE
fix(vr): derive projectile muzzles from model geometry

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -54,6 +54,9 @@ pub struct AnimatedModel {
     scene_objects: Vec<SceneObject>,
     hit_boxes: Rc<HashMap<u32, Aabb3<f32>>>,
     hit_box_shapes: Rc<HashMap<u32, HitBoxShape>>,
+    /// LGMD object meshes can be articulated while still carrying authored
+    /// object-space bounds. AI meshes do not currently expose an equivalent.
+    bounding_box: Option<Aabb3<f32>>,
     vhots: Vec<Vhot>,
     /// Set only for a `PMNM` mesh, whose vertices are in bind-pose model space
     /// rather than joint-local space. Holds `bind_inverse[j] * bind_correction`,
@@ -137,6 +140,7 @@ impl AnimatedModel {
             scene_objects: new_scene_objects,
             hit_boxes: self.hit_boxes.clone(),
             hit_box_shapes: self.hit_box_shapes.clone(),
+            bounding_box: self.bounding_box,
             vhots: self.vhots.clone(),
             bind: self.bind.clone(),
         }
@@ -159,6 +163,7 @@ impl AnimatedModel {
             scene_objects: new_scene_objects,
             hit_boxes: model.hit_boxes.clone(),
             hit_box_shapes: model.hit_box_shapes.clone(),
+            bounding_box: model.bounding_box,
             vhots: model.vhots.clone(),
             bind: model.bind.clone(),
         }
@@ -199,6 +204,7 @@ impl Model {
                     scene_objects,
                     hit_boxes: Rc::new(hit_boxes),
                     hit_box_shapes: Rc::new(HashMap::new()),
+                    bounding_box: Some(bounding_box),
                     vhots: static_mesh.vhots.clone(),
                     bind: None,
                 }),
@@ -266,6 +272,7 @@ impl Model {
                 scene_objects,
                 hit_boxes: Rc::new(hit_boxes),
                 hit_box_shapes: Rc::new(hit_box_shapes),
+                bounding_box: None,
                 vhots: vec![],
                 bind,
             }),
@@ -291,6 +298,7 @@ impl Model {
                     scene_objects,
                     hit_boxes: Rc::new(hit_boxes),
                     hit_box_shapes: Rc::new(HashMap::new()),
+                    bounding_box: Some(bounding_box),
                     vhots: vec![],
                     bind: None,
                 }),
@@ -374,7 +382,20 @@ impl Model {
 
     pub fn bounding_box(&self) -> Option<Aabb3<f32>> {
         match &self.inner {
-            InnerModel::Animated(_animated_model) => None,
+            InnerModel::Animated(_) => None,
+            InnerModel::Static(static_model) => Some(static_model.bounding_box),
+        }
+    }
+
+    /// Authored local-space bounds even when an LGMD object is articulated.
+    ///
+    /// `bounding_box` historically means "static-model bounds" to physics
+    /// fallback callers, so widening it would also invent colliders for
+    /// animated objects. Weapon fire geometry needs the underlying object
+    /// header without changing that behavior.
+    pub fn authored_bounding_box(&self) -> Option<Aabb3<f32>> {
+        match &self.inner {
+            InnerModel::Animated(animated_model) => animated_model.bounding_box,
             InnerModel::Static(static_model) => Some(static_model.bounding_box),
         }
     }

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -828,7 +828,6 @@ pub fn read_vhots<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Vec<
             vhots.push(Vhot::read(reader));
         }
     }
-    vhots.sort_by(|a, b| a.vhot_type.cmp(&b.vhot_type));
     vhots
 }
 
@@ -1319,6 +1318,32 @@ mod tests {
             offset_lights: 0,
             offset_normals: 0,
         }
+    }
+
+    /// A GunFlash vhot is an authored file index. Sorting this table by type
+    /// makes that index name a different point (ar15_w is the shipped example:
+    /// its type-1 muzzle precedes its type-0 breech in the file).
+    #[test]
+    fn vhots_keep_authored_file_order_for_indexed_properties() {
+        let mut header = header_with_mat_extra(8);
+        header.num_vhots = 2;
+        let mut bytes = Vec::new();
+        for (kind, point) in [
+            (VhotType::LightSource, point3(1.0, 2.0, 3.0)),
+            (VhotType::Unknown, point3(4.0, 5.0, 6.0)),
+        ] {
+            bytes.extend_from_slice(&(kind as u32).to_le_bytes());
+            for value in [point.x, point.y, point.z] {
+                bytes.extend_from_slice(&(value * SCALE_FACTOR).to_le_bytes());
+            }
+        }
+
+        let vhots = read_vhots(&header, &mut Cursor::new(bytes));
+
+        assert_eq!(vhots[0].vhot_type, VhotType::LightSource);
+        assert_eq!(vhots[0].point, point3(-1.0, 3.0, 2.0));
+        assert_eq!(vhots[1].vhot_type, VhotType::Unknown);
+        assert_eq!(vhots[1].point, point3(-4.0, 6.0, 5.0));
     }
 
     fn extra_chunk(records: &[(f32, f32)], stride: usize) -> Vec<u8> {

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -570,6 +570,7 @@ fn create_model(
         _v_rendertype,
         v_scale,
         mut rv_vhots,
+        mut rv_model_bounds,
     ) = world
         .borrow::<(
             EntitiesView,
@@ -581,6 +582,7 @@ fn create_model(
             View<PropRenderType>,
             View<PropScale>,
             ViewMut<RuntimePropVhots>,
+            ViewMut<RuntimePropModelBounds>,
         )>()
         .unwrap();
 
@@ -595,6 +597,13 @@ fn create_model(
 
         let vhots = model.vhots();
         entities.add_component(entity_id, &mut rv_vhots, RuntimePropVhots(vhots));
+        if let Some(bounds) = model.authored_bounding_box() {
+            entities.add_component(
+                entity_id,
+                &mut rv_model_bounds,
+                RuntimePropModelBounds(bounds),
+            );
+        }
 
         let qrotation = pos.rotation;
         let rotation = Matrix4::<f32>::from(qrotation);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -87,8 +87,8 @@ use crate::{
     runtime_props::{
         RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
-        RuntimePropLaunchedProjectile, RuntimePropReloading, RuntimePropSelectedAmmo,
-        RuntimePropTransform, RuntimePropVhots, RuntimePropVrGripOffset,
+        RuntimePropLaunchedProjectile, RuntimePropModelBounds, RuntimePropReloading,
+        RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots, RuntimePropVrGripOffset,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -5193,6 +5193,7 @@ impl MissionCore {
                         };
 
                         let vhots = new_model.vhots();
+                        let bounds = new_model.authored_bounding_box();
                         // An articulated VR-wielded first-person model (hand +
                         // arm + gun as skeleton sub-objects) renders unposed
                         // without a player, so give it the empty bind pose (it
@@ -5282,34 +5283,22 @@ impl MissionCore {
                             .add_component(entity_id, PropModelName(model_name));
 
                         self.world.add_component(entity_id, RuntimePropVhots(vhots));
+                        if let Some(bounds) = bounds {
+                            self.world
+                                .add_component(entity_id, RuntimePropModelBounds(bounds));
+                        } else {
+                            self.world.remove::<RuntimePropModelBounds>(entity_id);
+                        }
                     }
                 }
                 Effect::ClearModel { entity_id } => {
                     self.id_to_model.remove(&entity_id);
                     self.id_to_animation_player.remove(&entity_id);
                     self.world
-                        .remove::<(PropModelName, RuntimePropVhots)>(entity_id);
+                        .remove::<(PropModelName, RuntimePropVhots, RuntimePropModelBounds)>(
+                            entity_id,
+                        );
                     self.world.remove::<RuntimePropVrGripOffset>(entity_id);
-                }
-                Effect::SetVhotsFromModel {
-                    entity_id,
-                    model_name,
-                } => {
-                    if let Some(model) = self.id_to_model.get(&entity_id) {
-                        let xform = model.get_transform();
-                        // Same hazard as ChangeModel above: a missing donor
-                        // model must not panic the frame.
-                        let Some(donor_model) =
-                            asset_cache.get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
-                        else {
-                            tracing::error!(
-                                "SetVhotsFromModel: model '{model_name}.BIN' could not be loaded for entity {entity_id:?} - keeping current vhots"
-                            );
-                            continue;
-                        };
-                        let vhots = Model::transform(donor_model.as_ref(), xform).vhots();
-                        self.world.add_component(entity_id, RuntimePropVhots(vhots));
-                    }
                 }
                 Effect::PlayEmail { deck, email, force } => {
                     let email_file = get_email_sound_file(deck, email);

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -8,6 +8,7 @@
  * - They are not serialized / deserialized
  */
 use cgmath::{Matrix4, Point3, Vector3};
+use collision::Aabb3;
 use dark::ss2_bin_obj_loader::Vhot;
 use serde::{Deserialize, Deserializer, Serialize};
 use shipyard::Component;
@@ -112,6 +113,12 @@ pub struct RuntimeBitmapAnimationFrameCount(pub u32);
 
 #[derive(Component, Debug)]
 pub struct RuntimePropVhots(pub Vec<Vhot>);
+
+/// The rendered model's authored local-space bounds. Kept beside its vhots so
+/// systems that need model geometry do not have to reach back into the render
+/// cache.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropModelBounds(pub Aabb3<f32>);
 
 // RuntimePropDoNotSerialize - runtime prop to signal that this prop should not be serialized
 #[derive(Component)]

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -370,14 +370,6 @@ pub enum Effect {
     ClearModel {
         entity_id: EntityId,
     },
-    /// Replace the entity's fire-point vhots with those of `model_name`
-    /// without changing the rendered model. Used by the VR held-weapon path:
-    /// the world model stays rendered (#352), but its mesh has no vhots -
-    /// the muzzle points live in the _h viewmodel.
-    SetVhotsFromModel {
-        entity_id: EntityId,
-        model_name: String,
-    },
     CreateEntityByTemplateName {
         source_entity_id: EntityId,
         template_name: String,

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -45,7 +45,10 @@ impl Script for InternalSwitchHeldModelScript {
                     // Otherwise keep the world model: the classic _h meshes
                     // have their never-visible faces stripped for the fixed
                     // flat camera and look broken from VR's free viewpoints
-                    // (#352).
+                    // (#352). Its own bounds and vhots are also the only fire
+                    // geometry that matches the rendered barrel; borrowing
+                    // points from a differently-authored hand model can put an
+                    // X-axis muzzle on a Z-axis world model.
                     let mut effects = Vec::new();
 
                     // Self-heal cross-mode saves: a save made in flat while
@@ -61,16 +64,6 @@ impl Script for InternalSwitchHeldModelScript {
                                 model_name: original,
                             });
                         }
-                    }
-
-                    // The world model stays rendered, but its mesh has no
-                    // vhots - take the fire points (muzzle) from the hand
-                    // model so projectiles/flash don't spawn at the grip.
-                    if let Some(view_model) = get_view_model(world, entity_id) {
-                        effects.push(Effect::SetVhotsFromModel {
-                            entity_id,
-                            model_name: view_model,
-                        });
                     }
 
                     return Effect::Multiple(effects);

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -12,8 +12,8 @@ use crate::{
     mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateClassTags},
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::{
-        RuntimePropFlatAim, RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropTransform,
-        RuntimePropVhots,
+        RuntimePropFlatAim, RuntimePropModelBounds, RuntimePropReloading, RuntimePropSelectedAmmo,
+        RuntimePropTransform, RuntimePropVhots,
     },
     util::{get_rotation_from_forward_vector, resolve_proxy_entity},
     vr_config,
@@ -33,21 +33,55 @@ const MELEE_DAMAGE: f32 = 6.0;
 /// guns for now; per-weapon loudness is a follow-up.
 const GUNSHOT_NOISE_RADIUS: f32 = 50.0 / SCALE_FACTOR;
 
-/// Rotation taking the projectile's +Z travel axis onto the barrel of a 25AE
-/// first-person gun model, which is authored along the model's **-X** - that is
-/// where each of those meshes puts its muzzle vhot, and pointing that axis out
-/// of the hand is the whole job of every gun's -90 degree yaw in the
-/// `vr_config` grip table (pinned by its
-/// `gun_grips_aim_the_barrel_out_of_the_hand` test). So this one rotation aims
-/// every VR weapon - ballistic, energy and psi alike - down its own rendered
-/// barrel, with no per-weapon correction.
-///
-/// Caveat, pre-existing and unchanged by this: several *classic-install* world
-/// models (`atek_w`, `ar15_w`, `sg_w`, `gren_w`, `viro_w`, `al_w`) are authored
-/// barrel-along-Z instead, so VR mis-aims them by 90 degrees when the 25AE view
-/// models are unavailable. Tracked in #1034.
-fn barrel_axis_from_forward() -> Quaternion<f32> {
-    Quaternion::from_angle_y(Deg(-90.0))
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct MuzzleGeometry {
+    point: cgmath::Point3<f32>,
+    axis: cgmath::Vector3<f32>,
+}
+
+/// Resolve the fire point and direction from the same local-space geometry the
+/// renderer uses. Dark's guns are authored lengthwise on either X (25AE hand
+/// models and several classic models) or Z (the other classic world models),
+/// always toward the negative end. A real vhot wins for the fire point, chosen
+/// geometrically rather than by type/file position; a model without one uses
+/// the centre of its front bounding-box face instead of the grip.
+fn resolve_muzzle_geometry(
+    bounds: Option<collision::Aabb3<f32>>,
+    vhots: &[dark::ss2_bin_obj_loader::Vhot],
+) -> MuzzleGeometry {
+    let axis = bounds
+        .map(|bounds| {
+            let dimensions = bounds.max - bounds.min;
+            if dimensions.z > dimensions.x {
+                -cgmath::Vector3::unit_z()
+            } else {
+                -cgmath::Vector3::unit_x()
+            }
+        })
+        .unwrap_or_else(|| -cgmath::Vector3::unit_x());
+
+    let point = vhots
+        .iter()
+        .max_by(|a, b| {
+            a.point
+                .to_vec()
+                .dot(axis)
+                .total_cmp(&b.point.to_vec().dot(axis))
+        })
+        .map(|vhot| vhot.point)
+        .or_else(|| {
+            bounds.map(|bounds| {
+                let centre = bounds.min + (bounds.max - bounds.min) / 2.0;
+                if axis.x != 0.0 {
+                    point3(bounds.min.x, centre.y, centre.z)
+                } else {
+                    point3(centre.x, centre.y, bounds.min.z)
+                }
+            })
+        })
+        .unwrap_or_else(|| point3(0.0, 0.0, 0.0));
+
+    MuzzleGeometry { point, axis }
 }
 
 /// The weapon entity's current world position (from its live transform).
@@ -315,10 +349,16 @@ pub(super) fn create_muzzle_flash(
         .map(|vhots| vhots.0.clone())
         .unwrap_or_default();
 
+    let bounds = world
+        .borrow::<View<RuntimePropModelBounds>>()
+        .ok()
+        .and_then(|bounds| bounds.get(entity_id).ok().map(|bounds| bounds.0));
+    let fallback = resolve_muzzle_geometry(bounds, &vhots).point;
+
     let vhot_offset = vhots
         .get(options.vhot as usize)
         .map(|v| v.point)
-        .unwrap_or(point3(0.0, 0.0, 0.0));
+        .unwrap_or(fallback);
 
     let transform = v_transform.get(entity_id).unwrap();
 
@@ -389,22 +429,11 @@ pub(super) fn create_projectile(
         .get(entity_id)
         .map(|vhots| vhots.0.clone())
         .unwrap_or_default();
-    // The fire point is the model's first vhot, which the 25AE view models that
-    // carry one author at the -X tip of the barrel (atek_h, ar15_h, sg_h,
-    // lasehand, sfg_h, viro_h, amp_h).
-    //
-    // Documented fallback for a model with no vhot at all: the model origin,
-    // i.e. the grip. The shot still leaves along the barrel, just from the
-    // hand. This is not rare - `empgun_h`, `gren_h`, `fsn_h` and `al_h` ship
-    // with zero vhots, as do most classic-install world models - and a shot
-    // starting at the grip can strike the player when the weapon is held in
-    // close to the body (see #1034). Adding clearance is deliberately left to
-    // that issue: it changes where four more weapons fire from, which is a
-    // separate change from making the vhot-carrying weapons faithful.
-    let muzzle = vhots
-        .first()
-        .map(|v| v.point)
-        .unwrap_or(point3(0.0, 0.0, 0.0));
+    let bounds = world
+        .borrow::<View<RuntimePropModelBounds>>()
+        .ok()
+        .and_then(|bounds| bounds.get(entity_id).ok().map(|bounds| bounds.0));
+    let muzzle = resolve_muzzle_geometry(bounds, &vhots);
 
     let transform = v_transform.get(entity_id).unwrap();
 
@@ -417,8 +446,8 @@ pub(super) fn create_projectile(
         // Projectile velocity is `root_transform * (0, 0, magnitude)`, so put
         // the muzzle at the origin and aim +Z down the barrel.
         root_transform: transform.0
-            * Matrix4::from_translation(muzzle.to_vec())
-            * Matrix4::from(barrel_axis_from_forward()),
+            * Matrix4::from_translation(muzzle.point.to_vec())
+            * Matrix4::from(get_rotation_from_forward_vector(muzzle.axis)),
         options: CreateEntityOptions {
             force_visible: true,
             ..CreateEntityOptions::default()
@@ -495,12 +524,14 @@ mod tests {
     /// `CreateEntity` the script returns.
     fn vr_fire_geometry(
         transform: Matrix4<f32>,
+        bounds: collision::Aabb3<f32>,
         vhots: Vec<dark::ss2_bin_obj_loader::Vhot>,
     ) -> (cgmath::Vector3<f32>, cgmath::Vector3<f32>) {
         let mut world = World::new();
         let weapon = world.add_entity((
             Links::empty(),
             RuntimePropTransform(transform),
+            RuntimePropModelBounds(bounds),
             RuntimePropVhots(vhots),
         ));
 
@@ -534,6 +565,34 @@ mod tests {
         }
     }
 
+    fn muzzle_flash_offset(
+        bounds: collision::Aabb3<f32>,
+        vhots: Vec<dark::ss2_bin_obj_loader::Vhot>,
+        index: u32,
+    ) -> cgmath::Point3<f32> {
+        let mut world = World::new();
+        let weapon = world.add_entity((
+            Links::empty(),
+            dark::properties::PropModelName("test_weapon".to_owned()),
+            RuntimePropTransform(Matrix4::from_scale(1.0)),
+            RuntimePropModelBounds(bounds),
+            RuntimePropVhots(vhots),
+        ));
+        let effect = create_muzzle_flash(
+            &world,
+            weapon,
+            -1,
+            &GunFlashOptions {
+                vhot: index,
+                flags: 0,
+            },
+        );
+        let Effect::CreateEntity { position, .. } = effect else {
+            panic!("a muzzle flash link must create its effect");
+        };
+        position
+    }
+
     /// A VR shot leaves the model's muzzle vhot travelling down the barrel
     /// (the model's -X), for any pose the hand happens to hold the weapon in.
     #[test]
@@ -545,7 +604,8 @@ mod tests {
         let transform = Matrix4::from_translation(translation) * Matrix4::from(rotation);
         let vhot = point3(-0.77, -0.03, 0.06);
 
-        let (origin, forward) = vr_fire_geometry(transform, vec![muzzle_vhot(vhot)]);
+        let bounds = collision::Aabb3::new(point3(-0.8, -0.3, -0.2), point3(0.8, 0.3, 0.2));
+        let (origin, forward) = vr_fire_geometry(transform, bounds, vec![muzzle_vhot(vhot)]);
 
         let expected_origin = translation + rotation * vhot.to_vec();
         let expected_forward = rotation * vec3(-1.0, 0.0, 0.0);
@@ -559,17 +619,69 @@ mod tests {
         );
     }
 
-    /// A model with no vhot at all (the classic `laser` / `lasehand` meshes)
-    /// falls back to the model origin, still firing down the barrel.
+    /// A no-vhot viewmodel fires from the end of its actual barrel geometry,
+    /// not from the grip at the model origin.
     #[test]
-    fn a_vr_shot_from_a_vhotless_model_falls_back_to_the_model_origin() {
+    fn a_vr_shot_from_a_vhotless_model_falls_back_to_the_barrel_tip() {
         let rotation = Quaternion::from_angle_y(Deg(-90.0));
         let transform = Matrix4::from_translation(vec3(1.0, 2.0, 3.0)) * Matrix4::from(rotation);
+        let bounds = collision::Aabb3::new(point3(-1.2, -0.2, -0.4), point3(0.6, 0.2, 0.4));
 
-        let (origin, forward) = vr_fire_geometry(transform, vec![]);
+        let (origin, forward) = vr_fire_geometry(transform, bounds, vec![]);
 
-        assert!((origin - vec3(1.0, 2.0, 3.0)).magnitude() < 1e-5);
+        let expected_origin = transform.transform_point(point3(-1.2, 0.0, 0.0)).to_vec();
+        assert!((origin - expected_origin).magnitude() < 1e-5);
         assert!((forward - rotation * vec3(-1.0, 0.0, 0.0)).magnitude() < 1e-5);
+    }
+
+    /// Classic world models such as ar15_w are Z-long. Their muzzle vhot is
+    /// not necessarily first by type, so both the barrel axis and muzzle choice
+    /// come from geometry rather than list position.
+    #[test]
+    fn a_classic_z_long_weapon_uses_the_frontmost_vhot_and_z_barrel() {
+        let rotation = Quaternion::from_angle_y(Deg(23.0));
+        let translation = vec3(-2.0, 1.0, 4.0);
+        let transform = Matrix4::from_translation(translation) * Matrix4::from(rotation);
+        let bounds = collision::Aabb3::new(point3(-0.1, -0.4, -1.2), point3(0.1, 0.4, 1.2));
+        let breech = dark::ss2_bin_obj_loader::Vhot {
+            vhot_type: dark::ss2_bin_obj_loader::VhotType::Unknown,
+            point: point3(0.11, 0.2, -0.1),
+        };
+        let muzzle = dark::ss2_bin_obj_loader::Vhot {
+            vhot_type: dark::ss2_bin_obj_loader::VhotType::LightSource,
+            point: point3(0.0, 0.2, -1.24),
+        };
+
+        let (origin, forward) = vr_fire_geometry(transform, bounds, vec![breech, muzzle.clone()]);
+
+        assert!((origin - (translation + rotation * muzzle.point.to_vec())).magnitude() < 1e-5);
+        assert!((forward - rotation * vec3(0.0, 0.0, -1.0)).magnitude() < 1e-5);
+    }
+
+    /// A no-vhot weapon's projectile and flash must share the geometry-derived
+    /// fire point; otherwise the shot leaves the barrel while the visible flash
+    /// remains behind at the grip.
+    #[test]
+    fn a_vhotless_muzzle_flash_uses_the_barrel_tip_fallback() {
+        let bounds = collision::Aabb3::new(point3(-1.4, -0.3, -0.2), point3(0.7, 0.3, 0.2));
+
+        let flash = muzzle_flash_offset(bounds, vec![], 0);
+
+        assert_eq!(flash, point3(-1.4, 0.0, 0.0));
+    }
+
+    /// An in-range GunFlash vhot remains a literal authored file index. The
+    /// projectile's geometric "frontmost" selection must not rewrite casing
+    /// and flash attachment semantics.
+    #[test]
+    fn a_muzzle_flash_uses_its_authored_vhot_index() {
+        let bounds = collision::Aabb3::new(point3(-0.1, -0.4, -1.2), point3(0.1, 0.4, 1.2));
+        let muzzle = muzzle_vhot(point3(0.0, 0.2, -1.24));
+        let breech = muzzle_vhot(point3(0.11, 0.2, -0.1));
+
+        let casing = muzzle_flash_offset(bounds, vec![muzzle, breech.clone()], 1);
+
+        assert_eq!(casing, breech.point);
     }
 
     #[test]

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -26,26 +26,38 @@ import type { Quat } from "./helpers/vr-hand.js";
 // the barrel. Fired from a natural hold the bolt then crossed in front of the
 // player and spanged on their own collider instead of reaching the wall.
 //
-// Requires a 25th Anniversary install (DARK_ASSET_PATH): the vhots below are
-// the remastered `mods/sshock2ee.kpf` view models', which is what VR wields.
+// The ordinary matrix requires a 25th Anniversary install (DARK_ASSET_PATH):
+// its viewmodel geometry comes from `mods/sshock2ee.kpf`. The separately gated
+// classic case deliberately runs against an unpacked legacy install.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const classicE2eEnabled = e2eEnabled && process.env.SHOCK2_CLASSIC_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8102);
 
 /** Weapon templates cycled by DebugCycleWeapon (mission_core DEBUG_WEAPONS). */
 const LASER_PISTOL = -22;
+const EMP_RIFLE = -23;
+const GRENADE_LAUNCHER = -21;
 const PSI_AMP = -247;
 
 /** dark::SCALE_FACTOR - model units per world unit. */
 const SCALE_FACTOR = 2.5;
 
 /**
- * The muzzle vhot of each model, in world units (the model's vhot 0, read from
- * the 25AE `obj/*.bin` and divided by SCALE_FACTOR). Both sit at the model's
- * -X extreme, which is the authored barrel direction for these models.
+ * The resolved muzzle point of each model, in world units. Vhot-carrying
+ * models use the authored point; `empgun_h` has none, so its point is the
+ * centre of the -X face of its decoded model bounds. All three are authored
+ * barrel-along -X.
  */
-const MUZZLE_VHOT: Record<string, Vec3> = {
+const MUZZLE_POINT: Record<string, Vec3> = {
   lasehand: [-1.913 / SCALE_FACTOR, -0.0688 / SCALE_FACTOR, 0.16 / SCALE_FACTOR],
+  empgun_h: [-1.5118, 0, 0],
   amp_h: [-1.1072 / SCALE_FACTOR, 0.2719 / SCALE_FACTOR, -0.1199 / SCALE_FACTOR],
+  // Classic-install world model: no vhot, so the centre of its -Z bounds face.
+  gren_w: [0, 0, -1.1999],
+};
+
+const BARREL_AXIS: Record<string, Vec3> = {
+  gren_w: [0, 0, -1],
 };
 
 const len = (v: Vec3): number => Math.sqrt(dot(v, v));
@@ -114,11 +126,13 @@ async function fireAndTrack(
   await game.step({ frames: 5 });
 
   const weapon = await entityTransform(game, weaponId);
-  const vhot = MUZZLE_VHOT[weapon.model];
-  assert.ok(vhot, `VR should wield a view model with a known muzzle vhot, got "${weapon.model}"`);
-  const muzzle = add(weapon.position, quatRotate(weapon.rotation, vhot));
-  // The 25AE view models are authored with the barrel along the model's -X.
-  const barrel = quatRotate(weapon.rotation, [-1, 0, 0]);
+  const muzzlePoint = MUZZLE_POINT[weapon.model];
+  assert.ok(
+    muzzlePoint,
+    `VR should wield a view model with known muzzle geometry, got "${weapon.model}"`,
+  );
+  const muzzle = add(weapon.position, quatRotate(weapon.rotation, muzzlePoint));
+  const barrel = quatRotate(weapon.rotation, BARREL_AXIS[weapon.model] ?? [-1, 0, 0]);
 
   const before = new Set((await game.entities.list()).entities.map((e) => e.id));
   await game.input.set("right_hand.trigger", 1);
@@ -139,14 +153,18 @@ async function fireAndTrack(
   }
   assert.ok(track.length >= 3, "the trigger pull must spawn a travelling projectile");
 
+  const firstStep = sub(track[1], track[0]);
   const travel = sub(track[track.length - 1], track[0]);
-  const heading = normalize(travel);
+  // Initial direction is the barrel rule under test. Using the whole track
+  // would misclassify a correctly-launched physical grenade after gravity has
+  // bent its later trajectory.
+  const heading = normalize(firstStep);
   const muzzleToFirst = sub(track[0], muzzle);
   const axialDistance = dot(muzzleToFirst, heading);
   const lateral = sub(muzzleToFirst, scale(heading, axialDistance));
 
   return {
-    barrelDeviationDeg: angleBetweenDeg(travel, barrel),
+    barrelDeviationDeg: angleBetweenDeg(firstStep, barrel),
     lateralError: len(lateral),
     axialDistance,
     frameStep: len(sub(track[1], track[0])),
@@ -221,12 +239,102 @@ test(
 );
 
 test(
+  "a vhotless VR EMP rifle fires from its model bounds and clears a close hold",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    let emp: EntitySummary | undefined;
+    for (let cycle = 0; cycle < 12 && !emp; cycle += 1) {
+      await game.input.trigger("DebugCycleWeapon");
+      await game.step({ frames: 10 });
+      emp = (await game.entities.list()).entities.find((e) => e.template_id === EMP_RIFLE);
+    }
+    assert.ok(emp, "DebugCycleWeapon must spawn the EMP Rifle");
+
+    await grabWithRightHand(game, emp.position as Vec3);
+    const held = await game.info();
+    assert.equal(held.player.right_hand_entity_id, emp.id, "the hand must hold the EMP rifle");
+
+    const shot = await fireAndTrack(
+      game,
+      emp.id,
+      // The grip itself is in the player capsule. On the old fallback the EMP
+      // shot spawned there and detonated immediately; the bounds-derived tip
+      // sits outside the body and visibly launches down the barrel.
+      [0, 1, 0],
+      [-1, 0, 0],
+      (e) => e.name === "EMP Shot",
+    );
+
+    assertLeftTheMuzzle(shot, "EMP pulse");
+    assert.ok(
+      shot.distanceTravelled > 5,
+      `the EMP pulse must clear the close-held shooter, only travelled ${shot.distanceTravelled.toFixed(2)}`,
+    );
+  },
+);
+
+test(
+  "classic VR: a Z-long vhotless grenade launcher fires down its rendered barrel",
+  {
+    skip: classicE2eEnabled
+      ? false
+      : "set SHOCK2_E2E=1 and SHOCK2_CLASSIC_E2E=1 with classic assets to run",
+  },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 3,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    let launcher: EntitySummary | undefined;
+    for (let cycle = 0; cycle < 12 && !launcher; cycle += 1) {
+      await game.input.trigger("DebugCycleWeapon");
+      await game.step({ frames: 10 });
+      launcher = (await game.entities.list()).entities.find(
+        (e) => e.template_id === GRENADE_LAUNCHER,
+      );
+    }
+    assert.ok(launcher, "DebugCycleWeapon must spawn the Grenade Launcher");
+
+    await grabWithRightHand(game, launcher.position as Vec3);
+    const held = await game.info();
+    assert.equal(
+      held.player.right_hand_entity_id,
+      launcher.id,
+      "the hand must hold the grenade launcher",
+    );
+    assert.equal((await entityTransform(game, launcher.id)).model, "gren_w");
+
+    const shot = await fireAndTrack(
+      game,
+      launcher.id,
+      [0, 1, -2],
+      // The classic grip rotates model -Z onto hand +X. Turning the hand back
+      // maps that rendered barrel onto the debug scene's clear -X lane.
+      [0, 0, 1],
+      (e) => e.name.includes("Grenade Proj"),
+    );
+
+    assertLeftTheMuzzle(shot, "classic grenade");
+  },
+);
+
+test(
   "a VR-wielded psi amp casts from its muzzle vhot along the barrel",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: basePort + 1,
+      port: basePort + 2,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });


### PR DESCRIPTION
## Summary

- preserve model vhots in authored file order so `GunFlash.vhot` remains a literal file index
- resolve a shared muzzle point and barrel axis from the model actually rendered: frontmost real vhot when present, otherwise the center of the dominant-axis front face
- retain authored bounds on animated LGMD viewmodels and carry those bounds beside vhots through model swaps
- use the same resolved fallback for VR projectiles and no-vhot/out-of-range muzzle flashes
- stop grafting classic `_h` donor vhots onto differently oriented world geometry

Fixes #1034

## Pre-fix reproduction and root cause

All 25AE checks used `DARK_ASSET_PATH=/Users/bryan/ss2-25th` (verified `sshock2.kpf` plus remaster mods).

- The shipped 25AE viewmodels `empgun_h`, `gren_h`, `fsn_h`, and `al_h` have no vhots. Their decoded -X barrel tips are respectively `-1.5118`, `-1.0988`, `-1.2606`, and `-0.4886` world units from the grip, but `create_projectile` previously fell back to `(0,0,0)`. A close-held EMP therefore spawned inside the player and detonated at the grip.
- A separately labeled classic compatibility decode (`DARK_ASSET_PATH=/Users/bryan/ss2-data-unpacked`) found the requested world models `atek_w`, `ar15_w`, `sg_w`, `gren_w`, `viro_w`, and `al_w` are Z-long. The old unconditional -X fallback disagreed with the rendered barrels. `gren_w`, for example, is 2.3998 world units long on Z and has no vhot.
- Classic `ar15_w` authors file vhot 0 at the muzzle (`z=-1.2373`, type LightSource) and file vhot 1 at the breech (`z=-0.1004`, type Unknown). `Assault Flash` authors `GunFlash.vhot=0`, while the casing uses index 1. Sorting vhots by type reversed those indices; `.first()` then also selected the breech for projectile origin.

The new negative-first tests failed on each old behavior: sorted-vhot order, grip fallback, hard-coded X/front-vhot selection, no-vhot flash fallback, and sorted GunFlash indexing.

## Visual proof

![VR EMP projectile leaving the bounds-derived muzzle](https://gist.githubusercontent.com/tommy-xr/81fdef1e764f5f1397f2b92cc2a181ed/raw/issue-1034-vr-emp-muzzle.gif)

<sub>The close-held 25AE EMP Rifle now launches its blue pulse from the rendered barrel and carries it downrange. Captured headlessly in `debug_weapons --vr` through the production VR hand path using deterministic `/v1/step` and `/v1/screenshot` requests.</sub>

![Post-fix EMP pulse clear of the barrel](https://gist.githubusercontent.com/tommy-xr/81fdef1e764f5f1397f2b92cc2a181ed/raw/issue-1034-vr-emp-after.png)

## Before → after

![Matched base/fix comparison of the VR EMP muzzle](https://gist.githubusercontent.com/tommy-xr/81fdef1e764f5f1397f2b92cc2a181ed/raw/issue-1034-vr-emp-before-after.png)

<sub>Matched frame and request sequence: base `e67b851c` self-hits at the grip, producing the red damage tint with no downrange pulse; fix `8bdd32ed` derives the vhotless `empgun_h` muzzle from its -X bounding-box tip and visibly clears the barrel.</sub>

<details>
<summary>Motion inspection stills at two distinct simulation times</summary>

![EMP pulse beginning outside the barrel](https://gist.githubusercontent.com/tommy-xr/81fdef1e764f5f1397f2b92cc2a181ed/raw/issue-1034-vr-emp-fix-t0.png)

![EMP pulse separated downrange from the barrel](https://gist.githubusercontent.com/tommy-xr/81fdef1e764f5f1397f2b92cc2a181ed/raw/issue-1034-vr-emp-fix-t1.png)

</details>

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p dark`: 115 unit + 11 25AE-backed real-data integration tests passed
- `cargo test -p shock2vr --lib`: 890 passed
- `npm test`: 26 passed (E2E skipped by design)
- exact 25AE focused `vr-muzzle-origin.e2e.test.js`: laser authored-vhot, EMP no-vhot close hold, and psi authored-vhot passed; classic case gated
- exact 25AE flat regressions: 6/6 passed across close-range projectile, muzzle flash, slow-projectile spang, and world aim
- separately labeled classic compatibility run: `gren_w` Z-long/no-vhot case passed with `SHOCK2_CLASSIC_E2E=1`
- exact 25AE full SDK E2E: 306 total, 295 passed / 3 failed / 8 skipped. Creature-loot and Hydro3 transcript-spacing failed identically on exact base `e67b851c`; the saved-Wrench case passed on focused reruns of both base and this fix, classifying the one full-run miss as unrelated flake. Every affected muzzle/projectile case passed in the full run.

Additional exact-25AE live close-hold probes:

- `empgun_h` → `EMP Shot`: 8.120 units travelled, 0 lateral error, 0° barrel deviation
- `gren_h` → `Normal Grenade Proj`: 9.325 units, 0.0057 lateral error, 0.896° deviation (gravity begins bending the physical grenade)
- `fsn_h` → `Fusion Shot`: 6.960 units, 0 lateral error, 0° deviation
- `al_h` was held/rendered and reloaded from its authored `Small Worm Beaker` (ammo 0→4); firing reaches `AH Annelid Rocket` creation, where the existing `Unimplemented script: homing` panic prevents a post-spawn frame from being queried. The resolver's exact `al_h` bbox-tip rule is covered by the asset/unit matrix; implementing homing is outside this focused fix.

## Risk

Animated model bounds are retained as metadata only; existing static-only `bounding_box()` behavior is unchanged, so this does not add colliders to animated models. Current-good vhot weapons retain their authored muzzle point and direction. Classic behavior is deliberately derived from the model actually rendered rather than an unrelated hand-model donor.
