### PR TITLE
fix(gameplay): occlude explosion damage with cover

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -756,6 +756,160 @@ const MELEE_SWING_CLIP: &str = "leftswing";
 /// Tuned so a barrel blast (intensity 15) gives nearby props a solid toss.
 const BLAST_PUSH_SPEED_PER_INTENSITY: f32 = 0.5;
 
+const BLAST_OCCLUSION_GROUPS: physics::InternalCollisionGroups =
+    physics::InternalCollisionGroups::WORLD
+        .union(physics::InternalCollisionGroups::ENTITIES)
+        .union(physics::InternalCollisionGroups::SELECTABLE);
+
+/// Fraction of a victim's representative bounds points that can see the blast.
+///
+/// Rays use living-actor membership so interaction-only/model-bounds fixtures
+/// do not become blast-proof cover. The source and victim are filtered by ECS
+/// identity: an explosion can leave its own collider around for the fireball,
+/// while the target collider should terminate neither a center nor corner ray.
+fn blast_exposure(
+    physics: &PhysicsWorld,
+    source_entity: EntityId,
+    victim_entity: EntityId,
+    center: Vector3<f32>,
+    victim_position: Vector3<f32>,
+) -> f32 {
+    let mut sample_points = Vec::with_capacity(9);
+    if let Some(bounds) = physics.get_aabb2(victim_entity) {
+        let bounds_center = (bounds.min.to_vec() + bounds.max.to_vec()) * 0.5;
+        // Stay just inside the bounds so grazing a wall at exactly the same
+        // plane as a sample is stable across Rapier contact tolerances.
+        let half_extent = (bounds.max - bounds.min) * 0.45;
+        sample_points.push(bounds_center);
+        for x in [-1.0, 1.0] {
+            for y in [-1.0, 1.0] {
+                for z in [-1.0, 1.0] {
+                    sample_points.push(
+                        bounds_center
+                            + vec3(half_extent.x * x, half_extent.y * y, half_extent.z * z),
+                    );
+                }
+            }
+        }
+    } else {
+        sample_points.push(victim_position);
+    }
+
+    let start = Point3::from_vec(center);
+    let ray_can_hit_entity = |entity_id| entity_id != source_entity && entity_id != victim_entity;
+    let visible_samples = sample_points
+        .iter()
+        .filter(|sample| {
+            let end = Point3::from_vec(**sample);
+            let ray = end - start;
+            let distance_squared = ray.magnitude2();
+            distance_squared <= 1.0e-12
+                || physics
+                    .ray_cast2_as_actor_with_entity_filter(
+                        start,
+                        ray / distance_squared.sqrt(),
+                        distance_squared.sqrt(),
+                        BLAST_OCCLUSION_GROUPS,
+                        Some(source_entity),
+                        true,
+                        &ray_can_hit_entity,
+                    )
+                    .is_none()
+        })
+        .count();
+
+    visible_samples as f32 / sample_points.len() as f32
+}
+
+#[cfg(test)]
+mod blast_occlusion_tests {
+    use super::*;
+
+    fn identity_rotation() -> Quaternion<f32> {
+        Quaternion::from_sv(1.0, vec3(0.0, 0.0, 0.0))
+    }
+
+    fn exposure_with_cover(cover_size: Option<Vector3<f32>>, cover_blocks_actors: bool) -> f32 {
+        let mut world = World::new();
+        let source = world.add_entity(());
+        let victim = world.add_entity(());
+        let cover = world.add_entity(());
+        let player = world.add_entity(());
+
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            victim,
+            vec3(0.0, 0.0, 4.0),
+            identity_rotation(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(2.0, 2.0, 2.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        if let Some(size) = cover_size {
+            let group = if cover_blocks_actors {
+                CollisionGroup::entity()
+            } else {
+                CollisionGroup::entity().non_solid_to_characters()
+            };
+            physics.add_kinematic(
+                cover,
+                vec3(0.0, 0.0, 2.0),
+                identity_rotation(),
+                vec3(0.0, 0.0, 0.0),
+                size,
+                group,
+                false,
+            );
+        }
+        // A source-owned collider at the ray origin must not consume every
+        // sample before it leaves the explosion effect.
+        physics.add_kinematic(
+            source,
+            vec3(0.0, 0.0, 0.0),
+            identity_rotation(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.5, 0.5, 0.5),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player_handle = physics.create_player(vec3(50.0, 50.0, 50.0), player);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        blast_exposure(
+            &physics,
+            source,
+            victim,
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 4.0),
+        )
+    }
+
+    #[test]
+    fn uncovered_victim_feels_the_full_blast() {
+        assert_eq!(exposure_with_cover(None, true), 1.0);
+    }
+
+    #[test]
+    fn wall_fully_shields_a_victim_from_the_blast() {
+        assert_eq!(exposure_with_cover(Some(vec3(10.0, 10.0, 0.25)), true), 0.0);
+    }
+
+    #[test]
+    fn narrow_cover_reduces_instead_of_nullifying_the_blast() {
+        let exposure = exposure_with_cover(Some(vec3(0.5, 10.0, 0.25)), true);
+        assert_eq!(exposure, 8.0 / 9.0);
+    }
+
+    #[test]
+    fn interaction_only_geometry_does_not_shield_the_victim() {
+        assert_eq!(
+            exposure_with_cover(Some(vec3(10.0, 10.0, 0.25)), false),
+            1.0
+        );
+    }
+}
+
 /// Debug options accessible from scripts via UniqueView
 #[derive(Unique, Clone, Default)]
 pub struct DebugOptions {
@@ -3044,6 +3198,7 @@ impl MissionCore {
     /// Dynamic bodies in range are shoved outward regardless.
     fn radius_blast(
         &mut self,
+        source_entity_id: EntityId,
         center: Vector3<f32>,
         radius: f32,
         intensity: f32,
@@ -3059,11 +3214,22 @@ impl MissionCore {
             for (entity_id, (_hit_points, transform)) in
                 (&v_hit_points, &v_transform).iter().with_id()
             {
+                if entity_id == source_entity_id {
+                    continue;
+                }
                 let position = transform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
-                let distance = (crate::util::point3_to_vec3(position) - center).magnitude();
+                let position = crate::util::point3_to_vec3(position);
+                let distance = (position - center).magnitude();
                 if distance < radius {
                     let falloff = 1.0 - distance / radius;
-                    in_range.push((entity_id, intensity * falloff));
+                    let exposure = blast_exposure(
+                        &self.physics,
+                        source_entity_id,
+                        entity_id,
+                        center,
+                        position,
+                    );
+                    in_range.push((entity_id, intensity * falloff * exposure));
                 }
             }
         }
@@ -3077,7 +3243,17 @@ impl MissionCore {
             let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
             let distance = (player.pos - center).magnitude();
             if distance < radius && !in_range.iter().any(|(id, _)| *id == player.entity_id) {
-                in_range.push((player.entity_id, intensity * (1.0 - distance / radius)));
+                let exposure = blast_exposure(
+                    &self.physics,
+                    source_entity_id,
+                    player.entity_id,
+                    center,
+                    player.pos,
+                );
+                in_range.push((
+                    player.entity_id,
+                    intensity * (1.0 - distance / radius) * exposure,
+                ));
             }
         }
 
@@ -4260,12 +4436,19 @@ impl MissionCore {
                 }
 
                 Effect::RadiusBlast {
+                    source_entity_id,
                     center,
                     radius,
                     intensity,
                     stim_template_id,
                 } => {
-                    self.radius_blast(center, radius, intensity, stim_template_id);
+                    self.radius_blast(
+                        source_entity_id,
+                        center,
+                        radius,
+                        intensity,
+                        stim_template_id,
+                    );
                 }
 
                 Effect::RaiseNoise { origin, radius } => {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -343,6 +343,7 @@ pub enum Effect {
     /// shoved outward. Emitted once by `internal_explosion` from the entity's
     /// arSrcDesc data.
     RadiusBlast {
+        source_entity_id: EntityId,
         center: Vector3<f32>,
         radius: f32,
         intensity: f32,

--- a/shock2vr/src/scripts/internal_explosion.rs
+++ b/shock2vr/src/scripts/internal_explosion.rs
@@ -81,6 +81,7 @@ impl Script for InternalExplosion {
         let center = point3_to_vec3(transform.0.transform_point(point3(0.0, 0.0, 0.0)));
 
         Effect::RadiusBlast {
+            source_entity_id: entity_id,
             center,
             radius,
             intensity,

--- a/tools/shock2-sdk/test/explosion-occlusion.e2e.test.ts
+++ b/tools/shock2-sdk/test/explosion-occlusion.e2e.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// This medsci1 barrel sits beside the solid x=-3.2 corridor wall, with
+// walkable floor on both sides. Runtime ids change every launch; its mission
+// template backlink is stable.
+const COVER_BARREL_TEMPLATE_ID = 872;
+const PLAYER_HEIGHT_ABOVE_BARREL = 1.09;
+const PLAYER_HORIZONTAL_OFFSET = 3.0;
+
+async function coverBarrel(game: GameServer): Promise<EntitySummary> {
+  const { entities } = await game.entities.list({ filter: "Explode Barrel", limit: 20 });
+  const barrel = entities.find((entity) => entity.template_id === COVER_BARREL_TEMPLATE_ID);
+  assert.ok(barrel, `expected barrel template ${COVER_BARREL_TEMPLATE_ID}`);
+  return barrel;
+}
+
+async function detonateBesidePlayer(
+  playerSide: "covered" | "uncovered",
+  port: number,
+): Promise<{ damage: number; lineBlocked: boolean }> {
+  await using game = await GameServer.launch({ mission: "medsci1.mis", port });
+  await game.step({ frames: 2 });
+
+  const barrel = await coverBarrel(game);
+  const [bx, by, bz] = barrel.position;
+  const playerPosition: Vec3 = [
+    bx + (playerSide === "covered" ? -PLAYER_HORIZONTAL_OFFSET : PLAYER_HORIZONTAL_OFFSET),
+    by + PLAYER_HEIGHT_ABOVE_BARREL,
+    bz,
+  ];
+  await game.player.teleport({
+    x: playerPosition[0],
+    y: playerPosition[1],
+    z: playerPosition[2],
+  });
+  await game.step({ frames: 2 });
+
+  const settledPlayer = await game.info();
+  const hitPointsBefore = settledPlayer.player.hit_points;
+  assert.ok(hitPointsBefore !== null, "player should have a health pool");
+  const line = await game.raycast({
+    start: barrel.position,
+    end: settledPlayer.player.position,
+    collision_groups: ["world"],
+  });
+
+  await game.entities.sendMessage(barrel.id, { type: "Damage", amount: 5.0 });
+  await game.step({ frames: 8 });
+  const hitPointsAfter = (await game.info()).player.hit_points;
+  assert.ok(hitPointsAfter !== null, "player should retain a health pool");
+
+  return {
+    damage: hitPointsBefore - hitPointsAfter,
+    lineBlocked: line.hit,
+  };
+}
+
+test(
+  "Explosion occlusion: a corridor wall shields the player while open space does not",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const covered = await detonateBesidePlayer(
+      "covered",
+      Number(process.env.SHOCK2_E2E_PORT ?? 8144),
+    );
+    assert.ok(covered.lineBlocked, "the covered control ray must hit the corridor wall");
+    assert.equal(covered.damage, 0, "the wall must absorb the whole blast");
+
+    const uncovered = await detonateBesidePlayer(
+      "uncovered",
+      Number(process.env.SHOCK2_E2E_CONTROL_PORT ?? 8145),
+    );
+    assert.ok(!uncovered.lineBlocked, "the open-space control ray must stay clear");
+    assert.ok(uncovered.damage > 0, "the unobstructed blast must still hurt the player");
+  },
+);


### PR DESCRIPTION
Fixes #924

## Summary

- measure explosion exposure with nine deterministic rays to the victim's physics bounds
- scale blast damage by the visible sample fraction for both the player and AI/entities
- ignore the exploding source, the victim's own collider, sensors, and geometry authored non-solid to characters
- preserve distance falloff and physical blast impulse behavior

## Root cause and reproduction

`MissionCore::radius_blast` previously selected victims and scaled damage using Euclidean distance only. `Effect::RadiusBlast` also carried no source identity, so a future cover trace could not reliably ignore the exploding object's collider.

On the exact base (`42fdf125`), a real `medsci1.mis` `Explode Barrel` (stable template 872) had a solid corridor wall between its center and the player, yet the blast reduced HP from 30 to 27. The matched unobstructed control also reduced HP from 30 to 27. The negative-first physics test likewise reported full exposure (`1.0`) behind both full and partial solid cover.

The fix samples the victim bounds center plus eight inset corners. Full cover yields zero damage, open space preserves full distance-scaled damage, and partial cover scales damage smoothly by visible fraction instead of flickering all-or-nothing at an edge.

## Visual evidence

![Explosion occlusion: exact base, fixed cover, and open-space control](https://gist.githubusercontent.com/tommy-xr/f78c583718a6b98f241ddcc28de1cb31/raw/issue-924-explosion-occlusion.gif)

<sub>Real `medsci1.mis` corridor, `Explode Barrel` template 872. The exact base loses 3 HP through the x = -3.2 wall; the fix remains at 30 HP behind cover; the matched unobstructed control still loses 3 HP. Captured headlessly with the 25th Anniversary assets via deterministic fixed-timestep stepping.</sub>

### After

![After: wall-covered player remains at 30 HP](https://gist.githubusercontent.com/tommy-xr/f78c583718a6b98f241ddcc28de1cb31/raw/issue-924-after.png)

### Before to after

![Before and after: same covered blast sequence](https://gist.githubusercontent.com/tommy-xr/f78c583718a6b98f241ddcc28de1cb31/raw/issue-924-before-after.png)

### Unobstructed control

![Unobstructed blast still damages the player](https://gist.githubusercontent.com/tommy-xr/f78c583718a6b98f241ddcc28de1cb31/raw/issue-924-open-control.png)

## Verification

25AE root for every runtime scenario: `/Users/bryan/ss2-25th` (`sshock2.kpf` and `mods/` verified).

- negative-first Rust matrix: uncovered and authored-nonblocking controls passed; full and partial solid-cover cases failed with exposure `1.0` before the product change
- exact-base real mission: covered player lost 3 HP; unobstructed control lost 3 HP
- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo test -p shock2vr blast_occlusion_tests`: 4 passed (open, full cover, partial cover, nonblocking geometry)
- `cargo test -p shock2vr`: 905 passed, 2 ignored
- `CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm test`: 26 passed, 283 E2E skipped
- focused real-runtime explosion set: occlusion, barrel chain explosion, protocol-droid self-destruct all passed
- focused occlusion scenario repeated twice after final rebuild: 2/2 passed
- full SDK E2E: 295 passed, 6 failed, 8 fixture-gated skips across 309 tests. The occlusion case's aggregate failure was an `ENOSPC` linker launch failure and passed twice after cleanup. Hydro2 floor-pod passed in isolation. Four unrelated baseline scenarios reproduced independently (Baby Arachnid/saved-VR wrench contact timing, creature-loot reader selection, Hydro3 transcript whitespace); adjacent explosion, death-link, melee-ragdoll, and log-reader controls passed.

No relevant benchmark exists for this gameplay path.

## Risk

The nine deterministic raycasts occur only when a radius blast evaluates an in-range damageable target. Physical blast impulse remains distance-based and unchanged; only stimulus intensity is cover-scaled.
