### PR TITLE
fix(physics): reject mantle drops beneath supported floors

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1289,6 +1289,29 @@ fn plan_jump_mantle(
     let max_rise =
         (PLAYER_JUMP_SPEED * PLAYER_JUMP_SPEED) / (2.0 * PLAYER_JUMP_GRAVITY * SCALE_FACTOR);
     let minimum_forward = (2.0 * body_radius + 2.0 * PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
+    let current_floor_tolerance = (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
+    // A stacked lower route must terminate at an exterior vertical void inside
+    // the bounded search. SHODAN's finite upper shelf and lower side ring end
+    // together at that outer column. Engineering's unrelated lower deck keeps
+    // extending after the upper floor ends, so scripting to it would merely
+    // select another stacked floor and tunnel through the current one (#1085).
+    // Preserve the authored 40-foot descent budget; validate topology instead
+    // of turning its maximum depth into a proxy for connectivity.
+    let forward_search_end =
+        pos.translation.vector + direction * (PLAYER_JUMP_MANTLE_FORWARD / SCALE_FACTOR);
+    let exterior_probe_start = vector![
+        forward_search_end.x,
+        current_feet_y + current_floor_tolerance,
+        forward_search_end.z
+    ];
+    let exterior_probe = Ray::new(Point::from(exterior_probe_start), -Vector::y());
+    let forward_search_reaches_exterior_void = !validation_queries
+        .cast_ray_and_get_normal(
+            &exterior_probe,
+            PLAYER_JUMP_MANTLE_MAX_DROP / SCALE_FACTOR + 2.0 * current_floor_tolerance,
+            true,
+        )
+        .is_some_and(|(_, ground)| ground.normal.y > PLAYER_MIN_WALKABLE_NORMAL);
     let mut transition = None;
     let mut lower_transition = None;
     let mut rise_ss2 = PLAYER_JUMP_MANTLE_PROBE_STEP;
@@ -1397,7 +1420,11 @@ fn plan_jump_mantle(
                     // the sparse body only where the upper-floor ray proves
                     // authored stacked terrain overhangs the lower landing,
                     // and only while already crouched for that low route.
-                    .filter(|_| is_crouched && overhanging_current_floor)
+                    .filter(|_| {
+                        is_crouched
+                            && overhanging_current_floor
+                            && forward_search_reaches_exterior_void
+                    })
                     // Restore the continuous capsule an additional radius
                     // beyond the minimum crossing distance. The first point
                     // sample on a finite downhill tread can support the bottom
@@ -8145,6 +8172,68 @@ mod tests {
         assert!(
             end.x > 0.0 && end.y > 4.4,
             "jump should mantle onto the elevated platform, ended {end:?}"
+        );
+    }
+
+    /// Issue #1085: a stair-sized upper-floor seam must not make a vertically
+    /// disconnected floor below it eligible for the sparse-body fallback. The
+    /// parentless upper slab is a real supporting route; scripting the crouched
+    /// player to the lower slab would carry the compressed body straight through
+    /// that terrain, reproducing Engineering's reverse lip near Aux Storage 5.
+    #[test]
+    fn jump_mantle_rejects_lower_floor_beneath_supported_upper_route() {
+        let mut world = PhysicsWorld::new();
+        // Starting floor: top y=0, ending at the reverse-step seam x=0.
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::cuboid(4.0, 0.1, 4.0)
+                .translation(vector![-4.0, -0.1, 0.0])
+                .build(),
+        );
+        // Forward upper route: a 0.4-world-unit / one-SS2-foot riser. This is
+        // well inside ordinary step height and remains solid across the exact
+        // footprint where the lower landing probe runs.
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            ColliderBuilder::cuboid(4.0, 0.1, 4.0)
+                .translation(vector![4.0, 0.3, 0.0])
+                .build(),
+        );
+        // Stable but disconnected floor 12.174 world units below the starting
+        // surface, matching Engineering's ~30.44-SS2-foot erroneous fallback.
+        world.add_collider(
+            EntityId::from_inner(1002).unwrap(),
+            ColliderBuilder::cuboid(4.0, 0.1, 4.0)
+                .translation(vector![4.0, -12.274, 0.0])
+                .build(),
+        );
+        // Populate the broad phase without placing the real player fixture in
+        // the planner's casts.
+        let mut remote_player = world.create_player(
+            vec3(100.0, 100.0, 100.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut remote_player);
+
+        let validation_queries = query_pipeline(&world, QueryFilter::default());
+        let parented_only = QueryFilter::default()
+            .predicate(&|_handle: ColliderHandle, collider: &Collider| collider.parent().is_some());
+        let scripted_queries = validation_queries.with_filter(parented_only);
+        let start = Isometry::translation(-0.8, player_center_above_floor(true), 0.0);
+        let planned = plan_jump_mantle(
+            &player_character_controller(),
+            &validation_queries,
+            &scripted_queries,
+            &crouched_player_capsule(),
+            &start,
+            vector![0.1, 0.0, 0.0],
+            1.0 / 60.0,
+            true,
+        );
+
+        assert!(
+            planned.is_none(),
+            "a supported upper route must block the scripted fallback to the disconnected lower floor"
         );
     }
 

--- a/tools/shock2-sdk/test/jump.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump.e2e.test.ts
@@ -210,6 +210,82 @@ test(
   },
 );
 
+// Issue #1085: Engineering's reverse route near Aux Storage 5 has a normal
+// one-foot riser on the upper floor and a disconnected floor about 30.4 SS2
+// feet below the same forward footprint. The old stacked-terrain fallback
+// compressed a crouched player and scripted them through the still-solid upper
+// floor. Setup teleport only stages the campaign-confirmed pre-jump pose; the
+// crossing itself is the exact production VR crouch/jump/locomotion sequence.
+test(
+  "crouched jump at Engineering reverse lip stays on the upper route",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG1_REVERSE_LIP_PORT ?? 8143),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    // Standing center over the authored y=-13.2 start floor. Crouching plants
+    // the feet and produces the campaign-observed center near y=-12.596.
+    await game.player.teleport({ x: 7.75, y: -11.956, z: -128.4 });
+    await game.step({ frames: 30 });
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 5 });
+    const start = await game.player.position();
+
+    // The recorded route first makes an ordinary crouched jump onto the
+    // 0.4-world-unit upper lip. The second, otherwise identical jump is the one
+    // whose forward probe used to select the disconnected lower floor.
+    await game.input.lookAtWorldPoint([
+      start.x,
+      start.y + PLAYER_EYE_HEIGHT_WORLD,
+      start.z - 4,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 7 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 120 });
+    const upperLip = await game.player.position();
+    assert.ok(
+      upperLip.y > -12.3 && upperLip.z < -129.2,
+      `first jump must stage the authored upper lip (${JSON.stringify(start)} -> ${JSON.stringify(upperLip)})`,
+    );
+
+    await game.input.lookAtWorldPoint([
+      upperLip.x,
+      upperLip.y + PLAYER_EYE_HEIGHT_WORLD,
+      upperLip.z - 4,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 7 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    let minimumCenterY = (await game.player.position()).y;
+    for (let frame = 0; frame < 300; frame += 1) {
+      await game.step({ frames: 1 });
+      minimumCenterY = Math.min(minimumCenterY, (await game.player.position()).y);
+    }
+    const settled = await game.player.position();
+    await game.step({ frames: 120 });
+    const supported = await game.player.position();
+
+    assert.ok(
+      minimumCenterY > -12.8 &&
+        settled.y > -12.8 &&
+        supported.y > -12.8 &&
+        Math.abs(supported.y - settled.y) < 0.05,
+      `ordinary jump must remain above Engineering's solid y=-12.8 upper floor ` +
+        `(${JSON.stringify(start)} -> ${JSON.stringify(upperLip)} -> ` +
+        `${JSON.stringify(settled)} -> ` +
+        `${JSON.stringify(supported)}, minimum center y=${minimumCenterY})`,
+    );
+  },
+);
+
 // Engineering campaign `engineering · none · legacy · seed 1378752978`
 // reached this authored route from a clean playthrough. The shipped walk graph
 // continues through the Cargo 2 crate stack, but the parented mission crates


### PR DESCRIPTION
Fixes #1085

## What changed

- require a bounded lower mantle route to reach an exterior vertical void where the stacked upper and lower surfaces both terminate
- reject unrelated stacked floors beneath a still-supported ordinary jump route
- retain the authored 40 SS2-foot lower-transition budget used by SHODAN's final descent

## Regression coverage

- added a negative-first physics fixture for Engineering's 0.4-world-unit reverse step over a disconnected lower floor
- added a forced-VR `eng1.mis` production crouch/jump/locomotion scenario at the campaign-confirmed lip
- re-ran the existing SHODAN final-descent scenario to preserve the legitimate ~34-foot descent

## Validation

- `cargo test -p shock2vr --lib jump`
- `cargo test -p shock2vr --lib`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm test`
- targeted Engineering forced-VR jump e2e
- existing SHODAN final-descent e2e

## Campaign Configuration

`earth-to-hydro · detailed · 25th Anniversary · vr · seed 1600004333`

## Visual evidence

![Engineering mantle topology demo](https://gist.githubusercontent.com/tommy-xr/1a662bdc421597b24e8715ba43b3b358/raw/eng1-mantle-topology.gif)

<sub>Identical fresh-launch, forced-VR Engineering sequence on base `e67b851c` and fix `0b30b697`: the base controller compresses and tunnels through the solid upper floor to `y=-24.370`; the fix remains supported above it at `y=-12.196`. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Engineering mantle settled before/after](https://gist.githubusercontent.com/tommy-xr/1a662bdc421597b24e8715ba43b3b358/raw/eng1-mantle-before-after.png)


