### PR TITLE
feat(items): collect nanites as a player stat

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -127,7 +127,9 @@ impl FlatPlayerController {
     /// Apply the original flat pickup split: weapons become the first-person
     /// viewmodel, while ordinary loot goes straight into the backpack.
     fn pick_up(&mut self, world: &World, entity_id: EntityId) -> Vec<VirtualHandEffect> {
-        if uses_scripted_world_frob(world, entity_id) {
+        if uses_scripted_world_frob(world, entity_id)
+            || crate::scripts::script_util::is_nanite_pickup(world, entity_id)
+        {
             vec![out_message(entity_id, MessagePayload::Frob)]
         } else if is_wieldable_weapon(world, entity_id) {
             self.wield(entity_id)

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -73,6 +73,21 @@ fn needs_internal_ai(has_ai: bool, authored_scripts: &[String]) -> bool {
             .any(|script| script.eq_ignore_ascii_case("BaseMonster"))
 }
 
+/// Whether `template_id` (or an ancestor) is one of the nanite-pile
+/// templates - see `scripts::script_util::NANITE_PILE_TEMPLATE_IDS` for why
+/// this is narrower than the shared `Nanites` base template.
+fn is_nanite_pickup_template(
+    entity_info: &ss2_entity_info::SystemShock2EntityInfo,
+    template_id: i32,
+) -> bool {
+    let hierarchy = ss2_entity_info::get_hierarchy(entity_info);
+    let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, &template_id);
+    ancestors.push(template_id);
+    ancestors
+        .iter()
+        .any(|id| crate::scripts::script_util::NANITE_PILE_TEMPLATE_IDS.contains(id))
+}
+
 pub fn create_entity_with_position(
     template_id: i32,
     position: Point3<f32>,
@@ -370,6 +385,15 @@ pub fn create_entity_core(
     let v_keysrc = world.borrow::<View<PropKeySrc>>().unwrap();
     if v_keysrc.get(entity_id).is_ok() {
         processed_scripts.push("internal_keycard".to_owned());
+    }
+
+    // Nanites (the game's money) are collected straight into a player stat
+    // rather than the inventory - see `internal_nanites_script`. Identified
+    // via template ancestry rather than the shared `nan_ic` icon: the icon is
+    // also inherited by the `FakeNanites` bomb-trap decoy, which must keep
+    // going through the ordinary pickup path instead of being auto-collected.
+    if is_nanite_pickup_template(entity_info, template_id) {
+        processed_scripts.push("internal_nanites".to_owned());
     }
 
     // Player melee weapons are authored by their first-person limb model, not

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5120,6 +5120,22 @@ impl MissionCore {
                     }
                 }
 
+                Effect::AwardNanites { amount } => {
+                    let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    let balance = quests.player_stats_mut().award_nanites(amount);
+                    if amount > 0 {
+                        info!("Awarded {} nanites (stat balance now {})", amount, balance);
+                    }
+                }
+
+                Effect::SpendNanites { amount } => {
+                    let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    let spent = quests.player_stats_mut().spend_nanites(amount);
+                    if spent > 0 {
+                        info!("Spent {} nanites from the stat balance", spent);
+                    }
+                }
+
                 Effect::DrawDebugLines { lines } => {
                     if game_options.debug_draw {
                         for line in lines {

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -194,6 +194,15 @@ pub struct PlayerStats {
     /// keeps saves written before this field existed loadable.
     #[serde(default)]
     pub software: SoftwareVersions,
+    /// Nanites: the game's money. Collected directly into this counter by
+    /// world nanite pickups (`scripts::internal_nanites_script`) rather than
+    /// living as carried inventory items - mirrors `cyber_modules` above.
+    /// Legacy carried nanite stacks (pre-existing saves, panel-taken piles)
+    /// remain spendable too; see `scripts::script_util::player_nanite_total`.
+    /// `#[serde(default)]` keeps saves written before this field existed
+    /// loadable (they load with 0 stat nanites, carried stacks unaffected).
+    #[serde(default)]
+    pub nanites: i32,
 }
 
 /// The player has four O/S trait slots (one per single-use machine in the game).
@@ -217,6 +226,7 @@ impl Default for PlayerStats {
             psi_tier: 0,
             os_traits: Vec::new(),
             software: SoftwareVersions::default(),
+            nanites: 0,
         }
     }
 }
@@ -249,6 +259,27 @@ impl PlayerStats {
         } else {
             false
         }
+    }
+
+    /// Award nanites (the game's money). Negative or zero amounts are
+    /// ignored - awards only ever add. Returns the new balance.
+    pub fn award_nanites(&mut self, amount: i32) -> i32 {
+        if amount > 0 {
+            self.nanites = self.nanites.saturating_add(amount);
+        }
+        self.nanites
+    }
+
+    /// Spend up to `amount` nanites from the stat balance, clamped at 0 (never
+    /// goes negative). Returns the amount actually debited from the stat, so
+    /// a caller can fall back to legacy carried stacks for the remainder.
+    pub fn spend_nanites(&mut self, amount: i32) -> i32 {
+        if amount <= 0 {
+            return 0;
+        }
+        let spent = amount.min(self.nanites);
+        self.nanites -= spent;
+        spent
     }
 
     /// Current level of a primary stat.
@@ -609,6 +640,36 @@ mod tests {
         let legacy = r#"{"strength":1,"endurance":1,"agility":1,"psionic_ability":1,"cyber_affinity":1,"skills":{"standard_weapons":0,"energy_weapons":0,"heavy_weapons":0,"exotic_weapons":0,"hack":0,"repair":0,"modify":0,"maintenance":0,"research":0},"psi_disciplines":[],"granted_years":[]}"#;
         let loaded: PlayerStats = serde_json::from_str(legacy).unwrap();
         assert_eq!(loaded.cyber_modules, 0);
+    }
+
+    #[test]
+    fn nanites_award_and_spend_clamp_at_zero() {
+        let mut stats = PlayerStats::new();
+        assert_eq!(stats.nanites, 0);
+        assert_eq!(stats.award_nanites(20), 20);
+        // Non-positive awards are ignored.
+        assert_eq!(stats.award_nanites(0), 20);
+        assert_eq!(stats.award_nanites(-5), 20);
+
+        // Spending more than the balance clamps at 0 and reports what was
+        // actually debited, rather than going negative.
+        assert_eq!(stats.spend_nanites(25), 20);
+        assert_eq!(stats.nanites, 0);
+        assert_eq!(stats.spend_nanites(5), 0);
+    }
+
+    #[test]
+    fn nanites_survive_serde_and_default_for_old_saves() {
+        let mut stats = PlayerStats::new();
+        stats.award_nanites(30);
+        let json = serde_json::to_string(&stats).unwrap();
+        let back: PlayerStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.nanites, 30);
+        // A save written before this field existed (no `nanites` key) loads
+        // with the serde default of 0.
+        let legacy = r#"{"strength":1,"endurance":1,"agility":1,"psionic_ability":1,"cyber_affinity":1,"skills":{"standard_weapons":0,"energy_weapons":0,"heavy_weapons":0,"exotic_weapons":0,"hack":0,"repair":0,"modify":0,"maintenance":0,"research":0},"psi_disciplines":[],"granted_years":[]}"#;
+        let loaded: PlayerStats = serde_json::from_str(legacy).unwrap();
+        assert_eq!(loaded.nanites, 0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -127,6 +127,21 @@ pub enum Effect {
         amount: i32,
     },
 
+    /// Award nanites (the game's money) directly to the player's persistent
+    /// stat balance - the collect side of the "nanites as a player stat"
+    /// model. Emitted by `internal_nanites_script` on Frob.
+    AwardNanites {
+        amount: i32,
+    },
+
+    /// Debit nanites from the player's persistent stat balance, clamped at 0.
+    /// Spend paths debit the stat first, falling back to legacy carried
+    /// nanite stacks (`AdjustStackCount`/`DestroyEntity`) for any remainder -
+    /// see `scripts::script_util::spend_player_nanites`.
+    SpendNanites {
+        amount: i32,
+    },
+
     AdjustHitPoints {
         entity_id: EntityId,
         delta: i32,

--- a/shock2vr/src/scripts/internal_nanites_script.rs
+++ b/shock2vr/src/scripts/internal_nanites_script.rs
@@ -1,0 +1,137 @@
+use dark::properties::PropStackCount;
+use engine::audio::AudioHandle;
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// Retail's fallback "linebeep" cue reused as the nanite pickup sound. There
+/// is no dedicated retail nanite-pickup cue identified in this port's sound
+/// data yet, so this mirrors the `LOG_PICKUP_SOUND` fallback used by
+/// `scripts::gui::media` for the same reason - see that module for the
+/// precedent.
+const NANITE_PICKUP_SOUND: &str = "linebeep";
+
+/// Derived script attached to every world nanite pickup (see
+/// `mission::entity_creator` for the identification), mirroring
+/// `ExpCookie`/`internal_keycard`'s "collect directly into a player stat"
+/// shape. Frobbing (or, via `virtual_hand`/`flat_player_controller` routing,
+/// squeezing) a world nanite pile awards its stack count straight to the
+/// player's persistent nanite balance and removes the object - it never
+/// enters the inventory grid or the physical hand.
+pub struct InternalNanitesScript {}
+
+impl InternalNanitesScript {
+    pub fn new() -> InternalNanitesScript {
+        InternalNanitesScript {}
+    }
+}
+
+impl Script for InternalNanitesScript {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Frob => {
+                let amount = world
+                    .borrow::<View<PropStackCount>>()
+                    .ok()
+                    .and_then(|stacks| stacks.get(entity_id).ok().map(|s| s.0))
+                    .filter(|&n| n > 0)
+                    .unwrap_or(1);
+
+                Effect::Combined {
+                    effects: vec![
+                        Effect::AwardNanites { amount },
+                        Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            source: Some(entity_id),
+                            name: NANITE_PICKUP_SOUND.to_owned(),
+                            spatial: false,
+                        },
+                        Effect::DestroyEntity { entity_id },
+                    ],
+                }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::PropStackCount;
+
+    #[test]
+    fn frob_awards_nanites_plays_a_sound_and_destroys_the_pickup() {
+        let mut world = World::new();
+        let entity = world.add_entity(PropStackCount(20));
+
+        let effect = InternalNanitesScript::new().handle_message(
+            entity,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        let Effect::Combined { effects } = effect else {
+            panic!("expected a combined effect, got {effect:?}");
+        };
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::AwardNanites { amount } if *amount == 20))
+        );
+        assert!(effects.iter().any(
+            |e| matches!(e, Effect::PlaySound { source: Some(source), .. } if *source == entity)
+        ));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::DestroyEntity { entity_id } if *entity_id == entity))
+        );
+    }
+
+    #[test]
+    fn frob_without_a_stack_count_defaults_to_one() {
+        let mut world = World::new();
+        let entity = world.add_entity(());
+
+        let effect = InternalNanitesScript::new().handle_message(
+            entity,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        let Effect::Combined { effects } = effect else {
+            panic!("expected a combined effect, got {effect:?}");
+        };
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::AwardNanites { amount } if *amount == 1))
+        );
+    }
+
+    #[test]
+    fn non_frob_messages_are_ignored() {
+        let mut world = World::new();
+        let entity = world.add_entity(PropStackCount(5));
+
+        let effect = InternalNanitesScript::new().handle_message(
+            entity,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: entity },
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -32,6 +32,7 @@ mod internal_explosion;
 pub mod internal_fast_projectile;
 mod internal_frob_move;
 mod internal_keycard_script;
+mod internal_nanites_script;
 mod internal_simple_health;
 mod internal_switch_held_model;
 mod level_change_button;
@@ -152,6 +153,7 @@ use self::{
     internal_collision_type::InternalCollisionType,
     internal_explosion::InternalExplosion,
     internal_keycard_script::KeyCardScript,
+    internal_nanites_script::InternalNanitesScript,
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
     many_ride::{ParalyzePlayers, SitDownRightNow, StandUpAgain, WhiteOut},
@@ -943,6 +945,7 @@ impl ScriptWorld {
             "internal_explosion" => Box::new(InternalExplosion::new()),
             "internal_frob_move" => Box::new(InternalFrobMove::new()),
             "internal_keycard" => Box::new(KeyCardScript::new()),
+            "internal_nanites" => Box::new(InternalNanitesScript::new()),
             "internal_room_trigger" => Box::new(RoomTrigger::new()),
             "internal_simple_health" => Box::new(InternalSimpleHealth::new()),
             // Implemented

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -14,7 +14,9 @@ use dark::{
     ss2_entity_info::SystemShock2EntityInfo,
 };
 use engine::audio::AudioHandle;
-use shipyard::{Component, EntityId, Get, IntoIter, IntoWithId, UniqueView, View, ViewMut, World};
+use shipyard::{
+    Component, EntityId, Get, IntoIter, IntoWithId, UniqueView, UniqueViewMut, View, ViewMut, World,
+};
 use std::collections::HashMap;
 
 use super::{Effect, Message, MessagePayload};
@@ -33,6 +35,34 @@ pub(crate) fn entity_class_template_id(world: &World, entity: EntityId) -> Optio
                 .ok()
                 .and_then(|templates| templates.get(entity).ok().map(|id| id.template_id))
         })
+}
+
+/// Base gamesys templates for the three nanite pile sizes (Small/Medium/Big
+/// Nanite Pile). Deliberately narrower than their shared ultimate ancestor
+/// `Nanites` (-85): that ancestor also roots `FakeNanites` (-1271), a
+/// bomb-trap payload dressed up to look like a nanite pickup, which must keep
+/// going through the ordinary generic-frob/inventory path rather than being
+/// auto-collected as currency. The pile templates are the narrowest common
+/// ancestor of every real spawnable pickup (`1/5/10/20 Nanites` and any
+/// authored pile placed directly) while excluding that decoy.
+pub(crate) const NANITE_PILE_TEMPLATE_IDS: [i32; 3] = [-1589, -1590, -1591];
+
+/// Whether `entity` is a real world nanite pickup, identified via the runtime
+/// template hierarchy (see [`NANITE_PILE_TEMPLATE_IDS`]) rather than the
+/// legacy `nan_ic` icon check below (which also matches the `FakeNanites`
+/// decoy). Used to route VR squeeze / flat pickup through Frob instead of a
+/// physical grab - see `virtual_hand::uses_scripted_world_frob` and its flat
+/// call site.
+pub(crate) fn is_nanite_pickup(world: &World, entity: EntityId) -> bool {
+    let Ok(hierarchy) = world.borrow::<UniqueView<GlobalTemplateHierarchy>>() else {
+        return false;
+    };
+    let Some(template_id) = entity_class_template_id(world, entity) else {
+        return false;
+    };
+    NANITE_PILE_TEMPLATE_IDS
+        .iter()
+        .any(|class_id| hierarchy.is_or_descends_from(template_id, *class_id))
 }
 
 pub fn is_message_turnon_or_turnoff(msg: &MessagePayload) -> bool {
@@ -385,43 +415,70 @@ pub fn player_carried_items(world: &World) -> Vec<EntityId> {
     out
 }
 
-/// Build the effects that pay `amount` nanites from the player's real carried
-/// stacks. Nanites are identified by their inherited inventory icon
-/// (`nan_ic`), not by a mission/runtime id. Returns `None` without side effects
-/// when the carried total is insufficient.
+/// The player's persistent nanite stat balance (0 if there is no player /
+/// `QuestInfo`, e.g. a debug scene).
+fn stat_nanite_balance(world: &World) -> i32 {
+    world
+        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+        .map(|quests| quests.player_stats().nanites)
+        .unwrap_or(0)
+}
+
+/// Build the effects that pay `amount` nanites: debits the player's stat
+/// balance first (`Effect::SpendNanites`), then any legacy carried stacks
+/// (identified by their inherited inventory icon `nan_ic` - pre-existing
+/// saves, panel-taken piles) for the remainder. Returns `None` without side
+/// effects when the combined total is insufficient.
 pub fn spend_player_nanites(world: &World, amount: i32) -> Option<Effect> {
     if amount <= 0 {
         return Some(Effect::NoEffect);
     }
 
-    let (nanite_stacks, debits) = player_nanite_payment_plan(world, amount)?;
+    let stat_debit = amount.min(stat_nanite_balance(world)).max(0);
+    let remaining = amount - stat_debit;
+
     let mut effects = Vec::new();
-    for ((entity_id, stack), paid) in nanite_stacks.into_iter().zip(debits) {
-        if paid == 0 {
-            continue;
-        }
-        if paid == stack {
-            effects.push(Effect::DestroyEntity { entity_id });
-        } else {
-            effects.push(Effect::AdjustStackCount {
-                entity_id,
-                delta: -paid,
-            });
+    if stat_debit > 0 {
+        effects.push(Effect::SpendNanites { amount: stat_debit });
+    }
+    if remaining > 0 {
+        let (nanite_stacks, debits) = player_nanite_payment_plan(world, remaining)?;
+        for ((entity_id, stack), paid) in nanite_stacks.into_iter().zip(debits) {
+            if paid == 0 {
+                continue;
+            }
+            if paid == stack {
+                effects.push(Effect::DestroyEntity { entity_id });
+            } else {
+                effects.push(Effect::AdjustStackCount {
+                    entity_id,
+                    delta: -paid,
+                });
+            }
         }
     }
     Some(Effect::combine(effects))
 }
 
-/// Atomically debit the player's live carried nanite stacks. Returns the
-/// entities whose stack count reached zero so the mission can remove their
-/// runtime state before vending an item. A stale or insufficient plan leaves
-/// every stack unchanged.
+/// Atomically debit the player's nanite balance: the stat first, then any
+/// legacy carried stacks for the remainder. Returns the legacy entities whose
+/// stack count reached zero so the mission can remove their runtime state
+/// before vending an item. A stale or insufficient plan leaves every stack
+/// (and the stat) unchanged.
 pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>> {
     if amount <= 0 {
         return None;
     }
 
-    let (nanite_stacks, debits) = player_nanite_payment_plan(world, amount)?;
+    let stat_debit = amount.min(stat_nanite_balance(world)).max(0);
+    let remaining = amount - stat_debit;
+
+    let (nanite_stacks, debits) = if remaining > 0 {
+        player_nanite_payment_plan(world, remaining)?
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
     let mut stacks = world
         .borrow::<ViewMut<dark::properties::PropStackCount>>()
         .ok()?;
@@ -431,6 +488,13 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
         if *paid > 0 && stacks.get(*entity_id).ok()?.0 < *paid {
             return None;
         }
+    }
+
+    if stat_debit > 0 {
+        let mut quests = world
+            .borrow::<UniqueViewMut<crate::quest_info::QuestInfo>>()
+            .ok()?;
+        quests.player_stats_mut().spend_nanites(stat_debit);
     }
 
     let mut exhausted = Vec::new();
@@ -447,15 +511,18 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
     Some(exhausted)
 }
 
-/// The player's spendable nanite balance across all real carried stacks.
-/// Uses the same identification and traversal as [`spend_player_nanites`], so
-/// the UI balance and the debit path cannot disagree.
+/// The player's total spendable nanite balance: the persistent stat plus any
+/// legacy carried stacks (pre-existing saves, panel-taken piles - see
+/// `PlayerStats::nanites`). Uses the same identification and traversal as the
+/// legacy half of [`spend_player_nanites`], so the UI balance and the debit
+/// path cannot disagree.
 pub fn player_nanite_total(world: &World) -> i32 {
-    player_nanite_stacks(world)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|(_, stack)| stack)
-        .fold(0, i32::saturating_add)
+    stat_nanite_balance(world)
+        + player_nanite_stacks(world)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(_, stack)| stack)
+            .fold(0, i32::saturating_add)
 }
 
 fn player_nanite_payment_plan(
@@ -806,9 +873,11 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 #[cfg(test)]
 mod tests {
     use super::{
-        debit_player_nanites, door_blocks_pathfinding, door_is_closed, plan_stack_payment,
+        debit_player_nanites, door_blocks_pathfinding, door_is_closed, is_nanite_pickup,
+        plan_stack_payment, player_nanite_total, spend_player_nanites,
     };
     use crate::mission::PlayerInfo;
+    use crate::quest_info::QuestInfo;
     use crate::runtime_props::RuntimePropTransform;
     use cgmath::{Matrix4, Quaternion, Vector3, vec3};
     use dark::properties::{
@@ -956,5 +1025,89 @@ mod tests {
             None,
             "the authoritative debit path must reject a free purchase"
         );
+    }
+
+    fn world_with_stat_nanites(amount: i32) -> World {
+        let world = World::new();
+        let mut quests = QuestInfo::new();
+        quests.player_stats_mut().award_nanites(amount);
+        world.add_unique(quests);
+        world
+    }
+
+    #[test]
+    fn player_nanite_total_combines_stat_and_legacy_carried_stacks() {
+        let mut world = world_with_stat_nanites(15);
+        let first = world.add_entity((PropObjIcon("nan_ic".to_owned()), PropStackCount(2)));
+        let inventory = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(first)),
+                link: Link::Contains(0),
+            }],
+        });
+        let player = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        assert_eq!(player_nanite_total(&world), 17);
+    }
+
+    #[test]
+    fn spend_player_nanites_debits_the_stat_before_legacy_stacks() {
+        let mut world = world_with_stat_nanites(5);
+        let first = world.add_entity((PropObjIcon("nan_ic".to_owned()), PropStackCount(2)));
+        let inventory = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(first)),
+                link: Link::Contains(0),
+            }],
+        });
+        let player = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        // 6 nanites: 5 come from the stat, 1 from the legacy stack.
+        let effect = spend_player_nanites(&world, 6).expect("balance covers the cost");
+        let effects = match effect {
+            crate::scripts::Effect::Combined { effects } => effects,
+            other => vec![other],
+        };
+        assert!(
+            effects.iter().any(
+                |e| matches!(e, crate::scripts::Effect::SpendNanites { amount } if *amount == 5)
+            )
+        );
+        assert!(effects.iter().any(|e| matches!(
+            e,
+            crate::scripts::Effect::AdjustStackCount { entity_id, delta }
+                if *entity_id == first && *delta == -1
+        )));
+
+        // 100 nanites is more than the combined balance (7) - refused, no
+        // partial effect.
+        assert!(spend_player_nanites(&world, 100).is_none());
+    }
+
+    #[test]
+    fn is_nanite_pickup_false_without_a_template_hierarchy() {
+        // No `GlobalTemplateHierarchy` unique registered (e.g. a bare test
+        // world) - must not panic, and must not misidentify anything.
+        let mut world = World::new();
+        let entity = world.add_entity(());
+        assert!(!is_nanite_pickup(&world, entity));
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -449,12 +449,30 @@ fn handle_empty_hand_state(
             is_sensor: _,
         }) = result
         {
-            if Some(entity_id) != held_by_other_hand && can_grab_item(world, entity_id) {
+            let is_nanite_pickup = crate::scripts::script_util::is_nanite_pickup(world, entity_id);
+            if Some(entity_id) != held_by_other_hand
+                && can_grab_item(world, entity_id)
+                && !is_nanite_pickup
+            {
                 let position = &physics.get_position(rigid_body_handle).unwrap();
                 let _dir = hand_position - position;
                 msgs.push(VirtualHandEffect::HoldItem { entity_id });
 
                 next_hand_state = HandState::Grabbing { entity_id };
+            } else if Some(entity_id) != held_by_other_hand
+                && is_nanite_pickup
+                && last_frobbed_entity.is_none()
+            {
+                // Nanites are always collected via Frob (straight into the
+                // player stat), never squeeze-grabbed into the hand - see
+                // `scripts::internal_nanites_script`.
+                msgs.push(VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to: entity_id,
+                        payload: MessagePayload::Frob,
+                    },
+                });
+                last_frobbed_entity = Some(entity_id);
             }
         }
     }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -502,6 +502,12 @@ export interface PlayerStats {
   /** Installed software versions, raised by picking up a soft (softs
    * auto-install and never enter inventory). 0 = none installed. */
   software: SoftwareVersions;
+  /** Nanites: the game's money, collected directly into this counter by
+   * world nanite pickups (never inventory items). Legacy carried nanite
+   * stacks (pre-existing saves, panel-taken piles) remain separately
+   * spendable; see `player_nanite_total` in the Rust source. Defaults to 0
+   * for saves written before the stat existed. */
+  nanites: number;
 }
 
 /** Installed software versions, one per soft class. Installing keeps the

--- a/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
@@ -134,10 +134,10 @@ test(
     );
 
     await physicallyOpenEarthReplicator(game, replicator);
-    // Spend through both carried StackCounts. After Chips, 267 - 6*40 - 2*4
-    // leaves 19; the second Juice crosses the remaining balance of the first
-    // stack, so exact payment must remove that exhausted entity and continue
-    // into the other real stack.
+    // Spend down the pooled nanite stat. After Chips, 267 - 6*40 - 2*4 = 19;
+    // both nanite piles were collected straight into the stat balance
+    // (nothing is left as a carried inventory entity), so every purchase
+    // debits that one counter rather than crossing physical stacks.
     for (let purchase = 0; purchase < 6; purchase++) {
       const panel = (await game.ui.state()).active_panel;
       assert.ok(panel, `panel should remain open before clip purchase ${purchase + 1}`);
@@ -167,28 +167,20 @@ test(
     );
     assert.equal(
       remainingNanites.length,
-      1,
-      "cross-stack payment should remove the exhausted nanite entity",
+      0,
+      "nanites are collected straight into the player stat, never left as a carried inventory entity",
     );
-    const remainingStack = (
-      await game.entities.detail(remainingNanites[0].entity_id)
-    ).properties.find((property) => property.name === "StackCount");
     assert.equal(
-      Number(remainingStack?.value),
+      (await game.info()).player.stats?.nanites,
       19,
-      "cross-stack payment should leave the exact remainder on the live stack",
-    );
-    assert.equal(
-      inventoryAfterCrossStackPayment.count,
-      2,
-      "destroyed stack cleanup must remove its Contains link before a dispensed entity can recycle the id",
+      "the pooled stat balance should hold the exact remainder",
     );
     assert.deepEqual(
       new Set(
         inventoryAfterCrossStackPayment.items.map((item) => item.entity_id),
       ),
-      new Set([dispensedChips.id, remainingNanites[0].entity_id]),
-      "only the physically collected Chips and live nanite remainder should be carried",
+      new Set([dispensedChips.id]),
+      "only the physically collected Chips should be carried",
     );
 
     const clipsBeforeRefusal = await game.entities.list({

--- a/tools/shock2-sdk/test/helpers/earth-replicator.ts
+++ b/tools/shock2-sdk/test/helpers/earth-replicator.ts
@@ -4,10 +4,17 @@ import type { GameServer } from "../../src/index.js";
 import type { EntitySummary } from "../../src/types.js";
 import { teleportVerified } from "./teleport.js";
 
-/** Total every real carried nanite StackCount exposed through inventory. */
+/**
+ * The player's total spendable nanite balance: the persistent stat balance
+ * (world nanite pickups collect straight into it, never inventory) plus any
+ * legacy carried nanite StackCount entities exposed through inventory
+ * (pre-existing saves, panel-taken piles). Mirrors
+ * `script_util::player_nanite_total` on the Rust side.
+ */
 export async function carriedNaniteTotal(game: GameServer): Promise<number> {
+  const stat = (await game.info()).player.stats?.nanites ?? 0;
   const inventory = await game.player.inventory();
-  let total = 0;
+  let total = stat;
   for (const item of inventory.items) {
     if (!item.name?.toLowerCase().includes("nanite")) continue;
     const detail = await game.entities.detail(item.entity_id);

--- a/tools/shock2-sdk/test/nanite-player-stat.e2e.test.ts
+++ b/tools/shock2-sdk/test/nanite-player-stat.e2e.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable earth.mis mission-object ids (see nanite-stack-label.e2e.test.ts).
+// Both are "Big Nanite Pile" instances so frobbing one leaves the other
+// available to exercise squeeze separately.
+const FROB_PILE_OBJ = 257;
+const SQUEEZE_PILE_OBJ = 292;
+
+function stackCount(properties: { name: string; value: string }[]): number {
+  const stack = properties.find((property) => property.name === "StackCount");
+  assert.ok(stack, "expected an authored StackCount");
+  return Number(stack.value);
+}
+
+test(
+  "earth: frobbing and squeezing a world nanite pickup collects it as a player stat, never inventory",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8194),
+    });
+    await game.step({ frames: 2 });
+
+    const statsBefore = (await game.info()).player.stats;
+    assert.equal(
+      statsBefore?.nanites ?? 0,
+      0,
+      "a fresh earth character starts with no stat nanites",
+    );
+
+    // --- Frob ---
+    const [frobPile] = await game.entities.byTemplate(FROB_PILE_OBJ);
+    assert.ok(
+      frobPile,
+      `expected earth mission object ${FROB_PILE_OBJ} (Big Nanite Pile)`,
+    );
+    const frobStack = stackCount(
+      (await game.entities.detail(frobPile.id)).properties,
+    );
+    assert.ok(frobStack > 0, "expected a positive authored stack count");
+
+    await game.entities.sendMessage(frobPile.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    const afterFrob = (await game.info()).player.stats;
+    assert.equal(
+      afterFrob?.nanites,
+      frobStack,
+      "Frob should award the pile's full stack straight to the nanite stat",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (entry) => entry.entity_id === frobPile.id,
+      ),
+      undefined,
+      "a collected nanite pile must never enter the inventory grid",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: frobPile.id })).bodies.length,
+      0,
+      "the collected pile should no longer have a world body",
+    );
+
+    // --- Squeeze (the VR grab gesture, routed through virtual_hand) ---
+    const [squeezePile] = await game.entities.byTemplate(SQUEEZE_PILE_OBJ);
+    assert.ok(
+      squeezePile,
+      `expected earth mission object ${SQUEEZE_PILE_OBJ} (Big Nanite Pile)`,
+    );
+    const squeezeStack = stackCount(
+      (await game.entities.detail(squeezePile.id)).properties,
+    );
+
+    const [x, y, z] = (await game.entities.detail(squeezePile.id)).position;
+    await game.player.teleport({
+      x,
+      y: y - PLAYER_EYE_HEIGHT_WORLD,
+      z: z + 0.3,
+    });
+    const aim = await game.player.aimAt(squeezePile, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      aim.target_confirmed,
+      true,
+      `the pile should be selectable for squeeze: ${JSON.stringify(aim)}`,
+    );
+
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 5 });
+
+    const afterSqueeze = (await game.info()).player.stats;
+    assert.equal(
+      afterSqueeze?.nanites,
+      frobStack + squeezeStack,
+      "squeezing a nanite pile must also collect it straight into the stat",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (entry) => entry.entity_id === squeezePile.id,
+      ),
+      undefined,
+      "squeezing a nanite pile must never place it in the hand or the inventory grid",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: squeezePile.id })).bodies.length,
+      0,
+      "the squeezed pile should no longer have a world body",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Nanites (the game's money) stop living as inventory items. Both Frob and squeeze on a world nanite pickup now collect it straight into a new `PlayerStats.nanites` counter - never entering the inventory grid or the physical hand - mirroring how cyber modules already work (`expcookie` script -> `Effect::AwardXP` -> `PlayerStats.cyber_modules`). This is part of the "always-collect category" pattern established by the merged cyber-interface stack (#1107, #1111, #1113).

## What changed

- **Stat**: `PlayerStats.nanites: i32` (`shock2vr/src/player_stats.rs`) with `award_nanites`/`spend_nanites` (spend clamps at 0), serialized the same way as `cyber_modules` (`#[serde(default)]` keeps old saves loadable).
- **Effects**: `Effect::AwardNanites { amount }` / `Effect::SpendNanites { amount }`, handled in `mission_core.rs` next to `AwardXP`.
- **Derived collect script**: `internal_nanites` (`shock2vr/src/scripts/internal_nanites_script.rs`), attached in `entity_creator.rs` following the `internal_keycard` pattern. On Frob: awards the pile's stack count (default 1) to the stat, plays a pickup sound, and destroys the pickup.
- **Identification**: template ancestry from the three "Nanite Pile" templates (Small/Medium/Big, -1589/-1590/-1591) - deliberately narrower than the shared `Nanites` base template (-85), which also roots the `FakeNanites` decoy (-1271, a bomb-trap payload dressed up to look like a pickup). Using the narrower pile family keeps that decoy on its ordinary generic-frob/inventory path instead of being auto-collected as currency.
- **Squeeze/pickup routing**: VR squeeze (`virtual_hand.rs`) and flat pickup (`flat_player_controller.rs`) now route a nanite pickup through Frob instead of a physical grab/`StoreItem`, via a new `script_util::is_nanite_pickup` runtime predicate (checked against `GlobalTemplateHierarchy`).
- **Spend/HUD migration with legacy fallback**: `spend_player_nanites`/`debit_player_nanites`/`player_nanite_total` (used by the replicator and HRM hacking panels) now debit the stat first, then fall back to legacy carried `nan_ic` stacks for any remainder - so pre-existing saves and panel-taken nanites (container Take path, owned by #1097) keep spending correctly.

## Out of scope (per plan)

- Container-panel Take/squeeze routing (#1097's area) - a panel-taken nanite may transiently land in inventory; the legacy fallback above covers spending it.
- Backpack capacity enforcement, cyber-module/log squeeze generalization, any use-mode/cyber-interface changes.

## Test plan

- [x] `cargo test -p shock2vr --lib` - 937 passed (10 new: `player_stats::tests::nanites_*`, `scripts::internal_nanites_script::tests::*`, `scripts::script_util::tests::{is_nanite_pickup_false_without_a_template_hierarchy,player_nanite_total_combines_stat_and_legacy_carried_stacks,spend_player_nanites_debits_the_stat_before_legacy_stacks}`)
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` - clean
- [x] New SDK e2e (`tools/shock2-sdk/test/nanite-player-stat.e2e.test.ts`): frobs one earth.mis nanite pile and squeezes another - asserts the stat balance increments by each pile's stack count and neither ever appears in inventory or keeps a physics body.
- [x] `missions.e2e.test.ts` - all 23 missions load
- [x] Inventory-adjacent suites (world-frob-pickup, flat-world-pickup, inventory, inventory-drag, inventory-strip, nanite-stack-label, cyber-modules, trainer) - 10/10 pass
- [x] `earth-replicator-economy`, `earth-replicator-hacking` (updated for the new stat-pooled balance), `player-death` (QBR respawn nanite cost), `save-load` - all pass
- [x] Broad sample of the wider e2e suite (~45 additional files spanning AI, physics, UI, save/load, hacking, VR) - all pass except one pre-existing, unrelated failure (`baby-arachnid.e2e.test.ts`: melee wrench damage classification against a creature, no shared code path with this change)

## Media

See pr-visuals capture below (HUD/stat count incrementing on frob and squeeze).

![Nanite pile collection demo](https://gist.githubusercontent.com/tommy-xr/470b069e8f9431dc570c5b7570e265a8/raw/nanite-collect.gif)

<sub>earth.mis, entity 121 (Big Nanite Pile, template -257, StackCount 250): approach, frob, pile vanishes. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). There is no dedicated HUD nanite counter widget yet, so `player.stats.nanites` is burned onto the before/after stills below via PIL for visibility.</sub>

### Before → after (`player.stats.nanites`)

![Before/after nanites stat](https://gist.githubusercontent.com/tommy-xr/470b069e8f9431dc570c5b7570e265a8/raw/beforeafter.png)

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72
