### PR TITLE
feat(vr): cyber-interface pointer bridge and cursor-item drag

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -586,6 +586,13 @@ pub struct UiStateResult {
     /// The AMMOFULL ammo-cycle button (use mode + multi-ammo weapon); `Some`
     /// when shown. Click it to cycle the wielded weapon's ammo type.
     pub ammo_cycle: Option<shock2vr::game_scene::DebugUiElement>,
+    /// Where the pointer last landed on the shared canvas (flat: the mouse;
+    /// VR: the controller ray on the cyber-interface panel).
+    pub pointer: Option<shock2vr::game_scene::DebugUiPointer>,
+    /// The VR cyber-interface panel's pose, in pawn space; `Some` exactly
+    /// while the interface is up in VR. Aim a controller at a canvas rect by
+    /// mapping it through this.
+    pub panel_pose: Option<shock2vr::game_scene::DebugUiPanelPose>,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1163,6 +1163,8 @@ fn process_command(
                         strip: ui.strip,
                         cursor: ui.cursor,
                         ammo_cycle: ui.ammo_cycle,
+                        pointer: ui.pointer,
+                        panel_pose: ui.panel_pose,
                     }
                 })
                 .unwrap_or(commands::UiStateResult {
@@ -1171,6 +1173,8 @@ fn process_command(
                     strip: None,
                     cursor: None,
                     ammo_cycle: None,
+                    pointer: None,
+                    panel_pose: None,
                 });
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send ui state - receiver dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -547,8 +547,9 @@ pub struct DebugUiPointer {
     pub pressed: bool,
     /// The grab gesture (VR squeeze) is down.
     pub grabbing: bool,
-    /// "left" or "right" - which hand the gesture belongs to.
-    pub hand: String,
+    /// "left" or "right" - which hand the gesture belongs to, or `null` when
+    /// nothing is on the canvas (no hand owns the pointer).
+    pub hand: Option<String>,
 }
 
 /// The world panel a VR presentation hangs the shared canvas on, in pawn space

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -528,6 +528,42 @@ pub struct DebugUiState {
     /// wielded); clicking it cycles the wielded weapon's ammo type. `None`
     /// otherwise.
     pub ammo_cycle: Option<DebugUiElement>,
+    /// Where the pointer last landed on the shared canvas (flat: the mouse;
+    /// VR: the controller ray on the cyber-interface panel).
+    pub pointer: Option<DebugUiPointer>,
+    /// The VR cyber-interface panel's pose, in pawn space - `Some` exactly
+    /// while the interface is up in VR. Lets a client aim a controller at a
+    /// canvas rect without re-deriving the panel's placement.
+    pub panel_pose: Option<DebugUiPanelPose>,
+}
+
+/// One frame of pointing at the shared UI canvas.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugUiPointer {
+    /// Position on the 640x480 canvas, or `null` when the pointer is off it
+    /// (flat: the letterbox bars; VR: the ray missed the panel).
+    pub canvas: Option<[f32; 2]>,
+    /// The click button (flat LMB / VR trigger) is down.
+    pub pressed: bool,
+    /// The grab gesture (VR squeeze) is down.
+    pub grabbing: bool,
+    /// "left" or "right" - which hand the gesture belongs to.
+    pub hand: String,
+}
+
+/// The world panel a VR presentation hangs the shared canvas on, in pawn space
+/// (the same space `/v1/control/input` hand positions are given in).
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugUiPanelPose {
+    /// Panel center.
+    pub center: [f32; 3],
+    /// Panel orientation as `[x, y, z, w]`; the face normal is this applied to
+    /// `+Z`, and it points at the viewer.
+    pub rotation: [f32; 4],
+    /// Panel size in metres, `[width, height]`.
+    pub size: [f32; 2],
+    /// The authored canvas the panel presents, in pixels.
+    pub canvas: [f32; 2],
 }
 
 /// The item currently riding the cursor (a lifted inventory item): its runtime
@@ -820,6 +856,8 @@ pub trait DebuggableScene {
             strip: None,
             cursor: None,
             ammo_cycle: None,
+            pointer: None,
+            panel_pose: None,
         }
     }
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -140,6 +140,39 @@ pub struct CanvasPointer {
     pub bare_view: BareViewPress,
 }
 
+/// The cyber interface's pointer for one frame: a resolved VR pointer pass
+/// mapped into the host's canvas-pointer contract.
+///
+/// The whole VR side of the bridge, in one place: the ray's canvas hit is the
+/// cursor position, the trigger is the click button and the squeeze is the grab
+/// - reported for the hand the pass says owns the panel, which is also the hand
+/// a `GrabEntity` from a slot lands in.
+///
+/// A pointer is produced even when nothing is on the panel (`canvas_pos:
+/// None`). The trigger must stay accounted for while it is held off-panel, or
+/// sweeping a still-held press onto a slot would read as a fresh edge and lift
+/// an item nobody clicked.
+pub fn vr_canvas_pointer(
+    pass: &crate::ui::FrontendPointerPass,
+    input_context: &crate::input_context::InputContext,
+) -> CanvasPointer {
+    let hand = pass
+        .active_ray()
+        .map(|ray| ray.handedness)
+        .unwrap_or(Handedness::Right);
+    let input_hand = match hand {
+        Handedness::Left => &input_context.left_hand,
+        Handedness::Right => &input_context.right_hand,
+    };
+    CanvasPointer {
+        canvas_pos: pass.point(),
+        pressed: pass.pressed,
+        grabbing: input_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD,
+        hand,
+        bare_view: BareViewPress::Ignore,
+    }
+}
+
 /// The just-lifted item and where/when it was lifted, so a quick second click
 /// on the same slot reads as a double-click (wield) rather than a place.
 struct LiftMark {
@@ -1841,5 +1874,215 @@ mod tests {
         // Non-widget art with a "key" prefix must NOT label.
         assert_eq!(semantic_label("keypad2.pcx"), None);
         assert_eq!(semantic_label("crosshai.pcx"), None);
+    }
+
+    // --- The VR cyber interface's pointer bridge (slice 3) ---
+    //
+    // These drive the REAL pointer pass (`vr_frontend_pointer_pass`) against
+    // the REAL anchored panel (`test_support::test_panel`), then hand the
+    // result to the host through `vr_canvas_pointer` - the same three calls
+    // `mission_core` makes each frame. So they cover the whole bridge,
+    // ray -> canvas -> gesture, rather than a hand-rolled approximation of it.
+
+    use crate::input_context::{Hand, InputContext};
+    use crate::ui::{test_support, vr_frontend_pointer_pass};
+
+    /// One VR frame: the given hand aimed at a canvas point (or away), with a
+    /// trigger and squeeze, resolved exactly as the mission does.
+    fn vr_pointer(
+        hand: Handedness,
+        aim: Option<(f32, f32)>,
+        trigger: f32,
+        squeeze: f32,
+    ) -> CanvasPointer {
+        let posed = match aim {
+            Some((x, y)) => test_support::hand_aimed_at(CANVAS_SIZE, vec2(x, y), trigger),
+            None => test_support::hand_aimed_away(trigger),
+        };
+        let posed = Hand {
+            squeeze_value: squeeze,
+            ..posed
+        };
+        // The other controller is untracked, so it can neither steal the pass
+        // nor contribute a stray ray (the zero-quaternion guard).
+        let idle = Hand {
+            rotation: cgmath::Quaternion {
+                v: cgmath::vec3(0.0, 0.0, 0.0),
+                s: 0.0,
+            },
+            ..Hand::default()
+        };
+        let (right, left) = match hand {
+            Handedness::Right => (posed, idle),
+            Handedness::Left => (idle, posed),
+        };
+        let input = InputContext {
+            right_hand: right,
+            left_hand: left,
+            ..InputContext::default()
+        };
+        let pass = vr_frontend_pointer_pass(&input, CANVAS_SIZE, &test_support::test_panel());
+        vr_canvas_pointer(&pass, &input)
+    }
+
+    /// The bridge's core claim: a controller aimed at an inventory slot lands
+    /// on that slot's canvas pixels, and a trigger pull there lifts the item
+    /// onto the cursor - the same drag the flat mouse drives.
+    #[test]
+    fn a_controller_aimed_at_a_slot_lifts_its_item() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        // Slot 0's center on the shared canvas (as the flat drag tests use).
+        let slot = (23.5, 34.0);
+
+        let idle = vr_pointer(Handedness::Right, Some(slot), 0.0, 0.0);
+        let landed = idle.canvas_pos.expect("the ray should land on the panel");
+        assert!(
+            (landed.x - slot.0).abs() < 1.0 && (landed.y - slot.1).abs() < 1.0,
+            "the ray must land on the slot it was aimed at, got {:?}",
+            landed
+        );
+        host.update_canvas(&world, Some(idle));
+        assert!(host.cursor_debug().is_none(), "hovering must not lift");
+
+        host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Right, Some(slot), 1.0, 0.0)),
+        );
+        let cursor = host
+            .cursor_debug()
+            .expect("the trigger should lift the item");
+        assert_eq!(cursor.entity_id, wrench.inner() as i32);
+    }
+
+    /// Rule 6 of the vr-ui-design skill: a trigger already held as the
+    /// interface opens must not read as a click on whatever the ray first
+    /// crosses. Without `guard_held_press` the very first frame lifts an item.
+    #[test]
+    fn a_trigger_held_when_the_interface_opens_does_not_lift() {
+        let (world, mut host, _wrench, _inv) = drag_world();
+        let slot = (23.5, 34.0);
+        host.guard_held_press();
+
+        host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Right, Some(slot), 1.0, 0.0)),
+        );
+        assert!(
+            host.cursor_debug().is_none(),
+            "a carried-over press must not lift an item"
+        );
+
+        // Releasing and pulling again is a real click.
+        host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Right, Some(slot), 0.0, 0.0)),
+        );
+        host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Right, Some(slot), 1.0, 0.0)),
+        );
+        assert!(
+            host.cursor_debug().is_some(),
+            "a fresh pull after release must lift"
+        );
+    }
+
+    /// A press that starts off-panel and sweeps onto a slot while still held
+    /// is not a fresh edge: the pass reports the trigger even with nothing on
+    /// the panel, so the host has already swallowed it.
+    #[test]
+    fn a_press_swept_on_from_off_panel_does_not_lift() {
+        let (world, mut host, _wrench, _inv) = drag_world();
+        host.update_canvas(&world, Some(vr_pointer(Handedness::Right, None, 1.0, 0.0)));
+        host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Right, Some((23.5, 34.0)), 1.0, 0.0)),
+        );
+        assert!(
+            host.cursor_debug().is_none(),
+            "a press carried in from off-panel must not lift an item"
+        );
+    }
+
+    /// An untracked controller (the zero quaternion) reports no point at all,
+    /// so it can neither hover nor click from a hand nobody is holding.
+    #[test]
+    fn an_untracked_controller_never_points_at_the_interface() {
+        let (world, mut host, _wrench, _inv) = drag_world();
+        let untracked = InputContext::default();
+        let pass = vr_frontend_pointer_pass(&untracked, CANVAS_SIZE, &test_support::test_panel());
+        let pointer = vr_canvas_pointer(&pass, &untracked);
+        assert_eq!(pointer.canvas_pos, None);
+        host.update_canvas(&world, Some(pointer));
+        assert!(host.cursor_debug().is_none());
+    }
+
+    /// In VR the empty pixels of the panel are still the interface, not the 3D
+    /// view: a press there must not throw the item riding the cursor. On flat
+    /// the same press IS the bare view and throws it (the contrast is the
+    /// point - one `BareViewPress` decides it).
+    #[test]
+    fn an_off_widget_press_throws_on_flat_but_not_in_vr() {
+        // Empty canvas space, below the top-docked strip and clear of the
+        // (unopened) MFD slot.
+        let empty = (400.0, 400.0);
+
+        let (world, mut host, wrench, _inv) = drag_world();
+        press_edge(&mut host, &world, (23.5, 34.0));
+        assert!(host.cursor_debug().is_some(), "the item is on the cursor");
+        let actions = press_edge(&mut host, &world, empty);
+        assert_eq!(
+            actions,
+            vec![FlatUiDragAction::Throw(wrench)],
+            "flat: a click on the bare 3D view throws the held item"
+        );
+
+        let (world, mut host, _wrench, _inv) = drag_world();
+        press_edge(&mut host, &world, (23.5, 34.0));
+        assert!(host.cursor_debug().is_some());
+        host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Right, Some(empty), 0.0, 0.0)),
+        );
+        let (_msgs, actions) = host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Right, Some(empty), 1.0, 0.0)),
+        );
+        assert!(
+            actions.is_empty() && host.cursor_debug().is_some(),
+            "VR: empty panel space must keep the held item, not throw it"
+        );
+    }
+
+    /// Grab-to-hand parity: a squeeze on a slot reaches the strip's GuiScript
+    /// as a grab, addressed to the hand that is pointing - which is what makes
+    /// the panel emit `GrabEntity` into that hand, exactly as a loot panel
+    /// does. Without the squeeze/handedness passthrough the message says
+    /// "not grabbing, right hand" and the item never leaves the grid.
+    #[test]
+    fn a_squeeze_on_a_slot_reaches_the_strip_as_a_left_hand_grab() {
+        let (world, mut host, _wrench, inventory) = drag_world();
+        let (msgs, _actions) = host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Left, Some((23.5, 34.0)), 0.0, 1.0)),
+        );
+        let hover = msgs.first().expect("hovering a slot dispatches GUIHover");
+        assert_eq!(hover.to, inventory);
+        match hover.payload {
+            MessagePayload::GUIHover {
+                is_grabbing,
+                is_triggered,
+                hand,
+                ..
+            } => {
+                assert!(is_grabbing, "the squeeze must reach the panel as a grab");
+                assert_eq!(hand, Handedness::Left, "grabs land in the pointing hand");
+                assert!(
+                    !is_triggered,
+                    "the host owns strip clicks; the panel must not also see one"
+                );
+            }
+            ref other => panic!("expected a GUIHover, got {:?}", other),
+        }
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -229,6 +229,12 @@ pub struct FlatUiHost {
     /// `GET /v1/ui` - so a test can see where the VR ray actually landed on the
     /// canvas instead of inferring it from what lit up.
     last_pointer: Option<CanvasPointer>,
+    /// Whether the grab gesture was down last frame, so a *held* squeeze is
+    /// reported to the panel only on its rising edge. The panel's grab handler
+    /// is level-triggered (`GuiComponent::get_event` reads `is_grabbed`
+    /// directly), so a squeeze held while the ray swept the grid would take
+    /// every slot it crossed.
+    last_pointer_grabbing: bool,
     /// Last known render-target size, for pointer->canvas letterbox mapping
     /// (updated every rendered frame; 4:3 default until the first render).
     screen_size: Vector2<f32>,
@@ -259,6 +265,7 @@ impl FlatUiHost {
             hover_close: false,
             last_pointer_pressed: false,
             last_pointer: None,
+            last_pointer_grabbing: false,
             screen_size: CANVAS_SIZE,
         }
     }
@@ -290,10 +297,13 @@ impl FlatUiHost {
                 canvas: pointer.canvas_pos.map(|p| [p.x, p.y]),
                 pressed: pointer.pressed,
                 grabbing: pointer.grabbing,
-                hand: match pointer.hand {
+                // Only meaningful when something is actually on the canvas: off
+                // it there is no owning hand, and reporting one would invent a
+                // pointer the interface does not have.
+                hand: pointer.canvas_pos.map(|_| match pointer.hand {
                     Handedness::Left => "left".to_string(),
                     Handedness::Right => "right".to_string(),
-                },
+                }),
             })
     }
 
@@ -301,10 +311,10 @@ impl FlatUiHost {
     /// it cannot read as a fresh press-edge on the next frame.
     ///
     /// [`open`](Self::open) does this for the MFD slot (the frob that opened
-    /// the panel is still down); entering use mode needs the same guard - in VR
-    /// the interface can be opened with the trigger held, and rule 6 of the
-    /// vr-ui-design skill is that a screen entered under a held button starts
-    /// "already pressed".
+    /// the panel is still down); entering use mode needs the same guard, in
+    /// both presentations - an LMB overlapping the Tab, or a VR trigger held
+    /// while the interface opens. Rule 6 of the vr-ui-design skill: a screen
+    /// entered under a held button starts "already pressed".
     pub fn guard_held_press(&mut self) {
         self.last_pointer_pressed = true;
     }
@@ -530,7 +540,18 @@ impl FlatUiHost {
         world: &World,
         pointer: Option<CanvasPointer>,
     ) -> (Vec<Message>, Vec<FlatUiDragAction>) {
+        // Edge-detect the grab before anything can return early, so a squeeze
+        // held across frames is one gesture wherever the ray goes.
+        let grabbing = pointer.map(|p| p.grabbing).unwrap_or(false);
+        let grab_edge = grabbing && !self.last_pointer_grabbing;
+        self.last_pointer_grabbing = grabbing;
+        // `/v1/ui` reports the gesture as the player is making it (held or
+        // not); only what reaches the panel is reduced to the edge.
         self.last_pointer = pointer;
+        let pointer = pointer.map(|pointer| CanvasPointer {
+            grabbing: grab_edge,
+            ..pointer
+        });
         let pressed = pointer.map(|p| p.pressed).unwrap_or(false);
         let pressed_edge = pressed && !self.last_pointer_pressed;
         self.last_pointer_pressed = pressed;
@@ -2084,5 +2105,88 @@ mod tests {
             }
             ref other => panic!("expected a GUIHover, got {:?}", other),
         }
+    }
+
+    /// Both controllers on the panel, only the LEFT squeezing: the squeeze is
+    /// what claims the panel, so the grab must be reported for the left hand.
+    /// Trigger-only arbitration would fall back to the idle right hand, read
+    /// its (absent) squeeze, and take nothing - while the real left squeeze
+    /// went to the world instead.
+    #[test]
+    fn a_squeezing_hand_wins_the_panel_over_an_idle_one() {
+        let (world, mut host, _wrench, inventory) = drag_world();
+        let slot = vec2(23.5, 34.0);
+        let squeezing_left = Hand {
+            squeeze_value: 1.0,
+            ..test_support::hand_aimed_at(CANVAS_SIZE, slot, 0.0)
+        };
+        let idle_right = test_support::hand_aimed_at(CANVAS_SIZE, vec2(300.0, 60.0), 0.0);
+        let input = InputContext {
+            right_hand: idle_right,
+            left_hand: squeezing_left,
+            ..InputContext::default()
+        };
+        let pass = crate::ui::vr_pointer_pass(
+            &input,
+            CANVAS_SIZE,
+            &test_support::test_panel(),
+            crate::ui::PointerEngagement::TriggerOrGrab,
+        );
+        let pointer = vr_canvas_pointer(&pass, &input);
+        assert_eq!(pointer.hand, Handedness::Left);
+        assert!(pointer.grabbing);
+
+        let (msgs, _) = host.update_canvas(&world, Some(pointer));
+        let hover = msgs
+            .first()
+            .expect("the squeezing hand should hover a slot");
+        assert_eq!(hover.to, inventory);
+        match hover.payload {
+            MessagePayload::GUIHover {
+                is_grabbing, hand, ..
+            } => {
+                assert!(is_grabbing);
+                assert_eq!(hand, Handedness::Left);
+            }
+            ref other => panic!("expected a GUIHover, got {:?}", other),
+        }
+    }
+
+    /// The panel's grab handler is level-triggered, so a squeeze held while the
+    /// ray sweeps the grid would take every slot it crossed. Only the rising
+    /// edge reaches the panel.
+    #[test]
+    fn a_held_squeeze_grabs_once_however_far_the_ray_sweeps() {
+        let (world, mut host, _wrench, _inv) = drag_world();
+        let grabbing = |canvas: (f32, f32)| CanvasPointer {
+            canvas_pos: Some(vec2(canvas.0, canvas.1)),
+            pressed: false,
+            grabbing: true,
+            hand: Handedness::Right,
+            bare_view: BareViewPress::Ignore,
+        };
+        let grabs = |msgs: Vec<Message>| {
+            msgs.iter()
+                .filter(|m| {
+                    matches!(
+                        m.payload,
+                        MessagePayload::GUIHover {
+                            is_grabbing: true,
+                            ..
+                        }
+                    )
+                })
+                .count()
+        };
+        let (first, _) = host.update_canvas(&world, Some(grabbing((23.5, 34.0))));
+        assert_eq!(grabs(first), 1, "the squeeze's rising edge grabs");
+        let (held, _) = host.update_canvas(&world, Some(grabbing((23.5, 34.0))));
+        assert_eq!(grabs(held), 0, "the same held squeeze must not grab again");
+        let (swept, _) = host.update_canvas(&world, Some(grabbing((58.5, 34.0))));
+        assert_eq!(
+            grabs(swept),
+            0,
+            "sweeping a held squeeze onto another slot must not take it too"
+        );
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -34,8 +34,10 @@ use crate::{
     vr_config::Handedness,
 };
 
-/// The shared 640x480 virtual canvas the flat HUD renders on.
-const CANVAS_SIZE: Vector2<f32> = Vector2::new(640.0, 480.0);
+/// The shared 640x480 virtual canvas the flat HUD renders on - and, in VR, the
+/// canvas the cyber-interface panel presents, so a ray is mapped onto exactly
+/// the pixels the host lays its widgets out in.
+pub const CANVAS_SIZE: Vector2<f32> = Vector2::new(640.0, 480.0);
 
 /// The original game's left MFD slot anchor for world-object panels (keypad,
 /// container, ...) on the 640x480 canvas: rect `(2, 124, 188x300)`.
@@ -89,6 +91,55 @@ pub enum FlatUiDragAction {
 const DOUBLE_CLICK_WINDOW_FRAMES: u32 = 20;
 const DOUBLE_CLICK_RADIUS: f32 = 24.0;
 
+/// What a press that lands on neither the strip nor the MFD panel means.
+///
+/// The two presentations genuinely differ here, and only here. On flat the
+/// canvas is drawn over the 3D view, so everything the widgets do not cover
+/// *is* the world: clicking it is the original's exit gesture (close the MFD,
+/// throw the held item). In VR the same canvas is the cyber-interface panel
+/// hanging in front of the player - its empty pixels are still the interface,
+/// and a ray off the panel entirely means that hand is not pointing at the UI
+/// at all (it stays a world hand, see
+/// [`crate::ui::vr_frontend_pointer_pass`]).
+///
+/// This is an input-semantics difference, not a layout one: nothing here moves
+/// or resizes a widget, so the shared canvas still renders identically
+/// (AGENTS.md §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BareViewPress {
+    /// Flat: a press off the widgets is a click on the 3D view behind them.
+    Exit,
+    /// VR: a press off the widgets is not an exit gesture. (Throwing a held
+    /// item into the world from the panel is a later slice.)
+    Ignore,
+}
+
+/// One frame of pointing at the host's canvas, already resolved to canvas
+/// pixels.
+///
+/// The single input contract both presentations feed: flat resolves it from the
+/// mouse through [`pointer_to_canvas`], VR from the controller ray through
+/// [`crate::ui::ray_to_canvas`]. Everything downstream - hover routing, the
+/// close gestures, the cursor-is-the-item drag - runs on this one struct, so
+/// the mouse and the VR ray cannot drift into two different interfaces.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CanvasPointer {
+    /// Where the pointer is on the 640x480 canvas, or `None` when it is off it
+    /// (flat: the letterbox bars; VR: the ray missed the panel).
+    pub canvas_pos: Option<Vector2<f32>>,
+    /// The click button: flat LMB, VR trigger.
+    pub pressed: bool,
+    /// The grab gesture: the VR squeeze. Flat has none, so it is always false
+    /// there - the same `GUIHover` field the hand ray fills, which is what lets
+    /// a squeeze on a panel item pull it into the hand.
+    pub grabbing: bool,
+    /// Which hand the gesture belongs to, for the panel's per-hand edge
+    /// tracking and for `GrabEntity`'s destination hand. Flat reports `Right`.
+    pub hand: Handedness,
+    /// What a press away from the host's widgets means.
+    pub bare_view: BareViewPress,
+}
+
 /// The just-lifted item and where/when it was lifted, so a quick second click
 /// on the same slot reads as a double-click (wield) rather than a place.
 struct LiftMark {
@@ -141,6 +192,10 @@ pub struct FlatUiHost {
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
     last_pointer_pressed: bool,
+    /// The pointer of the latest [`update_canvas`](Self::update_canvas), for
+    /// `GET /v1/ui` - so a test can see where the VR ray actually landed on the
+    /// canvas instead of inferring it from what lit up.
+    last_pointer: Option<CanvasPointer>,
     /// Last known render-target size, for pointer->canvas letterbox mapping
     /// (updated every rendered frame; 4:3 default until the first render).
     screen_size: Vector2<f32>,
@@ -170,6 +225,7 @@ impl FlatUiHost {
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
+            last_pointer: None,
             screen_size: CANVAS_SIZE,
         }
     }
@@ -192,6 +248,32 @@ impl FlatUiHost {
                 entity_id: c.entity.inner() as i32,
                 label: c.label.clone(),
             })
+    }
+
+    /// Where the pointer last landed on the canvas, for `GET /v1/ui`.
+    pub fn pointer_debug(&self) -> Option<crate::game_scene::DebugUiPointer> {
+        self.last_pointer
+            .map(|pointer| crate::game_scene::DebugUiPointer {
+                canvas: pointer.canvas_pos.map(|p| [p.x, p.y]),
+                pressed: pointer.pressed,
+                grabbing: pointer.grabbing,
+                hand: match pointer.hand {
+                    Handedness::Left => "left".to_string(),
+                    Handedness::Right => "right".to_string(),
+                },
+            })
+    }
+
+    /// Swallow a button that is already held as the host takes over input, so
+    /// it cannot read as a fresh press-edge on the next frame.
+    ///
+    /// [`open`](Self::open) does this for the MFD slot (the frob that opened
+    /// the panel is still down); entering use mode needs the same guard - in VR
+    /// the interface can be opened with the trigger held, and rule 6 of the
+    /// vr-ui-design skill is that a screen entered under a held button starts
+    /// "already pressed".
+    pub fn guard_held_press(&mut self) {
+        self.last_pointer_pressed = true;
     }
 
     /// Set (or clear) the AMMOFULL ammo-cycle button's canvas rect for this
@@ -389,6 +471,33 @@ impl FlatUiHost {
         world: &World,
         pointer: Option<Pointer2D>,
     ) -> (Vec<Message>, Vec<FlatUiDragAction>) {
+        // Flat's only job is resolving the mouse onto the canvas; the gestures
+        // themselves live in the shared core below.
+        let pointer = pointer.map(|pointer| CanvasPointer {
+            canvas_pos: pointer_to_canvas(
+                CANVAS_SIZE,
+                pointer.position,
+                self.screen_size,
+                ScaleMode::PreserveAspect,
+            ),
+            pressed: pointer.pressed,
+            grabbing: false,
+            hand: Handedness::Right,
+            bare_view: BareViewPress::Exit,
+        });
+        self.update_canvas(world, pointer)
+    }
+
+    /// The presentation-free core of [`update`](Self::update): the same frame
+    /// of pointing, expressed in canvas pixels. VR's cyber-interface panel
+    /// enters here directly (its ray is already a canvas point), so both
+    /// presentations run one implementation of every gesture.
+    pub fn update_canvas(
+        &mut self,
+        world: &World,
+        pointer: Option<CanvasPointer>,
+    ) -> (Vec<Message>, Vec<FlatUiDragAction>) {
+        self.last_pointer = pointer;
         let pressed = pointer.map(|p| p.pressed).unwrap_or(false);
         let pressed_edge = pressed && !self.last_pointer_pressed;
         self.last_pointer_pressed = pressed;
@@ -442,21 +551,17 @@ impl FlatUiHost {
             self.hover_close = false;
             return (Vec::new(), Vec::new());
         };
-        let canvas_pos = pointer_to_canvas(
-            CANVAS_SIZE,
-            pointer.position,
-            self.screen_size,
-            ScaleMode::PreserveAspect,
-        );
+        let canvas_pos = pointer.canvas_pos;
         self.cursor_canvas = canvas_pos;
         if canvas_pos.is_none() {
             self.hover_close = false;
         }
 
-        // A press fully outside the canvas (letterbox bars) is a bare-view
-        // click: throw a held item, else close the panel.
+        // A press fully outside the canvas (flat: the letterbox bars) is a
+        // bare-view click: throw a held item, else close the panel. In VR the
+        // canvas is the panel, so an off-panel press belongs to the world hand.
         let Some(canvas_pos) = canvas_pos else {
-            if pressed_edge {
+            if pressed_edge && pointer.bare_view == BareViewPress::Exit {
                 if let Some(held) = self.cursor_item.take() {
                     return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
                 }
@@ -518,10 +623,11 @@ impl FlatUiHost {
                 }
                 return (Vec::new(), Vec::new());
             }
-            if over_panel || over_ammo {
+            if over_panel || over_ammo || pointer.bare_view == BareViewPress::Ignore {
                 // Escape hatch: a click on an open MFD or the AMMOFULL cycle
                 // button keeps the held item (a visible button must not throw
-                // the item you're carrying).
+                // the item you're carrying) - and so does empty panel space in
+                // VR, where there is no 3D view behind the canvas to throw at.
                 return (Vec::new(), Vec::new());
             }
             // Bare 3D view: throw the held item along the view ray.
@@ -562,7 +668,14 @@ impl FlatUiHost {
             }
             let rect = strip_rect.unwrap();
             let entity = self.strip.as_ref().unwrap().entity;
-            return (vec![gui_hover(entity, rect, canvas_pos, false)], Vec::new());
+            // The click (`is_triggered`) is deliberately withheld: the host
+            // owns strip clicks as the cursor-is-the-item drag above. The
+            // squeeze is not - it is how a VR hand takes an item straight out
+            // of the grid, exactly as it does from a loot panel.
+            return (
+                vec![gui_hover(entity, rect, canvas_pos, false, pointer)],
+                Vec::new(),
+            );
         }
 
         let Some(panel) = self.active_panel else {
@@ -586,12 +699,12 @@ impl FlatUiHost {
 
         if rect.contains(canvas_pos) {
             (
-                vec![gui_hover(panel, rect, canvas_pos, pointer.pressed)],
+                vec![gui_hover(panel, rect, canvas_pos, pointer.pressed, pointer)],
                 Vec::new(),
             )
         } else {
             // LMB on the bare 3D view closes the panels (manual p.7).
-            if pressed_edge {
+            if pressed_edge && pointer.bare_view == BareViewPress::Exit {
                 self.close();
             }
             (Vec::new(), Vec::new())
@@ -863,9 +976,16 @@ fn strip_canvas_rect(strip_size_px: Vector2<f32>) -> Rect {
 
 /// A `GUIHover` for `to`, in panel-local normalized coordinates - the same
 /// message the VR hand ray produces, so `GuiScript`'s hit-test/edge-detection
-/// runs unchanged. LMB maps to the right-hand trigger; flat has no grab
-/// gesture yet.
-fn gui_hover(to: EntityId, rect: Rect, canvas_pos: Vector2<f32>, pressed: bool) -> Message {
+/// runs unchanged. The click button maps to LMB on flat and the trigger in VR;
+/// the grab gesture is the VR squeeze (flat has none), and the hand it is
+/// reported for is where a `GrabEntity` from the panel lands.
+fn gui_hover(
+    to: EntityId,
+    rect: Rect,
+    canvas_pos: Vector2<f32>,
+    pressed: bool,
+    pointer: CanvasPointer,
+) -> Message {
     let local = point2(
         (canvas_pos.x - rect.x) / rect.w,
         (canvas_pos.y - rect.y) / rect.h,
@@ -876,8 +996,8 @@ fn gui_hover(to: EntityId, rect: Rect, canvas_pos: Vector2<f32>, pressed: bool) 
             held_entity_id: None,
             screen_coordinates: local,
             is_triggered: pressed,
-            is_grabbing: false,
-            hand: Handedness::Right,
+            is_grabbing: pointer.grabbing,
+            hand: pointer.hand,
         },
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -156,6 +156,43 @@ fn resolve_optional_log_art_texture(
 /// loop, so periodically let the host service its platform queues.
 const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
 
+/// Index of a hand in the per-hand `[left, right]` arrays this module keeps
+/// (the VR grab swallow, the on-panel arbitration). One conversion, so the two
+/// sides of a latch can never disagree about which slot a hand owns.
+fn hand_slot(hand: crate::vr_config::Handedness) -> usize {
+    match hand {
+        crate::vr_config::Handedness::Left => 0,
+        crate::vr_config::Handedness::Right => 1,
+    }
+}
+
+/// Advance the VR grab swallow one frame, per hand (see
+/// [`MissionCore::vr_squeeze_swallow`]).
+///
+/// `claims` is "the cyber interface owns this hand's squeeze right now" - its
+/// ray is on the panel with the interface up. The latch turns that instant into
+/// a gesture: once set it holds until the squeeze is released, so a squeeze
+/// begun on the panel cannot reach the world by sliding off the panel edge or
+/// by the mode closing under it. It also drops the moment the hand is holding
+/// something, because a hand that just took an item off the panel must see its
+/// own squeeze again - masking it would read as a release.
+///
+/// Pure, so the rule is exercised directly rather than through a whole mission.
+fn update_squeeze_swallow(
+    latched: &mut [bool; 2],
+    squeezing: [bool; 2],
+    hand_empty: [bool; 2],
+    claims: [bool; 2],
+) {
+    for slot in 0..latched.len() {
+        if !squeezing[slot] || !hand_empty[slot] {
+            latched[slot] = false;
+        } else if claims[slot] {
+            latched[slot] = true;
+        }
+    }
+}
+
 /// Head-relative authored-space placement for the wide VR backpack canvas.
 /// After `SCALE_FACTOR` conversion this is 2 world units forward and 1.2 up.
 /// The shared canvas keeps its authored pixels; the physical VR boundary
@@ -992,11 +1029,16 @@ pub struct MissionCore {
     /// (rule 5 of the vr-ui-design skill).
     vr_use_mode_pointer: Option<crate::ui::FrontendPointerPass>,
 
-    /// The beam/hand/dot the cyber-interface pointer draws. Holds the lazily
-    /// loaded glove model, like the frontend screens' copy.
-    /// (In a `RefCell` because the render path takes `&self` while the world
-    /// is borrowed - the same shape `VrInteraction` uses for its glove.)
-    vr_use_mode_pointer_visuals: std::cell::RefCell<crate::ui::PointerVisuals>,
+    /// VR grab swallow, per hand (indexed by [`hand_slot`]): while the cyber
+    /// interface masks a hand's squeeze, that hand keeps seeing a released
+    /// squeeze until the player actually lets go. World grabbing is
+    /// *level*-triggered (`VirtualHand` grabs whenever the squeeze is down), so
+    /// without this a squeeze begun on the panel would grab whatever the ray
+    /// hits the instant it slipped off the panel edge - or the moment the mode
+    /// closed. Cleared as soon as the hand releases, or as soon as it is
+    /// holding something: a hand that just took an item off the panel must see
+    /// its own squeeze again, or the eventual release would not drop it.
+    vr_squeeze_swallow: [bool; 2],
 
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
     /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
@@ -1797,7 +1839,7 @@ impl MissionCore {
             vr_use_mode_head: crate::ui::world_dim::UNTRACKED_HEAD,
             vr_trigger_swallow: false,
             vr_use_mode_pointer: None,
-            vr_use_mode_pointer_visuals: std::cell::RefCell::new(crate::ui::PointerVisuals::new()),
+            vr_squeeze_swallow: [false; 2],
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
@@ -2388,10 +2430,13 @@ impl MissionCore {
             );
             // The VR ray plays the role of the mouse: one pass resolves where
             // each controller lands on the panel and which one owns it.
-            self.vr_use_mode_pointer = Some(crate::ui::vr_frontend_pointer_pass(
+            self.vr_use_mode_pointer = Some(crate::ui::vr_pointer_pass(
                 input_context,
                 crate::mission::flat_ui_host::CANVAS_SIZE,
                 &panel,
+                // A squeeze claims the panel here, unlike on a frontend screen:
+                // it is how a hand takes an item out of a slot.
+                crate::ui::PointerEngagement::TriggerOrGrab,
             ));
         }
         if self.vr_trigger_swallow && !self.use_mode {
@@ -2403,48 +2448,55 @@ impl MissionCore {
             }
         }
 
-        // Which hand (if any) is currently pointing at the cyber-interface
-        // panel. Per-hand arbitration (cyber-interface plan, owner decision 4):
-        // that hand is a UI pointer this frame; the other stays an ordinary
-        // `VirtualHand` for world grab/drop.
-        let ui_pointer_hand = self
-            .vr_use_mode_pointer
-            .as_ref()
-            .and_then(|pass| pass.active_ray())
-            .map(|ray| ray.handedness);
+        // Per-hand arbitration (cyber-interface plan, owner decision 4): a hand
+        // whose ray is ON the panel is a UI pointer this frame; a hand off it
+        // stays an ordinary `VirtualHand` for world grab/drop. Note this is
+        // *every* hand on the panel, not just the one driving the point - an
+        // idle hand resting on the panel is not the pointer, but its squeeze
+        // must still not reach through the panel into the world.
+        let (left_hand_held, right_hand_held) = self.interaction.held_entities();
+        let hand_empty = [left_hand_held.is_none(), right_hand_held.is_none()];
+        let mut on_panel = [false; 2];
+        if let Some(pass) = self.vr_use_mode_pointer.as_ref() {
+            for ray in pass.rays.iter().filter(|ray| ray.canvas_hit.is_some()) {
+                on_panel[hand_slot(ray.handedness)] = true;
+            }
+        }
+        let squeezing = [
+            input_context.left_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD,
+            input_context.right_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD,
+        ];
+        update_squeeze_swallow(
+            &mut self.vr_squeeze_swallow,
+            squeezing,
+            hand_empty,
+            [self.use_mode && on_panel[0], self.use_mode && on_panel[1]],
+        );
 
         // VR weapon-safe: while the cyber interface is up (and until a
         // trigger held across its exit is released) the hands see zeroed
         // triggers, so the wielded weapon cannot fire - it stays wielded and
         // visible. The analog of the flat runtime's mouse-ownership swallow
-        // latch.
-        //
-        // The squeeze is masked far more narrowly: only for the hand driving
-        // the pointer, and only while it is *empty*. That is what lets a
-        // squeeze on an inventory slot pull the item into that hand (the panel
-        // emits `GrabEntity`) without the same squeeze also grabbing whatever
-        // the hand happens to be aimed at in the world. Masking a hand that is
-        // already holding something would read as a release and drop it.
-        let hands_held = self.interaction.held_entities();
-        let hand_is_empty = |hand: crate::vr_config::Handedness| match hand {
-            crate::vr_config::Handedness::Left => hands_held.0.is_none(),
-            crate::vr_config::Handedness::Right => hands_held.1.is_none(),
-        };
+        // latch. Squeezes are masked only per the latch above, so a squeeze on
+        // an inventory slot pulls the item into that hand (the panel emits
+        // `GrabEntity`) without also grabbing whatever the hand was aimed at.
+        let safe_triggers = self.use_mode || self.vr_trigger_swallow;
         let weapon_safe_input = (game_options.presentation_mode == crate::PresentationMode::Vr
-            && (self.use_mode || self.vr_trigger_swallow))
-            .then(|| {
-                let mut safe = input_context.clone();
+            && (safe_triggers || self.vr_squeeze_swallow.iter().any(|latched| *latched)))
+        .then(|| {
+            let mut safe = input_context.clone();
+            if safe_triggers {
                 safe.left_hand.trigger_value = 0.0;
                 safe.right_hand.trigger_value = 0.0;
-                match ui_pointer_hand.filter(|hand| hand_is_empty(*hand)) {
-                    Some(crate::vr_config::Handedness::Left) => safe.left_hand.squeeze_value = 0.0,
-                    Some(crate::vr_config::Handedness::Right) => {
-                        safe.right_hand.squeeze_value = 0.0
-                    }
-                    None => {}
-                }
-                safe
-            });
+            }
+            if self.vr_squeeze_swallow[hand_slot(crate::vr_config::Handedness::Left)] {
+                safe.left_hand.squeeze_value = 0.0;
+            }
+            if self.vr_squeeze_swallow[hand_slot(crate::vr_config::Handedness::Right)] {
+                safe.right_hand.squeeze_value = 0.0;
+            }
+            safe
+        });
         let hands_input = weapon_safe_input.as_ref().unwrap_or(input_context);
 
         // VR drives two hands; flat drives a single first-person weapon
@@ -2512,12 +2564,17 @@ impl MissionCore {
             // fed to the same host the mouse drives. Everything after this - the
             // hover routing, the cursor-is-the-item drag, grab-to-hand - is the
             // one shared implementation.
-            crate::PresentationMode::Vr => {
+            // Only while the interface is up: outside it the host has nothing
+            // bound in VR, and running its walk-away / bare-view logic against
+            // a pointer that does not exist would be a trap for whatever opens
+            // a host slot in VR next.
+            crate::PresentationMode::Vr if self.use_mode => {
                 let pointer = self.vr_use_mode_pointer.as_ref().map(|pass| {
                     crate::mission::flat_ui_host::vr_canvas_pointer(pass, input_context)
                 });
                 self.flat_ui.update_canvas(&self.world, pointer)
             }
+            crate::PresentationMode::Vr => (Vec::new(), Vec::new()),
         };
         for msg in ui_messages {
             self.script_world.dispatch(msg);
@@ -6969,9 +7026,12 @@ impl MissionCore {
     /// entry from the tracked head pose, world-locked, lazily recentered);
     /// the dim follows the live gaze, falling back to the panel while the
     /// head is untracked (see `crate::ui::world_dim::dim_pose`).
-    /// The pointer (beam, hand, hit dot) is drawn last, from the same pass the
+    /// The pointer (aim beams + hit dot) is drawn last, from the same pass the
     /// canvas was hit-tested with, so the dot can only ever mark the pixel the
-    /// interface actually reacted to.
+    /// interface actually reacted to. Deliberately hand-less: unlike a frontend
+    /// screen this is a mode of play, so the player's own hands are still being
+    /// rendered by the interaction controller, and a second static glove would
+    /// stack on top of them (the defect issue #1018 fixed for the pause menu).
     fn render_vr_use_mode(&self, asset_cache: &mut AssetCache) -> Vec<SceneObject> {
         use crate::ui::world_dim;
         let panel = self.vr_use_mode_anchor.panel();
@@ -6986,8 +7046,7 @@ impl MissionCore {
         objects.extend(self.flat_ui.render_world_space(asset_cache, &panel));
         if let Some(pass) = self.vr_use_mode_pointer.as_ref() {
             let panel_layers = objects.len();
-            objects.extend(self.vr_use_mode_pointer_visuals.borrow_mut().render(
-                asset_cache,
+            objects.extend(crate::ui::pointer_beams(
                 pass,
                 crate::mission::flat_ui_host::CANVAS_SIZE,
                 &panel,
@@ -9113,7 +9172,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             // The panel a client aims a controller at, reported straight off
             // the anchor that placed it - so a test cannot aim at a placement
             // the interface does not use.
-            panel_pose: self.vr_use_mode_pointer.as_ref().map(|_| {
+            panel_pose: self.vr_use_mode_pointer.is_some().then(|| {
                 let panel = self.vr_use_mode_anchor.panel();
                 crate::game_scene::DebugUiPanelPose {
                     center: [panel.center.x, panel.center.y, panel.center.z],
@@ -9993,6 +10052,64 @@ mod player_death_tests {
             active_resurrection_target(&world),
             Some((expected_position, expected_rotation))
         );
+    }
+}
+
+#[cfg(test)]
+mod vr_squeeze_swallow_tests {
+    use super::update_squeeze_swallow;
+
+    const LEFT: usize = 0;
+    const RIGHT: usize = 1;
+
+    /// The whole point of the latch: a squeeze that started on the panel keeps
+    /// being swallowed after the ray leaves it (and after the interface
+    /// closes), so it can never reach through into a world grab. Without the
+    /// latch the mask is recomputed per frame and vanishes the instant the
+    /// claim does - while `VirtualHand` grabs on the squeeze *level*.
+    #[test]
+    fn a_squeeze_begun_on_the_panel_never_reaches_the_world() {
+        let mut latched = [false; 2];
+        // On the panel, hand empty, squeezing: claimed.
+        update_squeeze_swallow(&mut latched, [true, false], [true, true], [true, false]);
+        assert!(latched[LEFT]);
+        // Ray slips off the panel - still swallowed.
+        update_squeeze_swallow(&mut latched, [true, false], [true, true], [false, false]);
+        assert!(latched[LEFT]);
+        // The interface closes (nothing claims anything) - still swallowed.
+        update_squeeze_swallow(&mut latched, [true, false], [true, true], [false, false]);
+        assert!(latched[LEFT]);
+        // Released at last: the next squeeze is the player's own again.
+        update_squeeze_swallow(&mut latched, [false, false], [true, true], [false, false]);
+        assert!(!latched[LEFT]);
+        update_squeeze_swallow(&mut latched, [true, false], [true, true], [false, false]);
+        assert!(
+            !latched[LEFT],
+            "a squeeze begun off the panel is the world's"
+        );
+    }
+
+    /// A hand that just took an item off the panel stops being masked, or the
+    /// mask would read as a release and drop what it just took.
+    #[test]
+    fn taking_an_item_hands_the_squeeze_back() {
+        let mut latched = [false; 2];
+        update_squeeze_swallow(&mut latched, [false, true], [true, true], [false, true]);
+        assert!(latched[RIGHT]);
+        // The grab landed: the hand is no longer empty, squeeze still held.
+        update_squeeze_swallow(&mut latched, [false, true], [true, false], [false, true]);
+        assert!(
+            !latched[RIGHT],
+            "a hand holding something must see its own squeeze"
+        );
+    }
+
+    /// Each hand latches on its own: the off-panel hand keeps world grabbing.
+    #[test]
+    fn the_off_panel_hand_is_untouched() {
+        let mut latched = [false; 2];
+        update_squeeze_swallow(&mut latched, [true, true], [true, true], [true, false]);
+        assert_eq!(latched, [true, false]);
     }
 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -983,6 +983,21 @@ pub struct MissionCore {
     /// `closed_under_a_held_press` rule, applied to the hands).
     vr_trigger_swallow: bool,
 
+    /// The cyber interface's pointer for this frame: every tracked
+    /// controller's ray against the panel, and which one the canvas is
+    /// listening to. `None` outside the mode. Resolved once per frame by
+    /// [`crate::ui::vr_frontend_pointer_pass`] - the same pass the frontend
+    /// screens use - so the canvas hit-test, the hand arbitration and the
+    /// drawn beam/dot can never disagree about where the player is pointing
+    /// (rule 5 of the vr-ui-design skill).
+    vr_use_mode_pointer: Option<crate::ui::FrontendPointerPass>,
+
+    /// The beam/hand/dot the cyber-interface pointer draws. Holds the lazily
+    /// loaded glove model, like the frontend screens' copy.
+    /// (In a `RefCell` because the render path takes `&self` while the world
+    /// is borrowed - the same shape `VrInteraction` uses for its glove.)
+    vr_use_mode_pointer_visuals: std::cell::RefCell<crate::ui::PointerVisuals>,
+
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
     /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
     /// `GuiManager` for the corresponding object-bound world panel.
@@ -1781,6 +1796,8 @@ impl MissionCore {
             vr_use_mode_anchor: crate::ui::FrontendPanelAnchor::new(),
             vr_use_mode_head: crate::ui::world_dim::UNTRACKED_HEAD,
             vr_trigger_swallow: false,
+            vr_use_mode_pointer: None,
+            vr_use_mode_pointer_visuals: std::cell::RefCell::new(crate::ui::PointerVisuals::new()),
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
@@ -2359,15 +2376,23 @@ impl MissionCore {
         }
 
         // VR cyber interface (use mode): follow the head for the anchor's
-        // lazy recenter and the comfort dim, and clear the weapon-safe latch
-        // once every trigger is released.
+        // lazy recenter and the comfort dim, resolve this frame's pointer, and
+        // clear the weapon-safe latch once every trigger is released.
+        self.vr_use_mode_pointer = None;
         if game_options.presentation_mode == crate::PresentationMode::Vr && self.use_mode {
             self.vr_use_mode_head = (input_context.head.position, input_context.head.rotation);
-            self.vr_use_mode_anchor.update(
+            let panel = self.vr_use_mode_anchor.update(
                 input_context.head.position,
                 input_context.head.rotation,
                 time.elapsed,
             );
+            // The VR ray plays the role of the mouse: one pass resolves where
+            // each controller lands on the panel and which one owns it.
+            self.vr_use_mode_pointer = Some(crate::ui::vr_frontend_pointer_pass(
+                input_context,
+                crate::mission::flat_ui_host::CANVAS_SIZE,
+                &panel,
+            ));
         }
         if self.vr_trigger_swallow && !self.use_mode {
             let held = |hand: &crate::input_context::Hand| {
@@ -2378,17 +2403,46 @@ impl MissionCore {
             }
         }
 
+        // Which hand (if any) is currently pointing at the cyber-interface
+        // panel. Per-hand arbitration (cyber-interface plan, owner decision 4):
+        // that hand is a UI pointer this frame; the other stays an ordinary
+        // `VirtualHand` for world grab/drop.
+        let ui_pointer_hand = self
+            .vr_use_mode_pointer
+            .as_ref()
+            .and_then(|pass| pass.active_ray())
+            .map(|ray| ray.handedness);
+
         // VR weapon-safe: while the cyber interface is up (and until a
         // trigger held across its exit is released) the hands see zeroed
         // triggers, so the wielded weapon cannot fire - it stays wielded and
-        // visible, and squeeze-driven grab/drop still works. The analog of
-        // the flat runtime's mouse-ownership swallow latch.
+        // visible. The analog of the flat runtime's mouse-ownership swallow
+        // latch.
+        //
+        // The squeeze is masked far more narrowly: only for the hand driving
+        // the pointer, and only while it is *empty*. That is what lets a
+        // squeeze on an inventory slot pull the item into that hand (the panel
+        // emits `GrabEntity`) without the same squeeze also grabbing whatever
+        // the hand happens to be aimed at in the world. Masking a hand that is
+        // already holding something would read as a release and drop it.
+        let hands_held = self.interaction.held_entities();
+        let hand_is_empty = |hand: crate::vr_config::Handedness| match hand {
+            crate::vr_config::Handedness::Left => hands_held.0.is_none(),
+            crate::vr_config::Handedness::Right => hands_held.1.is_none(),
+        };
         let weapon_safe_input = (game_options.presentation_mode == crate::PresentationMode::Vr
             && (self.use_mode || self.vr_trigger_swallow))
             .then(|| {
                 let mut safe = input_context.clone();
                 safe.left_hand.trigger_value = 0.0;
                 safe.right_hand.trigger_value = 0.0;
+                match ui_pointer_hand.filter(|hand| hand_is_empty(*hand)) {
+                    Some(crate::vr_config::Handedness::Left) => safe.left_hand.squeeze_value = 0.0,
+                    Some(crate::vr_config::Handedness::Right) => {
+                        safe.right_hand.squeeze_value = 0.0
+                    }
+                    None => {}
+                }
                 safe
             });
         let hands_input = weapon_safe_input.as_ref().unwrap_or(input_context);
@@ -2438,25 +2492,58 @@ impl MissionCore {
         // and drive it through the same GUIHover contract the VR hand ray
         // uses. Dispatched before the script update so hovers/clicks are
         // processed this frame.
-        if game_options.presentation_mode == crate::PresentationMode::Flat {
-            // Expose the AMMOFULL ammo-cycle button for hit-testing exactly when
-            // the flat HUD draws it (the shared visibility predicate, so the
-            // clickable rect never diverges from the rendered button).
-            let ammo_button = if crate::hud::ammo_cycle_button_visible(&self.world, self.use_mode) {
-                Some(crate::hud::AMMO_CYCLE_BUTTON)
-            } else {
-                None
-            };
-            self.flat_ui.set_ammo_cycle_button(ammo_button);
-
-            let (messages, drag_actions) = self.flat_ui.update(&self.world, input_context.pointer);
-            for msg in messages {
-                self.script_world.dispatch(msg);
+        let (ui_messages, ui_drag_actions) = match game_options.presentation_mode {
+            crate::PresentationMode::Flat => {
+                // Expose the AMMOFULL ammo-cycle button for hit-testing exactly
+                // when the flat HUD draws it (the shared visibility predicate,
+                // so the clickable rect never diverges from the rendered
+                // button).
+                let ammo_button =
+                    if crate::hud::ammo_cycle_button_visible(&self.world, self.use_mode) {
+                        Some(crate::hud::AMMO_CYCLE_BUTTON)
+                    } else {
+                        None
+                    };
+                self.flat_ui.set_ammo_cycle_button(ammo_button);
+                self.flat_ui.update(&self.world, input_context.pointer)
             }
-            for action in drag_actions {
-                let drag_effects = self.apply_flat_drag_action(action);
-                effects.extend(drag_effects);
+            // The cyber interface's pointer bridge: the controller ray's canvas
+            // hit, the trigger as the click button and the squeeze as the grab,
+            // fed to the same host the mouse drives. Everything after this - the
+            // hover routing, the cursor-is-the-item drag, grab-to-hand - is the
+            // one shared implementation.
+            crate::PresentationMode::Vr => {
+                let pointer = self.vr_use_mode_pointer.as_ref().map(|pass| {
+                    // A pointer is reported for every frame the mode is up,
+                    // even with nothing on the panel: the trigger must stay
+                    // accounted for while it is held off-panel, or sweeping a
+                    // still-held press onto a slot would read as a fresh edge
+                    // and lift an item nobody clicked.
+                    let handedness = pass
+                        .active_ray()
+                        .map(|ray| ray.handedness)
+                        .unwrap_or(crate::vr_config::Handedness::Right);
+                    let hand = match handedness {
+                        crate::vr_config::Handedness::Left => &input_context.left_hand,
+                        crate::vr_config::Handedness::Right => &input_context.right_hand,
+                    };
+                    crate::mission::flat_ui_host::CanvasPointer {
+                        canvas_pos: pass.point(),
+                        pressed: pass.pressed,
+                        grabbing: hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD,
+                        hand: handedness,
+                        bare_view: crate::mission::flat_ui_host::BareViewPress::Ignore,
+                    }
+                });
+                self.flat_ui.update_canvas(&self.world, pointer)
             }
+        };
+        for msg in ui_messages {
+            self.script_world.dispatch(msg);
+        }
+        for action in ui_drag_actions {
+            let drag_effects = self.apply_flat_drag_action(action);
+            effects.extend(drag_effects);
         }
 
         // Update scripts
@@ -4207,6 +4294,11 @@ impl MissionCore {
             .ok()
             .map(|player| player.inventory_entity_id);
         self.flat_ui.set_strip(strip_entity);
+        // Entered "already pressed": the button that opened the mode may still
+        // be down (in VR the interface can be opened with the trigger held), and
+        // a held press must never read as a click on whatever the pointer first
+        // crosses (rule 6 of the vr-ui-design skill).
+        self.flat_ui.guard_held_press();
     }
 
     pub fn handle_effects(
@@ -6896,6 +6988,9 @@ impl MissionCore {
     /// entry from the tracked head pose, world-locked, lazily recentered);
     /// the dim follows the live gaze, falling back to the panel while the
     /// head is untracked (see `crate::ui::world_dim::dim_pose`).
+    /// The pointer (beam, hand, hit dot) is drawn last, from the same pass the
+    /// canvas was hit-tested with, so the dot can only ever mark the pixel the
+    /// interface actually reacted to.
     fn render_vr_use_mode(&self, asset_cache: &mut AssetCache) -> Vec<SceneObject> {
         use crate::ui::world_dim;
         let panel = self.vr_use_mode_anchor.panel();
@@ -6908,6 +7003,16 @@ impl MissionCore {
             crate::util::render_source::USE_MODE_DIM,
         )];
         objects.extend(self.flat_ui.render_world_space(asset_cache, &panel));
+        if let Some(pass) = self.vr_use_mode_pointer.as_ref() {
+            let panel_layers = objects.len();
+            objects.extend(self.vr_use_mode_pointer_visuals.borrow_mut().render(
+                asset_cache,
+                pass,
+                crate::mission::flat_ui_host::CANVAS_SIZE,
+                &panel,
+                panel_layers,
+            ));
+        }
         objects
     }
 
@@ -9023,6 +9128,27 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             strip,
             cursor: self.flat_ui.cursor_debug(),
             ammo_cycle: self.flat_ui.ammo_cycle_debug(),
+            pointer: self.flat_ui.pointer_debug(),
+            // The panel a client aims a controller at, reported straight off
+            // the anchor that placed it - so a test cannot aim at a placement
+            // the interface does not use.
+            panel_pose: self.vr_use_mode_pointer.as_ref().map(|_| {
+                let panel = self.vr_use_mode_anchor.panel();
+                crate::game_scene::DebugUiPanelPose {
+                    center: [panel.center.x, panel.center.y, panel.center.z],
+                    rotation: [
+                        panel.rotation.v.x,
+                        panel.rotation.v.y,
+                        panel.rotation.v.z,
+                        panel.rotation.s,
+                    ],
+                    size: [panel.size.x, panel.size.y],
+                    canvas: [
+                        crate::mission::flat_ui_host::CANVAS_SIZE.x,
+                        crate::mission::flat_ui_host::CANVAS_SIZE.y,
+                    ],
+                }
+            }),
         }
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2514,26 +2514,7 @@ impl MissionCore {
             // one shared implementation.
             crate::PresentationMode::Vr => {
                 let pointer = self.vr_use_mode_pointer.as_ref().map(|pass| {
-                    // A pointer is reported for every frame the mode is up,
-                    // even with nothing on the panel: the trigger must stay
-                    // accounted for while it is held off-panel, or sweeping a
-                    // still-held press onto a slot would read as a fresh edge
-                    // and lift an item nobody clicked.
-                    let handedness = pass
-                        .active_ray()
-                        .map(|ray| ray.handedness)
-                        .unwrap_or(crate::vr_config::Handedness::Right);
-                    let hand = match handedness {
-                        crate::vr_config::Handedness::Left => &input_context.left_hand,
-                        crate::vr_config::Handedness::Right => &input_context.right_hand,
-                    };
-                    crate::mission::flat_ui_host::CanvasPointer {
-                        canvas_pos: pass.point(),
-                        pressed: pass.pressed,
-                        grabbing: hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD,
-                        hand: handedness,
-                        bare_view: crate::mission::flat_ui_host::BareViewPress::Ignore,
-                    }
+                    crate::mission::flat_ui_host::vr_canvas_pointer(pass, input_context)
                 });
                 self.flat_ui.update_canvas(&self.world, pointer)
             }

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -36,6 +36,39 @@ fn held(hand: &Hand) -> bool {
     hand.trigger_value > VR_TRIGGER_THRESHOLD
 }
 
+fn grabbing(hand: &Hand) -> bool {
+    hand.squeeze_value > VR_TRIGGER_THRESHOLD
+}
+
+/// Which gestures make a hand the one a panel is listening to.
+///
+/// The click button is the trigger everywhere. The difference is whether a
+/// *grab* also claims the panel:
+///
+/// - [`Trigger`](Self::Trigger) - the frontend screens. They have no grab
+///   gesture, and a squeeze there means nothing.
+/// - [`TriggerOrGrab`](Self::TriggerOrGrab) - the in-game cyber interface,
+///   where a squeeze on an inventory slot is a real interaction (it takes the
+///   item into that hand). Without it a left hand squeezing on the panel would
+///   lose arbitration to an idle right hand: the panel would read the idle
+///   hand's absent squeeze and take nothing, while the left squeeze went to the
+///   world instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointerEngagement {
+    Trigger,
+    TriggerOrGrab,
+}
+
+impl PointerEngagement {
+    /// Whether `hand` is actively working the panel under this policy.
+    fn engaged(self, hand: &Hand) -> bool {
+        match self {
+            Self::Trigger => held(hand),
+            Self::TriggerOrGrab => held(hand) || grabbing(hand),
+        }
+    }
+}
+
 /// One controller's aim ray against a frontend panel: where it starts, where it
 /// points, and where it lands on the canvas (if it lands at all).
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -129,6 +162,23 @@ pub fn vr_frontend_pointer_pass(
     canvas_size: Vector2<f32>,
     panel: &WorldPanel,
 ) -> FrontendPointerPass {
+    vr_pointer_pass(
+        input_context,
+        canvas_size,
+        panel,
+        PointerEngagement::Trigger,
+    )
+}
+
+/// [`vr_frontend_pointer_pass`] with an explicit engagement policy, for a panel
+/// whose gestures are richer than a frontend screen's (see
+/// [`PointerEngagement`]).
+pub fn vr_pointer_pass(
+    input_context: &InputContext,
+    canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
+    engagement: PointerEngagement,
+) -> FrontendPointerPass {
     let hands = [&input_context.right_hand, &input_context.left_hand];
     let handedness = [Handedness::Right, Handedness::Left];
 
@@ -142,8 +192,8 @@ pub fn vr_frontend_pointer_pass(
         }
     }
 
-    let any_held = held(hands[0]) || held(hands[1]);
-    let order = if held(hands[1]) && !held(hands[0]) {
+    let any_engaged = engagement.engaged(hands[0]) || engagement.engaged(hands[1]);
+    let order = if engagement.engaged(hands[1]) && !engagement.engaged(hands[0]) {
         [1, 0]
     } else {
         [0, 1]
@@ -151,11 +201,11 @@ pub fn vr_frontend_pointer_pass(
 
     let mut active = None;
     for slot in order {
-        // While a trigger is down, only the hand holding it may supply the
+        // While a hand is working the panel, only that hand may supply the
         // point: otherwise an idle hand resting on the panel would report
         // "not pressed" and clear the held state, so sweeping the pressed hand
         // onto a button would read as a fresh edge and click it.
-        if any_held && !held(hands[slot]) {
+        if any_engaged && !engagement.engaged(hands[slot]) {
             continue;
         }
         let Some(index) = ray_of_hand[slot] else {
@@ -172,8 +222,10 @@ pub fn vr_frontend_pointer_pass(
         active,
         // Nothing may be pointing at the screen; report the trigger anyway so a
         // press that starts off-panel is still consumed as "held" rather than
-        // becoming a fresh edge the moment the ray crosses onto a button.
-        pressed: any_held,
+        // becoming a fresh edge the moment the ray crosses onto a button. This
+        // is the *click* button, so it stays trigger-only whatever the
+        // engagement policy - a squeeze must never read as a click.
+        pressed: held(hands[0]) || held(hands[1]),
     }
 }
 

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -106,6 +106,16 @@ impl FrontendPointerPass {
     pub fn is_active(&self, index: usize) -> bool {
         self.active == Some(index)
     }
+
+    /// The ray the menu is listening to, when one is on the panel.
+    ///
+    /// Callers that need *which hand* is pointing (per-hand arbitration: the
+    /// pointing hand is a UI pointer, the other stays a world hand) must read
+    /// it off the same pass that decided the point, or the two answers can
+    /// disagree about which controller owns the panel.
+    pub fn active_ray(&self) -> Option<&FrontendRay> {
+        self.active.map(|index| &self.rays[index])
+    }
 }
 
 /// Resolve one frame of frontend pointing.

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -48,12 +48,13 @@ pub use frontend_menu::{
 #[cfg(test)]
 pub use frontend_pointer::test_support;
 pub use frontend_pointer::{
-    FrontendPointerPass, FrontendRay, VR_TRIGGER_THRESHOLD, vr_frontend_pointer_pass,
+    FrontendPointerPass, FrontendRay, PointerEngagement, VR_TRIGGER_THRESHOLD,
+    vr_frontend_pointer_pass, vr_pointer_pass,
 };
 pub use frontend_presentation::FrontendCanvasPresenter;
 pub use frontend_sfx::FrontendSfx;
 pub use panel_anchor::{FrontendPanelAnchor, PanelPlacement};
-pub use pointer_visual::PointerVisuals;
+pub use pointer_visual::{PointerVisuals, pointer_beams};
 
 /// Font name that resolves to the engine's compiled-in font rather than a
 /// `.FON` asset.

--- a/shock2vr/src/ui/pointer_visual.rs
+++ b/shock2vr/src/ui/pointer_visual.rs
@@ -250,7 +250,7 @@ impl PointerVisuals {
             .glove
             .get_or_insert_with(|| GloveRenderer::new(asset_cache))
             .as_mut();
-        let mut objects = render_pointer_rays(glove, pass, canvas_size, panel, panel_layers);
+        let mut objects = render_pointer_rays(glove, true, pass, canvas_size, panel, panel_layers);
         // The one pair of hands a frontend screen shows. Labelled so a check
         // can assert *both* halves of issue #1018's fix: the scene's hands are
         // gone, and these are still there.
@@ -259,11 +259,32 @@ impl PointerVisuals {
     }
 }
 
+/// The aim beams and hit dot alone, with no hands at the controllers.
+///
+/// For a panel shown *during play* - the VR cyber interface - where the
+/// player's own hands are already rendered by the interaction controller.
+/// Drawing [`PointerVisuals`]' static glove there would stack a second,
+/// empty-handed glove on top of the live one (and over a held weapon), so this
+/// path deliberately shows only where each controller is aiming. It needs no
+/// glove model, and so no asset cache.
+pub fn pointer_beams(
+    pass: &FrontendPointerPass,
+    canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
+    panel_layers: usize,
+) -> Vec<SceneObject> {
+    let mut objects = render_pointer_rays(None, false, pass, canvas_size, panel, panel_layers);
+    crate::util::tag_render_source(&mut objects, crate::util::render_source::USE_MODE_POINTER);
+    objects
+}
+
 /// The pointer's objects for one frame. Split out from [`PointerVisuals`] so
-/// the geometry can be exercised without an asset cache (`glove: None` draws
-/// the fallback proxy, exactly as a missing model does at runtime).
+/// the geometry can be exercised without an asset cache (`glove: None` with
+/// `draw_hand` draws the fallback proxy, exactly as a missing model does at
+/// runtime; `draw_hand: false` draws no hand at all - see [`pointer_beams`]).
 fn render_pointer_rays(
     mut glove: Option<&mut GloveRenderer>,
+    draw_hand: bool,
     pass: &FrontendPointerPass,
     canvas_size: Vector2<f32>,
     panel: &WorldPanel,
@@ -284,7 +305,7 @@ fn render_pointer_rays(
             objects.extend(beam_objects(geometry.start, along, length));
         }
 
-        match glove.as_deref_mut() {
+        match glove.as_deref_mut().filter(|_| draw_hand) {
             Some(glove) => objects.extend(glove.render_static_hand(
                 geometry.start,
                 ray.rotation,
@@ -293,7 +314,7 @@ fn render_pointer_rays(
             )),
             // No glove model: keep a proxy so the player can still see where
             // the controller is, rather than a beam growing out of nothing.
-            None if length >= 1e-4 => objects.push(box_object(
+            None if draw_hand && length >= 1e-4 => objects.push(box_object(
                 geometry.start,
                 CONTROLLER_PROXY_SIZE,
                 Quaternion::from_arc(vec3(0.0, 0.0, 1.0), along / length, None),
@@ -398,7 +419,7 @@ mod tests {
         };
         let pass = pass(untracked.clone(), untracked);
         assert!(pass.rays.is_empty());
-        assert!(render_pointer_rays(None, &pass, CANVAS, &test_panel(), LAYERS).is_empty());
+        assert!(render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS).is_empty());
     }
 
     #[test]
@@ -421,7 +442,7 @@ mod tests {
         // Each hand: a proxy plus its beam segments; the right hand also the
         // one dot.
         assert_eq!(
-            render_pointer_rays(None, &pass, CANVAS, &test_panel(), LAYERS).len(),
+            render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS).len(),
             2 * (BEAM_SEGMENTS + 1) + 1
         );
     }
@@ -457,7 +478,7 @@ mod tests {
             hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
             hand_aimed_away(0.0),
         );
-        let objects = render_pointer_rays(None, &pass, CANVAS, &test_panel(), LAYERS);
+        let objects = render_pointer_rays(None, true, &pass, CANVAS, &test_panel(), LAYERS);
         let translucent: Vec<_> = objects
             .iter()
             .filter(|object| object.effective_transparency().is_some_and(|t| t > 0.0))
@@ -495,7 +516,7 @@ mod tests {
                 ..Hand::default()
             },
         );
-        let objects = render_pointer_rays(None, &pass, CANVAS, &panel, LAYERS);
+        let objects = render_pointer_rays(None, true, &pass, CANVAS, &panel, LAYERS);
         assert!(
             objects
                 .iter()

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -340,6 +340,11 @@ pub mod render_source {
     pub const PAUSE_DIM: &str = "pause_dim";
     /// The VR cyber interface's comfort dim, behind the use-mode panel.
     pub const USE_MODE_DIM: &str = "use_mode_dim";
+    /// The VR cyber interface's aim beams and hit dot. Unlike
+    /// [`FRONTEND_POINTER`] this draws no hands: the interface is a mode of
+    /// play, so the player's real [`PLAYER_HANDS`] are still on screen and a
+    /// second static glove would stack on top of them.
+    pub const USE_MODE_POINTER: &str = "use_mode_pointer";
     /// The red rim tint shown for a moment after the player takes damage.
     pub const HIT_FEEDBACK: &str = "hit_feedback";
 }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -697,6 +697,42 @@ export interface UiState {
    * (Effect::CycleAmmo). null in shooter mode / unarmed / single-ammo weapons.
    */
   ammo_cycle: UiElement | null;
+  /**
+   * Where the pointer last landed on the shared canvas: the mouse on flat, the
+   * controller ray on the VR cyber-interface panel. null when nothing is
+   * driving the canvas this frame.
+   */
+  pointer: UiPointer | null;
+  /**
+   * The VR cyber-interface panel's pose, in pawn space (the same space
+   * `/v1/control/input` hand positions use). Present exactly while the
+   * interface is up in VR; null on flat. Aim a controller at a canvas rect by
+   * mapping it through this pose - see `test/helpers/vr-hand.ts`.
+   */
+  panel_pose: UiPanelPose | null;
+}
+
+/** One frame of pointing at the shared UI canvas. */
+export interface UiPointer {
+  /** Position on the 640x480 canvas, or null when the pointer is off it
+   * (flat: the letterbox bars; VR: the ray missed the panel). */
+  canvas: [number, number] | null;
+  /** The click button (flat LMB / VR trigger) is down. */
+  pressed: boolean;
+  /** The grab gesture (VR squeeze) is down. */
+  grabbing: boolean;
+  hand: "left" | "right";
+}
+
+/** The world panel a VR presentation hangs the shared canvas on (pawn space). */
+export interface UiPanelPose {
+  center: Vec3;
+  /** [x, y, z, w]; the face normal is this applied to +Z and points at the viewer. */
+  rotation: [number, number, number, number];
+  /** Panel size in metres, [width, height]. */
+  size: [number, number];
+  /** The authored canvas the panel presents, in pixels. */
+  canvas: [number, number];
 }
 
 export interface TransitionEntry {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -721,7 +721,8 @@ export interface UiPointer {
   pressed: boolean;
   /** The grab gesture (VR squeeze) is down. */
   grabbing: boolean;
-  hand: "left" | "right";
+  /** Which hand owns the pointer, or null when nothing is on the canvas. */
+  hand: "left" | "right" | null;
 }
 
 /** The world panel a VR presentation hangs the shared canvas on (pawn space). */

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -1,5 +1,5 @@
 import type { GameServer } from "../../src/index.js";
-import type { Vec3 } from "../../src/types.js";
+import type { UiPanelPose, Vec3 } from "../../src/types.js";
 
 export type Quat = [number, number, number, number];
 
@@ -60,6 +60,52 @@ export function quatFromTo(from: Vec3, to: Vec3): Quat {
     return [axis[0], axis[1], axis[2], 0];
   }
   return quatNormalize([...cross(a, b), 1 + d]);
+}
+
+/**
+ * Aim a controller at a point on the VR cyber-interface panel's canvas.
+ *
+ * The panel pose comes from `/v1/ui` (`panel_pose`) - the interface's own
+ * placement - and is in pawn space, which is the space `/v1/control/input`
+ * hand positions and rotations are given in, so no world round-trip is needed.
+ * This is the inverse of the runtime's ray -> canvas mapping: stand back along
+ * the panel's normal and look at the target.
+ */
+export async function aimVrHandAtCanvas(
+  game: GameServer,
+  panel: UiPanelPose,
+  canvas: [number, number],
+  {
+    hand = "right",
+    trigger = 0,
+    squeeze = 0,
+    standOff = 0.6,
+    facing = "panel",
+  }: {
+    hand?: "left" | "right";
+    trigger?: number;
+    squeeze?: number;
+    standOff?: number;
+    /** "away" keeps the controller where it is but turns it off the panel,
+     * for exercising the "not pointing at the UI" half of the arbitration. */
+    facing?: "panel" | "away";
+  } = {},
+): Promise<void> {
+  const u = canvas[0] / panel.canvas[0] - 0.5;
+  const v = 0.5 - canvas[1] / panel.canvas[1];
+  const target = add(
+    panel.center,
+    quatRotate(panel.rotation, [u * panel.size[0], v * panel.size[1], 0]),
+  );
+  const normal = quatRotate(panel.rotation, [0, 0, 1]);
+  const position = add(target, scale(normal, standOff));
+  const aim = facing === "panel" ? scale(normal, -1) : normal;
+  const rotation = quatFromTo([0, 0, -1], aim);
+
+  await game.input.set(`${hand}_hand.position`, position);
+  await game.input.set(`${hand}_hand.rotation`, rotation);
+  await game.input.set(`${hand}_hand.trigger`, trigger);
+  await game.input.set(`${hand}_hand.squeeze`, squeeze);
 }
 
 /** Aim the production VR hand ray at a world point without direct entity

--- a/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
@@ -68,6 +68,14 @@ test(
     const panel = requirePanel(ui);
     assert.deepEqual(panel.canvas, [640, 480], "the panel presents the shared canvas");
 
+    // Park the left controller off the panel so this scenario is about one
+    // hand. Per-hand arbitration means an idle hand resting on the panel is a
+    // pointer too - which the "aiming away" step below would otherwise pick up.
+    await aimVrHandAtCanvas(game, panel, [320, 240], {
+      hand: "left",
+      facing: "away",
+    });
+
     const slot = slotFor(ui, wrench.entity_id);
     assert.ok(slot, "the provisioned wrench must occupy a strip slot");
     const slotCenter = center(slot);

--- a/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiPanelPose, UiState } from "../src/index.js";
+import { aimVrHandAtCanvas } from "./helpers/vr-hand.js";
+
+// The VR cyber interface's pointer bridge (slice 3): a controller ray meets
+// the anchored panel, and where it lands drives the SAME host the flat mouse
+// drives - hover, the cursor-is-the-item drag, and (on the squeeze) the
+// grab-to-hand path loot panels already use.
+//
+// Negative-first: on the parent the interface has no pointer at all - /v1/ui
+// reports no `panel_pose` and no `pointer`, so aiming at a slot changes
+// nothing and every assertion below fails there.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8581);
+
+const center = (el: UiElement): [number, number] => [
+  el.rect[0] + el.rect[2] / 2,
+  el.rect[1] + el.rect[3] / 2,
+];
+
+async function openInterface(game: GameServer): Promise<UiState> {
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 5 });
+  return game.ui.state();
+}
+
+/** The strip element bound to `entityId`, or undefined once it has left the grid. */
+function slotFor(ui: UiState, entityId: number): UiElement | undefined {
+  return ui.strip?.elements.find((el) => el.entity_id === entityId);
+}
+
+function requirePanel(ui: UiState): UiPanelPose {
+  assert.ok(ui.panel_pose, "the VR cyber interface must report its panel pose");
+  return ui.panel_pose;
+}
+
+/** Release, then pull: a clean rising edge on the trigger. */
+async function clickAt(
+  game: GameServer,
+  panel: UiPanelPose,
+  canvas: [number, number],
+): Promise<void> {
+  await aimVrHandAtCanvas(game, panel, canvas, { trigger: 0 });
+  await game.step({ frames: 2 });
+  await aimVrHandAtCanvas(game, panel, canvas, { trigger: 1 });
+  await game.step({ frames: 2 });
+  await aimVrHandAtCanvas(game, panel, canvas, { trigger: 0 });
+  await game.step({ frames: 2 });
+}
+
+test(
+  "a VR controller ray hovers, clicks and drags on the cyber-interface canvas",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const wrench = await game.player.spawnItem("Wrench");
+    let ui = await openInterface(game);
+    assert.equal(ui.mode, "use");
+    const panel = requirePanel(ui);
+    assert.deepEqual(panel.canvas, [640, 480], "the panel presents the shared canvas");
+
+    const slot = slotFor(ui, wrench.entity_id);
+    assert.ok(slot, "the provisioned wrench must occupy a strip slot");
+    const slotCenter = center(slot);
+
+    // Hover: the ray must land on the pixels the interface laid the slot out
+    // at - the same canvas both presentations render.
+    await aimVrHandAtCanvas(game, panel, slotCenter);
+    await game.step({ frames: 3 });
+    ui = await game.ui.state();
+    assert.ok(ui.pointer?.canvas, "the ray must report a canvas hit");
+    const [hx, hy] = ui.pointer.canvas;
+    assert.ok(
+      Math.abs(hx - slotCenter[0]) < 4 && Math.abs(hy - slotCenter[1]) < 4,
+      `the ray must land on the slot (aimed ${slotCenter}, hit [${hx}, ${hy}])`,
+    );
+    assert.equal(ui.cursor, null, "hovering alone must not lift the item");
+
+    // Aiming away: no canvas hit, and that hand is a world hand again.
+    await aimVrHandAtCanvas(game, panel, [320, 240], { facing: "away" });
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.ui.state()).pointer?.canvas ?? null,
+      null,
+      "a ray pointed away from the panel must not report a canvas hit",
+    );
+
+    // Click: the trigger is the LMB analog - it lifts the item onto the cursor.
+    await clickAt(game, panel, slotCenter);
+    ui = await game.ui.state();
+    assert.equal(
+      ui.cursor?.entity_id,
+      wrench.entity_id,
+      "a trigger pull on a slot must lift the item onto the cursor",
+    );
+    assert.equal(
+      slotFor(ui, wrench.entity_id),
+      undefined,
+      "the lifted item leaves the strip grid while it rides the cursor",
+    );
+
+    // Drag + place: a click on an empty slot puts it down again, and the item
+    // reappears in the grid.
+    const emptySlot: [number, number] = [slotCenter[0] + 105, slotCenter[1]];
+    await clickAt(game, panel, emptySlot);
+    ui = await game.ui.state();
+    assert.equal(ui.cursor, null, "clicking an empty slot must place the item");
+    assert.ok(
+      slotFor(ui, wrench.entity_id),
+      "the placed item must be back in the strip grid",
+    );
+
+    // Empty panel space is still the interface, not the 3D view: a click there
+    // must not throw the item into the world.
+    await clickAt(game, panel, slotCenter);
+    assert.equal((await game.ui.state()).cursor?.entity_id, wrench.entity_id);
+    await clickAt(game, panel, [400, 400]);
+    assert.equal(
+      (await game.ui.state()).cursor?.entity_id,
+      wrench.entity_id,
+      "a click on empty panel space must keep the held item",
+    );
+    // Put it back so the grab below has a slot to take from.
+    await clickAt(game, panel, slotCenter);
+    ui = await game.ui.state();
+    assert.equal(ui.cursor, null);
+  },
+);
+
+test(
+  "a squeeze on an inventory slot pulls the item into that VR hand",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const wrench = await game.player.spawnItem("Wrench");
+    const ui = await openInterface(game);
+    const panel = requirePanel(ui);
+    const slot = slotFor(ui, wrench.entity_id);
+    assert.ok(slot, "the provisioned wrench must occupy a strip slot");
+
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      null,
+      "the hand starts empty",
+    );
+
+    // Grab-to-hand parity: squeeze on the slot, exactly as a hand takes an
+    // item out of a loot panel today. (That the grab lands in the *pointing*
+    // hand rather than a hardcoded one is covered by the unit test
+    // `a_squeeze_on_a_slot_reaches_the_strip_as_a_left_hand_grab`; /v1/info
+    // only reports the right hand's held entity.)
+    await aimVrHandAtCanvas(game, panel, center(slot), { squeeze: 0 });
+    await game.step({ frames: 3 });
+    await aimVrHandAtCanvas(game, panel, center(slot), { squeeze: 1 });
+    await game.step({ frames: 8 });
+
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.entity_id,
+      "a squeeze on the slot must pull the item into the pointing hand",
+    );
+    assert.equal(
+      slotFor(await game.ui.state(), wrench.entity_id),
+      undefined,
+      "the grabbed item must leave the backpack grid",
+    );
+
+    // The item stays held while the squeeze is held: the UI arbitration masks
+    // the squeeze only while the hand is empty, so taking an item cannot then
+    // read as a release and drop it.
+    await game.step({ frames: 20 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.entity_id,
+      "the taken item must stay held while the squeeze is held",
+    );
+  },
+);


### PR DESCRIPTION
Slice 3 of the cyber-interface plan, stacked on #1107 (the mode skeleton).

The interface gains a **pointer**: the controller ray meets the anchored panel, and where it lands drives the *same host the flat mouse drives* — hover routing, the cursor-is-the-item drag, the close gestures. The VR ray plays the role of the mouse rather than getting an interface of its own.

## How it fits together

- `FlatUiHost::update` is split into a **flat resolver** (mouse → canvas pixels) plus **`update_canvas`**, the presentation-free core every gesture lives in. VR enters there directly with the ray's canvas hit, so there is one implementation of lift/place/swap/throw/close.
- The ray comes from the existing **`vr_frontend_pointer_pass`** — the pass the pause menu and frontend screens already use — so no third pointing stack is introduced (the plan's explicit constraint). The drawn beam / hand / hit dot read that same pass (rule 5 of the vr-ui-design skill): the dot can only mark the pixel the interface hit-tested.
- **Trigger = LMB analog**, rising-edge, with a `guard_held_press()` on mode entry so a trigger held while opening cannot click (rule 6). A pointer is reported *even while the ray is off-panel*, so a press that starts off-panel stays accounted for instead of becoming a fresh edge when it sweeps onto a slot.
- **Grab-to-hand parity**: the strip's `GUIHover` now carries the real squeeze and the pointing hand, so a squeeze on an inventory slot emits the panel's existing `GrabEntity` — exactly how loot panels hand an item to a VR hand today.
- **Per-hand arbitration** (owner decision 4): the hand pointing at the panel is a UI pointer, and its squeeze is masked from `VirtualHand` **while it is empty**, so one gesture cannot both take from the grid and grab the world; the other hand stays an ordinary world hand. A hand already holding something is never masked — that would read as a release and drop it.

### The one per-presentation difference

`BareViewPress` names what a press *away from the widgets* means. On flat that region is the 3D view behind the canvas — the original's exit gesture (close the MFD, throw the held item). In VR the same pixels are empty panel space, which does nothing. It is input semantics only: nothing moves or resizes a widget, so the shared canvas still renders identically (AGENTS.md §3). Throwing a held item into the world from the VR panel stays an open thread in the plan.

## Introspection

`GET /v1/ui` gains `pointer` (where the pointer landed on the canvas, plus its buttons) and `panel_pose` (the VR panel in pawn space), so a test can aim a controller at a canvas rect from the interface's *own* placement and read back where the ray actually hit.

## Verification

- **Unit tests** (912 total, 10 new) drive the real pass against the real anchored panel and hand the result to the host through the same `vr_canvas_pointer` mapping the mission uses each frame — so they cover ray → canvas → gesture, not an approximation. Five behavioral ones (aim-and-lift, held-trigger-on-entry, swept-in press, empty-panel-space vs bare view, squeeze-as-grab-in-the-pointing-hand) each **fail when their mechanism is reverted**; an untracked (zero-quaternion) controller never points.
- **SDK e2e** (`vr-cyber-interface-pointer.e2e.test.ts`) drives a real `--vr` runtime: aim at a provisioned item's slot, verify the hit lands on the slot's canvas rect, click to lift, place on another slot, confirm empty panel space does not throw it, and squeeze to pull it into the hand — and that it stays held.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt`, `cargo test -p shock2vr` (901 tests) all green.
- Full SDK e2e suite against the post-review build: **311 tests, 300 pass, 8 skipped, 3 fail** — and all 3 failures **reproduce identically on the base branch** (`baby-arachnid`'s aimed wrench swing, `creature-loot`'s reader open, and `log-reader`'s hydro3 transcript wording), so they are pre-existing. Each also has a passing sibling covering the same mechanism in this run: flat melee damage at the authored swing event, the log-reader MFD open (flat and VR, including the VR corpse-loot variant). Every MFD panel type — keypad, container/loot, elevator, replicator, research, trainer, automap, the SHODAN finale hack — passed through the refactored host, as did the flat cursor-is-the-item drag, the VR container hand-ray grab, and #1018's VR hands/dim regression test.
- **Both presentations render-verified** (AGENTS.md §3): flat use mode is unchanged (strip docked, arrow cursor at the pointer), and in VR the same canvas draws the drag icon at the same canvas offset from the pointer as flat does — measured by locating the icon in both screenshots rather than eyeballing.

## Review round (xreview: Claude + Codex)

Both engines ran independently; two findings they **agreed** on, plus three more, are fixed in `fix(vr): harden the cyber-interface pointer's hand arbitration`:

- **[agreed] Two pairs of hands.** `PointerVisuals` draws a glove per ray, but this is a mode of *play* — `VrInteraction` is still drawing the player's real hands, so a second static glove stacked on top of them (and over a held weapon): exactly the defect #1018 fixed for the pause menu. The interface now draws aim beams + hit dot only, via a hand-less `pointer_beams` tagged `use_mode_pointer`. That also removed the render-path `RefCell`.
- **[agreed] A squeezing hand could lose the panel to an idle one.** Arbitration was trigger-only, so a left hand squeezing a slot lost to an idle right hand: the panel read the idle hand's absent squeeze and took nothing, while the real squeeze went to the world. Arbitration now takes an explicit `PointerEngagement` — frontend screens stay trigger-only (no grab gesture there), the cyber interface counts a squeeze as claiming the panel. The click button stays trigger-only in both.
- **The squeeze mask had no release latch.** World grabbing is *level*-triggered, so a squeeze begun on the panel grabbed whatever the ray hit the moment it slipped off the panel edge — or the moment the mode closed. A per-hand grab swallow (`update_squeeze_swallow`, pure and directly tested) holds until the player releases, and drops as soon as the hand is holding something so a hand that just took an item keeps hold of it.
- **Only the *active* ray was masked**, so a second hand resting on the panel could squeeze straight through it. Every hand whose ray is on the panel is masked now.
- **The grab reached the panel as a level, not an edge**, so a held squeeze took every slot the ray swept over. Only the rising edge is forwarded.

Deliberately not taken (worth an owner call, not this slice):

- The de-dup pass notes `FrontendMenu` already owns an anchor + pass + visuals + `panel_layers` assembly, and this is a third copy of it. The glove fix above removed the visuals half; extracting the rest is a refactor of existing frontend code and belongs in its own change.
- `FlatUiHost::update`'s flat reduction could call the shared `flat_pointer_state`, which treats *pointer loss* as not a release. Adopting it would change flat behavior that predates this PR.
- `pass.pressed` aggregates both triggers, so an off-hand trigger held off-panel freezes the pointer. That is the frontend's deliberate, tested semantics (`an_idle_hand_on_the_panel_does_not_release_the_other_hands_trigger`) and is unchanged here.

## Visuals

![cyber-interface pointer demo](https://gist.githubusercontent.com/tommy-xr/1819ce32b48486cd4c1529d056ef1d09/raw/cyber-pointer.gif)

<sub>VR use mode: the controller ray sweeps the anchored inventory panel (the white dot marks the pixel the interface hit-tested), hovers the Wrench slot, the trigger lifts it onto the cursor - the cursor becomes the item - and the item rides the pointer across the panel. Captured headlessly via the debug runtime (`--vr`, `/v1/step` + `/v1/screenshot`, deterministic fixed-timestep), aiming the controller from `GET /v1/ui`'s own `panel_pose`.</sub>

Still, mid-drag - the Wrench slot is empty and its icon rides the cursor:

![cursor-item drag mid-flight](https://gist.githubusercontent.com/tommy-xr/1819ce32b48486cd4c1529d056ef1d09/raw/cyber-pointer-drag.png)


https://claude.ai/code/session_016r6MXB6tSLqYZTJHMtJbei