### PR TITLE
refactor(audio): centralize logged playback

### DIFF
--- a/shock2vr/src/audio_log.rs
+++ b/shock2vr/src/audio_log.rs
@@ -21,11 +21,18 @@
 //! span a level transition; `sim_time` stays monotonic across one.
 
 use std::collections::VecDeque;
+use std::rc::Rc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use cgmath::Vector3;
+use engine::audio::{
+    AudioChannel, AudioClip, AudioContext, AudioHandle, AudioPlaybackSettings,
+    play_audio_with_settings, play_spatial_audio_with_gain,
+};
 use serde::Serialize;
+use shipyard::EntityId;
 
 const MAX_ENTRIES: usize = 64;
 
@@ -74,8 +81,8 @@ pub struct PlayedSound {
     pub still_playing: bool,
 }
 
-/// Arguments for [`record`], grouped so call sites stay readable.
-pub struct SoundRecord<'a> {
+/// Complete arguments for inserting one entry into the ring buffer.
+struct SoundRecord<'a> {
     pub sample: &'a str,
     pub volume_millibels: Option<i32>,
     pub gain: f32,
@@ -86,6 +93,45 @@ pub struct SoundRecord<'a> {
     pub duration: Option<Duration>,
     pub source_entity: Option<SourceEntity>,
     pub handle: Option<u64>,
+}
+
+/// Metadata mirrored into the audio log by [`play_and_record`]. Playback-owned
+/// fields (gain, position, pan application, clip duration and handle id) are
+/// filled from the same arguments used to start the sink, so they cannot drift
+/// from the real play.
+pub struct PlayRecord<'a> {
+    pub sample: &'a str,
+    pub volume_millibels: Option<i32>,
+    pub pan_millibels: Option<i32>,
+    pub tags: Vec<(String, String)>,
+    pub source_entity: Option<SourceEntity>,
+}
+
+/// The two playback paths supported by [`play_and_record`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PlayOptions {
+    ListenerRelative(AudioPlaybackSettings),
+    Spatial {
+        position: Vector3<f32>,
+        source: Option<EntityId>,
+        gain: f32,
+    },
+}
+
+impl PlayOptions {
+    fn recorded_position(self) -> [f32; 3] {
+        match self {
+            Self::ListenerRelative(_) => [0.0, 0.0, 0.0],
+            Self::Spatial { position, .. } => [position.x, position.y, position.z],
+        }
+    }
+
+    fn recorded_gain(self) -> f32 {
+        match self {
+            Self::ListenerRelative(settings) => settings.gain,
+            Self::Spatial { gain, .. } => gain,
+        }
+    }
 }
 
 static RECENT: Mutex<(u64, VecDeque<PlayedSound>)> = Mutex::new((0, VecDeque::new()));
@@ -104,6 +150,79 @@ fn sim_time() -> f64 {
     f64::from_bits(SIM_TIME_BITS.load(Ordering::Relaxed))
 }
 
+/// Start one listener-relative or spatial sound and mirror that exact play into
+/// the debug audio log. The duration and handle id are captured before their
+/// owners move into the engine, and preempted plays are retired before the new
+/// record is inserted so reusing a handle cannot stop its replacement.
+pub fn play_and_record(
+    audio_context: &mut AudioContext<EntityId, String>,
+    handle: AudioHandle,
+    channel: Option<AudioChannel>,
+    clip: Rc<AudioClip>,
+    options: PlayOptions,
+    record: PlayRecord<'_>,
+) -> Vec<u64> {
+    play_and_record_with(
+        handle,
+        channel,
+        clip,
+        options,
+        record,
+        |handle, channel, clip, options| match options {
+            PlayOptions::ListenerRelative(settings) => {
+                play_audio_with_settings(audio_context, handle, channel, clip, settings)
+            }
+            PlayOptions::Spatial {
+                position,
+                source,
+                gain,
+            } => play_spatial_audio_with_gain(
+                audio_context,
+                position,
+                source,
+                handle,
+                channel,
+                clip,
+                gain,
+            ),
+        },
+    )
+}
+
+fn play_and_record_with<F>(
+    handle: AudioHandle,
+    channel: Option<AudioChannel>,
+    clip: Rc<AudioClip>,
+    options: PlayOptions,
+    record_args: PlayRecord<'_>,
+    play: F,
+) -> Vec<u64>
+where
+    F: FnOnce(AudioHandle, Option<AudioChannel>, Rc<AudioClip>, PlayOptions) -> Vec<u64>,
+{
+    let duration = clip.total_duration();
+    let handle_id = handle.id();
+    let position = options.recorded_position();
+    let gain = options.recorded_gain();
+    let pan_applied =
+        record_args.pan_millibels.is_some() && matches!(options, PlayOptions::ListenerRelative(_));
+    let preempted = play(handle, channel, clip, options);
+    record_stops(&preempted);
+    record(SoundRecord {
+        sample: record_args.sample,
+        volume_millibels: record_args.volume_millibels,
+        gain,
+        pan_millibels: record_args.pan_millibels,
+        pan_applied,
+        tags: record_args.tags,
+        position,
+        duration,
+        source_entity: record_args.source_entity,
+        handle: Some(handle_id),
+    });
+    preempted
+}
+
 /// `sim_time` expressed in fixed 60 Hz frames. Shared with
 /// [`crate::message_trace`], which stamps its entries the same way.
 pub(crate) fn frame_of(sim_time: f64) -> u64 {
@@ -111,7 +230,7 @@ pub(crate) fn frame_of(sim_time: f64) -> u64 {
 }
 
 /// Record a successfully resolved + played sound.
-pub fn record(record: SoundRecord) {
+fn record(record: SoundRecord) {
     let sim_time = sim_time();
     let mut guard = RECENT.lock().unwrap();
     let (next_sequence, entries) = &mut *guard;
@@ -141,7 +260,7 @@ pub fn record(record: SoundRecord) {
 /// Mark several handles stopped at once - used for the plays a new play
 /// preempts (a single-slot channel, or a reused handle), which never reach
 /// `Effect::StopSound`.
-pub fn record_stops(handles: &[u64]) {
+fn record_stops(handles: &[u64]) {
     for handle in handles {
         record_stop(*handle);
     }
@@ -262,5 +381,133 @@ mod tests {
         assert_eq!(mine.len(), 2);
         assert_eq!(mine[0].stopped_at_sim_time, None);
         assert!(mine[1].stopped_at_sim_time.is_some());
+    }
+
+    #[test]
+    fn shared_play_retires_a_reused_handle_before_recording_its_replacement() {
+        let handle = engine::audio::AudioHandle::new();
+        let handle_id = handle.id();
+        let clip = std::rc::Rc::new(engine::audio::AudioClip::from_raw(1, 1, vec![0; 5]));
+
+        set_sim_time(20.0);
+        play_and_record_with(
+            handle.clone(),
+            None,
+            clip.clone(),
+            PlayOptions::ListenerRelative(engine::audio::AudioPlaybackSettings::default()),
+            PlayRecord {
+                sample: "shared-helper-reused-handle",
+                volume_millibels: None,
+                pan_millibels: None,
+                tags: vec![("kind".to_owned(), "first".to_owned())],
+                source_entity: None,
+            },
+            |_, _, _, _| vec![],
+        );
+
+        set_sim_time(21.0);
+        let preempted = play_and_record_with(
+            handle,
+            None,
+            clip,
+            PlayOptions::ListenerRelative(engine::audio::AudioPlaybackSettings::default()),
+            PlayRecord {
+                sample: "shared-helper-reused-handle",
+                volume_millibels: None,
+                pan_millibels: None,
+                tags: vec![("kind".to_owned(), "second".to_owned())],
+                source_entity: None,
+            },
+            |_, _, _, _| vec![handle_id],
+        );
+
+        let mine: Vec<_> = recent()
+            .into_iter()
+            .filter(|entry| entry.sample == "shared-helper-reused-handle")
+            .collect();
+        assert_eq!(preempted, vec![handle_id]);
+        assert_eq!(mine.len(), 2);
+        assert_eq!(mine[0].duration_secs, Some(5.0));
+        assert_eq!(mine[0].stopped_at_sim_time, Some(21.0));
+        assert!(!mine[0].still_playing);
+        assert_eq!(mine[1].stopped_at_sim_time, None);
+        assert!(mine[1].still_playing);
+    }
+
+    #[test]
+    fn shared_play_preserves_listener_relative_and_spatial_options() {
+        let clip = std::rc::Rc::new(engine::audio::AudioClip::from_raw(1, 2, vec![0; 2]));
+        let listener_settings = engine::audio::AudioPlaybackSettings {
+            gain: 0.25,
+            channel_gains: [0.5, 0.75],
+            looping: true,
+        };
+
+        play_and_record_with(
+            engine::audio::AudioHandle::new(),
+            None,
+            clip.clone(),
+            PlayOptions::ListenerRelative(listener_settings),
+            PlayRecord {
+                sample: "shared-helper-listener-relative",
+                volume_millibels: Some(-100),
+                pan_millibels: Some(500),
+                tags: vec![("kind".to_owned(), "listener".to_owned())],
+                source_entity: None,
+            },
+            |_, channel, _, options| {
+                assert!(channel.is_none());
+                assert_eq!(options, PlayOptions::ListenerRelative(listener_settings));
+                vec![]
+            },
+        );
+
+        let position = cgmath::vec3(1.0, 2.0, 3.0);
+        let source = shipyard::EntityId::new_from_index_and_gen(7, 0);
+        play_and_record_with(
+            engine::audio::AudioHandle::new(),
+            None,
+            clip,
+            PlayOptions::Spatial {
+                position,
+                source: Some(source),
+                gain: 0.75,
+            },
+            PlayRecord {
+                sample: "shared-helper-spatial",
+                volume_millibels: Some(-200),
+                pan_millibels: Some(-500),
+                tags: vec![("kind".to_owned(), "spatial".to_owned())],
+                source_entity: None,
+            },
+            |_, channel, _, options| {
+                assert!(channel.is_none());
+                assert_eq!(
+                    options,
+                    PlayOptions::Spatial {
+                        position,
+                        source: Some(source),
+                        gain: 0.75,
+                    }
+                );
+                vec![]
+            },
+        );
+
+        let listener = recent()
+            .into_iter()
+            .find(|entry| entry.sample == "shared-helper-listener-relative")
+            .unwrap();
+        assert_eq!(listener.position, [0.0, 0.0, 0.0]);
+        assert_eq!(listener.gain, 0.25);
+        assert!(listener.pan_applied);
+
+        let spatial = recent()
+            .into_iter()
+            .find(|entry| entry.sample == "shared-helper-spatial")
+            .unwrap();
+        assert_eq!(spatial.position, [1.0, 2.0, 3.0]);
+        assert_eq!(spatial.gain, 0.75);
+        assert!(!spatial.pan_applied);
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5394,31 +5394,25 @@ impl MissionCore {
                         quests.mark_email_as_played(&email_file);
                         let audio_clip =
                             asset_cache.get(&AUDIO_IMPORTER, &format!("{email_file}.wav"));
-                        let duration = audio_clip.total_duration();
                         let handle = AudioHandle::new();
-                        let preempted = engine::audio::play_audio(
+                        crate::audio_log::play_and_record(
                             audio_context,
                             handle.clone(),
                             Some(AudioChannel::new("email".to_owned())),
                             audio_clip,
+                            crate::audio_log::PlayOptions::ListenerRelative(
+                                AudioPlaybackSettings::default(),
+                            ),
+                            // Observability: record the email so the headless
+                            // e2e can assert it played (and only once).
+                            crate::audio_log::PlayRecord {
+                                sample: &email_file,
+                                volume_millibels: None,
+                                pan_millibels: None,
+                                tags: vec![("kind".to_string(), "email".to_string())],
+                                source_entity: None,
+                            },
                         );
-                        // Observability: record the email so the headless e2e
-                        // can assert it played (and only once). Anything this
-                        // play cut short (the email channel is single-slot) is
-                        // marked stopped first, so `still_playing` stays honest.
-                        crate::audio_log::record_stops(&preempted);
-                        crate::audio_log::record(crate::audio_log::SoundRecord {
-                            sample: &email_file,
-                            volume_millibels: None,
-                            gain: 1.0,
-                            pan_millibels: None,
-                            pan_applied: false,
-                            tags: vec![("kind".to_string(), "email".to_string())],
-                            position: [0.0, 0.0, 0.0],
-                            duration,
-                            source_entity: None,
-                            handle: Some(handle.id()),
-                        });
                     }
                     drop(quests);
                 }
@@ -5435,8 +5429,6 @@ impl MissionCore {
 
                     if let Some(audio_clip) = maybe_audio_clip {
                         info!("Playing clip: {} handle: {:?}", name, &handle);
-                        let duration = audio_clip.total_duration();
-                        let handle_id = handle.id();
                         let gain = resolved.linear_gain();
                         // Spatial emitters (TrapSound narrations anchored at
                         // their authored station) play at the source entity,
@@ -5449,22 +5441,14 @@ impl MissionCore {
                         } else {
                             None
                         };
-                        let preempted = if let Some(position) = maybe_position {
-                            engine::audio::play_spatial_audio_with_gain(
-                                audio_context,
+                        let play_options = if let Some(position) = maybe_position {
+                            crate::audio_log::PlayOptions::Spatial {
                                 position,
                                 source,
-                                handle,
-                                None,
-                                audio_clip,
                                 gain,
-                            )
+                            }
                         } else {
-                            engine::audio::play_audio_with_settings(
-                                audio_context,
-                                handle,
-                                None,
-                                audio_clip,
+                            crate::audio_log::PlayOptions::ListenerRelative(
                                 AudioPlaybackSettings::listener_relative(
                                     gain,
                                     resolved.channel_gains(),
@@ -5474,20 +5458,20 @@ impl MissionCore {
                         // Observability: record scripted one-shot sounds (audio
                         // logs, keypad beeps, ...) so headless tooling can assert
                         // a schema actually resolved and played.
-                        let position = maybe_position.unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
-                        crate::audio_log::record_stops(&preempted);
-                        crate::audio_log::record(crate::audio_log::SoundRecord {
-                            sample: &resolved.sample_name,
-                            volume_millibels: has_schema.then_some(resolved.volume_millibels),
-                            gain,
-                            pan_millibels: has_schema.then_some(resolved.pan_millibels),
-                            pan_applied: has_schema && maybe_position.is_none(),
-                            tags: vec![("kind".to_string(), "sound".to_string())],
-                            position: [position.x, position.y, position.z],
-                            duration,
-                            source_entity: source.map(|id| source_entity(&self.world, id)),
-                            handle: Some(handle_id),
-                        });
+                        crate::audio_log::play_and_record(
+                            audio_context,
+                            handle,
+                            None,
+                            audio_clip,
+                            play_options,
+                            crate::audio_log::PlayRecord {
+                                sample: &resolved.sample_name,
+                                volume_millibels: has_schema.then_some(resolved.volume_millibels),
+                                pan_millibels: has_schema.then_some(resolved.pan_millibels),
+                                tags: vec![("kind".to_string(), "sound".to_string())],
+                                source_entity: source.map(|id| source_entity(&self.world, id)),
+                            },
+                        );
                     } else {
                         warn!("Unable to load clip: {}", name)
                     }
@@ -5508,53 +5492,43 @@ impl MissionCore {
                         if let Some(audio_clip) = asset_cache.get_opt(&AUDIO_IMPORTER, &audio_path)
                         {
                             let handle = AudioHandle::new();
-                            let duration = audio_clip.total_duration();
-                            let handle_id = handle.id();
                             let gain = resolved.linear_gain();
                             let maybe_position = get_entity_position(&self.world, entity_id);
-                            let preempted = if let Some(position) = maybe_position {
-                                engine::audio::play_spatial_audio_with_gain(
-                                    audio_context,
+                            let play_options = if let Some(position) = maybe_position {
+                                crate::audio_log::PlayOptions::Spatial {
                                     position,
-                                    Some(entity_id),
-                                    handle,
-                                    None,
-                                    audio_clip,
+                                    source: Some(entity_id),
                                     gain,
-                                )
+                                }
                             } else {
-                                engine::audio::play_audio_with_settings(
-                                    audio_context,
-                                    handle,
-                                    None,
-                                    audio_clip,
+                                crate::audio_log::PlayOptions::ListenerRelative(
                                     AudioPlaybackSettings::listener_relative(
                                         gain,
                                         resolved.channel_gains(),
                                     ),
                                 )
                             };
-                            crate::audio_log::record_stops(&preempted);
                             // Observability: speech is the loudest source of
                             // overlapping audio, so trace it like the rest.
-                            let position = maybe_position.unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
                             let mut sound_tags = vec![
                                 ("kind".to_string(), "speech".to_string()),
                                 ("concept".to_string(), concept.clone()),
                             ];
                             sound_tags.extend(tags.iter().cloned());
-                            crate::audio_log::record(crate::audio_log::SoundRecord {
-                                sample: &resolved.sample_name,
-                                volume_millibels: Some(resolved.volume_millibels),
-                                gain,
-                                pan_millibels: Some(resolved.pan_millibels),
-                                pan_applied: maybe_position.is_none(),
-                                tags: sound_tags,
-                                position: [position.x, position.y, position.z],
-                                duration,
-                                source_entity: Some(source_entity(&self.world, entity_id)),
-                                handle: Some(handle_id),
-                            });
+                            crate::audio_log::play_and_record(
+                                audio_context,
+                                handle,
+                                None,
+                                audio_clip,
+                                play_options,
+                                crate::audio_log::PlayRecord {
+                                    sample: &resolved.sample_name,
+                                    volume_millibels: Some(resolved.volume_millibels),
+                                    pan_millibels: Some(resolved.pan_millibels),
+                                    tags: sound_tags,
+                                    source_entity: Some(source_entity(&self.world, entity_id)),
+                                },
+                            );
                         } else {
                             warn!(
                                 "Unable to load speech clip '{}' for concept '{}'",
@@ -8017,31 +7991,25 @@ fn play_environmental_sound(
         );
         // Log the resolved play so headless tooling (debug runtime
         // /v1/audio/recent) can assert a schema actually played.
-        let duration = audio_clip.total_duration();
-        let handle_id = audio_handle.id();
         let gain = resolved.linear_gain();
-        let preempted = engine::audio::play_spatial_audio_with_gain(
+        crate::audio_log::play_and_record(
             audio_context,
-            position,
-            None,
             audio_handle,
             None,
             audio_clip,
-            gain,
+            crate::audio_log::PlayOptions::Spatial {
+                position,
+                source: None,
+                gain,
+            },
+            crate::audio_log::PlayRecord {
+                sample: &resolved.sample_name,
+                volume_millibels: Some(resolved.volume_millibels),
+                pan_millibels: Some(resolved.pan_millibels),
+                tags: query.tag_values(),
+                source_entity: None,
+            },
         );
-        crate::audio_log::record_stops(&preempted);
-        crate::audio_log::record(crate::audio_log::SoundRecord {
-            sample: &resolved.sample_name,
-            volume_millibels: Some(resolved.volume_millibels),
-            gain,
-            pan_millibels: Some(resolved.pan_millibels),
-            pan_applied: false,
-            tags: query.tag_values(),
-            position: [position.x, position.y, position.z],
-            duration,
-            source_entity: None,
-            handle: Some(handle_id),
-        });
     }
 }
 

--- a/shock2vr/src/ui/frontend_sfx.rs
+++ b/shock2vr/src/ui/frontend_sfx.rs
@@ -25,9 +25,7 @@
 
 use engine::{
     assets::asset_cache::AssetCache,
-    audio::{
-        AudioContext, AudioHandle, AudioPlaybackSettings, play_audio_with_settings, stop_audio,
-    },
+    audio::{AudioContext, AudioHandle, AudioPlaybackSettings, stop_audio},
 };
 use shipyard::EntityId;
 use tracing::warn;
@@ -186,22 +184,20 @@ impl<TWidget: Copy + PartialEq> FrontendSfx<TWidget> {
             self.unavailable = true;
             return false;
         };
-        let duration = clip.total_duration();
-        let preempted =
-            play_audio_with_settings(audio_context, handle.clone(), None, clip, settings);
-        crate::audio_log::record_stops(&preempted);
-        crate::audio_log::record(crate::audio_log::SoundRecord {
-            sample: name,
-            volume_millibels: None,
-            gain: settings.gain,
-            pan_millibels: None,
-            pan_applied: false,
-            tags: vec![("kind".to_owned(), "menu".to_owned())],
-            position: [0.0, 0.0, 0.0],
-            duration,
-            source_entity: None,
-            handle: Some(handle.id()),
-        });
+        crate::audio_log::play_and_record(
+            audio_context,
+            handle.clone(),
+            None,
+            clip,
+            crate::audio_log::PlayOptions::ListenerRelative(settings),
+            crate::audio_log::PlayRecord {
+                sample: name,
+                volume_millibels: None,
+                pan_millibels: None,
+                tags: vec![("kind".to_owned(), "menu".to_owned())],
+                source_entity: None,
+            },
+        );
         true
     }
 }


### PR DESCRIPTION
## Reproduction

On exact `origin/main` `42fdf125`, the same clip-load / duration / play / preemption-log / play-log sequence was hand-written in five places:

- `Effect::PlayEmail`
- `Effect::PlaySound`
- `Effect::PlaySpeech`
- `play_environmental_sound`
- `FrontendSfx::play`

The copies independently carried the easy-to-drop semantics from #982: query `total_duration()` before moving the clip, preserve listener-relative versus spatial playback settings, return and retire channel/handle preemptions before inserting the replacement record, and mirror the exact handle, tags, position, and stable source identity into `GET /v1/audio/recent`.

The negative-first helper tests failed on base with 14 missing-symbol errors because no shared playback/logging seam existed.

## Refactor

- add `audio_log::play_and_record`, covering listener-relative and spatial playback while returning the preempted handle ids
- derive logged gain, position, pan application, duration, and handle directly from the real playback inputs
- keep playback's runtime source `EntityId` separate from the stable `SourceEntity` recorded for cross-run diagnostics
- retire preempted records before inserting the replacement, including reused-handle plays
- make direct ring insertion and bulk preemption recording private so future callers must use the complete seam
- migrate all five existing call sites without changing playback, tags, channel behavior, or attribution

## Verification

All runtime verification explicitly used the verified System Shock 2 25th Anniversary Remaster root `/Users/bryan/ss2-25th`, sentinel `/Users/bryan/ss2-25th/sshock2.kpf`, with the remaster `mods/*.kpf` assets present.

- negative-first focused helper test: failed on base with 14 missing seam symbols
- `cargo test -p shock2vr audio_log::tests`: 6 passed
- `cargo test -p shock2vr --lib`: 903 passed
- `RUSTFLAGS=-Dwarnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed
- `cargo fmt --all -- --check`: passed
- SDK unit suite: 26 passed, 282 E2E-gated tests skipped as designed
- focused 25AE `/v1/audio/recent` matrix: 7 passed, covering spatial sound gain/source/position/duration + stop, email playback, environmental collision tags/position, frontend looping/lifecycle, and flat/VR parity
- full serialized 25AE SDK E2E: 297 passed, 3 failed, 8 explicit fixture skips; all 23 mission loads and every audio-focused scenario passed
  - creature-loot reader MFD state and Hydro3 Korenchkin transcript spacing are known unrelated current-main baselines
  - the unrelated MedSci saved-Wrench contact failure passed immediately in isolated rerun (2/2 melee scenarios passed)

## Visual verification

Manager-approved non-renderable rationale: this is an internal behavior-preserving consolidation whose contract is that audible playback and every rendered frame remain exactly unchanged. Its observable acceptance surface is the playback options/preemption ordering and `GET /v1/audio/recent`; a screenshot or GIF cannot exercise whether the shared bookkeeping seam was used and would therefore provide misleading evidence. Semantic unit tests plus matched runtime audio-log scenarios are the appropriate proof, so no visual media is attached.

Fixes #982
