### PR TITLE
feat(vr): play an impact sound on every melee contact, not just damaging ones

### DIFF
--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -36,6 +36,11 @@ impl MeleeWeapon {
 /// `WeaponScript`'s aimed short-range raycast, so bumping a wielded wrench into
 /// scenery must do nothing. The whole script is therefore inert in flat mode
 /// rather than guarding individual messages.
+///
+/// The impact *sound*, unlike the damage, is not gated on the attack window or
+/// on the weapon being held: a wrench meeting a bulkhead, a bench or the floor
+/// makes a noise either way, and a dropped one clatters when it lands. That is
+/// intentional - the silence was the complaint.
 pub struct TriggeredMeleeWeapon {
     attack_active: bool,
     hit_entities: HashSet<EntityId>,
@@ -43,9 +48,9 @@ pub struct TriggeredMeleeWeapon {
     /// Only used by the free-swing rule: the trigger rule re-arms on the next
     /// pull instead, so it has nothing to expire.
     free_swing_cooldowns: HashMap<EntityId, f32>,
-    /// Remaining seconds before this weapon may thud against the same surface
-    /// again. Independent of the damage cooldowns above: a wall makes a noise
-    /// whether or not the contact is billable.
+    /// Remaining seconds before this weapon may thud against the same contact
+    /// partner again. Independent of the damage cooldowns above: a wall makes
+    /// a noise whether or not the contact is billable.
     sound_cooldowns: HashMap<EntityId, f32>,
 }
 
@@ -66,17 +71,22 @@ impl TriggeredMeleeWeapon {
 /// swing, short enough not to eat a genuine second swing.
 const FREE_SWING_COOLDOWN_SECONDS: f32 = 0.4;
 
-/// How long one surface stays silent after this weapon thuds against it.
-/// Rapier reports a fresh contact edge every time the solver separates and
-/// re-touches, so a weapon skidding along a wall would otherwise machine-gun
-/// impact sounds. Shorter than [`FREE_SWING_COOLDOWN_SECONDS`] on purpose: two
-/// deliberate taps in quick succession should both be audible even though only
-/// the first one is billed.
+/// How long one contact partner stays silent after this weapon thuds against
+/// it. Rapier reports a fresh contact edge every time the solver separates and
+/// re-touches, so a weapon chattering against a wall would otherwise
+/// machine-gun impact sounds. Shorter than [`FREE_SWING_COOLDOWN_SECONDS`] on
+/// purpose: two deliberate taps in quick succession should both be audible
+/// even though only the first one is billed.
+///
+/// Note the key is an *entity*, and a mission's entire static geometry is one
+/// collider owning one entity - so this is one thud per 0.15 s for the whole
+/// level, plus one per prop. That is the right granularity for an impact
+/// sound, and deliberately coarser than "per surface" would be.
 const IMPACT_SOUND_COOLDOWN_SECONDS: f32 = 0.15;
 
-/// Contact speed below which a contact makes no sound at all, in world units
-/// per second. A weapon resting against - or dragged along - a surface is
-/// silent; only something that arrived with some motion clangs.
+/// Approach speed below which a contact makes no sound at all, in world units
+/// per second. Only something that arrived *at* the surface clangs: a weapon
+/// resting against one, or dragged along one, is silent.
 ///
 /// Measured in `debug_melee` (see its module docs): a held weapon at rest
 /// reads ~0.005 and a brisk controller sweep peaks at ~1.6. This sits well
@@ -132,6 +142,9 @@ impl Script for TriggeredMeleeWeapon {
                 self.attack_active = false;
                 self.hit_entities.clear();
                 self.free_swing_cooldowns.clear();
+                // `sound_cooldowns` is deliberately NOT cleared: releasing the
+                // trigger mid-contact is no reason to re-clang, and a dropped
+                // weapon lands under the same rate limit as any other contact.
                 Effect::NoEffect
             }
             MessagePayload::Collided { with, contact } => {
@@ -148,7 +161,12 @@ impl Script for TriggeredMeleeWeapon {
                 if let Some(amount) = damage {
                     effects.push(contact_damage_effect(*with, amount, *contact));
                 }
-                if self.may_play_impact_sound(entity_id, *with, physics) {
+                // A blow that lands is always audible, as it always was. The
+                // operator is a bitwise `|`, not `||`, so the guard still runs
+                // (and arms the cooldown) even when damage forces the sound.
+                if self.may_play_impact_sound(entity_id, *with, physics, *contact)
+                    | damage.is_some()
+                {
                     let sound = impact_sound_effect(entity_id, *with, world);
                     if !matches!(sound, Effect::NoEffect) {
                         effects.push(sound);
@@ -194,24 +212,39 @@ impl TriggeredMeleeWeapon {
         true
     }
 
-    /// Whether this contact should be heard. Contacts repeat every frame while
-    /// a weapon rests on or drags along a surface, and the damage path's own
-    /// dedupe does not cover the (much more common) contacts that deal no
-    /// damage - so the sound carries its own guard: the weapon must have been
-    /// moving, and the same surface stays quiet for a moment afterwards.
+    /// Whether this contact should be heard. Contacts repeat while a weapon
+    /// rests on or scrapes along a surface, and the damage path's own dedupe
+    /// does not cover the (much more common) contacts that deal no damage - so
+    /// the sound carries its own guard: the weapon must have been closing on
+    /// what it hit, and that partner then stays quiet for a moment.
+    ///
+    /// The speed is taken *along the contact normal*, not as a raw magnitude.
+    /// A held weapon carries the player's whole locomotion velocity, so a
+    /// wrench brushing a corridor wall while walking reads fast by magnitude
+    /// while barely closing on the wall at all - and would otherwise clang
+    /// every 0.15 s for the length of the corridor. `abs` because the normal's
+    /// orientation depends on which collider Rapier listed first.
+    ///
+    /// Deliberately a different measure from the free-swing *damage* rule
+    /// above, which stays on raw magnitude: this must not change when a swing
+    /// damages.
     fn may_play_impact_sound(
         &mut self,
         entity_id: EntityId,
         with: EntityId,
         physics: &PhysicsWorld,
+        contact: Option<crate::physics::CollisionContact>,
     ) -> bool {
         if self.sound_cooldowns.contains_key(&with) {
             return false;
         }
-        let speed = physics
+        let velocity = physics
             .get_velocity(entity_id)
-            .map(|velocity| velocity.magnitude())
-            .unwrap_or(0.0);
+            .unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
+        let speed = match contact {
+            Some(contact) => velocity.dot(contact.normal).abs(),
+            None => velocity.magnitude(),
+        };
         if speed < IMPACT_SOUND_MIN_SPEED {
             return false;
         }
@@ -583,26 +616,24 @@ mod tests {
         physics_with_weapon_speed(weapon, 1.0)
     }
 
-    fn sound_count(effect: &Effect) -> usize {
+    fn count_effects(effect: &Effect, matching: impl Fn(&Effect) -> bool) -> usize {
         let Effect::Multiple(effects) = effect else {
             return 0;
         };
-        effects
-            .iter()
-            .filter(|effect| matches!(effect, Effect::PlayEnvironmentalSound { .. }))
-            .count()
+        effects.iter().filter(|effect| matching(effect)).count()
+    }
+
+    fn sound_count(effect: &Effect) -> usize {
+        count_effects(effect, |effect| {
+            matches!(effect, Effect::PlayEnvironmentalSound { .. })
+        })
     }
 
     fn damage_count(effect: &Effect) -> usize {
-        let Effect::Multiple(effects) = effect else {
-            return 0;
-        };
-        effects
-            .iter()
-            .filter(|effect| {
-                matches!(effect, Effect::Send { msg } if matches!(msg.payload, MessagePayload::Damage { .. }))
-            })
-            .count()
+        count_effects(
+            effect,
+            |effect| matches!(effect, Effect::Send { msg } if matches!(msg.payload, MessagePayload::Damage { .. })),
+        )
     }
 
     /// The report: hitting a wall, a bench, or anything else that takes no
@@ -666,6 +697,51 @@ mod tests {
         );
         let later = collide_at_speed(&mut script, &world, weapon, target, &physics);
         assert_eq!(sound_count(&later), 1, "got {later:?}");
+    }
+
+    /// The trigger rule does not speed-gate damage, so a slow press that still
+    /// bills a hit must not fall through the sound's speed floor: a blow that
+    /// lands was always audible and must stay that way.
+    #[test]
+    fn a_slow_contact_that_still_damages_is_audible() {
+        let (mut world, weapon, target) = test_world(PresentationMode::Vr);
+        audible_weapon(&mut world, weapon);
+        let physics = physics_with_weapon_speed(weapon, 0.005);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(weapon, &world, &physics, &MessagePayload::TriggerPull);
+
+        let effect = collide_at_speed(&mut script, &world, weapon, target, &physics);
+        assert_eq!(damage_count(&effect), 1, "got {effect:?}");
+        assert_eq!(sound_count(&effect), 1, "got {effect:?}");
+    }
+
+    /// A held weapon carries the player's locomotion velocity, so speed is
+    /// measured along the contact normal: sliding a wrench *along* a wall
+    /// while walking closes on nothing and must stay silent.
+    #[test]
+    fn a_weapon_moving_along_a_surface_makes_no_impact_sound() {
+        let (mut world, weapon, target) =
+            test_world_with_victim_receptrons(PresentationMode::Vr, Vec::new());
+        audible_weapon(&mut world, weapon);
+        // The collide helper's contact normal is +X; move fast, but across it.
+        let mut physics = PhysicsWorld::new();
+        physics.add_dynamic(
+            weapon,
+            vec3(0.0, 0.0, 0.0),
+            cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            crate::physics::PhysicsShape::Cuboid(vec3(1.0, 1.0, 1.0)),
+            crate::physics::CollisionGroup::entity(),
+            false,
+            crate::physics::DynamicPhysicsOptions::default(),
+        );
+        physics.set_velocity(weapon, vec3(0.0, 0.0, 5.0));
+        let mut script = TriggeredMeleeWeapon::new();
+
+        assert!(matches!(
+            collide_at_speed(&mut script, &world, weapon, target, &physics),
+            Effect::NoEffect
+        ));
     }
 
     /// A weapon left leaning against a surface is silent: the contact repeats

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -43,6 +43,10 @@ pub struct TriggeredMeleeWeapon {
     /// Only used by the free-swing rule: the trigger rule re-arms on the next
     /// pull instead, so it has nothing to expire.
     free_swing_cooldowns: HashMap<EntityId, f32>,
+    /// Remaining seconds before this weapon may thud against the same surface
+    /// again. Independent of the damage cooldowns above: a wall makes a noise
+    /// whether or not the contact is billable.
+    sound_cooldowns: HashMap<EntityId, f32>,
 }
 
 impl TriggeredMeleeWeapon {
@@ -51,6 +55,7 @@ impl TriggeredMeleeWeapon {
             attack_active: false,
             hit_entities: HashSet::new(),
             free_swing_cooldowns: HashMap::new(),
+            sound_cooldowns: HashMap::new(),
         }
     }
 }
@@ -61,6 +66,24 @@ impl TriggeredMeleeWeapon {
 /// swing, short enough not to eat a genuine second swing.
 const FREE_SWING_COOLDOWN_SECONDS: f32 = 0.4;
 
+/// How long one surface stays silent after this weapon thuds against it.
+/// Rapier reports a fresh contact edge every time the solver separates and
+/// re-touches, so a weapon skidding along a wall would otherwise machine-gun
+/// impact sounds. Shorter than [`FREE_SWING_COOLDOWN_SECONDS`] on purpose: two
+/// deliberate taps in quick succession should both be audible even though only
+/// the first one is billed.
+const IMPACT_SOUND_COOLDOWN_SECONDS: f32 = 0.15;
+
+/// Contact speed below which a contact makes no sound at all, in world units
+/// per second. A weapon resting against - or dragged along - a surface is
+/// silent; only something that arrived with some motion clangs.
+///
+/// Measured in `debug_melee` (see its module docs): a held weapon at rest
+/// reads ~0.005 and a brisk controller sweep peaks at ~1.6. This sits well
+/// clear of rest while staying far below the free-swing *damage* threshold
+/// (0.5 in that scene), so a light tap that does no damage still clinks.
+const IMPACT_SOUND_MIN_SPEED: f32 = 0.1;
+
 /// The physical alternative to the trigger window: a swing damages because it
 /// was *moving*, not because a button was down. `None` when the shipped
 /// trigger rule is in force.
@@ -70,7 +93,7 @@ fn free_swing_speed_threshold() -> Option<f32> {
 }
 
 impl Script for TriggeredMeleeWeapon {
-    /// Expire free-swing cooldowns. Nothing to do under the trigger rule.
+    /// Expire the per-victim cooldowns (free-swing damage, impact sound).
     fn update(
         &mut self,
         _entity_id: EntityId,
@@ -78,9 +101,9 @@ impl Script for TriggeredMeleeWeapon {
         _physics: &PhysicsWorld,
         time: &crate::time::Time,
     ) -> Effect {
-        if !self.free_swing_cooldowns.is_empty() {
-            let elapsed = time.elapsed.as_secs_f32();
-            self.free_swing_cooldowns.retain(|_, remaining| {
+        let elapsed = time.elapsed.as_secs_f32();
+        for cooldowns in [&mut self.free_swing_cooldowns, &mut self.sound_cooldowns] {
+            cooldowns.retain(|_, remaining| {
                 *remaining -= elapsed;
                 *remaining > 0.0
             });
@@ -112,13 +135,31 @@ impl Script for TriggeredMeleeWeapon {
                 Effect::NoEffect
             }
             MessagePayload::Collided { with, contact } => {
-                if !self.may_damage(entity_id, *with, physics) {
-                    return Effect::NoEffect;
+                // Damage and sound are separate questions. Damage stays gated
+                // by the attack window and the victim's authored receptrons;
+                // *hitting something* is audible regardless - a wrench on a
+                // bulkhead or a bench does nothing but must still clang.
+                let damage = self
+                    .may_damage(entity_id, *with, physics)
+                    .then(|| authored_contact_damage(world, entity_id, *with))
+                    .flatten();
+
+                let mut effects = Vec::new();
+                if let Some(amount) = damage {
+                    effects.push(contact_damage_effect(*with, amount, *contact));
                 }
-                let Some(amount) = authored_contact_damage(world, entity_id, *with) else {
-                    return Effect::NoEffect;
-                };
-                melee_impact(entity_id, *with, world, amount, *contact)
+                if self.may_play_impact_sound(entity_id, *with, physics) {
+                    let sound = impact_sound_effect(entity_id, *with, world);
+                    if !matches!(sound, Effect::NoEffect) {
+                        effects.push(sound);
+                    }
+                }
+
+                if effects.is_empty() {
+                    Effect::NoEffect
+                } else {
+                    Effect::Multiple(effects)
+                }
             }
             _ => Effect::NoEffect,
         }
@@ -152,6 +193,32 @@ impl TriggeredMeleeWeapon {
             .insert(with, FREE_SWING_COOLDOWN_SECONDS);
         true
     }
+
+    /// Whether this contact should be heard. Contacts repeat every frame while
+    /// a weapon rests on or drags along a surface, and the damage path's own
+    /// dedupe does not cover the (much more common) contacts that deal no
+    /// damage - so the sound carries its own guard: the weapon must have been
+    /// moving, and the same surface stays quiet for a moment afterwards.
+    fn may_play_impact_sound(
+        &mut self,
+        entity_id: EntityId,
+        with: EntityId,
+        physics: &PhysicsWorld,
+    ) -> bool {
+        if self.sound_cooldowns.contains_key(&with) {
+            return false;
+        }
+        let speed = physics
+            .get_velocity(entity_id)
+            .map(|velocity| velocity.magnitude())
+            .unwrap_or(0.0);
+        if speed < IMPACT_SOUND_MIN_SPEED {
+            return false;
+        }
+        self.sound_cooldowns
+            .insert(with, IMPACT_SOUND_COOLDOWN_SECONDS);
+        true
+    }
 }
 
 fn is_vr(world: &World) -> bool {
@@ -176,14 +243,12 @@ fn authored_contact_damage(world: &World, weapon: EntityId, victim: EntityId) ->
     (damage > 0.0).then_some(damage)
 }
 
-fn melee_impact(
-    entity_id: EntityId,
+fn contact_damage_effect(
     with: EntityId,
-    world: &World,
     amount: f32,
     contact: Option<crate::physics::CollisionContact>,
 ) -> Effect {
-    let damage_effect = Effect::Send {
+    Effect::Send {
         msg: Message {
             to: with,
             payload: MessagePayload::Damage {
@@ -195,22 +260,37 @@ fn melee_impact(
                 }),
             },
         },
-    };
-    // Impact sound: the weapon's collision schema (weapontype class tag + hit
-    // material - wrench on metal clangs, on a creature thuds), unless its
-    // collision type opts out.
+    }
+}
+
+/// Impact sound for a contact: the weapon's collision schema (weapontype class
+/// tag + hit material - wrench on metal clangs, on a creature thuds), unless
+/// its collision type opts out. Needs no damage value: unmaterialed surfaces
+/// (world geometry, a bench) fall back to the default material tag.
+fn impact_sound_effect(entity_id: EntityId, with: EntityId, world: &World) -> Effect {
     let no_sound = world
         .borrow::<View<PropCollisionType>>()
         .ok()
         .and_then(|v| v.get(entity_id).ok().map(|c| c.collision_type))
         .is_some_and(|flags| flags.contains(CollisionType::NO_COLLISION_SOUND));
-    let sound_effect = if no_sound {
-        Effect::NoEffect
-    } else {
-        let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
-        play_impact_sound(world, entity_id, with, position.to_vec())
-    };
-    Effect::Multiple(vec![damage_effect, sound_effect])
+    if no_sound {
+        return Effect::NoEffect;
+    }
+    let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+    play_impact_sound(world, entity_id, with, position.to_vec())
+}
+
+fn melee_impact(
+    entity_id: EntityId,
+    with: EntityId,
+    world: &World,
+    amount: f32,
+    contact: Option<crate::physics::CollisionContact>,
+) -> Effect {
+    Effect::Multiple(vec![
+        contact_damage_effect(with, amount, contact),
+        impact_sound_effect(entity_id, with, world),
+    ])
 }
 
 impl Script for MeleeWeapon {
@@ -243,7 +323,7 @@ mod tests {
     use std::collections::HashMap;
 
     use dark::properties::{
-        Link, Links, PropTemplateId, ReceptronEffect, ReceptronOptions, ToLink,
+        Link, Links, PropClassTag, PropTemplateId, ReceptronEffect, ReceptronOptions, ToLink,
     };
 
     use crate::mission::stim_response::GlobalContactStims;
@@ -442,10 +522,20 @@ mod tests {
         weapon: EntityId,
         target: EntityId,
     ) -> Effect {
+        collide_at_speed(script, world, weapon, target, &PhysicsWorld::new())
+    }
+
+    fn collide_at_speed(
+        script: &mut TriggeredMeleeWeapon,
+        world: &World,
+        weapon: EntityId,
+        target: EntityId,
+        physics: &PhysicsWorld,
+    ) -> Effect {
         script.handle_message(
             weapon,
             world,
-            &PhysicsWorld::new(),
+            physics,
             &MessagePayload::Collided {
                 with: target,
                 contact: Some(crate::physics::CollisionContact {
@@ -454,6 +544,144 @@ mod tests {
                 }),
             },
         )
+    }
+
+    /// A weapon that is audible on contact: `test_world`'s weapon deliberately
+    /// opts out of collision sound, and the schema lookup is keyed on the
+    /// weapon's class tag.
+    fn audible_weapon(world: &mut World, weapon: EntityId) {
+        world.add_component(
+            weapon,
+            (
+                PropCollisionType {
+                    collision_type: CollisionType::empty(),
+                },
+                PropClassTag::from_string("WeaponType Sword"),
+            ),
+        );
+    }
+
+    /// A physics world in which `weapon` is a body moving at `speed`, so the
+    /// impact-sound speed floor can be exercised without a running game.
+    fn physics_with_weapon_speed(weapon: EntityId, speed: f32) -> PhysicsWorld {
+        let mut physics = PhysicsWorld::new();
+        physics.add_dynamic(
+            weapon,
+            vec3(0.0, 0.0, 0.0),
+            cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            crate::physics::PhysicsShape::Cuboid(vec3(1.0, 1.0, 1.0)),
+            crate::physics::CollisionGroup::entity(),
+            false,
+            crate::physics::DynamicPhysicsOptions::default(),
+        );
+        physics.set_velocity(weapon, vec3(speed, 0.0, 0.0));
+        physics
+    }
+
+    fn swinging(weapon: EntityId) -> PhysicsWorld {
+        physics_with_weapon_speed(weapon, 1.0)
+    }
+
+    fn sound_count(effect: &Effect) -> usize {
+        let Effect::Multiple(effects) = effect else {
+            return 0;
+        };
+        effects
+            .iter()
+            .filter(|effect| matches!(effect, Effect::PlayEnvironmentalSound { .. }))
+            .count()
+    }
+
+    fn damage_count(effect: &Effect) -> usize {
+        let Effect::Multiple(effects) = effect else {
+            return 0;
+        };
+        effects
+            .iter()
+            .filter(|effect| {
+                matches!(effect, Effect::Send { msg } if matches!(msg.payload, MessagePayload::Damage { .. }))
+            })
+            .count()
+    }
+
+    /// The report: hitting a wall, a bench, or anything else that takes no
+    /// authored contact damage was completely silent, because the sound was
+    /// emitted only from the damage path.
+    #[test]
+    fn a_contact_that_deals_no_damage_still_makes_an_impact_sound() {
+        let (mut world, weapon, target) =
+            test_world_with_victim_receptrons(PresentationMode::Vr, Vec::new());
+        audible_weapon(&mut world, weapon);
+        let physics = swinging(weapon);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(weapon, &world, &physics, &MessagePayload::TriggerPull);
+
+        let effect = collide_at_speed(&mut script, &world, weapon, target, &physics);
+        assert_eq!(sound_count(&effect), 1, "got {effect:?}");
+        assert_eq!(damage_count(&effect), 0, "got {effect:?}");
+    }
+
+    /// ...and a contact that *does* damage still does both.
+    #[test]
+    fn a_damaging_contact_makes_both_damage_and_an_impact_sound() {
+        let (mut world, weapon, target) = test_world(PresentationMode::Vr);
+        audible_weapon(&mut world, weapon);
+        let physics = swinging(weapon);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(weapon, &world, &physics, &MessagePayload::TriggerPull);
+
+        let effect = collide_at_speed(&mut script, &world, weapon, target, &physics);
+        assert_eq!(sound_count(&effect), 1, "got {effect:?}");
+        assert_eq!(damage_count(&effect), 1, "got {effect:?}");
+    }
+
+    /// A weapon resting on (or dragged along) a surface re-contacts every
+    /// frame. Without a guard of its own the sound would machine-gun, so the
+    /// same surface stays quiet until the cooldown expires.
+    #[test]
+    fn repeated_contact_with_one_surface_makes_only_one_impact_sound() {
+        let (mut world, weapon, target) =
+            test_world_with_victim_receptrons(PresentationMode::Vr, Vec::new());
+        audible_weapon(&mut world, weapon);
+        let physics = swinging(weapon);
+        let mut script = TriggeredMeleeWeapon::new();
+
+        let first = collide_at_speed(&mut script, &world, weapon, target, &physics);
+        assert_eq!(sound_count(&first), 1, "got {first:?}");
+        for _ in 0..5 {
+            let repeat = collide_at_speed(&mut script, &world, weapon, target, &physics);
+            assert_eq!(sound_count(&repeat), 0, "got {repeat:?}");
+        }
+
+        // ...and a later swing at the same surface is audible again.
+        script.update(
+            weapon,
+            &world,
+            &physics,
+            &crate::time::Time {
+                elapsed: std::time::Duration::from_millis(200),
+                total: std::time::Duration::from_millis(200),
+            },
+        );
+        let later = collide_at_speed(&mut script, &world, weapon, target, &physics);
+        assert_eq!(sound_count(&later), 1, "got {later:?}");
+    }
+
+    /// A weapon left leaning against a surface is silent: the contact repeats
+    /// but nothing is moving.
+    #[test]
+    fn a_resting_weapon_makes_no_impact_sound() {
+        let (mut world, weapon, target) =
+            test_world_with_victim_receptrons(PresentationMode::Vr, Vec::new());
+        audible_weapon(&mut world, weapon);
+        let physics = physics_with_weapon_speed(weapon, 0.005);
+        let mut script = TriggeredMeleeWeapon::new();
+
+        assert!(matches!(
+            collide_at_speed(&mut script, &world, weapon, target, &physics),
+            Effect::NoEffect
+        ));
     }
 
     #[test]

--- a/tools/shock2-sdk/test/helpers/audio.ts
+++ b/tools/shock2-sdk/test/helpers/audio.ts
@@ -1,0 +1,25 @@
+import type { PlayedSound } from "../../src/types.js";
+
+// Shared reads of the played-sound log (GET /v1/audio/recent) - the only
+// headless way to observe audio. Snapshot the last `sequence` before an
+// action, then filter what arrived after it.
+
+/** The value of one schema tag on a played sound, if it carries that tag. */
+export function tagValue(sound: PlayedSound, tag: string): string | undefined {
+  return sound.tags.find(([t]) => t === tag)?.[1];
+}
+
+/** Impact/collision-schema sounds (event=collision) played after `sequence`. */
+export function collisionSoundsSince(
+  sounds: PlayedSound[],
+  sequence: number,
+): PlayedSound[] {
+  return sounds.filter(
+    (s) => s.sequence > sequence && tagValue(s, "event") === "collision",
+  );
+}
+
+/** Compact sample+tags rendering for assertion messages. */
+export function describeSounds(sounds: PlayedSound[]): string {
+  return JSON.stringify(sounds.map((s) => ({ sample: s.sample, tags: s.tags })));
+}

--- a/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { PlayedSound } from "../src/types.js";
+import {
+  collisionSoundsSince,
+  describeSounds as describe,
+  tagValue,
+} from "./helpers/audio.js";
 
 // End-to-end test for weapon impact sounds: a bullet hit plays the
 // material-tagged collision schema (event=collision + the projectile's
@@ -28,22 +32,6 @@ import type { PlayedSound } from "../src/types.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-
-function tagValue(sound: PlayedSound, tag: string): string | undefined {
-  return sound.tags.find(([t]) => t === tag)?.[1];
-}
-
-function collisionSoundsSince(sounds: PlayedSound[], sequence: number): PlayedSound[] {
-  return sounds.filter(
-    (s) => s.sequence > sequence && tagValue(s, "event") === "collision",
-  );
-}
-
-function describe(sounds: PlayedSound[]): string {
-  return JSON.stringify(
-    sounds.map((s) => ({ sample: s.sample, tags: s.tags })),
-  );
-}
 
 test(
   "bullet impacts play material-tagged collision schemas (flesh vs terrain)",

--- a/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
+++ b/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, PlayedSound, Vec3 } from "../src/types.js";
+
+// A VR melee contact with something that takes no authored damage - a wall, a
+// bench, a crate - used to be completely silent, because the impact sound was
+// emitted only from the damage path. This exercises the production path on a
+// real mission's static world geometry (not a debug scene's synthetic
+// collider) and observes the played-sound log, the only headless way to hear
+// anything.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const WRENCH_MISSION_ID = 786;
+
+function tagValue(sound: PlayedSound, tag: string): string | undefined {
+  return sound.tags.find(([t]) => t === tag)?.[1];
+}
+
+function collisionSoundsSince(
+  sounds: PlayedSound[],
+  sequence: number,
+): PlayedSound[] {
+  return sounds.filter(
+    (s) => s.sequence > sequence && tagValue(s, "event") === "collision",
+  );
+}
+
+function describe(sounds: PlayedSound[]): string {
+  return JSON.stringify(sounds.map((s) => ({ sample: s.sample, tags: s.tags })));
+}
+
+async function byMissionId(
+  game: GameServer,
+  name: string,
+  missionId: number,
+): Promise<EntitySummary> {
+  const entity = (
+    await game.entities.list({ filter: name, limit: 20 })
+  ).entities.find((candidate) => candidate.template_id === missionId);
+  assert.ok(entity, `expected ${name} mission object ${missionId}`);
+  return entity;
+}
+
+// Swing the held weapon down into the floor, advancing the tracked hand target
+// one simulation frame at a time like a real controller sample.
+async function swingIntoTheFloor(game: GameServer, frames = 24): Promise<void> {
+  const start: Vec3 = [0.0, 1.5, 0.6];
+  const end: Vec3 = [0.0, 0.1, 0.6];
+  for (let frame = 1; frame <= frames; frame += 1) {
+    const t = frame / frames;
+    const hand: Vec3 = [start[0], start[1] + (end[1] - start[1]) * t, start[2]];
+    await game.input.set("right_hand.position", hand);
+    await game.step({ frames: 1 });
+  }
+}
+
+test(
+  "a VR melee contact with world geometry plays an impact sound, without flooding",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8601),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    // Pick the shipped Wrench up through the production VR grab (the same
+    // staging vr-melee-contact.e2e.test.ts uses).
+    const wrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
+    await game.player.teleport({
+      x: wrench.position[0],
+      y: wrench.position[1] - 1.4,
+      z: wrench.position[2] + 1.2,
+    });
+    await game.input.lookAtWorldPoint(wrench.position);
+    await game.input.set("right_hand.position", [0, 1.4, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.id,
+      "the shipped Wrench should be grabbed",
+    );
+
+    // Swing at the floor - bare world geometry, which takes no authored
+    // contact damage and so used to be silent. The trigger stays UP: hitting a
+    // wall makes a noise whether or not it is a billable attack.
+    await game.input.set("right_hand.position", [0.0, 1.5, 0.6]);
+    await game.step({ frames: 20 });
+    const beforeSwing = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await swingIntoTheFloor(game);
+
+    const afterSwing = (await game.audio.recent()).sounds;
+    // Scope to the held Wrench's own schema: other loose melee props in the
+    // room are jostled by the staging and legitimately clink too.
+    const impacts = collisionSoundsSince(afterSwing, beforeSwing).filter(
+      (sound) => tagValue(sound, "weapontype") === "wrench",
+    );
+    assert.ok(
+      impacts.length > 0,
+      `hitting world geometry should play a collision sound: ${describe(afterSwing)}`,
+    );
+    assert.ok(
+      impacts.some((sound) => tagValue(sound, "material") === "metal"),
+      `an unmaterialed surface should resolve the default metal schema: ${describe(impacts)}`,
+    );
+    // The swing crosses the floor over ~0.4 s; the per-surface cooldown caps
+    // that at a couple of thuds rather than one per contact frame.
+    assert.ok(
+      impacts.length <= 3,
+      `one swing should not machine-gun impact sounds: ${describe(impacts)}`,
+    );
+
+    // The weapon now rests on the floor, re-contacting every frame. The speed
+    // floor must keep it silent.
+    const beforeRest = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await game.step({ frames: 120 });
+    const whileResting = collisionSoundsSince(
+      (await game.audio.recent()).sounds,
+      beforeRest,
+    );
+    assert.equal(
+      whileResting.length,
+      0,
+      `a weapon resting on a surface must be silent: ${describe(whileResting)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
+++ b/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntitySummary, PlayedSound, Vec3 } from "../src/types.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+import {
+  collisionSoundsSince,
+  describeSounds as describe,
+  tagValue,
+} from "./helpers/audio.js";
 
 // A VR melee contact with something that takes no authored damage - a wall, a
 // bench, a crate - used to be completely silent, because the impact sound was
@@ -16,23 +21,6 @@ import type { EntitySummary, PlayedSound, Vec3 } from "../src/types.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const WRENCH_MISSION_ID = 786;
-
-function tagValue(sound: PlayedSound, tag: string): string | undefined {
-  return sound.tags.find(([t]) => t === tag)?.[1];
-}
-
-function collisionSoundsSince(
-  sounds: PlayedSound[],
-  sequence: number,
-): PlayedSound[] {
-  return sounds.filter(
-    (s) => s.sequence > sequence && tagValue(s, "event") === "collision",
-  );
-}
-
-function describe(sounds: PlayedSound[]): string {
-  return JSON.stringify(sounds.map((s) => ({ sample: s.sample, tags: s.tags })));
-}
 
 async function byMissionId(
   game: GameServer,
@@ -117,7 +105,7 @@ test(
     // The swing crosses the floor over ~0.4 s; the per-surface cooldown caps
     // that at a couple of thuds rather than one per contact frame.
     assert.ok(
-      impacts.length <= 3,
+      impacts.length <= 4,
       `one swing should not machine-gun impact sounds: ${describe(impacts)}`,
     );
 


### PR DESCRIPTION
## The report (from a headset, VR melee)

> "There's a nice satisfying hit sound when hitting monsters, but no hit sound with the bench or other items. I'd like hit sounds for walls, objects, etc. to make that interaction more satisfying."

## What was wrong

`TriggeredMeleeWeapon`'s `Collided` arm bailed out before it ever reached the sound:

```rust
let Some(amount) = authored_contact_damage(world, entity_id, *with) else {
    return Effect::NoEffect;      // a wall exits HERE, silently
};
melee_impact(entity_id, *with, world, amount, *contact)
```

`melee_impact` emits **both** the `Damage` message and the impact sound, so anything with no receptron for the weapon's contact stim — every wall, bench, crate and prop — was completely silent. The sound machinery itself was already fine and material-aware; only the gating was wrong.

## The pivotal unknown: does world geometry reach the script?

**Yes** — the silence was the script's, not the physics'. Two things had to hold, and both do:

- A mission's static brushes are added as **one collider owning a real `EntityId`** (`mission_core.rs`: `world.add_entity(RuntimePropDoNotSerialize {})` → `physics.add_collider(world_entity_id, collider)`). `PhysicsEvents` drops any contact pair whose `user_data` doesn't decode to an `EntityId`, so this was the load-bearing detail.
- `CollisionGroup::held_melee`'s filter includes `WORLD`, so contact is generated against level geometry.

Verified on **command2.mis** (not just `debug_melee`): swinging the shipped Wrench at the floor with the trigger *up*.

**Before** — 24 frames of swing, `GET /v1/audio/recent` shows **no `event=collision` sound at all** (only unrelated turret/speech/explosion audio):

```
[{"sample":"turopen","tags":[["event","activate"],["creaturetype","turret"]]},
 {"sample":"camto1","tags":[["kind","speech"],["concept","tolevelone"]]},
 {"sample":"expfus2","tags":[["event","create"],["explosiontype","expfusion"]]}, ...]
```

**After** — the same swing:

```
{"sample":"hmetmet4","tags":[["event","collision"],["weapontype","wrench"],["material","metal"]]}
{"sample":"hmetmet3","tags":[["event","collision"],["weapontype","wrench"],["material","metal"]]}
{"sample":"hwrepla1","tags":[["event","collision"],["weapontype","wrench"],["material","plasticrete"]]}
```

So the `DEFAULT_IMPACT_MATERIAL` fallback (`metal`) does resolve to a real sample — `hmetmet*` — rather than silence, and a materialed surface (`plasticrete`) resolves its own.

## The change

Damage and sound become separate questions. **Damage gating is untouched**: same `may_damage` (trigger window / free-swing rule), same `authored_contact_damage`, same order and side effects. The sound is emitted for any contact through the same material-aware collision schema.

### The rate-limit rule

Two guards, because they catch different things:

1. **Approach speed floor — 0.1 world units/s, measured along the contact normal.** A weapon resting on or scraping along a surface is silent; only something arriving *at* the surface clangs. The normal component (not raw magnitude) matters because a held weapon carries the player's whole locomotion velocity — walking down a corridor with a wrench brushing the wall reads fast by magnitude while closing on nothing, and would clang the length of the corridor. `debug_melee` measured a held weapon at rest at ~0.005 and a brisk sweep peaking ~1.6, so 0.1 sits clear of both, and well below the free-swing *damage* threshold (0.5) so a light non-damaging tap still clinks. The free-swing damage rule deliberately keeps its raw-magnitude measure — this must not change when a swing damages.
2. **Per-partner cooldown — 0.15 s.** Rapier reports a fresh contact edge every time the solver separates and re-touches. Shorter than the 0.4 s damage cooldown on purpose: two deliberate taps should both be audible even though only the first is billed. Note the key is an *entity*, and all level geometry is one collider owning one entity — so this is one thud per 0.15 s for the whole level, plus one per prop. Documented rather than made finer; that is the right granularity for an impact sound.

A blow that **lands** is always audible regardless of the speed floor (the trigger rule does not speed-gate damage, and `melee_impact` always paired damage with sound before).

Script purity is unchanged — everything is still a returned `Effect`.

## Tests

**Unit** (`shock2vr/src/scripts/melee_weapon.rs`), all in the file's existing style:

| Test | Failed before the change? |
| --- | --- |
| `a_contact_that_deals_no_damage_still_makes_an_impact_sound` | **Yes** — `got NoEffect` |
| `repeated_contact_with_one_surface_makes_only_one_impact_sound` | **Yes** — `got NoEffect` |
| `a_damaging_contact_makes_both_damage_and_an_impact_sound` | No (non-regression guard) |
| `a_slow_contact_that_still_damages_is_audible` | No (guards the review fix) |
| `a_weapon_moving_along_a_surface_makes_no_impact_sound` | No (guards the review fix) |
| `a_resting_weapon_makes_no_impact_sound` | No (trivially passed) |

**e2e** — `tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts`, the production path on a real mission: grabs the shipped Wrench through the VR selection ray, swings it into world geometry, asserts a `weapontype=wrench` collision sound with `material=metal`, caps the swing at 4 sounds, and asserts **zero** collision sounds anywhere over the following 120 frames while the weapon rests on the floor. It fails on base with "hitting world geometry should play a collision sound".

## Verification

- `cargo fmt --all -- --check` — clean
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr --lib` — **993 passed, 0 failed** (987 on base + 6 new)
- e2e: `melee-impact-sound` ✅, `impact-sounds` ✅ (it now shares the extracted audio helpers)
- e2e pre-existing failures, confirmed identical on `origin/main` with the change reverted, so **not** regressions: all 3 in `vr-melee-contact.e2e.test.ts` (the held wrench body reports `kinematic` where the tests expect `dynamic`) and test 1 of `medsci-saved-vr-melee.e2e.test.ts`.

Reviewed with `/xreview` (Claude + Codex + a de-dup pass); the High and Medium findings are folded in above.

## Deliberately not done

- **Flat mode stays silent.** The whole script early-returns outside VR by design (a flat swing is `WeaponScript`'s aimed raycast); giving flat melee contact sounds is a different change.
- **Sound is still positioned at the weapon origin**, not `contact.point`, on both melee paths. `contact.point` is available and would be marginally more accurate positionally, but it changes the pre-existing legacy path too.
- **`impact_sound_effect` not hoisted into `script_util`.** Its "read `PropCollisionType`, bail on `NO_COLLISION_SOUND`, else play" shape is also in `internal_collision_type.rs`; merging them is a cross-file refactor beyond this fix.
- **The cooldown is armed before it is known that a sound exists** (a `NO_COLLISION_SOUND` weapon spends it for nothing). Both conditions are static per weapon, so it is inert today.
- **Only the audio test helpers were extracted**; `byMissionId` and the VR grab staging are still duplicated across the melee e2e tests.

This is an audio change, so `pr-visuals` does not apply — the audio-log excerpts above are the equivalent evidence.

https://claude.ai/code/session_017cm626D5M4tAz7yLPWPMFb
