### PR TITLE
fix(vr): bound melee damage to authored swings

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -29,6 +29,7 @@ pub mod pathfinding;
 pub mod paths;
 pub mod pause_menu;
 mod physics;
+mod player_melee;
 pub mod player_stats;
 mod psi;
 pub mod quest_info;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -713,11 +713,6 @@ mod endurance_upgrade_tests {
 /// First-person player-melee idle clip (motiondb ActorType 1, `+plyrmelee:0`),
 /// used to pose the flat melee viewmodel in its ready stance.
 const MELEE_IDLE_CLIP: &str = "ph212203";
-/// First-person player-melee swing clip (motiondb `+plyrmelee:2 +plyrmeleeswing`),
-/// played once on a melee attack then auto-returns to the idle. The shipped game
-/// always uses the medium-left swing.
-const MELEE_SWING_CLIP: &str = "leftswing";
-
 /// Velocity (world units/s) a radius blast adds per point of stim intensity to
 /// a dynamic body at its center (falling off linearly to zero at the radius).
 /// Tuned so a barrel blast (intensity 15) gives nearby props a solid toss.
@@ -6387,9 +6382,10 @@ impl MissionCore {
         if self.flat_melee_anim.is_some() {
             return;
         }
-        if let Some(clip) =
-            asset_cache.get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{MELEE_SWING_CLIP}_.mc"))
-        {
+        if let Some(clip) = asset_cache.get_opt(
+            &ANIMATION_CLIP_IMPORTER,
+            &format!("{}_.mc", crate::player_melee::SWING_CLIP),
+        ) {
             let player = AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip);
             self.flat_melee_anim = Some((entity_id, player));
         }

--- a/shock2vr/src/player_melee.rs
+++ b/shock2vr/src/player_melee.rs
@@ -1,0 +1,16 @@
+//! Shared timing for the shipped player-melee swing.
+//!
+//! Flat presentation plays this exact clip and resolves damage from its
+//! `MF_TRIGGER1` event. VR leaves the motion to the player's hand, but uses the
+//! same authored contact duration and full-swing cadence for damage gating.
+
+/// Shipped `+plyrmelee:2 +plyrmeleeswing` motion used by player weapons.
+pub(crate) const SWING_CLIP: &str = "leftswing";
+
+const SWING_FRAMES: f32 = 31.0;
+const SWING_FRAMES_PER_SECOND: f32 = 30.0;
+const CONTACT_START_FRAME: f32 = 20.0;
+
+pub(crate) const CONTACT_WINDOW_SECONDS: f32 =
+    (SWING_FRAMES - CONTACT_START_FRAME) / SWING_FRAMES_PER_SECOND;
+pub(crate) const SWING_INTERVAL_SECONDS: f32 = SWING_FRAMES / SWING_FRAMES_PER_SECOND;

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -8,6 +8,8 @@ use crate::{
     PresentationMode,
     mission::{GlobalPresentationMode, stim_response::contact_stim_damage},
     physics::PhysicsWorld,
+    player_melee,
+    time::Time,
     util::get_position_from_transform,
 };
 
@@ -29,28 +31,58 @@ impl MeleeWeapon {
 ///
 /// Dark opens melee collision only during an attack window. In VR the trigger
 /// edge is that production attack gesture: contacts before it, after release,
-/// and after dropping the weapon are harmless. A target can be damaged only
-/// once per pull even if the physical swing chatters across several contacts.
+/// after the authored window, and after dropping the weapon are harmless. A
+/// target can be damaged only once per swing even if the physical contact
+/// chatters across several frames.
 ///
 /// Physical contact is *never* the damage trigger outside VR - a flat swing is
 /// `WeaponScript`'s aimed short-range raycast, so bumping a wielded wrench into
 /// scenery must do nothing. The whole script is therefore inert in flat mode
 /// rather than guarding individual messages.
 pub struct TriggeredMeleeWeapon {
-    attack_active: bool,
+    attack_remaining: f32,
+    swing_cooldown_remaining: f32,
     hit_entities: HashSet<EntityId>,
 }
 
 impl TriggeredMeleeWeapon {
     pub fn new() -> Self {
         Self {
-            attack_active: false,
+            attack_remaining: 0.0,
+            swing_cooldown_remaining: 0.0,
             hit_entities: HashSet::new(),
         }
+    }
+
+    fn close_attack(&mut self) {
+        self.attack_remaining = 0.0;
+        self.hit_entities.clear();
     }
 }
 
 impl Script for TriggeredMeleeWeapon {
+    fn update(
+        &mut self,
+        _entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        if !is_vr(world) {
+            return Effect::NoEffect;
+        }
+
+        let elapsed = time.elapsed.as_secs_f32();
+        self.swing_cooldown_remaining = (self.swing_cooldown_remaining - elapsed).max(0.0);
+        if self.attack_remaining > 0.0 {
+            self.attack_remaining = (self.attack_remaining - elapsed).max(0.0);
+            if self.attack_remaining == 0.0 {
+                self.hit_entities.clear();
+            }
+        }
+        Effect::NoEffect
+    }
+
     fn handle_message(
         &mut self,
         entity_id: EntityId,
@@ -64,17 +96,19 @@ impl Script for TriggeredMeleeWeapon {
 
         match msg {
             MessagePayload::TriggerPull => {
-                self.attack_active = true;
-                self.hit_entities.clear();
+                if self.swing_cooldown_remaining == 0.0 {
+                    self.attack_remaining = player_melee::CONTACT_WINDOW_SECONDS;
+                    self.swing_cooldown_remaining = player_melee::SWING_INTERVAL_SECONDS;
+                    self.hit_entities.clear();
+                }
                 Effect::NoEffect
             }
             MessagePayload::TriggerRelease | MessagePayload::Drop => {
-                self.attack_active = false;
-                self.hit_entities.clear();
+                self.close_attack();
                 Effect::NoEffect
             }
             MessagePayload::Collided { with }
-                if self.attack_active && self.hit_entities.insert(*with) =>
+                if self.attack_remaining > 0.0 && self.hit_entities.insert(*with) =>
             {
                 let Some(amount) = authored_contact_damage(world, entity_id, *with) else {
                     return Effect::NoEffect;
@@ -160,13 +194,13 @@ impl Script for MeleeWeapon {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use dark::properties::{
         Link, Links, PropTemplateId, ReceptronEffect, ReceptronOptions, ToLink,
     };
 
-    use crate::mission::stim_response::GlobalContactStims;
+    use crate::{mission::stim_response::GlobalContactStims, time::Time};
 
     use super::*;
 
@@ -333,6 +367,18 @@ mod tests {
         )
     }
 
+    fn advance(script: &mut TriggeredMeleeWeapon, world: &World, seconds: f32) {
+        script.update(
+            EntityId::dead(),
+            world,
+            &PhysicsWorld::new(),
+            &Time {
+                elapsed: Duration::from_secs_f32(seconds),
+                total: Duration::from_secs_f32(seconds),
+            },
+        );
+    }
+
     #[test]
     fn authored_melee_contact_is_harmless_until_vr_trigger_pull() {
         let (world, weapon, target) = test_world(PresentationMode::Vr);
@@ -367,6 +413,74 @@ mod tests {
             collide(&mut script, &world, weapon, target),
             Effect::NoEffect
         ));
+    }
+
+    #[test]
+    fn a_held_vr_trigger_does_not_leave_melee_armed_forever() {
+        let (world, weapon, target) = test_world(PresentationMode::Vr);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+
+        // The authored player-melee impact window has ended well before this.
+        advance(&mut script, &world, 0.5);
+        assert!(matches!(
+            collide(&mut script, &world, weapon, target),
+            Effect::NoEffect
+        ));
+    }
+
+    #[test]
+    fn vr_melee_trigger_spam_waits_for_the_authored_swing_interval() {
+        let (world, weapon, target) = test_world(PresentationMode::Vr);
+        let mut script = TriggeredMeleeWeapon::new();
+
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+        assert_damage(collide(&mut script, &world, weapon, target), target);
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerRelease,
+        );
+
+        // A fresh edge cannot create a second hit inside one authored swing.
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+        assert!(matches!(
+            collide(&mut script, &world, weapon, target),
+            Effect::NoEffect
+        ));
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerRelease,
+        );
+
+        // Once the leftswing cadence has elapsed, another pull is a new swing
+        // and the same victim is eligible again.
+        advance(&mut script, &world, 1.1);
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+        assert_damage(collide(&mut script, &world, weapon, target), target);
     }
 
     #[test]

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -60,6 +60,13 @@ async function sweepHeldWrench(game: GameServer): Promise<void> {
   }
 }
 
+async function sweepHeldWrenchAcrossXPane(game: GameServer): Promise<void> {
+  for (const x of [-0.4, -0.8, -1.2, -1.6, -1.9, -2.1]) {
+    await game.input.set("right_hand.position", [x, 1.6, 0]);
+    await game.step({ frames: 2 });
+  }
+}
+
 async function paneStillExists(game: GameServer, runtimeId: number): Promise<boolean> {
   return (
     await game.entities.list({ filter: "Window 2", limit: 20 })
@@ -196,6 +203,118 @@ test(
       await paneStillExists(game, dropPane.id),
       true,
       "drop contact must remain harmless",
+    );
+  },
+);
+
+// Regression for #955. TriggerPull is an edge, so an expired or rate-limited
+// pull must never become armed later merely because the level stays held. The
+// shipped one-HP panes let the sequence prove harmless contacts and the next
+// accepted swing without relying on a debug damage shim.
+test(
+  "a held VR melee trigger expires and trigger chatter cannot rearm it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT_SWING_WINDOW ?? 8144),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    const wrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
+    const pane = await byMissionId(
+      game,
+      "Window 2",
+      BREAKABLE_PANE_MISSION_ID,
+    );
+
+    await game.player.teleport({
+      x: wrench.position[0],
+      y: wrench.position[1] - 1.4,
+      z: wrench.position[2] + 1.2,
+    });
+    await game.input.lookAtWorldPoint(wrench.position);
+    await game.input.set("right_hand.position", [0, 1.4, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+
+    await game.player.teleport({
+      x: pane.position[0],
+      y: pane.position[1] - 1.04,
+      z: pane.position[2] - 2.6,
+    });
+    await game.step({ frames: 2 });
+    await game.input.lookAtWorldPoint(pane.position);
+    await game.input.set("right_hand.position", HAND_REST);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 3 });
+
+    // Hold past the 11-frame authored contact duration before touching the
+    // pane. This is the permanent-arm bug from the issue.
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 30 });
+    await sweepHeldWrench(game);
+    assert.equal(
+      await paneStillExists(game, pane.id),
+      true,
+      "contact after the held-trigger attack window expires must be harmless",
+    );
+
+    // A release/re-pull still inside the 31-frame swing cadence is rejected.
+    // Finishing that held contact after the cooldown expires must not arm it
+    // late: only a newly accepted rising edge starts another swing.
+    await game.input.set("right_hand.position", HAND_REST);
+    await game.step({ frames: 10 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await sweepHeldWrench(game);
+    assert.equal(
+      await paneStillExists(game, pane.id),
+      true,
+      "trigger chatter inside one authored swing must not create another hit",
+    );
+
+    // After a complete release, stage at another authored one-HP pane. Using a
+    // fresh physical target avoids asking Rapier to synthesize another
+    // CollisionStarted edge for the thin pane we already crossed twice.
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    const freshPane = await byMissionId(
+      game,
+      "Window 2",
+      DROP_PANE_MISSION_ID,
+    );
+    await game.player.teleport({
+      x: freshPane.position[0] + 2,
+      y: freshPane.position[1] - 1.6,
+      z: freshPane.position[2] + 0.4,
+    });
+    await game.input.lookAtWorldPoint(freshPane.position);
+    await game.input.set("right_hand.position", [0, 1.6, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.step({ frames: 5 });
+    const beforeFreshSwing =
+      (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await sweepHeldWrenchAcrossXPane(game);
+    const freshSwingMessages = (await game.messages.recent()).messages.filter(
+      (message) => message.sequence > beforeFreshSwing,
+    );
+    assert.equal(
+      await paneStillExists(game, freshPane.id),
+      false,
+      `the next accepted swing should damage a fresh pane: ${JSON.stringify(freshSwingMessages)}`,
     );
   },
 );


### PR DESCRIPTION
## Reproduction

On exact base `e67b851cffc76c161b26794826ad446e977c25c4`, `TriggeredMeleeWeapon` stayed armed from `TriggerPull` until release/drop. Two negative-first Rust regressions failed:

- contact after 0.5 seconds of a continuously held trigger still dealt damage
- an immediate release/re-pull dealt a second hit with no swing-rate limit

The matched real-runtime reproduction uses the authored Wrench (mission object 786) and one-HP `Window 2` pane (mission object 82) in `command2.mis --vr`. After the production trigger edge, it waits exactly 30 fixed frames before the controller-driven sweep. Base emitted real `Damage` + `Slay` at frame 49 and removed the pane; this branch leaves it intact with no pane damage message.

## Fix

- Share the shipped player-melee timing source between flat and VR: `leftswing` is 31 frames at 30 fps and authors `MF_TRIGGER1` on frame 20.
- Open VR contact damage immediately for the authored remaining 11-frame contact duration (`0.367s`) while the player's hand supplies the physical gesture.
- Accept a new trigger edge only after the full 31-frame swing interval (`1.033s`), without arming a rejected held edge later.
- Close the window on timeout, release, or drop; clear per-target hit state per accepted swing so a later swing can damage the same target again.
- Keep the state transient across save/load, as before.

Flat presentation still plays the same shared `leftswing` clip and resolves damage only from its authored `MF_TRIGGER1` event. The collider-volume work in #1057 and impact-direction work in #1074 remain out of scope.

## Verification

Every runtime/SDK invocation used `DARK_ASSET_PATH=/Users/bryan/ss2-25th`, verified by `sshock2.kpf` and remaster mods `sshock2ee`, `scp`, `patch_ext`, `shtup`, and `400`.

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` — 889 passed
- focused melee-script module — 10 passed, including both negative-first regressions
- SDK unit suite — 305 total: 26 passed, 279 opt-in E2E skipped
- new real `command2.mis --vr` expiry/chatter/next-swing scenario — 3/3 repeated passes, plus a clean isolated-target pass after exact-base classification
- complete `vr-melee-contact.e2e.test.ts` — 4 passed
- flat authored swing-event regression + saved MedSci cross-deck/save-load VR melee — 2 passed
- full serialized 25AE E2E — 305 total: 296 passed, 2 failed, 7 skipped; all 23 mission loads passed

The two full-suite failures reproduce identically on exact base `e67b851c` in an isolated targeted run:

- creature-loot reader binding: `-1 !== 251` (tracked by #931)
- Hydro3 Korenchkin transcript spacing expectation

## Visual verification

![VR melee attack-window comparison](https://gist.githubusercontent.com/tommy-xr/582ea89ec2898cf80a071f1600d3556a/raw/melee-window-demo.gif)

<sub>Same authored Wrench and one-HP Window 2 pane in `command2.mis --vr`: after holding the trigger for 30 fixed simulation frames before contact, the old unbounded attack breaks the pane while the fixed 11-frame authored contact window leaves it intact. Captured headlessly against the exact base and fix refs with deterministic `/v1/step` + `/v1/screenshot`.</sub>

### Before → after

![Held-trigger late-sweep before and after](https://gist.githubusercontent.com/tommy-xr/582ea89ec2898cf80a071f1600d3556a/raw/melee-window-before-after.png)

### Post-fix still

![Post-fix late sweep leaves the pane intact](https://gist.githubusercontent.com/tommy-xr/582ea89ec2898cf80a071f1600d3556a/raw/melee-window-after.png)

[Visual evidence gist](https://gist.github.com/tommy-xr/582ea89ec2898cf80a071f1600d3556a)

Fixes #955
