### PR TITLE
fix(gameplay): preserve scripted corpse loot

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -407,20 +407,21 @@ pub fn create_entity_core(
         processed_scripts.push("internal_triggered_melee_weapon".to_owned());
     }
 
-    // `MOVE` is an engine frob action, not an object script. Ordinary goodies
-    // such as Med Patches and armor only inherit that flag, so give them the
-    // internal handler that moves them into the backpack on Frob. Objects that
-    // also request SCRIPT keep their existing authored ownership (notably
-    // FrobQB's circuit-board/quest-item transfer). Nanite piles also inherit
-    // MOVE but must go exclusively through `internal_nanites` above - a
-    // second Frob handler here would race it to move the pile into the
-    // backpack instead of awarding+destroying it.
+    // `MOVE` is an engine frob action, not an object script. Give every
+    // grabbable world-frob item the internal move handler even when it also
+    // requests SCRIPT: the authored scripts contribute side effects and the
+    // engine still performs the physical transfer. The only exceptions are
+    // paths that explicitly own transfer/consumption themselves (`FrobQB` and
+    // the injected keycard script). Nanite piles also inherit MOVE but must go
+    // exclusively through `internal_nanites` above - a second Frob handler
+    // here would race it to move the pile into the backpack instead of
+    // awarding+destroying it.
     let needs_frob_move = {
         let v_frob_info = world.borrow::<View<PropFrobInfo>>().unwrap();
         v_frob_info.get(entity_id).is_ok_and(|frob| {
-            !frob.world_action.contains(FrobFlag::SCRIPT)
-                && (frob.world_action.contains(FrobFlag::MOVE)
-                    || frob.world_action.contains(FrobFlag::USE_AMMO))
+            (frob.world_action.contains(FrobFlag::MOVE)
+                || frob.world_action.contains(FrobFlag::USE_AMMO))
+                && !crate::virtual_hand::scripted_world_frob_owns_transfer(world, entity_id)
         }) && !is_nanite_pickup_template(entity_info, template_id)
     };
     if needs_frob_move {

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -408,17 +408,13 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // feeds an item into a container (drop_entity_into_container).
             // Guarded by the same grabbability check as the debug give
             // lever: reparenting a non-grabbable entity would corrupt it.
-            // Use-only contained objects (notably corpse audio logs) still
-            // need their normal Frob behavior when clicked; they are consumed
-            // or recorded in place rather than moved into the backpack.
+            // Scripted contained objects must run their authored Frob behavior
+            // first. `MOVE | SCRIPT` objects receive the engine move handler
+            // as another script, while keycards and FrobQB objects keep sole
+            // ownership of their established transfer/consumption paths.
+            // Ordinary MOVE loot keeps the direct transfer below.
             ContainerGuiMsg::Take(ent) => {
-                // The always-collected categories are decided before anything
-                // physical is considered: a nanite pile is grabbable metadata-
-                // wise (`MOVE`), so without this it would be banked as an inert
-                // can instead of being credited. Keycards, modules and logs took
-                // the Frob branches below already; routing all four here is what
-                // makes the rule one rule (#583, and the M2 recovery path).
-                if crate::scripts::script_util::is_always_collected(world, *ent) {
+                if crate::virtual_hand::uses_scripted_world_frob(world, *ent) {
                     return (
                         state.clone(),
                         Effect::Send {
@@ -433,10 +429,8 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                     let is_use_only = world
                         .borrow::<View<PropFrobInfo>>()
                         .map(|frob| {
-                            frob.get(*ent).is_ok_and(|frob| {
-                                frob.world_action.contains(FrobFlag::SCRIPT)
-                                    || frob.inventory_action.contains(FrobFlag::SCRIPT)
-                            })
+                            frob.get(*ent)
+                                .is_ok_and(|frob| frob.inventory_action.contains(FrobFlag::SCRIPT))
                         })
                         .unwrap_or(false);
                     return if is_use_only {
@@ -453,10 +447,6 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                         (state.clone(), Effect::NoEffect)
                     };
                 }
-                // Deliberately *not* gated on the broader
-                // `uses_scripted_world_frob`: that also matches authored
-                // MOVE|SCRIPT items like eng1's circuit board, which keep their
-                // pre-existing Take behavior of moving into the backpack.
                 let inventory_entity = world
                     .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
                     .map(|player| player.inventory_entity_id)
@@ -560,12 +550,12 @@ mod tests {
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
     /// through.
-    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+    fn loot_world_with_action(world_action: FrobFlag) -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
         let item = world.add_entity((
             PropObjIcon("icn_psi".to_owned()),
             PropFrobInfo {
-                world_action: FrobFlag::MOVE,
+                world_action,
                 inventory_action: FrobFlag::empty(),
                 tool_action: FrobFlag::empty(),
             },
@@ -599,6 +589,10 @@ mod tests {
                 lock_id: 0,
             }),
         );
+    }
+
+    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+        loot_world_with_action(FrobFlag::MOVE)
     }
 
     fn input_at(cursor: cgmath::Point2<f32>, pressed: bool) -> GuiInputInfo {
@@ -773,6 +767,33 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn loot_container_click_frobs_a_scripted_pickup() {
+        let (world, container, item, _inventory) =
+            loot_world_with_action(FrobFlag::MOVE | FrobFlag::SCRIPT);
+        let gui = ContainerGui::loot_container();
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+
+        assert!(
+            matches!(
+                effect,
+                Effect::Send {
+                    msg: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                } if to == item
+            ),
+            "taking MOVE | SCRIPT loot must run its authored Frob path, got {effect:?}"
+        );
     }
 
     /// Both panels' item grids must land on their cell separators - the loot

--- a/shock2vr/src/scripts/internal_frob_move.rs
+++ b/shock2vr/src/scripts/internal_frob_move.rs
@@ -5,12 +5,12 @@ use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script, script_util::player_carried_items};
 
-/// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior for
-/// ordinary pickup items that do not ask an authored script to handle Frob.
+/// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior.
 ///
-/// `MOVE | SCRIPT` objects keep their existing scripted ownership. In
-/// particular, `FrobQB` must award the Engineering circuit board's quest bit
-/// and transfer it exactly once.
+/// `MOVE | SCRIPT` means both actions happen: authored scripts keep their side
+/// effects while this handler performs the physical transfer. Entities whose
+/// scripts explicitly own transfer/consumption (`FrobQB` and keycards) never
+/// receive this handler and are guarded here too.
 pub struct InternalFrobMove;
 
 impl InternalFrobMove {
@@ -31,14 +31,17 @@ impl Script for InternalFrobMove {
             return Effect::NoEffect;
         }
 
+        if crate::virtual_hand::scripted_world_frob_owns_transfer(world, entity_id) {
+            return Effect::NoEffect;
+        }
+
         let handles_move = {
             let frob_info = world
                 .borrow::<View<dark::properties::PropFrobInfo>>()
                 .unwrap();
             frob_info.get(entity_id).is_ok_and(|frob_info| {
-                !frob_info.world_action.contains(FrobFlag::SCRIPT)
-                    && (frob_info.world_action.contains(FrobFlag::MOVE)
-                        || frob_info.world_action.contains(FrobFlag::USE_AMMO))
+                frob_info.world_action.contains(FrobFlag::MOVE)
+                    || frob_info.world_action.contains(FrobFlag::USE_AMMO)
             })
         };
         if !handles_move {
@@ -65,7 +68,10 @@ impl Script for InternalFrobMove {
 #[cfg(test)]
 mod tests {
     use cgmath::{Quaternion, vec3};
-    use dark::properties::{FrobFlag, Link, Links, PropFrobInfo, ToLink, WrappedEntityId};
+    use dark::properties::{
+        FrobFlag, KeyCard, Link, Links, PropFrobInfo, PropKeySrc, PropScripts, ToLink,
+        WrappedEntityId,
+    };
     use shipyard::World;
 
     use crate::{
@@ -144,8 +150,8 @@ mod tests {
     }
 
     #[test]
-    fn scripted_move_remains_owned_by_the_authored_script() {
-        let (world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+    fn scripted_move_preserves_the_engine_transfer() {
+        let (world, item, inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
 
         let effect = InternalFrobMove::new().handle_message(
             item,
@@ -154,6 +160,61 @@ mod tests {
             &MessagePayload::Frob,
         );
 
-        assert!(matches!(effect, Effect::NoEffect));
+        assert!(matches!(
+            effect,
+            Effect::DropEntityInfo {
+                parent_entity_id,
+                dropped_entity_id,
+            } if parent_entity_id == inventory && dropped_entity_id == item
+        ));
+    }
+
+    #[test]
+    fn keycard_script_remains_the_sole_transfer_owner() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+        world.add_component(
+            item,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "internal_keycard must remain the sole transfer owner, got {effect:?}"
+        );
+    }
+
+    #[test]
+    fn frob_qb_remains_the_sole_transfer_owner() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+        world.add_component(
+            item,
+            PropScripts {
+                scripts: vec!["BaseButton".to_owned(), "FrobQB".to_owned()],
+                inherits: true,
+            },
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "FrobQB must remain the sole transfer owner, got {effect:?}"
+        );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -615,6 +615,37 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
     has_authored_world_script || crate::scripts::script_util::is_always_collected(world, entity_id)
 }
 
+/// Whether an authored script is already the sole owner of this item's
+/// physical fate on world Frob.
+///
+/// Most `MOVE | SCRIPT` objects need both halves of `PropFrobInfo`: their
+/// scripts run side effects while the engine performs `MOVE`. Two established
+/// script paths are exceptions: keycards' injected `internal_keycard` script
+/// and `FrobQB` both deliberately transfer or consume the object themselves.
+/// Giving either the engine move handler as well would reparent or destroy the
+/// same entity twice.
+pub(crate) fn scripted_world_frob_owns_transfer(world: &World, entity_id: EntityId) -> bool {
+    let is_keycard = world
+        .borrow::<View<dark::properties::PropKeySrc>>()
+        .map(|keycards| keycards.get(entity_id).is_ok())
+        .unwrap_or(false);
+    if is_keycard {
+        return true;
+    }
+
+    world
+        .borrow::<View<dark::properties::PropScripts>>()
+        .map(|scripts| {
+            scripts.get(entity_id).is_ok_and(|scripts| {
+                scripts
+                    .scripts
+                    .iter()
+                    .any(|script| script.eq_ignore_ascii_case("frobqb"))
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
 /// a melee arm (`PropLimbModel`). Clicking one in the backpack/strip wields it
 /// (`Effect::GrabEntity`) instead of using it; shared by `ContainerGui` and the

--- a/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8194);
+
+// Stable ops3 mission-object ids. Runtime ids are rediscovered after every
+// launch and load.
+const DOCILE = 125;
+const CHIP_C = 840;
+const WRENCH = 1176;
+const OPS3_BULKHEAD = 185;
+
+const cyberModules = async (game: GameServer) =>
+  (await game.info()).player.stats?.cyber_modules;
+
+const property = (detail: EntityDetailResult, name: string) =>
+  detail.properties.find((candidate) => candidate.name === name)?.value;
+
+const squeeze = async (game: GameServer) => {
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  await game.step({ frames: 8 });
+};
+
+const swingWrench = async (game: GameServer) => {
+  await game.input.set("right_hand.trigger_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger_value", 0);
+  // The shipped 31-frame leftswing runs at 30 fps and authors its impact at
+  // frame 20. Let that production event land, then let the clip return to idle
+  // so the next trigger edge begins a distinct swing (#951).
+  await game.step({ frames: 68 });
+};
+
+test(
+  "ops3: after an authored bulkhead transition, normal combat and corpse UI transfer Chip C once",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `ops_chip_c_e2e_${Date.now()}`;
+
+    // Start in another mission and cross a process boundary before entering
+    // ops3. This matches the campaign's frontier-save restore and authored
+    // level-transition lifecycle.
+    {
+      await using game = await GameServer.launch({
+        mission: "ops2.mis",
+        port: basePort,
+      });
+      await game.step({ frames: 5 });
+      // Match frontier-009's raw ShodanRoom bits (1), which permits this
+      // already-reached bulkhead without pretending the objective is complete.
+      await game.quests.set("ShodanRoom", "incomplete");
+      await game.save(saveName);
+    }
+
+    {
+      await using game = await GameServer.launch({
+        mission: "ops2.mis",
+        port: basePort,
+      });
+      await game.load(saveName);
+      const [bulkhead] = await game.entities.byTemplate(OPS3_BULKHEAD);
+      assert.equal(
+        bulkhead?.name,
+        "Bulk_On_Button",
+        "expected ops2's authored ops3 bulkhead object 185",
+      );
+      await teleportVerified(game, { x: 32.244, y: -8.596, z: 16.665 });
+      await game.player.aimAt(bulkhead, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      await squeeze(game);
+      assert.equal(
+        (await game.info()).mission.toLowerCase(),
+        "ops3.mis",
+        "normal squeeze on the authored ops2 bulkhead must transition to ops3",
+      );
+
+      const [docile] = await game.entities.byTemplate(DOCILE);
+      const [chip] = await game.entities.byTemplate(CHIP_C);
+      const [wrench] = await game.entities.byTemplate(WRENCH);
+      assert.ok(docile, "expected ops3 Docile mission object 125");
+      assert.equal(chip?.name, "Chip C", "expected ops3 Chip C mission object 840");
+      assert.equal(wrench?.name, "Wrench", "expected ops3 Wrench mission object 1176");
+      assert.equal(await cyberModules(game), 0, "fresh character starts with 0 modules");
+
+      const containedBefore = (await game.entities.detail(docile.id)).outgoing_links.filter(
+        (link) => link.link_type.startsWith("Contains"),
+      );
+      assert.ok(
+        containedBefore.some((link) => link.target_id === chip.id),
+        "Docile must contain the authored Chip C",
+      );
+
+      // Acquire the authored world Wrench through the production flat frob
+      // edge, then use its normal first-person attack path for every hit.
+      await teleportVerified(game, {
+        x: wrench.position[0] + 1.225,
+        y: wrench.position[1] + 0.634,
+        z: wrench.position[2] + 0.917,
+      });
+      await game.player.aimAt(wrench, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      await squeeze(game);
+
+      const armedInventory = await game.player.inventory();
+      assert.equal(
+        armedInventory.items.find((item) => item.entity_id === wrench.id)?.location,
+        "left_hand",
+        `world-frobbing the Wrench must wield it; got ${JSON.stringify(armedInventory.items)}`,
+      );
+      assert.equal(
+        (await game.info()).player.wielded_entity_id,
+        wrench.id,
+        "the authored Wrench must drive the production attack path",
+      );
+
+      let liveDocile = await game.entities.detail(docile.id);
+      assert.equal(Number(property(liveDocile, "HitPoints")), 48);
+      await teleportVerified(game, {
+        x: liveDocile.position[0] + 0.599,
+        y: liveDocile.position[1] - 0.695,
+        z: liveDocile.position[2] - 0.865,
+      });
+
+      for (const expectedHitPoints of [42, 36, 30, 24, 18, 12, 6, 0]) {
+        await game.player.aimAt(docile, {
+          hitbox: "torso",
+          visibility: "required",
+        });
+        await swingWrench(game);
+        liveDocile = await game.entities.detail(docile.id);
+        assert.equal(
+          Number(property(liveDocile, "HitPoints")),
+          expectedHitPoints,
+          `an ordinary Wrench swing must reduce Docile to ${expectedHitPoints} HP`,
+        );
+      }
+      assert.equal(property(liveDocile, "AIBehavior"), "Dead");
+      assert.equal(
+        (await game.info()).player.hit_points,
+        30,
+        "the docile encounter should not damage the player",
+      );
+
+      // The loot action uses the same aim/squeeze edge as a real corpse frob,
+      // followed by the semantic UI click that fires both BaseButton's reward
+      // and the engine's MOVE transfer.
+      await game.player.aimAt(docile, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      await squeeze(game);
+
+      const panel = (await game.ui.state()).active_panel;
+      assert.ok(panel, "frobbing slain Docile should open its creature loot panel");
+      const chipButton = panel.elements.find(
+        (element) =>
+          element.kind === "button" &&
+          element.entity_id === chip.id &&
+          element.label === "Chip C",
+      );
+      assert.ok(chipButton, "Docile's corpse panel should expose the Chip C button");
+
+      await clickUiElement(game, chipButton);
+
+      const inventory = await game.player.inventory();
+      assert.equal(
+        inventory.items.filter(
+          (item) => item.entity_id === chip.id && item.location === "inventory",
+        ).length,
+        1,
+        `Chip C must transfer to the backpack exactly once; got ${JSON.stringify(inventory.items)}`,
+      );
+      assert.equal(
+        await cyberModules(game),
+        10,
+        "Chip C's BaseButton must fire its authored 10-module reward exactly once",
+      );
+      assert.ok(
+        !(await game.entities.detail(docile.id)).outgoing_links.some(
+          (link) => link.link_type.startsWith("Contains") && link.target_id === chip.id,
+        ),
+        "the transfer must remove Chip C from Docile's contents",
+      );
+      assert.ok(
+        !(await game.ui.state()).active_panel?.elements.some(
+          (element) => element.entity_id === chip.id,
+        ),
+        "the transferred Chip C must disappear from the live corpse panel",
+      );
+
+      await game.save(saveName);
+    }
+
+    // A new runtime proves both halves survive the production save format:
+    // the unique physical chip remains carried and the one-shot reward does
+    // not re-fire during load.
+    await using reloaded = await GameServer.launch({
+      mission: "ops3.mis",
+      port: basePort,
+    });
+    await reloaded.load(saveName);
+    await reloaded.step({ frames: 5 });
+
+    const inventory = await reloaded.player.inventory();
+    assert.equal(
+      inventory.items.filter(
+        (item) => item.name === "Chip C" && item.location === "inventory",
+      ).length,
+      1,
+      `fresh-runtime load must retain exactly one Chip C; got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      await cyberModules(reloaded),
+      10,
+      "fresh-runtime load must retain the single 10-module reward",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- run authored Frob behavior when a player clicks scripted loot in a corpse panel
- preserve the Dark engine's physical `MOVE` action alongside `SCRIPT` side effects
- keep keycards and `FrobQB` as sole-transfer exceptions, while leaving ordinary `MOVE` loot unchanged
- add a production-faithful Operations scenario covering transition, combat, corpse UI, reward, inventory, and save/reload

Current `main` at `e67b851cffc76c161b26794826ad446e977c25c4` did not contain the earlier stacked fix from #683: its merge commit is not an ancestor of `main`. A negative-first test on that exact base returned `NoEffect` for `MOVE | SCRIPT`, and the real Operations path transferred Chip C while leaving the player's modules at 0 because the corpse panel bypassed the item's authored scripts.

The fix routes scripted panel clicks through Frob, injects the engine-level move handler for `MOVE | SCRIPT`, and excludes the established paths whose scripts already own the physical fate (`PropKeySrc` / `internal_keycard` and `FrobQB`).

## Production verification

Using the explicit verified 25th Anniversary asset root `/Users/bryan/ss2-25th` (sentinel `sshock2.kpf`) and a fresh isolated Cargo target, the scenario:

1. starts in `ops2.mis`, creates a fresh save, and reloads it through the normal process boundary
2. uses authored bulkhead 185 to transition to `ops3.mis`
3. picks up the real Wrench (object 1176), kills the real Docile hybrid (object 125) with eight visible 6-damage swings, and opens its corpse panel
4. clicks the real Chip C (object 840) once and asserts one inventory copy, exactly +10 modules, removal from the corpse, and removal from the panel
5. creates another fresh save/reload and asserts one Chip C and 10 modules remain

That full path passed 3/3 repeated runs on `ff61ea5a` (and once again after the final fetch/rebase check).

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` — 890 passed
- focused internal-move tests — 5 passed
- focused container tests — 12 passed
- SDK unit suite — 26 passed, 279 E2E-gated skips
- serialized 25AE SDK suite — 295 passed, 3 failed, 7 skipped; all 23 mission loads and this new Chip C scenario passed

The three full-suite failures were classified separately: creature-loot reader state and Hydro3 transcript spacing reproduce identically on exact base `e67b851c`; the saved MedSci VR Wrench timing case passed on exact base and then 3/3 on the fix, classifying the single serialized-run failure as transient and unrelated to this diff.

## Visual proof

![Real Chip C corpse loot](https://gist.githubusercontent.com/tommy-xr/943de2ffe798111a87f446c6e4d454f6/raw/issue-682-chip-c-loot.gif)

<sub>The authored Operations path now awards Chip C's 10 cyber modules exactly once while transferring the chip into the backpack. Captured headlessly with the same deterministic request sequence on exact base and fix refs.</sub>

### After

![Authored Tech Trainer showing 10 modules](https://gist.githubusercontent.com/tommy-xr/943de2ffe798111a87f446c6e4d454f6/raw/issue-682-after.png)

### Exact base → fix

![Exact base versus fix module reward](https://gist.githubusercontent.com/tommy-xr/943de2ffe798111a87f446c6e4d454f6/raw/issue-682-base-vs-fix.png)

Fixes #682
