### PR TITLE
fix(vr): keep backpack clear of nearby walls

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -163,6 +163,9 @@ const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
 const VR_BACKPACK_FORWARD: f32 = 5.0;
 const VR_BACKPACK_UP: f32 = 3.0;
 const VR_BACKPACK_WORLD_SCALE: f32 = 0.55;
+const VR_BACKPACK_CANVAS_SIZE_PX: Vector2<f32> = Vector2::new(635.0, 120.0);
+/// Viewer-side air gap retained after the panel visibility probes find a wall.
+const VR_BACKPACK_WORLD_CLEARANCE: f32 = 0.1;
 
 /// Head-relative authored-space placement for the narrow portrait reader.
 /// After Dark's scale conversion the panel center is 1.5 world units forward
@@ -183,13 +186,52 @@ fn presentation_world_panel_size(
     }
 }
 
+fn vr_backpack_position(
+    physics: &PhysicsWorld,
+    player_position: Vector3<f32>,
+    head_rotation: Quaternion<f32>,
+) -> (Vector3<f32>, Quaternion<f32>) {
+    let intended_distance = VR_BACKPACK_FORWARD / SCALE_FACTOR;
+    let forward = head_rotation * vec3(0.0, 0.0, -1.0);
+    let panel_rotation = Quaternion::from_angle_y(cgmath::Deg(180.0)) * head_rotation;
+    let center_at_viewer =
+        player_position + head_rotation * vec3(0.0, VR_BACKPACK_UP / SCALE_FACTOR, 0.0);
+    let panel_size = presentation_world_panel_size(
+        crate::PresentationMode::Vr,
+        true,
+        VR_BACKPACK_CANVAS_SIZE_PX * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+    );
+    let mut clear_distance = intended_distance;
+    // Moving the fixed-size panel closer changes the corner-ray angles. Re-probe
+    // the new candidate so an obstruction revealed by that angle change also
+    // receives the same viewer-side clearance.
+    for _ in 0..3 {
+        let Some(obstruction) = physics.world_panel_obstruction_distance(
+            vec3_to_point3(center_at_viewer),
+            panel_rotation,
+            panel_size,
+            forward,
+            clear_distance,
+        ) else {
+            break;
+        };
+        let next = (obstruction - VR_BACKPACK_WORLD_CLEARANCE).max(0.0);
+        if next >= clear_distance {
+            break;
+        }
+        clear_distance = next;
+    }
+
+    (center_at_viewer + forward * clear_distance, panel_rotation)
+}
+
 #[cfg(test)]
 mod vr_backpack_panel_tests {
     use super::*;
 
     #[test]
     fn only_vr_scales_the_shared_backpack_canvas_at_the_world_boundary() {
-        let authored = vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE;
+        let authored = VR_BACKPACK_CANVAS_SIZE_PX * crate::gui::GUI_PIXEL_TO_WORLD_SIZE;
         assert_eq!(
             presentation_world_panel_size(crate::PresentationMode::Flat, true, authored),
             authored
@@ -6348,28 +6390,23 @@ impl MissionCore {
                             player.inventory_entity_id,
                         )
                     };
-                    // Keep the wide VR panel within an ordinary arm's reach;
-                    // the old placeholder cube sat farther out and commonly
-                    // landed the new canvas inside a nearby wall. Preserve that
-                    // diagnostic cube's established desktop placement.
-                    let distance = if game_options.presentation_mode == crate::PresentationMode::Vr
-                    {
-                        VR_BACKPACK_FORWARD
-                    } else {
-                        8.0
-                    };
-                    let vertical = if game_options.presentation_mode == crate::PresentationMode::Vr
-                    {
-                        VR_BACKPACK_UP
-                    } else {
-                        0.5
-                    };
-                    let forward =
-                        rot * vec3(0.0, vertical / SCALE_FACTOR, -distance / SCALE_FACTOR);
+                    // Probe the wide VR panel's full visible footprint toward
+                    // the intended 2 m position, stopping on the viewer side
+                    // of level geometry. Preserve the desktop diagnostic
+                    // cube's established placement unchanged.
+                    let (inventory_position, inventory_rotation) =
+                        if game_options.presentation_mode == crate::PresentationMode::Vr {
+                            vr_backpack_position(&self.physics, pos, rot)
+                        } else {
+                            (
+                                pos + rot * vec3(0.0, 0.5 / SCALE_FACTOR, -8.0 / SCALE_FACTOR),
+                                Quaternion::from_angle_y(cgmath::Deg(180.0)) * rot,
+                            )
+                        };
                     PlayerInventoryEntity::set_position_rotation(
                         &mut self.world,
-                        pos + forward,
-                        Quaternion::from_angle_y(cgmath::Deg(180.0)) * rot,
+                        inventory_position,
+                        inventory_rotation,
                     );
 
                     // VR has no cursor/metagame mode: the controller binding

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use util::*;
 
 use bitflags::bitflags;
-use cgmath::{InnerSpace, Point3, Quaternion, Vector3, point3, vec3};
+use cgmath::{InnerSpace, Point3, Quaternion, Vector2, Vector3, point3, vec3};
 use dark::{SCALE_FACTOR, mission::SystemShock2Level};
 use engine::scene::SceneObject;
 use rapier3d::{
@@ -4534,6 +4534,63 @@ impl PhysicsWorld {
         )
     }
 
+    /// Probe a panel-sized visibility fan through level geometry and return
+    /// the nearest obstruction's distance along `direction`.
+    ///
+    /// A center ray is insufficient for wide diegetic UI: a wall or pillar can
+    /// cover a corner while leaving the middle unobstructed. Rays fan from the
+    /// viewer to the center, corners, edge midpoints, and horizontal quarter
+    /// points, conservatively covering the unusually wide backpack footprint
+    /// without requiring the full-width panel to fit beside the viewer before
+    /// it has reached its destination. Only `WORLD` membership is queried, so
+    /// creatures and loose props do not make a player-facing panel jump closer
+    /// when it is placed.
+    pub fn world_panel_obstruction_distance(
+        &self,
+        center: Point3<f32>,
+        rotation: Quaternion<f32>,
+        panel_size: Vector2<f32>,
+        direction: Vector3<f32>,
+        max_distance: f32,
+    ) -> Option<f32> {
+        let direction_length2 = direction.magnitude2();
+        if !self.has_stepped
+            || !direction_length2.is_finite()
+            || direction_length2 == 0.0
+            || !max_distance.is_finite()
+            || max_distance <= 0.0
+            || !panel_size.x.is_finite()
+            || !panel_size.y.is_finite()
+            || panel_size.x <= 0.0
+            || panel_size.y <= 0.0
+        {
+            return None;
+        }
+
+        let forward = direction / direction_length2.sqrt();
+        let mut nearest = None::<f32>;
+        for x in [-0.5, -0.25, 0.0, 0.25, 0.5] {
+            for y in [-0.5, 0.0, 0.5] {
+                let offset = rotation * vec3(panel_size.x * x, panel_size.y * y, 0.0);
+                let target = center + forward * max_distance + offset;
+                let ray = target - center;
+                let Some(hit) = self.ray_cast2(
+                    center,
+                    ray,
+                    ray.magnitude(),
+                    InternalCollisionGroups::WORLD,
+                    None,
+                    true,
+                ) else {
+                    continue;
+                };
+                let distance = (hit.hit_point - center).dot(forward).max(0.0);
+                nearest = Some(nearest.map_or(distance, |current| current.min(distance)));
+            }
+        }
+        nearest
+    }
+
     /// Raycast using a living actor's collision membership. Unlike a generic
     /// interaction/visibility ray (whose membership is `ALL`), this respects
     /// colliders that explicitly opt out of blocking creature movement.
@@ -5639,6 +5696,89 @@ mod tests {
 
     fn identity_quat() -> Quaternion<f32> {
         Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    fn add_world_box(world: &mut PhysicsWorld, center: Vector3<f32>, half: Vector3<f32>) {
+        world.add_kinematic(
+            EntityId::from_inner(1095).unwrap(),
+            center,
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            half * 2.0,
+            CollisionGroup::solid(InteractionGroups::new(
+                InternalCollisionGroups::WORLD.bits.into(),
+                InternalCollisionGroups::ALL.bits.into(),
+                Default::default(),
+            )),
+            false,
+        );
+    }
+
+    #[test]
+    fn world_panel_visibility_preserves_open_distance() {
+        let (mut world, mut player) = world_with_floor();
+        step(&mut world, &mut player, 1);
+
+        assert_eq!(
+            world.world_panel_obstruction_distance(
+                point3(0.0, 2.0, 0.0),
+                identity_quat(),
+                cgmath::vec2(1.4, 0.3),
+                vec3(0.0, 0.0, 1.0),
+                2.0,
+            ),
+            None,
+            "open space must leave the caller's intended distance unchanged"
+        );
+    }
+
+    #[test]
+    fn world_panel_visibility_catches_an_edge_obstruction_that_a_center_ray_misses() {
+        let (mut world, mut player) = world_with_floor();
+        // This narrow pillar covers only the right edge of a 1.4-wide panel.
+        // A center ray at x=0 is clear, so the footprint probes are load-bearing.
+        add_world_box(&mut world, vec3(0.65, 2.0, 1.8), vec3(0.2, 0.5, 0.15));
+        step(&mut world, &mut player, 1);
+
+        assert!(
+            world
+                .ray_cast2(
+                    point3(0.0, 2.0, 0.0),
+                    vec3(0.0, 0.0, 1.0),
+                    2.0,
+                    InternalCollisionGroups::WORLD,
+                    None,
+                    true,
+                )
+                .is_none(),
+            "fixture must not be visible to a center-only probe"
+        );
+        assert!(
+            world
+                .ray_cast2(
+                    point3(0.0, 2.0, 0.0),
+                    vec3(0.7, 0.0, 2.0),
+                    vec3(0.7, 0.0, 2.0).magnitude(),
+                    InternalCollisionGroups::WORLD,
+                    None,
+                    true,
+                )
+                .is_some(),
+            "fixture must cover the panel's right-edge visibility ray"
+        );
+        let obstruction = world
+            .world_panel_obstruction_distance(
+                point3(0.0, 2.0, 0.0),
+                identity_quat(),
+                cgmath::vec2(1.4, 0.3),
+                vec3(0.0, 0.0, 1.0),
+                2.0,
+            )
+            .expect("the wide panel edge must meet the pillar");
+        assert!(
+            (1.5..1.8).contains(&obstruction),
+            "panel edge ray should meet the pillar's near face, got {obstruction}"
+        );
     }
 
     #[test]

--- a/tools/shock2-sdk/test/vr-backpack-clearance.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-backpack-clearance.e2e.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { PhysicsBodySummary, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Production-VR regression for #1095. The stance and +90-degree head yaw are
+// the independently reproduced Hydro chemical-storage case: fixed 2 m
+// placement puts the backpack behind the wall at x=61.2. Setup provisions one
+// real item into slot zero, but opening and retrieval use the same Quest-X,
+// world-panel collider, controller ray, and squeeze path as the headset.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const HYDRO_WALL_X = 61.2;
+const HYDRO_STANCE = [59.377445, -1.956119, -41.344913] as const;
+const BACKPACK_CANVAS_PX: Vec3 = [635, 120, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const VR_BACKPACK_SCALE = 0.55;
+
+function uiPanel(bodies: PhysicsBodySummary[]): PhysicsBodySummary {
+  const panels = bodies.filter((body) => body.collision_groups.includes("ui"));
+  assert.equal(panels.length, 1, "MoveInventory must expose one physical VR panel");
+  return panels[0];
+}
+
+function horizontalDistance(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[2] - b[2]);
+}
+
+test(
+  "VR backpack clears the Hydro wall, stays 2 m in open space, and remains clickable",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8595),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+    const toxin = await game.player.spawnItem(-1341);
+    await teleportVerified(game, {
+      x: HYDRO_STANCE[0],
+      y: HYDRO_STANCE[1],
+      z: HYDRO_STANCE[2],
+    });
+
+    // Control: looking into the open aisle keeps the authored 2 m distance.
+    let player = (await game.info()).player;
+    await game.input.lookAtWorldPoint(
+      add(player.position, [0, player.camera_offset[1], 10]),
+      { eyeHeight: player.camera_offset[1] },
+    );
+    await game.step({ frames: 2 });
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+    player = (await game.info()).player;
+    let panel = uiPanel((await game.physics.bodies()).bodies);
+    assert.ok(
+      Math.abs(horizontalDistance(panel.position, player.position) - 2.0) < 0.01,
+      `open-space backpack distance must remain 2 m: player=${player.position}, panel=${panel.position}`,
+    );
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 3 });
+
+    // Reopen toward +X at the exact failing wall. The complete panel footprint
+    // must stop on the viewer side, not just its center ray.
+    player = (await game.info()).player;
+    await game.input.lookAtWorldPoint(
+      add(player.position, [10, player.camera_offset[1], 0]),
+      { eyeHeight: player.camera_offset[1] },
+    );
+    await game.step({ frames: 2 });
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+    player = (await game.info()).player;
+    panel = uiPanel((await game.physics.bodies()).bodies);
+    const clampedDistance = horizontalDistance(panel.position, player.position);
+    assert.ok(
+      clampedDistance < 1.9,
+      `nearby geometry must clamp the fixed 2 m placement, got ${clampedDistance}`,
+    );
+    assert.ok(
+      panel.position[0] <= HYDRO_WALL_X - 0.09,
+      `backpack center must retain viewer-side wall clearance: ${panel.position[0]}`,
+    );
+
+    const ui = (await game.ui.state()).active_panel;
+    assert.ok(ui, "the clamped backpack remains the active production panel");
+    const item = ui.elements.find((element) => element.entity_id === toxin.entity_id);
+    assert.ok(item, `the provisioned toxin must render in the backpack: ${JSON.stringify(ui)}`);
+    const [x, y, width, height] = item.rect;
+    const panelSize: Vec3 = [
+      BACKPACK_CANVAS_PX[0] * GUI_PIXEL_TO_WORLD_SIZE * VR_BACKPACK_SCALE,
+      BACKPACK_CANVAS_PX[1] * GUI_PIXEL_TO_WORLD_SIZE * VR_BACKPACK_SCALE,
+      0,
+    ];
+    const localPoint: Vec3 = [
+      panelSize[0] * (0.5 - (x + width / 2) / BACKPACK_CANVAS_PX[0]),
+      panelSize[1] * (0.5 - (y + height / 2) / BACKPACK_CANVAS_PX[1]),
+      0,
+    ];
+    const itemWorld = add(panel.position, quatRotate(panel.rotation, localPoint));
+    const aim = await aimVrHandAt(game, itemWorld, 0.35);
+    const firstHit = await game.raycast({
+      start: aim.start,
+      end: aim.target,
+      collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+      max_distance: 1,
+    });
+    assert.equal(
+      firstHit.entity_id,
+      panel.entity_id,
+      `controller ray must reach the backpack before the wall: ${JSON.stringify(firstHit)}`,
+    );
+
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (candidate) => candidate.entity_id === toxin.entity_id,
+      )?.location,
+      "right_hand",
+      "production squeeze must retrieve the exact visible item",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- keep the production VR backpack at its authored 2 m distance in open space
- probe the wide panel's center, corners, edges, and quarter points against world geometry, then retain 0.1 m of viewer-side clearance when obstructed
- add deterministic physics coverage and a `hydro2.mis --vr` regression at the exact reported stance that retrieves a real inventory item through the production controller/squeeze path

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (903 passed)
- `npm test` in `tools/shock2-sdk` (26 passed, 283 E2E skipped)
- `SHOCK2_E2E=1 SHOCK2_E2E_PORT=8595 node --test dist/test/vr-backpack-clearance.e2e.test.js` (1 passed)

## Visual evidence

Exact Hydro stance facing the x=61.2 wall. Before, the fixed-distance panel center is x=61.3775 and the backpack is occluded. After, collision-aware placement moves it to x=60.6989, visibly and interactably in front of the wall.

![Before and after](https://gist.githubusercontent.com/tommy-xr/54c5b7557a4e988715e5713341dbd561/raw/backpack-wall-before-after.png)

![Looping before and after](https://gist.githubusercontent.com/tommy-xr/54c5b7557a4e988715e5713341dbd561/raw/backpack-wall-clearance.gif)

Fixes #1095
