### PR TITLE
feat(vr): cyber-interface entry/exit feel

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -157,6 +157,25 @@ pub trait GameScene {
         false
     }
 
+    /// Degrees to pull the flat FOV in by this frame (subtracted from the
+    /// base FOV), eased over a personal-UI mode's entry/exit ramp - see the
+    /// cyber interface's `ui::entry_ramp`. Implementations must return 0 in
+    /// VR: OpenXR view FOVs are used as-is, and rendering at a different FOV
+    /// than submitted causes compositor reprojection warping. Default: no
+    /// pull (non-mission scenes have no such mode).
+    fn fov_pull_deg(&self, _game_options: &GameOptions) -> f32 {
+        0.0
+    }
+
+    /// Peak rim-vignette intensity (0..1) this scene wants blended in this
+    /// frame, on top of (not merged with) `HitFeedback`'s own damage tint -
+    /// see the cyber interface's `ui::entry_ramp`. The two are drawn as
+    /// separate layered quads with their own colors, so a hit still reads
+    /// while a personal-UI mode is open. Default: none.
+    fn use_mode_vignette_intensity(&self) -> f32 {
+        0.0
+    }
+
     /// Collision-valid, supported position to serialize for the player.
     /// Mission scenes return a specific refusal reason while transient
     /// locomotion, death, or unsupported space makes a durable save unsafe.

--- a/shock2vr/src/hit_feedback.rs
+++ b/shock2vr/src/hit_feedback.rs
@@ -83,8 +83,8 @@ const COVERAGE_MARGIN: f32 = 1.25;
 /// picture's own extents come from the host's projection matrix, so the same
 /// two numbers describe the same visible effect on a 45-degree monitor and on
 /// a headset's much wider asymmetric per-eye frustum.
-pub const CLEAR_FIELD_FRACTION: f32 = 0.5;
-pub const FULL_FIELD_FRACTION: f32 = 1.0;
+const CLEAR_FIELD_FRACTION: f32 = 0.5;
+const FULL_FIELD_FRACTION: f32 = 1.0;
 
 /// How far the picture reaches from the view axis, as the tangents of the
 /// half-angles on each axis: `(horizontal, vertical)`.
@@ -278,8 +278,6 @@ fn hit_layer(
         eye_forward,
         TINT_COLOR,
         intensity,
-        CLEAR_FIELD_FRACTION,
-        FULL_FIELD_FRACTION,
         crate::util::render_source::HIT_FEEDBACK,
     )
 }
@@ -289,20 +287,15 @@ fn hit_layer(
 /// entry/exit vignette ([`crate::ui::entry_ramp`]). The two are drawn as
 /// separate layers with their own color/intensity rather than merged into one
 /// number, so a hit still reads while the interface is open (they blend
-/// naturally, being translucent).
-///
-/// See [`hit_layer`]'s callers for what each parameter means; `clear_field`
-/// and `full_field` are fractions of the picture (0..1) the same way
-/// [`CLEAR_FIELD_FRACTION`]/[`FULL_FIELD_FRACTION`] are.
-#[allow(clippy::too_many_arguments)]
+/// naturally, being translucent). Both callers want the same field-of-view
+/// geometry ([`CLEAR_FIELD_FRACTION`]/[`FULL_FIELD_FRACTION`]) - only the
+/// color and intensity differ, so those two stay the only variables.
 pub fn vignette_layer(
     view_extents: (f32, f32),
     eye_position: Vector3<f32>,
     eye_forward: Vector3<f32>,
     color: Vector3<f32>,
     intensity: f32,
-    clear_field: f32,
-    full_field: f32,
     source: &str,
 ) -> SceneObject {
     let (horizontal, vertical) = view_extents;
@@ -315,8 +308,8 @@ pub fn vignette_layer(
             // The quad is `COVERAGE_MARGIN` wider than the picture, so the
             // edge of the picture sits at `1 / COVERAGE_MARGIN` in the shader's
             // radius units and the fractions scale down to match.
-            clear_field / COVERAGE_MARGIN,
-            full_field / COVERAGE_MARGIN,
+            CLEAR_FIELD_FRACTION / COVERAGE_MARGIN,
+            FULL_FIELD_FRACTION / COVERAGE_MARGIN,
         ),
         Box::new(engine::scene::quad::create()),
     );
@@ -658,8 +651,6 @@ mod tests {
             vec3(0.0, 0.0, -1.0),
             color,
             0.4,
-            0.3,
-            0.9,
             "use_mode_vignette",
         );
         assert_eq!(

--- a/shock2vr/src/hit_feedback.rs
+++ b/shock2vr/src/hit_feedback.rs
@@ -83,8 +83,8 @@ const COVERAGE_MARGIN: f32 = 1.25;
 /// picture's own extents come from the host's projection matrix, so the same
 /// two numbers describe the same visible effect on a 45-degree monitor and on
 /// a headset's much wider asymmetric per-eye frustum.
-const CLEAR_FIELD_FRACTION: f32 = 0.5;
-const FULL_FIELD_FRACTION: f32 = 1.0;
+pub const CLEAR_FIELD_FRACTION: f32 = 0.5;
+pub const FULL_FIELD_FRACTION: f32 = 1.0;
 
 /// How far the picture reaches from the view axis, as the tangents of the
 /// half-angles on each axis: `(horizontal, vertical)`.
@@ -272,18 +272,51 @@ fn hit_layer(
     eye_forward: Vector3<f32>,
     intensity: f32,
 ) -> SceneObject {
+    vignette_layer(
+        view_extents,
+        eye_position,
+        eye_forward,
+        TINT_COLOR,
+        intensity,
+        CLEAR_FIELD_FRACTION,
+        FULL_FIELD_FRACTION,
+        crate::util::render_source::HIT_FEEDBACK,
+    )
+}
+
+/// One view-locked, double-sided rim-vignette quad - the shared geometry
+/// behind both [`hit_layer`] (the damage tint) and the cyber interface's own
+/// entry/exit vignette ([`crate::ui::entry_ramp`]). The two are drawn as
+/// separate layers with their own color/intensity rather than merged into one
+/// number, so a hit still reads while the interface is open (they blend
+/// naturally, being translucent).
+///
+/// See [`hit_layer`]'s callers for what each parameter means; `clear_field`
+/// and `full_field` are fractions of the picture (0..1) the same way
+/// [`CLEAR_FIELD_FRACTION`]/[`FULL_FIELD_FRACTION`] are.
+#[allow(clippy::too_many_arguments)]
+pub fn vignette_layer(
+    view_extents: (f32, f32),
+    eye_position: Vector3<f32>,
+    eye_forward: Vector3<f32>,
+    color: Vector3<f32>,
+    intensity: f32,
+    clear_field: f32,
+    full_field: f32,
+    source: &str,
+) -> SceneObject {
     let (horizontal, vertical) = view_extents;
     let width = 2.0 * LAYER_DISTANCE * horizontal * COVERAGE_MARGIN;
     let height = 2.0 * LAYER_DISTANCE * vertical * COVERAGE_MARGIN;
     let mut object = SceneObject::new(
         engine::scene::vignette_material::create(
-            TINT_COLOR,
+            color,
             intensity,
             // The quad is `COVERAGE_MARGIN` wider than the picture, so the
             // edge of the picture sits at `1 / COVERAGE_MARGIN` in the shader's
             // radius units and the fractions scale down to match.
-            CLEAR_FIELD_FRACTION / COVERAGE_MARGIN,
-            FULL_FIELD_FRACTION / COVERAGE_MARGIN,
+            clear_field / COVERAGE_MARGIN,
+            full_field / COVERAGE_MARGIN,
         ),
         Box::new(engine::scene::quad::create()),
     );
@@ -301,9 +334,7 @@ fn hit_layer(
     // orders this key explicitly, so host concatenation cannot move the tint
     // over the HUD on Quest or under the world on flat/debug.
     object.set_render_layer(RenderLayer::SceneOverlay);
-    object.set_debug_tag(Some(crate::util::render_source_tag(
-        crate::util::render_source::HIT_FEEDBACK,
-    )));
+    object.set_debug_tag(Some(crate::util::render_source_tag(source)));
     object
 }
 
@@ -612,6 +643,33 @@ mod tests {
             vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0)
         );
         assert_eq!(forward, vec3(0.0, 0.0, -1.0));
+    }
+
+    /// [`vignette_layer`] is the shared geometry `hit_layer` and the cyber
+    /// interface's own rim tint both build on - a caller with different
+    /// color/fractions/source gets a layer tagged and colored as its own,
+    /// not silently relabeled as hit feedback.
+    #[test]
+    fn vignette_layer_carries_the_callers_own_color_and_source() {
+        let color = vec3(0.05, 0.35, 0.55);
+        let object = vignette_layer(
+            VR_EXTENTS,
+            Vector3::zero(),
+            vec3(0.0, 0.0, -1.0),
+            color,
+            0.4,
+            0.3,
+            0.9,
+            "use_mode_vignette",
+        );
+        assert_eq!(
+            object.debug_tag().and_then(|tag| tag.source.clone()),
+            Some("use_mode_vignette".to_owned())
+        );
+        let transparency = object
+            .effective_transparency()
+            .expect("must draw translucent");
+        assert!((transparency - 0.6).abs() < 1e-5);
     }
 
     #[test]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -91,10 +91,10 @@ pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS + physics::PLAYER_EY
 pub const PLAYER_CROUCH_EYE_HEIGHT: f32 = 1.2;
 
 /// Default vertical FOV, in degrees, for the flat runtimes' projection
-/// matrix. `Game::desired_fov_deg` starts here and can be driven game-side
-/// (see `Game::set_desired_fov_deg`) - the planned first consumer is a
-/// "cyber interface" mode that pulls the FOV in while its overlay is up.
-/// `oculus_runtime` is untouched: OpenXR view FOVs must be used as-is.
+/// matrix. `Game::desired_fov_deg` starts here and is driven game-side each
+/// frame (see `Game::set_desired_fov_deg`) by the cyber interface's FOV pull
+/// while its overlay is open. `oculus_runtime` is untouched: OpenXR view
+/// FOVs must be used as-is.
 pub const DEFAULT_FOV_DEG: f32 = 45.0;
 
 /// Resolves `base` against `dev_params::FOV_OVERRIDE_DEG`: `0` (its default)
@@ -1840,11 +1840,11 @@ impl Game {
     }
 
     /// Vertical FOV (degrees) the flat runtimes should build their projection
-    /// matrix with this frame. Defaults to [`DEFAULT_FOV_DEG`] and is unset by
-    /// anything today; [`Game::set_desired_fov_deg`] is the internal seam a
-    /// future gameplay/UI mode (e.g. the cyber-interface overlay) will drive
-    /// it from. `dev_params::FOV_OVERRIDE_DEG` can force a value live for
-    /// testing without a rebuild.
+    /// matrix with this frame. Defaults to [`DEFAULT_FOV_DEG`] and is driven
+    /// each frame by [`Game::set_desired_fov_deg`] - the active scene's
+    /// `GameScene::fov_pull_deg` (the cyber-interface overlay's FOV pull is
+    /// the first consumer). `dev_params::FOV_OVERRIDE_DEG` can force a value
+    /// live for testing without a rebuild.
     ///
     /// VR is explicitly out of scope: OpenXR view FOVs must be used as-is, so
     /// `oculus_runtime` does not read this.
@@ -1906,9 +1906,10 @@ impl Game {
         // pawn transform the runtime builds its camera from.
         let pawn_to_world = Matrix4::from_translation(pos) * Matrix4::from(rot);
 
-        // The hit tint occupies the explicit scene-overlay layer: over the
-        // world, behind scene UI and the pause menu, identically in flat and
-        // VR. It remains view-locked, so only the eye pose differs.
+        // Eye pose shared by both view-locked rim layers below (the hit tint
+        // and the cyber interface's vignette) - both occupy the explicit
+        // scene-overlay layer: over the world, behind scene UI and the pause
+        // menu, identically in flat and VR.
         let (mut eye_position, eye_forward) =
             hit_feedback::eye_pose(self.head_pose.0, self.head_pose.1);
         // Centre the layer on the eye the frame is actually drawn from, which
@@ -1919,20 +1920,16 @@ impl Game {
         // rim by ~13 degrees and drag the ramp onto the crosshair. The same
         // clamp the cameras use is a no-op standing.
         eye_position.y = eye_position.y.min(self.player_eye_cap_above_center());
-        if let Some(mut layer) =
-            self.hit_feedback
-                .render(self.view_extents, eye_position, eye_forward)
-        {
-            layer.set_transform(pawn_to_world * layer.get_transform());
-            scene.push(layer);
-        }
 
         // The cyber interface's own entry/exit vignette: a second, separately
         // colored rim layer rather than merged into the hit tint's intensity,
-        // so a hit still reads (as red, on top of the cyan) while the
-        // interface is open or easing shut. Same view-locked geometry as the
-        // hit tint (`hit_feedback::vignette_layer`), identically in flat and
-        // VR - only the eye pose differs.
+        // so a hit still reads while the interface is open or easing shut.
+        // Same view-locked geometry as the hit tint
+        // (`hit_feedback::vignette_layer`), identically in flat and VR - only
+        // the eye pose differs. Pushed *before* the hit tint below: within one
+        // render layer the renderer draws in push order (`gl_engine.rs`), so
+        // the damage red always ends up painted on top of the interface cyan
+        // rather than the reverse.
         let use_mode_vignette = self.active_game_scene.use_mode_vignette_intensity();
         if use_mode_vignette > 0.0 {
             let mut layer = hit_feedback::vignette_layer(
@@ -1941,10 +1938,19 @@ impl Game {
                 eye_forward,
                 ui::entry_ramp::VIGNETTE_COLOR,
                 use_mode_vignette,
-                hit_feedback::CLEAR_FIELD_FRACTION,
-                hit_feedback::FULL_FIELD_FRACTION,
                 util::render_source::USE_MODE_VIGNETTE,
             );
+            layer.set_transform(pawn_to_world * layer.get_transform());
+            scene.push(layer);
+        }
+
+        // The hit tint occupies the explicit scene-overlay layer: over the
+        // world, behind scene UI and the pause menu, identically in flat and
+        // VR. It remains view-locked, so only the eye pose differs.
+        if let Some(mut layer) =
+            self.hit_feedback
+                .render(self.view_extents, eye_position, eye_forward)
+        {
             layer.set_transform(pawn_to_world * layer.get_transform());
             scene.push(layer);
         }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1357,6 +1357,15 @@ impl Game {
             action_effects,
         );
 
+        // A personal-UI mode (the cyber interface) can pull the flat FOV in a
+        // little while it is open, eased over its own entry/exit ramp -
+        // `fov_pull_deg` already smooths this, so nothing further is needed
+        // here. VR scenes return 0 (OpenXR view FOVs are used as-is), making
+        // this a no-op there.
+        self.set_desired_fov_deg(
+            DEFAULT_FOV_DEG - self.active_game_scene.fov_pull_deg(&self.options),
+        );
+
         // Handle ambient audio
         let ambient_state = self.active_game_scene.ambient_audio_state();
         let player_pose = self
@@ -1844,13 +1853,13 @@ impl Game {
     }
 
     /// Internal seam for gameplay/UI code to drive [`Game::desired_fov_deg`].
-    /// Not called anywhere yet - the first consumer is the planned
-    /// cyber-interface mode. Smoothing/easing is the caller's responsibility.
+    /// Driven once per frame from [`Game::update`] by the active scene's
+    /// `GameScene::fov_pull_deg` (the cyber interface's entry/exit ramp is
+    /// the first consumer). Smoothing/easing is the caller's responsibility.
     /// Rejects non-finite or out-of-range degrees (valid input to
     /// `cgmath::perspective` is strictly between 0 and 180) by leaving the
     /// current value unchanged, so a bad caller can't poison the flat
     /// runtimes' projection into a panic.
-    #[allow(dead_code)]
     pub(crate) fn set_desired_fov_deg(&mut self, fov_deg: f32) {
         if fov_deg.is_finite() && fov_deg > 0.0 && fov_deg < 180.0 {
             self.desired_fov_deg = fov_deg;
@@ -1914,6 +1923,28 @@ impl Game {
             self.hit_feedback
                 .render(self.view_extents, eye_position, eye_forward)
         {
+            layer.set_transform(pawn_to_world * layer.get_transform());
+            scene.push(layer);
+        }
+
+        // The cyber interface's own entry/exit vignette: a second, separately
+        // colored rim layer rather than merged into the hit tint's intensity,
+        // so a hit still reads (as red, on top of the cyan) while the
+        // interface is open or easing shut. Same view-locked geometry as the
+        // hit tint (`hit_feedback::vignette_layer`), identically in flat and
+        // VR - only the eye pose differs.
+        let use_mode_vignette = self.active_game_scene.use_mode_vignette_intensity();
+        if use_mode_vignette > 0.0 {
+            let mut layer = hit_feedback::vignette_layer(
+                self.view_extents,
+                eye_position,
+                eye_forward,
+                ui::entry_ramp::VIGNETTE_COLOR,
+                use_mode_vignette,
+                hit_feedback::CLEAR_FIELD_FRACTION,
+                hit_feedback::FULL_FIELD_FRACTION,
+                util::render_source::USE_MODE_VIGNETTE,
+            );
             layer.set_transform(pawn_to_world * layer.get_transform());
             scene.push(layer);
         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2445,8 +2445,17 @@ impl MissionCore {
         // lazy recenter and the comfort dim, resolve this frame's pointer, and
         // clear the weapon-safe latch once every trigger is released.
         self.vr_use_mode_pointer = None;
-        if game_options.presentation_mode == crate::PresentationMode::Vr && self.use_mode {
+        // The dim is drawn (see `render`) for the trailing exit-ramp window
+        // too, after `use_mode` has already gone false - it must keep
+        // following the live head there as well, or a head turn during the
+        // release exposes its edge (`world_dim`'s own invariant: "locked to
+        // the live head pose ... not to the panel").
+        if game_options.presentation_mode == crate::PresentationMode::Vr
+            && (self.use_mode || !self.use_mode_ramp.is_settled_closed())
+        {
             self.vr_use_mode_head = (input_context.head.position, input_context.head.rotation);
+        }
+        if game_options.presentation_mode == crate::PresentationMode::Vr && self.use_mode {
             let panel = self.vr_use_mode_anchor.update(
                 input_context.head.position,
                 input_context.head.rotation,
@@ -4594,6 +4603,14 @@ impl MissionCore {
                     self.flat_ui.close();
                     if self.use_mode {
                         effects.push_front(self.leave_use_mode());
+                        // A takeover, not the deliberate two-way toggle: snap
+                        // the ramp shut rather than ease it. The pause menu
+                        // suspends the scene from the next frame, so nothing
+                        // would call `use_mode_ramp.update` again until it
+                        // closes - a graceful release would otherwise hang
+                        // the vignette/dim/FOV pull at whatever strength they
+                        // were at for the whole pause.
+                        self.use_mode_ramp.snap_closed();
                     }
                 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -206,6 +206,16 @@ const VR_BACKPACK_WORLD_SCALE: f32 = 0.55;
 const VR_MEDIA_FORWARD: f32 = 3.75;
 const VR_MEDIA_UP: f32 = 3.5;
 
+/// The use-mode ("cyber interface") open/close sting: the shipped gamesys's
+/// own `UI_SCH` schema pair for opening/closing the game's main panel
+/// (`cargo dq templates 610`/`611`) - a faithful "interface open/close"
+/// chime, addressed by symbolic name like `repfail`/`hackfail` elsewhere in
+/// this file, rather than an invented sound. Played from the single
+/// `enter_use_mode`/`leave_use_mode` pair both presentations share, so flat
+/// and VR always sound the same.
+const USE_MODE_OPEN_SOUND: &str = "mainpanel_op";
+const USE_MODE_CLOSE_SOUND: &str = "mainpanel_cl";
+
 fn presentation_world_panel_size(
     presentation: crate::PresentationMode,
     is_player_backpack: bool,
@@ -1000,6 +1010,13 @@ pub struct MissionCore {
     /// dimmed behind it and the wielded weapon safed. Unlike the pause menu,
     /// the world keeps simulating while it is up.
     pub use_mode: bool,
+
+    /// Entry/exit feel for `use_mode`: one eased 0..1 ramp driving the rim
+    /// vignette (both presentations), the VR comfort dim's strength, and the
+    /// flat FOV pull - see [`crate::ui::entry_ramp`]. Advanced every update
+    /// regardless of presentation or `use_mode` itself, so it keeps easing
+    /// out after the panel has already been put away.
+    use_mode_ramp: crate::ui::entry_ramp::EntryExitRamp,
 
     /// Where the VR cyber-interface panel hangs: placed once on entry from
     /// the tracked head pose, world-locked, lazily recentered (rule 3 of the
@@ -1835,6 +1852,7 @@ impl MissionCore {
             debug_weapon_index: 0,
             flat_melee_anim: None,
             use_mode: false,
+            use_mode_ramp: crate::ui::entry_ramp::EntryExitRamp::new(),
             vr_use_mode_anchor: crate::ui::FrontendPanelAnchor::new(),
             vr_use_mode_head: crate::ui::world_dim::UNTRACKED_HEAD,
             vr_trigger_swallow: false,
@@ -2416,6 +2434,12 @@ impl MissionCore {
                 &mut self.id_to_physics,
             );
         }
+
+        // Entry/exit ramp: advanced every update regardless of presentation
+        // or `use_mode` itself, so the vignette/dim/FOV pull keeps easing out
+        // after the panel has already been put away (see `render`'s
+        // `is_settled_closed()` gate).
+        self.use_mode_ramp.update(time.elapsed.as_secs_f32());
 
         // VR cyber interface (use mode): follow the head for the anchor's
         // lazy recenter and the comfort dim, resolve this frame's pointer, and
@@ -4308,7 +4332,7 @@ impl MissionCore {
     ///
     /// Shared by `ToggleUseMode` and `CloseUseMode` so the two exits from use
     /// mode cannot drift apart.
-    fn leave_use_mode(&mut self) {
+    fn leave_use_mode(&mut self) -> Effect {
         self.use_mode = false;
         self.flat_ui.take_cursor_item();
         self.flat_ui.set_strip(None);
@@ -4318,13 +4342,23 @@ impl MissionCore {
         // flat (the consumption site is VR-gated) and self-clearing once
         // nothing is pressed.
         self.vr_trigger_swallow = true;
+        // The panel disappears immediately; the ramp keeps easing the
+        // vignette/dim/FOV pull back to nothing on its own release timing
+        // (see `render`'s `use_mode_ramp.is_settled_closed()` gate).
+        self.use_mode_ramp.close();
+        Effect::PlaySound {
+            handle: AudioHandle::new(),
+            source: None,
+            name: USE_MODE_CLOSE_SOUND.to_owned(),
+            spatial: false,
+        }
     }
 
     /// Enter "use" (metagame) mode: bind the top-docked inventory strip to
     /// the player's `internal_inventory` entity (whose GuiScript already
     /// emits SetUI every frame). Shared by both presentations - the strip
     /// canvas is the mode; only where it is presented differs.
-    fn enter_use_mode(&mut self) {
+    fn enter_use_mode(&mut self) -> Effect {
         self.use_mode = true;
         let strip_entity = self
             .world
@@ -4337,6 +4371,14 @@ impl MissionCore {
         // a held press must never read as a click on whatever the pointer first
         // crosses (rule 6 of the vr-ui-design skill).
         self.flat_ui.guard_held_press();
+        self.use_mode_ramp
+            .open(crate::ui::entry_ramp::DEFAULT_ENTRY_EXIT);
+        Effect::PlaySound {
+            handle: AudioHandle::new(),
+            source: None,
+            name: USE_MODE_OPEN_SOUND.to_owned(),
+            spatial: false,
+        }
     }
 
     pub fn handle_effects(
@@ -4505,9 +4547,9 @@ impl MissionCore {
                             if self.flat_ui.active_panel().is_some() {
                                 self.flat_ui.close();
                             } else if self.use_mode {
-                                self.leave_use_mode();
+                                effects.push_front(self.leave_use_mode());
                             } else {
-                                self.enter_use_mode();
+                                effects.push_front(self.enter_use_mode());
                             }
                         }
                         crate::PresentationMode::Vr => {
@@ -4517,7 +4559,7 @@ impl MissionCore {
                             // world keeps simulating - unlike the pause menu,
                             // this is a mode of play, not a suspension of it.
                             if self.use_mode {
-                                self.leave_use_mode();
+                                effects.push_front(self.leave_use_mode());
                             } else if self.player_is_alive() {
                                 // Edge policy: no cyber interface over the
                                 // death sequence - that moment belongs to the
@@ -4528,7 +4570,7 @@ impl MissionCore {
                                 // open, and a level transition replaces this
                                 // scene (taking the mission-owned mode state
                                 // with it).
-                                self.enter_use_mode();
+                                effects.push_front(self.enter_use_mode());
                                 // Place the panel from the pose of *this*
                                 // entry, not wherever the player stood last
                                 // time - and let the anchor wait out an
@@ -4551,7 +4593,7 @@ impl MissionCore {
                     // cyber interface.
                     self.flat_ui.close();
                     if self.use_mode {
-                        self.leave_use_mode();
+                        effects.push_front(self.leave_use_mode());
                     }
                 }
 
@@ -7025,7 +7067,13 @@ impl MissionCore {
     /// Placement comes from [`Self::vr_use_mode_anchor`] alone (placed on
     /// entry from the tracked head pose, world-locked, lazily recentered);
     /// the dim follows the live gaze, falling back to the panel while the
-    /// head is untracked (see `crate::ui::world_dim::dim_pose`).
+    /// head is untracked (see `crate::ui::world_dim::dim_pose`). Its strength
+    /// is scaled by [`Self::use_mode_ramp`]'s eased progress, so it fades in
+    /// on entry and keeps fading out after `use_mode` itself has already gone
+    /// false (the caller keeps calling this for exactly that trailing window
+    /// - see `render`'s `is_settled_closed()` gate). The canvas itself is
+    /// empty once the strip has been cleared on exit, so only the dim
+    /// actually lingers.
     /// The pointer (aim beams + hit dot) is drawn last, from the same pass the
     /// canvas was hit-tested with, so the dot can only ever mark the pixel the
     /// interface actually reacted to. Deliberately hand-less: unlike a frontend
@@ -7037,10 +7085,11 @@ impl MissionCore {
         let panel = self.vr_use_mode_anchor.panel();
         let (head_position, head_rotation) = self.vr_use_mode_head;
         let (dim_position, dim_forward) = world_dim::dim_pose(head_position, head_rotation, &panel);
-        let mut objects = vec![world_dim::world_dim_layer(
+        let mut objects = vec![world_dim::world_dim_layer_scaled(
             dim_position,
             dim_forward,
             world_dim::dim_distance(dim_position, &panel),
+            self.use_mode_ramp.eased(),
             crate::util::render_source::USE_MODE_DIM,
         )];
         objects.extend(self.flat_ui.render_world_space(asset_cache, &panel));
@@ -7427,7 +7476,12 @@ impl MissionCore {
         // the canvas), built in the tracked pawn space and rebased into world
         // coordinates with the same pawn transform the runtime builds its
         // camera from.
-        if options.presentation_mode == crate::PresentationMode::Vr && self.use_mode {
+        // Kept up (dim only, once `use_mode` itself has gone false) until the
+        // exit ramp finishes releasing, so the comfort dim eases out instead
+        // of vanishing the instant the panel does.
+        if options.presentation_mode == crate::PresentationMode::Vr
+            && (self.use_mode || !self.use_mode_ramp.is_settled_closed())
+        {
             let pawn_to_world =
                 Matrix4::from_translation(player.pos) * Matrix4::from(player.rotation);
             let mut use_mode_objects = self.render_vr_use_mode(asset_cache);
@@ -7476,6 +7530,22 @@ impl MissionCore {
     /// it, so the mode's truthy answer there is inert.
     pub fn wants_pointer(&self) -> bool {
         self.flat_ui.active_panel().is_some() || self.use_mode
+    }
+
+    /// See [`crate::game_scene::GameScene::fov_pull_deg`]. VR must not react
+    /// to the cyber interface's ramp - OpenXR view FOVs are used as-is - so
+    /// this is gated on presentation even though the ramp itself runs in
+    /// both.
+    pub fn fov_pull_deg(&self, game_options: &GameOptions) -> f32 {
+        if game_options.presentation_mode == crate::PresentationMode::Vr {
+            return 0.0;
+        }
+        self.use_mode_ramp.fov_pull_deg()
+    }
+
+    /// See [`crate::game_scene::GameScene::use_mode_vignette_intensity`].
+    pub fn use_mode_vignette_intensity(&self) -> f32 {
+        self.use_mode_ramp.vignette_intensity()
     }
 
     /// Actual crouch state of the player collider (stand-up can be refused

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -265,6 +265,14 @@ impl crate::game_scene::GameScene for Mission {
         self.mission_core.player_is_crouched()
     }
 
+    fn fov_pull_deg(&self, game_options: &GameOptions) -> f32 {
+        self.mission_core.fov_pull_deg(game_options)
+    }
+
+    fn use_mode_vignette_intensity(&self) -> f32 {
+        self.mission_core.use_mode_vignette_intensity()
+    }
+
     fn player_save_position(&self) -> Result<Vector3<f32>, crate::game_scene::PlayerSavePoseError> {
         self.mission_core.player_save_position()
     }

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -270,6 +270,14 @@ impl GameScene for DebugScene {
         self.core.player_is_crouched()
     }
 
+    fn fov_pull_deg(&self, game_options: &GameOptions) -> f32 {
+        self.core.fov_pull_deg(game_options)
+    }
+
+    fn use_mode_vignette_intensity(&self) -> f32 {
+        self.core.use_mode_vignette_intensity()
+    }
+
     fn player_save_position(&self) -> Result<Vector3<f32>, crate::game_scene::PlayerSavePoseError> {
         self.core.player_save_position()
     }
@@ -492,6 +500,14 @@ impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
 
     fn player_is_crouched(&self) -> bool {
         self.core.player_is_crouched()
+    }
+
+    fn fov_pull_deg(&self, game_options: &GameOptions) -> f32 {
+        self.core.fov_pull_deg(game_options)
+    }
+
+    fn use_mode_vignette_intensity(&self) -> f32 {
+        self.core.use_mode_vignette_intensity()
     }
 
     fn player_save_position(&self) -> Result<Vector3<f32>, crate::game_scene::PlayerSavePoseError> {

--- a/shock2vr/src/ui/entry_ramp.rs
+++ b/shock2vr/src/ui/entry_ramp.rs
@@ -1,0 +1,267 @@
+//! The cyber interface's entry/exit ramp: a single eased 0..1 value driving
+//! every "the world becomes UI now" cue - the rim vignette (both
+//! presentations), the VR comfort dim's strength, and the flat FOV pull -
+//! instead of each snapping on with the panel.
+//!
+//! [`RampParams`] packages *how strong* and *how long*, so a future caller
+//! (the plan's `ReadLastUnreadLog` shortcut, which wants a softer, shorter
+//! ramp straight into the log reader) only has to build a different
+//! `RampParams` rather than touch [`EntryExitRamp`] itself.
+
+/// How a ramp attacks/releases and what it drives at full strength.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RampParams {
+    /// Seconds to go from closed to fully open.
+    pub attack_secs: f32,
+    /// Seconds to go from open back to closed.
+    pub release_secs: f32,
+    /// Peak rim-vignette intensity (0..1) at full ramp.
+    pub vignette_peak: f32,
+    /// Flat FOV pulled in by this many degrees at full ramp (VR ignores it).
+    pub fov_pull_deg: f32,
+}
+
+/// The deliberate cyber-interface open: a real "jacking in" moment.
+pub const DEFAULT_ENTRY_EXIT: RampParams = RampParams {
+    attack_secs: 0.35,
+    release_secs: 0.25,
+    vignette_peak: 0.45,
+    fov_pull_deg: 6.0,
+};
+
+/// The rim tint blended in for the cyber interface - a cool cyan rather than
+/// [`crate::hit_feedback`]'s arterial red, so the two read as different
+/// things when they land on screen together.
+pub const VIGNETTE_COLOR: cgmath::Vector3<f32> = cgmath::Vector3 {
+    x: 0.05,
+    y: 0.35,
+    z: 0.55,
+};
+
+/// A single-target, eased attack/release envelope.
+///
+/// `progress` chases `target` (0 or 1) linearly at a rate set by whichever of
+/// `attack_secs`/`release_secs` is currently relevant, and [`Self::eased`]
+/// smoothsteps it for consumers. Re-targeting mid-ramp (open while closing,
+/// or vice versa) just reverses the chase from wherever `progress` already
+/// is - there is no snap.
+#[derive(Debug, Clone, Copy)]
+pub struct EntryExitRamp {
+    params: RampParams,
+    progress: f32,
+    target: f32,
+}
+
+impl Default for EntryExitRamp {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EntryExitRamp {
+    pub fn new() -> Self {
+        Self {
+            params: DEFAULT_ENTRY_EXIT,
+            progress: 0.0,
+            target: 0.0,
+        }
+    }
+
+    /// Start (or continue) opening, adopting `params` for this ramp - so a
+    /// re-open while still closing can pick different timing/peaks than the
+    /// ramp it interrupts.
+    pub fn open(&mut self, params: RampParams) {
+        self.params = params;
+        self.target = 1.0;
+    }
+
+    /// Start (or continue) closing, at the same `params` the ramp last opened
+    /// with.
+    pub fn close(&mut self) {
+        self.target = 0.0;
+    }
+
+    /// Advance by `delta_time_secs`. Negative or non-finite deltas are
+    /// treated as no time passing, so a bad caller can't push `progress`
+    /// outside 0..1 or send it the wrong way.
+    pub fn update(&mut self, delta_time_secs: f32) {
+        if !delta_time_secs.is_finite() || delta_time_secs <= 0.0 {
+            return;
+        }
+        let duration = if self.target > self.progress {
+            self.params.attack_secs
+        } else {
+            self.params.release_secs
+        };
+        let step = delta_time_secs / duration.max(1e-4);
+        self.progress = if self.target >= self.progress {
+            (self.progress + step).min(self.target)
+        } else {
+            (self.progress - step).max(self.target)
+        }
+        .clamp(0.0, 1.0);
+    }
+
+    /// Raw linear progress, 0 (closed) .. 1 (open).
+    pub fn progress(&self) -> f32 {
+        self.progress
+    }
+
+    /// Smoothstepped progress - what every visual consumer reads, so the ramp
+    /// eases rather than moves at a constant rate.
+    pub fn eased(&self) -> f32 {
+        let t = self.progress;
+        t * t * (3.0 - 2.0 * t)
+    }
+
+    /// Peak rim-vignette intensity scaled by the current ramp.
+    pub fn vignette_intensity(&self) -> f32 {
+        self.eased() * self.params.vignette_peak
+    }
+
+    /// Flat FOV pull (degrees, to subtract from the base FOV) scaled by the
+    /// current ramp.
+    pub fn fov_pull_deg(&self) -> f32 {
+        self.eased() * self.params.fov_pull_deg
+    }
+
+    /// True once the ramp has fully released and nothing is targeting open -
+    /// the point at which a renderer can stop drawing anything for it.
+    pub fn is_settled_closed(&self) -> bool {
+        self.target <= 0.0 && self.progress <= 0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FAST: RampParams = RampParams {
+        attack_secs: 1.0,
+        release_secs: 0.5,
+        vignette_peak: 0.5,
+        fov_pull_deg: 10.0,
+    };
+
+    /// Negative test: an untouched ramp must already read as closed and
+    /// settled, or every other test below is meaningless.
+    #[test]
+    fn a_fresh_ramp_is_closed_and_settled() {
+        let ramp = EntryExitRamp::new();
+        assert_eq!(ramp.progress(), 0.0);
+        assert_eq!(ramp.eased(), 0.0);
+        assert_eq!(ramp.vignette_intensity(), 0.0);
+        assert_eq!(ramp.fov_pull_deg(), 0.0);
+        assert!(ramp.is_settled_closed());
+    }
+
+    #[test]
+    fn opening_ramps_up_over_the_attack_time_and_not_before() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        assert!(!ramp.is_settled_closed());
+
+        // Halfway through the attack, progress is partway open (linearly),
+        // strictly short of fully open.
+        ramp.update(FAST.attack_secs * 0.5);
+        assert!(ramp.progress() > 0.0 && ramp.progress() < 1.0);
+        assert!((ramp.progress() - 0.5).abs() < 1e-4);
+
+        // And it reaches (and clamps at) fully open, not past it.
+        ramp.update(FAST.attack_secs);
+        assert_eq!(ramp.progress(), 1.0);
+        ramp.update(10.0);
+        assert_eq!(ramp.progress(), 1.0);
+    }
+
+    #[test]
+    fn closing_releases_over_the_release_time_then_settles() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        ramp.update(FAST.attack_secs);
+        assert_eq!(ramp.progress(), 1.0);
+
+        ramp.close();
+        assert!(!ramp.is_settled_closed(), "still ramping down");
+        ramp.update(FAST.release_secs * 0.5);
+        assert!(ramp.progress() > 0.0 && ramp.progress() < 1.0);
+
+        ramp.update(FAST.release_secs);
+        assert_eq!(ramp.progress(), 0.0);
+        assert!(ramp.is_settled_closed());
+    }
+
+    /// Re-entry mid-ramp: opening again while still closing must reverse
+    /// smoothly from wherever the ramp already is, never snap back to 0 first.
+    #[test]
+    fn reopening_mid_close_reverses_from_where_it_is() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        ramp.update(FAST.attack_secs);
+        ramp.close();
+        ramp.update(FAST.release_secs * 0.5);
+        let before = ramp.progress();
+        assert!(before > 0.0 && before < 1.0);
+
+        ramp.open(FAST);
+        // No time has passed yet - re-targeting alone must not move progress.
+        assert_eq!(ramp.progress(), before);
+        assert!(!ramp.is_settled_closed());
+
+        ramp.update(0.01);
+        assert!(
+            ramp.progress() > before,
+            "reopening must move progress back up, not leave it falling"
+        );
+    }
+
+    /// Symmetric case: closing mid-open reverses from wherever it is too.
+    #[test]
+    fn closing_mid_open_reverses_from_where_it_is() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        ramp.update(FAST.attack_secs * 0.5);
+        let before = ramp.progress();
+
+        ramp.close();
+        assert_eq!(ramp.progress(), before);
+        ramp.update(0.01);
+        assert!(ramp.progress() < before);
+    }
+
+    #[test]
+    fn a_non_finite_or_negative_delta_does_nothing() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        ramp.update(FAST.attack_secs * 0.5);
+        let before = ramp.progress();
+
+        ramp.update(f32::NAN);
+        assert_eq!(ramp.progress(), before);
+        ramp.update(-1.0);
+        assert_eq!(ramp.progress(), before);
+        ramp.update(0.0);
+        assert_eq!(ramp.progress(), before);
+    }
+
+    #[test]
+    fn vignette_and_fov_scale_with_the_eased_ramp_and_its_own_params() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        ramp.update(FAST.attack_secs);
+        assert_eq!(ramp.eased(), 1.0);
+        assert_eq!(ramp.vignette_intensity(), FAST.vignette_peak);
+        assert_eq!(ramp.fov_pull_deg(), FAST.fov_pull_deg);
+    }
+
+    /// The eased curve must actually ease (sit at or above the linear ramp
+    /// through the middle of the attack) rather than just proxy `progress`
+    /// straight through - otherwise `eased()` is a pointless rename.
+    #[test]
+    fn eased_is_a_real_smoothstep_not_a_passthrough() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        ramp.update(FAST.attack_secs * 0.25);
+        assert!(ramp.eased() < ramp.progress());
+    }
+}

--- a/shock2vr/src/ui/entry_ramp.rs
+++ b/shock2vr/src/ui/entry_ramp.rs
@@ -81,6 +81,17 @@ impl EntryExitRamp {
         self.target = 0.0;
     }
 
+    /// Close instantly, skipping the release entirely - for a takeover
+    /// rather than a graceful exit (the pause menu forcing the interface
+    /// shut via `Effect::CloseUseMode`). Without this the release keeps
+    /// `update` un-advanced while the scene is suspended for the pause, so
+    /// the vignette/dim/FOV pull would otherwise hang at whatever strength
+    /// they were at for the entire pause.
+    pub fn snap_closed(&mut self) {
+        self.progress = 0.0;
+        self.target = 0.0;
+    }
+
     /// Advance by `delta_time_secs`. Negative or non-finite deltas are
     /// treated as no time passing, so a bad caller can't push `progress`
     /// outside 0..1 or send it the wrong way.
@@ -227,6 +238,27 @@ mod tests {
         assert_eq!(ramp.progress(), before);
         ramp.update(0.01);
         assert!(ramp.progress() < before);
+    }
+
+    /// A takeover (`CloseUseMode`) must not leave the ramp mid-release for a
+    /// scene that has stopped calling `update` (the pause menu suspends the
+    /// scene) - `snap_closed` has to reach 0 immediately, not just retarget.
+    #[test]
+    fn snap_closed_settles_immediately_even_mid_open() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(FAST);
+        ramp.update(FAST.attack_secs * 0.5);
+        assert!(ramp.progress() > 0.0);
+
+        ramp.snap_closed();
+        assert_eq!(ramp.progress(), 0.0);
+        assert_eq!(ramp.eased(), 0.0);
+        assert!(ramp.is_settled_closed());
+
+        // And a caller that never calls `update` again (the exact pause
+        // scenario) must not see it drift back open on its own.
+        ramp.update(10.0);
+        assert!(ramp.is_settled_closed());
     }
 
     #[test]

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -32,6 +32,7 @@ use shipyard::EntityId;
 use crate::vr_config::Handedness;
 
 pub mod dev_params_panel;
+pub mod entry_ramp;
 mod frontend_menu;
 mod frontend_pointer;
 mod frontend_presentation;

--- a/shock2vr/src/ui/world_dim.rs
+++ b/shock2vr/src/ui/world_dim.rs
@@ -118,6 +118,22 @@ pub fn world_dim_layer(
     distance: f32,
     source: &str,
 ) -> SceneObject {
+    world_dim_layer_scaled(head_position, head_forward, distance, 1.0, source)
+}
+
+/// Same as [`world_dim_layer`], but [`world_dim_strength`] is scaled by
+/// `ramp` (0..1, clamped) first - lets a caller with an entry/exit ramp (the
+/// cyber interface's [`crate::ui::entry_ramp`]) fade the dim in and out
+/// instead of snapping to full strength the instant the overlay opens. The
+/// pause menu has no such ramp and always gets full strength via
+/// [`world_dim_layer`].
+pub fn world_dim_layer_scaled(
+    head_position: Vector3<f32>,
+    head_forward: Vector3<f32>,
+    distance: f32,
+    ramp: f32,
+    source: &str,
+) -> SceneObject {
     let extent = distance * WORLD_DIM_EXTENT_RATIO;
     let mut object = SceneObject::new(
         color_material::create(WORLD_DIM_COLOR),
@@ -132,7 +148,7 @@ pub fn world_dim_layer(
     );
     // The material speaks in transparency (0 = opaque), the strength in "how
     // dark does the world go" - the direction a human tunes in.
-    object.set_transparency(Some(1.0 - world_dim_strength()));
+    object.set_transparency(Some(1.0 - world_dim_strength() * ramp.clamp(0.0, 1.0)));
     // Translucent, and drawn before the panel: writing depth here would let the
     // dim occlude the canvas that draws over it.
     object.set_depth_write(false);
@@ -162,4 +178,66 @@ pub fn dim_pose(
         panel.center + panel.normal() * frontend_panel_distance(),
         -panel.normal(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Negative test: at `ramp = 1.0` the scaled layer must be identical to
+    /// the unscaled one the pause menu still uses - only a `ramp < 1.0`
+    /// caller (the cyber interface, mid-fade) should ever see it differ.
+    #[test]
+    fn full_ramp_matches_the_unscaled_layer() {
+        let head = vec3(0.0, 1.7, 0.0);
+        let forward = vec3(0.0, 0.0, -1.0);
+        let full = world_dim_layer(head, forward, 3.0, "test");
+        let scaled = world_dim_layer_scaled(head, forward, 3.0, 1.0, "test");
+        assert_eq!(
+            full.effective_transparency(),
+            scaled.effective_transparency()
+        );
+    }
+
+    /// A ramp partway open must dim the world less than full strength, and a
+    /// ramp of zero must not dim it at all (fully transparent).
+    #[test]
+    fn a_partial_ramp_dims_less_than_full_strength() {
+        let head = vec3(0.0, 1.7, 0.0);
+        let forward = vec3(0.0, 0.0, -1.0);
+        let full = world_dim_layer_scaled(head, forward, 3.0, 1.0, "test")
+            .effective_transparency()
+            .unwrap();
+        let half = world_dim_layer_scaled(head, forward, 3.0, 0.5, "test")
+            .effective_transparency()
+            .unwrap();
+        let none = world_dim_layer_scaled(head, forward, 3.0, 0.0, "test")
+            .effective_transparency()
+            .unwrap();
+        // Transparency is `1 - dim`, so a weaker dim reads as MORE transparent.
+        assert!(none > half && half > full);
+        assert_eq!(none, 1.0, "a zero ramp must leave the world untouched");
+    }
+
+    /// An out-of-range ramp must clamp rather than invert the dim or panic.
+    #[test]
+    fn ramp_is_clamped_to_0_1() {
+        let head = vec3(0.0, 1.7, 0.0);
+        let forward = vec3(0.0, 0.0, -1.0);
+        let over = world_dim_layer_scaled(head, forward, 3.0, 5.0, "test")
+            .effective_transparency()
+            .unwrap();
+        let full = world_dim_layer_scaled(head, forward, 3.0, 1.0, "test")
+            .effective_transparency()
+            .unwrap();
+        assert_eq!(over, full);
+
+        let under = world_dim_layer_scaled(head, forward, 3.0, -5.0, "test")
+            .effective_transparency()
+            .unwrap();
+        let none = world_dim_layer_scaled(head, forward, 3.0, 0.0, "test")
+            .effective_transparency()
+            .unwrap();
+        assert_eq!(under, none);
+    }
 }

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -347,6 +347,10 @@ pub mod render_source {
     pub const USE_MODE_POINTER: &str = "use_mode_pointer";
     /// The red rim tint shown for a moment after the player takes damage.
     pub const HIT_FEEDBACK: &str = "hit_feedback";
+    /// The cyber interface's own rim vignette, eased in/out with its
+    /// entry/exit ramp - layered alongside (not merged with) [`HIT_FEEDBACK`],
+    /// so a hit still reads while the interface is open.
+    pub const USE_MODE_VIGNETTE: &str = "use_mode_vignette";
 }
 
 /// A tag that records only which render path produced an object.


### PR DESCRIPTION
Slice 4 of the cyber-interface plan, stacked on #1111 (the pointer bridge).

The interface gains a **feel**: opening/closing eases a rim vignette (both presentations), the VR comfort dim's strength, and a flat FOV pull, instead of everything snapping on/off with the panel. An audio sting plays on open and close.

## How it fits together

- **`ui::entry_ramp::EntryExitRamp`** - a single eased attack/release 0..1 progress value, packaged with a `RampParams` struct (durations + peak intensities) so a future shorter/softer variant (the plan's `ReadLastUnreadLog` shortcut) is just a different params value, not new machinery.
- **Vignette**: `hit_feedback::hit_layer`'s geometry is factored into a shared `vignette_layer` helper so the interface's own cyan rim tint reuses the same view-locked quad as the red damage tint. The two are drawn as **separate layered quads**, not merged into one intensity, so a hit still reads while the interface is open - `Game::render` pushes the cyan layer first, the red tint second, so damage always paints on top.
- **VR comfort dim**: `world_dim::world_dim_layer` gains a `_scaled` variant that multiplies the dim strength by the ramp's eased progress. The dim (and only the dim - the panel itself disappears immediately on close, since its canvas goes empty) keeps rendering after `use_mode` goes false until the exit ramp settles, so it eases out rather than vanishing with the panel.
- **Flat FOV pull**: wired through `GameScene::fov_pull_deg` into `Game::set_desired_fov_deg` (PR #1089's plumbing, its first real consumer). VR always reports 0 - OpenXR view FOVs are used as-is.
- **Audio sting**: the shipped gamesys's own `mainpanel_op`/`mainpanel_cl` `UI_SCH` schema pair (found via `cargo dq templates 610`/`611` - a faithful "open/close the main panel" chime, not an invented sound), played from the single `enter_use_mode`/`leave_use_mode` pair both presentations already share.

## Review round (xreview: Claude + Codex)

Both engines ran independently in parallel (plus a dedicated de-dup pass). Two findings they **agreed** on are fixed in a follow-up commit:

- **[agreed] Pausing while the interface was open froze the ramp mid-release.** `Effect::CloseUseMode` (what the pause menu sends) called `leave_use_mode()`, which starts the graceful release - but the scene's `update()` (which advances the ramp) stops running the very next frame once the pause menu suspends the scene. The vignette/dim/FOV pull were left frozen at whatever strength they were at for the *entire* pause. Fixed with `EntryExitRamp::snap_closed()`, called only from the `CloseUseMode` path (a takeover, not the deliberate two-way toggle) - the graceful ease is untouched for `ToggleUseMode`.
- **[agreed] The VR dim used a stale head pose during the exit ramp.** `vr_use_mode_head` was only refreshed while `use_mode` was true, but the dim keeps rendering (and following the head, per its own documented invariant) through the trailing release window; a head turn during that ~0.25s could expose its edge. The refresh is now hoisted to cover `use_mode || !ramp.is_settled_closed()` too.
- One engine additionally flagged that `vignette_layer`'s two field-of-view-fraction parameters had no real variation (both callers passed the same constants) - simplified back to a 6-arg signature with the constants private again, and the `clippy::too_many_arguments` allow is gone.
- The de-dup pass found nothing actionable beyond a note that `eased()`'s smoothstep curve is now the third Rust/GLSL copy of `t*t*(3-2t)` in the tree - noted for a future extraction, not blocking this slice.

Re-validated after fixes: `cargo test -p shock2vr --lib` (925/925, incl. a new `snap_closed` test), `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, and a fresh debug-runtime (`--vr`) round-trip - opening the pause menu mid-interface no longer leaves a lingering dim/vignette (screenshots one frame and one second after pausing are pixel-identical).

## Verification

- **Unit tests**: 925 total (13 new: `entry_ramp`'s ramp math incl. re-entry-mid-ramp and the pause-takeover `snap_closed` case, `world_dim`'s scaled-dim ramp behavior, `hit_feedback`'s shared `vignette_layer`).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt`, all green.
- **Debug-runtime round-trips**, both presentations, headless (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep): flat shows the vignette ramp in and the FOV visibly pull in over the attack, then ease back out (with the audio sting `panmaino`/`panmainc` confirmed via `/v1/audio/recent`); VR shows the same vignette + a genuinely deepening comfort dim with **no** FOV change, confirming the presentation gate.
- SDK e2e (`SHOCK2_E2E=1`): full 179-file suite was launched and progressed cleanly (60+ missions/scenarios green, no failures observed) before being interrupted by an environment timeout with no useful log captured. Re-ran the targeted, directly-relevant subset instead: `missions.e2e.test.ts` (all 23 missions load) + every `*cyber-interface*`/`cyber-modules` scenario (VR pointer bridge, squeeze-to-hand, `ToggleUseMode` strip presentation, weapon-safe/trigger-swallow across exit) - **28/28 passing**, 0 failed, 0 skipped.

## Visuals

![flat open/close demo](https://gist.githubusercontent.com/tommy-xr/fc858709ae42085f30c473f5e7c1d6dd/raw/demo.gif)

<sub>Flat: shooter → interface open (vignette ramps in, FOV pulls in ~6°) → settled → close (eases back to shooter, panel gone instantly, vignette/FOV ease out). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![vr dim before/after](https://gist.githubusercontent.com/tommy-xr/fc858709ae42085f30c473f5e7c1d6dd/raw/vr-dim-beforeafter.png)

<sub>VR: shooter vs. the interface open and settled - comfort dim + cyan vignette eased in, no FOV change (VR always reports 0 pull).</sub>

![pause takeover fix](https://gist.githubusercontent.com/tommy-xr/fc858709ae42085f30c473f5e7c1d6dd/raw/vr-pause-fix.png)

<sub>The pause-takeover fix: interface open, then the pause menu one frame later (no lingering dim/vignette under the panel), then one second after that (pixel-identical to the +1-frame shot - confirms `snap_closed` and not a slow fade nobody could see).</sub>

https://claude.ai/code/session_016r6MXB6tSLqYZTJHMtJbei

