### PR TITLE
fix(items): harden nanite collection after #1118 review

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -127,9 +127,7 @@ impl FlatPlayerController {
     /// Apply the original flat pickup split: weapons become the first-person
     /// viewmodel, while ordinary loot goes straight into the backpack.
     fn pick_up(&mut self, world: &World, entity_id: EntityId) -> Vec<VirtualHandEffect> {
-        if uses_scripted_world_frob(world, entity_id)
-            || crate::scripts::script_util::is_nanite_pickup(world, entity_id)
-        {
+        if uses_scripted_world_frob(world, entity_id) {
             vec![out_message(entity_id, MessagePayload::Frob)]
         } else if is_wieldable_weapon(world, entity_id) {
             self.wield(entity_id)

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -80,12 +80,10 @@ fn is_nanite_pickup_template(
     entity_info: &ss2_entity_info::SystemShock2EntityInfo,
     template_id: i32,
 ) -> bool {
-    let hierarchy = ss2_entity_info::get_hierarchy(entity_info);
-    let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, &template_id);
-    ancestors.push(template_id);
-    ancestors
-        .iter()
-        .any(|id| crate::scripts::script_util::NANITE_PILE_TEMPLATE_IDS.contains(id))
+    crate::scripts::script_util::is_nanite_pile_template(
+        ss2_entity_info::get_hierarchy(entity_info),
+        template_id,
+    )
 }
 
 pub fn create_entity_with_position(
@@ -409,14 +407,17 @@ pub fn create_entity_core(
     // such as Med Patches and armor only inherit that flag, so give them the
     // internal handler that moves them into the backpack on Frob. Objects that
     // also request SCRIPT keep their existing authored ownership (notably
-    // FrobQB's circuit-board/quest-item transfer).
+    // FrobQB's circuit-board/quest-item transfer). Nanite piles also inherit
+    // MOVE but must go exclusively through `internal_nanites` above - a
+    // second Frob handler here would race it to move the pile into the
+    // backpack instead of awarding+destroying it.
     let needs_frob_move = {
         let v_frob_info = world.borrow::<View<PropFrobInfo>>().unwrap();
         v_frob_info.get(entity_id).is_ok_and(|frob| {
             !frob.world_action.contains(FrobFlag::SCRIPT)
                 && (frob.world_action.contains(FrobFlag::MOVE)
                     || frob.world_action.contains(FrobFlag::USE_AMMO))
-        })
+        }) && !is_nanite_pickup_template(entity_info, template_id)
     };
     if needs_frob_move {
         processed_scripts.push("internal_frob_move".to_owned());

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -907,12 +907,26 @@ pub struct GlobalHrmParams(pub Option<dark::gamesys::HrmParams>);
 #[derive(Unique, Clone)]
 pub struct GlobalSkillParams(pub Option<dark::gamesys::SkillParams>);
 
+/// Whether `template_id` is `class_template_id` or inherits from it, given a
+/// template-inheritance hierarchy (MetaProp parent map). A free function
+/// (rather than only the `GlobalTemplateHierarchy` method below) so callers
+/// that only have the raw hierarchy - e.g. `mission::entity_creator` at
+/// load time, before the `World` and its uniques exist - share the same
+/// ancestry check instead of re-deriving it.
+pub(crate) fn template_is_or_descends_from(
+    hierarchy: &HashMap<i32, Vec<i32>>,
+    template_id: i32,
+    class_template_id: i32,
+) -> bool {
+    template_id == class_template_id
+        || dark::ss2_entity_info::get_ancestors(hierarchy, &template_id)
+            .contains(&class_template_id)
+}
+
 impl GlobalTemplateHierarchy {
     /// Whether `template_id` is `class_template_id` or inherits from it.
     pub fn is_or_descends_from(&self, template_id: i32, class_template_id: i32) -> bool {
-        template_id == class_template_id
-            || dark::ss2_entity_info::get_ancestors(&self.0, &template_id)
-                .contains(&class_template_id)
+        template_is_or_descends_from(&self.0, template_id, class_template_id)
     }
 }
 

--- a/shock2vr/src/scripts/internal_nanites_script.rs
+++ b/shock2vr/src/scripts/internal_nanites_script.rs
@@ -20,11 +20,20 @@ const NANITE_PICKUP_SOUND: &str = "linebeep";
 /// squeezing) a world nanite pile awards its stack count straight to the
 /// player's persistent nanite balance and removes the object - it never
 /// enters the inventory grid or the physical hand.
-pub struct InternalNanitesScript {}
+pub struct InternalNanitesScript {
+    // The entity is destroyed the same frame it is first collected (effects
+    // apply after the whole message batch), so a second Frob delivered in
+    // that same batch - both VR hands squeezing the same pile, or trigger and
+    // squeeze from different hands - would otherwise still see it alive and
+    // award nanites twice while only one DestroyEntity is ever queued. Latch
+    // in-memory on the first award; the entity is gone by the next frame, so
+    // this never needs to survive a save.
+    collected: bool,
+}
 
 impl InternalNanitesScript {
     pub fn new() -> InternalNanitesScript {
-        InternalNanitesScript {}
+        InternalNanitesScript { collected: false }
     }
 }
 
@@ -37,7 +46,9 @@ impl Script for InternalNanitesScript {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
+            MessagePayload::Frob if !self.collected => {
+                self.collected = true;
+
                 let amount = world
                     .borrow::<View<PropStackCount>>()
                     .ok()
@@ -95,6 +106,45 @@ mod tests {
             effects
                 .iter()
                 .any(|e| matches!(e, Effect::DestroyEntity { entity_id } if *entity_id == entity))
+        );
+    }
+
+    /// Negative-first regression: the destroy effect only applies after the
+    /// whole message batch, so a second Frob in the same batch - both VR
+    /// hands squeezing the same pile, or trigger and squeeze from different
+    /// hands - still finds the entity alive. Without the `collected` latch,
+    /// this would award nanites twice for one pickup.
+    #[test]
+    fn a_second_frob_in_the_same_batch_awards_nothing_more() {
+        let mut world = World::new();
+        let entity = world.add_entity(PropStackCount(20));
+        let mut script = InternalNanitesScript::new();
+
+        let first =
+            script.handle_message(entity, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+        let second =
+            script.handle_message(entity, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+
+        let award_count = |effect: &Effect| -> usize {
+            match effect {
+                Effect::Combined { effects } => effects
+                    .iter()
+                    .filter(|e| matches!(e, Effect::AwardNanites { .. }))
+                    .count(),
+                Effect::AwardNanites { .. } => 1,
+                _ => 0,
+            }
+        };
+
+        assert_eq!(award_count(&first), 1, "first Frob should award nanites");
+        assert_eq!(
+            award_count(&second),
+            0,
+            "second Frob in the same batch must not award nanites again"
+        );
+        assert!(
+            matches!(second, Effect::NoEffect),
+            "second Frob should be a no-op, got {second:?}"
         );
     }
 

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -438,6 +438,15 @@ fn stat_nanite_balance(world: &World) -> i32 {
         .unwrap_or(0)
 }
 
+/// Split `amount` (assumed positive) into the stat-first debit and the
+/// legacy-stack remainder. Shared by `spend_player_nanites` and
+/// `debit_player_nanites` so the two spend paths can't drift on which nanites
+/// get spent first.
+fn stat_first_split(world: &World, amount: i32) -> (i32, i32) {
+    let stat_debit = amount.min(stat_nanite_balance(world));
+    (stat_debit, amount - stat_debit)
+}
+
 /// Build the effects that pay `amount` nanites: debits the player's stat
 /// balance first (`Effect::SpendNanites`), then any legacy carried stacks
 /// (identified by their inherited inventory icon `nan_ic` - pre-existing
@@ -448,8 +457,7 @@ pub fn spend_player_nanites(world: &World, amount: i32) -> Option<Effect> {
         return Some(Effect::NoEffect);
     }
 
-    let stat_debit = amount.min(stat_nanite_balance(world)).max(0);
-    let remaining = amount - stat_debit;
+    let (stat_debit, remaining) = stat_first_split(world, amount);
 
     let mut effects = Vec::new();
     if stat_debit > 0 {
@@ -484,8 +492,7 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
         return None;
     }
 
-    let stat_debit = amount.min(stat_nanite_balance(world)).max(0);
-    let remaining = amount - stat_debit;
+    let (stat_debit, remaining) = stat_first_split(world, amount);
 
     let (nanite_stacks, debits) = if remaining > 0 {
         player_nanite_payment_plan(world, remaining)?
@@ -504,13 +511,10 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
         }
     }
 
-    if stat_debit > 0 {
-        let mut quests = world
-            .borrow::<UniqueViewMut<crate::quest_info::QuestInfo>>()
-            .ok()?;
-        quests.player_stats_mut().spend_nanites(stat_debit);
-    }
-
+    // Apply the stack mutations before the stat debit: if a `.get` here were
+    // ever to fail despite passing validation above, bailing out via `?` must
+    // still leave the stat untouched, matching the doc's "leaves every stack
+    // (and the stat) unchanged" guarantee.
     let mut exhausted = Vec::new();
     for ((entity_id, _), paid) in nanite_stacks.into_iter().zip(debits) {
         if paid == 0 {
@@ -522,6 +526,14 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
             exhausted.push(entity_id);
         }
     }
+
+    if stat_debit > 0 {
+        let mut quests = world
+            .borrow::<UniqueViewMut<crate::quest_info::QuestInfo>>()
+            .ok()?;
+        quests.player_stats_mut().spend_nanites(stat_debit);
+    }
+
     Some(exhausted)
 }
 
@@ -531,12 +543,13 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
 /// legacy half of [`spend_player_nanites`], so the UI balance and the debit
 /// path cannot disagree.
 pub fn player_nanite_total(world: &World) -> i32 {
-    stat_nanite_balance(world)
-        + player_nanite_stacks(world)
+    stat_nanite_balance(world).saturating_add(
+        player_nanite_stacks(world)
             .unwrap_or_default()
             .into_iter()
             .map(|(_, stack)| stack)
-            .fold(0, i32::saturating_add)
+            .fold(0, i32::saturating_add),
+    )
 }
 
 fn player_nanite_payment_plan(
@@ -1049,14 +1062,23 @@ mod tests {
         world
     }
 
-    #[test]
-    fn player_nanite_total_combines_stat_and_legacy_carried_stacks() {
-        let mut world = world_with_stat_nanites(15);
-        let first = world.add_entity((PropObjIcon("nan_ic".to_owned()), PropStackCount(2)));
+    /// As [`world_with_stat_nanites`], plus one legacy carried nanite stack
+    /// (in the player's backpack) of `carried_amount` - the setup shared by
+    /// every test that exercises the stat-then-legacy-stack split. Returns
+    /// the stack entity so callers can assert on it directly.
+    fn world_with_stat_and_carried_nanites(
+        stat_amount: i32,
+        carried_amount: i32,
+    ) -> (World, EntityId) {
+        let mut world = world_with_stat_nanites(stat_amount);
+        let stack = world.add_entity((
+            PropObjIcon("nan_ic".to_owned()),
+            PropStackCount(carried_amount),
+        ));
         let inventory = world.add_entity(Links {
             to_links: vec![ToLink {
                 to_template_id: 0,
-                to_entity_id: Some(WrappedEntityId(first)),
+                to_entity_id: Some(WrappedEntityId(stack)),
                 link: Link::Contains(0),
             }],
         });
@@ -1069,30 +1091,19 @@ mod tests {
             right_hand_entity_id: None,
             inventory_entity_id: inventory,
         });
+        (world, stack)
+    }
+
+    #[test]
+    fn player_nanite_total_combines_stat_and_legacy_carried_stacks() {
+        let (world, _first) = world_with_stat_and_carried_nanites(15, 2);
 
         assert_eq!(player_nanite_total(&world), 17);
     }
 
     #[test]
     fn spend_player_nanites_debits_the_stat_before_legacy_stacks() {
-        let mut world = world_with_stat_nanites(5);
-        let first = world.add_entity((PropObjIcon("nan_ic".to_owned()), PropStackCount(2)));
-        let inventory = world.add_entity(Links {
-            to_links: vec![ToLink {
-                to_template_id: 0,
-                to_entity_id: Some(WrappedEntityId(first)),
-                link: Link::Contains(0),
-            }],
-        });
-        let player = world.add_entity(());
-        world.add_unique(PlayerInfo {
-            pos: vec3(0.0, 0.0, 0.0),
-            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            entity_id: player,
-            left_hand_entity_id: None,
-            right_hand_entity_id: None,
-            inventory_entity_id: inventory,
-        });
+        let (world, first) = world_with_stat_and_carried_nanites(5, 2);
 
         // 6 nanites: 5 come from the stat, 1 from the legacy stack.
         let effect = spend_player_nanites(&world, 6).expect("balance covers the cost");

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -53,14 +53,19 @@ pub(crate) const NANITE_PILE_TEMPLATE_IDS: [i32; 3] = [-1589, -1590, -1591];
 /// can't silently drift between them: `mission::entity_creator` (script
 /// attachment, from the load-time `SystemShock2EntityInfo` hierarchy) and
 /// [`is_nanite_pickup`] below (from the runtime `GlobalTemplateHierarchy`
-/// unique, which is that same hierarchy cloned into the `World`).
+/// unique, which is that same hierarchy cloned into the `World`). The
+/// ancestry check itself is shared with `GlobalTemplateHierarchy::
+/// is_or_descends_from` via `mission_core::template_is_or_descends_from`.
 pub(crate) fn is_nanite_pile_template(
     hierarchy: &HashMap<i32, Vec<i32>>,
     template_id: i32,
 ) -> bool {
     NANITE_PILE_TEMPLATE_IDS.iter().any(|class_id| {
-        template_id == *class_id
-            || dark::ss2_entity_info::get_ancestors(hierarchy, &template_id).contains(class_id)
+        crate::mission::mission_core::template_is_or_descends_from(
+            hierarchy,
+            template_id,
+            *class_id,
+        )
     })
 }
 
@@ -443,7 +448,10 @@ fn stat_nanite_balance(world: &World) -> i32 {
 /// `debit_player_nanites` so the two spend paths can't drift on which nanites
 /// get spent first.
 fn stat_first_split(world: &World, amount: i32) -> (i32, i32) {
-    let stat_debit = amount.min(stat_nanite_balance(world));
+    // `.max(0)` guards a corrupt/negative stat balance (e.g. an old save): a
+    // negative `stat_debit` here would inflate `remaining` past `amount` and
+    // overcharge the carried stacks.
+    let stat_debit = amount.min(stat_nanite_balance(world).max(0));
     (stat_debit, amount - stat_debit)
 }
 
@@ -503,6 +511,19 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
     let mut stacks = world
         .borrow::<ViewMut<dark::properties::PropStackCount>>()
         .ok()?;
+    // Acquire every fallible borrow up front, before any mutation, so no
+    // ordering of the mutations below can leave one applied and the other
+    // not - a late-failing borrow here must not have already spent the stat
+    // or a stack.
+    let mut quests = if stat_debit > 0 {
+        Some(
+            world
+                .borrow::<UniqueViewMut<crate::quest_info::QuestInfo>>()
+                .ok()?,
+        )
+    } else {
+        None
+    };
 
     // Validate every live stack before applying any mutation.
     for ((entity_id, _), paid) in nanite_stacks.iter().zip(&debits) {
@@ -511,10 +532,6 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
         }
     }
 
-    // Apply the stack mutations before the stat debit: if a `.get` here were
-    // ever to fail despite passing validation above, bailing out via `?` must
-    // still leave the stat untouched, matching the doc's "leaves every stack
-    // (and the stat) unchanged" guarantee.
     let mut exhausted = Vec::new();
     for ((entity_id, _), paid) in nanite_stacks.into_iter().zip(debits) {
         if paid == 0 {
@@ -527,10 +544,7 @@ pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>>
         }
     }
 
-    if stat_debit > 0 {
-        let mut quests = world
-            .borrow::<UniqueViewMut<crate::quest_info::QuestInfo>>()
-            .ok()?;
+    if let Some(quests) = quests.as_mut() {
         quests.player_stats_mut().spend_nanites(stat_debit);
     }
 

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -47,12 +47,28 @@ pub(crate) fn entity_class_template_id(world: &World, entity: EntityId) -> Optio
 /// authored pile placed directly) while excluding that decoy.
 pub(crate) const NANITE_PILE_TEMPLATE_IDS: [i32; 3] = [-1589, -1590, -1591];
 
+/// Whether `template_id` is one of [`NANITE_PILE_TEMPLATE_IDS`] or descends
+/// from one, given a template-inheritance hierarchy (MetaProp parent map).
+/// The single predicate both call sites consult so "is this a nanite pile"
+/// can't silently drift between them: `mission::entity_creator` (script
+/// attachment, from the load-time `SystemShock2EntityInfo` hierarchy) and
+/// [`is_nanite_pickup`] below (from the runtime `GlobalTemplateHierarchy`
+/// unique, which is that same hierarchy cloned into the `World`).
+pub(crate) fn is_nanite_pile_template(
+    hierarchy: &HashMap<i32, Vec<i32>>,
+    template_id: i32,
+) -> bool {
+    NANITE_PILE_TEMPLATE_IDS.iter().any(|class_id| {
+        template_id == *class_id
+            || dark::ss2_entity_info::get_ancestors(hierarchy, &template_id).contains(class_id)
+    })
+}
+
 /// Whether `entity` is a real world nanite pickup, identified via the runtime
-/// template hierarchy (see [`NANITE_PILE_TEMPLATE_IDS`]) rather than the
-/// legacy `nan_ic` icon check below (which also matches the `FakeNanites`
-/// decoy). Used to route VR squeeze / flat pickup through Frob instead of a
-/// physical grab - see `virtual_hand::uses_scripted_world_frob` and its flat
-/// call site.
+/// template hierarchy rather than the legacy `nan_ic` icon check below (which
+/// also matches the `FakeNanites` decoy). Used to route VR squeeze / flat
+/// pickup through Frob instead of a physical grab - see
+/// `virtual_hand::uses_scripted_world_frob` and its flat call site.
 pub(crate) fn is_nanite_pickup(world: &World, entity: EntityId) -> bool {
     let Ok(hierarchy) = world.borrow::<UniqueView<GlobalTemplateHierarchy>>() else {
         return false;
@@ -60,9 +76,7 @@ pub(crate) fn is_nanite_pickup(world: &World, entity: EntityId) -> bool {
     let Some(template_id) = entity_class_template_id(world, entity) else {
         return false;
     };
-    NANITE_PILE_TEMPLATE_IDS
-        .iter()
-        .any(|class_id| hierarchy.is_or_descends_from(template_id, *class_id))
+    is_nanite_pile_template(&hierarchy.0, template_id)
 }
 
 pub fn is_message_turnon_or_turnoff(msg: &MessagePayload) -> bool {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -901,7 +901,7 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 mod tests {
     use super::{
         debit_player_nanites, door_blocks_pathfinding, door_is_closed, is_nanite_pickup,
-        plan_stack_payment, player_nanite_total, spend_player_nanites,
+        plan_stack_payment, player_nanite_total, spend_player_nanites, stat_nanite_balance,
     };
     use crate::mission::PlayerInfo;
     use crate::quest_info::QuestInfo;
@@ -1092,6 +1092,68 @@ mod tests {
             inventory_entity_id: inventory,
         });
         (world, stack)
+    }
+
+    /// End-to-end coverage of the authoritative live-mutation path
+    /// (`debit_player_nanites`, the same call `gui::replicator`'s
+    /// `Effect::ReplicatorPurchase` handler in `mission_core` makes) with
+    /// BOTH a stat balance and a carried legacy stack present. Every world
+    /// nanite pickup now collects straight into the stat and never leaves a
+    /// carried entity behind, so a live mission can no longer reach this
+    /// stat-then-legacy-stack crossing without an old save or a debug-spawned
+    /// pile - this is the unit-level stand-in for that scenario.
+    #[test]
+    fn live_nanite_debit_crosses_from_the_stat_into_a_carried_stack_and_exhausts_it() {
+        let (world, stack) = world_with_stat_and_carried_nanites(5, 8);
+
+        // 6 nanites: 5 from the stat, 1 from the carried stack.
+        let exhausted = debit_player_nanites(&world, 6).expect("balance covers the cost");
+        assert!(
+            exhausted.is_empty(),
+            "a partial stack debit must not report the stack as exhausted"
+        );
+        assert_eq!(
+            stat_nanite_balance(&world),
+            0,
+            "the stat should be fully drained before the carried stack is touched"
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(stack)
+                .unwrap()
+                .0,
+            7,
+            "8 - 1 = 7 remaining in the carried stack"
+        );
+
+        // A further debit of 7 exactly exhausts the carried stack (the stat
+        // is already at zero), so it must be reported for destruction - the
+        // mission's ReplicatorPurchase handler destroys exactly these ids.
+        let exhausted =
+            debit_player_nanites(&world, 7).expect("the remaining carried stack covers this");
+        assert_eq!(
+            exhausted,
+            vec![stack],
+            "an exactly-exhausted carried stack must be returned for destruction"
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(stack)
+                .unwrap()
+                .0,
+            0
+        );
+
+        // Both the stat and the carried stack are now spent.
+        assert_eq!(
+            debit_player_nanites(&world, 1),
+            None,
+            "a debit against an exhausted stat and stack must be refused"
+        );
     }
 
     #[test]

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -436,7 +436,11 @@ fn handle_empty_hand_state(
                 // Also, frob any items that may be nearby...
             }
         }
-    } else {
+    } else if input_hand.squeeze_value <= 0.5 {
+        // Only clear the latch once neither trigger nor squeeze is engaged -
+        // otherwise a squeeze held across frames (below) would see the latch
+        // cleared every frame the trigger is idle and re-frob the same
+        // entity every tick it survives.
         last_frobbed_entity = None
     }
 
@@ -449,10 +453,10 @@ fn handle_empty_hand_state(
             is_sensor: _,
         }) = result
         {
-            let is_nanite_pickup = crate::scripts::script_util::is_nanite_pickup(world, entity_id);
+            let needs_scripted_frob = uses_scripted_world_frob(world, entity_id);
             if Some(entity_id) != held_by_other_hand
                 && can_grab_item(world, entity_id)
-                && !is_nanite_pickup
+                && !needs_scripted_frob
             {
                 let position = &physics.get_position(rigid_body_handle).unwrap();
                 let _dir = hand_position - position;
@@ -460,12 +464,13 @@ fn handle_empty_hand_state(
 
                 next_hand_state = HandState::Grabbing { entity_id };
             } else if Some(entity_id) != held_by_other_hand
-                && is_nanite_pickup
+                && needs_scripted_frob
                 && last_frobbed_entity.is_none()
             {
-                // Nanites are always collected via Frob (straight into the
-                // player stat), never squeeze-grabbed into the hand - see
-                // `scripts::internal_nanites_script`.
+                // Items whose taking must go through a script (nanites
+                // collected straight into the player stat, keycards, ...) are
+                // always Frob'd, never squeeze-grabbed into the hand - see
+                // `uses_scripted_world_frob`.
                 msgs.push(VirtualHandEffect::OutMessage {
                     message: Message {
                         to: entity_id,
@@ -545,7 +550,10 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
 /// transfer. An authored `SCRIPT` world action owns its side effects and item
 /// fate (for example `FrobQB` awards a quest bit and moves the item exactly
 /// once). `PropKeySrc` items also receive an `internal_keycard` script at
-/// runtime even when their authored world action is only `MOVE`.
+/// runtime even when their authored world action is only `MOVE`, and nanite
+/// piles receive `internal_nanites` the same way (see
+/// `scripts::script_util::is_nanite_pickup`) - both must route through Frob
+/// rather than a physical grab in every presentation.
 pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bool {
     let has_authored_world_script = world
         .borrow::<View<PropFrobInfo>>()
@@ -560,7 +568,9 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
         .map(|keycards| keycards.get(entity_id).is_ok())
         .unwrap_or(false);
 
-    has_authored_world_script || has_derived_keycard_script
+    has_authored_world_script
+        || has_derived_keycard_script
+        || crate::scripts::script_util::is_nanite_pickup(world, entity_id)
 }
 
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
@@ -904,5 +914,87 @@ mod tests {
 
         assert!(shows_hand_visual(&world, None));
         assert!(shows_hand_visual(&world, Some(consumable)));
+    }
+
+    fn scripted_world_pickup(world: &mut World, physics: &mut PhysicsWorld) -> EntityId {
+        use dark::properties::{KeyCard, PropKeySrc};
+
+        let entity = world.add_entity(PropKeySrc(KeyCard {
+            is_master: false,
+            region_id: 0,
+            lock_id: 0,
+        }));
+        physics.add_kinematic(
+            entity,
+            vec3(0.0, 0.0, -0.5),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            Vector3::zero(),
+            vec3(1.0, 1.0, 1.0),
+            CollisionGroup::selectable(),
+            false,
+        );
+        update_queries(world, physics);
+        entity
+    }
+
+    fn frob_message_count(effects: &[VirtualHandEffect]) -> usize {
+        effects
+            .iter()
+            .filter(|effect| {
+                matches!(
+                    effect,
+                    VirtualHandEffect::OutMessage {
+                        message: Message {
+                            payload: MessagePayload::Frob,
+                            ..
+                        }
+                    }
+                )
+            })
+            .count()
+    }
+
+    /// Negative-first regression: a scripted world pickup (here, a keycard -
+    /// nanite piles are the motivating case) is not physically grabbable, so
+    /// squeeze routes it through Frob (see `uses_scripted_world_frob`). The
+    /// trigger-idle branch used to clear the frob latch unconditionally every
+    /// frame, so a squeeze held across frames re-sent Frob every tick the
+    /// entity survived instead of just once on the rising edge.
+    #[test]
+    fn held_squeeze_frobs_a_scripted_pickup_only_once() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        scripted_world_pickup(&mut world, &mut physics);
+
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+
+        let (hand, effects) = handle_empty_hand_state(
+            Handedness::Right,
+            Vector3::zero(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            None,
+            &world,
+            &physics,
+            &input,
+            None,
+        );
+        assert_eq!(frob_message_count(&effects), 1, "first frame should Frob");
+
+        let (_, effects) = handle_empty_hand_state(
+            Handedness::Right,
+            Vector3::zero(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            hand.last_frobbed_entity,
+            &world,
+            &physics,
+            &input,
+            None,
+        );
+        assert_eq!(
+            frob_message_count(&effects),
+            0,
+            "a held squeeze must not re-frob every frame"
+        );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -417,7 +417,7 @@ fn handle_empty_hand_state(
             is_sensor: _,
         }) = result
         {
-            if last_frobbed_entity.is_none() {
+            if last_frobbed_entity != Some(entity) {
                 msgs.push(VirtualHandEffect::OutMessage {
                     message: Message {
                         to: entity,
@@ -465,7 +465,7 @@ fn handle_empty_hand_state(
                 next_hand_state = HandState::Grabbing { entity_id };
             } else if Some(entity_id) != held_by_other_hand
                 && needs_scripted_frob
-                && last_frobbed_entity.is_none()
+                && last_frobbed_entity != Some(entity_id)
             {
                 // Items whose taking must go through a script (nanites
                 // collected straight into the player stat, keycards, ...) are
@@ -793,6 +793,29 @@ mod tests {
         physics.update(Vector3::zero(), &mut player_handle);
     }
 
+    /// Register `entity` as a selectable kinematic body and refresh the
+    /// query pipeline so it is immediately raycastable. Shared by every
+    /// fixture below that plants an entity for the raycast to hit.
+    fn register_kinematic_body(
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        entity: EntityId,
+        position: Vector3<f32>,
+        size: Vector3<f32>,
+        collision_group: CollisionGroup,
+    ) {
+        physics.add_kinematic(
+            entity,
+            position,
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            Vector3::zero(),
+            size,
+            collision_group,
+            false,
+        );
+        update_queries(world, physics);
+    }
+
     fn add_occluder(
         world: &mut World,
         physics: &mut PhysicsWorld,
@@ -800,16 +823,14 @@ mod tests {
         collision_group: CollisionGroup,
     ) -> EntityId {
         let entity = world.add_entity(());
-        physics.add_kinematic(
+        register_kinematic_body(
+            world,
+            physics,
             entity,
             vec3(0.0, 0.0, z),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            Vector3::zero(),
             vec3(1.0, 1.0, 0.1),
             collision_group,
-            false,
         );
-        update_queries(world, physics);
         entity
     }
 
@@ -916,25 +937,43 @@ mod tests {
         assert!(shows_hand_visual(&world, Some(consumable)));
     }
 
-    fn scripted_world_pickup(world: &mut World, physics: &mut PhysicsWorld) -> EntityId {
+    /// A scripted world pickup (here, a keycard - nanite piles are the
+    /// motivating case) that also carries a `MOVE` frob action, so a test can
+    /// tell the deliberate "route through Frob" branch apart from simply
+    /// never being grabbable (`can_grab_item` alone would already be false
+    /// without it).
+    fn scripted_world_pickup_at(
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        position: Vector3<f32>,
+    ) -> EntityId {
         use dark::properties::{KeyCard, PropKeySrc};
 
-        let entity = world.add_entity(PropKeySrc(KeyCard {
-            is_master: false,
-            region_id: 0,
-            lock_id: 0,
-        }));
-        physics.add_kinematic(
+        let entity = world.add_entity((
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 0,
+                lock_id: 0,
+            }),
+            PropFrobInfo {
+                world_action: FrobFlag::MOVE,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+        register_kinematic_body(
+            world,
+            physics,
             entity,
-            vec3(0.0, 0.0, -0.5),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            Vector3::zero(),
+            position,
             vec3(1.0, 1.0, 1.0),
             CollisionGroup::selectable(),
-            false,
         );
-        update_queries(world, physics);
         entity
+    }
+
+    fn scripted_world_pickup(world: &mut World, physics: &mut PhysicsWorld) -> EntityId {
+        scripted_world_pickup_at(world, physics, vec3(0.0, 0.0, -0.5))
     }
 
     fn frob_message_count(effects: &[VirtualHandEffect]) -> usize {
@@ -995,6 +1034,66 @@ mod tests {
             frob_message_count(&effects),
             0,
             "a held squeeze must not re-frob every frame"
+        );
+    }
+
+    /// Negative-first regression: the once-per-hold latch above must be keyed
+    /// by entity, not merely "something was frobbed". A latch keyed only on
+    /// `is_none()` would block Frobbing a *second* pickup the hand sweeps
+    /// onto while squeeze is still held from the first.
+    #[test]
+    fn held_squeeze_sweeping_onto_a_new_scripted_pickup_frobs_it_too() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let first = scripted_world_pickup_at(&mut world, &mut physics, vec3(0.0, 0.0, -0.5));
+        let second = scripted_world_pickup_at(&mut world, &mut physics, vec3(1.0, 0.0, -0.5));
+
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+
+        let (hand, effects) = handle_empty_hand_state(
+            Handedness::Right,
+            Vector3::zero(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            None,
+            &world,
+            &physics,
+            &input,
+            None,
+        );
+        assert_eq!(
+            frob_message_count(&effects),
+            1,
+            "the first pickup should be Frobbed"
+        );
+        assert_eq!(hand.last_frobbed_entity, Some(first));
+
+        // Squeeze never releases, but the hand sweeps sideways onto a second
+        // pickup.
+        let (_, effects) = handle_empty_hand_state(
+            Handedness::Right,
+            vec3(1.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            hand.last_frobbed_entity,
+            &world,
+            &physics,
+            &input,
+            None,
+        );
+        let frobbed_second = effects.iter().any(|effect| {
+            matches!(
+                effect,
+                VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    }
+                } if *to == second
+            )
+        });
+        assert!(
+            frobbed_second,
+            "a new target under the hand must be Frobbed even though squeeze never released, got {effects:?}"
         );
     }
 }

--- a/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
@@ -19,6 +19,15 @@ import { clickUiElement } from "./helpers/ui.js";
 // opens the replicator and a Chips click creates collectible template -92, but
 // the panel exposes neither authored prices nor the carried balance and the
 // both real StackCount entities remain unchanged at 250 + 20.
+//
+// Since #1118, every world nanite pickup collects straight into the player
+// stat rather than a carried StackCount entity, so this scenario (built on
+// ordinary world pickups) only ever spends from the stat - it can no longer
+// reach the legacy stat-then-carried-stack crossing that
+// script_util::debit_player_nanites also handles (pre-existing saves,
+// panel-taken piles). That crossing, including a carried stack that lands on
+// exactly zero and must be destroyed, is covered at the unit level instead:
+// script_util::tests::live_nanite_debit_crosses_from_the_stat_into_a_carried_stack_and_exhausts_it.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const EARTH_NANITES = 257;
@@ -161,8 +170,8 @@ test(
       19,
       "successful purchases should each deduct exactly their authored price",
     );
-    const inventoryAfterCrossStackPayment = await game.player.inventory();
-    const remainingNanites = inventoryAfterCrossStackPayment.items.filter(
+    const inventoryAfterStatPayment = await game.player.inventory();
+    const remainingNanites = inventoryAfterStatPayment.items.filter(
       (item) => item.name?.toLowerCase().includes("nanite"),
     );
     assert.equal(
@@ -177,7 +186,7 @@ test(
     );
     assert.deepEqual(
       new Set(
-        inventoryAfterCrossStackPayment.items.map((item) => item.entity_id),
+        inventoryAfterStatPayment.items.map((item) => item.entity_id),
       ),
       new Set([dispensedChips.id]),
       "only the physically collected Chips should be carried",

--- a/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
+++ b/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { UiElement, UiPanel } from "../src/types.js";
+import { carriedNaniteTotal } from "./helpers/nanites.js";
 import { teleportVerified } from "./helpers/teleport.js";
 import { clickUiElement } from "./helpers/ui.js";
 
@@ -60,19 +61,6 @@ async function frobCrate(game: GameServer, crateId: number): Promise<void> {
   await game.step({ frames: 3 });
   await game.entities.sendMessage(crateId, { type: "Frob" });
   await game.step({ frames: 5 });
-}
-
-/** Total every carried nanite StackCount exposed through inventory. */
-async function carriedNanites(game: GameServer): Promise<number> {
-  const inventory = await game.player.inventory();
-  let total = 0;
-  for (const item of inventory.items) {
-    if (!item.name?.toLowerCase().includes("nanite")) continue;
-    const detail = await game.entities.detail(item.entity_id);
-    const stack = detail.properties.find((p) => p.name === "StackCount");
-    if (stack) total += Number(stack.value);
-  }
-  return total;
 }
 
 async function containsLinks(game: GameServer, entityId: number) {
@@ -177,7 +165,7 @@ test(
     // pays the authored per-attempt cost. ---
     await game.player.setStats({ cyber_affinity: 6, skills: { hack: 6 } });
     await game.player.spawnItem(BIG_NANITE_PILE);
-    const nanitesBefore = await carriedNanites(game);
+    const nanitesBefore = await carriedNaniteTotal(game);
     assert.ok(nanitesBefore > 0, "the test wallet should hold nanites");
 
     // --- KEY (#811): frobbing the crate opens the shared retail HRM board.
@@ -209,7 +197,7 @@ test(
     // --- Genuinely play the board; the first START charges the cost. ---
     await clickUiElement(game, button(board, "start-hack"));
     assert.equal(
-      await carriedNanites(game),
+      await carriedNaniteTotal(game),
       nanitesBefore - 5,
       "starting a hack should charge exactly the authored cost",
     );

--- a/tools/shock2-sdk/test/helpers/earth-replicator.ts
+++ b/tools/shock2-sdk/test/helpers/earth-replicator.ts
@@ -1,31 +1,10 @@
-import assert from "node:assert/strict";
-
 import type { GameServer } from "../../src/index.js";
 import type { EntitySummary } from "../../src/types.js";
 import { teleportVerified } from "./teleport.js";
 
-/**
- * The player's total spendable nanite balance: the persistent stat balance
- * (world nanite pickups collect straight into it, never inventory) plus any
- * legacy carried nanite StackCount entities exposed through inventory
- * (pre-existing saves, panel-taken piles). Mirrors
- * `script_util::player_nanite_total` on the Rust side.
- */
-export async function carriedNaniteTotal(game: GameServer): Promise<number> {
-  const stat = (await game.info()).player.stats?.nanites ?? 0;
-  const inventory = await game.player.inventory();
-  let total = stat;
-  for (const item of inventory.items) {
-    if (!item.name?.toLowerCase().includes("nanite")) continue;
-    const detail = await game.entities.detail(item.entity_id);
-    const stack = detail.properties.find(
-      (property) => property.name === "StackCount",
-    );
-    assert.ok(stack, `carried nanite entity ${item.entity_id} needs StackCount`);
-    total += Number(stack.value);
-  }
-  return total;
-}
+// Re-exported for existing importers - the balance helper itself is not
+// replicator-specific, so it lives in ./nanites.js alongside stackCount.
+export { carriedNaniteTotal } from "./nanites.js";
 
 /**
  * Stage at Earth Technical Training's clear standing point and physically frob

--- a/tools/shock2-sdk/test/helpers/nanites.ts
+++ b/tools/shock2-sdk/test/helpers/nanites.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+
+import type { GameServer } from "../../src/index.js";
+
+/**
+ * Read the authored `StackCount` property off an entity's `properties` list
+ * (as returned by `game.entities.detail`), if present.
+ */
+export function stackCount(
+  properties: { name: string; value: string }[],
+): number | undefined {
+  const stack = properties.find((property) => property.name === "StackCount");
+  return stack === undefined ? undefined : Number(stack.value);
+}
+
+/**
+ * The player's total spendable nanite balance: the persistent stat balance
+ * (world nanite pickups collect straight into it, never inventory) plus any
+ * legacy carried nanite StackCount entities exposed through inventory
+ * (pre-existing saves, panel-taken piles). Mirrors
+ * `script_util::player_nanite_total` on the Rust side.
+ */
+export async function carriedNaniteTotal(game: GameServer): Promise<number> {
+  const stat = (await game.info()).player.stats?.nanites ?? 0;
+  const inventory = await game.player.inventory();
+  let total = stat;
+  for (const item of inventory.items) {
+    if (!item.name?.toLowerCase().includes("nanite")) continue;
+    const detail = await game.entities.detail(item.entity_id);
+    const stack = stackCount(detail.properties);
+    assert.ok(stack !== undefined, `carried nanite entity ${item.entity_id} needs StackCount`);
+    total += stack;
+  }
+  return total;
+}

--- a/tools/shock2-sdk/test/nanite-player-stat.e2e.test.ts
+++ b/tools/shock2-sdk/test/nanite-player-stat.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import { stackCount as rawStackCount } from "./helpers/nanites.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
@@ -12,9 +13,9 @@ const FROB_PILE_OBJ = 257;
 const SQUEEZE_PILE_OBJ = 292;
 
 function stackCount(properties: { name: string; value: string }[]): number {
-  const stack = properties.find((property) => property.name === "StackCount");
-  assert.ok(stack, "expected an authored StackCount");
-  return Number(stack.value);
+  const stack = rawStackCount(properties);
+  assert.ok(stack !== undefined, "expected an authored StackCount");
+  return stack;
 }
 
 test(

--- a/tools/shock2-sdk/test/nanite-stack-label.e2e.test.ts
+++ b/tools/shock2-sdk/test/nanite-stack-label.e2e.test.ts
@@ -2,13 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { stackCount } from "./helpers/nanites.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-
-function stackCount(properties: { name: string; value: string }[]): number | undefined {
-  const stack = properties.find((property) => property.name === "StackCount");
-  return stack === undefined ? undefined : Number(stack.value);
-}
 
 test(
   "Earth nanite world-label visual smoke preserves the authored stack",


### PR DESCRIPTION
## Summary

Fast-follow addressing an adversarial cross-review of #1118 ("collect nanites
as a player stat"). Findings and disposition:

**High — economy dupe**
- `internal_nanites_script.rs`: added a `collected: bool` latch. Effects apply
  after the whole message batch, so two Frobs in one batch (both hands
  squeezing the same pile, or trigger+squeeze across hands) awarded nanites
  twice while only destroying the pile once. Fixed. Negative-first unit test.
- `virtual_hand.rs`: the trigger-idle branch cleared the frob latch
  unconditionally, so a held squeeze re-Frobbed the same entity every frame it
  survived. Fixed by only clearing when neither trigger nor squeeze is
  engaged. Negative-first unit test. (A follow-up xreview pass then found the
  fix over-corrected - see below.)

**Medium**
- `entity_creator.rs`: nanite piles inherit `MOVE` frob info, so they also got
  `internal_frob_move` alongside `internal_nanites` - two competing Frob
  handlers on one Frob. Excluded nanite piles from `needs_frob_move`.
- Unified the "is this a nanite pile" predicate
  (`script_util::is_nanite_pile_template`) consumed by both
  `mission::entity_creator` and `script_util::is_nanite_pickup` (previously
  two independent ancestry walks that could silently drift). Folded nanite
  routing into `virtual_hand::uses_scripted_world_frob` so flat's `pick_up()`
  drops its `|| is_nanite_pickup` bolt-on and VR's squeeze branch consults the
  same predicate as flat (this also moves VR-squeeze keycards from a physical
  grab to Frob, matching flat's existing behavior - noted, not separately
  re-verified in VR beyond the unit-level routing tests).
- `earth-replicator-economy.e2e.test.ts`: the legacy cross-stack payment
  invariant (`player_nanite_payment_plan` crossing from the stat into a
  carried `StackCount` entity, and destroying one that lands on exactly zero)
  is no longer reachable via ordinary world pickups, since every world nanite
  pickup now collects straight into the stat. Restoring it via debug-spawned
  piles would mean landing an exact zero-out against fixed authored prices
  (3/4/40) and fixed pile sizes (10/20/50) - fragile for little gain over a
  controlled test. Instead: renamed the now-misleading
  `inventoryAfterCrossStackPayment` variable, documented the gap in the file's
  header comment, and added
  `live_nanite_debit_crosses_from_the_stat_into_a_carried_stack_and_exhausts_it`,
  a unit test exercising the same `debit_player_nanites` call the replicator's
  `Effect::ReplicatorPurchase` handler makes, end-to-end with both a stat
  balance and a carried stack present.
- `hackable-crate.e2e.test.ts`: its private `carriedNanites` summed
  inventory-only, stale since nanites are no longer carried in inventory.
  Deleted it and switched to the shared `carriedNaniteTotal` (stat + carried).

**Low**
- `player_nanite_total`: `saturating_add` the stat+carried sum.
- `debit_player_nanites`: moved the stat debit relative to the stack-mutation
  loop for atomicity, then a follow-up xreview pass found the reorder had
  just swapped which half could be left half-applied on a late bail - fixed
  properly by acquiring every fallible borrow (stacks *and* `QuestInfo`)
  before any mutation.
- Extracted the repeated "stat first, then legacy-stack remainder" split into
  `stat_first_split`, shared by both spend paths; dropped the dead `.max(0)`
  in the initial extraction, then restored it after xreview flagged that a
  corrupt/negative stat balance would otherwise overcharge carried stacks.
- Deduped test scaffolding: widened `world_with_stat_nanites` into
  `world_with_stat_and_carried_nanites` for the two `script_util` tests that
  pasted the same carried-stack+`PlayerInfo` setup; moved the e2e
  `stackCount(properties)` helper (two copies) and `carriedNaniteTotal`
  (previously replicator-scoped, not actually replicator-specific) into a
  neutral `tools/shock2-sdk/test/helpers/nanites.ts`.

**Post-fix xreview pass** (Claude adversarial subagent + a dedicated de-dup
pass; Codex CLI hit its usage limit and was unavailable) caught two more real
issues, both fixed and re-verified:
- The squeeze/trigger frob latch was keyed on "something was frobbed"
  (`is_none()`), not on *which* entity - a held squeeze sweeping from pickup A
  onto pickup B would latch on A and silently refuse to Frob B until release.
  Keyed the latch by entity instead; added a negative-first regression
  (verified failing pre-fix) and gave the test fixture a real `PropFrobInfo`
  so the grab-vs-Frob branch is genuinely exercised.
- `is_nanite_pile_template` duplicated
  `GlobalTemplateHierarchy::is_or_descends_from`'s ancestry check instead of
  sharing it (flagged independently by both reviewers). Extracted a shared
  `mission_core::template_is_or_descends_from` free function that both now
  call.

Two minor de-dup findings were left alone as out of scope: a near-identical
test fixture shared with `gui::replicator`'s own test (different module,
different entity shape), and pre-existing `stackCount` copies in TS files this
branch never touched.

## Test plan

- [x] `cargo test -p shock2vr --lib` - 941 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` - clean
- [x] `cargo fmt --check` - clean
- [x] `npm test` (fast unit tests, tools/shock2-sdk) - 26 passed, 0 failed
- [x] `SHOCK2_E2E=1` `nanite-player-stat.e2e.test.ts` - pass
- [x] `SHOCK2_E2E=1` `earth-replicator-economy.e2e.test.ts` - pass
- [x] `SHOCK2_E2E=1` `earth-replicator-hacking.e2e.test.ts` - pass
- [x] `SHOCK2_E2E=1` `hackable-crate.e2e.test.ts` - pass
- [x] `SHOCK2_E2E=1` `missions.e2e.test.ts` - all 23 missions load

No visible/rendering change, so pr-visuals was not run.


## Visual evidence

The stat-only change here has no HUD widget (per #1118, nanites are tracked as
a player stat with no on-screen counter), so this captures the debug runtime's
`player.stats.nanites` value burned into the frame with PIL - same technique
`pr-visuals` skill used for #1118.

![nanite collection](https://gist.githubusercontent.com/tommy-xr/a4a60ef71a14209bda3a9b1e7b1afac0/raw/demo.gif)

<sub>Frobbing two nanite piles in earth.mis (Medium Nanite Pile, stack 20; Big
Nanite Pile, stack 250) via the debug runtime's `/v1/entities/:id/message`
endpoint. `player.stats.nanites` goes 0 -> 20 -> 270 - each pile awards its
stack exactly once. Captured headlessly (`/v1/step` + `/v1/screenshot`,
deterministic fixed-timestep).</sub>

### Before-state (pre-#1118-review-fix) repro attempt

The bug this PR hardens against is a same-batch double-Frob race: two `Frob`
messages landing in `InternalNanitesScript::handle_message` before the first's
`DestroyEntity` effect applies (effects apply only after the whole message
batch - see the updated doc comment on `InternalNanitesScript`). I built the
pre-fix binary at 994041cd (the #1118 merge commit, before this PR's
`collected` latch) and tried several ways to force two `Frob`s into the same
batch via the debug HTTP API:

- Two sequential `POST /v1/entities/:id/message {"type":"Frob"}` calls with no
  `/v1/step` between them.
- The same two calls fired concurrently (backgrounded, and 4-way parallel).
- Driving both VR hands' `squeeze`/`trigger` input channels at a pile in one
  `/v1/step` (the real in-game path: `VrInteraction::update` runs the right
  hand then the left hand in one `game.update()` call, so two hands squeezing
  the same pile in one frame is the scenario `a_second_frob_in_the_same_batch_awards_nothing_more`
  was written to pin) - the debug runtime's own request-handling loop appears
  to drain and apply the message queue opportunistically between HTTP round
  trips (observed via server logs: the award+destroy for a single `Frob`
  logged before a *second*, concurrently-fired `Frob` request even reached the
  server), so a genuine same-batch double-dispatch via this API could not be
  landed reliably on either the before or after binary in several honest
  attempts.

Because the pre-fix race could not be reproduced externally through the debug
HTTP API, no fabricated "double award" before/after clip is included here.
The regression is instead pinned by a negative-first unit test added in this
PR:

`shock2vr/src/scripts/internal_nanites_script.rs::tests::a_second_frob_in_the_same_batch_awards_nothing_more`
(asserts a second `Frob` delivered to the same script instance in the same
batch awards nothing further and returns `Effect::NoEffect`, confirmed to fail
without the `collected` latch and pass with it).

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72
