### PR TITLE
feat(ui): launch debug scenes from the Developer screen

### DIFF
--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -109,7 +109,7 @@ dev_params! {
     /// is untouched: OpenXR view FOVs must be used as-is. (`debug_runtime`
     /// shares its single flat projection between flat and `--vr` mode, so this
     /// override reaches both there.)
-    FOV_OVERRIDE_DEG = float("fov_override_deg", "FOV override (deg)", 0.0, 0.0, 120.0, 1.0),
+    FOV_OVERRIDE_DEG = float("fov_override_deg", "FOV override", 0.0, 0.0, 120.0, 1.0),
     /// Ceiling on how fast a physically simulated held melee weapon may be
     /// driven onto its tracked-hand target, in world units per second.
     ///
@@ -120,9 +120,9 @@ dev_params! {
     /// without a ceiling that becomes one enormous impulse into the geometry.
     /// Read before every physics step, so a headset can tune it without a
     /// rebuild.
-    MELEE_MAX_SPEED = float("melee_max_speed", "Melee max speed", 60.0, 1.0, 200.0, 5.0),
+    MELEE_MAX_SPEED = float("melee_max_speed", "Melee speed", 60.0, 1.0, 200.0, 5.0),
     /// The angular counterpart of [`MELEE_MAX_SPEED`], in radians per second.
-    MELEE_MAX_TURN = float("melee_max_turn", "Melee max turn", 60.0, 1.0, 200.0, 5.0),
+    MELEE_MAX_TURN = float("melee_max_turn", "Melee turn", 60.0, 1.0, 200.0, 5.0),
     /// Minimum contact speed, in world units per second, at which a held melee
     /// weapon damages what it touches *without* the trigger being pulled.
     ///
@@ -133,7 +133,7 @@ dev_params! {
     /// the swing/graze threshold so a weapon resting against a creature does
     /// nothing. `debug_melee` turns it on; missions leave it at 0 until the
     /// physical model is the shipped one.
-    MELEE_FREE_SWING_SPEED = float("melee_free_swing", "Melee free swing", 0.0, 0.0, 20.0, 0.5),
+    MELEE_FREE_SWING_SPEED = float("melee_free_swing", "Free swing", 0.0, 0.0, 20.0, 0.5),
     /// Draw the tracked-hand glove *in addition to* a wielded weapon's own
     /// first-person model, instead of letting the weapon model stand in for the
     /// hand. `0` off, `1` on.
@@ -146,7 +146,7 @@ dev_params! {
     ///
     /// A 0/1 float because the registry has no `Bool` kind yet; it should
     /// become one when that lands.
-    MELEE_GLOVE_OVERLAY = float("melee_glove_overlay", "Melee glove overlay", 0.0, 0.0, 1.0, 1.0),
+    MELEE_GLOVE_OVERLAY = float("melee_glove_overlay", "Show hands", 0.0, 0.0, 1.0, 1.0),
     /// Draw the live contact volume of every held melee weapon as a world-space
     /// wireframe. `0` off, `1` on.
     ///
@@ -154,7 +154,7 @@ dev_params! {
     /// where my hand is", this one answers "is the damage volume where the
     /// weapon is". Read out of Rapier at the collider's own isometry, so it
     /// shows what is actually simulated rather than what the wield intended.
-    MELEE_VOLUMES = float("melee_volumes", "Melee volumes", 0.0, 0.0, 1.0, 1.0),
+    MELEE_VOLUMES = float("melee_volumes", "Show hurtbox", 0.0, 0.0, 1.0, 1.0),
     /// Uniform scale applied to a wielded melee `_h` view model, about the
     /// baked fist so the grip stays on the controller.
     ///
@@ -176,7 +176,7 @@ dev_params! {
     /// single scale makes both right. 0.7 draws a 46 cm Wrench on a 40 cm arm;
     /// making the arm exactly life-size (0.79) would leave the Wrench at 52,
     /// and making the Wrench right (~0.5) would leave a child's arm.
-    MELEE_WIELD_SCALE = float("melee_scale", "Melee wield scale", 0.7, 0.25, 1.5, 0.05),
+    MELEE_WIELD_SCALE = float("melee_scale", "Melee scale", 0.7, 0.25, 1.5, 0.05),
 }
 
 /// Every parameter with its id, in declaration order.

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1775,6 +1775,23 @@ impl Game {
                 self.pending_transition = None;
                 self.set_active_scene(Box::new(DeveloperScene::new()));
             }
+            GlobalEffect::LaunchDebugScene { name } => {
+                // A scene swap like the frontend ones: no ledger write-back,
+                // and any pending transition is abandoned. Built through the
+                // same registry `--mission debug_x` dispatches from, so a scene
+                // started here is the scene the CLI would have started.
+                self.pending_transition = None;
+                match scenes::create_debug_scene(
+                    &name,
+                    &self.global_context,
+                    &self.options,
+                    &mut self.asset_cache,
+                    &mut self.audio_context,
+                ) {
+                    Some(scene) => self.set_active_scene(scene),
+                    None => warn!("Unknown debug scene '{}'", name),
+                }
+            }
             GlobalEffect::PlayerHit { damage } => {
                 self.hit_feedback.trigger(damage);
             }

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -1,4 +1,5 @@
-//! Developer screen (live-tunable runtime parameters).
+//! Developer screen (live-tunable runtime parameters, and the debug-scene
+//! launcher).
 //!
 //! The frontend host for [`crate::ui::dev_params_panel`]: the shared row
 //! builder on the `GAMELOD.PCX` archive frame, reached from the main menu's
@@ -6,9 +7,21 @@
 //! pause overlay hosts the very same builder as its Developer page, so the
 //! screen is identical whichever way it is reached.
 //!
+//! The screen has a second page: a list of the debug scenes, reached from the
+//! upper framed button (the load screen's "Load" frame) and returning to the
+//! parameters with its own "Done". It exists because a headset picks its scene
+//! from a file read at startup, so without an in-game entry point every change
+//! of debug scene - or every death inside one - costs an APK relaunch. The
+//! names come from the same registry `--mission debug_x` dispatches from
+//! ([`crate::scenes::debug_scene_names`]), so the launcher cannot drift from
+//! what the game can actually start.
+//!
 //! Structurally a sibling of [`crate::scenes::LoadGameScene`]: one canvas,
 //! rendered screen-space when flat and on a world panel in VR, with the
-//! shared rising-edge click rules.
+//! shared rising-edge click rules. Every rect on both pages is resolved once,
+//! in canvas pixels, and handed to the hit test and the draw alike - which is
+//! what makes the flat pointer and the VR ray land on the same widget
+//! (AGENTS.md §3).
 
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
 use engine::{
@@ -27,14 +40,17 @@ use crate::{
     time::Time,
     ui::{
         FrontendMenu,
+        HAlign,
         Rect,
         ScaleMode,
         UiCanvas,
+        VAlign,
         dev_params_panel,
         // The archive-database frame: a header line, a dark pane the rows sit
         // in, and framed button art for "Done" - the geometry the panel is
         // laid out against, owned by the panel so both hosts share it.
-        dev_params_panel::{BACKDROP_TEXTURE, DevParamsEvent, PanelRects},
+        dev_params_panel::{BACKDROP_TEXTURE, DevParamsEvent, FIELD_TOP_Y, PanelRects},
+        list_scroll::{self, ScrollHalf},
     },
 };
 
@@ -52,45 +68,200 @@ const CANVAS_H: f32 = 480.0;
 /// The 4:3 art is letterboxed (not stretched) on non-4:3 windows.
 const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 
+/// Display font for the header and the framed buttons, and the small data font
+/// the scene names read as data in - the same pairing the parameter rows and
+/// the load screen's save rows use.
+const MENU_FONT: &str = "metafont.fon";
+const LIST_FONT: &str = "mainfont.fon";
+
+/// Row pitch of the launcher's list, matching the load screen's save rows -
+/// the same art, the same font, the same rows.
+const SCENE_ROW_H: f32 = 19.0;
+/// Horizontal inset for a scene name, on both edges of the row so the text
+/// clears the pane's border. Hit-testing uses the whole row, so it costs no
+/// click.
+const SCENE_TEXT_INSET: f32 = 8.0;
+
+/// Opacity for a button that cannot be acted on, one that can, and the
+/// selected row / hovered button - the load screen's three levels.
+const DISABLED_OPACITY: f32 = 0.3;
+const IDLE_OPACITY: f32 = 0.65;
+const ACTIVE_OPACITY: f32 = 1.0;
+
+const SCENES_HEADER_LABEL: &str = "Select a debug scene.";
+/// The upper framed button: the launcher's door on the parameters page, and
+/// the launch itself on the launcher page.
+const OPEN_SCENES_LABEL: &str = "Scenes";
+const LAUNCH_LABEL: &str = "Launch";
+const DONE_LABEL: &str = "Done";
+
+/// Which page of the screen is showing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeveloperPage {
+    /// The tunable parameter rows ([`dev_params_panel`]).
+    Params,
+    /// The debug-scene launcher.
+    Scenes,
+}
+
+/// What a click on the screen asks for, whichever page it landed on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeveloperAction {
+    /// Something on the parameter page: a step, its scroll, or "Done".
+    Param(DevParamsEvent),
+    /// Open the debug-scene launcher.
+    OpenScenes,
+    /// Highlight the debug scene at this index in the registry.
+    SelectScene(usize),
+    /// Launch the highlighted debug scene.
+    LaunchScene,
+    /// Scroll the launcher's list.
+    ScrollScenes(ScrollHalf),
+    /// Leave the launcher, back to the parameters.
+    CloseScenes,
+}
+
+/// Everything a click depends on, resolved once per frame and handed to the
+/// hit test and the draw alike so the two can never disagree about where a
+/// widget is - or about which page it belongs to.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ScreenState {
+    page: DeveloperPage,
+    rects: PanelRects,
+    /// Registry index drawn in the parameter pane's top row.
+    scroll: usize,
+    /// Registry index drawn in the launcher's top row.
+    scene_scroll: usize,
+    /// Whether a scene row is highlighted - "Launch" is inert without one,
+    /// exactly as the load screen's "Load" is.
+    has_selection: bool,
+}
+
+/// How many debug scenes the launcher lists.
+fn scene_count() -> usize {
+    super::debug_scene_names().count()
+}
+
+fn scene_rows_per_page(rects: PanelRects) -> usize {
+    list_scroll::rows_per_page(rects.list_rect(), FIELD_TOP_Y, SCENE_ROW_H)
+}
+
+fn scene_max_scroll(rects: PanelRects) -> usize {
+    list_scroll::max_scroll(scene_count(), scene_rows_per_page(rects))
+}
+
+/// The registry indices on screen at `scene_scroll`, clamped to the page.
+fn scene_visible_rows(rects: PanelRects, scene_scroll: usize) -> std::ops::Range<usize> {
+    list_scroll::visible_rows(scene_count(), scene_rows_per_page(rects), scene_scroll)
+}
+
+/// The launcher's scroll rocker, in the gutter down the pane's right edge -
+/// the very same one the parameter page scrolls with.
+fn scene_rocker(rects: PanelRects) -> Option<list_scroll::Rocker> {
+    list_scroll::rocker(rects.list_rect(), FIELD_TOP_Y, scene_max_scroll(rects) > 0)
+}
+
+/// The canvas rect of the launcher's `slot`-th visible row. The rows stop
+/// short of the scroll gutter whenever it is in use, so a row and the rocker
+/// can never claim the same point.
+fn scene_row_rect(rects: PanelRects, slot: usize) -> Rect {
+    let list = rects.list_rect();
+    let gutter = if scene_max_scroll(rects) > 0 {
+        list_scroll::GUTTER_W
+    } else {
+        0.0
+    };
+    Rect::new(
+        list.x,
+        list.y + slot as f32 * SCENE_ROW_H,
+        (list.w - gutter).max(0.0),
+        SCENE_ROW_H,
+    )
+}
+
+/// The rect a scene name is drawn in: the row, inset on both edges.
+fn scene_text_rect(rects: PanelRects, slot: usize) -> Rect {
+    let row = scene_row_rect(rects, slot);
+    Rect::new(
+        row.x + SCENE_TEXT_INSET,
+        row.y,
+        (row.w - 2.0 * SCENE_TEXT_INSET).max(0.0),
+        row.h,
+    )
+}
+
+/// What is at a canvas point, on whichever page is showing. Shared by the
+/// click, the hover highlight and the rollover sound - and by both
+/// presentations, so the flat pointer and the VR ray resolve identically.
+fn hit(state: ScreenState, point: Vector2<f32>) -> Option<DeveloperAction> {
+    match state.page {
+        DeveloperPage::Params => {
+            if state.rects.action_rect().contains(point) {
+                return Some(DeveloperAction::OpenScenes);
+            }
+            dev_params_panel::hit(state.rects, state.scroll, point).map(DeveloperAction::Param)
+        }
+        DeveloperPage::Scenes => {
+            // "Launch" is inert with nothing selected rather than launching
+            // whatever happens to be first.
+            if state.has_selection && state.rects.action_rect().contains(point) {
+                return Some(DeveloperAction::LaunchScene);
+            }
+            if state.rects.done_rect().contains(point) {
+                return Some(DeveloperAction::CloseScenes);
+            }
+            let rows = scene_visible_rows(state.rects, state.scene_scroll);
+            if let Some(rocker) = scene_rocker(state.rects) {
+                if let Some(half) =
+                    list_scroll::hit(&rocker, rows.start, scene_max_scroll(state.rects), point)
+                {
+                    return Some(DeveloperAction::ScrollScenes(half));
+                }
+            }
+            // Rows carry the index of the scene scrolled into that slot, never
+            // the slot itself: a positional index would launch whatever scene
+            // *used* to be in the row the moment the list scrolls.
+            (0..rows.len())
+                .find(|slot| scene_row_rect(state.rects, *slot).contains(point))
+                .map(|slot| DeveloperAction::SelectScene(rows.start + slot))
+        }
+    }
+}
+
 /// Shared click core: both presentations reduce to "a point on the canvas plus
-/// a pressed flag", so the rising-edge rule lives here once. The hit regions
-/// themselves are the panel's ([`dev_params_panel::hit`]).
+/// a pressed flag", so the rising-edge rule lives here once.
 #[cfg(test)]
 fn resolve_click_at(
-    rects: PanelRects,
-    scroll: usize,
+    state: ScreenState,
     point: Option<Vector2<f32>>,
     pressed: bool,
     last_pressed: bool,
-) -> (Option<DevParamsEvent>, bool) {
-    shell_resolve_click_at(point, pressed, last_pressed, |point| {
-        dev_params_panel::hit(rects, scroll, point)
-    })
+) -> (Option<DeveloperAction>, bool) {
+    shell_resolve_click_at(point, pressed, last_pressed, |point| hit(state, point))
 }
 
 /// Pure click resolution for the flat pointer.
 #[cfg(test)]
 fn resolve_click(
-    rects: PanelRects,
-    scroll: usize,
+    state: ScreenState,
     pointer: Option<Pointer2D>,
     last_pressed: bool,
     screen_size: Vector2<f32>,
-) -> (Option<DevParamsEvent>, bool, Option<Vector2<f32>>) {
+) -> (Option<DeveloperAction>, bool, Option<Vector2<f32>>) {
     resolve_flat_click(
         pointer,
         last_pressed,
         screen_size,
         vec2(CANVAS_W, CANVAS_H),
         SCALE_MODE,
-        |point| dev_params_panel::hit(rects, scroll, point),
+        |point| hit(state, point),
     )
 }
 
 pub struct DeveloperScene {
     world: World,
     scene_name: String,
-    menu: FrontendMenu<DevParamsEvent>,
+    menu: FrontendMenu<DeveloperAction>,
     /// The panel's widget rects, re-resolved from `GAMELODR.BIN` each update
     /// (the render path takes `&self`, so it reads the resolved value here).
     panel_rects: PanelRects,
@@ -98,6 +269,12 @@ pub struct DeveloperScene {
     /// itself is stateless, so the scroll position lives with the host and is
     /// handed to the hit test and the render alike.
     scroll: usize,
+    /// Which page is showing.
+    page: DeveloperPage,
+    /// Index of the debug scene drawn in the launcher's top row.
+    scene_scroll: usize,
+    /// The highlighted debug scene, as an index into the registry.
+    selected_scene: Option<usize>,
 }
 
 impl DeveloperScene {
@@ -108,6 +285,23 @@ impl DeveloperScene {
             menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
             panel_rects: PanelRects::default(),
             scroll: 0,
+            page: DeveloperPage::Params,
+            // Preselect the first scene so "Launch" is immediately meaningful,
+            // the way the load screen preselects the most recent save.
+            scene_scroll: 0,
+            selected_scene: (scene_count() > 0).then_some(0),
+        }
+    }
+
+    /// Everything a click on this frame depends on, in one value shared by the
+    /// hit test and the draw.
+    fn state(&self) -> ScreenState {
+        ScreenState {
+            page: self.page,
+            rects: self.panel_rects,
+            scroll: self.scroll,
+            scene_scroll: self.scene_scroll,
+            has_selection: self.selected_scene.is_some(),
         }
     }
 
@@ -116,8 +310,128 @@ impl DeveloperScene {
     fn build_canvas(&self, pointer_canvas: Option<Vector2<f32>>) -> UiCanvas {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
-        dev_params_panel::draw(&mut canvas, self.panel_rects, self.scroll, pointer_canvas);
+
+        let state = self.state();
+        let hovered = pointer_canvas.and_then(|point| hit(state, point));
+        let button = |canvas: &mut UiCanvas, rect: Rect, text: &str, action, enabled: bool| {
+            let opacity = if !enabled {
+                DISABLED_OPACITY
+            } else if hovered == Some(action) {
+                ACTIVE_OPACITY
+            } else {
+                IDLE_OPACITY
+            };
+            canvas
+                .text_native(rect, text, MENU_FONT, HAlign::Center, VAlign::Middle)
+                .opacity(opacity);
+        };
+
+        match self.page {
+            DeveloperPage::Params => {
+                // The rows, the header and "Done" are the shared panel's; the
+                // launcher's door is this host's, because the pause overlay
+                // hosts the same panel and cannot swap the scene under itself.
+                dev_params_panel::draw(&mut canvas, self.panel_rects, self.scroll, pointer_canvas);
+                button(
+                    &mut canvas,
+                    self.panel_rects.action_rect(),
+                    OPEN_SCENES_LABEL,
+                    DeveloperAction::OpenScenes,
+                    true,
+                );
+            }
+            DeveloperPage::Scenes => {
+                canvas.text_native(
+                    self.panel_rects.header_rect(),
+                    SCENES_HEADER_LABEL,
+                    MENU_FONT,
+                    HAlign::Center,
+                    VAlign::Middle,
+                );
+
+                let rows = scene_visible_rows(self.panel_rects, self.scene_scroll);
+                for (slot, name) in super::debug_scene_names()
+                    .skip(rows.start)
+                    .take(rows.len())
+                    .enumerate()
+                {
+                    canvas
+                        .text_native_fit(
+                            scene_text_rect(self.panel_rects, slot),
+                            name,
+                            LIST_FONT,
+                            HAlign::Left,
+                            VAlign::Middle,
+                        )
+                        .opacity(if self.selected_scene == Some(rows.start + slot) {
+                            ACTIVE_OPACITY
+                        } else {
+                            IDLE_OPACITY
+                        });
+                }
+
+                if let Some(rocker) = scene_rocker(self.panel_rects) {
+                    list_scroll::draw(
+                        &mut canvas,
+                        &rocker,
+                        rows.start,
+                        scene_max_scroll(self.panel_rects),
+                        match hovered {
+                            Some(DeveloperAction::ScrollScenes(half)) => Some(half),
+                            _ => None,
+                        },
+                    );
+                }
+
+                button(
+                    &mut canvas,
+                    self.panel_rects.action_rect(),
+                    LAUNCH_LABEL,
+                    DeveloperAction::LaunchScene,
+                    self.selected_scene.is_some(),
+                );
+                button(
+                    &mut canvas,
+                    self.panel_rects.done_rect(),
+                    DONE_LABEL,
+                    DeveloperAction::CloseScenes,
+                    true,
+                );
+            }
+        }
+
         canvas
+    }
+
+    /// Apply a clicked action. Only a launch and leaving the screen reach
+    /// `Game`; the pages, the scroll and the selection are absorbed here.
+    fn handle_action(&mut self, action: DeveloperAction) -> Vec<Effect> {
+        match action {
+            DeveloperAction::Param(event) => {
+                if dev_params_panel::activate(self.panel_rects, event, &mut self.scroll) {
+                    return vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)];
+                }
+            }
+            DeveloperAction::OpenScenes => self.page = DeveloperPage::Scenes,
+            DeveloperAction::CloseScenes => self.page = DeveloperPage::Params,
+            DeveloperAction::SelectScene(index) => self.selected_scene = Some(index),
+            DeveloperAction::ScrollScenes(half) => list_scroll::apply(
+                half,
+                &mut self.scene_scroll,
+                scene_max_scroll(self.panel_rects),
+            ),
+            DeveloperAction::LaunchScene => {
+                if let Some(name) = self
+                    .selected_scene
+                    .and_then(|index| super::debug_scene_names().nth(index))
+                {
+                    return vec![Effect::GlobalEffect(GlobalEffect::LaunchDebugScene {
+                        name: name.to_owned(),
+                    })];
+                }
+            }
+        }
+        Vec::new()
     }
 }
 
@@ -140,29 +454,24 @@ impl GameScene for DeveloperScene {
             *world_time = time.clone();
         }
 
-        // The rows ride the backdrop's authored widget rects, so they are
+        // Both pages ride the backdrop's authored widget rects, so they are
         // resolved from the layout file rather than hardcoded (see
         // `dev_params_panel::PanelRects`).
         self.panel_rects = dev_params_panel::rects(asset_cache);
-        let rects = self.panel_rects;
-        let scroll = self.scroll;
+        let state = self.state();
 
-        let event = self.menu.update(
+        let action = self.menu.update(
             time.elapsed,
             input_context,
             game_options.presentation_mode,
-            |point| dev_params_panel::hit(rects, scroll, point),
-            |point| dev_params_panel::hit(rects, scroll, point),
+            |point| hit(state, point),
+            |point| hit(state, point),
         );
 
-        if let Some(event) = event {
-            // Steps are applied to the registry here, scrolling moves the
-            // list, and "Done" returns to the main menu.
-            if dev_params_panel::activate(rects, event, &mut self.scroll) {
-                return vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)];
-            }
+        match action {
+            Some(action) => self.handle_action(action),
+            None => Vec::new(),
         }
-        Vec::new()
     }
 
     fn render(
@@ -254,6 +563,28 @@ mod tests {
     // and normalized coords map straight onto the 640x480 canvas.
     const SCREEN: Vector2<f32> = Vector2 { x: 800.0, y: 600.0 };
 
+    /// The parameters page at `scroll`, on the decoded fallback rects.
+    fn params_state(scroll: usize) -> ScreenState {
+        ScreenState {
+            page: DeveloperPage::Params,
+            rects: PanelRects::default(),
+            scroll,
+            scene_scroll: 0,
+            has_selection: true,
+        }
+    }
+
+    /// The debug-scene launcher at `scene_scroll`.
+    fn scenes_state(scene_scroll: usize, has_selection: bool) -> ScreenState {
+        ScreenState {
+            page: DeveloperPage::Scenes,
+            rects: PanelRects::default(),
+            scroll: 0,
+            scene_scroll,
+            has_selection,
+        }
+    }
+
     fn pointer_at(canvas_point: Vector2<f32>, pressed: bool) -> Option<Pointer2D> {
         Some(Pointer2D {
             position: vec2(canvas_point.x / CANVAS_W, canvas_point.y / CANVAS_H),
@@ -280,25 +611,42 @@ mod tests {
         panic!("no increment arrow found on the canvas");
     }
 
+    fn first_increment_action() -> DeveloperAction {
+        let (id, _) = dev_params::all().next().unwrap();
+        DeveloperAction::Param(DevParamsEvent::Increment(id))
+    }
+
+    /// The single `GlobalEffect` an action produced, if any.
+    fn global_effect(effects: Vec<Effect>) -> Option<GlobalEffect> {
+        effects.into_iter().find_map(|effect| match effect {
+            Effect::GlobalEffect(global) => Some(global),
+            _ => None,
+        })
+    }
+
+    fn launched_scene(effects: Vec<Effect>) -> Option<String> {
+        match global_effect(effects) {
+            Some(GlobalEffect::LaunchDebugScene { name }) => Some(name),
+            _ => None,
+        }
+    }
+
     #[test]
     fn rising_edge_over_an_arrow_yields_its_event() {
-        let (id, _) = dev_params::all().next().unwrap();
         let (event, last, _) = resolve_click(
-            PanelRects::default(),
-            0,
+            params_state(0),
             pointer_at(first_increment_point(), true),
             false,
             SCREEN,
         );
-        assert_eq!(event, Some(DevParamsEvent::Increment(id)));
+        assert_eq!(event, Some(first_increment_action()));
         assert!(last);
     }
 
     #[test]
     fn held_press_does_not_re_activate() {
         let (event, last, _) = resolve_click(
-            PanelRects::default(),
-            0,
+            params_state(0),
             pointer_at(first_increment_point(), true),
             true,
             SCREEN,
@@ -315,8 +663,7 @@ mod tests {
         // "Quit" area on the shared canvas).
         let scene = DeveloperScene::new();
         let (event, _, _) = resolve_click(
-            PanelRects::default(),
-            0,
+            params_state(0),
             pointer_at(first_increment_point(), true),
             scene.menu.last_pressed(),
             SCREEN,
@@ -342,21 +689,15 @@ mod tests {
     fn a_pointerless_frame_keeps_the_held_press_guard() {
         let scene = DeveloperScene::new();
         assert!(scene.menu.last_pressed());
-        let (event, last, point) = resolve_click(
-            PanelRects::default(),
-            0,
-            None,
-            scene.menu.last_pressed(),
-            SCREEN,
-        );
+        let (event, last, point) =
+            resolve_click(params_state(0), None, scene.menu.last_pressed(), SCREEN);
         assert_eq!(event, None);
         assert_eq!(point, None);
         assert!(last, "a pointerless frame must carry the guard through");
 
         // ...so the press reappearing still resolves to nothing.
         let (event, _, _) = resolve_click(
-            PanelRects::default(),
-            0,
+            params_state(0),
             pointer_at(first_increment_point(), true),
             last,
             SCREEN,
@@ -367,8 +708,7 @@ mod tests {
     #[test]
     fn click_on_bare_backdrop_does_nothing() {
         let (event, _, _) = resolve_click(
-            PanelRects::default(),
-            0,
+            params_state(0),
             pointer_at(vec2(50.0, 50.0), true),
             false,
             SCREEN,
@@ -390,17 +730,9 @@ mod tests {
             &crate::ui::test_support::test_panel(),
         );
         let ray_point = pass.point().expect("the ray should land on the panel");
-        let (id, _) = dev_params::all().next().unwrap();
         assert_eq!(
-            resolve_click_at(
-                PanelRects::default(),
-                0,
-                Some(ray_point),
-                pass.pressed,
-                false
-            )
-            .0,
-            Some(DevParamsEvent::Increment(id))
+            resolve_click_at(params_state(0), Some(ray_point), pass.pressed, false).0,
+            Some(first_increment_action())
         );
     }
 
@@ -410,5 +742,221 @@ mod tests {
         // `to_save_data` on the outgoing world; it must carry the uniques.
         let scene = DeveloperScene::new();
         let _ = crate::save_load::to_save_data(scene.world());
+    }
+
+    // ---------------------------------------------------------------------
+    // The debug-scene launcher.
+    // ---------------------------------------------------------------------
+
+    /// The upper framed button (`GAMELODR.BIN` rect 2) - the load screen's
+    /// "Load" frame, which this screen spends on the launcher.
+    fn action_point() -> Vector2<f32> {
+        PanelRects::default().action_rect().center()
+    }
+
+    #[test]
+    fn the_upper_framed_button_opens_the_launcher() {
+        assert_eq!(
+            hit(params_state(0), action_point()),
+            Some(DeveloperAction::OpenScenes)
+        );
+        // ...and it really is the authored rect, not a hand-placed one.
+        assert_eq!(
+            PanelRects::default().action_rect(),
+            Rect::new(527.0, 161.0, 96.0, 62.0)
+        );
+        // A click there opens the page rather than reaching `Game`.
+        let mut scene = DeveloperScene::new();
+        assert!(scene.handle_action(DeveloperAction::OpenScenes).is_empty());
+        assert_eq!(scene.page, DeveloperPage::Scenes);
+    }
+
+    #[test]
+    fn every_debug_scene_is_reachable_and_carries_its_own_name() {
+        let names: Vec<&str> = super::super::debug_scene_names().collect();
+        assert!(!names.is_empty(), "there are debug scenes to launch");
+        let rects = PanelRects::default();
+        for (index, name) in names.iter().enumerate() {
+            // Scrolling to a scene's own index always shows it (clamped when
+            // it is inside the last page).
+            let rows = scene_visible_rows(rects, index);
+            assert!(rows.contains(&index), "scene {name} is off screen");
+            let row = scene_row_rect(rects, index - rows.start);
+            assert_eq!(
+                hit(scenes_state(index, true), row.center()),
+                Some(DeveloperAction::SelectScene(index)),
+                "row for {name}"
+            );
+
+            // ...and selecting it launches *that* scene.
+            let mut scene = DeveloperScene::new();
+            scene.handle_action(DeveloperAction::SelectScene(index));
+            assert_eq!(
+                launched_scene(scene.handle_action(DeveloperAction::LaunchScene)),
+                Some((*name).to_owned()),
+                "launch of {name}"
+            );
+        }
+    }
+
+    /// The bug a scrolling list invites: the rows move but the hit test still
+    /// indexes positionally, so clicking a row launches whatever scene *used*
+    /// to be there.
+    #[test]
+    fn the_launcher_hit_test_follows_its_scroll() {
+        let rects = PanelRects::default();
+        let max = scene_max_scroll(rects);
+        assert!(max > 0, "the shipped scene list must scroll to test this");
+        for scroll in 1..=max {
+            let slot0 = scene_row_rect(rects, 0);
+            assert_eq!(
+                hit(scenes_state(scroll, true), slot0.center()),
+                Some(DeveloperAction::SelectScene(scroll)),
+                "top row at scroll {scroll}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_launchers_rocker_scrolls_and_stops_at_both_ends() {
+        let rects = PanelRects::default();
+        let rocker = scene_rocker(rects).expect("the shipped scene list scrolls");
+        let max = scene_max_scroll(rects);
+
+        // At the top the "Up" half is inert; at the bottom, "Dn" is.
+        assert_eq!(hit(scenes_state(0, true), rocker.up.center()), None);
+        assert_eq!(
+            hit(scenes_state(0, true), rocker.down.center()),
+            Some(DeveloperAction::ScrollScenes(ScrollHalf::Down))
+        );
+        assert_eq!(hit(scenes_state(max, true), rocker.down.center()), None);
+        assert_eq!(
+            hit(scenes_state(max, true), rocker.up.center()),
+            Some(DeveloperAction::ScrollScenes(ScrollHalf::Up))
+        );
+
+        let mut scene = DeveloperScene::new();
+        scene.page = DeveloperPage::Scenes;
+        for _ in 0..max + 3 {
+            scene.handle_action(DeveloperAction::ScrollScenes(ScrollHalf::Down));
+        }
+        assert_eq!(scene.scene_scroll, max);
+        scene.handle_action(DeveloperAction::ScrollScenes(ScrollHalf::Up));
+        assert_eq!(scene.scene_scroll, max - 1);
+
+        // A row's text must never run under the rocker it shares the pane with.
+        assert!(scene_text_rect(rects, 0).x + scene_text_rect(rects, 0).w <= rocker.up.x);
+    }
+
+    #[test]
+    fn launch_requires_a_selection() {
+        assert_eq!(
+            hit(scenes_state(0, true), action_point()),
+            Some(DeveloperAction::LaunchScene)
+        );
+        // With nothing selected the button is inert rather than launching
+        // whatever happens to be first.
+        assert_eq!(hit(scenes_state(0, false), action_point()), None);
+        let mut scene = DeveloperScene::new();
+        scene.selected_scene = None;
+        assert!(scene.handle_action(DeveloperAction::LaunchScene).is_empty());
+    }
+
+    #[test]
+    fn done_leaves_the_launcher_for_the_parameters_not_the_main_menu() {
+        let done = PanelRects::default().done_rect().center();
+        assert_eq!(
+            hit(scenes_state(0, true), done),
+            Some(DeveloperAction::CloseScenes)
+        );
+        let mut scene = DeveloperScene::new();
+        scene.page = DeveloperPage::Scenes;
+        assert!(
+            scene.handle_action(DeveloperAction::CloseScenes).is_empty(),
+            "leaving the launcher must not swap the scene"
+        );
+        assert_eq!(scene.page, DeveloperPage::Params);
+
+        // ...while "Done" on the parameters page still returns to the menu.
+        assert!(matches!(
+            global_effect(scene.handle_action(DeveloperAction::Param(DevParamsEvent::Done))),
+            Some(GlobalEffect::ShowMainMenu)
+        ));
+    }
+
+    /// The parameter rows belong to the other page: on the launcher, the pane
+    /// is a list of scenes and nothing in it steps a value.
+    #[test]
+    fn the_pages_do_not_share_their_widgets() {
+        let arrow = first_increment_point();
+        assert!(matches!(
+            hit(params_state(0), arrow),
+            Some(DeveloperAction::Param(_))
+        ));
+        assert!(!matches!(
+            hit(scenes_state(0, true), arrow),
+            Some(DeveloperAction::Param(_))
+        ));
+        // And the launcher's rows are not on the parameters page.
+        let row = scene_row_rect(PanelRects::default(), 0);
+        assert!(!matches!(
+            hit(params_state(0), row.center()),
+            Some(DeveloperAction::SelectScene(_))
+        ));
+    }
+
+    /// The VR controller ray resolves through the very same hit test as the
+    /// flat pointer, so the launcher's widgets land in the same place in both
+    /// presentations (AGENTS.md §3).
+    #[test]
+    fn a_vr_ray_can_open_the_launcher_and_launch_a_scene() {
+        let aim = |point: Vector2<f32>| {
+            let hand = crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, 1.0);
+            let input = InputContext {
+                right_hand: hand,
+                ..InputContext::default()
+            };
+            let pass = vr_frontend_pointer_pass(
+                &input,
+                vec2(CANVAS_W, CANVAS_H),
+                &crate::ui::test_support::test_panel(),
+            );
+            (
+                pass.point().expect("the ray should land on the panel"),
+                pass.pressed,
+            )
+        };
+
+        let (point, pressed) = aim(action_point());
+        assert_eq!(
+            resolve_click_at(params_state(0), Some(point), pressed, false).0,
+            Some(DeveloperAction::OpenScenes)
+        );
+        assert_eq!(
+            resolve_click_at(scenes_state(0, true), Some(point), pressed, false).0,
+            Some(DeveloperAction::LaunchScene)
+        );
+
+        // A row on the launcher, through the same ray.
+        let row = scene_row_rect(PanelRects::default(), 2).center();
+        let (point, pressed) = aim(row);
+        assert_eq!(
+            resolve_click_at(scenes_state(0, true), Some(point), pressed, false).0,
+            Some(DeveloperAction::SelectScene(2))
+        );
+    }
+
+    /// Every launcher row - and both framed buttons - must sit inside the
+    /// backdrop's own art, clear of the painted field the rows stop above.
+    #[test]
+    fn the_launchers_rows_stay_inside_the_pane() {
+        let rects = PanelRects::default();
+        let list = rects.list_rect();
+        let rows = scene_visible_rows(rects, 0);
+        assert!(rows.len() >= 10, "the pane should show a useful page");
+        let last = scene_row_rect(rects, rows.len() - 1);
+        assert!(last.y + last.h <= FIELD_TOP_Y);
+        assert!(last.y + last.h <= list.y + list.h);
+        assert_eq!(scene_row_rect(rects, 0).x, list.x);
     }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -112,6 +112,99 @@ pub struct SceneInitResult {
 
 const ENDING_CUTSCENE_CANDIDATES: &[&str] = &["enhanced/cs3.ogv", "cs3.avi", "cs3.ogv"];
 
+/// How a debug scene is built. Every entry in [`DEBUG_SCENES`] has this shape,
+/// so a scene that needs none of the arguments simply ignores them.
+type DebugSceneCtor = fn(
+    &GlobalContext,
+    &GameOptions,
+    &mut AssetCache,
+    &mut AudioContext<EntityId, String>,
+) -> Box<dyn GameScene>;
+
+/// Every debug scene, by the name that launches it.
+///
+/// The single source of truth: [`create_debug_scene`] dispatches from this
+/// table and the Developer screen's launcher lists it, so a scene added here
+/// is both reachable by name (`--mission debug_x`) and offered in the launcher
+/// - they cannot drift apart the way a hand-copied menu list would.
+const DEBUG_SCENES: &[(&str, DebugSceneCtor)] = &[
+    // Visual-only scene to inspect the missing-assets screen. The real one is
+    // shown by the runtimes *instead of* a `Game`, since it exists precisely
+    // when there is no gamesys to build one from - which also means it cannot
+    // be reached on a machine that has the data. This entry renders the same
+    // scene against a stand-in status so the screen can be render-verified in
+    // both presentations without uninstalling the game.
+    ("debug_no_assets", |_global, _options, _assets, _audio| {
+        // A stand-in root, deliberately NOT the real one. On a machine that has
+        // the data, `paths::data_root()` points at a directory that is not in
+        // fact missing anything, so the message would be nonsense - and it puts
+        // a local home-directory path (with the developer's username) into every
+        // screenshot taken of this scene.
+        let status = crate::install::InstallStatus {
+            data_root: std::path::PathBuf::from("/sdcard/shock2quest"),
+            kind: crate::install::InstallKind::Missing,
+            found: Vec::new(),
+            missing_mods: Vec::new(),
+        };
+        Box::new(NoAssetsScene::new(&status))
+    }),
+    // Visual-only scene to inspect the loading screen UI
+    // (projects/loading-screen.md, PR 1) independent of any real loading.
+    ("debug_loading", |_global, _options, _assets, _audio| {
+        Box::new(LoadingScene::new_demo())
+    }),
+    ("debug_minimal", |global, options, assets, audio| {
+        Box::new(DebugMinimalScene::create(global, options, assets, audio))
+    }),
+    ("debug_weapons", |global, options, assets, audio| {
+        Box::new(create_debug_weapons_scene(global, options, assets, audio))
+    }),
+    ("debug_melee", create_debug_melee_scene),
+    ("debug_psi", create_debug_psi_scene),
+    ("debug_teleport", |global, options, assets, audio| {
+        Box::new(DebugTeleportScene::create(global, options, assets, audio))
+    }),
+    ("debug_camera", DebugCameraScene::new),
+    ("debug_protocol_droid", DebugProtocolDroidScene::new),
+    ("debug_turret", DebugTurretScene::new),
+    ("debug_hud", |_global, _options, _assets, _audio| {
+        Box::new(DebugHudScene::new())
+    }),
+    ("debug_gloves", DebugGlovesScene::new),
+    ("debug_hand_poses", DebugHandPosesScene::new),
+    ("debug_joint_constraint", DebugJointConstraintScene::new),
+    ("debug_map", |_global, _options, _assets, _audio| {
+        Box::new(DebugMapScene::new())
+    }),
+    ("debug_ragdoll", DebugRagdollScene::new),
+    ("debug_particles", DebugParticlesScene::new),
+    ("debug_hitbox", DebugHitboxScene::new),
+];
+
+/// The debug scenes' names, in the order the launcher lists them.
+pub fn debug_scene_names() -> impl Iterator<Item = &'static str> {
+    DEBUG_SCENES.iter().map(|(name, _)| *name)
+}
+
+/// Build the debug scene called `name`, or `None` if it is not one.
+///
+/// Both entry points come through here: the runtime's `--mission debug_x` (via
+/// [`create_initial_scene`]) and the Developer screen's launcher
+/// (`GlobalEffect::LaunchDebugScene`), so a scene behaves identically however
+/// it was started.
+pub fn create_debug_scene(
+    name: &str,
+    global_context: &GlobalContext,
+    options: &GameOptions,
+    asset_cache: &mut AssetCache,
+    audio_context: &mut AudioContext<EntityId, String>,
+) -> Option<Box<dyn GameScene>> {
+    DEBUG_SCENES
+        .iter()
+        .find(|(scene_name, _)| name.eq_ignore_ascii_case(scene_name))
+        .map(|(_, create)| create(global_context, options, asset_cache, audio_context))
+}
+
 pub fn create_initial_scene(
     asset_cache: &mut AssetCache,
     audio_context: &mut AudioContext<EntityId, String>,
@@ -146,175 +239,15 @@ pub fn create_initial_scene(
         };
     }
 
-    // Visual-only scene to inspect the missing-assets screen. The real one is
-    // shown by the runtimes *instead of* a `Game`, since it exists precisely
-    // when there is no gamesys to build one from - which also means it cannot
-    // be reached on a machine that has the data. This entry renders the same
-    // scene against a stand-in status so the screen can be render-verified in
-    // both presentations without uninstalling the game.
-    if options.mission.eq_ignore_ascii_case("debug_no_assets") {
-        // A stand-in root, deliberately NOT the real one. On a machine that has
-        // the data, `paths::data_root()` points at a directory that is not in
-        // fact missing anything, so the message would be nonsense - and it puts
-        // a local home-directory path (with the developer's username) into every
-        // screenshot taken of this scene.
-        let status = crate::install::InstallStatus {
-            data_root: std::path::PathBuf::from("/sdcard/shock2quest"),
-            kind: crate::install::InstallKind::Missing,
-            found: Vec::new(),
-            missing_mods: Vec::new(),
-        };
+    if let Some(scene) = create_debug_scene(
+        &options.mission,
+        global_context,
+        options,
+        asset_cache,
+        audio_context,
+    ) {
         return SceneInitResult {
-            scene: Box::new(NoAssetsScene::new(&status)),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    // Visual-only scene to inspect the loading screen UI (projects/loading-screen.md,
-    // PR 1) independent of any real loading.
-    if options.mission.eq_ignore_ascii_case("debug_loading") {
-        return SceneInitResult {
-            scene: Box::new(LoadingScene::new_demo()),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_minimal") {
-        return SceneInitResult {
-            scene: Box::new(DebugMinimalScene::create(
-                global_context,
-                options,
-                asset_cache,
-                audio_context,
-            )),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_weapons") {
-        return SceneInitResult {
-            scene: Box::new(create_debug_weapons_scene(
-                global_context,
-                options,
-                asset_cache,
-                audio_context,
-            )),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_melee") {
-        return SceneInitResult {
-            scene: create_debug_melee_scene(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_psi") {
-        return SceneInitResult {
-            scene: create_debug_psi_scene(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_teleport") {
-        return SceneInitResult {
-            scene: Box::new(DebugTeleportScene::create(
-                global_context,
-                options,
-                asset_cache,
-                audio_context,
-            )),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_camera") {
-        return SceneInitResult {
-            scene: DebugCameraScene::new(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_protocol_droid") {
-        return SceneInitResult {
-            scene: DebugProtocolDroidScene::new(
-                global_context,
-                options,
-                asset_cache,
-                audio_context,
-            ),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_turret") {
-        return SceneInitResult {
-            scene: DebugTurretScene::new(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_hud") {
-        return SceneInitResult {
-            scene: Box::new(DebugHudScene::new()),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_gloves") {
-        return SceneInitResult {
-            scene: DebugGlovesScene::new(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_hand_poses") {
-        return SceneInitResult {
-            scene: DebugHandPosesScene::new(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options
-        .mission
-        .eq_ignore_ascii_case("debug_joint_constraint")
-    {
-        return SceneInitResult {
-            scene: DebugJointConstraintScene::new(
-                global_context,
-                options,
-                asset_cache,
-                audio_context,
-            ),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_map") {
-        return SceneInitResult {
-            scene: Box::new(DebugMapScene::new()),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_ragdoll") {
-        return SceneInitResult {
-            scene: DebugRagdollScene::new(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_particles") {
-        return SceneInitResult {
-            scene: DebugParticlesScene::new(global_context, options, asset_cache, audio_context),
-            mission_save_data: HashMap::new(),
-        };
-    }
-
-    if options.mission.eq_ignore_ascii_case("debug_hitbox") {
-        return SceneInitResult {
-            scene: DebugHitboxScene::new(global_context, options, asset_cache, audio_context),
+            scene,
             mission_save_data: HashMap::new(),
         };
     }
@@ -473,6 +406,39 @@ pub(crate) fn resolve_ending_cutscene() -> (String, PathBuf) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The launcher offers exactly what the dispatcher can build, and every
+    /// name is a distinct `debug_` name the CLI accepts too.
+    #[test]
+    fn the_debug_scene_registry_is_one_list_of_distinct_launchable_names() {
+        let names: Vec<&str> = debug_scene_names().collect();
+        assert_eq!(names.len(), DEBUG_SCENES.len());
+        assert!(names.len() > 1);
+        for name in &names {
+            assert!(name.starts_with("debug_"), "'{name}' is not a debug scene");
+            assert_eq!(
+                names.iter().filter(|other| *other == name).count(),
+                1,
+                "'{name}' is listed twice"
+            );
+        }
+        // A few the docs promise by name, so a rename shows up here.
+        for expected in ["debug_ragdoll", "debug_hud", "debug_weapons"] {
+            assert!(names.contains(&expected), "'{expected}' is missing");
+        }
+        // Nothing else answers to a debug name: an unknown one is not a scene,
+        // and the lookup is case-insensitive like the rest of the dispatcher.
+        assert!(
+            DEBUG_SCENES
+                .iter()
+                .any(|(name, _)| "DEBUG_Ragdoll".eq_ignore_ascii_case(name))
+        );
+        assert!(
+            !DEBUG_SCENES
+                .iter()
+                .any(|(name, _)| "debug_nonexistent".eq_ignore_ascii_case(name))
+        );
+    }
 
     #[test]
     fn recognizes_classic_and_enhanced_cutscene_extensions() {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -69,6 +69,14 @@ pub enum GlobalEffect {
     /// unloaded to reach it.
     ShowDeveloper,
 
+    /// Launch the named debug scene (see `scenes::DEBUG_SCENES`), replacing
+    /// whatever scene is active. Reached from the Developer screen's launcher:
+    /// on a headset the runtime picks its scene from a file at startup, so
+    /// without an in-game entry point a scene change costs an APK relaunch.
+    LaunchDebugScene {
+        name: String,
+    },
+
     /// Play the retail ending and enter the campaign's terminal state.
     CompleteCampaign,
 

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -23,7 +23,10 @@ use cgmath::{Vector2, vec2};
 use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
 use engine::assets::asset_cache::AssetCache;
 
-use super::{HAlign, Rect, UiCanvas, VAlign};
+use super::{
+    HAlign, Rect, UiCanvas, VAlign,
+    list_scroll::{self, ScrollHalf},
+};
 use crate::dev_params::{self, DevParamId, DevParamKind};
 
 /// The frontend screens are authored on the original 640x480 canvas.
@@ -40,22 +43,26 @@ const ROW_FONT: &str = "mainfont.fon";
 pub const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
 const LAYOUT_FILE: &str = "GAMELODR.BIN";
 
-/// Indices into `GAMELODR.BIN`: header line, the dark list pane, (2 is the
-/// load screen's "Load" button, still unused here) and the bottom-right
-/// button art.
+/// Indices into `GAMELODR.BIN`: header line, the dark list pane, the upper
+/// framed button (the load screen's "Load"; the Developer screen puts its
+/// debug-scene launcher there) and the bottom-right button art.
 const HEADER_RECT_INDEX: usize = 0;
 const LIST_RECT_INDEX: usize = 1;
+const ACTION_RECT_INDEX: usize = 2;
 const DONE_RECT_INDEX: usize = 3;
 
 /// Decoded `GAMELODR.BIN` values, used when the layout file is absent - the
 /// same fallbacks the load screen carries for the same art.
 const FALLBACK_HEADER: Rect = Rect::new(261.0, 31.0, 202.0, 20.0);
 const FALLBACK_LIST: Rect = Rect::new(261.0, 54.0, 202.0, 290.0);
+const FALLBACK_ACTION: Rect = Rect::new(527.0, 161.0, 96.0, 62.0);
 const FALLBACK_DONE: Rect = Rect::new(527.0, 405.0, 95.0, 62.0);
 
 /// Canvas y where the backdrop paints its bordered name-entry field; rows
-/// stop above it (see the sibling constant on the load screen).
-const FIELD_TOP_Y: f32 = 323.0;
+/// stop above it (see the sibling constant on the load screen). Public so the
+/// other page drawn on this backdrop - the Developer screen's debug-scene
+/// launcher - stops its own rows at the same painted border.
+pub const FIELD_TOP_Y: f32 = 323.0;
 
 /// The panel's widget rects, resolved from `GAMELODR.BIN`.
 ///
@@ -68,6 +75,7 @@ const FIELD_TOP_Y: f32 = 323.0;
 pub struct PanelRects {
     header: Rect,
     list: Rect,
+    action: Rect,
     done: Rect,
 }
 
@@ -76,6 +84,7 @@ impl Default for PanelRects {
         Self {
             header: FALLBACK_HEADER,
             list: FALLBACK_LIST,
+            action: FALLBACK_ACTION,
             done: FALLBACK_DONE,
         }
     }
@@ -99,6 +108,7 @@ impl PanelRects {
         Self {
             header: at(HEADER_RECT_INDEX, FALLBACK_HEADER),
             list: at(LIST_RECT_INDEX, FALLBACK_LIST),
+            action: at(ACTION_RECT_INDEX, FALLBACK_ACTION),
             done: at(DONE_RECT_INDEX, FALLBACK_DONE),
         }
     }
@@ -108,6 +118,26 @@ impl PanelRects {
     /// asserts that its "Quit" button sits under it).
     pub fn done_center(&self) -> Vector2<f32> {
         self.done.center()
+    }
+
+    /// The header line, the list pane and the upper framed button, for a host
+    /// that draws its own page on this same backdrop (the Developer screen's
+    /// debug-scene launcher). Read here rather than re-resolved so every page
+    /// of that screen rides one set of authored rects.
+    pub fn header_rect(&self) -> Rect {
+        self.header
+    }
+
+    pub fn list_rect(&self) -> Rect {
+        self.list
+    }
+
+    pub fn action_rect(&self) -> Rect {
+        self.action
+    }
+
+    pub fn done_rect(&self) -> Rect {
+        self.done
     }
 }
 
@@ -133,16 +163,13 @@ const TEXT_INSET: f32 = 8.0;
 const ARROW_W: f32 = 20.0;
 /// Width of the value readout between the arrows.
 const VALUE_W: f32 = 48.0;
-/// The scroll gutter down the list pane's right edge, and the height of each
-/// of its two buttons.
-const SCROLL_GUTTER_W: f32 = 26.0;
-const SCROLL_BUTTON_H: f32 = 20.0;
+/// The scroll gutter down the list pane's right edge. The rocker itself - its
+/// geometry, its labels and its "an end that cannot move is inert" rule - is
+/// [`list_scroll`]'s, shared with the debug-scene launcher.
+const SCROLL_GUTTER_W: f32 = list_scroll::GUTTER_W;
 
 /// Opacity for an element the pointer is not over.
 const IDLE_OPACITY: f32 = 0.65;
-/// Opacity for a scroll button that cannot move any further, matching the
-/// load screen's inert "Load". Such a button is not hit-testable either.
-const DISABLED_OPACITY: f32 = 0.3;
 /// Opacity for the element under the pointer.
 const HOVER_OPACITY: f32 = 1.0;
 /// Labels and values are readouts, not click targets: drawn steady, between
@@ -198,18 +225,14 @@ fn row_rects(rects: PanelRects, index: usize) -> RowRects {
 /// How many rows fit in the pane above the backdrop's painted field - the
 /// size of one page of the list, however long the registry is.
 fn rows_per_page(rects: PanelRects) -> usize {
-    let list = rects.list;
-    let usable = (list.y + list.h).min(FIELD_TOP_Y) - list.y;
-    (usable / ROW_PITCH).floor().max(0.0) as usize
+    list_scroll::rows_per_page(rects.list, FIELD_TOP_Y, ROW_PITCH)
 }
 
 /// The furthest the list can scroll: the first-row index that puts the tail
 /// of the registry against the bottom of the pane. Zero when everything fits
 /// at once, which is also what hides the scroll rocker.
 fn max_scroll(rects: PanelRects) -> usize {
-    dev_params::PARAMS
-        .len()
-        .saturating_sub(rows_per_page(rects))
+    list_scroll::max_scroll(dev_params::PARAMS.len(), rows_per_page(rects))
 }
 
 /// The registry indices on screen at `scroll`, with `scroll` clamped to what
@@ -220,9 +243,7 @@ fn max_scroll(rects: PanelRects) -> usize {
 /// *step* another's - the failure a positional row index invites the moment
 /// the list scrolls.
 fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
-    let first = scroll.min(max_scroll(rects));
-    let count = rows_per_page(rects).min(dev_params::PARAMS.len() - first);
-    first..first + count
+    list_scroll::visible_rows(dev_params::PARAMS.len(), rows_per_page(rects), scroll)
 }
 
 /// The scroll rocker's two halves - "Up" and "Down" - in a gutter down the
@@ -230,25 +251,17 @@ fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
 /// registry fits on one page.
 ///
 /// Deliberately *not* on the upper framed button: that is the load screen's
-/// "Load" frame, the only other authored click target on this backdrop, and
-/// it is wanted for a debug-scene launcher. Scrolling belongs against its own
-/// list anyway - a scrollbar's place is beside what it scrolls, not across
-/// the screen from it.
+/// "Load" frame, which the Developer screen now spends on its debug-scene
+/// launcher ([`ACTION_RECT_INDEX`]). Scrolling belongs against its own list
+/// anyway - a scrollbar's place is beside what it scrolls, not across the
+/// screen from it.
+fn rocker(rects: PanelRects) -> Option<list_scroll::Rocker> {
+    list_scroll::rocker(rects.list, FIELD_TOP_Y, max_scroll(rects) > 0)
+}
+
+#[cfg(test)]
 fn scroll_rects(rects: PanelRects) -> Option<(Rect, Rect)> {
-    (max_scroll(rects) > 0).then(|| {
-        let list = rects.list;
-        let x = list.x + list.w - SCROLL_GUTTER_W;
-        let bottom = (list.y + list.h).min(FIELD_TOP_Y);
-        (
-            Rect::new(x, list.y, SCROLL_GUTTER_W, SCROLL_BUTTON_H),
-            Rect::new(
-                x,
-                bottom - SCROLL_BUTTON_H,
-                SCROLL_GUTTER_W,
-                SCROLL_BUTTON_H,
-            ),
-        )
-    })
+    rocker(rects).map(|r| (r.up, r.down))
 }
 
 /// The value readout: floats as `{:.2}`, the format the step grids are
@@ -277,16 +290,17 @@ pub fn hit(rects: PanelRects, scroll: usize, point: Vector2<f32>) -> Option<DevP
         canvas.button(row.decrement, "", DevParamsEvent::Decrement(id));
         canvas.button(row.increment, "", DevParamsEvent::Increment(id));
     }
-    if let Some((up, down)) = scroll_rects(rects) {
-        // A rocker half that cannot move is inert, not just dimmed.
-        if rows.start > 0 {
-            canvas.button(up, "", DevParamsEvent::ScrollUp);
-        }
-        if rows.start < max_scroll(rects) {
-            canvas.button(down, "", DevParamsEvent::ScrollDown);
+    canvas.button(rects.done, "", DevParamsEvent::Done);
+    // A rocker half that cannot move is inert, not just dimmed - the rule lives
+    // in `list_scroll`, so every scrolling list obeys the same one.
+    if let Some(rocker) = rocker(rects) {
+        if let Some(half) = list_scroll::hit(&rocker, rows.start, max_scroll(rects), point) {
+            return Some(match half {
+                ScrollHalf::Up => DevParamsEvent::ScrollUp,
+                ScrollHalf::Down => DevParamsEvent::ScrollDown,
+            });
         }
     }
-    canvas.button(rects.done, "", DevParamsEvent::Done);
     canvas.click_at(point)
 }
 
@@ -362,29 +376,18 @@ pub fn draw(
             .opacity(hover_opacity(DevParamsEvent::Increment(id)));
     }
 
-    if let Some((up, down)) = scroll_rects(rects) {
-        for (rect, text, event, enabled) in [
-            (up, "Up", DevParamsEvent::ScrollUp, rows.start > 0),
-            (
-                down,
-                "Dn",
-                DevParamsEvent::ScrollDown,
-                rows.start < max_scroll(rects),
-            ),
-        ] {
-            // The row font, and "Dn" rather than "Down": `text_native` does
-            // not shrink to its rect, so the display font's "Up"/"Down"
-            // overhung the gutter and drew across the values beside them.
-            // Render-verified rather than assumed - that overlap is exactly
-            // what a screenshot catches and a layout assertion does not.
-            canvas
-                .text_native(rect, text, ROW_FONT, HAlign::Center, VAlign::Middle)
-                .opacity(if enabled {
-                    hover_opacity(event)
-                } else {
-                    DISABLED_OPACITY
-                });
-        }
+    if let Some(rocker) = rocker(rects) {
+        list_scroll::draw(
+            canvas,
+            &rocker,
+            rows.start,
+            max_scroll(rects),
+            match hovered {
+                Some(DevParamsEvent::ScrollUp) => Some(ScrollHalf::Up),
+                Some(DevParamsEvent::ScrollDown) => Some(ScrollHalf::Down),
+                _ => None,
+            },
+        );
     }
 
     canvas
@@ -419,11 +422,11 @@ pub fn activate(rects: PanelRects, event: DevParamsEvent, scroll: &mut usize) ->
             false
         }
         DevParamsEvent::ScrollUp => {
-            *scroll = scroll.saturating_sub(1);
+            list_scroll::apply(ScrollHalf::Up, scroll, max_scroll(rects));
             false
         }
         DevParamsEvent::ScrollDown => {
-            *scroll = (*scroll + 1).min(max_scroll(rects));
+            list_scroll::apply(ScrollHalf::Down, scroll, max_scroll(rects));
             false
         }
         DevParamsEvent::Done => true,

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -338,8 +338,14 @@ pub fn draw(
         .enumerate()
     {
         let row = row_rects(rects, slot);
+        // Fitted, not plain: a label is authored text of unbounded length and
+        // `text_native` does not shrink to its rect, so a long one ("FOV
+        // override (deg)", "Melee glove overlay") ran past the label column
+        // and struck the `<` arrow beside it. Ellipsizing keeps the row
+        // legible and the arrow clickable; the registry is free to name a
+        // parameter clearly without measuring it first.
         canvas
-            .text_native(
+            .text_native_fit(
                 row.label,
                 param.label,
                 ROW_FONT,

--- a/shock2vr/src/ui/list_scroll.rs
+++ b/shock2vr/src/ui/list_scroll.rs
@@ -1,0 +1,228 @@
+//! One scrolling list, described once for every screen that has one.
+//!
+//! A frontend list pane is always the same shape: rows at a fixed pitch, a page
+//! of them bounded by the backdrop art, and - when the contents outrun the page
+//! - a two-button rocker in a gutter down the pane's right edge. This module
+//! owns that geometry, its enablement rule ("a half that cannot move is inert,
+//! not just dimmed") and its labels, so the Developer parameter list and the
+//! debug-scene launcher scroll the same way rather than each growing their own.
+//!
+//! Everything here is in canvas pixels and presentation-free: hosts hand the
+//! result to their hit test and their draw alike, which is what keeps flatscreen
+//! and VR identical (AGENTS.md §3).
+
+use std::ops::Range;
+
+use cgmath::Vector2;
+
+use super::{HAlign, Rect, UiCanvas, VAlign};
+
+/// The gutter the rocker lives in, and the height of each of its halves.
+pub const GUTTER_W: f32 = 26.0;
+const BUTTON_H: f32 = 20.0;
+
+/// The small data font, and "Dn" rather than "Down": `text_native` does not
+/// shrink to its rect, so the display font's labels overhung the gutter and
+/// drew across the rows beside them.
+const LABEL_FONT: &str = "mainfont.fon";
+const UP_LABEL: &str = "Up";
+const DOWN_LABEL: &str = "Dn";
+
+/// Opacity for a half that cannot move any further - which is also not
+/// hit-testable.
+const DISABLED_OPACITY: f32 = 0.3;
+/// Opacity for a movable half the pointer is not over.
+const IDLE_OPACITY: f32 = 0.65;
+/// Opacity for the half under the pointer.
+const HOVER_OPACITY: f32 = 1.0;
+
+/// Which half of the rocker a point is over.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScrollHalf {
+    Up,
+    Down,
+}
+
+/// The rocker's two halves, stacked at the top and bottom of the gutter.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Rocker {
+    pub up: Rect,
+    pub down: Rect,
+}
+
+/// How many rows fit in `list` at `row_pitch`, stopping at `bottom_limit` (the
+/// y where the backdrop starts painting something rows must clear) when the
+/// pane runs past it.
+pub fn rows_per_page(list: Rect, bottom_limit: f32, row_pitch: f32) -> usize {
+    let usable = (list.y + list.h).min(bottom_limit) - list.y;
+    (usable / row_pitch).floor().max(0.0) as usize
+}
+
+/// The furthest the list can scroll: the first-row index that puts the tail of
+/// the contents against the bottom of the pane. Zero when everything fits at
+/// once, which is also what hides the rocker.
+pub fn max_scroll(items: usize, rows_per_page: usize) -> usize {
+    items.saturating_sub(rows_per_page)
+}
+
+/// The item indices on screen at `scroll`, with `scroll` clamped to what the
+/// pane can actually show.
+///
+/// The one place a screen row is tied to an item: draw and hit-test both walk
+/// this range, so a row can never *show* one item and *act on* another - the
+/// failure a positional row index invites the moment the list scrolls.
+pub fn visible_rows(items: usize, rows_per_page: usize, scroll: usize) -> Range<usize> {
+    let first = scroll.min(max_scroll(items, rows_per_page));
+    let count = rows_per_page.min(items - first);
+    first..first + count
+}
+
+/// The rocker in a gutter down the pane's right edge, or `None` when the whole
+/// list fits on one page. `needed` is `max_scroll(..) > 0`.
+pub fn rocker(list: Rect, bottom_limit: f32, needed: bool) -> Option<Rocker> {
+    needed.then(|| {
+        let x = list.x + list.w - GUTTER_W;
+        let bottom = (list.y + list.h).min(bottom_limit);
+        Rocker {
+            up: Rect::new(x, list.y, GUTTER_W, BUTTON_H),
+            down: Rect::new(x, bottom - BUTTON_H, GUTTER_W, BUTTON_H),
+        }
+    })
+}
+
+/// Which half is at a canvas point, if any. `scroll` is the *clamped* offset
+/// (i.e. `visible_rows(..).start`), so a half that cannot move is inert rather
+/// than clickable-but-useless.
+pub fn hit(
+    rocker: &Rocker,
+    scroll: usize,
+    max_scroll: usize,
+    point: Vector2<f32>,
+) -> Option<ScrollHalf> {
+    if scroll > 0 && rocker.up.contains(point) {
+        return Some(ScrollHalf::Up);
+    }
+    if scroll < max_scroll && rocker.down.contains(point) {
+        return Some(ScrollHalf::Down);
+    }
+    None
+}
+
+/// Move `scroll` by one row, stopping at either end.
+pub fn apply(half: ScrollHalf, scroll: &mut usize, max_scroll: usize) {
+    match half {
+        ScrollHalf::Up => *scroll = scroll.saturating_sub(1),
+        ScrollHalf::Down => *scroll = (*scroll + 1).min(max_scroll),
+    }
+}
+
+/// Describe the rocker onto a host's canvas. `scroll` is the clamped offset and
+/// `hovered` the result of the host's own hit test, so the highlight and the
+/// click can never disagree.
+pub fn draw(
+    canvas: &mut UiCanvas,
+    rocker: &Rocker,
+    scroll: usize,
+    max_scroll: usize,
+    hovered: Option<ScrollHalf>,
+) {
+    for (half, rect, text, enabled) in [
+        (ScrollHalf::Up, rocker.up, UP_LABEL, scroll > 0),
+        (
+            ScrollHalf::Down,
+            rocker.down,
+            DOWN_LABEL,
+            scroll < max_scroll,
+        ),
+    ] {
+        canvas
+            .text_native(rect, text, LABEL_FONT, HAlign::Center, VAlign::Middle)
+            .opacity(if !enabled {
+                DISABLED_OPACITY
+            } else if hovered == Some(half) {
+                HOVER_OPACITY
+            } else {
+                IDLE_OPACITY
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::vec2;
+
+    use super::*;
+
+    const LIST: Rect = Rect::new(261.0, 54.0, 202.0, 290.0);
+    const FIELD_TOP_Y: f32 = 323.0;
+
+    #[test]
+    fn a_page_stops_at_the_painted_field_not_the_pane_bottom() {
+        assert_eq!(rows_per_page(LIST, FIELD_TOP_Y, 19.0), 14);
+        // A pane clear of the field uses its full height...
+        assert_eq!(
+            rows_per_page(Rect::new(261.0, 20.0, 202.0, 190.0), FIELD_TOP_Y, 19.0),
+            10
+        );
+        // ...and one starting below it shows nothing rather than underflowing.
+        assert_eq!(
+            rows_per_page(Rect::new(261.0, 400.0, 202.0, 60.0), FIELD_TOP_Y, 19.0),
+            0
+        );
+    }
+
+    #[test]
+    fn the_visible_window_follows_the_scroll_and_clamps_at_the_end() {
+        assert_eq!(visible_rows(20, 5, 0), 0..5);
+        assert_eq!(visible_rows(20, 5, 3), 3..8);
+        assert_eq!(visible_rows(20, 5, 15), 15..20);
+        // An over-scroll cannot walk the list off its end.
+        assert_eq!(visible_rows(20, 5, 99), 15..20);
+        // Everything fitting means no scrolling at all.
+        assert_eq!(max_scroll(3, 5), 0);
+        assert_eq!(visible_rows(3, 5, 4), 0..3);
+    }
+
+    #[test]
+    fn the_rocker_sits_in_the_gutter_and_its_ends_are_inert() {
+        let rocker = rocker(LIST, FIELD_TOP_Y, true).expect("this list scrolls");
+        assert_eq!(rocker.up.x, LIST.x + LIST.w - GUTTER_W);
+        assert_eq!(rocker.up.y, LIST.y);
+        assert_eq!(rocker.down.x, rocker.up.x);
+        assert_eq!(rocker.down.y + BUTTON_H, FIELD_TOP_Y);
+
+        let max = 4;
+        assert_eq!(hit(&rocker, 0, max, rocker.up.center()), None);
+        assert_eq!(
+            hit(&rocker, 0, max, rocker.down.center()),
+            Some(ScrollHalf::Down)
+        );
+        assert_eq!(hit(&rocker, max, max, rocker.down.center()), None);
+        assert_eq!(
+            hit(&rocker, max, max, rocker.up.center()),
+            Some(ScrollHalf::Up)
+        );
+        assert_eq!(hit(&rocker, 1, max, vec2(0.0, 0.0)), None);
+
+        // A list that fits has no rocker at all.
+        assert_eq!(rocker_none(), None);
+    }
+
+    fn rocker_none() -> Option<Rocker> {
+        rocker(LIST, FIELD_TOP_Y, false)
+    }
+
+    #[test]
+    fn scrolling_stops_at_both_ends() {
+        let max = 3;
+        let mut scroll = 0;
+        apply(ScrollHalf::Up, &mut scroll, max);
+        assert_eq!(scroll, 0);
+        for _ in 0..max + 3 {
+            apply(ScrollHalf::Down, &mut scroll, max);
+        }
+        assert_eq!(scroll, max);
+        apply(ScrollHalf::Up, &mut scroll, max);
+        assert_eq!(scroll, max - 1);
+    }
+}

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -37,6 +37,7 @@ mod frontend_menu;
 mod frontend_pointer;
 mod frontend_presentation;
 mod frontend_sfx;
+pub mod list_scroll;
 mod panel_anchor;
 mod pointer_visual;
 pub mod world_dim;

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -38,6 +38,18 @@ const ROW0_DECREMENT: [number, number] = [
 ];
 const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
 
+// The upper framed button (`GAMELODR.BIN` rect 2 - the load screen's "Load"
+// frame): the debug-scene launcher's door on the parameters page, and the
+// launch itself on the launcher page.
+const ACTION: [number, number] = [527 + 96 / 2, 161 + 62 / 2];
+/**
+ * A row of the launcher's list: 19px rows from the pane top (y=54), x well
+ * inside the pane and clear of the scroll gutter. Row 2 is `debug_minimal` -
+ * the cheapest scene to actually start.
+ */
+const sceneRow = (index: number): [number, number] => [330, 54 + index * 19 + 9];
+const DEBUG_MINIMAL_ROW = 2;
+
 /** SIMR.BIN pause entries: five 179x76 buttons at x=400, top 20, 92px pitch. */
 const pauseEntry = (index: number): [number, number] =>
   norm(400 + 179 / 2, 20 + index * 92 + 76 / 2);
@@ -228,5 +240,77 @@ test(
     await game.input.set("pointer.pressed", 0);
     await game.step({ frames: 5 });
     assert.equal((await game.info()).paused, false, "Continue on the root resumes");
+  },
+);
+
+// The debug-scene launcher (`scenes/developer.rs`). On a headset the runtime
+// picks its scene from a file read at startup, so without this page a change
+// of debug scene - or a death inside one - costs an APK relaunch. Both
+// presentations drive the same page through the same hit test.
+//
+// Negative-first: before the launcher existed the upper framed button was
+// inert, so the first assertion of each test (the page turn away from the
+// parameter rows) fails - the screen stays on the rows.
+
+test(
+  "the flat Developer screen launches a debug scene and can back out of the list",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "main_menu", port: 8134 });
+    await game.step({ frames: 10 });
+    await click(game, [489, 202]);
+    assert.equal((await game.info()).mission, "developer");
+
+    // The upper framed button turns the page - it does not swap the scene.
+    await click(game, ACTION);
+    assert.equal((await game.info()).mission, "developer");
+    await game.screenshot("dev-scenes-flat.png");
+
+    // "Done" on the launcher goes back to the parameters, not to the menu...
+    await click(game, DONE);
+    assert.equal((await game.info()).mission, "developer");
+    // ...and the parameter rows really are back: `>` steps a value again.
+    const before = await paramValue(game, "panel_distance");
+    await click(game, ROW0_INCREMENT);
+    assert.ok(
+      Math.abs((await paramValue(game, "panel_distance")) - (before + 0.1)) < 1e-4,
+      "Done on the launcher must return to the parameter rows",
+    );
+    await click(game, ROW0_DECREMENT);
+
+    // Select a scene and launch it.
+    await click(game, ACTION);
+    await click(game, sceneRow(DEBUG_MINIMAL_ROW));
+    await click(game, ACTION);
+    assert.equal(
+      (await game.info()).mission,
+      "debug_minimal",
+      "Launch must start the selected scene",
+    );
+  },
+);
+
+test(
+  "the VR Developer screen launches a debug scene through the controller ray",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "main_menu",
+      port: 8135,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+    await vrClick(game, [400 + 179 / 2, 20 + 2 * 76 + 30]);
+    assert.equal((await game.info()).mission, "developer");
+
+    // The same canvas points as the flat run, reached by the ray.
+    await vrClick(game, ACTION);
+    assert.equal((await game.info()).mission, "developer");
+    await game.step({ frames: 5 });
+    await game.screenshot("dev-scenes-vr.png");
+
+    await vrClick(game, sceneRow(DEBUG_MINIMAL_ROW));
+    await vrClick(game, ACTION);
+    assert.equal((await game.info()).mission, "debug_minimal");
   },
 );


### PR DESCRIPTION
Stacked on **#1123**. Review that first.

## Why

Play-testing debug scenes on a Quest, there was **no way back into a debug
scene from the frontend**. The device runtime reads its scene from
`/sdcard/shock2quest/vr-mission.txt` at startup, so dying in one — or leaving
it — meant relaunching the APK to get back. (The other half of that trap,
game-over "Quit" closing the application outright, is #1120.)

![Developer scene launcher demo](https://gist.githubusercontent.com/tommy-xr/ec7bc166190c6ac2482e3578d3d3d651/raw/scene-launcher.gif)

<sub>Developer parameters page &rarr; "Scenes" &rarr; the scrollable scene list &rarr; scroll &rarr; select `debug_melee` &rarr; "Launch" boots the scene. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![Scene list with debug_melee selected](https://gist.githubusercontent.com/tommy-xr/ec7bc166190c6ac2482e3578d3d3d651/raw/scene-list.png)

<sub>The launcher page: the scrolled list with `debug_melee` selected, the framed button relabelled "Launch", "Done" backing out to the parameters page.</sub>

## What

A second **page** on the Developer screen, not a new scene. `GAMELODR.BIN`
rect 2 — the load screen's "Load" frame, which this screen never used and
which #1123 deliberately kept free by putting its scroll rocker in a list
gutter instead — draws **"Scenes"** on the parameters page and **"Launch"** on
the launcher page. "Done" backs out of the launcher to the parameters; the
parameters page's own "Done" still returns to the main menu.

One `hit(ScreenState, point)` covers both pages and is handed to
`FrontendMenu::update` as the same closure twice, so the flat pointer and the
VR ray resolve identically (AGENTS.md §3).

Three design calls worth surfacing:

- **The launcher lives on the host** (`scenes/developer.rs`), not in the
  shared `dev_params_panel`. The pause overlay hosts that same panel and
  cannot swap the scene out from under itself — a button in the panel would
  have shipped **dead in the pause menu**. The panel gained rect accessors so
  both pages ride one set of authored rects.
- **One scene registry.** `scenes/mod.rs` now holds
  `DEBUG_SCENES: &[(&str, DebugSceneCtor)]`; both `create_initial_scene`
  (replacing 18 hand-written `eq_ignore_ascii_case` blocks) and the launcher's
  new `GlobalEffect::LaunchDebugScene` dispatch from it, so `--mission
  debug_x` and the launcher cannot drift.
- **One scrolling implementation.** The rocker #1123 added moved to
  `ui/list_scroll.rs`; the parameter list delegates to it and the launcher
  reuses it (18 scenes, 14 rows per page).

## Label overhang, fixed here too

`text_native` does not shrink to its rect, so long labels ran past the label
column and **struck the `<` arrow beside them** — a readout drawn over a click
target. Plain in a screenshot, invisible to every layout assertion in the
file, which is why it survived several passes over this screen.

Both halves, because either alone is wrong: labels now draw with
`text_native_fit` so any future name ellipsizes rather than overhangs, **and**
the offending names are shortened so the ellipsis does not fire on ordinary
ones ("Melee max speed"/"Melee max turn" truncated to an ambiguous "Melee max
s..."/"Melee max t..."). The melee overlay pair takes @tommy-xr's own words —
**"Show hands"** and **"Show hurtbox"**. Only display labels move; every `key`
is the stable HTTP/SDK identity and is untouched.

## Verification

- `cargo test -p shock2vr --lib`: **967 passed**, 1 ignored (+14 new).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean.
- `cargo fmt --all -- --check`: clean.
- `dev-menu.e2e`: **5/5** — the 3 pre-existing cases plus flat and VR launcher
  flows. `missions.e2e`: all 23 missions still load (the dispatch rewrite is
  exactly the change that could have broken every one).
- Render-verified in **both** presentations: main menu → Developer → Scenes →
  select → scroll → Launch, with `/v1/info` confirming `developer` after the
  page turn and the chosen scene after Launch.

**Negative-first**, via six targeted reversions, each confirmed to fail the
right test and then reverted: removing the rect-2 door; indexing rows
positionally instead of by scroll offset; dropping the selection guard;
launching the first name regardless of selection; making launcher-"Done" emit
`ShowMainMenu`; making a spent rocker half clickable.

