### PR TITLE
docs: correct the stale control and input-system references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,14 @@ Discrete, non-contextual inputs (quick save/load, debug spawns, pathfinding test
 ```
 Desktop:  GLFW polling → DesktopInputMapper → InputActionState → ActionDispatcher → Effects
 Debug:    HTTP POST /v1/input/action      → InputActionState → ActionDispatcher → Effects
-Oculus:   (no mapper yet - passes an empty InputActionState)
+Oculus:   OpenXR action states            → InputActionState → ActionDispatcher → Effects
 ```
+
+Quest button/chord paths live beside their actions in
+`InputAction::quest_touch_click_path` / `quest_touch_chord_paths`, so the
+mapping is host-testable even though `oculus_runtime` only builds for Android.
+The current key and controller bindings are listed in
+[DEVELOPMENT.md](DEVELOPMENT.md#debug--developer-keys).
 
 - **`InputAction`** (`input/actions.rs`) - serde-enabled enum of all discrete actions
 - **`InputActionState`** (`input/state.rs`) - edge-triggered action state, consumed once per `Game::update`

--- a/README.md
+++ b/README.md
@@ -41,11 +41,9 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `Q` `E` - control left hand or right hand, respectively. Mouse look will move the hand, left click will 'trigger', and right click will 'grab'.
 - `Ctrl` - crouch
 - `Space` - jump
-- `I` - move the floating inventory in front of you
+- `Tab` / `I` - toggle the cyber interface ("use" mode): a cursor-driven UI over the 3D view
 - `Alt+S` / `Alt+L` - quick save / quick load
-- `P` - cycle the pathfinding test (set start → set goal → show path)
-- Quest VR: press the left controller's `X` button to place/toggle the backpack;
-  point at a stored item and squeeze to retrieve it into that hand.
+- Quest VR: press the left controller's `X` button to toggle the cyber interface.
 - Quest VR: press the left controller's `Y` button to open the newest unread
   audio log. Press `Y` again to close it; after every log is read, `Y` replays
   the most recently collected log.
@@ -54,6 +52,9 @@ However, you can play with a keyboard and a mouse, using the following hard-code
   `6` EMP Rifle, `7` Electro Shock, `8` Grenade Launcher, `9` Stasis Field
   Generator, `0` Fusion Cannon, `-` Crystal Shard, `=` Viral Proliferator,
   `\` Worm Launcher, and `` ` `` / `~` Psi Amp
+
+Development builds carry additional debug keys and a Developer options screen -
+see [DEVELOPMENT.md](DEVELOPMENT.md#debug--developer-keys).
 
 ## Building
 


### PR DESCRIPTION
Two documentation corrections found while documenting the debug keys, separated out because neither traces to that change.

**README** described `I` as moving a floating inventory and the Quest's left `X` as placing a backpack. Both became the cyber-interface toggle when the world-quad backpack (`MoveInventory`) was removed, so the lines documented controls that no longer exist. It also listed the pathfinding debug key among player controls, where it does not belong.

**AGENTS.md** claimed `oculus_runtime` "passes an empty InputActionState (no mapper yet)". It has synced discrete button actions since the Quest X/Y/Menu bindings landed, so the line sent readers off to write a mapper that already exists.

No code changes.

https://claude.ai/code/session_01LtYWgpGWumTuUgV98JbttN
