### PR TITLE
fix(vr): draw world loot panels over their host geometry

### DIFF
--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use cgmath::{Deg, EuclideanSpace, InnerSpace, Matrix4, Vector2, Vector3, vec3};
 
-use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+use engine::{
+    assets::asset_cache::AssetCache,
+    scene::{RenderLayer, SceneObject},
+};
 use rapier3d::prelude::RigidBodyHandle;
 use shipyard::{Component, EntitiesView, EntityId, Get, UniqueView, View, World};
 
@@ -443,7 +446,20 @@ impl GuiManager {
             let canvas = UiCanvas::from_elements(size_px, elements);
             let z_step =
                 COMPONENT_Z_STEP.min(PANEL_DEPTH_BUDGET / canvas.element_count().max(1) as f32);
-            ret.extend(canvas.render_world_space(asset_cache, root_transform, None, None, z_step));
+            let mut panel_objects =
+                canvas.render_world_space(asset_cache, root_transform, None, None, z_step);
+            // Draw over everything the panel's own host mesh might otherwise
+            // occlude it with (issue #1100: a wide host like Hydro3 Desk #2
+            // encloses the panel plane, burying it behind the desk's own
+            // geometry). `SceneUi` is the same "draw over the world" layer the
+            // per-eye HUD/viewmodel are bumped into (see `lib.rs`); it clears
+            // depth at its own group boundary and is drawn before
+            // `SystemOverlay`, so the pause menu and cyber interface still
+            // draw over an open panel.
+            for object in &mut panel_objects {
+                object.set_render_layer(RenderLayer::SceneUi);
+            }
+            ret.extend(panel_objects);
 
             // gui_obj.set_local_transform(
             //     Matrix4::from_translation(info.offset)

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -1,7 +1,6 @@
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::{
-    FrobFlag, Link, PhysicsModelType, PropFrobInfo, PropInventoryDimensions, PropObjIcon,
-    PropPhysDimensions, PropPhysType, ReceptronEffect,
+    FrobFlag, Link, PropFrobInfo, PropInventoryDimensions, PropObjIcon, ReceptronEffect,
 };
 
 use shipyard::{EntityId, Get, View, World};
@@ -85,12 +84,6 @@ const BACKPACK_GRID_ORIGIN: Vector2<f32> = Vector2::new(4.0, 17.0);
 /// `res/iface/BLOCK.PCX` is authored to cover one cell's 34x32 interior,
 /// leaving the separators in `INVBACK.PCX` visible around it.
 const BLOCK_SIZE: Vector2<f32> = Vector2::new(34.0, 32.0);
-
-/// Keep the thin world-panel collider wholly outside an authored host OBB.
-/// Rapier clamps its zero authored depth to 0.01 world units; this leaves a
-/// further half-thickness of air so the host can never win the hand ray at
-/// coincident surfaces.
-const LOOT_PANEL_HOST_CLEARANCE: f32 = 0.01;
 
 impl ContainerGui {
     pub fn loot_container() -> ContainerGui {
@@ -273,37 +266,6 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             world_offset: Vector3::new(0.0, if self.take_on_click { 1.0 } else { 0.0 }, 0.0),
             screen_size_in_pixels: Vector2::new(self.width, self.height),
         }
-    }
-
-    fn get_config_for(
-        &self,
-        entity_id: EntityId,
-        world: &World,
-        _state: &ContainerGuiState,
-    ) -> GuiConfig {
-        let mut config = self.get_config();
-        if !self.take_on_click {
-            return config;
-        }
-
-        // The canvas rects are shared by flat and VR. This named hosting
-        // conversion only places the already-resolved loot canvas on the
-        // physical object's local front surface in VR. Without it, wide hosts
-        // such as Hydro3 Desk #2 enclose the panel plane and occlude its lower
-        // rows from the production controller ray.
-        if let Ok((dimensions, phys_types)) =
-            world.borrow::<(View<PropPhysDimensions>, View<PropPhysType>)>()
-            && let (Ok(dimensions), Ok(phys_type)) =
-                (dimensions.get(entity_id), phys_types.get(entity_id))
-            && phys_type.phys_type == PhysicsModelType::ORIENTED_BOUNDING_BOX
-            && dimensions.offset0.z.is_finite()
-            && dimensions.size.z.is_finite()
-            && dimensions.size.z != 0.0
-        {
-            config.world_offset.z =
-                dimensions.offset0.z - dimensions.size.z.abs() / 2.0 - LOOT_PANEL_HOST_CLEARANCE;
-        }
-        config
     }
 
     /// A creature's loot panel opens on frob only when it is lootable (corpse
@@ -704,50 +666,6 @@ mod tests {
         assert_eq!(
             ContainerGui::loot_container().get_config().world_offset,
             vec3(0.0, 1.0, 0.0)
-        );
-    }
-
-    #[test]
-    fn loot_panel_sits_in_front_of_the_hosts_authored_collider() {
-        let mut world = World::new();
-        let desk_dimensions = PropPhysDimensions {
-            radius0: 0.0,
-            radius1: 0.0,
-            offset0: vec3(0.0, -0.072, 0.0),
-            offset1: vec3(0.0, 0.0, 0.0),
-            size: vec3(-3.2, 1.28, 1.2),
-            unk1: 0,
-            unk2: 0,
-        };
-        let desk = world.add_entity((
-            desk_dimensions.clone(),
-            PropPhysType {
-                phys_type: PhysicsModelType::ORIENTED_BOUNDING_BOX,
-                num_submodels: 6,
-                remove_on_sleep: false,
-                is_special: false,
-            },
-        ));
-
-        let config =
-            ContainerGui::loot_container().get_config_for(desk, &world, &ContainerGuiState {});
-        let front_face = desk_dimensions.offset0.z - desk_dimensions.size.z.abs() / 2.0;
-
-        assert_eq!(
-            config.world_offset.y, 1.0,
-            "keep the authored loot-panel lift"
-        );
-        assert!(
-            config.world_offset.z < front_face,
-            "the panel plane at z={} must clear the host front face at z={front_face}",
-            config.world_offset.z
-        );
-        assert_eq!(
-            ContainerGui::inv_container()
-                .get_config_for(desk, &world, &ContainerGuiState {})
-                .world_offset,
-            vec3(0.0, 0.0, 0.0),
-            "the player backpack is head-positioned, not hosted on the desk"
         );
     }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -1,6 +1,7 @@
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::{
-    FrobFlag, Link, PropFrobInfo, PropInventoryDimensions, PropObjIcon, ReceptronEffect,
+    FrobFlag, Link, PhysicsModelType, PropFrobInfo, PropInventoryDimensions, PropObjIcon,
+    PropPhysDimensions, PropPhysType, ReceptronEffect,
 };
 
 use shipyard::{EntityId, Get, View, World};
@@ -84,6 +85,12 @@ const BACKPACK_GRID_ORIGIN: Vector2<f32> = Vector2::new(4.0, 17.0);
 /// `res/iface/BLOCK.PCX` is authored to cover one cell's 34x32 interior,
 /// leaving the separators in `INVBACK.PCX` visible around it.
 const BLOCK_SIZE: Vector2<f32> = Vector2::new(34.0, 32.0);
+
+/// Keep the thin world-panel collider wholly outside an authored host OBB.
+/// Rapier clamps its zero authored depth to 0.01 world units; this leaves a
+/// further half-thickness of air so the host can never win the hand ray at
+/// coincident surfaces.
+const LOOT_PANEL_HOST_CLEARANCE: f32 = 0.01;
 
 impl ContainerGui {
     pub fn loot_container() -> ContainerGui {
@@ -266,6 +273,37 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             world_offset: Vector3::new(0.0, if self.take_on_click { 1.0 } else { 0.0 }, 0.0),
             screen_size_in_pixels: Vector2::new(self.width, self.height),
         }
+    }
+
+    fn get_config_for(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        _state: &ContainerGuiState,
+    ) -> GuiConfig {
+        let mut config = self.get_config();
+        if !self.take_on_click {
+            return config;
+        }
+
+        // The canvas rects are shared by flat and VR. This named hosting
+        // conversion only places the already-resolved loot canvas on the
+        // physical object's local front surface in VR. Without it, wide hosts
+        // such as Hydro3 Desk #2 enclose the panel plane and occlude its lower
+        // rows from the production controller ray.
+        if let Ok((dimensions, phys_types)) =
+            world.borrow::<(View<PropPhysDimensions>, View<PropPhysType>)>()
+            && let (Ok(dimensions), Ok(phys_type)) =
+                (dimensions.get(entity_id), phys_types.get(entity_id))
+            && phys_type.phys_type == PhysicsModelType::ORIENTED_BOUNDING_BOX
+            && dimensions.offset0.z.is_finite()
+            && dimensions.size.z.is_finite()
+            && dimensions.size.z != 0.0
+        {
+            config.world_offset.z =
+                dimensions.offset0.z - dimensions.size.z.abs() / 2.0 - LOOT_PANEL_HOST_CLEARANCE;
+        }
+        config
     }
 
     /// A creature's loot panel opens on frob only when it is lootable (corpse
@@ -666,6 +704,50 @@ mod tests {
         assert_eq!(
             ContainerGui::loot_container().get_config().world_offset,
             vec3(0.0, 1.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn loot_panel_sits_in_front_of_the_hosts_authored_collider() {
+        let mut world = World::new();
+        let desk_dimensions = PropPhysDimensions {
+            radius0: 0.0,
+            radius1: 0.0,
+            offset0: vec3(0.0, -0.072, 0.0),
+            offset1: vec3(0.0, 0.0, 0.0),
+            size: vec3(-3.2, 1.28, 1.2),
+            unk1: 0,
+            unk2: 0,
+        };
+        let desk = world.add_entity((
+            desk_dimensions.clone(),
+            PropPhysType {
+                phys_type: PhysicsModelType::ORIENTED_BOUNDING_BOX,
+                num_submodels: 6,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+        ));
+
+        let config =
+            ContainerGui::loot_container().get_config_for(desk, &world, &ContainerGuiState {});
+        let front_face = desk_dimensions.offset0.z - desk_dimensions.size.z.abs() / 2.0;
+
+        assert_eq!(
+            config.world_offset.y, 1.0,
+            "keep the authored loot-panel lift"
+        );
+        assert!(
+            config.world_offset.z < front_face,
+            "the panel plane at z={} must clear the host front face at z={front_face}",
+            config.world_offset.z
+        );
+        assert_eq!(
+            ContainerGui::inv_container()
+                .get_config_for(desk, &world, &ContainerGuiState {})
+                .world_offset,
+            vec3(0.0, 0.0, 0.0),
+            "the player backpack is head-positioned, not hosted on the desk"
         );
     }
 

--- a/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
@@ -8,9 +8,19 @@ import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 
 // Production-VR regression for #1100. Hydro3 mission Desk #2 (2116) has an
 // authored desk_sd OBB and Contains the deck-3/log-16 Audio Log (200) in its
-// third row. Before the fix the panel plane is at the host origin: that row's
-// y=1.671..1.807 span is below the desk top at y=1.809, so the production hand
-// ray hits the desk before its UI proxy and the log cannot be collected.
+// third row. Before the fix the panel plane rendered inside the desk mesh:
+// that row's y=1.671..1.807 span is below the desk top at y=1.809, so the
+// desk's own geometry buried the panel and it z-fought/occluded rather than
+// showing (clickable via #1115's host-bypass hit-testing, but not visible).
+//
+// #1115 already fixed hit-testing (a panel bypasses its own host collider),
+// so this no longer asserts on a raw nearest-hit raycast against world
+// geometry - that guards physics, not what the player sees. Instead it
+// asserts the player-observable outcomes: the buried row is still clickable
+// end-to-end (aim + trigger collects it), and the panel's rendered quads
+// report the render-over-everything overlay layer rather than the ordinary
+// world layer that would let the desk occlude them (see `GuiManager` in
+// `shock2vr/src/gui/gui_manager.rs`).
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const HYDRO3_DESK_2 = 2116;
@@ -19,7 +29,7 @@ const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 
 test(
-  "Hydro3 Desk #2 exposes log 200 in front of its collider to the production VR hand",
+  "Hydro3 Desk #2 draws log 200 over its collider and lets the production VR hand collect it",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -43,6 +53,18 @@ test(
     );
 
     await teleportVerified(game, { x: 29.2, y: 1.644, z: -3.2 });
+
+    // Before the panel opens, no world-panel quads are on the render-over
+    // layer (only the ordinary world scene is up).
+    const sceneUiBeforeOpen = (await game.scene.objects()).objects.filter(
+      (object) => object.render_layer === "scene_ui",
+    );
+    assert.equal(
+      sceneUiBeforeOpen.length,
+      0,
+      "no scene_ui-layer geometry should exist before any panel is open",
+    );
+
     const deskAim = await game.player.aimAt(desk, {
       hitbox: "center",
       visibility: "required",
@@ -61,6 +83,26 @@ test(
     );
     assert.ok(logButton, "the third loot row must render Audio Log 200");
 
+    // Visual claim: the open panel's quads must be on the depth-bypass
+    // overlay layer (`scene_ui`), the same "draw over the world" layer the
+    // per-eye HUD/viewmodel use - not the ordinary `world` layer a wide host
+    // like Desk #2 can depth-test in front of and bury. Every panel element
+    // (background, row art, text, cursor) becomes at least one opaque quad,
+    // so opening the panel must add at least that many scene_ui objects, and
+    // none of them may be the see-through-the-world default (depth_write
+    // false would mean the panel could show the desk drawn through it).
+    const sceneUiAfterOpen = (await game.scene.objects()).objects.filter(
+      (object) => object.render_layer === "scene_ui",
+    );
+    assert.ok(
+      sceneUiAfterOpen.length >= panelState.elements.length,
+      `opening Desk #2's panel must add at least ${panelState.elements.length} scene_ui objects, got ${sceneUiAfterOpen.length}`,
+    );
+    assert.ok(
+      sceneUiAfterOpen.every((object) => object.depth_write),
+      "every panel quad must write depth so it still self-occludes correctly, just not against the world",
+    );
+
     const panelBodies = (await game.physics.bodies()).bodies.filter((body) =>
       body.collision_groups.includes("ui"),
     );
@@ -76,19 +118,11 @@ test(
     ];
     const localLog: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
     const logWorld = add(panel.position, quatRotate(panel.rotation, localLog));
-    const handRay = await aimVrHandAt(game, logWorld, 0.35);
-    const nearestHit = await game.raycast({
-      start: handRay.start,
-      end: handRay.target,
-      collision_groups: ["all"],
-      max_distance: 1,
-    });
-    assert.equal(
-      nearestHit.entity_id,
-      panel.entity_id,
-      `the production ray must reach the log row before the desk (got ${JSON.stringify(nearestHit)})`,
-    );
+    await aimVrHandAt(game, logWorld, 0.35);
 
+    // The buried row is still clickable end-to-end through the production
+    // hand path (#1115's host-bypass hit-testing) - the point of this
+    // regression is that it is now also visible, asserted above.
     await game.input.set("right_hand.trigger", 1);
     await game.step({ frames: 2 });
     await game.input.set("right_hand.trigger", 0);

--- a/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Production-VR regression for #1100. Hydro3 mission Desk #2 (2116) has an
+// authored desk_sd OBB and Contains the deck-3/log-16 Audio Log (200) in its
+// third row. Before the fix the panel plane is at the host origin: that row's
+// y=1.671..1.807 span is below the desk top at y=1.809, so the production hand
+// ray hits the desk before its UI proxy and the log cannot be collected.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const HYDRO3_DESK_2 = 2116;
+const HYDRO3_AUDIO_LOG = 200;
+const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+
+test(
+  "Hydro3 Desk #2 exposes log 200 in front of its collider to the production VR hand",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8600),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [desk] = await game.entities.byTemplate(HYDRO3_DESK_2);
+    assert.ok(desk, "hydro3 must contain Desk #2 mission object 2116");
+    const contains = (await game.entities.detail(desk.id)).outgoing_links.filter((link) =>
+      link.link_type.startsWith("Contains"),
+    );
+    const logLink = contains.find((link) => link.target_name === "Audio Log");
+    assert.ok(logLink, "Desk #2 must contain its Audio Log");
+    assert.equal(
+      (await game.entities.detail(logLink.target_id)).template_id,
+      HYDRO3_AUDIO_LOG,
+      "the contained disc must be mission object 200",
+    );
+
+    await teleportVerified(game, { x: 29.2, y: 1.644, z: -3.2 });
+    const deskAim = await game.player.aimAt(desk, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(deskAim.target_confirmed, true, "Desk #2 must be hand-reachable");
+    await aimVrHandAt(game, deskAim.world_point);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    const panelState = (await game.ui.state()).active_panel;
+    assert.equal(panelState?.template_id, HYDRO3_DESK_2, "the real desk frob must open its panel");
+    const logButton = panelState.elements.find(
+      (element) => element.kind === "button" && element.entity_id === logLink.target_id,
+    );
+    assert.ok(logButton, "the third loot row must render Audio Log 200");
+
+    const panelBodies = (await game.physics.bodies()).bodies.filter((body) =>
+      body.collision_groups.includes("ui"),
+    );
+    assert.equal(panelBodies.length, 1, "exactly one world panel should be open");
+    const panel = panelBodies[0];
+    const [x, y, width, height] = logButton.rect;
+    const u = (x + width / 2) / PANEL_SIZE_PX[0];
+    const v = (y + height / 2) / PANEL_SIZE_PX[1];
+    const panelSize: Vec3 = [
+      PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
+      PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
+      0,
+    ];
+    const localLog: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+    const logWorld = add(panel.position, quatRotate(panel.rotation, localLog));
+    const handRay = await aimVrHandAt(game, logWorld, 0.35);
+    const nearestHit = await game.raycast({
+      start: handRay.start,
+      end: handRay.target,
+      collision_groups: ["all"],
+      max_distance: 1,
+    });
+    assert.equal(
+      nearestHit.entity_id,
+      panel.entity_id,
+      `the production ray must reach the log row before the desk (got ${JSON.stringify(nearestHit)})`,
+    );
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    assert.ok(
+      (await game.info()).player.collected_logs.some(
+        (log) => log.deck === 3 && log.log === 16,
+      ),
+      "clicking the visible row must collect deck-3/log-16",
+    );
+    assert.ok(
+      !(await game.ui.state()).active_panel?.elements.some(
+        (element) => element.entity_id === logLink.target_id,
+      ),
+      "the collected log must leave the desk panel",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #1100

## Summary

Reworked per owner direction (see PR comments): the placement approach in
the original version of this PR is superseded by #1115, which already fixed
hit-testing/reachability by letting a panel bypass its own host collider.
The remaining problem was purely visual — a loot panel whose plane sits
inside its host mesh (Hydro3 Desk #2) rendered buried/z-fighting: clickable,
but not visible.

- **Reverted** the OBB front-face placement change in `ContainerGui` (and its
  unit test) — no longer needed now that #1115 covers reachability.
- **Draw world loot panels over everything**, the way other VR system panels
  already present: `GuiManager::render_filtered` (the single shared draw path
  for every `GuiScript` world panel — container/loot, keypads, computers,
  replicators, etc.) now tags its panel quads `RenderLayer::SceneUi`, the same
  "draw over the world" depth-bypass layer the per-eye HUD/viewmodel are
  bumped into. Each `RenderLayer` clears depth at its own group boundary
  (`engine/src/gl_engine.rs`), so a panel on this layer can never be occluded
  by earlier `World`-layer geometry (the host mesh), while still sitting
  *before* `SystemOverlay` — so the pause menu and the cyber interface still
  draw over an open panel. This fixes the whole class of "panel plane buried
  in its host" bugs (any host, not just Desk #2) with one shared-path change
  instead of a per-object placement heuristic.
- Flat presentation is untouched: the flat MFD-docked panel renders through
  `FlatUiHost`/`flat_ui_host.rs`, a completely separate screen-space path that
  never touches `GuiManager`'s world-space quads.
- Kept the PR's Hydro3 Desk #2 regression, but rewrote its pivotal assertion:
  dropped the raw-raycast nearest-hit check (it guarded raw physics geometry,
  which is no longer meaningful post-#1115 since the hand ray bypasses the
  host collider regardless of panel placement). It now asserts the
  player-observable outcomes instead: the buried Audio Log row is still
  clickable end-to-end (aim + trigger collects it), and — for the visual claim
  — the panel's rendered quads report `render_layer: "scene_ui"` (not
  `"world"`) via `GET /v1/scene`, with `depth_write: true` on every quad.

## Visual evidence

![Hydro3 Desk #2 loot panel drawn over the desk](https://gist.githubusercontent.com/tommy-xr/a3b2d328b2e9625d89427b804471c6e5/raw/demo.gif)

<sub>Hydro3 Desk #2: the Audio Log row now renders fully visible, drawn over the desk's own geometry instead of buried behind it. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Before and after: the Audio Log disc is no longer clipped by the desk's top surface](https://gist.githubusercontent.com/tommy-xr/a3b2d328b2e9625d89427b804471c6e5/raw/beforeafter.png)

<sub>Before: the disc icon is sliced by the desk's top-surface edge, its lower ~40% invisible. After: the same disc renders fully in front of the desk, unclipped.</sub>

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib`
- `npm run build && npm test` in `tools/shock2-sdk`
- `SHOCK2_E2E=1 node --test --test-concurrency=1 dist/test/hydro3-vr-desk-loot.e2e.test.js` (rewritten)
- `SHOCK2_E2E=1 node --test --test-concurrency=1 dist/test/vr-container-world-panel.e2e.test.js`
- `SHOCK2_E2E=1 node --test --test-concurrency=1 dist/test/container-loot.e2e.test.js` (flat MFD path, unaffected)
- `SHOCK2_E2E=1 node --test --test-concurrency=1 dist/test/vr-cyber-interface.e2e.test.js` (SystemOverlay still draws over the panel's SceneUi layer)
- `SHOCK2_E2E=1 node --test --test-concurrency=1 dist/test/missions.e2e.test.js` (23/23)
- Full SDK e2e suite (`npm run test:e2e`)
