### PR TITLE
fix(ai): execute scripted player metaproperty responses

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -93,6 +93,7 @@ use serde::{
 };
 
 use std::{
+    any::TypeId,
     collections::HashMap,
     convert::identity,
     fmt,
@@ -2101,6 +2102,14 @@ where
     fn initialize(&self, world: &mut World, entity: EntityId) {
         world.add_component(entity, self.clone());
     }
+
+    fn component_type_id(&self) -> TypeId {
+        TypeId::of::<C>()
+    }
+
+    fn remove(&self, world: &mut World, entity: EntityId) {
+        world.delete_component::<C>(entity);
+    }
 }
 
 #[derive(Debug)]
@@ -2136,6 +2145,14 @@ where
         drop(view);
         world.add_component(entity, value_to_set);
     }
+
+    fn component_type_id(&self) -> TypeId {
+        TypeId::of::<C>()
+    }
+
+    fn remove(&self, world: &mut World, entity: EntityId) {
+        world.delete_component::<C>(entity);
+    }
 }
 
 // `Send + Sync` is required so the level parse (which builds `Vec<Arc<Box<dyn Property>>>`)
@@ -2143,6 +2160,8 @@ where
 // for free: both blanket impls below already require `C: Send + Sync`.
 pub trait Property: fmt::Debug + Send + Sync {
     fn initialize(&self, world: &mut World, entity: EntityId);
+    fn component_type_id(&self) -> TypeId;
+    fn remove(&self, world: &mut World, entity: EntityId);
 }
 
 // `Send + Sync` so the shared `GlobalContext` (which holds these definition objects)

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -43,7 +43,7 @@ use dark::{
         PropModelName, PropMotionActorTags, PropObjState, PropParticleGroup,
         PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity, PropPhysState,
         PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts, PropSymName,
-        PropTeleported, PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState,
+        PropTeleported, PropTemplateId, PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState,
         PropTweqModelConfig, PropertyDefinition, RenderType, TeleportSource, ToLink, TripFlags,
         TweqAnimationState, WrappedEntityId,
     },
@@ -88,8 +88,8 @@ use crate::{
     runtime_props::{
         RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
-        RuntimePropLaunchedProjectile, RuntimePropReloading, RuntimePropSelectedAmmo,
-        RuntimePropTransform, RuntimePropVhots, RuntimePropVrGripOffset,
+        RuntimePropLaunchedProjectile, RuntimePropMetaProperties, RuntimePropReloading,
+        RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots, RuntimePropVrGripOffset,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -868,6 +868,230 @@ impl GlobalTemplateHierarchy {
         template_id == class_template_id
             || dark::ss2_entity_info::get_ancestors(&self.0, &template_id)
                 .contains(&class_template_id)
+    }
+}
+
+fn template_lineage_excluding(
+    hierarchy: &HashMap<i32, Vec<i32>>,
+    template_id: i32,
+    excluded: &HashSet<i32>,
+) -> Vec<i32> {
+    fn visit(
+        hierarchy: &HashMap<i32, Vec<i32>>,
+        parents: Option<&Vec<i32>>,
+        excluded: &HashSet<i32>,
+        visited: &mut HashSet<i32>,
+        out: &mut Vec<i32>,
+    ) {
+        let Some(parents) = parents else { return };
+        for parent in parents {
+            if !excluded.contains(parent) && visited.insert(*parent) {
+                out.push(*parent);
+            }
+        }
+        for parent in parents {
+            if !excluded.contains(parent) {
+                visit(hierarchy, hierarchy.get(parent), excluded, visited, out);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    visit(
+        hierarchy,
+        hierarchy.get(&template_id),
+        excluded,
+        &mut HashSet::new(),
+        &mut out,
+    );
+    out.dedup();
+    out.reverse();
+    out
+}
+
+/// Apply one runtime metaproperty relation change without rebuilding unrelated
+/// live state. Only component types contributed by the changed branch are
+/// removed and then recomposed from the remaining authored/dynamic ancestry.
+fn apply_meta_property_relation(
+    world: &mut World,
+    entity_info: &SystemShock2EntityInfo,
+    hierarchy: &HashMap<i32, Vec<i32>>,
+    entity_id: EntityId,
+    meta_template_id: i32,
+    add: bool,
+) -> bool {
+    let entity_template_id = world
+        .borrow::<View<PropTemplateId>>()
+        .ok()
+        .and_then(|templates| templates.get(entity_id).ok().map(|id| id.template_id));
+    let Some(entity_template_id) = entity_template_id else {
+        return false;
+    };
+
+    let mut state = world
+        .borrow::<View<RuntimePropMetaProperties>>()
+        .ok()
+        .and_then(|states| states.get(entity_id).ok().cloned())
+        .unwrap_or_default();
+    let statically_inherited = dark::ss2_entity_info::get_ancestors(hierarchy, &entity_template_id)
+        .contains(&meta_template_id);
+    if add {
+        state.removed.retain(|id| *id != meta_template_id);
+        if !statically_inherited && !state.added.contains(&meta_template_id) {
+            state.added.push(meta_template_id);
+        }
+    } else {
+        state.added.retain(|id| *id != meta_template_id);
+        if !state.removed.contains(&meta_template_id) {
+            state.removed.push(meta_template_id);
+        }
+    }
+
+    let no_exclusions = HashSet::new();
+    let mut affected_templates =
+        template_lineage_excluding(hierarchy, meta_template_id, &no_exclusions);
+    affected_templates.push(meta_template_id);
+    let affected_properties = affected_templates
+        .iter()
+        .filter_map(|template| entity_info.entity_to_properties.get(template))
+        .flat_map(|properties| properties.iter().cloned())
+        .collect::<Vec<_>>();
+    let affected_types = affected_properties
+        .iter()
+        .map(|property| property.component_type_id())
+        .collect::<HashSet<_>>();
+
+    // Delete each affected component type once. The representative property
+    // knows its concrete Shipyard component despite this layer being erased.
+    let mut removed_types = HashSet::new();
+    for property in &affected_properties {
+        if removed_types.insert(property.component_type_id()) {
+            property.remove(world, entity_id);
+        }
+    }
+
+    let excluded = state.removed.iter().copied().collect::<HashSet<_>>();
+    let mut effective_templates =
+        template_lineage_excluding(hierarchy, entity_template_id, &excluded);
+    effective_templates.push(entity_template_id);
+    for added in &state.added {
+        for template in template_lineage_excluding(hierarchy, *added, &excluded) {
+            if !effective_templates.contains(&template) {
+                effective_templates.push(template);
+            }
+        }
+        if !effective_templates.contains(added) {
+            effective_templates.push(*added);
+        }
+    }
+
+    for template in effective_templates {
+        if let Some(properties) = entity_info.entity_to_properties.get(&template) {
+            for property in properties {
+                if affected_types.contains(&property.component_type_id()) {
+                    property.initialize(world, entity_id);
+                }
+            }
+        }
+    }
+    world.add_component(entity_id, state);
+    true
+}
+
+#[cfg(test)]
+mod meta_property_tests {
+    use super::*;
+    use dark::properties::{AIAlertLevel, PropAIAlertCap, Property};
+    use std::sync::Arc;
+
+    fn boxed_property<T: Property + 'static>(property: T) -> Arc<Box<dyn Property>> {
+        Arc::new(Box::new(property))
+    }
+
+    #[test]
+    fn removing_and_adding_meta_recomposes_only_its_component_types() {
+        const BASE: i32 = -10;
+        const DOCILE: i32 = -20;
+        const ENTITY_TEMPLATE: i32 = 30;
+        let ordinary_cap = PropAIAlertCap {
+            max_level: AIAlertLevel::High,
+            min_level: AIAlertLevel::Lowest,
+            min_relax: AIAlertLevel::Low,
+        };
+        let docile_cap = PropAIAlertCap {
+            max_level: AIAlertLevel::Lowest,
+            min_level: AIAlertLevel::Lowest,
+            min_relax: AIAlertLevel::Lowest,
+        };
+        // Dark stores direct parents derived-first; traversal reverses them to
+        // initialize base first and let Docile override its alert cap.
+        let hierarchy = HashMap::from([(ENTITY_TEMPLATE, vec![DOCILE, BASE])]);
+        let mut entity_info = SystemShock2EntityInfo::empty();
+        entity_info
+            .entity_to_properties
+            .insert(BASE, vec![boxed_property(ordinary_cap.clone())]);
+        entity_info
+            .entity_to_properties
+            .insert(DOCILE, vec![boxed_property(docile_cap.clone())]);
+
+        let mut world = World::new();
+        let entity = world.add_entity((
+            PropTemplateId {
+                template_id: ENTITY_TEMPLATE,
+            },
+            docile_cap,
+            PropHitPoints { hit_points: 73 },
+        ));
+
+        assert!(apply_meta_property_relation(
+            &mut world,
+            &entity_info,
+            &hierarchy,
+            entity,
+            DOCILE,
+            false,
+        ));
+        assert_eq!(
+            world
+                .borrow::<View<PropAIAlertCap>>()
+                .unwrap()
+                .get(entity)
+                .unwrap()
+                .max_level,
+            AIAlertLevel::High
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropHitPoints>>()
+                .unwrap()
+                .get(entity)
+                .unwrap()
+                .hit_points,
+            73,
+            "unrelated live state must not be rebuilt"
+        );
+
+        assert!(apply_meta_property_relation(
+            &mut world,
+            &entity_info,
+            &hierarchy,
+            entity,
+            DOCILE,
+            true,
+        ));
+        assert_eq!(
+            world
+                .borrow::<View<PropAIAlertCap>>()
+                .unwrap()
+                .get(entity)
+                .unwrap()
+                .max_level,
+            AIAlertLevel::Lowest
+        );
+        let state = world.borrow::<View<RuntimePropMetaProperties>>().unwrap();
+        let state = state.get(entity).unwrap();
+        assert!(state.added.is_empty());
+        assert!(state.removed.is_empty());
     }
 }
 
@@ -6130,6 +6354,50 @@ impl MissionCore {
                                 );
                             }
                         }
+                    }
+                }
+
+                Effect::SetMetaProperty {
+                    entity_id,
+                    name,
+                    add,
+                } => {
+                    let template_id = self
+                        .template_name_to_template_id
+                        .get(&name.to_ascii_lowercase())
+                        .map(|metadata| metadata.template_id);
+                    let hierarchy = self
+                        .world
+                        .borrow::<UniqueView<GlobalTemplateHierarchy>>()
+                        .ok()
+                        .map(|hierarchy| hierarchy.0.clone());
+                    let applied =
+                        template_id
+                            .zip(hierarchy)
+                            .is_some_and(|(template_id, hierarchy)| {
+                                apply_meta_property_relation(
+                                    &mut self.world,
+                                    &self.entity_info,
+                                    &hierarchy,
+                                    entity_id,
+                                    template_id,
+                                    add,
+                                )
+                            });
+                    if applied {
+                        effects.push_front(Effect::Send {
+                            msg: Message {
+                                to: entity_id,
+                                payload: MessagePayload::RefreshAIProperties,
+                            },
+                        });
+                    } else {
+                        warn!(
+                            "scripted metaproperty {} '{}' could not be applied to {:?}",
+                            if add { "Add" } else { "Remove" },
+                            name,
+                            entity_id
+                        );
                     }
                 }
                 Effect::SetAICurrentPatrol { entity_id, target } => {

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -46,6 +46,18 @@ pub struct RuntimePropAITargetAwareness {
 #[derive(Component, Clone, Copy)]
 pub struct RuntimePropLocomotionScale(pub f32);
 
+/// Runtime changes to an object's authored metaproperty relations.
+///
+/// The effective Dark properties themselves are saved through the ordinary
+/// property registry. This relation delta is persisted separately by
+/// `EntitySaveData` so a later scripted Add/Remove can still recompose only
+/// the affected component types after a load.
+#[derive(Component, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RuntimePropMetaProperties {
+    pub added: Vec<i32>,
+    pub removed: Vec<i32>,
+}
+
 #[derive(Component)]
 pub struct RuntimePropJointTransforms(pub [Matrix4<f32>; 40]);
 

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -7,7 +7,7 @@ use shipyard::{EntityId, World};
 
 use crate::runtime_props::{
     RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropLaunchedProjectile,
-    RuntimePropSelectedAmmo,
+    RuntimePropMetaProperties, RuntimePropSelectedAmmo,
 };
 use crate::scripts::SavedScriptState;
 
@@ -39,6 +39,11 @@ pub struct EntitySaveData {
     /// from taking velocity ownership after load.
     #[serde(default)]
     pub launched_projectiles: Vec<u64 /* entity id */>,
+    /// Runtime Add/Remove metaproperty relation deltas. The resulting Dark
+    /// components are already in `properties`; this preserves enough relation
+    /// state for a later scripted metaproperty action to recompose correctly.
+    #[serde(default)]
+    pub meta_properties: HashMap<u64 /* entity id */, RuntimePropMetaProperties>,
     /// Opt-in private state owned by scripts on these entities. Registered ECS
     /// properties and links remain in their existing fields above; this is only
     /// for runtime modes, timers, latches, and similar script internals.
@@ -57,6 +62,7 @@ impl EntitySaveData {
             selected_ammo: HashMap::new(),
             canonical_template_ids: HashMap::new(),
             launched_projectiles: Vec::new(),
+            meta_properties: HashMap::new(),
             script_states: Vec::new(),
         }
     }
@@ -128,6 +134,12 @@ impl EntitySaveData {
                 world.add_component(*new_entity_id, RuntimePropLaunchedProjectile);
             }
         }
+        for (old_entity_id, meta_properties) in &self.meta_properties {
+            let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
+            if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
+                world.add_component(*new_entity_id, meta_properties.clone());
+            }
+        }
         (template_to_entity_id, old_entity_id_to_new_entity_id)
     }
 }
@@ -152,6 +164,33 @@ mod tests {
         .unwrap();
 
         assert!(save.death_poses.is_empty());
+        assert!(save.meta_properties.is_empty());
+    }
+
+    #[test]
+    fn instantiate_restores_runtime_metaproperty_relations() {
+        let old_entity = EntityId::new_from_index_and_gen(22, 1);
+        let mut data = EntitySaveData::empty();
+        data.all_entities.push(old_entity.inner());
+        data.meta_properties.insert(
+            old_entity.inner(),
+            RuntimePropMetaProperties {
+                added: vec![-40],
+                removed: vec![-1073],
+            },
+        );
+
+        let mut world = World::new();
+        let (_, remap) = data.instantiate(&mut world);
+        let restored = remap[&old_entity];
+        let states = world.borrow::<View<RuntimePropMetaProperties>>().unwrap();
+        assert_eq!(
+            states.get(restored).unwrap(),
+            &RuntimePropMetaProperties {
+                added: vec![-40],
+                removed: vec![-1073],
+            }
+        );
     }
 
     #[test]

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     mission::{GlobalTemplateIdMap, PlayerInfo},
     runtime_props::{
         RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropDoNotSerialize,
-        RuntimePropLaunchedProjectile, RuntimePropSelectedAmmo,
+        RuntimePropLaunchedProjectile, RuntimePropMetaProperties, RuntimePropSelectedAmmo,
     },
     scripts::{ScriptWorld, script_util},
     util::partition_map,
@@ -133,6 +133,7 @@ pub fn to_save_data_with_scripts(
     let v_launched_projectiles = world
         .borrow::<View<RuntimePropLaunchedProjectile>>()
         .unwrap();
+    let v_meta_properties = world.borrow::<View<RuntimePropMetaProperties>>().unwrap();
     let v_entities = world.borrow::<EntitiesView>().unwrap();
 
     let (all_properties, _, _) = dark::properties::get::<File>();
@@ -225,6 +226,16 @@ pub fn to_save_data_with_scripts(
             world_launched_projectiles.push(entity_id.inner());
         }
     }
+    let raw_meta_properties: HashMap<u64, RuntimePropMetaProperties> = v_meta_properties
+        .iter()
+        .with_id()
+        .filter(|(entity_id, _)| !entities_to_filter.contains(&entity_id.inner()))
+        .map(|(entity_id, state)| (entity_id.inner(), state.clone()))
+        .collect();
+    let (held_meta_properties, world_meta_properties) =
+        partition_map(raw_meta_properties, |entity_id| {
+            held_entities.contains(entity_id)
+        });
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
         template_id_to_entity_id: template_id_to_entity_id.0.clone(),
@@ -234,6 +245,7 @@ pub fn to_save_data_with_scripts(
         selected_ammo: world_selected_ammo,
         canonical_template_ids: world_canonical_templates,
         launched_projectiles: world_launched_projectiles,
+        meta_properties: world_meta_properties,
         script_states: world_script_states,
     };
 
@@ -246,6 +258,7 @@ pub fn to_save_data_with_scripts(
         selected_ammo: held_selected_ammo,
         canonical_template_ids: held_canonical_templates,
         launched_projectiles: held_launched_projectiles,
+        meta_properties: held_meta_properties,
         script_states: held_script_states,
     };
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1264,6 +1264,10 @@ impl Script for AnimatedMonsterAI {
                     Effect::NoEffect
                 }
             }
+            MessagePayload::RefreshAIProperties => {
+                self.config = Self::build_config(world, entity_id);
+                Effect::NoEffect
+            }
             MessagePayload::SetAlertness { level, pin } => {
                 // Dead AIs stay dead - a corpse keeps a live script, and the
                 // broadcast (DebugAlertAll) reaches every creature

--- a/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
@@ -4,9 +4,9 @@ use cgmath::{Deg, InnerSpace, vec3};
 use dark::{
     SCALE_FACTOR,
     motion::MotionQueryItem,
-    properties::{AIScriptedAction, AIScriptedActionType, PropPosition},
+    properties::{AIScriptedAction, AIScriptedActionType, PropLocalPlayer, PropPosition},
 };
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
 
 use crate::{
     physics::PhysicsWorld,
@@ -15,8 +15,8 @@ use crate::{
         ai::{
             ai_util,
             steering::{
-                self, ChaseEntitySteeringStrategy, CollisionAvoidanceSteeringStrategy, Steering,
-                SteeringOutput, SteeringStrategy,
+                self, ChaseEntitySteeringStrategy, ChasePlayerSteeringStrategy,
+                CollisionAvoidanceSteeringStrategy, Steering, SteeringOutput, SteeringStrategy,
             },
         },
         script_util,
@@ -114,6 +114,10 @@ impl Behavior for ScriptedSequenceBehavior {
 
     fn turn_speed(&self) -> Deg<f32> {
         self.current_scripted_action.borrow().turn_speed()
+    }
+
+    fn is_locomotion(&self) -> bool {
+        self.current_scripted_action.borrow().is_locomotion()
     }
 
     fn steer(
@@ -236,12 +240,35 @@ fn get_behavior_from_action(
             speed: _, // TODO: Incorporate speed
         } => Box::new(RefCell::new(GotoScriptedAction::new(world, &waypoint_name))),
 
+        AIScriptedActionType::MetaProperty {
+            action_type,
+            arg1,
+            arg2: _,
+        } => Box::new(RefCell::new(MetaPropertyScriptedAction::new(
+            owner,
+            action_type,
+            arg1,
+        ))),
+
         AIScriptedActionType::Wait(duration) => {
             Box::new(RefCell::new(WaitScriptedAction::new(*duration)))
         }
         _ => Box::new(RefCell::new(NoopScriptedAction)),
     };
     current_behavior
+}
+
+/// Dark scripted actions reserve `player` as a target name. The runtime
+/// player is synthetic and intentionally has no `PropSymName`, so ordinary
+/// by-name lookup cannot resolve it.
+fn resolve_scripted_target(world: &World, entity_name: &str) -> Option<EntityId> {
+    if entity_name.eq_ignore_ascii_case("player") {
+        return world
+            .borrow::<View<PropLocalPlayer>>()
+            .ok()
+            .and_then(|players| players.iter().with_id().next().map(|(id, _)| id));
+    }
+    script_util::get_first_entity_by_name(world, entity_name)
 }
 
 /// ScriptedAction
@@ -265,6 +292,10 @@ trait ScriptedAction {
 
     fn completion_effect(&self) -> Effect {
         Effect::NoEffect
+    }
+
+    fn is_locomotion(&self) -> bool {
+        false
     }
 
     /// Called when the entity's current animation clip finishes (also fires
@@ -390,7 +421,7 @@ pub struct SendSignalScriptedAction {
 impl SendSignalScriptedAction {
     pub fn new(world: &World, entity_name: &str, signal: String) -> SendSignalScriptedAction {
         SendSignalScriptedAction {
-            target: script_util::get_first_entity_by_name(world, entity_name),
+            target: resolve_scripted_target(world, entity_name),
             signal,
         }
     }
@@ -422,6 +453,45 @@ impl ScriptedAction for NoopScriptedAction {
     fn animation(self: &NoopScriptedAction) -> Vec<MotionQueryItem> {
         // vec![MotionQueryItem::with_value("cs", 2)]
         vec![MotionQueryItem::new("__NULL_ANIMATION__")]
+    }
+}
+
+pub struct MetaPropertyScriptedAction {
+    owner: EntityId,
+    name: String,
+    add: Option<bool>,
+}
+
+impl MetaPropertyScriptedAction {
+    fn new(owner: EntityId, action_type: &str, name: &str) -> Self {
+        let add = if action_type.eq_ignore_ascii_case("add") {
+            Some(true)
+        } else if action_type.eq_ignore_ascii_case("remove") {
+            Some(false)
+        } else {
+            None
+        };
+        Self {
+            owner,
+            name: name.to_owned(),
+            add,
+        }
+    }
+}
+
+impl ScriptedAction for MetaPropertyScriptedAction {
+    fn animation(&self) -> Vec<MotionQueryItem> {
+        vec![MotionQueryItem::new("__NULL_ANIMATION__")]
+    }
+
+    fn initial_effect(&self) -> Effect {
+        self.add
+            .map(|add| Effect::SetMetaProperty {
+                entity_id: self.owner,
+                name: self.name.clone(),
+                add,
+            })
+            .unwrap_or(Effect::NoEffect)
     }
 }
 
@@ -463,7 +533,7 @@ pub struct FrobScriptedAction(Option<EntityId>);
 
 impl FrobScriptedAction {
     pub fn new(world: &World, entity_name: &str) -> FrobScriptedAction {
-        let maybe_entity = script_util::get_first_entity_by_name(world, entity_name);
+        let maybe_entity = resolve_scripted_target(world, entity_name);
         FrobScriptedAction(maybe_entity)
     }
 }
@@ -488,31 +558,44 @@ impl ScriptedAction for FrobScriptedAction {
 }
 
 pub struct GotoScriptedAction {
-    target_id: Option<EntityId>,
+    target: GotoTarget,
     steering_strategy: Box<dyn SteeringStrategy>,
+}
+
+enum GotoTarget {
+    Player,
+    Entity(EntityId),
+    Missing,
 }
 
 impl GotoScriptedAction {
     pub fn new(world: &World, entity_name: &str) -> GotoScriptedAction {
-        let maybe_entity = script_util::get_first_entity_by_name(world, entity_name);
-
         let mut steering_strategies: Vec<Box<dyn SteeringStrategy>> = vec![Box::new(
             CollisionAvoidanceSteeringStrategy::conservative(), /* conservative so we can focus on the chase */
         )];
 
-        if let Some(ent) = maybe_entity {
-            steering_strategies.push(Box::new(ChaseEntitySteeringStrategy::new(ent)))
-            //steering_strategies.push(Box::new(ChasePlayerSteeringStrategy))
-        }
+        let target = if entity_name.eq_ignore_ascii_case("player") {
+            steering_strategies.push(Box::new(ChasePlayerSteeringStrategy));
+            GotoTarget::Player
+        } else if let Some(entity) = resolve_scripted_target(world, entity_name) {
+            steering_strategies.push(Box::new(ChaseEntitySteeringStrategy::new(entity)));
+            GotoTarget::Entity(entity)
+        } else {
+            GotoTarget::Missing
+        };
 
         GotoScriptedAction {
-            target_id: maybe_entity,
+            target,
             steering_strategy: steering::chained(steering_strategies),
         }
     }
 }
 
 impl ScriptedAction for GotoScriptedAction {
+    fn is_locomotion(&self) -> bool {
+        true
+    }
+
     fn turn_speed(&self) -> Deg<f32> {
         Deg(540.0)
     }
@@ -536,22 +619,26 @@ impl ScriptedAction for GotoScriptedAction {
     }
 
     fn is_complete(&self, entity_id: EntityId, world: &World) -> bool {
-        let v_prop_pos = world.borrow::<View<PropPosition>>().unwrap();
-        if let Some(target_entity_id) = self.target_id {
-            if let Ok(target_pos) = v_prop_pos.get(target_entity_id) {
-                if let Ok(entity_pos) = v_prop_pos.get(entity_id) {
-                    let from = vec3(entity_pos.position.x, 0.0, entity_pos.position.z);
-                    let to = vec3(target_pos.position.x, 0.0, target_pos.position.z);
-                    let distance = (from - to).magnitude();
+        match self.target {
+            GotoTarget::Player => ai_util::chase_target_distance(world, entity_id)
+                .is_none_or(|distance| distance < (3.0 / SCALE_FACTOR)),
+            GotoTarget::Entity(target_entity_id) => {
+                let v_prop_pos = world.borrow::<View<PropPosition>>().unwrap();
+                if let Ok(target_pos) = v_prop_pos.get(target_entity_id) {
+                    if let Ok(entity_pos) = v_prop_pos.get(entity_id) {
+                        let from = vec3(entity_pos.position.x, 0.0, entity_pos.position.z);
+                        let to = vec3(target_pos.position.x, 0.0, target_pos.position.z);
+                        let distance = (from - to).magnitude();
 
-                    // HACK: This is an arbitrary value that I just tested with some sequences
-                    // (ie, in rec1). I'm not sure the best criteria for this step yet.
-                    return distance < (3.0 / SCALE_FACTOR);
+                        // HACK: This is an arbitrary value that I just tested with some sequences
+                        // (ie, in rec1). I'm not sure the best criteria for this step yet.
+                        return distance < (3.0 / SCALE_FACTOR);
+                    }
                 }
+                true
             }
+            GotoTarget::Missing => true,
         }
-
-        true
     }
 }
 
@@ -562,7 +649,7 @@ pub struct FaceScriptedAction {
 
 impl FaceScriptedAction {
     pub fn new(world: &World, entity_name: &str) -> FaceScriptedAction {
-        let maybe_entity = script_util::get_first_entity_by_name(world, entity_name);
+        let maybe_entity = resolve_scripted_target(world, entity_name);
 
         let mut steering_strategies: Vec<Box<dyn SteeringStrategy>> = vec![];
 
@@ -613,5 +700,70 @@ impl ScriptedAction for FaceScriptedAction {
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mission::PlayerInfo;
+    use cgmath::{One, Quaternion};
+    use dark::properties::PropSymName;
+
+    #[test]
+    fn reserved_player_target_resolves_without_a_symbolic_name() {
+        let mut world = World::new();
+        let player = world.add_entity(PropLocalPlayer {});
+        let named = world.add_entity(PropSymName("Waypoint".to_owned()));
+
+        assert_eq!(resolve_scripted_target(&world, "PLAYER"), Some(player));
+        assert_eq!(resolve_scripted_target(&world, "waypoint"), Some(named));
+    }
+
+    #[test]
+    fn metaproperty_action_emits_a_pure_world_effect() {
+        let mut world = World::new();
+        let owner = world.add_entity(());
+        let action = AIScriptedAction {
+            action_type: AIScriptedActionType::MetaProperty {
+                action_type: "Remove".to_owned(),
+                arg1: "Docile".to_owned(),
+                arg2: String::new(),
+            },
+        };
+
+        let behavior = get_behavior_from_action(&world, owner, &action);
+        assert!(matches!(
+            behavior.borrow().initial_effect(),
+            Effect::SetMetaProperty {
+                entity_id,
+                ref name,
+                add: false,
+            } if entity_id == owner && name == "Docile"
+        ));
+    }
+
+    #[test]
+    fn goto_player_uses_live_player_position_and_requests_locomotion() {
+        let mut world = World::new();
+        let owner = world.add_entity(PropPosition {
+            position: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::one(),
+            cell: 0,
+        });
+        let player = world.add_entity(PropLocalPlayer {});
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 10.0),
+            rotation: Quaternion::one(),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        let action = GotoScriptedAction::new(&world, "player");
+        assert!(action.is_locomotion());
+        assert!(!action.is_complete(owner, &world));
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -682,6 +682,14 @@ pub enum Effect {
         update: AIPropertyUpdate,
     },
 
+    /// Add or remove one named Dark metaproperty and recompose only the
+    /// component types contributed by that metaproperty's inheritance branch.
+    SetMetaProperty {
+        entity_id: EntityId,
+        name: String,
+        add: bool,
+    },
+
     /// Replace Dark's runtime-only `AICurrentPatrol` relation for one AI.
     /// `None` removes the relation when patrol stops or gives up.
     SetAICurrentPatrol {

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -344,18 +344,25 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // Use-only contained objects (notably corpse audio logs) still
             // need their normal Frob behavior when clicked; they are consumed
             // or recorded in place rather than moved into the backpack.
+            // Grabbable `MOVE | SCRIPT` loot needs both authored halves: Frob
+            // runs its scripted acquisition side effect, then DropEntityInfo
+            // performs the engine-owned MOVE. The immediate transfer removes
+            // the panel button, so one press cannot enqueue either half twice.
             ContainerGuiMsg::Take(ent) => {
-                if !crate::virtual_hand::can_grab_item(world, *ent) {
-                    let is_use_only = world
-                        .borrow::<View<PropFrobInfo>>()
-                        .map(|frob| {
-                            frob.get(*ent).is_ok_and(|frob| {
-                                frob.world_action.contains(FrobFlag::SCRIPT)
-                                    || frob.inventory_action.contains(FrobFlag::SCRIPT)
-                            })
+                let (world_frob_is_scripted, inventory_frob_is_scripted) = world
+                    .borrow::<View<PropFrobInfo>>()
+                    .ok()
+                    .and_then(|frob| {
+                        frob.get(*ent).ok().map(|frob| {
+                            (
+                                frob.world_action.contains(FrobFlag::SCRIPT),
+                                frob.inventory_action.contains(FrobFlag::SCRIPT),
+                            )
                         })
-                        .unwrap_or(false);
-                    return if is_use_only {
+                    })
+                    .unwrap_or((false, false));
+                if !crate::virtual_hand::can_grab_item(world, *ent) {
+                    return if world_frob_is_scripted || inventory_frob_is_scripted {
                         (
                             state.clone(),
                             Effect::Send {
@@ -370,10 +377,10 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                     };
                 }
                 // PropKeySrc gets an `internal_keycard` script even when its
-                // retail frob metadata is just MOVE. Scripted loot must run
-                // that Frob before any generic transfer, or the physical card
-                // reaches the backpack without its unlock credential (#583).
-                if crate::virtual_hand::uses_scripted_world_frob(world, *ent) {
+                // retail frob metadata is just MOVE. It remains the sole owner
+                // of both credential acquisition and physical item fate; the
+                // generic transfer below would race its DestroyEntity (#583).
+                if crate::virtual_hand::is_key_source(world, *ent) {
                     return (
                         state.clone(),
                         Effect::Send {
@@ -389,13 +396,26 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                     .map(|player| player.inventory_entity_id)
                     .ok();
                 match inventory_entity {
-                    Some(inventory_entity) => (
-                        state.clone(),
-                        Effect::DropEntityInfo {
+                    Some(inventory_entity) => {
+                        let transfer = Effect::DropEntityInfo {
                             parent_entity_id: inventory_entity,
                             dropped_entity_id: *ent,
-                        },
-                    ),
+                        };
+                        let effect = if world_frob_is_scripted {
+                            Effect::combine(vec![
+                                Effect::Send {
+                                    msg: Message {
+                                        payload: MessagePayload::Frob,
+                                        to: *ent,
+                                    },
+                                },
+                                transfer,
+                            ])
+                        } else {
+                            transfer
+                        };
+                        (state.clone(), effect)
+                    }
                     None => (state.clone(), Effect::NoEffect),
                 }
             }
@@ -442,12 +462,12 @@ mod tests {
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
     /// through.
-    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+    fn loot_world_with_action(world_action: FrobFlag) -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
         let item = world.add_entity((
             PropObjIcon("icn_psi".to_owned()),
             PropFrobInfo {
-                world_action: FrobFlag::MOVE,
+                world_action,
                 inventory_action: FrobFlag::empty(),
                 tool_action: FrobFlag::empty(),
             },
@@ -470,6 +490,10 @@ mod tests {
             inventory_entity_id: inventory,
         });
         (world, container, item, inventory)
+    }
+
+    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+        loot_world_with_action(FrobFlag::MOVE)
     }
 
     fn mark_as_keycard(world: &mut World, item: EntityId) {
@@ -617,6 +641,55 @@ mod tests {
                 } if entity_id == ordinary
             ),
             "ordinary MOVE loot must remain grabbable, got {effect:?}"
+        );
+    }
+
+    /// Ops2 Chip A (mission object 554) is authored `MOVE | SCRIPT`: one
+    /// trigger-click must run BaseButton's reward side effect and perform the
+    /// ordinary container-to-backpack transfer, with neither half duplicated.
+    #[test]
+    fn loot_container_click_frobs_and_takes_a_scripted_pickup_once() {
+        let (world, container, item, inventory) =
+            loot_world_with_action(FrobFlag::MOVE | FrobFlag::SCRIPT);
+        let gui = ContainerGui::loot_container();
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+        let effects = Effect::flatten(vec![effect]);
+
+        assert_eq!(
+            effects
+                .iter()
+                .filter(|effect| matches!(
+                    effect,
+                    Effect::Send {
+                        msg: Message {
+                            to,
+                            payload: MessagePayload::Frob,
+                        },
+                    } if *to == item
+                ))
+                .count(),
+            1,
+            "taking MOVE | SCRIPT loot must run its authored Frob exactly once: {effects:?}"
+        );
+        assert_eq!(
+            effects
+                .iter()
+                .filter(|effect| matches!(
+                    effect,
+                    Effect::DropEntityInfo {
+                        parent_entity_id,
+                        dropped_entity_id,
+                    } if *parent_entity_id == inventory && *dropped_entity_id == item
+                ))
+                .count(),
+            1,
+            "taking MOVE | SCRIPT loot must transfer it exactly once: {effects:?}"
         );
     }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -301,21 +301,11 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
         match msg {
             ContainerGuiMsg::GrabbedWithLeftHand(ent) => (
                 state.clone(),
-                Effect::GrabEntity {
-                    entity_id: *ent,
-                    hand: crate::vr_config::Handedness::Left,
-                    // TODO: Set this up to break link
-                    current_parent_id: None,
-                },
+                panel_grab_effect(world, *ent, crate::vr_config::Handedness::Left),
             ),
             ContainerGuiMsg::GrabbedWithRightHand(ent) => (
                 state.clone(),
-                Effect::GrabEntity {
-                    entity_id: *ent,
-                    hand: crate::vr_config::Handedness::Right,
-                    // TODO: Set this up to break link
-                    current_parent_id: None,
-                },
+                panel_grab_effect(world, *ent, crate::vr_config::Handedness::Right),
             ),
             // Wield-or-use (backpack click): a carried weapon - gun
             // (PropPlayerGun) or melee (PropLimbModel) - is wielded through
@@ -379,6 +369,21 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                         (state.clone(), Effect::NoEffect)
                     };
                 }
+                // PropKeySrc gets an `internal_keycard` script even when its
+                // retail frob metadata is just MOVE. Scripted loot must run
+                // that Frob before any generic transfer, or the physical card
+                // reaches the backpack without its unlock credential (#583).
+                if crate::virtual_hand::uses_scripted_world_frob(world, *ent) {
+                    return (
+                        state.clone(),
+                        Effect::Send {
+                            msg: Message {
+                                payload: MessagePayload::Frob,
+                                to: *ent,
+                            },
+                        },
+                    );
+                }
                 let inventory_entity = world
                     .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
                     .map(|player| player.inventory_entity_id)
@@ -398,13 +403,41 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
     }
 }
 
+/// A squeeze over a panel normally retrieves the icon into that hand. A
+/// keycard is the one semantic exception: it represents a collected access
+/// credential, so every panel (corpse loot and the backpack alike) must route
+/// the gesture through its derived keycard Frob instead of physically holding
+/// an unregistered object.
+fn panel_grab_effect(
+    world: &World,
+    entity_id: EntityId,
+    hand: crate::vr_config::Handedness,
+) -> Effect {
+    if crate::virtual_hand::is_key_source(world, entity_id) {
+        Effect::Send {
+            msg: Message {
+                payload: MessagePayload::Frob,
+                to: entity_id,
+            },
+        }
+    } else {
+        Effect::GrabEntity {
+            entity_id,
+            hand,
+            current_parent_id: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::gui::GuiInputInfo;
     use crate::mission::PlayerInfo;
     use cgmath::{Quaternion, point2, vec3};
-    use dark::properties::{FrobFlag, Links, PropFrobInfo, PropHitPoints, ToLink, WrappedEntityId};
+    use dark::properties::{
+        FrobFlag, KeyCard, Links, PropFrobInfo, PropHitPoints, PropKeySrc, ToLink, WrappedEntityId,
+    };
 
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
@@ -437,6 +470,17 @@ mod tests {
             inventory_entity_id: inventory,
         });
         (world, container, item, inventory)
+    }
+
+    fn mark_as_keycard(world: &mut World, item: EntityId) {
+        world.add_component(
+            item,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 128,
+                lock_id: 0,
+            }),
+        );
     }
 
     fn input_at(cursor: cgmath::Point2<f32>, pressed: bool) -> GuiInputInfo {
@@ -490,6 +534,90 @@ mod tests {
             }
             other => panic!("Take should transfer via DropEntityInfo, got {:?}", other),
         }
+    }
+
+    /// Hydro2 Card B is both grabbable (`MOVE`) and a derived key source. A
+    /// loot-panel trigger click must run `internal_keycard` instead of silently
+    /// reparenting the object and skipping the region-128 credential.
+    #[test]
+    fn loot_container_click_frobs_a_keycard() {
+        let (mut world, container, item, _inventory) = loot_world();
+        mark_as_keycard(&mut world, item);
+        let gui = ContainerGui::loot_container();
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+
+        assert!(
+            matches!(
+                effect,
+                Effect::Send {
+                    msg: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                } if to == item
+            ),
+            "taking a keycard must collect its credential, got {effect:?}"
+        );
+    }
+
+    /// In VR a squeeze over either a corpse-loot or backpack icon normally
+    /// emits `GrabbedWith*`. Keycards are collected credentials, so that edge
+    /// must Frob them rather than putting an unregistered physical card in the
+    /// hand. Ordinary MOVE loot keeps the existing grab behavior.
+    #[test]
+    fn vr_panel_grab_frobs_only_keycards() {
+        let (mut world, container, keycard, _inventory) = loot_world();
+        mark_as_keycard(&mut world, keycard);
+        let ordinary = world.add_entity(PropFrobInfo {
+            world_action: FrobFlag::MOVE,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        });
+        let gui = ContainerGui::loot_container();
+
+        for message in [
+            ContainerGuiMsg::GrabbedWithLeftHand(keycard),
+            ContainerGuiMsg::GrabbedWithRightHand(keycard),
+        ] {
+            let (_state, effect) =
+                gui.handle_msg(container, &world, &ContainerGuiState {}, &message);
+            assert!(
+                matches!(
+                    effect,
+                    Effect::Send {
+                        msg: Message {
+                            to,
+                            payload: MessagePayload::Frob,
+                        },
+                    } if to == keycard
+                ),
+                "VR keycard squeeze must collect instead of hold, got {effect:?}"
+            );
+        }
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::GrabbedWithRightHand(ordinary),
+        );
+        assert!(
+            matches!(
+                effect,
+                Effect::GrabEntity {
+                    entity_id,
+                    hand: crate::vr_config::Handedness::Right,
+                    ..
+                } if entity_id == ordinary
+            ),
+            "ordinary MOVE loot must remain grabbable, got {effect:?}"
+        );
     }
 
     /// Both panels' item grids must land on the cell separators authored into

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -263,6 +263,10 @@ pub enum MessagePayload {
         name: String,
     },
 
+    /// A metaproperty mutation changed authored AI configuration components;
+    /// rebuild the script's cached view after the effect applier updates ECS.
+    RefreshAIProperties,
+
     // Debug: force an AI's alertness level (clamped by its alert cap).
     // `pin` holds it against decay (and tracks the live player) until a
     // non-pinned SetAlertness clears it.

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -484,11 +484,25 @@ fn handle_empty_hand_state(
         }) = result
         {
             if Some(entity_id) != held_by_other_hand && can_grab_item(world, entity_id) {
-                let position = &physics.get_position(rigid_body_handle).unwrap();
-                let _dir = hand_position - position;
-                msgs.push(VirtualHandEffect::HoldItem { entity_id });
+                if is_key_source(world, entity_id) {
+                    // Keycards are collected credentials, not hand-held tools.
+                    // Dispatch the same Frob as the trigger path so
+                    // internal_keycard records the access and consumes the
+                    // physical pickup instead of leaving an unregistered card
+                    // in the hand (#583).
+                    msgs.push(VirtualHandEffect::OutMessage {
+                        message: Message {
+                            to: entity_id,
+                            payload: MessagePayload::Frob,
+                        },
+                    });
+                } else {
+                    let position = &physics.get_position(rigid_body_handle).unwrap();
+                    let _dir = hand_position - position;
+                    msgs.push(VirtualHandEffect::HoldItem { entity_id });
 
-                next_hand_state = HandState::Grabbing { entity_id };
+                    next_hand_state = HandState::Grabbing { entity_id };
+                }
             }
         }
     }
@@ -527,6 +541,13 @@ fn get_held_position_orientation(
 /// protocol even though the Weapon archetype also inherits that inventory
 /// flag. The decision stays tied to Dark's production frob metadata.
 fn held_trigger_press_payload(world: &World, entity_id: EntityId) -> MessagePayload {
+    // PropKeySrc injects `internal_keycard` at runtime even though retail ID
+    // cards do not author an inventory SCRIPT flag. A physical card held by an
+    // older save therefore still needs the production trigger to collect it.
+    if is_key_source(world, entity_id) {
+        return MessagePayload::Frob;
+    }
+
     let has_scripted_inventory_use = world
         .borrow::<View<PropFrobInfo>>()
         .map(|frob_info| {
@@ -557,6 +578,16 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     false
 }
 
+/// Whether this object is a key source. Every PropKeySrc receives the derived
+/// `internal_keycard` script, whose Frob records the credential and consumes
+/// the pickup; bypassing it creates a physical card that cannot unlock doors.
+pub(crate) fn is_key_source(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<dark::properties::PropKeySrc>>()
+        .map(|keycards| keycards.get(entity_id).is_ok())
+        .unwrap_or(false)
+}
+
 /// Whether taking this world item must go through a script before the physical
 /// transfer. An authored `SCRIPT` world action owns its side effects and item
 /// fate (for example `FrobQB` awards a quest bit and moves the item exactly
@@ -571,12 +602,7 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
                 .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
         })
         .unwrap_or(false);
-    let has_derived_keycard_script = world
-        .borrow::<View<dark::properties::PropKeySrc>>()
-        .map(|keycards| keycards.get(entity_id).is_ok())
-        .unwrap_or(false);
-
-    has_authored_world_script || has_derived_keycard_script
+    has_authored_world_script || is_key_source(world, entity_id)
 }
 
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
@@ -647,7 +673,7 @@ fn resolve_hit_proxy_entity(world: &World, ray_cast_result: RayCastResult) -> Ra
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dark::properties::{PropFrobInfo, PropPlayerGun};
+    use dark::properties::{KeyCard, PropFrobInfo, PropKeySrc, PropPlayerGun};
 
     fn scripted_inventory_use() -> PropFrobInfo {
         PropFrobInfo {
@@ -723,6 +749,32 @@ mod tests {
         assert!(matches!(
             held_trigger_payload(&world, weapon_or_psi_amp),
             MessagePayload::TriggerPull
+        ));
+    }
+
+    /// A keycard physically held by an older save or a pre-fix backpack grab
+    /// must still be recoverable through the production VR trigger gesture.
+    /// Its inventory metadata has no SCRIPT bit, so PropKeySrc is the semantic
+    /// source of truth.
+    #[test]
+    fn held_keycard_trigger_collects_it_through_frob() {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            PropFrobInfo {
+                world_action: FrobFlag::MOVE,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 128,
+                lock_id: 0,
+            }),
+        ));
+
+        assert!(matches!(
+            held_trigger_payload(&world, keycard),
+            MessagePayload::Frob
         ));
     }
 

--- a/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Authentic Hydro2 Card B chain for #583:
+//   corpse 754 --Contains--> card 942 (PropKeySrc region 128)
+//   card slots 1120/1122 --SwitchLink--> HydroSectorB door 1127
+//
+// Both cases use default VR and production hand input. The backpack case uses
+// /give only to stage the authored card in the backpack; credential acquisition
+// itself must come from squeezing the rendered slot, not an injected Frob.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const CORPSE = 754;
+const CARD = 942;
+const CARD_SLOT = 1120;
+const DOOR = 1127;
+const CARD_ARCHETYPE = -1495;
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const BACKPACK_PANEL_SIZE_PX: Vec3 = [635, 120, 0];
+const VR_BACKPACK_WORLD_SCALE = 0.55;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+function distance(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+async function squeezeWorldPanelElement(
+  game: GameServer,
+  panelSizePx: Vec3,
+  worldScale: number,
+  element: UiElement,
+): Promise<void> {
+  const panel = (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+  assert.equal(panel.length, 1, "expected exactly one production VR panel collider");
+  const [x, y, width, height] = element.screen_rect;
+  const u = x + width / 2;
+  const v = y + height / 2;
+  const panelSize: Vec3 = [
+    panelSizePx[0] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
+    panelSizePx[1] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
+    0,
+  ];
+  const local: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+  const target = add(panel[0].position, quatRotate(panel[0].rotation, local));
+  const aim = await aimVrHandAt(game, target, 0.35);
+  const hit = await game.raycast({
+    start: aim.start,
+    end: aim.target,
+    collision_groups: ["ui"],
+    max_distance: 1,
+  });
+  assert.equal(hit.entity_id, panel[0].entity_id, "production hand ray must hit the panel");
+
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 4 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+}
+
+async function assertCardCollectedAndDoorOpens(
+  game: GameServer,
+  collectedTemplate: number,
+): Promise<void> {
+  assert.equal(
+    (await game.entities.byTemplate(collectedTemplate)).length,
+    0,
+    "collecting Card B must consume the physical keycard object",
+  );
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    null,
+    "a collected credential must not remain physically held",
+  );
+
+  const slot = only(await game.entities.byTemplate(CARD_SLOT), "Hydro2 Card B slot 1120");
+  const door = only(await game.entities.byTemplate(DOOR), "HydroSectorB door 1127");
+  const before = (await game.entities.detail(door.id)).position;
+  await teleportVerified(game, {
+    x: slot.position[0] + 1.1,
+    y: slot.position[1] + 0.4,
+    z: slot.position[2] + 1.1,
+  });
+  const aim = await game.player.aimAt(slot, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+  await aimVrHandAt(game, aim.world_point);
+  const since = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 180 });
+
+  const after = (await game.entities.detail(door.id)).position;
+  assert.ok(
+    distance(after, before) > 0.5,
+    `Card B credential must open door 1127: before=${before}, after=${after}`,
+  );
+  const played = (await game.audio.recent()).sounds
+    .filter((sound) => sound.sequence > since)
+    .map((sound) => sound.sample.toLowerCase());
+  assert.ok(!played.includes("hackfail"), `Card B slot refused credential: ${played}`);
+}
+
+test(
+  "Hydro2 VR corpse-panel squeeze collects Card B and opens its authored door",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8620),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+    const corpse = only(await game.entities.byTemplate(CORPSE), "Hydro2 corpse 754");
+    const card = only(await game.entities.byTemplate(CARD), "Hydro Card B 942");
+
+    // Reviewed campaign standing point under this alcove's seven-foot ceiling.
+    await teleportVerified(game, { x: 73.08, y: -0.76, z: -14.92 });
+    await game.step({ frames: 20 });
+    const corpseAim = await game.player.aimAt(corpse, {
+      hitbox: "center",
+    });
+    await aimVrHandAt(game, corpseAim.world_point);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 8 });
+
+    const active = (await game.ui.state()).active_panel;
+    assert.equal(active?.entity_id, corpse.id, "corpse 754 must open its real loot panel");
+    const cardElement = active.elements.find(
+      (element) => element.kind === "button" && element.entity_id === card.id,
+    );
+    assert.ok(cardElement, "corpse 754 must expose its real Card B button");
+    await squeezeWorldPanelElement(game, LOOT_PANEL_SIZE_PX, 1, cardElement);
+    await assertCardCollectedAndDoorOpens(game, CARD);
+  },
+);
+
+test(
+  "Hydro2 VR backpack squeeze repairs an unregistered carried Card B",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8622),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+    const card = await game.player.spawnItem(CARD_ARCHETYPE);
+    assert.equal(
+      (await game.player.inventory()).items.find((item) => item.entity_id === card.entity_id)
+        ?.location,
+      "inventory",
+      "setup must stage the exact authored card in the backpack",
+    );
+
+    await game.input.set("head.look", [0, 0]);
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 8 });
+    const active = (await game.ui.state()).active_panel;
+    const cardElement = active?.elements.find(
+      (element) => element.kind === "button" && element.entity_id === card.entity_id,
+    );
+    assert.ok(cardElement, "VR backpack must expose the staged Card B button");
+    await squeezeWorldPanelElement(
+      game,
+      BACKPACK_PANEL_SIZE_PX,
+      VR_BACKPACK_WORLD_SCALE,
+      cardElement,
+    );
+    await assertCardCollectedAndDoorOpens(game, CARD_ARCHETYPE);
+  },
+);

--- a/tools/shock2-sdk/test/ops2-vr-chip-a-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-vr-chip-a-loot.e2e.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { PhysicsBodySummary, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable ops2 mission-object ids. Runtime ids are rediscovered each launch.
+const RED_ASSASSIN = 254;
+const CHIP_A = 554;
+const EXPERIENCE_TRAP = 1089;
+const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const FIRST_LOOT_SLOT_CENTER_PX: Vec3 = [15 + 35 / 2, 153 + 34 / 2, 0];
+
+const uiBodies = async (game: GameServer): Promise<PhysicsBodySummary[]> =>
+  (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+
+async function triggerClick(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 8 });
+}
+
+test(
+  "ops2 VR trigger-click runs Chip A's reward once and transfers it from the corpse",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8554),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [assassin] = await game.entities.byTemplate(RED_ASSASSIN);
+    const [chip] = await game.entities.byTemplate(CHIP_A);
+    const [experienceTrap] = await game.entities.byTemplate(EXPERIENCE_TRAP);
+    assert.ok(assassin, "expected ops2 Red Assassin mission object 254");
+    assert.equal(chip?.name, "Chip A", "expected ops2 Chip A mission object 554");
+    assert.ok(experienceTrap, "expected Chip A Experience Trap mission object 1089");
+    assert.equal((await game.info()).player.stats?.cyber_modules, 0);
+    assert.ok(
+      (await game.entities.detail(assassin.id)).outgoing_links.some(
+        (link) => link.link_type.startsWith("Contains") && link.target_id === chip.id,
+      ),
+      "the Red Assassin must initially contain Chip A",
+    );
+
+    // Lethal damage is test setup only. Opening the corpse and clicking its
+    // rendered world panel below both use the production VR trigger ray.
+    await game.entities.sendMessage(assassin.id, { type: "Damage", amount: 100 });
+    await game.step({ frames: 120 });
+    const corpse = await game.entities.detail(assassin.id);
+    assert.equal(
+      corpse.properties.find((property) => property.name === "AIBehavior")?.value,
+      "Dead",
+      "lethal setup damage must leave a lootable corpse",
+    );
+
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.2,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.2,
+    });
+    const corpseAim = await game.player.aimAt(assassin, {
+      hitbox: "torso",
+      visibility: "required",
+    });
+    await aimVrHandAt(game, corpseAim.world_point);
+    await triggerClick(game);
+
+    const panels = await uiBodies(game);
+    assert.equal(panels.length, 1, "trigger-frobbing the corpse must open one VR loot panel");
+    const panel = panels[0];
+
+    // Invert ProxyGuiScript's panel mapping for the center of the first loot
+    // slot. Chip A is the corpse's sole contained item, so ContainerGui packs
+    // its real button into this authored cell.
+    const panelSize: Vec3 = [
+      PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
+      PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
+      0,
+    ];
+    const u = FIRST_LOOT_SLOT_CENTER_PX[0] / PANEL_SIZE_PX[0];
+    const v = FIRST_LOOT_SLOT_CENTER_PX[1] / PANEL_SIZE_PX[1];
+    const localSlot: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+    const slotWorld = add(panel.position, quatRotate(panel.rotation, localSlot));
+    await aimVrHandAt(game, slotWorld, 0.35);
+    await triggerClick(game);
+
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.filter(
+        (item) => item.entity_id === chip.id && item.location === "inventory",
+      ).length,
+      1,
+      `one trigger-click must put one Chip A in the backpack: ${JSON.stringify(inventory.items)}`,
+    );
+    assert.ok(
+      !(await game.entities.detail(assassin.id)).outgoing_links.some(
+        (link) => link.link_type.startsWith("Contains") && link.target_id === chip.id,
+      ),
+      "the transfer must remove the corpse's Contains link to Chip A",
+    );
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      10,
+      "Chip A's authored Experience side effect must run exactly once",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(EXPERIENCE_TRAP)).length,
+      0,
+      "TrapEXPOnce must consume the authored Experience Trap",
+    );
+
+    // Repeating the same production trigger edge over the now-empty slot must
+    // neither duplicate the item nor re-award the destroyed one-shot trap.
+    await aimVrHandAt(game, slotWorld, 0.35);
+    await triggerClick(game);
+    assert.equal((await game.info()).player.stats?.cyber_modules, 10);
+    assert.equal(
+      (await game.player.inventory()).items.filter((item) => item.entity_id === chip.id).length,
+      1,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ops4-scripted-droid.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-scripted-droid.e2e.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const port = Number(process.env.SHOCK2_E2E_PORT ?? 8398);
+
+const TRIPWIRE = 519;
+const SIGNAL_TRAP = 1315;
+const SECURITY_DROID = 325;
+const DOORS = [514, 515] as const;
+
+test(
+  "ops4: IRobot response removes Docile and clears the Command Center entrance (#1108)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops4.mis",
+      port,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [tripwire] = await game.entities.byTemplate(TRIPWIRE);
+    const [signalTrap] = await game.entities.byTemplate(SIGNAL_TRAP);
+    const [droid] = await game.entities.byTemplate(SECURITY_DROID);
+    assert.ok(tripwire, `expected Ops4 tripwire ${TRIPWIRE}`);
+    assert.ok(signalTrap, `expected Ops4 AI Signal Trap ${SIGNAL_TRAP}`);
+    assert.ok(droid, `expected Ops4 Security Droid ${SECURITY_DROID}`);
+    const initialDroid = await game.entities.detail(droid.id);
+
+    // Spatial setup stays north of the tripwire. Enter it with the bounded,
+    // collision-valid player movement path that drives production sensors.
+    await game.player.teleport({ x: 66.0, y: -9.556, z: -87.0 });
+    await game.step({ frames: 5 });
+    const entered = await game.player.moveTo({ x: 66.0, y: -9.556, z: -90.0 });
+    assert.equal(entered.blocked, false, JSON.stringify(entered));
+    await game.step({ frames: 60 });
+
+    const trace = (await game.messages.recent()).messages;
+    assert.ok(
+      trace.some(
+        (message) =>
+          message.payload === "TurnOn" &&
+          message.from?.template_id === TRIPWIRE &&
+          message.to.template_id === SIGNAL_TRAP,
+      ),
+      `tripwire must activate the authored signal trap: ${JSON.stringify(trace)}`,
+    );
+    assert.ok(
+      trace.some(
+        (message) =>
+          message.payload === "Signal" &&
+          message.to.template_id === SECURITY_DROID,
+      ),
+      `signal trap must deliver IRobot to the droid: ${JSON.stringify(trace)}`,
+    );
+
+    const openedDoors = await Promise.all(
+      DOORS.map(async (template) => (await game.entities.byTemplate(template))[0]),
+    );
+    assert.ok(openedDoors.every(Boolean), "expected both Command Center door leaves");
+    assert.ok(
+      openedDoors[0].position[0] < 63 && openedDoors[1].position[0] > 69,
+      `tripwire should fully spread both door leaves: ${JSON.stringify(openedDoors)}`,
+    );
+
+    // Draw the scripted Goto target away from the 3.2-unit opening. Before
+    // the fix the droid remains near z=-93.5 in Idle, filling the doorway.
+    await game.player.moveTo({ x: 64.6, y: -9.556, z: -86.8 });
+    await game.step({ frames: 600 });
+    const movedDroid = await game.entities.detail(droid.id);
+    assert.ok(
+      movedDroid.position[2] > -90.5,
+      `IRobot droid must leave the doorway toward the player; got ${JSON.stringify(movedDroid)}`,
+    );
+    assert.ok(
+      movedDroid.position[2] - initialDroid.position[2] > 3,
+      `the droid's full collider must clear its authored doorway position: ` +
+        `${JSON.stringify(initialDroid.position)} -> ${JSON.stringify(movedDroid.position)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- execute authored scripted `MetaProperty Add/Remove` actions through the central effect applier
- recompose only affected Dark component types from remaining ancestry, refresh cached AI configuration, and persist runtime metaproperty relation deltas across saves
- resolve reserved scripted `player` targets through live player state and make scripted Goto actions drive locomotion
- add an authentic Ops4 VR regression covering tripwire 519, signal trap 1315, Security Droid 325, opened door leaves, and the droid collider leaving the doorway

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr --lib` — 910 passed
- `npm test` in `tools/shock2-sdk` — 26 passed, 286 opt-in E2Es skipped
- `SHOCK2_E2E=1 SHOCK2_E2E_PORT=8398 node --test dist/test/ops4-scripted-droid.e2e.test.js` — 1 passed
- deterministic VR before/after capture via `/v1/step` and `/v1/screenshot`

## Stack

This PR intentionally targets `fix/ops-chip-trigger-loot-transfer` (#1106).

## Visual evidence

![Ops4 scripted droid response](https://gist.githubusercontent.com/tommy-xr/1eadb8b21344043f82bcfb014b545365/raw/ops4-droid-response.gif)

<sub>The authored trip/signal sequence leaves the base droid idle in the doorway; the fixed build removes Docile and executes `Goto player`, visibly advancing the droid. Captured headlessly in VR with deterministic fixed-timestep stepping.</sub>

### Before → after

![Ops4 scripted droid before and after](https://gist.githubusercontent.com/tommy-xr/1eadb8b21344043f82bcfb014b545365/raw/ops4-droid-before-after.png)

Fixes #1108
