### PR TITLE
fix(vr): collect keycards from every grab path

### DIFF
--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -302,21 +302,11 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
         match msg {
             ContainerGuiMsg::GrabbedWithLeftHand(ent) => (
                 state.clone(),
-                Effect::GrabEntity {
-                    entity_id: *ent,
-                    hand: crate::vr_config::Handedness::Left,
-                    // TODO: Set this up to break link
-                    current_parent_id: None,
-                },
+                panel_grab_effect(world, *ent, crate::vr_config::Handedness::Left),
             ),
             ContainerGuiMsg::GrabbedWithRightHand(ent) => (
                 state.clone(),
-                Effect::GrabEntity {
-                    entity_id: *ent,
-                    hand: crate::vr_config::Handedness::Right,
-                    // TODO: Set this up to break link
-                    current_parent_id: None,
-                },
+                panel_grab_effect(world, *ent, crate::vr_config::Handedness::Right),
             ),
             // Wield-or-use (backpack click): a carried weapon - gun
             // (PropPlayerGun) or melee (PropLimbModel) - is wielded through
@@ -380,6 +370,21 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                         (state.clone(), Effect::NoEffect)
                     };
                 }
+                // PropKeySrc gets an `internal_keycard` script even when its
+                // retail frob metadata is just MOVE. Scripted loot must run
+                // that Frob before any generic transfer, or the physical card
+                // reaches the backpack without its unlock credential (#583).
+                if crate::virtual_hand::uses_scripted_world_frob(world, *ent) {
+                    return (
+                        state.clone(),
+                        Effect::Send {
+                            msg: Message {
+                                payload: MessagePayload::Frob,
+                                to: *ent,
+                            },
+                        },
+                    );
+                }
                 let inventory_entity = world
                     .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
                     .map(|player| player.inventory_entity_id)
@@ -399,13 +404,41 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
     }
 }
 
+/// A squeeze over a panel normally retrieves the icon into that hand. A
+/// keycard is the one semantic exception: it represents a collected access
+/// credential, so every panel (corpse loot and the backpack alike) must route
+/// the gesture through its derived keycard Frob instead of physically holding
+/// an unregistered object.
+fn panel_grab_effect(
+    world: &World,
+    entity_id: EntityId,
+    hand: crate::vr_config::Handedness,
+) -> Effect {
+    if crate::virtual_hand::is_key_source(world, entity_id) {
+        Effect::Send {
+            msg: Message {
+                payload: MessagePayload::Frob,
+                to: entity_id,
+            },
+        }
+    } else {
+        Effect::GrabEntity {
+            entity_id,
+            hand,
+            current_parent_id: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::gui::GuiInputInfo;
     use crate::mission::PlayerInfo;
     use cgmath::{Quaternion, point2, vec3};
-    use dark::properties::{FrobFlag, Links, PropFrobInfo, PropHitPoints, ToLink, WrappedEntityId};
+    use dark::properties::{
+        FrobFlag, KeyCard, Links, PropFrobInfo, PropHitPoints, PropKeySrc, ToLink, WrappedEntityId,
+    };
 
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
@@ -438,6 +471,17 @@ mod tests {
             inventory_entity_id: inventory,
         });
         (world, container, item, inventory)
+    }
+
+    fn mark_as_keycard(world: &mut World, item: EntityId) {
+        world.add_component(
+            item,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 128,
+                lock_id: 0,
+            }),
+        );
     }
 
     fn input_at(cursor: cgmath::Point2<f32>, pressed: bool) -> GuiInputInfo {
@@ -491,6 +535,90 @@ mod tests {
             }
             other => panic!("Take should transfer via DropEntityInfo, got {:?}", other),
         }
+    }
+
+    /// Hydro2 Card B is both grabbable (`MOVE`) and a derived key source. A
+    /// loot-panel trigger click must run `internal_keycard` instead of silently
+    /// reparenting the object and skipping the region-128 credential.
+    #[test]
+    fn loot_container_click_frobs_a_keycard() {
+        let (mut world, container, item, _inventory) = loot_world();
+        mark_as_keycard(&mut world, item);
+        let gui = ContainerGui::loot_container();
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+
+        assert!(
+            matches!(
+                effect,
+                Effect::Send {
+                    msg: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                } if to == item
+            ),
+            "taking a keycard must collect its credential, got {effect:?}"
+        );
+    }
+
+    /// In VR a squeeze over either a corpse-loot or backpack icon normally
+    /// emits `GrabbedWith*`. Keycards are collected credentials, so that edge
+    /// must Frob them rather than putting an unregistered physical card in the
+    /// hand. Ordinary MOVE loot keeps the existing grab behavior.
+    #[test]
+    fn vr_panel_grab_frobs_only_keycards() {
+        let (mut world, container, keycard, _inventory) = loot_world();
+        mark_as_keycard(&mut world, keycard);
+        let ordinary = world.add_entity(PropFrobInfo {
+            world_action: FrobFlag::MOVE,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        });
+        let gui = ContainerGui::loot_container();
+
+        for message in [
+            ContainerGuiMsg::GrabbedWithLeftHand(keycard),
+            ContainerGuiMsg::GrabbedWithRightHand(keycard),
+        ] {
+            let (_state, effect) =
+                gui.handle_msg(container, &world, &ContainerGuiState {}, &message);
+            assert!(
+                matches!(
+                    effect,
+                    Effect::Send {
+                        msg: Message {
+                            to,
+                            payload: MessagePayload::Frob,
+                        },
+                    } if to == keycard
+                ),
+                "VR keycard squeeze must collect instead of hold, got {effect:?}"
+            );
+        }
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::GrabbedWithRightHand(ordinary),
+        );
+        assert!(
+            matches!(
+                effect,
+                Effect::GrabEntity {
+                    entity_id,
+                    hand: crate::vr_config::Handedness::Right,
+                    ..
+                } if entity_id == ordinary
+            ),
+            "ordinary MOVE loot must remain grabbable, got {effect:?}"
+        );
     }
 
     /// Both panels' item grids must land on the cell separators authored into

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -374,7 +374,12 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                 // retail frob metadata is just MOVE. Scripted loot must run
                 // that Frob before any generic transfer, or the physical card
                 // reaches the backpack without its unlock credential (#583).
-                if crate::virtual_hand::uses_scripted_world_frob(world, *ent) {
+                // Gated on `is_key_source` specifically (not the broader
+                // `uses_scripted_world_frob`, which also matches authored
+                // MOVE|SCRIPT items like eng1's circuit board) so other
+                // scripted-but-grabbable loot keeps its pre-existing Take
+                // behavior - the same predicate `panel_grab_effect` uses below.
+                if crate::virtual_hand::is_key_source(world, *ent) {
                     return (
                         state.clone(),
                         Effect::Send {

--- a/shock2vr/src/scripts/internal_keycard_script.rs
+++ b/shock2vr/src/scripts/internal_keycard_script.rs
@@ -6,10 +6,21 @@ use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script};
 
-pub struct KeyCardScript {}
+pub struct KeyCardScript {
+    // The entity is destroyed the same frame it is first collected (effects
+    // apply after the whole message batch), so a second Frob delivered in
+    // that same batch - e.g. both a panel squeeze and a direct world squeeze
+    // routing to the same entity in one update - would otherwise still see it
+    // alive and push a duplicate credential while only one DestroyEntity is
+    // ever queued (`add_key_card` is a bare `Vec::push`, not idempotent).
+    // Latch in-memory on the first award, mirroring
+    // `InternalNanitesScript::collected`; the entity is gone by the next
+    // frame, so this never needs to survive a save.
+    collected: bool,
+}
 impl KeyCardScript {
     pub fn new() -> KeyCardScript {
-        KeyCardScript {}
+        KeyCardScript { collected: false }
     }
 }
 
@@ -22,7 +33,9 @@ impl Script for KeyCardScript {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
+            MessagePayload::Frob if !self.collected => {
+                self.collected = true;
+
                 let v_keycard_src = world.borrow::<View<PropKeySrc>>().unwrap();
                 let maybe_keycard = v_keycard_src.get(entity_id);
                 let acquire_key_card = {
@@ -43,5 +56,88 @@ impl Script for KeyCardScript {
             // Does turn off need to be done for email?
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::KeyCard;
+
+    fn keycard() -> KeyCard {
+        KeyCard {
+            is_master: false,
+            region_id: 128,
+            lock_id: 0,
+        }
+    }
+
+    /// Negative-first regression: the destroy effect only applies after the
+    /// whole message batch, so a second Frob in the same batch - e.g. a panel
+    /// squeeze and a direct world squeeze both landing on the same card -
+    /// still finds the entity alive. Without the `collected` latch, this
+    /// would push a duplicate credential (`add_key_card` is a bare
+    /// `Vec::push`).
+    #[test]
+    fn a_second_frob_in_the_same_batch_acquires_nothing_more() {
+        let mut world = World::new();
+        let entity = world.add_entity(PropKeySrc(keycard()));
+        let mut script = KeyCardScript::new();
+
+        let first =
+            script.handle_message(entity, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+        let second =
+            script.handle_message(entity, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+
+        let acquire_count = |effect: &Effect| -> usize {
+            match effect {
+                Effect::Combined { effects } => effects
+                    .iter()
+                    .filter(|e| matches!(e, Effect::AcquireKeyCard { .. }))
+                    .count(),
+                Effect::AcquireKeyCard { .. } => 1,
+                _ => 0,
+            }
+        };
+
+        assert_eq!(
+            acquire_count(&first),
+            1,
+            "first Frob should acquire the credential"
+        );
+        assert_eq!(
+            acquire_count(&second),
+            0,
+            "second Frob in the same batch must not acquire the credential again"
+        );
+        assert!(
+            matches!(second, Effect::NoEffect),
+            "second Frob should be a no-op, got {second:?}"
+        );
+    }
+
+    #[test]
+    fn frob_acquires_the_credential_and_destroys_the_card() {
+        let mut world = World::new();
+        let entity = world.add_entity(PropKeySrc(keycard()));
+
+        let effect = KeyCardScript::new().handle_message(
+            entity,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        let Effect::Combined { effects } = effect else {
+            panic!("expected a combined effect, got {effect:?}");
+        };
+        assert!(effects.iter().any(
+            |e| matches!(e, Effect::AcquireKeyCard { key_card } if key_card.region_id == 128)
+        ));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::DestroyEntity { entity_id } if *entity_id == entity))
+        );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -516,6 +516,13 @@ fn get_held_position_orientation(
 /// protocol even though the Weapon archetype also inherits that inventory
 /// flag. The decision stays tied to Dark's production frob metadata.
 fn held_trigger_press_payload(world: &World, entity_id: EntityId) -> MessagePayload {
+    // PropKeySrc injects `internal_keycard` at runtime even though retail ID
+    // cards do not author an inventory SCRIPT flag. A physical card held by an
+    // older save therefore still needs the production trigger to collect it.
+    if is_key_source(world, entity_id) {
+        return MessagePayload::Frob;
+    }
+
     let has_scripted_inventory_use = world
         .borrow::<View<PropFrobInfo>>()
         .map(|frob_info| {
@@ -546,6 +553,16 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     false
 }
 
+/// Whether this object is a key source. Every PropKeySrc receives the derived
+/// `internal_keycard` script, whose Frob records the credential and consumes
+/// the pickup; bypassing it creates a physical card that cannot unlock doors.
+pub(crate) fn is_key_source(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<dark::properties::PropKeySrc>>()
+        .map(|keycards| keycards.get(entity_id).is_ok())
+        .unwrap_or(false)
+}
+
 /// Whether taking this world item must go through a script before the physical
 /// transfer. An authored `SCRIPT` world action owns its side effects and item
 /// fate (for example `FrobQB` awards a quest bit and moves the item exactly
@@ -563,13 +580,8 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
                 .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
         })
         .unwrap_or(false);
-    let has_derived_keycard_script = world
-        .borrow::<View<dark::properties::PropKeySrc>>()
-        .map(|keycards| keycards.get(entity_id).is_ok())
-        .unwrap_or(false);
-
     has_authored_world_script
-        || has_derived_keycard_script
+        || is_key_source(world, entity_id)
         || crate::scripts::script_util::is_nanite_pickup(world, entity_id)
 }
 
@@ -704,7 +716,7 @@ fn interaction_ray_cast(
 mod tests {
     use super::*;
     use crate::physics::CollisionGroup;
-    use dark::properties::{PropFrobInfo, PropPlayerGun};
+    use dark::properties::{KeyCard, PropFrobInfo, PropKeySrc, PropPlayerGun};
 
     fn scripted_inventory_use() -> PropFrobInfo {
         PropFrobInfo {
@@ -913,6 +925,32 @@ mod tests {
         assert!(matches!(
             held_trigger_payload(&world, weapon_or_psi_amp),
             MessagePayload::TriggerPull
+        ));
+    }
+
+    /// A keycard physically held by an older save or a pre-fix backpack grab
+    /// must still be recoverable through the production VR trigger gesture.
+    /// Its inventory metadata has no SCRIPT bit, so PropKeySrc is the semantic
+    /// source of truth.
+    #[test]
+    fn held_keycard_trigger_collects_it_through_frob() {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            PropFrobInfo {
+                world_action: FrobFlag::MOVE,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 128,
+                lock_id: 0,
+            }),
+        ));
+
+        assert!(matches!(
+            held_trigger_payload(&world, keycard),
+            MessagePayload::Frob
         ));
     }
 

--- a/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
@@ -2,17 +2,23 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
+import type { EntitySummary, UiElement, UiPanelPose, UiState, Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import { add, aimVrHandAt, aimVrHandAtCanvas, quatRotate } from "./helpers/vr-hand.js";
 
 // Authentic Hydro2 Card B chain for #583:
 //   corpse 754 --Contains--> card 942 (PropKeySrc region 128)
 //   card slots 1120/1122 --SwitchLink--> HydroSectorB door 1127
 //
-// Both cases use default VR and production hand input. The backpack case uses
-// /give only to stage the authored card in the backpack; credential acquisition
-// itself must come from squeezing the rendered slot, not an injected Frob.
+// Both cases use default VR and production hand input. With the fix, a
+// keycard can never come to rest in the backpack strip through any live
+// squeeze path - `panel_grab_effect` Frobs it (collecting the credential)
+// instead of holding it, on the corpse's real loot panel and the use-mode
+// strip alike. The second scenario stages a card directly into the backpack
+// (bypassing every fixed path, the way an old save or the still-open flat
+// cursor-drag gap - #583's deferred M2 - could) and verifies the strip
+// squeeze still recovers the credential rather than leaving an inert card
+// sitting in the grid.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const CORPSE = 754;
 const CARD = 942;
@@ -21,8 +27,6 @@ const DOOR = 1127;
 const CARD_ARCHETYPE = -1495;
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
-const BACKPACK_PANEL_SIZE_PX: Vec3 = [635, 120, 0];
-const VR_BACKPACK_WORLD_SCALE = 0.55;
 
 function only(matches: EntitySummary[], label: string): EntitySummary {
   assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
@@ -66,6 +70,16 @@ async function squeezeWorldPanelElement(
   await game.step({ frames: 4 });
   await game.input.set("right_hand.squeeze", 0);
   await game.step({ frames: 8 });
+}
+
+/** The strip element bound to `entityId`, or undefined once it has left the grid. */
+function stripSlotFor(ui: UiState, entityId: number): UiElement | undefined {
+  return ui.strip?.elements.find((element) => element.entity_id === entityId);
+}
+
+function requirePanel(ui: UiState): UiPanelPose {
+  assert.ok(ui.panel_pose, "the VR cyber interface must report its panel pose");
+  return ui.panel_pose;
 }
 
 async function assertCardCollectedAndDoorOpens(
@@ -151,7 +165,7 @@ test(
 );
 
 test(
-  "Hydro2 VR backpack squeeze repairs an unregistered carried Card B",
+  "Hydro2 VR strip squeeze recovers an already-inventoried Card B instead of holding it",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -160,6 +174,12 @@ test(
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
+
+    // Stage the authored card directly in the backpack, bypassing every
+    // squeeze/click path this PR fixes - the state an old save (or the
+    // still-open flat cursor-drag gap, #583's deferred M2) could leave
+    // behind. The fix's contract is that this card is never left inert:
+    // squeezing it out of the strip must still Frob it, not lift it.
     const card = await game.player.spawnItem(CARD_ARCHETYPE);
     assert.equal(
       (await game.player.inventory()).items.find((item) => item.entity_id === card.entity_id)
@@ -169,19 +189,39 @@ test(
     );
 
     await game.input.set("head.look", [0, 0]);
-    await game.input.trigger("MoveInventory");
+    await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 8 });
-    const active = (await game.ui.state()).active_panel;
-    const cardElement = active?.elements.find(
-      (element) => element.kind === "button" && element.entity_id === card.entity_id,
+    let ui = await game.ui.state();
+    assert.equal(ui.mode, "use", "ToggleUseMode must open the cyber interface in VR");
+    const panel = requirePanel(ui);
+    const cardSlot = stripSlotFor(ui, card.entity_id);
+    assert.ok(cardSlot, "the staged Card B must occupy a strip slot");
+    const [x, y, width, height] = cardSlot.rect;
+    const slotCenter: [number, number] = [x + width / 2, y + height / 2];
+
+    await aimVrHandAtCanvas(game, panel, slotCenter, { squeeze: 0 });
+    await game.step({ frames: 3 });
+    await aimVrHandAtCanvas(game, panel, slotCenter, { squeeze: 1 });
+    await game.step({ frames: 8 });
+
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      null,
+      "a keycard squeeze must Frob the credential, never land it in the hand",
     );
-    assert.ok(cardElement, "VR backpack must expose the staged Card B button");
-    await squeezeWorldPanelElement(
-      game,
-      BACKPACK_PANEL_SIZE_PX,
-      VR_BACKPACK_WORLD_SCALE,
-      cardElement,
+    ui = await game.ui.state();
+    assert.equal(
+      stripSlotFor(ui, card.entity_id),
+      undefined,
+      "the collected card must leave the strip grid",
     );
+
+    // Leave the cyber interface - it swallows the world trigger while open,
+    // so the reader interaction below needs the ordinary shooter-mode hand.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).mode, "shooter");
+
     await assertCardCollectedAndDoorOpens(game, CARD_ARCHETYPE);
   },
 );

--- a/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Authentic Hydro2 Card B chain for #583:
+//   corpse 754 --Contains--> card 942 (PropKeySrc region 128)
+//   card slots 1120/1122 --SwitchLink--> HydroSectorB door 1127
+//
+// Both cases use default VR and production hand input. The backpack case uses
+// /give only to stage the authored card in the backpack; credential acquisition
+// itself must come from squeezing the rendered slot, not an injected Frob.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const CORPSE = 754;
+const CARD = 942;
+const CARD_SLOT = 1120;
+const DOOR = 1127;
+const CARD_ARCHETYPE = -1495;
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const BACKPACK_PANEL_SIZE_PX: Vec3 = [635, 120, 0];
+const VR_BACKPACK_WORLD_SCALE = 0.55;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+function distance(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+async function squeezeWorldPanelElement(
+  game: GameServer,
+  panelSizePx: Vec3,
+  worldScale: number,
+  element: UiElement,
+): Promise<void> {
+  const panel = (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+  assert.equal(panel.length, 1, "expected exactly one production VR panel collider");
+  const [x, y, width, height] = element.screen_rect;
+  const u = x + width / 2;
+  const v = y + height / 2;
+  const panelSize: Vec3 = [
+    panelSizePx[0] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
+    panelSizePx[1] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
+    0,
+  ];
+  const local: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+  const target = add(panel[0].position, quatRotate(panel[0].rotation, local));
+  const aim = await aimVrHandAt(game, target, 0.35);
+  const hit = await game.raycast({
+    start: aim.start,
+    end: aim.target,
+    collision_groups: ["ui"],
+    max_distance: 1,
+  });
+  assert.equal(hit.entity_id, panel[0].entity_id, "production hand ray must hit the panel");
+
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 4 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+}
+
+async function assertCardCollectedAndDoorOpens(
+  game: GameServer,
+  collectedTemplate: number,
+): Promise<void> {
+  assert.equal(
+    (await game.entities.byTemplate(collectedTemplate)).length,
+    0,
+    "collecting Card B must consume the physical keycard object",
+  );
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    null,
+    "a collected credential must not remain physically held",
+  );
+
+  const slot = only(await game.entities.byTemplate(CARD_SLOT), "Hydro2 Card B slot 1120");
+  const door = only(await game.entities.byTemplate(DOOR), "HydroSectorB door 1127");
+  const before = (await game.entities.detail(door.id)).position;
+  await teleportVerified(game, {
+    x: slot.position[0] + 1.1,
+    y: slot.position[1] + 0.4,
+    z: slot.position[2] + 1.1,
+  });
+  const aim = await game.player.aimAt(slot, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+  await aimVrHandAt(game, aim.world_point);
+  const since = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 180 });
+
+  const after = (await game.entities.detail(door.id)).position;
+  assert.ok(
+    distance(after, before) > 0.5,
+    `Card B credential must open door 1127: before=${before}, after=${after}`,
+  );
+  const played = (await game.audio.recent()).sounds
+    .filter((sound) => sound.sequence > since)
+    .map((sound) => sound.sample.toLowerCase());
+  assert.ok(!played.includes("hackfail"), `Card B slot refused credential: ${played}`);
+}
+
+test(
+  "Hydro2 VR corpse-panel squeeze collects Card B and opens its authored door",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8620),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+    const corpse = only(await game.entities.byTemplate(CORPSE), "Hydro2 corpse 754");
+    const card = only(await game.entities.byTemplate(CARD), "Hydro Card B 942");
+
+    // Reviewed campaign standing point under this alcove's seven-foot ceiling.
+    await teleportVerified(game, { x: 73.08, y: -0.76, z: -14.92 });
+    await game.step({ frames: 20 });
+    const corpseAim = await game.player.aimAt(corpse, {
+      hitbox: "center",
+    });
+    await aimVrHandAt(game, corpseAim.world_point);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 8 });
+
+    const active = (await game.ui.state()).active_panel;
+    assert.equal(active?.entity_id, corpse.id, "corpse 754 must open its real loot panel");
+    const cardElement = active.elements.find(
+      (element) => element.kind === "button" && element.entity_id === card.id,
+    );
+    assert.ok(cardElement, "corpse 754 must expose its real Card B button");
+    await squeezeWorldPanelElement(game, LOOT_PANEL_SIZE_PX, 1, cardElement);
+    await assertCardCollectedAndDoorOpens(game, CARD);
+  },
+);
+
+test(
+  "Hydro2 VR backpack squeeze repairs an unregistered carried Card B",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8622),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+    const card = await game.player.spawnItem(CARD_ARCHETYPE);
+    assert.equal(
+      (await game.player.inventory()).items.find((item) => item.entity_id === card.entity_id)
+        ?.location,
+      "inventory",
+      "setup must stage the exact authored card in the backpack",
+    );
+
+    await game.input.set("head.look", [0, 0]);
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 8 });
+    const active = (await game.ui.state()).active_panel;
+    const cardElement = active?.elements.find(
+      (element) => element.kind === "button" && element.entity_id === card.entity_id,
+    );
+    assert.ok(cardElement, "VR backpack must expose the staged Card B button");
+    await squeezeWorldPanelElement(
+      game,
+      BACKPACK_PANEL_SIZE_PX,
+      VR_BACKPACK_WORLD_SCALE,
+      cardElement,
+    );
+    await assertCardCollectedAndDoorOpens(game, CARD_ARCHETYPE);
+  },
+);


### PR DESCRIPTION
## Summary

- route every `PropKeySrc` acquisition gesture through the derived `internal_keycard` Frob semantics
- cover corpse/container Take, VR panel squeeze, direct VR world squeeze, and held-card trigger recovery while leaving ordinary MOVE loot grabbable
- add default-VR Hydro2 regressions for authentic corpse 754 / Card B 942 and backpack acquisition, then verify reader 1120 opens HydroSectorB door 1127 without `hackfail`

## Play-through configuration

- scenario: `hydroponics`
- detail: `detailed`
- presentation: `VR`
- assets: `25th Anniversary`
- seed: `392917474`

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (904 passed)
- `cd tools/shock2-sdk && npm test` (310 tests; 26 passed, 284 e2e-gated)
- focused production VR E2E: 2 passed (`hydro2-vr-keycard.e2e.test.ts`)

## Visual verification

![VR keycard acquisition demo](https://gist.githubusercontent.com/tommy-xr/d0f1bdcf8cbec4118aa47b44f2ee9e46/raw/keycard-acquisition.gif)

<sub>Same deterministic default-VR Hydro2 sequence on base and fix: open corpse 754's real world panel and squeeze Card B 942. Before, the physical card enters the hand and the reader answers `hackfail`; after, the credential is collected and door 1127 moves from y=0.1 to y=3.7. Captured headlessly through `/v1/step` + `/v1/screenshot`.</sub>

### Before → after

![Before and after Card B acquisition](https://gist.githubusercontent.com/tommy-xr/d0f1bdcf8cbec4118aa47b44f2ee9e46/raw/before-after.png)

Fixes #583
