### PR TITLE
fix(gameplay): preserve scripted corpse-loot transfer

### DIFF
--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -411,6 +411,10 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // Use-only contained objects (notably corpse audio logs) still
             // need their normal Frob behavior when clicked; they are consumed
             // or recorded in place rather than moved into the backpack.
+            // Grabbable `MOVE | SCRIPT` loot needs both authored halves: Frob
+            // runs its scripted acquisition side effect, then DropEntityInfo
+            // performs the engine-owned MOVE. The immediate transfer removes
+            // the panel button, so one press cannot enqueue either half twice.
             ContainerGuiMsg::Take(ent) => {
                 // The always-collected categories are decided before anything
                 // physical is considered: a nanite pile is grabbable metadata-
@@ -429,17 +433,20 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                         },
                     );
                 }
-                if !crate::virtual_hand::can_grab_item(world, *ent) {
-                    let is_use_only = world
-                        .borrow::<View<PropFrobInfo>>()
-                        .map(|frob| {
-                            frob.get(*ent).is_ok_and(|frob| {
-                                frob.world_action.contains(FrobFlag::SCRIPT)
-                                    || frob.inventory_action.contains(FrobFlag::SCRIPT)
-                            })
+                let (world_frob_is_scripted, inventory_frob_is_scripted) = world
+                    .borrow::<View<PropFrobInfo>>()
+                    .ok()
+                    .and_then(|frob| {
+                        frob.get(*ent).ok().map(|frob| {
+                            (
+                                frob.world_action.contains(FrobFlag::SCRIPT),
+                                frob.inventory_action.contains(FrobFlag::SCRIPT),
+                            )
                         })
-                        .unwrap_or(false);
-                    return if is_use_only {
+                    })
+                    .unwrap_or((false, false));
+                if !crate::virtual_hand::can_grab_item(world, *ent) {
+                    return if world_frob_is_scripted || inventory_frob_is_scripted {
                         (
                             state.clone(),
                             Effect::Send {
@@ -462,13 +469,26 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                     .map(|player| player.inventory_entity_id)
                     .ok();
                 match inventory_entity {
-                    Some(inventory_entity) => (
-                        state.clone(),
-                        Effect::DropEntityInfo {
+                    Some(inventory_entity) => {
+                        let transfer = Effect::DropEntityInfo {
                             parent_entity_id: inventory_entity,
                             dropped_entity_id: *ent,
-                        },
-                    ),
+                        };
+                        let effect = if world_frob_is_scripted {
+                            Effect::combine(vec![
+                                Effect::Send {
+                                    msg: Message {
+                                        payload: MessagePayload::Frob,
+                                        to: *ent,
+                                    },
+                                },
+                                transfer,
+                            ])
+                        } else {
+                            transfer
+                        };
+                        (state.clone(), effect)
+                    }
                     None => (state.clone(), Effect::NoEffect),
                 }
             }
@@ -560,12 +580,12 @@ mod tests {
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
     /// through.
-    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+    fn loot_world_with_action(world_action: FrobFlag) -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
         let item = world.add_entity((
             PropObjIcon("icn_psi".to_owned()),
             PropFrobInfo {
-                world_action: FrobFlag::MOVE,
+                world_action,
                 inventory_action: FrobFlag::empty(),
                 tool_action: FrobFlag::empty(),
             },
@@ -588,6 +608,10 @@ mod tests {
             inventory_entity_id: inventory,
         });
         (world, container, item, inventory)
+    }
+
+    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+        loot_world_with_action(FrobFlag::MOVE)
     }
 
     fn mark_as_keycard(world: &mut World, item: EntityId) {
@@ -773,6 +797,55 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Ops2 Chip A (mission object 554) is authored `MOVE | SCRIPT`: one
+    /// trigger-click must run BaseButton's reward side effect and perform the
+    /// ordinary container-to-backpack transfer, with neither half duplicated.
+    #[test]
+    fn loot_container_click_frobs_and_takes_a_scripted_pickup_once() {
+        let (world, container, item, inventory) =
+            loot_world_with_action(FrobFlag::MOVE | FrobFlag::SCRIPT);
+        let gui = ContainerGui::loot_container();
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+        let effects = Effect::flatten(vec![effect]);
+
+        assert_eq!(
+            effects
+                .iter()
+                .filter(|effect| matches!(
+                    effect,
+                    Effect::Send {
+                        msg: Message {
+                            to,
+                            payload: MessagePayload::Frob,
+                        },
+                    } if *to == item
+                ))
+                .count(),
+            1,
+            "taking MOVE | SCRIPT loot must run its authored Frob exactly once: {effects:?}"
+        );
+        assert_eq!(
+            effects
+                .iter()
+                .filter(|effect| matches!(
+                    effect,
+                    Effect::DropEntityInfo {
+                        parent_entity_id,
+                        dropped_entity_id,
+                    } if *parent_entity_id == inventory && *dropped_entity_id == item
+                ))
+                .count(),
+            1,
+            "taking MOVE | SCRIPT loot must transfer it exactly once: {effects:?}"
+        );
     }
 
     /// Both panels' item grids must land on their cell separators - the loot

--- a/tools/shock2-sdk/test/ops2-vr-chip-a-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-vr-chip-a-loot.e2e.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { PhysicsBodySummary, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable ops2 mission-object ids. Runtime ids are rediscovered each launch.
+const RED_ASSASSIN = 254;
+const CHIP_A = 554;
+const EXPERIENCE_TRAP = 1089;
+const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const FIRST_LOOT_SLOT_CENTER_PX: Vec3 = [15 + 35 / 2, 153 + 34 / 2, 0];
+
+const uiBodies = async (game: GameServer): Promise<PhysicsBodySummary[]> =>
+  (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+
+async function triggerClick(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 8 });
+}
+
+test(
+  "ops2 VR trigger-click runs Chip A's reward once and transfers it from the corpse",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8554),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [assassin] = await game.entities.byTemplate(RED_ASSASSIN);
+    const [chip] = await game.entities.byTemplate(CHIP_A);
+    const [experienceTrap] = await game.entities.byTemplate(EXPERIENCE_TRAP);
+    assert.ok(assassin, "expected ops2 Red Assassin mission object 254");
+    assert.equal(chip?.name, "Chip A", "expected ops2 Chip A mission object 554");
+    assert.ok(experienceTrap, "expected Chip A Experience Trap mission object 1089");
+    assert.equal((await game.info()).player.stats?.cyber_modules, 0);
+    assert.ok(
+      (await game.entities.detail(assassin.id)).outgoing_links.some(
+        (link) => link.link_type.startsWith("Contains") && link.target_id === chip.id,
+      ),
+      "the Red Assassin must initially contain Chip A",
+    );
+
+    // Lethal damage is test setup only. Opening the corpse and clicking its
+    // rendered world panel below both use the production VR trigger ray.
+    await game.entities.sendMessage(assassin.id, { type: "Damage", amount: 100 });
+    await game.step({ frames: 120 });
+    const corpse = await game.entities.detail(assassin.id);
+    assert.equal(
+      corpse.properties.find((property) => property.name === "AIBehavior")?.value,
+      "Dead",
+      "lethal setup damage must leave a lootable corpse",
+    );
+
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.2,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.2,
+    });
+    const corpseAim = await game.player.aimAt(assassin, {
+      hitbox: "torso",
+      visibility: "required",
+    });
+    await aimVrHandAt(game, corpseAim.world_point);
+    await triggerClick(game);
+
+    const panels = await uiBodies(game);
+    assert.equal(panels.length, 1, "trigger-frobbing the corpse must open one VR loot panel");
+    const panel = panels[0];
+
+    // Invert ProxyGuiScript's panel mapping for the center of the first loot
+    // slot. Chip A is the corpse's sole contained item, so ContainerGui packs
+    // its real button into this authored cell.
+    const panelSize: Vec3 = [
+      PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
+      PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
+      0,
+    ];
+    const u = FIRST_LOOT_SLOT_CENTER_PX[0] / PANEL_SIZE_PX[0];
+    const v = FIRST_LOOT_SLOT_CENTER_PX[1] / PANEL_SIZE_PX[1];
+    const localSlot: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+    const slotWorld = add(panel.position, quatRotate(panel.rotation, localSlot));
+    await aimVrHandAt(game, slotWorld, 0.35);
+    await triggerClick(game);
+
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.filter(
+        (item) => item.entity_id === chip.id && item.location === "inventory",
+      ).length,
+      1,
+      `one trigger-click must put one Chip A in the backpack: ${JSON.stringify(inventory.items)}`,
+    );
+    assert.ok(
+      !(await game.entities.detail(assassin.id)).outgoing_links.some(
+        (link) => link.link_type.startsWith("Contains") && link.target_id === chip.id,
+      ),
+      "the transfer must remove the corpse's Contains link to Chip A",
+    );
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      10,
+      "Chip A's authored Experience side effect must run exactly once",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(EXPERIENCE_TRAP)).length,
+      0,
+      "TrapEXPOnce must consume the authored Experience Trap",
+    );
+
+    // Repeating the same production trigger edge over the now-empty slot must
+    // neither duplicate the item nor re-award the destroyed one-shot trap.
+    await aimVrHandAt(game, slotWorld, 0.35);
+    await triggerClick(game);
+    assert.equal((await game.info()).player.stats?.cyber_modules, 10);
+    assert.equal(
+      (await game.player.inventory()).items.filter((item) => item.entity_id === chip.id).length,
+      1,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- preserve the authored `Frob` side effect when a corpse-loot button takes grabbable `MOVE | SCRIPT` loot
- perform the normal `DropEntityInfo` transfer in the same UI action, while retaining keycards as their script-owned special case
- cover the one-shot effect pair in `ContainerGui` and with a production VR trigger-ray Ops2 scenario

## Campaign finding

Campaign: `hydroponics → operations → recreation · detailed · 25th · vr · seed 392917474`

Ops2 Chip A is mission object `554` (template `-1555`), contained by Red Assassin mission object `254` (template `-3398`), and linked to Experience Trap mission object `1089`. On the dependency base, one production VR trigger click ran Chip A's scripted reward but left the chip in the corpse: the before/after panel frames were byte-identical and the negative-first E2E failed with an empty backpack.

After this change, that same trigger click awards exactly 10 cyber modules, destroys the one-shot Experience Trap, removes the corpse's `Contains` link, and places exactly one Chip A in the backpack. Repeating the click over the now-empty cell changes neither modules nor inventory.

This PR is intentionally stacked on #1097 because that change exposes the scripted container-take path; the diff against `fix/583-vr-keycard-acquisition` is one focused commit.

## Visual evidence

Deterministic headless debug-runtime capture using fixed stepping and the production VR trigger ray:

![Dependency base versus fixed trigger-click](https://gist.githubusercontent.com/tommy-xr/5e9b58804f9ced0172917e81186f9c43/raw/ops2-chip-a-trigger-base-vs-fix.gif)

![Annotated still comparison](https://gist.githubusercontent.com/tommy-xr/5e9b58804f9ced0172917e81186f9c43/raw/ops2-chip-a-trigger-base-vs-fix.png)

[Before still](https://gist.githubusercontent.com/tommy-xr/5e9b58804f9ced0172917e81186f9c43/raw/ops2-chip-a-trigger-before.png) · [artifact gist](https://gist.github.com/tommy-xr/5e9b58804f9ced0172917e81186f9c43)

## Validation

- negative-first `ContainerGui` unit: failed because scripted Frob count was 0
- negative-first Ops2 VR E2E on the dependency behavior: failed at the expected inventory assertion (`0 !== 1`), with the corpse panel unchanged
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/bryan/code/shock2quest2/target RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `CARGO_TARGET_DIR=/Users/bryan/code/shock2quest2/target cargo test -p shock2vr --lib` (905 passed)
- `npm test` in `tools/shock2-sdk` (26 passed, 285 E2E-gated skips)
- focused `SHOCK2_E2E=1` Ops2 VR scenario (passed)

Fixes #1104
