### PR TITLE
fix(debug): report incoming entity links

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -663,6 +663,7 @@ pub struct EntityDetailResult {
     pub properties: Vec<PropertyInfo>,
     pub outgoing_links: Vec<LinkInfo>,
     pub incoming_links: Vec<LinkInfo>,
+    pub contained_by: Option<i32>,
     pub aim_points: Vec<AimPointInfo>,
 }
 
@@ -686,6 +687,7 @@ pub struct PropertyInfo {
 #[derive(Debug, Serialize)]
 pub struct LinkInfo {
     pub link_type: String,
+    /// The target for an outgoing link and the source for an incoming link.
     pub target_id: i32,
     pub target_name: String,
     pub contains_ordinal: Option<u32>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1456,6 +1456,7 @@ fn process_command(
                                 contains_ordinal: l.contains_ordinal,
                             })
                             .collect(),
+                        contained_by: detail.contained_by,
                         aim_points: detail
                             .aim_points
                             .into_iter()

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -252,6 +252,9 @@ pub struct DebugEntityDetail {
     pub properties: Vec<DebugPropertyInfo>,
     pub outgoing_links: Vec<DebugLinkInfo>,
     pub incoming_links: Vec<DebugLinkInfo>,
+    /// Runtime entity id of the source of an incoming `Contains` link, when
+    /// this entity lives inside a container.
+    pub contained_by: Option<i32>,
     pub aim_points: Vec<DebugAimPoint>,
 }
 
@@ -275,6 +278,8 @@ pub struct DebugPropertyInfo {
 #[derive(Debug, Serialize, Clone)]
 pub struct DebugLinkInfo {
     pub link_type: String,
+    /// The entity at the opposite end of the link: the target for an outgoing
+    /// link and the source for an incoming link.
     pub target_id: i32,
     pub target_name: String,
     /// Inventory cell ordinal for `Contains` links. Kept separate from the

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7991,6 +7991,97 @@ impl MissionCore {
     }
 }
 
+fn debug_link_info(
+    opposite_id: EntityId,
+    link: &ToLink,
+    names: &View<PropSymName>,
+) -> crate::game_scene::DebugLinkInfo {
+    crate::game_scene::DebugLinkInfo {
+        link_type: format!("{:?}", link.link),
+        target_id: opposite_id.inner() as i32,
+        target_name: names
+            .get(opposite_id)
+            .map(|name| name.0.clone())
+            .unwrap_or_else(|_| format!("Entity_{}", opposite_id.inner())),
+        contains_ordinal: match link.link {
+            Link::Contains(ordinal) => Some(ordinal),
+            _ => None,
+        },
+    }
+}
+
+/// Return both directions of every live link touching `id`. `Links` stores
+/// only its outgoing half, so incoming links must be resolved by scanning the
+/// sources. Each [`DebugLinkInfo`](crate::game_scene::DebugLinkInfo) names the
+/// opposite endpoint: destination in `outgoing`, source in `incoming`.
+fn debug_entity_links(
+    id: EntityId,
+    links: &View<Links>,
+    names: &View<PropSymName>,
+) -> (
+    Vec<crate::game_scene::DebugLinkInfo>,
+    Vec<crate::game_scene::DebugLinkInfo>,
+) {
+    let mut outgoing = Vec::new();
+    let mut incoming = Vec::new();
+
+    if let Ok(entity_links) = links.get(id) {
+        for link in &entity_links.to_links {
+            if let Some(target) = link.to_entity_id {
+                outgoing.push(debug_link_info(target.0, link, names));
+            }
+        }
+    }
+
+    for (source_id, source_links) in links.iter().with_id() {
+        for link in &source_links.to_links {
+            if link.to_entity_id.map(|target| target.0) == Some(id) {
+                incoming.push(debug_link_info(source_id, link, names));
+            }
+        }
+    }
+
+    (outgoing, incoming)
+}
+
+#[cfg(test)]
+mod debug_entity_link_tests {
+    use super::*;
+
+    #[test]
+    fn reports_outgoing_targets_and_incoming_sources_with_contains_metadata() {
+        let mut world = World::new();
+        let item = world.add_entity(PropSymName("Hydro Card A".to_owned()));
+        let container = world.add_entity((
+            PropSymName("Hydro Corpse".to_owned()),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 934,
+                    to_entity_id: Some(WrappedEntityId(item)),
+                    link: Link::Contains(7),
+                }],
+            },
+        ));
+
+        world.run(|links: View<Links>, names: View<PropSymName>| {
+            let (container_outgoing, container_incoming) =
+                debug_entity_links(container, &links, &names);
+            assert_eq!(container_incoming.len(), 0);
+            assert_eq!(container_outgoing.len(), 1);
+            assert_eq!(container_outgoing[0].target_id, item.inner() as i32);
+            assert_eq!(container_outgoing[0].target_name, "Hydro Card A");
+            assert_eq!(container_outgoing[0].contains_ordinal, Some(7));
+
+            let (item_outgoing, item_incoming) = debug_entity_links(item, &links, &names);
+            assert_eq!(item_outgoing.len(), 0);
+            assert_eq!(item_incoming.len(), 1);
+            assert_eq!(item_incoming[0].target_id, container.inner() as i32);
+            assert_eq!(item_incoming[0].target_name, "Hydro Corpse");
+            assert_eq!(item_incoming[0].contains_ordinal, Some(7));
+        });
+    }
+}
+
 impl crate::game_scene::DebuggableScene for MissionCore {
     fn list_entities(
         &self,
@@ -8184,9 +8275,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn entity_detail(&self, id: EntityId) -> Option<crate::game_scene::DebugEntityDetail> {
-        use crate::game_scene::{
-            DebugAimPoint, DebugEntityDetail, DebugLinkInfo, DebugPropertyInfo,
-        };
+        use crate::game_scene::{DebugAimPoint, DebugEntityDetail, DebugPropertyInfo};
         use shipyard::*;
 
         let aim_points = self
@@ -8431,31 +8520,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     });
                 }
 
-                // Build links
-                let mut outgoing_links = Vec::new();
-                let incoming_links = Vec::new();
-
-                if let Ok(links) = v_links.get(id) {
-                    for link in &links.to_links {
-                        if let Some(target_entity) = link.to_entity_id {
-                            outgoing_links.push(DebugLinkInfo {
-                                link_type: format!("{:?}", link.link),
-                                target_id: target_entity.0.inner() as i32,
-                                target_name: v_sym_name
-                                    .get(target_entity.0)
-                                    .map(|s| s.0.clone())
-                                    .unwrap_or_else(|_| {
-                                        format!("Entity_{}", target_entity.0.inner())
-                                    }),
-                                contains_ordinal: match link.link {
-                                    dark::properties::Link::Contains(ordinal) => Some(ordinal),
-                                    _ => None,
-                                },
-                            });
-                        }
-                    }
-                    // TODO: Incoming links require scanning all entities - simplified for now
-                }
+                let (outgoing_links, incoming_links) =
+                    debug_entity_links(id, &v_links, &v_sym_name);
+                let contained_by = incoming_links
+                    .iter()
+                    .find(|link| link.contains_ordinal.is_some())
+                    .map(|link| link.target_id);
 
                 Some(DebugEntityDetail {
                     entity_id: id.inner() as i32,
@@ -8471,6 +8541,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties,
                     outgoing_links,
                     incoming_links,
+                    contained_by,
                     aim_points: aim_points.clone(),
                 })
             },

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -59,6 +59,10 @@ await game.player.setStats({
 // Entities
 const doors = await game.entities.list({ filter: "*Door*", limit: 10 });
 const detail = await game.entities.detail(doors.entities[0].id);
+// Link details expose both directions. `target_*` names the opposite endpoint:
+// destination in `outgoing_links`, source in `incoming_links`. A contained
+// entity also reports its container's runtime id directly.
+const containerId = detail.contained_by; // number, null, or undefined on an older runtime
 
 // Inject a script message into an entity (damage, frob, AI signal)
 await game.entities.sendMessage(doors.entities[0].id, { type: "Damage", amount: 5 });

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -124,6 +124,7 @@ export interface PropertyInfo {
 
 export interface LinkInfo {
   link_type: string;
+  /** Opposite endpoint: target for outgoing links, source for incoming links. */
   target_id: number;
   target_name: string;
   /** Exact inventory cell for a Contains link; null for other link types. */
@@ -140,6 +141,8 @@ export interface EntityDetailResult {
   properties: PropertyInfo[];
   outgoing_links: LinkInfo[];
   incoming_links: LinkInfo[];
+  /** Runtime id of the container owning this entity, or null when it is loose. */
+  contained_by?: number | null;
   /**
    * Live classified creature hitboxes. Optional for compatibility with debug
    * runtimes predating the aim-point capability.

--- a/tools/shock2-sdk/test/entity-containment-links.e2e.test.ts
+++ b/tools/shock2-sdk/test/entity-containment-links.e2e.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Hydro2's authored corpse/card pair from #809:
+//   corpse 1297 --Contains--> Hydro Card A 934
+// Runtime ids vary per launch, so both endpoints are resolved by their stable
+// mission template ids before checking the live bidirectional API response.
+const HYDRO_CARD_A_CORPSE = 1297;
+const HYDRO_CARD_A = 934;
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "entity detail reports both endpoints of authored containment",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
+    });
+    await game.step({ frames: 5 });
+
+    const corpses = await game.entities.byTemplate(HYDRO_CARD_A_CORPSE);
+    const cards = await game.entities.byTemplate(HYDRO_CARD_A);
+    assert.equal(corpses.length, 1, "expected Hydro2 corpse 1297");
+    assert.equal(cards.length, 1, "expected Hydro Card A 934");
+    const [corpse] = corpses;
+    const [card] = cards;
+
+    const corpseDetail = await game.entities.detail(corpse.id);
+    const outgoingContains = corpseDetail.outgoing_links.filter(
+      (link) => link.link_type.startsWith("Contains") && link.target_id === card.id,
+    );
+    assert.equal(outgoingContains.length, 1, "corpse must expose its Contains link to Hydro Card A");
+    assert.equal(outgoingContains[0].target_id, card.id);
+    assert.equal(outgoingContains[0].target_name, card.name);
+
+    const cardDetail = await game.entities.detail(card.id);
+    const incomingContains = cardDetail.incoming_links.filter((link) =>
+      link.link_type.startsWith("Contains"),
+    );
+    assert.equal(
+      incomingContains.length,
+      1,
+      "contained card must expose the corpse's incoming Contains link",
+    );
+    assert.equal(incomingContains[0].target_id, corpse.id);
+    assert.equal(incomingContains[0].target_name, corpse.name);
+    assert.equal(incomingContains[0].contains_ordinal, outgoingContains[0].contains_ordinal);
+    assert.equal(cardDetail.contained_by, corpse.id);
+  },
+);


### PR DESCRIPTION
## Summary

- populate `incoming_links` by scanning the live source-side `Links` components instead of returning the permanent empty placeholder
- define `target_id` / `target_name` as the opposite endpoint (destination for outgoing links, source for incoming links) and preserve exact `Contains` ordinals in both directions
- expose `contained_by` as the container's runtime entity id for direct loose-vs-contained classification
- document the typed SDK contract and cover the exact authored Hydro2 corpse/card pair reported in the issue

## Pre-fix reproduction

On exact base `e67b851cffc76c161b26794826ad446e977c25c4`, a negative-first SDK scenario launched `hydro2.mis`, resolved mission object 1297 (`HYD Female Corpse`) and mission object 934 (`Hydro Card A`) by stable template id, then inspected both runtime endpoints.

The corpse correctly exposed its outgoing `Contains(0)` link to the card. The card returned `incoming_links: []`, so the assertion expecting the owning corpse failed `0 !== 1`. This exactly reproduces the debug-tooling misclassification: the contained card has no physics/render presence, but the detail API made it look loose.

## Fix

`Links` is intentionally stored only on each source entity. Entity detail now preserves the existing outgoing response and also scans live `Links` sources for references to the inspected entity. Incoming entries carry the source id/name as the opposite endpoint and the same `contains_ordinal` as the outgoing entry. `contained_by` selects the source of the incoming containment edge.

The focused fix-side HTTP response was:

```json
{
  "corpse": {
    "id": 1157,
    "outgoing": [{
      "link_type": "Contains(0)",
      "target_id": 450,
      "target_name": "Hydro Card A",
      "contains_ordinal": 0
    }]
  },
  "card": {
    "id": 450,
    "incoming": [{
      "link_type": "Contains(0)",
      "target_id": 1157,
      "target_name": "HYD Female Corpse",
      "contains_ordinal": 0
    }],
    "contained_by": 1157
  }
}
```

Runtime ids vary per launch; the regression discovers both endpoints from stable mission template ids.

Open PR #769 adds carried-location data to entity summaries for #565. It does not implement incoming link detail or claim this issue; this change is semantically independent of that open work.

## Verification

Every runtime/SDK invocation used the explicit 25th Anniversary root `/Users/bryan/ss2-25th`, verified by sentinel `sshock2.kpf` and remaster mods `sshock2ee`, `400`, `shtup`, `scp`, and `patch_ext`.

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS='-D warnings' cargo test -p shock2vr --lib` — 888 passed
- focused bidirectional Rust regression — 1 passed
- SDK unit suite — 305 total: 26 passed, 279 opt-in E2E skips
- authored Hydro2 containment HTTP scenario — 1 passed, including outgoing, incoming, ordinal, opposite endpoint name/id, and `contained_by`
- full serialized 25AE SDK suite — 305 total: 296 passed, 2 failed, 7 fixture-gated skips; all 23 mission loads and the new containment scenario passed
  - creature-loot reader MFD expected `251`, got `-1`
  - Hydro3 Korenchkin transcript fixture expects double spacing while the transcript is present with single spacing
- both failures rerun together on detached exact base `e67b851c` with the same 25AE root — 0 passed / 2 failed with identical values and text
- post-fetch (`origin/main` unchanged at `e67b851c`) focused Rust, SDK unit, and authored Hydro2 scenario rerun green

## Visual assessment

Approved non-renderable rationale: this change only exposes already-existing containment metadata in the debug runtime's JSON response and typed SDK. It does not mutate ECS containment, `HasRefs`, physics, rendering, UI, input, or simulation; identical runtime state produces identical rendered frames. A GIF or screenshot cannot display an HTTP response, so exact base/fix API assertions are the faithful evidence and no fabricated media is included.

Fixes #809
