### PR TITLE
feat(camera): let a fallen player look around, and drop their hands

### DIFF
--- a/shock2vr/src/death_camera.rs
+++ b/shock2vr/src/death_camera.rs
@@ -62,6 +62,19 @@ pub const FALLEN_EYE_HEIGHT: f32 = 0.45;
 /// toppling over rather than sinking straight down.
 const FALL_LATERAL: f32 = 0.75;
 
+/// How long, after the fall settles, the tracked head takes to regain its
+/// influence over the view.
+///
+/// A fully pinned camera is the single most uncomfortable state in VR: the
+/// horizon stops answering head movement, which reads as the world moving
+/// rather than the player. The fall itself is short enough to be a deliberate
+/// jolt, but the corpse then lies there for the rest of the death window, so
+/// the tracked head is let back in as a *delta* on the fallen frame - the
+/// player can look around from where they fell, and the punishing part (being
+/// on the floor, on your side, unable to act) is untouched. Flat runtimes are
+/// unaffected: their look input is already suppressed while dead.
+const LOOK_RECOVERY_SECONDS: f32 = 0.6;
+
 /// An eye pose in pawn space: the same space the runtimes' `head_offset` and
 /// `head_rotation` live in.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -111,6 +124,11 @@ pub struct DeathCameraSample {
     pub eye: EyePose,
     /// 0 = the tracked head is authoritative, 1 = the fallen eye is.
     pub weight: f32,
+    /// The tracked head rotation at the moment of death, and how much of the
+    /// player's movement away from it to re-admit (0 during the fall, ramping
+    /// to 1 once it settles). See [`LOOK_RECOVERY_SECONDS`].
+    pub look_frame: Quaternion<f32>,
+    pub look_recovery: f32,
 }
 
 /// The fall itself: a target pose chosen once when the player dies, and the
@@ -123,6 +141,10 @@ pub struct DeathCameraSample {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DeathCamera {
     target: EyePose,
+    /// The tracked head rotation this death started from, so the player's later
+    /// head movement can be measured against it rather than against the fallen
+    /// frame it knows nothing about.
+    look_frame: Quaternion<f32>,
     elapsed_seconds: f32,
 }
 
@@ -170,6 +192,7 @@ impl DeathCamera {
 
         DeathCamera {
             target,
+            look_frame: live_eye.rotation,
             elapsed_seconds: 0.0,
         }
     }
@@ -184,6 +207,10 @@ impl DeathCamera {
         DeathCameraSample {
             eye: self.target,
             weight: ease_in_out(self.elapsed_seconds / FALL_SECONDS),
+            look_frame: self.look_frame,
+            look_recovery: ease_in_out(
+                (self.elapsed_seconds - FALL_SECONDS) / LOOK_RECOVERY_SECONDS,
+            ),
         }
     }
 }
@@ -218,9 +245,50 @@ pub fn resolve(
 
     CameraPose {
         head_offset: tracked_head_offset.lerp(sample.eye.position, weight),
-        head_rotation: slerp_safe(tracked_head_rotation, sample.eye.rotation, weight),
+        head_rotation: slerp_safe(
+            tracked_head_rotation,
+            fallen_rotation(&sample, tracked_head_rotation),
+            weight,
+        ),
         ..passthrough
     }
+}
+
+/// The fallen frame, with as much of the player's head movement since they died
+/// re-admitted as [`DeathCameraSample::look_recovery`] allows.
+///
+/// The movement is measured against the tracked rotation at death rather than
+/// applied absolutely: the fallen view is a new frame of reference, and what
+/// carries over is how far the player has turned since, not where they were
+/// facing before.
+fn fallen_rotation(
+    sample: &DeathCameraSample,
+    tracked_head_rotation: Quaternion<f32>,
+) -> Quaternion<f32> {
+    let recovery = if sample.look_recovery.is_finite() {
+        sample.look_recovery.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    if recovery <= 0.0 {
+        return sample.eye.rotation;
+    }
+    let (Some(look_frame), Some(tracked)) = (unit(sample.look_frame), unit(tracked_head_rotation))
+    else {
+        return sample.eye.rotation;
+    };
+    let delta = slerp_safe(
+        Quaternion::one(),
+        look_frame.conjugate() * tracked,
+        recovery,
+    );
+    sample.eye.rotation * delta
+}
+
+/// The unit form of a rotation, or `None` for a degenerate one that carries no
+/// rotation information.
+fn unit(rotation: Quaternion<f32>) -> Option<Quaternion<f32>> {
+    (rotation.magnitude2() > 1.0e-6).then(|| rotation.normalize())
 }
 
 /// `Quaternion::slerp` is only defined for unit quaternions and produces NaN
@@ -228,14 +296,7 @@ pub fn resolve(
 /// frame. A zero-length input is treated as "no rotation information", so the
 /// blend falls back to the other end rather than to garbage.
 fn slerp_safe(from: Quaternion<f32>, to: Quaternion<f32>, weight: f32) -> Quaternion<f32> {
-    let normalize = |q: Quaternion<f32>| {
-        if q.magnitude2() > 1.0e-6 {
-            Some(q.normalize())
-        } else {
-            None
-        }
-    };
-    match (normalize(from), normalize(to)) {
+    match (unit(from), unit(to)) {
         (Some(from), Some(to)) => from.slerp(to, weight),
         (None, Some(to)) => to,
         (Some(from), None) => from,
@@ -314,22 +375,16 @@ pub fn reapply_eye_offset(
     }
 }
 
-/// The eye pose a live, upright player renders from, for callers that need a
-/// neutral starting pose (tests, and the death-camera hand-off).
-pub fn upright_eye(eye_height: f32) -> EyePose {
-    EyePose {
-        position: vec3(0.0, eye_height, 0.0),
-        rotation: Quaternion::one(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use cgmath::{AbsDiffEq, Deg, Rotation, Rotation3, Zero};
 
     fn live_eye() -> EyePose {
-        upright_eye(2.6)
+        EyePose {
+            position: vec3(0.0, 2.6, 0.0),
+            rotation: Quaternion::one(),
+        }
     }
 
     fn camera(sample: Option<DeathCameraSample>) -> CameraPose {
@@ -596,6 +651,105 @@ mod tests {
         assert_eq!(
             reapply_eye_offset(resolved, vec3(0.5, 0.0, 0.0), Quaternion::zero()),
             resolved
+        );
+    }
+
+    #[test]
+    fn the_fall_ignores_head_movement_while_it_plays() {
+        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let settled = DeathCameraSample {
+            weight: 1.0,
+            look_recovery: 0.0,
+            ..death.sample()
+        };
+        // A player turning their head mid-fall does not steer the fall.
+        for turn in [0.0, 45.0, 180.0] {
+            let resolved = resolve(
+                Vector3::zero(),
+                Quaternion::one(),
+                Vector3::zero(),
+                Quaternion::from_angle_y(Deg(turn)),
+                Some(settled),
+            );
+            assert!(
+                resolved
+                    .head_rotation
+                    .abs_diff_eq(&settled.eye.rotation, 1.0e-5),
+                "turn {turn} steered the fall"
+            );
+        }
+    }
+
+    #[test]
+    fn once_settled_the_player_can_look_around_from_where_they_fell() {
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        death.advance(FALL_SECONDS + LOOK_RECOVERY_SECONDS);
+        let sample = death.sample();
+        assert_eq!(sample.weight, 1.0);
+        assert_eq!(sample.look_recovery, 1.0);
+
+        // Standing still leaves the fallen view exactly where the fall put it.
+        let still = resolve(
+            Vector3::zero(),
+            Quaternion::one(),
+            Vector3::zero(),
+            live_eye().rotation,
+            Some(sample),
+        );
+        assert!(
+            still
+                .head_rotation
+                .abs_diff_eq(&sample.eye.rotation, 1.0e-5)
+        );
+
+        // Turning the head 90 degrees turns the view by 90 degrees - about the
+        // fallen frame's own axis, not the world's.
+        let turned = resolve(
+            Vector3::zero(),
+            Quaternion::one(),
+            Vector3::zero(),
+            live_eye().rotation * Quaternion::from_angle_y(Deg(90.0)),
+            Some(sample),
+        );
+        let relative = sample.eye.rotation.conjugate() * turned.head_rotation;
+        assert!(
+            relative.abs_diff_eq(&Quaternion::from_angle_y(Deg(90.0)), 1.0e-4),
+            "expected a 90 degree turn in the fallen frame, got {relative:?}"
+        );
+    }
+
+    #[test]
+    fn the_look_recovery_only_starts_once_the_fall_has_landed() {
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        assert_eq!(death.sample().look_recovery, 0.0);
+        death.advance(FALL_SECONDS);
+        assert_eq!(death.sample().look_recovery, 0.0);
+        death.advance(LOOK_RECOVERY_SECONDS / 2.0);
+        let partial = death.sample().look_recovery;
+        assert!(partial > 0.0 && partial < 1.0, "got {partial}");
+        death.advance(LOOK_RECOVERY_SECONDS);
+        assert_eq!(death.sample().look_recovery, 1.0);
+    }
+
+    #[test]
+    fn a_degenerate_look_frame_leaves_the_fallen_view_alone() {
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        death.advance(FALL_SECONDS + LOOK_RECOVERY_SECONDS);
+        let sample = DeathCameraSample {
+            look_frame: Quaternion::zero(),
+            ..death.sample()
+        };
+        let resolved = resolve(
+            Vector3::zero(),
+            Quaternion::one(),
+            Vector3::zero(),
+            Quaternion::from_angle_y(Deg(90.0)),
+            Some(sample),
+        );
+        assert!(
+            resolved
+                .head_rotation
+                .abs_diff_eq(&sample.eye.rotation, 1.0e-5)
         );
     }
 

--- a/shock2vr/src/death_camera.rs
+++ b/shock2vr/src/death_camera.rs
@@ -71,8 +71,7 @@ const FALL_LATERAL: f32 = 0.75;
 /// jolt, but the corpse then lies there for the rest of the death window, so
 /// the tracked head is let back in as a *delta* on the fallen frame - the
 /// player can look around from where they fell, and the punishing part (being
-/// on the floor, on your side, unable to act) is untouched. Flat runtimes are
-/// unaffected: their look input is already suppressed while dead.
+/// on the floor, on your side, unable to act) is untouched.
 const LOOK_RECOVERY_SECONDS: f32 = 0.6;
 
 /// An eye pose in pawn space: the same space the runtimes' `head_offset` and
@@ -279,10 +278,17 @@ fn fallen_rotation(
     };
     let delta = slerp_safe(
         Quaternion::one(),
-        look_frame.conjugate() * tracked,
+        tracked * look_frame.conjugate(),
         recovery,
     );
-    sample.eye.rotation * delta
+    // LEFT-multiplied, deliberately. Right-multiplying would apply the turn in
+    // the fallen view's own frame, where the roll has taken "up" onto a
+    // horizontal axis - so the player's real yaw (which their inner ear feels
+    // as rotation about world up) would come back as visual ROLL. That
+    // vestibular-visual axis mismatch is a stronger nausea source than the
+    // pinned camera this recovery exists to avoid. Left-multiplying keeps head
+    // yaw producing view yaw about world up.
+    delta * sample.eye.rotation
 }
 
 /// The unit form of a rotation, or `None` for a degenerate one that carries no
@@ -378,7 +384,15 @@ pub fn reapply_eye_offset(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::{AbsDiffEq, Deg, Rotation, Rotation3, Zero};
+    use cgmath::{AbsDiffEq, Deg, Rad, Rotation, Rotation3, Zero};
+
+    /// Angle between two rotations, in degrees. Compared this way rather than
+    /// componentwise because `q` and `-q` are the same rotation, and `slerp`
+    /// is free to return either.
+    fn angle_between(a: Quaternion<f32>, b: Quaternion<f32>) -> f32 {
+        let dot = (a.normalize().dot(b.normalize())).abs().min(1.0);
+        Deg::from(Rad(2.0 * dot.acos())).0
+    }
 
     fn live_eye() -> EyePose {
         EyePose {
@@ -656,7 +670,7 @@ mod tests {
 
     #[test]
     fn the_fall_ignores_head_movement_while_it_plays() {
-        let death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         let settled = DeathCameraSample {
             weight: 1.0,
             look_recovery: 0.0,
@@ -672,9 +686,7 @@ mod tests {
                 Some(settled),
             );
             assert!(
-                resolved
-                    .head_rotation
-                    .abs_diff_eq(&settled.eye.rotation, 1.0e-5),
+                angle_between(resolved.head_rotation, settled.eye.rotation) < 0.01,
                 "turn {turn} steered the fall"
             );
         }
@@ -682,7 +694,7 @@ mod tests {
 
     #[test]
     fn once_settled_the_player_can_look_around_from_where_they_fell() {
-        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         death.advance(FALL_SECONDS + LOOK_RECOVERY_SECONDS);
         let sample = death.sample();
         assert_eq!(sample.weight, 1.0);
@@ -702,8 +714,10 @@ mod tests {
                 .abs_diff_eq(&sample.eye.rotation, 1.0e-5)
         );
 
-        // Turning the head 90 degrees turns the view by 90 degrees - about the
-        // fallen frame's own axis, not the world's.
+        // Turning the head 90 degrees turns the view by 90 degrees about WORLD
+        // UP - the axis the player's inner ear felt it about. Applying it in
+        // the fallen frame instead would come back as roll, which is the
+        // vestibular mismatch this whole ramp exists to avoid.
         let turned = resolve(
             Vector3::zero(),
             Quaternion::one(),
@@ -711,16 +725,20 @@ mod tests {
             live_eye().rotation * Quaternion::from_angle_y(Deg(90.0)),
             Some(sample),
         );
-        let relative = sample.eye.rotation.conjugate() * turned.head_rotation;
+        let applied = turned.head_rotation * sample.eye.rotation.conjugate();
         assert!(
-            relative.abs_diff_eq(&Quaternion::from_angle_y(Deg(90.0)), 1.0e-4),
-            "expected a 90 degree turn in the fallen frame, got {relative:?}"
+            angle_between(applied, Quaternion::from_angle_y(Deg(90.0))) < 0.05,
+            "expected a 90 degree turn about world up, got {applied:?}"
         );
+        // ...and the fallen horizon is still where the body left it: the view
+        // yawed, it did not roll further.
+        let up = turned.head_rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+        assert!(up.y.abs() < 1.0e-3, "the turn rolled the view: up {up:?}");
     }
 
     #[test]
     fn the_look_recovery_only_starts_once_the_fall_has_landed() {
-        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         assert_eq!(death.sample().look_recovery, 0.0);
         death.advance(FALL_SECONDS);
         assert_eq!(death.sample().look_recovery, 0.0);
@@ -733,7 +751,7 @@ mod tests {
 
     #[test]
     fn a_degenerate_look_frame_leaves_the_fallen_view_alone() {
-        let mut death = DeathCamera::begin(live_eye(), -1.6, 7);
+        let mut death = DeathCamera::begin(live_eye(), -1.6, 7, FALL_LATERAL);
         death.advance(FALL_SECONDS + LOOK_RECOVERY_SECONDS);
         let sample = DeathCameraSample {
             look_frame: Quaternion::zero(),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1891,6 +1891,21 @@ impl Game {
     /// presentations instead of once per runtime (AGENTS.md section 3).
     ///
     /// While the player is alive this returns its inputs verbatim.
+    /// Whether the player's own body - VR hands in [`Game::render`], the flat
+    /// weapon viewmodel and HUD in [`Game::render_per_eye`] - should be dropped
+    /// this frame because the death camera has taken the view.
+    ///
+    /// The hands and the viewmodel stay anchored to the play space while the
+    /// camera falls away from it, so a dying player would watch their own hands
+    /// hang in the air above them. Once the camera is no longer theirs to move,
+    /// their body is no longer theirs to see. One predicate, used by both emit
+    /// paths, so the two presentations cannot drift apart here.
+    fn player_visuals_hidden(&self) -> bool {
+        self.active_game_scene
+            .death_camera()
+            .is_some_and(|sample| sample.weight > 0.0)
+    }
+
     pub fn resolve_camera(
         &self,
         pawn_position: Vector3<f32>,
@@ -1918,15 +1933,8 @@ impl Game {
         // scene that emits hands is covered, present and future, and nothing is
         // left latched when the menu closes. The same `is_open()` gate drops the
         // scene's screen-space UI in `render_per_eye`.
-        // The same drop covers the death camera: the hands stay anchored to the
-        // play space while the view falls away from it, so a dying player would
-        // watch their own hands hang in the air above them. Once the camera is
-        // no longer theirs to move, the hands are no longer theirs to see.
-        let dying = self
-            .active_game_scene
-            .death_camera()
-            .is_some_and(|sample| sample.weight > 0.0);
-        if self.pause_menu.is_open() || dying {
+        // The same drop covers the death camera - see `player_visuals_hidden`.
+        if self.pause_menu.is_open() || self.player_visuals_hidden() {
             scene.retain(|object| {
                 object.debug_tag().and_then(|tag| tag.source.as_deref())
                     != Some(util::render_source::PLAYER_HANDS)
@@ -2046,7 +2054,13 @@ impl Game {
         // the list (the debug runtime appends, the oculus runtime prepends), so
         // leaving them in would depth-fight the panel on one host only. The 3D
         // world is unaffected - `render` still emits it every frame.
-        let mut objs = if self.pause_menu.is_open() {
+        // ...and the same drop covers the death camera, for the SAME reason it
+        // covers the VR hands in `render`: the flat weapon viewmodel is emitted
+        // here, not there, so gating only on `render` would leave a flat player
+        // with a gun welded to their face while the camera rolled onto the
+        // floor - the two presentations diverging on exactly the beat this
+        // feature exists for (AGENTS.md section 3).
+        let mut objs = if self.pause_menu.is_open() || self.player_visuals_hidden() {
             Vec::new()
         } else {
             self.active_game_scene.render_per_eye(

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1918,7 +1918,15 @@ impl Game {
         // scene that emits hands is covered, present and future, and nothing is
         // left latched when the menu closes. The same `is_open()` gate drops the
         // scene's screen-space UI in `render_per_eye`.
-        if self.pause_menu.is_open() {
+        // The same drop covers the death camera: the hands stay anchored to the
+        // play space while the view falls away from it, so a dying player would
+        // watch their own hands hang in the air above them. Once the camera is
+        // no longer theirs to move, the hands are no longer theirs to see.
+        let dying = self
+            .active_game_scene
+            .death_camera()
+            .is_some_and(|sample| sample.weight > 0.0);
+        if self.pause_menu.is_open() || dying {
             scene.retain(|object| {
                 object.debug_tag().and_then(|tag| tag.source.as_deref())
                     != Some(util::render_source::PLAYER_HANDS)

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -187,6 +187,57 @@ test(
 );
 
 test(
+  "the player's own body stops being drawn in BOTH presentations while they fall",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // Flat: the weapon viewmodel and HUD come from `render_per_eye` and land on
+    // the scene-UI layer.
+    {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        port: basePort + 7,
+      });
+      await game.step({ frames: 30 });
+      const sceneUi = async () =>
+        (await game.scene.objects()).objects.filter((object) => object.render_layer === "scene_ui")
+          .length;
+      assert.ok((await sceneUi()) > 0, "a live flat player draws a viewmodel/HUD");
+
+      await killPlayer(game);
+      await game.step({ frames: FALL_FRAMES });
+      assert.equal(
+        await sceneUi(),
+        0,
+        "a flat player must not keep a gun welded to their face while the camera rolls onto the floor",
+      );
+    }
+
+    // VR: the hands come from `render`, a different emit path - which is
+    // exactly why one shared predicate gates both (AGENTS.md section 3).
+    {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        port: basePort + 8,
+        debugFlags: ["--vr"],
+      });
+      await game.step({ frames: 30 });
+      const hands = async () =>
+        (await game.scene.objects()).objects.filter((object) => object.source === "player_hands")
+          .length;
+      assert.ok((await hands()) > 0, "a live VR player has hands");
+
+      await killPlayer(game);
+      await game.step({ frames: FALL_FRAMES });
+      assert.equal(
+        await hands(),
+        0,
+        "a dying VR player must not watch their own hands hang in the air above them",
+      );
+    }
+  },
+);
+
+test(
   "a QBR reconstruction puts the camera back on the player's feet",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -129,6 +129,63 @@ test(
   },
 );
 
+// `death_camera::LOOK_RECOVERY_SECONDS`, in fixed-timestep frames.
+const LOOK_RECOVERY_FRAMES = Math.ceil(0.6 * 60);
+
+/** Angle (degrees) between two unit quaternions `[w, x, y, z]`. */
+function angleBetween(
+  a: [number, number, number, number],
+  b: [number, number, number, number],
+): number {
+  const dot = Math.abs(a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]);
+  return (2 * Math.acos(Math.min(1, dot)) * 180) / Math.PI;
+}
+
+test(
+  "the fall ignores head movement, then hands looking back to the player",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 6,
+    });
+    await game.step({ frames: 5 });
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 2 });
+
+    await killPlayer(game);
+    // The moment the fall lands, the camera belongs to the death and not to the
+    // head: the recovery ramp has not started, so turning the head does nothing.
+    // (Earlier in the fall the tracked head still holds its share of the blend -
+    // that is the fall easing in, not the player steering it.)
+    await game.step({ frames: FALL_FRAMES });
+    const landed = (await game.info()).player.camera_rotation;
+    await game.input.set("head.look", [90, 0]);
+    await game.step({ frames: 1 });
+    const stillPinned = (await game.info()).player.camera_rotation;
+    assert.ok(
+      angleBetween(landed, stillPinned) < 15,
+      `a 90 degree head turn must not move the just-landed camera, moved ${angleBetween(landed, stillPinned).toFixed(1)} degrees`,
+    );
+
+    // Once it has landed and the recovery ramp has run, head movement moves the
+    // view again - relative to the fallen frame. A camera welded to the death
+    // pose is the most nauseating state in VR, so it must not stay welded.
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: FALL_FRAMES + LOOK_RECOVERY_FRAMES });
+    const settled = (await game.info()).player.camera_rotation;
+    await game.input.set("head.look", [90, 0]);
+    await game.step({ frames: 2 });
+    const looked = (await game.info()).player.camera_rotation;
+    const turned = angleBetween(settled, looked);
+    assert.ok(
+      turned > 80 && turned < 100,
+      `a settled death camera should follow a 90 degree head turn, got ${turned.toFixed(1)} degrees`,
+    );
+    assert.equal(lifeState((await game.info()).player), "dead", "still dead, just able to look");
+  },
+);
+
 test(
   "a QBR reconstruction puts the camera back on the player's feet",
   { skip: !e2eEnabled, timeout: 600_000 },


### PR DESCRIPTION
Top of the stack. Two things the bare fall left wrong. Stacked on #1124.

![death camera, VR](https://gist.githubusercontent.com/tommy-xr/7caa387dd7653ec8e6e86e21edcc4397/raw/vr-death.gif)

<sub>Quest 3, earth.mis, left eye of the stereo pair, captured from this branch's HEAD release APK. Framing is poor because the headset was resting on a desk — head rotation cannot be overridden (the render pose comes from the tracked OpenXR views), so the camera looks where the physical HMD looked.</sub>

## 1. A fallen player can look around

A camera welded to the death pose is the single most uncomfortable state in VR — the horizon stops answering head movement, which reads as the world moving rather than the player — and the corpse lies there for the rest of the death window.

So once the fall lands, the tracked head is let back in over `LOOK_RECOVERY_SECONDS` as a **delta on the fallen frame**. The fall itself stays entirely authored, and the punishing part — on the floor, on your side, unable to act — is untouched.

The delta is **left-multiplied**, deliberately. Right-multiplying applies the turn in the fallen view's own frame, where the roll has taken "up" onto a horizontal axis — so real yaw, which the inner ear feels as rotation about world up, comes back as visual **roll**. That vestibular mismatch is a stronger nausea source than the pinning this ramp exists to avoid.

## 2. The player's body stops being drawn — in both presentations

Hands and viewmodel stay anchored to the play space while the camera falls away from it, so a dying player watched their own hands hang in the air above them.

The subtle half: VR hands are emitted from `Game::render`, the flat weapon viewmodel from `render_per_eye`. Gating only the first would have left flat players with a gun welded to their face while the camera rolled onto the floor — the exact presentation divergence AGENTS.md §3 forbids, on the one beat this feature exists for. Both paths now consult one `player_visuals_hidden` predicate, and the e2e test asserts **both**: flat scene-UI draws and VR `player_hands` draws each go to zero.

## Device verification

Measured on a Quest 3, fraction of non-black pixels per eye across a real death:

| moment | L | R |
|---|---|---|
| alive | 0.7916 | 0.8096 |
| ~1/3 through fall | 0.7344 | 0.7342 |
| ~2/3 through fall | 0.7511 | 0.7464 |
| **settled** | **0.7537** | **0.7487** |

Symmetric and steady. This number matters because an earlier attempt at the compositor layer pose (reverted in #1122, with the measurement recorded in the code) read **L 0.00 / R 0.13** here — a black screen for the entire death.

Also confirmed on device: stereo survives the fall (per-eye disparity +475 px on a near creature, −300 px on a far ceiling window — opposite-signed, so genuine depth, not a rigid offset), and the VR hands are gone from the death instant onward.

![settled, left eye](https://gist.githubusercontent.com/tommy-xr/7caa387dd7653ec8e6e86e21edcc4397/raw/vr-settled.png)

## Known artifact

A reprojection seam is visible mid-fall, when the rendered and tracked poses disagree most:

![reprojection seam mid-fall](https://gist.githubusercontent.com/tommy-xr/7caa387dd7653ec8e6e86e21edcc4397/raw/vr-fall-seam.png)

This is the accepted cost of submitting the tracked pose to the compositor (see #1122) — transient, ~0.6 s, versus a three-second blackout for the alternative.

## Not yet verified

**Head yaw producing view yaw rather than roll has not been confirmed by a human in the headset.** The recovery ramp was verified live on device (fires only after the fall lands, smooth, completes in its window), and `once_settled_the_player_can_look_around_from_where_they_fell` asserts the world-up property in a unit test — but the capture agent could not physically turn the HMD. Worth 30 seconds of wearing it before merge.

## Verification

- `cargo test -p shock2vr` — 974 pass (20 in `death_camera`)
- `cargo apk check`
- Full SDK e2e suite: 302 pass; the 8 failures are pre-existing on `origin/main` (verified by running them there) and unrelated to this stack.
