### PR TITLE
feat(vr): bind weapon reload and ammo cycling on Quest

### DIFF
--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -363,6 +363,15 @@ fn main() {
         .create_action::<bool>("menu", "Pause Menu", &[])
         .unwrap();
 
+    // The gun hand's two face buttons: A reloads, B swaps ammo type.
+    let reload_action = action_set
+        .create_action::<bool>("reload", "Reload Weapon", &[])
+        .unwrap();
+
+    let cycle_ammo_action = action_set
+        .create_action::<bool>("cycle_ammo", "Cycle Ammo Type", &[])
+        .unwrap();
+
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
     // interaction profile
@@ -471,6 +480,26 @@ fn main() {
                             shock2vr::input::InputAction::TogglePauseMenu
                                 .quest_touch_click_path()
                                 .expect("Quest pause-menu binding"),
+                        )
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &reload_action,
+                    xr_instance
+                        .string_to_path(
+                            shock2vr::input::InputAction::Reload
+                                .quest_touch_click_path()
+                                .expect("Quest reload binding"),
+                        )
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &cycle_ammo_action,
+                    xr_instance
+                        .string_to_path(
+                            shock2vr::input::InputAction::CycleAmmo
+                                .quest_touch_click_path()
+                                .expect("Quest cycle-ammo binding"),
                         )
                         .unwrap(),
                 ),
@@ -786,6 +815,8 @@ fn main() {
         let use_mode_state = use_mode_action.state(&session, xr::Path::NULL).unwrap();
         let audio_log_state = audio_log_action.state(&session, xr::Path::NULL).unwrap();
         let menu_state = menu_action.state(&session, xr::Path::NULL).unwrap();
+        let reload_state = reload_action.state(&session, xr::Path::NULL).unwrap();
+        let cycle_ammo_state = cycle_ammo_action.state(&session, xr::Path::NULL).unwrap();
         // Only edge-detect while the action is live: with the session merely
         // VISIBLE (system overlay up), current_state reads false even though
         // the button may still be physically held, and treating that as a
@@ -813,6 +844,18 @@ fn main() {
             menu_state.is_active,
             menu_state.changed_since_last_sync,
             menu_state.current_state,
+        );
+        action_state.sync_discrete_button(
+            shock2vr::input::InputAction::Reload,
+            reload_state.is_active,
+            reload_state.changed_since_last_sync,
+            reload_state.current_state,
+        );
+        action_state.sync_discrete_button(
+            shock2vr::input::InputAction::CycleAmmo,
+            cycle_ammo_state.is_active,
+            cycle_ammo_state.changed_since_last_sync,
+            cycle_ammo_state.current_state,
         );
 
         let left_trigger_value = left_trigger

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -171,7 +171,8 @@ impl InputAction {
         }
     }
 
-    /// Production Meta Quest Touch binding for the two player-owned panels.
+    /// Production Meta Quest Touch binding for the player-owned panels and the
+    /// weapon-handling actions.
     /// Keeping these paths beside their semantic actions makes the Oculus
     /// mapping host-testable even though that runtime only compiles for Android.
     pub fn quest_touch_click_path(&self) -> Option<&'static str> {
@@ -183,6 +184,10 @@ impl InputAction {
             // The right controller's menu button is reserved by the Quest
             // system UI; the left one is the app's.
             InputAction::TogglePauseMenu => Some("/user/hand/left/input/menu/click"),
+            // The right controller holds the gun, so its two face buttons own
+            // the two gun-handling actions - A reloads, B swaps ammo type.
+            InputAction::Reload => Some("/user/hand/right/input/a/click"),
+            InputAction::CycleAmmo => Some("/user/hand/right/input/b/click"),
             _ => None,
         }
     }
@@ -255,6 +260,30 @@ mod tests {
             InputAction::TogglePauseMenu.quest_touch_click_path(),
             Some("/user/hand/left/input/menu/click")
         );
+    }
+
+    #[test]
+    fn quest_touch_assigns_the_right_face_buttons_to_gun_handling() {
+        assert_eq!(
+            InputAction::Reload.quest_touch_click_path(),
+            Some("/user/hand/right/input/a/click")
+        );
+        assert_eq!(
+            InputAction::CycleAmmo.quest_touch_click_path(),
+            Some("/user/hand/right/input/b/click")
+        );
+    }
+
+    #[test]
+    fn quest_touch_click_paths_are_unique() {
+        let mut paths: Vec<&'static str> = InputAction::all()
+            .iter()
+            .filter_map(|action| action.quest_touch_click_path())
+            .collect();
+        let total = paths.len();
+        paths.sort_unstable();
+        paths.dedup();
+        assert_eq!(paths.len(), total, "two actions share a Quest binding");
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4764,7 +4764,8 @@ impl MissionCore {
                     // Whichever hand holds the gun - the input action is not
                     // hand-specific (see `crate::wielded_weapon`).
                     if let Some(weapon) = crate::wielded_weapon::wielded_weapon(&self.world) {
-                        self.begin_reload(weapon);
+                        let cue = self.begin_reload(weapon);
+                        effects.push_back(cue);
                     }
                 }
 
@@ -7002,7 +7003,13 @@ impl MissionCore {
     /// time (`PropBaseGunDesc.reload_time_ms`). No-op for non-guns (no
     /// `PropBaseGunDesc`), while a reload is already in progress, or when no
     /// compatible reserve rounds are available.
-    fn begin_reload(&mut self, weapon: EntityId) {
+    ///
+    /// Returns the reload's audible cue (the weapon's schema "reload" event),
+    /// or `Effect::NoEffect` when nothing was reloaded. The cue is what tells a
+    /// VR player the reload started at all: the pitch animation below is a
+    /// first-person viewmodel tilt, which a hand-held VR weapon never shows.
+    #[must_use]
+    fn begin_reload(&mut self, weapon: EntityId) -> Effect {
         // Sensible fallbacks used only when a gun has no PropPlayerGun at all, so
         // the reload is still visible.
         const FALLBACK_PEAK_DEG: f32 = -45.0;
@@ -7024,12 +7031,12 @@ impl MissionCore {
                 .borrow::<View<dark::properties::PropBaseGunDesc>>();
             match v_desc.as_ref().ok().and_then(|v| v.get(weapon).ok()) {
                 Some(d) => (d.clip, d.reload_time_ms as f32 / 1000.0),
-                None => return,
+                None => return Effect::NoEffect,
             }
         };
         if let Ok(v) = self.world.borrow::<View<RuntimePropReloading>>() {
             if v.get(weapon).is_ok_and(|r| !r.is_done()) {
-                return;
+                return Effect::NoEffect;
             }
         }
 
@@ -7058,7 +7065,7 @@ impl MissionCore {
         // backpack. Multiple small stacks may contribute to one magazine.
         let reload = crate::mission::reload::load_from_reserve(&self.world, weapon, clip);
         if reload.rounds_loaded == 0 {
-            return;
+            return Effect::NoEffect;
         }
         for item in reload.depleted_items {
             self.interaction.on_entity_destroyed(item);
@@ -7077,6 +7084,18 @@ impl MissionCore {
                 peak_deg,
             },
         );
+
+        // Audible confirmation the reload began, from the weapon's own sound
+        // schema (the "reload" event, resolved from its class tags exactly like
+        // "shoot"/"dryfire"). Best-effort: a weapon with no matching schema
+        // simply stays silent.
+        crate::scripts::script_util::play_environmental_sound(
+            &self.world,
+            weapon,
+            "reload",
+            vec![],
+            AudioHandle::new(),
+        )
     }
 
     /// Cycle `weapon` to its next ammo type (next `Projectile` link). No-op when

--- a/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, PlayedSound, Vec3 } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// End-to-end coverage for gun handling from a VR-HELD weapon. The reload and
+// ammo-cycle machinery is presentation-shared, but until the Quest face-button
+// bindings landed there was no way to reach it in the headset: an empty clip
+// just dry-fired forever. These scenarios drive the same `Reload` / `CycleAmmo`
+// input actions the Quest's right A / B buttons now emit, against a weapon held
+// by the production VR hand rather than wielded as a flat viewmodel.
+//
+// The audible reload cue is the VR-specific half: flat's reload feedback is a
+// first-person viewmodel pitch, which a hand-held VR weapon never renders, so
+// the weapon's authored "reload" sound schema is the only signal a VR player
+// gets that the reload started. `/v1/audio/recent` is the only headless way to
+// see it.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8412);
+
+/** Pistol (first DebugCycleWeapon roster entry) and its standard clip. */
+const PISTOL = -17;
+const STD_CLIP = -31;
+
+function propOf(
+  detail: { properties: { name: string; value: string }[] },
+  name: string,
+): number | undefined {
+  const p = detail.properties.find((x) => x.name === name);
+  return p === undefined ? undefined : Number(p.value);
+}
+
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const value = propOf(detail, "Ammo");
+  assert.ok(value !== undefined, "weapon should expose an Ammo property");
+  return value;
+}
+
+function stackOf(detail: { properties: { name: string; value: string }[] }): number {
+  const value = propOf(detail, "StackCount");
+  assert.ok(value !== undefined, "reserve clip should expose a StackCount property");
+  return value;
+}
+
+/** Rounds still in a reserve clip. An exhausted stack is destroyed outright, so
+ * a vanished entity means zero rounds rather than a missing readout. */
+async function remainingRounds(game: GameServer, entityId: number): Promise<number> {
+  const live = (await game.entities.list()).entities.some((e) => e.id === entityId);
+  return live ? stackOf(await game.entities.detail(entityId)) : 0;
+}
+
+function tagValue(sound: PlayedSound, tag: string): string | undefined {
+  return sound.tags.find(([t]) => t === tag)?.[1];
+}
+
+/** Spawn the pistol into the scene and take hold of it with the VR right hand. */
+async function grabPistol(game: GameServer): Promise<EntitySummary> {
+  // In VR `wield` is a no-op, so DebugCycleWeapon drops each weapon in front of
+  // the player as a world pickup. The pistol is the first roster entry.
+  await game.input.trigger("DebugCycleWeapon");
+  await game.step({ frames: 10 });
+  const pistol = (await game.entities.list()).entities.find((e) => e.template_id === PISTOL);
+  assert.ok(pistol, "DebugCycleWeapon must spawn the Pistol");
+
+  await aimVrHandAt(game, pistol.position as Vec3, 0.3);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    pistol.id,
+    "the VR right hand must hold the pistol",
+  );
+  return pistol;
+}
+
+/** Fire until the magazine is empty (the pistol holds a dozen rounds). */
+async function emptyTheMagazine(game: GameServer, pistol: EntitySummary): Promise<void> {
+  for (let shot = 0; shot < 40; shot += 1) {
+    if (ammoOf(await game.entities.detail(pistol.id)) === 0) return;
+    await fireOnce(game);
+  }
+  assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0, "the pistol should be empty");
+}
+
+test(
+  "a VR-held pistol reloads from reserve and announces it audibly",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = await grabPistol(game);
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "std",
+      "a hand-held weapon is the wielded weapon in VR",
+    );
+
+    const capacity = ammoOf(await game.entities.detail(pistol.id));
+    assert.ok(capacity > 0, "the debug pistol starts loaded");
+    await emptyTheMagazine(game, pistol);
+
+    // Reserve rounds are what a reload consumes. Two standard clips so the
+    // reload has to drain the first and dip into the second.
+    const first = await game.player.spawnItem(STD_CLIP);
+    const second = await game.player.spawnItem(STD_CLIP);
+    const perClip = stackOf(await game.entities.detail(first.entity_id));
+    assert.ok(perClip > 0, "a spawned standard clip carries rounds");
+
+    const before = await game.audio.recent();
+    const lastSequence = before.sounds.at(-1)?.sequence ?? 0;
+
+    await game.input.trigger("Reload");
+    await game.step({ frames: 2 });
+
+    const info = await game.info();
+    assert.equal(info.player.reloading, true, "the reload action must start a reload in VR");
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      capacity,
+      "the magazine refills to capacity from reserve",
+    );
+
+    // The audible cue: without it a VR player has no feedback at all, since the
+    // reload animation is a flat-only viewmodel pitch.
+    const played = (await game.audio.recent()).sounds.filter(
+      (s) => s.sequence > lastSequence,
+    );
+    const cue = played.find((s) => tagValue(s, "event") === "reload");
+    assert.ok(
+      cue,
+      `the reload must play the weapon's authored reload schema, got ${JSON.stringify(
+        played.map((s) => ({ sample: s.sample, tags: s.tags })),
+      )}`,
+    );
+
+    // Reserve accounting: exactly `capacity` rounds left the backpack.
+    const drained =
+      2 * perClip -
+      ((await remainingRounds(game, first.entity_id)) +
+        (await remainingRounds(game, second.entity_id)));
+    assert.equal(drained, capacity, "reserve stacks drain by exactly the rounds loaded");
+
+    // A reload at capacity is a no-op, so the remainder is never minted away.
+    await game.step({ frames: 130 });
+    assert.equal((await game.info()).player.reloading, false, "the reload finishes");
+    await game.input.trigger("Reload");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.reloading, false, "a full gun does not reload");
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), capacity);
+  },
+);
+
+test(
+  "a VR-held empty pistol cycles through its ammo types",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = await grabPistol(game);
+    assert.equal((await game.info()).player.wielded_ammo_type, "std");
+
+    // Loaded rounds have an established projectile identity, so cycling is
+    // refused until the magazine is empty.
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "std",
+      "a loaded VR-held pistol cannot change ammo type",
+    );
+
+    await emptyTheMagazine(game, pistol);
+
+    const sequence: (string | null)[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      await game.input.trigger("CycleAmmo");
+      await game.step({ frames: 2 });
+      sequence.push((await game.info()).player.wielded_ammo_type);
+    }
+    assert.deepEqual(
+      sequence,
+      ["ap", "he", "std"],
+      "the ammo-cycle action advances in ProjectileOptions.order and wraps",
+    );
+  },
+);


### PR DESCRIPTION
## What

The reload and ammo-cycle machinery has been presentation-shared since it landed, but VR had no way to reach it: an empty clip in the headset just dry-fired forever. Both right-hand face buttons were completely unbound, so the gun hand's own buttons now own the two gun-handling actions:

- **right A** -> `InputAction::Reload`
- **right B** -> `InputAction::CycleAmmo`

Flat's reload feedback is a first-person viewmodel pitch, which a hand-held VR weapon never renders, so `begin_reload` now also returns the weapon's authored **"reload" sound-schema cue** (resolved from its class tags exactly like `shoot`/`dryfire`). That is the only signal a VR player gets that the reload started, and it costs flat nothing.

## Tests

Negative-first: with the schema cue removed from `begin_reload`, the new VR scenario fails with an empty sound log (`the reload must play the weapon's authored reload schema, got []`); restoring it makes it green.

- `tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts` (new) - takes hold of the pistol with the **production VR hand** (`--vr`, `aimVrHandAt` + squeeze, not `wield`, which is a no-op in VR), empties the magazine, provisions two standard clips, triggers `Reload`, and asserts `player.reloading` goes true, the magazine refills to capacity, an `event=reload` sound plays (`/v1/audio/recent`), and reserve stacks drain by *exactly* the rounds loaded. A second scenario cycles ammo on the hand-held pistol: refused while loaded, then `std -> ap -> he -> std` once empty.
- `cargo test -p shock2vr --lib`: **989 passed, 0 failed**
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean
- e2e: `vr-weapon-reload` (2/2), `weapon-reload` flat (1/1), `weapon-ammo-type` (1/1), `weapon-cycle-authenticity` (1/1), `missions` (**23/23**)
- **Oculus cross-compile: `cargo apk check` passes** for `aarch64-linux-android` (verified it genuinely type-checks `oculus_runtime/src/lib.rs` by injecting a deliberate type error and seeing it reported)

## Visuals

![VR reload and ammo cycle](https://gist.githubusercontent.com/tommy-xr/510093a1b6be12156d8e4dd5a7b2743b/raw/vr-reload-demo.gif)

<sub>`debug_weapons` in **VR** (`cargo dbgr --mission debug_weapons --vr`): the production VR right hand takes hold of the pistol, empties the magazine, dry-fires on empty, then `Reload` (right A) refills it from two provisioned Standard Clips - reserve drops 24 -> 12 - and `CycleAmmo` (right B) flips the empty gun std -> ap. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). The caption on each frame is the frame's real state, sampled at capture time from `/v1/entities/<pistol>` (`Ammo`), `/v1/info` (`reloading`, `wielded_ammo_type`) and the reserve clips' `StackCount` - the VR forearm ammo panel renders as an unlabeled quad at this distance, so the numbers are burned in rather than read off the panel. The reload cue itself is audible-only (`l_pistol`, `event=reload`, confirmed via `/v1/audio/recent`) and therefore cannot appear in a screenshot.</sub>

![magazine refilled](https://gist.githubusercontent.com/tommy-xr/510093a1b6be12156d8e4dd5a7b2743b/raw/vr-reload-refilled.png)

<sub>Still at the moment the magazine is back to 12 with 12 rounds left in reserve.</sub>

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72
