### PR TITLE
fix(ui): pass presentation mode in developer scene

### DIFF
--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -172,7 +172,9 @@ impl GameScene for DeveloperScene {
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
         let canvas = self.build_canvas(self.menu.pointer_canvas());
-        let objects = self.menu.render_world_space(asset_cache, canvas);
+        let objects = self
+            .menu
+            .render_world_space(asset_cache, canvas, options.presentation_mode);
         (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
@@ -193,7 +195,7 @@ impl GameScene for DeveloperScene {
         let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
         let canvas = self.build_canvas(pointer_canvas);
         self.menu
-            .render_screen_space(asset_cache, canvas, screen_size)
+            .render_screen_space(asset_cache, canvas, screen_size, options.presentation_mode)
     }
 
     fn handle_effects(


### PR DESCRIPTION
## Summary

`main` is broken: `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` fails with 2 `E0061` errors in `shock2vr/src/scenes/developer.rs`, calling `FrontendMenu::render_world_space` / `render_screen_space` with too few arguments.

**Root cause**: two PRs collided.
- #1082 (`refactor(ui): share the developer frontend shell`) added `developer.rs`'s calls to `render_world_space(asset_cache, canvas)` / `render_screen_space(asset_cache, canvas, screen_size)`.
- #1084 (`refactor(ui): share frontend canvas presentation`), merged after, added a `presentation_mode: PresentationMode` parameter to both methods and updated every other call site (`main_menu.rs`, `game_over.rs`, `load_game.rs`) — but `developer.rs` didn't exist yet on that branch, so it was never updated.

**Fix**: pass `options.presentation_mode` at both call sites in `developer.rs`, matching every other `FrontendMenu` host (`main_menu.rs`, `game_over.rs`, `load_game.rs`). No behavior change — the developer scene already branches on `options.presentation_mode` elsewhere in the same file, so this just brings it in line with the current signature and the repo's flat/VR-parity rule (placement decided once in shared layout, no per-presentation logic added here).

## Test plan
- [x] `cargo fmt`
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean, no warnings/errors
- [x] `cargo test -p shock2vr` — 897 passed, 0 failed

https://claude.ai/code/session_0174dXmd6obrfd5YAgLihr42