### PR TITLE
feat(render): plumb game-driven FOV to flat runtimes

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -780,7 +780,7 @@ fn run_game_blocking(
         // Render the game
         let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
         let projection_matrix: cgmath::Matrix4<f32> =
-            cgmath::perspective(cgmath::Deg(45.0), ratio, 0.1, 1000.0);
+            cgmath::perspective(cgmath::Deg(game.desired_fov_deg()), ratio, 0.1, 1000.0);
 
         let screen_size = vec2(SCR_WIDTH as f32, SCR_HEIGHT as f32);
 

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -456,10 +456,6 @@ pub fn main() {
             }
         }
 
-        let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
-        let projection_matrix: cgmath::Matrix4<f32> =
-            cgmath::perspective(cgmath::Deg(45.0), ratio, 0.1, 1000.0);
-
         let time = Time {
             elapsed: Duration::from_secs_f32(delta_time),
             total: Duration::from_secs_f32(time - start_time),
@@ -474,6 +470,13 @@ pub fn main() {
         if game.should_quit() {
             window.set_should_close(true);
         }
+
+        // Built after `game.update` so this frame's `desired_fov_deg()` (game-
+        // driven, e.g. the planned cyber-interface FOV pull) is reflected
+        // immediately rather than lagging a frame.
+        let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
+        let projection_matrix: cgmath::Matrix4<f32> =
+            cgmath::perspective(cgmath::Deg(game.desired_fov_deg()), ratio, 0.1, 1000.0);
 
         let screen_size = vec2(SCR_WIDTH as f32, SCR_HEIGHT as f32);
 

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -102,6 +102,12 @@ dev_params! {
     /// deferral). Consequently the debug runtime cannot exercise this knob;
     /// it needs a worn check on device.
     EYE_HEIGHT_OFFSET = float("eye_offset", "Eye height (m)", 0.0, -0.5, 0.5, 0.02),
+    /// Live override for the flat runtimes' projection FOV, in degrees. `0`
+    /// (the default) means "no override - use `Game::desired_fov_deg()`";
+    /// any positive value forces that FOV instead, for verifying the
+    /// game-driven FOV seam (issue #1088) without a rebuild. VR is
+    /// untouched: OpenXR view FOVs must be used as-is.
+    FOV_OVERRIDE_DEG = float("fov_override_deg", "FOV override (deg)", 0.0, 0.0, 120.0, 1.0),
 }
 
 /// Every parameter with its id, in declaration order.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -105,8 +105,10 @@ dev_params! {
     /// Live override for the flat runtimes' projection FOV, in degrees. `0`
     /// (the default) means "no override - use `Game::desired_fov_deg()`";
     /// any positive value forces that FOV instead, for verifying the
-    /// game-driven FOV seam (issue #1088) without a rebuild. VR is
-    /// untouched: OpenXR view FOVs must be used as-is.
+    /// game-driven FOV seam (issue #1088) without a rebuild. `oculus_runtime`
+    /// is untouched: OpenXR view FOVs must be used as-is. (`debug_runtime`
+    /// shares its single flat projection between flat and `--vr` mode, so this
+    /// override reaches both there.)
     FOV_OVERRIDE_DEG = float("fov_override_deg", "FOV override (deg)", 0.0, 0.0, 120.0, 1.0),
 }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -94,8 +94,21 @@ pub const PLAYER_CROUCH_EYE_HEIGHT: f32 = 1.2;
 /// matrix. `Game::desired_fov_deg` starts here and can be driven game-side
 /// (see `Game::set_desired_fov_deg`) - the planned first consumer is a
 /// "cyber interface" mode that pulls the FOV in while its overlay is up.
-/// VR is untouched: OpenXR view FOVs must be used as-is.
+/// `oculus_runtime` is untouched: OpenXR view FOVs must be used as-is.
 pub const DEFAULT_FOV_DEG: f32 = 45.0;
+
+/// Resolves `base` against `dev_params::FOV_OVERRIDE_DEG`: `0` (its default)
+/// means "no override - use `base`"; any positive value forces that FOV
+/// instead. Shared by `Game::desired_fov_deg` and the `App::MissingAssets`
+/// fallback so the override rule lives in exactly one place.
+fn resolve_fov_deg(base: f32) -> f32 {
+    let override_deg = dev_params::get(dev_params::FOV_OVERRIDE_DEG);
+    if override_deg > 0.0 {
+        override_deg
+    } else {
+        base
+    }
+}
 
 /// Real-world meters per world unit: 1 world unit is `dark::SCALE_FACTOR`
 /// (2.5) SS2 feet, and an SS2 foot is a real foot (0.3048 m). VR runtimes
@@ -469,7 +482,11 @@ pub struct Game {
     /// the host knows that (a Quest eye is roughly twice a 45-degree flat
     /// screen, and much closer to square). Carried a frame, because `render`
     /// runs before `render_per_eye` and the projection does not change between
-    /// them.
+    /// them - true whenever `desired_fov_deg` is held steady, but a caller
+    /// that changes it every frame (a hypothetical unsmoothed FOV animation)
+    /// would see the rim sized one frame stale. Not a concern for the
+    /// dev-param override (a one-off manual poke) or the planned
+    /// cyber-interface consumer (a single step, not a per-frame tween).
     view_extents: (f32, f32),
 
     /// Per-frame desired FOV (vertical, degrees) for the flat runtimes'
@@ -1817,20 +1834,21 @@ impl Game {
     /// VR is explicitly out of scope: OpenXR view FOVs must be used as-is, so
     /// `oculus_runtime` does not read this.
     pub fn desired_fov_deg(&self) -> f32 {
-        let override_deg = dev_params::get(dev_params::FOV_OVERRIDE_DEG);
-        if override_deg > 0.0 {
-            override_deg
-        } else {
-            self.desired_fov_deg
-        }
+        resolve_fov_deg(self.desired_fov_deg)
     }
 
     /// Internal seam for gameplay/UI code to drive [`Game::desired_fov_deg`].
     /// Not called anywhere yet - the first consumer is the planned
     /// cyber-interface mode. Smoothing/easing is the caller's responsibility.
+    /// Rejects non-finite or out-of-range degrees (valid input to
+    /// `cgmath::perspective` is strictly between 0 and 180) by leaving the
+    /// current value unchanged, so a bad caller can't poison the flat
+    /// runtimes' projection into a panic.
     #[allow(dead_code)]
     pub(crate) fn set_desired_fov_deg(&mut self, fov_deg: f32) {
-        self.desired_fov_deg = fov_deg;
+        if fov_deg.is_finite() && fov_deg > 0.0 && fov_deg < 180.0 {
+            self.desired_fov_deg = fov_deg;
+        }
     }
 
     /// Height (world units) of the player collider's center above the surface
@@ -2224,14 +2242,7 @@ impl App {
     pub fn desired_fov_deg(&self) -> f32 {
         match self {
             App::Ready(game) => game.desired_fov_deg(),
-            App::MissingAssets(_) => {
-                let override_deg = dev_params::get(dev_params::FOV_OVERRIDE_DEG);
-                if override_deg > 0.0 {
-                    override_deg
-                } else {
-                    DEFAULT_FOV_DEG
-                }
-            }
+            App::MissingAssets(_) => resolve_fov_deg(DEFAULT_FOV_DEG),
         }
     }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -90,6 +90,13 @@ pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS + physics::PLAYER_EY
 /// cannot poke through a low ceiling the collider clears.
 pub const PLAYER_CROUCH_EYE_HEIGHT: f32 = 1.2;
 
+/// Default vertical FOV, in degrees, for the flat runtimes' projection
+/// matrix. `Game::desired_fov_deg` starts here and can be driven game-side
+/// (see `Game::set_desired_fov_deg`) - the planned first consumer is a
+/// "cyber interface" mode that pulls the FOV in while its overlay is up.
+/// VR is untouched: OpenXR view FOVs must be used as-is.
+pub const DEFAULT_FOV_DEG: f32 = 45.0;
+
 /// Real-world meters per world unit: 1 world unit is `dark::SCALE_FACTOR`
 /// (2.5) SS2 feet, and an SS2 foot is a real foot (0.3048 m). VR runtimes
 /// divide floor-relative tracked poses (meters) by this before feeding them
@@ -464,6 +471,10 @@ pub struct Game {
     /// runs before `render_per_eye` and the projection does not change between
     /// them.
     view_extents: (f32, f32),
+
+    /// Per-frame desired FOV (vertical, degrees) for the flat runtimes'
+    /// projection matrix. See [`Game::desired_fov_deg`].
+    desired_fov_deg: f32,
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -1245,6 +1256,7 @@ impl Game {
                 Quaternion::new(1.0, 0.0, 0.0, 0.0),
             ),
             view_extents: hit_feedback::DEFAULT_VIEW_EXTENTS,
+            desired_fov_deg: DEFAULT_FOV_DEG,
         }
     }
 
@@ -1795,6 +1807,32 @@ impl Game {
         player_eye_height_for(self.active_game_scene.player_is_crouched())
     }
 
+    /// Vertical FOV (degrees) the flat runtimes should build their projection
+    /// matrix with this frame. Defaults to [`DEFAULT_FOV_DEG`] and is unset by
+    /// anything today; [`Game::set_desired_fov_deg`] is the internal seam a
+    /// future gameplay/UI mode (e.g. the cyber-interface overlay) will drive
+    /// it from. `dev_params::FOV_OVERRIDE_DEG` can force a value live for
+    /// testing without a rebuild.
+    ///
+    /// VR is explicitly out of scope: OpenXR view FOVs must be used as-is, so
+    /// `oculus_runtime` does not read this.
+    pub fn desired_fov_deg(&self) -> f32 {
+        let override_deg = dev_params::get(dev_params::FOV_OVERRIDE_DEG);
+        if override_deg > 0.0 {
+            override_deg
+        } else {
+            self.desired_fov_deg
+        }
+    }
+
+    /// Internal seam for gameplay/UI code to drive [`Game::desired_fov_deg`].
+    /// Not called anywhere yet - the first consumer is the planned
+    /// cyber-interface mode. Smoothing/easing is the caller's responsibility.
+    #[allow(dead_code)]
+    pub(crate) fn set_desired_fov_deg(&mut self, fov_deg: f32) {
+        self.desired_fov_deg = fov_deg;
+    }
+
     /// Height (world units) of the player collider's center above the surface
     /// it stands on, for the current stance. VR runtimes subtract this from
     /// the pawn position returned by [`Game::render`] to anchor floor-relative
@@ -2179,6 +2217,21 @@ impl App {
         match self {
             App::Ready(game) => game.player_center_above_floor(),
             App::MissingAssets(_) => physics::player_center_above_floor(false),
+        }
+    }
+
+    /// See [`Game::desired_fov_deg`].
+    pub fn desired_fov_deg(&self) -> f32 {
+        match self {
+            App::Ready(game) => game.desired_fov_deg(),
+            App::MissingAssets(_) => {
+                let override_deg = dev_params::get(dev_params::FOV_OVERRIDE_DEG);
+                if override_deg > 0.0 {
+                    override_deg
+                } else {
+                    DEFAULT_FOV_DEG
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Flat runtimes (`desktop_runtime`, `debug_runtime`) hardcoded `Deg(45.0)` for their projection matrix, so no gameplay/UI feature had a channel to influence FOV.
- `shock2vr::Game` now exposes `desired_fov_deg()` (defaults to `DEFAULT_FOV_DEG` = 45°, unchanged behavior) and an internal `set_desired_fov_deg()` seam for a future game-side driver — the planned "cyber interface" mode is the first consumer, not implemented here.
- A new dev param `FOV_OVERRIDE_DEG` (`shock2vr/src/dev_params.rs`) lets the FOV be forced live via the debug runtime's `/v1/dev-params` HTTP endpoint, for verification without a rebuild.
- Both flat runtimes now read `game.desired_fov_deg()` when building their projection. In `desktop_runtime`, the projection-matrix construction moved from before `game.update()` to after it, so the frame's FOV isn't stale by one frame.
- `oculus_runtime` is untouched — OpenXR view FOVs must be used as-is (rendering at a different FOV than submitted causes compositor reprojection warping).

## Verification

Ran the headless debug runtime (`cargo dbgr --mission medsci1.mis`), stepped to a stable frame, then forced `fov_override_deg` via `POST /v1/dev-params` and re-screenshotted to prove the projection actually changes:

![fov comparison](https://gist.githubusercontent.com/tommy-xr/0c05b9630314ae1e801732f620030447/raw/fov_comparison.png)

<sub>Same camera position/frame, only `fov_override_deg` changed (45° → 100°). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

The wider FOV clearly reveals more of the room (a "SAFETY FIRST" wall sign and a Tri-Optimum screen come into view) confirming the seam reaches the actual projection matrix.

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo test -p shock2vr --lib hit_feedback` — 19/19 pass (view_extents/projection-derived tests unaffected).
- `cargo fmt` run.
- Ran `/xreview` (Claude subagent + Codex CLI, both parallel + a dedicated de-dup pass); addressed the agreed findings: extracted a single `resolve_fov_deg()` helper (was duplicated in `Game::desired_fov_deg` and the `App::MissingAssets` fallback), clamped `set_desired_fov_deg` to reject non-finite/out-of-range degrees (defensive - nothing calls it yet), and corrected doc wording ("VR is untouched" -> "oculus_runtime is untouched", since `debug_runtime --vr` shares the same flat projection). Re-validated after fixes (cargo check + a fresh runtime screenshot, unchanged result).

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [x] `cargo test -p shock2vr --lib hit_feedback`
- [x] Debug runtime screenshot comparison at default vs. overridden FOV (embedded above)
- [x] `/xreview` findings addressed

Fixes #1088
