### PR TITLE
refactor(ui): share frontend canvas presentation

### DIFF
--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -32,11 +32,11 @@ use engine::{
 use shipyard::EntityId;
 
 use crate::{
-    GameOptions, PresentationMode,
+    GameOptions,
     input_context::InputContext,
     ui::{
-        FrontendMenu, FrontendMenuItem, HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel,
-        dev_params_panel, frontend_panel_distance, hit_menu_item,
+        FrontendCanvasPresenter, FrontendMenu, FrontendMenuItem, HAlign, Rect, ScaleMode, UiCanvas,
+        VAlign, WorldPanel, dev_params_panel, frontend_panel_distance, hit_menu_item,
     },
 };
 
@@ -659,38 +659,44 @@ impl PauseMenu {
         options: &GameOptions,
         pawn_to_world: Matrix4<f32>,
     ) -> Vec<SceneObject> {
-        if !self.open || options.presentation_mode != PresentationMode::Vr {
+        if !self.open {
             return Vec::new();
         }
-        let panel = self.menu.panel();
-        let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
-        // First in the list, and therefore first in the overlay group: the
-        // comfort dim, which the depth clear below rides on.
-        let (dim_position, dim_forward) = dim_pose(self.head.0, self.head.1, &panel);
-        let mut objects = vec![world_dim_layer(
-            dim_position,
-            dim_forward,
-            dim_distance(dim_position, &panel),
-        )];
-        let canvas_objects = self.menu.render_world_space(asset_cache, canvas);
-        // The controllers and their aim rays, drawn from the same pass that
-        // resolved the highlight, so the beams can never promise a hover the
-        // menu will not give. The canvas objects already in hand are the layer
-        // stack the hit dot has to float clear of - the dim is not one of them,
-        // it hangs behind the panel rather than on it.
-        objects.extend(canvas_objects);
-        // Everything above was built in the tracked play space (where the head,
-        // the hands and therefore the panel anchor live). A frontend *scene*
-        // has no pawn, so it renders that space directly; the pause menu hangs
-        // over a mission whose pawn is wherever the player is standing, so it
-        // rebases every object into world coordinates here - once, at the
-        // boundary, rather than by anchoring the panel differently.
-        for object in &mut objects {
-            object.set_transform(pawn_to_world * object.get_transform());
-        }
-        // Game assigns this whole ordered stack to the system-overlay layer:
-        // dim first, then panel and rays, all over the world and scene UI.
-        objects
+        FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_world_space(
+            || {
+                let panel = self.menu.panel();
+                let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
+                // First in the list, and therefore first in the overlay group: the
+                // comfort dim, which the depth clear below rides on.
+                let (dim_position, dim_forward) = dim_pose(self.head.0, self.head.1, &panel);
+                let mut objects = vec![world_dim_layer(
+                    dim_position,
+                    dim_forward,
+                    dim_distance(dim_position, &panel),
+                )];
+                let canvas_objects =
+                    self.menu
+                        .render_world_space(asset_cache, canvas, options.presentation_mode);
+                // The controllers and their aim rays, drawn from the same pass that
+                // resolved the highlight, so the beams can never promise a hover the
+                // menu will not give. The canvas objects already in hand are the layer
+                // stack the hit dot has to float clear of - the dim is not one of them,
+                // it hangs behind the panel rather than on it.
+                objects.extend(canvas_objects);
+                // Everything above was built in the tracked play space (where the head,
+                // the hands and therefore the panel anchor live). A frontend *scene*
+                // has no pawn, so it renders that space directly; the pause menu hangs
+                // over a mission whose pawn is wherever the player is standing, so it
+                // rebases every object into world coordinates here - once, at the
+                // boundary, rather than by anchoring the panel differently.
+                for object in &mut objects {
+                    object.set_transform(pawn_to_world * object.get_transform());
+                }
+                // Game assigns this whole ordered stack to the system-overlay layer:
+                // dim first, then panel and rays, all over the world and scene UI.
+                objects
+            },
+        )
     }
 
     /// Screen-space presentation. Empty when closed or in VR (where a
@@ -701,13 +707,21 @@ impl PauseMenu {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        if !self.open || options.presentation_mode == PresentationMode::Vr {
+        if !self.open {
             return Vec::new();
         }
-        let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
-        let canvas = self.build_canvas(asset_cache, pointer_canvas);
-        self.menu
-            .render_screen_space(asset_cache, canvas, screen_size)
+        FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_screen_space(
+            || {
+                let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
+                let canvas = self.build_canvas(asset_cache, pointer_canvas);
+                self.menu.render_screen_space(
+                    asset_cache,
+                    canvas,
+                    screen_size,
+                    options.presentation_mode,
+                )
+            },
+        )
     }
 
     fn rects(&self, asset_cache: &mut AssetCache) -> Vec<Rect> {

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -21,7 +21,7 @@ use engine::{
 use shipyard::{EntityId, UniqueViewMut, World};
 
 use crate::{
-    GameOptions, PresentationMode,
+    GameOptions,
     game_scene::GameScene,
     input_context::InputContext,
     mission::{GlobalContext, PlayerLifeState},
@@ -290,16 +290,10 @@ impl GameScene for GameOverScene {
         options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        // In flat presentation the screen is drawn in screen space in
-        // `render_per_eye` (which has the screen size); the 3D scene is empty.
-        if options.presentation_mode != PresentationMode::Vr {
-            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
-        }
-
-        // In VR there is no screen to draw on, so the same canvas is presented
-        // on a world-space panel in front of the player.
         let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
-        let objects = self.menu.render_world_space(asset_cache, canvas);
+        let objects = self
+            .menu
+            .render_world_space(asset_cache, canvas, options.presentation_mode);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -311,16 +305,10 @@ impl GameScene for GameOverScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        // In VR the screen lives on a world-space panel drawn by `render`; a
-        // screen-space copy here would paste the whole canvas over both eyes
-        // and hide it.
-        if options.presentation_mode == PresentationMode::Vr {
-            return Vec::new();
-        }
         let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(asset_cache, pointer_canvas);
         self.menu
-            .render_screen_space(asset_cache, canvas, screen_size)
+            .render_screen_space(asset_cache, canvas, screen_size, options.presentation_mode)
     }
 
     fn handle_effects(

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -22,7 +22,7 @@ use shipyard::{EntityId, UniqueViewMut, World};
 use std::collections::HashMap;
 
 use crate::{
-    GameOptions, PresentationMode,
+    GameOptions,
     game_scene::GameScene,
     input_context::InputContext,
     mission::GlobalContext,
@@ -418,16 +418,10 @@ impl GameScene for LoadGameScene {
         options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        // In flat presentation the screen is drawn in screen space in
-        // `render_per_eye` (which has the screen size); the 3D scene is empty.
-        if options.presentation_mode != PresentationMode::Vr {
-            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
-        }
-
-        // In VR there is no screen to draw on, so the same canvas is presented
-        // on a world-space panel in front of the player.
         let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
-        let objects = self.menu.render_world_space(asset_cache, canvas);
+        let objects = self
+            .menu
+            .render_world_space(asset_cache, canvas, options.presentation_mode);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -439,16 +433,10 @@ impl GameScene for LoadGameScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        // In VR the screen lives on a world-space panel drawn by `render`; a
-        // screen-space copy here would paste the whole canvas over both eyes
-        // and hide it.
-        if options.presentation_mode == PresentationMode::Vr {
-            return Vec::new();
-        }
         let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(asset_cache, pointer_canvas);
         self.menu
-            .render_screen_space(asset_cache, canvas, screen_size)
+            .render_screen_space(asset_cache, canvas, screen_size, options.presentation_mode)
     }
 
     fn handle_effects(

--- a/shock2vr/src/scenes/loading.rs
+++ b/shock2vr/src/scenes/loading.rs
@@ -24,13 +24,13 @@ use engine::{
 use shipyard::{EntityId, UniqueViewMut, World};
 
 use crate::{
-    GameOptions, PresentationMode,
+    GameOptions,
     game_scene::GameScene,
     input_context::InputContext,
     mission::GlobalContext,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{FrontendPanelAnchor, Rect, ScaleMode, UiCanvas, VR_COMPONENT_Z_STEP},
+    ui::{FrontendCanvasPresenter, FrontendPanelAnchor, Rect, ScaleMode, UiCanvas},
 };
 
 /// The loading art is authored on the original 640x480 `LOADING.PCX` canvas.
@@ -190,26 +190,10 @@ impl GameScene for LoadingScene {
         options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        // In flat presentation the screen is drawn in screen space in
-        // `render_per_eye` (which has the screen size); the 3D scene is empty.
-        if options.presentation_mode != PresentationMode::Vr {
-            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
-        }
-
-        // In VR there is no screen to draw on, so the same canvas is presented
-        // on a world-space panel in front of the player - without which a level
-        // transition in the headset shows nothing at all (#1002). Nothing here
-        // is clickable, so there is no pointer.
         let panel = self.panel_anchor.panel();
-        let objects = self
-            .build_canvas_from_cache(asset_cache)
-            .render_world_space(
-                asset_cache,
-                panel.transform(),
-                None,
-                None,
-                VR_COMPONENT_Z_STEP,
-            );
+        let canvas = self.build_canvas_from_cache(asset_cache);
+        let objects = FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE)
+            .render_world_space(asset_cache, &canvas, &panel, None);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -221,14 +205,12 @@ impl GameScene for LoadingScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        // In VR the screen lives on the world-space panel drawn by `render`; a
-        // screen-space copy here would paste the whole canvas over both eyes
-        // and hide it.
-        if options.presentation_mode == PresentationMode::Vr {
-            return Vec::new();
-        }
-        self.build_canvas_from_cache(asset_cache)
-            .render_screen_space(asset_cache, screen_size, SCALE_MODE)
+        let canvas = self.build_canvas_from_cache(asset_cache);
+        FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).render_screen_space(
+            asset_cache,
+            &canvas,
+            screen_size,
+        )
     }
 
     fn handle_effects(

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -26,7 +26,7 @@ use engine::{
 use shipyard::{EntityId, UniqueViewMut, World};
 
 use crate::{
-    GameOptions, PresentationMode,
+    GameOptions,
     game_scene::GameScene,
     input_context::InputContext,
     mission::GlobalContext,
@@ -344,16 +344,10 @@ impl GameScene for MainMenuScene {
         options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        // In flat presentation the menu is drawn in screen space in
-        // `render_per_eye` (which has the screen size); the 3D scene is empty.
-        if options.presentation_mode != PresentationMode::Vr {
-            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
-        }
-
-        // In VR there is no screen to draw on, so the same canvas is presented
-        // on a world-space panel in front of the player.
         let canvas = self.build_canvas(asset_cache, self.menu.pointer_canvas());
-        let objects = self.menu.render_world_space(asset_cache, canvas);
+        let objects = self
+            .menu
+            .render_world_space(asset_cache, canvas, options.presentation_mode);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -365,16 +359,10 @@ impl GameScene for MainMenuScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        // In VR the menu lives on a world-space panel drawn by `render`; a
-        // screen-space copy here would paste the whole canvas over both eyes
-        // and hide it.
-        if options.presentation_mode == PresentationMode::Vr {
-            return Vec::new();
-        }
         let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(asset_cache, pointer_canvas);
         self.menu
-            .render_screen_space(asset_cache, canvas, screen_size)
+            .render_screen_space(asset_cache, canvas, screen_size, options.presentation_mode)
     }
 
     fn handle_effects(

--- a/shock2vr/src/scenes/no_assets.rs
+++ b/shock2vr/src/scenes/no_assets.rs
@@ -28,7 +28,7 @@ use engine::{
 use shipyard::{EntityId, World};
 
 use crate::{
-    GameOptions, PresentationMode,
+    GameOptions,
     game_scene::GameScene,
     input_context::InputContext,
     install::InstallStatus,
@@ -36,8 +36,8 @@ use crate::{
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{
-        BUILTIN_FONT, FrontendPanelAnchor, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
-        VR_COMPONENT_Z_STEP,
+        BUILTIN_FONT, FrontendCanvasPresenter, FrontendPanelAnchor, HAlign, Rect, ScaleMode,
+        UiCanvas, VAlign,
     },
 };
 
@@ -276,19 +276,10 @@ impl GameScene for NoAssetsScene {
         options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        if options.presentation_mode != PresentationMode::Vr {
-            // Flat draws in screen space from `render_per_eye`, which is where
-            // the screen size is known.
-            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
-        }
         let panel = self.panel_anchor.panel();
-        let objects = self.build_canvas().render_world_space(
-            asset_cache,
-            panel.transform(),
-            None,
-            None,
-            VR_COMPONENT_Z_STEP,
-        );
+        let canvas = self.build_canvas();
+        let objects = FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE)
+            .render_world_space(asset_cache, &canvas, &panel, None);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -300,13 +291,12 @@ impl GameScene for NoAssetsScene {
         screen_size: Vector2<f32>,
         options: &GameOptions,
     ) -> Vec<SceneObject> {
-        if options.presentation_mode == PresentationMode::Vr {
-            // In VR the panel from `render` already carries the canvas; a
-            // screen-space copy would paste it over both eyes and hide it.
-            return Vec::new();
-        }
-        self.build_canvas()
-            .render_screen_space(asset_cache, screen_size, SCALE_MODE)
+        let canvas = self.build_canvas();
+        FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).render_screen_space(
+            asset_cache,
+            &canvas,
+            screen_size,
+        )
     }
 
     fn handle_effects(

--- a/shock2vr/src/ui/frontend_menu.rs
+++ b/shock2vr/src/ui/frontend_menu.rs
@@ -22,8 +22,8 @@ use crate::{
 };
 
 use super::{
-    FrontendPanelAnchor, FrontendPointerPass, PointerVisuals, Rect, ScaleMode, UiCanvas,
-    VR_COMPONENT_Z_STEP, WorldPanel, pointer_to_canvas, vr_frontend_pointer_pass,
+    FrontendCanvasPresenter, FrontendPanelAnchor, FrontendPointerPass, PointerVisuals, Rect,
+    ScaleMode, UiCanvas, WorldPanel, pointer_to_canvas, vr_frontend_pointer_pass,
 };
 
 use super::frontend_sfx::FrontendSfx;
@@ -310,24 +310,25 @@ impl<A: Copy + PartialEq> FrontendMenu<A> {
         &mut self,
         asset_cache: &mut AssetCache,
         canvas: UiCanvas,
+        presentation_mode: PresentationMode,
     ) -> Vec<SceneObject> {
         let panel = self.panel();
-        let mut objects = canvas.render_world_space(
+        FrontendCanvasPresenter::new(presentation_mode, self.scale_mode).render_world_space_with(
             asset_cache,
-            panel.transform(),
-            self.pointer_canvas,
-            None,
-            VR_COMPONENT_Z_STEP,
-        );
-        let panel_layers = objects.len();
-        objects.extend(self.vr_pointer_visuals.render(
-            asset_cache,
-            &self.vr_pointer,
-            self.canvas_size,
+            &canvas,
             &panel,
-            panel_layers,
-        ));
-        objects
+            self.pointer_canvas,
+            |asset_cache, objects| {
+                let panel_layers = objects.len();
+                objects.extend(self.vr_pointer_visuals.render(
+                    asset_cache,
+                    &self.vr_pointer,
+                    self.canvas_size,
+                    &panel,
+                    panel_layers,
+                ));
+            },
+        )
     }
 
     pub fn render_screen_space(
@@ -335,8 +336,13 @@ impl<A: Copy + PartialEq> FrontendMenu<A> {
         asset_cache: &mut AssetCache,
         canvas: UiCanvas,
         screen_size: Vector2<f32>,
+        presentation_mode: PresentationMode,
     ) -> Vec<SceneObject> {
-        canvas.render_screen_space(asset_cache, screen_size, self.scale_mode)
+        FrontendCanvasPresenter::new(presentation_mode, self.scale_mode).render_screen_space(
+            asset_cache,
+            &canvas,
+            screen_size,
+        )
     }
 
     pub fn pump_sfx(
@@ -366,6 +372,42 @@ impl<A: Copy + PartialEq> FrontendMenu<A> {
 mod tests {
     use super::*;
     use cgmath::vec2;
+
+    use crate::ui::{FrontendCanvasPresenter, VR_COMPONENT_Z_STEP};
+
+    #[test]
+    fn frontend_presenter_selects_one_target_and_keeps_geometry_policy() {
+        let flat = FrontendCanvasPresenter::new(PresentationMode::Flat, ScaleMode::PreserveAspect);
+        assert!(!flat.renders_world_space());
+        assert!(flat.renders_screen_space());
+        assert_eq!(flat.scale_mode(), ScaleMode::PreserveAspect);
+        assert_eq!(flat.component_z_step(), VR_COMPONENT_Z_STEP);
+
+        let vr = FrontendCanvasPresenter::new(PresentationMode::Vr, ScaleMode::PreserveAspect);
+        assert!(vr.renders_world_space());
+        assert!(!vr.renders_screen_space());
+        assert_eq!(vr.scale_mode(), ScaleMode::PreserveAspect);
+        assert_eq!(vr.component_z_step(), VR_COMPONENT_Z_STEP);
+    }
+
+    #[test]
+    fn original_frontend_scenes_do_not_own_presentation_mode_branches() {
+        let consumers = [
+            ("main menu", include_str!("../scenes/main_menu.rs")),
+            ("load game", include_str!("../scenes/load_game.rs")),
+            ("game over", include_str!("../scenes/game_over.rs")),
+            ("loading", include_str!("../scenes/loading.rs")),
+            ("no assets", include_str!("../scenes/no_assets.rs")),
+        ];
+
+        for (name, source) in consumers {
+            assert!(
+                !source.contains("options.presentation_mode != PresentationMode::Vr")
+                    && !source.contains("options.presentation_mode == PresentationMode::Vr"),
+                "{name} must delegate flat/VR presentation selection to FrontendCanvasPresenter"
+            );
+        }
+    }
 
     #[test]
     fn pointer_loss_does_not_rearm_a_held_press() {

--- a/shock2vr/src/ui/frontend_presentation.rs
+++ b/shock2vr/src/ui/frontend_presentation.rs
@@ -1,0 +1,121 @@
+//! One flat/VR presentation boundary for frontend canvases.
+//!
+//! Scenes describe a canvas, panel, pointer and scale policy. This presenter
+//! alone decides whether that canvas belongs in the shared world render or the
+//! per-eye screen overlay, and owns the fixed world-layer spacing.
+
+use cgmath::Vector2;
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+
+use crate::PresentationMode;
+
+use super::{ScaleMode, UiCanvas, VR_COMPONENT_Z_STEP, WorldPanel};
+
+/// Maps an already-resolved frontend canvas into exactly one presentation.
+#[derive(Clone, Copy, Debug)]
+pub struct FrontendCanvasPresenter {
+    presentation_mode: PresentationMode,
+    scale_mode: ScaleMode,
+}
+
+impl FrontendCanvasPresenter {
+    pub fn new(presentation_mode: PresentationMode, scale_mode: ScaleMode) -> Self {
+        Self {
+            presentation_mode,
+            scale_mode,
+        }
+    }
+
+    /// Render a canvas on its anchored panel in VR, or emit nothing in flat
+    /// mode (where the same canvas is presented by [`Self::render_screen_space`]).
+    pub fn render_world_space<TEvent: Clone>(
+        self,
+        asset_cache: &mut AssetCache,
+        canvas: &UiCanvas<TEvent>,
+        panel: &WorldPanel,
+        pointer: Option<Vector2<f32>>,
+    ) -> Vec<SceneObject> {
+        self.render_world_space_with(asset_cache, canvas, panel, pointer, |_, _| {})
+    }
+
+    /// The menu shell extends the common panel stack with pointer rays and a
+    /// hit dot. Keeping that decoration inside this guarded call prevents a
+    /// stale VR pointer from leaking into the flat presentation.
+    pub(crate) fn render_world_space_with<TEvent: Clone>(
+        self,
+        asset_cache: &mut AssetCache,
+        canvas: &UiCanvas<TEvent>,
+        panel: &WorldPanel,
+        pointer: Option<Vector2<f32>>,
+        decorate: impl FnOnce(&mut AssetCache, &mut Vec<SceneObject>),
+    ) -> Vec<SceneObject> {
+        self.present_world_space(|| {
+            let mut objects = canvas.render_world_space(
+                asset_cache,
+                panel.transform(),
+                pointer,
+                None,
+                VR_COMPONENT_Z_STEP,
+            );
+            decorate(asset_cache, &mut objects);
+            objects
+        })
+    }
+
+    /// Render a canvas in the per-eye screen overlay in flat mode, or emit
+    /// nothing in VR (where the panel from [`Self::render_world_space`] owns it).
+    pub fn render_screen_space<TEvent: Clone>(
+        self,
+        asset_cache: &mut AssetCache,
+        canvas: &UiCanvas<TEvent>,
+        screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
+        self.present_screen_space(|| {
+            canvas.render_screen_space(asset_cache, screen_size, self.scale_mode)
+        })
+    }
+
+    /// Run a complete world-space frontend composition only in VR. This is
+    /// used by overlays whose panel stack includes objects outside the canvas
+    /// itself (for example the pause comfort dim).
+    pub fn present_world_space(
+        self,
+        render: impl FnOnce() -> Vec<SceneObject>,
+    ) -> Vec<SceneObject> {
+        if self.renders_world_space() {
+            render()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Run a complete screen-space frontend composition only in flat mode.
+    pub fn present_screen_space(
+        self,
+        render: impl FnOnce() -> Vec<SceneObject>,
+    ) -> Vec<SceneObject> {
+        if self.renders_screen_space() {
+            render()
+        } else {
+            Vec::new()
+        }
+    }
+
+    pub(crate) fn renders_world_space(self) -> bool {
+        self.presentation_mode == PresentationMode::Vr
+    }
+
+    pub(crate) fn renders_screen_space(self) -> bool {
+        !self.renders_world_space()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn scale_mode(self) -> ScaleMode {
+        self.scale_mode
+    }
+
+    #[cfg(test)]
+    pub(crate) fn component_z_step(self) -> f32 {
+        VR_COMPONENT_Z_STEP
+    }
+}

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -34,6 +34,7 @@ use crate::vr_config::Handedness;
 pub mod dev_params_panel;
 mod frontend_menu;
 mod frontend_pointer;
+mod frontend_presentation;
 mod frontend_sfx;
 mod panel_anchor;
 mod pointer_visual;
@@ -48,6 +49,7 @@ pub use frontend_pointer::test_support;
 pub use frontend_pointer::{
     FrontendPointerPass, FrontendRay, VR_TRIGGER_THRESHOLD, vr_frontend_pointer_pass,
 };
+pub use frontend_presentation::FrontendCanvasPresenter;
 pub use frontend_sfx::FrontendSfx;
 pub use panel_anchor::{FrontendPanelAnchor, PanelPlacement};
 pub use pointer_visual::PointerVisuals;


### PR DESCRIPTION
## Summary

- add `FrontendCanvasPresenter` as the one flat/VR target-selection boundary for frontend canvases
- route Main Menu, Load Game, Game Over, Loading, No Assets, and the Pause overlay through it
- keep screen scale policy, world-panel transform, pointer stack, comfort dim, and `VR_COMPONENT_Z_STEP` unchanged
- add an architecture guard so the five original issue sites cannot regain hand-written presentation-mode branches

## Pre-fix reproduction

On exact base `e67b851cffc76c161b26794826ad446e977c25c4`, PR #1055 had already moved Main Menu, Load Game, and Game Over into `FrontendMenu`, but those scenes still selected flat versus VR themselves. `LoadingScene` and `NoAssetsScene` retained the original direct copies, and Pause repeated the same selection around its larger panel stack.

The negative-first architecture/geometry test failed on that base because no shared `FrontendCanvasPresenter` existed. The new regression proves that one target is selected, that `ScaleMode::PreserveAspect` and `VR_COMPONENT_Z_STEP` remain the geometry policy, and that none of the five original scene sources owns the old `PresentationMode::Vr` guards.

## Scope boundaries

- Open PR #1082 independently ports `DeveloperScene` onto `FrontendMenu` for issue #1046. This PR neither modifies nor depends on that unmerged work; once #1082 lands, Developer inherits this presentation boundary through `FrontendMenu`.
- The issue's smaller SDK sibling is already present on main: `game.scene` / `SceneApi` was added by PR #1020, so no SDK source change is needed here.

## Verification

Every runtime launch used the explicit 25th Anniversary root `/Users/bryan/ss2-25th`, verified by `sshock2.kpf` and all five remaster mod archives.

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS='-D warnings' cargo test -p shock2vr --lib` — 889 passed
- presenter architecture/geometry tests — 3 passed
- Pause tests — 30 passed
- SDK unit suite — 26 passed, 278 E2E-gated
- focused real-runtime frontend matrix — 16 passed: Main flat/VR; Load round-trip/restore; Pause flat/VR plus mission/debug/death; Game Over/load/quick-load; Loading flat/VR
- post-rebase direct Main/Load/Loading matrix — 6 passed
- full serialized 25AE SDK E2E — 304 total: 295 passed, 2 exact-base failures, 7 fixture-gated skips; all 23 missions loaded
  - creature-loot reader MFD expected `251`, got `-1` (#931)
  - Hydro3 Korenchkin transcript fixture expects double spacing while the transcript is present
- both failures were rerun alone on exact base `e67b851c` with the same 25AE root and reproduced with identical assertion values (0 passed / 2 failed)

## Visual verification

![Frontend presentation loading-cycle parity](https://gist.githubusercontent.com/tommy-xr/2e216fdde8b0a586929d673f28309f08/raw/frontend-loading-base-fix-flat-vr.gif)

<sub>The shared presentation boundary preserves the animated LoadingScene in flat and VR. Exact base/fix captures used the same deterministic 60 Hz request sequence with verified 25AE assets.</sub>

### Post-refactor — both presentation families

![Post-refactor Main Menu and LoadingScene in flat and VR](https://gist.githubusercontent.com/tommy-xr/2e216fdde8b0a586929d673f28309f08/raw/frontend-presentation-after.png)

### Base ↔ fix and flat ↔ VR parity

![Base/fix and flat/VR parity](https://gist.githubusercontent.com/tommy-xr/2e216fdde8b0a586929d673f28309f08/raw/frontend-presentation-base-fix-flat-vr.png)

<sub>All 62 matched base/fix frames are pixel-identical: 0 differing pixels, maximum channel delta 0, aggregate RMSE 0.</sub>

No headset pass is required: this refactor changes shared canvas dispatch only, not OpenXR lifecycle, pose acquisition, or device-only rendering. The deterministic runtime exercises both presentation and pointer paths.

Fixes #1004
