### PR TITLE
feat(camera): death-camera seam resolved once for every runtime

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -27,9 +27,7 @@ extern crate glfw;
 use self::glfw::{Context, WindowEvent};
 use cgmath::{Quaternion, Rotation3, vec2, vec3};
 use dark::SCALE_FACTOR;
-use engine::{
-    EngineRenderContext, profile, scene::Scene, util::compute_view_matrix_from_render_context,
-};
+use engine::{profile, scene::Scene, util::compute_view_matrix_from_render_context};
 use shock2vr::{
     Game, GameOptions, SpawnLocation,
     input::{InputAction, InputActionState, remote as remote_input},
@@ -790,29 +788,22 @@ fn run_game_blocking(
         // player is dying the game blends this tracked pose toward the fallen
         // death pose, once, for every runtime (see `shock2vr::death_camera`).
         // Alive, it hands back exactly what went in.
-        let camera = game.resolve_camera(
-            pawn_offset,
-            pawn_rotation,
-            // Crouch-aware eye height, shared with desktop and the flat
-            // controller via Game::player_eye_height, so the debug-runtime
-            // camera sits at the same height as desktop and shots land on the
-            // crosshair.
-            vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
-            // Same head rotation fed to game.update, so the rendered view and the
-            // flat viewmodel agree. Controllable via `/v1/control/input` head.look.
-            current_input.head.rotation,
-        );
-
-        // Create a simple render context for debug view
-        let render_context = EngineRenderContext {
-            time: actual_game_time, // Use accumulated game time, not real time
-            camera_offset: camera.pawn_position,
-            camera_rotation: camera.pawn_rotation,
-            head_offset: camera.head_offset,
-            head_rotation: camera.head_rotation,
-            projection_matrix,
-            screen_size,
-        };
+        let render_context = game
+            .resolve_camera(
+                pawn_offset,
+                pawn_rotation,
+                // Crouch-aware eye height, shared with desktop and the flat
+                // controller via Game::player_eye_height, so the debug-runtime
+                // camera sits at the same height as desktop and shots land on
+                // the crosshair.
+                vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
+                // Same head rotation fed to game.update, so the rendered view
+                // and the flat viewmodel agree. Controllable via
+                // `/v1/control/input` head.look.
+                current_input.head.rotation,
+            )
+            // Accumulated game time, not real time.
+            .into_render_context(actual_game_time, projection_matrix, screen_size);
 
         let view = compute_view_matrix_from_render_context(&render_context);
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -786,19 +786,30 @@ fn run_game_blocking(
 
         let (mut scene, pawn_offset, pawn_rotation) = profile!("game.render", game.render());
 
-        // Create a simple render context for debug view
-        let render_context = EngineRenderContext {
-            time: actual_game_time, // Use accumulated game time, not real time
-            camera_offset: pawn_offset,
-            camera_rotation: pawn_rotation,
+        // Routed through `resolve_camera` rather than used directly: while the
+        // player is dying the game blends this tracked pose toward the fallen
+        // death pose, once, for every runtime (see `shock2vr::death_camera`).
+        // Alive, it hands back exactly what went in.
+        let camera = game.resolve_camera(
+            pawn_offset,
+            pawn_rotation,
             // Crouch-aware eye height, shared with desktop and the flat
             // controller via Game::player_eye_height, so the debug-runtime
             // camera sits at the same height as desktop and shots land on the
             // crosshair.
-            head_offset: vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
+            vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
             // Same head rotation fed to game.update, so the rendered view and the
             // flat viewmodel agree. Controllable via `/v1/control/input` head.look.
-            head_rotation: current_input.head.rotation,
+            current_input.head.rotation,
+        );
+
+        // Create a simple render context for debug view
+        let render_context = EngineRenderContext {
+            time: actual_game_time, // Use accumulated game time, not real time
+            camera_offset: camera.pawn_position,
+            camera_rotation: camera.pawn_rotation,
+            head_offset: camera.head_offset,
+            head_rotation: camera.head_rotation,
             projection_matrix,
             screen_size,
         };

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -490,23 +490,14 @@ pub fn main() {
         // player is dying the game blends this tracked pose toward the fallen
         // death pose, once, for every runtime (see `shock2vr::death_camera`).
         // Alive, it hands back exactly what went in.
-        let camera = game.resolve_camera(
-            pawn_offset,
-            pawn_rotation,
-            vec3(0.0, head_height / SCALE_FACTOR, 0.0),
-            camera_rotation(&camera_context),
-        );
-        let render_context = engine::EngineRenderContext {
-            time: glfw.get_time() as f32,
-            camera_offset: camera.pawn_position,
-            camera_rotation: camera.pawn_rotation,
-
-            head_offset: camera.head_offset,
-            head_rotation: camera.head_rotation,
-
-            projection_matrix,
-            screen_size,
-        };
+        let render_context = game
+            .resolve_camera(
+                pawn_offset,
+                pawn_rotation,
+                vec3(0.0, head_height / SCALE_FACTOR, 0.0),
+                camera_rotation(&camera_context),
+            )
+            .into_render_context(glfw.get_time() as f32, projection_matrix, screen_size);
 
         let view = compute_view_matrix_from_render_context(&render_context);
         let per_eye_scene = profile!(

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -486,13 +486,23 @@ pub fn main() {
         // is refused without headroom), so the camera can't rise through a
         // ceiling the body still crouches under.
         let head_height = game.player_eye_height();
+        // Routed through `resolve_camera` rather than used directly: while the
+        // player is dying the game blends this tracked pose toward the fallen
+        // death pose, once, for every runtime (see `shock2vr::death_camera`).
+        // Alive, it hands back exactly what went in.
+        let camera = game.resolve_camera(
+            pawn_offset,
+            pawn_rotation,
+            vec3(0.0, head_height / SCALE_FACTOR, 0.0),
+            camera_rotation(&camera_context),
+        );
         let render_context = engine::EngineRenderContext {
             time: glfw.get_time() as f32,
-            camera_offset: pawn_offset,
-            camera_rotation: pawn_rotation,
+            camera_offset: camera.pawn_position,
+            camera_rotation: camera.pawn_rotation,
 
-            head_offset: vec3(0.0, head_height / SCALE_FACTOR, 0.0),
-            head_rotation: camera_rotation(&camera_context),
+            head_offset: camera.head_offset,
+            head_rotation: camera.head_rotation,
 
             projection_matrix,
             screen_size,

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -1625,13 +1625,19 @@ fn render_swapchain(
     );
     let projection_matrix = create_projection_matrix(&view.fov, 0.1, 1000.);
     let screen_size = vec2(width as f32, height as f32);
+    // Routed through `resolve_camera` rather than used directly: while the
+    // player is dying the game blends this tracked pose toward the fallen death
+    // pose, once, for every runtime (see `shock2vr::death_camera`) - so the fall
+    // reads the same in VR as it does flat. Alive, it hands back exactly what
+    // went in, per eye.
+    let camera = game.resolve_camera(camera_pos, camera_rot, head_offset, head_rotation);
     let render_context = engine::EngineRenderContext {
         time,
-        camera_offset: camera_pos,
-        camera_rotation: camera_rot,
+        camera_offset: camera.pawn_position,
+        camera_rotation: camera.pawn_rotation,
 
-        head_offset,
-        head_rotation,
+        head_offset: camera.head_offset,
+        head_rotation: camera.head_rotation,
 
         projection_matrix,
 

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -1185,7 +1185,7 @@ fn main() {
             (views[0].pose.position.y + views[1].pose.position.y) / 2.0,
             (views[0].pose.position.z + views[1].pose.position.z) / 2.0,
         );
-        let (left_eye_elapsed, _, left_rendered_pose) = render_swapchain(
+        let (left_eye_elapsed, _) = render_swapchain(
             &mut game,
             &engine,
             camera_pos,
@@ -1198,7 +1198,7 @@ fn main() {
             &scene,
             false,
         );
-        let (right_eye_elapsed, finish_elapsed, right_rendered_pose) = render_swapchain(
+        let (right_eye_elapsed, finish_elapsed) = render_swapchain(
             &mut game,
             &engine,
             camera_pos,
@@ -1239,21 +1239,31 @@ fn main() {
             xr_frame_state.predicted_display_time,
             environment_blend_mode,
             &[
-                // The RENDERED pose, not the tracked one. Late-stage
-                // reprojection corrects a submitted frame in the frame of the
-                // pose it was told the frame came from, so while the death
-                // camera holds the view rolled and displaced away from the
-                // tracked head, submitting `views[i].pose` would have the
-                // compositor shear every reprojected frame about the wrong
-                // axis - judder exactly when the discrepancy is largest. Alive,
-                // these are the tracked poses round-tripped unchanged.
+                // The TRACKED pose, even while the death camera is rendering
+                // from somewhere else entirely. This looks like a bug and is
+                // not: reprojection warps a submitted frame toward the real
+                // head pose at display time, so declaring "this frame was
+                // rendered from down on the floor, on its side" makes the
+                // compositor correct out precisely the displacement the death
+                // camera just introduced. Measured on a Quest 3: submitting the
+                // rendered pose drags the image out of the display frustum and
+                // the fraction of non-black pixels falls 0.83 -> 0.00 (left)
+                // and 0.13 (right) as the fall lands, then holds there for the
+                // whole death window - a black screen for the entire death.
+                // With the tracked pose the same death renders correctly
+                // (0.74-0.75, symmetric, holds to game-over).
+                //
+                // The cost is a small reprojection seam at the image edge
+                // during the 0.9 s fall, when rendered and tracked poses
+                // disagree most. That is the accepted trade: a fraction of a
+                // second of edge artifact, against a three-second blackout.
                 &xr::CompositionLayerProjection::new().space(&stage).views(&[
                     xr::CompositionLayerProjectionView::new()
-                        .pose(left_rendered_pose)
+                        .pose(views[0].pose)
                         .fov(views[0].fov)
                         .sub_image(sub1),
                     xr::CompositionLayerProjectionView::new()
-                        .pose(right_rendered_pose)
+                        .pose(views[1].pose)
                         .fov(views[1].fov)
                         .sub_image(sub2),
                 ]),
@@ -1602,7 +1612,7 @@ fn render_swapchain(
     _log: bool,
     scene: &Vec<SceneObject>,
     is_last: bool,
-) -> (Duration, Duration, xr::Posef) {
+) -> (Duration, Duration) {
     let eye_started = Instant::now();
     let mut xr_swapchain = swapchain.handle.borrow_mut();
     let image_index1 = xr_swapchain.acquire_image().unwrap();
@@ -1712,40 +1722,7 @@ fn render_swapchain(
     (
         eye_started.elapsed().saturating_sub(finish_elapsed),
         finish_elapsed,
-        // The pose this eye was ACTUALLY rendered from, back in stage space, so
-        // the compositor is told the truth (see the layer submission).
-        xr::Posef {
-            position: to_xr_vector(pawn_to_stage(
-                camera.head_offset,
-                game.player_center_above_floor(),
-            )),
-            orientation: to_xr_quaternion(camera.head_rotation),
-        },
     )
-}
-
-/// Inverse of [`stage_to_pawn`]: a pawn-space position back into the stage
-/// space the compositor's layer poses are expressed in.
-fn pawn_to_stage(position_pawn: Vector3<f32>, center_above_floor: f32) -> Vector3<f32> {
-    (position_pawn + vec3(0.0, center_above_floor, 0.0)) * shock2vr::METERS_PER_WORLD_UNIT
-        - vec3(0.0, stage_offset_meters(), 0.0)
-}
-
-fn to_xr_vector(v: Vector3<f32>) -> xr::Vector3f {
-    xr::Vector3f {
-        x: v.x,
-        y: v.y,
-        z: v.z,
-    }
-}
-
-fn to_xr_quaternion(q: Quaternion<f32>) -> xr::Quaternionf {
-    xr::Quaternionf {
-        x: q.v.x,
-        y: q.v.y,
-        z: q.v.z,
-        w: q.s,
-    }
 }
 
 const VIEW_TYPE: xr::ViewConfigurationType = xr::ViewConfigurationType::PRIMARY_STEREO;

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -1178,7 +1178,14 @@ fn main() {
 
         // Render to each eye
         let time = now.elapsed().as_secs_f32();
-        let (left_eye_elapsed, _) = render_swapchain(
+        // The midpoint of the two eyes: what the death camera resolves from, so
+        // it cannot pull the eyes together (see `render_swapchain`).
+        let head_centre_stage = vec3(
+            (views[0].pose.position.x + views[1].pose.position.x) / 2.0,
+            (views[0].pose.position.y + views[1].pose.position.y) / 2.0,
+            (views[0].pose.position.z + views[1].pose.position.z) / 2.0,
+        );
+        let (left_eye_elapsed, _, left_rendered_pose) = render_swapchain(
             &mut game,
             &engine,
             camera_pos,
@@ -1186,11 +1193,12 @@ fn main() {
             &swapchain[0],
             time,
             &views[0],
+            head_centre_stage,
             true,
             &scene,
             false,
         );
-        let (right_eye_elapsed, finish_elapsed) = render_swapchain(
+        let (right_eye_elapsed, finish_elapsed, right_rendered_pose) = render_swapchain(
             &mut game,
             &engine,
             camera_pos,
@@ -1198,6 +1206,7 @@ fn main() {
             &swapchain[1],
             time,
             &views[1],
+            head_centre_stage,
             true,
             &scene,
             true,
@@ -1230,13 +1239,21 @@ fn main() {
             xr_frame_state.predicted_display_time,
             environment_blend_mode,
             &[
+                // The RENDERED pose, not the tracked one. Late-stage
+                // reprojection corrects a submitted frame in the frame of the
+                // pose it was told the frame came from, so while the death
+                // camera holds the view rolled and displaced away from the
+                // tracked head, submitting `views[i].pose` would have the
+                // compositor shear every reprojected frame about the wrong
+                // axis - judder exactly when the discrepancy is largest. Alive,
+                // these are the tracked poses round-tripped unchanged.
                 &xr::CompositionLayerProjection::new().space(&stage).views(&[
                     xr::CompositionLayerProjectionView::new()
-                        .pose(views[0].pose)
+                        .pose(left_rendered_pose)
                         .fov(views[0].fov)
                         .sub_image(sub1),
                     xr::CompositionLayerProjectionView::new()
-                        .pose(views[1].pose)
+                        .pose(right_rendered_pose)
                         .fov(views[1].fov)
                         .sub_image(sub2),
                 ]),
@@ -1579,10 +1596,13 @@ fn render_swapchain(
     swapchain: &Swapchain,
     time: f32,
     view: &xr::View,
+    // Midpoint of the two eyes in STAGE space. The death camera resolves from
+    // the head centre, never per eye - see the comment on `camera` below.
+    head_centre_stage: Vector3<f32>,
     _log: bool,
     scene: &Vec<SceneObject>,
     is_last: bool,
-) -> (Duration, Duration) {
+) -> (Duration, Duration, xr::Posef) {
     let eye_started = Instant::now();
     let mut xr_swapchain = swapchain.handle.borrow_mut();
     let image_index1 = xr_swapchain.acquire_image().unwrap();
@@ -1629,20 +1649,21 @@ fn render_swapchain(
     // player is dying the game blends this tracked pose toward the fallen death
     // pose, once, for every runtime (see `shock2vr::death_camera`) - so the fall
     // reads the same in VR as it does flat. Alive, it hands back exactly what
-    // went in, per eye.
-    let camera = game.resolve_camera(camera_pos, camera_rot, head_offset, head_rotation);
-    let render_context = engine::EngineRenderContext {
-        time,
-        camera_offset: camera.pawn_position,
-        camera_rotation: camera.pawn_rotation,
-
-        head_offset: camera.head_offset,
-        head_rotation: camera.head_rotation,
-
-        projection_matrix,
-
-        screen_size,
-    };
+    // went in.
+    //
+    // Resolved from the HEAD CENTRE, not from this eye. The fallen target is a
+    // single eye-independent point, so resolving per eye would walk both eyes
+    // onto it and collapse the IPD to zero over the fall - a stereo view going
+    // monoscopic while the horizon rolls. Instead the eye's own displacement is
+    // re-applied afterwards, carried into the fallen camera's frame so the eyes
+    // roll with the new horizon rather than staying level with the room.
+    let head_centre_pawn = stage_to_pawn(head_centre_stage, game.player_center_above_floor());
+    let camera = shock2vr::death_camera::reapply_eye_offset(
+        game.resolve_camera(camera_pos, camera_rot, head_centre_pawn, head_rotation),
+        head_offset - head_centre_pawn,
+        head_rotation,
+    );
+    let render_context = camera.into_render_context(time, projection_matrix, screen_size);
 
     let view_matrix = engine::util::compute_view_matrix_from_render_context(&render_context);
     let mut all_scene_objs = game.render_per_eye(view_matrix, projection_matrix, screen_size);
@@ -1691,7 +1712,40 @@ fn render_swapchain(
     (
         eye_started.elapsed().saturating_sub(finish_elapsed),
         finish_elapsed,
+        // The pose this eye was ACTUALLY rendered from, back in stage space, so
+        // the compositor is told the truth (see the layer submission).
+        xr::Posef {
+            position: to_xr_vector(pawn_to_stage(
+                camera.head_offset,
+                game.player_center_above_floor(),
+            )),
+            orientation: to_xr_quaternion(camera.head_rotation),
+        },
     )
+}
+
+/// Inverse of [`stage_to_pawn`]: a pawn-space position back into the stage
+/// space the compositor's layer poses are expressed in.
+fn pawn_to_stage(position_pawn: Vector3<f32>, center_above_floor: f32) -> Vector3<f32> {
+    (position_pawn + vec3(0.0, center_above_floor, 0.0)) * shock2vr::METERS_PER_WORLD_UNIT
+        - vec3(0.0, stage_offset_meters(), 0.0)
+}
+
+fn to_xr_vector(v: Vector3<f32>) -> xr::Vector3f {
+    xr::Vector3f {
+        x: v.x,
+        y: v.y,
+        z: v.z,
+    }
+}
+
+fn to_xr_quaternion(q: Quaternion<f32>) -> xr::Quaternionf {
+    xr::Quaternionf {
+        x: q.v.x,
+        y: q.v.y,
+        z: q.v.z,
+        w: q.s,
+    }
 }
 
 const VIEW_TYPE: xr::ViewConfigurationType = xr::ViewConfigurationType::PRIMARY_STEREO;

--- a/shock2vr/src/death_camera.rs
+++ b/shock2vr/src/death_camera.rs
@@ -1,0 +1,389 @@
+//! The death camera: the fall to the floor that plays when the player dies.
+//!
+//! # Why this lives here and not in the runtimes
+//!
+//! The rendered view is built from two transforms (`engine::util::compute_view_matrix`):
+//!
+//! ```text
+//! view = inv(head_translation * head_rotation) * inv(pawn_translation * pawn_rotation)
+//! ```
+//!
+//! The pawn comes from [`crate::Game::render`], but the *head* is synthesized
+//! per-runtime - the flat runtimes from [`crate::Game::player_eye_height`] plus
+//! their look rotation, `oculus_runtime` from the OpenXR view pose mapped into
+//! pawn space and capped to the collider crown. Three independent producers.
+//!
+//! If each runtime blended the death camera into its own head pose, the fall
+//! would drift between flat and VR exactly the way AGENTS.md section 3 forbids.
+//! So the blend happens once, here, over an already-resolved tracked head pose:
+//! a runtime hands in the head it would have rendered with and gets back the
+//! head it should render with, making no placement decision of its own.
+//!
+//! # What it blends
+//!
+//! Only the *head* component moves. The pawn transform is also the play-space
+//! to world map for the hands and the world-space UI panels
+//! (`Game::render`'s `pawn_to_world`), so dropping the pawn would drag them to
+//! the floor with the camera. Blending the head alone lets the view fall while
+//! the world stays where it is.
+//!
+//! The blend weight is the death pose's authority over the tracked head: at 0
+//! the runtime's tracked pose is untouched (bit-identical passthrough, which is
+//! every frame the player is alive), at 1 the camera is pinned to the fallen
+//! pose.
+
+use cgmath::{InnerSpace, Matrix3, One, Quaternion, Rad, Vector3, VectorSpace, vec3};
+
+/// How long the fall to the floor takes, in seconds. Comfortably inside the
+/// shortest death window it plays in (the 3 s terminal-death sequence), so the
+/// camera is settled before the game-over screen takes over.
+pub const FALL_SECONDS: f32 = 0.9;
+
+/// Where the fallen eye ends up above the floor, in world units. Kept well
+/// clear of the 0.1 world-unit near plane so the floor does not clip through
+/// the camera once it lands.
+const FALLEN_EYE_HEIGHT: f32 = 0.45;
+
+/// How far the eye drifts horizontally as it falls, in world units - the body
+/// toppling over rather than sinking straight down.
+const FALL_LATERAL: f32 = 0.75;
+
+/// An eye pose in pawn space: the same space the runtimes' `head_offset` and
+/// `head_rotation` live in.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EyePose {
+    pub position: Vector3<f32>,
+    pub rotation: Quaternion<f32>,
+}
+
+/// The full camera a runtime renders from, in the terms it hands to
+/// `engine::EngineRenderContext`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CameraPose {
+    pub pawn_position: Vector3<f32>,
+    pub pawn_rotation: Quaternion<f32>,
+    pub head_offset: Vector3<f32>,
+    pub head_rotation: Quaternion<f32>,
+}
+
+/// One frame of the death camera: where the fallen eye sits, and how much
+/// authority it has over the runtime's tracked head pose.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DeathCameraSample {
+    pub eye: EyePose,
+    /// 0 = the tracked head is authoritative, 1 = the fallen eye is.
+    pub weight: f32,
+}
+
+/// The fall itself: a target pose chosen once when the player dies, and the
+/// elapsed time that ramps its authority in.
+///
+/// The fall is expressed purely as a *weight*, never as a remembered start
+/// pose: [`resolve`] blends from whatever the tracked head is doing right now,
+/// so a VR player still moving their head during the fall is carried along
+/// smoothly instead of being snapped to a stale snapshot.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeathCamera {
+    target: EyePose,
+    elapsed_seconds: f32,
+}
+
+impl DeathCamera {
+    /// Choose where this death lands. `live_eye` is the eye pose at the moment
+    /// of death and `floor_y` the pawn-space height of the surface underfoot
+    /// (`-Game::player_center_above_floor()`). `seed` picks the fall direction
+    /// and is the only source of randomness, so a replayed death - a captured
+    /// screenshot sequence, an e2e assertion - falls exactly the same way.
+    pub fn begin(live_eye: EyePose, floor_y: f32, seed: u64) -> Self {
+        let azimuth = Rad(unit_from_seed(seed) * std::f32::consts::TAU);
+        let (sin, cos) = azimuth.0.sin_cos();
+
+        // "Up" ends up pointing along a random horizontal direction: the view
+        // rolls onto its side as the body topples. Forward stays horizontal
+        // (world up crossed with the new up), so the fallen camera looks along
+        // the floor rather than into it.
+        let up = vec3(sin, 0.0, cos);
+        let forward = vec3(cos, 0.0, -sin);
+        let right = forward.cross(up);
+        // `head_rotation` maps head-local axes into pawn space, and cgmath's
+        // camera convention looks down local -Z.
+        let rotation = Quaternion::from(Matrix3::from_cols(right, up, -forward));
+
+        let target = EyePose {
+            position: vec3(
+                live_eye.position.x + up.x * FALL_LATERAL,
+                floor_y + FALLEN_EYE_HEIGHT,
+                live_eye.position.z + up.z * FALL_LATERAL,
+            ),
+            rotation,
+        };
+
+        DeathCamera {
+            target,
+            elapsed_seconds: 0.0,
+        }
+    }
+
+    pub fn advance(&mut self, delta_seconds: f32) {
+        if delta_seconds.is_finite() && delta_seconds > 0.0 {
+            self.elapsed_seconds += delta_seconds;
+        }
+    }
+
+    pub fn sample(&self) -> DeathCameraSample {
+        DeathCameraSample {
+            eye: self.target,
+            weight: ease_in_out(self.elapsed_seconds / FALL_SECONDS),
+        }
+    }
+}
+
+/// Fold the death camera's contribution into the camera a runtime would
+/// otherwise have rendered with.
+///
+/// With no sample - which is every frame the player is alive - this returns the
+/// inputs verbatim, so the alive path is bit-identical to reading the tracked
+/// pose directly.
+pub fn resolve(
+    pawn_position: Vector3<f32>,
+    pawn_rotation: Quaternion<f32>,
+    tracked_head_offset: Vector3<f32>,
+    tracked_head_rotation: Quaternion<f32>,
+    sample: Option<DeathCameraSample>,
+) -> CameraPose {
+    let passthrough = CameraPose {
+        pawn_position,
+        pawn_rotation,
+        head_offset: tracked_head_offset,
+        head_rotation: tracked_head_rotation,
+    };
+
+    let Some(sample) = sample else {
+        return passthrough;
+    };
+    if !sample.weight.is_finite() || sample.weight <= 0.0 {
+        return passthrough;
+    }
+    let weight = sample.weight.min(1.0);
+
+    CameraPose {
+        head_offset: tracked_head_offset.lerp(sample.eye.position, weight),
+        head_rotation: slerp_safe(tracked_head_rotation, sample.eye.rotation, weight),
+        ..passthrough
+    }
+}
+
+/// `Quaternion::slerp` is only defined for unit quaternions and produces NaN
+/// for a degenerate one - which would poison the view matrix and blank the
+/// frame. A zero-length input is treated as "no rotation information", so the
+/// blend falls back to the other end rather than to garbage.
+fn slerp_safe(from: Quaternion<f32>, to: Quaternion<f32>, weight: f32) -> Quaternion<f32> {
+    let normalize = |q: Quaternion<f32>| {
+        if q.magnitude2() > 1.0e-6 {
+            Some(q.normalize())
+        } else {
+            None
+        }
+    };
+    match (normalize(from), normalize(to)) {
+        (Some(from), Some(to)) => from.slerp(to, weight),
+        (None, Some(to)) => to,
+        (Some(from), None) => from,
+        (None, None) => Quaternion::one(),
+    }
+}
+
+/// Smoothstep over the normalized fall. Named rather than inlined so the feel
+/// (a settle bounce at the end) can be tuned in one place.
+fn ease_in_out(t: f32) -> f32 {
+    if !t.is_finite() || t <= 0.0 {
+        return 0.0;
+    }
+    let t = t.min(1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// A deterministic [0, 1) draw from a seed - splitmix64, avalanched and taken
+/// from the high bits. Keeps the fall direction reproducible without pulling a
+/// seedable RNG (and its cargo feature) in for a single number.
+fn unit_from_seed(seed: u64) -> f32 {
+    let mut z = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^= z >> 31;
+    ((z >> 40) as f32) / ((1u32 << 24) as f32)
+}
+
+/// The eye pose a live, upright player renders from, for callers that need a
+/// neutral starting pose (tests, and the death-camera hand-off).
+pub fn upright_eye(eye_height: f32) -> EyePose {
+    EyePose {
+        position: vec3(0.0, eye_height, 0.0),
+        rotation: Quaternion::one(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{AbsDiffEq, Deg, Rotation, Rotation3, Zero};
+
+    fn live_eye() -> EyePose {
+        upright_eye(2.6)
+    }
+
+    fn camera(sample: Option<DeathCameraSample>) -> CameraPose {
+        resolve(
+            vec3(10.0, 1.0, -4.0),
+            Quaternion::from_angle_y(Deg(30.0)),
+            live_eye().position,
+            live_eye().rotation,
+            sample,
+        )
+    }
+
+    #[test]
+    fn no_sample_passes_the_tracked_camera_through_untouched() {
+        let resolved = camera(None);
+        assert_eq!(resolved.pawn_position, vec3(10.0, 1.0, -4.0));
+        assert_eq!(resolved.pawn_rotation, Quaternion::from_angle_y(Deg(30.0)));
+        assert_eq!(resolved.head_offset, live_eye().position);
+        assert_eq!(resolved.head_rotation, live_eye().rotation);
+    }
+
+    #[test]
+    fn a_zero_weight_sample_is_also_an_exact_passthrough() {
+        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let sample = DeathCameraSample {
+            weight: 0.0,
+            ..death.sample()
+        };
+        assert_eq!(camera(Some(sample)), camera(None));
+    }
+
+    #[test]
+    fn a_non_finite_weight_falls_back_to_the_tracked_camera() {
+        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        for weight in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let sample = DeathCameraSample {
+                weight,
+                ..death.sample()
+            };
+            assert_eq!(camera(Some(sample)), camera(None), "weight {weight}");
+        }
+    }
+
+    #[test]
+    fn full_weight_pins_the_head_to_the_fallen_eye() {
+        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let sample = DeathCameraSample {
+            weight: 1.0,
+            ..death.sample()
+        };
+        let resolved = camera(Some(sample));
+        assert!(
+            resolved
+                .head_offset
+                .abs_diff_eq(&sample.eye.position, 1.0e-5)
+        );
+        assert!(
+            resolved
+                .head_rotation
+                .abs_diff_eq(&sample.eye.rotation, 1.0e-5)
+        );
+    }
+
+    #[test]
+    fn the_pawn_transform_is_never_touched() {
+        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        for weight in [0.0, 0.25, 0.5, 1.0] {
+            let resolved = camera(Some(DeathCameraSample {
+                weight,
+                ..death.sample()
+            }));
+            assert_eq!(resolved.pawn_position, vec3(10.0, 1.0, -4.0));
+            assert_eq!(resolved.pawn_rotation, Quaternion::from_angle_y(Deg(30.0)));
+        }
+    }
+
+    #[test]
+    fn the_eye_falls_monotonically_toward_the_floor() {
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let mut previous = camera(Some(death.sample())).head_offset.y;
+        for _ in 0..60 {
+            death.advance(FALL_SECONDS / 60.0);
+            let height = camera(Some(death.sample())).head_offset.y;
+            assert!(
+                height <= previous + 1.0e-5,
+                "{height} rose above {previous}"
+            );
+            previous = height;
+        }
+        assert!(
+            (previous - (-1.6 + FALLEN_EYE_HEIGHT)).abs() < 1.0e-3,
+            "settled at {previous}"
+        );
+    }
+
+    #[test]
+    fn the_weight_saturates_rather_than_overshooting() {
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        death.advance(FALL_SECONDS * 10.0);
+        assert_eq!(death.sample().weight, 1.0);
+    }
+
+    #[test]
+    fn the_fallen_eye_stays_clear_of_the_near_plane() {
+        for seed in 0..64 {
+            let death = DeathCamera::begin(live_eye(), -1.6, seed);
+            assert!(death.sample().eye.position.y > -1.6 + 0.1);
+        }
+    }
+
+    #[test]
+    fn the_fallen_view_lies_on_its_side_looking_along_the_floor() {
+        for seed in 0..64 {
+            let death = DeathCamera::begin(live_eye(), -1.6, seed);
+            let rotation = death.sample().eye.rotation;
+            let up = rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+            let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+            assert!(up.y.abs() < 1.0e-4, "seed {seed}: up is {up:?}");
+            assert!(
+                forward.y.abs() < 1.0e-4,
+                "seed {seed}: forward is {forward:?}"
+            );
+            assert!((rotation.magnitude() - 1.0).abs() < 1.0e-4, "seed {seed}");
+        }
+    }
+
+    #[test]
+    fn the_fall_direction_is_seeded_and_reproducible() {
+        let a = DeathCamera::begin(live_eye(), -1.6, 11);
+        let b = DeathCamera::begin(live_eye(), -1.6, 11);
+        assert_eq!(a, b);
+
+        let directions: Vec<f32> = (0..32)
+            .map(|seed| DeathCamera::begin(live_eye(), -1.6, seed).target.position.x)
+            .collect();
+        let spread = directions.iter().cloned().fold(f32::MIN, f32::max).max(0.0)
+            - directions.iter().cloned().fold(f32::MAX, f32::min).min(0.0);
+        assert!(spread > FALL_LATERAL, "fall directions barely vary");
+    }
+
+    #[test]
+    fn a_degenerate_tracked_rotation_does_not_poison_the_blend() {
+        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let resolved = resolve(
+            Vector3::zero(),
+            Quaternion::one(),
+            Vector3::zero(),
+            Quaternion::zero(),
+            Some(DeathCameraSample {
+                weight: 0.5,
+                ..death.sample()
+            }),
+        );
+        assert!(resolved.head_rotation.magnitude().is_finite());
+        assert!((resolved.head_rotation.magnitude() - 1.0).abs() < 1.0e-4);
+    }
+}

--- a/shock2vr/src/death_camera.rs
+++ b/shock2vr/src/death_camera.rs
@@ -31,8 +31,22 @@
 //! the runtime's tracked pose is untouched (bit-identical passthrough, which is
 //! every frame the player is alive), at 1 the camera is pinned to the fallen
 //! pose.
+//!
+//! # Stereo
+//!
+//! [`resolve`] takes the head *centre*, not a per-eye pose. A stereo runtime
+//! renders two eyes displaced from that centre by half the IPD, and the fallen
+//! target is a single eye-independent point - so blending each eye toward it
+//! directly would converge them, shrinking the IPD to zero over the fall and
+//! leaving the settled corpse view monoscopic. A depth cue dissolving under you
+//! is its own discomfort trigger, on top of losing stereo exactly when the view
+//! is most disorienting. So VR resolves once from the centre and re-applies its
+//! eye offset with [`reapply_eye_offset`], which rotates with the camera so the
+//! eyes stay level with the fallen horizon.
 
-use cgmath::{InnerSpace, Matrix3, One, Quaternion, Rad, Vector3, VectorSpace, vec3};
+use cgmath::{
+    InnerSpace, Matrix3, Matrix4, One, Quaternion, Rotation, Vector2, Vector3, VectorSpace, vec3,
+};
 
 /// How long the fall to the floor takes, in seconds. Comfortably inside the
 /// shortest death window it plays in (the 3 s terminal-death sequence), so the
@@ -66,6 +80,30 @@ pub struct CameraPose {
     pub head_rotation: Quaternion<f32>,
 }
 
+impl CameraPose {
+    /// Build the render context a runtime submits for this camera. The four
+    /// fields of a `CameraPose` *are* the first four of an
+    /// `EngineRenderContext`, and every runtime pairs them with the same three
+    /// per-frame values, so the unpack lives here once rather than being
+    /// retyped (and drifting) in each runtime.
+    pub fn into_render_context(
+        self,
+        time: f32,
+        projection_matrix: Matrix4<f32>,
+        screen_size: Vector2<f32>,
+    ) -> engine::EngineRenderContext {
+        engine::EngineRenderContext {
+            time,
+            camera_offset: self.pawn_position,
+            camera_rotation: self.pawn_rotation,
+            head_offset: self.head_offset,
+            head_rotation: self.head_rotation,
+            projection_matrix,
+            screen_size,
+        }
+    }
+}
+
 /// One frame of the death camera: where the fallen eye sits, and how much
 /// authority it has over the runtime's tracked head pose.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -95,15 +133,18 @@ impl DeathCamera {
     /// and is the only source of randomness, so a replayed death - a captured
     /// screenshot sequence, an e2e assertion - falls exactly the same way.
     pub fn begin(live_eye: EyePose, floor_y: f32, seed: u64) -> Self {
-        let azimuth = Rad(unit_from_seed(seed) * std::f32::consts::TAU);
-        let (sin, cos) = azimuth.0.sin_cos();
-
-        // "Up" ends up pointing along a random horizontal direction: the view
-        // rolls onto its side as the body topples. Forward stays horizontal
-        // (world up crossed with the new up), so the fallen camera looks along
-        // the floor rather than into it.
-        let up = vec3(sin, 0.0, cos);
-        let forward = vec3(cos, 0.0, -sin);
+        // The body topples SIDEWAYS from where the player was looking, rather
+        // than onto a freely random heading: whatever killed you stays in
+        // frame while you go down. A random heading reads as the view being
+        // yanked away from the fight, and hides the one thing the player most
+        // wants to see. The seed picks which side you fall on - that is the
+        // randomness, and it is what keeps two deaths from looking identical.
+        let forward = death_facing(live_eye.rotation);
+        let side = if seed_is_left(seed) { 1.0 } else { -1.0 };
+        // Up leaves world-up for the horizontal perpendicular to the gaze: the
+        // view rolls onto its side. Forward stays horizontal, so the fallen
+        // camera looks along the floor rather than into it.
+        let up = vec3(-forward.z, 0.0, forward.x) * side;
         let right = forward.cross(up);
         // `head_rotation` maps head-local axes into pawn space, and cgmath's
         // camera convention looks down local -Z.
@@ -193,25 +234,62 @@ fn slerp_safe(from: Quaternion<f32>, to: Quaternion<f32>, weight: f32) -> Quater
     }
 }
 
-/// Smoothstep over the normalized fall. Named rather than inlined so the feel
-/// (a settle bounce at the end) can be tuned in one place.
+/// The fall's ease over its normalized duration. Named rather than inlined so
+/// the feel (a settle bounce at the end) can be tuned in one place.
 fn ease_in_out(t: f32) -> f32 {
-    if !t.is_finite() || t <= 0.0 {
-        return 0.0;
-    }
-    let t = t.min(1.0);
-    t * t * (3.0 - 2.0 * t)
+    crate::util::smoothstep(t)
 }
 
-/// A deterministic [0, 1) draw from a seed - splitmix64, avalanched and taken
-/// from the high bits. Keeps the fall direction reproducible without pulling a
-/// seedable RNG (and its cargo feature) in for a single number.
-fn unit_from_seed(seed: u64) -> f32 {
+/// Which side the body falls on, from the seed - splitmix64 avalanched down to
+/// its top bit. A seedable RNG (and its cargo feature) would be a lot of
+/// machinery for one coin flip.
+fn seed_is_left(seed: u64) -> bool {
     let mut z = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
     z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
     z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
     z ^= z >> 31;
-    ((z >> 40) as f32) / ((1u32 << 24) as f32)
+    z >> 63 == 1
+}
+
+/// The horizontal direction the player was facing when they died. A gaze that
+/// is straight up or down (or an untracked head) has no horizontal component to
+/// fall away from, so it falls back to the pawn's forward axis rather than
+/// normalizing a zero vector into NaN.
+fn death_facing(head_rotation: Quaternion<f32>) -> Vector3<f32> {
+    let fallback = vec3(0.0, 0.0, -1.0);
+    let Some(rotation) = crate::util::tracked_rotation(head_rotation) else {
+        return fallback;
+    };
+    let gaze = rotation.rotate_vector(fallback);
+    let flat = vec3(gaze.x, 0.0, gaze.z);
+    if flat.magnitude2() < 1.0e-6 {
+        fallback
+    } else {
+        flat.normalize()
+    }
+}
+
+/// Re-apply a stereo eye's displacement from the head centre to a resolved
+/// camera, so the two eyes keep their separation through the fall instead of
+/// converging on one point (see the module's Stereo section).
+///
+/// `eye_offset_from_centre` is the eye's displacement in the same space the
+/// tracked head pose was given in; it is carried into the resolved camera's
+/// frame so the eyes roll with the fallen horizon rather than staying level
+/// with the room.
+pub fn reapply_eye_offset(
+    camera: CameraPose,
+    eye_offset_from_centre: Vector3<f32>,
+    tracked_head_rotation: Quaternion<f32>,
+) -> CameraPose {
+    let Some(tracked) = crate::util::tracked_rotation(tracked_head_rotation) else {
+        return camera;
+    };
+    let in_head_space = tracked.invert().rotate_vector(eye_offset_from_centre);
+    CameraPose {
+        head_offset: camera.head_offset + camera.head_rotation.rotate_vector(in_head_space),
+        ..camera
+    }
 }
 
 /// The eye pose a live, upright player renders from, for callers that need a
@@ -362,12 +440,140 @@ mod tests {
         let b = DeathCamera::begin(live_eye(), -1.6, 11);
         assert_eq!(a, b);
 
-        let directions: Vec<f32> = (0..32)
-            .map(|seed| DeathCamera::begin(live_eye(), -1.6, seed).target.position.x)
-            .collect();
-        let spread = directions.iter().cloned().fold(f32::MIN, f32::max).max(0.0)
-            - directions.iter().cloned().fold(f32::MAX, f32::min).min(0.0);
-        assert!(spread > FALL_LATERAL, "fall directions barely vary");
+        // The seed is a coin flip over which side the body lands on, and both
+        // sides have to come up - a seed that always fell the same way would
+        // make every death look identical.
+        let sides: Vec<bool> = (0..32).map(seed_is_left).collect();
+        assert!(sides.iter().any(|&left| left), "never falls left");
+        assert!(sides.iter().any(|&left| !left), "never falls right");
+    }
+
+    #[test]
+    fn the_body_topples_sideways_so_the_killer_stays_in_frame() {
+        // Looking along +X when killed.
+        let facing = Quaternion::from_angle_y(Deg(-90.0));
+        let eye = EyePose {
+            position: vec3(0.0, 2.6, 0.0),
+            rotation: facing,
+        };
+        for seed in 0..32 {
+            let death = DeathCamera::begin(eye, -1.6, seed);
+            let gaze = death
+                .sample()
+                .eye
+                .rotation
+                .rotate_vector(vec3(0.0, 0.0, -1.0));
+            // Still looking where they were looking - the roll is sideways.
+            assert!(
+                (gaze.x - 1.0).abs() < 1.0e-4 && gaze.y.abs() < 1.0e-4,
+                "seed {seed}: fell away from the killer, gaze {gaze:?}"
+            );
+            // ...and the body went over to one side of that gaze, not along it.
+            let drift = death.target.position - eye.position;
+            assert!(
+                drift.x.abs() < 1.0e-4 && drift.z.abs() > 0.1,
+                "seed {seed}: toppled along the gaze rather than across it, drift {drift:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_vertical_or_untracked_gaze_still_produces_a_finite_fall() {
+        for rotation in [
+            Quaternion::from_angle_x(Deg(90.0)),
+            Quaternion::from_angle_x(Deg(-90.0)),
+            Quaternion::zero(),
+        ] {
+            let eye = EyePose {
+                position: vec3(0.0, 2.6, 0.0),
+                rotation,
+            };
+            let target = DeathCamera::begin(eye, -1.6, 3).target;
+            assert!(
+                target.position.x.is_finite()
+                    && target.position.z.is_finite()
+                    && (target.rotation.magnitude() - 1.0).abs() < 1.0e-4,
+                "degenerate gaze {rotation:?} produced {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_stereo_pair_keeps_its_separation_all_the_way_through_the_fall() {
+        // Two eyes half an IPD either side of the tracked head centre.
+        let ipd = 0.2_f32;
+        let centre = vec3(0.0, 2.6, 0.0);
+        let tracked_rotation = Quaternion::from_angle_y(Deg(20.0));
+        let offsets = [
+            tracked_rotation.rotate_vector(vec3(-ipd / 2.0, 0.0, 0.0)),
+            tracked_rotation.rotate_vector(vec3(ipd / 2.0, 0.0, 0.0)),
+        ];
+
+        let mut death = DeathCamera::begin(
+            EyePose {
+                position: centre,
+                rotation: tracked_rotation,
+            },
+            -1.6,
+            5,
+        );
+        for _ in 0..=60 {
+            let resolved = resolve(
+                Vector3::zero(),
+                Quaternion::one(),
+                centre,
+                tracked_rotation,
+                Some(death.sample()),
+            );
+            let eyes: Vec<Vector3<f32>> = offsets
+                .iter()
+                .map(|offset| reapply_eye_offset(resolved, *offset, tracked_rotation).head_offset)
+                .collect();
+            let separation = (eyes[1] - eyes[0]).magnitude();
+            assert!(
+                (separation - ipd).abs() < 1.0e-4,
+                "stereo separation drifted to {separation} (want {ipd})"
+            );
+            death.advance(FALL_SECONDS / 60.0);
+        }
+    }
+
+    #[test]
+    fn the_stereo_eyes_roll_with_the_fallen_horizon() {
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 5);
+        death.advance(FALL_SECONDS * 2.0);
+        let resolved = resolve(
+            Vector3::zero(),
+            Quaternion::one(),
+            live_eye().position,
+            live_eye().rotation,
+            Some(death.sample()),
+        );
+        // A settled camera lying on its side separates its eyes vertically: the
+        // interocular axis has rolled with the view, so the two images stay
+        // level with the fallen horizon rather than with the room.
+        let right_eye = reapply_eye_offset(resolved, vec3(0.5, 0.0, 0.0), live_eye().rotation);
+        let displacement = right_eye.head_offset - resolved.head_offset;
+        assert!(
+            displacement.y.abs() > 0.49,
+            "the eye offset did not roll with the camera: {displacement:?}"
+        );
+    }
+
+    #[test]
+    fn an_untracked_head_leaves_the_stereo_offset_alone() {
+        let death = DeathCamera::begin(live_eye(), -1.6, 5);
+        let resolved = resolve(
+            Vector3::zero(),
+            Quaternion::one(),
+            live_eye().position,
+            live_eye().rotation,
+            Some(death.sample()),
+        );
+        assert_eq!(
+            reapply_eye_offset(resolved, vec3(0.5, 0.0, 0.0), Quaternion::zero()),
+            resolved
+        );
     }
 
     #[test]

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -10,6 +10,7 @@ use std::any::Any;
 
 use crate::{
     GameOptions,
+    death_camera::DeathCameraSample,
     input_context::InputContext,
     mission::GlobalContext,
     quest_info::QuestInfo,
@@ -181,6 +182,17 @@ pub trait GameScene {
     /// locomotion, death, or unsupported space makes a durable save unsafe.
     fn player_save_position(&self) -> Result<Vector3<f32>, PlayerSavePoseError> {
         Err(PlayerSavePoseError::NoPlayer)
+    }
+
+    /// The death camera's contribution to this frame's view, if the player is
+    /// dying. Consumed by [`crate::Game::resolve_camera`], which folds it into
+    /// whatever tracked head pose the runtime resolved, so flat and VR fall the
+    /// same way from one implementation (see `crate::death_camera`).
+    ///
+    /// `None` - the default, and every frame a live player renders - leaves the
+    /// runtime's camera untouched.
+    fn death_camera(&self) -> Option<DeathCameraSample> {
+        None
     }
 
     /// Get lighting information for VR enhancement

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -2337,13 +2337,13 @@ impl App {
                 tracked_head_offset,
                 tracked_head_rotation,
             ),
-            App::MissingAssets(_) => death_camera::resolve(
+            // Nothing here can die, so the tracked camera IS the camera.
+            App::MissingAssets(_) => death_camera::CameraPose {
                 pawn_position,
                 pawn_rotation,
-                tracked_head_offset,
-                tracked_head_rotation,
-                None,
-            ),
+                head_offset: tracked_head_offset,
+                head_rotation: tracked_head_rotation,
+            },
         }
     }
 }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -16,6 +16,7 @@ pub mod time;
 pub mod career;
 mod creature;
 pub mod data_files;
+pub mod death_camera;
 pub mod dev_params;
 mod flat_player_controller;
 mod gui;
@@ -1882,6 +1883,30 @@ impl Game {
         physics::player_eye_cap_above_center(self.active_game_scene.player_is_crouched())
     }
 
+    /// Fold the death camera into the camera a runtime is about to render
+    /// from. Every runtime resolves its own tracked head pose - the flat ones
+    /// from [`Game::player_eye_height`] plus their look rotation, the VR one
+    /// from the OpenXR view pose - then routes it through here on the way into
+    /// `EngineRenderContext`, so the fall to the floor is decided once for both
+    /// presentations instead of once per runtime (AGENTS.md section 3).
+    ///
+    /// While the player is alive this returns its inputs verbatim.
+    pub fn resolve_camera(
+        &self,
+        pawn_position: Vector3<f32>,
+        pawn_rotation: Quaternion<f32>,
+        tracked_head_offset: Vector3<f32>,
+        tracked_head_rotation: Quaternion<f32>,
+    ) -> death_camera::CameraPose {
+        death_camera::resolve(
+            pawn_position,
+            pawn_rotation,
+            tracked_head_offset,
+            tracked_head_rotation,
+            self.active_game_scene.death_camera(),
+        )
+    }
+
     pub fn render(&mut self) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let (mut scene, pos, rot) = self
             .active_game_scene
@@ -2293,6 +2318,32 @@ impl App {
         match self {
             App::Ready(game) => game.player_eye_cap_above_center(),
             App::MissingAssets(_) => physics::player_eye_cap_above_center(false),
+        }
+    }
+
+    /// See [`Game::resolve_camera`]. The missing-assets screen has no player
+    /// to kill, so it renders from the tracked camera unchanged.
+    pub fn resolve_camera(
+        &self,
+        pawn_position: Vector3<f32>,
+        pawn_rotation: Quaternion<f32>,
+        tracked_head_offset: Vector3<f32>,
+        tracked_head_rotation: Quaternion<f32>,
+    ) -> death_camera::CameraPose {
+        match self {
+            App::Ready(game) => game.resolve_camera(
+                pawn_position,
+                pawn_rotation,
+                tracked_head_offset,
+                tracked_head_rotation,
+            ),
+            App::MissingAssets(_) => death_camera::resolve(
+                pawn_position,
+                pawn_rotation,
+                tracked_head_offset,
+                tracked_head_rotation,
+                None,
+            ),
         }
     }
 }

--- a/shock2vr/src/ui/panel_anchor.rs
+++ b/shock2vr/src/ui/panel_anchor.rs
@@ -142,9 +142,7 @@ impl PanelPlacement {
 /// endpoints are exactly `from` and `to`.
 fn lerp_placement(from: PanelPlacement, to: PanelPlacement, t: f32) -> PanelPlacement {
     let t = t.clamp(0.0, 1.0);
-    // Smoothstep: no velocity discontinuity at either end, which is what makes
-    // the re-placement read as a move rather than a jump.
-    let s = t * t * (3.0 - 2.0 * t);
+    let s = crate::util::smoothstep(t);
     let head_position = from.head_position + (to.head_position - from.head_position) * s;
     // Turn along the shortest arc at a constant rate. Blending the direction
     // vectors instead would stall near the start of a half-turn and snap

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -184,16 +184,29 @@ pub fn tracked_gaze(
     head_position: Vector3<f32>,
     head_rotation: Quaternion<f32>,
 ) -> Option<(Vector3<f32>, Vector3<f32>)> {
-    if head_rotation.magnitude2() < 1e-6 {
-        return None;
-    }
     use cgmath::Rotation;
-    Some((
-        head_position,
-        head_rotation
-            .normalize()
-            .rotate_vector(vec3(0.0, 0.0, -1.0)),
-    ))
+    let rotation = tracked_rotation(head_rotation)?;
+    Some((head_position, rotation.rotate_vector(vec3(0.0, 0.0, -1.0))))
+}
+
+/// The unit form of a tracked rotation, or `None` when it carries no rotation
+/// information (a zero quaternion - an untracked head, or a default-constructed
+/// pose). The same rule [`tracked_gaze`] applies, exposed for callers that need
+/// the rotation itself rather than a gaze ray: normalizing a zero quaternion
+/// yields NaN, and a NaN rotation poisons whatever matrix it reaches.
+pub fn tracked_rotation(rotation: Quaternion<f32>) -> Option<Quaternion<f32>> {
+    (rotation.magnitude2() >= 1e-6).then(|| rotation.normalize())
+}
+
+/// Smoothstep over `t`, clamped to `[0, 1]`: no velocity discontinuity at
+/// either end, which is what makes a timed ease read as a move rather than a
+/// jump. Shared by the UI panel re-placement ease and the death camera's fall.
+pub fn smoothstep(t: f32) -> f32 {
+    if !t.is_finite() || t <= 0.0 {
+        return 0.0;
+    }
+    let t = t.min(1.0);
+    t * t * (3.0 - 2.0 * t)
 }
 
 pub fn get_rotation_from_forward_vector(forward: Vector3<f32>) -> Quaternion<f32> {


### PR DESCRIPTION
Bottom of a 3-PR stack adding a **death experience**: when the player dies the camera falls to the floor and rolls onto its side.

This PR is the **seam only — no behavior change.**

## Why a seam

The rendered view is built from two transforms (`engine::util::compute_view_matrix`):

```
view = inv(head_translation * head_rotation) * inv(pawn_translation * pawn_rotation)
```

The pawn comes from `Game::render`, but the **head is synthesized per-runtime** — the flat runtimes from `Game::player_eye_height` plus their look rotation, `oculus_runtime` from the OpenXR view pose mapped into pawn space and capped to the collider crown. Three independent producers of the same thing.

Blending a death camera into each of them separately would let flat and VR drift apart exactly the way AGENTS.md §3 forbids. So `shock2vr::death_camera` owns the blend: each runtime hands in the head pose it *would* have rendered with, and renders with whatever comes back, deciding nothing itself.

**Only the head component moves.** The pawn transform is also the play-space→world map for the hands and world-space UI panels, so dropping the pawn would drag them to the floor with the camera.

## Proving it is a no-op

Nothing implements `GameScene::death_camera` yet, so every frame resolves to `None`. `no_sample_passes_the_tracked_camera_through_untouched` asserts **exact** equality, not approximate.

Empirically: same deterministic request sequence against the pre-change and post-change binaries differs by 34,741 px — while **re-running the same binary twice** differs by 36,019 px (particle/AI jitter). Same magnitude, localised bbox; a camera shift would move every pixel in the frame.

## Also here

The fall's maths, fully unit-tested (20 tests): a seeded topple direction, a target that rolls the view onto its side at floor height, a weight that ramps the fallen pose's authority, stereo-preserving `reapply_eye_offset`, and NaN/degenerate-quaternion guards.

Shared `util::smoothstep` / `util::tracked_rotation` rather than a fourth open-coded copy of each, and `CameraPose::into_render_context` so the four fields are not retyped in three runtimes.

## Verification

- `cargo test -p shock2vr` — 974 pass
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo apk check` (oculus)
