### PR TITLE
fix(vr): allow world frob while the cyber interface is open

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -193,6 +193,43 @@ fn update_squeeze_swallow(
     }
 }
 
+/// Which hands must not see their own trigger this frame, while the VR cyber
+/// interface is up (see [`MissionCore::vr_trigger_swallow`]).
+///
+/// The trigger is overloaded: for a hand holding a weapon it is fire, and for
+/// an empty hand it is the universal world "interact" (`MessagePayload::Frob`)
+/// - the two diverge in `VirtualHand::update`, between the `Grabbing` arm's
+/// `held_trigger_press_payload` and `handle_empty_hand_state`. Safing the
+/// weapon while the interface is up must therefore not be done by zeroing both
+/// triggers, or it takes the interact gesture with it and the player cannot
+/// frob a door or an item with the panel open. So the mask is per hand, and
+/// keyed on what that hand holds:
+///
+/// - `swallow_all` - a trigger still held from before the interface closed -
+///   masks both hands until it is released, unchanged.
+/// - A hand whose ray is on the panel is a UI pointer this frame: its trigger
+///   is the UI click and must not also reach through into the world.
+/// - A hand holding a wieldable weapon is safed - it stays wielded and visible
+///   but cannot fire.
+/// - Any other hand off the panel keeps its own trigger, so an empty hand can
+///   still Frob the world and a held consumable still works.
+///
+/// Pure, so the matrix is exercised directly rather than through a mission.
+fn trigger_safe_mask(
+    use_mode: bool,
+    swallow_all: bool,
+    on_panel: [bool; 2],
+    holds_weapon: [bool; 2],
+) -> [bool; 2] {
+    let mut mask = [swallow_all; 2];
+    if use_mode {
+        for slot in 0..mask.len() {
+            mask[slot] |= on_panel[slot] || holds_weapon[slot];
+        }
+    }
+    mask
+}
+
 /// Head-relative authored-space placement for the wide VR backpack canvas.
 /// After `SCALE_FACTOR` conversion this is 2 world units forward and 1.2 up.
 /// The shared canvas keeps its authored pixels; the physical VR boundary
@@ -2520,20 +2557,37 @@ impl MissionCore {
             [self.use_mode && on_panel[0], self.use_mode && on_panel[1]],
         );
 
-        // VR weapon-safe: while the cyber interface is up (and until a
-        // trigger held across its exit is released) the hands see zeroed
-        // triggers, so the wielded weapon cannot fire - it stays wielded and
-        // visible. The analog of the flat runtime's mouse-ownership swallow
-        // latch. Squeezes are masked only per the latch above, so a squeeze on
-        // an inventory slot pulls the item into that hand (the panel emits
-        // `GrabEntity`) without also grabbing whatever the hand was aimed at.
-        let safe_triggers = self.use_mode || self.vr_trigger_swallow;
+        // VR weapon-safe: while the cyber interface is up (and until a trigger
+        // held across its exit is released) a wielding hand sees a zeroed
+        // trigger, so the weapon cannot fire - it stays wielded and visible.
+        // The analog of the flat runtime's mouse-ownership swallow latch. The
+        // mask is per hand (see `trigger_safe_mask`) because the trigger is
+        // also the world interact gesture: a hand that is neither pointing at
+        // the panel nor holding a weapon keeps its trigger, so the player can
+        // still frob doors and items with the interface open. Squeezes are
+        // masked only per the latch above, so a squeeze on an inventory slot
+        // pulls the item into that hand (the panel emits `GrabEntity`) without
+        // also grabbing whatever the hand was aimed at.
+        let holds_weapon = [left_hand_held, right_hand_held].map(|held| {
+            held.is_some_and(|entity_id| {
+                crate::virtual_hand::is_wieldable_weapon(&self.world, entity_id)
+            })
+        });
+        let trigger_safe = trigger_safe_mask(
+            self.use_mode,
+            self.vr_trigger_swallow,
+            on_panel,
+            holds_weapon,
+        );
         let weapon_safe_input = (game_options.presentation_mode == crate::PresentationMode::Vr
-            && (safe_triggers || self.vr_squeeze_swallow.iter().any(|latched| *latched)))
+            && (trigger_safe.iter().any(|safe| *safe)
+                || self.vr_squeeze_swallow.iter().any(|latched| *latched)))
         .then(|| {
             let mut safe = input_context.clone();
-            if safe_triggers {
+            if trigger_safe[hand_slot(crate::vr_config::Handedness::Left)] {
                 safe.left_hand.trigger_value = 0.0;
+            }
+            if trigger_safe[hand_slot(crate::vr_config::Handedness::Right)] {
                 safe.right_hand.trigger_value = 0.0;
             }
             if self.vr_squeeze_swallow[hand_slot(crate::vr_config::Handedness::Left)] {
@@ -10274,6 +10328,78 @@ mod vr_squeeze_swallow_tests {
         let mut latched = [false; 2];
         update_squeeze_swallow(&mut latched, [true, true], [true, true], [true, false]);
         assert_eq!(latched, [true, false]);
+    }
+}
+
+#[cfg(test)]
+mod vr_trigger_safe_tests {
+    use super::trigger_safe_mask;
+
+    const LEFT: usize = 0;
+    const RIGHT: usize = 1;
+
+    const NEITHER: [bool; 2] = [false, false];
+
+    /// The bug this rule exists to fix: with the interface up, a hand that is
+    /// not pointing at the panel and is not holding a weapon must keep its
+    /// trigger, because that trigger is the world interact (Frob) gesture -
+    /// not only weapon fire. Safing the weapon by zeroing both triggers took
+    /// the interact with it.
+    #[test]
+    fn an_off_panel_empty_hand_keeps_its_trigger() {
+        let mask = trigger_safe_mask(true, false, NEITHER, NEITHER);
+        assert_eq!(
+            mask, NEITHER,
+            "an empty hand off the panel must still be able to frob the world"
+        );
+    }
+
+    /// The pointer bridge: a hand on the panel is a UI pointer, so its trigger
+    /// is the click and must not also reach through into the world.
+    #[test]
+    fn a_hand_on_the_panel_is_masked() {
+        let mask = trigger_safe_mask(true, false, [true, false], NEITHER);
+        assert_eq!(mask, [true, false]);
+    }
+
+    /// Weapons stay safed - wielded and visible, but they cannot fire while
+    /// the interface is up, on the panel or off it.
+    #[test]
+    fn a_wielding_hand_is_safed_wherever_it_points() {
+        assert_eq!(
+            trigger_safe_mask(true, false, NEITHER, [false, true]),
+            [false, true]
+        );
+        assert_eq!(
+            trigger_safe_mask(true, false, [false, true], [false, true]),
+            [false, true]
+        );
+    }
+
+    /// Per hand: one hand may be safed while the other still interacts.
+    #[test]
+    fn the_hands_are_masked_independently() {
+        // Left wields a weapon, right is empty and off the panel.
+        let mask = trigger_safe_mask(true, false, NEITHER, [true, false]);
+        assert!(mask[LEFT], "the wielding hand cannot fire");
+        assert!(!mask[RIGHT], "the free hand can still frob");
+    }
+
+    /// The trigger-held-across-exit edge is unchanged: both hands stay
+    /// swallowed until the trigger is released, even with the mode closed, so
+    /// closing the interface on a held trigger cannot fire or frob.
+    #[test]
+    fn a_trigger_held_across_the_exit_is_swallowed_on_both_hands() {
+        assert_eq!(trigger_safe_mask(false, true, NEITHER, NEITHER), [true; 2]);
+    }
+
+    /// With the interface closed and nothing held over, nothing is masked.
+    #[test]
+    fn a_closed_interface_masks_nothing() {
+        assert_eq!(
+            trigger_safe_mask(false, false, [true, true], [true, true]),
+            NEITHER
+        );
     }
 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -205,8 +205,6 @@ fn update_squeeze_swallow(
 /// frob a door or an item with the panel open. So the mask is per hand, and
 /// keyed on what that hand holds:
 ///
-/// - `swallow_all` - a trigger still held from before the interface closed -
-///   masks both hands until it is released, unchanged.
 /// - A hand whose ray is on the panel is a UI pointer this frame: its trigger
 ///   is the UI click and must not also reach through into the world.
 /// - A hand holding a wieldable weapon is safed - it stays wielded and visible
@@ -214,20 +212,54 @@ fn update_squeeze_swallow(
 /// - Any other hand off the panel keeps its own trigger, so an empty hand can
 ///   still Frob the world and a held consumable still works.
 ///
+/// This is the per-frame decision only; [`latch_trigger_safe`] freezes it for
+/// the length of a pull, and the caller ORs in `vr_trigger_swallow` afterwards.
+///
 /// Pure, so the matrix is exercised directly rather than through a mission.
-fn trigger_safe_mask(
-    use_mode: bool,
-    swallow_all: bool,
-    on_panel: [bool; 2],
-    holds_weapon: [bool; 2],
-) -> [bool; 2] {
-    let mut mask = [swallow_all; 2];
+fn trigger_safe_mask(use_mode: bool, on_panel: [bool; 2], holds_weapon: [bool; 2]) -> [bool; 2] {
+    let mut mask = [false; 2];
     if use_mode {
         for slot in 0..mask.len() {
-            mask[slot] |= on_panel[slot] || holds_weapon[slot];
+            mask[slot] = on_panel[slot] || holds_weapon[slot];
         }
     }
     mask
+}
+
+/// Freeze each hand's trigger mask for the length of one pull.
+///
+/// [`trigger_safe_mask`] is a per-frame decision, but a trigger pull is a
+/// *gesture*, and `VirtualHand` edge-detects it (`prev.trigger_value < 0.5 &&
+/// input > 0.5`). A mask that flips mid-pull therefore manufactures a brand new
+/// press out of a trigger the player never released - and `on_panel` really
+/// does flip mid-pull, because the panel is head-anchored: a head turn alone
+/// slides it out from under a motionless hand.
+///
+/// Both directions are bugs without this latch. A UI click begun on the panel
+/// would become a world `Frob` the moment the ray slipped off the edge (the
+/// hazard [`update_squeeze_swallow`] already guards for the squeeze). And a
+/// `Frob` begun off the panel would be re-fired every time the ray swept back
+/// across the panel, because masking a hand mid-pull makes
+/// `handle_empty_hand_state` clear its `last_frobbed_entity` debounce - worse
+/// for a held consumable, whose `Grabbing` arm has no debounce at all and would
+/// spend one item per crossing.
+///
+/// So the decision taken when the trigger crossed the threshold is the decision
+/// that pull keeps until it is released. `None` means "no pull in flight".
+fn latch_trigger_safe(
+    latched: &mut [Option<bool>; 2],
+    pressed: [bool; 2],
+    mask: [bool; 2],
+) -> [bool; 2] {
+    let mut effective = mask;
+    for slot in 0..effective.len() {
+        if pressed[slot] {
+            effective[slot] = *latched[slot].get_or_insert(mask[slot]);
+        } else {
+            latched[slot] = None;
+        }
+    }
+    effective
 }
 
 /// Head-relative authored-space placement for the wide VR backpack canvas.
@@ -1108,6 +1140,14 @@ pub struct MissionCore {
     /// its own squeeze again, or the eventual release would not drop it.
     vr_squeeze_swallow: [bool; 2],
 
+    /// The trigger-safe decision in flight for each hand (indexed by
+    /// [`hand_slot`]), or `None` when that hand's trigger is released. The
+    /// squeeze counterpart above latches because grabbing is *level*-triggered;
+    /// this one latches because firing and frobbing are *edge*-triggered, so a
+    /// mask that changes under a held trigger fabricates a press the player
+    /// never made. See [`latch_trigger_safe`].
+    vr_trigger_safe_latch: [Option<bool>; 2],
+
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
     /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
     /// `GuiManager` for the corresponding object-bound world panel.
@@ -1909,6 +1949,7 @@ impl MissionCore {
             vr_trigger_swallow: false,
             vr_use_mode_pointer: None,
             vr_squeeze_swallow: [false; 2],
+            vr_trigger_safe_latch: [None; 2],
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
@@ -2573,12 +2614,21 @@ impl MissionCore {
                 crate::virtual_hand::is_wieldable_weapon(&self.world, entity_id)
             })
         });
-        let trigger_safe = trigger_safe_mask(
-            self.use_mode,
-            self.vr_trigger_swallow,
-            on_panel,
-            holds_weapon,
+        // Decide, latch for the length of the pull, then OR in the
+        // across-exit swallow - which is deliberately *outside* the latch, so
+        // closing the interface under a held trigger always safes it.
+        let pressed = [
+            input_context.left_hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD,
+            input_context.right_hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD,
+        ];
+        let mut trigger_safe = latch_trigger_safe(
+            &mut self.vr_trigger_safe_latch,
+            pressed,
+            trigger_safe_mask(self.use_mode, on_panel, holds_weapon),
         );
+        for safe in trigger_safe.iter_mut() {
+            *safe |= self.vr_trigger_swallow;
+        }
         let weapon_safe_input = (game_options.presentation_mode == crate::PresentationMode::Vr
             && (trigger_safe.iter().any(|safe| *safe)
                 || self.vr_squeeze_swallow.iter().any(|latched| *latched)))
@@ -10333,12 +10383,13 @@ mod vr_squeeze_swallow_tests {
 
 #[cfg(test)]
 mod vr_trigger_safe_tests {
-    use super::trigger_safe_mask;
+    use super::{latch_trigger_safe, trigger_safe_mask};
 
     const LEFT: usize = 0;
     const RIGHT: usize = 1;
 
     const NEITHER: [bool; 2] = [false, false];
+    const BOTH: [bool; 2] = [true, true];
 
     /// The bug this rule exists to fix: with the interface up, a hand that is
     /// not pointing at the panel and is not holding a weapon must keep its
@@ -10347,7 +10398,7 @@ mod vr_trigger_safe_tests {
     /// the interact with it.
     #[test]
     fn an_off_panel_empty_hand_keeps_its_trigger() {
-        let mask = trigger_safe_mask(true, false, NEITHER, NEITHER);
+        let mask = trigger_safe_mask(true, NEITHER, NEITHER);
         assert_eq!(
             mask, NEITHER,
             "an empty hand off the panel must still be able to frob the world"
@@ -10358,8 +10409,10 @@ mod vr_trigger_safe_tests {
     /// is the click and must not also reach through into the world.
     #[test]
     fn a_hand_on_the_panel_is_masked() {
-        let mask = trigger_safe_mask(true, false, [true, false], NEITHER);
-        assert_eq!(mask, [true, false]);
+        assert_eq!(
+            trigger_safe_mask(true, [true, false], NEITHER),
+            [true, false]
+        );
     }
 
     /// Weapons stay safed - wielded and visible, but they cannot fire while
@@ -10367,11 +10420,11 @@ mod vr_trigger_safe_tests {
     #[test]
     fn a_wielding_hand_is_safed_wherever_it_points() {
         assert_eq!(
-            trigger_safe_mask(true, false, NEITHER, [false, true]),
+            trigger_safe_mask(true, NEITHER, [false, true]),
             [false, true]
         );
         assert_eq!(
-            trigger_safe_mask(true, false, [false, true], [false, true]),
+            trigger_safe_mask(true, [false, true], [false, true]),
             [false, true]
         );
     }
@@ -10380,25 +10433,75 @@ mod vr_trigger_safe_tests {
     #[test]
     fn the_hands_are_masked_independently() {
         // Left wields a weapon, right is empty and off the panel.
-        let mask = trigger_safe_mask(true, false, NEITHER, [true, false]);
+        let mask = trigger_safe_mask(true, NEITHER, [true, false]);
         assert!(mask[LEFT], "the wielding hand cannot fire");
         assert!(!mask[RIGHT], "the free hand can still frob");
     }
 
-    /// The trigger-held-across-exit edge is unchanged: both hands stay
-    /// swallowed until the trigger is released, even with the mode closed, so
-    /// closing the interface on a held trigger cannot fire or frob.
-    #[test]
-    fn a_trigger_held_across_the_exit_is_swallowed_on_both_hands() {
-        assert_eq!(trigger_safe_mask(false, true, NEITHER, NEITHER), [true; 2]);
-    }
-
-    /// With the interface closed and nothing held over, nothing is masked.
+    /// With the interface closed nothing is masked by the mode itself (the
+    /// across-exit swallow is ORed in by the caller, outside this rule).
     #[test]
     fn a_closed_interface_masks_nothing() {
+        assert_eq!(trigger_safe_mask(false, BOTH, BOTH), NEITHER);
+    }
+
+    /// The latch's reason to exist: a click begun on the panel keeps being
+    /// masked after the ray leaves it, so it can never turn into a world Frob
+    /// partway through. Without it the hand sees a fresh rising edge - the
+    /// player never released the trigger - and frobs whatever it now points at.
+    #[test]
+    fn a_pull_begun_on_the_panel_never_reaches_the_world() {
+        let mut latched = [None; 2];
+        // Pull starts with the ray on the panel: masked.
+        assert!(latch_trigger_safe(&mut latched, [true, false], [true, false])[LEFT]);
+        // Ray slides off the panel, trigger still held - still masked.
+        assert!(latch_trigger_safe(&mut latched, [true, false], NEITHER)[LEFT]);
+        // Released: the latch drops and the next pull is judged fresh.
+        assert!(!latch_trigger_safe(&mut latched, NEITHER, NEITHER)[LEFT]);
+        assert_eq!(latched[LEFT], None);
+        assert!(
+            !latch_trigger_safe(&mut latched, [true, false], NEITHER)[LEFT],
+            "a pull begun off the panel is the world's"
+        );
+    }
+
+    /// The other direction: a Frob begun off the panel must not be re-fired
+    /// every time the ray sweeps across the head-anchored panel. Masking a hand
+    /// mid-pull would clear `handle_empty_hand_state`'s `last_frobbed_entity`
+    /// debounce, and a held consumable would be spent once per crossing.
+    #[test]
+    fn a_pull_begun_off_the_panel_survives_crossing_it() {
+        let mut latched = [None; 2];
+        assert!(!latch_trigger_safe(&mut latched, [false, true], NEITHER)[RIGHT]);
+        assert!(
+            !latch_trigger_safe(&mut latched, [false, true], [false, true])[RIGHT],
+            "sweeping across the panel mid-pull must not re-mask the hand"
+        );
+    }
+
+    /// An untouched trigger is judged fresh every frame - the latch only ever
+    /// speaks for a pull that is actually in flight.
+    #[test]
+    fn a_released_hand_tracks_the_live_decision() {
+        let mut latched = [None; 2];
+        assert_eq!(latch_trigger_safe(&mut latched, NEITHER, BOTH), BOTH);
+        assert_eq!(latched, [None, None]);
+        assert_eq!(latch_trigger_safe(&mut latched, NEITHER, NEITHER), NEITHER);
+    }
+
+    /// Each hand latches its own pull.
+    #[test]
+    fn the_hands_latch_independently() {
+        let mut latched = [None; 2];
+        // Left pulls on the panel; right is not pulling at all.
         assert_eq!(
-            trigger_safe_mask(false, false, [true, true], [true, true]),
-            NEITHER
+            latch_trigger_safe(&mut latched, [true, false], [true, false]),
+            [true, false]
+        );
+        // Left slides off (still latched), right now pulls off-panel.
+        assert_eq!(
+            latch_trigger_safe(&mut latched, BOTH, NEITHER),
+            [true, false]
         );
     }
 }

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -109,12 +109,15 @@ export async function aimVrHandAtCanvas(
 }
 
 /** Aim the production VR hand ray at a world point without direct entity
- * messages. Pass `squeeze = 1` to preserve an already-held item while aiming. */
+ * messages. Pass `squeeze = 1` to preserve an already-held item while aiming,
+ * and `trigger = 1` to keep a pull in flight across the re-aim (releasing it
+ * would end the gesture, which matters wherever a latch spans the movement). */
 export async function aimVrHandAt(
   game: GameServer,
   target: Vec3,
   standOff = 0.45,
   squeeze = 0,
+  trigger = 0,
 ): Promise<{ start: Vec3; target: Vec3 }> {
   const snapshot = await game.info();
   const pawn = snapshot.player.position;
@@ -137,7 +140,7 @@ export async function aimVrHandAt(
   });
   await game.input.set("right_hand.position", localHand);
   await game.input.set("right_hand.rotation", localHandRotation);
-  await game.input.set("right_hand.trigger", 0);
+  await game.input.set("right_hand.trigger", trigger);
   await game.input.set("right_hand.squeeze", squeeze);
   await game.step({ frames: 3 });
   return { start: worldHand, target };

--- a/tools/shock2-sdk/test/vr-cyber-interface-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-frob.e2e.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 import { stackCount } from "./helpers/nanites.js";
-import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
 
 // The VR trigger is overloaded: for a hand holding a weapon it is fire, and
 // for an empty hand it is the universal world interact (Frob). Safing the
@@ -21,6 +21,8 @@ const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8577);
  * nanite-player-stat.e2e.test.ts). Collecting it moves a known amount into
  * `player.stats.nanites`, which makes the frob cleanly observable. */
 const NANITE_PILE_OBJ = 257;
+/** A second pile, so the latch scenario below starts from an uncollected one. */
+const LATCH_PILE_OBJ = 292;
 
 test(
   "an off-panel hand still frobs the world while the VR cyber interface is open",
@@ -88,6 +90,66 @@ test(
       (await game.ui.state()).mode,
       "use",
       "frobbing the world must leave the cyber interface open",
+    );
+  },
+);
+
+test(
+  "a trigger pull begun on the cyber-interface panel cannot slide off into a world frob",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const [pile] = await game.entities.byTemplate(LATCH_PILE_OBJ);
+    assert.ok(pile, `expected earth mission object ${LATCH_PILE_OBJ} (Big Nanite Pile)`);
+    const detail = await game.entities.detail(pile.id);
+    const stack = stackCount(detail.properties);
+    assert.ok(stack !== undefined && stack > 0, "expected a positive authored stack count");
+
+    const [x, y, z] = detail.position;
+    await game.player.teleport({ x, y: y - PLAYER_EYE_HEIGHT_WORLD, z: z + 0.3 });
+    await game.step({ frames: 5 });
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const panel = (await game.ui.state()).panel_pose;
+    assert.ok(panel, "the cyber interface must expose its panel pose");
+
+    // Begin the pull ON the panel - this is a UI click, not a world interact.
+    await aimVrHandAtCanvas(game, panel, [320, 240], { trigger: 1 });
+    await game.step({ frames: 5 });
+    assert.ok(
+      (await game.ui.state()).pointer?.hand,
+      "the pull must start with the hand owning the canvas pointer",
+    );
+
+    // Slide the ray off the panel onto the pile WITHOUT releasing. The panel is
+    // head-anchored, so this happens in ordinary play from a head turn alone.
+    // The gesture keeps the meaning it started with: it must not become a Frob.
+    await aimVrHandAt(game, detail.position, 0.45, 0, 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.stats?.nanites ?? 0,
+      0,
+      "a click begun on the panel must not turn into a world frob when the ray slides off",
+    );
+
+    // Release and pull again, now genuinely off-panel: the latch has dropped
+    // and this fresh gesture is the world's, so the pile collects. Without
+    // this the assertion above could pass for the wrong reason.
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.stats?.nanites ?? 0,
+      stack,
+      "a fresh pull off the panel must still frob the world",
     );
   },
 );

--- a/tools/shock2-sdk/test/vr-cyber-interface-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-frob.e2e.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import { stackCount } from "./helpers/nanites.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// The VR trigger is overloaded: for a hand holding a weapon it is fire, and
+// for an empty hand it is the universal world interact (Frob). Safing the
+// weapon while the cyber interface is up used to zero BOTH hands' trigger,
+// which took the interact gesture with it - with the panel open the player
+// could not frob anything in the world. The mask is now per hand, so a hand
+// that is neither pointing at the panel nor holding a weapon still frobs.
+//
+// Negative-first: on the parent this fails at the "collected" assertion -
+// the pile is still sitting there with the stat unchanged.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8577);
+
+/** Stable earth.mis mission object: a "Big Nanite Pile" (see
+ * nanite-player-stat.e2e.test.ts). Collecting it moves a known amount into
+ * `player.stats.nanites`, which makes the frob cleanly observable. */
+const NANITE_PILE_OBJ = 257;
+
+test(
+  "an off-panel hand still frobs the world while the VR cyber interface is open",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const [pile] = await game.entities.byTemplate(NANITE_PILE_OBJ);
+    assert.ok(pile, `expected earth mission object ${NANITE_PILE_OBJ} (Big Nanite Pile)`);
+    const detail = await game.entities.detail(pile.id);
+    const stack = stackCount(detail.properties);
+    assert.ok(stack !== undefined && stack > 0, "expected a positive authored stack count");
+    assert.equal(
+      (await game.info()).player.stats?.nanites ?? 0,
+      0,
+      "a fresh earth character starts with no stat nanites",
+    );
+
+    // Stand over the pile and aim the production hand ray down at it. The
+    // interface panel hangs at head height along the head's yaw (it is
+    // gravity-aligned and yaw-only), so a steeply downward ray is genuinely
+    // off the panel - which the pointer assertion below confirms rather than
+    // assumes.
+    const [x, y, z] = detail.position;
+    await game.player.teleport({ x, y: y - PLAYER_EYE_HEIGHT_WORLD, z: z + 0.3 });
+    await game.step({ frames: 5 });
+    await aimVrHandAt(game, detail.position);
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).mode, "use", "the cyber interface must be open");
+
+    // Re-aim after the panel is placed, then prove the hand is off-panel: no
+    // hand owns the canvas pointer, so this trigger is not a UI click.
+    await aimVrHandAt(game, detail.position);
+    assert.equal(
+      (await game.ui.state()).pointer?.hand ?? null,
+      null,
+      "the hand must be off the panel for this to be the world-interact case",
+    );
+
+    // The interact gesture: a trigger pull from the empty, off-panel hand.
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.info()).player.stats?.nanites ?? 0,
+      stack,
+      "an off-panel trigger must still frob the world while the interface is open",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: pile.id })).bodies.length,
+      0,
+      "the collected pile should no longer have a world body",
+    );
+    // The frob must not have disturbed the interface itself.
+    assert.equal(
+      (await game.ui.state()).mode,
+      "use",
+      "frobbing the world must leave the cyber interface open",
+    );
+  },
+);


### PR DESCRIPTION
## The bug

While the VR cyber interface (use mode) is open, the player cannot frob/interact with world items that have clear focus — a door, a button, an item. Reported by the owner as a regression-by-design-gap in the merged cyber-interface stack.

## Where fire and frob diverge

The VR trigger is overloaded, and the two meanings split inside `VirtualHand::update` (`shock2vr/src/virtual_hand.rs`):

- **`HandState::Grabbing`** (a hand holding something) → on the trigger's rising edge it sends `held_trigger_press_payload(world, entity_id)` — `MessagePayload::TriggerPull` for a wieldable weapon (**fire**), `Frob` for a scripted consumable.
- **`HandState::Empty`** → `handle_empty_hand_state` sends `MessagePayload::Frob` at the raycast hit whenever `trigger_value > 0.5` — the **universal world interact** gesture.

`mission_core.rs`'s weapon-safe step zeroed `trigger_value` on **both** hands before `self.interaction.update(...)`. That safes the weapon, but because the same input field carries the interact gesture, world frob died globally as a side effect. Squeeze-grab was already arbitrated per hand (`vr_squeeze_swallow` + `on_panel`); the trigger was not.

## The fix

Replace the global zeroing with a per-hand mask, `trigger_safe_mask`, keyed on what each hand holds:

| hand state | on panel | off panel |
| --- | --- | --- |
| empty | UI click, no world frob | **world Frob** (was: nothing) |
| holding weapon | UI click, no fire | no fire |
| holding non-weapon item | UI click | unchanged (held-item trigger / keycard Frob path) |

`vr_trigger_swallow` (a trigger held across use mode's exit) still masks **both** hands until release, unchanged. Flat use mode's separate mouse-ownership swallow is untouched, and the `last_frobbed_entity` debounce from #1119 is not touched — it keeps working exactly as before, now that the trigger actually reaches it.

**Denial feedback:** the owner's design calls for a denial click/haptic on an attempted fire while safed. There is no cheap existing precedent for a per-attempt denial cue on this path (`mainpanel_op`/`mainpanel_cl` are the mode's own open/close stings, played once from `enter_use_mode`/`leave_use_mode`, not a per-input denial), so this slice **suppresses fire silently**, as agreed for that case. Worth a follow-up if the silence reads as unresponsive on device.

## Latching the decision (from review)

The first cut made the mask a **per-frame** decision. Adversarial review caught that this is wrong, because `VirtualHand` **edge-detects** the trigger (`prev.trigger_value < 0.5 && input > 0.5`) — so a mask that flips mid-pull fabricates a press the player never made. And `on_panel` really does flip mid-pull: the panel is head-anchored, so a head turn alone slides it out from under a motionless hand.

Both directions were bugs:

- A UI click begun **on** the panel became a world `Frob` the instant the ray slipped off the edge — exactly the hazard `update_squeeze_swallow` already guards for the squeeze. **Reproduced:** with the latch stubbed out, the e2e slide-off scenario collects 50 nanites that the player never aimed at.
- A `Frob` begun **off** the panel was re-fired on every sweep back across the panel, because masking a hand mid-pull makes `handle_empty_hand_state` clear its `last_frobbed_entity` debounce (#1119). Worse for a held consumable, whose `Grabbing` arm has no debounce at all and would spend one item per crossing.

So `latch_trigger_safe` freezes the decision taken when the trigger crossed the threshold: each pull keeps one meaning for its whole life. `vr_trigger_swallow` is ORed in *outside* the latch, so closing the interface under a held trigger still safes both hands.

## Tests

**Unit** (`shock2vr/src/mission/mission_core.rs`, `vr_trigger_safe_tests`) — 9 tests over the two pure functions: the mask matrix, and the latch (a pull begun on the panel never reaches the world; a pull begun off it survives crossing the panel; a released hand tracks the live decision; hands latch independently). Negative-first: with the mask stubbed back to the old global `[use_mode || swallow_all; 2]`, 4 of the mask tests fail (the ones that pass are the deliberately-unchanged edges).

**e2e** (`tools/shock2-sdk/test/vr-cyber-interface-frob.e2e.test.ts`, new, 2 scenarios) — (1) drives the production VR hand ray in `--vr`: stand over an earth.mis nanite pile, open the interface, assert **no hand owns the canvas pointer** (so the trigger is genuinely the world-interact case and not a UI click), pull the trigger, and assert the pile collects into `player.stats.nanites` while `ui.mode` stays `"use"`. Negative-first: 0 collected vs the authored 250 without the fix.

(2) the latch: begin the pull **on** the panel, slide the ray onto the pile without releasing, and assert the pile is **not** collected — then release, pull again off-panel, and assert it *is*, so the first assertion cannot pass for the wrong reason. Negative-first: without the latch it collects 50 nanites on the slide-off.

The existing `vr-cyber-interface.e2e.test.ts` needed **no expectation changes** — its weapon-safe scenario only exercises the *wielding* hand, which stays safed, and the held-trigger-across-exit case, which is preserved.

Results:
- `cargo test -p shock2vr --lib` — 963 passed, 0 failed (rebased onto `ab6fe003`)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean
- e2e: `vr-cyber-interface`, `vr-cyber-interface-pointer`, `vr-cyber-interface-frob` (5/5); `missions` (23/23); `vr-held-model`, `vr-weapon-handedness`, `earth-vr-world-panel-arbitration`, `medsci2-vr-released-item` (8/8)

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72

## Visuals

![off-panel frob with the cyber interface open](https://gist.githubusercontent.com/tommy-xr/7619d54a3ec85030df15e8877e4e654e/raw/demo.gif)

<sub>earth.mis, VR presentation. The cyber interface is open (the INVENTORY/EQUIP panel on the left); the right hand points off-panel at a Big Nanite Pile (labelled `Nanites: "250 nanites."`, right) and pulls the trigger - the pile is frobbed, collected, and the panel stays open. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep); the UI pointer is `null` throughout, so this is the world-interact case and not a panel click.</sub>

## Before -> after

![before/after](https://gist.githubusercontent.com/tommy-xr/7619d54a3ec85030df15e8877e4e654e/raw/beforeafter.png)

<sub>Same request sequence against both builds - the frames before the trigger pull are byte-identical. Before (the parent's behaviour, restored by stubbing `trigger_safe_mask` back to swallowing both hands in use mode): the pull does nothing, the pile and its label are still there and `player.stats.nanites` stays 0. After: the off-panel hand keeps its trigger, the pile is collected and `player.stats.nanites` reads 250.</sub>

