### PR TITLE
feat(vr): drop a held item into the cyber-interface inventory

### DIFF
--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -280,6 +280,18 @@ impl FlatUiHost {
         self.strip.as_ref().map(|s| s.entity)
     }
 
+    /// Whether `canvas_pos` lands on the top-docked inventory strip.
+    ///
+    /// The strip is the interface's "put it in the backpack" surface, so a VR
+    /// hand releasing a held item over it deposits rather than drops (see
+    /// `MissionCore::strip_deposit_entities`). Answered from the same
+    /// [`strip_rect`](Self::strip_rect) the host hit-tests its own gestures
+    /// against, so the drop target can never drift from the drawn strip.
+    pub fn strip_contains(&self, canvas_pos: Vector2<f32>) -> bool {
+        self.strip_rect()
+            .is_some_and(|rect| rect.contains(canvas_pos))
+    }
+
     /// The item currently held on the cursor mid-drag (for `/v1/ui` `cursor`).
     pub fn cursor_debug(&self) -> Option<crate::game_scene::DebugUiCursor> {
         self.cursor_item

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2826,9 +2826,10 @@ impl MissionCore {
         // `VirtualHand` performs. (A hand that is holding something never has
         // its squeeze swallowed - `update_squeeze_swallow` drops the latch the
         // moment the hand is full - so this cannot fire on a masked squeeze.)
-        // Resolved up front: without a backpack to deposit into there is
-        // nothing to claim, and the ordinary world drop must stay intact
-        // rather than be suppressed into an item that goes nowhere.
+        //
+        // The backpack is resolved first, and nothing is claimed without one:
+        // the ordinary world drop must stay intact rather than be suppressed
+        // into an item that goes nowhere.
         let player_inventory = self
             .world
             .borrow::<UniqueView<PlayerInfo>>()

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -285,31 +285,88 @@ fn strip_deposit_entities(
         .collect()
 }
 
-/// Take the world-drop half out of a release that [`strip_deposit_entities`]
-/// claimed as a deposit.
+/// Rewrite a release that [`strip_deposit_entities`] claimed, from the world
+/// drop `VirtualHand` emitted into the backpack deposit the player meant.
 ///
-/// Two effects have to go. `DropItem` is the world drop itself - it restores
-/// the item's world refs and rebuilds its physics body, which is the very
-/// outcome the deposit replaces. And `ProvideForConsumption` is the offer the
-/// hand makes to whatever its release raycast hit: because the panel is not
-/// physical that ray reaches straight through it, so a container standing
-/// behind the interface would otherwise take the item as well and the deposit
-/// would land twice. Everything else the hand emitted this frame is untouched.
-fn suppress_world_drop(effects: &mut Vec<VirtualHandEffect>, deposits: &[EntityId]) {
-    if deposits.is_empty() {
+/// Each claimed item's `DropItem` - the world drop itself, which restores its
+/// world refs and rebuilds its physics body - becomes the `Drop` message its
+/// scripts are always owed on leaving the hand (the world-model restore and
+/// psi-charge cancel that [`VirtualHandEffect::StoreItem`] documents a *held*
+/// store must be paired with), followed by the store itself. Both stay hand
+/// effects so they are applied in `process_virtual_hand_effects`, in the same
+/// frame and at the same point the drop they replace would have been - the
+/// `Drop` therefore still reaches this frame's `script_world.update`.
+///
+/// `collect` is the keycard exception (see the caller): those are Frobbed
+/// rather than stored, so the credential is recorded instead of an inert card
+/// being banked.
+///
+/// The `ProvideForConsumption` offer goes too. It is what the hand offers to
+/// whatever its release raycast hit, and because the panel is not physical
+/// that ray reaches straight through it - so a container standing behind the
+/// interface would otherwise take the item as well and the deposit would land
+/// twice. Everything else the hand emitted this frame is untouched.
+fn rewrite_strip_release(
+    effects: &mut Vec<VirtualHandEffect>,
+    store: &[EntityId],
+    collect: &[EntityId],
+) {
+    if store.is_empty() && collect.is_empty() {
         return;
     }
-    effects.retain(|effect| match effect {
-        VirtualHandEffect::DropItem { entity_id } => !deposits.contains(entity_id),
-        VirtualHandEffect::OutMessage {
-            message:
-                Message {
-                    payload: MessagePayload::ProvideForConsumption { entity },
-                    ..
-                },
-        } => !deposits.contains(entity),
-        _ => true,
-    });
+    let claimed = |entity_id: &EntityId| store.contains(entity_id) || collect.contains(entity_id);
+    let mut rewritten = Vec::with_capacity(effects.len());
+    for effect in effects.drain(..) {
+        match effect {
+            VirtualHandEffect::DropItem { entity_id } if claimed(&entity_id) => {
+                rewritten.push(VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to: entity_id,
+                        payload: MessagePayload::Drop,
+                    },
+                });
+                rewritten.push(if collect.contains(&entity_id) {
+                    VirtualHandEffect::OutMessage {
+                        message: Message {
+                            to: entity_id,
+                            payload: MessagePayload::Frob,
+                        },
+                    }
+                } else {
+                    VirtualHandEffect::StoreItem { entity_id }
+                });
+            }
+            VirtualHandEffect::OutMessage {
+                message:
+                    Message {
+                        payload: MessagePayload::ProvideForConsumption { entity },
+                        ..
+                    },
+            } if claimed(&entity) => {}
+            kept => rewritten.push(kept),
+        }
+    }
+    *effects = rewritten;
+}
+
+/// Whether the player's backpack can actually take a deposit right now.
+///
+/// This is exactly [`move_live_entity_into_container`]'s success condition for
+/// a live item: a container without `Links` has nowhere to record the new
+/// `Contains`, and the transfer silently does nothing. Claiming a release the
+/// backpack cannot accept would suppress the world drop for an item that then
+/// lands nowhere at all, so the claim is gated on it and an unusable backpack
+/// simply leaves the ordinary world drop alone.
+fn backpack_accepts_deposit(world: &World) -> bool {
+    let Ok(inventory_entity) = world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .map(|player| player.inventory_entity_id)
+    else {
+        return false;
+    };
+    world
+        .borrow::<View<Links>>()
+        .is_ok_and(|links| links.get(inventory_entity).is_ok())
 }
 
 /// Head-relative authored-space placement for the wide VR backpack canvas.
@@ -2752,7 +2809,14 @@ impl MissionCore {
                     continue;
                 };
                 on_panel[hand_slot(ray.handedness)] = true;
-                if self.use_mode && self.flat_ui.strip_contains(canvas_hit) {
+                // Stated locally rather than leaned on: the pointer pass only
+                // exists in VR use mode, but the deposit below reads
+                // `held_entities()`, whose slot 0 is the *wielded weapon* in
+                // flat - so the VR gate must be visible where the claim is
+                // made, not two indirections away.
+                if game_options.presentation_mode == crate::PresentationMode::Vr
+                    && self.flat_ui.strip_contains(canvas_hit)
+                {
                     on_strip[hand_slot(ray.handedness)] = true;
                 }
             }
@@ -2827,26 +2891,32 @@ impl MissionCore {
         // its squeeze swallowed - `update_squeeze_swallow` drops the latch the
         // moment the hand is full - so this cannot fire on a masked squeeze.)
         //
-        // The backpack is resolved first, and nothing is claimed without one:
-        // the ordinary world drop must stay intact rather than be suppressed
-        // into an item that goes nowhere.
-        let player_inventory = self
-            .world
-            .borrow::<UniqueView<PlayerInfo>>()
-            .map(|player| player.inventory_entity_id)
-            .ok();
-        let strip_deposits = player_inventory
-            .map(|_| {
-                strip_deposit_entities(
-                    on_strip,
-                    [left_hand_held, right_hand_held],
-                    [
-                        hands_input.left_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
-                        hands_input.right_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
-                    ],
-                )
-            })
-            .unwrap_or_default();
+        // Nothing is claimed unless the backpack can actually take it, so a
+        // release is never suppressed into an item that lands nowhere.
+        let strip_deposits = if backpack_accepts_deposit(&self.world) {
+            strip_deposit_entities(
+                on_strip,
+                [left_hand_held, right_hand_held],
+                [
+                    hands_input.left_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
+                    hands_input.right_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
+                ],
+            )
+        } else {
+            Vec::new()
+        };
+        // The keycard exception, the same one `ContainerGui`'s own `Take`
+        // makes on the same predicate: a `PropKeySrc` carries a runtime
+        // `internal_keycard` script whose Frob records the credential, so
+        // banking the card bodily would put an object in the pack that unlocks
+        // nothing. Reachable only for a card restored into a hand by an older
+        // save - grabbing one routes through Frob - which is exactly why
+        // `held_trigger_press_payload` keeps its own keycard arm.
+        let (collect, store): (Vec<_>, Vec<_>) = strip_deposits
+            .iter()
+            .partition(|entity_id| crate::virtual_hand::is_key_source(&self.world, **entity_id));
+        let collect: Vec<_> = collect.into_iter().copied().collect();
+        let store: Vec<_> = store.into_iter().copied().collect();
 
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.
@@ -2859,11 +2929,8 @@ impl MissionCore {
             head_rotation: input_context.head.rotation,
             eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
         });
-        suppress_world_drop(&mut interaction_msgs, &strip_deposits);
+        rewrite_strip_release(&mut interaction_msgs, &store, &collect);
         self.process_virtual_hand_effects(asset_cache, interaction_msgs);
-        if let Some(inventory_entity) = player_inventory.filter(|_| !strip_deposits.is_empty()) {
-            effects.extend(self.strip_deposit_effects(inventory_entity, &strip_deposits));
-        }
 
         // Tag the wielded weapon with the flat camera/crosshair fire ray so its
         // firing scripts spawn projectiles along the crosshair (camera-origin
@@ -3875,55 +3942,6 @@ impl MissionCore {
             self.make_un_physical(dropped_entity_id);
         }
         moved
-    }
-
-    /// Put the items released onto the cyber interface's inventory strip into
-    /// the player's backpack (see [`strip_deposit_entities`]).
-    ///
-    /// Each one gets the `Drop` its release always owes it - the world-model
-    /// restore and psi-charge cancel that [`VirtualHandEffect::StoreItem`]
-    /// documents must precede storing a *held* item - and then the transfer
-    /// itself. A key source takes the panel's own exception: `PropKeySrc`
-    /// carries a runtime `internal_keycard` script whose Frob records the
-    /// credential, so moving the card bodily into the backpack would bank an
-    /// object that unlocks nothing (the same call `ContainerGui`'s `Take`
-    /// makes, on the same `is_key_source` predicate).
-    ///
-    /// No capacity check: `drop_entity_into_container` accepts into a full
-    /// pack, and this path deliberately does not change that.
-    fn strip_deposit_effects(
-        &self,
-        inventory_entity: EntityId,
-        deposits: &[EntityId],
-    ) -> Vec<Effect> {
-        deposits
-            .iter()
-            .flat_map(|entity_id| {
-                let entity_id = *entity_id;
-                let transfer = if crate::virtual_hand::is_key_source(&self.world, entity_id) {
-                    Effect::Send {
-                        msg: Message {
-                            payload: MessagePayload::Frob,
-                            to: entity_id,
-                        },
-                    }
-                } else {
-                    Effect::DropEntityInfo {
-                        parent_entity_id: inventory_entity,
-                        dropped_entity_id: entity_id,
-                    }
-                };
-                [
-                    Effect::Send {
-                        msg: Message {
-                            payload: MessagePayload::Drop,
-                            to: entity_id,
-                        },
-                    },
-                    transfer,
-                ]
-            })
-            .collect()
     }
 
     /// Re-encode the backpack's stored cells after effective Strength changes.
@@ -10779,9 +10797,9 @@ mod vr_trigger_safe_tests {
 
 #[cfg(test)]
 mod strip_deposit_tests {
-    use super::*;
+    use cgmath::One;
 
-    const LEFT: usize = 0;
+    use super::*;
 
     fn two_entities() -> (World, EntityId, EntityId) {
         let mut world = World::new();
@@ -10839,19 +10857,64 @@ mod strip_deposit_tests {
         );
     }
 
-    /// The world-drop half of a claimed release has to go, or the item is
-    /// both banked and spawned as a loose prop.
+    /// The world drop becomes the store, in place: the item is banked instead
+    /// of spawned as a loose prop, and the `Drop` its scripts are owed still
+    /// goes out first (and still as a hand effect, so it lands in this frame's
+    /// dispatch rather than a later effect pass).
     #[test]
-    fn a_claimed_release_loses_its_world_drop() {
+    fn a_claimed_release_becomes_a_backpack_store() {
         let (_world, item, other) = two_entities();
         let mut effects = vec![
             VirtualHandEffect::DropItem { entity_id: item },
             VirtualHandEffect::DropItem { entity_id: other },
         ];
-        suppress_world_drop(&mut effects, &[item]);
+        rewrite_strip_release(&mut effects, &[item], &[]);
         assert!(
-            matches!(effects.as_slice(), [VirtualHandEffect::DropItem { entity_id }] if *entity_id == other),
-            "only the deposited item's world drop is suppressed, got {effects:?}"
+            matches!(
+                effects.as_slice(),
+                [
+                    VirtualHandEffect::OutMessage {
+                        message: Message {
+                            to,
+                            payload: MessagePayload::Drop
+                        }
+                    },
+                    VirtualHandEffect::StoreItem { entity_id },
+                    VirtualHandEffect::DropItem {
+                        entity_id: untouched
+                    },
+                ] if *to == item && *entity_id == item && *untouched == other
+            ),
+            "got {effects:?}"
+        );
+    }
+
+    /// The keycard exception: a card is collected through its Frob, not banked
+    /// as an object that unlocks nothing.
+    #[test]
+    fn a_claimed_key_source_is_frobbed_instead() {
+        let (_world, card, _other) = two_entities();
+        let mut effects = vec![VirtualHandEffect::DropItem { entity_id: card }];
+        rewrite_strip_release(&mut effects, &[], &[card]);
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [
+                    VirtualHandEffect::OutMessage {
+                        message: Message {
+                            payload: MessagePayload::Drop,
+                            ..
+                        }
+                    },
+                    VirtualHandEffect::OutMessage {
+                        message: Message {
+                            to,
+                            payload: MessagePayload::Frob
+                        }
+                    },
+                ] if *to == card
+            ),
+            "got {effects:?}"
         );
     }
 
@@ -10867,14 +10930,15 @@ mod strip_deposit_tests {
                 payload: MessagePayload::ProvideForConsumption { entity: item },
             },
         }];
-        suppress_world_drop(&mut effects, &[item]);
+        rewrite_strip_release(&mut effects, &[item], &[]);
         assert!(effects.is_empty(), "got {effects:?}");
     }
 
     /// Everything else the hand emitted this frame is none of this rule's
-    /// business - notably the `Hover` every frame carries.
+    /// business - notably the `Hover` every frame carries. Order is preserved
+    /// too, so a rewritten frame stays the frame the hand meant.
     #[test]
-    fn unrelated_hand_effects_survive() {
+    fn unrelated_hand_effects_survive_in_order() {
         let (_world, item, other) = two_entities();
         let mut effects = vec![
             VirtualHandEffect::OutMessage {
@@ -10885,8 +10949,22 @@ mod strip_deposit_tests {
             },
             VirtualHandEffect::HoldItem { entity_id: item },
         ];
-        suppress_world_drop(&mut effects, &[item]);
-        assert_eq!(effects.len(), 2, "got {effects:?}");
+        rewrite_strip_release(&mut effects, &[item], &[]);
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [
+                    VirtualHandEffect::OutMessage {
+                        message: Message {
+                            payload: MessagePayload::TriggerRelease,
+                            ..
+                        }
+                    },
+                    VirtualHandEffect::HoldItem { .. },
+                ]
+            ),
+            "got {effects:?}"
+        );
     }
 
     /// With nothing claimed the frame is untouched, whatever it holds.
@@ -10894,15 +10972,36 @@ mod strip_deposit_tests {
     fn an_unclaimed_frame_is_untouched() {
         let (_world, item, _other) = two_entities();
         let mut effects = vec![VirtualHandEffect::DropItem { entity_id: item }];
-        suppress_world_drop(&mut effects, &[]);
-        assert_eq!(effects.len(), 1);
+        rewrite_strip_release(&mut effects, &[], &[]);
+        assert!(
+            matches!(effects.as_slice(), [VirtualHandEffect::DropItem { .. }]),
+            "got {effects:?}"
+        );
     }
 
-    /// `LEFT` is the slot the rest of this module indexes by, so the arrays
-    /// this rule reads cannot silently disagree with `hand_slot`.
+    /// The claim's precondition: a backpack that cannot record a `Contains`
+    /// would swallow the transfer silently, so nothing may be claimed against
+    /// it and the ordinary world drop must survive.
     #[test]
-    fn the_left_slot_matches_hand_slot() {
-        assert_eq!(hand_slot(crate::vr_config::Handedness::Left), LEFT);
+    fn a_linkless_backpack_accepts_nothing() {
+        let mut world = World::new();
+        let inventory_entity_id = world.add_entity(PropHasRefs(false));
+        let entity_id = world.add_entity(PropHasRefs(false));
+        world.add_unique(PlayerInfo {
+            pos: Vector3::zero(),
+            rotation: Quaternion::one(),
+            entity_id,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id,
+        });
+        assert!(
+            !backpack_accepts_deposit(&world),
+            "a backpack with no Links cannot take a deposit"
+        );
+
+        world.add_component(inventory_entity_id, Links::empty());
+        assert!(backpack_accepts_deposit(&world));
     }
 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -263,6 +263,55 @@ fn latch_trigger_safe(
     effective
 }
 
+/// Which held entities are being released onto the cyber interface's inventory
+/// strip this frame, and so belong in the backpack rather than on the floor.
+///
+/// `VirtualHand` knows exactly one release: opening the hand ejects the item as
+/// a loose world prop, and offers it to whatever the release raycast hit (that
+/// is how a physical container is fed). The strip cannot be hit by that ray -
+/// it is a head-anchored UI quad with no collider - so a release over it would
+/// otherwise land the item on the floor in front of the player. This turns that
+/// release into the deposit the player meant.
+///
+/// Pure, so the rule is exercised directly rather than through a mission.
+fn strip_deposit_entities(
+    on_strip: [bool; 2],
+    held: [Option<EntityId>; 2],
+    releasing: [bool; 2],
+) -> Vec<EntityId> {
+    (0..held.len())
+        .filter(|&slot| on_strip[slot] && releasing[slot])
+        .filter_map(|slot| held[slot])
+        .collect()
+}
+
+/// Take the world-drop half out of a release that [`strip_deposit_entities`]
+/// claimed as a deposit.
+///
+/// Two effects have to go. `DropItem` is the world drop itself - it restores
+/// the item's world refs and rebuilds its physics body, which is the very
+/// outcome the deposit replaces. And `ProvideForConsumption` is the offer the
+/// hand makes to whatever its release raycast hit: because the panel is not
+/// physical that ray reaches straight through it, so a container standing
+/// behind the interface would otherwise take the item as well and the deposit
+/// would land twice. Everything else the hand emitted this frame is untouched.
+fn suppress_world_drop(effects: &mut Vec<VirtualHandEffect>, deposits: &[EntityId]) {
+    if deposits.is_empty() {
+        return;
+    }
+    effects.retain(|effect| match effect {
+        VirtualHandEffect::DropItem { entity_id } => !deposits.contains(entity_id),
+        VirtualHandEffect::OutMessage {
+            message:
+                Message {
+                    payload: MessagePayload::ProvideForConsumption { entity },
+                    ..
+                },
+        } => !deposits.contains(entity),
+        _ => true,
+    });
+}
+
 /// Head-relative authored-space placement for the wide VR backpack canvas.
 /// After `SCALE_FACTOR` conversion this is 2 world units forward and 1.2 up.
 /// The shared canvas keeps its authored pixels; the physical VR boundary
@@ -2693,9 +2742,19 @@ impl MissionCore {
         let (left_hand_held, right_hand_held) = self.interaction.held_entities();
         let hand_empty = [left_hand_held.is_none(), right_hand_held.is_none()];
         let mut on_panel = [false; 2];
+        // The strip specifically, for the release-deposit below: the rest of
+        // the canvas is not a drop target, so a release there stays an
+        // ordinary world drop.
+        let mut on_strip = [false; 2];
         if let Some(pass) = self.vr_use_mode_pointer.as_ref() {
-            for ray in pass.rays.iter().filter(|ray| ray.canvas_hit.is_some()) {
+            for ray in pass.rays.iter() {
+                let Some(canvas_hit) = ray.canvas_hit else {
+                    continue;
+                };
                 on_panel[hand_slot(ray.handedness)] = true;
+                if self.use_mode && self.flat_ui.strip_contains(canvas_hit) {
+                    on_strip[hand_slot(ray.handedness)] = true;
+                }
             }
         }
         let squeezing = [
@@ -2761,9 +2820,36 @@ impl MissionCore {
         });
         let hands_input = weapon_safe_input.as_ref().unwrap_or(input_context);
 
+        // Opening a hand over the inventory strip puts the item in the
+        // backpack instead of on the floor. Decided from the input the hands
+        // are about to see, so the release this claims is exactly the release
+        // `VirtualHand` performs. (A hand that is holding something never has
+        // its squeeze swallowed - `update_squeeze_swallow` drops the latch the
+        // moment the hand is full - so this cannot fire on a masked squeeze.)
+        // Resolved up front: without a backpack to deposit into there is
+        // nothing to claim, and the ordinary world drop must stay intact
+        // rather than be suppressed into an item that goes nowhere.
+        let player_inventory = self
+            .world
+            .borrow::<UniqueView<PlayerInfo>>()
+            .map(|player| player.inventory_entity_id)
+            .ok();
+        let strip_deposits = player_inventory
+            .map(|_| {
+                strip_deposit_entities(
+                    on_strip,
+                    [left_hand_held, right_hand_held],
+                    [
+                        hands_input.left_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
+                        hands_input.right_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
+                    ],
+                )
+            })
+            .unwrap_or_default();
+
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.
-        let interaction_msgs = self.interaction.update(&InteractionContext {
+        let mut interaction_msgs = self.interaction.update(&InteractionContext {
             physics: &self.physics,
             world: &self.world,
             input: hands_input,
@@ -2772,7 +2858,11 @@ impl MissionCore {
             head_rotation: input_context.head.rotation,
             eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
         });
+        suppress_world_drop(&mut interaction_msgs, &strip_deposits);
         self.process_virtual_hand_effects(asset_cache, interaction_msgs);
+        if let Some(inventory_entity) = player_inventory.filter(|_| !strip_deposits.is_empty()) {
+            effects.extend(self.strip_deposit_effects(inventory_entity, &strip_deposits));
+        }
 
         // Tag the wielded weapon with the flat camera/crosshair fire ray so its
         // firing scripts spawn projectiles along the crosshair (camera-origin
@@ -3784,6 +3874,55 @@ impl MissionCore {
             self.make_un_physical(dropped_entity_id);
         }
         moved
+    }
+
+    /// Put the items released onto the cyber interface's inventory strip into
+    /// the player's backpack (see [`strip_deposit_entities`]).
+    ///
+    /// Each one gets the `Drop` its release always owes it - the world-model
+    /// restore and psi-charge cancel that [`VirtualHandEffect::StoreItem`]
+    /// documents must precede storing a *held* item - and then the transfer
+    /// itself. A key source takes the panel's own exception: `PropKeySrc`
+    /// carries a runtime `internal_keycard` script whose Frob records the
+    /// credential, so moving the card bodily into the backpack would bank an
+    /// object that unlocks nothing (the same call `ContainerGui`'s `Take`
+    /// makes, on the same `is_key_source` predicate).
+    ///
+    /// No capacity check: `drop_entity_into_container` accepts into a full
+    /// pack, and this path deliberately does not change that.
+    fn strip_deposit_effects(
+        &self,
+        inventory_entity: EntityId,
+        deposits: &[EntityId],
+    ) -> Vec<Effect> {
+        deposits
+            .iter()
+            .flat_map(|entity_id| {
+                let entity_id = *entity_id;
+                let transfer = if crate::virtual_hand::is_key_source(&self.world, entity_id) {
+                    Effect::Send {
+                        msg: Message {
+                            payload: MessagePayload::Frob,
+                            to: entity_id,
+                        },
+                    }
+                } else {
+                    Effect::DropEntityInfo {
+                        parent_entity_id: inventory_entity,
+                        dropped_entity_id: entity_id,
+                    }
+                };
+                [
+                    Effect::Send {
+                        msg: Message {
+                            payload: MessagePayload::Drop,
+                            to: entity_id,
+                        },
+                    },
+                    transfer,
+                ]
+            })
+            .collect()
     }
 
     /// Re-encode the backpack's stored cells after effective Strength changes.
@@ -10634,6 +10773,135 @@ mod vr_trigger_safe_tests {
             latch_trigger_safe(&mut latched, BOTH, NEITHER),
             [true, false]
         );
+    }
+}
+
+#[cfg(test)]
+mod strip_deposit_tests {
+    use super::*;
+
+    const LEFT: usize = 0;
+
+    fn two_entities() -> (World, EntityId, EntityId) {
+        let mut world = World::new();
+        let item = world.add_entity(PropHasRefs(false));
+        let other = world.add_entity(PropHasRefs(false));
+        (world, item, other)
+    }
+
+    /// The bug: opening the hand over the inventory strip drops the item on
+    /// the floor, because the strip is a head-anchored UI quad with no
+    /// collider and `VirtualHand` only ever knows the world drop.
+    #[test]
+    fn a_release_over_the_strip_is_a_deposit() {
+        let (_world, item, _other) = two_entities();
+        assert_eq!(
+            strip_deposit_entities([true, false], [Some(item), None], [true, false]),
+            vec![item],
+            "a held item released with the hand on the strip belongs in the backpack"
+        );
+    }
+
+    /// Off the strip nothing changes: that release is still the ordinary
+    /// world drop, including feeding a physical container.
+    #[test]
+    fn a_release_off_the_strip_is_left_alone() {
+        let (_world, item, _other) = two_entities();
+        assert!(
+            strip_deposit_entities([false, false], [Some(item), None], [true, false]).is_empty()
+        );
+    }
+
+    /// Still squeezing is still holding - the deposit is the *release*.
+    #[test]
+    fn a_hand_still_holding_deposits_nothing() {
+        let (_world, item, _other) = two_entities();
+        assert!(
+            strip_deposit_entities([true, false], [Some(item), None], [false, false]).is_empty()
+        );
+    }
+
+    /// An empty hand sweeping the strip has nothing to deposit.
+    #[test]
+    fn an_empty_hand_deposits_nothing() {
+        assert!(strip_deposit_entities([true, true], [None, None], [true, true]).is_empty());
+    }
+
+    /// Each hand is judged on its own: one may deposit while the other drops.
+    #[test]
+    fn the_hands_deposit_independently() {
+        let (_world, item, other) = two_entities();
+        assert_eq!(
+            strip_deposit_entities([true, false], [Some(item), Some(other)], [true, true]),
+            vec![item],
+            "only the hand on the strip deposits"
+        );
+    }
+
+    /// The world-drop half of a claimed release has to go, or the item is
+    /// both banked and spawned as a loose prop.
+    #[test]
+    fn a_claimed_release_loses_its_world_drop() {
+        let (_world, item, other) = two_entities();
+        let mut effects = vec![
+            VirtualHandEffect::DropItem { entity_id: item },
+            VirtualHandEffect::DropItem { entity_id: other },
+        ];
+        suppress_world_drop(&mut effects, &[item]);
+        assert!(
+            matches!(effects.as_slice(), [VirtualHandEffect::DropItem { entity_id }] if *entity_id == other),
+            "only the deposited item's world drop is suppressed, got {effects:?}"
+        );
+    }
+
+    /// The panel is not physical, so the release raycast reaches straight
+    /// through it: a container standing behind the interface would take the
+    /// item too, and the deposit would land twice.
+    #[test]
+    fn a_claimed_release_loses_its_consumption_offer() {
+        let (_world, item, container) = two_entities();
+        let mut effects = vec![VirtualHandEffect::OutMessage {
+            message: Message {
+                to: container,
+                payload: MessagePayload::ProvideForConsumption { entity: item },
+            },
+        }];
+        suppress_world_drop(&mut effects, &[item]);
+        assert!(effects.is_empty(), "got {effects:?}");
+    }
+
+    /// Everything else the hand emitted this frame is none of this rule's
+    /// business - notably the `Hover` every frame carries.
+    #[test]
+    fn unrelated_hand_effects_survive() {
+        let (_world, item, other) = two_entities();
+        let mut effects = vec![
+            VirtualHandEffect::OutMessage {
+                message: Message {
+                    to: other,
+                    payload: MessagePayload::TriggerRelease,
+                },
+            },
+            VirtualHandEffect::HoldItem { entity_id: item },
+        ];
+        suppress_world_drop(&mut effects, &[item]);
+        assert_eq!(effects.len(), 2, "got {effects:?}");
+    }
+
+    /// With nothing claimed the frame is untouched, whatever it holds.
+    #[test]
+    fn an_unclaimed_frame_is_untouched() {
+        let (_world, item, _other) = two_entities();
+        let mut effects = vec![VirtualHandEffect::DropItem { entity_id: item }];
+        suppress_world_drop(&mut effects, &[]);
+        assert_eq!(effects.len(), 1);
+    }
+
+    /// `LEFT` is the slot the rest of this module indexes by, so the arrays
+    /// this rule reads cannot silently disagree with `hand_slot`.
+    #[test]
+    fn the_left_slot_matches_hand_slot() {
+        assert_eq!(hand_slot(crate::vr_config::Handedness::Left), LEFT);
     }
 }
 

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -64,14 +64,16 @@ pub enum VirtualHandEffect {
     HoldItem {
         entity_id: EntityId,
     },
-    /// Flat-only: move an item into the player's backpack - a world pickup of
-    /// ordinary loot, or the weapon a wield swap displaced. VR preserves its
-    /// physical hand-grab path and never emits this.
+    /// Move an item into the player's backpack - a flat world pickup of
+    /// ordinary loot, the weapon a wield swap displaced, or a VR hand opened
+    /// over the cyber interface's inventory strip. VR's ordinary release is
+    /// still the physical `DropItem`; only the strip claims one.
     ///
     /// Storing an item that was HELD must be paired with a preceding
-    /// `MessagePayload::Drop` to it (see `FlatPlayerController::wield`): unlike
-    /// `DropItem`, this variant does not dispatch one, so the world-model
-    /// restore and psi-charge cancel would otherwise be skipped.
+    /// `MessagePayload::Drop` to it (see `FlatPlayerController::wield` and
+    /// `mission_core`'s `rewrite_strip_release`): unlike `DropItem`, this
+    /// variant does not dispatch one, so the world-model restore and
+    /// psi-charge cancel would otherwise be skipped.
     StoreItem {
         entity_id: EntityId,
     },

--- a/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
@@ -25,6 +25,10 @@ const CLIP_OBJ = 249;
  * 636x121 on the shared 640x480 canvas, so this is comfortably inside it. */
 const STRIP_CANVAS: [number, number] = [320, 60];
 
+/** On the panel but well below the strip: the boundary the rule narrows to,
+ * and the case a ray aimed off the panel entirely cannot cover. */
+const BELOW_STRIP_CANVAS: [number, number] = [320, 400];
+
 async function launchWithHeldClip(port: number): Promise<{
   game: GameServer;
   clip: EntitySummary;
@@ -160,6 +164,102 @@ test(
     assert.ok(
       (await game.physics.bodies({ entityId: clip.id })).bodies.length > 0,
       "an off-strip release must leave a loose world prop",
+    );
+  },
+);
+
+test(
+  "releasing a held item on the cyber-interface canvas below the strip still drops it into the world",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    const { game, clip } = await launchWithHeldClip(basePort + 2);
+    await using _game = game;
+
+    // The actual boundary the rule draws: the hand IS on the panel (it owns
+    // the canvas pointer), but not on the strip - which is the only drop
+    // target. Aiming off the panel entirely cannot exercise this.
+    const pose = (await game.ui.state()).panel_pose!;
+    await aimVrHandAtCanvas(game, pose, BELOW_STRIP_CANVAS, { squeeze: 1 });
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.ui.state()).pointer?.hand ?? null,
+      "right",
+      "this release must genuinely be on the panel, just not on the strip",
+    );
+
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (item) => item.entity_id === clip.id,
+      )?.location,
+      undefined,
+      "the rest of the canvas is not a drop target",
+    );
+    assert.ok(
+      (await game.physics.bodies({ entityId: clip.id })).bodies.length > 0,
+      "a below-strip release must leave a loose world prop",
+    );
+  },
+);
+
+test(
+  "an item squeezed out of a strip slot and released in place returns to the backpack",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    // The other direction through the same rule: the strip's own squeeze-grab
+    // pulls an item into the hand, and letting go without moving off the slot
+    // puts it back rather than dropping it on the floor. (Before this change
+    // that release littered the item at the player's feet.)
+    //
+    // A fresh earth character carries nothing, so deposit the clip first - the
+    // scenario above, which is now the setup for the round trip.
+    const { game, clip } = await launchWithHeldClip(basePort + 3);
+    await using _game = game;
+    const item = clip.id;
+
+    const pose = (await game.ui.state()).panel_pose!;
+    await aimVrHandAtCanvas(game, pose, STRIP_CANVAS, { squeeze: 1 });
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    const slot = (await game.ui.state()).strip?.elements.find(
+      (element) => element.entity_id === item,
+    );
+    assert.ok(slot, "the deposited clip must have a strip slot to grab back");
+    const slotCanvas: [number, number] = [
+      slot.rect[0] + slot.rect[2] / 2,
+      slot.rect[1] + slot.rect[3] / 2,
+    ];
+
+    // Squeeze the slot: ContainerGui's production grab pulls it into the hand.
+    await aimVrHandAtCanvas(game, pose, slotCanvas, { squeeze: 1 });
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      item,
+      "a squeeze on a strip slot must pull that item into the hand",
+    );
+
+    // Let go without leaving the slot.
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (entry) => entry.entity_id === item,
+      )?.location,
+      "inventory",
+      "releasing over the strip must put it back, not litter it",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: item })).bodies.length,
+      0,
+      "the item must not become a loose world prop",
     );
   },
 );

--- a/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
+
+// Releasing a held item while the VR cyber interface is open used to drop it
+// on the floor wherever the hand was pointing - including straight through the
+// inventory strip, which is a head-anchored UI quad with no collider, so
+// `VirtualHand`'s release raycast never sees it. A release over the strip is
+// now the deposit the player meant.
+//
+// Negative-first: on the parent the first scenario fails at "the clip must be
+// in the backpack" - the clip is a loose world prop on the floor instead, with
+// a physics body and no Contains link.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8619);
+
+/** Stable earth.mis mission object: the Weapons Training standard clip, a
+ * loose grabbable world prop (see flat-world-pickup.e2e.test.ts). */
+const CLIP_OBJ = 249;
+
+/** The middle of the top-docked inventory strip - anchored at (2, 0) and
+ * 636x121 on the shared 640x480 canvas, so this is comfortably inside it. */
+const STRIP_CANVAS: [number, number] = [320, 60];
+
+async function launchWithHeldClip(port: number): Promise<{
+  game: GameServer;
+  clip: EntitySummary;
+}> {
+  const game = await GameServer.launch({
+    mission: "earth.mis",
+    port,
+    debugFlags: ["--vr"],
+  });
+  await game.step({ frames: 30 });
+
+  const clip = (await game.entities.list()).entities.find(
+    (entity) => entity.template_id === CLIP_OBJ,
+  );
+  assert.ok(clip, `expected earth mission object ${CLIP_OBJ} (Standard Clip)`);
+  assert.ok(
+    (await game.physics.bodies({ entityId: clip.id })).bodies.length > 0,
+    "the clip must start as a physical world prop",
+  );
+
+  // Stand an arm's length off and squeeze-grab it with the production VR hand
+  // ray. The offset matters: the hand is placed a stand-off *back* along the
+  // eye->item ray, so standing on top of the item would put it behind the eye.
+  const [x, y, z] = clip.position;
+  await game.player.teleport({ x: x + 1.2, y: y - 0.8, z: z + 1.2 });
+  await game.step({ frames: 30 });
+  const aim = await game.player.aimAt(clip.id, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+  await aimVrHandAt(game, aim.world_point, 0.35, 1);
+  await game.step({ frames: 5 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    clip.id,
+    "the world squeeze must put the clip in the hand",
+  );
+
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 5 });
+  const ui = await game.ui.state();
+  assert.equal(ui.mode, "use", "the cyber interface must be open");
+  assert.ok(ui.panel_pose, "the open interface must report its panel pose");
+
+  return { game, clip };
+}
+
+test(
+  "releasing a held item over the VR inventory strip deposits it in the backpack",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    const { game, clip } = await launchWithHeldClip(basePort);
+    await using _game = game;
+
+    const pose = (await game.ui.state()).panel_pose!;
+    // Aim the holding hand at the strip, squeeze still held so the item stays
+    // in the hand across the re-aim.
+    await aimVrHandAtCanvas(game, pose, STRIP_CANVAS, { squeeze: 1 });
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      clip.id,
+      "aiming at the panel must not by itself drop the item",
+    );
+    const pointer = (await game.ui.state()).pointer;
+    assert.deepEqual(
+      [pointer?.hand ?? null, pointer?.canvas !== undefined],
+      ["right", true],
+      `the holding hand must own the canvas pointer: ${JSON.stringify(pointer)}`,
+    );
+
+    // Open the hand over the strip.
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      null,
+      "the release must empty the hand",
+    );
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === clip.id)?.location,
+      "inventory",
+      `the clip must be in the backpack, got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: clip.id })).bodies.length,
+      0,
+      "a deposited item must not also be a loose world prop",
+    );
+    const strip = (await game.ui.state()).strip;
+    assert.ok(
+      strip?.elements.some((element) => element.entity_id === clip.id),
+      `the strip must show the deposited clip: ${JSON.stringify(strip?.elements)}`,
+    );
+  },
+);
+
+test(
+  "releasing a held item away from the VR inventory strip still drops it into the world",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    const { game, clip } = await launchWithHeldClip(basePort + 1);
+    await using _game = game;
+
+    const pose = (await game.ui.state()).panel_pose!;
+    // Same spot, same held squeeze - but the controller is turned off the
+    // panel, so this release is the ordinary world drop.
+    await aimVrHandAtCanvas(game, pose, STRIP_CANVAS, {
+      squeeze: 1,
+      facing: "away",
+    });
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.ui.state()).pointer?.hand ?? null,
+      null,
+      "the hand must be off the panel for this to be the world-drop case",
+    );
+
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (item) => item.entity_id === clip.id,
+      )?.location,
+      undefined,
+      "an off-strip release must not deposit the item",
+    );
+    assert.ok(
+      (await game.physics.bodies({ entityId: clip.id })).bodies.length > 0,
+      "an off-strip release must leave a loose world prop",
+    );
+  },
+);


### PR DESCRIPTION
## The bug

With the VR cyber interface open, holding a world item and opening the hand over the inventory strip drops the item on the floor. There is nowhere else to put it: the strip is the interface's backpack surface, and the gesture the player makes at it is the one the game already understands everywhere else.

## Why the release never reaches the strip

`VirtualHand::update` (`shock2vr/src/virtual_hand.rs`) knows exactly **one** release. On `squeeze_value < 0.5` while `Grabbing` it emits `VirtualHandEffect::DropItem` - the item regains its world refs and a physics body - and does its own physics raycast, offering the item to whatever it hit via `MessagePayload::ProvideForConsumption` (that is how a physical container is fed).

The cyber-interface panel is a **head-anchored UI quad with no collider** (`FlatUiHost::update_canvas` drives it from a non-physical pointer stack), so that raycast reaches straight *through* it. A release over the strip is indistinguishable, to the hand, from a release into empty air.

## The fix

Claim that release in `MissionCore::update`, in the same per-hand arbitration block #1126 restructured - it already resolves each hand's ray against the panel every frame, so the strip test is one extra `Rect::contains` on the canvas hit the pointer pass produced:

- **`strip_deposit_entities`** (pure) names the held items whose hand is on the strip **and** whose squeeze is released this frame. It reads `hands_input` - the input the hands are *about to see* - so the release it claims is exactly the release `VirtualHand` performs. (A holding hand never has its squeeze swallowed: `update_squeeze_swallow` drops the latch the moment the hand is full.)
- **`rewrite_strip_release`** (pure) rewrites the claimed release **in place, as a hand effect**: `DropItem` becomes the `Drop` the item's scripts are owed on leaving the hand, followed by `VirtualHandEffect::StoreItem` - which already *is* "put this in the player's backpack" (`drop_entity_into_container`), and is applied by `process_virtual_hand_effects` at the same point in the same frame as the drop it replaces. The `ProvideForConsumption` offer goes too - without that, **a container standing behind the panel would take the item as well** and the deposit would land twice.
- **`backpack_accepts_deposit`** gates the claim on exactly what `move_live_entity_into_container` needs of the container, so a backpack that would decline the transfer leaves the ordinary world drop alone rather than suppressing a release into an item that lands nowhere.
- **`FlatUiHost::strip_contains`** answers the hit test from the same `strip_rect()` the host tests its own gestures against, so the drop target can never drift from the drawn strip.

Expressing the whole thing as hand effects is what keeps it honest: the `Drop` reaches **this** frame's `script_world.update` (a queued `Effect::Send` would arrive after it), and the transfer is not separated from the suppression by an effect pass. Both of those were adversarial-review findings on the first cut - see the review notes below.

### Scope, deliberately

| release | behaviour |
| --- | --- |
| hand on the **strip** | deposit into the backpack (this PR) |
| hand on the panel but **off** the strip | unchanged world drop - the rest of the canvas is not a drop target |
| hand **off the panel** | unchanged world drop, including feeding a physical container via `ProvideForConsumption` |

This also makes the strip's own take gesture forgiving: squeezing an item *out* of a slot and letting go without leaving the slot now puts it back, where before it littered the item at the player's feet. Covered by its own scenario.

**Held key sources** take the panel's own exception. `PropKeySrc` gets a runtime `internal_keycard` script whose Frob records the credential, so banking the card bodily would put an object in the pack that unlocks nothing. A key source released on the strip therefore routes through `MessagePayload::Frob` instead - the same rule and the same `is_key_source` predicate `ContainerGui::Take` uses. Reachable only for a card an older save restored into a hand (grabbing one routes through Frob), which is exactly why `held_trigger_press_payload` keeps its own keycard arm.

**No capacity check.** `drop_entity_into_container` accepts into a full pack today, and this path deliberately does not change that; "no room" rejection is a separate slice.

#1126's trigger-safe latch and #1119's `last_frobbed_entity` debounce are untouched - this rule reads the squeeze, and adds no branch to either. The VR gate is stated where the claim is made (`presentation_mode == Vr`) rather than inherited from the pointer pass's existence, because `held_entities()`'s slot 0 is the *wielded weapon* in flat.

## Tests

**Unit** (`mission_core.rs`, `strip_deposit_tests`, 11 tests): the claim matrix (on/off strip, holding/released, empty hand, per-hand independence), the rewrite (drop -> `Drop` + `StoreItem`, the keycard arm's `Drop` + `Frob`, the consumption offer removed, unrelated effects surviving in order, an unclaimed frame untouched), and the backpack precondition. Negative-first: with the claim stubbed to name nothing and the rewrite stubbed to a no-op, 4 of them fail.

**e2e** (`tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts`, new, 4 scenarios) drives the production VR hand in `--vr` on earth.mis:

1. squeeze-grab the Weapons Training clip off the floor, open the interface, release **on** the strip: the hand empties, the clip's inventory location is `inventory`, it has **no** physics body, and it appears in `/v1/ui`'s strip elements.
2. same release with the hand turned **off the panel** (pointer reports no owning hand): not in the backpack, and a loose world prop again.
3. same release **on the panel but below the strip** (pointer reports the right hand, so it genuinely is on the canvas): still a world drop. This is the boundary the rule actually draws, and scenario 2 cannot reach it.
4. the round trip: deposit the clip, then squeeze it back **out** of its strip slot and release without leaving the slot - it returns to the backpack instead of littering.

Negative-first: with the claim stubbed out, (1) fails on an empty backpack while (2) still passes, so the off-strip leg cannot be carrying the first.

Results:
- `cargo test -p shock2vr --lib` - 998 passed, 0 failed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` - clean
- e2e: `vr-cyber-interface-deposit` (4/4), plus `vr-cyber-interface`, `vr-cyber-interface-frob`, `vr-cyber-interface-pointer`, `medsci2-vr-released-item`, `container-loot`, `inventory-strip`, `vaporize-inventory`, and `missions` (23/23).

## Review

`/xreview` (a Claude reviewer + Codex, independently, plus a dedicated duplication pass). No Critical or High findings survived. Two Medium findings **both engines raised** are fixed above: the `Drop` message arriving a frame late as a queued effect, and the suppression not being atomic with the fallible transfer. The duplication pass independently reached the same conclusion as the Claude reviewer - that `StoreItem` already expressed the deposit - which is what the rewrite adopts; it deleted a 35-line method and the `PlayerInfo` plumbing. Its remaining suggestion (extracting a shared keycard-or-transfer helper with `ContainerGui::Take`) dissolved once this side stopped emitting `DropEntityInfo`. The reviewers' two test gaps became e2e scenarios 3 and 4.

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72

## Visuals

![VR cyber-interface strip deposit](https://gist.githubusercontent.com/tommy-xr/293d802e3724d4e5d23b534d490afd47/raw/strip-deposit.gif)

<sub>Holding the earth.mis clip in the VR hand, opening the cyber interface, swinging the hand onto the top-docked inventory strip and releasing - the clip leaves the world and appears as an icon in the strip. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![strip deposit - final state](https://gist.githubusercontent.com/tommy-xr/293d802e3724d4e5d23b534d490afd47/raw/strip-deposit-after.png)

## Before -> after

![before/after](https://gist.githubusercontent.com/tommy-xr/293d802e3724d4e5d23b534d490afd47/raw/strip-deposit-before-after.png)

<sub>Same request sequence against a build with the strip-deposit claim stubbed out (parent behaviour): the release falls through to the ordinary world drop, so the clip lands back in the world and the strip stays empty.</sub>

