### PR TITLE
fix(gameplay): make Rad Patch clear radiation

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -315,6 +315,20 @@ impl PropMotionActorTags {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropSelfIllumination(pub f32);
 
+/// How quickly the player's stored radiation level is reduced after leaving
+/// an irradiated environment. Authored on `The Player` as `P$RadRecove`.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropRadiationRecovery(pub f32);
+
+/// How quickly ambient radiation is absorbed into the player's stored level.
+/// Authored on `The Player` as `P$RadAbsorb`.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropRadiationAbsorb(pub f32);
+
+/// Retail radiation-drain tuning authored on `The Player` as `P$RadDrain`.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropRadiationDrain(pub f32);
+
 /// A container's inventory grid, in cells. The `Contains` link's ordinal is
 /// `y * width + x` against *this* width, so it is what makes a stored cell
 /// mean anything.
@@ -760,8 +774,11 @@ pub enum ReceptronEffect {
     Amplify { factor: f32 },
     /// Swallow the stim entirely (Invulnerable).
     Abort,
+    /// Add radiation exposure scaled by `multiplier`. The player authors this
+    /// response to the Radiation stimulus with a multiplier of 1.
+    Radiate { multiplier: f32 },
     /// An effect the game does not implement yet (EnvSound, add_metaprop,
-    /// radiate, Freeze, Stun, toxin, ...).
+    /// Freeze, Stun, toxin, ...).
     Unhandled(String),
 }
 
@@ -810,6 +827,9 @@ impl ReceptronOptions {
             },
             "Amplify" => ReceptronEffect::Amplify { factor: param_56 },
             "Abort" => ReceptronEffect::Abort,
+            "radiate" => ReceptronEffect::Radiate {
+                multiplier: param_56,
+            },
             _ => ReceptronEffect::Unhandled(name),
         };
 
@@ -1684,6 +1704,24 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$RadAbsorb",
+            |reader, _len| read_single(reader),
+            PropRadiationAbsorb,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RadDrain",
+            |reader, _len| read_single(reader),
+            PropRadiationDrain,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RadRecove",
+            |reader, _len| read_single(reader),
+            PropRadiationRecovery,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$Position",
             read_prop_position,
             identity,
@@ -2509,6 +2547,14 @@ mod tests {
             other.effect,
             ReceptronEffect::Unhandled("EnvSound".to_string())
         );
+    }
+
+    #[test]
+    fn receptron_radiate_keeps_the_authored_exposure_multiplier() {
+        // The Player -> Radiation in shock2.gam: `radiate` x1. The multiplier
+        // lives at +56, just like the original reaction implementation reads.
+        let opts = read_receptron(receptron_payload(69, "radiate", 1.0, 0.0, 0));
+        assert_eq!(opts.effect, ReceptronEffect::Radiate { multiplier: 1.0 });
     }
 
     fn scale_definition() -> Box<dyn PropertyDefinition<Box<dyn ReadAndSeek>>> {

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -761,6 +761,8 @@ pub struct PlayerInfo {
     /// no psi pool. See `shock2vr::PlayerStateSnapshot`.
     pub psi_points: Option<i32>,
     pub max_psi_points: Option<i32>,
+    /// Accumulated retail radiation level (0 when clear).
+    pub radiation_level: f32,
     /// The gamesys name of the selected psi power (what the psi amp casts),
     /// e.g. "Cryokinesis". Cycle with the `CyclePsiPower` input action.
     pub selected_psi_power: Option<String>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2107,6 +2107,7 @@ fn capture_frame_snapshot(
                 max_psi_points: state
                     .as_ref()
                     .and_then(|s| s.psi_points.map(|(_, max)| max)),
+                radiation_level: state.as_ref().map(|s| s.radiation_level).unwrap_or(0.0),
                 selected_psi_power: state.as_ref().and_then(|s| s.selected_psi_power.clone()),
                 psi_charge: state.as_ref().and_then(|s| s.psi_charge.map(|(f, _)| f)),
                 psi_charge_phase: state

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -534,6 +534,9 @@ pub struct PlayerStateSnapshot {
     /// The player's psi pool (current, max), or `None` when the player has no
     /// psi state (e.g. gamesys not loaded).
     pub psi_points: Option<(i32, i32)>,
+    /// Accumulated retail `RadLevel` after ambient absorption. Zero when the
+    /// player has no active radiation status.
+    pub radiation_level: f32,
     /// The gamesys name of the currently selected psi power (what the psi amp
     /// casts), e.g. "Cryokinesis".
     pub selected_psi_power: Option<String>,
@@ -654,6 +657,10 @@ impl Game {
                         .ok()
                         .map(|p| (p.psi_points, p.max_psi_points))
                 }),
+            radiation_level: world
+                .borrow::<shipyard::UniqueView<crate::scripts::radiation::ActiveRadiation>>()
+                .map(|radiation| radiation.level())
+                .unwrap_or(0.0),
             selected_psi_power: (|| {
                 let powers = world
                     .borrow::<UniqueView<crate::psi::GlobalPsiPowers>>()
@@ -1679,6 +1686,12 @@ impl Game {
                 .active_game_scene
                 .world()
                 .borrow::<UniqueView<crate::scripts::healing_item::ActiveHealing>>()
+                .map(|active| active.clone())
+                .unwrap_or_default(),
+            active_radiation: self
+                .active_game_scene
+                .world()
+                .borrow::<UniqueView<crate::scripts::radiation::ActiveRadiation>>()
                 .map(|active| active.clone())
                 .unwrap_or_default(),
             active_mission: self.active_game_scene.scene_name().to_string(),

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -447,6 +447,25 @@ pub fn create_entity_core(
                 })
             })
     };
+    // `Rad Burst` is the persistent corpse effect spawned by a destroyed
+    // radioactive barrel. Its radius source is ambient (no explosion push),
+    // and must refresh the player's authored Radiate receptron while in range.
+    let has_radiation_source = {
+        let v_links = world.borrow::<View<Links>>().unwrap();
+        v_links.get(entity_id).is_ok_and(|links| {
+            links.to_links.iter().any(|link| {
+                link.to_template_id
+                    == crate::scripts::internal_radiation_source::RADIATION_STIM_TEMPLATE_ID
+                    && matches!(
+                        link.link,
+                        Link::StimSource(StimSourceOptions {
+                            propagator: StimPropagator::Radius { .. },
+                            ..
+                        })
+                    )
+            })
+        })
+    };
     // Release the property views before add_component below needs the world
     // mutably; nothing after this point reads them.
     drop(v_scripts);
@@ -463,6 +482,8 @@ pub fn create_entity_core(
         // (has_fired) is not persisted, so a saved mid-animation explosion
         // would re-detonate on every load.
         world.add_component(entity_id, RuntimePropDoNotSerialize);
+    } else if has_radiation_source {
+        processed_scripts.push("internal_radiation_source".to_owned());
     }
 
     // ...and remove any duplicates!

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -496,6 +496,13 @@ enum HealingItemUseOutcome {
     DestroyEntity,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RadiationPatchUseOutcome {
+    NotUsed,
+    DecrementedStack,
+    DestroyEntity,
+}
+
 fn update_player_psi_points(world: &World, update: impl FnOnce(i32) -> i32) -> bool {
     let player_entity = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
     let mut psi_states = world
@@ -669,6 +676,48 @@ fn apply_healing_item_use(
         HealingItemUseOutcome::DecrementedStack
     } else {
         HealingItemUseOutcome::DestroyEntity
+    }
+}
+
+/// Clear live player radiation and consume exactly one carried patch. Status
+/// mutation and stack lifetime resolve atomically in the effect pass, so a
+/// duplicate use cannot clear twice or consume an already-destroyed source.
+fn apply_radiation_patch_use(
+    world: &World,
+    entity_id: EntityId,
+    amount: f32,
+) -> RadiationPatchUseOutcome {
+    let is_alive = world
+        .borrow::<EntitiesView>()
+        .is_ok_and(|entities| entities.is_alive(entity_id));
+    if !is_alive || !crate::scripts::script_util::player_carried_items(world).contains(&entity_id) {
+        return RadiationPatchUseOutcome::NotUsed;
+    }
+    let stack_count = world
+        .borrow::<View<dark::properties::PropStackCount>>()
+        .ok()
+        .and_then(|stacks| stacks.get(entity_id).ok().map(|stack| stack.0));
+    if stack_count.is_some_and(|stack| stack <= 0) {
+        return RadiationPatchUseOutcome::NotUsed;
+    }
+
+    let cleared = world
+        .borrow::<UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
+        .is_ok_and(|mut radiation| radiation.clear(amount));
+    if !cleared {
+        return RadiationPatchUseOutcome::NotUsed;
+    }
+
+    if stack_count.is_some_and(|stack| stack > 1) {
+        let mut stacks = world
+            .borrow::<ViewMut<dark::properties::PropStackCount>>()
+            .unwrap();
+        if let Ok(stack) = (&mut stacks).get(entity_id) {
+            stack.0 -= 1;
+        }
+        RadiationPatchUseOutcome::DecrementedStack
+    } else {
+        RadiationPatchUseOutcome::DestroyEntity
     }
 }
 
@@ -1449,6 +1498,7 @@ impl MissionCore {
         world.add_unique(known_powers);
         world.add_unique(crate::psi::ActivePsiPowers::default());
         world.add_unique(crate::scripts::healing_item::ActiveHealing::default());
+        world.add_unique(crate::scripts::radiation::ActiveRadiation::default());
 
         // ** Entity creation
 
@@ -2396,6 +2446,12 @@ impl MissionCore {
             time.elapsed.as_secs_f32(),
         ) {
             effects.push(healing);
+        }
+        if let Some(radiation) = crate::scripts::radiation::tick_player_radiation(
+            &self.world,
+            time.elapsed.as_secs_f32(),
+        ) {
+            effects.push(radiation);
         }
         effects.extend(command_effects);
 
@@ -3482,12 +3538,27 @@ impl MissionCore {
         did_slay
     }
 
-    /// Apply a radius stim blast (Effect::RadiusBlast): every entity with hit
-    /// points in range receives the stim at linear-falloff intensity, and its
-    /// receptrons decide the damage (no receptron for the stim = no response -
-    /// the type-effectiveness mechanism: EMP does nothing to organics).
-    /// Dynamic bodies in range are shoved outward regardless.
+    /// Apply a radius stim blast and its physical impulse.
     fn radius_blast(
+        &mut self,
+        center: Vector3<f32>,
+        radius: f32,
+        intensity: f32,
+        stim_template_id: i32,
+    ) {
+        self.apply_radius_stimulus(center, radius, intensity, stim_template_id);
+        self.physics.apply_radial_impulse(
+            center,
+            radius,
+            intensity * BLAST_PUSH_SPEED_PER_INTENSITY,
+        );
+    }
+
+    /// Apply a radius stimulus: every entity with hit points in range receives
+    /// linear-falloff intensity, and authored receptrons decide damage or
+    /// radiation status. Persistent environmental sources call this without
+    /// the explosion-only physical impulse.
+    fn apply_radius_stimulus(
         &mut self,
         center: Vector3<f32>,
         radius: f32,
@@ -3537,6 +3608,13 @@ impl MissionCore {
                 stim_template_id,
                 felt_intensity,
             );
+            crate::scripts::radiation::apply_player_stimulus(
+                &self.world,
+                entity_id,
+                &receptrons,
+                stim_template_id,
+                felt_intensity,
+            );
             // Explosions only ever deal damage: dispatch a Damage message only
             // for a positive result. A zero amount (fully shielded) would still
             // read as "took damage" and aggro AI; a negative one (a heal
@@ -3555,12 +3633,6 @@ impl MissionCore {
                 }
             }
         }
-
-        self.physics.apply_radial_impulse(
-            center,
-            radius,
-            intensity * BLAST_PUSH_SPEED_PER_INTENSITY,
-        );
     }
 
     /// Propagate a noise (Effect::RaiseNoise): every creature within `radius`
@@ -4756,6 +4828,15 @@ impl MissionCore {
                     self.radius_blast(center, radius, intensity, stim_template_id);
                 }
 
+                Effect::RadiusStim {
+                    center,
+                    radius,
+                    intensity,
+                    stim_template_id,
+                } => {
+                    self.apply_radius_stimulus(center, radius, intensity, stim_template_id);
+                }
+
                 Effect::RaiseNoise { origin, radius } => {
                     self.raise_noise(origin, radius);
                 }
@@ -5264,6 +5345,28 @@ impl MissionCore {
                         AudioHandle::new(),
                     );
                     if outcome == HealingItemUseOutcome::DestroyEntity {
+                        self.destroy_entity(entity_id);
+                    }
+                    if !matches!(sound, Effect::NoEffect) {
+                        effects.push_front(sound);
+                    }
+                }
+
+                Effect::UseRadiationPatch { entity_id, amount } => {
+                    let outcome = apply_radiation_patch_use(&self.world, entity_id, amount);
+                    if outcome == RadiationPatchUseOutcome::NotUsed {
+                        game_log!(INFO, "No current radiation to remove.");
+                        continue;
+                    }
+
+                    let sound = crate::scripts::script_util::play_environmental_sound(
+                        &self.world,
+                        entity_id,
+                        "activate",
+                        vec![],
+                        AudioHandle::new(),
+                    );
+                    if outcome == RadiationPatchUseOutcome::DestroyEntity {
                         self.destroy_entity(entity_id);
                     }
                     if !matches!(sound, Effect::NoEffect) {
@@ -11077,6 +11180,138 @@ mod healing_item_use_tests {
                 .unwrap()
                 .advance(0.1, 8, 30),
             2
+        );
+    }
+}
+
+#[cfg(test)]
+mod radiation_patch_use_tests {
+    use dark::properties::{Link, Links, PropStackCount, ToLink, WrappedEntityId};
+    use shipyard::{EntitiesView, Get, UniqueView, View};
+
+    use super::*;
+    use crate::scripts::radiation::ActiveRadiation;
+
+    fn world_with_patch(stack: i32, carried: bool) -> (World, EntityId) {
+        let mut world = World::new();
+        let patch = world.add_entity(PropStackCount(stack));
+        let inventory = world.add_entity(if carried {
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(patch)),
+                    link: Link::Contains(0),
+                }],
+            }
+        } else {
+            Links::empty()
+        });
+        let player = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        world.add_unique(ActiveRadiation::default());
+        (world, patch)
+    }
+
+    fn set_radiation_level(world: &World, level: f32) {
+        let mut radiation = world
+            .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
+            .unwrap();
+        assert!(radiation.observe_ambient(level));
+        assert_eq!(radiation.advance(0.1, level, 3.0), 0);
+    }
+
+    #[test]
+    fn irradiated_player_clears_level_and_consumes_one_stack_unit() {
+        let (world, patch) = world_with_patch(2, true);
+        set_radiation_level(&world, 8.0);
+
+        assert_eq!(
+            apply_radiation_patch_use(&world, patch, 6.0),
+            RadiationPatchUseOutcome::DecrementedStack
+        );
+        assert_eq!(
+            world
+                .borrow::<UniqueView<ActiveRadiation>>()
+                .unwrap()
+                .level(),
+            2.0
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(patch)
+                .unwrap()
+                .0,
+            1
+        );
+    }
+
+    #[test]
+    fn clear_player_refuses_without_consuming() {
+        let (world, patch) = world_with_patch(1, true);
+
+        assert_eq!(
+            apply_radiation_patch_use(&world, patch, 6.0),
+            RadiationPatchUseOutcome::NotUsed
+        );
+        assert!(world.borrow::<EntitiesView>().unwrap().is_alive(patch));
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(patch)
+                .unwrap()
+                .0,
+            1
+        );
+    }
+
+    #[test]
+    fn world_object_cannot_bypass_inventory_use() {
+        let (world, patch) = world_with_patch(1, false);
+        set_radiation_level(&world, 8.0);
+
+        assert_eq!(
+            apply_radiation_patch_use(&world, patch, 6.0),
+            RadiationPatchUseOutcome::NotUsed
+        );
+        assert_eq!(
+            world
+                .borrow::<UniqueView<ActiveRadiation>>()
+                .unwrap()
+                .level(),
+            8.0
+        );
+    }
+
+    #[test]
+    fn duplicate_use_of_destroyed_source_cannot_clear_twice() {
+        let (mut world, patch) = world_with_patch(1, true);
+        set_radiation_level(&world, 12.0);
+        assert_eq!(
+            apply_radiation_patch_use(&world, patch, 6.0),
+            RadiationPatchUseOutcome::DestroyEntity
+        );
+        world.delete_entity(patch);
+
+        assert_eq!(
+            apply_radiation_patch_use(&world, patch, 6.0),
+            RadiationPatchUseOutcome::NotUsed
+        );
+        assert_eq!(
+            world
+                .borrow::<UniqueView<ActiveRadiation>>()
+                .unwrap()
+                .level(),
+            6.0
         );
     }
 }

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -151,11 +151,43 @@ pub fn resolve_stim_damage(
                     flat_damage += multiplier;
                 }
             }
+            ReceptronEffect::Radiate { .. } => {}
             ReceptronEffect::Unhandled(_) => {}
         }
     }
 
     has_damage.then(|| flat_damage + intensity * amplify * intensity_multiplier)
+}
+
+/// Resolve a radiation reaction through the same act/react chain as damage.
+/// `Radiate` is an authored receptron effect (The Player -> Radiation), so a
+/// source without that response remains inert and Amplify/Abort modifiers keep
+/// their normal meaning.
+pub fn resolve_stim_radiation(
+    receptrons: &[(i32, ReceptronOptions)],
+    stim_template_id: i32,
+    intensity: f32,
+) -> Option<f32> {
+    let mut amplify = 1.0;
+    let mut multiplier = 0.0;
+    let mut has_radiate = false;
+
+    for (_, options) in receptrons
+        .iter()
+        .filter(|(stim, _)| *stim == stim_template_id)
+    {
+        match &options.effect {
+            ReceptronEffect::Abort => return None,
+            ReceptronEffect::Amplify { factor } => amplify *= factor,
+            ReceptronEffect::Radiate { multiplier: factor } => {
+                has_radiate = true;
+                multiplier += factor;
+            }
+            ReceptronEffect::Damage { .. } | ReceptronEffect::Unhandled(_) => {}
+        }
+    }
+
+    has_radiate.then_some(intensity * amplify * multiplier)
 }
 
 #[cfg(test)]
@@ -247,6 +279,24 @@ mod tests {
             resolve_stim_damage(&invulnerable, HIGH_EXPLOSIVE, 10.0),
             None
         );
+    }
+
+    #[test]
+    fn authored_radiate_reaction_accumulates_amplified_exposure() {
+        const RADIATION: i32 = -386;
+        let player = vec![
+            (
+                RADIATION,
+                receptron(69, ReceptronEffect::Radiate { multiplier: 1.0 }),
+            ),
+            (
+                RADIATION,
+                receptron(80, ReceptronEffect::Amplify { factor: 0.5 }),
+            ),
+        ];
+
+        assert_eq!(resolve_stim_radiation(&player, RADIATION, 8.0), Some(4.0));
+        assert_eq!(resolve_stim_damage(&player, RADIATION, 8.0), None);
     }
 
     #[test]

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -6,6 +6,7 @@
 use super::{EntitySaveData, HeldItemSaveData, PlayerVitals};
 use crate::quest_info::QuestInfo;
 use crate::scripts::healing_item::ActiveHealing;
+use crate::scripts::radiation::ActiveRadiation;
 use cgmath::{Quaternion, Vector3};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -52,6 +53,9 @@ pub struct GlobalData {
     /// Ordinary level transitions intentionally start with an empty queue.
     #[serde(default)]
     pub active_healing: ActiveHealing,
+    /// Accumulated player radiation and its retail damage/recovery clock.
+    #[serde(default)]
+    pub active_radiation: ActiveRadiation,
     pub active_mission: String,
     /// Whether the player was crouched at save time. Defaults false for
     /// saves that predate crouch.
@@ -73,6 +77,7 @@ mod tests {
             held_items: HeldItemSaveData::empty(),
             player_vitals,
             active_healing: ActiveHealing::default(),
+            active_radiation: ActiveRadiation::default(),
             active_mission: "earth.mis".to_owned(),
             is_crouched: false,
         }
@@ -130,5 +135,24 @@ mod tests {
             .unwrap();
         let decoded: GlobalData = serde_json::from_value(legacy).unwrap();
         assert_eq!(decoded.active_healing, ActiveHealing::default());
+    }
+
+    #[test]
+    fn active_radiation_round_trips_and_older_saves_default_clear() {
+        let mut original = global_data(Some(sample_vitals()));
+        assert!(original.active_radiation.observe_ambient(8.0));
+        assert_eq!(original.active_radiation.advance(0.1, 8.0, 3.0), 0);
+        let encoded = serde_json::to_value(&original).unwrap();
+        let decoded: GlobalData = serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(decoded.active_radiation, original.active_radiation);
+
+        let mut legacy = encoded;
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("active_radiation")
+            .unwrap();
+        let decoded: GlobalData = serde_json::from_value(legacy).unwrap();
+        assert_eq!(decoded.active_radiation, ActiveRadiation::default());
     }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -363,6 +363,7 @@ pub fn load_mission_from_save_data(
 ) -> (Mission, HashMap<String, EntitySaveData>) {
     let current_mission = save_data.global_data.active_mission.clone();
     let active_healing = save_data.global_data.active_healing.clone();
+    let active_radiation = save_data.global_data.active_radiation.clone();
 
     let populator: Box<dyn EntityPopulator> = {
         if let Some(save_data) = save_data
@@ -403,6 +404,13 @@ pub fn load_mission_from_save_data(
         .borrow::<shipyard::UniqueViewMut<crate::scripts::healing_item::ActiveHealing>>()
     {
         *healing = active_healing;
+    }
+    if let Ok(mut radiation) = active_mission
+        .mission_core
+        .world
+        .borrow::<shipyard::UniqueViewMut<crate::scripts::radiation::ActiveRadiation>>()
+    {
+        *radiation = active_radiation;
     }
 
     // A loaded mission rebuilds Rapier from scratch. Mark the restored player

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -302,6 +302,14 @@ pub enum Effect {
         pulse_interval_secs: f32,
     },
 
+    /// Atomically subtract one retail Rad Patch dose from the live player's
+    /// accumulated radiation and consume one source unit. A zero-radiation
+    /// use leaves the item untouched.
+    UseRadiationPatch {
+        entity_id: EntityId,
+        amount: f32,
+    },
+
     /// Install a soft on the character sheet and consume the object it came
     /// from. Emitted by `scripts::auto_install_soft` when a soft is frobbed in
     /// the world or taken from a container. The applier does the atomic
@@ -358,6 +366,16 @@ pub enum Effect {
     /// shoved outward. Emitted once by `internal_explosion` from the entity's
     /// arSrcDesc data.
     RadiusBlast {
+        center: Vector3<f32>,
+        radius: f32,
+        intensity: f32,
+        stim_template_id: i32,
+    },
+
+    /// Persistent radius stimulus without an explosion's physical impulse.
+    /// Radiation sources refresh this every frame while their player is in
+    /// range; the player status integrates the ambient exposure separately.
+    RadiusStim {
         center: Vector3<f32>,
         radius: f32,
         intensity: f32,

--- a/shock2vr/src/scripts/internal_radiation_source.rs
+++ b/shock2vr/src/scripts/internal_radiation_source.rs
@@ -1,0 +1,107 @@
+use cgmath::{Transform, point3};
+use dark::properties::{Link, StimPropagator};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+use crate::runtime_props::RuntimePropTransform;
+use crate::time::Time;
+use crate::util::point3_to_vec3;
+
+use super::{Effect, Script, script_util::get_all_links_with_template};
+
+/// Radiation stimulus archetype authored by `The Player`'s Radiate
+/// receptron and emitted by the persistent `Rad Burst` corpse effect.
+pub const RADIATION_STIM_TEMPLATE_ID: i32 = -386;
+
+/// Refresh a persistent radius radiation source every frame. `RadCheck`
+/// integrates that ambient value on its own retail 100 ms cadence, so this is
+/// an observation rather than repeated additive damage.
+pub struct InternalRadiationSource;
+
+impl Script for InternalRadiationSource {
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        _time: &Time,
+    ) -> Effect {
+        let source = get_all_links_with_template(world, entity_id, |link| match link {
+            Link::StimSource(options) => Some(*options),
+            _ => None,
+        })
+        .into_iter()
+        .find_map(|(stim_template_id, options)| {
+            if stim_template_id != RADIATION_STIM_TEMPLATE_ID {
+                return None;
+            }
+            let StimPropagator::Radius { radius } = options.propagator else {
+                return None;
+            };
+            Some((options.intensity, radius))
+        });
+        let Some((intensity, radius)) = source else {
+            return Effect::NoEffect;
+        };
+
+        let transforms = world.borrow::<View<RuntimePropTransform>>().unwrap();
+        let Ok(transform) = transforms.get(entity_id) else {
+            return Effect::NoEffect;
+        };
+        let center = point3_to_vec3(transform.0.transform_point(point3(0.0, 0.0, 0.0)));
+
+        Effect::RadiusStim {
+            center,
+            radius,
+            intensity,
+            stim_template_id: RADIATION_STIM_TEMPLATE_ID,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Matrix4, vec3};
+    use dark::properties::{Link, Links, StimPropagator, StimSourceOptions, ToLink};
+    use shipyard::World;
+
+    use crate::{
+        physics::PhysicsWorld,
+        runtime_props::RuntimePropTransform,
+        scripts::{Effect, Script},
+        time::Time,
+    };
+
+    use super::{InternalRadiationSource, RADIATION_STIM_TEMPLATE_ID};
+
+    #[test]
+    fn authored_rad_burst_emits_ambient_radius_stim_without_blast_force() {
+        let mut world = World::new();
+        let source = world.add_entity((
+            RuntimePropTransform(Matrix4::from_translation(vec3(1.0, 2.0, 3.0))),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: RADIATION_STIM_TEMPLATE_ID,
+                    to_entity_id: None,
+                    link: Link::StimSource(StimSourceOptions {
+                        intensity: 8.0,
+                        propagator: StimPropagator::Radius { radius: 6.0 },
+                    }),
+                }],
+            },
+        ));
+
+        let effect =
+            InternalRadiationSource.update(source, &world, &PhysicsWorld::new(), &Time::default());
+
+        assert!(matches!(
+            effect,
+            Effect::RadiusStim {
+                center,
+                radius: 6.0,
+                intensity: 8.0,
+                stim_template_id: RADIATION_STIM_TEMPLATE_ID,
+            } if center == vec3(1.0, 2.0, 3.0)
+        ));
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -33,6 +33,7 @@ pub mod internal_fast_projectile;
 mod internal_frob_move;
 mod internal_keycard_script;
 mod internal_nanites_script;
+pub(crate) mod internal_radiation_source;
 mod internal_simple_health;
 mod internal_switch_held_model;
 mod level_change_button;
@@ -46,6 +47,7 @@ pub mod player_script;
 mod psi_amp_script;
 mod psi_kit;
 mod put_bomb_in_replicator;
+pub mod radiation;
 mod reduce_psi;
 mod reroute_elevator_button;
 mod researchable;
@@ -126,6 +128,7 @@ use self::picture_swap::PictureSwap;
 use self::psi_amp_script::PsiAmpScript;
 use self::psi_kit::PsiKitScript;
 use self::put_bomb_in_replicator::PutBombInReplicator;
+use self::radiation::RadPatchScript;
 use self::reduce_psi::ReducePsi;
 use self::reroute_elevator_button::RerouteElevatorButton;
 use self::researchable::ResearchableScript;
@@ -154,6 +157,7 @@ use self::{
     internal_explosion::InternalExplosion,
     internal_keycard_script::KeyCardScript,
     internal_nanites_script::InternalNanitesScript,
+    internal_radiation_source::InternalRadiationSource,
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
     many_ride::{ParalyzePlayers, SitDownRightNow, StandUpAgain, WhiteOut},
@@ -943,6 +947,7 @@ impl ScriptWorld {
             "internal_media" => gui_script(Box::new(MediaGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
+            "internal_radiation_source" => Box::new(InternalRadiationSource),
             "internal_frob_move" => Box::new(InternalFrobMove::new()),
             "internal_keycard" => Box::new(KeyCardScript::new()),
             "internal_nanites" => Box::new(InternalNanitesScript::new()),
@@ -1064,7 +1069,7 @@ impl ScriptWorld {
             "expcookie" => Box::new(ExpCookie::new()), // cyber modules
             "medkitscript" => Box::new(HealingItemScript::new(HealingItemKind::MedicalKit)),
             "speedpatch" => Box::new(UnimplementedScript::new(&script_name)), // speed boost
-            "radpatch" => Box::new(UnimplementedScript::new(&script_name)),   // speed boost
+            "radpatch" => Box::new(RadPatchScript),
             "autoinstallsoft" => Box::new(AutoInstallSoft::new()), // auto install software
             "strboost" => Box::new(UnimplementedScript::new(&script_name)), // strength boost
             "intboost" => Box::new(UnimplementedScript::new(&script_name)),

--- a/shock2vr/src/scripts/radiation.rs
+++ b/shock2vr/src/scripts/radiation.rs
@@ -1,0 +1,392 @@
+use dark::properties::{PropRadiationAbsorb, PropRadiationRecovery, ReceptronOptions};
+use serde::{Deserialize, Serialize};
+use shipyard::{Get, Unique, UniqueView, View, World};
+
+use crate::{mission::PlayerInfo, physics::PhysicsWorld, quest_info::QuestInfo};
+
+use super::{Effect, MessagePayload, Script};
+use crate::scripts::gui::TRAIT_PHARMO_FRIENDLY;
+
+/// Amount removed by retail `RadPatch`, recovered from the shipped
+/// `allobjs` module. Pharmo-Friendly applies the same 20% item bonus as the
+/// healing scripts, producing 7.2 instead of 6.0.
+pub const RAD_PATCH_CLEAR_AMOUNT: f32 = 6.0;
+pub const RAD_PATCH_PHARMO_CLEAR_AMOUNT: f32 = 7.2;
+
+/// Retail schedules `RadDamage` every 6000 ms. The shipped implementation
+/// converts the stored level to damage with a 0.25 multiplier before the
+/// normal-difficulty scalar (shock2quest currently has no difficulty option).
+pub const RADIATION_DAMAGE_INTERVAL_SECS: f32 = 6.0;
+pub const RADIATION_CHECK_INTERVAL_SECS: f32 = 0.1;
+const RADIATION_DAMAGE_PER_LEVEL: f32 = 0.25;
+const DEFAULT_RADIATION_ABSORB: f32 = 0.05;
+const DEFAULT_RADIATION_RECOVERY: f32 = 3.0;
+
+/// Retail `RadPatch`: clear part of the player's accumulated radiation and
+/// consume one patch only when radiation is actually present.
+pub struct RadPatchScript;
+
+impl RadPatchScript {
+    fn pharmo_friendly(world: &World) -> bool {
+        world
+            .borrow::<UniqueView<QuestInfo>>()
+            .is_ok_and(|quests| quests.player_stats().has_os_trait(TRAIT_PHARMO_FRIENDLY))
+    }
+}
+
+impl Script for RadPatchScript {
+    fn handle_message(
+        &mut self,
+        entity_id: shipyard::EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::Frob) {
+            return Effect::NoEffect;
+        }
+
+        let amount = if Self::pharmo_friendly(world) {
+            RAD_PATCH_PHARMO_CLEAR_AMOUNT
+        } else {
+            RAD_PATCH_CLEAR_AMOUNT
+        };
+        Effect::UseRadiationPatch { entity_id, amount }
+    }
+}
+
+fn default_damage_timer() -> f32 {
+    RADIATION_DAMAGE_INTERVAL_SECS
+}
+
+fn default_check_timer() -> f32 {
+    RADIATION_CHECK_INTERVAL_SECS
+}
+
+/// Player radiation survives after the source item or source effect is gone,
+/// so it is global save state rather than script-private state. Radius sources
+/// refresh `ambient_level` every frame; the retail 100 ms `RadCheck` timer then
+/// raises stored level by the authored `RadAbsorb` step until ambient is met.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Unique)]
+pub struct ActiveRadiation {
+    level: f32,
+    #[serde(default, skip)]
+    ambient_level: f32,
+    #[serde(default = "default_check_timer")]
+    seconds_until_check: f32,
+    #[serde(default = "default_damage_timer")]
+    seconds_until_damage: f32,
+}
+
+impl Default for ActiveRadiation {
+    fn default() -> Self {
+        Self {
+            level: 0.0,
+            ambient_level: 0.0,
+            seconds_until_check: RADIATION_CHECK_INTERVAL_SECS,
+            seconds_until_damage: RADIATION_DAMAGE_INTERVAL_SECS,
+        }
+    }
+}
+
+impl ActiveRadiation {
+    pub fn level(&self) -> f32 {
+        self.level
+    }
+
+    /// Refresh the final act/react ambient intensity after
+    /// Amplify/Abort/Radiate. Multiple overlapping sources keep the strongest
+    /// level for this frame, matching environmental exposure rather than
+    /// summing a full source intensity into stored `RadLevel` every frame.
+    pub fn observe_ambient(&mut self, amount: f32) -> bool {
+        if !amount.is_finite() || amount <= 0.0 {
+            return false;
+        }
+        self.ambient_level = self.ambient_level.max(amount);
+        true
+    }
+
+    /// Remove one patch's amount. There is deliberately no protection timer:
+    /// retail subtracts from `RadLevel` immediately, and later exposure starts
+    /// accumulating again from the remaining level.
+    pub fn clear(&mut self, amount: f32) -> bool {
+        if !amount.is_finite() || amount <= 0.0 || !self.level.is_finite() || self.level <= 0.0 {
+            return false;
+        }
+        self.level = (self.level - amount).max(0.0);
+        true
+    }
+
+    /// Advance the retail 6-second damage/recovery clock and return ordinary
+    /// hit-point damage for MissionCore's central HP effect handler.
+    pub fn advance(
+        &mut self,
+        elapsed_secs: f32,
+        absorb_per_check: f32,
+        recovery_per_tick: f32,
+    ) -> i32 {
+        if !elapsed_secs.is_finite() || elapsed_secs <= 0.0 {
+            return 0;
+        }
+        if !self.level.is_finite() || self.level < 0.0 {
+            self.level = 0.0;
+        }
+        if !self.ambient_level.is_finite() || self.ambient_level < 0.0 {
+            self.ambient_level = 0.0;
+        }
+        if !self.seconds_until_check.is_finite()
+            || self.seconds_until_check < -RADIATION_CHECK_INTERVAL_SECS
+        {
+            self.seconds_until_check = RADIATION_CHECK_INTERVAL_SECS;
+        }
+        if !self.seconds_until_damage.is_finite()
+            || self.seconds_until_damage < -RADIATION_DAMAGE_INTERVAL_SECS
+        {
+            self.seconds_until_damage = RADIATION_DAMAGE_INTERVAL_SECS;
+        }
+        let absorb = if absorb_per_check.is_finite() && absorb_per_check > 0.0 {
+            absorb_per_check
+        } else {
+            DEFAULT_RADIATION_ABSORB
+        };
+        let recovery = if recovery_per_tick.is_finite() && recovery_per_tick > 0.0 {
+            recovery_per_tick
+        } else {
+            DEFAULT_RADIATION_RECOVERY
+        };
+
+        self.seconds_until_check -= elapsed_secs;
+        while self.seconds_until_check <= 0.0 {
+            if self.ambient_level > self.level {
+                self.level += absorb.min(self.ambient_level - self.level);
+            }
+            self.seconds_until_check += RADIATION_CHECK_INTERVAL_SECS;
+        }
+
+        self.seconds_until_damage -= elapsed_secs;
+        let mut damage = 0_i32;
+        while self.seconds_until_damage <= 0.0 {
+            if self.level >= 1.0 {
+                let pulse = (self.level * RADIATION_DAMAGE_PER_LEVEL)
+                    .trunc()
+                    .clamp(0.0, i32::MAX as f32) as i32;
+                damage = damage.saturating_add(pulse);
+            }
+            if self.ambient_level <= 0.0 {
+                self.level = (self.level - recovery).max(0.0);
+            }
+            self.seconds_until_damage += RADIATION_DAMAGE_INTERVAL_SECS;
+        }
+        // Radius sources refresh this after the effect pass. Clearing it here
+        // lets the following frame faithfully represent leaving the source.
+        self.ambient_level = 0.0;
+        damage
+    }
+}
+
+/// Feed one target's authored radiation reaction into the live player status.
+/// Production calls this only while applying `Effect::RadiusBlast`, keeping
+/// mutation at the mission effect choke point.
+pub fn apply_player_stimulus(
+    world: &World,
+    target: shipyard::EntityId,
+    receptrons: &[(i32, ReceptronOptions)],
+    stim_template_id: i32,
+    intensity: f32,
+) -> bool {
+    let is_player = world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .is_ok_and(|player| player.entity_id == target);
+    if !is_player {
+        return false;
+    }
+    let Some(amount) = crate::mission::stim_response::resolve_stim_radiation(
+        receptrons,
+        stim_template_id,
+        intensity,
+    ) else {
+        return false;
+    };
+    world
+        .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
+        .is_ok_and(|mut radiation| radiation.observe_ambient(amount))
+}
+
+pub fn tick_player_radiation(world: &World, elapsed_secs: f32) -> Option<Effect> {
+    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
+    let recovery = world
+        .borrow::<View<PropRadiationRecovery>>()
+        .ok()
+        .and_then(|values| values.get(player).ok().map(|value| value.0))
+        .unwrap_or(DEFAULT_RADIATION_RECOVERY);
+    let absorb = world
+        .borrow::<View<PropRadiationAbsorb>>()
+        .ok()
+        .and_then(|values| values.get(player).ok().map(|value| value.0))
+        .unwrap_or(DEFAULT_RADIATION_ABSORB);
+    let damage = world
+        .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
+        .ok()
+        .map(|mut radiation| radiation.advance(elapsed_secs, absorb, recovery))
+        .unwrap_or(0);
+    (damage > 0).then_some(Effect::AdjustHitPoints {
+        entity_id: player,
+        delta: -damage,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{ReceptronEffect, ReceptronOptions};
+    use shipyard::{UniqueView, World};
+
+    use crate::{
+        mission::PlayerInfo,
+        physics::PhysicsWorld,
+        quest_info::QuestInfo,
+        scripts::{Effect, MessagePayload, Script},
+    };
+    use cgmath::{Quaternion, vec3};
+    use serde_json::json;
+
+    use super::{
+        ActiveRadiation, RAD_PATCH_CLEAR_AMOUNT, RAD_PATCH_PHARMO_CLEAR_AMOUNT, RadPatchScript,
+        apply_player_stimulus,
+    };
+
+    #[test]
+    fn frob_routes_rad_patch_through_a_real_use_effect() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let patch = world.add_entity(());
+
+        let effect = RadPatchScript.handle_message(
+            patch,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(matches!(
+            effect,
+            Effect::UseRadiationPatch { entity_id, amount }
+                if entity_id == patch && amount == RAD_PATCH_CLEAR_AMOUNT
+        ));
+    }
+
+    #[test]
+    fn pharmo_friendly_uses_retail_twenty_percent_bonus() {
+        let mut world = World::new();
+        let mut quests = QuestInfo::new();
+        assert!(quests.player_stats_mut().add_os_trait(2));
+        world.add_unique(quests);
+        let patch = world.add_entity(());
+
+        let effect = RadPatchScript.handle_message(
+            patch,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(matches!(
+            effect,
+            Effect::UseRadiationPatch { amount, .. }
+                if amount == RAD_PATCH_PHARMO_CLEAR_AMOUNT
+        ));
+    }
+
+    #[test]
+    fn patch_clears_level_without_granting_future_protection() {
+        let mut radiation = ActiveRadiation::default();
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0), 0);
+        assert!(radiation.clear(6.0));
+        assert_eq!(radiation.level(), 2.0);
+
+        assert!(radiation.observe_ambient(6.0));
+        assert_eq!(radiation.advance(0.1, 4.0, 3.0), 0);
+        assert_eq!(radiation.level(), 6.0);
+    }
+
+    #[test]
+    fn damage_and_recovery_follow_the_retail_six_second_clock() {
+        let mut radiation = ActiveRadiation::default();
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0), 0);
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(5.89, 0.05, 3.0), 0);
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(0.02, 0.05, 3.0), 2);
+        assert_eq!(radiation.level(), 8.0, "active exposure delays recovery");
+        assert_eq!(radiation.advance(6.0, 0.05, 3.0), 2);
+        assert_eq!(radiation.level(), 5.0);
+    }
+
+    #[test]
+    fn corrupt_restored_timers_are_normalized_without_looping() {
+        let mut radiation: ActiveRadiation = serde_json::from_value(json!({
+            "level": 8.0,
+            "seconds_until_check": -1.0e30,
+            "seconds_until_damage": -1.0e30
+        }))
+        .unwrap();
+
+        assert_eq!(radiation.advance(1.0 / 60.0, 0.05, 3.0), 0);
+        assert_eq!(radiation.level(), 8.0);
+    }
+
+    #[test]
+    fn authored_radiate_receptron_updates_only_the_player_status() {
+        const RADIATION_STIM: i32 = -386;
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let other = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        world.add_unique(ActiveRadiation::default());
+        let receptrons = vec![(
+            RADIATION_STIM,
+            ReceptronOptions {
+                order: 69,
+                effect: ReceptronEffect::Radiate { multiplier: 1.0 },
+            },
+        )];
+
+        assert!(!apply_player_stimulus(
+            &world,
+            other,
+            &receptrons,
+            RADIATION_STIM,
+            8.0,
+        ));
+        assert!(apply_player_stimulus(
+            &world,
+            player,
+            &receptrons,
+            RADIATION_STIM,
+            8.0,
+        ));
+        assert_eq!(
+            world
+                .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
+                .unwrap()
+                .advance(0.1, 0.05, 3.0),
+            0
+        );
+        assert_eq!(
+            world
+                .borrow::<UniqueView<ActiveRadiation>>()
+                .unwrap()
+                .level(),
+            0.05
+        );
+    }
+}

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -437,6 +437,8 @@ export interface PlayerSnapshot {
    * no psi pool. */
   psi_points: number | null;
   max_psi_points: number | null;
+  /** Accumulated retail radiation level (zero when clear). */
+  radiation_level: number;
   /** The gamesys name of the selected psi power (what the psi amp casts),
    * e.g. "Cryokinesis". Cycle with the CyclePsiPower input action. */
   selected_psi_power: string | null;

--- a/tools/shock2-sdk/test/rad-patch.e2e.test.ts
+++ b/tools/shock2-sdk/test/rad-patch.e2e.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end regression for #1137. A destroyed medsci2 Rad Barrel authors a
+// Corpse link to the persistent Rad Burst (-1219), whose radius Radiation
+// stimulus (-386) reaches The Player's retail `radiate` receptron. The patch
+// must subtract 6 from stored RadLevel, consume only on a successful clear,
+// and grant no protection against subsequent exposure.
+//
+// Negative-first on origin/main 83c3a9ea: `RadPatch` resolved to
+// UnimplementedScript, the item survived Frob, and no radiation status flow
+// existed to change.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "medsci2 VR Rad Barrel exposure is cleared by a consumed Rad Patch and resumes",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8737),
+      repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const barrels = (await game.entities.list({ filter: "Rad Barrel" })).entities;
+    assert.ok(barrels.length > 0, "medsci2 should contain an authored Rad Barrel");
+    const barrel = barrels[0];
+    await teleportVerified(game, {
+      x: barrel.position[0] + 1.0,
+      y: barrel.position[1] + 0.5,
+      z: barrel.position[2],
+    });
+    await game.entities.sendMessage(barrel.id, { type: "Damage", amount: 100 });
+    await game.step({ frames: 24 });
+
+    const exposed = (await game.info()).player.radiation_level;
+    assert.ok(exposed > 0, `Rad Burst must accumulate radiation, got ${exposed}`);
+
+    const patch = await game.player.spawnItem("Rad Patch");
+    await game.entities.sendMessage(patch.entity_id, { type: "Frob" });
+    await game.step({ frames: 2 });
+    const cleared = (await game.info()).player.radiation_level;
+    assert.ok(cleared < exposed, `Rad Patch must lower RadLevel (${exposed} -> ${cleared})`);
+    assert.ok(
+      !(await game.player.inventory()).items.some(
+        (item) => item.entity_id === patch.entity_id,
+      ),
+      "a successful Rad Patch use must consume its exact source entity",
+    );
+
+    await game.step({ frames: 24 });
+    const reexposed = (await game.info()).player.radiation_level;
+    assert.ok(
+      reexposed > cleared,
+      `Rad Patch must not grant a protection duration (${cleared} -> ${reexposed})`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #1137

## Summary

- replace the inert `RadPatch` script with an atomic carried-item use that removes 6.0 stored radiation (7.2 with Pharmo-Friendly), consumes one stack unit only on success, and refuses use at zero radiation
- implement the authored player radiation path: `Radiate` receptrons, persistent `Rad Burst` ambient radius sources, 100 ms absorption, 6-second damage/recovery cadence, and save/load persistence
- expose `radiation_level` through debug snapshots and cover the full VR lifecycle against a real MedSci2 radioactive barrel

## Retail faithfulness

This follows the shipped 25th Anniversary data and `allobjs-windows-x86_64.dll`, rather than treating the patch as timed protection:

- `MISC.STR` authors `CantUseRadPatch` as “No current radiation to remove.”
- the retail `RadPatch` handler reads `RadLevel`, subtracts 6.0 (7.2 for Pharmo-Friendly trait 2), clamps at zero, then activates and consumes one stack unit
- later exposure is not blocked; there is no patch duration or protection stack
- `The Player` authors `Radiate { multiplier: 1.0 }`, `RadAbsorb = 0.05`, `RadDrain = 50.0`, and `RadRecover = 3.0`
- `Rad Burst` authors Radiation intensity 8.0 at radius 6.0; retail schedules `RadCheck` at 100 ms and `RadDamage` at 6000 ms

## Campaign reproduction

- mission: Engineering (`eng1.mis`), fresh start
- run type: Detailed test run
- assets: 25th Anniversary
- presentation: VR
- seed: `197323719`
- observed input: Hold frame 354, Frob frame 357, TriggerRelease frame 359 reached the Rad Patch, which previously resolved to `UnimplementedScript`

Engineering contains the reproduced Rad Patch but no authored Rad Barrel. The end-to-end exposure test therefore uses MedSci2’s retail Rad Barrel → Corpse `Rad Burst` → player `Radiate` chain, while retaining VR presentation.

## Validation

- `cargo fmt --check --all`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 1000 passed, 3 ignored
- `cd tools/shock2-sdk && npm test` — 32 passed, 299 skipped
- `SHOCK2_E2E=1 node --test dist/test/rad-patch.e2e.test.js` — passed
- negative-first regression confirmed the prior Rad Patch Frob returned `NoEffect`

## Visual evidence

Captured headlessly in VR with the same MedSci2 Rad Barrel and inventory sequence on `origin/main` and this branch.

![Rad Patch consumption demo](https://gist.githubusercontent.com/tommy-xr/d4df475191f939fb74ccdfc761113a33/raw/rad-patch-consumption.gif)

<sub>In VR, a successfully used Rad Patch clears stored radiation and disappears from the inventory. Captured headlessly via the debug runtime's fixed timestep.</sub>

### Before → after

![Rad Patch before/after](https://gist.githubusercontent.com/tommy-xr/d4df475191f939fb74ccdfc761113a33/raw/rad-patch-before-after.png)
