### PR TITLE
fix(physics): use visible surfaces for compound frob rays

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -7,7 +7,7 @@ use crate::{
     ss2_bin_obj_loader::{self, SystemShock2ObjectMesh, Vhot},
     ss2_skeleton::{self, AnimationInfo, Bone, Skeleton},
 };
-use cgmath::{Matrix4, SquareMatrix, Transform, Vector2};
+use cgmath::{Matrix4, Point3, SquareMatrix, Transform, Vector2, Vector3, prelude::*};
 use collision::{Aabb, Aabb3};
 use engine::{
     assets::asset_cache::AssetCache,
@@ -37,6 +37,7 @@ pub struct StaticModel {
     bounding_box: Aabb3<f32>,
     vhots: Vec<Vhot>,
     sub_objects: Vec<SubObject>,
+    interaction_triangles: Rc<Vec<[Vector3<f32>; 3]>>,
 }
 
 impl StaticModel {
@@ -63,6 +64,7 @@ impl StaticModel {
             bounding_box: model.bounding_box,
             vhots: model.vhots.clone(),
             sub_objects: model.sub_objects.clone(),
+            interaction_triangles: model.interaction_triangles.clone(),
         }
     }
 }
@@ -85,6 +87,7 @@ pub struct AnimatedModel {
     /// there is no record of the pose the model is actually drawn in, and a
     /// corpse lying flat would be bounded by the standing rest skeleton.
     posed_bounds: Option<Aabb3<f32>>,
+    interaction_triangles: Rc<Vec<[Vector3<f32>; 3]>>,
 }
 
 /// Build the render palette, undoing the bind pose first when the geometry needs
@@ -202,6 +205,7 @@ impl AnimatedModel {
             sub_objects: self.sub_objects.clone(),
             bind: self.bind.clone(),
             posed_bounds: joint_box_bounds(&animated_skeleton.get_transforms(), &self.hit_boxes),
+            interaction_triangles: self.interaction_triangles.clone(),
         }
     }
 
@@ -226,6 +230,7 @@ impl AnimatedModel {
             sub_objects: model.sub_objects.clone(),
             bind: model.bind.clone(),
             posed_bounds: model.posed_bounds,
+            interaction_triangles: model.interaction_triangles.clone(),
         }
     }
 
@@ -240,6 +245,35 @@ pub enum InnerModel {
     Animated(AnimatedModel),
 }
 
+fn object_interaction_triangles(mesh: &SystemShock2ObjectMesh) -> Vec<[Vector3<f32>; 3]> {
+    let sub_object_transforms = ss2_bin_obj_loader::sub_object_transforms(mesh);
+    ss2_bin_obj_loader::to_vertices(mesh)
+        .into_values()
+        .flat_map(|vertices| {
+            vertices
+                .chunks_exact(3)
+                .map(|triangle| {
+                    let transform_vertex =
+                        |vertex: &engine::scene::VertexPositionTextureSkinnedNormal| {
+                            let transform = sub_object_transforms
+                                .get(vertex.bone_indices[0] as usize)
+                                .map(|(_, transform)| *transform)
+                                .unwrap_or_else(Matrix4::identity);
+                            transform
+                                .transform_point(Point3::from_vec(vertex.position))
+                                .to_vec()
+                        };
+                    [
+                        transform_vertex(&triangle[0]),
+                        transform_vertex(&triangle[1]),
+                        transform_vertex(&triangle[2]),
+                    ]
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 #[derive(Clone)]
 pub struct Model {
     inner: InnerModel,
@@ -251,6 +285,7 @@ impl Model {
         static_mesh: SystemShock2ObjectMesh,
         asset_cache: &mut AssetCache,
     ) -> Model {
+        let interaction_triangles = Rc::new(object_interaction_triangles(&static_mesh));
         let (scene_objects, skeleton) =
             ss2_bin_obj_loader::to_scene_objects(&static_mesh, asset_cache);
         let bounding_box = static_mesh.bounding_box;
@@ -282,6 +317,7 @@ impl Model {
                     sub_objects,
                     bind: None,
                     posed_bounds: None,
+                    interaction_triangles,
                 }),
             }
         } else {
@@ -292,6 +328,7 @@ impl Model {
                     bounding_box,
                     vhots: static_mesh.vhots.clone(),
                     sub_objects,
+                    interaction_triangles,
                 }),
             }
         }
@@ -352,6 +389,7 @@ impl Model {
                 sub_objects: vec![],
                 bind,
                 posed_bounds: None,
+                interaction_triangles: Rc::new(Vec::new()),
             }),
         }
     }
@@ -379,6 +417,7 @@ impl Model {
                     sub_objects: vec![],
                     bind: None,
                     posed_bounds: None,
+                    interaction_triangles: Rc::new(Vec::new()),
                 }),
             }
         } else {
@@ -391,6 +430,7 @@ impl Model {
                     bounding_box,
                     vhots: vec![],
                     sub_objects: vec![],
+                    interaction_triangles: Rc::new(Vec::new()),
                 }),
             }
         }
@@ -485,6 +525,16 @@ impl Model {
         };
         for obj in objs {
             obj.set_depth_bias(enabled);
+        }
+    }
+
+    /// Triangle soup in object-local bind-pose space for precise interaction
+    /// queries. Physical simulation continues to use the authored PhysType;
+    /// this is only the visible surface the player can point at.
+    pub fn interaction_triangles(&self) -> Rc<Vec<[Vector3<f32>; 3]>> {
+        match &self.inner {
+            InnerModel::Animated(animated_model) => animated_model.interaction_triangles.clone(),
+            InnerModel::Static(static_model) => static_model.interaction_triangles.clone(),
         }
     }
 

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -158,7 +158,7 @@ impl FlatPlayerController {
         let forward = look.rotate_vector(vec3(0.0, 0.0, -1.0));
         self.last_aim = Some((point3(camera_pos.x, camera_pos.y, camera_pos.z), forward));
         let highlighted = physics
-            .ray_cast2(
+            .ray_cast_interaction(
                 point3(camera_pos.x, camera_pos.y, camera_pos.z),
                 forward,
                 FROB_REACH,

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1548,6 +1548,39 @@ fn create_physics_representation_with_options(
                 // the hand grip query needs the authored per-face bits.
                 physics.set_climbable_sides(entity_id, climbable_sides);
             }
+
+            // Multi-submodel OBBs are compound visible fixtures in Dark, but
+            // this port deliberately keeps their authored aggregate OBB as
+            // the conservative simulation hull. Add the bind-pose render mesh
+            // as a query-only sibling so flat and VR frob rays do not treat
+            // the empty corners of that aggregate box as visible matter
+            // (#1101). Sensors remain volume queries and must not acquire a
+            // surface interpretation.
+            if !is_sensor
+                && phys_type.phys_type == PhysicsModelType::ORIENTED_BOUNDING_BOX
+                && phys_type.num_submodels > 1
+            {
+                if let Some(model) = maybe_model.as_ref() {
+                    let triangles = model.interaction_triangles();
+                    if !triangles.is_empty() {
+                        let mut vertices = Vec::with_capacity(triangles.len() * 3);
+                        let mut indices = Vec::with_capacity(triangles.len());
+                        for triangle in triangles.iter() {
+                            let base = vertices.len() as u32;
+                            vertices.extend(triangle.iter().map(|vertex| {
+                                vec3(
+                                    vertex.x * scale_factor.x.abs(),
+                                    vertex.y * scale_factor.y.abs(),
+                                    vertex.z * scale_factor.z.abs(),
+                                )
+                            }));
+                            indices.push([base, base + 1, base + 2]);
+                        }
+                        let _ =
+                            physics.attach_interaction_mesh(rigid_body_handle, vertices, indices);
+                    }
+                }
+            }
             Some(rigid_body_handle)
         } else {
             None

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2213,6 +2213,17 @@ impl CollisionGroup {
         })
     }
 
+    /// A render-faithful surface used only by pointer/frob queries. The
+    /// authored collider on the same body remains responsible for movement,
+    /// projectiles, and ordinary physics rays.
+    pub fn interaction_surface() -> CollisionGroup {
+        Self::solid(InteractionGroups {
+            memberships: InternalCollisionGroups::RAYCAST.bits.into(),
+            filter: InternalCollisionGroups::ALL.bits.into(),
+            test_mode: Default::default(),
+        })
+    }
+
     pub fn ui() -> CollisionGroup {
         Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::UI.bits.into(),
@@ -6208,6 +6219,32 @@ impl PhysicsWorld {
             entity_to_ignore,
             ignore_sensors,
             None,
+            false,
+        )
+    }
+
+    /// Player interaction ray. A body with a render-faithful `RAYCAST`
+    /// surface is tested against that surface instead of its coarse physical
+    /// `ENTITY` hull; every other collider keeps normal nearest-hit behavior.
+    pub fn ray_cast_interaction(
+        &self,
+        start_point: Point3<f32>,
+        direction: Vector3<f32>,
+        max_toi: f32,
+        collision_groups: InternalCollisionGroups,
+        entity_to_ignore: Option<EntityId>,
+        ignore_sensors: bool,
+    ) -> Option<RayCastResult> {
+        self.ray_cast2_with_memberships(
+            InternalCollisionGroups::ALL,
+            start_point,
+            direction,
+            max_toi,
+            collision_groups,
+            entity_to_ignore,
+            ignore_sensors,
+            None,
+            true,
         )
     }
 
@@ -6232,6 +6269,7 @@ impl PhysicsWorld {
             entity_to_ignore,
             ignore_sensors,
             None,
+            false,
         )
     }
 
@@ -6263,6 +6301,7 @@ impl PhysicsWorld {
             entity_to_ignore,
             ignore_sensors,
             Some(entity_filter),
+            false,
         )
     }
 
@@ -6289,6 +6328,7 @@ impl PhysicsWorld {
             entity_to_ignore,
             ignore_sensors,
             Some(entity_filter),
+            false,
         )
     }
 
@@ -6302,6 +6342,7 @@ impl PhysicsWorld {
         entity_to_ignore: Option<EntityId>,
         ignore_sensors: bool,
         entity_filter: Option<&dyn Fn(EntityId) -> bool>,
+        prefer_interaction_surfaces: bool,
     ) -> Option<RayCastResult> {
         // Guard against degenerate rays. A zero-length direction normalizes to
         // NaN, and a NaN/zero ray direction sends parry's `clip_aabb_line` down
@@ -6350,6 +6391,26 @@ impl PhysicsWorld {
             }
             if let (Some(entity_id), Some(entity_filter)) = (maybe_entity_id, entity_filter)
                 && !entity_filter(entity_id)
+            {
+                return false;
+            }
+            if prefer_interaction_surfaces
+                && collider
+                    .collision_groups()
+                    .memberships
+                    .intersects(InternalCollisionGroups::ENTITY.bits.into())
+                && collider.parent().is_some_and(|parent| {
+                    self.rigid_body_set.get(parent).is_some_and(|body| {
+                        body.colliders().iter().any(|handle| {
+                            self.collider_set.get(*handle).is_some_and(|sibling| {
+                                sibling
+                                    .collision_groups()
+                                    .memberships
+                                    .intersects(InternalCollisionGroups::RAYCAST.bits.into())
+                            })
+                        })
+                    })
+                })
             {
                 return false;
             }
@@ -6923,6 +6984,34 @@ impl PhysicsWorld {
             density,
             collision_group,
         );
+    }
+
+    /// Attach a triangle mesh that participates only in player interaction
+    /// queries. Its parent body's ordinary collider remains unchanged.
+    pub fn attach_interaction_mesh(
+        &mut self,
+        handle: RigidBodyHandle,
+        vertices: Vec<Vector3<f32>>,
+        indices: Vec<[u32; 3]>,
+    ) -> bool {
+        let vertices = vertices.into_iter().map(vec_to_npoint).collect();
+        let Ok(shape) = SharedShape::trimesh(vertices, indices) else {
+            return false;
+        };
+        let user_data = self
+            .rigid_body_set
+            .get(handle)
+            .map(|body| body.user_data)
+            .unwrap_or_default();
+        let group = CollisionGroup::interaction_surface();
+        let mut collider = ColliderBuilder::new(shape)
+            .collision_groups(group.collision)
+            .solver_groups(group.solver)
+            .build();
+        collider.user_data = user_data;
+        self.collider_set
+            .insert_with_parent(collider, handle, &mut self.rigid_body_set);
+        true
     }
 
     /// Attach a collider to a body with a local-space translation offset. Used by
@@ -8006,6 +8095,57 @@ mod tests {
             actor_hit.is_none(),
             "AI movement probes must pass through the obstacle"
         );
+    }
+
+    #[test]
+    fn interaction_ray_uses_detailed_surface_without_weakening_physical_hull() {
+        let mut world = PhysicsWorld::new();
+        let fixture = EntityId::from_inner(44).unwrap();
+        let pickup = EntityId::from_inner(45).unwrap();
+        let fixture_body = world.add_kinematic(
+            fixture,
+            vec3(0.0, 0.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(2.0, 2.0, 2.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        assert!(world.attach_interaction_mesh(
+            fixture_body,
+            vec![
+                vec3(1.0, -1.0, -1.0),
+                vec3(1.0, 1.0, -1.0),
+                vec3(1.0, 0.0, 1.0),
+            ],
+            vec![[0, 1, 2]],
+        ));
+        world.add_kinematic(
+            pickup,
+            vec3(0.0, 0.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::selectable(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(46).unwrap());
+        world.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let origin = point3(-3.0, 0.0, 0.0);
+        let groups = InternalCollisionGroups::ENTITIES
+            | InternalCollisionGroups::SELECTABLE
+            | InternalCollisionGroups::RAYCAST;
+        let ordinary = world
+            .ray_cast2(origin, Vector3::unit_x(), 10.0, groups, None, true)
+            .expect("ordinary ray should hit the physical hull");
+        let interaction = world
+            .ray_cast_interaction(origin, Vector3::unit_x(), 10.0, groups, None, true)
+            .expect("interaction ray should reach the nested pickup");
+
+        assert_eq!(ordinary.maybe_entity_id, Some(fixture));
+        assert_eq!(interaction.maybe_entity_id, Some(pickup));
     }
 
     /// A world with a large static floor whose top surface is at `y = 0`, plus a

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -735,7 +735,7 @@ fn interaction_ray_cast(
             .or(Some(ui_hit))
     } else {
         physics
-            .ray_cast2(
+            .ray_cast_interaction(
                 ray_start,
                 forward,
                 FROB_REACH,

--- a/tools/shock2-sdk/test/hydro3-console-audio-log.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro3-console-audio-log.e2e.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// Hydro3 mission object 382 is authored as a loose audio log resting on the
+// sloped face of Computer Console 208. The console's six-submodel OBB physics
+// is currently represented by one coarse cuboid, which encloses the disc and
+// wins every production hand ray before LogDiscScript can receive Frob (#1101).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const COMPUTER_CONSOLE = 208;
+const GLORY_AUDIO_LOG = 382;
+
+test(
+  "Quest VR can collect Hydro3 audio log 382 from console 208 without weakening its physical hull",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8645),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [log] = await game.entities.byTemplate(GLORY_AUDIO_LOG);
+    const [console] = await game.entities.byTemplate(COMPUTER_CONSOLE);
+    assert.ok(log, "hydro3 must contain loose audio log mission object 382");
+    assert.ok(console, "hydro3 must contain Computer Console mission object 208");
+
+    const [consoleBody] = (await game.physics.bodies({ entityId: console.id })).bodies;
+    assert.ok(consoleBody, "console 208 must retain its authored physical body");
+    assert.equal(consoleBody.body_type, "kinematic");
+    assert.equal(consoleBody.is_sensor, false);
+    assert.ok(consoleBody.collision_groups.includes("entity"));
+
+    await teleportVerified(game, { x: 17.4825, y: 3.244, z: 3.4797 });
+    const aim = await aimVrHandAt(game, log.position, 0.7);
+
+    // The ordinary physics query must keep seeing the authored hull. The VR
+    // interaction path alone resolves the console against its visible mesh,
+    // so this also guards against a broad "ray through entities" workaround.
+    const hit = await game.raycast({
+      start: aim.start,
+      end: aim.target,
+      collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+      max_distance: 1,
+    });
+    assert.equal(hit.entity_id, console.id, "the console must keep its physical ray hull");
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.physics.bodies({ entityId: log.id })).bodies.length,
+      0,
+      "LogDiscScript must remove the loose disc from the world",
+    );
+    assert.deepEqual((await game.info()).player.collected_logs, [
+      { deck: 3, log: 12, read: false },
+    ]);
+  },
+);


### PR DESCRIPTION
## Summary

- retain object-model bind-pose triangles for precise interaction queries
- give authored multi-submodel OBB fixtures a query-only visible surface while preserving their coarse physical hull
- route the shared flat/VR frob pointer through that surface, without changing movement, projectile, AI, or ordinary physics rays
- cover Hydro3 mission object 382 with an authentic production-VR trigger regression

Fixes #1101

## Player-visible evidence

Before, every approach to the loose “re: Glory” disc resolves against Computer Console 208's enclosing OBB, so the trigger does nothing:

![Before: the console blocks the hidden audio log](https://gist.githubusercontent.com/tommy-xr/4b6d16f134082df28f5e957a1631f1b7/raw/hydro3-log382-baseline.png)

After, the same VR hand aim reaches the part of the disc that protrudes above the console's visible mesh. The trigger files deck 3/log 12 unread, removes its world body, and the normal reader action opens its authored transcript:

![After: the collected Glory log opens in the VR reader](https://gist.githubusercontent.com/tommy-xr/4b6d16f134082df28f5e957a1631f1b7/raw/hydro3-log382-after-reader.png)

![VR before/after interaction loop](https://gist.githubusercontent.com/tommy-xr/4b6d16f134082df28f5e957a1631f1b7/raw/hydro3-log382-vr-before-after.gif)

The regression separately asserts that an ordinary ray still hits the console and that its kinematic, non-sensor entity body remains in place. This is not a through-wall selectable ray.

## Verification

- Negative-first: the new Hydro3 e2e failed before the fix because LogDiscScript never collected the disc.
- `SHOCK2_E2E=1 SHOCK2_E2E_PORT=8645 node --test dist/test/hydro3-console-audio-log.e2e.test.js`
- `cargo test -p shock2vr` — 902 passed
- `CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm run build` in `tools/shock2-sdk`

The screenshots and GIF were captured from fresh isolated Hydro3 `--vr` debug runtimes; all were shut down after capture.
