### PR TITLE
spike(vr): hold a gun physically too, behind physical_held_items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,6 +570,20 @@ The project supports experimental flags for gating in-progress features during d
   default is the only reachable setting without a rebuild. Tell-tale log line:
   `high-detail (PMNM) meshes: true|false`.
 
+- **`physical_held_items`**: give a VR-held **gun** the same movement
+  properties a held melee weapon has had since #1121 - a swept kinematic body
+  that stops at world geometry instead of sliding through it. The collider is
+  fitted to the rendered `_h` view model (arm geometry excluded, by material),
+  and the held body is **inert**: no memberships, no filter, so it generates no
+  contacts, is invisible to the projectile raycast that starts inside its own
+  barrel, and cannot shove anything spawned at the muzzle. Only the level holds
+  it back. Melee weapons are unaffected either way (their body is their damage
+  volume and keeps `CollisionGroup::held_melee`), and the flat presentation is
+  untouched. Note a blocked weapon *renders* where its body is, so the shot -
+  which leaves the rendered muzzle vhot - leaves from the held-back position
+  too. VR only; without the flag a held gun has no body at all, exactly as
+  before. Tell-tale log line: `wield '<model>': rendered weapon WxHxD cm`.
+
 #### Adding New Experimental Features
 
 1. **Gate the feature in code**:

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -261,13 +261,21 @@ fn obj_weapon_geometry(obj: &SystemShock2ObjectMesh) -> Option<VrHeldWeaponGeome
 }
 
 fn weapon_geometry(mesh: &SystemShockContentModel) -> Option<VrHeldWeaponGeometry> {
-    let SystemShockContentModel::Mesh(ai_mesh, skeleton, pmnm) = mesh else {
-        let SystemShockContentModel::Obj(obj) = mesh else {
-            return None;
-        };
-        return obj_weapon_geometry(obj);
-    };
+    match mesh {
+        SystemShockContentModel::Obj(obj) => obj_weapon_geometry(obj),
+        SystemShockContentModel::Mesh(ai_mesh, skeleton, pmnm) => {
+            skinned_weapon_geometry(ai_mesh, skeleton, pmnm)
+        }
+    }
+}
 
+/// The weapon-only geometry of an LGMM skinned first-person model - the melee
+/// `_h` rigs, with or without a 25AE high-detail `PMNM` chunk.
+fn skinned_weapon_geometry(
+    ai_mesh: &SystemShock2AIMesh,
+    skeleton: &Rc<Skeleton>,
+    pmnm: &Option<crate::ss2_bin_pmnm::PmnmMesh>,
+) -> Option<VrHeldWeaponGeometry> {
     if let Some(pmnm) = pmnm {
         let runs = pmnm.to_skinned_vertices();
         let has_named_arm = runs

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -225,9 +225,40 @@ fn split_at_terminal_joint(
         .partition(|vertex| rigid_joint(vertex) == Some(terminal_joint))
 }
 
+/// The weapon-only geometry of an LGMD first-person model (the 25AE gun `_h`
+/// meshes, and any classic world model wielded as-is).
+///
+/// These carry no skeleton of their own: the "joints" are the sub-object
+/// hierarchy, which is how a slide or a magazine moves, and the renderer poses
+/// them through exactly the skeleton [`ss2_bin_obj_loader::build_skeleton`]
+/// builds. The weapon/arm split is by material rather than by terminal joint -
+/// a gun's arm is not a joint, it is `ND-arm*` geometry that can ride any
+/// sub-object (see [`is_first_person_arm_material`]).
+fn obj_weapon_geometry(obj: &SystemShock2ObjectMesh) -> Option<VrHeldWeaponGeometry> {
+    let mut vertices = Vec::new();
+    let mut arm_vertices = Vec::new();
+    for (material, run) in ss2_bin_obj_loader::to_vertices_by_material(obj) {
+        if is_first_person_arm_material(&material) {
+            arm_vertices.extend(run);
+        } else {
+            vertices.extend(run);
+        }
+    }
+
+    (!vertices.is_empty()).then(|| VrHeldWeaponGeometry {
+        vertices,
+        arm_vertices,
+        skeleton: Rc::new(ss2_bin_obj_loader::build_skeleton(obj)),
+        bind: None,
+    })
+}
+
 fn weapon_geometry(mesh: &SystemShockContentModel) -> Option<VrHeldWeaponGeometry> {
     let SystemShockContentModel::Mesh(ai_mesh, skeleton, pmnm) = mesh else {
-        return None;
+        let SystemShockContentModel::Obj(obj) = mesh else {
+            return None;
+        };
+        return obj_weapon_geometry(obj);
     };
 
     if let Some(pmnm) = pmnm {

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -234,6 +234,13 @@ fn split_at_terminal_joint(
 /// builds. The weapon/arm split is by material rather than by terminal joint -
 /// a gun's arm is not a joint, it is `ND-arm*` geometry that can ride any
 /// sub-object (see [`is_first_person_arm_material`]).
+///
+/// Like both skinned branches below, this measures the *authored* geometry: the
+/// renderer additionally drops any slot whose texture will not resolve, and
+/// this fit does not. A model missing a texture would therefore be fitted
+/// slightly larger than it draws - which is the safe direction (the weapon
+/// stops short rather than sinking in), and is how the melee fit has always
+/// behaved.
 fn obj_weapon_geometry(obj: &SystemShock2ObjectMesh) -> Option<VrHeldWeaponGeometry> {
     let mut vertices = Vec::new();
     let mut arm_vertices = Vec::new();

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -145,10 +145,8 @@ pub fn to_scene_objects(
         .into_iter()
         .collect::<Vec<(u16, Vec<VertexPositionTextureSkinnedNormal>)>>();
 
-    let mut bones = Vec::new();
-    build_skeleton_for_obj_mesh(&mesh, 0, None, &mut bones);
-    let is_skinned = bones.len() > 1;
-    let skeleton = Skeleton::create_from_bones(bones);
+    let skeleton = build_skeleton(mesh);
+    let is_skinned = skeleton.bone_count() > 1;
 
     let mut mesh_objects = vertices
         .into_iter()
@@ -635,6 +633,27 @@ pub fn sub_object_transforms(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Matr
         .collect()
 }
 
+/// [`to_vertices`] keyed by material name rather than by slot, so a caller can
+/// select geometry the way the 25AE authors it - by material - without
+/// re-deriving the slot table. Ordered by slot, and slots with no material
+/// entry are dropped (nothing can draw them either).
+pub fn to_vertices_by_material(
+    mesh: &SystemShock2ObjectMesh,
+) -> Vec<(String, Vec<VertexPositionTextureSkinnedNormal>)> {
+    let mut by_slot = to_vertices(mesh).into_iter().collect::<Vec<_>>();
+    by_slot.sort_by_key(|(slot, _)| *slot);
+    by_slot
+        .into_iter()
+        .filter_map(|(slot, vertices)| {
+            let material = mesh
+                .materials
+                .iter()
+                .find(|material| material.slot_num as u16 == slot)?;
+            Some((material.name.clone(), vertices))
+        })
+        .collect()
+}
+
 pub fn to_vertices(
     mesh: &SystemShock2ObjectMesh,
 ) -> HashMap<u16, Vec<VertexPositionTextureSkinnedNormal>> {
@@ -706,6 +725,16 @@ fn get_bone_index_for_point(header: &SystemShock2ObjectMesh, usize: u16) -> u32 
     }
 
     0
+}
+
+/// The sub-object hierarchy of an object mesh as a skeleton - one bone per
+/// sub-object, in the same joint order [`to_vertices`] indexes. The render path
+/// and any measurement of the mesh must pose it the same way, so both go
+/// through this.
+pub fn build_skeleton(mesh: &SystemShock2ObjectMesh) -> Skeleton {
+    let mut bones = Vec::new();
+    build_skeleton_for_obj_mesh(mesh, 0, None, &mut bones);
+    Skeleton::create_from_bones(bones)
 }
 
 fn build_skeleton_for_obj_mesh(
@@ -1238,6 +1267,34 @@ mod tests {
             polygons,
             sub_objects: Vec::new(),
         }
+    }
+
+    /// Fitting a collider to a first-person model's *weapon* means selecting
+    /// geometry by material (the arm is `ND-arm*`), so the vertex runs have to
+    /// come back labelled with the material that draws them.
+    #[test]
+    fn vertices_come_back_grouped_by_their_material() {
+        let mut mesh = mesh_with(
+            vec![
+                material_in_slot("ND-ar15.psd", 0),
+                material_in_slot("ND-arm.psd", 1),
+            ],
+            vec![polygon_in_slot(0), polygon_in_slot(1)],
+        );
+        mesh.vertices = vec![
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        ];
+
+        let runs = to_vertices_by_material(&mesh);
+
+        let names = runs
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["ND-ar15.psd", "ND-arm.psd"]);
+        assert!(runs.iter().all(|(_, vertices)| vertices.len() == 3));
     }
 
     #[test]

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -617,9 +617,7 @@ fn wrist_and_fingertip(points: &[Point3<f32>]) -> Option<(Point3<f32>, Point3<f3
 /// sub-objects (`@s01_han`, `@s02_han`) are posed onto the weapon by hand, so
 /// their transforms say exactly where a hand belongs on that gun.
 pub fn sub_object_transforms(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Matrix4<f32>)> {
-    let mut bones = Vec::new();
-    build_skeleton_for_obj_mesh(mesh, 0, None, &mut bones);
-    let skeleton = Skeleton::create_from_bones(bones);
+    let skeleton = build_skeleton(mesh);
 
     mesh.sub_objects
         .iter()

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -643,10 +643,14 @@ pub fn to_vertices_by_material(
     by_slot
         .into_iter()
         .filter_map(|(slot, vertices)| {
+            // Last entry wins on a duplicated slot, matching the map
+            // `to_scene_objects` builds - so a caller selecting geometry by
+            // material selects what the renderer draws with.
             let material = mesh
                 .materials
                 .iter()
-                .find(|material| material.slot_num as u16 == slot)?;
+                .filter(|material| material.slot_num as u16 == slot)
+                .next_back()?;
             Some((material.name.clone(), vertices))
         })
         .collect()

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -999,6 +999,14 @@ pub struct DebugOptions {
 #[derive(Unique, Clone, Copy)]
 pub struct GlobalPresentationMode(pub crate::PresentationMode);
 
+/// Whether `--experimental physical_held_items` is on: a VR-held gun keeps a
+/// swept body, like a held melee weapon, so it stops at the level's geometry
+/// instead of passing through it. Accessible from the paths that establish
+/// held-item physics without `GameOptions` in hand (the restore path, the
+/// virtual-hand effects).
+#[derive(Unique, Clone, Copy)]
+pub struct GlobalPhysicalHeldItems(pub bool);
+
 /// Pathfinding service accessible from scripts (steering strategies) via
 /// UniqueView. None when the mission has no AIPATH data (e.g. debug scenes).
 #[derive(Unique, Clone)]
@@ -1455,6 +1463,11 @@ impl MissionCore {
             debug_ai: game_options.debug_ai,
         });
         world.add_unique(GlobalPresentationMode(game_options.presentation_mode));
+        world.add_unique(GlobalPhysicalHeldItems(
+            game_options
+                .experimental_features
+                .contains("physical_held_items"),
+        ));
         let template_class_tags = create_template_class_tag_map(&entity_info_rc);
         world.add_unique(GlobalTemplateClassTags(template_class_tags));
         world.add_unique(
@@ -5641,11 +5654,11 @@ impl MissionCore {
                     if self.interaction.is_holding(entity_id) {
                         // A grab routed through this effect (equip a carried
                         // weapon, a backpack double-click) never emits
-                        // `HoldItem`, so establish the melee contact body here
-                        // too - otherwise a weapon equipped this way is held
-                        // without a collider and never reports contacts.
-                        if self.is_vr_melee_weapon(entity_id) {
-                            self.attach_held_item_physics(entity_id);
+                        // `HoldItem`, so establish the held body here too -
+                        // otherwise a weapon equipped this way is held without
+                        // a collider and never reports contacts.
+                        if let Some(group) = self.held_item_collision_group(entity_id) {
+                            self.attach_held_item_physics(entity_id, group);
                         }
 
                         // Let the scripts know we are now holding the item..
@@ -6091,6 +6104,51 @@ impl MissionCore {
                             }
                         } else if was_vr_held && !new_model.is_animated() {
                             self.id_to_animation_player.remove(&entity_id);
+                        }
+
+                        // A physically held gun (`physical_held_items`) is
+                        // swept against the level with a cuboid fitted to the
+                        // *rendered* view model, exactly as a melee weapon is.
+                        // Without this it would keep the loose-prop box, which
+                        // is the size of the WORLD model and centred on the
+                        // grip rather than on the barrel - so the weapon would
+                        // stop at the wrong distance from a wall, in both
+                        // directions. Guns author no grip correction (their
+                        // offset moves the entity, not the mesh), so model
+                        // space is the body's own frame and the fit needs no
+                        // transform. Melee took its own fit above, with the
+                        // posed arm's correction.
+                        let is_physical_gun = vr_held
+                            && !is_vr_melee_weapon(&self.world, entity_id)
+                            && self.interaction.is_holding(entity_id)
+                            && self.held_item_collision_group(entity_id).is_some();
+                        if is_physical_gun {
+                            // The same player the model is rendered with, so
+                            // the fit measures the pose the player sees.
+                            let player = self
+                                .id_to_animation_player
+                                .get(&entity_id)
+                                .cloned()
+                                .unwrap_or_else(AnimationPlayer::empty);
+                            if let Some(bounds) = vr_held_source.as_ref().and_then(|source| {
+                                source.posed_weapon_bounds(&player, Matrix4::identity())
+                            }) {
+                                let cm = crate::METERS_PER_WORLD_UNIT * 100.0;
+                                tracing::info!(
+                                    "wield '{model_name}': rendered weapon {:.0}x{:.0}x{:.0} cm, center ({:.3}, {:.3}, {:.3})",
+                                    bounds.size.x * cm,
+                                    bounds.size.y * cm,
+                                    bounds.size.z * cm,
+                                    bounds.center.x,
+                                    bounds.center.y,
+                                    bounds.center.z,
+                                );
+                                self.physics.fit_held_item_cuboid(
+                                    entity_id,
+                                    bounds.size,
+                                    bounds.center,
+                                );
+                            }
                         }
                         self.id_to_model.insert(entity_id, new_model);
                         self.world
@@ -8222,13 +8280,13 @@ impl MissionCore {
                     );
                 }
                 VirtualHandEffect::HoldItem { entity_id } => {
-                    if self.is_vr_melee_weapon(entity_id) {
-                        // Held guns/items stay unphysical, but a VR melee
-                        // weapon needs its authored collider to report genuine
-                        // contacts. A joint motor drives its dynamic body
-                        // toward the tracked hand while world contact can hold
-                        // the rendered weapon back.
-                        self.attach_held_item_physics(entity_id);
+                    // Most held items stay unphysical and pass through
+                    // everything. A VR melee weapon needs its collider to
+                    // report genuine contacts; with `physical_held_items` a
+                    // held gun keeps one too, purely so world geometry can
+                    // hold the rendered weapon back.
+                    if let Some(group) = self.held_item_collision_group(entity_id) {
+                        self.attach_held_item_physics(entity_id, group);
                     } else {
                         self.make_un_physical(entity_id);
                     }
@@ -8251,9 +8309,11 @@ impl MissionCore {
                     if !restore_live_entity_world_refs(&mut self.world, entity_id) {
                         continue;
                     }
-                    if self.is_vr_melee_weapon(entity_id) {
+                    if self.held_item_collision_group(entity_id).is_some() {
                         // Recreate from authored physics so the released item
-                        // is an ordinary dynamic, harmless loose prop again.
+                        // is an ordinary dynamic, harmless loose prop again -
+                        // the held body is a swept kinematic with a fitted
+                        // collider and must not survive the drop.
                         self.make_un_physical(entity_id);
                     }
                     // After the body is gone (so this writes the entity's
@@ -8272,8 +8332,10 @@ impl MissionCore {
         }
     }
 
-    fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {
-        is_vr_melee_weapon(&self.world, entity_id)
+    /// The collision group this entity is held with, or `None` when it is
+    /// held with no body (see [`held_item_collision_group`]).
+    fn held_item_collision_group(&self, entity_id: EntityId) -> Option<CollisionGroup> {
+        held_item_collision_group(&self.world, entity_id)
     }
 
     /// Undo a computed grip offset before a released item becomes a loose prop
@@ -8315,12 +8377,13 @@ impl MissionCore {
         self.set_entity_position_rotation(entity_id, hand, rotation, vec3(1.0, 1.0, 1.0));
     }
 
-    /// Give a held melee weapon the contact body the VR damage window needs.
-    /// Idempotent: `make_physical` no-ops when the body already exists, so this
-    /// is safe on both a fresh grab and a restore.
-    fn attach_held_item_physics(&mut self, entity_id: EntityId) {
+    /// Give a held item the swept body its wield needs - the contact volume a
+    /// melee weapon damages with, or the inert one that keeps a gun out of the
+    /// level's geometry. Idempotent: `make_physical` no-ops when the body
+    /// already exists, so this is safe on both a fresh grab and a restore.
+    fn attach_held_item_physics(&mut self, entity_id: EntityId, group: CollisionGroup) {
         self.make_physical(entity_id);
-        self.physics.set_held_item_physical(entity_id);
+        self.physics.set_held_item_physical(entity_id, group);
     }
 
     /// Queue an entity to be triggered after scripts are initialized
@@ -8757,6 +8820,34 @@ pub fn is_vr_melee_weapon(world: &World, entity_id: EntityId) -> bool {
             .is_ok_and(|limb_models| limb_models.get(entity_id).is_ok())
 }
 
+/// How this entity behaves physically while held in a VR hand, or `None` if it
+/// is held with no body at all (which is what every held item did before the
+/// melee weapons needed contacts).
+///
+/// Two cases, and the difference is what the body is *for*:
+/// - a melee weapon's body is its damage volume, so it must generate contacts;
+/// - a gun's body only has to stop the weapon travelling into the level, so it
+///   takes part in no collision at all (see [`CollisionGroup::held_inert`]).
+///   Opt-in, because a weapon the world can hold back is a change to how
+///   aiming and firing feel, not just to how the wield looks.
+pub fn held_item_collision_group(world: &World, entity_id: EntityId) -> Option<CollisionGroup> {
+    if is_vr_melee_weapon(world, entity_id) {
+        return Some(CollisionGroup::held_melee());
+    }
+
+    let is_vr = world
+        .borrow::<UniqueView<GlobalPresentationMode>>()
+        .is_ok_and(|mode| mode.0 == crate::PresentationMode::Vr);
+    let physical_held_items = world
+        .borrow::<UniqueView<GlobalPhysicalHeldItems>>()
+        .is_ok_and(|enabled| enabled.0);
+    let is_gun = world
+        .borrow::<View<dark::properties::PropPlayerGun>>()
+        .is_ok_and(|guns| guns.get(entity_id).is_ok());
+
+    (is_vr && physical_held_items && is_gun).then(CollisionGroup::held_inert)
+}
+
 /// Physics for an item restored into a hand by save/load or a level change.
 ///
 /// The restore path cannot reuse `VirtualHandEffect::HoldItem` - only a fresh
@@ -8770,10 +8861,9 @@ fn restore_held_item_physics(
     physics: &mut PhysicsWorld,
     entity_id: EntityId,
 ) {
-    if is_vr_melee_weapon(world, entity_id) {
-        physics.set_held_item_physical(entity_id);
-    } else {
-        make_un_physical2(id_to_physics, physics, entity_id);
+    match held_item_collision_group(world, entity_id) {
+        Some(group) => physics.set_held_item_physical(entity_id, group),
+        None => make_un_physical2(id_to_physics, physics, entity_id),
     }
 }
 
@@ -11644,5 +11734,84 @@ impl crate::game_scene::GameScene for MissionCore {
 
     fn wants_pointer(&self) -> bool {
         self.wants_pointer()
+    }
+}
+
+#[cfg(test)]
+mod held_item_physics_tests {
+    use super::*;
+    use dark::properties::{PropLimbModel, PropPlayerGun};
+
+    fn world_with(mode: crate::PresentationMode, physical_held_items: bool) -> World {
+        let world = World::new();
+        world.add_unique(GlobalPresentationMode(mode));
+        world.add_unique(GlobalPhysicalHeldItems(physical_held_items));
+        world
+    }
+
+    fn gun(world: &mut World) -> EntityId {
+        world.add_entity((PropPlayerGun {
+            flags: 0,
+            hand_model: "atek_h".to_owned(),
+            icon_file: String::new(),
+            model_offset: cgmath::Vector3::new(0.0, 0.0, 0.0),
+            fire_offset: cgmath::Vector3::new(0.0, 0.0, 0.0),
+            heading: 0,
+            reload_pitch: 0,
+            reload_rate: 0,
+            gun_type: 0,
+        },))
+    }
+
+    fn melee(world: &mut World) -> EntityId {
+        world.add_entity((PropLimbModel("wrench_h".to_owned()),))
+    }
+
+    /// The shipped behavior: a VR-held gun has no body at all, so it passes
+    /// through the level exactly as it always has.
+    #[test]
+    fn a_held_gun_is_unphysical_without_the_experimental_flag() {
+        let mut world = world_with(crate::PresentationMode::Vr, false);
+        let gun = gun(&mut world);
+
+        assert!(held_item_collision_group(&world, gun).is_none());
+    }
+
+    /// With the flag, it gets a body - and an *inert* one: the point is world
+    /// geometry holding the weapon back, not the weapon touching anything.
+    #[test]
+    fn a_held_gun_takes_an_inert_body_with_the_experimental_flag() {
+        let mut world = world_with(crate::PresentationMode::Vr, true);
+        let gun = gun(&mut world);
+
+        let group =
+            held_item_collision_group(&world, gun).expect("a held gun should take a swept body");
+        assert!(group.is_inert(), "a held gun must not generate contacts");
+    }
+
+    /// A melee weapon is unaffected by the flag in either direction: its body
+    /// is its damage volume and must keep reporting contacts.
+    #[test]
+    fn a_held_melee_weapon_keeps_its_contact_body_either_way() {
+        for physical_held_items in [false, true] {
+            let mut world = world_with(crate::PresentationMode::Vr, physical_held_items);
+            let wrench = melee(&mut world);
+
+            let group = held_item_collision_group(&world, wrench)
+                .expect("a held melee weapon always takes a contact body");
+            assert!(!group.is_inert());
+        }
+    }
+
+    /// Flat swings and flat shots are raycasts against the world; nothing in
+    /// the flat presentation wants a body in the player's hand.
+    #[test]
+    fn nothing_is_held_physically_in_the_flat_presentation() {
+        let mut world = world_with(crate::PresentationMode::Flat, true);
+        let gun = gun(&mut world);
+        let wrench = melee(&mut world);
+
+        assert!(held_item_collision_group(&world, gun).is_none());
+        assert!(held_item_collision_group(&world, wrench).is_none());
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5645,7 +5645,7 @@ impl MissionCore {
                         // too - otherwise a weapon equipped this way is held
                         // without a collider and never reports contacts.
                         if self.is_vr_melee_weapon(entity_id) {
-                            self.attach_held_melee_physics(entity_id);
+                            self.attach_held_item_physics(entity_id);
                         }
 
                         // Let the scripts know we are now holding the item..
@@ -6067,7 +6067,7 @@ impl MissionCore {
                                                         "wield '{model_name}': baked arm unmeasured"
                                                     ),
                                                 }
-                                                self.physics.fit_held_melee_cuboid(
+                                                self.physics.fit_held_item_cuboid(
                                                     entity_id,
                                                     bounds.size,
                                                     bounds.center,
@@ -8228,7 +8228,7 @@ impl MissionCore {
                         // contacts. A joint motor drives its dynamic body
                         // toward the tracked hand while world contact can hold
                         // the rendered weapon back.
-                        self.attach_held_melee_physics(entity_id);
+                        self.attach_held_item_physics(entity_id);
                     } else {
                         self.make_un_physical(entity_id);
                     }
@@ -8318,9 +8318,9 @@ impl MissionCore {
     /// Give a held melee weapon the contact body the VR damage window needs.
     /// Idempotent: `make_physical` no-ops when the body already exists, so this
     /// is safe on both a fresh grab and a restore.
-    fn attach_held_melee_physics(&mut self, entity_id: EntityId) {
+    fn attach_held_item_physics(&mut self, entity_id: EntityId) {
         self.make_physical(entity_id);
-        self.physics.set_held_melee(entity_id);
+        self.physics.set_held_item_physical(entity_id);
     }
 
     /// Queue an entity to be triggered after scripts are initialized
@@ -8771,7 +8771,7 @@ fn restore_held_item_physics(
     entity_id: EntityId,
 ) {
     if is_vr_melee_weapon(world, entity_id) {
-        physics.set_held_melee(entity_id);
+        physics.set_held_item_physical(entity_id);
     } else {
         make_un_physical2(id_to_physics, physics, entity_id);
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -6119,9 +6119,10 @@ impl MissionCore {
                         // transform. Melee took its own fit above, with the
                         // posed arm's correction.
                         let is_physical_gun = vr_held
-                            && !is_vr_melee_weapon(&self.world, entity_id)
                             && self.interaction.is_holding(entity_id)
-                            && self.held_item_collision_group(entity_id).is_some();
+                            && self
+                                .held_item_collision_group(entity_id)
+                                .is_some_and(|group| group.is_inert());
                         if is_physical_gun {
                             // The same player the model is rendered with, so
                             // the fit measures the pose the player sees.
@@ -8830,6 +8831,13 @@ pub fn is_vr_melee_weapon(world: &World, entity_id: EntityId) -> bool {
 ///   takes part in no collision at all (see [`CollisionGroup::held_inert`]).
 ///   Opt-in, because a weapon the world can hold back is a change to how
 ///   aiming and firing feel, not just to how the wield looks.
+///
+/// A gun additionally has to be one VR actually wields as a first-person `_h`
+/// model, which is the same condition `InternalSwitchHeldModelScript` swaps on.
+/// On a classic install VR deliberately keeps the *world* model, so no `_h`
+/// wield happens and there is nothing to fit a collider to - the gun would
+/// sweep the inherited loose-pickup box, sized and centred for a different
+/// mesh, and stop at the wrong distance from every wall. No fit, no body.
 pub fn held_item_collision_group(world: &World, entity_id: EntityId) -> Option<CollisionGroup> {
     if is_vr_melee_weapon(world, entity_id) {
         return Some(CollisionGroup::held_melee());
@@ -8844,8 +8852,11 @@ pub fn held_item_collision_group(world: &World, entity_id: EntityId) -> Option<C
     let is_gun = world
         .borrow::<View<dark::properties::PropPlayerGun>>()
         .is_ok_and(|guns| guns.get(entity_id).is_ok());
+    let wields_a_view_model = crate::is_25th_anniversary_install()
+        && crate::scripts::internal_switch_held_model::get_raw_view_model(world, entity_id)
+            .is_some_and(|model| crate::vr_config::is_vr_view_model(&model));
 
-    (is_vr && physical_held_items && is_gun).then(CollisionGroup::held_inert)
+    (is_vr && physical_held_items && is_gun && wields_a_view_model).then(CollisionGroup::held_inert)
 }
 
 /// Physics for an item restored into a hand by save/load or a level change.
@@ -11784,9 +11795,20 @@ mod held_item_physics_tests {
         let mut world = world_with(crate::PresentationMode::Vr, true);
         let gun = gun(&mut world);
 
-        let group =
-            held_item_collision_group(&world, gun).expect("a held gun should take a swept body");
-        assert!(group.is_inert(), "a held gun must not generate contacts");
+        let group = held_item_collision_group(&world, gun);
+
+        // The swept body needs a collider fitted to the `_h` view model, which
+        // only a 25AE install wields - so on a classic install the correct
+        // answer is still "no body", and this asserts that rather than
+        // skipping.
+        assert_eq!(
+            group.is_some(),
+            crate::is_25th_anniversary_install(),
+            "a held gun is swept exactly when VR wields its view model"
+        );
+        if let Some(group) = group {
+            assert!(group.is_inert(), "a held gun must not generate contacts");
+        }
     }
 
     /// A melee weapon is unaffected by the flag in either direction: its body

--- a/shock2vr/src/physics/held_item_drive.rs
+++ b/shock2vr/src/physics/held_item_drive.rs
@@ -126,7 +126,7 @@ fn spawn_held_wrench(world: &mut PhysicsWorld, at: Vector3<f32>) -> (EntityId, R
         false,
         DynamicPhysicsOptions::default(),
     );
-    world.set_held_item_physical(weapon);
+    world.set_held_item_physical(weapon, CollisionGroup::held_melee());
     world.fit_held_item_cuboid(weapon, WEAPON_HALF_EXTENTS * 2.0, WEAPON_COLLIDER_CENTER);
     (weapon, handle)
 }

--- a/shock2vr/src/physics/held_item_drive.rs
+++ b/shock2vr/src/physics/held_item_drive.rs
@@ -37,7 +37,7 @@ use super::{
 
 /// A wrench-scale fitted melee volume. The body origin sits on the rendered
 /// weapon head and the fitted cuboid extends back over the handle, which is
-/// what production builds via `fit_held_melee_cuboid`; the offset, elongated
+/// what production builds via `fit_held_item_cuboid`; the offset, elongated
 /// shape is the inertia-awkward case a drive has to hold.
 const WEAPON_HALF_EXTENTS: Vector3<f32> = Vector3::new(0.045, 0.30, 0.045);
 const WEAPON_COLLIDER_CENTER: Vector3<f32> = Vector3::new(0.0, -0.30, 0.0);
@@ -126,8 +126,8 @@ fn spawn_held_wrench(world: &mut PhysicsWorld, at: Vector3<f32>) -> (EntityId, R
         false,
         DynamicPhysicsOptions::default(),
     );
-    world.set_held_melee(weapon);
-    world.fit_held_melee_cuboid(weapon, WEAPON_HALF_EXTENTS * 2.0, WEAPON_COLLIDER_CENTER);
+    world.set_held_item_physical(weapon);
+    world.fit_held_item_cuboid(weapon, WEAPON_HALF_EXTENTS * 2.0, WEAPON_COLLIDER_CENTER);
     (weapon, handle)
 }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2041,7 +2041,9 @@ impl CollisionGroup {
     /// Whether this group takes part in no collision at all
     /// ([`Self::held_inert`]).
     pub fn is_inert(&self) -> bool {
-        self.collision.memberships.is_empty() && self.collision.filter.is_empty()
+        [self.collision, self.solver]
+            .iter()
+            .all(|groups| groups.memberships.is_empty() && groups.filter.is_empty())
     }
 
     /// Collision behavior for a living creature capsule. It collides exactly

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3759,7 +3759,10 @@ impl PhysicsWorld {
     /// Rotational sweeps are expensive and ill-defined against thin geometry,
     /// and the failure they would prevent (turning the blade into a wall) is
     /// far milder than the one taking the hand's rotation prevents (a weapon
-    /// whose angle is not the angle of the hand holding it).
+    /// whose angle is not the angle of the hand holding it). A held gun makes
+    /// that more visible than a wrench does - a long barrel can be *turned*
+    /// into a wall it cannot be *pushed* into - but the tradeoff is the same
+    /// one, and the same choice.
     ///
     /// Only WORLD geometry blocks. Actors deliberately do not: a swing has to
     /// travel *into* a creature to damage it, and loose props are better
@@ -6144,10 +6147,10 @@ mod tests {
         assert!(world.get_velocity(weapon).unwrap().magnitude() < 1.0e-4);
     }
 
-    /// World solver contact must win over the hand motor, then releasing that
-    /// obstruction must let the weapon return to the tracked pose.
-    #[test]
-    fn held_melee_weapon_stops_at_world_geometry_then_springs_back() {
+    /// Drive a held body of `group` from x=-1 at a fixed wall at x=0, then let
+    /// the hand retreat. Shared by the melee and inert cases: what the level
+    /// does to a held body must not depend on which group it is held with.
+    fn held_item_pushed_into_a_wall_then_withdrawn(group: CollisionGroup) {
         let (mut world, mut player) = world_with_floor();
         world.add_collider(
             EntityId::from_inner(2).unwrap(),
@@ -6166,7 +6169,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
+        world.set_held_item_physical(weapon, group);
         world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
         world.set_position_rotation2(weapon, vec3(1.0, 1.0, 0.0), identity_quat());
@@ -6176,7 +6179,7 @@ mod tests {
         let blocked_x = world.get_position(handle).unwrap().x;
         assert!(
             blocked_x < -0.20,
-            "the dynamic weapon crossed the fixed wall instead of stopping: x={blocked_x}"
+            "the held body crossed the fixed wall instead of stopping: x={blocked_x}"
         );
 
         world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
@@ -6184,8 +6187,15 @@ mod tests {
         let returned_x = world.get_position(handle).unwrap().x;
         assert!(
             returned_x < -0.8,
-            "the weapon did not spring back after the target cleared the wall: x={returned_x}"
+            "the held body did not spring back after the target cleared the wall: x={returned_x}"
         );
+    }
+
+    /// World solver contact must win over the hand motor, then releasing that
+    /// obstruction must let the weapon return to the tracked pose.
+    #[test]
+    fn held_melee_weapon_stops_at_world_geometry_then_springs_back() {
+        held_item_pushed_into_a_wall_then_withdrawn(CollisionGroup::held_melee());
     }
 
     /// The `physical_held_items` case: a held gun only has to stop travelling
@@ -6195,44 +6205,7 @@ mod tests {
     /// the whole design rests on it.
     #[test]
     fn an_inert_held_item_is_still_stopped_by_world_geometry() {
-        let (mut world, mut player) = world_with_floor();
-        world.add_collider(
-            EntityId::from_inner(2).unwrap(),
-            ColliderBuilder::cuboid(0.05, 1.0, 1.0)
-                .translation(vector![0.0, 1.0, 0.0])
-                .build(),
-        );
-        let gun = EntityId::from_inner(3).unwrap();
-        let handle = world.add_dynamic(
-            gun,
-            vec3(-1.0, 1.0, 0.0),
-            identity_quat(),
-            vec3(0.0, 0.0, 0.0),
-            PhysicsShape::Cuboid(vec3(0.4, 0.4, 0.4)),
-            CollisionGroup::entity(),
-            false,
-            DynamicPhysicsOptions::default(),
-        );
-        world.set_held_item_physical(gun, CollisionGroup::held_inert());
-        world.set_position_rotation2(gun, vec3(-1.0, 1.0, 0.0), identity_quat());
-        step(&mut world, &mut player, 1);
-        world.set_position_rotation2(gun, vec3(1.0, 1.0, 0.0), identity_quat());
-
-        step(&mut world, &mut player, 120);
-
-        let blocked_x = world.get_position(handle).unwrap().x;
-        assert!(
-            blocked_x < -0.20,
-            "an inert held item crossed the fixed wall instead of stopping: x={blocked_x}"
-        );
-
-        world.set_position_rotation2(gun, vec3(-1.0, 1.0, 0.0), identity_quat());
-        step(&mut world, &mut player, 60);
-        let returned_x = world.get_position(handle).unwrap().x;
-        assert!(
-            returned_x < -0.8,
-            "the item did not return once the target cleared the wall: x={returned_x}"
-        );
+        held_item_pushed_into_a_wall_then_withdrawn(CollisionGroup::held_inert());
     }
 
     /// ...and it touches nothing while it does. A held gun swept through a

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2271,7 +2271,7 @@ pub struct PlayerHandle {
 /// target out of `entity_id_to_body` makes the weapon remain the entity's one
 /// authoritative rendered/contact body.
 #[derive(Clone, Copy)]
-struct HeldMeleeDrive {
+struct HeldItemDrive {
     target: RigidBodyHandle,
     /// The loose/restored world body is seated at the first tracked pose once;
     /// later hand poses move only `target` so world contact stays physical.
@@ -2305,7 +2305,7 @@ impl PlayerHandle {
 
 /// Clearance the held-melee sweep stops short of a surface by, so a weapon
 /// resting against one does not re-report a zero-distance hit every frame.
-const HELD_MELEE_SKIN: f32 = 0.01;
+const HELD_ITEM_SKIN: f32 = 0.01;
 
 pub struct PhysicsWorld {
     gravity: Vector<Real>,
@@ -2351,7 +2351,7 @@ pub struct PhysicsWorld {
     // Dynamic held-melee bodies driven toward invisible controller targets by
     // Rapier joint motors. Keyed by the weapon body handle so the normal
     // set_position_rotation path can redirect hand poses to the target.
-    held_melee_drives: HashMap<RigidBodyHandle, HeldMeleeDrive>,
+    held_item_drives: HashMap<RigidBodyHandle, HeldItemDrive>,
 
     // TODO:
     // physics_hooks: Box<dyn PhysicsHooks>,
@@ -2523,7 +2523,7 @@ impl PhysicsWorld {
             vector: vec_to_nvec(position),
         };
 
-        if let Some(drive) = self.held_melee_drives.get(&handle).copied() {
+        if let Some(drive) = self.held_item_drives.get(&handle).copied() {
             let mut just_seated = false;
             if !drive.seated {
                 if let Some(weapon) = self.rigid_body_set.get_mut(handle) {
@@ -2531,7 +2531,7 @@ impl PhysicsWorld {
                     weapon.set_linvel(Vector::zeros(), true);
                     weapon.set_angvel(Vector::zeros(), true);
                 }
-                if let Some(drive) = self.held_melee_drives.get_mut(&handle) {
+                if let Some(drive) = self.held_item_drives.get_mut(&handle) {
                     drive.seated = true;
                 }
                 just_seated = true;
@@ -2681,13 +2681,13 @@ impl PhysicsWorld {
     /// The hand pose drives an invisible kinematic target; each step the
     /// visible weapon is *shape-cast* from where it is toward that target and
     /// stopped at the first world surface in the way (see
-    /// [`Self::drive_held_melee`]). Kinematic, not dynamic: a dynamic weapon
+    /// [`Self::drive_held_items`]). Kinematic, not dynamic: a dynamic weapon
     /// is subject to contact impulses, and a contact against a body whose
     /// origin sits out on the weapon head torques it - which in a headset
     /// read as the weapon spinning out of the player's hand the moment it
     /// touched anything. A swept kinematic body cannot be spun by the solver,
     /// cannot tunnel, and still reports every contact.
-    pub fn set_held_melee(&mut self, entity_id: EntityId) {
+    pub fn set_held_item_physical(&mut self, entity_id: EntityId) {
         let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
             return;
         };
@@ -2702,15 +2702,15 @@ impl PhysicsWorld {
             (*body.position(), body.colliders().to_vec())
         };
 
-        if !self.held_melee_drives.contains_key(&handle) {
+        if !self.held_item_drives.contains_key(&handle) {
             let target = self.rigid_body_set.insert(
                 RigidBodyBuilder::kinematic_position_based()
                     .pose(pose)
                     .build(),
             );
-            self.held_melee_drives.insert(
+            self.held_item_drives.insert(
                 handle,
-                HeldMeleeDrive {
+                HeldItemDrive {
                     target,
                     seated: false,
                 },
@@ -2738,20 +2738,20 @@ impl PhysicsWorld {
     /// The rigid-body target stays controller-driven at the authored weapon
     /// joint; the collider's parent-relative center covers the rest of the
     /// handle/blade without moving the rendered model or the motor target.
-    pub fn fit_held_melee_cuboid(
+    pub fn fit_held_item_cuboid(
         &mut self,
         entity_id: EntityId,
         size: Vector3<f32>,
         center: Vector3<f32>,
     ) {
-        let size = sanitize_collider_size(entity_id, "fit_held_melee_cuboid", size);
+        let size = sanitize_collider_size(entity_id, "fit_held_item_cuboid", size);
         let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
             return;
         };
         let Some(body) = self.rigid_body_set.get(handle) else {
             return;
         };
-        if !self.held_melee_drives.contains_key(&handle) {
+        if !self.held_item_drives.contains_key(&handle) {
             return;
         }
 
@@ -2862,7 +2862,7 @@ impl PhysicsWorld {
     ) {
         let previous =
             nvec_to_cgmath(*self.rigid_body_set[player_handle.character_handle].translation());
-        self.translate_held_melee_for_player_relocation(position - previous);
+        self.translate_held_items_for_player_relocation(position - previous);
         player_handle.top_out = None;
         player_handle.slope_displacement = Vector::zeros();
         player_handle.is_grounded = false;
@@ -2895,13 +2895,13 @@ impl PhysicsWorld {
     /// tries to motor across the entire level through every wall in between.
     /// Ordinary hand motion remains motor-driven because it never calls the
     /// player relocation seam.
-    fn translate_held_melee_for_player_relocation(&mut self, delta: Vector3<f32>) {
+    fn translate_held_items_for_player_relocation(&mut self, delta: Vector3<f32>) {
         if delta.magnitude2() <= f32::EPSILON {
             return;
         }
         let delta = vec_to_nvec(delta);
         let pairs = self
-            .held_melee_drives
+            .held_item_drives
             .iter()
             .map(|(weapon, drive)| (*weapon, drive.target))
             .collect::<Vec<_>>();
@@ -3733,11 +3733,11 @@ impl PhysicsWorld {
     /// Only WORLD geometry blocks. Actors deliberately do not: a swing has to
     /// travel *into* a creature to damage it, and loose props are better
     /// swept through than treated as walls.
-    fn drive_held_melee(&mut self) {
+    fn drive_held_items(&mut self) {
         let max_step = crate::dev_params::get(crate::dev_params::MELEE_MAX_SPEED)
             * self.integration_parameters.dt;
         let pairs = self
-            .held_melee_drives
+            .held_item_drives
             .iter()
             .map(|(weapon, drive)| (*weapon, drive.target))
             .collect::<Vec<_>>();
@@ -3765,14 +3765,14 @@ impl PhysicsWorld {
             // how a fast hand walks the weapon through a wall, and "fast" is
             // not a rare case in a test or a hitched frame. A genuine
             // teleport does not need the bypass either: it carries both motor
-            // endpoints together (`translate_held_melee_for_player_relocation`),
+            // endpoints together (`translate_held_items_for_player_relocation`),
             // so the error the drive sees is already near zero.
             let step = distance.min(max_step);
             let allowed = if distance <= 1.0e-6 {
                 0.0
             } else {
                 let direction = delta / distance;
-                step * self.held_melee_sweep_fraction(weapon, &current, direction, step)
+                step * self.held_item_sweep_fraction(weapon, &current, direction, step)
             };
 
             let mut next = desired;
@@ -3789,7 +3789,7 @@ impl PhysicsWorld {
 
     /// How far along `direction * distance` this weapon's colliders may travel
     /// before one of them meets world geometry, as a fraction in `0..=1`.
-    fn held_melee_sweep_fraction(
+    fn held_item_sweep_fraction(
         &self,
         weapon: RigidBodyHandle,
         current: &Isometry<Real>,
@@ -3832,7 +3832,7 @@ impl PhysicsWorld {
                     max_time_of_impact: distance,
                     // Leave a hair of clearance so a weapon resting on a
                     // surface does not re-report a zero-distance hit forever.
-                    target_distance: HELD_MELEE_SKIN,
+                    target_distance: HELD_ITEM_SKIN,
                     // An already-penetrating start must not pin the weapon in
                     // place; let it keep sweeping out.
                     stop_at_penetration: false,
@@ -3862,7 +3862,7 @@ impl PhysicsWorld {
         });
         let drives_to_remove = bodies_to_remove
             .iter()
-            .filter_map(|handle| self.held_melee_drives.remove(handle))
+            .filter_map(|handle| self.held_item_drives.remove(handle))
             .collect::<Vec<_>>();
         for drive in drives_to_remove {
             self.rigid_body_set.remove(
@@ -4105,7 +4105,7 @@ impl PhysicsWorld {
             live_creature_sweep_recovery: HashMap::new(),
             pending_player_push_velocity: HashMap::new(),
             kinematic_attachments: HashMap::new(),
-            held_melee_drives: HashMap::new(),
+            held_item_drives: HashMap::new(),
 
             debug_pipeline,
 
@@ -4334,7 +4334,7 @@ impl PhysicsWorld {
         // (tram floor + walls/buttons) therefore advance as one physical body,
         // matching Dark's source->destination attachment flow.
         self.update_kinematic_attachments();
-        self.drive_held_melee();
+        self.drive_held_items();
 
         // Attribute any non-finite body state to its entity before the step
         // consumes it (see report_nonfinite_rigid_body_state) - by the time
@@ -5987,7 +5987,7 @@ fn collision_group_names(bits: u32) -> Vec<String> {
 }
 
 #[cfg(test)]
-mod held_melee_drive;
+mod held_item_drive;
 
 #[cfg(test)]
 mod tests {
@@ -6016,7 +6016,7 @@ mod tests {
             DynamicPhysicsOptions::default(),
         );
 
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon);
 
         let body = world
             .debug_list_bodies()
@@ -6068,7 +6068,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon);
         world.set_position_rotation2(weapon, vec3(-2.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
         world.set_position_rotation2(weapon, vec3(0.0, 1.0, 0.0), identity_quat());
@@ -6080,7 +6080,7 @@ mod tests {
             (weapon_x - 0.0).abs() < 0.02,
             "the weapon should arrive on the tracked hand: x={weapon_x}"
         );
-        let target = world.held_melee_drives[&handle].target;
+        let target = world.held_item_drives[&handle].target;
         assert!((world.get_position(target).unwrap().x - 0.0).abs() < 1.0e-4);
     }
 
@@ -6101,12 +6101,12 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon);
 
         let tracked_pose = vec3(3.0, 1.0, -4.0);
         world.set_position_rotation2(weapon, tracked_pose, identity_quat());
 
-        let drive = world.held_melee_drives[&handle];
+        let drive = world.held_item_drives[&handle];
         assert!(drive.seated);
         assert!((world.get_position(handle).unwrap() - tracked_pose).magnitude() < 1.0e-4);
         assert!((world.get_position(drive.target).unwrap() - tracked_pose).magnitude() < 1.0e-4);
@@ -6135,7 +6135,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon);
         world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
         world.set_position_rotation2(weapon, vec3(1.0, 1.0, 0.0), identity_quat());
@@ -6174,8 +6174,8 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
-        let target_handle = world.held_melee_drives[&weapon_handle].target;
+        world.set_held_item_physical(weapon);
+        let target_handle = world.held_item_drives[&weapon_handle].target;
         let weapon_before = world.get_position(weapon_handle).unwrap();
         let target_before = world.get_position(target_handle).unwrap();
         let player_before = world.get_player_translation(&player);
@@ -6210,11 +6210,11 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon);
 
         let rendered_size = vec3(0.24, 1.02, 0.18);
         let rendered_center = vec3(0.0, -0.51, 0.01);
-        world.fit_held_melee_cuboid(weapon, rendered_size, rendered_center);
+        world.fit_held_item_cuboid(weapon, rendered_size, rendered_center);
 
         assert_eq!(world.cuboid_full_size(handle), Some(rendered_size));
         let collider = &world.collider_set[world.rigid_body_set[handle].colliders()[0]];
@@ -6273,7 +6273,7 @@ mod tests {
                 friction: 0.0,
             },
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon);
 
         // Seat the just-held body at its first tracked pose, establish the
         // broad phase, then put only the hand target beyond the actor. The
@@ -6355,9 +6355,9 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_melee(weapon);
+        world.set_held_item_physical(weapon);
         let held_handle = world.entity_id_to_body[&weapon];
-        let target_handle = world.held_melee_drives[&held_handle].target;
+        let target_handle = world.held_item_drives[&held_handle].target;
         let held_collider = &world.collider_set[world.rigid_body_set[held_handle].colliders()[0]];
         assert!(!held_collider.solver_groups().test(actor.solver));
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2018,6 +2018,32 @@ impl CollisionGroup {
         CollisionGroup { collision, solver }
     }
 
+    /// A held item that must only stop passing through the level: it takes
+    /// part in no collision at all.
+    ///
+    /// The swept drive stops a held item at world geometry through its own
+    /// query (see `held_item_sweep_fraction`), which does not consult the
+    /// body's groups - so an item whose *only* requirement is "don't go into
+    /// the wall" needs no memberships and no filter. That is deliberately
+    /// stronger than a narrow filter for a held gun: with no membership it is
+    /// also invisible to the projectile raycast, which starts inside the
+    /// weapon's own barrel (`internal_fast_projectile`) and would otherwise
+    /// report a hit on the gun in the player's hand at distance zero, and
+    /// nothing spawned at the muzzle - a grenade, say - can be shoved by it.
+    pub fn held_inert() -> CollisionGroup {
+        Self::solid(InteractionGroups {
+            memberships: Group::empty(),
+            filter: Group::empty(),
+            test_mode: Default::default(),
+        })
+    }
+
+    /// Whether this group takes part in no collision at all
+    /// ([`Self::held_inert`]).
+    pub fn is_inert(&self) -> bool {
+        self.collision.memberships.is_empty() && self.collision.filter.is_empty()
+    }
+
     /// Collision behavior for a living creature capsule. It collides exactly
     /// like an ordinary physical entity, but its distinct membership lets
     /// interaction-only fixtures and unsimulated movable debris opt out of
@@ -2675,8 +2701,13 @@ impl PhysicsWorld {
         }
     }
 
-    /// Turn an existing loose-prop body into a swept kinematic contact shape
-    /// while a melee weapon is held in VR.
+    /// Turn an existing loose-prop body into a swept kinematic shape while the
+    /// item is held in VR, so it cannot travel through the level.
+    ///
+    /// `group` decides what the held body is to everything else: a melee
+    /// weapon takes [`CollisionGroup::held_melee`] (contacts, so the
+    /// trigger-gated damage script sees them), a merely physical held item
+    /// takes [`CollisionGroup::held_inert`].
     ///
     /// The hand pose drives an invisible kinematic target; each step the
     /// visible weapon is *shape-cast* from where it is toward that target and
@@ -2687,7 +2718,7 @@ impl PhysicsWorld {
     /// read as the weapon spinning out of the player's hand the moment it
     /// touched anything. A swept kinematic body cannot be spun by the solver,
     /// cannot tunnel, and still reports every contact.
-    pub fn set_held_item_physical(&mut self, entity_id: EntityId) {
+    pub fn set_held_item_physical(&mut self, entity_id: EntityId, group: CollisionGroup) {
         let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
             return;
         };
@@ -2729,7 +2760,7 @@ impl PhysicsWorld {
                 );
             }
         }
-        self.set_collision_group(entity_id, CollisionGroup::held_melee());
+        self.set_collision_group(entity_id, group);
     }
 
     /// Replace a held melee body's inherited loose-pickup box with the local
@@ -6016,7 +6047,7 @@ mod tests {
             DynamicPhysicsOptions::default(),
         );
 
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         let body = world
             .debug_list_bodies()
@@ -6068,7 +6099,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
         world.set_position_rotation2(weapon, vec3(-2.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
         world.set_position_rotation2(weapon, vec3(0.0, 1.0, 0.0), identity_quat());
@@ -6101,7 +6132,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         let tracked_pose = vec3(3.0, 1.0, -4.0);
         world.set_position_rotation2(weapon, tracked_pose, identity_quat());
@@ -6135,7 +6166,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
         world.set_position_rotation2(weapon, vec3(-1.0, 1.0, 0.0), identity_quat());
         step(&mut world, &mut player, 1);
         world.set_position_rotation2(weapon, vec3(1.0, 1.0, 0.0), identity_quat());
@@ -6157,6 +6188,121 @@ mod tests {
         );
     }
 
+    /// The `physical_held_items` case: a held gun only has to stop travelling
+    /// into the level, so it is held with no collision membership and no
+    /// filter at all. The sweep that stops it runs its own query, which does
+    /// not consult the body's groups - this is the test that says so, because
+    /// the whole design rests on it.
+    #[test]
+    fn an_inert_held_item_is_still_stopped_by_world_geometry() {
+        let (mut world, mut player) = world_with_floor();
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(0.05, 1.0, 1.0)
+                .translation(vector![0.0, 1.0, 0.0])
+                .build(),
+        );
+        let gun = EntityId::from_inner(3).unwrap();
+        let handle = world.add_dynamic(
+            gun,
+            vec3(-1.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.4, 0.4, 0.4)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        world.set_held_item_physical(gun, CollisionGroup::held_inert());
+        world.set_position_rotation2(gun, vec3(-1.0, 1.0, 0.0), identity_quat());
+        step(&mut world, &mut player, 1);
+        world.set_position_rotation2(gun, vec3(1.0, 1.0, 0.0), identity_quat());
+
+        step(&mut world, &mut player, 120);
+
+        let blocked_x = world.get_position(handle).unwrap().x;
+        assert!(
+            blocked_x < -0.20,
+            "an inert held item crossed the fixed wall instead of stopping: x={blocked_x}"
+        );
+
+        world.set_position_rotation2(gun, vec3(-1.0, 1.0, 0.0), identity_quat());
+        step(&mut world, &mut player, 60);
+        let returned_x = world.get_position(handle).unwrap().x;
+        assert!(
+            returned_x < -0.8,
+            "the item did not return once the target cleared the wall: x={returned_x}"
+        );
+    }
+
+    /// ...and it touches nothing while it does. A held gun swept through a
+    /// creature must report no contact: contact is what bills melee damage
+    /// (`TriggeredMeleeWeapon`), and a gun that bludgeons by touch would be a
+    /// nasty surprise from a change that is only about walls. The same sweep
+    /// with `held_melee` reports the contact (see
+    /// `held_melee_contacts_live_actor_without_solver_launch`).
+    #[test]
+    fn an_inert_held_item_touches_nothing_it_sweeps_through() {
+        let (mut world, mut player) = world_with_floor();
+        let gun = EntityId::from_inner(2).unwrap();
+        let actor = EntityId::from_inner(3).unwrap();
+
+        world.add_dynamic(
+            actor,
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Capsule {
+                height: 0.8,
+                radius: 0.4,
+            },
+            CollisionGroup::actor(),
+            false,
+            DynamicPhysicsOptions {
+                gravity_scale: 0.0,
+                restitution: 0.0,
+                friction: 0.0,
+            },
+        );
+        world.set_enabled_rotations(actor, false, false, false);
+        world.add_dynamic(
+            gun,
+            vec3(-2.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.3, 0.1, 0.1)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions {
+                gravity_scale: 0.0,
+                restitution: 0.0,
+                friction: 0.0,
+            },
+        );
+        world.set_held_item_physical(gun, CollisionGroup::held_inert());
+
+        world.set_position_rotation2(gun, vec3(-2.0, 1.0, 0.0), identity_quat());
+        step(&mut world, &mut player, 1);
+        world.set_position_rotation2(gun, vec3(0.0, 1.0, 0.0), identity_quat());
+        let mut events = Vec::new();
+        for _ in 0..30 {
+            let (_, mut frame_events) = world.update(vec3(0.0, 0.0, 0.0), &mut player);
+            events.append(&mut frame_events);
+        }
+
+        assert!(
+            !events.iter().any(|event| matches!(
+                event,
+                CollisionEvent::CollisionStarted {
+                    entity1_id,
+                    entity2_id,
+                    ..
+                } if *entity1_id == gun || *entity2_id == gun
+            )),
+            "an inert held item reported a contact"
+        );
+    }
+
     /// A player teleport moves the tracked stage, not the hand relative to the
     /// player. Carry both motor endpoints by the same delta so the weapon does
     /// not attempt to traverse the intervening level geometry.
@@ -6174,7 +6320,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
         let target_handle = world.held_item_drives[&weapon_handle].target;
         let weapon_before = world.get_position(weapon_handle).unwrap();
         let target_before = world.get_position(target_handle).unwrap();
@@ -6210,7 +6356,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         let rendered_size = vec3(0.24, 1.02, 0.18);
         let rendered_center = vec3(0.0, -0.51, 0.01);
@@ -6273,7 +6419,7 @@ mod tests {
                 friction: 0.0,
             },
         );
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
 
         // Seat the just-held body at its first tracked pose, establish the
         // broad phase, then put only the hand target beyond the actor. The
@@ -6355,7 +6501,7 @@ mod tests {
             false,
             DynamicPhysicsOptions::default(),
         );
-        world.set_held_item_physical(weapon);
+        world.set_held_item_physical(weapon, CollisionGroup::held_melee());
         let held_handle = world.entity_id_to_body[&weapon];
         let target_handle = world.held_item_drives[&held_handle].target;
         let held_collider = &world.collider_set[world.rigid_body_set[held_handle].colliders()[0]];

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -112,7 +112,9 @@ impl Script for InternalSwitchHeldModelScript {
 
 /// The entity's authored first-person model name, unfiltered:
 /// `PropPlayerGun.hand_model` for guns, `PropLimbModel` for melee.
-fn get_raw_view_model(world: &World, entity_id: EntityId) -> Option<String> {
+/// The first-person model this weapon authors, whether or not VR will wield it
+/// (`PropPlayerGun.hand_model` for a gun, `PropLimbModel` for melee).
+pub(crate) fn get_raw_view_model(world: &World, entity_id: EntityId) -> Option<String> {
     let v_player_gun = world.borrow::<View<PropPlayerGun>>().unwrap();
     let v_melee_weapon = world.borrow::<View<PropLimbModel>>().unwrap();
 

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -34,7 +34,7 @@ mod internal_frob_move;
 mod internal_keycard_script;
 mod internal_nanites_script;
 mod internal_simple_health;
-mod internal_switch_held_model;
+pub(crate) mod internal_switch_held_model;
 mod level_change_button;
 mod many_ride;
 mod melee_weapon;


### PR DESCRIPTION
Spike answering: *"could we have the same movement properties for held ranged weapons (i.e. just don't pass through solid stuff)?"*

Short answer: **yes, and the machinery generalises almost for free** — but two things had to be answered honestly first, and one of them (the collider) needed real work. It is behind `--experimental physical_held_items`, default OFF, VR only, so nothing shipped changes until you try it in a headset.

## 1. Does the melee drive generalise?

Yes. Nothing in `set_held_melee` / `drive_held_melee` reads a melee property — the drive is about *held physicality*: sweep the body from where it is toward the tracked hand each step, stop at the first WORLD surface, take the hand's rotation exactly. Commit 1 is a pure rename (`held_melee*` -> `held_item*`, no behavior change) so the wider gate reads honestly. The genuinely melee-specific pieces keep their names: `CollisionGroup::held_melee` and `is_vr_melee_weapon`.

## 2. Colliders — this was the real work

`posed_weapon_bounds` covered only **LGMM skinned** meshes (the melee `_h` rigs). The 25AE gun `_h` models are **LGMD object meshes**, so `weapon_geometry` returned `None` for every gun and a held gun would have kept its loose-prop box: the size of the **world** model and centred on the **grip**, i.e. wrong in both directions.

Extended it instead: an object mesh's sub-object hierarchy *is* a skeleton (the same one the renderer poses it with), and the weapon/arm split is by **material** (`ND-arm*`) rather than by terminal joint, because a gun's arm is not a joint — `split_at_terminal_joint` is a melee-rig heuristic and does not apply. New: `obj_weapon_geometry` + `ss2_bin_obj_loader::{to_vertices_by_material, build_skeleton}`.

Measured on the shipped pistol at wield time:

```
wield 'atek_h': rendered weapon 46x30x8 cm, center (-0.365, -0.005, 0.020)
```

(46 cm is a *pistol*: the view models are ~2x life size, the same finding the melee scale work landed on.)

## 3. Does contact damage leak?

No, and now it cannot. `TriggeredMeleeWeapon` is attached only to `PropLimbModel` entities (`entity_creator`), and guns author no `PropLimbModel` (`cargo dq templates 17` — Pistol has `PropPlayerGun` + `WeaponScript`, no limb model). But rather than rely on that, a held gun takes **`CollisionGroup::held_inert()`** — empty memberships, empty filter — so it generates no contacts at all.

That is not just belt-and-braces; it removes two hazards that would otherwise have been blockers:

- **The gun would be shot by its own bullets.** `internal_fast_projectile` starts its ray `0.25 * SCALE_FACTOR` = 0.625 units *behind* the muzzle — inside the barrel — and a solid raycast reports a shape containing the origin at distance 0. A gun with an ordinary `ENTITY` membership is in that ray's mask.
- **Anything spawned at the muzzle would be shoved by it** — a grenade, say.

The sweep that stops the weapon runs its **own** query and does not consult the body's groups, so an inert body is still blocked by the level while touching nothing. There is a test for exactly that claim.

## 4. What breaks?

The one that matters: **a blocked weapon renders where its body is** (the render transform comes from physics), and a VR shot leaves the **rendered** muzzle vhot (`create_projectile`). So a gun held back by a wall also fires from the held-back position. That is self-consistent — you shoot from where you can see the barrel — but it *is* a change to how firing into cover behaves, and it is the thing to judge in a headset.

Everything else checked out: `store` and `drop` remove the body through the same `make_un_physical` the melee path uses (the gate now covers guns at all five sites, including the save/load restore); the two-handed/backpack paths route through `GrabEntity`, which is gated; reload does not touch the body.

## 5. Recommendation

**Worth trying.** The win (no gun clipping through walls, the classic VR immersion break) is real, the drive was already built and proven, and the inert group makes the gameplay risk structural rather than a matter of care. The residual risk is feel — a gun that visibly detaches from your hand near geometry, and the muzzle displacement above — which is exactly what a flag is for.

## Verification

Measured headlessly on the debug runtime (`--mission medsci1.mis --vr`), same deterministic sequence both times: wield the pistol, face a wall 1.42 units ahead, push the hand 1.9 units forward (0.83 past the wall).

| hand (pawn z) | flag OFF | flag ON |
| --- | --- | --- |
| 0.55 — free | weapon at x = -34.409 | -34.409 (identical) |
| 1.9 — into the wall at x = -33.9 | **-33.072** (0.83 units *through* the wall) | **-33.976** (stopped at the face) |

- Held gun with the flag: `kinematic`, `collision_groups: []` — inert, as designed.
- Held gun without the flag: **no body at all** — shipped behavior preserved.
- Held wrench, flag either way: `kinematic`, `collision_groups: ["entity"]` — melee unchanged.
- Fired blocked and unblocked: both shots hit level geometry; **no `Damage` message to the pistol itself**.

Tests:
- `an_inert_held_item_is_still_stopped_by_world_geometry` — negative-first: with the sweep stubbed out it fails with `x=1` (straight through the wall).
- `an_inert_held_item_touches_nothing_it_sweeps_through` — the counterpart to the existing melee-contact test.
- Four gate tests (`held_item_physics_tests`): gun unphysical without the flag, inert with it, melee keeps its contact body either way, nothing physical in flat.
- `vertices_come_back_grouped_by_their_material` in the obj loader.

Also `SHOCK2_E2E=1 test/missions.e2e.test.ts` — **all 23 missions load** (this change adds a world unique at level load, which is exactly that test's blast radius). The full e2e suite was not run to completion: it parks on the `earth.mis` hacking scenario, which is one of the three tests that already fail on `main` itself, so its verdict would not have been about this change either way.

```
cargo fmt --all -- --check                                              clean
RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime   clean
RUSTFLAGS="-D warnings" cargo test -p shock2vr --lib                    993 passed
RUSTFLAGS="-D warnings" cargo test -p dark --lib                        118 passed
```

## No GIF — and why

The visible effect is *where the weapon is*, and the numbers below pin it exactly. I could not get a frame that shows it honestly: the debug runtime's VR eye sits about a metre behind the hand looking `+Z`, and every reachable WORLD wall in medsci1 is off to the side of that view — with the flag OFF the gun ends up **behind** the wall and is depth-culled out of frame entirely, so the "before" shot is a picture of a wall. A headset is the right instrument for this one, which is what the flag is for. What a still *can* show is that the VR `_h` wield the fit measures is real and rendering — this is the pistol pressed against that wall, flag on, and it is the same 46 cm view model the log line reports:

![VR wielded pistol, held against a wall](https://gist.githubusercontent.com/tommy-xr/a7c594d697fe0c593c152009dc273af7/raw/vr-wielded-pistol.png)

## Review

`/xreview` (Claude + Codex + a de-dup pass) found **no correctness defect in the drive or the lifecycle** — both engines independently confirmed the melee path is unchanged and that every un-hold path (drop, store, destroy, level change) removes the body and its drive target. It did catch one real hole, now fixed in its own commit:

- **A classic install would have got a body with no fit.** The gate keyed on `PropPlayerGun` alone, but on a classic install VR keeps the *world* model, so no `_h` wield fires and the fit never runs — the gun would have swept its inherited loose-pickup box. The gate now asks the same question `InternalSwitchHeldModelScript` asks before swapping, so "no fit" means "no body", and the gate test asserts that both ways round.

Plus small simplicity fixes (redundant predicate, an unreachable `let-else` arm, last-wins material lookup, `is_inert` also checking solver groups, one duplicated test folded into a group-parameterized scenario) and two knowingly-inherited limits now documented rather than papered over:

- **Rotation is never swept**, only translation — so a long barrel can be *turned* into a wall it cannot be *pushed* into. That is the drive's existing, deliberate tradeoff (a rotationally-swept weapon whose angle is not the hand's angle was judged worse); a gun just makes it more visible.
- **`melee_max_speed` also clamps a gun's tracking**, at 60 units/s. It never binds for a real hand, so it is left shared rather than forked into a second dev param.

Claude-Session: https://claude.ai/code/session_017cm626D5M4tAz7yLPWPMFb
