### PR TITLE
refactor(sdk): learn the runtime's port instead of guessing it

### DIFF
--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -21,10 +21,11 @@ import { GameServer } from "@shock2vr/sdk";
 
 // Spawns `cargo run -p debug_runtime`, waits for /v1/health, captures logs.
 // `await using` shuts the runtime down automatically at scope exit.
-await using game = await GameServer.launch({
-  mission: "medsci1.mis",
-  port: 8091,
-});
+// No port: the runtime binds an OS-assigned one and announces it, so
+// concurrent launches never collide. `game.baseUrl` reports it.
+// Pass `port` only when something outside the SDK must know it up front
+// (`adb forward`, a hand-run `curl`) - then it binds that port or fails loudly.
+await using game = await GameServer.launch({ mission: "medsci1.mis" });
 
 // The game starts paused; advance it explicitly.
 await game.step({ frames: 10 });
@@ -147,6 +148,11 @@ const game = await GameServer.connect("http://127.0.0.1:8080");
 - `GameServer.launch` finds the cargo workspace by walking up from `cwd`;
   pass `repoRoot` to override. First launch may take minutes while cargo
   compiles; the default readiness timeout is 5 minutes.
+- SDK-launched runtimes get `--idle-timeout-secs 600`: if the owning process is
+  SIGKILLed (so neither `shutdown()` nor the SIGINT/SIGTERM hook runs), the
+  runtime exits by itself after ten quiet minutes instead of holding ~700 MB.
+  In-flight requests - including a long `step({ duration: "600s" })` - count as
+  activity.
 - Injected actions apply on the next game update, which runs even while
   paused (with zero delta time).
 - `game.logs()` returns recent runtime output (also included in launch
@@ -157,9 +163,11 @@ const game = await GameServer.connect("http://127.0.0.1:8080");
 - Writing a new scenario test: copy `test/pathfinding.e2e.test.ts`. Gate
   long-running tests behind `SHOCK2_E2E=1` so `npm test` stays fast.
 - The e2e suite runs **serially** (`--test-concurrency=1`): each test spawns its
-  own heavy debug runtime, so one-at-a-time avoids port/resource contention
-  without hand-syncing ports across files (a unique default port per file is
-  still kept as a courtesy for running files individually).
+  own heavy debug runtime, so one-at-a-time avoids resource contention. Ports
+  no longer need hand-syncing across files - omit `port` and each runtime gets
+  its own ephemeral one. (Existing tests still pass a fixed port; that is now
+  an exact request, so a leftover runtime on it fails the launch loudly instead
+  of silently drifting to the next port.)
 - Reliability runs (catch flakiness in timing-sensitive tests): `npm run
   test:e2e:reliability` runs the e2e suite 10x (also serial). Target one test
   with `node scripts/reliability.mjs <count> "<name pattern>"`, e.g.

--- a/tools/shock2-sdk/playthrough-sweep.mjs
+++ b/tools/shock2-sdk/playthrough-sweep.mjs
@@ -50,13 +50,14 @@ async function shot(game, name) {
   return `(screenshot ${name} unavailable)`;
 }
 
-async function sweepMission(mission, index) {
-  const port = 8140 + index;
+async function sweepMission(mission) {
+  // No port: the runtime binds an ephemeral one and the SDK reads it back, so
+  // a leftover runtime can never collide with this sweep.
   const lines = [`\n## ${mission}`];
   let loaded = false;
   let game;
   try {
-    game = await GameServer.launch({ mission: `${mission}.mis`, port });
+    game = await GameServer.launch({ mission: `${mission}.mis` });
   } catch (e) {
     lines.push(`- **LOAD FAILED** — \`${String(e.message).slice(0, 200)}\``);
     lines.push(`- GAP [functionality]: ${mission} did not launch/become ready.`);
@@ -130,7 +131,7 @@ async function sweepMission(mission, index) {
 
 console.log(`Sweeping ${MISSIONS.length} missions...`);
 for (let i = 0; i < MISSIONS.length; i++) {
-  await sweepMission(MISSIONS[i], i);
+  await sweepMission(MISSIONS[i]);
 }
 
 // Assemble report

--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -1,7 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { createServer } from "node:net";
 import { dirname, join } from "node:path";
 
 import { HttpClient } from "./client.js";
@@ -11,10 +10,15 @@ export interface LaunchOptions {
   /** Mission file or debug scene, e.g. "medsci1.mis" or "debug_minimal". */
   mission: string;
   /**
-   * Port for the debug runtime HTTP server (default 8080). Treated as a
-   * HINT: if it is already taken (another agent's test run, a lingering
-   * runtime), the next free port is used instead - read `game.baseUrl` for
-   * the actual address.
+   * Exact port for the debug runtime HTTP server. Omit it (the default) and
+   * the runtime binds an OS-assigned ephemeral port, which the SDK learns
+   * from the runtime's own `SHOCK2QUEST_PORT` line - that has no collision
+   * window at all, so concurrent launches can never fight over a port.
+   *
+   * Pass one only when something OUTSIDE the SDK must know the address up
+   * front (`adb forward` for the Quest, a hand-run `curl`). Then it is an
+   * exact request: the runtime binds it or exits loudly. Either way,
+   * `game.baseUrl` reports the address actually in use.
    */
   port?: number;
   /** Experimental feature flags, e.g. ["teleport"]. */
@@ -53,15 +57,51 @@ export function findRepoRoot(startDir: string): string | undefined {
 const MAX_LOG_LINES = 2000;
 
 /**
- * Ports handed out by findFreePort that are still in use by this process.
- * The OS probe alone can't see a sibling launch that probed the same port
- * but whose child hasn't bound yet (cargo may compile for minutes first).
+ * `--idle-timeout-secs` for SDK-launched runtimes, well under the runtime's
+ * own 30-minute default.
+ *
+ * The runtime's default has to survive a *hand* launch, where minutes of
+ * think-time between two `curl`s is normal. The SDK's situation is much
+ * tighter: it owns the process, shuts it down on dispose, and kills the
+ * process group on SIGINT/SIGTERM, so the watchdog is only ever reached when
+ * the owning process dies without running any of that (SIGKILL, an OOM, a
+ * yanked CI runner). Every SDK call is an HTTP request and an in-flight one
+ * never counts as idle - a `step({duration: "600s"})` holds the clock open for
+ * its whole run - so the only real gap is a caller pausing between calls.
+ * Ten minutes clears the longest such pause by a wide margin - the worst case
+ * is a runtime held while a sibling launch waits out a cold `cargo` build,
+ * which the launch timeout itself caps at five minutes - and still bounds a
+ * SIGKILL leak (~700 MB) to ten minutes instead of thirty.
  */
-const reservedPorts = new Set<number>();
+const SDK_IDLE_TIMEOUT_SECS = 600;
 
 /** Children that must not outlive this process (see hookSignalCleanup). */
 const liveServers = new Set<GameServer>();
+/**
+ * Spawned runtimes that do not have a GameServer yet - a launch is between
+ * `spawn` and the port marker, which can be MINUTES while cargo compiles.
+ * They need the same signal cleanup; without it a Ctrl-C during a cold build
+ * orphans the very runtime it was building.
+ */
+const pendingChildren = new Set<ChildProcess>();
 let signalCleanupHooked = false;
+
+/**
+ * SIGKILL a detached child's whole process group (cargo + the game binary it
+ * exec'd). Killing only cargo orphans a runtime that keeps the port bound and
+ * burns CPU forever.
+ */
+function killProcessGroup(pid: number | undefined): void {
+  if (pid === undefined) return;
+  try {
+    // Negative pid = the process group created by detached: true
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    // ESRCH: the group is already gone. Deliberately NO fallback to a
+    // positive-pid kill - the pid may have been reused by an unrelated
+    // process by now.
+  }
+}
 
 /**
  * Detached children receive no terminal signals, so a Ctrl-C of the test
@@ -76,6 +116,9 @@ function hookSignalCleanup(): void {
       for (const server of liveServers) {
         server.killProcessTreeForSignalCleanup();
       }
+      for (const child of pendingChildren) {
+        killProcessGroup(child.pid);
+      }
       process.kill(process.pid, signal);
     });
   }
@@ -84,35 +127,77 @@ function hookSignalCleanup(): void {
 /** Max lines included in a launch-failure error message. */
 const MAX_ERROR_LOG_LINES = 120;
 
-/** How many ports to try, walking up from the requested one. */
-const MAX_PORT_ATTEMPTS = 50;
+/** What the runtime announces once it has bound its HTTP port. */
+export interface PortMarker {
+  /** The port actually bound (never 0, even when 0 was requested). */
+  port: number;
+  /** Empty when the launcher passed no --instance-id (a hand launch). */
+  instanceId: string;
+  /** The runtime process's pid, if it reported one. */
+  pid?: number;
+  /** e.g. "127.0.0.1:54321", if it reported one. */
+  address?: string;
+}
 
-/** Resolves true when the port can be bound on localhost right now. */
-function portIsFree(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const probe = createServer();
-    probe.once("error", () => resolve(false));
-    probe.listen({ port, host: "127.0.0.1" }, () => {
-      probe.close(() => resolve(true));
-    });
-  });
+const PORT_MARKER_PREFIX = "SHOCK2QUEST_PORT ";
+
+/**
+ * Parse the runtime's `SHOCK2QUEST_PORT port=.. pid=.. instance_id=.. address=..`
+ * line, or undefined if this is not a well-formed marker.
+ *
+ * Strict about the two fields the SDK acts on - a half-read port would send
+ * the client at the wrong address - and lenient about the rest: `pid` and
+ * `address` are reported for humans, so a future change to them must not break
+ * every launch. The runtime sanitizes instance ids into the `key=value`
+ * framing, so plain splitting is enough.
+ */
+export function parsePortMarker(line: string): PortMarker | undefined {
+  const index = line.indexOf(PORT_MARKER_PREFIX);
+  if (index < 0) return undefined;
+  const fields = new Map<string, string>();
+  for (const field of line.slice(index + PORT_MARKER_PREFIX.length).trim().split(/\s+/)) {
+    const eq = field.indexOf("=");
+    if (eq > 0) fields.set(field.slice(0, eq), field.slice(eq + 1));
+  }
+  const port = Number(fields.get("port"));
+  const instanceId = fields.get("instance_id");
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return undefined;
+  if (instanceId === undefined) return undefined;
+  const pid = Number(fields.get("pid"));
+  return {
+    port,
+    instanceId,
+    pid: Number.isInteger(pid) && pid > 0 ? pid : undefined,
+    address: fields.get("address"),
+  };
 }
 
 /**
- * Walk up from `start` to the first free port. Multiple agents commonly run
- * e2e suites with the same hardcoded test ports on one machine; treating the
- * port as a hint keeps them out of each other's way.
+ * Split a byte stream into lines, carrying the tail between chunks.
+ *
+ * A chunk boundary can fall anywhere - including mid-marker - so splitting
+ * each chunk on its own would silently lose the one line the launch blocks
+ * on. Call the returned `flush` at end-of-stream to emit a final unterminated
+ * line.
  */
-export async function findFreePort(start: number): Promise<number> {
-  for (let port = start; port < start + MAX_PORT_ATTEMPTS; port++) {
-    if (!reservedPorts.has(port) && (await portIsFree(port))) {
-      reservedPorts.add(port);
-      return port;
-    }
-  }
-  throw new Error(
-    `no free port found in [${start}, ${start + MAX_PORT_ATTEMPTS})`,
-  );
+export function createLineAssembler(onLine: (line: string) => void): {
+  push: (chunk: string) => void;
+  flush: () => void;
+} {
+  let carry = "";
+  return {
+    push(chunk) {
+      const parts = (carry + chunk).split("\n");
+      carry = parts.pop() ?? "";
+      for (const line of parts) {
+        if (line.length > 0) onLine(line);
+      }
+    },
+    flush() {
+      if (carry.length > 0) onLine(carry);
+      carry = "";
+    },
+  };
 }
 
 /**
@@ -146,7 +231,6 @@ export class GameServer extends Game implements AsyncDisposable {
     private readonly child: ChildProcess | undefined,
     private readonly logLines: string[],
     private readonly instanceId: string | undefined,
-    private readonly port: number | undefined,
   ) {
     super(client);
   }
@@ -160,9 +244,6 @@ export class GameServer extends Game implements AsyncDisposable {
   }
 
   private releaseResources(): void {
-    if (this.port !== undefined) {
-      reservedPorts.delete(this.port);
-    }
     liveServers.delete(this);
   }
 
@@ -178,45 +259,29 @@ export class GameServer extends Game implements AsyncDisposable {
 
   /** Connect to an already-running debug runtime. shutdown() will stop it; dispose will not spawn-kill anything. */
   static async connect(baseUrl = "http://127.0.0.1:8080"): Promise<GameServer> {
-    const server = new GameServer(new HttpClient(baseUrl), undefined, [], undefined, undefined);
+    const server = new GameServer(new HttpClient(baseUrl), undefined, [], undefined);
     await server.health();
     return server;
   }
 
   /**
-   * Spawn a debug runtime via `cargo run -p debug_runtime` and wait for it
-   * to be ready. Retries on the next free port when another process wins a
-   * port race (bind failure / foreign instance id) between our probe and
-   * the child's bind.
+   * Spawn a debug runtime via `cargo run -p debug_runtime` and wait for it to
+   * be ready.
+   *
+   * By default the child binds an ephemeral port (`--port 0`) and announces it
+   * on stdout; the SDK reads that line and connects there. That is why there
+   * is no free-port probe and no retry loop any more: probing then letting the
+   * child bind left a window in which another process could take the port, and
+   * *every* mitigation for that window (a reserved-port set, instance-id
+   * checks, three attempts on different ports) existed only to paper over it.
+   * Letting the OS pick at bind time closes the window instead of guarding it.
+   *
+   * An explicit `options.port` keeps no probe either, on purpose: a caller
+   * naming a port has something outside the SDK pointed at it, so quietly
+   * drifting to another port would break exactly that caller. The runtime
+   * binds it or exits with `failed to bind`, and the error says so.
    */
   static async launch(options: LaunchOptions): Promise<GameServer> {
-    const hint = options.port ?? 8080;
-    let lastError: unknown;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      try {
-        return await GameServer.launchOnce(options, hint + attempt);
-      } catch (error) {
-        lastError = error;
-        const message = String(error);
-        // "failed to bind" comes from the runtime's own logs (it binds in
-        // main() before the game starts); a crash for any other reason -
-        // bad mission, panic during load - must NOT retry.
-        const lostPortRace =
-          message.includes("different debug_runtime instance") ||
-          message.includes("failed to bind");
-        if (!lostPortRace) {
-          throw error;
-        }
-      }
-    }
-    throw lastError;
-  }
-
-  private static async launchOnce(
-    options: LaunchOptions,
-    portHint: number,
-  ): Promise<GameServer> {
-    const port = await findFreePort(portHint);
     const repoRoot = options.repoRoot ?? findRepoRoot(process.cwd());
     if (repoRoot === undefined) {
       throw new Error(
@@ -224,11 +289,10 @@ export class GameServer extends Game implements AsyncDisposable {
       );
     }
 
-    // Identifies OUR runtime: /v1/health echoes it, and readiness checks
-    // reject a different instance on the same port (e.g. another agent's
-    // runtime grabbing the port between our free-port probe and the child's
-    // bind). Cross-talk with a foreign runtime looks like impossible test
-    // failures, so fail loudly instead.
+    // Identifies OUR runtime: the port marker and /v1/health both echo it, so
+    // the SDK can prove it is driving the process it spawned rather than some
+    // other agent's runtime. Cross-talk with a foreign runtime looks like
+    // impossible test failures, so fail loudly instead.
     const instanceId = randomUUID();
 
     const args = [
@@ -238,10 +302,13 @@ export class GameServer extends Game implements AsyncDisposable {
       "--",
       "--mission",
       options.mission,
+      // 0 = let the OS assign; the child tells us what it got.
       "--port",
-      String(port),
+      String(options.port ?? 0),
       "--instance-id",
       instanceId,
+      "--idle-timeout-secs",
+      String(SDK_IDLE_TIMEOUT_SECS),
       ...(options.experimental?.length
         ? ["--experimental", options.experimental.join(",")]
         : []),
@@ -264,30 +331,111 @@ export class GameServer extends Game implements AsyncDisposable {
       // orphans a runtime that keeps the port bound and burns CPU forever.
       detached: true,
     });
+    pendingChildren.add(child);
+    hookSignalCleanup();
 
-    const capture = (chunk: Buffer) => {
-      for (const line of chunk.toString().split("\n")) {
-        if (line.length === 0) continue;
-        logLines.push(line);
-        if (logLines.length > MAX_LOG_LINES) logLines.shift();
-        if (options.echoLogs) process.stderr.write(`[debug_runtime] ${line}\n`);
+    let marker: PortMarker | undefined;
+    let onMarker: ((found: PortMarker) => void) | undefined;
+    const noteLine = (line: string) => {
+      logLines.push(line);
+      if (logLines.length > MAX_LOG_LINES) logLines.shift();
+      if (options.echoLogs) process.stderr.write(`[debug_runtime] ${line}\n`);
+      if (marker !== undefined) return;
+      const found = parsePortMarker(line);
+      if (found !== undefined) {
+        marker = found;
+        onMarker?.(found);
       }
     };
-    child.stdout?.on("data", capture);
-    child.stderr?.on("data", capture);
+    for (const stream of [child.stdout, child.stderr]) {
+      const assembler = createLineAssembler(noteLine);
+      stream?.on("data", (chunk: Buffer) => assembler.push(chunk.toString()));
+      stream?.on("end", () => assembler.flush());
+    }
+
+    const deadline = Date.now() + (options.launchTimeoutMs ?? 300_000);
+    const fail = (error: unknown): never => {
+      // Only while the child is still ours: after it exits the pid can be
+      // reused, and a group SIGKILL would then hit an unrelated process (the
+      // same reason killProcessGroup has no positive-pid fallback).
+      if (child.exitCode === null && child.signalCode === null) {
+        killProcessGroup(child.pid);
+      }
+      pendingChildren.delete(child);
+      throw new Error(
+        `debug_runtime failed to start: ${error}\nRecent output:\n${formatCrashOutput(logLines)}`,
+      );
+    };
+
+    // Block on the marker rather than on a port we chose. It arrives after
+    // the child has bound (and can be minutes away on a cold `cargo` build),
+    // so the launch timeout covers it and an early exit aborts it.
+    let bound: PortMarker;
+    try {
+      // No `await` has run since the listeners were attached, so the marker
+      // cannot have arrived yet - this promise is always the thing that waits.
+      bound = await new Promise<PortMarker>((resolve, reject) => {
+        const settle = () => {
+          clearTimeout(timer);
+          onMarker = undefined;
+          child.off("exit", onExit);
+          child.off("error", onSpawnError);
+        };
+        const onExit = () => {
+          settle();
+          reject(
+            new Error(
+              `process exited early (code ${child.exitCode}, signal ${child.signalCode}) before announcing its port`,
+            ),
+          );
+        };
+        // A failed spawn (no `cargo` on PATH) emits 'error' and never
+        // 'exit', so without this the launch would wait out its whole
+        // timeout - and an unhandled 'error' throws.
+        const onSpawnError = (error: Error) => {
+          settle();
+          reject(new Error(`could not spawn cargo: ${error.message}`));
+        };
+        const timer = setTimeout(() => {
+          settle();
+          reject(
+            new Error(
+              `runtime never announced its port (SHOCK2QUEST_PORT) within ${options.launchTimeoutMs ?? 300_000}ms`,
+            ),
+          );
+        }, Math.max(1_000, deadline - Date.now()));
+        onMarker = (found) => {
+          settle();
+          resolve(found);
+        };
+        child.once("exit", onExit);
+        child.once("error", onSpawnError);
+      });
+    } catch (error) {
+      return fail(error);
+    }
+    if (bound.instanceId !== instanceId) {
+      // Can only happen if something between us and the runtime rewrote the
+      // marker; treat it exactly like the foreign-runtime case rather than
+      // connecting to a port we cannot vouch for.
+      return fail(
+        new Error(
+          `port marker reports a different instance (expected ${instanceId}, got ${bound.instanceId || "none"})`,
+        ),
+      );
+    }
 
     const server = new GameServer(
-      new HttpClient(`http://127.0.0.1:${port}`),
+      new HttpClient(`http://127.0.0.1:${bound.port}`),
       child,
       logLines,
       instanceId,
-      port,
     );
+    pendingChildren.delete(child);
     liveServers.add(server);
-    hookSignalCleanup();
 
     try {
-      await server.waitUntilReady(options.launchTimeoutMs ?? 300_000);
+      await server.waitUntilReady(Math.max(1_000, deadline - Date.now()));
     } catch (error) {
       server.killProcessTree();
       server.releaseResources();
@@ -299,24 +447,9 @@ export class GameServer extends Game implements AsyncDisposable {
     return server;
   }
 
-  /**
-   * SIGKILL the child's whole process group (cargo + the game binary it
-   * exec'd). Falls back to killing just the direct child if the group is
-   * already gone.
-   */
+  /** SIGKILL the child's whole process group (cargo + the game binary). */
   private killProcessTree(): void {
-    const pid = this.child?.pid;
-    if (pid === undefined) {
-      return;
-    }
-    try {
-      // Negative pid = the process group created by detached: true
-      process.kill(-pid, "SIGKILL");
-    } catch {
-      // ESRCH: the group is already gone. Deliberately NO fallback to a
-      // positive-pid kill - the pid may have been reused by an unrelated
-      // process by now.
-    }
+    killProcessGroup(this.child?.pid);
   }
 
   private async waitUntilReady(timeoutMs: number): Promise<void> {
@@ -328,10 +461,11 @@ export class GameServer extends Game implements AsyncDisposable {
         );
       }
       try {
-        // Verify we're talking to OUR instance before trusting the port. A
-        // different (or missing) instance id means another process holds the
-        // port - keep waiting only if our child is still alive, since the
-        // holder may be an older runtime mid-shutdown.
+        // Belt and braces on the marker's identity check: the port came from
+        // our own child's marker, so a foreign runtime answering here would
+        // mean the child died and something else rebound the port between the
+        // marker and this request. Cross-talk with a foreign runtime looks
+        // like impossible test failures, so keep failing loudly on it.
         const health = await this.client.get<{ instance_id?: string | null }>(
           "/v1/health",
         );

--- a/tools/shock2-sdk/test/concurrent-launch.e2e.test.ts
+++ b/tools/shock2-sdk/test/concurrent-launch.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Two launches at once, neither naming a port, must each get their own runtime.
+//
+// This is the case the SDK used to guard rather than prevent: it probed for a
+// free port and only then let the child bind it, so a sibling launch (or any
+// other process) could take the port in between. Now the child binds an
+// OS-assigned port and reports it, so there is no window to lose.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "two concurrent launches with no port get separate runtimes",
+  { skip: !e2eEnabled, timeout: 420_000 },
+  async () => {
+    // Genuinely simultaneous: both launches are in flight at once, which is
+    // exactly when the old probe-then-bind window could be lost.
+    const launches = await Promise.allSettled([
+      GameServer.launch({ mission: "debug_minimal" }),
+      GameServer.launch({ mission: "debug_minimal" }),
+    ]);
+    // allSettled, not all: if one launch fails the other still needs shutting
+    // down, or the test leaks a runtime.
+    const servers = launches
+      .filter((result) => result.status === "fulfilled")
+      .map((result) => result.value);
+
+    try {
+      const failures = launches.filter((result) => result.status === "rejected");
+      assert.equal(
+        failures.length,
+        0,
+        `both launches should succeed: ${failures.map((f) => f.reason).join("\n")}`,
+      );
+      const [first, second] = servers;
+      assert.ok(first && second);
+
+      const firstPort = Number(new URL(first.baseUrl).port);
+      const secondPort = Number(new URL(second.baseUrl).port);
+      assert.ok(firstPort, "first runtime should report a bound port");
+      assert.ok(secondPort, "second runtime should report a bound port");
+      assert.notEqual(firstPort, secondPort, "each runtime needs its own port");
+
+      // The port came from the OS at bind time, not from the SDK guessing: the
+      // old probe-then-bind path handed out 8080/8081 here, so this assertion
+      // is the one that fails against it.
+      for (const port of [firstPort, secondPort]) {
+        assert.ok(
+          port !== 8080 && port !== 8081,
+          `expected an ephemeral port, got the old hardcoded default ${port}`,
+        );
+      }
+
+      // ...and each client is talking to its OWN runtime, not the other one.
+      const firstHealth = (await first.health()) as { instance_id?: string };
+      const secondHealth = (await second.health()) as { instance_id?: string };
+      assert.ok(firstHealth.instance_id, "health should echo the instance id");
+      assert.notEqual(
+        firstHealth.instance_id,
+        secondHealth.instance_id,
+        "the two clients must not be pointed at the same runtime",
+      );
+
+      // Both are genuinely live and independently steppable.
+      const [firstStep, secondStep] = await Promise.all([
+        first.step({ frames: 2 }),
+        second.step({ frames: 2 }),
+      ]);
+      assert.equal(firstStep.frames_advanced, 2);
+      assert.equal(secondStep.frames_advanced, 2);
+    } finally {
+      await Promise.all(servers.map((server) => server.shutdown()));
+    }
+  },
+);

--- a/tools/shock2-sdk/test/runtime-lifecycle.e2e.test.ts
+++ b/tools/shock2-sdk/test/runtime-lifecycle.e2e.test.ts
@@ -3,7 +3,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { createServer } from "node:net";
 import { test } from "node:test";
 
-import { findRepoRoot } from "../src/server.js";
+import { createLineAssembler, findRepoRoot, parsePortMarker } from "../src/server.js";
 
 // Real-process coverage for the debug runtime's lifecycle contract:
 //  - it always announces the port it actually bound (SHOCK2QUEST_PORT), so a
@@ -53,19 +53,12 @@ function spawnRuntime(args: string[]): Runtime {
     }
   };
   // A chunk can split mid-line (and the marker line is exactly what we wait
-  // for), so carry the tail of each stream between chunks instead of assuming
-  // whole lines arrive together.
+  // for), so use the same line assembler the SDK's own launch path uses rather
+  // than assuming whole lines arrive together.
   const captureFrom = (stream: NodeJS.ReadableStream | null) => {
-    let carry = "";
-    stream?.on("data", (chunk: Buffer) => {
-      const parts = (carry + chunk.toString()).split("\n");
-      carry = parts.pop() ?? "";
-      for (const line of parts) emit(line);
-    });
-    stream?.on("end", () => {
-      emit(carry);
-      carry = "";
-    });
+    const assembler = createLineAssembler(emit);
+    stream?.on("data", (chunk: Buffer) => assembler.push(chunk.toString()));
+    stream?.on("end", () => assembler.flush());
   };
   captureFrom(child.stdout);
   captureFrom(child.stderr);
@@ -166,9 +159,11 @@ function occupyAnyPort(): Promise<{ port: number; release: () => void }> {
 }
 
 function parseBoundPort(markerLine: string): number {
-  const match = /SHOCK2QUEST_PORT port=(\d+)/.exec(markerLine);
-  assert.ok(match, `marker line has no port=: ${markerLine}`);
-  return Number(match[1]);
+  // Parsed with the SDK's own parser, so this test covers the code the SDK
+  // actually depends on rather than a lookalike regex.
+  const marker = parsePortMarker(markerLine);
+  assert.ok(marker, `not a well-formed port marker: ${markerLine}`);
+  return marker.port;
 }
 
 const LAUNCH_TIMEOUT_MS = 300_000;

--- a/tools/shock2-sdk/test/unit.test.ts
+++ b/tools/shock2-sdk/test/unit.test.ts
@@ -3,7 +3,11 @@ import { test } from "node:test";
 
 import { Game, findRepoRoot } from "../src/index.js";
 import { HttpClient } from "../src/client.js";
-import { formatCrashOutput } from "../src/server.js";
+import {
+  createLineAssembler,
+  formatCrashOutput,
+  parsePortMarker,
+} from "../src/server.js";
 
 test("formatCrashOutput keeps the panic message and backtrace together", () => {
   const lines = [
@@ -57,22 +61,85 @@ test("waitFor times out with a descriptive error", async () => {
   );
 });
 
-test("findFreePort skips ports that are already bound", async () => {
-  const { findFreePort } = await import("../src/server.js");
-  const { createServer } = await import("node:net");
-
-  // Occupy a port, then ask for it: the next one up should come back.
-  const blocker = createServer();
-  await new Promise<void>((resolve) =>
-    blocker.listen({ port: 0, host: "127.0.0.1" }, resolve),
+test("parsePortMarker reads the port, pid and instance id the runtime bound", () => {
+  const marker = parsePortMarker(
+    "SHOCK2QUEST_PORT port=54321 pid=8123 instance_id=abc-123 address=127.0.0.1:54321",
   );
-  const address = blocker.address();
-  assert.ok(address && typeof address === "object");
-  const taken = address.port;
-  try {
-    const free = await findFreePort(taken);
-    assert.ok(free > taken, `expected a port above ${taken}, got ${free}`);
-  } finally {
-    await new Promise((resolve) => blocker.close(resolve));
+  assert.deepEqual(marker, {
+    port: 54321,
+    instanceId: "abc-123",
+    pid: 8123,
+    address: "127.0.0.1:54321",
+  });
+});
+
+test("parsePortMarker accepts an empty instance id (a hand launch)", () => {
+  const marker = parsePortMarker(
+    "SHOCK2QUEST_PORT port=8080 pid=7 instance_id= address=127.0.0.1:8080",
+  );
+  assert.equal(marker?.instanceId, "");
+  assert.equal(marker?.port, 8080);
+});
+
+test("parsePortMarker ignores lines that are not the marker", () => {
+  for (const line of [
+    "INFO Starting debug runtime on port 0 with mission: debug_minimal",
+    "",
+    "SHOCK2QUEST_IDLE_EXIT idle_secs=1800.4 timeout_secs=1800",
+  ]) {
+    assert.equal(parsePortMarker(line), undefined, line);
   }
+});
+
+test("parsePortMarker rejects a marker whose port or instance id is unusable", () => {
+  // The two fields the SDK acts on: half-reading either would point the client
+  // at the wrong runtime.
+  for (const line of [
+    "SHOCK2QUEST_PORT pid=8123 instance_id= address=127.0.0.1:1",
+    "SHOCK2QUEST_PORT port=notanumber pid=8123 instance_id= address=x",
+    "SHOCK2QUEST_PORT port=0 pid=8123 instance_id= address=127.0.0.1:0",
+    "SHOCK2QUEST_PORT port=99999 pid=8123 instance_id= address=x",
+    "SHOCK2QUEST_PORT port=8080 pid=8123 address=127.0.0.1:8080",
+  ]) {
+    assert.equal(parsePortMarker(line), undefined, line);
+  }
+});
+
+test("parsePortMarker tolerates missing pid/address, which the SDK never uses", () => {
+  // Reported for humans only - a future change to them must not break every
+  // launch.
+  const marker = parsePortMarker("SHOCK2QUEST_PORT port=8080 instance_id=abc");
+  assert.equal(marker?.port, 8080);
+  assert.equal(marker?.instanceId, "abc");
+  assert.equal(marker?.pid, undefined);
+  assert.equal(marker?.address, undefined);
+});
+
+test("a marker split across stdout chunks is still read as one line", () => {
+  const lines: string[] = [];
+  const assembler = createLineAssembler((line) => lines.push(line));
+  // A chunk boundary can fall anywhere, including mid-marker.
+  assembler.push("INFO warming up\nSHOCK2QUEST_PORT port=543");
+  assert.equal(
+    lines.filter((line) => parsePortMarker(line) !== undefined).length,
+    0,
+    "half a marker must not parse",
+  );
+  assembler.push("21 pid=8123 instance_id=abc address=127.0.0.1:54321\nINFO ready\n");
+
+  const markers = lines.map(parsePortMarker).filter((m) => m !== undefined);
+  assert.equal(markers.length, 1);
+  assert.equal(markers[0]?.port, 54321);
+  assert.equal(markers[0]?.instanceId, "abc");
+});
+
+test("createLineAssembler emits a final unterminated line on flush", () => {
+  const lines: string[] = [];
+  const assembler = createLineAssembler((line) => lines.push(line));
+  assembler.push("tail with no newline");
+  assert.deepEqual(lines, []);
+  assembler.flush();
+  assert.deepEqual(lines, ["tail with no newline"]);
+  assembler.flush();
+  assert.deepEqual(lines, ["tail with no newline"], "flush is not repeatable");
 });


### PR DESCRIPTION
Stacked on **#1130** — review that first.

## The race this removes

`GameServer.launch` guessed: `findFreePort` probed for a free port, *then* the
child bound it. Another process can win that window, so the SDK carried three
mitigations for it — a reservation set, a 3-attempt retry on `failed to bind`,
and an instance-id check on readiness. All of them guard the gap rather than
close it.

Letting the OS pick the port **at bind time** closes it. The SDK now spawns with
`--port 0` and reads the port back from #1130's `SHOCK2QUEST_PORT` marker before
it polls anything. There is no window.

So `findFreePort`, `portIsFree`, `reservedPorts`, `MAX_PORT_ATTEMPTS`, the retry
loop and `launchOnce` are **deleted**, not left as a fallback. Keeping them for
the explicit-port path would be actively wrong: a caller naming a port has
something outside the SDK pointed at it (`adb forward`, a hand-run `curl`), so
drifting to a different port breaks precisely that caller. `options.port` is now
an exact request — bind it or fail loudly.

The instance id is verified from the marker before the client is even
constructed; the `/v1/health` check stays as belt-and-braces, since the child
could die and something else rebind in between.

SDK launches pass `--idle-timeout-secs 600` rather than the runtime's 30-minute
default: the SDK shuts down on dispose and kills the group on SIGINT/SIGTERM, so
the watchdog is only ever reached after a SIGKILL/OOM of the owner, and a
tighter net bounds that leak. 600 s rather than 300 s because a runtime held
while a sibling launch waits out a cold `cargo` build can legitimately be quiet
for the full default launch timeout.

Two fixes the marker forced, both real bugs in their own right: stdout is now
assembled into lines **across chunk boundaries** (a marker split by a chunk
boundary was silently missed), and children spawned but not yet announced join
`pendingChildren`, so Ctrl-C during a cold build no longer orphans one.

## Verification

- `npm test` — 32 pass / 0 fail.
- `missions.e2e` — **23/23**, the safety net for a launch-path change.
- `concurrent-launch` + `runtime-lifecycle` (#1130's) + `launch-failure` — 5/5.
- By hand: squat 8531, launch with `port: 8531` → fails immediately with the
  runtime's own `failed to bind` surfaced.
- `cargo fmt --all -- --check` clean; no Rust touched.

**Fail-first:** `two concurrent launches with no port get separate runtimes`
fails against `HEAD` with *"expected an ephemeral port, got the old hardcoded
default 8080"*. The `parsePortMarker` unit tests cannot fail against the old
code — it has no parser — so the e2e test is the honest regression guard. Unit
tests cover the split-across-chunks marker, empty instance id, and a marker
missing optional fields.

## What this does NOT do

**182 of 183 e2e test files still pass a fixed `port:`**, so they get none of
this — and they are now *less* forgiving, since a foreign runtime on their port
fails the launch loudly instead of drifting to the next one. That is not
hypothetical: in one full `missions.e2e` run `rec2.mis` (8114) and
`command1.mis` (8116) failed and then passed on four subsequent runs, consistent
with another agent's runtime holding those ports.

Sweeping `port:` out of 183 files is mechanical but large, touches helper
signatures, and can only be validated by a multi-hour full e2e run, so it is
deliberately not in this PR. It is the immediate follow-up, and it is what
actually delivers collision immunity to the suite.

## On #852

With #1130 and this landed, a caller that does not care which port never
contends, and orphans expire on their own. What remains uncovered is reclaiming
one *exact* port from your own orphan without waiting out the idle timeout —
which is the case `--port 0` is designed to make unnecessary. #852 is worth
re-reading against that, rather than closed on this PR's say-so.

https://claude.ai/code/session_017cm626D5M4tAz7yLPWPMFb
