### PR TITLE
test(projectiles): make shooter filter tests nonvacuous

### DIFF
--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -323,18 +323,34 @@ mod tests {
     use crate::creature::{HitBoxType, RuntimePropHitBox};
     use crate::physics::PhysicsWorld;
     use cgmath::{Quaternion, point3, vec3};
-    use dark::SCALE_FACTOR;
     use dark::properties::PropCreature;
     use shipyard::{EntityId, World};
 
-    #[test]
-    fn projectile_raycast_hits_the_player_collider() {
+    fn shooter_and_target_fixture() -> (PhysicsWorld, World, EntityId, EntityId) {
         let mut physics = PhysicsWorld::new();
+        // Put the player's capsule between the ray origin and the target so
+        // changing only the PLAYER mask changes which entity the ray hits.
         let player_entity = EntityId::from_inner(1).unwrap();
-        let mut player = physics.create_player(vec3(0.0, 0.0, 5.0), player_entity);
+        let mut player = physics.create_player(vec3(0.0, 0.0, 2.0), player_entity);
+
+        let target = EntityId::from_inner(2).unwrap();
+        physics.add_kinematic(
+            target,
+            vec3(0.0, 0.0, 5.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(2.0, 2.0, 2.0),
+            crate::physics::CollisionGroup::selectable(),
+            false,
+        );
         physics.update(vec3(0.0, 0.0, 0.0), &mut player);
 
-        let world = World::new();
+        (physics, World::new(), player_entity, target)
+    }
+
+    #[test]
+    fn projectile_raycast_hits_the_player_collider() {
+        let (physics, world, player_entity, _target) = shooter_and_target_fixture();
         let hit = projectile_ray_cast(
             point3(0.0, 0.0, 0.0),
             vec3(0.0, 0.0, 1.0),
@@ -351,43 +367,22 @@ mod tests {
         );
     }
 
-    /// The flat crosshair ray starts at the player's eye, which is inside the
-    /// player's own capsule (the eye is the head sphere). A solid raycast
-    /// reports a containing shape as a distance-0 hit, so the player's own
-    /// collider must be excluded or every flat shot hits the shooter.
     #[test]
-    fn camera_origin_projectile_shoots_past_the_shooters_own_collider() {
-        let mut physics = PhysicsWorld::new();
-        let player_entity = EntityId::from_inner(1).unwrap();
-        let mut player = physics.create_player(vec3(0.0, 0.0, 0.0), player_entity);
-        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
-        // The eye: on the capsule axis, inside the player's own collider.
-        let body = physics.get_player_translation(&player);
-        let eye = point3(
-            body.x,
-            body.y + crate::PLAYER_EYE_HEIGHT / SCALE_FACTOR,
-            body.z,
-        );
-
-        let target = EntityId::from_inner(2).unwrap();
-        physics.add_kinematic(
-            target,
-            vec3(0.0, eye.y, 5.0),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            vec3(0.0, 0.0, 0.0),
-            vec3(2.0, 2.0, 2.0),
-            crate::physics::CollisionGroup::selectable(),
+    fn player_fired_projectile_raycast_shoots_past_the_shooters_collider() {
+        let (physics, world, _player_entity, target) = shooter_and_target_fixture();
+        let hit = projectile_ray_cast(
+            point3(0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 1.0),
+            &physics,
+            10.0,
+            &world,
             false,
         );
-        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
-
-        let world = World::new();
-        let hit = projectile_ray_cast(eye, vec3(0.0, 0.0, 1.0), &physics, 10.0, &world, false);
 
         assert_eq!(
             hit.and_then(|result| result.maybe_entity_id),
             Some(target),
-            "a shot fired from the player's own eye must reach the target, not the shooter",
+            "a player-fired ray must reach the target, not the shooter",
         );
     }
 


### PR DESCRIPTION
## Reproduction

On exact `origin/main` `42fdf125`, the two `internal_fast_projectile` raycast tests passed in their normal configuration. Swapping both `can_hit_player` arguments showed that the issue's blanket claim was only partly true on current main:

- `projectile_raycast_hits_the_player_collider` correctly failed when changed from `true` to `false` (`left: None`, `right: Some(player)`)
- `camera_origin_projectile_shoots_past_the_shooters_own_collider` still passed when changed from `false` to `true`

A direct PLAYER-only ray from that test's computed eye `(0, 1.04, 0)` also returned `None`. The ray started inside the player capsule, but this `cast_ray_and_get_normal` query did not report the containing collider, so the purported safety assertion reached the target regardless of the PLAYER mask.

## Fix

- build one shared physics fixture with the player capsule physically between the ray origin and a selectable target
- exercise both sides of the actual mask contract: AI/turret rays include PLAYER and hit the player; player-fired rays exclude PLAYER and reach the target
- rename the exclusion test and remove the false camera-containment explanation

This changes tests only; runtime behavior is unchanged.

## Mutation proof

Temporarily inverting the production mask branch from `if can_hit_player` to `if !can_hit_player` makes both safety branches fail:

- include-player test: `left: Some(target)`, `right: Some(player)`
- exclude-player test: `left: Some(player)`, `right: Some(target)`

After restoring the production branch, the focused module is green: 3 passed, 0 failed.

The nearby negative ownership test was audited too: temporarily inverting `hitbox.parent_entity_id == parent` to `!= parent` makes `refined_hitbox_must_belong_to_the_coarse_creature` fail immediately, so it does not share this vacuous-setup problem.

## Verification

- `cargo test -p shock2vr --lib` — 901 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed
- `cargo fmt --all -- --check` — passed
- post-rebase `cargo test -p shock2vr internal_fast_projectile::tests` — 3 passed
- `git diff --check` — passed

The verified 25th Anniversary root is `/Users/bryan/ss2-25th` with sentinel `/Users/bryan/ss2-25th/sshock2.kpf` and remaster `mods/*.kpf` present. No runtime or SDK E2E was run because this patch changes only `#[cfg(test)]` code and does not need assets to validate the fixture.

## Visual verification

Manager-approved non-renderable rationale: this patch changes only test fixture construction and assertions; the compiled non-test/runtime behavior is byte-for-byte unchanged. Its acceptance surface is whether the automated suite detects an inverted PLAYER collision-mask safety property, and both branches now fail under inversion. No rendered frame or sequence can show test sensitivity, so a GIF or PNG would be misleading rather than evidence.

Fixes #1052
