### PR TITLE
feat(vr): prototype on-weapon ammo meter + glance-gated wrist health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -630,6 +630,16 @@ The project supports experimental flags for gating in-progress features during d
   default is the only reachable setting without a rebuild. Tell-tale log line:
   `high-detail (PMNM) meshes: true|false`.
 
+- **`ambient_meters`**: prototype VR ambient-meter model (flat HUD untouched).
+  The ammo readout moves onto the wielded weapon - a small AMMOFULL panel
+  anchored to the weapon's live transform, facing the shooter - and the
+  right-forearm ammo panel is retired while the flag is on. The left-forearm
+  health panel stays but renders only when the wrist is glanced at (panel
+  normal vs eye vector, with hysteresis; untracked poses hide it). Layout and
+  tuning knobs (weapon-local offset/tilt/size, glance thresholds) live in
+  `shock2vr/src/hud/ambient_meters.rs`. Without the flag, both forearm panels
+  render exactly as before.
+
 #### Adding New Experimental Features
 
 1. **Gate the feature in code**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,14 +631,17 @@ The project supports experimental flags for gating in-progress features during d
   `high-detail (PMNM) meshes: true|false`.
 
 - **`ambient_meters`**: prototype VR ambient-meter model (flat HUD untouched).
-  The ammo readout moves onto the wielded weapon - a small AMMOFULL panel
-  anchored to the weapon's live transform, facing the shooter - and the
-  right-forearm ammo panel is retired while the flag is on. The left-forearm
-  health panel stays but renders only when the wrist is glanced at (panel
-  normal vs eye vector, with hysteresis; untracked poses hide it). Layout and
-  tuning knobs (weapon-local offset/tilt/size, glance thresholds) live in
-  `shock2vr/src/hud/ambient_meters.rs`. Without the flag, both forearm panels
-  render exactly as before.
+  The ammo readout moves onto the wielded weapon - the compact AMMOBACK square
+  (round count + ammo type, the same gauge the flat HUD shows outside use
+  mode), anchored to the weapon's live transform and facing the shooter like a
+  rear-sight status tag - and the right-forearm ammo panel is retired while the
+  flag is on. The left-forearm health panel stays but renders only when the
+  wrist is glanced at (panel normal vs eye vector, with hysteresis; untracked
+  poses hide it). Panel shape/tilt/size and the glance thresholds live in
+  `shock2vr/src/hud/ammo_panel.rs` + `shock2vr/src/hud/ambient_meters.rs`; the
+  per-weapon anchor (where the tag hangs in the weapon's own frame) lives in
+  `vr_config::weapon_meter_anchor_*`, beside the grip-offset table. Without the
+  flag, both forearm panels render exactly as before.
 
 #### Adding New Experimental Features
 

--- a/shock2vr/src/hud/ambient_meters.rs
+++ b/shock2vr/src/hud/ambient_meters.rs
@@ -16,6 +16,7 @@ use crate::vr_config::Handedness;
 
 use super::ammo_panel;
 use super::virtual_arms;
+use virtual_arms::OVERLAY_Z_OFFSET;
 
 /// The experimental-features name gating all of this.
 pub(crate) const FEATURE: &str = "ambient_meters";
@@ -26,24 +27,29 @@ pub(crate) const FEATURE: &str = "ambient_meters";
 // -X, +X back toward the shooter, +Y up out of the gun body (see
 // `vr_config`'s "authored barrel along -X" note). Offsets are in world units
 // (1 unit = 0.762 m), the same space `RuntimePropTransform` lives in.
+// The per-weapon anchor itself lives in `vr_config::weapon_meter_anchor_*`,
+// beside the grip-offset table; these are the shared shape knobs.
 
-/// Where the meter hangs off the weapon origin (the grip): above and slightly
-/// behind the gun body.
-pub(crate) const WEAPON_METER_OFFSET: Vector3<f32> = vec3(0.05, 0.17, 0.0);
-/// Lean the panel top away from the shooter so it reads like a rear sight
-/// display when the gun is held in a natural aim pose.
+/// Lean the panel top away from the shooter so it reads like a rear-sight
+/// status tag when the gun is held in a natural aim pose.
 pub(crate) const WEAPON_METER_TILT: Deg<f32> = Deg(-20.0);
-/// Panel size in world units, preserving the AMMOFULL 260x64 aspect.
-pub(crate) const WEAPON_METER_WIDTH: f32 = 0.20;
-pub(crate) const WEAPON_METER_HEIGHT: f32 = WEAPON_METER_WIDTH * (64.0 / 260.0);
+/// Panel size in world units, preserving the compact AMMOBACK crop's 94x64
+/// aspect.
+pub(crate) const WEAPON_METER_WIDTH: f32 = 0.10;
+pub(crate) const WEAPON_METER_HEIGHT: f32 =
+    WEAPON_METER_WIDTH * (ammo_panel::COMPACT_H / ammo_panel::COMPACT_W);
 
 /// Root transform for the on-weapon ammo panel: canvas convention (+Z at the
-/// viewer, +X the viewer's right) hung in the weapon's local frame, facing
-/// back along the barrel toward the shooter. The single placement decision -
-/// any presentation that draws this meter maps the same canvas through it.
-pub(crate) fn weapon_meter_transform(weapon_transform: Matrix4<f32>) -> Matrix4<f32> {
+/// viewer, +X the viewer's right) hung at `anchor` in the weapon's local
+/// frame, facing back along the barrel toward the shooter. The single
+/// placement decision - any presentation that draws this meter maps the same
+/// canvas through it.
+pub(crate) fn weapon_meter_transform(
+    weapon_transform: Matrix4<f32>,
+    anchor: Vector3<f32>,
+) -> Matrix4<f32> {
     weapon_transform
-        * Matrix4::from_translation(WEAPON_METER_OFFSET)
+        * Matrix4::from_translation(anchor)
         // Panel +Z -> weapon +X (toward the shooter); panel +X -> weapon -Z,
         // which is the viewer's right when looking down +X at the panel.
         * Matrix4::from_angle_y(Deg(90.0))
@@ -51,15 +57,25 @@ pub(crate) fn weapon_meter_transform(weapon_transform: Matrix4<f32>) -> Matrix4<
         * Matrix4::from_nonuniform_scale(WEAPON_METER_WIDTH, WEAPON_METER_HEIGHT, 1.0)
 }
 
-/// Spacing between the backdrop and the readout canvas, matching the forearm
-/// panels' overlay step.
-const OVERLAY_Z_OFFSET: f32 = 0.001;
+/// A transform's translation + rotation with any (positive) scale stripped:
+/// `RuntimePropTransform` bakes `PropScale` in, and a scaled weapon must not
+/// scale the meter's authored offset or panel size. (A negative/mirroring
+/// scale stays mirrored - no weapon the player wields authors one.)
+fn without_scale(m: Matrix4<f32>) -> Matrix4<f32> {
+    Matrix4::from_cols(
+        m.x.truncate().normalize().extend(0.0),
+        m.y.truncate().normalize().extend(0.0),
+        m.z.truncate().normalize().extend(0.0),
+        m.w,
+    )
+}
 
-/// The on-weapon ammo meter: the same AMMOFULL backdrop + shared
-/// [`ammo_panel`] readout the right forearm wears today, hung off the wielded
-/// weapon's live `RuntimePropTransform` instead (the anchor
-/// `systems/attachment.rs` uses for muzzle flashes). Empty when nothing with
-/// a clip (or the psi amp) is wielded, or the weapon has no transform.
+/// The on-weapon ammo meter: the compact AMMOBACK readout (round count + type,
+/// the flat HUD's non-use-mode square, laid out once in [`ammo_panel`]) hung
+/// off the wielded weapon's live `RuntimePropTransform` (the anchor
+/// `systems/attachment.rs` uses for muzzle flashes), behind the gun body like
+/// a rear-sight status tag. Empty when nothing with a clip (or the psi amp)
+/// is wielded, or the weapon has no transform.
 pub(crate) fn create_weapon_ammo_meter(
     asset_cache: &mut AssetCache,
     world: &World,
@@ -81,14 +97,15 @@ pub(crate) fn create_weapon_ammo_meter(
         return Vec::new();
     };
 
-    let root = weapon_meter_transform(weapon_transform);
+    let anchor = crate::vr_config::weapon_meter_anchor_from_entity(world, weapon);
+    let root = weapon_meter_transform(without_scale(weapon_transform), anchor);
     let mut objects = vec![virtual_arms::panel_backdrop(
         asset_cache,
-        "AMMOFULL.PCX",
+        "AMMOBACK.PCX",
         root,
     )];
     objects.append(
-        &mut ammo_panel::build_readout_canvas(&readout).render_world_space(
+        &mut ammo_panel::build_compact_readout_canvas(&readout).render_world_space(
             asset_cache,
             root * Matrix4::from_translation(vec3(0.0, 0.0, OVERLAY_Z_OFFSET)),
             None,
@@ -108,23 +125,17 @@ pub(crate) const GLANCE_SHOW_DOT: f32 = 0.55;
 /// does not flicker at the boundary).
 pub(crate) const GLANCE_HIDE_DOT: f32 = 0.30;
 
-/// Poses arrive as the ZERO quaternion while untracked, and cgmath's
-/// `rotate_vector` silently passes the input through - treat near-zero as
-/// "untracked", never as a valid pose (vr-ui-design rule 7).
-pub(crate) fn is_tracked(rotation: Quaternion<f32>) -> bool {
-    rotation.magnitude2() > 1e-6
-}
-
 /// How well the left wrist panel faces the eye this frame: the dot of the
 /// panel's outward normal (local +Z of the shared forearm pose - the same
 /// side its overlays stack toward) with the unit vector from the panel to the
-/// eye. `None` when the hand pose is untracked or the eye is on the panel.
+/// eye. `None` when the hand pose is untracked (VR rule 7 - see
+/// [`crate::util::is_tracked_rotation`]) or the eye is on the panel.
 pub(crate) fn wrist_glance_alignment(
     left_hand_position: Vector3<f32>,
     left_hand_rotation: Quaternion<f32>,
     eye_position: Vector3<f32>,
 ) -> Option<f32> {
-    if !is_tracked(left_hand_rotation) {
+    if !crate::util::is_tracked_rotation(left_hand_rotation) {
         return None;
     }
     let (panel_position, panel_rotation) =
@@ -161,7 +172,7 @@ impl GlanceState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::SquareMatrix;
+    use cgmath::{SquareMatrix, vec4};
 
     #[test]
     fn glance_gate_uses_hysteresis_not_a_single_threshold() {
@@ -188,32 +199,52 @@ mod tests {
     }
 
     #[test]
-    fn the_zero_quaternion_is_untracked() {
-        assert!(!is_tracked(Quaternion::new(0.0, 0.0, 0.0, 0.0)));
-        assert!(is_tracked(Quaternion::new(1.0, 0.0, 0.0, 0.0)));
+    fn an_untracked_wrist_yields_no_alignment() {
+        assert_eq!(
+            wrist_glance_alignment(
+                vec3(0.0, 0.0, 0.0),
+                Quaternion::new(0.0, 0.0, 0.0, 0.0),
+                vec3(0.0, 1.0, 0.0),
+            ),
+            None
+        );
     }
 
     #[test]
-    fn the_weapon_meter_hangs_at_its_authored_offset() {
-        let root = weapon_meter_transform(Matrix4::identity());
-        // The translation column is exactly the tuning offset (rotation/scale
-        // do not move the panel origin).
+    fn the_weapon_meter_hangs_at_its_anchor() {
+        let anchor = vec3(0.25, 0.15, 0.0);
+        let root = weapon_meter_transform(Matrix4::identity(), anchor);
+        // The translation column is exactly the anchor (rotation/scale do not
+        // move the panel origin).
         assert_eq!(
             vec3(root.w.x, root.w.y, root.w.z),
-            WEAPON_METER_OFFSET,
-            "panel centre must sit at the weapon-local tuning offset"
+            anchor,
+            "panel centre must sit at the weapon-local anchor"
         );
     }
 
     #[test]
     fn the_weapon_meter_faces_back_toward_the_shooter() {
-        // With no tilt the panel's +Z (its outward face) must map to the
+        // The panel's +Z (its outward face) must map dominantly to the
         // weapon's +X - the direction back along the barrel at the shooter.
-        let root = weapon_meter_transform(Matrix4::identity());
-        let face = root * cgmath::vec4(0.0, 0.0, 1.0, 0.0);
+        let root = weapon_meter_transform(Matrix4::identity(), vec3(0.0, 0.0, 0.0));
+        let face = root * vec4(0.0, 0.0, 1.0, 0.0);
         assert!(
             face.x > 0.9,
             "panel normal should point at the shooter (+X), got {face:?}"
         );
+    }
+
+    #[test]
+    fn a_scaled_weapon_does_not_scale_the_meter() {
+        // A weapon with PropScale baked into its transform must not move or
+        // resize the meter: the anchor lands at the unscaled offset.
+        let scaled = Matrix4::from_nonuniform_scale(2.0, 3.0, 2.0);
+        let anchor = vec3(0.25, 0.15, 0.0);
+        let root = weapon_meter_transform(without_scale(scaled), anchor);
+        assert_eq!(vec3(root.w.x, root.w.y, root.w.z), anchor);
+        // ...and the panel's world width stays the authored width.
+        let width_axis = root * vec4(1.0, 0.0, 0.0, 0.0);
+        assert!((width_axis.truncate().magnitude() - WEAPON_METER_WIDTH).abs() < 1e-5);
     }
 }

--- a/shock2vr/src/hud/ambient_meters.rs
+++ b/shock2vr/src/hud/ambient_meters.rs
@@ -1,0 +1,219 @@
+//! Prototype "ambient meters" (experimental flag [`FEATURE`]): ammo lives on
+//! the wielded weapon, health stays on the left wrist but only shows when the
+//! wrist is glanced at (rotated toward the face).
+//!
+//! Layout/placement decisions live HERE (and in [`super::ammo_panel`], which
+//! authors the readout's pixels) - a presentation supplies only a root
+//! transform (AGENTS.md section 3). Only the VR presentation consumes these
+//! today; the flat HUD is untouched by the flag.
+
+use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation, Vector3, vec3};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+use shipyard::{Get, View, World};
+
+use crate::runtime_props::RuntimePropTransform;
+use crate::vr_config::Handedness;
+
+use super::ammo_panel;
+use super::virtual_arms;
+
+/// The experimental-features name gating all of this.
+pub(crate) const FEATURE: &str = "ambient_meters";
+
+// --- On-weapon ammo meter placement (weapon-local, tuning knobs) -------------
+//
+// Weapon-local frame, for the 25AE `_h` view models VR wields: barrel along
+// -X, +X back toward the shooter, +Y up out of the gun body (see
+// `vr_config`'s "authored barrel along -X" note). Offsets are in world units
+// (1 unit = 0.762 m), the same space `RuntimePropTransform` lives in.
+
+/// Where the meter hangs off the weapon origin (the grip): above and slightly
+/// behind the gun body.
+pub(crate) const WEAPON_METER_OFFSET: Vector3<f32> = vec3(0.05, 0.17, 0.0);
+/// Lean the panel top away from the shooter so it reads like a rear sight
+/// display when the gun is held in a natural aim pose.
+pub(crate) const WEAPON_METER_TILT: Deg<f32> = Deg(-20.0);
+/// Panel size in world units, preserving the AMMOFULL 260x64 aspect.
+pub(crate) const WEAPON_METER_WIDTH: f32 = 0.20;
+pub(crate) const WEAPON_METER_HEIGHT: f32 = WEAPON_METER_WIDTH * (64.0 / 260.0);
+
+/// Root transform for the on-weapon ammo panel: canvas convention (+Z at the
+/// viewer, +X the viewer's right) hung in the weapon's local frame, facing
+/// back along the barrel toward the shooter. The single placement decision -
+/// any presentation that draws this meter maps the same canvas through it.
+pub(crate) fn weapon_meter_transform(weapon_transform: Matrix4<f32>) -> Matrix4<f32> {
+    weapon_transform
+        * Matrix4::from_translation(WEAPON_METER_OFFSET)
+        // Panel +Z -> weapon +X (toward the shooter); panel +X -> weapon -Z,
+        // which is the viewer's right when looking down +X at the panel.
+        * Matrix4::from_angle_y(Deg(90.0))
+        * Matrix4::from_angle_x(WEAPON_METER_TILT)
+        * Matrix4::from_nonuniform_scale(WEAPON_METER_WIDTH, WEAPON_METER_HEIGHT, 1.0)
+}
+
+/// Spacing between the backdrop and the readout canvas, matching the forearm
+/// panels' overlay step.
+const OVERLAY_Z_OFFSET: f32 = 0.001;
+
+/// The on-weapon ammo meter: the same AMMOFULL backdrop + shared
+/// [`ammo_panel`] readout the right forearm wears today, hung off the wielded
+/// weapon's live `RuntimePropTransform` instead (the anchor
+/// `systems/attachment.rs` uses for muzzle flashes). Empty when nothing with
+/// a clip (or the psi amp) is wielded, or the weapon has no transform.
+pub(crate) fn create_weapon_ammo_meter(
+    asset_cache: &mut AssetCache,
+    world: &World,
+) -> Vec<SceneObject> {
+    let Some(weapon) = crate::wielded_weapon::wielded_weapon(world) else {
+        return Vec::new();
+    };
+    let readout = ammo_panel::AmmoReadout::from_world(world, false);
+    if readout.is_empty() {
+        return Vec::new();
+    }
+    let Ok(weapon_transform) = world
+        .borrow::<View<RuntimePropTransform>>()
+        .map(|v| v.get(weapon).map(|t| t.0))
+    else {
+        return Vec::new();
+    };
+    let Ok(weapon_transform) = weapon_transform else {
+        return Vec::new();
+    };
+
+    let root = weapon_meter_transform(weapon_transform);
+    let mut objects = vec![virtual_arms::panel_backdrop(
+        asset_cache,
+        "AMMOFULL.PCX",
+        root,
+    )];
+    objects.append(
+        &mut ammo_panel::build_readout_canvas(&readout).render_world_space(
+            asset_cache,
+            root * Matrix4::from_translation(vec3(0.0, 0.0, OVERLAY_Z_OFFSET)),
+            None,
+            None,
+            OVERLAY_Z_OFFSET,
+        ),
+    );
+    objects
+}
+
+// --- Glance-gated wrist health ----------------------------------------------
+
+/// Show the wrist panel when its outward normal points this well toward the
+/// eye...
+pub(crate) const GLANCE_SHOW_DOT: f32 = 0.55;
+/// ...and keep it until alignment drops below this (hysteresis so the panel
+/// does not flicker at the boundary).
+pub(crate) const GLANCE_HIDE_DOT: f32 = 0.30;
+
+/// Poses arrive as the ZERO quaternion while untracked, and cgmath's
+/// `rotate_vector` silently passes the input through - treat near-zero as
+/// "untracked", never as a valid pose (vr-ui-design rule 7).
+pub(crate) fn is_tracked(rotation: Quaternion<f32>) -> bool {
+    rotation.magnitude2() > 1e-6
+}
+
+/// How well the left wrist panel faces the eye this frame: the dot of the
+/// panel's outward normal (local +Z of the shared forearm pose - the same
+/// side its overlays stack toward) with the unit vector from the panel to the
+/// eye. `None` when the hand pose is untracked or the eye is on the panel.
+pub(crate) fn wrist_glance_alignment(
+    left_hand_position: Vector3<f32>,
+    left_hand_rotation: Quaternion<f32>,
+    eye_position: Vector3<f32>,
+) -> Option<f32> {
+    if !is_tracked(left_hand_rotation) {
+        return None;
+    }
+    let (panel_position, panel_rotation) =
+        virtual_arms::forearm_pose(left_hand_position, left_hand_rotation, Handedness::Left);
+    let normal = panel_rotation.rotate_vector(vec3(0.0, 0.0, 1.0));
+    let to_eye = eye_position - panel_position;
+    if to_eye.magnitude2() < 1e-6 {
+        return None;
+    }
+    Some(normal.dot(to_eye.normalize()))
+}
+
+/// Hysteresis latch for the wrist-glance gate.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct GlanceState {
+    visible: bool,
+}
+
+impl GlanceState {
+    /// Feed one frame's alignment: the dot of the panel's outward normal with
+    /// the unit vector from the panel toward the eye. `None` means the pose
+    /// was untracked this frame - the panel hides rather than latching a
+    /// stale/garbage pose.
+    pub(crate) fn update(&mut self, alignment: Option<f32>) -> bool {
+        self.visible = match alignment {
+            None => false,
+            Some(dot) if self.visible => dot > GLANCE_HIDE_DOT,
+            Some(dot) => dot > GLANCE_SHOW_DOT,
+        };
+        self.visible
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::SquareMatrix;
+
+    #[test]
+    fn glance_gate_uses_hysteresis_not_a_single_threshold() {
+        let mut gate = GlanceState::default();
+        // Below the show threshold: stays hidden.
+        assert!(!gate.update(Some(0.5)));
+        // Crosses the show threshold: appears.
+        assert!(gate.update(Some(0.6)));
+        // Dips between the two thresholds: STAYS visible (no flicker).
+        assert!(gate.update(Some(0.4)));
+        // Drops below the hide threshold: disappears.
+        assert!(!gate.update(Some(0.2)));
+        // Back in the dead band while hidden: STAYS hidden.
+        assert!(!gate.update(Some(0.4)));
+    }
+
+    #[test]
+    fn an_untracked_pose_hides_the_panel_and_clears_the_latch() {
+        let mut gate = GlanceState::default();
+        assert!(gate.update(Some(0.9)));
+        assert!(!gate.update(None), "untracked frame must hide, not hold");
+        // After tracking resumes mid-deadband, the gate re-arms from hidden.
+        assert!(!gate.update(Some(0.4)));
+    }
+
+    #[test]
+    fn the_zero_quaternion_is_untracked() {
+        assert!(!is_tracked(Quaternion::new(0.0, 0.0, 0.0, 0.0)));
+        assert!(is_tracked(Quaternion::new(1.0, 0.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn the_weapon_meter_hangs_at_its_authored_offset() {
+        let root = weapon_meter_transform(Matrix4::identity());
+        // The translation column is exactly the tuning offset (rotation/scale
+        // do not move the panel origin).
+        assert_eq!(
+            vec3(root.w.x, root.w.y, root.w.z),
+            WEAPON_METER_OFFSET,
+            "panel centre must sit at the weapon-local tuning offset"
+        );
+    }
+
+    #[test]
+    fn the_weapon_meter_faces_back_toward_the_shooter() {
+        // With no tilt the panel's +Z (its outward face) must map to the
+        // weapon's +X - the direction back along the barrel at the shooter.
+        let root = weapon_meter_transform(Matrix4::identity());
+        let face = root * cgmath::vec4(0.0, 0.0, 1.0, 0.0);
+        assert!(
+            face.x > 0.9,
+            "panel normal should point at the shooter (+X), got {face:?}"
+        );
+    }
+}

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -79,7 +79,7 @@ pub(crate) fn emit_compact(canvas: &mut UiCanvas, origin: Vector2<f32>, readout:
         VAlign::Middle,
     );
     if let Some(ammo_type) = &readout.ammo_type {
-        canvas.text_native(
+        canvas.text_native_fit(
             at(origin, TYPE_LABEL),
             &ammo_type.to_ascii_uppercase(),
             "mainfont.fon",
@@ -181,7 +181,7 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
         canvas.image(at(origin, ICON), icon);
     }
     if let Some(ammo_type) = &readout.ammo_type {
-        canvas.text_native(
+        canvas.text_native_fit(
             at(origin, TYPE_LABEL),
             &ammo_type.to_ascii_uppercase(),
             "mainfont.fon",
@@ -297,6 +297,48 @@ mod tests {
                 "{rect:?} overflows the panel height"
             );
         }
+    }
+
+    /// Long ammo-type names ("lasershot", "annelid") are wider than the
+    /// 94px `TYPE_LABEL` rect shared by flat and VR, so the label must be
+    /// ellipsized to fit rather than overflow it - in both the full and
+    /// compact (AMMOBACK) readouts.
+    #[test]
+    fn a_long_ammo_type_name_fits_the_label_rect() {
+        let fit_to_rect_of_at = |canvas: &UiCanvas, target: Vector2<f32>| {
+            canvas.elements().iter().find_map(|element| {
+                if let crate::ui::UiElement::Text {
+                    position,
+                    fit_to_rect,
+                    ..
+                } = element
+                {
+                    if *position == target {
+                        return Some(*fit_to_rect);
+                    }
+                }
+                None
+            })
+        };
+
+        let readout = gun(12, None, Some("lasershot"));
+        assert_eq!(
+            fit_to_rect_of_at(
+                &build_readout_canvas(&readout),
+                vec2(TYPE_LABEL.x, TYPE_LABEL.y)
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            fit_to_rect_of_at(
+                &build_compact_readout_canvas(&readout),
+                vec2(
+                    TYPE_LABEL.x - COMPACT_ORIGIN.x,
+                    TYPE_LABEL.y - COMPACT_ORIGIN.y
+                )
+            ),
+            Some(true)
+        );
     }
 
     #[test]

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -40,6 +40,63 @@ pub(crate) const fn at(origin: Vector2<f32>, rect: Rect) -> Rect {
     Rect::new(origin.x + rect.x, origin.y + rect.y, rect.w, rect.h)
 }
 
+/// The compact readout is the AMMOBACK crop of the AMMOFULL panel: the right
+/// 94x64 (the gauge footprint the flat HUD shows outside use mode). Elements
+/// authored inside that crop - the round count and the type label - keep their
+/// AMMOFULL positions, re-origined by this offset, so the compact and full
+/// readouts can never drift apart.
+pub(crate) const COMPACT_ORIGIN: Vector2<f32> = vec2(166.0, 0.0);
+pub(crate) const COMPACT_W: f32 = PANEL_W - COMPACT_ORIGIN.x;
+pub(crate) const COMPACT_H: f32 = PANEL_H;
+pub(crate) const COMPACT_SIZE: Vector2<f32> = vec2(COMPACT_W, COMPACT_H);
+
+/// Emit the compact (AMMOBACK-sized) readout: the round count and type label
+/// - the elements of [`emit`] that are authored inside the AMMOBACK crop -
+/// with the crop's upper-left at `origin`. The psi amp shows its tier where a
+/// gun shows its clip (its badge/name are authored outside the crop and are a
+/// full-panel affordance).
+pub(crate) fn emit_compact(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoReadout) {
+    // Re-origin so an AMMOFULL-authored rect lands crop-local.
+    let origin = vec2(origin.x - COMPACT_ORIGIN.x, origin.y - COMPACT_ORIGIN.y);
+    if let Some((_, tier)) = &readout.psi_power {
+        canvas.text_native(
+            at(origin, COUNT),
+            &format!("{tier}"),
+            "mainfont.fon",
+            HAlign::Center,
+            VAlign::Middle,
+        );
+        return;
+    }
+    let Some(rounds) = readout.ammo else {
+        return;
+    };
+    canvas.text_native(
+        at(origin, COUNT),
+        &format!("{rounds}"),
+        "mainfont.fon",
+        HAlign::Center,
+        VAlign::Middle,
+    );
+    if let Some(ammo_type) = &readout.ammo_type {
+        canvas.text_native(
+            at(origin, TYPE_LABEL),
+            &ammo_type.to_ascii_uppercase(),
+            "mainfont.fon",
+            HAlign::Center,
+            VAlign::Middle,
+        );
+    }
+}
+
+/// The compact readout as a canvas the size of the AMMOBACK crop - what the
+/// on-weapon ammo meter lays over its AMMOBACK backdrop quad.
+pub(crate) fn build_compact_readout_canvas(readout: &AmmoReadout) -> UiCanvas {
+    let mut canvas = UiCanvas::new(COMPACT_SIZE);
+    emit_compact(&mut canvas, vec2(0.0, 0.0), readout);
+    canvas
+}
+
 /// What the ammo readout says this frame. Presentation-agnostic: both the flat
 /// HUD and the VR forearm panel build one of these from the world.
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -4,6 +4,7 @@ pub use item_outline::*;
 pub(crate) mod virtual_arms;
 pub use virtual_arms::*;
 
+pub(crate) mod ambient_meters;
 pub(crate) mod ammo_panel;
 
 mod flat_hud;

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -35,7 +35,7 @@ const PSI_BAR_START: (f32, f32) = (BAR_HORIZONTAL_OFFSET + 8.0, 17.0 + BAR_VERTI
 const PSI_BAR_END: (f32, f32) = (BAR_HORIZONTAL_OFFSET + 88.0, 31.0 + BAR_VERTICAL_OFFSET);
 
 /// Z-offset for overlay layers to ensure proper rendering order
-const OVERLAY_Z_OFFSET: f32 = 0.001;
+pub(crate) const OVERLAY_Z_OFFSET: f32 = 0.001;
 
 /// Which forearm panels to draw. The default (both) is the shipped behavior;
 /// the `ambient_meters` experiment retires the right-forearm ammo panel (the

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -37,6 +37,24 @@ const PSI_BAR_END: (f32, f32) = (BAR_HORIZONTAL_OFFSET + 88.0, 31.0 + BAR_VERTIC
 /// Z-offset for overlay layers to ensure proper rendering order
 const OVERLAY_Z_OFFSET: f32 = 0.001;
 
+/// Which forearm panels to draw. The default (both) is the shipped behavior;
+/// the `ambient_meters` experiment retires the right-forearm ammo panel (the
+/// readout moves onto the weapon) and glance-gates the left health panel.
+#[derive(Debug, Clone, Copy)]
+pub struct ArmPanelVisibility {
+    pub health: bool,
+    pub ammo: bool,
+}
+
+impl Default for ArmPanelVisibility {
+    fn default() -> Self {
+        Self {
+            health: true,
+            ammo: true,
+        }
+    }
+}
+
 /// Create HUD panels for both arms with health/psi overlays
 pub fn create_arm_hud_panels(
     asset_cache: &mut AssetCache,
@@ -45,22 +63,27 @@ pub fn create_arm_hud_panels(
     left_hand_rotation: Quaternion<f32>,
     right_hand_position: Vector3<f32>,
     right_hand_rotation: Quaternion<f32>,
+    visibility: ArmPanelVisibility,
 ) -> Vec<SceneObject> {
     let mut scene_objects = Vec::new();
 
     // Create left arm HUD with health/psi overlays (BIOFULL base)
-    let mut left_hud_layers = create_forearm_hud_with_overlays(
-        asset_cache,
-        world,
-        left_hand_position,
-        left_hand_rotation,
-    );
-    scene_objects.append(&mut left_hud_layers);
+    if visibility.health {
+        let mut left_hud_layers = create_forearm_hud_with_overlays(
+            asset_cache,
+            world,
+            left_hand_position,
+            left_hand_rotation,
+        );
+        scene_objects.append(&mut left_hud_layers);
+    }
 
     // Create right arm HUD (AMMOFULL) with the live ammo readout on it
-    let mut right_hud_layers =
-        create_ammo_forearm_panel(asset_cache, world, right_hand_position, right_hand_rotation);
-    scene_objects.append(&mut right_hud_layers);
+    if visibility.ammo {
+        let mut right_hud_layers =
+            create_ammo_forearm_panel(asset_cache, world, right_hand_position, right_hand_rotation);
+        scene_objects.append(&mut right_hud_layers);
+    }
 
     // Part of the player's hand visuals: labelled here rather than at the call
     // sites so the `debug_hud` scene, which emits these without an interaction
@@ -346,36 +369,44 @@ fn create_forearm_hud_panel(
     hand_rotation: Quaternion<f32>,
     handedness: Handedness,
 ) -> SceneObject {
-    // Load appropriate texture based on handedness
+    // Appropriate texture based on handedness
+    let texture_name = match handedness {
+        Handedness::Left => "BIOFULL.PCX",
+        Handedness::Right => "AMMOFULL.PCX",
+    };
+
+    // Placed by the shared forearm pose
+    panel_backdrop(
+        asset_cache,
+        texture_name,
+        forearm_panel_transform(hand_position, hand_rotation, handedness),
+    )
+}
+
+/// A HUD panel backdrop quad: `texture_name` on a unit quad placed by
+/// `transform` (which carries the panel's world size). Shared between the
+/// forearm panels and the on-weapon ammo meter so they are lit identically.
+pub(crate) fn panel_backdrop(
+    asset_cache: &mut AssetCache,
+    texture_name: &str,
+    transform: Matrix4<f32>,
+) -> SceneObject {
     let texture_options = TextureOptions {
         wrap: false,
         ..Default::default()
     };
-    let texture = match handedness {
-        Handedness::Left => asset_cache.get_ext(&TEXTURE_IMPORTER, "BIOFULL.PCX", &texture_options),
-        Handedness::Right => {
-            asset_cache.get_ext(&TEXTURE_IMPORTER, "AMMOFULL.PCX", &texture_options)
-        }
-    };
+    let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, texture_name, &texture_options);
 
-    // Create BasicMaterial with the loaded texture (casting to the expected trait object)
+    // BasicMaterial with the loaded texture (casting to the expected trait object)
     let material = engine::scene::basic_material::create(
         texture.clone() as std::rc::Rc<dyn engine::texture::TextureTrait>,
         0.0, // No emissivity
         0.0, // No transparency
     );
 
-    // Create quad geometry
     let geometry = Box::new(engine::scene::quad::create());
-
-    // Create scene object, placed by the shared forearm pose
     let mut scene_object = SceneObject::new(material, geometry);
-    scene_object.set_transform(forearm_panel_transform(
-        hand_position,
-        hand_rotation,
-        handedness,
-    ));
-
+    scene_object.set_transform(transform);
     scene_object
 }
 
@@ -383,7 +414,7 @@ fn create_forearm_hud_panel(
 /// toward the body and tilted flat against the arm like a wrist computer.
 /// The single source of forearm placement - the panel quad, its overlays and
 /// the ammo readout canvas all derive from this, so they cannot drift apart.
-fn forearm_pose(
+pub(crate) fn forearm_pose(
     hand_position: Vector3<f32>,
     hand_rotation: Quaternion<f32>,
     handedness: Handedness,

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -63,7 +63,12 @@ pub trait PlayerInteraction {
     /// 3D visuals owned by the controller (VR: hand models + forearm HUD
     /// panels). Flat draws nothing here; its weapon is drawn from
     /// `viewmodel_entity`.
-    fn render(&self, _asset_cache: &mut AssetCache, _world: &World) -> Vec<SceneObject> {
+    fn render(
+        &self,
+        _asset_cache: &mut AssetCache,
+        _world: &World,
+        _options: &GameOptions,
+    ) -> Vec<SceneObject> {
         Vec::new()
     }
 
@@ -115,6 +120,12 @@ pub struct VrInteraction {
     /// `Option` is "have we tried yet" - a glove that failed to load stays
     /// `Some(None)` so we don't hit the asset cache's miss path every frame.
     glove_renderer: RefCell<Option<Option<GloveRenderer>>>,
+    /// Eye position (world space) captured each `update`, so `render` can gate
+    /// the wrist health panel on how well it faces the eye (`ambient_meters`).
+    eye_position: Vector3<f32>,
+    /// Hysteresis latch for the glance-gated wrist health panel. RefCell
+    /// because `render` is `&self` (same pattern as `glove_renderer`).
+    wrist_glance: RefCell<crate::hud::ambient_meters::GlanceState>,
 }
 
 impl VrInteraction {
@@ -123,6 +134,8 @@ impl VrInteraction {
             left_hand: VirtualHand::new(Handedness::Left),
             right_hand: VirtualHand::new(Handedness::Right),
             glove_renderer: RefCell::new(None),
+            eye_position: Vector3::new(0.0, 0.0, 0.0),
+            wrist_glance: RefCell::new(Default::default()),
         }
     }
 }
@@ -161,6 +174,9 @@ impl PlayerInteraction for VrInteraction {
         );
         self.left_hand = left_hand;
 
+        // Captured for the glance gate in `render` (which has no ctx).
+        self.eye_position = ctx.player_pos + Vector3::new(0.0, ctx.eye_height, 0.0);
+
         left_msgs.append(&mut right_msgs);
         left_msgs
     }
@@ -182,7 +198,14 @@ impl PlayerInteraction for VrInteraction {
         .collect()
     }
 
-    fn render(&self, asset_cache: &mut AssetCache, world: &World) -> Vec<SceneObject> {
+    fn render(
+        &self,
+        asset_cache: &mut AssetCache,
+        world: &World,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        use crate::hud::ambient_meters;
+
         let mut glove_slot = self.glove_renderer.borrow_mut();
         let glove_renderer = glove_slot
             .get_or_insert_with(|| GloveRenderer::new(asset_cache))
@@ -204,6 +227,25 @@ impl PlayerInteraction for VrInteraction {
         // forearm panels carry their own label from `create_arm_hud_panels`,
         // which the `debug_hud` scene emits without going through here.
         crate::util::tag_render_source(&mut objs, crate::util::render_source::PLAYER_HANDS);
+
+        // Prototype `ambient_meters` (experimental): ammo moves onto the
+        // wielded weapon, health stays on the wrist but only when glanced at.
+        let ambient = options
+            .experimental_features
+            .contains(ambient_meters::FEATURE);
+        let visibility = if ambient {
+            let alignment = ambient_meters::wrist_glance_alignment(
+                self.left_hand.get_position(),
+                self.left_hand.get_rotation(),
+                self.eye_position,
+            );
+            crate::hud::ArmPanelVisibility {
+                health: self.wrist_glance.borrow_mut().update(alignment),
+                ammo: false, // retired: the readout lives on the weapon now
+            }
+        } else {
+            crate::hud::ArmPanelVisibility::default()
+        };
         objs.append(&mut create_arm_hud_panels(
             asset_cache,
             world,
@@ -211,7 +253,15 @@ impl PlayerInteraction for VrInteraction {
             self.left_hand.get_rotation(),
             self.right_hand.get_position(),
             self.right_hand.get_rotation(),
+            visibility,
         ));
+        if ambient {
+            let mut meter = ambient_meters::create_weapon_ammo_meter(asset_cache, world);
+            // Same label as the forearm panels, so the pause menu's
+            // player-hands suppression covers the meter too.
+            crate::util::tag_render_source(&mut meter, crate::util::render_source::PLAYER_HANDS);
+            objs.append(&mut meter);
+        }
         objs
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8442,7 +8442,7 @@ impl MissionCore {
         // + forearm HUD panels; flat draws nothing here (its weapon viewmodel is
         // drawn on top in `render_per_eye`). They are labelled `PLAYER_HANDS_SOURCE`
         // so `Game` can drop them while the pause menu is up (issue #1018).
-        scene.append(&mut self.interaction.render(asset_cache, &self.world));
+        scene.append(&mut self.interaction.render(asset_cache, &self.world, options));
 
         // The old synthetic blue inventory cube remains a desktop diagnostic.
         // VR presents the authored INVBACK canvas through GuiManager instead.

--- a/shock2vr/src/scenes/debug_hud.rs
+++ b/shock2vr/src/scenes/debug_hud.rs
@@ -207,6 +207,7 @@ impl GameScene for DebugHudScene {
             self.left_hand_rotation,
             self.right_hand_position,
             self.right_hand_rotation,
+            Default::default(),
         );
 
         (hud_panels, self.player_position, self.player_rotation)

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -209,6 +209,13 @@ pub fn smoothstep(t: f32) -> f32 {
     t * t * (3.0 - 2.0 * t)
 }
 
+/// Whether a pose rotation is a real tracked pose: untracked poses arrive as
+/// the ZERO quaternion (see [`tracked_gaze`]'s docs - VR rule 7). The single
+/// home for the check, so view-locked layers cannot each grow their own copy.
+pub fn is_tracked_rotation(rotation: Quaternion<f32>) -> bool {
+    rotation.magnitude2() >= 1e-6
+}
+
 pub fn get_rotation_from_forward_vector(forward: Vector3<f32>) -> Quaternion<f32> {
     let mut default_up = Vector3::new(0.0, 1.0, 0.0);
 

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -361,6 +361,70 @@ fn melee_wield_pose_correction_scaled(arm: MeleePosedArm, scale: f32) -> cgmath:
         * Matrix4::from_translation(-arm.fist)
 }
 
+// --- On-weapon ammo meter anchors --------------------------------------------
+//
+// Where the `ambient_meters` ammo tag hangs in the *weapon's* local frame (see
+// `hud::ambient_meters` for the panel's shape/orientation). Same authored
+// frame the grip table above works in: the wielded gun models run barrel along
+// -X, so +X is back toward the shooter, +Y up out of the gun body, +Z across
+// it. Units are world units (1 unit = 0.762 m), the space
+// `RuntimePropTransform` lives in.
+//
+// The tag reads like a rear-sight status plate: sat on the receiver, behind
+// the body of the gun, just high enough to clear the top line of the model.
+
+/// Anchor for a weapon with no entry below: over the receiver, a little back
+/// from the model origin and above a typical gun body.
+const WEAPON_METER_ANCHOR_DEFAULT: Vector3<f32> = vec3(0.16, 0.29, 0.0);
+
+/// Per-model anchor overrides, keyed like [`HAND_MODEL_POSITIONING`]
+/// (lowercased `PropModelName`). Entries cover [`VR_25AE_VIEW_MODELS`]'s guns
+/// - the models VR actually wields - and are derived from each model's
+/// authored bounding box: back along the barrel by 30% of the model's
+/// half-length, and clear of the top of its body (half-height + a small
+/// margin), so the tag sits over the receiver instead of inside it. A weapon
+/// with no entry (a classic install's world model) takes the default.
+static WEAPON_METER_ANCHORS: Lazy<HashMap<&str, Vector3<f32>>> = Lazy::new(|| {
+    HashMap::from([
+        ("atek_h", vec3(0.24, 0.27, 0.0)),
+        ("ar15_h", vec3(0.14, 0.35, 0.0)),
+        ("sg_h", vec3(0.35, 0.29, 0.0)),
+        ("empgun_h", vec3(0.18, 0.22, 0.0)),
+        ("lasehand", vec3(0.22, 0.27, 0.0)),
+        ("gren_h", vec3(0.33, 0.42, 0.0)),
+        ("sfg_h", vec3(0.17, 0.67, 0.0)),
+        ("fsn_h", vec3(0.13, 0.26, 0.0)),
+        ("al_h", vec3(0.15, 0.39, 0.0)),
+        ("viro_h", vec3(0.18, 0.35, 0.0)),
+        ("amp_h", vec3(0.15, 0.34, 0.0)),
+    ])
+});
+
+/// Where the on-weapon ammo meter hangs on `entity_id`'s model. Mirrors
+/// [`get_vr_hand_model_adjustments_from_entity`]'s lookup: the entity's
+/// `PropModelName`, lowercased, against the anchor table, falling back to
+/// [`WEAPON_METER_ANCHOR_DEFAULT`].
+pub fn weapon_meter_anchor_from_entity(world: &World, entity_id: EntityId) -> Vector3<f32> {
+    let Ok(v_model_name) = world.borrow::<View<PropModelName>>() else {
+        return WEAPON_METER_ANCHOR_DEFAULT;
+    };
+    let Ok(model_name) = v_model_name
+        .get(entity_id)
+        .map(|sz| sz.0.to_ascii_lowercase())
+    else {
+        return WEAPON_METER_ANCHOR_DEFAULT;
+    };
+    weapon_meter_anchor_from_model(&model_name)
+}
+
+/// [`weapon_meter_anchor_from_entity`] by model name.
+pub fn weapon_meter_anchor_from_model(model_name: &str) -> Vector3<f32> {
+    WEAPON_METER_ANCHORS
+        .get(model_name)
+        .copied()
+        .unwrap_or(WEAPON_METER_ANCHOR_DEFAULT)
+}
+
 pub fn get_vr_hand_model_adjustments_from_entity(
     entity_id: EntityId,
     world: &World,
@@ -432,6 +496,37 @@ mod tests {
                 "missing HAND_MODEL_POSITIONING entry for {name}"
             );
         }
+    }
+
+    /// A typo'd anchor key would silently fall back to the default instead of
+    /// failing, so pin every key to a model the grip table already knows.
+    #[test]
+    fn every_meter_anchor_names_a_known_weapon_model() {
+        for name in WEAPON_METER_ANCHORS.keys() {
+            assert!(
+                HAND_MODEL_POSITIONING.contains_key(name),
+                "WEAPON_METER_ANCHORS key {name} is not a known weapon model"
+            );
+        }
+    }
+
+    /// An unknown model still gets a usable tag rather than one buried at the
+    /// grip.
+    #[test]
+    fn an_unknown_weapon_model_falls_back_to_the_default_anchor() {
+        assert_eq!(
+            weapon_meter_anchor_from_model("not_a_weapon"),
+            WEAPON_METER_ANCHOR_DEFAULT
+        );
+        // ...and a model WITH an entry gets that entry, not the default.
+        assert_eq!(
+            weapon_meter_anchor_from_model("ar15_h"),
+            WEAPON_METER_ANCHORS["ar15_h"]
+        );
+        assert_ne!(
+            weapon_meter_anchor_from_model("ar15_h"),
+            WEAPON_METER_ANCHOR_DEFAULT
+        );
     }
 
     /// Flat's wield swap is frozen: growing the VR grip table must not change

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -386,7 +386,7 @@ const WEAPON_METER_ANCHOR_DEFAULT: Vector3<f32> = vec3(0.16, 0.29, 0.0);
 /// with no entry (a classic install's world model) takes the default.
 static WEAPON_METER_ANCHORS: Lazy<HashMap<&str, Vector3<f32>>> = Lazy::new(|| {
     HashMap::from([
-        ("atek_h", vec3(0.24, 0.27, 0.0)),
+        ("atek_h", vec3(0.10, 0.15, 0.0)),
         ("ar15_h", vec3(0.14, 0.35, 0.0)),
         ("sg_h", vec3(0.35, 0.29, 0.0)),
         ("empgun_h", vec3(0.18, 0.22, 0.0)),


### PR DESCRIPTION
**PROTOTYPE for design validation — not polish.** Explores the approved ambient-meter direction (ammo on the weapon, Alyx-style; health on the wrist but glance-gated, watch-style) to validate feel and architecture against the `virtual_arms` rendering path. Behind `--experimental ambient_meters`; without the flag (and everywhere in flat), behavior is unchanged.

## What it does (VR only)

- **On-weapon ammo meter** — the AMMOFULL readout (count / ammo icon / type, the exact `hud/ammo_panel.rs` canvas the right forearm wears today) is hung off the wielded weapon's live `RuntimePropTransform` (the same anchor muzzle flashes use), floating above the gun body and facing the shooter. The right-forearm ammo panel is retired while the flag is on.
- **Glance-gated wrist health** — the left-forearm BIOFULL panel renders only when the wrist panel's outward normal points at the eye (dot-product gate with hysteresis so it can't flicker at the boundary). Untracked zero-quaternion hand poses hide it (vr-ui-design rule 7).

Placement is decided once, in `shock2vr/src/hud/ambient_meters.rs` (§3 parity: the readout canvas is the shared `ammo_panel` layout; the meter module only supplies a root transform). A drive-by one-liner fixes `scenes/developer.rs`, which did not compile on main after #1082/#1084 crossed.

## Tuning knobs (all in `hud/ambient_meters.rs`)

| Knob | Value | Meaning |
| --- | --- | --- |
| `vr_config::WEAPON_METER_ANCHORS` | per weapon | weapon-local hang point (world units; +Y up out of the gun, +X back at the shooter) - see the update section below |
| `WEAPON_METER_TILT` | `-20°` | lean of the panel top away from the shooter |
| `WEAPON_METER_WIDTH` | `0.10` | panel width in world units (AMMOBACK 94:64 aspect preserved) |
| `GLANCE_SHOW_DOT` / `GLANCE_HIDE_DOT` | `0.55` / `0.30` | hysteresis thresholds on dot(panel normal, to-eye) |

## Demo

![ambient meters demo](https://gist.githubusercontent.com/tommy-xr/e2515af35ea2f5ab25ec42ee78f689c3/raw/ambient_meters.gif)

<sub>VR `debug_weapons`: two shots fired — the on-weapon meter counts 12 → 10 → 8 live — then the left wrist rolls toward the face and the health panel appears, and hides again on roll-away. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| On-weapon meter + wrist glance (VR) | Flat: unchanged |
| --- | --- |
| ![vr still](https://gist.githubusercontent.com/tommy-xr/e2515af35ea2f5ab25ec42ee78f689c3/raw/vr_glance_still.png) | ![flat unchanged](https://gist.githubusercontent.com/tommy-xr/e2515af35ea2f5ab25ec42ee78f689c3/raw/flat_unchanged.png) |

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p shock2vr` 902 passed (5 new unit tests: hysteresis, untracked-pose latch clear, zero-quaternion guard, meter transform offset + facing).
- VR runtime: meter appears when a gun is held, tracks the weapon, counts down on fire; wrist panel toggles at the glance threshold (verified via `/v1/scene` object counts: 7 ↔ 10) with no flicker.
- Flat (`cargo dbgr --mission debug_weapons`, no flag): HUD identical to main (screenshot above).

## Open questions for the owner

- **Readability at arm's length**: the wrist panel is small when glanced from a natural pose; may want a scale-up-on-glance or a larger authored panel.
- **Occlusion by hands/weapon**: the meter floats clear of the pistol, but long weapons (AR, shotgun) may intersect it — the offset likely wants to be per-model, like the vr_config grip table.
- **Glance threshold vs rest pose**: the dot-gate is position-dependent (it uses the true to-eye vector); at some rest poses the panel is already "glanced". Should the gate also require head gaze toward the wrist?
- **Reserve ammo**: the shared readout shows loaded clip + type only (as today's HUD does); if the meter should show loaded/reserve, the reserve count needs a new world query.
- Fade in/out on the glance transition (nice-to-have, skipped in the prototype).

## Review notes

Non-Critical review findings are tracked here rather than fixed (prototype): REVIEW_NOTES

https://claude.ai/code/session_01VNfTgRktqGXQ3C4xn6B7fK

## Update - condensed readout, anchored per weapon (owner feedback)

> *"we should we use the more 'condensed' UI (ie, the one that shows in flat when not in interface mode) - with just the single square for ammo (+ ammo type). I also wonder if we could bring it behind the weapon (we may need to customize attachment points for each weapon?)"*

- **Condensed readout.** The meter now draws the **AMMOBACK crop** of the AMMOFULL panel (94x64 - the single gauge square the flat HUD shows outside use mode): round count + ammo type, no icon, no wide backdrop. The crop's elements keep their AMMOFULL-authored rects, re-origined by one offset, so the compact and full readouts cannot drift apart (AGENTS.md §3).
- **Per-weapon attachment points.** Where the tag hangs is now a per-model anchor in `vr_config::weapon_meter_anchor_*`, beside the grip-offset table it mirrors. Anchors are derived from each 25AE view model's **authored bounding box** - back along the barrel by ~30% of its half-length, and clear of the top of its body - so the tag sits over the receiver like a rear-sight status plate instead of inside it. Unknown models (a classic install's world model) take a sensible default.
- **Scale fix.** `RuntimePropTransform` bakes `PropScale` in, so the meter root now strips scale - a scaled weapon no longer scales or displaces the tag.

![compact on-weapon ammo tag](https://gist.githubusercontent.com/tommy-xr/9e3c936cf97d1767cafd530a7797a33f/raw/ammo_tag.gif)

<sub>VR `debug_weapons`, AR15 wielded: the compact tag rides above the receiver and counts 12 → 11 → 10 → 9 as rounds go out. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/9e3c936cf97d1767cafd530a7797a33f/raw/beforeafter.png)

### Still

![compact tag still](https://gist.githubusercontent.com/tommy-xr/9e3c936cf97d1767cafd530a7797a33f/raw/ammo_tag_still.png)

### Verification of the update

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo fmt`; `cargo test -p shock2vr` **905 passed** (new: compact-anchor fallback, anchor keys pin to known models, scaled weapon does not scale the tag).
- VR runtime (`cargo dbgr --mission debug_weapons --vr --experimental ambient_meters`): cycled and wielded pistol / AR / shotgun / EMP / grenade launcher / stasis / fusion / worm launcher / viral proliferator, screenshotting each - the tag reads legibly over the body with no model clipping.

## Update — two owner-flagged leftovers fixed

**1. Ammo-type label overflow** — the ammo-type label shares its 94px `TYPE_LABEL` rect with the flat AMMOFULL/AMMOBACK readout, and an unbounded-length string could run past it (out of the panel entirely at extreme lengths). Fixed in 644a9aa5 by switching the ammo-type label to `canvas.text_native_fit(...)` (the existing shared ellipsize-at-layout facility) in both `emit` and `emit_compact` in `shock2vr/src/hud/ammo_panel.rs`.

Every real ammo-type string in the current weapon roster (`std`/`he`/`ap`/`pellet`/`rslug`/`lasershot`/`empshot`/`fusionshot`/`stasisshot`/`annrocket`/`viralshot`/the grenade-type family) measures comfortably under the 94px budget with `mainfont.fon` — none currently overflow, so there's no live repro with real ammo names. To make the fix visible, the before/after below temporarily forces a synthetic 25-character ammo-type string (`superlonghypotheticalammo`) through the same `emit`/`emit_compact` path, clearly overflowing the panel with the old `text_native` and cleanly ellipsizing (`SUPERLONGHYP...`) with the fix. This is a robustness/defensive fix for any string that does exceed the budget (a longer future ammo type, a mod, or localization) rather than a currently-visible defect with shipped content — confirmed via direct instrumentation of the shared `place_text` layout function against every real ammo-type string.

![label overflow before/after](https://gist.githubusercontent.com/tommy-xr/ac1448e0c40d7347f528b76168c6f71a/raw/label_overflow_before_after.png)

<sub>Flat `debug_weapons` HUD, ammo-type label forced to a synthetic 25-char string via a temporary capture-only override (reverted before landing). Before: `text_native` runs the label straight off the panel and off-screen. After: `text_native_fit` ellipsizes it to `SUPERLONGHYP...`, fully inside the 94px rect. Captured headlessly via the debug runtime.</sub>

**2. atek_h (pistol) tag anchor** — the arm-mesh-inflated bounding box floated the ammo tag about a panel-height above the pistol. Fixed earlier in e65146b6 by tightening `WEAPON_METER_ANCHORS["atek_h"]` from `(0.24, 0.27, 0.0)` to `(0.10, 0.15, 0.0)`; captured here (same framing, only the anchor constant changed) to refresh the PR's media.

![atek_h anchor before/after](https://gist.githubusercontent.com/tommy-xr/ac1448e0c40d7347f528b76168c6f71a/raw/atek_h_anchor_before_after.png)

<sub>VR `debug_weapons`, pistol grabbed and viewed from a fixed free-camera framing (same weapon pose, only `WEAPON_METER_ANCHORS["atek_h"]` changed). Before: the tag floats well clear of the gun, disconnected from it. After: the tag hugs the rear of the slide like a rear-sight status plate. Captured headlessly via the debug runtime.</sub>

**9-weapon verification (VR, `--experimental ambient_meters`)**: grabbed all 9 debug-scene weapons in turn via the runtime's grab raycast (pistol, laser pistol, assault rifle, shotgun, EMP rifle, grenade launcher, stasis field generator, fusion cannon, worm launcher) and confirmed each swaps to its expected `_h` first-person model (`atek_h`, `lasehand`, `ar15_h`, `sg_h`, `empgun_h`, `gren_h`, `sfg_h`, `fsn_h`, `al_h`) with the compact ammo tag rendering legibly beside it — no overflow, no floating-tag regression on any weapon. One pre-existing, unrelated cosmetic artifact noted in passing: the pistol's rear iron sight renders as a flat solid-blue polygon (present in flat mode too, unaffected by this PR — likely a missing/placeholder texture on that one sight mesh).

