### PR TITLE
refactor(ui): share the developer frontend shell

### DIFF
--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -21,26 +21,28 @@ use shipyard::{EntityId, UniqueViewMut, World};
 use crate::{
     GameOptions, PresentationMode,
     game_scene::GameScene,
-    input_context::{InputContext, Pointer2D},
+    input_context::InputContext,
     mission::GlobalContext,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        FrontendPanelAnchor,
-        FrontendPointerPass,
-        FrontendSfx,
-        PointerVisuals,
+        FrontendMenu,
         Rect,
         ScaleMode,
         UiCanvas,
-        VR_COMPONENT_Z_STEP,
         dev_params_panel,
         // The archive-database frame: a header line, a dark pane the rows sit
         // in, and framed button art for "Done" - the geometry the panel is
         // laid out against, owned by the panel so both hosts share it.
         dev_params_panel::{BACKDROP_TEXTURE, DevParamsEvent, PanelRects},
-        pointer_to_canvas,
-        vr_frontend_pointer_pass,
+    },
+};
+
+#[cfg(test)]
+use crate::{
+    input_context::Pointer2D,
+    ui::{
+        resolve_click_at as shell_resolve_click_at, resolve_flat_click, vr_frontend_pointer_pass,
     },
 };
 
@@ -53,67 +55,40 @@ const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 /// Shared click core: both presentations reduce to "a point on the canvas plus
 /// a pressed flag", so the rising-edge rule lives here once. The hit regions
 /// themselves are the panel's ([`dev_params_panel::hit`]).
+#[cfg(test)]
 fn resolve_click_at(
     rects: PanelRects,
     point: Option<Vector2<f32>>,
     pressed: bool,
     last_pressed: bool,
 ) -> (Option<DevParamsEvent>, bool) {
-    if !pressed || last_pressed {
-        return (None, pressed);
-    }
-    (point.and_then(|p| dev_params_panel::hit(rects, p)), pressed)
+    shell_resolve_click_at(point, pressed, last_pressed, |point| {
+        dev_params_panel::hit(rects, point)
+    })
 }
 
 /// Pure click resolution for the flat pointer.
+#[cfg(test)]
 fn resolve_click(
     rects: PanelRects,
     pointer: Option<Pointer2D>,
     last_pressed: bool,
     screen_size: Vector2<f32>,
 ) -> (Option<DevParamsEvent>, bool, Option<Vector2<f32>>) {
-    match pointer {
-        Some(p) => {
-            let point = pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            );
-            let (event, pressed) = resolve_click_at(rects, point, p.pressed, last_pressed);
-            (event, pressed, point)
-        }
-        // A frame with no pointer at all carries `last_pressed` through rather
-        // than clearing it: clearing would re-arm the click edge under a
-        // still-held button, so a trigger held across scene entry (which is
-        // exactly why the scene starts with `last_pressed = true`) would fire
-        // the moment the pointer reappears. Same rule the pause overlay keeps.
-        None => (None, last_pressed, None),
-    }
+    resolve_flat_click(
+        pointer,
+        last_pressed,
+        screen_size,
+        vec2(CANVAS_W, CANVAS_H),
+        SCALE_MODE,
+        |point| dev_params_panel::hit(rects, point),
+    )
 }
 
 pub struct DeveloperScene {
     world: World,
     scene_name: String,
-    /// Pointer from the latest update, used for hover highlighting in render.
-    pointer: Option<Pointer2D>,
-    /// Where the VR controller ray last met the panel, in canvas pixels.
-    vr_pointer_canvas: Option<Vector2<f32>>,
-    /// The pointer pass that hit-tested this frame, kept so `render` draws the
-    /// beams and dot from the very rays `update` resolved the highlight from.
-    vr_pointer: FrontendPointerPass,
-    /// The drawn half of that pointer (hands, beams, dot).
-    vr_pointer_visuals: PointerVisuals,
-    /// Where the VR panel is anchored: placed from the head on scene entry
-    /// and world-locked after that.
-    panel_anchor: FrontendPanelAnchor,
-    /// Whether the pointer was pressed last frame (for rising-edge clicks).
-    last_pressed: bool,
-    /// Screen size from the latest render, so `update` can map the pointer
-    /// into canvas space consistently with how the canvas is drawn.
-    last_screen_size: Vector2<f32>,
-    /// The frontend's hum, rollover and select sounds.
-    sfx: FrontendSfx<DevParamsEvent>,
+    menu: FrontendMenu<DevParamsEvent>,
     /// The panel's widget rects, re-resolved from `GAMELODR.BIN` each update
     /// (the render path takes `&self`, so it reads the resolved value here).
     panel_rects: PanelRects,
@@ -124,18 +99,7 @@ impl DeveloperScene {
         Self {
             world: super::ui_scene_world(),
             scene_name: "developer".to_owned(),
-            pointer: None,
-            vr_pointer_canvas: None,
-            vr_pointer: FrontendPointerPass::default(),
-            vr_pointer_visuals: PointerVisuals::new(),
-            panel_anchor: FrontendPanelAnchor::new(),
-            // A press held across a scene swap must not read as a click here:
-            // every frontend screen sits on the same 640x480 canvas and their
-            // widgets overlap, so starting "already pressed" makes the next
-            // rising edge require a real release first.
-            last_pressed: true,
-            last_screen_size: vec2(CANVAS_W, CANVAS_H),
-            sfx: FrontendSfx::new(),
+            menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
             panel_rects: PanelRects::default(),
         }
     }
@@ -175,45 +139,13 @@ impl GameScene for DeveloperScene {
         self.panel_rects = dev_params_panel::rects(asset_cache);
         let rects = self.panel_rects;
 
-        // The panel is placed from the head on scene entry and world-locked
-        // after that; advancing it here keeps the ray and the render agreeing
-        // on where the screen is, in either presentation.
-        let panel = self.panel_anchor.update(
-            input_context.head.position,
-            input_context.head.rotation,
+        let event = self.menu.update(
             time.elapsed,
+            input_context,
+            game_options.presentation_mode,
+            |point| dev_params_panel::hit(rects, point),
+            |point| dev_params_panel::hit(rects, point),
         );
-
-        let (event, last_pressed, point) = if game_options.presentation_mode == PresentationMode::Vr
-        {
-            // VR has no 2D cursor: the pointer is where a controller ray
-            // meets the panel, and the trigger is the button.
-            self.vr_pointer =
-                vr_frontend_pointer_pass(input_context, vec2(CANVAS_W, CANVAS_H), &panel);
-            let (point, pressed) = (self.vr_pointer.point(), self.vr_pointer.pressed);
-            self.vr_pointer_canvas = point;
-            self.pointer = None;
-            let (event, last_pressed) = resolve_click_at(rects, point, pressed, self.last_pressed);
-            (event, last_pressed, point)
-        } else {
-            self.pointer = input_context.pointer;
-            self.vr_pointer = FrontendPointerPass::default();
-            resolve_click(
-                rects,
-                input_context.pointer,
-                self.last_pressed,
-                self.last_screen_size,
-            )
-        };
-        self.last_pressed = last_pressed;
-
-        // Hover and click feedback from the same hit test that resolves the
-        // click, so a sound plays exactly when a button lights up.
-        self.sfx
-            .hover(point.and_then(|p| dev_params_panel::hit(rects, p)));
-        if event.is_some() {
-            self.sfx.click();
-        }
 
         if let Some(event) = event {
             // Steps are applied to the registry here; "Done" returns to the
@@ -239,25 +171,8 @@ impl GameScene for DeveloperScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = self.panel_anchor.panel();
-        let canvas = self.build_canvas(self.vr_pointer_canvas);
-        let mut objects = canvas.render_world_space(
-            asset_cache,
-            panel.transform(),
-            self.vr_pointer_canvas,
-            None,
-            VR_COMPONENT_Z_STEP,
-        );
-        // The controllers and their aim rays, so the player can see where they
-        // are pointing before a button lights up.
-        let panel_layers = objects.len();
-        objects.extend(self.vr_pointer_visuals.render(
-            asset_cache,
-            &self.vr_pointer,
-            vec2(CANVAS_W, CANVAS_H),
-            &panel,
-            panel_layers,
-        ));
+        let canvas = self.build_canvas(self.menu.pointer_canvas());
+        let objects = self.menu.render_world_space(asset_cache, canvas);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -269,23 +184,16 @@ impl GameScene for DeveloperScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        self.last_screen_size = screen_size;
         // In VR the screen lives on a world-space panel drawn by `render`; a
         // screen-space copy here would paste the whole canvas over both eyes
         // and hide it.
         if options.presentation_mode == PresentationMode::Vr {
             return Vec::new();
         }
-        let pointer_canvas = self.pointer.and_then(|p| {
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            )
-        });
+        let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(pointer_canvas);
-        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+        self.menu
+            .render_screen_space(asset_cache, canvas, screen_size)
     }
 
     fn handle_effects(
@@ -296,7 +204,7 @@ impl GameScene for DeveloperScene {
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Vec<GlobalEffect> {
-        self.sfx.pump(asset_cache, audio_context);
+        self.menu.pump_sfx(asset_cache, audio_context);
         effects
             .into_iter()
             .filter_map(|e| match e {
@@ -307,7 +215,7 @@ impl GameScene for DeveloperScene {
     }
 
     fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
-        self.sfx.stop(audio_context);
+        self.menu.stop_sfx(audio_context);
     }
 
     fn wants_pointer(&self) -> bool {
@@ -397,10 +305,19 @@ mod tests {
         let (event, _, _) = resolve_click(
             PanelRects::default(),
             pointer_at(first_increment_point(), true),
-            scene.last_pressed,
+            scene.menu.last_pressed(),
             SCREEN,
         );
         assert_eq!(event, None);
+    }
+
+    /// The frontend shell must own the cross-scene press latch. Keeping a
+    /// second latch on this host is exactly how otherwise-identical screens
+    /// drift when the shared pointer rules change.
+    #[test]
+    fn the_shared_frontend_shell_owns_the_entry_press_guard() {
+        let scene = DeveloperScene::new();
+        assert!(scene.menu.last_pressed());
     }
 
     /// A frame with no pointer must not re-arm the click edge: the scene is
@@ -411,9 +328,13 @@ mod tests {
     #[test]
     fn a_pointerless_frame_keeps_the_held_press_guard() {
         let scene = DeveloperScene::new();
-        assert!(scene.last_pressed);
-        let (event, last, point) =
-            resolve_click(PanelRects::default(), None, scene.last_pressed, SCREEN);
+        assert!(scene.menu.last_pressed());
+        let (event, last, point) = resolve_click(
+            PanelRects::default(),
+            None,
+            scene.menu.last_pressed(),
+            SCREEN,
+        );
         assert_eq!(event, None);
         assert_eq!(point, None);
         assert!(last, "a pointerless frame must carry the guard through");


### PR DESCRIPTION
## Summary

- port `DeveloperScene` onto the existing generic `FrontendMenu<DevParamsEvent>` host
- make the shared shell own its pointer arbitration, held-press latch, VR panel anchor, pointer visuals, frontend audio, and presentation boundary
- retain the Developer screen's authored `GAMELODR.BIN` rect resolution, canvas contents, parameter actions, and Done navigation as screen-owned behavior

PR #1055 already extracted this shell for Main, Load, Game Over, and Pause. Developer was the remaining interactive frontend host with a hand-written seven-field copy, so this makes the exact current interactive set five consumers of one implementation.

`NoAssetsScene` is deliberately not included: it cannot load a layout, strings, backdrop, or audio, and it has no pointer or actions. Its remaining flat/VR presentation branch belongs to #1004. The scrollable-list functionality proposed alongside the issue is likewise kept independently reviewable in #928.

## Reproduction and negative-first evidence

On exact base `e67b851cffc76c161b26794826ad446e977c25c4`, `DeveloperScene` separately owned `pointer`, VR pointer state and visuals, `FrontendPanelAnchor`, `last_pressed`, `last_screen_size`, and `FrontendSfx`, then repeated the same update/render lifecycle as the other frontend screens.

The architecture regression `the_shared_frontend_shell_owns_the_entry_press_guard` failed first on that base with `E0609`: `DeveloperScene` had no `menu` field, and the compiler listed the duplicated shell fields. After the extraction, it and all seven existing Developer action/input characterizations pass.

The refactor is one file and removes more code than it adds (`54` insertions, `133` deletions). The load screen's backdrop-field row clamp, the held-press guards across scene/page swaps, debug-runtime Quit observation, and every screen-specific action remain covered and unchanged.

## Verification

Every runtime and SDK launch used the explicit 25th Anniversary root `/Users/bryan/ss2-25th`, verified by `sshock2.kpf` and the five remaster mod archives.

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS='-D warnings' cargo test -p shock2vr --lib` — 888 passed
- focused Developer Rust tests — 8 passed
- SDK unit suite — 26 passed, 278 E2E-gated
- focused real-runtime frontend suite — 11 passed: Developer flat/VR/pause actions, load navigation, frontend SFX, and flat/VR debug-runtime Quit observation
- full serialized 25AE SDK E2E — 304 total: 295 passed, 2 exact-base failures, 7 fixture-gated skips; all 23 missions loaded
  - creature-loot reader MFD expected `251`, got `-1` (#931)
  - Hydro3 Korenchkin transcript fixture expects different spacing while the transcript is present
- the two failures were rerun alone on exact base `e67b851c` with the same 25AE root and reproduced byte-for-byte in their assertion values (2 passed / 2 failed in that targeted base run)

## Visual verification

![Developer shell interaction parity](https://gist.githubusercontent.com/tommy-xr/bd60e632ca5e852ba351f662193dfaf6/raw/developer-shell-interactions.gif)

<sub>Matched exact-base/refactor flatscreen sequence: hover `>`, increment Panel distance from 2.00 to 2.10, hover `<`, restore 2.00, then hover Done. Every corresponding base/refactor frame is byte-identical. Captured headlessly from the Main Menu with the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) against the verified 25AE install.</sub>

### Exact base → refactor · flat + VR

![Developer shell flat and VR parity](https://gist.githubusercontent.com/tommy-xr/bd60e632ca5e852ba351f662193dfaf6/raw/developer-shell-flat-vr-parity.png)

<sub>Exact base `e67b851c` and the refactor render identically in both presentations after the same Main Menu → Developer inputs. All five flat frame pairs and both VR frame pairs are byte- and pixel-identical. The VR capture also shows the controller ray's stable hover on `>`.</sub>

### Post-refactor still

![Developer panel incremented](https://gist.githubusercontent.com/tommy-xr/bd60e632ca5e852ba351f662193dfaf6/raw/developer-shell-incremented.png)

No headset pass is required: this only replaces duplicated frontend orchestration with the same existing shell and does not touch Oculus/OpenXR lifecycle, tracked-pose acquisition, or device-only rendering. Both flat and VR geometry and interaction paths were exercised through the deterministic debug-runtime harness.

Fixes #1046
