### PR TITLE
feat(debug): fly the free camera with the locomotion controls

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -151,6 +151,29 @@ from cam** when you would rather just look at things. The developer option is
 the gate: while it is off the `Alt+V` / `A`+`B` toggle does nothing, and turning
 it off while detached re-attaches the camera.
 
+Flying uses the ordinary locomotion controls, so they are the ones your hands
+already know - and while the camera has them, the player stands still rather
+than sleepwalking off:
+
+| Control | Desktop | Effect |
+| ------- | ------- | ------ |
+| Right thumbstick | `W` `A` `S` `D` | fly along the view / strafe |
+| Left thumbstick x | `←` `→` | turn |
+| Left thumbstick y | `↑` `↓` | rise / fall |
+| Head / mouse | mouse | aim (the camera is a freeze-frame of the eye, so looking works as it always does) |
+| — | `Shift` | double speed |
+
+The camera noclips - flying through a wall to look at the far side is the tool
+working, not a bug. **Cam speed** sets the pace in the player's own speed
+units - the default *is* the player's walk speed. Those are pre-scale SS2
+units, not world units per second (the default 25 travels 10 world units a
+second), because the camera divides by `dark::SCALE_FACTOR` exactly as
+locomotion does.
+
+Headlessly, `GET /v1/camera` reports whether the camera is detached and the
+pose it is rendering from, so a test can check what the camera did without
+reading pixels - see `tools/shock2-sdk/test/free-camera.e2e.test.ts`.
+
 #### 3b. Oculus Quest 2
 
 ##### Pre-requisites

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -227,6 +227,24 @@ dev_params! {
     /// something. Inert while the camera is attached (the two poses are the
     /// same pose).
     FREE_CAMERA_CULL_FROM_CAMERA = bool("free_camera_cull", "Cull from cam", false),
+    /// How fast the free camera flies, in the player's own speed units - the
+    /// default IS [`PLAYER_MOVE_SPEED`], so "walking pace" cannot drift from
+    /// what walking actually is. These are pre-scale SS2 units, not world
+    /// units per second: the consumer divides by `dark::SCALE_FACTOR` (2.5)
+    /// exactly as the player's locomotion does, so the default 25 travels 10
+    /// world units a second, not 25. The range spans a crawl to a fast survey of a
+    /// deck; live-tunable because the right speed depends entirely on what is
+    /// being inspected.
+    ///
+    /// [`PLAYER_MOVE_SPEED`]: crate::mission::PLAYER_MOVE_SPEED
+    FREE_CAMERA_SPEED = float(
+        "free_camera_speed",
+        "Cam speed",
+        crate::mission::PLAYER_MOVE_SPEED,
+        5.0,
+        200.0,
+        5.0
+    ),
 }
 
 /// Every parameter with its id, in declaration order.

--- a/shock2vr/src/free_camera.rs
+++ b/shock2vr/src/free_camera.rs
@@ -16,12 +16,21 @@
 //!   while detached - the player (default) or the camera. See
 //!   [`FreeCamera::cull_from_camera`].
 //!
-//! Movement is not implemented yet: the camera snaps to the eye it detached
-//! from and holds that pose.
+//! Flying reuses the player's own locomotion channels, so the controls are
+//! the ones the hands already know and no runtime needs its own mapping:
+//! right thumbstick strafes and moves along the view, left thumbstick turns
+//! (x) and rises/falls (y). On the desktop those are `W`/`A`/`S`/`D` and the
+//! arrow keys, and mouse-look aims the camera because the runtimes compose
+//! the head rotation onto the camera pose themselves. While detached those
+//! channels are withheld from the scene (see `Game::update`), so the pawn
+//! stands still rather than sleepwalking off while you fly.
 
-use cgmath::{Matrix4, Quaternion, SquareMatrix, Vector3};
+use cgmath::{Matrix4, Quaternion, Rotation, Rotation3, SquareMatrix, Vector3, vec3};
 
 use crate::dev_params;
+use crate::input_context::InputContext;
+use crate::mission::PLAYER_TURN_RATE;
+use crate::time::Time;
 
 /// A camera pose: where it is, and which way it faces.
 pub type Pose = (Vector3<f32>, Quaternion<f32>);
@@ -96,6 +105,57 @@ impl FreeCamera {
         dev_params::get_bool(dev_params::FREE_CAMERA_CULL_FROM_CAMERA)
     }
 
+    /// Fly the camera for one frame. A no-op while attached, and while the
+    /// pose has not been captured yet (the detach frame), so the camera never
+    /// moves before it has somewhere to move from.
+    ///
+    /// The motion is `mission_core`'s player locomotion with the physics
+    /// removed: the same channels, the same axes, the same turn rate - only
+    /// integrated straight into the pose instead of driven through a
+    /// character controller. That is what makes it noclip, and deliberately
+    /// so: flying through a wall to look at the far side is the tool working.
+    pub fn fly(&mut self, time: &Time, input_context: &InputContext) {
+        let Some((position, rotation)) = self.pose else {
+            return;
+        };
+        let delta_time = time.elapsed.as_secs_f32();
+        if delta_time == 0.0 {
+            // A paused sim must not drift, and the debug runtime pauses by
+            // calling update with a zero dt.
+            return;
+        }
+
+        let turn = input_context.left_hand.thumbstick.x * delta_time * PLAYER_TURN_RATE;
+        let rotation =
+            rotation * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), cgmath::Rad(turn));
+
+        // The head rotation is composed in for the *direction of travel* only.
+        // It is deliberately not stored: the runtimes apply it to the camera
+        // pose themselves when they build the view matrix, so keeping it would
+        // apply a tracked headset's rotation twice.
+        let facing = rotation * input_context.head.rotation;
+        let speed = dev_params::get(dev_params::FREE_CAMERA_SPEED) / dark::SCALE_FACTOR;
+        let step = delta_time * speed;
+        let move_thumbstick = input_context.right_hand.thumbstick;
+        let position = position
+            + facing.rotate_vector(vec3(
+                -step * move_thumbstick.x,
+                0.0,
+                -step * move_thumbstick.y,
+            ))
+            + vec3(0.0, step * input_context.left_hand.thumbstick.y, 0.0);
+
+        self.pose = Some((position, rotation));
+    }
+
+    /// Whether the scene should be denied this frame's locomotion input,
+    /// because the free camera is consuming it. The pawn keeps everything
+    /// else - it can still be looked at, damaged, and scripted - it just does
+    /// not walk while the sticks are flying the camera.
+    pub fn consumes_locomotion(&self) -> bool {
+        self.detached
+    }
+
     /// The pose to render this frame from, given the player's own. Captures
     /// the pawn pose on the first call after a detach.
     pub fn camera_pose(&mut self, pawn: Pose) -> Pose {
@@ -124,6 +184,28 @@ impl FreeCamera {
         let pawn_to_world = Matrix4::from_translation(pawn.0) * Matrix4::from(pawn.1);
         Some(camera_to_world * pawn_to_world.invert()?)
     }
+}
+
+/// The input context with the channels that move the body zeroed - what the
+/// scene sees while the free camera is flying on them. A copy rather than a
+/// mutation so the runtime's own context is left intact for the next frame,
+/// and so the hands keep their poses, triggers and grips: only moving the
+/// body is withheld, and the body can still be aimed, fired and inspected.
+///
+/// `crouch` is withheld along with the sticks, even though it is not
+/// locomotion, because the flat runtimes build their camera `head_offset`
+/// from the crouch-aware [`Game::player_eye_height`]: left through, it would
+/// drop the supposedly frozen camera by the crouch delta. (In VR the tracked
+/// head legitimately moves the view and never goes through that accessor.)
+///
+/// [`Game::player_eye_height`]: crate::Game::player_eye_height
+pub fn without_locomotion(input_context: &InputContext) -> InputContext {
+    let mut withheld = input_context.clone();
+    withheld.left_hand.thumbstick = cgmath::Vector2::new(0.0, 0.0);
+    withheld.right_hand.thumbstick = cgmath::Vector2::new(0.0, 0.0);
+    withheld.jump = false;
+    withheld.crouch = false;
+    withheld
 }
 
 #[cfg(test)]
@@ -202,6 +284,116 @@ mod tests {
         assert!(!FreeCamera::is_enabled());
         camera.sync_gate();
         assert!(!camera.is_detached());
+    }
+
+    fn one_second() -> Time {
+        Time {
+            elapsed: std::time::Duration::from_secs(1),
+            total: std::time::Duration::from_secs(1),
+        }
+    }
+
+    /// A camera detached and flown forward for a second. Returns its pose.
+    fn flown(stick: impl Fn(&mut InputContext)) -> Pose {
+        let mut camera = FreeCamera::new();
+        camera.toggle();
+        camera.camera_pose((vec3(0.0, 0.0, 0.0), Quaternion::from_angle_y(Deg(0.0_f32))));
+        let mut input = InputContext::default();
+        input.head.rotation = Quaternion::from_angle_y(Deg(0.0_f32));
+        stick(&mut input);
+        camera.fly(&one_second(), &input);
+        camera.camera_pose((
+            vec3(99.0, 99.0, 99.0),
+            Quaternion::from_angle_y(Deg(0.0_f32)),
+        ))
+    }
+
+    /// Forward on the right stick moves along -Z, the same axis the player
+    /// walks along in `mission_core`.
+    #[test]
+    fn the_right_stick_flies_along_the_view() {
+        let (position, _) = flown(|input| input.right_hand.thumbstick.y = 1.0);
+        assert!(position.z < -0.1, "expected -Z travel, got {position:?}");
+        assert!(position.x.abs() < 1e-4 && position.y.abs() < 1e-4);
+    }
+
+    /// The left stick's y is vertical, in world space - flying up is up
+    /// however the camera is pitched.
+    #[test]
+    fn the_left_stick_y_flies_vertically() {
+        let (position, _) = flown(|input| input.left_hand.thumbstick.y = 1.0);
+        assert!(position.y > 0.1, "expected +Y travel, got {position:?}");
+        assert!(position.x.abs() < 1e-4 && position.z.abs() < 1e-4);
+    }
+
+    /// The left stick's x turns and does not translate.
+    #[test]
+    fn the_left_stick_x_turns_in_place() {
+        let (position, rotation) = flown(|input| input.left_hand.thumbstick.x = 1.0);
+        assert!(position.magnitude() < 1e-4, "turning must not move");
+        let facing = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(facing.x.abs() > 0.1, "expected a yaw, got {facing:?}");
+        assert!(facing.y.abs() < 1e-4, "yaw must not pitch the camera");
+    }
+
+    /// An attached camera ignores the sticks entirely - the player is walking
+    /// on them.
+    #[test]
+    fn an_attached_camera_does_not_fly() {
+        let mut camera = FreeCamera::new();
+        let mut input = InputContext::default();
+        input.right_hand.thumbstick.y = 1.0;
+        camera.fly(&one_second(), &input);
+        assert_eq!(camera.camera_pose(pawn()), pawn());
+    }
+
+    /// A paused sim must not drift: the debug runtime pauses by calling
+    /// update with a zero dt.
+    #[test]
+    fn a_zero_timestep_does_not_move_the_camera() {
+        let mut camera = FreeCamera::new();
+        camera.toggle();
+        camera.camera_pose(pawn());
+        let mut input = InputContext::default();
+        input.right_hand.thumbstick.y = 1.0;
+        camera.fly(
+            &Time {
+                elapsed: std::time::Duration::ZERO,
+                total: std::time::Duration::from_secs(1),
+            },
+            &input,
+        );
+        assert_eq!(camera.camera_pose(pawn()), pawn());
+    }
+
+    /// Withholding must take the channels that move the body and nothing
+    /// else: the hands keep working, so the body can still be aimed and fired
+    /// while the camera watches from outside.
+    #[test]
+    fn withholding_locomotion_keeps_everything_but_walking() {
+        let mut input = InputContext::default();
+        input.left_hand.thumbstick = cgmath::Vector2::new(1.0, 1.0);
+        input.right_hand.thumbstick = cgmath::Vector2::new(1.0, 1.0);
+        input.jump = true;
+        input.crouch = true;
+        input.right_hand.trigger_value = 1.0;
+        input.head.position = vec3(0.0, 5.6, 0.0);
+
+        let withheld = without_locomotion(&input);
+        assert_eq!(
+            withheld.left_hand.thumbstick,
+            cgmath::Vector2::new(0.0, 0.0)
+        );
+        assert_eq!(
+            withheld.right_hand.thumbstick,
+            cgmath::Vector2::new(0.0, 0.0)
+        );
+        assert!(!withheld.jump);
+        // Crouch moves the flat runtimes' camera through the crouch-aware eye
+        // height, so a "frozen" camera must not see it either.
+        assert!(!withheld.crouch);
+        assert_eq!(withheld.right_hand.trigger_value, 1.0);
+        assert_eq!(withheld.head.position, input.head.position);
     }
 
     /// The point of the fixup: composed onto the camera's view matrix it must

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1376,6 +1376,21 @@ impl Game {
         let action_effects = input::ActionDispatcher::dispatch(actions, input_context);
         actions.clear_triggered();
 
+        // Fly the detached camera, then withhold the channels it consumed from
+        // the scene so the pawn does not sleepwalk off while the sticks are
+        // flying. Everything else in the context still reaches the scene: the
+        // body can be looked at, damaged and scripted as usual - it just does
+        // not walk. Done here, in the one place the scene is updated, so no
+        // runtime has to know the camera exists.
+        self.free_camera.fly(time, input_context);
+        let withheld;
+        let input_context = if self.free_camera.consumes_locomotion() {
+            withheld = free_camera::without_locomotion(input_context);
+            &withheld
+        } else {
+            input_context
+        };
+
         // Update the scene (handles movement, physics, collision, teleport internally)
         let effects = self.active_game_scene.update(
             time,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1136,6 +1136,18 @@ struct FailedAnimationGuard {
     completion_owed: bool,
 }
 
+/// How fast the player turns on the left thumbstick, in radians per second at
+/// full deflection. Shared with the free camera ([`crate::free_camera`]) so
+/// the detached view turns at the rate the body does; retuning one retunes
+/// both, rather than the two silently drifting apart.
+pub const PLAYER_TURN_RATE: f32 = 2.0;
+
+/// How fast the player walks, in SS2 units per second at full deflection
+/// (divided by `dark::SCALE_FACTOR` at the point of use). Shared with the
+/// free camera, whose speed dev param defaults to it so "walking pace" stays
+/// the same pace.
+pub const PLAYER_MOVE_SPEED: f32 = 25.0;
+
 pub struct MissionCore {
     pub level_name: String,
     pub gui: GuiManager,
@@ -2520,10 +2532,9 @@ impl MissionCore {
                     .update(input_context, player.pos, player.rotation, delta_time);
             effects.extend(teleport_effects);
         }
-        let rot_speed = 2.0;
         let additional_rotation = cgmath::Quaternion::from_axis_angle(
             cgmath::vec3(0.0, 1.0, 0.0),
-            cgmath::Rad(input_context.left_hand.thumbstick.x * delta_time * rot_speed),
+            cgmath::Rad(input_context.left_hand.thumbstick.x * delta_time * PLAYER_TURN_RATE),
         );
 
         let new_rotation = player.rotation * additional_rotation;
@@ -2532,9 +2543,9 @@ impl MissionCore {
         let facing = dir.rotate_vector(cgmath::vec3(0.0, 0.0, -1.0));
         let move_thumbstick_value = input_context.right_hand.thumbstick;
         let forward = dir.rotate_vector(cgmath::vec3(
-            -delta_time * move_thumbstick_value.x * 25. / dark::SCALE_FACTOR,
+            -delta_time * move_thumbstick_value.x * PLAYER_MOVE_SPEED / dark::SCALE_FACTOR,
             0.0,
-            -delta_time * move_thumbstick_value.y * 25. / dark::SCALE_FACTOR,
+            -delta_time * move_thumbstick_value.y * PLAYER_MOVE_SPEED / dark::SCALE_FACTOR,
         ));
 
         let up_value = input_context.left_hand.thumbstick.y / dark::SCALE_FACTOR;

--- a/tools/shock2-sdk/test/free-camera.e2e.test.ts
+++ b/tools/shock2-sdk/test/free-camera.e2e.test.ts
@@ -12,8 +12,9 @@ import { GameServer } from "../src/index.js";
 // Negative-first, per assertion:
 //   - "the gate withholds the toggle" fails if the gate check is removed from
 //     `Game::update` (the camera detaches with the developer option off).
-//   - "the camera holds its pose" fails against a build that returns the pawn
-//     pose unconditionally from `Game::render`.
+//   - "flying moves the camera, not the pawn" fails both ways without this
+//     change: with no override the camera does not fly, and without
+//     `without_locomotion` the pawn walks off on the same stick.
 //   - "a level reload re-attaches" fails against the first version of this
 //     change, which left `free_camera` untouched in `set_active_scene` and so
 //     carried a stale pose (and `detached: true`) into the new scene.
@@ -53,7 +54,7 @@ test("the free camera is inert until the developer option enables it", { skip },
   assert.equal((await game.camera.state()).detached, false);
 });
 
-test("a detached camera holds its pose while the player walks", { skip }, async () => {
+test("flying the camera moves it and leaves the pawn standing", { skip }, async () => {
   await using game = await GameServer.launch({
     mission: "medsci1.mis",
     port: 8114,
@@ -68,8 +69,8 @@ test("a detached camera holds its pose while the player walks", { skip }, async 
   assert.ok(camera.position, "expected a captured camera pose");
   const playerBefore = await game.player.position();
 
-  // Walk the player away. The camera must not follow: it is a render-layer
-  // override, and the simulation underneath it is untouched.
+  // Push forward on the stick. The camera flies; the pawn must NOT walk,
+  // because the camera is holding those channels.
   await game.input.set("right_hand.thumbstick", [0, 1]);
   await game.step({ frames: 90 });
   await game.input.set("right_hand.thumbstick", [0, 0]);
@@ -77,21 +78,21 @@ test("a detached camera holds its pose while the player walks", { skip }, async 
 
   const after = await game.camera.state();
   assert.ok(after.position);
-  for (let axis = 0; axis < 3; axis++) {
-    assert.ok(
-      Math.abs(after.position[axis] - camera.position[axis]) < 1e-3,
-      `camera drifted on axis ${axis}: ${camera.position} -> ${after.position}`,
-    );
-  }
+  const flew = Math.hypot(
+    after.position[0] - camera.position[0],
+    after.position[2] - camera.position[2],
+  );
+  assert.ok(flew > 1, `expected the camera to fly (moved ${flew})`);
 
-  // ...and the player really did move, so the camera holding still is a
-  // decoupled camera rather than a frozen simulation.
   const playerAfter = await game.player.position();
   const walked = Math.hypot(
     playerAfter.x - playerBefore.x,
     playerAfter.z - playerBefore.z,
   );
-  assert.ok(walked > 1, `expected the pawn to walk away (moved ${walked})`);
+  assert.ok(
+    walked < 0.1,
+    `the pawn must not walk while the camera flies (moved ${walked})`,
+  );
 });
 
 test("a level reload re-attaches the camera", { skip }, async () => {


### PR DESCRIPTION
Stacked on #1134.

Gives the detached camera movement, on the channels the player already walks on:

| Control | Desktop | Effect |
| --- | --- | --- |
| Right thumbstick | `W` `A` `S` `D` | fly along the view / strafe |
| Left thumbstick x | `←` `→` | turn |
| Left thumbstick y | `↑` `↓` | rise / fall |
| Head | mouse | aim |
| — | `Shift` | double speed |

Because it reuses the player's own `InputContext` locomotion channels, there is **no per-runtime code**: desktop keys, Quest sticks and `/v1/control/input` all fly it through one mapping, and the controls transfer from walking without being learned. Mouse-look aims the camera for free, because the runtimes compose the head rotation onto the camera pose themselves.

The motion is `mission_core`'s player locomotion with the physics removed — same axes, same turn rate — integrated straight into the pose. That is what makes it **noclip**, deliberately: flying through a wall to look at the far side is the tool working. The two constants are now shared (`PLAYER_TURN_RATE`, `PLAYER_MOVE_SPEED`) rather than copied, so retuning the player retunes the camera instead of silently desyncing it; the speed dev param's default *is* the player's walk speed. (Those are pre-scale SS2 units, as locomotion's are: the default 25 travels 10 world units a second, since both divide by `dark::SCALE_FACTOR`.)

While the camera holds those channels the scene is handed a context with them zeroed, so the pawn stands still instead of sleepwalking off while you fly. Only body movement is withheld — hand poses, triggers and grips still reach the scene, so the body can be aimed and fired while you watch from outside. `crouch` is withheld too, because the flat runtimes build their camera `head_offset` from the crouch-aware `player_eye_height()` and would otherwise drop the supposedly frozen camera by the crouch delta. A zero timestep — how the debug runtime pauses — does not drift.

## Verification

The e2e from #1134 gains the flight case: fly forward for 1.5 s and assert the camera moved while `/v1/player/position` did not. Locally the pawn moved <1e-4 across the whole flight.

963 unit tests pass (covering each axis, the zero-dt pause, and that withholding takes only the body-moving channels); `-D warnings` check clean on the three host crates; `cargo apk check` clean for the Quest.

## Media

![free camera flight demo](https://gist.githubusercontent.com/tommy-xr/57e4799816adf3196bc4a991589a9b62/raw/free-camera-demo.gif)

<sub>medsci1, flat presentation. The view holds still for the first ~0.4 s after detaching (the pawn is frozen, the sim keeps running), then the ordinary locomotion channels fly it forward, up through the light fixture and pitch it down over the floor — a pose the character controller cannot reach. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### `free_camera_cull` — which pose culling follows

![cull from player vs cull from camera](https://gist.githubusercontent.com/tommy-xr/57e4799816adf3196bc4a991589a9b62/raw/free-camera-culling.png)

<sub>The same detached camera pose, flown up out of the med bay start into the pipe chase above it. Left: the default, culling from the **player** — the cells around the camera are not in the pawn's visibility set, so most of the frame is legitimately black. Right: `free_camera_cull=1`, culling from the **camera** — the world renders normally around it.</sub>

https://claude.ai/code/session_01LtYWgpGWumTuUgV98JbttN

