### PR TITLE
feat(camera): drop the camera to the floor when the player dies

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -788,20 +788,7 @@ fn run_game_blocking(
         // player is dying the game blends this tracked pose toward the fallen
         // death pose, once, for every runtime (see `shock2vr::death_camera`).
         // Alive, it hands back exactly what went in.
-        let render_context = game
-            .resolve_camera(
-                pawn_offset,
-                pawn_rotation,
-                // Crouch-aware eye height, shared with desktop and the flat
-                // controller via Game::player_eye_height, so the debug-runtime
-                // camera sits at the same height as desktop and shots land on
-                // the crosshair.
-                vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
-                // Same head rotation fed to game.update, so the rendered view
-                // and the flat viewmodel agree. Controllable via
-                // `/v1/control/input` head.look.
-                current_input.head.rotation,
-            )
+        let render_context = resolved_camera(&game, pawn_offset, pawn_rotation, &current_input)
             // Accumulated game time, not real time.
             .into_render_context(actual_game_time, projection_matrix, screen_size);
 
@@ -1861,6 +1848,32 @@ fn input_snapshot_from_context(input: &InputContext) -> InputSnapshot {
     }
 }
 
+/// The camera this frame renders from: the crouch-aware eye height shared with
+/// desktop and the flat controller via `Game::player_eye_height` (so the
+/// debug-runtime camera sits at the same height as desktop and shots land on
+/// the crosshair), the same head rotation fed to `game.update` (so the rendered
+/// view and the flat viewmodel agree; controllable via `/v1/control/input`
+/// head.look), routed through `resolve_camera` so a death camera in progress
+/// moves the view.
+///
+/// Shared with `/v1/info` rather than written twice: the snapshot reports the
+/// camera the runtime actually rendered from, which is what makes the death
+/// camera observable headlessly, and a second copy of this expression would
+/// drift from the one that matters.
+fn resolved_camera(
+    game: &Game,
+    pawn_offset: Vector3<f32>,
+    pawn_rotation: Quaternion<f32>,
+    input: &InputContext,
+) -> shock2vr::death_camera::CameraPose {
+    game.resolve_camera(
+        pawn_offset,
+        pawn_rotation,
+        vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
+        input.head.rotation,
+    )
+}
+
 /// Capture current game state as a frame snapshot
 fn capture_frame_snapshot(
     game: &Game,
@@ -1927,11 +1940,11 @@ fn capture_frame_snapshot(
 
     // Only the head component is reported, so the pawn is passed as the
     // identity it is relative to - `resolve_camera` never touches it anyway.
-    let rendered_camera = game.resolve_camera(
+    let rendered_camera = resolved_camera(
+        game,
         vec3(0.0, 0.0, 0.0),
         Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
-        current_input.head.rotation,
+        current_input,
     );
 
     FrameSnapshot {

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1925,6 +1925,15 @@ fn capture_frame_snapshot(
     // TODO: Find player entity specifically
     // TODO: Track frame counter
 
+    // Only the head component is reported, so the pawn is passed as the
+    // identity it is relative to - `resolve_camera` never touches it anyway.
+    let rendered_camera = game.resolve_camera(
+        vec3(0.0, 0.0, 0.0),
+        Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
+        current_input.head.rotation,
+    );
+
     FrameSnapshot {
         frame_index: frame_counter,
         time: TimeInfo {
@@ -1954,10 +1963,19 @@ fn capture_frame_snapshot(
                     .as_ref()
                     .map(|s| s.life_state.clone())
                     .unwrap_or_else(|| "alive".to_owned()),
-                // The LIVE eye height, not the standing constant: automation
-                // aims from this, and a crouched player's camera is lower.
-                camera_offset: [0.0, game.player_eye_height() / SCALE_FACTOR, 0.0],
-                camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
+                // The camera the runtime actually renders from, resolved the
+                // same way the render loop resolves it: the LIVE eye height
+                // (automation aims from this, and a crouched player's camera is
+                // lower), then routed through `resolve_camera` so a death
+                // camera in progress is observable headlessly rather than only
+                // in a screenshot.
+                camera_offset: rendered_camera.head_offset.into(),
+                camera_rotation: [
+                    rendered_camera.head_rotation.s,
+                    rendered_camera.head_rotation.v.x,
+                    rendered_camera.head_rotation.v.y,
+                    rendered_camera.head_rotation.v.z,
+                ],
                 wielded_entity_id: state.as_ref().and_then(|s| s.wielded_entity_id),
                 right_hand_entity_id: state.as_ref().and_then(|s| s.right_hand_entity_id),
                 reloading: state.as_ref().is_some_and(|s| s.reloading),

--- a/shock2vr/src/death_camera.rs
+++ b/shock2vr/src/death_camera.rs
@@ -56,7 +56,7 @@ pub const FALL_SECONDS: f32 = 0.9;
 /// Where the fallen eye ends up above the floor, in world units. Kept well
 /// clear of the 0.1 world-unit near plane so the floor does not clip through
 /// the camera once it lands.
-const FALLEN_EYE_HEIGHT: f32 = 0.45;
+pub const FALLEN_EYE_HEIGHT: f32 = 0.45;
 
 /// How far the eye drifts horizontally as it falls, in world units - the body
 /// toppling over rather than sinking straight down.
@@ -132,7 +132,7 @@ impl DeathCamera {
     /// (`-Game::player_center_above_floor()`). `seed` picks the fall direction
     /// and is the only source of randomness, so a replayed death - a captured
     /// screenshot sequence, an e2e assertion - falls exactly the same way.
-    pub fn begin(live_eye: EyePose, floor_y: f32, seed: u64) -> Self {
+    pub fn begin(live_eye: EyePose, floor_y: f32, seed: u64, lateral: f32) -> Self {
         // The body topples SIDEWAYS from where the player was looking, rather
         // than onto a freely random heading: whatever killed you stays in
         // frame while you go down. A random heading reads as the view being
@@ -140,21 +140,30 @@ impl DeathCamera {
         // wants to see. The seed picks which side you fall on - that is the
         // randomness, and it is what keeps two deaths from looking identical.
         let forward = death_facing(live_eye.rotation);
-        let side = if seed_is_left(seed) { 1.0 } else { -1.0 };
         // Up leaves world-up for the horizontal perpendicular to the gaze: the
         // view rolls onto its side. Forward stays horizontal, so the fallen
         // camera looks along the floor rather than into it.
-        let up = vec3(-forward.z, 0.0, forward.x) * side;
+        let up = topple_direction(live_eye.rotation, seed);
         let right = forward.cross(up);
         // `head_rotation` maps head-local axes into pawn space, and cgmath's
         // camera convention looks down local -Z.
         let rotation = Quaternion::from(Matrix3::from_cols(right, up, -forward));
 
+        // `lateral` is how far the body may actually topple - the caller
+        // shortens it when something is in the way (see
+        // `MissionCore::begin_death_camera`). Dying with your back to a wall is
+        // the common case when cornered, and an unclamped drift would put the
+        // camera inside it.
+        let lateral = if lateral.is_finite() {
+            lateral.clamp(0.0, FALL_LATERAL)
+        } else {
+            0.0
+        };
         let target = EyePose {
             position: vec3(
-                live_eye.position.x + up.x * FALL_LATERAL,
+                live_eye.position.x + up.x * lateral,
                 floor_y + FALLEN_EYE_HEIGHT,
-                live_eye.position.z + up.z * FALL_LATERAL,
+                live_eye.position.z + up.z * lateral,
             ),
             rotation,
         };
@@ -251,6 +260,19 @@ fn seed_is_left(seed: u64) -> bool {
     z >> 63 == 1
 }
 
+/// The horizontal direction the body topples in: perpendicular to where the
+/// player was looking, on the side the seed picks. Public so the caller can
+/// sweep it for obstructions before deciding how far the fall may carry (see
+/// [`DeathCamera::begin`]'s `lateral`).
+pub fn topple_direction(head_rotation: Quaternion<f32>, seed: u64) -> Vector3<f32> {
+    let forward = death_facing(head_rotation);
+    let side = if seed_is_left(seed) { 1.0 } else { -1.0 };
+    vec3(-forward.z, 0.0, forward.x) * side
+}
+
+/// How far the body topples when nothing is in the way, in world units.
+pub const MAX_FALL_LATERAL: f32 = FALL_LATERAL;
+
 /// The horizontal direction the player was facing when they died. A gaze that
 /// is straight up or down (or an untracked head) has no horizontal component to
 /// fall away from, so it falls back to the pawn's forward axis rather than
@@ -331,7 +353,7 @@ mod tests {
 
     #[test]
     fn a_zero_weight_sample_is_also_an_exact_passthrough() {
-        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         let sample = DeathCameraSample {
             weight: 0.0,
             ..death.sample()
@@ -341,7 +363,7 @@ mod tests {
 
     #[test]
     fn a_non_finite_weight_falls_back_to_the_tracked_camera() {
-        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         for weight in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
             let sample = DeathCameraSample {
                 weight,
@@ -353,7 +375,7 @@ mod tests {
 
     #[test]
     fn full_weight_pins_the_head_to_the_fallen_eye() {
-        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         let sample = DeathCameraSample {
             weight: 1.0,
             ..death.sample()
@@ -373,7 +395,7 @@ mod tests {
 
     #[test]
     fn the_pawn_transform_is_never_touched() {
-        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         for weight in [0.0, 0.25, 0.5, 1.0] {
             let resolved = camera(Some(DeathCameraSample {
                 weight,
@@ -386,7 +408,7 @@ mod tests {
 
     #[test]
     fn the_eye_falls_monotonically_toward_the_floor() {
-        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         let mut previous = camera(Some(death.sample())).head_offset.y;
         for _ in 0..60 {
             death.advance(FALL_SECONDS / 60.0);
@@ -405,7 +427,7 @@ mod tests {
 
     #[test]
     fn the_weight_saturates_rather_than_overshooting() {
-        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         death.advance(FALL_SECONDS * 10.0);
         assert_eq!(death.sample().weight, 1.0);
     }
@@ -413,7 +435,7 @@ mod tests {
     #[test]
     fn the_fallen_eye_stays_clear_of_the_near_plane() {
         for seed in 0..64 {
-            let death = DeathCamera::begin(live_eye(), -1.6, seed);
+            let death = DeathCamera::begin(live_eye(), -1.6, seed, FALL_LATERAL);
             assert!(death.sample().eye.position.y > -1.6 + 0.1);
         }
     }
@@ -421,7 +443,7 @@ mod tests {
     #[test]
     fn the_fallen_view_lies_on_its_side_looking_along_the_floor() {
         for seed in 0..64 {
-            let death = DeathCamera::begin(live_eye(), -1.6, seed);
+            let death = DeathCamera::begin(live_eye(), -1.6, seed, FALL_LATERAL);
             let rotation = death.sample().eye.rotation;
             let up = rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
             let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
@@ -436,8 +458,8 @@ mod tests {
 
     #[test]
     fn the_fall_direction_is_seeded_and_reproducible() {
-        let a = DeathCamera::begin(live_eye(), -1.6, 11);
-        let b = DeathCamera::begin(live_eye(), -1.6, 11);
+        let a = DeathCamera::begin(live_eye(), -1.6, 11, FALL_LATERAL);
+        let b = DeathCamera::begin(live_eye(), -1.6, 11, FALL_LATERAL);
         assert_eq!(a, b);
 
         // The seed is a coin flip over which side the body lands on, and both
@@ -457,7 +479,7 @@ mod tests {
             rotation: facing,
         };
         for seed in 0..32 {
-            let death = DeathCamera::begin(eye, -1.6, seed);
+            let death = DeathCamera::begin(eye, -1.6, seed, FALL_LATERAL);
             let gaze = death
                 .sample()
                 .eye
@@ -488,7 +510,7 @@ mod tests {
                 position: vec3(0.0, 2.6, 0.0),
                 rotation,
             };
-            let target = DeathCamera::begin(eye, -1.6, 3).target;
+            let target = DeathCamera::begin(eye, -1.6, 3, FALL_LATERAL).target;
             assert!(
                 target.position.x.is_finite()
                     && target.position.z.is_finite()
@@ -516,6 +538,7 @@ mod tests {
             },
             -1.6,
             5,
+            FALL_LATERAL,
         );
         for _ in 0..=60 {
             let resolved = resolve(
@@ -540,7 +563,7 @@ mod tests {
 
     #[test]
     fn the_stereo_eyes_roll_with_the_fallen_horizon() {
-        let mut death = DeathCamera::begin(live_eye(), -1.6, 5);
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 5, FALL_LATERAL);
         death.advance(FALL_SECONDS * 2.0);
         let resolved = resolve(
             Vector3::zero(),
@@ -562,7 +585,7 @@ mod tests {
 
     #[test]
     fn an_untracked_head_leaves_the_stereo_offset_alone() {
-        let death = DeathCamera::begin(live_eye(), -1.6, 5);
+        let death = DeathCamera::begin(live_eye(), -1.6, 5, FALL_LATERAL);
         let resolved = resolve(
             Vector3::zero(),
             Quaternion::one(),
@@ -578,7 +601,7 @@ mod tests {
 
     #[test]
     fn a_degenerate_tracked_rotation_does_not_poison_the_blend() {
-        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         let resolved = resolve(
             Vector3::zero(),
             Quaternion::one(),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1935,8 +1935,20 @@ impl Game {
         // and the cyber interface's vignette) - both occupy the explicit
         // scene-overlay layer: over the world, behind scene UI and the pause
         // menu, identically in flat and VR.
+        // Through the death camera first: these layers are view-LOCKED, and
+        // while the player is dying the rendered view is no longer the tracked
+        // head. Anchored to the raw tracked pose, the damage tint would slide
+        // off to the side as the camera falls away from it - and the killing
+        // blow is exactly when it is on screen.
+        let rendered_eye = death_camera::resolve(
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            self.head_pose.0,
+            self.head_pose.1,
+            self.active_game_scene.death_camera(),
+        );
         let (mut eye_position, eye_forward) =
-            hit_feedback::eye_pose(self.head_pose.0, self.head_pose.1);
+            hit_feedback::eye_pose(rendered_eye.head_offset, rendered_eye.head_rotation);
         // Centre the layer on the eye the frame is actually drawn from, which
         // is NOT the eye the input context reports: both flat runtimes put the
         // *standing* eye in `head.position` while rendering from a crouch-aware

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -75,6 +75,7 @@ use tracing::{info, trace, warn};
 use crate::{
     GameOptions,
     creature::{HitBoxManager, RagDollManager, get_creature_definition},
+    death_camera::{self, DeathCamera, DeathCameraSample},
     game_scene::AmbientAudioState,
     game_scene::PlayerSavePoseError,
     gui::GuiManager,
@@ -324,6 +325,17 @@ impl PlayerLifeState {
     pub fn is_alive(&self) -> bool {
         matches!(self, PlayerLifeState::Alive)
     }
+}
+
+/// Seed the death camera's fall direction from where the player died, so a
+/// replayed death topples the same way while two deaths in different places do
+/// not. The float bits are mixed rather than the value quantized: neighbouring
+/// positions should give unrelated directions, not the same one.
+fn death_seed(position: Vector3<f32>) -> u64 {
+    let mix = |seed: u64, value: f32| {
+        seed.rotate_left(17) ^ u64::from(value.to_bits()).wrapping_mul(0x9e37_79b9_7f4a_7c15)
+    };
+    mix(mix(mix(0, position.x), position.y), position.z)
 }
 
 const PLAYER_RESPAWN_DELAY_SECONDS: f32 = 5.0;
@@ -1084,6 +1096,11 @@ pub struct MissionCore {
     /// White transition cover shared by both flat and per-eye VR rendering.
     screen_fade_alpha: f32,
     screen_fade_texture: Rc<dyn TextureTrait>,
+
+    /// The fall to the floor that plays while the player is dying, or `None`
+    /// while they are alive. Runtime-only, like [`PlayerLifeState`] itself: a
+    /// dead game cannot be saved, so there is no death mid-fall to restore.
+    death_camera: Option<DeathCamera>,
 }
 
 pub struct GlobalContext {
@@ -1876,6 +1893,7 @@ impl MissionCore {
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
             screen_fade_texture,
+            death_camera: None,
         };
         for (index, entity_id) in backpack_load_remap.overflow.into_iter().enumerate() {
             mission_core.spill_backpack_overflow(entity_id, index);
@@ -1949,6 +1967,8 @@ impl MissionCore {
             .borrow::<UniqueViewMut<PlayerLifeState>>()
             .unwrap() = next_state;
 
+        self.death_camera = Some(self.begin_death_camera());
+
         vec![Effect::PlaySound {
             handle: AudioHandle::new(),
             source: None,
@@ -1958,6 +1978,45 @@ impl MissionCore {
                 .to_string(),
             spatial: false,
         }]
+    }
+
+    /// Choose where this death lands. The fall direction is seeded from the
+    /// position the player died at, so a reproducible death - a captured
+    /// screenshot sequence, an e2e assertion - falls exactly the same way,
+    /// while two deaths in different places do not topple identically.
+    fn begin_death_camera(&self) -> DeathCamera {
+        let (position, eye_height) = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            (
+                player.pos,
+                crate::player_eye_height_for(self.player_is_crouched()),
+            )
+        };
+        // The eye and the floor are both expressed relative to the pawn (the
+        // collider center), which is the space the runtimes' `head_offset`
+        // lives in - see `crate::death_camera`.
+        let live_eye = death_camera::upright_eye(eye_height / SCALE_FACTOR);
+        let floor_y = -physics::player_center_above_floor(self.player_is_crouched());
+        DeathCamera::begin(live_eye, floor_y, death_seed(position))
+    }
+
+    /// Drive the fall, and end it when the player is no longer dying. A QBR
+    /// reconstruction puts a live player back on their feet, so the camera has
+    /// to be back under their control the same frame - otherwise the
+    /// reconstructed body renders from the floor where the old one fell.
+    fn advance_death_camera(&mut self, elapsed_seconds: f32) {
+        if self.player_is_alive() {
+            self.death_camera = None;
+            return;
+        }
+        if let Some(death_camera) = &mut self.death_camera {
+            death_camera.advance(elapsed_seconds);
+        }
+    }
+
+    /// This frame's death-camera contribution, for [`crate::Game::resolve_camera`].
+    pub fn death_camera(&self) -> Option<DeathCameraSample> {
+        self.death_camera.as_ref().map(DeathCamera::sample)
     }
 
     /// Advance the death pause: perform the QBR reconstruction once its retail
@@ -2086,6 +2145,7 @@ impl MissionCore {
             life_state_effects.append(&mut self.begin_player_death());
         }
         life_state_effects.append(&mut self.update_player_life_state(time.elapsed.as_secs_f32()));
+        self.advance_death_camera(time.elapsed.as_secs_f32());
 
         // A dead player's physical head can still look around in VR, but all
         // actionable movement, hand, trigger, crouch, and pointer channels are

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1097,6 +1097,12 @@ pub struct MissionCore {
     screen_fade_alpha: f32,
     screen_fade_texture: Rc<dyn TextureTrait>,
 
+    /// The tracked head rotation this frame. The death camera needs the gaze
+    /// the player died with, and a death arriving through `handle_effects` sees
+    /// no input context - so it is recorded here each update rather than
+    /// threaded through the effect path.
+    last_head_rotation: Quaternion<f32>,
+
     /// The fall to the floor that plays while the player is dying, or `None`
     /// while they are alive. Runtime-only, like [`PlayerLifeState`] itself: a
     /// dead game cannot be saved, so there is no death mid-fall to restore.
@@ -1893,6 +1899,7 @@ impl MissionCore {
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
             screen_fade_texture,
+            last_head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
             death_camera: None,
         };
         for (index, entity_id) in backpack_load_remap.overflow.into_iter().enumerate() {
@@ -1985,19 +1992,62 @@ impl MissionCore {
     /// screenshot sequence, an e2e assertion - falls exactly the same way,
     /// while two deaths in different places do not topple identically.
     fn begin_death_camera(&self) -> DeathCamera {
-        let (position, eye_height) = {
+        let (position, player_rotation, player_entity) = {
             let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-            (
-                player.pos,
-                crate::player_eye_height_for(self.player_is_crouched()),
-            )
+            (player.pos, player.rotation, player.entity_id)
         };
         // The eye and the floor are both expressed relative to the pawn (the
         // collider center), which is the space the runtimes' `head_offset`
         // lives in - see `crate::death_camera`.
-        let live_eye = death_camera::upright_eye(eye_height / SCALE_FACTOR);
+        let eye_height = crate::player_eye_height_for(self.player_is_crouched());
+        let live_eye = death_camera::EyePose {
+            position: cgmath::vec3(0.0, eye_height / SCALE_FACTOR, 0.0),
+            // Where the player was actually looking: the body topples sideways
+            // from their gaze, so whatever killed them stays in frame.
+            rotation: self.last_head_rotation,
+        };
         let floor_y = -physics::player_center_above_floor(self.player_is_crouched());
-        DeathCamera::begin(live_eye, floor_y, death_seed(position))
+        let seed = death_seed(position);
+        let lateral =
+            self.clear_topple_distance(position, player_rotation, player_entity, seed, floor_y);
+        DeathCamera::begin(live_eye, floor_y, seed, lateral)
+    }
+
+    /// How far the body may topple before something stops it. Dying backed into
+    /// a wall is the common case when cornered, and an unclamped drift would
+    /// leave the camera inside the geometry. The path is swept at the height the
+    /// eye actually ends at - walls run floor to ceiling, but a waist-high crate
+    /// does not, and the fallen eye is low.
+    fn clear_topple_distance(
+        &self,
+        player_position: Vector3<f32>,
+        player_rotation: Quaternion<f32>,
+        player_entity: EntityId,
+        seed: u64,
+        floor_y: f32,
+    ) -> f32 {
+        // Keep the camera off whatever surface it stops against.
+        const CLEARANCE: f32 = 0.15;
+
+        let direction =
+            player_rotation * death_camera::topple_direction(self.last_head_rotation, seed);
+        let start = Point3::from_vec(
+            player_position + cgmath::vec3(0.0, floor_y + death_camera::FALLEN_EYE_HEIGHT, 0.0),
+        );
+        let blocked = self
+            .physics
+            .ray_cast2(
+                start,
+                direction,
+                death_camera::MAX_FALL_LATERAL,
+                physics::InternalCollisionGroups::ALL,
+                Some(player_entity),
+                true,
+            )
+            .map(|hit| (hit.hit_point - start).magnitude() - CLEARANCE);
+        blocked
+            .unwrap_or(death_camera::MAX_FALL_LATERAL)
+            .clamp(0.0, death_camera::MAX_FALL_LATERAL)
     }
 
     /// Drive the fall, and end it when the player is no longer dying. A QBR
@@ -2140,6 +2190,7 @@ impl MissionCore {
                 })
                 .unwrap_or(false)
         };
+        self.last_head_rotation = input_context.head.rotation;
         let mut life_state_effects = Vec::new();
         if self.player_is_alive() && player_health_depleted {
             life_state_effects.append(&mut self.begin_player_death());

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -273,6 +273,10 @@ impl crate::game_scene::GameScene for Mission {
         self.mission_core.use_mode_vignette_intensity()
     }
 
+    fn death_camera(&self) -> Option<crate::death_camera::DeathCameraSample> {
+        self.mission_core.death_camera()
+    }
+
     fn player_save_position(&self) -> Result<Vector3<f32>, crate::game_scene::PlayerSavePoseError> {
         self.mission_core.player_save_position()
     }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -411,6 +411,10 @@ export interface PlayerSnapshot {
    * activated QBR), which hands off to the `game_over` screen after three
    * seconds; `respawning` is the five-second QBR reconstruction delay. */
   life_state: "alive" | "dead" | "game_over" | "respawning";
+  /** The eye the runtime actually renders from, relative to the player's
+   * collider centre, and its orientation `[w, x, y, z]`. Live and crouch-aware,
+   * and it carries the death camera: while the player is dying these report the
+   * fall to the floor rather than the upright tracked pose. */
   camera_offset: Vec3;
   camera_rotation: [number, number, number, number];
   /** The wielded/first-person weapon in flatscreen mode; null when unarmed. */

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -65,6 +65,109 @@ test(
   },
 );
 
+// `death_camera::FALL_SECONDS`, in fixed-timestep frames.
+const FALL_FRAMES = Math.ceil(0.9 * 60);
+
+/** The camera's up axis in pawn space - `camera_rotation` is `[w, x, y, z]`. */
+function cameraUp([w, x, y, z]: [number, number, number, number]): [number, number, number] {
+  // R * (0, 1, 0)
+  return [2 * (x * y - w * z), 1 - 2 * (x * x + z * z), 2 * (y * z + w * x)];
+}
+
+test(
+  "dying drops the camera to the floor and rolls it onto its side",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 4,
+    });
+    await game.step({ frames: 5 });
+
+    const alive = (await game.info()).player;
+    assert.ok(alive.camera_offset[1] > 1.0, "a live player renders from a standing eye");
+    assert.ok(
+      Math.abs(cameraUp(alive.camera_rotation)[1] - 1.0) < 0.01,
+      `a live camera is upright, got up=${JSON.stringify(cameraUp(alive.camera_rotation))}`,
+    );
+
+    await killPlayer(game);
+
+    // The fall ramps in rather than snapping: one frame after death the camera
+    // has barely left the tracked pose.
+    const justDied = (await game.info()).player;
+    assert.equal(lifeState(justDied), "dead");
+    assert.ok(
+      Math.abs(justDied.camera_offset[1] - alive.camera_offset[1]) < 0.05,
+      `the death camera must ease in, not cut: ${justDied.camera_offset[1]} vs ${alive.camera_offset[1]}`,
+    );
+
+    await game.step({ frames: Math.floor(FALL_FRAMES / 2) });
+    const midFall = (await game.info()).player;
+    assert.ok(
+      midFall.camera_offset[1] < alive.camera_offset[1] - 0.2 &&
+        midFall.camera_offset[1] > justDied.camera_offset[1] - alive.camera_offset[1],
+      `mid-fall the camera is between the eye and the floor, got ${midFall.camera_offset[1]}`,
+    );
+
+    await game.step({ frames: FALL_FRAMES });
+    const fallen = (await game.info()).player;
+    assert.equal(lifeState(fallen), "dead", "the fall settles inside the death sequence");
+    assert.ok(
+      fallen.camera_offset[1] < alive.camera_offset[1] - 1.0,
+      `the fallen camera lies near the floor, got ${fallen.camera_offset[1]} (alive ${alive.camera_offset[1]})`,
+    );
+    // Lying on its side: the view's up axis now points along the ground.
+    const up = cameraUp(fallen.camera_rotation);
+    assert.ok(
+      Math.abs(up[1]) < 0.02,
+      `the fallen camera has rolled onto its side, got up=${JSON.stringify(up)}`,
+    );
+    assert.ok(Math.hypot(up[0], up[2]) > 0.98, `and its up axis is horizontal: ${JSON.stringify(up)}`);
+  },
+);
+
+test(
+  "a QBR reconstruction puts the camera back on the player's feet",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 5,
+    });
+    await game.step({ frames: 5 });
+
+    await game.player.spawnItem("20 Nanites");
+    const [button] = await game.entities.byTemplate(RESURRECTION_BUTTON);
+    assert.ok(button, "medsci1 should contain its authored QBR scanner button");
+    await game.entities.sendMessage(button.id, { type: "Frob" });
+    await game.step({ frames: 2 });
+
+    const alive = (await game.info()).player;
+    await killPlayer(game);
+    await game.step({ frames: FALL_FRAMES });
+
+    const dying = (await game.info()).player;
+    assert.equal(lifeState(dying), "respawning", "the fall plays for a QBR death too");
+    assert.ok(
+      dying.camera_offset[1] < alive.camera_offset[1] - 1.0,
+      `a reconstructing player still falls, got ${dying.camera_offset[1]}`,
+    );
+
+    await game.step({ frames: RESPAWN_DELAY_FRAMES });
+    const revived = (await game.info()).player;
+    assert.equal(lifeState(revived), "alive");
+    assert.ok(
+      Math.abs(revived.camera_offset[1] - alive.camera_offset[1]) < 0.01,
+      `reconstruction must hand the camera back, got ${revived.camera_offset[1]} (was ${alive.camera_offset[1]})`,
+    );
+    assert.ok(
+      Math.abs(cameraUp(revived.camera_rotation)[1] - 1.0) < 0.01,
+      `and upright, got up=${JSON.stringify(cameraUp(revived.camera_rotation))}`,
+    );
+  },
+);
+
 test(
   "an activated resurrection station revives the player after charging 10 nanites",
   { skip: !e2eEnabled, timeout: 600_000 },

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -103,15 +103,17 @@ test(
     );
 
     await game.step({ frames: Math.floor(FALL_FRAMES / 2) });
-    const midFall = (await game.info()).player;
-    assert.ok(
-      midFall.camera_offset[1] < alive.camera_offset[1] - 0.2 &&
-        midFall.camera_offset[1] > justDied.camera_offset[1] - alive.camera_offset[1],
-      `mid-fall the camera is between the eye and the floor, got ${midFall.camera_offset[1]}`,
-    );
+    const midFall = (await game.info()).player.camera_offset[1];
 
     await game.step({ frames: FALL_FRAMES });
     const fallen = (await game.info()).player;
+    // Strictly between the standing eye and where it settles - the fall is a
+    // ramp, not a cut. (Compared against the settled height, which is only
+    // known after the fall lands, so this assertion runs here.)
+    assert.ok(
+      midFall < alive.camera_offset[1] - 0.2 && midFall > fallen.camera_offset[1] + 0.05,
+      `mid-fall the camera should be between the standing eye ${alive.camera_offset[1]} and the settled ${fallen.camera_offset[1]}, got ${midFall}`,
+    );
     assert.equal(lifeState(fallen), "dead", "the fall settles inside the death sequence");
     assert.ok(
       fallen.camera_offset[1] < alive.camera_offset[1] - 1.0,


### PR DESCRIPTION
Drives the death camera from the existing `PlayerLifeState` timers. Stacked on #1122.

Dying froze the view mid-air at standing eye height for three seconds (five with a QBR) while the death vocalization played — the player's body was gone but their camera sat exactly where a live one would.

![death camera](https://gist.githubusercontent.com/tommy-xr/7caa387dd7653ec8e6e86e21edcc4397/raw/death-fall.gif)

<sub>medsci1, flat. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![before and after](https://gist.githubusercontent.com/tommy-xr/7caa387dd7653ec8e6e86e21edcc4397/raw/death-beforeafter.png)

The crates and steam that run horizontally when alive run **vertically** once fallen — a 90° roll at floor level. Crosshair and HUD are gone (that half lands in #1128).

## Behavior

- **Both death paths.** Terminal death falls and stays down until the game-over screen takes over; a QBR reconstruction falls too, and hands the camera back the frame the rebuilt player stands up. `advance_death_camera` clears the fall on any live player rather than waiting to be told, so a body reconstructed elsewhere can never inherit the floor the old one fell to.
- **The body topples sideways from the death-time gaze**, so whatever killed you stays in frame; the seed picks which side you go down on.
- **The fall is swept against geometry** at the height the eye actually lands at, and shortened to the first hit — dying backed into a wall is the common case when cornered.

## Headless observability

`/v1/info` now reports the camera the runtime actually rendered from, and fills in `camera_rotation`, which was a hardcoded identity marked `TODO`. That is what makes the fall assertable without screenshots.

## Verification

- New e2e tests assert the eye drops toward the floor and the view's up axis rolls onto the horizontal.
- **Negative test:** stubbing `MissionCore::death_camera` back to `None` fails them (`mid-fall the camera is between the eye and the floor, got 1.04`); restoring the drive passes.
- `cargo test -p shock2vr` — 974 pass.
