### PR TITLE
feat(vr): add physical held melee

### DIFF
--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -110,6 +110,14 @@ dev_params! {
     /// shares its single flat projection between flat and `--vr` mode, so this
     /// override reaches both there.)
     FOV_OVERRIDE_DEG = float("fov_override_deg", "FOV override (deg)", 0.0, 0.0, 120.0, 1.0),
+    /// Acceleration-based stiffness for all six axes of the motor joining a
+    /// physically simulated held melee weapon to its tracked-hand target.
+    /// Read before every physics step so headset tuning needs no rebuild.
+    MELEE_SPRING_STIFFNESS = float("melee_spring", "Melee spring", 900.0, 0.0, 3000.0, 50.0),
+    /// Damping paired with [`MELEE_SPRING_STIFFNESS`]. A value near
+    /// `2 * sqrt(stiffness)` is critically damped in Rapier's acceleration-
+    /// based motor model; the default is therefore critical at stiffness 900.
+    MELEE_SPRING_DAMPING = float("melee_damping", "Melee damping", 60.0, 0.0, 200.0, 5.0),
 }
 
 /// Every parameter with its id, in declaration order.
@@ -196,6 +204,8 @@ mod tests {
     fn defaults_equal_the_consts_they_replaced() {
         assert_eq!(get(FRONTEND_PANEL_DISTANCE), 2.0);
         assert_eq!(get(WORLD_DIM_STRENGTH), 0.72);
+        assert_eq!(get(MELEE_SPRING_STIFFNESS), 900.0);
+        assert_eq!(get(MELEE_SPRING_DAMPING), 60.0);
     }
 
     /// Every declared default must be finite and inside its own range, or

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7337,8 +7337,9 @@ impl MissionCore {
                     if self.is_vr_melee_weapon(entity_id) {
                         // Held guns/items stay unphysical, but a VR melee
                         // weapon needs its authored collider to report genuine
-                        // controller-driven contacts. Kinematic motion keeps it
-                        // seated in the hand without gravity or solver drift.
+                        // contacts. A joint motor drives its dynamic body
+                        // toward the tracked hand while world contact can hold
+                        // the rendered weapon back.
                         self.attach_held_melee_physics(entity_id);
                     } else {
                         self.make_un_physical(entity_id);

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1989,10 +1989,10 @@ impl CollisionGroup {
         })
     }
 
-    /// A player-held VR melee weapon remains a kinematic contact shape so an
-    /// actual controller swing can meet authored world/actor collision, while
+    /// A player-held VR melee weapon remains a physical contact shape so an
+    /// actual controller swing can meet authored world/actor collision while
     /// ignoring the player's own capsule. Damage is still owned by the
-    /// weapon's trigger-gated script; this group only preserves contact events.
+    /// weapon's trigger-gated script; this group only filters physical contact.
     pub fn held_melee() -> CollisionGroup {
         let collision = InteractionGroups {
             memberships: InternalCollisionGroups::ENTITY.bits.into(),
@@ -2007,8 +2007,8 @@ impl CollisionGroup {
             // Contact generation still includes ACTOR through `collision`,
             // so TriggeredMeleeWeapon receives CollisionStarted and owns the
             // authored damage. Only Rapier's physical impulse is suppressed:
-            // a controller-driven kinematic pose must not launch a living
-            // dynamic capsule. World and loose-prop response remains solid.
+            // a motor-driven weapon must not launch a living dynamic capsule.
+            // World and loose-prop response remains solid.
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::ENTITY.bits
                 | InternalCollisionGroups::SELECTABLE.bits)
@@ -2256,6 +2256,20 @@ pub struct PlayerHandle {
     jump_was_pressed: bool,
 }
 
+/// The physical-hand seam for one held melee weapon. `target` is an invisible
+/// controller-driven kinematic body; `joint` motors the visible dynamic weapon
+/// toward it on all six degrees of freedom. Keeping the target out of
+/// `entity_id_to_body` makes the weapon remain the entity's one authoritative
+/// rendered/contact body.
+#[derive(Clone, Copy)]
+struct HeldMeleeDrive {
+    target: RigidBodyHandle,
+    joint: ImpulseJointHandle,
+    /// The loose/restored world body is seated at the first tracked pose once;
+    /// later hand poses move only `target` so world contact stays physical.
+    seated: bool,
+}
+
 #[derive(Clone, Copy, Debug)]
 struct KinematicAttachment {
     parent: RigidBodyHandle,
@@ -2321,6 +2335,11 @@ pub struct PhysicsWorld {
     // from its parent's next translation plus an authored world-space offset.
     // Keyed by child because Dark permits at most one physical parent.
     kinematic_attachments: HashMap<RigidBodyHandle, KinematicAttachment>,
+
+    // Dynamic held-melee bodies driven toward invisible controller targets by
+    // Rapier joint motors. Keyed by the weapon body handle so the normal
+    // set_position_rotation path can redirect hand poses to the target.
+    held_melee_drives: HashMap<RigidBodyHandle, HeldMeleeDrive>,
 
     // TODO:
     // physics_hooks: Box<dyn PhysicsHooks>,
@@ -2479,21 +2498,39 @@ impl PhysicsWorld {
         position: Vector3<f32>,
         rotation: Quaternion<f32>,
     ) {
-        let maybe_rigid_body = self.rigid_body_set.get_mut(handle);
+        let nquat = nalgebra::geometry::Quaternion::new(
+            rotation.s,
+            rotation.v.x,
+            rotation.v.y,
+            rotation.v.z,
+        );
+        let nquat_unit = UnitQuaternion::from_quaternion(nquat);
+        let mut xform = Isometry::identity();
+        xform.append_rotation_mut(&nquat_unit);
+        xform.translation = Translation {
+            vector: vec_to_nvec(position),
+        };
 
-        if let Some(rigid_body) = maybe_rigid_body {
-            let nquat = nalgebra::geometry::Quaternion::new(
-                rotation.s,
-                rotation.v.x,
-                rotation.v.y,
-                rotation.v.z,
-            );
-            let nquat_unit = UnitQuaternion::from_quaternion(nquat);
-            let mut xform = Isometry::identity();
-            xform.append_rotation_mut(&nquat_unit);
-            xform.translation = Translation {
-                vector: vec_to_nvec(position),
-            };
+        if let Some(drive) = self.held_melee_drives.get(&handle).copied() {
+            let mut just_seated = false;
+            if !drive.seated {
+                if let Some(weapon) = self.rigid_body_set.get_mut(handle) {
+                    weapon.set_position(xform, true);
+                    weapon.set_linvel(Vector::zeros(), true);
+                    weapon.set_angvel(Vector::zeros(), true);
+                }
+                if let Some(drive) = self.held_melee_drives.get_mut(&handle) {
+                    drive.seated = true;
+                }
+                just_seated = true;
+            }
+            if let Some(target) = self.rigid_body_set.get_mut(drive.target) {
+                if just_seated {
+                    target.set_position(xform, true);
+                }
+                target.set_next_kinematic_position(xform);
+            }
+        } else if let Some(rigid_body) = self.rigid_body_set.get_mut(handle) {
             if rigid_body.is_kinematic() {
                 rigid_body.set_next_kinematic_position(xform);
             } else {
@@ -2626,26 +2663,65 @@ impl PhysicsWorld {
         }
     }
 
-    /// Turn an existing loose-prop body into the controller-driven contact
-    /// shape used while a melee weapon is held in VR.
+    /// Turn an existing loose-prop body into a spring-driven contact shape
+    /// while a melee weapon is held in VR.
+    ///
+    /// The hand pose drives an invisible kinematic target. A six-axis generic
+    /// joint motors the visible weapon body toward that target, leaving the
+    /// weapon dynamic so Rapier can stop it against world geometry. This is
+    /// the physical-hand pattern: tracked and rendered poses may disconnect
+    /// under load, then the weapon springs back when the obstruction clears.
     pub fn set_held_melee(&mut self, entity_id: EntityId) {
         let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
             return;
         };
-        let Some(body) = self.rigid_body_set.get_mut(handle) else {
-            return;
+        let (pose, collider_handles) = {
+            let Some(body) = self.rigid_body_set.get_mut(handle) else {
+                return;
+            };
+            body.set_body_type(RigidBodyType::Dynamic, true);
+            body.set_linvel(Vector::zeros(), true);
+            body.set_angvel(Vector::zeros(), true);
+            body.set_gravity_scale(0.0, true);
+            body.enable_ccd(true);
+            (*body.position(), body.colliders().to_vec())
         };
-        body.set_body_type(RigidBodyType::KinematicPositionBased, true);
-        body.set_linvel(Vector::zeros(), true);
-        body.set_angvel(Vector::zeros(), true);
-        let collider_handles = body.colliders().to_vec();
+
+        if !self.held_melee_drives.contains_key(&handle) {
+            let target = self.rigid_body_set.insert(
+                RigidBodyBuilder::kinematic_position_based()
+                    .pose(pose)
+                    .build(),
+            );
+            let stiffness = crate::dev_params::get(crate::dev_params::MELEE_SPRING_STIFFNESS);
+            let damping = crate::dev_params::get(crate::dev_params::MELEE_SPRING_DAMPING);
+            let mut joint = GenericJointBuilder::new(JointAxesMask::empty());
+            for axis in [
+                JointAxis::LinX,
+                JointAxis::LinY,
+                JointAxis::LinZ,
+                JointAxis::AngX,
+                JointAxis::AngY,
+                JointAxis::AngZ,
+            ] {
+                joint = joint
+                    .motor_model(axis, MotorModel::AccelerationBased)
+                    .motor_position(axis, 0.0, stiffness, damping);
+            }
+            let joint = self.impulse_joint_set.insert(target, handle, joint, true);
+            self.held_melee_drives.insert(
+                handle,
+                HeldMeleeDrive {
+                    target,
+                    joint,
+                    seated: false,
+                },
+            );
+        }
+
         for collider_handle in collider_handles {
             if let Some(collider) = self.collider_set.get_mut(collider_handle) {
-                collider.set_active_collision_types(
-                    ActiveCollisionTypes::default()
-                        | ActiveCollisionTypes::KINEMATIC_KINEMATIC
-                        | ActiveCollisionTypes::KINEMATIC_FIXED,
-                );
+                collider.set_active_collision_types(ActiveCollisionTypes::default());
             }
         }
         self.set_collision_group(entity_id, CollisionGroup::held_melee());
@@ -2654,10 +2730,9 @@ impl PhysicsWorld {
     /// Replace a held melee body's inherited loose-pickup box with the local
     /// bounds of the weapon geometry rendered in the hand.
     ///
-    /// The rigid-body origin stays controller-driven at the authored weapon
+    /// The rigid-body target stays controller-driven at the authored weapon
     /// joint; the collider's parent-relative center covers the rest of the
-    /// handle/blade without moving the rendered model or changing the future
-    /// spring-body architecture tracked in #1053.
+    /// handle/blade without moving the rendered model or the motor target.
     pub fn fit_held_melee_cuboid(
         &mut self,
         entity_id: EntityId,
@@ -2671,7 +2746,7 @@ impl PhysicsWorld {
         let Some(body) = self.rigid_body_set.get(handle) else {
             return;
         };
-        if body.body_type() != RigidBodyType::KinematicPositionBased {
+        if !self.held_melee_drives.contains_key(&handle) {
             return;
         }
 
@@ -2780,6 +2855,9 @@ impl PhysicsWorld {
         position: Vector3<f32>,
         player_handle: &mut PlayerHandle,
     ) {
+        let previous =
+            nvec_to_cgmath(*self.rigid_body_set[player_handle.character_handle].translation());
+        self.translate_held_melee_for_player_relocation(position - previous);
         player_handle.top_out = None;
         player_handle.slope_displacement = Vector::zeros();
         player_handle.is_grounded = false;
@@ -2803,6 +2881,38 @@ impl PhysicsWorld {
         // absent one would drop the first frame of a ride they land in the
         // middle of (a teleport, or a save restored onto a moving deck).
         self.refresh_player_support(player_handle);
+    }
+
+    /// Carry the complete physical-hand pair through a discontinuous player
+    /// relocation. The controller's next local pose cannot communicate that a
+    /// debug/scripted teleport moved the whole tracked stage; without this the
+    /// invisible target appears at the destination while the dynamic weapon
+    /// tries to motor across the entire level through every wall in between.
+    /// Ordinary hand motion remains motor-driven because it never calls the
+    /// player relocation seam.
+    fn translate_held_melee_for_player_relocation(&mut self, delta: Vector3<f32>) {
+        if delta.magnitude2() <= f32::EPSILON {
+            return;
+        }
+        let delta = vec_to_nvec(delta);
+        let pairs = self
+            .held_melee_drives
+            .iter()
+            .map(|(weapon, drive)| (*weapon, drive.target))
+            .collect::<Vec<_>>();
+        for (weapon, target) in pairs {
+            if let Some(body) = self.rigid_body_set.get_mut(weapon) {
+                let mut pose = *body.position();
+                pose.translation.vector += delta;
+                body.set_position(pose, true);
+            }
+            if let Some(body) = self.rigid_body_set.get_mut(target) {
+                let mut pose = *body.position();
+                pose.translation.vector += delta;
+                body.set_position(pose, true);
+                body.set_next_kinematic_position(pose);
+            }
+        }
     }
 
     /// Place the player at an authored pose, stepping aside only when their
@@ -3593,6 +3703,29 @@ impl PhysicsWorld {
         }
     }
 
+    /// Refresh the live tuning values on every held-melee motor. The developer
+    /// registry is intentionally read per frame, so a headset can tune feel
+    /// without rebuilding or recreating the held body.
+    fn update_held_melee_motors(&mut self) {
+        let stiffness = crate::dev_params::get(crate::dev_params::MELEE_SPRING_STIFFNESS);
+        let damping = crate::dev_params::get(crate::dev_params::MELEE_SPRING_DAMPING);
+        for drive in self.held_melee_drives.values() {
+            let Some(joint) = self.impulse_joint_set.get_mut(drive.joint, true) else {
+                continue;
+            };
+            for axis in [
+                JointAxis::LinX,
+                JointAxis::LinY,
+                JointAxis::LinZ,
+                JointAxis::AngX,
+                JointAxis::AngY,
+                JointAxis::AngZ,
+            ] {
+                joint.data.set_motor_position(axis, 0.0, stiffness, damping);
+            }
+        }
+    }
+
     pub fn remove(&mut self, entity_id: EntityId) {
         let entity_as_int = entity_id.inner() as u128;
         let mut bodies_to_remove = Vec::new();
@@ -3604,6 +3737,21 @@ impl PhysicsWorld {
         self.kinematic_attachments.retain(|child, attachment| {
             !bodies_to_remove.contains(child) && !bodies_to_remove.contains(&attachment.parent)
         });
+        let drives_to_remove = bodies_to_remove
+            .iter()
+            .filter_map(|handle| self.held_melee_drives.remove(handle))
+            .collect::<Vec<_>>();
+        for drive in drives_to_remove {
+            self.impulse_joint_set.remove(drive.joint, true);
+            self.rigid_body_set.remove(
+                drive.target,
+                &mut self.island_manager,
+                &mut self.collider_set,
+                &mut self.impulse_joint_set,
+                &mut self.multibody_joint_set,
+                true,
+            );
+        }
         for handle in bodies_to_remove {
             self.rigid_body_set.remove(
                 handle,
@@ -3835,6 +3983,7 @@ impl PhysicsWorld {
             live_creature_sweep_recovery: HashMap::new(),
             pending_player_push_velocity: HashMap::new(),
             kinematic_attachments: HashMap::new(),
+            held_melee_drives: HashMap::new(),
 
             debug_pipeline,
 
@@ -4004,6 +4153,7 @@ impl PhysicsWorld {
         // (tram floor + walls/buttons) therefore advance as one physical body,
         // matching Dark's source->destination attachment flow.
         self.update_kinematic_attachments();
+        self.update_held_melee_motors();
 
         // Attribute any non-finite body state to its entity before the step
         // consumes it (see report_nonfinite_rigid_body_state) - by the time
@@ -5642,7 +5792,7 @@ mod tests {
     }
 
     #[test]
-    fn held_melee_is_controller_driven_contact_without_blocking_player() {
+    fn held_melee_is_spring_driven_contact_without_blocking_player() {
         let mut world = PhysicsWorld::new();
         let weapon = EntityId::from_inner(1).unwrap();
         world.add_dynamic(
@@ -5663,11 +5813,14 @@ mod tests {
             .into_iter()
             .find(|body| body.entity_id == Some(weapon.inner() as i32))
             .unwrap();
-        assert_eq!(body.body_type, "kinematic");
+        assert_eq!(
+            body.body_type, "dynamic",
+            "the rendered weapon must remain solver-driven instead of teleporting to the hand"
+        );
         assert!(!body.blocks_player, "the weapon must ignore its owner");
         assert!(
             body.blocks_actor,
-            "the controller-driven weapon must retain actor contact detection"
+            "the spring-driven weapon must retain actor contact detection"
         );
         assert_eq!(body.linear_velocity, [0.0; 3]);
         assert_eq!(body.angular_velocity, [0.0; 3]);
@@ -5675,9 +5828,6 @@ mod tests {
         let body_handle = world.entity_id_to_body[&weapon];
         let collider_handle = world.rigid_body_set[body_handle].colliders()[0];
         let collider = &world.collider_set[collider_handle];
-        let active_types = collider.active_collision_types();
-        assert!(active_types.contains(ActiveCollisionTypes::KINEMATIC_KINEMATIC));
-        assert!(active_types.contains(ActiveCollisionTypes::KINEMATIC_FIXED));
         let actor = CollisionGroup::actor();
         assert!(
             collider.collision_groups().test(actor.collision),
@@ -5686,6 +5836,147 @@ mod tests {
         assert!(
             !collider.solver_groups().test(actor.solver),
             "held melee must not solve impulses against living actors"
+        );
+    }
+
+    /// The controller target may move instantly, but the visible/contact body
+    /// must travel through simulation instead of adopting that pose verbatim.
+    #[test]
+    fn held_melee_weapon_lags_behind_its_controller_target() {
+        let (mut world, mut player) = world_with_floor();
+        let weapon = EntityId::from_inner(2).unwrap();
+        let handle = world.add_dynamic(
+            weapon,
+            vec3(-2.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.2, 0.4, 0.2)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        world.set_held_melee(weapon);
+        world.set_position_rotation2(weapon, vec3(-2.0, 1.0, 0.0), identity_quat());
+        step(&mut world, &mut player, 1);
+        world.set_position_rotation2(weapon, vec3(0.0, 1.0, 0.0), identity_quat());
+
+        step(&mut world, &mut player, 3);
+
+        let weapon_x = world.get_position(handle).unwrap().x;
+        assert!(
+            weapon_x > -2.0 && weapon_x < 0.5 && weapon_x.abs() > 0.01,
+            "the motor should advance without snapping to the target: x={weapon_x}"
+        );
+        let target = world.held_melee_drives[&handle].target;
+        assert!((world.get_position(target).unwrap().x - 0.0).abs() < 1.0e-4);
+    }
+
+    /// A restored or newly wielded loose body may still carry a world pose
+    /// unrelated to the tracked hand. Its first held pose establishes the
+    /// physical-hand pair; only subsequent motion is spring-driven.
+    #[test]
+    fn held_melee_first_tracked_pose_seats_both_motor_endpoints() {
+        let mut world = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(2).unwrap();
+        let handle = world.add_dynamic(
+            weapon,
+            vec3(-40.0, 8.0, 20.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.2, 0.4, 0.2)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        world.set_held_melee(weapon);
+
+        let tracked_pose = vec3(3.0, 1.0, -4.0);
+        world.set_position_rotation2(weapon, tracked_pose, identity_quat());
+
+        let drive = world.held_melee_drives[&handle];
+        assert!(drive.seated);
+        assert!((world.get_position(handle).unwrap() - tracked_pose).magnitude() < 1.0e-4);
+        assert!((world.get_position(drive.target).unwrap() - tracked_pose).magnitude() < 1.0e-4);
+        assert!(world.get_velocity(weapon).unwrap().magnitude() < 1.0e-4);
+    }
+
+    /// World solver contact must win over the hand motor, then releasing that
+    /// obstruction must let the weapon return to the tracked pose.
+    #[test]
+    fn held_melee_weapon_stops_at_world_geometry_then_springs_back() {
+        let (mut world, mut player) = world_with_floor();
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(0.05, 1.0, 1.0)
+                .translation(vector![0.0, 1.0, 0.0])
+                .build(),
+        );
+        let weapon = EntityId::from_inner(3).unwrap();
+        let handle = world.add_dynamic(
+            weapon,
+            vec3(-1.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.4, 0.4, 0.4)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        world.set_held_melee(weapon);
+        world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
+        step(&mut world, &mut player, 1);
+        world.set_position_rotation2(weapon, vec3(1.0, 1.0, 0.0), identity_quat());
+
+        step(&mut world, &mut player, 120);
+
+        let blocked_x = world.get_position(handle).unwrap().x;
+        assert!(
+            blocked_x < -0.20,
+            "the dynamic weapon crossed the fixed wall instead of stopping: x={blocked_x}"
+        );
+
+        world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
+        step(&mut world, &mut player, 60);
+        let returned_x = world.get_position(handle).unwrap().x;
+        assert!(
+            returned_x < -0.8,
+            "the weapon did not spring back after the target cleared the wall: x={returned_x}"
+        );
+    }
+
+    /// A player teleport moves the tracked stage, not the hand relative to the
+    /// player. Carry both motor endpoints by the same delta so the weapon does
+    /// not attempt to traverse the intervening level geometry.
+    #[test]
+    fn player_relocation_carries_the_held_melee_body_and_target_together() {
+        let (mut world, mut player) = world_with_floor();
+        let weapon = EntityId::from_inner(2).unwrap();
+        let weapon_handle = world.add_dynamic(
+            weapon,
+            vec3(-2.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.2, 0.4, 0.2)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        world.set_held_melee(weapon);
+        let target_handle = world.held_melee_drives[&weapon_handle].target;
+        let weapon_before = world.get_position(weapon_handle).unwrap();
+        let target_before = world.get_position(target_handle).unwrap();
+        let player_before = world.get_player_translation(&player);
+        let delta = vec3(80.0, 4.0, -60.0);
+
+        world.set_player_translation(player_before + delta, &mut player);
+
+        assert!(
+            (world.get_position(weapon_handle).unwrap() - weapon_before - delta).magnitude()
+                < 1.0e-4
+        );
+        assert!(
+            (world.get_position(target_handle).unwrap() - target_before - delta).magnitude()
+                < 1.0e-4
         );
     }
 
@@ -5720,7 +6011,7 @@ mod tests {
         );
         assert_eq!(
             world.rigid_body_set[handle].body_type(),
-            RigidBodyType::KinematicPositionBased
+            RigidBodyType::Dynamic
         );
     }
 
@@ -5771,12 +6062,15 @@ mod tests {
         );
         world.set_held_melee(weapon);
 
-        // Establish the initial broad-phase pose, then cross the actor in one
-        // ordinary 60 Hz controller update.
+        // Seat the just-held body at its first tracked pose, establish the
+        // broad phase, then put only the hand target beyond the actor. The
+        // visible weapon must cross through simulation, report contact, and
+        // still leave actor solver response disabled.
+        world.set_position_rotation2(weapon, vec3(-2.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
+        world.set_position_rotation2(weapon, vec3(0.0, 1.0, 0.0), identity_quat());
         let mut events = Vec::new();
-        for x in [-1.0, -0.7, -0.4, -0.2, 0.0] {
-            world.set_position_rotation2(weapon, vec3(x, 1.0, 0.0), identity_quat());
+        for _ in 0..30 {
             let (_, mut frame_events) = world.update(vec3(0.0, 0.0, 0.0), &mut player);
             events.append(&mut frame_events);
         }
@@ -5850,6 +6144,7 @@ mod tests {
         );
         world.set_held_melee(weapon);
         let held_handle = world.entity_id_to_body[&weapon];
+        let target_handle = world.held_melee_drives[&held_handle].target;
         let held_collider = &world.collider_set[world.rigid_body_set[held_handle].colliders()[0]];
         assert!(!held_collider.solver_groups().test(actor.solver));
 
@@ -5857,6 +6152,10 @@ mod tests {
         assert!(
             !world.entity_id_to_body.contains_key(&weapon),
             "store/destroy must remove the held physics body"
+        );
+        assert!(
+            world.rigid_body_set.get(target_handle).is_none(),
+            "store/destroy must remove the invisible hand target too"
         );
 
         let loose_handle = world.add_dynamic(

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -29,6 +29,9 @@ const SHOTGUN_HYBRID = 1392;
 const BREAKABLE_PANE = 237;
 const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const WRENCH_WINDUP_DISTANCE = 1.5;
+const WRENCH_SWEEP_END_DISTANCE = -0.75;
+const WRENCH_SWEEP_FRAMES = 45;
 
 const add = (a: Vec3, b: Vec3): Vec3 => a.map((x, i) => x + b[i]) as Vec3;
 const sub = (a: Vec3, b: Vec3): Vec3 => a.map((x, i) => x - b[i]) as Vec3;
@@ -118,16 +121,36 @@ async function measureHeldContactOffset(game: GameServer): Promise<void> {
   // Let the pawn settle first: while it is still falling the hand it carries
   // trails the physics body the reading is compared against.
   await game.step({ frames: 45 });
-  // Take the pawn from the *same response* as the body. Physics free-runs
+  // Take the pawn from the *same response* as the bodies. Physics free-runs
   // between HTTP requests, so a pawn read a request later has already fallen a
   // little further and the difference lands straight in the offset (measured:
   // 0.2 of bogus reach).
-  const bodies = await game.physics.bodies({ entityId: held });
-  const body = bodies.bodies[0];
+  const bodies = await game.physics.bodies();
+  const body = bodies.bodies.find((candidate) => candidate.entity_id === held);
   assert.ok(body, "the held weapon must have a contact body");
   const pawnRotation = (await game.info()).player.rotation;
   const handWorld = add(bodies.player_position, qrotate(pawnRotation, local));
-  heldContactOffset = qrotate(qconj(pawnRotation), sub(body.position, handWorld));
+  // The visible dynamic body may be held back by world contact—that separation
+  // is the feature under test. Measure the intended grip from its colliderless
+  // kinematic motor target instead (the nearest anonymous kinematic body to
+  // the hand), while every damage assertion below still uses the dynamic body.
+  const driveTarget = bodies.bodies
+    .filter(
+      (candidate) =>
+        candidate.entity_id === null &&
+        candidate.body_type === "kinematic" &&
+        candidate.collision_groups.length === 0,
+    )
+    .sort(
+      (a, b) =>
+        Math.sqrt(dot(sub(a.position, handWorld), sub(a.position, handWorld))) -
+        Math.sqrt(dot(sub(b.position, handWorld), sub(b.position, handWorld))),
+    )[0];
+  assert.ok(driveTarget, "the held weapon must have a controller target");
+  heldContactOffset = qrotate(
+    qconj(pawnRotation),
+    sub(driveTarget.position, handWorld),
+  );
 
   // Staging follows this measurement, so assert its shape or the gesture would
   // silently compensate for a misplaced collider and still pass. The wielded
@@ -147,7 +170,7 @@ async function measureHeldContactOffset(game: GameServer): Promise<void> {
 }
 
 // This is the production play-through gesture: orient the physical right hand
-// along the eye-to-target ray, wind up two units away, pull the trigger, and
+// along the eye-to-target ray, wind up clear of contact, pull the trigger, and
 // sweep the rendered weapon head into the target. No damage/script message is
 // injected by the test.
 async function poseWrench(
@@ -185,6 +208,42 @@ async function poseWrench(
   await game.input.set("right_hand.rotation", localRotation);
   await game.input.set("right_hand.squeeze", 1);
   await game.step({ frames });
+}
+
+// Feed one tracked-hand pose per physics frame, matching the controller path
+// that drives the spring target in production. The former kinematic body could
+// jump from the four-unit wind-up straight into the victim; a dynamic weapon
+// must travel the intervening distance and make an authentic contact.
+async function sweepWrenchThrough(
+  game: GameServer,
+  target: EntitySummary,
+  initialTargetPoint: Vec3,
+): Promise<Vec3> {
+  const startDistance = WRENCH_WINDUP_DISTANCE;
+  const endDistance = WRENCH_SWEEP_END_DISTANCE;
+  const sweepFrames = WRENCH_SWEEP_FRAMES;
+  let targetPoint = initialTargetPoint;
+  for (let frame = 1; frame <= sweepFrames; frame += 1) {
+    // Reacquire a moving torso every frame without turning a pane that breaks
+    // during the sweep into a failed entity-detail request.
+    try {
+      const current = await game.entities.detail(target.id);
+      targetPoint =
+        current.aim_points?.find(
+          (point) => point.classification === "torso",
+        )?.position ?? current.position;
+    } catch {
+      // A breakable world target may already have been slain by this swing.
+    }
+    const t = frame / sweepFrames;
+    await poseWrench(
+      game,
+      targetPoint,
+      startDistance + (endDistance - startDistance) * t,
+      1,
+    );
+  }
+  return targetPoint;
 }
 
 async function bodyFor(
@@ -248,7 +307,7 @@ async function armedSweep(
   await game.player.teleport({
     x: live.position[0] + 0.815,
     y: live.position[1] + 0.236,
-    z: live.position[2] - 2.245,
+    z: live.position[2] + 2.245,
   });
   await game.entities.sendMessage(target.id, {
     type: "SetAlertness",
@@ -260,25 +319,19 @@ async function armedSweep(
   let targetPoint =
     afterTeleport.aim_points?.find((point) => point.classification === "torso")
       ?.position ?? afterTeleport.position;
-  await poseWrench(game, targetPoint, 4);
-  await game.step({ frames: 4 });
+  await poseWrench(game, targetPoint, WRENCH_WINDUP_DISTANCE, 45);
   await game.input.set("right_hand.trigger", 0);
   await game.step({ frames: 2 });
   const sequence =
     (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
   await game.input.set("right_hand.trigger", 1);
   await game.step({ frames: 2 });
-  const current = await game.entities.detail(target.id);
-  targetPoint =
-    current.aim_points?.find((point) => point.classification === "torso")
-      ?.position ?? current.position;
-  await poseWrench(game, targetPoint, -0.1, 1);
-  await game.step({ frames: 2 });
+  targetPoint = await sweepWrenchThrough(game, target, targetPoint);
   return { sequence, targetId: target.id, targetPoint };
 }
 
 // The #984 report/review's live-torso incremental approach. Arm from a
-// measured-clear four-unit pose, then reacquire the moving torso as the
+// measured-clear wind-up pose, then reacquire the moving torso as the
 // rendered weapon head crosses it.
 async function reviewedIncrementalSweep(
   game: GameServer,
@@ -286,7 +339,7 @@ async function reviewedIncrementalSweep(
 ): Promise<{ sequence: number; targetId: number; targetPoint: Vec3 }> {
   const live = await game.entities.detail(target.id);
   await game.player.teleport({
-    x: live.position[0] + 0.815,
+    x: live.position[0] - 0.815,
     y: live.position[1] + 0.236,
     z: live.position[2] - 2.245,
   });
@@ -298,20 +351,13 @@ async function reviewedIncrementalSweep(
   let targetPoint =
     live.aim_points?.find((point) => point.classification === "torso")
       ?.position ?? live.position;
-  await poseWrench(game, targetPoint, 4, 4);
+  await poseWrench(game, targetPoint, WRENCH_WINDUP_DISTANCE, 45);
 
   const sequence =
     (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
   await game.input.set("right_hand.trigger", 1);
   await game.step({ frames: 2 });
-  for (const handDistance of [1.5, 1.0, 0.5, 0.15, -0.1]) {
-    const current = await game.entities.detail(target.id);
-    targetPoint =
-      current.aim_points?.find((point) => point.classification === "torso")
-        ?.position ?? current.position;
-    await poseWrench(game, targetPoint, handDistance, 1);
-  }
-  await game.step({ frames: 2 });
+  targetPoint = await sweepWrenchThrough(game, target, targetPoint);
   return { sequence, targetId: target.id, targetPoint };
 }
 
@@ -322,7 +368,7 @@ async function releaseTrigger(
   await game.input.set("right_hand.trigger", 0);
   await game.step({ frames: 2 });
   if (targetPoint) {
-    await poseWrench(game, targetPoint, 4);
+    await poseWrench(game, targetPoint, WRENCH_WINDUP_DISTANCE, 30);
   }
 }
 
@@ -437,7 +483,7 @@ async function assertNineDamagePull(
   assert.equal(
     hitPoints(await game.entities.detail(targetId)),
     initialHp - 9,
-    `${name} must take exactly 9 HP during the four-frame contact pose`,
+    `${name} must take exactly 9 HP during the physical controller sweep`,
   );
   await releaseTrigger(game, targetPoint);
 }
@@ -599,7 +645,7 @@ test(
     assert.equal(
       (await game.physics.bodies({ entityId: restoredWrench.id })).bodies[0]
         ?.body_type,
-      "kinematic",
+      "dynamic",
     );
 
     const combatBaseline = `medsci_saved_vr_melee_combat_baseline_${stamp}`;
@@ -643,7 +689,7 @@ test(
     await releaseTrigger(game, targetPoint);
 
     // Drop through the real VR squeeze edge. The held-only solver filter must
-    // leave with the old kinematic body: the recreated world Wrench is again a
+    // leave with the old motor-driven body: the recreated world Wrench is a
     // normal dynamic, actor-solid loose prop and remains finite under gravity.
     await game.input.set("right_hand.position", [0, 0.6, -0.6]);
     await game.input.set("right_hand.squeeze", 1);
@@ -702,10 +748,10 @@ test(
     await game.step({ frames: 2 });
     assert.equal(hitPoints(await game.entities.detail(monster.id)), 9);
 
-    const { sequence, targetId } = await reviewedIncrementalSweep(
-      game,
-      monster,
-    );
+    // This debug-spawn point sits against the opposite side of the MedSci
+    // corridor from the shipped shotgun doorway; use the clear-side staging
+    // shared by the single-contact targets above.
+    const { sequence, targetId } = await armedSweep(game, monster);
     const lethalMessages = await damageMessagesSince(game, sequence, targetId);
     assert.equal(
       lethalMessages.length,

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -34,28 +34,29 @@ async function byMissionId(
 // wield, on the rendered weapon head - see `vr_config::melee_contact_offset`).
 // Staging is expressed relative to the pane rather than as bare magic
 // coordinates; the pane is tall enough that the sweep crosses it either way.
-const HAND_Y = 1.03;
-const HAND_REST: Vec3 = [0.55, HAND_Y, 1.1];
-const HAND_SWEEP: Vec3[] = [
-  [0.5, HAND_Y, 1.4],
-  [0.42, HAND_Y, 1.7],
-  [0.34, HAND_Y, 2.0],
-  [0.26, HAND_Y, 2.3],
-  [0.18, HAND_Y, 2.6],
-  [0.1, HAND_Y, 2.8],
-  [0.05, HAND_Y, 3.0],
-];
+// Aim the weapon's fitted (handle-to-head) volume through the pane center. The
+// old pose-teleported collider could skim the upper frame and still jump into
+// the glass; a solver-driven body correctly stops on that frame instead.
+const HAND_Y = 0.45;
+// Retract far enough that the wrench's full fitted cuboid, not merely its
+// body origin, clears the pane before the next contact edge.
+const HAND_REST: Vec3 = [0.7, HAND_Y, 0.3];
+const HAND_SWEEP_END: Vec3 = [0.05, HAND_Y, 3.4];
+const HAND_SWEEP_FRAMES = 60;
 
 async function sweepHeldWrench(game: GameServer): Promise<void> {
-  for (const hand of HAND_SWEEP) {
+  for (let frame = 1; frame <= HAND_SWEEP_FRAMES; frame += 1) {
+    const t = frame / HAND_SWEEP_FRAMES;
+    const hand: Vec3 = [
+      HAND_REST[0] + (HAND_SWEEP_END[0] - HAND_REST[0]) * t,
+      HAND_Y,
+      HAND_REST[2] + (HAND_SWEEP_END[2] - HAND_REST[2]) * t,
+    ];
     await game.input.set("right_hand.position", hand);
-    // Two frames per sample, not one: the sweep's last sample lands the fitted
-    // weapon box right on the pane plane. At one frame per sample whether the
-    // contact is generated came down to how much physics free-ran between the
-    // HTTP requests - the same swing passed or failed purely on request
-    // latency. Two frames gives the contact a real overlap window instead of a
-    // tangential touch; nothing else about the gesture changes.
-    await game.step({ frames: 2 });
+    // Advance the tracked target every simulation frame, like a real
+    // controller sample. This matters now that the visible/contact weapon is
+    // a spring-driven body instead of a pose-teleported kinematic.
+    await game.step({ frames: 1 });
   }
 }
 
@@ -75,7 +76,6 @@ test(
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
-
     const wrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
     const pane = await byMissionId(
       game,
@@ -121,7 +121,7 @@ test(
     await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
     await game.input.set("right_hand.squeeze", 1);
     await game.input.set("right_hand.trigger", 0);
-    await game.step({ frames: 3 });
+    await game.step({ frames: 30 });
 
     // Negative first: physically sweep through the pane without pulling the
     // trigger. Before the fix the authored Wrench had no collision damage at
@@ -132,11 +132,20 @@ test(
       true,
       "idle held-Wrench contact must remain harmless",
     );
+    const blockedWrench = (await game.physics.bodies({ entityId: wrench.id }))
+      .bodies[0];
+    assert.ok(blockedWrench, "the held Wrench should retain its physics body");
+    assert.ok(
+      blockedWrench.position[2] < pane.position[2] - 0.1,
+      `the physical Wrench should stop on the near side while its tracked target crosses the pane: ${JSON.stringify(blockedWrench)}`,
+    );
 
     // Leave contact, open the attack window with the production VR trigger,
     // then make a fresh controller-driven physics contact.
     await game.input.set("right_hand.position", HAND_REST);
-    await game.step({ frames: 5 });
+    // Unlike the old pose-teleported body, the physical weapon needs time to
+    // spring clear of the pane before Rapier can report the next contact edge.
+    await game.step({ frames: 30 });
     const beforeAttack =
       (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
     await game.input.set("right_hand.trigger", 1);
@@ -247,12 +256,12 @@ test(
     );
 
     // The actual regression: the restored weapon must still have a live,
-    // controller-driven contact body.
+    // spring-driven contact body.
     const bodies = (await game.physics.bodies({ entityId: restoredWrench.id })).bodies;
     assert.equal(
       bodies[0]?.body_type,
-      "kinematic",
-      `a restored held melee weapon must keep its kinematic contact body: ${JSON.stringify(bodies)}`,
+      "dynamic",
+      `a restored held melee weapon must keep its motor-driven contact body: ${JSON.stringify(bodies)}`,
     );
 
     // ...and it must still actually damage an authored one-HP pane.
@@ -326,8 +335,8 @@ test(
     assert.equal(afterRejectedGrab.player.right_hand_entity_id, wrench.id);
     assert.equal(
       (await game.physics.bodies({ entityId: wrench.id })).bodies[0]?.body_type,
-      "kinematic",
-      "a rejected second-hand grab must leave #943's live held-melee body intact",
+      "dynamic",
+      "a rejected second-hand grab must leave the live spring-driven melee body intact",
     );
 
     await game.input.set("left_hand.squeeze", 0);


### PR DESCRIPTION
## Reproduction

On origin/main at 42fdf125, a held Wrench was still a KinematicPositionBased body updated with set_next_kinematic_position. The focused negative test failed with body type kinematic instead of dynamic, confirming that the visible fitted collider could overlap walls but could never be stopped by the solver.

The repository is pinned to Rapier 0.31. Its existing generic-joint position motors, acceleration motor model, per-axis force limits, CCD, shape casts, and collision hooks are sufficient; no dependency upgrade is needed.

## Fix

- Keep the fitted cuboid authored from the posed melee render geometry, but make the visible weapon a zero-gravity dynamic rigid body.
- Drive it toward an invisible colliderless kinematic controller target with a six-axis Rapier spring motor, with live melee_spring and melee_damping tuning parameters.
- Preserve the held-melee collision-group split: world and props physically stop it, actors receive contact damage without solver launch, and the player remains ignored.
- Seat both motor endpoints on the first tracked pose after hold, save/load, or level transition, and carry both endpoints together across explicit player teleports.
- Cover lag, world contact and rebound, fitted shape, actor contact, cleanup, save/load, deck transitions, canonical damage, and lethal ragdoll direction.

## Verification

All runtime evidence used DARK_ASSET_PATH=/Users/bryan/ss2-25th. Sentinel: /Users/bryan/ss2-25th/sshock2.kpf.

- cargo test -p shock2vr --lib: 905 passed
- RUSTFLAGS=-Dwarnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime: passed
- cargo fmt --all -- --check: passed
- tools/shock2-sdk npm test: 26 passed, 282 skipped, 0 failed
- Focused 25AE contact: passed in 24.0 s; the dynamic Wrench stays on the near side while its tracked target crosses the pane, then trigger-gated contact breaks the one-HP pane.
- Focused saved/deck-transition melee: passed in 119.8 s with canonical 9-damage Wrench hits across save/load and decks.
- Focused lethal-contact ragdoll: passed in 26.7 s; save-loaded contact body/damage passed in 18.5 s.
- Full 25AE SDK E2E: 297 passed, 3 failed, 8 skipped. Two deterministic failures are unrelated baseline failures reproduced identically on exact base 42fdf125: creature-loot reader MFD state and Hydro3 Korenchkin transcript spacing. The third was a transient shared-target debug-runtime ENOENT; its crouch test passed on immediate rerun. Every physical-melee scenario passed in the aggregate run.

The delegated deterministic before/after capture follows in the visual verification section.

## Visual verification

![Physical VR melee matched before/after demo](https://gist.githubusercontent.com/tommy-xr/6413f9f6e267412f0e1dc25e3486de05/raw/issue1053-physical-melee.gif)

<sub>Matched 60 Hz controller sequence on base and fix. Red is the live fitted Rapier collider; cyan is capture-only instrumentation for the otherwise invisible tracked target. The trigger-up pass keeps the one-HP pane intact: before, the weapon follows the target through it; after, the weapon stops on the near face. The trigger-down fresh contact then drops HP 1 → 0 and opens the pane. Captured headlessly via `/v1/step` + `/v1/screenshot` with the verified 25AE install.</sub>

![Physical stop followed by trigger-gated pane damage](https://gist.githubusercontent.com/tommy-xr/6413f9f6e267412f0e1dc25e3486de05/raw/issue1053-physical-melee-still.png)

### Before → after

![Pose-teleported melee compared with spring-driven physical melee](https://gist.githubusercontent.com/tommy-xr/6413f9f6e267412f0e1dc25e3486de05/raw/issue1053-physical-melee-before-after.png)

Fixes #1053
