### PR TITLE
feat(debug): detachable free camera, gated by a developer option

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -105,6 +105,52 @@ Example:
 cargo dr --release --experimental teleport
 ```
 
+### Debug & developer keys
+
+Player-facing controls are listed in [README.md](README.md#controls). The keys
+below are development tools; they are bound in
+`runtimes/desktop_runtime/src/input_mapper.rs` (the authoritative list) and, on
+the Quest, in `InputAction::quest_touch_click_path` /
+`quest_touch_chord_paths` (`shock2vr/src/input/actions.rs`).
+
+Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay keys.
+
+| Key | Action | Notes |
+| --- | ------ | ----- |
+| `P` | `PathfindingTestCycle` | set start → set goal → show path |
+| `B` | `DebugCycleWeapon` | spawns and wields the next weapon (unlike the number row) |
+| `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | |
+| `U` | `ReadLastUnreadLog` | Quest: left `Y` |
+| `M` | `ToggleMap` | flat only |
+| `Tab` / `I` | `ToggleUseMode` | the cyber interface; Quest: left `X` |
+| `Esc` | `TogglePauseMenu` | Quest: left `Menu` |
+| `Alt+S` / `Alt+L` | `QuickSave` / `QuickLoad` | |
+| `Alt+G` | `DebugForceChase` | every monster hunts the player, pinned |
+| `Alt+C` | `DebugCalmAll` | clears the pin |
+| `Alt+V` | `ToggleFreeCamera` | requires the **Free camera** developer option; Quest: right `A`+`B` together |
+
+Every action is also triggerable without a keyboard - over HTTP on the debug
+runtime (`POST /v1/input/action`) or through the SDK (`game.input.trigger(...)`).
+`GET /v1/input/actions` lists them.
+
+### Developer options
+
+The **Developer** screen (from the main menu, or the pause overlay's Developer
+page) hosts the live-tunable parameters registered in
+`shock2vr/src/dev_params.rs` - panel distance, pause dim, FOV override, and the
+free-camera switches. Values are read every frame, so a change is live on the
+next one, and the same registry is exposed over HTTP by the debug runtime
+(`GET`/`POST /v1/dev-params`) for headless runs.
+
+**Free camera** detaches the view from the player: the camera stays where it
+was while the pawn stands still, so you can watch the simulation from outside
+without perturbing it. Nothing in the simulation follows it - AI keeps reading
+the player's body position - and by default neither does culling, so flying out
+shows exactly what the *player's* viewpoint decided to draw. Turn on **Cull
+from cam** when you would rather just look at things. The developer option is
+the gate: while it is off the `Alt+V` / `A`+`B` toggle does nothing, and turning
+it off while detached re-attaches the camera.
+
 #### 3b. Oculus Quest 2
 
 ##### Pre-requisites

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -108,6 +108,10 @@ pub enum RuntimeCommand {
     /// Get current player position
     GetPlayerPosition(oneshot::Sender<Vector3<f32>>),
 
+    /// Get the free (debug) camera's state: detached, and the pose it is
+    /// rendering from when it is.
+    GetCameraState(oneshot::Sender<CameraStateSnapshot>),
+
     /// Pathfinding test command (set_start, set_goal, reset)
     PathfindingTest(String, oneshot::Sender<CommandResult>),
 
@@ -698,6 +702,22 @@ pub struct LinkInfo {
     pub target_id: i32,
     pub target_name: String,
     pub contains_ordinal: Option<u32>,
+}
+
+/// The free (debug) camera's state, as `GET /v1/camera` reports it.
+///
+/// `position`/`rotation` are `None` while the camera is attached: there is no
+/// separate camera pose then, only the player's eye, which
+/// `GET /v1/player/position` already reports.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CameraStateSnapshot {
+    /// Whether the camera is detached from the player.
+    pub detached: bool,
+    /// Whether the free camera is enabled at all (the developer option).
+    pub enabled: bool,
+    pub position: Option<[f32; 3]>,
+    /// Rotation as `[w, x, y, z]`.
+    pub rotation: Option<[f32; 4]>,
 }
 
 /// Current state of the game

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -364,6 +364,7 @@ async fn start_http_server(
         )
         .route("/v1/entities/:id/animation", get(get_animation_state))
         .route("/v1/player/position", get(get_player_position))
+        .route("/v1/camera", get(get_camera_state))
         .route("/v1/player/teleport", axum::routing::post(teleport_player))
         .route(
             "/v1/player/move",
@@ -439,6 +440,7 @@ async fn start_http_server(
         "  GET  /v1/entities/{{id}}/animation - Animation playback state + posed skeleton (world-space joints)"
     );
     info!("  GET  /v1/player/position  - Get current player position");
+    info!("  GET  /v1/camera           - Get free (debug) camera state");
     info!("  POST /v1/player/teleport  - Teleport player to coordinates (raw, unbounded)");
     info!("  POST /v1/player/move      - Bounded, collision-valid move toward {{x,y,z}}");
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
@@ -1362,6 +1364,19 @@ fn process_command(
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send give-item result - receiver dropped");
+            }
+        }
+        RuntimeCommand::GetCameraState(reply) => {
+            let (detached, pose) = game.free_camera_state();
+            let snapshot = CameraStateSnapshot {
+                detached,
+                enabled: shock2vr::free_camera::FreeCamera::is_enabled(),
+                position: pose.map(|(position, _)| [position.x, position.y, position.z]),
+                rotation: pose
+                    .map(|(_, rotation)| [rotation.s, rotation.v.x, rotation.v.y, rotation.v.z]),
+            };
+            if reply.send(snapshot).is_err() {
+                tracing::warn!("Failed to send camera state - receiver dropped");
             }
         }
         RuntimeCommand::GetPlayerPosition(reply) => {
@@ -2473,6 +2488,32 @@ async fn get_player_position(
         })),
         Err(_) => {
             tracing::error!("Failed to receive player position - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler reporting the free (debug) camera's state. Lets an agent
+/// verify the camera - that it detached, held its pose while the player
+/// moved, flew where it was told, and re-attached on a level change - without
+/// reading pixels out of a screenshot.
+async fn get_camera_state(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<CameraStateSnapshot>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if command_tx
+        .send(RuntimeCommand::GetCameraState(reply_tx))
+        .is_err()
+    {
+        tracing::error!("Failed to send GetCameraState command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+
+    match reply_rx.await {
+        Ok(snapshot) => Ok(Json(snapshot)),
+        Err(_) => {
+            tracing::error!("Failed to receive camera state - sender dropped");
             Err(game_loop_unavailable())
         }
     }
@@ -3673,17 +3714,23 @@ async fn trigger_input_action(
 async fn list_dev_params() -> Json<Value> {
     let params: Vec<Value> = shock2vr::dev_params::all()
         .map(|(id, param)| {
-            let shock2vr::dev_params::DevParamKind::Float { min, max, step } = param.kind;
-            json!({
-                "key": param.key,
-                "label": param.label,
-                "kind": "float",
-                "min": min,
-                "max": max,
-                "step": step,
-                "value": shock2vr::dev_params::get(id),
-                "default": param.default,
-            })
+            // A bool carries no range: reporting one would invite a client to
+            // walk a grid that does not exist. `value`/`default` stay the
+            // registry's own 0.0/1.0 so every kind reads the same way.
+            let key = param.key;
+            let label = param.label;
+            let value = shock2vr::dev_params::get(id);
+            let default = param.default;
+            match param.kind {
+                shock2vr::dev_params::DevParamKind::Float { min, max, step } => json!({
+                    "key": key, "label": label, "value": value, "default": default,
+                    "kind": "float", "min": min, "max": max, "step": step,
+                }),
+                shock2vr::dev_params::DevParamKind::Bool => json!({
+                    "key": key, "label": label, "value": value, "default": default,
+                    "kind": "bool",
+                }),
+            }
         })
         .collect();
     Json(json!({ "params": params }))

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -180,6 +180,15 @@ impl DesktopInputMapper {
                 modifier: Modifier::None,
                 action: InputAction::ToggleMap,
             },
+            // Detach/re-attach the debug camera. Alt-modified like the other
+            // debug bindings above, and inert unless the `free_camera` dev
+            // param is on (the gate lives in `Game`, so every runtime and
+            // HTTP injection share one rule). Alt is Option on macOS.
+            Binding {
+                key: Key::V,
+                modifier: Modifier::Alt,
+                action: InputAction::ToggleFreeCamera,
+            },
         ];
 
         Self {

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -845,16 +845,48 @@ fn main() {
             menu_state.changed_since_last_sync,
             menu_state.current_state,
         );
-        action_state.sync_discrete_button(
-            shock2vr::input::InputAction::Reload,
-            reload_state.is_active,
-            reload_state.changed_since_last_sync,
+        // Right A and B carry two meanings: on their own they reload and swap
+        // ammo (#1144), and together they toggle the free camera. There is no
+        // unbound button left on the Touch to give the camera, so it shares
+        // these - and only while its developer option is on, which is the one
+        // time the player is deliberately debugging rather than shooting.
+        //
+        // While the gate is on, a button whose partner is ALREADY held is
+        // suppressed, so completing the chord cannot also swap your ammo. The
+        // first button pressed still fires its own action (its edge lands
+        // before the chord exists), which is why the pair is A-reloads-first
+        // rather than B: an extra reload costs nothing, an ammo swap is a
+        // change you have to undo. With the option off, both behave exactly as
+        // #1144 defines them.
+        let free_camera_gate = shock2vr::free_camera::FreeCamera::is_enabled();
+        let suppress_reload = free_camera_gate && cycle_ammo_state.current_state;
+        let suppress_cycle_ammo = free_camera_gate && reload_state.current_state;
+        if !suppress_reload {
+            action_state.sync_discrete_button(
+                shock2vr::input::InputAction::Reload,
+                reload_state.is_active,
+                reload_state.changed_since_last_sync,
+                reload_state.current_state,
+            );
+        }
+        if !suppress_cycle_ammo {
+            action_state.sync_discrete_button(
+                shock2vr::input::InputAction::CycleAmmo,
+                cycle_ammo_state.is_active,
+                cycle_ammo_state.changed_since_last_sync,
+                cycle_ammo_state.current_state,
+            );
+        }
+        // A chord is edge-detected from the pair's raw states, so it takes
+        // them directly rather than through `sync_discrete_button`. Activity
+        // is passed through rather than folded into the button states: while
+        // the pair is inactive `sync_chord` holds its latch, so refocusing
+        // with both buttons still held cannot mint a toggle nobody pressed -
+        // the same hazard the latched crouch above guards against.
+        action_state.sync_chord(
+            shock2vr::input::InputAction::ToggleFreeCamera,
+            reload_state.is_active && cycle_ammo_state.is_active,
             reload_state.current_state,
-        );
-        action_state.sync_discrete_button(
-            shock2vr::input::InputAction::CycleAmmo,
-            cycle_ammo_state.is_active,
-            cycle_ammo_state.changed_since_last_sync,
             cycle_ammo_state.current_state,
         );
 

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -32,8 +32,12 @@ pub enum DevParamKind {
     /// A float clamped to `min..=max`; [`set`] snaps to the nearest multiple
     /// of `step` from `min` (the grid the future menu's `<`/`>` arrows walk).
     Float { min: f32, max: f32, step: f32 },
-    // `Bool` and `Enum(&'static [&'static str])` go here when a param needs
-    // them - stored in the same f32 bits as 0.0/1.0 and the variant index.
+    /// An on/off switch, stored in the same f32 bits as 0.0/1.0. Anything
+    /// non-zero [`set`] receives becomes 1.0, so a caller cannot store a
+    /// third state.
+    Bool,
+    // `Enum(&'static [&'static str])` goes here when a param needs it -
+    // stored as the variant index in the same bits.
 }
 
 /// One registered parameter: a stable string key (HTTP + future persistence),
@@ -52,23 +56,55 @@ pub struct DevParamId(usize);
 
 /// Declares the parameter table. One line per parameter generates its
 /// [`PARAMS`] entry *and* its `pub const` id, so the two cannot drift.
+/// One declaration's [`DevParam`] entry. Split out of [`dev_params!`] so the
+/// table can mix kinds: the outer macro matches each line as
+/// `kind(args...)` and defers the shape of `args` to these arms.
+macro_rules! dev_param_entry {
+    (float($key:literal, $label:literal, $default:expr, $min:expr, $max:expr, $step:expr)) => {
+        DevParam {
+            key: $key,
+            label: $label,
+            kind: DevParamKind::Float {
+                min: $min,
+                max: $max,
+                step: $step,
+            },
+            default: dev_param_default!(float($key, $label, $default, $min, $max, $step)),
+        }
+    };
+    (bool($key:literal, $label:literal, $default:expr)) => {
+        DevParam {
+            key: $key,
+            label: $label,
+            kind: DevParamKind::Bool,
+            default: dev_param_default!(bool($key, $label, $default)),
+        }
+    };
+}
+
+/// One declaration's default, as the `f32` the value table stores. A `bool`
+/// cannot be `as f32`, and this is the one place that conversion belongs.
+macro_rules! dev_param_default {
+    (float($key:literal, $label:literal, $default:expr, $min:expr, $max:expr, $step:expr)) => {
+        ($default as f32)
+    };
+    (bool($key:literal, $label:literal, $default:expr)) => {
+        if $default { 1.0f32 } else { 0.0f32 }
+    };
+}
+
 macro_rules! dev_params {
-    ($($(#[$doc:meta])* $id:ident = float($key:literal, $label:literal, $default:expr, $min:expr, $max:expr, $step:expr)),+ $(,)?) => {
+    ($($(#[$doc:meta])* $id:ident = $kind:ident ( $($args:tt)* )),+ $(,)?) => {
         /// Every registered parameter, in declaration order (index == id).
         pub static PARAMS: &[DevParam] = &[
-            $(DevParam {
-                key: $key,
-                label: $label,
-                kind: DevParamKind::Float { min: $min, max: $max, step: $step },
-                default: $default,
-            }),+
+            $(dev_param_entry!($kind($($args)*))),+
         ];
 
         /// Current values, as `f32` bits, seeded with the defaults. A sized
         /// array, not a `&[_]` slice: a borrow of interior-mutable data
         /// cannot be promoted to `'static` (E0492).
-        static VALUES: [AtomicU32; [$(($default as f32)),+].len()] =
-            [$(AtomicU32::new(($default as f32).to_bits())),+];
+        static VALUES: [AtomicU32; [$(dev_param_default!($kind($($args)*))),+].len()] =
+            [$(AtomicU32::new(dev_param_default!($kind($($args)*)).to_bits())),+];
 
         #[allow(non_camel_case_types, clippy::upper_case_acronyms, dead_code)]
         enum __DevParamIndex { $($id),+ }
@@ -177,6 +213,20 @@ dev_params! {
     /// making the arm exactly life-size (0.79) would leave the Wrench at 52,
     /// and making the Wrench right (~0.5) would leave a child's arm.
     MELEE_WIELD_SCALE = float("melee_scale", "Melee scale", 0.7, 0.25, 1.5, 0.05),
+    /// Enables the detached debug ("free") camera. This is the *gate*, not
+    /// the camera's own on/off: while it is false the toggle input is not
+    /// even read, so a stray `Alt+V` (or controller chord) during normal play
+    /// cannot detach the view. Turning it back off while detached also
+    /// re-attaches the camera, so the switch is always a way out.
+    FREE_CAMERA = bool("free_camera", "Free camera", false),
+    /// Which pose the visibility engine culls from while the free camera is
+    /// detached. Off (the default) culls from the *player*, so flying out
+    /// shows exactly what the player's viewpoint decided - cells the player
+    /// cannot see are genuinely absent, which is the point of the tool. On
+    /// culls from the free camera instead, for when you just want to look at
+    /// something. Inert while the camera is attached (the two poses are the
+    /// same pose).
+    FREE_CAMERA_CULL_FROM_CAMERA = bool("free_camera_cull", "Cull from cam", false),
 }
 
 /// Every parameter with its id, in declaration order.
@@ -199,6 +249,13 @@ pub fn get(id: DevParamId) -> f32 {
     f32::from_bits(VALUES[id.0].load(Ordering::Relaxed))
 }
 
+/// A [`DevParamKind::Bool`] parameter's current value. Any non-zero reading
+/// is true, so this is also correct for a value written before the registry
+/// normalized it.
+pub fn get_bool(id: DevParamId) -> bool {
+    get(id) != 0.0
+}
+
 /// Set a parameter, clamped into its range and snapped to its step grid.
 /// Returns the value actually applied. A non-finite request is refused
 /// (the current value is returned unchanged) so no consumer can ever read
@@ -219,6 +276,13 @@ fn apply(kind: &DevParamKind, current: f32, value: f32) -> f32 {
         return current;
     }
     match *kind {
+        DevParamKind::Bool => {
+            if value == 0.0 {
+                0.0
+            } else {
+                1.0
+            }
+        }
         DevParamKind::Float { min, max, step } => {
             if step > 0.0 {
                 // Clamp the grid *index*, not the snapped value: clamping
@@ -272,15 +336,24 @@ mod tests {
     #[test]
     fn every_default_is_within_its_declared_range() {
         for (_, param) in all() {
-            let DevParamKind::Float { min, max, step } = param.kind;
             assert!(param.default.is_finite());
-            assert!(
-                (min..=max).contains(&param.default),
-                "{}: default {} outside {min}..={max}",
-                param.key,
-                param.default
-            );
-            assert!(step >= 0.0, "{}: negative step", param.key);
+            match param.kind {
+                DevParamKind::Float { min, max, step } => {
+                    assert!(
+                        (min..=max).contains(&param.default),
+                        "{}: default {} outside {min}..={max}",
+                        param.key,
+                        param.default
+                    );
+                    assert!(step >= 0.0, "{}: negative step", param.key);
+                }
+                DevParamKind::Bool => assert!(
+                    param.default == 0.0 || param.default == 1.0,
+                    "{}: bool default {} is neither 0 nor 1",
+                    param.key,
+                    param.default
+                ),
+            }
         }
     }
 
@@ -343,6 +416,29 @@ mod tests {
         assert_eq!(apply(&GRID, 2.0, f32::NAN), 2.0);
         assert_eq!(apply(&GRID, 2.0, f32::INFINITY), 2.0);
         assert_eq!(apply(&GRID, 2.0, f32::NEG_INFINITY), 2.0);
+    }
+
+    /// A bool normalizes to exactly 0.0/1.0, so no consumer can read a third
+    /// state out of the registry (and `get_bool`'s `!= 0.0` can never see a
+    /// value the panel would then format inconsistently).
+    #[test]
+    fn apply_normalizes_a_bool_to_zero_or_one() {
+        assert_eq!(apply(&DevParamKind::Bool, 0.0, 1.0), 1.0);
+        assert_eq!(apply(&DevParamKind::Bool, 1.0, 0.0), 0.0);
+        assert_eq!(apply(&DevParamKind::Bool, 0.0, 0.5), 1.0);
+        assert_eq!(apply(&DevParamKind::Bool, 0.0, -3.0), 1.0);
+    }
+
+    #[test]
+    fn a_non_finite_bool_is_refused() {
+        assert_eq!(apply(&DevParamKind::Bool, 1.0, f32::NAN), 1.0);
+    }
+
+    /// The free camera is a debug tool: it must be off until asked for.
+    #[test]
+    fn the_free_camera_gate_defaults_off() {
+        assert!(!get_bool(FREE_CAMERA));
+        assert!(!get_bool(FREE_CAMERA_CULL_FROM_CAMERA));
     }
 
     #[test]

--- a/shock2vr/src/free_camera.rs
+++ b/shock2vr/src/free_camera.rs
@@ -1,0 +1,247 @@
+//! The detached debug ("free") camera.
+//!
+//! A render-layer override and nothing more: while it is detached the runtime
+//! draws from a camera pose of its own, but the player pawn does not move, is
+//! not teleported, and never learns the camera left. Everything that reads the
+//! player's position - AI (`PlayerInfo.pos`), triggers, audio - therefore keeps
+//! reading the *body*, which is the point: the camera is a way to watch the
+//! simulation from outside without perturbing it.
+//!
+//! Two switches gate it, both [`crate::dev_params`] bools:
+//!
+//! * `free_camera` is the enable. Until it is on, the toggle input is not even
+//!   read, so a stray keypress or controller chord during normal play cannot
+//!   detach the view. Turning it back off re-attaches (see [`FreeCamera::sync_gate`]).
+//! * `free_camera_cull` picks which pose the visibility engine culls from
+//!   while detached - the player (default) or the camera. See
+//!   [`FreeCamera::cull_from_camera`].
+//!
+//! Movement is not implemented yet: the camera snaps to the eye it detached
+//! from and holds that pose.
+
+use cgmath::{Matrix4, Quaternion, SquareMatrix, Vector3};
+
+use crate::dev_params;
+
+/// A camera pose: where it is, and which way it faces.
+pub type Pose = (Vector3<f32>, Quaternion<f32>);
+
+/// The free camera's state. Attached (the default) is `pose: None`; the pose
+/// is captured on the first frame rendered after detaching, so the camera
+/// always starts exactly where the player's eye was and the toggle reads as a
+/// freeze rather than a jump.
+#[derive(Debug, Default, Clone)]
+pub struct FreeCamera {
+    detached: bool,
+    /// The captured pose. `None` while attached, and also for the single
+    /// frame between a detach and the render that captures it.
+    pose: Option<Pose>,
+}
+
+impl FreeCamera {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the camera is currently detached from the player.
+    pub fn is_detached(&self) -> bool {
+        self.detached
+    }
+
+    /// Act on the toggle input. Detaching only *arms* the camera; the pose is
+    /// captured by the next [`camera_pose`], which is the one place that knows
+    /// where the eye actually is.
+    ///
+    /// [`camera_pose`]: Self::camera_pose
+    pub fn toggle(&mut self) {
+        if self.detached {
+            self.attach();
+        } else {
+            self.detached = true;
+        }
+    }
+
+    /// Re-attach to the player, dropping the override. Nothing has to be
+    /// restored: the pawn never moved.
+    pub fn attach(&mut self) {
+        self.detached = false;
+        self.pose = None;
+    }
+
+    /// The captured pose, or `None` while attached (or on the single frame
+    /// between a detach and the render that captures it).
+    pub fn pose(&self) -> Option<Pose> {
+        self.pose
+    }
+
+    /// Enforce the `free_camera` dev param every frame, so turning the switch
+    /// off on the Developer screen is always a way back to the body - including
+    /// from a camera flown somewhere the menu is hard to reach.
+    pub fn sync_gate(&mut self) {
+        if !Self::is_enabled() && self.is_detached() {
+            self.attach();
+        }
+    }
+
+    /// Whether the free camera is enabled at all.
+    pub fn is_enabled() -> bool {
+        dev_params::get_bool(dev_params::FREE_CAMERA)
+    }
+
+    /// Whether culling should follow the detached camera rather than the
+    /// player. Off by default: culling from the player is what makes the
+    /// camera a tool for *inspecting* visibility rather than just a way to
+    /// fly around.
+    pub fn cull_from_camera() -> bool {
+        dev_params::get_bool(dev_params::FREE_CAMERA_CULL_FROM_CAMERA)
+    }
+
+    /// The pose to render this frame from, given the player's own. Captures
+    /// the pawn pose on the first call after a detach.
+    pub fn camera_pose(&mut self, pawn: Pose) -> Pose {
+        if !self.detached {
+            return pawn;
+        }
+        *self.pose.get_or_insert(pawn)
+    }
+
+    /// The correction that turns the *camera's* view matrix back into the
+    /// *player's*, or `None` when the two are the same view (attached, or
+    /// deliberately culling from the camera).
+    ///
+    /// Returned as a right-multiplied fixup rather than a rebuilt view matrix
+    /// because only the runtime knows the rest of the chain - in VR the view
+    /// also carries the tracked head offset, which `Game` never sees. Since
+    /// both views share that prefix (`view = head * world_to_eye`), composing
+    /// `camera_to_world * world_to_pawn` on the right cancels the camera and
+    /// substitutes the pawn exactly, whatever the prefix was.
+    pub fn view_fixup(&self, pawn: Pose) -> Option<Matrix4<f32>> {
+        let camera = self.pose?;
+        if !self.detached || Self::cull_from_camera() {
+            return None;
+        }
+        let camera_to_world = Matrix4::from_translation(camera.0) * Matrix4::from(camera.1);
+        let pawn_to_world = Matrix4::from_translation(pawn.0) * Matrix4::from(pawn.1);
+        Some(camera_to_world * pawn_to_world.invert()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Deg, InnerSpace, Rad, Rotation3, Vector4, vec3};
+
+    fn pawn() -> Pose {
+        (
+            vec3(3.0, 5.6, -2.0),
+            Quaternion::from_angle_y(Deg(35.0_f32)),
+        )
+    }
+
+    fn elsewhere() -> Pose {
+        (
+            vec3(-40.0, 22.0, 17.0),
+            Quaternion::from_angle_x(Deg(-20.0_f32)),
+        )
+    }
+
+    /// Attached, the override is the identity: the runtime gets exactly the
+    /// pose the scene produced.
+    #[test]
+    fn an_attached_camera_passes_the_pawn_pose_through() {
+        let mut camera = FreeCamera::new();
+        assert!(!camera.is_detached());
+        assert_eq!(camera.camera_pose(pawn()).0, pawn().0);
+        assert!(camera.view_fixup(pawn()).is_none());
+    }
+
+    /// Detaching freezes the view where the eye already was - no jump on the
+    /// frame the toggle lands.
+    #[test]
+    fn detaching_captures_the_pose_it_detached_from() {
+        let mut camera = FreeCamera::new();
+        camera.toggle();
+        assert!(camera.is_detached());
+        assert_eq!(camera.camera_pose(pawn()), pawn());
+    }
+
+    /// Once captured, the camera holds its pose while the player walks away.
+    /// This is the property the whole tool rests on.
+    #[test]
+    fn a_detached_camera_does_not_follow_the_player() {
+        let mut camera = FreeCamera::new();
+        camera.toggle();
+        camera.camera_pose(pawn());
+        assert_eq!(camera.camera_pose(elsewhere()), pawn());
+    }
+
+    #[test]
+    fn re_attaching_snaps_back_to_the_player_and_re_arms() {
+        let mut camera = FreeCamera::new();
+        camera.toggle();
+        camera.camera_pose(pawn());
+
+        camera.toggle();
+        assert!(!camera.is_detached());
+        assert_eq!(camera.camera_pose(elsewhere()), elsewhere());
+
+        // A second detach captures the NEW pose, not the stale one.
+        camera.toggle();
+        assert_eq!(camera.camera_pose(elsewhere()), elsewhere());
+    }
+
+    /// The dev-param gate is a way back: switching it off re-attaches even
+    /// though nothing pressed the toggle.
+    #[test]
+    fn the_gate_re_attaches_a_detached_camera() {
+        let mut camera = FreeCamera::new();
+        camera.toggle();
+        camera.camera_pose(pawn());
+        // `free_camera` defaults off and no test mutates the process-global
+        // registry, so this is the "switch turned off while detached" case.
+        assert!(!FreeCamera::is_enabled());
+        camera.sync_gate();
+        assert!(!camera.is_detached());
+    }
+
+    /// The point of the fixup: composed onto the camera's view matrix it must
+    /// reproduce the *player's* view matrix exactly - including the tracked
+    /// head offset in the prefix, which `Game` never sees.
+    #[test]
+    fn the_view_fixup_reproduces_the_players_view() {
+        let head_position = vec3(0.1, 1.7, -0.3);
+        let head_rotation = Quaternion::from_angle_z(Rad(0.2_f32));
+
+        let mut camera = FreeCamera::new();
+        camera.toggle();
+        camera.camera_pose(elsewhere());
+
+        let camera_view = engine::util::compute_view_matrix(
+            elsewhere().0,
+            elsewhere().1,
+            head_position,
+            head_rotation,
+        );
+        let expected =
+            engine::util::compute_view_matrix(pawn().0, pawn().1, head_position, head_rotation);
+
+        let fixup = camera
+            .view_fixup(pawn())
+            .expect("a detached camera culling from the player has a fixup");
+        let corrected = camera_view * fixup;
+
+        let columns = [
+            (corrected.x, expected.x),
+            (corrected.y, expected.y),
+            (corrected.z, expected.z),
+            (corrected.w, expected.w),
+        ];
+        for (actual_column, expected_column) in columns {
+            let difference: Vector4<f32> = actual_column - expected_column;
+            assert!(
+                difference.magnitude() < 1e-4,
+                "corrected view {corrected:?} != player view {expected:?}"
+            );
+        }
+    }
+}

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -88,6 +88,15 @@ pub enum InputAction {
     /// an effect routed through the scene could never close the menu again.
     TogglePauseMenu,
 
+    /// Toggle the detached debug ("free") camera. Like `TogglePauseMenu`
+    /// this is consumed by `Game` itself rather than becoming an `Effect`:
+    /// the free camera is render-layer state that deliberately leaves the
+    /// simulation untouched (the pawn stays put, AI keeps reading its
+    /// position), so routing it through the world would be both wrong and
+    /// unnecessary. Ignored unless the `free_camera` dev param is on, so a
+    /// stray press during normal play cannot detach the view.
+    ToggleFreeCamera,
+
     /// Open/play the newest unread audio log (the original's
     /// `play_unread_log`), or replay the newest collected log once all are read.
     /// Collecting a disc only files it in the PDA, so this is how it is read.
@@ -131,6 +140,7 @@ impl InputAction {
             InputAction::ReadLastUnreadLog,
             InputAction::ToggleMap,
             InputAction::TogglePauseMenu,
+            InputAction::ToggleFreeCamera,
         ]
     }
 
@@ -168,6 +178,7 @@ impl InputAction {
             InputAction::ReadLastUnreadLog => "ReadLastUnreadLog",
             InputAction::ToggleMap => "ToggleMap",
             InputAction::TogglePauseMenu => "TogglePauseMenu",
+            InputAction::ToggleFreeCamera => "ToggleFreeCamera",
         }
     }
 
@@ -188,6 +199,33 @@ impl InputAction {
             // the two gun-handling actions - A reloads, B swaps ammo type.
             InputAction::Reload => Some("/user/hand/right/input/a/click"),
             InputAction::CycleAmmo => Some("/user/hand/right/input/b/click"),
+            _ => None,
+        }
+    }
+
+    /// Production Meta Quest Touch binding for actions reached by a two-button
+    /// **chord** rather than a button of their own.
+    ///
+    /// The Touch has no button left to give: `X`, `Y` and the left `Menu` are
+    /// taken, both thumbstick clicks are jump and crouch, right `A` and `B`
+    /// are reload and swap-ammo, and the right `Menu` belongs to the Quest
+    /// system UI. So a debug toggle *shares* a pair rather than owning one -
+    /// here right `A`+`B`, whose own actions only matter with a weapon in
+    /// hand. The pair's edge is resolved by [`InputActionState::sync_chord`].
+    ///
+    /// Sharing is safe because the chord is dead unless the free camera's
+    /// developer option is on. While it IS on, `oculus_runtime` suppresses
+    /// whichever button is pressed *second*, so completing the chord cannot
+    /// also swap your ammo; the first press still fires its own action, which
+    /// is why the harmless one (`Reload`) is the natural opener.
+    ///
+    /// [`InputActionState::sync_chord`]: crate::input::InputActionState::sync_chord
+    pub fn quest_touch_chord_paths(&self) -> Option<(&'static str, &'static str)> {
+        match self {
+            InputAction::ToggleFreeCamera => Some((
+                "/user/hand/right/input/a/click",
+                "/user/hand/right/input/b/click",
+            )),
             _ => None,
         }
     }
@@ -260,6 +298,43 @@ mod tests {
             InputAction::TogglePauseMenu.quest_touch_click_path(),
             Some("/user/hand/left/input/menu/click")
         );
+    }
+
+    /// The free camera is a chord, not a button, and must never quietly
+    /// become one: a single-path binding here would consume a face button the
+    /// Touch does not have to spare.
+    ///
+    /// Its two halves deliberately DO collide with `Reload` and `CycleAmmo`
+    /// (#1144) - there is no unbound button left - which is exactly why
+    /// `oculus_runtime` suppresses the second press while the developer
+    /// option is on. Pinning that here means a future rebinding of either gun
+    /// action has to come back and re-read the suppression rule rather than
+    /// silently making the chord fire both.
+    #[test]
+    fn the_free_camera_chord_shares_the_two_gun_buttons() {
+        assert_eq!(InputAction::ToggleFreeCamera.quest_touch_click_path(), None);
+        let (first, second) = InputAction::ToggleFreeCamera
+            .quest_touch_chord_paths()
+            .expect("free camera chord binding");
+        assert_eq!(first, InputAction::Reload.quest_touch_click_path().unwrap());
+        assert_eq!(
+            second,
+            InputAction::CycleAmmo.quest_touch_click_path().unwrap()
+        );
+        assert_eq!(first, "/user/hand/right/input/a/click");
+        assert_eq!(second, "/user/hand/right/input/b/click");
+    }
+
+    /// Every action is reachable by exactly one kind of binding, or none.
+    #[test]
+    fn no_action_is_both_a_button_and_a_chord() {
+        for action in InputAction::all() {
+            assert!(
+                action.quest_touch_click_path().is_none()
+                    || action.quest_touch_chord_paths().is_none(),
+                "{action}"
+            );
+        }
     }
 
     #[test]

--- a/shock2vr/src/input/state.rs
+++ b/shock2vr/src/input/state.rs
@@ -67,6 +67,46 @@ impl InputActionState {
             self.release(action);
         }
     }
+
+    /// Feed a two-button chord into semantic input state: the action fires on
+    /// the frame both buttons are down and does not fire again until at least
+    /// one is released. The held set is the latch, so a chord needs no state
+    /// of its own - and, unlike [`sync_discrete_button`], this takes the raw
+    /// current states rather than OpenXR edges, because the chord's edge is a
+    /// property of the *pair* and neither button's own edge implies it.
+    ///
+    /// `is_active` must be false unless BOTH halves are live. While the pair
+    /// is inactive the latch is left exactly as it was and nothing is minted:
+    /// with the session merely VISIBLE (a system overlay up) OpenXR reports
+    /// `current_state` false even for a physically held button, so treating
+    /// that as a release would re-arm the chord and fire a second, unpressed
+    /// toggle the moment focus came back with both buttons still down. This
+    /// is the same hazard the runtime's latched crouch guards against.
+    ///
+    /// Chords exist so a debug toggle can be reachable on a headset without
+    /// consuming a face button that gameplay may want later: each half stays
+    /// individually unbound.
+    ///
+    /// [`sync_discrete_button`]: Self::sync_discrete_button
+    pub fn sync_chord(
+        &mut self,
+        action: InputAction,
+        is_active: bool,
+        first_down: bool,
+        second_down: bool,
+    ) {
+        if !is_active {
+            return;
+        }
+        let chord_down = first_down && second_down;
+        if chord_down {
+            if !self.is_held(action) {
+                self.trigger(action);
+            }
+        } else {
+            self.release(action);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -102,6 +142,78 @@ mod tests {
 
         state.release(InputAction::QuickSave);
         assert!(!state.is_held(InputAction::QuickSave));
+    }
+
+    /// The chord fires once, not every frame it is held - the defect a naive
+    /// `a && b -> trigger` would have.
+    #[test]
+    fn a_chord_fires_once_per_press() {
+        let mut state = InputActionState::new();
+
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        assert!(state.just_triggered(InputAction::ToggleFreeCamera));
+
+        // Still held on the next frame: no new edge.
+        state.clear_triggered();
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        assert!(!state.just_triggered(InputAction::ToggleFreeCamera));
+        assert!(state.is_held(InputAction::ToggleFreeCamera));
+    }
+
+    /// Releasing either half re-arms it; neither half alone fires it.
+    #[test]
+    fn a_chord_rearms_when_either_half_releases() {
+        let mut state = InputActionState::new();
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        state.clear_triggered();
+
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, false);
+        assert!(!state.is_held(InputAction::ToggleFreeCamera));
+        assert!(!state.just_triggered(InputAction::ToggleFreeCamera));
+
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        assert!(state.just_triggered(InputAction::ToggleFreeCamera));
+    }
+
+    #[test]
+    fn one_half_of_a_chord_never_fires_it() {
+        let mut state = InputActionState::new();
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, false);
+        state.sync_chord(InputAction::ToggleFreeCamera, true, false, true);
+        assert!(!state.just_triggered(InputAction::ToggleFreeCamera));
+        assert!(!state.is_held(InputAction::ToggleFreeCamera));
+    }
+
+    /// Losing focus with the chord held must not mint a second toggle when
+    /// focus returns: OpenXR reports a held button as `current_state` false
+    /// while the action is inactive, so an unguarded chord would read that as
+    /// a release, re-arm, and fire again on reactivation.
+    #[test]
+    fn an_inactive_chord_keeps_its_latch_and_mints_nothing() {
+        let mut state = InputActionState::new();
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        assert!(state.just_triggered(InputAction::ToggleFreeCamera));
+        state.clear_triggered();
+
+        // System overlay up: inactive, and OpenXR reports both as up.
+        state.sync_chord(InputAction::ToggleFreeCamera, false, false, false);
+        assert!(
+            state.is_held(InputAction::ToggleFreeCamera),
+            "the latch must survive an inactive frame"
+        );
+        assert!(!state.just_triggered(InputAction::ToggleFreeCamera));
+
+        // Focus returns with both buttons still physically held.
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        assert!(
+            !state.just_triggered(InputAction::ToggleFreeCamera),
+            "refocusing on a held chord must not toggle"
+        );
+
+        // A genuine release still re-arms it.
+        state.sync_chord(InputAction::ToggleFreeCamera, true, false, false);
+        state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        assert!(state.just_triggered(InputAction::ToggleFreeCamera));
     }
 
     #[test]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -19,6 +19,7 @@ pub mod data_files;
 pub mod death_camera;
 pub mod dev_params;
 mod flat_player_controller;
+pub mod free_camera;
 mod gui;
 mod hand_forearm;
 mod hand_glove;
@@ -493,6 +494,17 @@ pub struct Game {
     /// Per-frame desired FOV (vertical, degrees) for the flat runtimes'
     /// projection matrix. See [`Game::desired_fov_deg`].
     desired_fov_deg: f32,
+
+    /// The detached debug camera. Purely a render-layer override: while it is
+    /// detached the pawn stays put and every system that reads the player's
+    /// position keeps reading the body. See [`crate::free_camera`].
+    free_camera: free_camera::FreeCamera,
+
+    /// The correction that turns the camera's view matrix back into the
+    /// player's, carried from `render` to `finish_render` so the visibility
+    /// engine culls from the *player* while the free camera is off flying.
+    /// `None` whenever the two views are the same.
+    free_camera_view_fixup: Option<Matrix4<f32>>,
 }
 
 /// Player state for debug introspection. Entity ids use `EntityId::inner() as
@@ -1281,6 +1293,8 @@ impl Game {
             ),
             view_extents: hit_feedback::DEFAULT_VIEW_EXTENTS,
             desired_fov_deg: DEFAULT_FOV_DEG,
+            free_camera: free_camera::FreeCamera::new(),
+            free_camera_view_fixup: None,
         }
     }
 
@@ -1306,6 +1320,19 @@ impl Game {
         // frozen at full strength until the simulation resumes.
         self.head_pose = (input_context.head.position, input_context.head.rotation);
         self.hit_feedback.update(delta_time);
+
+        // The free camera is consumed here rather than dispatched as an
+        // `Effect`, for the same reason `TogglePauseMenu` is: it is `Game`'s
+        // own render-layer state and deliberately changes nothing in the
+        // world. The gate is enforced here too - once, for every runtime and
+        // for HTTP injection alike, so no input path can drift from the rule
+        // that the toggle is inert until the Developer screen enables it.
+        self.free_camera.sync_gate();
+        if actions.just_triggered(input::InputAction::ToggleFreeCamera)
+            && free_camera::FreeCamera::is_enabled()
+        {
+            self.free_camera.toggle();
+        }
 
         // Drive a background transition: the loading screen animates while the parse
         // runs on its worker thread. Once the parse has finished AND the loading screen
@@ -1835,6 +1862,23 @@ impl Game {
         // taken mid-fight must not open on a red rim, and the main menu must
         // never show one at all.
         self.hit_feedback.clear();
+        // The free camera's pose is in the *outgoing* scene's coordinates, so
+        // carrying it across a level transition, quickload or a return to the
+        // menu would render the new scene from a point inside its geometry or
+        // outside it entirely. Worse, it strands the player: the frontend
+        // panel is pawn-anchored, so a detached camera cannot see the menu it
+        // would take to switch the camera back off.
+        self.free_camera.attach();
+        self.free_camera_view_fixup = None;
+    }
+
+    /// The free camera's observable state: whether it is detached, and the
+    /// pose it is rendering from (`None` while attached, when the camera is
+    /// simply the player's eye). Exposed for the debug runtime's
+    /// `GET /v1/camera`, which is what lets an agent verify the camera
+    /// without reading pixels.
+    pub fn free_camera_state(&self) -> (bool, Option<free_camera::Pose>) {
+        (self.free_camera.is_detached(), self.free_camera.pose())
     }
 
     /// Get hand spotlights for enhanced lighting when experimental flag is enabled
@@ -2041,7 +2085,15 @@ impl Game {
         // let text = SceneObject::world_space_text("test1234567890", font, 0.0);
         // scene.push(RefCell::new(text));
 
-        (scene, pos, rot)
+        // The camera override is applied last, to the returned pose ONLY.
+        // Everything above has already been anchored with `pawn_to_world`, so
+        // the pause panel and the view-locked rim layers stay with the player
+        // - which is what a spectator camera should show: the body's HUD where
+        // the body is.
+        self.free_camera_view_fixup = self.free_camera.view_fixup((pos, rot));
+        let (camera_position, camera_rotation) = self.free_camera.camera_pose((pos, rot));
+
+        (scene, camera_position, camera_rotation)
     }
 
     pub fn render_per_eye(
@@ -2136,6 +2188,14 @@ impl Game {
         projection: Matrix4<f32>,
         screen_size: Vector2<f32>,
     ) {
+        // Culling follows the *player*, not the detached camera: flying out
+        // then shows exactly what the player's viewpoint decided to draw,
+        // which is the whole point of watching from outside. The fixup was
+        // computed in `render`, from the two poses that frame was built with.
+        let view = match self.free_camera_view_fixup {
+            Some(fixup) => view * fixup,
+            None => view,
+        };
         self.active_game_scene
             .finish_render(&mut self.asset_cache, view, projection, screen_size)
     }

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -269,6 +269,7 @@ fn scroll_rects(rects: PanelRects) -> Option<(Rect, Rect)> {
 fn format_value(kind: &DevParamKind, value: f32) -> String {
     match kind {
         DevParamKind::Float { .. } => format!("{value:.2}"),
+        DevParamKind::Bool => if value != 0.0 { "On" } else { "Off" }.to_owned(),
     }
 }
 
@@ -412,11 +413,17 @@ pub fn draw(
 /// the host must act on (leave the screen); the steps and the scrolling are
 /// absorbed here so both hosts stay a one-liner.
 pub fn activate(rects: PanelRects, event: DevParamsEvent, scroll: &mut usize) -> bool {
-    let step_by = |id: DevParamId, direction: f32| {
-        let DevParamKind::Float { step, .. } = dev_params::spec(id).kind;
-        // `set` clamps into range and snaps to the step grid, so walking off
-        // either end just pins to it.
-        dev_params::set(id, dev_params::get(id) + direction * step);
+    let step_by = |id: DevParamId, direction: f32| match dev_params::spec(id).kind {
+        DevParamKind::Float { step, .. } => {
+            // `set` clamps into range and snaps to the step grid, so walking
+            // off either end just pins to it.
+            dev_params::set(id, dev_params::get(id) + direction * step);
+        }
+        // A switch has no grid to walk: either arrow flips it, so the row
+        // behaves the same whichever side the pointer lands on.
+        DevParamKind::Bool => {
+            dev_params::set(id, if dev_params::get_bool(id) { 0.0 } else { 1.0 });
+        }
     };
     match event {
         DevParamsEvent::Decrement(id) => {
@@ -551,28 +558,41 @@ mod tests {
         assert_eq!(scroll, max_scroll(rects) - 1);
     }
 
-    /// A pane tall enough for the whole registry has no rocker at all: the
-    /// framed art stays empty, exactly as it was before the list scrolled.
+    /// The registry no longer fits any pane this backdrop can authorize, so
+    /// the rocker is always present - even on the tallest pane the canvas
+    /// allows.
+    ///
+    /// This used to assert the opposite ("a pane tall enough has no rocker").
+    /// Rows are capped at `FIELD_TOP_Y / ROW_PITCH` = 11 however tall the
+    /// authored pane is, and the table passed that when the free-camera
+    /// switches landed. The fits-on-one-page branch is still live code and
+    /// still covered, generically, by
+    /// `list_scroll::the_rocker_sits_in_the_gutter_and_its_ends_are_inert`.
     #[test]
-    fn a_pane_that_fits_everything_has_no_rocker() {
+    fn the_tallest_authored_pane_still_needs_the_rocker() {
         let tall = PanelRects::from_layout(Some(&[
             MapRect::new(261, 31, 463, 51),
-            // Starts at the top of the canvas, so it clears FIELD_TOP_Y with
-            // room for more rows than the registry has.
+            // Starts at the top of the canvas, so it reaches FIELD_TOP_Y -
+            // the most rows any authored layout can get.
             MapRect::new(261, 0, 463, 320),
             MapRect::new(527, 161, 623, 223),
             MapRect::new(527, 405, 622, 467),
         ]));
-        assert!(rows_per_page(tall) > dev_params::PARAMS.len());
-        assert_eq!(max_scroll(tall), 0);
-        assert_eq!(scroll_rects(tall), None);
-        // With nothing to scroll, the gutter is not reserved either: a row's
-        // increment runs to the pane's own inset, as it did before scrolling.
+        let cap = (FIELD_TOP_Y / ROW_PITCH).floor() as usize;
+        assert_eq!(rows_per_page(tall), cap);
+        assert!(
+            dev_params::PARAMS.len() > cap,
+            "if the registry ever fits again, restore the no-rocker assertions"
+        );
+        assert!(max_scroll(tall) > 0);
+        assert!(scroll_rects(tall).is_some());
+        // Scrolling means the gutter is reserved: a row's increment stops
+        // short of the pane's inset by the gutter width.
         assert_eq!(
             row_rects(tall, 0).increment.x + ARROW_W,
-            tall.list.x + tall.list.w - TEXT_INSET
+            tall.list.x + tall.list.w - TEXT_INSET - SCROLL_GUTTER_W
         );
-        assert_eq!(visible_rows(tall, 0), 0..dev_params::PARAMS.len());
+        assert_eq!(visible_rows(tall, 0), 0..cap);
     }
 
     #[test]
@@ -717,5 +737,11 @@ mod tests {
         // The snap grid's f32 wobble (0.71999997) must not leak into the UI.
         assert_eq!(format_value(&kind, 0.719_999_97), "0.72");
         assert_eq!(format_value(&kind, 2.0), "2.00");
+    }
+
+    #[test]
+    fn bools_format_as_on_and_off() {
+        assert_eq!(format_value(&DevParamKind::Bool, 1.0), "On");
+        assert_eq!(format_value(&DevParamKind::Bool, 0.0), "Off");
     }
 }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -4,6 +4,7 @@ import type {
   CommandResult,
   DebugEntityMessage,
   DevParamSetResult,
+  CameraState,
   DevParamsListResult,
   EntityDetailResult,
   EntityListResult,
@@ -607,6 +608,21 @@ export class DevParamsApi {
   }
 }
 
+/** The free (debug) camera - a detached view that leaves the pawn alone. */
+export class CameraApi {
+  constructor(private readonly client: HttpClient) {}
+
+  /**
+   * Whether the camera is detached, and the pose it is rendering from. Lets a
+   * test assert what the camera did without reading pixels: that it held its
+   * pose while the player walked, flew where it was told, and re-attached on
+   * a level change.
+   */
+  async state(): Promise<CameraState> {
+    return this.client.get<CameraState>("/v1/camera");
+  }
+}
+
 /** Interactive pathfinding test (visual A* debugging). */
 export class PathfindingTestApi {
   constructor(private readonly client: HttpClient) {}
@@ -739,6 +755,7 @@ export class Game {
   readonly physics: PhysicsApi;
   readonly scene: SceneApi;
   readonly devParams: DevParamsApi;
+  readonly camera: CameraApi;
   readonly quests: QuestsApi;
   readonly ui: UiApi;
   readonly audio: AudioApi;
@@ -753,6 +770,7 @@ export class Game {
     this.physics = new PhysicsApi(client);
     this.scene = new SceneApi(client);
     this.devParams = new DevParamsApi(client);
+    this.camera = new CameraApi(client);
     this.quests = new QuestsApi(client);
     this.ui = new UiApi(client);
     this.audio = new AudioApi(client);

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -364,20 +364,53 @@ export interface SceneListResult {
   frame_index: number;
 }
 
-/** One live-tunable developer parameter (GET /v1/dev-params). */
-export interface DevParamSummary {
+/** What every developer parameter reports, whatever its kind. */
+export interface DevParamCommon {
   key: string;
   label: string;
-  kind: "float";
-  min: number;
-  max: number;
-  step: number;
+  /** Current value. Bools are 0 or 1, the registry's own representation. */
   value: number;
   default: number;
 }
 
+/** A float parameter, clamped to `min..=max` and snapped to `step`. */
+export interface DevParamFloat extends DevParamCommon {
+  kind: "float";
+  min: number;
+  max: number;
+  step: number;
+}
+
+/** A bool parameter. It carries no range - `value` is 0 or 1. */
+export interface DevParamBool extends DevParamCommon {
+  kind: "bool";
+}
+
+/**
+ * One live-tunable developer parameter (GET /v1/dev-params).
+ *
+ * A discriminated union on `kind`: narrow before reading `min`/`max`/`step`,
+ * which only a float carries.
+ */
+export type DevParamSummary = DevParamFloat | DevParamBool;
+
 export interface DevParamsListResult {
   params: DevParamSummary[];
+}
+
+/**
+ * The free (debug) camera's state (GET /v1/camera).
+ *
+ * `position`/`rotation` are null while the camera is attached - there is no
+ * separate camera pose then, only the player's eye.
+ */
+export interface CameraState {
+  detached: boolean;
+  /** Whether the developer option that gates the camera is on. */
+  enabled: boolean;
+  position: [number, number, number] | null;
+  /** Rotation as [w, x, y, z]. */
+  rotation: [number, number, number, number] | null;
 }
 
 /** What a POST /v1/dev-params actually applied (after clamp/snap). */

--- a/tools/shock2-sdk/test/free-camera.e2e.test.ts
+++ b/tools/shock2-sdk/test/free-camera.e2e.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// The free (debug) camera detaches the view from the player without touching
+// the simulation. These are the parts that unit tests over `FreeCamera` in
+// isolation cannot reach: that the real gate really withholds the toggle, that
+// a detached camera really holds its pose while the live player walks, and
+// that a scene swap really re-attaches it.
+//
+// Negative-first, per assertion:
+//   - "the gate withholds the toggle" fails if the gate check is removed from
+//     `Game::update` (the camera detaches with the developer option off).
+//   - "the camera holds its pose" fails against a build that returns the pawn
+//     pose unconditionally from `Game::render`.
+//   - "a level reload re-attaches" fails against the first version of this
+//     change, which left `free_camera` untouched in `set_active_scene` and so
+//     carried a stale pose (and `detached: true`) into the new scene.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const skip = !e2eEnabled && "set SHOCK2_E2E=1 to run";
+
+test("the free camera is inert until the developer option enables it", { skip }, async () => {
+  await using game = await GameServer.launch({
+    mission: "medsci1.mis",
+    port: 8113,
+  });
+  await game.step({ frames: 30 });
+
+  const before = await game.camera.state();
+  assert.equal(before.enabled, false, "the gate must default off");
+  assert.equal(before.detached, false);
+
+  // Toggling with the gate off must do nothing at all.
+  await game.input.trigger("ToggleFreeCamera");
+  await game.step({ frames: 2 });
+  const gated = await game.camera.state();
+  assert.equal(gated.detached, false, "a gated toggle must not detach");
+  assert.equal(gated.position, null);
+
+  // With the gate on, the same toggle detaches.
+  await game.devParams.set("free_camera", 1);
+  await game.input.trigger("ToggleFreeCamera");
+  await game.step({ frames: 2 });
+  const detached = await game.camera.state();
+  assert.equal(detached.detached, true);
+  assert.ok(detached.position, "a detached camera reports its pose");
+
+  // Turning the option back off is always a way home, even without the toggle.
+  await game.devParams.set("free_camera", 0);
+  await game.step({ frames: 2 });
+  assert.equal((await game.camera.state()).detached, false);
+});
+
+test("a detached camera holds its pose while the player walks", { skip }, async () => {
+  await using game = await GameServer.launch({
+    mission: "medsci1.mis",
+    port: 8114,
+  });
+  await game.step({ frames: 30 });
+
+  await game.devParams.set("free_camera", 1);
+  await game.input.trigger("ToggleFreeCamera");
+  await game.step({ frames: 2 });
+
+  const camera = await game.camera.state();
+  assert.ok(camera.position, "expected a captured camera pose");
+  const playerBefore = await game.player.position();
+
+  // Walk the player away. The camera must not follow: it is a render-layer
+  // override, and the simulation underneath it is untouched.
+  await game.input.set("right_hand.thumbstick", [0, 1]);
+  await game.step({ frames: 90 });
+  await game.input.set("right_hand.thumbstick", [0, 0]);
+  await game.step({ frames: 3 });
+
+  const after = await game.camera.state();
+  assert.ok(after.position);
+  for (let axis = 0; axis < 3; axis++) {
+    assert.ok(
+      Math.abs(after.position[axis] - camera.position[axis]) < 1e-3,
+      `camera drifted on axis ${axis}: ${camera.position} -> ${after.position}`,
+    );
+  }
+
+  // ...and the player really did move, so the camera holding still is a
+  // decoupled camera rather than a frozen simulation.
+  const playerAfter = await game.player.position();
+  const walked = Math.hypot(
+    playerAfter.x - playerBefore.x,
+    playerAfter.z - playerBefore.z,
+  );
+  assert.ok(walked > 1, `expected the pawn to walk away (moved ${walked})`);
+});
+
+test("a level reload re-attaches the camera", { skip }, async () => {
+  await using game = await GameServer.launch({
+    mission: "medsci1.mis",
+    port: 8115,
+  });
+  await game.step({ frames: 30 });
+
+  await game.devParams.set("free_camera", 1);
+  await game.input.trigger("ToggleFreeCamera");
+  await game.step({ frames: 2 });
+  assert.equal((await game.camera.state()).detached, true);
+
+  // A scene swap: the camera's pose belongs to the outgoing scene, so carrying
+  // it over would render the new one from inside its geometry - and strand the
+  // player, since the pawn-anchored menu is not visible from a detached camera.
+  await game.input.trigger("DebugReloadLevel");
+  await game.step({ frames: 120 });
+
+  const after = await game.camera.state();
+  assert.equal(after.detached, false, "a scene swap must re-attach the camera");
+  assert.equal(after.position, null);
+  assert.equal(after.enabled, true, "the developer option itself is not reset");
+});


### PR DESCRIPTION
Stacked on #1131.

Adds the debug camera's core: a **render-layer pose override** that detaches the view from the player while leaving the simulation untouched. The pawn does not move, so everything that reads the player's position — AI (`PlayerInfo.pos`), triggers, audio — keeps reading the body. Movement is the next PR; here the camera freezes where it detached.

## Culling stays on the player

Deliberately: flying out then shows exactly what the *player's* viewpoint decided to draw, which is the point of watching from outside. `finish_render` applies a fixup composed in `render` from the two poses that frame was built with — a right-multiplied correction rather than a rebuilt view matrix, because only the runtime knows the rest of the chain (in VR the view also carries the tracked head offset, which `Game` never sees). Since both views share that prefix, composing `camera_to_world * world_to_pawn` on the right cancels the camera and substitutes the pawn exactly, whatever the prefix was. A unit test proves this against a synthetic head offset.

The **Cull from cam** switch opts into culling from the camera for when you would rather just look at things.

## Two switches gate it

The registry's first `Bool` params (a kind its own comments already anticipated).

- **Free camera** is the enable. Until it is on the toggle input is not read at all, so a stray press during normal play cannot detach the view; turning it off while detached re-attaches. The gate lives at the single consumption point in `Game::update` — beside `TogglePauseMenu`, and not an `Effect` for the same reason — so desktop, Quest and HTTP injection cannot drift from one rule.
- **Cull from cam** picks which pose feeds `CullingInfo`.

## Controls

Desktop `Alt+V` (`Option+V` on macOS), matching the Alt-modified debug bindings already there. On the Quest it is a **chord** (right `A`+`B`) rather than a button — and after rebasing onto #1144, which gave right `A` to Reload and right `B` to CycleAmmo, there is no unbound button left on the Touch at all (`X`, `Y`, left `Menu`, both stick clicks are taken; right `Menu` belongs to the system UI). So the chord **shares** those two gun buttons. That is safe because it is dead unless the developer option is on; while it *is* on, `oculus_runtime` suppresses whichever button is pressed **second**, so completing the chord cannot also swap your ammo. The first press still fires its own action, which is why the harmless one (Reload, right `A`) is the natural opener. With the option off, both buttons behave exactly as #1144 defines them.

`sync_chord` resolves the pair's edge using the existing held set as its latch, and holds that latch across inactive frames so refocusing with both buttons held cannot mint a toggle nobody pressed. Also triggerable over HTTP as `ToggleFreeCamera`.

## Verification

`GET /v1/camera` reports the camera's state (detached, enabled, and the pose it renders from) so this is checkable without reading pixels. `tools/shock2-sdk/test/free-camera.e2e.test.ts` covers the gate withholding the toggle, the camera holding its pose while the live player walks away, and re-attachment on a scene swap.

Rebasing also pushed the registry past what the Developer pane can show at once (rows cap at `FIELD_TOP_Y / ROW_PITCH` = 11), so the free-camera switches sit **below the fold** and are reached with the scroll rocker #1129 added. The panel test that asserted "a tall pane needs no rocker" asserted a premise that no longer exists; it now pins the cap instead, and that branch keeps generic coverage in `list_scroll`'s own tests.

- 1045 unit tests pass; `RUSTFLAGS="-D warnings" cargo check` clean on `shock2vr`, `desktop_runtime`, `debug_runtime`; `cargo apk check` clean for the Quest.
- Reviewed with `/xreview` (two independent engines + a de-dup pass). Fixed before opening: re-attach on `set_active_scene` (a detached camera survived a level change and stranded the player behind a pawn-anchored menu), the chord's refocus edge, and the SDK's `DevParamSummary` type, which still declared `kind: "float"` with required `min`/`max`/`step`.

## Media

### `free_camera_cull` — which pose culling follows

![cull from player vs cull from camera](https://gist.githubusercontent.com/tommy-xr/57e4799816adf3196bc4a991589a9b62/raw/free-camera-culling.png)

<sub>The same detached camera pose in medsci1, flown up out of the med bay start into the pipe chase above it. Left: the default, culling from the **player** — the cells around the camera are not in the pawn's visibility set, so most of the frame is legitimately black, which is what makes the camera a tool for *inspecting* visibility. Right: `free_camera_cull=1`, culling from the **camera** — the world renders normally around it.</sub>

![free camera detach and fly](https://gist.githubusercontent.com/tommy-xr/57e4799816adf3196bc4a991589a9b62/raw/free-camera-demo.gif)

<sub>Detach freezes the view on the pawn's pose (the first ~0.4 s here are byte-identical frames while the sim keeps running), after which the camera flies free of the body. Flight itself lands in #1135. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

https://claude.ai/code/session_01LtYWgpGWumTuUgV98JbttN

