### PR TITLE
feat(vr): melee calibration overlays, on a Developer list that scrolls

### DIFF
--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -134,6 +134,27 @@ dev_params! {
     /// nothing. `debug_melee` turns it on; missions leave it at 0 until the
     /// physical model is the shipped one.
     MELEE_FREE_SWING_SPEED = float("melee_free_swing", "Melee free swing", 0.0, 0.0, 20.0, 0.5),
+    /// Draw the tracked-hand glove *in addition to* a wielded weapon's own
+    /// first-person model, instead of letting the weapon model stand in for the
+    /// hand. `0` off, `1` on.
+    ///
+    /// This is the melee grip calibration instrument: the `_h` melee rigs bake
+    /// their own arm and fist, and nothing else in the game shows where that
+    /// baked fist lands relative to where the controller actually is. With both
+    /// drawn at once the offset is directly visible - and directly tunable,
+    /// since the registry reaches a headset without a rebuild.
+    ///
+    /// A 0/1 float because the registry has no `Bool` kind yet; it should
+    /// become one when that lands.
+    MELEE_GLOVE_OVERLAY = float("melee_glove_overlay", "Melee glove overlay", 0.0, 0.0, 1.0, 1.0),
+    /// Draw the live contact volume of every held melee weapon as a world-space
+    /// wireframe. `0` off, `1` on.
+    ///
+    /// The companion to [`MELEE_GLOVE_OVERLAY`]: that one answers "is the hand
+    /// where my hand is", this one answers "is the damage volume where the
+    /// weapon is". Read out of Rapier at the collider's own isometry, so it
+    /// shows what is actually simulated rather than what the wield intended.
+    MELEE_VOLUMES = float("melee_volumes", "Melee volumes", 0.0, 0.0, 1.0, 1.0),
     /// Uniform scale applied to a wielded melee `_h` view model, about the
     /// baked fist so the grip stays on the controller.
     ///

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7494,6 +7494,26 @@ impl MissionCore {
             scene.append(&mut debug_render.clone());
         }
 
+        // Held-melee contact volumes. Emitted in the shared world pass, so
+        // flat and VR draw the identical overlay - required, since the
+        // question it answers ("is the damage volume on the weapon I can
+        // see?") was raised in a headset. A melee wield is the only thing
+        // that carries RuntimePropVrGripOffset, so that component *is* the
+        // set of held melee weapons.
+        if crate::dev_params::get(crate::dev_params::MELEE_VOLUMES) > 0.5 {
+            let held = self
+                .world
+                .borrow::<View<RuntimePropVrGripOffset>>()
+                .map(|grips| grips.iter().with_id().map(|(id, _)| id).collect::<Vec<_>>())
+                .unwrap_or_default();
+            for entity_id in held {
+                scene.extend(
+                    self.physics
+                        .debug_entity_collider_lines(entity_id, vec3(1.0, 0.25, 0.25)),
+                );
+            }
+        }
+
         // Render debug pathfinding
         if options.debug_pathfinding {
             if let Some(ref path_database) = self.path_database {

--- a/shock2vr/src/pause_menu.rs
+++ b/shock2vr/src/pause_menu.rs
@@ -242,13 +242,14 @@ fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<PauseMenuEntry> {
 fn target_at(
     page: PauseMenuPage,
     panel_rects: dev_params_panel::PanelRects,
+    panel_scroll: usize,
     rects: &[Rect],
     point: Vector2<f32>,
 ) -> Option<PauseMenuTarget> {
     match page {
         PauseMenuPage::Root => hit(point, rects).map(PauseMenuTarget::Root),
         PauseMenuPage::Developer => {
-            dev_params_panel::hit(panel_rects, point).map(PauseMenuTarget::Developer)
+            dev_params_panel::hit(panel_rects, panel_scroll, point).map(PauseMenuTarget::Developer)
         }
     }
 }
@@ -302,6 +303,10 @@ pub struct PauseMenu {
     /// The Developer page's widget rects, re-resolved from `GAMELODR.BIN`
     /// each update (the render path takes `&self`, so it reads them here).
     panel_rects: dev_params_panel::PanelRects,
+    /// Index of the registry parameter in the Developer page's top row. The
+    /// panel is stateless, so its scroll position lives here and is handed to
+    /// the hit test and the render alike.
+    panel_scroll: usize,
 }
 
 impl Default for PauseMenu {
@@ -322,6 +327,7 @@ impl PauseMenu {
             ),
             closed_under_a_held_press: false,
             panel_rects: dev_params_panel::PanelRects::default(),
+            panel_scroll: 0,
         }
     }
 
@@ -422,12 +428,13 @@ impl PauseMenu {
 
         let page = self.page;
         let panel_rects = self.panel_rects;
+        let panel_scroll = self.panel_scroll;
         let target = self.menu.update(
             elapsed,
             input_context,
             options.presentation_mode,
-            |point| target_at(page, panel_rects, &rects, point),
-            |point| target_at(page, panel_rects, &rects, point),
+            |point| target_at(page, panel_rects, panel_scroll, &rects, point),
+            |point| target_at(page, panel_rects, panel_scroll, &rects, point),
         );
         self.handle_target(target)
     }
@@ -451,11 +458,12 @@ impl PauseMenu {
     ) -> Option<PauseAction> {
         let page = self.page;
         let panel_rects = self.panel_rects;
+        let panel_scroll = self.panel_scroll;
         let target = self.menu.resolve_pointer(
             point,
             pressed,
-            |point| target_at(page, panel_rects, rects, point),
-            |point| target_at(page, panel_rects, rects, point),
+            |point| target_at(page, panel_rects, panel_scroll, rects, point),
+            |point| target_at(page, panel_rects, panel_scroll, rects, point),
         );
         self.handle_target(target)
     }
@@ -489,7 +497,7 @@ impl PauseMenu {
         event: Option<dev_params_panel::DevParamsEvent>,
     ) -> Option<PauseAction> {
         if let Some(event) = event {
-            if dev_params_panel::activate(event) {
+            if dev_params_panel::activate(self.panel_rects, event, &mut self.panel_scroll) {
                 self.page = PauseMenuPage::Root;
             }
         }
@@ -602,7 +610,12 @@ impl PauseMenu {
                 Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H),
                 DEVELOPER_BACKDROP_TEXTURE,
             );
-            dev_params_panel::draw(&mut canvas, self.panel_rects, pointer_canvas);
+            dev_params_panel::draw(
+                &mut canvas,
+                self.panel_rects,
+                self.panel_scroll,
+                pointer_canvas,
+            );
             return canvas;
         }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -4118,6 +4118,65 @@ impl PhysicsWorld {
         }
     }
 
+    /// A line wireframe of every collider on `entity_id`'s primary body, read
+    /// straight out of Rapier at each collider's own live world isometry.
+    ///
+    /// Deliberately *not* a recomputation of what the wield intended: a
+    /// recomputation would agree with the renderer by construction and so
+    /// could never show the case worth seeing, which is the simulated volume
+    /// sitting somewhere other than the drawn weapon. Reuses `dark::hit_box`'s
+    /// existing builders rather than growing a second debug-draw path.
+    pub fn debug_entity_collider_lines(
+        &self,
+        entity_id: EntityId,
+        color: Vector3<f32>,
+    ) -> Vec<SceneObject> {
+        let Some(handle) = self.entity_id_to_body.get(&entity_id) else {
+            return Vec::new();
+        };
+        let Some(body) = self.rigid_body_set.get(*handle) else {
+            return Vec::new();
+        };
+        let mut objects = Vec::new();
+        for collider_handle in body.colliders() {
+            let Some(collider) = self.collider_set.get(*collider_handle) else {
+                continue;
+            };
+            let shape = match collider.shape().as_typed_shape() {
+                TypedShape::Cuboid(cuboid) => dark::hit_box::HitBoxShape::Cuboid {
+                    half_extents: nvec_to_cgmath(cuboid.half_extents),
+                    center: Vector3::new(0.0, 0.0, 0.0),
+                },
+                TypedShape::Ball(ball) => dark::hit_box::HitBoxShape::Cuboid {
+                    half_extents: Vector3::new(ball.radius, ball.radius, ball.radius),
+                    center: Vector3::new(0.0, 0.0, 0.0),
+                },
+                TypedShape::Capsule(capsule) => dark::hit_box::HitBoxShape::Capsule {
+                    a: nvec_to_cgmath(capsule.segment.a.coords),
+                    b: nvec_to_cgmath(capsule.segment.b.coords),
+                    radius: capsule.radius,
+                },
+                // Compounds and meshes have no single primitive to draw; a
+                // held melee weapon never has one, and silently drawing an
+                // approximation would be worse than drawing nothing.
+                _ => continue,
+            };
+            let isometry = collider.position();
+            let rotation = isometry.rotation;
+            let world: cgmath::Matrix4<f32> =
+                cgmath::Matrix4::from_translation(nvec_to_cgmath(isometry.translation.vector))
+                    * cgmath::Matrix4::from(Quaternion::new(
+                        rotation.w, rotation.i, rotation.j, rotation.k,
+                    ));
+            objects.extend(dark::hit_box::draw_debug_hit_box_shapes(
+                &std::collections::HashMap::from([(0u32, shape)]),
+                &[world],
+                color,
+            ));
+        }
+        objects
+    }
+
     pub fn debug_render(&mut self) -> Vec<SceneObject> {
         let mut debug_renderer = DebugRenderer::new();
 

--- a/shock2vr/src/scenes/debug_melee.rs
+++ b/shock2vr/src/scenes/debug_melee.rs
@@ -114,6 +114,12 @@ pub fn create_debug_melee_scene(
 ) -> Box<dyn GameScene> {
     // Contact damages on its own here - see the module docs.
     dev_params::set(dev_params::MELEE_FREE_SWING_SPEED, FREE_SWING_SPEED);
+    // Both calibration overlays default ON in this scene: it exists to answer
+    // "is the hand where my hand is" and "is the damage volume on the weapon I
+    // can see", and neither question can be asked with them off. They stay off
+    // by default everywhere else, and both are on the Developer page.
+    dev_params::set(dev_params::MELEE_GLOVE_OVERLAY, 1.0);
+    dev_params::set(dev_params::MELEE_VOLUMES, 1.0);
 
     // The unit cube spans [-0.5, 0.5], so a nonuniform scale is twice the
     // matching collider half-extent. Every piece is a (visual, collider) pair
@@ -198,10 +204,11 @@ pub fn create_debug_melee_scene(
         "[debug_melee] A rack of every player melee weapon is within reach ahead;\n\
          grab one (squeeze) and swing at the creatures that come down the corridor.\n\
          Contact damages on its own above {FREE_SWING_SPEED} units/s - no trigger needed.\n\
-         `melee_scale` sizes the wielded view model (takes effect on the next grab);\n\
-         `melee_glove_overlay` = 1 draws the tracked-hand glove alongside the weapon's\n\
-         own arm, so the `_h` fist can be compared against the controller pose.\n\
-         Both live on the Developer screen and at POST /v1/dev-params."
+         The tracked-hand glove and the live contact volume are both drawn here by\n\
+         default (`melee_glove_overlay`, `melee_volumes`) so the wield can be compared\n\
+         against where the controller and the damage box actually are.\n\
+         `melee_scale` sizes the view model - it takes effect on the NEXT grab.\n\
+         All three live on the Developer screen and at POST /v1/dev-params."
     );
 
     Box::new(HookedDebugScene::new(core, MeleeHooks::default()))
@@ -219,6 +226,8 @@ impl Drop for MeleeHooks {
     /// contradicting the parameter's own contract that missions leave it at 0.
     fn drop(&mut self) {
         dev_params::reset(dev_params::MELEE_FREE_SWING_SPEED);
+        dev_params::reset(dev_params::MELEE_GLOVE_OVERLAY);
+        dev_params::reset(dev_params::MELEE_VOLUMES);
     }
 }
 

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -58,12 +58,13 @@ const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 #[cfg(test)]
 fn resolve_click_at(
     rects: PanelRects,
+    scroll: usize,
     point: Option<Vector2<f32>>,
     pressed: bool,
     last_pressed: bool,
 ) -> (Option<DevParamsEvent>, bool) {
     shell_resolve_click_at(point, pressed, last_pressed, |point| {
-        dev_params_panel::hit(rects, point)
+        dev_params_panel::hit(rects, scroll, point)
     })
 }
 
@@ -71,6 +72,7 @@ fn resolve_click_at(
 #[cfg(test)]
 fn resolve_click(
     rects: PanelRects,
+    scroll: usize,
     pointer: Option<Pointer2D>,
     last_pressed: bool,
     screen_size: Vector2<f32>,
@@ -81,7 +83,7 @@ fn resolve_click(
         screen_size,
         vec2(CANVAS_W, CANVAS_H),
         SCALE_MODE,
-        |point| dev_params_panel::hit(rects, point),
+        |point| dev_params_panel::hit(rects, scroll, point),
     )
 }
 
@@ -92,6 +94,10 @@ pub struct DeveloperScene {
     /// The panel's widget rects, re-resolved from `GAMELODR.BIN` each update
     /// (the render path takes `&self`, so it reads the resolved value here).
     panel_rects: PanelRects,
+    /// Index of the registry parameter drawn in the pane's top row. The panel
+    /// itself is stateless, so the scroll position lives with the host and is
+    /// handed to the hit test and the render alike.
+    scroll: usize,
 }
 
 impl DeveloperScene {
@@ -101,6 +107,7 @@ impl DeveloperScene {
             scene_name: "developer".to_owned(),
             menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
             panel_rects: PanelRects::default(),
+            scroll: 0,
         }
     }
 
@@ -109,7 +116,7 @@ impl DeveloperScene {
     fn build_canvas(&self, pointer_canvas: Option<Vector2<f32>>) -> UiCanvas {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
-        dev_params_panel::draw(&mut canvas, self.panel_rects, pointer_canvas);
+        dev_params_panel::draw(&mut canvas, self.panel_rects, self.scroll, pointer_canvas);
         canvas
     }
 }
@@ -138,19 +145,20 @@ impl GameScene for DeveloperScene {
         // `dev_params_panel::PanelRects`).
         self.panel_rects = dev_params_panel::rects(asset_cache);
         let rects = self.panel_rects;
+        let scroll = self.scroll;
 
         let event = self.menu.update(
             time.elapsed,
             input_context,
             game_options.presentation_mode,
-            |point| dev_params_panel::hit(rects, point),
-            |point| dev_params_panel::hit(rects, point),
+            |point| dev_params_panel::hit(rects, scroll, point),
+            |point| dev_params_panel::hit(rects, scroll, point),
         );
 
         if let Some(event) = event {
-            // Steps are applied to the registry here; "Done" returns to the
-            // main menu.
-            if dev_params_panel::activate(event) {
+            // Steps are applied to the registry here, scrolling moves the
+            // list, and "Done" returns to the main menu.
+            if dev_params_panel::activate(rects, event, &mut self.scroll) {
                 return vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)];
             }
         }
@@ -262,7 +270,7 @@ mod tests {
         for y in (0..480).step_by(2) {
             for x in (0..640).step_by(2) {
                 let p = vec2(x as f32, y as f32);
-                if dev_params_panel::hit(PanelRects::default(), p)
+                if dev_params_panel::hit(PanelRects::default(), 0, p)
                     == Some(DevParamsEvent::Increment(id))
                 {
                     return p;
@@ -277,6 +285,7 @@ mod tests {
         let (id, _) = dev_params::all().next().unwrap();
         let (event, last, _) = resolve_click(
             PanelRects::default(),
+            0,
             pointer_at(first_increment_point(), true),
             false,
             SCREEN,
@@ -289,6 +298,7 @@ mod tests {
     fn held_press_does_not_re_activate() {
         let (event, last, _) = resolve_click(
             PanelRects::default(),
+            0,
             pointer_at(first_increment_point(), true),
             true,
             SCREEN,
@@ -306,6 +316,7 @@ mod tests {
         let scene = DeveloperScene::new();
         let (event, _, _) = resolve_click(
             PanelRects::default(),
+            0,
             pointer_at(first_increment_point(), true),
             scene.menu.last_pressed(),
             SCREEN,
@@ -333,6 +344,7 @@ mod tests {
         assert!(scene.menu.last_pressed());
         let (event, last, point) = resolve_click(
             PanelRects::default(),
+            0,
             None,
             scene.menu.last_pressed(),
             SCREEN,
@@ -344,6 +356,7 @@ mod tests {
         // ...so the press reappearing still resolves to nothing.
         let (event, _, _) = resolve_click(
             PanelRects::default(),
+            0,
             pointer_at(first_increment_point(), true),
             last,
             SCREEN,
@@ -355,6 +368,7 @@ mod tests {
     fn click_on_bare_backdrop_does_nothing() {
         let (event, _, _) = resolve_click(
             PanelRects::default(),
+            0,
             pointer_at(vec2(50.0, 50.0), true),
             false,
             SCREEN,
@@ -378,7 +392,14 @@ mod tests {
         let ray_point = pass.point().expect("the ray should land on the panel");
         let (id, _) = dev_params::all().next().unwrap();
         assert_eq!(
-            resolve_click_at(PanelRects::default(), Some(ray_point), pass.pressed, false).0,
+            resolve_click_at(
+                PanelRects::default(),
+                0,
+                Some(ray_point),
+                pass.pressed,
+                false
+            )
+            .0,
             Some(DevParamsEvent::Increment(id))
         );
     }

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -11,10 +11,13 @@
 //! The geometry rides the `GAMELOD.PCX` backdrop both hosts use for this
 //! page: the header line, the dark list pane, and the framed button art in
 //! the bottom-right corner (the decoded `GAMELODR.BIN` rects, shared with
-//! [`crate::scenes::LoadGameScene`]). Rows live inside the pane; "Done" sits
-//! on the button art.
+//! [`crate::scenes::LoadGameScene`]). Rows live inside the pane, scrolling in
+//! a gutter down its right edge so a registry larger than the pane stays
+//! fully reachable; "Done" sits on the button art.
 //!
 //! [`DeveloperScene`]: crate::scenes::DeveloperScene
+
+use std::ops::Range;
 
 use cgmath::{Vector2, vec2};
 use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
@@ -38,7 +41,8 @@ pub const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
 const LAYOUT_FILE: &str = "GAMELODR.BIN";
 
 /// Indices into `GAMELODR.BIN`: header line, the dark list pane, (2 is the
-/// load screen's "Load" button, unused here) and the bottom-right button art.
+/// load screen's "Load" button, still unused here) and the bottom-right
+/// button art.
 const HEADER_RECT_INDEX: usize = 0;
 const LIST_RECT_INDEX: usize = 1;
 const DONE_RECT_INDEX: usize = 3;
@@ -116,6 +120,10 @@ pub fn rects(asset_cache: &mut AssetCache) -> PanelRects {
 /// Vertical distance between row tops, and each row's own height. Taller
 /// than the load list's 19px rows: these rows carry click targets (the
 /// arrows), so they get more air and a bigger hit area.
+///
+/// These were briefly shaved to 25/22 to squeeze a tenth parameter into the
+/// pane. That trade is gone: the list scrolls, so the pane holds whatever it
+/// comfortably can and the registry may grow without touching the pitch.
 const ROW_PITCH: f32 = 28.0;
 const ROW_H: f32 = 24.0;
 /// Horizontal inset from the pane's edges, matching the load list's text
@@ -125,9 +133,16 @@ const TEXT_INSET: f32 = 8.0;
 const ARROW_W: f32 = 20.0;
 /// Width of the value readout between the arrows.
 const VALUE_W: f32 = 48.0;
+/// The scroll gutter down the list pane's right edge, and the height of each
+/// of its two buttons.
+const SCROLL_GUTTER_W: f32 = 26.0;
+const SCROLL_BUTTON_H: f32 = 20.0;
 
 /// Opacity for an element the pointer is not over.
 const IDLE_OPACITY: f32 = 0.65;
+/// Opacity for a scroll button that cannot move any further, matching the
+/// load screen's inert "Load". Such a button is not hit-testable either.
+const DISABLED_OPACITY: f32 = 0.3;
 /// Opacity for the element under the pointer.
 const HOVER_OPACITY: f32 = 1.0;
 /// Labels and values are readouts, not click targets: drawn steady, between
@@ -141,6 +156,10 @@ const READOUT_OPACITY: f32 = 0.85;
 pub enum DevParamsEvent {
     Decrement(DevParamId),
     Increment(DevParamId),
+    /// Scroll the list one row towards the top of the registry.
+    ScrollUp,
+    /// Scroll the list one row towards its end.
+    ScrollDown,
     Done,
 }
 
@@ -155,7 +174,15 @@ struct RowRects {
 fn row_rects(rects: PanelRects, index: usize) -> RowRects {
     let list = rects.list;
     let y = list.y + index as f32 * ROW_PITCH;
-    let right = list.x + list.w - TEXT_INSET;
+    // Leave the scroll gutter clear whenever it is in use, so a row's `>`
+    // never sits under the rocker (they resolve through one hit test, so an
+    // overlap is a genuine ambiguity, not just a visual one).
+    let gutter = if max_scroll(rects) > 0 {
+        SCROLL_GUTTER_W
+    } else {
+        0.0
+    };
+    let right = list.x + list.w - TEXT_INSET - gutter;
     let increment_x = right - ARROW_W;
     let value_x = increment_x - VALUE_W;
     let decrement_x = value_x - ARROW_W;
@@ -168,13 +195,60 @@ fn row_rects(rects: PanelRects, index: usize) -> RowRects {
     }
 }
 
-/// How many rows fit in the pane above the backdrop's painted field. The
-/// registry is expected to stay well under this; the cap only keeps a grown
-/// table from drawing rows through the art.
-fn visible_row_count(rects: PanelRects) -> usize {
+/// How many rows fit in the pane above the backdrop's painted field - the
+/// size of one page of the list, however long the registry is.
+fn rows_per_page(rects: PanelRects) -> usize {
     let list = rects.list;
     let usable = (list.y + list.h).min(FIELD_TOP_Y) - list.y;
-    ((usable / ROW_PITCH).floor().max(0.0) as usize).min(dev_params::PARAMS.len())
+    (usable / ROW_PITCH).floor().max(0.0) as usize
+}
+
+/// The furthest the list can scroll: the first-row index that puts the tail
+/// of the registry against the bottom of the pane. Zero when everything fits
+/// at once, which is also what hides the scroll rocker.
+fn max_scroll(rects: PanelRects) -> usize {
+    dev_params::PARAMS
+        .len()
+        .saturating_sub(rows_per_page(rects))
+}
+
+/// The registry indices on screen at `scroll`, with `scroll` clamped to what
+/// the pane can actually show.
+///
+/// The one place a screen row is tied to a parameter: [`draw`] and [`hit`]
+/// both walk this range, so a row can never *show* one parameter's value and
+/// *step* another's - the failure a positional row index invites the moment
+/// the list scrolls.
+fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
+    let first = scroll.min(max_scroll(rects));
+    let count = rows_per_page(rects).min(dev_params::PARAMS.len() - first);
+    first..first + count
+}
+
+/// The scroll rocker's two halves - "Up" and "Down" - in a gutter down the
+/// list pane's right edge, beside the rows they scroll. `None` when the whole
+/// registry fits on one page.
+///
+/// Deliberately *not* on the upper framed button: that is the load screen's
+/// "Load" frame, the only other authored click target on this backdrop, and
+/// it is wanted for a debug-scene launcher. Scrolling belongs against its own
+/// list anyway - a scrollbar's place is beside what it scrolls, not across
+/// the screen from it.
+fn scroll_rects(rects: PanelRects) -> Option<(Rect, Rect)> {
+    (max_scroll(rects) > 0).then(|| {
+        let list = rects.list;
+        let x = list.x + list.w - SCROLL_GUTTER_W;
+        let bottom = (list.y + list.h).min(FIELD_TOP_Y);
+        (
+            Rect::new(x, list.y, SCROLL_GUTTER_W, SCROLL_BUTTON_H),
+            Rect::new(
+                x,
+                bottom - SCROLL_BUTTON_H,
+                SCROLL_GUTTER_W,
+                SCROLL_BUTTON_H,
+            ),
+        )
+    })
 }
 
 /// The value readout: floats as `{:.2}`, the format the step grids are
@@ -187,12 +261,30 @@ fn format_value(kind: &DevParamKind, value: f32) -> String {
 
 /// The event at a canvas point, if any. Shared by the click and the hover
 /// highlight, so the two can never disagree about where a button is.
-pub fn hit(rects: PanelRects, point: Vector2<f32>) -> Option<DevParamsEvent> {
+pub fn hit(rects: PanelRects, scroll: usize, point: Vector2<f32>) -> Option<DevParamsEvent> {
     let mut canvas = UiCanvas::<DevParamsEvent>::with_events(vec2(CANVAS_W, CANVAS_H));
-    for (index, (id, _)) in dev_params::all().take(visible_row_count(rects)).enumerate() {
-        let row = row_rects(rects, index);
+    // Rows are addressed by *screen slot* but carry the id of the registry
+    // entry scrolled into that slot. Resolving the slot from anything other
+    // than this same offset is the bug this whole seam invites: the panel
+    // would draw one parameter and the click would change another.
+    let rows = visible_rows(rects, scroll);
+    for (slot, (id, _)) in dev_params::all()
+        .skip(rows.start)
+        .take(rows.len())
+        .enumerate()
+    {
+        let row = row_rects(rects, slot);
         canvas.button(row.decrement, "", DevParamsEvent::Decrement(id));
         canvas.button(row.increment, "", DevParamsEvent::Increment(id));
+    }
+    if let Some((up, down)) = scroll_rects(rects) {
+        // A rocker half that cannot move is inert, not just dimmed.
+        if rows.start > 0 {
+            canvas.button(up, "", DevParamsEvent::ScrollUp);
+        }
+        if rows.start < max_scroll(rects) {
+            canvas.button(down, "", DevParamsEvent::ScrollDown);
+        }
     }
     canvas.button(rects.done, "", DevParamsEvent::Done);
     canvas.click_at(point)
@@ -202,8 +294,13 @@ pub fn hit(rects: PanelRects, point: Vector2<f32>) -> Option<DevParamsEvent> {
 /// and "Done". `pointer_canvas` is the hover position in canvas pixels,
 /// whatever produced it - the mouse or a VR controller ray; the highlight
 /// resolves through the very same [`hit`] the click does.
-pub fn draw(canvas: &mut UiCanvas, rects: PanelRects, pointer_canvas: Option<Vector2<f32>>) {
-    let hovered = pointer_canvas.and_then(|point| hit(rects, point));
+pub fn draw(
+    canvas: &mut UiCanvas,
+    rects: PanelRects,
+    scroll: usize,
+    pointer_canvas: Option<Vector2<f32>>,
+) {
+    let hovered = pointer_canvas.and_then(|point| hit(rects, scroll, point));
     let hover_opacity = |event: DevParamsEvent| {
         if hovered == Some(event) {
             HOVER_OPACITY
@@ -220,8 +317,13 @@ pub fn draw(canvas: &mut UiCanvas, rects: PanelRects, pointer_canvas: Option<Vec
         VAlign::Middle,
     );
 
-    for (index, (id, param)) in dev_params::all().take(visible_row_count(rects)).enumerate() {
-        let row = row_rects(rects, index);
+    let rows = visible_rows(rects, scroll);
+    for (slot, (id, param)) in dev_params::all()
+        .skip(rows.start)
+        .take(rows.len())
+        .enumerate()
+    {
+        let row = row_rects(rects, slot);
         canvas
             .text_native(
                 row.label,
@@ -260,6 +362,31 @@ pub fn draw(canvas: &mut UiCanvas, rects: PanelRects, pointer_canvas: Option<Vec
             .opacity(hover_opacity(DevParamsEvent::Increment(id)));
     }
 
+    if let Some((up, down)) = scroll_rects(rects) {
+        for (rect, text, event, enabled) in [
+            (up, "Up", DevParamsEvent::ScrollUp, rows.start > 0),
+            (
+                down,
+                "Dn",
+                DevParamsEvent::ScrollDown,
+                rows.start < max_scroll(rects),
+            ),
+        ] {
+            // The row font, and "Dn" rather than "Down": `text_native` does
+            // not shrink to its rect, so the display font's "Up"/"Down"
+            // overhung the gutter and drew across the values beside them.
+            // Render-verified rather than assumed - that overlap is exactly
+            // what a screenshot catches and a layout assertion does not.
+            canvas
+                .text_native(rect, text, ROW_FONT, HAlign::Center, VAlign::Middle)
+                .opacity(if enabled {
+                    hover_opacity(event)
+                } else {
+                    DISABLED_OPACITY
+                });
+        }
+    }
+
     canvas
         .text_native(
             rects.done,
@@ -271,10 +398,11 @@ pub fn draw(canvas: &mut UiCanvas, rects: PanelRects, pointer_canvas: Option<Vec
         .opacity(hover_opacity(DevParamsEvent::Done));
 }
 
-/// Apply a clicked event to the registry. Returns `true` when the event was
-/// [`DevParamsEvent::Done`] - the one thing the host must act on (leave the
-/// screen); the steps are absorbed here so both hosts stay a one-liner.
-pub fn activate(event: DevParamsEvent) -> bool {
+/// Apply a clicked event to the registry, or to the host's `scroll` offset.
+/// Returns `true` when the event was [`DevParamsEvent::Done`] - the one thing
+/// the host must act on (leave the screen); the steps and the scrolling are
+/// absorbed here so both hosts stay a one-liner.
+pub fn activate(rects: PanelRects, event: DevParamsEvent, scroll: &mut usize) -> bool {
     let step_by = |id: DevParamId, direction: f32| {
         let DevParamKind::Float { step, .. } = dev_params::spec(id).kind;
         // `set` clamps into range and snaps to the step grid, so walking off
@@ -290,6 +418,14 @@ pub fn activate(event: DevParamsEvent) -> bool {
             step_by(id, 1.0);
             false
         }
+        DevParamsEvent::ScrollUp => {
+            *scroll = scroll.saturating_sub(1);
+            false
+        }
+        DevParamsEvent::ScrollDown => {
+            *scroll = (*scroll + 1).min(max_scroll(rects));
+            false
+        }
         DevParamsEvent::Done => true,
     }
 }
@@ -302,15 +438,132 @@ mod tests {
         dev_params::all().map(|(id, _)| id).collect()
     }
 
-    /// Every registered parameter must actually fit on the screen - a row
-    /// drawn below the cap would be visible art damage AND an unreachable
-    /// control, so growth past the pane is a test failure, not a truncation.
+    /// Every registered parameter must be *reachable*: whatever the registry
+    /// grows to, some scroll offset puts it on screen with working arrows.
+    /// (Its predecessor asserted every param fit on one page, which is what
+    /// forced a pitch shave per new knob; the list scrolls now, so the
+    /// invariant is reachability, not fitting.)
     #[test]
-    fn every_registered_param_fits_in_the_pane() {
+    fn every_registered_param_is_reachable_by_scrolling() {
         let rects = PanelRects::default();
-        assert_eq!(visible_row_count(rects), dev_params::PARAMS.len());
-        let last = row_rects(rects, dev_params::PARAMS.len() - 1);
-        assert!(last.label.y + ROW_H <= FIELD_TOP_Y);
+        let ids = param_ids();
+        for (index, id) in ids.iter().enumerate() {
+            // Scrolling to a param's own index always shows it (clamped when
+            // it is inside the last page).
+            let scroll = index;
+            let rows = visible_rows(rects, scroll);
+            assert!(
+                rows.contains(&index),
+                "param {index} is not on screen at scroll {scroll}"
+            );
+            let row = row_rects(rects, index - rows.start);
+            assert_eq!(
+                hit(rects, scroll, row.increment.center()),
+                Some(DevParamsEvent::Increment(*id)),
+                "param {index} > at scroll {scroll}"
+            );
+        }
+    }
+
+    /// The last parameter in particular: it is only reachable at the bottom
+    /// of the scroll, which is the offset a clamp bug lands one short of.
+    #[test]
+    fn the_last_param_is_reachable_at_the_bottom_of_the_scroll() {
+        let rects = PanelRects::default();
+        let last_index = dev_params::PARAMS.len() - 1;
+        let last_id = *param_ids().last().unwrap();
+        let bottom = max_scroll(rects);
+        let rows = visible_rows(rects, bottom);
+        assert_eq!(rows.end, dev_params::PARAMS.len());
+        let row = row_rects(rects, last_index - rows.start);
+        assert_eq!(
+            hit(rects, bottom, row.decrement.center()),
+            Some(DevParamsEvent::Decrement(last_id))
+        );
+        // ...and every drawn row clears the backdrop's painted field.
+        assert!(row.label.y + ROW_H <= FIELD_TOP_Y);
+        // An over-scroll cannot walk the list off its end.
+        assert_eq!(visible_rows(rects, bottom + 99), rows);
+    }
+
+    /// The bug a scrolling list invites: the rows move but the hit test still
+    /// indexes the registry positionally, so clicking a row steps whatever
+    /// parameter *used* to be there. Slot 0 must belong to the first VISIBLE
+    /// param, not to `PARAMS[0]`.
+    #[test]
+    fn the_hit_test_follows_the_scroll_offset() {
+        let rects = PanelRects::default();
+        let ids = param_ids();
+        assert!(max_scroll(rects) > 0, "the pane must be scrollable to test");
+        for scroll in 1..=max_scroll(rects) {
+            let slot0 = row_rects(rects, 0);
+            assert_eq!(
+                hit(rects, scroll, slot0.increment.center()),
+                Some(DevParamsEvent::Increment(ids[scroll])),
+                "top row at scroll {scroll}"
+            );
+            assert_eq!(
+                hit(rects, scroll, slot0.decrement.center()),
+                Some(DevParamsEvent::Decrement(ids[scroll])),
+                "top row at scroll {scroll}"
+            );
+            // The param that was on top before is now off screen entirely.
+            assert!(!visible_rows(rects, scroll).contains(&(scroll - 1)));
+        }
+    }
+
+    #[test]
+    fn the_rocker_scrolls_and_stops_at_both_ends() {
+        let rects = PanelRects::default();
+        let (up, down) = scroll_rects(rects).expect("the shipped registry scrolls");
+        let mut scroll = 0;
+
+        // At the top the "Up" half is inert - and stays inert if activated.
+        assert_eq!(hit(rects, scroll, up.center()), None);
+        assert_eq!(
+            hit(rects, scroll, down.center()),
+            Some(DevParamsEvent::ScrollDown)
+        );
+        assert!(!activate(rects, DevParamsEvent::ScrollUp, &mut scroll));
+        assert_eq!(scroll, 0);
+
+        // Walking down stops at the bottom rather than scrolling past the end.
+        for _ in 0..max_scroll(rects) + 3 {
+            activate(rects, DevParamsEvent::ScrollDown, &mut scroll);
+        }
+        assert_eq!(scroll, max_scroll(rects));
+        assert_eq!(hit(rects, scroll, down.center()), None);
+        assert_eq!(
+            hit(rects, scroll, up.center()),
+            Some(DevParamsEvent::ScrollUp)
+        );
+
+        activate(rects, DevParamsEvent::ScrollUp, &mut scroll);
+        assert_eq!(scroll, max_scroll(rects) - 1);
+    }
+
+    /// A pane tall enough for the whole registry has no rocker at all: the
+    /// framed art stays empty, exactly as it was before the list scrolled.
+    #[test]
+    fn a_pane_that_fits_everything_has_no_rocker() {
+        let tall = PanelRects::from_layout(Some(&[
+            MapRect::new(261, 31, 463, 51),
+            // Starts at the top of the canvas, so it clears FIELD_TOP_Y with
+            // room for more rows than the registry has.
+            MapRect::new(261, 0, 463, 320),
+            MapRect::new(527, 161, 623, 223),
+            MapRect::new(527, 405, 622, 467),
+        ]));
+        assert!(rows_per_page(tall) > dev_params::PARAMS.len());
+        assert_eq!(max_scroll(tall), 0);
+        assert_eq!(scroll_rects(tall), None);
+        // With nothing to scroll, the gutter is not reserved either: a row's
+        // increment runs to the pane's own inset, as it did before scrolling.
+        assert_eq!(
+            row_rects(tall, 0).increment.x + ARROW_W,
+            tall.list.x + tall.list.w - TEXT_INSET
+        );
+        assert_eq!(visible_rows(tall, 0), 0..dev_params::PARAMS.len());
     }
 
     #[test]
@@ -332,25 +585,29 @@ mod tests {
     fn the_arrows_and_done_hit_test() {
         let rects = PanelRects::default();
         let ids = param_ids();
-        for (index, id) in ids.iter().enumerate() {
+        // Unscrolled, slot N is param N for every row the pane shows.
+        for (index, id) in ids.iter().enumerate().take(rows_per_page(rects)) {
             let row = row_rects(rects, index);
             assert_eq!(
-                hit(rects, row.decrement.center()),
+                hit(rects, 0, row.decrement.center()),
                 Some(DevParamsEvent::Decrement(*id)),
                 "row {index} <"
             );
             assert_eq!(
-                hit(rects, row.increment.center()),
+                hit(rects, 0, row.increment.center()),
                 Some(DevParamsEvent::Increment(*id)),
                 "row {index} >"
             );
             // The label and the value are readouts, not buttons.
-            assert_eq!(hit(rects, row.label.center()), None);
-            assert_eq!(hit(rects, row.value.center()), None);
+            assert_eq!(hit(rects, 0, row.label.center()), None);
+            assert_eq!(hit(rects, 0, row.value.center()), None);
         }
-        assert_eq!(hit(rects, rects.done.center()), Some(DevParamsEvent::Done));
+        assert_eq!(
+            hit(rects, 0, rects.done.center()),
+            Some(DevParamsEvent::Done)
+        );
         // Bare backdrop is not a control.
-        assert_eq!(hit(rects, vec2(50.0, 50.0)), None);
+        assert_eq!(hit(rects, 0, vec2(50.0, 50.0)), None);
     }
 
     /// The rows follow the layout FILE, not the decoded fallbacks: an
@@ -372,10 +629,10 @@ mod tests {
                 lr_y: 300,
             },
             MapRect {
-                ul_x: 0,
-                ul_y: 0,
-                lr_x: 1,
-                lr_y: 1,
+                ul_x: 350,
+                ul_y: 100,
+                lr_x: 396,
+                lr_y: 160,
             },
             MapRect {
                 ul_x: 400,
@@ -392,8 +649,29 @@ mod tests {
         let row = row_rects(rects, 0);
         assert_eq!(row.label.x, 20.0 + TEXT_INSET);
         assert_eq!(row.label.y, 60.0);
-        assert_eq!(hit(rects, rects.done.center()), Some(DevParamsEvent::Done));
-        assert_eq!(hit(rects, FALLBACK_DONE.center()), None);
+        assert_eq!(
+            hit(rects, 0, rects.done.center()),
+            Some(DevParamsEvent::Done)
+        );
+        assert_eq!(hit(rects, 0, FALLBACK_DONE.center()), None);
+        // The rocker rides the authored *list pane*, so a moved backdrop takes
+        // it along with the rows it scrolls - and the rows shorten to keep
+        // their `>` out from under it.
+        let (up, down) = scroll_rects(rects).expect("this pane is too short to fit the registry");
+        let list_right = 20.0 + 280.0;
+        assert_eq!(up.x, list_right - SCROLL_GUTTER_W);
+        assert_eq!(up.y, 60.0);
+        assert_eq!(down.x, up.x);
+        assert!(down.y > up.y, "the rocker's halves must not overlap");
+        assert!(
+            row.increment.x + row.increment.w <= up.x,
+            "a row's increment must stay clear of the scroll gutter"
+        );
+        assert_eq!(
+            hit(rects, 0, down.center()),
+            Some(DevParamsEvent::ScrollDown)
+        );
+        assert_eq!(hit(rects, 0, FALLBACK_LIST.center()), None);
     }
 
     /// A missing layout file leaves every rect on the decoded fallback.
@@ -410,7 +688,13 @@ mod tests {
         // `get + step` through `set`'s tested clamp/snap; that a click
         // really moves a value is proven by the SDK e2e
         // (`dev-menu.e2e.test.ts`).
-        assert!(activate(DevParamsEvent::Done));
+        let mut scroll = 0;
+        assert!(activate(
+            PanelRects::default(),
+            DevParamsEvent::Done,
+            &mut scroll
+        ));
+        assert_eq!(scroll, 0, "leaving the screen must not scroll it");
     }
 
     #[test]

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -597,6 +597,12 @@ pub(crate) fn is_wieldable_weapon(world: &World, entity_id: EntityId) -> bool {
 /// otherwise the weapon's world model is drawn. Anything else - an empty hand,
 /// or a held object that is not a wieldable weapon - keeps the hand.
 pub(crate) fn shows_hand_visual(world: &World, held_entity: Option<EntityId>) -> bool {
+    // Calibration override: draw the glove *as well as* the weapon model, so
+    // the `_h` rig's baked fist can be compared against where the controller
+    // actually is. See `dev_params::MELEE_GLOVE_OVERLAY`.
+    if crate::dev_params::get(crate::dev_params::MELEE_GLOVE_OVERLAY) > 0.5 {
+        return true;
+    }
     match held_entity {
         None => true,
         Some(entity_id) => !is_wieldable_weapon(world, entity_id),

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -24,8 +24,18 @@ const DEVELOPER_ENTRY = menuEntry(2);
 // pane starting at y=54 on a 28px pitch (24px tall), arrows 20px wide ending
 // 8px inside the pane's right edge at x=463, "Done" on the GAMELODR button
 // art. Row 0 is `panel_distance` (declaration order of the registry).
-const ROW0_INCREMENT: [number, number] = [463 - 8 - 10, 54 + 12];
-const ROW0_DECREMENT: [number, number] = [463 - 8 - 20 - 48 - 10, 54 + 12];
+//
+// The list now scrolls, and its rocker takes a 26px gutter off the pane's
+// right edge whenever there is something to scroll - which shifts every row's
+// arrows left by that much. Written as its own term rather than folded into
+// the numbers, so the next person can see why these are not simply the pane
+// edge minus the inset.
+const SCROLL_GUTTER = 26;
+const ROW0_INCREMENT: [number, number] = [463 - 8 - SCROLL_GUTTER - 10, 54 + 12];
+const ROW0_DECREMENT: [number, number] = [
+  463 - 8 - SCROLL_GUTTER - 20 - 48 - 10,
+  54 + 12,
+];
 const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
 
 /** SIMR.BIN pause entries: five 179x76 buttons at x=400, top 20, 92px pitch. */


### PR DESCRIPTION
Stacked on **#1121**, which is stacked on **#1094**. Review those first.

Two questions the melee wield could not answer from inside a headset — and the
screen room to ask them.

![melee calibration overlays](https://gist.githubusercontent.com/tommy-xr/37a515e0e15a2c0b483b8300f1c2d0b7/raw/melee-overlays.gif)

<sub>`debug_melee` in VR, wrench held: the tracked-hand glove drawn alongside the weapon's baked `_h` fist, and the live Rapier contact volume as a red wireframe. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![overlays still](https://gist.githubusercontent.com/tommy-xr/37a515e0e15a2c0b483b8300f1c2d0b7/raw/overlays-still.png)

### Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/37a515e0e15a2c0b483b8300f1c2d0b7/raw/overlays-before-after.png)

<sub>Same pose, same request sequence — only `melee_glove_overlay` / `melee_volumes` differ.</sub>

### The Developer list scrolls

![developer list scrolling](https://gist.githubusercontent.com/tommy-xr/37a515e0e15a2c0b483b8300f1c2d0b7/raw/dev-scroll.gif)

<sub>The "Dn" rocker in the list pane's right gutter brings the tenth parameter ("Melee wield scale") into view; "Up" returns.</sub>

## The two overlays

**`melee_glove_overlay`** — draws the tracked-hand glove *as well as* the
wielded weapon's own `_h` model. The glove sits at the controller pose
exactly, so the gap between it and the rig's baked fist **is** the grip error,
directly readable instead of inferred.

**`melee_volumes`** — draws the live contact volume of every held melee weapon
as a world-space wireframe. Read out of Rapier at each collider's own
isometry, deliberately **not** recomputed from what the wield intended: a
recomputation agrees with the renderer by construction, so it could never show
the one case worth seeing — a damage box sitting somewhere other than the drawn
weapon. It reuses `dark::hit_box`'s existing line builders rather than growing
a second debug-draw path, and is emitted in the **shared world pass**, so flat
and VR draw the identical overlay.

`debug_melee` turns both on by default — asking those two questions is what it
exists for — and resets them on teardown, as it already does for free-swing.

## The Developer list scrolls

These two rows are what finally broke it. The panel drew
`all().take(visible_row_count(rects))`, so a registry larger than the pane
silently lost its tail, and the previous change had already shaved `ROW_PITCH`
from 28 to 25 to squeeze in a tenth. Pitch is back to 28/24 and the registry
can grow freely.

The rocker sits in a **gutter down the list pane's right edge**, not on the
upper framed button — that is the load screen's "Load" frame, the only other
authored click target on this backdrop, and @tommy-xr wants it for a
debug-scene launcher. A scrollbar belongs beside what it scrolls anyway. Rows
shorten by the gutter so a row's `>` never sits under the rocker: they resolve
through one hit test, so an overlap would be a genuine ambiguity, not a
cosmetic one.

The offset is threaded through `hit` alongside the render from a single field
on the host. Rows are addressed by *screen slot* but carry the id of the entry
scrolled into that slot — resolving the slot from anything but that same offset
would draw one parameter and change another, which is the bug this seam
invites. `the_hit_test_follows_the_scroll_offset` covers it.
`every_registered_param_fits_in_the_pane` is replaced by
`every_registered_param_is_reachable_by_scrolling`: its premise — that the pane
must hold the whole registry — is exactly what this removes.

## Verification

- `cargo test -p shock2vr --lib`: **913 passed**, 1 ignored.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean.
- `cargo fmt --all -- --check`: clean.
- `dev-menu.e2e`: **3/3** — flat pointer, VR controller ray, and the pause
  overlay's Developer page. Its row coordinates shift by the gutter width,
  kept as its own named term rather than folded into the literals.

Render-verified in both presentations per AGENTS.md §3, and it earned it: the
rocker's first labels were drawn in the display font and **overhung the gutter,
striking through the values beside them** — plain in a screenshot, invisible to
every layout assertion in the file.

