### PR TITLE
feat(debug): idle-exit watchdog and a machine-readable bound-port marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,18 @@ For debugging visual/rendering changes without a full interactive session:
 
    # With no --mission it boots the main menu (same entry point as the flat
    # desktop runtime), so always pass one when a scene/mission is what you want.
+   #
+   # --port binds EXACTLY the port given and fails loudly if it is taken (a
+   # silent move to another port would leave callers talking to somebody
+   # else's runtime). For a throwaway capture, pass `--port 0` to get an
+   # OS-assigned port. Either way the runtime prints the port it bound before
+   # it serves anything, so read it rather than assume it:
+   #   SHOCK2QUEST_PORT port=54321 requested=0 address=127.0.0.1:54321
+   #
+   # The runtime also exits by itself after 30 minutes with NO HTTP request
+   # (`--idle-timeout-secs`, 0 disables), logging SHOCK2QUEST_IDLE_EXIT, so a
+   # runtime orphaned by a dead session stops holding ~700 MB and a port. Any
+   # request resets the timer; a request in flight never counts as idle.
 
    # Control via HTTP
    curl http://127.0.0.1:8080/v1/step -X POST -d '{"frames": 10}'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,8 +267,9 @@ For debugging visual/rendering changes without a full interactive session:
    # silent move to another port would leave callers talking to somebody
    # else's runtime). For a throwaway capture, pass `--port 0` to get an
    # OS-assigned port. Either way the runtime prints the port it bound before
-   # it serves anything, so read it rather than assume it:
-   #   SHOCK2QUEST_PORT port=54321 requested=0 address=127.0.0.1:54321
+   # it serves anything, so read it rather than assume it (the pid and
+   # instance_id answer "what is running, and is it mine?" without lsof):
+   #   SHOCK2QUEST_PORT port=54321 pid=8123 instance_id= address=127.0.0.1:54321
    #
    # The runtime also exits by itself after 30 minutes with NO HTTP request
    # (`--idle-timeout-secs`, 0 disables), logging SHOCK2QUEST_IDLE_EXIT, so a

--- a/runtimes/debug_runtime/src/lifecycle.rs
+++ b/runtimes/debug_runtime/src/lifecycle.rs
@@ -1,0 +1,222 @@
+//! Process-lifetime concerns for the debug runtime: how it reports the port it
+//! bound, and when it gives up and exits on its own.
+//!
+//! Both exist because runtimes are launched by agents and CI jobs that can die
+//! without cleaning up. A leaked runtime holds ~700 MB and a port for as long
+//! as the machine stays up, and a caller that has to *assume* a port ends up
+//! talking to somebody else's runtime.
+
+use std::net::SocketAddr;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Default idle timeout before the runtime exits by itself.
+///
+/// Chosen to sit between two failure modes:
+/// - Too short is destructive: an agent legitimately parks a paused runtime
+///   while it reasons, reads screenshots, or waits on another build - gaps of
+///   several minutes are normal, and killing a live session's runtime is far
+///   worse than leaking one.
+/// - Too long is pointless: the leak this guards against is an *orphan* (its
+///   owner crashed or was killed), and an orphan must not survive a working
+///   day - by then several have piled up, each holding ~700 MB.
+///
+/// 30 minutes is comfortably above any plausible think-time gap and still
+/// bounds a leak to half an hour. Note the runtime is paused by default and
+/// only advances on `/v1/step`, so "no HTTP request at all" is a sound
+/// liveness signal; "not stepping" would NOT be (someone watching a
+/// free-running scene never steps).
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 30 * 60;
+
+/// How often the watchdog task re-checks. Small relative to any sane timeout,
+/// so the reported idle time is accurate to about a second.
+pub const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The line printed once the HTTP server is bound - before it is usable - so
+/// any caller (shell, agent, CI) can read the real port instead of assuming
+/// it. `requested` is the value passed to `--port` (0 = "any free port"), so
+/// the log shows which of the two the caller asked for.
+pub fn port_marker_line(addr: SocketAddr, requested: u16) -> String {
+    format!(
+        "SHOCK2QUEST_PORT port={} requested={} address={}",
+        addr.port(),
+        requested,
+        addr
+    )
+}
+
+/// The line printed when the watchdog decides to exit.
+pub fn idle_exit_marker_line(idle: Duration, timeout: Duration) -> String {
+    format!(
+        "SHOCK2QUEST_IDLE_EXIT idle_secs={:.1} timeout_secs={}",
+        idle.as_secs_f64(),
+        timeout.as_secs()
+    )
+}
+
+#[derive(Debug)]
+struct IdleState {
+    /// When the most recent request started or finished.
+    last_activity: Instant,
+    /// Requests currently being served. A long-running request (a big
+    /// `/v1/step`) must never look like idleness.
+    in_flight: u32,
+}
+
+/// Tracks HTTP activity so the runtime can exit after a quiet period.
+///
+/// The clock is injected (`now` is a parameter) so the decision logic is
+/// unit-testable without sleeping.
+#[derive(Debug)]
+pub struct IdleWatchdog {
+    /// `None` disables the watchdog entirely (`--idle-timeout-secs 0`).
+    timeout: Option<Duration>,
+    state: Mutex<IdleState>,
+}
+
+impl IdleWatchdog {
+    pub fn new(timeout: Option<Duration>, now: Instant) -> Self {
+        Self {
+            timeout,
+            state: Mutex::new(IdleState {
+                last_activity: now,
+                in_flight: 0,
+            }),
+        }
+    }
+
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
+    }
+
+    pub fn request_started(&self, now: Instant) {
+        let mut state = self.state.lock().unwrap();
+        state.last_activity = now;
+        state.in_flight += 1;
+    }
+
+    pub fn request_finished(&self, now: Instant) {
+        let mut state = self.state.lock().unwrap();
+        state.last_activity = now;
+        state.in_flight = state.in_flight.saturating_sub(1);
+    }
+
+    /// How long the runtime has been idle, or `None` while a request is in
+    /// flight (a runtime serving a request is by definition not idle).
+    pub fn idle_for(&self, now: Instant) -> Option<Duration> {
+        let state = self.state.lock().unwrap();
+        if state.in_flight > 0 {
+            return None;
+        }
+        Some(now.saturating_duration_since(state.last_activity))
+    }
+
+    /// The elapsed idle time when the runtime should exit, else `None`.
+    pub fn expired(&self, now: Instant) -> Option<Duration> {
+        let timeout = self.timeout?;
+        let idle = self.idle_for(now)?;
+        (idle >= timeout).then_some(idle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn watchdog(secs: u64) -> (IdleWatchdog, Instant) {
+        let start = Instant::now();
+        (
+            IdleWatchdog::new(Some(Duration::from_secs(secs)), start),
+            start,
+        )
+    }
+
+    #[test]
+    fn watchdog_fires_after_the_timeout_elapses() {
+        let (watchdog, start) = watchdog(60);
+
+        assert_eq!(watchdog.expired(start + Duration::from_secs(59)), None);
+        assert_eq!(
+            watchdog.expired(start + Duration::from_secs(60)),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn any_request_resets_the_idle_clock() {
+        let (watchdog, start) = watchdog(60);
+
+        let request_at = start + Duration::from_secs(59);
+        watchdog.request_started(request_at);
+        watchdog.request_finished(request_at);
+
+        // 61s after start, but only 2s after the request.
+        assert_eq!(watchdog.expired(start + Duration::from_secs(61)), None);
+        assert_eq!(
+            watchdog.expired(request_at + Duration::from_secs(60)),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn an_in_flight_request_is_never_idle() {
+        let (watchdog, start) = watchdog(60);
+
+        // A request that outlives the timeout (e.g. a long /v1/step) must not
+        // let the watchdog kill the runtime out from under its caller.
+        watchdog.request_started(start);
+        let much_later = start + Duration::from_secs(600);
+        assert_eq!(watchdog.idle_for(much_later), None);
+        assert_eq!(watchdog.expired(much_later), None);
+
+        watchdog.request_finished(much_later);
+        assert_eq!(watchdog.expired(much_later), None);
+        assert_eq!(
+            watchdog.expired(much_later + Duration::from_secs(60)),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn overlapping_requests_keep_the_runtime_busy_until_the_last_one_ends() {
+        let (watchdog, start) = watchdog(60);
+
+        watchdog.request_started(start);
+        watchdog.request_started(start);
+        watchdog.request_finished(start);
+        assert_eq!(watchdog.idle_for(start + Duration::from_secs(600)), None);
+
+        watchdog.request_finished(start);
+        assert_eq!(
+            watchdog.idle_for(start + Duration::from_secs(600)),
+            Some(Duration::from_secs(600))
+        );
+    }
+
+    #[test]
+    fn a_zero_timeout_disables_the_watchdog() {
+        let start = Instant::now();
+        let watchdog = IdleWatchdog::new(None, start);
+
+        assert_eq!(watchdog.expired(start + Duration::from_secs(86_400)), None);
+    }
+
+    #[test]
+    fn port_marker_reports_the_resolved_port_not_the_request() {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 54321);
+
+        assert_eq!(
+            port_marker_line(addr, 0),
+            "SHOCK2QUEST_PORT port=54321 requested=0 address=127.0.0.1:54321"
+        );
+    }
+
+    #[test]
+    fn idle_exit_marker_reports_both_durations() {
+        assert_eq!(
+            idle_exit_marker_line(Duration::from_millis(1_800_400), Duration::from_secs(1_800)),
+            "SHOCK2QUEST_IDLE_EXIT idle_secs=1800.4 timeout_secs=1800"
+        );
+    }
+}

--- a/runtimes/debug_runtime/src/lifecycle.rs
+++ b/runtimes/debug_runtime/src/lifecycle.rs
@@ -7,7 +7,7 @@
 //! talking to somebody else's runtime.
 
 use std::net::SocketAddr;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 /// Default idle timeout before the runtime exits by itself.
@@ -22,10 +22,16 @@ use std::time::{Duration, Instant};
 ///   day - by then several have piled up, each holding ~700 MB.
 ///
 /// 30 minutes is comfortably above any plausible think-time gap and still
-/// bounds a leak to half an hour. Note the runtime is paused by default and
-/// only advances on `/v1/step`, so "no HTTP request at all" is a sound
-/// liveness signal; "not stepping" would NOT be (someone watching a
-/// free-running scene never steps).
+/// bounds a leak to half an hour. It is on by DEFAULT deliberately: the
+/// callers most likely to orphan a runtime (a `curl`-driven agent, a hand
+/// launch) are exactly the ones who would never pass an opt-in flag.
+///
+/// Note the runtime is paused by default and only advances on `/v1/step`, so
+/// "no HTTP request at all" is a sound liveness signal; "not stepping" would
+/// NOT be. The one real false positive follows from that: a human running
+/// `--visible`, free-running a scene and watching it for half an hour without
+/// touching HTTP, gets shut down. `--idle-timeout-secs 0` is the escape hatch
+/// (it is named in the flag's help text for exactly that moment).
 pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 30 * 60;
 
 /// How often the watchdog task re-checks. Small relative to any sane timeout,
@@ -34,13 +40,33 @@ pub const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// The line printed once the HTTP server is bound - before it is usable - so
 /// any caller (shell, agent, CI) can read the real port instead of assuming
-/// it. `requested` is the value passed to `--port` (0 = "any free port"), so
-/// the log shows which of the two the caller asked for.
-pub fn port_marker_line(addr: SocketAddr, requested: u16) -> String {
+/// it.
+///
+/// It carries the identity of the process too, because "where do I connect"
+/// is only half the discovery question; the other half is "what is running,
+/// and is it mine?", which today is answered with `lsof` and guesswork.
+/// `instance_id` is empty when the launcher did not pass one (a hand launch
+/// rather than the SDK) - the field is always present so a parser can rely on
+/// it.
+pub fn port_marker_line(addr: SocketAddr, pid: u32, instance_id: Option<&str>) -> String {
+    // --instance-id is opaque caller-supplied text; keep it to characters that
+    // cannot break the `key=value` framing (or forge a second marker line).
+    let instance_id: String = instance_id
+        .unwrap_or("")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '?'
+            }
+        })
+        .collect();
     format!(
-        "SHOCK2QUEST_PORT port={} requested={} address={}",
+        "SHOCK2QUEST_PORT port={} pid={} instance_id={} address={}",
         addr.port(),
-        requested,
+        pid,
+        instance_id,
         addr
     )
 }
@@ -89,13 +115,28 @@ impl IdleWatchdog {
         self.timeout
     }
 
-    pub fn request_started(&self, now: Instant) {
+    /// Mark a request as in flight until the returned guard is dropped.
+    ///
+    /// The guard exists because a client can vanish mid-request (curl Ctrl-C,
+    /// an aborted fetch, a killed session - exactly the orphan case this
+    /// watchdog is for), in which case the server future is dropped rather
+    /// than run to completion. A hand-written "decrement afterwards" would
+    /// then never run and leave the runtime permanently "busy", silently
+    /// disabling the watchdog forever.
+    pub fn request_scope(self: &Arc<Self>, now: Instant) -> ActivityGuard {
+        self.request_started(now);
+        ActivityGuard {
+            watchdog: Arc::clone(self),
+        }
+    }
+
+    fn request_started(&self, now: Instant) {
         let mut state = self.state.lock().unwrap();
         state.last_activity = now;
         state.in_flight += 1;
     }
 
-    pub fn request_finished(&self, now: Instant) {
+    fn request_finished(&self, now: Instant) {
         let mut state = self.state.lock().unwrap();
         state.last_activity = now;
         state.in_flight = state.in_flight.saturating_sub(1);
@@ -103,7 +144,7 @@ impl IdleWatchdog {
 
     /// How long the runtime has been idle, or `None` while a request is in
     /// flight (a runtime serving a request is by definition not idle).
-    pub fn idle_for(&self, now: Instant) -> Option<Duration> {
+    fn idle_for(&self, now: Instant) -> Option<Duration> {
         let state = self.state.lock().unwrap();
         if state.in_flight > 0 {
             return None;
@@ -116,6 +157,19 @@ impl IdleWatchdog {
         let timeout = self.timeout?;
         let idle = self.idle_for(now)?;
         (idle >= timeout).then_some(idle)
+    }
+}
+
+/// Keeps the runtime marked busy for as long as one request lives. Dropping
+/// it - normally, or because the request was cancelled - ends that request's
+/// claim and restarts the idle clock.
+pub struct ActivityGuard {
+    watchdog: Arc<IdleWatchdog>,
+}
+
+impl Drop for ActivityGuard {
+    fn drop(&mut self) {
+        self.watchdog.request_finished(Instant::now());
     }
 }
 
@@ -195,6 +249,22 @@ mod tests {
     }
 
     #[test]
+    fn dropping_a_request_scope_releases_the_runtime() {
+        // A cancelled request (client hung up mid-request) unwinds by dropping
+        // the response future, so the release must ride on Drop - otherwise
+        // one aborted request would wedge the runtime "busy" forever and
+        // silently disable the watchdog.
+        let start = Instant::now();
+        let watchdog = Arc::new(IdleWatchdog::new(Some(Duration::from_secs(60)), start));
+
+        let guard = watchdog.request_scope(start);
+        assert_eq!(watchdog.idle_for(start + Duration::from_secs(600)), None);
+
+        drop(guard);
+        assert!(watchdog.idle_for(Instant::now()).is_some());
+    }
+
+    #[test]
     fn a_zero_timeout_disables_the_watchdog() {
         let start = Instant::now();
         let watchdog = IdleWatchdog::new(None, start);
@@ -207,8 +277,30 @@ mod tests {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 54321);
 
         assert_eq!(
-            port_marker_line(addr, 0),
-            "SHOCK2QUEST_PORT port=54321 requested=0 address=127.0.0.1:54321"
+            port_marker_line(addr, 4242, Some("abc-123")),
+            "SHOCK2QUEST_PORT port=54321 pid=4242 instance_id=abc-123 address=127.0.0.1:54321"
+        );
+    }
+
+    #[test]
+    fn port_marker_neutralizes_an_instance_id_that_would_break_parsing() {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+
+        assert_eq!(
+            port_marker_line(addr, 7, Some("a b\nSHOCK2QUEST_PORT port=1")),
+            "SHOCK2QUEST_PORT port=8080 pid=7 instance_id=a?b?SHOCK2QUEST_PORT?port?1 address=127.0.0.1:8080"
+        );
+    }
+
+    #[test]
+    fn port_marker_keeps_the_instance_id_field_when_there_is_none() {
+        // A hand launch passes no --instance-id; the field stays present (and
+        // empty) so a parser never has to special-case a missing key.
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+
+        assert_eq!(
+            port_marker_line(addr, 7, None),
+            "SHOCK2QUEST_PORT port=8080 pid=7 instance_id= address=127.0.0.1:8080"
         );
     }
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -15,12 +15,20 @@ use cgmath::Vector3;
 use clap::Parser;
 use serde::Deserialize;
 use serde_json::{Value, json};
-use std::{collections::HashSet, net::SocketAddr, thread, time::Duration};
+use std::{
+    collections::HashSet,
+    net::SocketAddr,
+    sync::Arc,
+    thread,
+    time::{Duration, Instant},
+};
 use tokio::{signal, sync::mpsc, sync::oneshot};
 use tracing::info;
 
 mod commands;
+mod lifecycle;
 use commands::*;
+use lifecycle::{DEFAULT_IDLE_TIMEOUT_SECS, IDLE_POLL_INTERVAL, IdleWatchdog};
 
 // Game engine imports
 extern crate glfw;
@@ -86,9 +94,21 @@ struct Args {
     #[arg(short, long, default_value = "main_menu")]
     mission: String,
 
-    /// Port to bind HTTP server to
+    /// Port to bind the HTTP server to. Bound exactly as given: a taken port
+    /// is a hard, loud failure rather than a silent move to another port,
+    /// because a caller that then talks to the old port would be driving
+    /// somebody else's runtime. Pass `0` to bind an OS-assigned ephemeral
+    /// port instead - the runtime always prints the port it actually bound as
+    /// `SHOCK2QUEST_PORT port=<n>`, so a caller can read it rather than guess.
     #[arg(short, long, default_value = "8080")]
     port: u16,
+
+    /// Exit after this many seconds with no HTTP request at all (0 disables).
+    /// Keeps an orphaned runtime - one whose owning agent or session died -
+    /// from holding ~700 MB and a port indefinitely. Any request resets the
+    /// timer, and a request in flight never counts as idle.
+    #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
+    idle_timeout_secs: u64,
 
     /// Enable debug physics rendering
     #[arg(long)]
@@ -234,8 +254,25 @@ fn main() -> anyhow::Result<()> {
         .block_on(tokio::net::TcpListener::bind(addr))
         .map_err(|e| anyhow::anyhow!("failed to bind {}: {}", addr, e))?;
 
+    // Announce the bound port before the server can serve anything, so a
+    // caller can block on this line and then use the address - essential with
+    // `--port 0`, where only the OS knows the port. println! (not tracing) so
+    // it survives any RUST_LOG filter, matching the other SHOCK2QUEST_*
+    // markers.
+    let bound_addr = listener.local_addr()?;
+    println!("{}", lifecycle::port_marker_line(bound_addr, args.port));
+
+    let idle_timeout =
+        (args.idle_timeout_secs > 0).then(|| Duration::from_secs(args.idle_timeout_secs));
+    let watchdog = Arc::new(IdleWatchdog::new(idle_timeout, Instant::now()));
+
     // Start the HTTP server in a background task
-    let server_handle = rt.spawn(start_http_server(listener, command_tx));
+    let server_handle = rt.spawn(start_http_server(
+        listener,
+        command_tx.clone(),
+        watchdog.clone(),
+    ));
+    rt.spawn(run_idle_watchdog(watchdog, command_tx));
 
     // Run the game on the main thread (required for GLFW)
     let game_result = run_game_blocking(args, command_rx);
@@ -248,11 +285,56 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Watch for a quiet period and shut the runtime down when it passes.
+///
+/// This is the only thing that reclaims an *orphaned* runtime: if the agent or
+/// session that launched it dies, nothing else will ever send it a
+/// `/v1/shutdown`, and it would otherwise sit on ~700 MB and a port until the
+/// machine reboots. It routes through the same `Shutdown` command the HTTP
+/// endpoint uses, so the game loop tears down normally.
+async fn run_idle_watchdog(
+    watchdog: Arc<IdleWatchdog>,
+    command_tx: mpsc::UnboundedSender<RuntimeCommand>,
+) {
+    let Some(timeout) = watchdog.timeout() else {
+        info!("Idle watchdog disabled (--idle-timeout-secs 0)");
+        return;
+    };
+    info!(
+        "Idle watchdog armed: exiting after {}s with no HTTP request",
+        timeout.as_secs()
+    );
+
+    loop {
+        tokio::time::sleep(IDLE_POLL_INTERVAL).await;
+        if let Some(idle) = watchdog.expired(Instant::now()) {
+            println!("{}", lifecycle::idle_exit_marker_line(idle, timeout));
+            request_game_loop_shutdown(&command_tx);
+            return;
+        }
+    }
+}
+
+/// Note every request against the idle watchdog, so that any traffic - not
+/// just stepping - keeps the runtime alive, and so a long request in flight
+/// (a big `/v1/step`) is never mistaken for idleness.
+async fn track_http_activity(
+    State(watchdog): State<Arc<IdleWatchdog>>,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    watchdog.request_started(Instant::now());
+    let response = next.run(request).await;
+    watchdog.request_finished(Instant::now());
+    response
+}
+
 /// Start the HTTP server on an already-bound listener (binding happens in
 /// main so a taken port fails the process fast)
 async fn start_http_server(
     listener: tokio::net::TcpListener,
     command_tx: mpsc::UnboundedSender<RuntimeCommand>,
+    watchdog: Arc<IdleWatchdog>,
 ) -> anyhow::Result<()> {
     let signal_command_tx = command_tx.clone();
 
@@ -318,7 +400,11 @@ async fn start_http_server(
         .route("/v1/audio/recent", get(get_recent_audio))
         .route("/v1/messages/recent", get(get_recent_messages))
         .route("/v1/screenshot", axum::routing::post(take_screenshot))
-        .with_state(command_tx);
+        .with_state(command_tx)
+        .layer(axum::middleware::from_fn_with_state(
+            watchdog,
+            track_http_activity,
+        ));
 
     let addr = listener.local_addr()?;
     info!("Debug runtime listening on http://{}", addr);

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -103,10 +103,12 @@ struct Args {
     #[arg(short, long, default_value = "8080")]
     port: u16,
 
-    /// Exit after this many seconds with no HTTP request at all (0 disables).
-    /// Keeps an orphaned runtime - one whose owning agent or session died -
-    /// from holding ~700 MB and a port indefinitely. Any request resets the
-    /// timer, and a request in flight never counts as idle.
+    /// Exit after this many seconds with no HTTP request at all. Keeps an
+    /// orphaned runtime - one whose owning agent or session died - from
+    /// holding ~700 MB and a port indefinitely. Any request resets the timer,
+    /// and a request in flight never counts as idle. Pass 0 to disable: the
+    /// case that needs it is watching a `--visible` free-running scene by
+    /// hand, where no HTTP traffic happens for a long time.
     #[arg(long, default_value_t = DEFAULT_IDLE_TIMEOUT_SECS)]
     idle_timeout_secs: u64,
 
@@ -260,7 +262,10 @@ fn main() -> anyhow::Result<()> {
     // it survives any RUST_LOG filter, matching the other SHOCK2QUEST_*
     // markers.
     let bound_addr = listener.local_addr()?;
-    println!("{}", lifecycle::port_marker_line(bound_addr, args.port));
+    println!(
+        "{}",
+        lifecycle::port_marker_line(bound_addr, std::process::id(), args.instance_id.as_deref())
+    );
 
     let idle_timeout =
         (args.idle_timeout_secs > 0).then(|| Duration::from_secs(args.idle_timeout_secs));
@@ -291,7 +296,15 @@ fn main() -> anyhow::Result<()> {
 /// session that launched it dies, nothing else will ever send it a
 /// `/v1/shutdown`, and it would otherwise sit on ~700 MB and a port until the
 /// machine reboots. It routes through the same `Shutdown` command the HTTP
-/// endpoint uses, so the game loop tears down normally.
+/// endpoint uses, so the game loop tears down normally - GLFW owns the main
+/// thread, so exiting the process from this task would skip that teardown.
+///
+/// Two deliberate limits, both matching what `/v1/shutdown` already does:
+/// a game loop wedged elsewhere (a hung level load) will not act on the
+/// command until it is unwedged, and the idle clock starts when the socket
+/// binds rather than when the mission finishes loading - so a very short
+/// `--idle-timeout-secs` can expire during a cold load. Neither matters at the
+/// 30-minute default.
 async fn run_idle_watchdog(
     watchdog: Arc<IdleWatchdog>,
     command_tx: mpsc::UnboundedSender<RuntimeCommand>,
@@ -323,10 +336,11 @@ async fn track_http_activity(
     request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    watchdog.request_started(Instant::now());
-    let response = next.run(request).await;
-    watchdog.request_finished(Instant::now());
-    response
+    // The guard releases on Drop, so a request the client abandons mid-flight
+    // still ends its claim (a plain "decrement after the await" would not run
+    // when the response future is dropped, wedging the runtime "busy").
+    let _activity = watchdog.request_scope(Instant::now());
+    next.run(request).await
 }
 
 /// Start the HTTP server on an already-bound listener (binding happens in

--- a/tools/shock2-sdk/test/runtime-lifecycle.e2e.test.ts
+++ b/tools/shock2-sdk/test/runtime-lifecycle.e2e.test.ts
@@ -42,20 +42,33 @@ function spawnRuntime(args: string[]): Runtime {
 
   const lines: string[] = [];
   const waiters: { pattern: RegExp; resolve: (line: string) => void }[] = [];
-  const capture = (chunk: Buffer) => {
-    for (const line of chunk.toString().split("\n")) {
-      if (line.length === 0) continue;
-      lines.push(line);
-      for (const waiter of [...waiters]) {
-        if (waiter.pattern.test(line)) {
-          waiters.splice(waiters.indexOf(waiter), 1);
-          waiter.resolve(line);
-        }
+  const emit = (line: string) => {
+    if (line.length === 0) return;
+    lines.push(line);
+    for (const waiter of [...waiters]) {
+      if (waiter.pattern.test(line)) {
+        waiters.splice(waiters.indexOf(waiter), 1);
+        waiter.resolve(line);
       }
     }
   };
-  child.stdout?.on("data", capture);
-  child.stderr?.on("data", capture);
+  // A chunk can split mid-line (and the marker line is exactly what we wait
+  // for), so carry the tail of each stream between chunks instead of assuming
+  // whole lines arrive together.
+  const captureFrom = (stream: NodeJS.ReadableStream | null) => {
+    let carry = "";
+    stream?.on("data", (chunk: Buffer) => {
+      const parts = (carry + chunk.toString()).split("\n");
+      carry = parts.pop() ?? "";
+      for (const line of parts) emit(line);
+    });
+    stream?.on("end", () => {
+      emit(carry);
+      carry = "";
+    });
+  };
+  captureFrom(child.stdout);
+  captureFrom(child.stderr);
 
   let exited = false;
   const exitWaiters: (() => void)[] = [];
@@ -72,6 +85,17 @@ function spawnRuntime(args: string[]): Runtime {
       // Already gone.
     }
   };
+
+  // These runtimes are spawned raw (not via GameServer, which needs a ready
+  // instance we deliberately do not have here), so they are not covered by the
+  // SDK's own signal cleanup. Without this, Ctrl-C of the test runner would
+  // orphan exactly the kind of runtime this file exists to test.
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      kill();
+      process.kill(process.pid, signal);
+    });
+  }
 
   return {
     child,
@@ -121,14 +145,23 @@ function spawnRuntime(args: string[]): Runtime {
   };
 }
 
-/** Bind a port and hold it, so the runtime cannot have it. */
-function occupyPort(port: number): Promise<() => void> {
+/**
+ * Hold an OS-chosen port, so the runtime cannot have it. Deliberately not a
+ * fixed port: the test only needs *a* taken one, and a hardcoded port is the
+ * very collision this file is about.
+ */
+function occupyAnyPort(): Promise<{ port: number; release: () => void }> {
   return new Promise((resolve, reject) => {
     const squatter = createServer();
     squatter.once("error", reject);
-    squatter.listen({ port, host: "127.0.0.1" }, () =>
-      resolve(() => squatter.close()),
-    );
+    squatter.listen({ port: 0, host: "127.0.0.1" }, () => {
+      const address = squatter.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("squatter did not report a TCP port"));
+        return;
+      }
+      resolve({ port: address.port, release: () => squatter.close() });
+    });
   });
 }
 
@@ -153,6 +186,13 @@ test(
       const port = parseBoundPort(marker);
       assert.notEqual(port, 0, "must report the resolved port, not the request");
       assert.ok(port > 1024, `expected an ephemeral port, got ${port}`);
+      // The marker also answers "what is running, and is it mine?".
+      assert.match(marker, /pid=\d+/, "marker should carry the pid");
+      assert.match(
+        marker,
+        /instance_id=/,
+        "the instance_id field is present even when unset (hand launch)",
+      );
 
       const health = await fetch(`http://127.0.0.1:${port}/v1/health`);
       assert.equal(health.status, 200);
@@ -168,8 +208,7 @@ test(
   "an explicit --port that is taken fails loudly instead of drifting",
   { skip: !e2eEnabled, timeout: 360_000 },
   async () => {
-    const port = Number(process.env.SHOCK2_E2E_PORT ?? 8504);
-    const release = await occupyPort(port);
+    const { port, release } = await occupyAnyPort();
     const runtime = spawnRuntime(["--port", String(port)]);
     try {
       await runtime.waitForExit(LAUNCH_TIMEOUT_MS);

--- a/tools/shock2-sdk/test/runtime-lifecycle.e2e.test.ts
+++ b/tools/shock2-sdk/test/runtime-lifecycle.e2e.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { test } from "node:test";
+
+import { findRepoRoot } from "../src/server.js";
+
+// Real-process coverage for the debug runtime's lifecycle contract:
+//  - it always announces the port it actually bound (SHOCK2QUEST_PORT), so a
+//    caller never has to assume - in particular with `--port 0`;
+//  - it exits on its own after `--idle-timeout-secs` with no HTTP traffic, so
+//    an orphaned runtime (crashed agent, killed session) stops holding ~700 MB
+//    and a port forever;
+//  - any request resets that idle clock.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const repoRoot = findRepoRoot(process.cwd());
+
+interface Runtime {
+  child: ChildProcess;
+  lines: string[];
+  /** Resolves with the first log line matching `pattern`. */
+  waitForLine(pattern: RegExp, timeoutMs: number): Promise<string>;
+  /** Resolves when the process exits; rejects on timeout. */
+  waitForExit(timeoutMs: number): Promise<void>;
+  exited(): boolean;
+  kill(): void;
+}
+
+function spawnRuntime(args: string[]): Runtime {
+  assert.ok(repoRoot, "could not find cargo workspace root");
+  const child = spawn(
+    "cargo",
+    ["run", "-p", "debug_runtime", "--", "--mission", "debug_minimal", ...args],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, RUST_LOG: "debug_runtime=info" },
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    },
+  );
+
+  const lines: string[] = [];
+  const waiters: { pattern: RegExp; resolve: (line: string) => void }[] = [];
+  const capture = (chunk: Buffer) => {
+    for (const line of chunk.toString().split("\n")) {
+      if (line.length === 0) continue;
+      lines.push(line);
+      for (const waiter of [...waiters]) {
+        if (waiter.pattern.test(line)) {
+          waiters.splice(waiters.indexOf(waiter), 1);
+          waiter.resolve(line);
+        }
+      }
+    }
+  };
+  child.stdout?.on("data", capture);
+  child.stderr?.on("data", capture);
+
+  let exited = false;
+  const exitWaiters: (() => void)[] = [];
+  child.on("exit", () => {
+    exited = true;
+    for (const resolve of exitWaiters.splice(0)) resolve();
+  });
+
+  const kill = () => {
+    if (exited || child.pid === undefined) return;
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  };
+
+  return {
+    child,
+    lines,
+    exited: () => exited,
+    kill,
+    waitForLine(pattern, timeoutMs) {
+      const existing = lines.find((line) => pattern.test(line));
+      if (existing !== undefined) return Promise.resolve(existing);
+      return new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `timed out waiting for ${pattern}\nRecent output:\n${lines.slice(-40).join("\n")}`,
+              ),
+            ),
+          timeoutMs,
+        );
+        waiters.push({
+          pattern,
+          resolve: (line) => {
+            clearTimeout(timer);
+            resolve(line);
+          },
+        });
+      });
+    },
+    waitForExit(timeoutMs) {
+      if (exited) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `runtime did not exit within ${timeoutMs}ms\nRecent output:\n${lines.slice(-40).join("\n")}`,
+              ),
+            ),
+          timeoutMs,
+        );
+        exitWaiters.push(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+/** Bind a port and hold it, so the runtime cannot have it. */
+function occupyPort(port: number): Promise<() => void> {
+  return new Promise((resolve, reject) => {
+    const squatter = createServer();
+    squatter.once("error", reject);
+    squatter.listen({ port, host: "127.0.0.1" }, () =>
+      resolve(() => squatter.close()),
+    );
+  });
+}
+
+function parseBoundPort(markerLine: string): number {
+  const match = /SHOCK2QUEST_PORT port=(\d+)/.exec(markerLine);
+  assert.ok(match, `marker line has no port=: ${markerLine}`);
+  return Number(match[1]);
+}
+
+const LAUNCH_TIMEOUT_MS = 300_000;
+
+test(
+  "--port 0 binds an ephemeral port and reports it",
+  { skip: !e2eEnabled, timeout: 360_000 },
+  async () => {
+    const runtime = spawnRuntime(["--port", "0"]);
+    try {
+      const marker = await runtime.waitForLine(
+        /SHOCK2QUEST_PORT /,
+        LAUNCH_TIMEOUT_MS,
+      );
+      const port = parseBoundPort(marker);
+      assert.notEqual(port, 0, "must report the resolved port, not the request");
+      assert.ok(port > 1024, `expected an ephemeral port, got ${port}`);
+
+      const health = await fetch(`http://127.0.0.1:${port}/v1/health`);
+      assert.equal(health.status, 200);
+      await fetch(`http://127.0.0.1:${port}/v1/shutdown`, { method: "POST" });
+      await runtime.waitForExit(60_000);
+    } finally {
+      runtime.kill();
+    }
+  },
+);
+
+test(
+  "an explicit --port that is taken fails loudly instead of drifting",
+  { skip: !e2eEnabled, timeout: 360_000 },
+  async () => {
+    const port = Number(process.env.SHOCK2_E2E_PORT ?? 8504);
+    const release = await occupyPort(port);
+    const runtime = spawnRuntime(["--port", String(port)]);
+    try {
+      await runtime.waitForExit(LAUNCH_TIMEOUT_MS);
+      const output = runtime.lines.join("\n");
+      assert.match(output, new RegExp(`failed to bind 127\\.0\\.0\\.1:${port}`));
+      assert.doesNotMatch(
+        output,
+        /SHOCK2QUEST_PORT /,
+        "a failed bind must not announce a port",
+      );
+    } finally {
+      runtime.kill();
+      release();
+    }
+  },
+);
+
+test(
+  "the idle watchdog exits an untouched runtime, and requests reset it",
+  { skip: !e2eEnabled, timeout: 420_000 },
+  async () => {
+    const idleSecs = 15;
+    const runtime = spawnRuntime(["--port", "0", "--idle-timeout-secs", String(idleSecs)]);
+    try {
+      const marker = await runtime.waitForLine(
+        /SHOCK2QUEST_PORT /,
+        LAUNCH_TIMEOUT_MS,
+      );
+      const port = parseBoundPort(marker);
+
+      // Keep it alive well past the timeout purely by talking to it.
+      const keepAliveUntil = Date.now() + idleSecs * 2000;
+      while (Date.now() < keepAliveUntil) {
+        const health = await fetch(`http://127.0.0.1:${port}/v1/health`);
+        assert.equal(health.status, 200);
+        await new Promise((resolve) => setTimeout(resolve, idleSecs * 200));
+      }
+      assert.ok(
+        !runtime.exited(),
+        "requests must reset the idle clock - the runtime should still be up",
+      );
+
+      // Now go quiet: it should exit on its own.
+      await runtime.waitForExit(idleSecs * 1000 + 60_000);
+      assert.match(runtime.lines.join("\n"), /SHOCK2QUEST_IDLE_EXIT /);
+    } finally {
+      runtime.kill();
+    }
+  },
+);


### PR DESCRIPTION
Two concrete failures we hit repeatedly when several agents/sessions drive debug runtimes on one machine:

1. **Port collisions between concurrent agents.** Coordination is currently hand-written into agent prompts ("use port 8481, avoid 8391-8393"), which does not scale. A caller that has to *assume* a port can end up driving somebody else's runtime.
2. **Orphaned runtimes.** A runtime whose owner dies (crashed agent, killed session) lives forever — nothing ever sends it `/v1/shutdown`. Each holds ~700 MB and a port until the machine reboots.

## What this does

**A. Idle-exit watchdog.** The runtime exits by itself after `--idle-timeout-secs` with **no HTTP request at all**. Default **1800 s (30 min)**, on by default deliberately: the callers most likely to orphan a runtime (a `curl`-driven agent, a hand launch) are exactly the ones who would never pass an opt-in flag. 30 minutes is comfortably above any plausible agent think-time gap (reasoning, reading screenshots, waiting on another build) and still bounds a leak to half an hour.

- Any request resets the clock — not just stepping. The runtime is *paused by default* and only advances on `/v1/step`, so "no requests" is a sound liveness signal where "no stepping" would not be.
- A request **in flight** never counts as idle, so a long `POST /v1/step {"duration":"600s"}` can't be killed under its caller. The claim is released by a `Drop` guard, so a request the client abandons mid-flight (curl Ctrl-C, aborted fetch) still releases it — a plain decrement-after-await would leave the runtime wedged "busy" and silently disable the watchdog forever.
- It shuts down through the **same `Shutdown` command as `/v1/shutdown`** (GLFW owns the main thread, so exiting the process from the tokio task would skip teardown).
- Logs `SHOCK2QUEST_IDLE_EXIT idle_secs=… timeout_secs=…`, greppable like the other `SHOCK2QUEST_*` markers.
- Known false positive, called out in the flag's help text: watching a `--visible` free-running scene by hand for half an hour sends no HTTP traffic. `--idle-timeout-secs 0` disables.

**B. Report the bound port (and who is running).** Before the server can serve anything:

```
SHOCK2QUEST_PORT port=54321 pid=8123 instance_id= address=127.0.0.1:54321
```

- `--port N` **keeps today's behaviour exactly**: bind it or fail loudly. No retry, no fallback, no new flag. Silently drifting to another port would turn a loud, actionable `failed to bind 8080` into cross-talk with another agent's runtime — a baffling failure. The Quest `adb forward` path and anything else needing a fixed port is unaffected.
- `--port 0` is the new opt-in: an OS-assigned ephemeral port, for throwaway captures where the caller reads the marker instead of guessing.
- `pid` and `instance_id` ride along because "where do I connect" is only half the discovery question; "what is running, and is it mine?" currently has no answer but `lsof` and guesswork. `instance_id` is empty (but always present) for a hand launch, and is sanitized so caller text can't break the `key=value` framing.

## Relationship to #852

This is the root fix, but it does **not** supersede #852 today. Honest sequencing:

1. This lands: orphans expire on their own, and `--port 0` + the marker make contention avoidable.
2. An SDK follow-up adopts `--port 0` and parses `SHOCK2QUEST_PORT` — that is where most of B's value is actually realised. Until then the SDK's own `findFreePort` + retry stays genuinely useful and is untouched here.
3. Only then does #852's exact-port reclamation stop mattering.

#852's safety design is careful and correct — checkout-scoped lease, double identity check, no process-name scan — and its `instance_id` shutdown guard is already on main and untouched by this PR. What this PR does **not** do is #852's immediate reclamation of one *exact* port: a caller that genuinely needs port N back from its own orphan still has to wait out the idle timeout. If that matters for fixed-port callers, #852 is still wanted; the owner should judge that after step 2 rather than on this PR.

Also explicitly **not** solved: several *live* runtimes each holding ~700 MB. That is a policy question about how many agents run at once, not something a runtime flag fixes.

## Tests

- `runtimes/debug_runtime/src/lifecycle.rs` unit tests (pure, clock-injected — no sleeps): watchdog fires at the timeout; any request resets the clock; an in-flight request is never idle; overlapping requests stay busy until the last ends; a dropped `ActivityGuard` releases the runtime; a zero timeout disables it; marker formatting (resolved port, empty-but-present `instance_id`, sanitized `instance_id`).
- `tools/shock2-sdk/test/runtime-lifecycle.e2e.test.ts` — real processes: `--port 0` binds and reports an ephemeral port that answers on `/v1/health`; an explicit `--port` that is taken fails loudly and prints **no** marker; the watchdog exits an untouched runtime while HTTP traffic keeps it alive (short injected timeout, ~45 s).

Negative-tested first: on `origin/main` the `--port 0` marker test fails (no `SHOCK2QUEST_PORT` line ever appears) and the watchdog test fails (`error: unexpected argument '--idle-timeout-secs'`). The taken-port test passes before and after — it is the regression guard on the unchanged fail-loudly behaviour.

Verification: `cargo fmt --all -- --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; `cargo test -p debug_runtime` (16 unit tests); `cargo test -p shock2vr --lib` (954 passing, unchanged); the lifecycle + missions e2e suites; and by hand — `--port 0` reported `port=63889`, a second launch on `63889` failed with `failed to bind 127.0.0.1:63889: Address already in use`, and the idle runtime logged `SHOCK2QUEST_IDLE_EXIT idle_secs=40.4 timeout_secs=40` 40 s after its last request and released the port.

https://claude.ai/code/session_017cm626D5M4tAz7yLPWPMFb
