### PR TITLE
fix(input): count double clicks by simulation frames

### DIFF
--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -630,6 +630,20 @@ impl FlatUiHost {
         }
     }
 
+    /// Advance frame-counted gestures by one simulation frame.
+    ///
+    /// The debug runtime also calls [`update`](Self::update) with zero elapsed
+    /// time when it applies an HTTP command. Those administrative updates must
+    /// not consume the documented double-click window.
+    pub fn advance_simulation_frame(&mut self) {
+        if let Some(mark) = self.last_lift.as_mut() {
+            match mark.frames_left.checked_sub(1) {
+                Some(remaining) => mark.frames_left = remaining,
+                None => self.last_lift = None,
+            }
+        }
+    }
+
     /// The active panel's rect on the 640x480 canvas (None until its first
     /// `SetUI` arrives).
     fn panel_rect(&self) -> Option<Rect> {
@@ -717,14 +731,6 @@ impl FlatUiHost {
         let pressed = pointer.map(|p| p.pressed).unwrap_or(false);
         let pressed_edge = pressed && !self.last_pointer_pressed;
         self.last_pointer_pressed = pressed;
-
-        // Age out the double-click window since the last lift.
-        if let Some(mark) = self.last_lift.as_mut() {
-            match mark.frames_left.checked_sub(1) {
-                Some(remaining) => mark.frames_left = remaining,
-                None => self.last_lift = None,
-            }
-        }
 
         // MFD-slot auto-close: the bound object is gone (destroyed / level
         // state changed), or the player walked away from it (the original's
@@ -2429,6 +2435,36 @@ mod tests {
         let second = press_edge(&mut host, &world, (23.5, 34.0));
         assert_eq!(second, vec![FlatUiDragAction::Wield(wrench)]);
         assert!(host.cursor_debug().is_none(), "wielding clears the cursor");
+    }
+
+    #[test]
+    fn paused_updates_do_not_consume_the_double_click_window() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        let position = norm(23.5, 34.0);
+        let pointer = |pressed| Some(Pointer2D { position, pressed });
+
+        // The HTTP input command itself is a zero-time update and observes
+        // the first press edge before the requested stepped frames begin.
+        host.update(&world, pointer(false));
+        let (_, first) = host.update(&world, pointer(true));
+        assert!(first.is_empty());
+
+        // Six held frames, six released frames, and six more released frames
+        // before the second click: the two press edges are 18 sim frames apart.
+        for pressed in [true, false, false] {
+            for _ in 0..6 {
+                host.advance_simulation_frame();
+                host.update(&world, pointer(pressed));
+            }
+            // Setting an input channel while paused invokes a zero-time update.
+            // It must not age the gesture window.
+            for _ in 0..8 {
+                host.update(&world, pointer(pressed));
+            }
+        }
+
+        let (_, second) = host.update(&world, pointer(true));
+        assert_eq!(second, vec![FlatUiDragAction::Wield(wrench)]);
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4144,6 +4144,11 @@ impl MissionCore {
         // uses. Dispatched before the script update so hovers/clicks are
         // processed this frame.
         self.refresh_readouts();
+        // Double-click windows are counted in simulation frames, so the debug
+        // runtime's zero-time administrative updates do not consume them.
+        if !time.elapsed.is_zero() {
+            self.flat_ui.advance_simulation_frame();
+        }
         let (ui_messages, ui_drag_actions) = match game_options.presentation_mode {
             crate::PresentationMode::Flat => {
                 self.flat_ui.update(&self.world, input_context.pointer)

--- a/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
@@ -44,15 +44,16 @@ test(
     };
     // A discrete click at a screen point: hover (an unpressed frame so the
     // press is an edge), press, release.
-    const clickAt = async (screen: [number, number]) => {
+    const clickAt = async (screen: [number, number], phaseFrames = 2) => {
       await setPointer(screen, 0);
-      await game.step({ frames: 2 });
+      await game.step({ frames: phaseFrames });
       await setPointer(screen, 1);
-      await game.step({ frames: 2 });
+      await game.step({ frames: phaseFrames });
       await setPointer(screen, 0);
-      await game.step({ frames: 2 });
+      await game.step({ frames: phaseFrames });
     };
-    const clickElement = (el: UiElement) => clickAt(center(el));
+    const clickElement = (el: UiElement, phaseFrames = 2) =>
+      clickAt(center(el), phaseFrames);
 
     // Loot an item honestly through a PR-3 loot MFD (frob corpse -> take).
     const lootFromCorpse = async (template: number, itemName: string) => {
@@ -157,8 +158,11 @@ test(
     // --- WIELD: a DOUBLE-click on the Wrench equips it (single=lift,
     // double=wield - the faithful single-button mapping) ---
     const wrenchEl2 = stripItem(await game.ui.state(), "Wrench")!;
-    await clickElement(wrenchEl2); // first click lifts...
-    await clickElement(wrenchEl2); // ...quick second click on the same slot wields
+    // Six stepped frames per phase put the two press edges 18 simulation
+    // frames apart: inside the documented 20-frame window, while exercising
+    // a natural multi-frame hold/release rather than one-frame pulses.
+    await clickElement(wrenchEl2, 6); // first click lifts...
+    await clickElement(wrenchEl2, 6); // ...quick second click on the same slot wields
     ui = await game.ui.state();
     assert.ok(!ui.cursor, "wielding clears the cursor");
     const afterWield = await game.player.inventory();


### PR DESCRIPTION
## Summary

- advance the flat inventory double-click clock only when simulation time advances
- preserve pointer edges processed by the debug runtime's paused zero-time command updates without letting those administrative updates consume the 20-frame gesture window
- extend the production MedSci1 inventory-drag regression to use natural six-frame hover/press/release phases

## Reproduction and root cause

On exact base `42fdf125`, the existing two-frame and four-frame click phases both wielded the Wrench, but six-frame phases failed: the Wrench returned to inventory instead of being wielded even though the two rising press edges were only 18 stepped simulation frames apart, inside the documented 20-frame window.

The debug runtime deliberately calls `Game::update` with zero elapsed time whenever a paused HTTP command is applied. `FlatUiHost::update` decremented its `frames_left` counter on every update, so setting pointer position/pressed channels silently consumed the gesture window in addition to `/v1/step` frames. The fix separates clock advancement from pointer processing and advances it only for nonzero mission updates.

## Visual evidence

![Natural multi-frame double-click now wields the Wrench](https://gist.githubusercontent.com/tommy-xr/8e4be0a8cc2b070f3f381470f4811c5b/raw/issue-798-double-click.gif)

<sub>Two natural clicks use six simulation frames for every hover, press, and release phase, placing their press edges 18 frames apart. The second click now wields the Wrench through the production inventory path. Captured headlessly in 25AE `medsci1.mis` via deterministic fixed-timestep stepping.</sub>

### After

![Wrench equipped in the flat viewmodel](https://gist.githubusercontent.com/tommy-xr/8e4be0a8cc2b070f3f381470f4811c5b/raw/issue-798-after.png)

### Before → after

![Before: Wrench remains in inventory; after: Wrench is wielded](https://gist.githubusercontent.com/tommy-xr/8e4be0a8cc2b070f3f381470f4811c5b/raw/issue-798-before-after.png)

[Artifact gist](https://gist.github.com/tommy-xr/8e4be0a8cc2b070f3f381470f4811c5b)

## Verification

All runtime verification explicitly used the System Shock 2 25th Anniversary Remaster root `/Users/bryan/ss2-25th`, including sentinel `/Users/bryan/ss2-25th/sshock2.kpf` and its remaster `mods/*.kpf`.

- negative-first authentic MedSci1 E2E: 6-frame phases failed on base with the Wrench still in inventory
- focused fixed MedSci1 E2E: passed before and after the final rebase
- focused paused-update regression: passed
- existing focused double-click regression: passed
- `cargo fmt --all -- --check`: passed
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed
- `cargo test -p shock2vr`: 902 passed, 2 ignored
- SDK unit suite: 26 passed, 282 E2E-gated skips
- full serialized SDK E2E: 296 passed, 4 failed, 8 fixture skips across 308 tests; the changed inventory-drag scenario and all 23 mission loads passed
- isolated failure set: saved-VR Wrench and its ragdoll control passed; Baby Arachnid contact, creature-loot reader binding, and Hydro3 transcript spacing reproduced their unrelated current-main failures

No relevant benchmark exists for this input/UI path.

## Risk

The change only affects the host-side double-click countdown. Pointer edges, drag placement/throw behavior, and the fixed 20-simulation-frame window are unchanged; paused zero-time updates simply stop aging the window.

Fixes #798
