### PR TITLE
feat(weapons): unload the magazine when switching ammo

### DIFF
--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -216,8 +216,9 @@ pub(crate) fn create_flat_hud(
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
 }
 
-/// Whether the wielded weapon may cycle ammo (empty, with 2+ selectable
-/// projectile types). Uses the same predicate as `cycle_ammo`.
+/// Whether the wielded weapon may cycle ammo (2+ selectable projectile types,
+/// and a magazine that can be ejected if it is loaded). Uses the same predicate
+/// as `cycle_ammo`.
 pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
     let Some(weapon) = crate::wielded_weapon::wielded_weapon(world) else {
         return false;
@@ -228,9 +229,10 @@ pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
 /// The single source of truth for whether the AMMOFULL ammo-cycle button is
 /// shown/active this frame - used for BOTH rendering (via `create_flat_hud`'s
 /// `can_cycle_ammo`) and pointer hit-testing (`mission_core`), so the drawn and
-/// clickable regions never diverge. Requires use mode, a wielded gun with a
-/// empty clip, 2+ ammo types, and no psi-amp display (which replaces the ammo
-/// section - `build_flat_hud_canvas`'s psi-power early return).
+/// clickable regions never diverge. Requires use mode, a wielded gun that may
+/// cycle (2+ ammo types, and an ejectable magazine when loaded), and no psi-amp
+/// display (which replaces the ammo section - `build_flat_hud_canvas`'s
+/// psi-power early return).
 pub(crate) fn ammo_cycle_button_visible(world: &World, use_mode: bool) -> bool {
     use_mode
         && get_wielded_psi_power(world).is_none()

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -77,7 +77,7 @@ const CURSOR_SIZE: Vector2<f32> = Vector2::new(12.0, 16.0);
 pub enum FlatUiDragAction {
     Throw(EntityId),
     Wield(EntityId),
-    /// Cycle the empty wielded weapon's ammo type (the AMMOFULL cycle button
+    /// Cycle the wielded weapon's ammo type (the AMMOFULL cycle button
     /// was clicked). Not tied to a cursor item - the caller maps it to
     /// `Effect::CycleAmmo`, which acts on the wielded weapon.
     CycleAmmo,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7111,9 +7111,24 @@ impl MissionCore {
         if !crate::scripts::script_util::can_cycle_ammo(&self.world, weapon) {
             return;
         }
-        let ejected = crate::mission::reload::unload_to_reserve(&self.world, weapon);
-        if let Some((clip_template, rounds)) = ejected.spawn_clip {
+        if let Some((clip_template, rounds)) =
+            crate::mission::reload::unload_to_reserve(&self.world, weapon).spawn_clip
+        {
             self.give_ejected_clip(asset_cache, weapon, clip_template, rounds);
+        }
+        // The switch is earned by an empty magazine, never assumed. Every way an
+        // eject can fall short - the fresh clip refused by the backpack, a
+        // borrow that did not come through - leaves rounds loaded, and switching
+        // then would convert them to the next type for free, which is the exact
+        // thing this ejection exists to prevent.
+        let still_loaded = self
+            .world
+            .borrow::<View<dark::properties::PropGunState>>()
+            .ok()
+            .and_then(|states| states.get(weapon).ok().map(|state| state.ammo > 0))
+            .unwrap_or(false);
+        if still_loaded {
+            return;
         }
         let count =
             crate::scripts::script_util::ordered_projectile_links(&self.world, weapon).len();
@@ -7131,8 +7146,9 @@ impl MissionCore {
     /// an ejection [`reload::unload_to_reserve`] cannot do itself, since
     /// instantiating an entity needs the entity creator.
     ///
-    /// If the fresh clip cannot be carried the rounds go back into `weapon`
-    /// rather than vanishing, leaving the magazine exactly as it was.
+    /// The magazine is emptied only AFTER the fresh clip is genuinely carried,
+    /// so the rounds exist in exactly one place at every instant: a refused
+    /// clip simply leaves the weapon loaded and the swap unearned.
     fn give_ejected_clip(
         &mut self,
         asset_cache: &mut AssetCache,
@@ -7140,36 +7156,49 @@ impl MissionCore {
         clip_template: i32,
         rounds: i32,
     ) {
-        // Containment makes the clip non-physical immediately, so the spawn
-        // point is never observed - it only has to be valid for instantiation.
+        let entity_id = match self.spawn_into_backpack(asset_cache, clip_template) {
+            Ok(entity_id) => entity_id,
+            Err(e) => {
+                game_log!(WARN, "Ejected clip could not be carried: {e}");
+                return;
+            }
+        };
+        // The archetype carries its authored stack size; this clip holds
+        // exactly what came out of the magazine.
+        self.world
+            .add_component(entity_id, dark::properties::PropStackCount(rounds));
+        crate::mission::reload::empty_magazine(&self.world, weapon);
+    }
+
+    /// Instantiate `template_id` and route it through the ordinary pickup path
+    /// into the backpack, destroying it again if it is refused so a failure
+    /// leaves nothing behind.
+    ///
+    /// Spawned at the player's position: containment makes the item
+    /// non-physical immediately, so the spawn point is never observed - it just
+    /// has to be somewhere valid for instantiation.
+    fn spawn_into_backpack(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        template_id: i32,
+    ) -> Result<EntityId, String> {
         let (position, rotation) = {
             let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
             (vec3_to_point3(player.pos), player.rotation)
         };
         let info = self.create_entity_with_position(
             asset_cache,
-            clip_template,
+            template_id,
             position,
             rotation,
             Matrix4::identity(),
             CreateEntityOptions::default(),
         );
-        // The archetype carries its authored stack size; this clip holds
-        // exactly what came out of the magazine.
-        self.world
-            .add_component(info.entity_id, dark::properties::PropStackCount(rounds));
         if let Err(e) = self.give_item(info.entity_id) {
-            game_log!(WARN, "Ejected clip could not be carried: {e}");
             self.destroy_entity(info.entity_id);
-            if let Ok(mut states) = self
-                .world
-                .borrow::<ViewMut<dark::properties::PropGunState>>()
-            {
-                if let Ok(state) = (&mut states).get(weapon) {
-                    state.ammo = rounds;
-                }
-            }
+            return Err(e);
         }
+        Ok(info.entity_id)
     }
 
     /// Advance any in-progress reload by `dt` and clear it when complete.
@@ -9893,37 +9922,13 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             return Err(format!("unknown template id {}", template_id));
         }
 
-        // Spawn at the player's position: containment immediately makes the
-        // item non-physical, so the spawn point is never observed - it just has
-        // to be somewhere valid for instantiation.
-        let (position, rotation) = {
-            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-            (vec3_to_point3(player.pos), player.rotation)
-        };
-        let info = self.create_entity_with_position(
-            asset_cache,
-            template_id,
-            position,
-            rotation,
-            Matrix4::identity(),
-            CreateEntityOptions::default(),
-        );
-        let entity_id = info.entity_id;
-
-        // Route the fresh entity through the very same pickup path as an item
-        // found in the world, so provisioning inherits its eligibility rule:
-        // only genuine pickup items land in the backpack. A creature or door
-        // template is rejected here - and destroyed again, so a refused request
-        // leaves nothing behind.
-        if let Err(e) = self.give_item(entity_id) {
-            self.destroy_entity(entity_id);
-            // Report the template, not the entity: the instance is gone, and the
-            // caller never saw its id.
-            return Err(format!(
-                "template {} is not a pickup item ({})",
-                template_id, e
-            ));
-        }
+        // Provisioning inherits the ordinary pickup path's eligibility rule:
+        // only genuine pickup items land in the backpack, so a creature or door
+        // template is refused here. Report the TEMPLATE, not the entity - the
+        // instance is gone again and the caller never saw its id.
+        let entity_id = self
+            .spawn_into_backpack(asset_cache, template_id)
+            .map_err(|e| format!("template {} is not a pickup item ({})", template_id, e))?;
 
         let name = self
             .world

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4771,7 +4771,7 @@ impl MissionCore {
 
                 Effect::CycleAmmo => {
                     if let Some(weapon) = crate::wielded_weapon::wielded_weapon(&self.world) {
-                        self.cycle_ammo(weapon);
+                        self.cycle_ammo(asset_cache, weapon);
                     }
                 }
 
@@ -7099,12 +7099,21 @@ impl MissionCore {
     }
 
     /// Cycle `weapon` to its next ammo type (next `Projectile` link). No-op when
-    /// the weapon has fewer than two projectile links or still has loaded
-    /// rounds; until magazine-unload semantics exist, requiring an empty gun
-    /// prevents standard rounds from turning into AP/HE rounds for free.
-    fn cycle_ammo(&mut self, weapon: EntityId) {
+    /// the weapon has fewer than two projectile links.
+    ///
+    /// A loaded magazine is EJECTED first, as the original does: the rounds go
+    /// back to the backpack as clips of the ammo type they already are, so a
+    /// mid-magazine swap costs the player a reload rather than converting
+    /// standard rounds into AP for free. The only magazine that still has to be
+    /// fired off is one whose projectile has no clip archetype to return to
+    /// (`can_cycle_ammo`).
+    fn cycle_ammo(&mut self, asset_cache: &mut AssetCache, weapon: EntityId) {
         if !crate::scripts::script_util::can_cycle_ammo(&self.world, weapon) {
             return;
+        }
+        let ejected = crate::mission::reload::unload_to_reserve(&self.world, weapon);
+        if let Some((clip_template, rounds)) = ejected.spawn_clip {
+            self.give_ejected_clip(asset_cache, weapon, clip_template, rounds);
         }
         let count =
             crate::scripts::script_util::ordered_projectile_links(&self.world, weapon).len();
@@ -7116,6 +7125,51 @@ impl MissionCore {
             .unwrap_or(0);
         self.world
             .add_component(weapon, RuntimePropSelectedAmmo((current + 1) % count));
+    }
+
+    /// Mint `rounds` rounds of `clip_template` into the backpack - the half of
+    /// an ejection [`reload::unload_to_reserve`] cannot do itself, since
+    /// instantiating an entity needs the entity creator.
+    ///
+    /// If the fresh clip cannot be carried the rounds go back into `weapon`
+    /// rather than vanishing, leaving the magazine exactly as it was.
+    fn give_ejected_clip(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        weapon: EntityId,
+        clip_template: i32,
+        rounds: i32,
+    ) {
+        // Containment makes the clip non-physical immediately, so the spawn
+        // point is never observed - it only has to be valid for instantiation.
+        let (position, rotation) = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            (vec3_to_point3(player.pos), player.rotation)
+        };
+        let info = self.create_entity_with_position(
+            asset_cache,
+            clip_template,
+            position,
+            rotation,
+            Matrix4::identity(),
+            CreateEntityOptions::default(),
+        );
+        // The archetype carries its authored stack size; this clip holds
+        // exactly what came out of the magazine.
+        self.world
+            .add_component(info.entity_id, dark::properties::PropStackCount(rounds));
+        if let Err(e) = self.give_item(info.entity_id) {
+            game_log!(WARN, "Ejected clip could not be carried: {e}");
+            self.destroy_entity(info.entity_id);
+            if let Ok(mut states) = self
+                .world
+                .borrow::<ViewMut<dark::properties::PropGunState>>()
+            {
+                if let Ok(state) = (&mut states).get(weapon) {
+                    state.ammo = rounds;
+                }
+            }
+        }
     }
 
     /// Advance any in-progress reload by `dt` and clear it when complete.

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -5,7 +5,7 @@ pub mod flat_ui_host;
 pub mod mission_core;
 pub mod pathfinding_debug;
 pub mod pathfinding_test;
-mod reload;
+pub(crate) mod reload;
 pub mod spatial_query;
 mod spawn_location;
 pub mod stim_response;

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -19,11 +19,25 @@ impl GlobalProjectileClips {
         // Relations inherit just like properties. Build the effective Clip
         // relation for every archetype so a concrete projectile child can use a
         // relation authored on its family archetype.
+        //
+        // MOST-DERIVED FIRST, and that order is load-bearing: an unload mints
+        // `[0]` as the ammo type's canonical clip, so a projectile's OWN
+        // authored clip must outrank anything it merely inherits, and the
+        // data's own preference must be preserved within a template (the
+        // pistol's standard bullet lists the full Standard Clip first, the
+        // assault rifle's lists the Small Standard Clip first - each weapon
+        // family's intended default). `get_ancestors` is root-first, so it is
+        // reversed here. Compatibility checks elsewhere only test membership
+        // and are indifferent to the order.
         for template_id in entity_info.entity_to_properties.keys() {
-            let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, template_id);
-            ancestors.push(*template_id);
+            let mut lineage = vec![*template_id];
+            lineage.extend(
+                ss2_entity_info::get_ancestors(hierarchy, template_id)
+                    .into_iter()
+                    .rev(),
+            );
             let mut compatible_clips = Vec::new();
-            for ancestor in ancestors {
+            for ancestor in lineage {
                 let Some(links) = entity_info.template_to_links.get(&ancestor) else {
                     continue;
                 };
@@ -112,7 +126,10 @@ fn compatible_reserve_items(world: &World, clip_templates: &[i32]) -> Vec<Entity
             else {
                 return false;
             };
-            stacks.get(*item).is_ok()
+            // A zero stack is neither a source to load from nor a target to
+            // merge into: it is destroyed on depletion, and rounds merged into
+            // one that somehow survived would go with it.
+            stacks.get(*item).is_ok_and(|stack| stack.0 > 0)
                 && clip_templates.iter().any(|clip_template| {
                     hierarchy.is_or_descends_from(class_template_id, *clip_template)
                 })
@@ -149,11 +166,6 @@ pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) 
             if rounds_needed == 0 {
                 break;
             }
-            // An empty stack is destroyed on depletion, so this only guards
-            // against one that somehow survived at zero.
-            if (&stacks).get(item).is_ok_and(|stack| stack.0 <= 0) {
-                continue;
-            }
             let Ok(stack) = (&mut stacks).get(item) else {
                 continue;
             };
@@ -178,11 +190,14 @@ pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) 
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct UnloadOutcome {
-    /// Rounds taken out of the magazine (0 when nothing was unloaded).
+    /// Rounds that have ALREADY moved out of the magazine (0 when nothing was
+    /// unloaded, and 0 alongside a `spawn_clip` request, which has not happened
+    /// yet).
     pub rounds_unloaded: i32,
-    /// The clip archetype the caller must instantiate into the backpack, and
-    /// how many rounds it carries. `None` when the rounds merged into a stack
-    /// the player already had.
+    /// The clip archetype the caller must instantiate into the backpack, and how
+    /// many rounds it must carry. The magazine still holds them until the caller
+    /// has placed it and called [`empty_magazine`]. `None` when the rounds
+    /// merged into a stack the player already had.
     pub spawn_clip: Option<(i32, i32)>,
 }
 
@@ -198,11 +213,15 @@ pub(crate) fn can_unload(world: &World, weapon: EntityId) -> bool {
 /// player swap ammo type without the loaded rounds either vanishing or being
 /// silently converted.
 ///
-/// Rounds merge into the first compatible reserve stack; with no such stack the
-/// outcome asks the CALLER to mint the clip archetype, because instantiating an
-/// entity needs the mission's entity creator, which this module has no access
-/// to. The magazine is emptied here either way, so a caller that cannot place
-/// `spawn_clip` must put the rounds back.
+/// Rounds merge into the first compatible reserve stack, which cannot fail, so
+/// that case empties the magazine here. With no such stack the outcome instead
+/// asks the CALLER to mint the clip archetype - instantiating an entity needs
+/// the mission's entity creator, which this module has no access to - and the
+/// magazine is deliberately left LOADED until that placement succeeds. Nothing
+/// then has to be undone: rounds exist in exactly one place at every instant.
+///
+/// So `rounds_unloaded` counts rounds that have already moved; a `spawn_clip`
+/// outcome is a request, not a completed unload.
 ///
 /// Reserve stacks have no capacity ceiling in this port - `load_from_reserve`
 /// drains them without one and the game never caps them on pickup - so the
@@ -224,29 +243,38 @@ pub(crate) fn unload_to_reserve(world: &World, weapon: EntityId) -> UnloadOutcom
         .into_iter()
         .next();
 
-    let mut outcome = UnloadOutcome {
+    let Some(item) = destination else {
+        // The most-derived authored clip is the ammo type's canonical archetype.
+        return UnloadOutcome {
+            rounds_unloaded: 0,
+            spawn_clip: Some((compatible_clip_templates[0], loaded)),
+        };
+    };
+
+    {
+        let Ok(mut stacks) = world.borrow::<ViewMut<PropStackCount>>() else {
+            return UnloadOutcome::default();
+        };
+        let Ok(stack) = (&mut stacks).get(item) else {
+            return UnloadOutcome::default();
+        };
+        stack.0 += loaded;
+    }
+    empty_magazine(world, weapon);
+    UnloadOutcome {
         rounds_unloaded: loaded,
         spawn_clip: None,
-    };
-    match destination {
-        Some(item) => {
-            let Ok(mut stacks) = world.borrow::<ViewMut<PropStackCount>>() else {
-                return UnloadOutcome::default();
-            };
-            let Ok(stack) = (&mut stacks).get(item) else {
-                return UnloadOutcome::default();
-            };
-            stack.0 += loaded;
-        }
-        // The first authored clip is the ammo type's canonical archetype.
-        None => outcome.spawn_clip = Some((compatible_clip_templates[0], loaded)),
     }
+}
 
-    let mut states = world.borrow::<ViewMut<PropGunState>>().unwrap();
+/// Zero `weapon`'s magazine, once its rounds are safely somewhere else.
+pub(crate) fn empty_magazine(world: &World, weapon: EntityId) {
+    let Ok(mut states) = world.borrow::<ViewMut<PropGunState>>() else {
+        return;
+    };
     if let Ok(state) = (&mut states).get(weapon) {
         state.ammo = 0;
     }
-    outcome
 }
 
 #[cfg(test)]
@@ -653,13 +681,30 @@ mod tests {
         assert_eq!(
             outcome,
             UnloadOutcome {
-                rounds_unloaded: 5,
-                // The first authored clip for the standard projectile.
+                // Nothing has moved yet - this is a request, not a completed
+                // unload, so the rounds are still counted in the magazine.
+                rounds_unloaded: 0,
                 spawn_clip: Some((STD_CLIP, 5)),
             }
         );
-        assert_eq!(fixture.ammo(), 0);
         assert_eq!(fixture.rounds(mismatched), 6, "HE reserve is untouched");
+    }
+
+    #[test]
+    fn a_requested_clip_leaves_the_magazine_loaded_until_it_is_placed() {
+        // The rounds must exist in exactly one place at every instant: if the
+        // caller cannot carry the fresh clip, the weapon is simply still loaded
+        // and the swap is unearned. Emptying up front would need an undo, and a
+        // missed undo is a free ammo-type conversion.
+        let fixture = Fixture::new(5, 0);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(outcome.spawn_clip, Some((STD_CLIP, 5)));
+        assert_eq!(fixture.ammo(), 5, "still loaded until the clip is carried");
+
+        empty_magazine(&fixture.world, fixture.weapon);
+        assert_eq!(fixture.ammo(), 0);
     }
 
     #[test]

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -52,6 +52,74 @@ pub(crate) struct ReloadOutcome {
     pub depleted_items: Vec<EntityId>,
 }
 
+/// The clip archetypes that hold `weapon`'s CURRENTLY selected ammo, in the
+/// order the data's `Clip` relation authors them. `None` when the weapon has no
+/// projectile links at all, or the selected projectile has no clip archetype -
+/// which is also what makes its rounds unreturnable (see [`can_unload`]).
+fn selected_clip_templates(world: &World, weapon: EntityId) -> Option<Vec<i32>> {
+    let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
+    if projectiles.is_empty() {
+        return None;
+    }
+    let selected = world
+        .borrow::<View<crate::runtime_props::RuntimePropSelectedAmmo>>()
+        .ok()
+        .and_then(|selected| selected.get(weapon).ok().map(|selected| selected.0))
+        .unwrap_or(0);
+    let projectile_template = projectiles[selected % projectiles.len()].0;
+    world
+        .borrow::<UniqueView<GlobalProjectileClips>>()
+        .ok()
+        .and_then(|clips| clips.0.get(&projectile_template).cloned())
+        .filter(|clips| !clips.is_empty())
+}
+
+/// The backpack's stackable items whose class descends from one of
+/// `clip_templates` - the reserve a reload draws from and an unload merges into.
+fn compatible_reserve_items(world: &World, clip_templates: &[i32]) -> Vec<EntityId> {
+    let Ok(inventory) = world
+        .borrow::<UniqueView<crate::mission::PlayerInfo>>()
+        .map(|player| player.inventory_entity_id)
+    else {
+        return Vec::new();
+    };
+    let reserve_items: Vec<EntityId> = {
+        let Ok(links) = world.borrow::<View<Links>>() else {
+            return Vec::new();
+        };
+        let Ok(inventory_links) = links.get(inventory) else {
+            return Vec::new();
+        };
+        inventory_links
+            .to_links
+            .iter()
+            .filter(|link| matches!(link.link, Link::Contains(_)))
+            .filter_map(|link| link.to_entity_id.map(|id| id.0))
+            .collect()
+    };
+
+    let Ok((stacks, hierarchy)) = world.borrow::<(
+        View<PropStackCount>,
+        UniqueView<crate::mission::GlobalTemplateHierarchy>,
+    )>() else {
+        return Vec::new();
+    };
+    reserve_items
+        .into_iter()
+        .filter(|item| {
+            let Some(class_template_id) =
+                crate::scripts::script_util::entity_class_template_id(world, *item)
+            else {
+                return false;
+            };
+            stacks.get(*item).is_ok()
+                && clip_templates.iter().any(|clip_template| {
+                    hierarchy.is_or_descends_from(class_template_id, *clip_template)
+                })
+        })
+        .collect()
+}
+
 /// Move matching reserve rounds from the backpack into `weapon`.
 ///
 pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) -> ReloadOutcome {
@@ -67,65 +135,10 @@ pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) 
         return ReloadOutcome::default();
     }
 
-    let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
-    if projectiles.is_empty() {
-        return ReloadOutcome::default();
-    }
-    let selected = world
-        .borrow::<View<crate::runtime_props::RuntimePropSelectedAmmo>>()
-        .ok()
-        .and_then(|selected| selected.get(weapon).ok().map(|selected| selected.0))
-        .unwrap_or(0);
-    let projectile_template = projectiles[selected % projectiles.len()].0;
-    let compatible_clip_templates = world
-        .borrow::<UniqueView<GlobalProjectileClips>>()
-        .ok()
-        .and_then(|clips| clips.0.get(&projectile_template).cloned());
-    let Some(compatible_clip_templates) = compatible_clip_templates else {
+    let Some(compatible_clip_templates) = selected_clip_templates(world, weapon) else {
         return ReloadOutcome::default();
     };
-
-    let inventory = match world.borrow::<UniqueView<crate::mission::PlayerInfo>>() {
-        Ok(player) => player.inventory_entity_id,
-        Err(_) => return ReloadOutcome::default(),
-    };
-    let reserve_items: Vec<EntityId> = {
-        let Ok(links) = world.borrow::<View<Links>>() else {
-            return ReloadOutcome::default();
-        };
-        let Ok(inventory_links) = links.get(inventory) else {
-            return ReloadOutcome::default();
-        };
-        inventory_links
-            .to_links
-            .iter()
-            .filter(|link| matches!(link.link, Link::Contains(_)))
-            .filter_map(|link| link.to_entity_id.map(|id| id.0))
-            .collect()
-    };
-
-    let matching_reserve: Vec<EntityId> = {
-        let Ok((stacks, hierarchy)) = world.borrow::<(
-            View<PropStackCount>,
-            UniqueView<crate::mission::GlobalTemplateHierarchy>,
-        )>() else {
-            return ReloadOutcome::default();
-        };
-        reserve_items
-            .into_iter()
-            .filter(|item| {
-                let Some(class_template_id) =
-                    crate::scripts::script_util::entity_class_template_id(world, *item)
-                else {
-                    return false;
-                };
-                let compatible = compatible_clip_templates.iter().any(|clip_template| {
-                    hierarchy.is_or_descends_from(class_template_id, *clip_template)
-                });
-                compatible && stacks.get(*item).is_ok_and(|stack| stack.0 > 0)
-            })
-            .collect()
-    };
+    let matching_reserve = compatible_reserve_items(world, &compatible_clip_templates);
 
     let mut outcome = ReloadOutcome::default();
     {
@@ -135,6 +148,11 @@ pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) 
         for item in matching_reserve {
             if rounds_needed == 0 {
                 break;
+            }
+            // An empty stack is destroyed on depletion, so this only guards
+            // against one that somehow survived at zero.
+            if (&stacks).get(item).is_ok_and(|stack| stack.0 <= 0) {
+                continue;
             }
             let Ok(stack) = (&mut stacks).get(item) else {
                 continue;
@@ -154,6 +172,79 @@ pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) 
         if let Ok(state) = (&mut states).get(weapon) {
             state.ammo = (state.ammo.max(0) + outcome.rounds_loaded).min(capacity.max(0));
         }
+    }
+    outcome
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct UnloadOutcome {
+    /// Rounds taken out of the magazine (0 when nothing was unloaded).
+    pub rounds_unloaded: i32,
+    /// The clip archetype the caller must instantiate into the backpack, and
+    /// how many rounds it carries. `None` when the rounds merged into a stack
+    /// the player already had.
+    pub spawn_clip: Option<(i32, i32)>,
+}
+
+/// Whether `weapon`'s loaded rounds could be returned to the backpack. A
+/// projectile with no authored clip archetype has no reserve representation, so
+/// its rounds can only be fired.
+pub(crate) fn can_unload(world: &World, weapon: EntityId) -> bool {
+    selected_clip_templates(world, weapon).is_some()
+}
+
+/// Return `weapon`'s loaded rounds to the backpack as clips of the ammo type
+/// they actually are - the reverse of [`load_from_reserve`], and what lets a
+/// player swap ammo type without the loaded rounds either vanishing or being
+/// silently converted.
+///
+/// Rounds merge into the first compatible reserve stack; with no such stack the
+/// outcome asks the CALLER to mint the clip archetype, because instantiating an
+/// entity needs the mission's entity creator, which this module has no access
+/// to. The magazine is emptied here either way, so a caller that cannot place
+/// `spawn_clip` must put the rounds back.
+///
+/// Reserve stacks have no capacity ceiling in this port - `load_from_reserve`
+/// drains them without one and the game never caps them on pickup - so the
+/// merge is unconditional rather than spilling into a second stack.
+pub(crate) fn unload_to_reserve(world: &World, weapon: EntityId) -> UnloadOutcome {
+    let loaded = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|states| states.get(weapon).ok().map(|state| state.ammo))
+        .unwrap_or(0);
+    if loaded <= 0 {
+        return UnloadOutcome::default();
+    }
+    let Some(compatible_clip_templates) = selected_clip_templates(world, weapon) else {
+        return UnloadOutcome::default();
+    };
+
+    let destination = compatible_reserve_items(world, &compatible_clip_templates)
+        .into_iter()
+        .next();
+
+    let mut outcome = UnloadOutcome {
+        rounds_unloaded: loaded,
+        spawn_clip: None,
+    };
+    match destination {
+        Some(item) => {
+            let Ok(mut stacks) = world.borrow::<ViewMut<PropStackCount>>() else {
+                return UnloadOutcome::default();
+            };
+            let Ok(stack) = (&mut stacks).get(item) else {
+                return UnloadOutcome::default();
+            };
+            stack.0 += loaded;
+        }
+        // The first authored clip is the ammo type's canonical archetype.
+        None => outcome.spawn_clip = Some((compatible_clip_templates[0], loaded)),
+    }
+
+    let mut states = world.borrow::<ViewMut<PropGunState>>().unwrap();
+    if let Ok(state) = (&mut states).get(weapon) {
+        state.ammo = 0;
     }
     outcome
 }
@@ -513,5 +604,126 @@ mod tests {
         assert_eq!(fixture.ammo(), 6);
         assert_eq!(first.rounds_loaded, 6);
         assert_eq!(second, ReloadOutcome::default());
+    }
+
+    /// A projectile the data authors no `Clip` relation for: its rounds have no
+    /// reserve representation, so they can never be ejected.
+    const CLIPLESS_PROJECTILE: i32 = -9999;
+
+    #[test]
+    fn ejecting_an_empty_magazine_does_nothing() {
+        let fixture = Fixture::new(0, 0);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(outcome, UnloadOutcome::default());
+        assert_eq!(fixture.ammo(), 0);
+    }
+
+    #[test]
+    fn ejecting_merges_into_a_matching_reserve_stack() {
+        let mut fixture = Fixture::new(5, 0);
+        let reserve = fixture.reserve(EARTH_SMALL_STD_CLIP, 6);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(
+            outcome,
+            UnloadOutcome {
+                rounds_unloaded: 5,
+                spawn_clip: None,
+            }
+        );
+        assert_eq!(fixture.ammo(), 0);
+        assert_eq!(
+            fixture.rounds(reserve),
+            11,
+            "the stack absorbs the magazine"
+        );
+    }
+
+    #[test]
+    fn ejecting_without_a_matching_stack_asks_for_a_fresh_clip() {
+        let mut fixture = Fixture::new(5, 0);
+        // Carrying only HE, while standard is loaded and selected.
+        let mismatched = fixture.reserve(HE_CLIP, 6);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(
+            outcome,
+            UnloadOutcome {
+                rounds_unloaded: 5,
+                // The first authored clip for the standard projectile.
+                spawn_clip: Some((STD_CLIP, 5)),
+            }
+        );
+        assert_eq!(fixture.ammo(), 0);
+        assert_eq!(fixture.rounds(mismatched), 6, "HE reserve is untouched");
+    }
+
+    #[test]
+    fn ejecting_returns_the_selected_ammo_type_not_the_first() {
+        // HE selected, HE loaded: the rounds must come back as HE even though
+        // standard is the weapon's first projectile link.
+        let mut fixture = Fixture::new(4, 1);
+        let he = fixture.reserve(HE_CLIP, 2);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(outcome.rounds_unloaded, 4);
+        assert_eq!(outcome.spawn_clip, None);
+        assert_eq!(fixture.rounds(he), 6);
+    }
+
+    #[test]
+    fn a_magazine_with_no_clip_archetype_is_not_ejected() {
+        let mut fixture = Fixture::new(5, 0);
+        fixture.set_standard_projectile(CLIPLESS_PROJECTILE);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(outcome, UnloadOutcome::default());
+        assert_eq!(fixture.ammo(), 5, "unreturnable rounds stay loaded");
+    }
+
+    // `can_cycle_ammo` lives in `script_util`, but its contract is this
+    // module's: cycling is allowed exactly when a loaded magazine could be
+    // ejected. Tested here because the eject fixture is what it needs.
+    use crate::scripts::script_util::can_cycle_ammo;
+
+    #[test]
+    fn a_loaded_multi_ammo_weapon_may_cycle_because_it_can_eject() {
+        let fixture = Fixture::new(5, 0);
+
+        assert!(can_cycle_ammo(&fixture.world, fixture.weapon));
+    }
+
+    #[test]
+    fn a_loaded_weapon_whose_rounds_cannot_be_returned_still_refuses_to_cycle() {
+        let mut fixture = Fixture::new(5, 0);
+        fixture.set_standard_projectile(CLIPLESS_PROJECTILE);
+
+        assert!(!can_cycle_ammo(&fixture.world, fixture.weapon));
+    }
+
+    #[test]
+    fn a_single_ammo_weapon_still_refuses_to_cycle() {
+        let fixture = Fixture::new(0, 0);
+        {
+            let mut links = fixture.world.borrow::<ViewMut<Links>>().unwrap();
+            (&mut links)
+                .get(fixture.weapon)
+                .unwrap()
+                .to_links
+                .retain(|link| {
+                    !matches!(
+                        link.link,
+                        Link::Projectile(ProjectileOptions { order: 1, .. })
+                    )
+                });
+        }
+
+        assert!(!can_cycle_ammo(&fixture.world, fixture.weapon));
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -235,16 +235,22 @@ pub fn ordered_projectile_links(world: &World, weapon: EntityId) -> Vec<(i32, Pr
     links
 }
 
-/// Whether `weapon` may select a different projectile type. Until magazine
-/// unload semantics exist, a gun must be empty so loaded rounds cannot be
-/// converted to a different ammo type for free.
+/// Whether `weapon` may select a different projectile type: it needs two or
+/// more selectable projectiles, and any rounds already loaded must be
+/// returnable to the backpack, since `cycle_ammo` ejects the magazine first.
+/// Loaded rounds are never converted - they go back as the ammo type they are -
+/// so an unreturnable magazine (a projectile with no clip archetype) is the one
+/// case that still has to be fired off before the type can change.
 pub fn can_cycle_ammo(world: &World, weapon: EntityId) -> bool {
+    if ordered_projectile_links(world, weapon).len() < 2 {
+        return false;
+    }
     let is_empty = world
         .borrow::<View<PropGunState>>()
         .ok()
         .and_then(|states| states.get(weapon).ok().map(|state| state.ammo <= 0))
         .unwrap_or(false);
-    is_empty && ordered_projectile_links(world, weapon).len() >= 2
+    is_empty || crate::mission::reload::can_unload(world, weapon)
 }
 
 pub fn get_first_link_with_template_and_data<TData: Clone>(

--- a/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
@@ -162,7 +162,7 @@ test(
 );
 
 test(
-  "a VR-held empty pistol cycles through its ammo types",
+  "a VR-held pistol cycles through its ammo types",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
   async () => {
     await using game = await GameServer.launch({
@@ -175,20 +175,20 @@ test(
     const pistol = await grabPistol(game);
     assert.equal((await game.info()).player.wielded_ammo_type, "std");
 
-    // Loaded rounds have an established projectile identity, so cycling is
-    // refused until the magazine is empty.
+    // The first swap is made on a LOADED gun, which ejects the magazine back
+    // to the backpack rather than converting it (weapon-ammo-eject covers where
+    // the rounds land; here it just has to work from the VR hand).
+    assert.ok(ammoOf(await game.entities.detail(pistol.id)) > 0, "the pistol starts loaded");
     await game.input.trigger("CycleAmmo");
     await game.step({ frames: 2 });
     assert.equal(
-      (await game.info()).player.wielded_ammo_type,
-      "std",
-      "a loaded VR-held pistol cannot change ammo type",
+      ammoOf(await game.entities.detail(pistol.id)),
+      0,
+      "swapping ammo type ejects the magazine",
     );
 
-    await emptyTheMagazine(game, pistol);
-
-    const sequence: (string | null)[] = [];
-    for (let i = 0; i < 3; i += 1) {
+    const sequence: (string | null)[] = [(await game.info()).player.wielded_ammo_type];
+    for (let i = 0; i < 2; i += 1) {
       await game.input.trigger("CycleAmmo");
       await game.step({ frames: 2 });
       sequence.push((await game.info()).player.wielded_ammo_type);

--- a/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
@@ -24,6 +24,10 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 /** The pistol's standard clip - the archetype an ejected std magazine becomes. */
 const STD_CLIP = -31;
+/** The Assault Rifle's *first* authored standard clip, which is the SMALL one -
+ * the reverse of the pistol's preference, and the case that catches an eject
+ * minting a family-wide default instead of the weapon's own authored choice. */
+const SMALL_STD_CLIP = -1358;
 
 function propOf(
   detail: { properties: { name: string; value: string }[] },
@@ -45,14 +49,22 @@ function stackOf(detail: { properties: { name: string; value: string }[] }): num
   return value;
 }
 
-/** Every standard clip the player is carrying, by runtime id. */
-async function carriedStandardClips(game: GameServer): Promise<EntitySummary[]> {
+/** Every carried clip of `template`, by runtime id. */
+async function carriedClips(
+  game: GameServer,
+  template: number,
+): Promise<EntitySummary[]> {
   const carried = new Set(
     (await game.player.inventory()).items.map((item) => item.entity_id),
   );
   return (await game.entities.list()).entities.filter(
-    (entity) => entity.template_id === STD_CLIP && carried.has(entity.id),
+    (entity) => entity.template_id === template && carried.has(entity.id),
   );
+}
+
+/** Every standard clip the player is carrying, by runtime id. */
+async function carriedStandardClips(game: GameServer): Promise<EntitySummary[]> {
+  return carriedClips(game, STD_CLIP);
 }
 
 /** Total standard rounds held in reserve (across however many stacks). */
@@ -146,5 +158,49 @@ test(
 
     // (Save/load of the selection an eject leaves behind is `weapon-reload`'s,
     // on earth.mis - debug scenes have no serializable level to save into.)
+  },
+);
+
+test(
+  "the ejected clip is the weapon's own authored archetype, not a family default",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // The pistol's standard bullet authors [Standard Clip, Small Standard Clip];
+    // the ASSAULT RIFLE's authors those two the other way round. Each weapon's
+    // own first choice must win, so an eject that reached for a shared family
+    // default - or that let an inherited relation outrank the projectile's own -
+    // would mint the wrong archetype here while still looking right for the
+    // pistol.
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8415),
+    });
+
+    await game.step({ frames: 5 });
+    // DebugCycleWeapon's roster is Pistol, then Assault Rifle.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+
+    const rifle = (await game.info()).player.wielded_entity_id;
+    assert.ok(rifle !== null, "the assault rifle should be wielded");
+    assert.equal((await game.info()).player.wielded_ammo_type, "std");
+    const loaded = ammoOf(await game.entities.detail(rifle));
+    assert.ok(loaded > 0, "the debug assault rifle starts loaded");
+
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal(ammoOf(await game.entities.detail(rifle)), 0, "the magazine was ejected");
+
+    const small = await carriedClips(game, SMALL_STD_CLIP);
+    const full = await carriedClips(game, STD_CLIP);
+    assert.equal(
+      full.length,
+      0,
+      "the pistol's full-size Standard Clip is NOT the assault rifle's choice",
+    );
+    assert.equal(small.length, 1, "the assault rifle ejects into its own Small Standard Clip");
+    assert.equal(stackOf(await game.entities.detail(small[0].id)), loaded);
   },
 );

--- a/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/index.js";
+
+// End-to-end coverage for magazine unload: cycling ammo on a LOADED weapon
+// ejects the magazine back to the backpack first, as clips of the ammo type the
+// rounds already are, and then switches. Cycling used to require an empty gun
+// precisely because there was nowhere to put loaded rounds, so a half-full
+// magazine had to be fired off before the type could change.
+//
+// The two placements the eject has to get right are both exercised here: with
+// no matching stack carried it mints the ammo type's canonical clip archetype,
+// and with one carried the rounds merge into it rather than cluttering the
+// backpack with a second stack.
+//
+// (`weapon-reload` and `weapon-ammo-type` used to assert the old refusal; that
+// assertion moved here, inverted.)
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The pistol's standard clip - the archetype an ejected std magazine becomes. */
+const STD_CLIP = -31;
+
+function propOf(
+  detail: { properties: { name: string; value: string }[] },
+  name: string,
+): number | undefined {
+  const p = detail.properties.find((x) => x.name === name);
+  return p === undefined ? undefined : Number(p.value);
+}
+
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const value = propOf(detail, "Ammo");
+  assert.ok(value !== undefined, "weapon should expose an Ammo property");
+  return value;
+}
+
+function stackOf(detail: { properties: { name: string; value: string }[] }): number {
+  const value = propOf(detail, "StackCount");
+  assert.ok(value !== undefined, "reserve clip should expose a StackCount property");
+  return value;
+}
+
+/** Every standard clip the player is carrying, by runtime id. */
+async function carriedStandardClips(game: GameServer): Promise<EntitySummary[]> {
+  const carried = new Set(
+    (await game.player.inventory()).items.map((item) => item.entity_id),
+  );
+  return (await game.entities.list()).entities.filter(
+    (entity) => entity.template_id === STD_CLIP && carried.has(entity.id),
+  );
+}
+
+/** Total standard rounds held in reserve (across however many stacks). */
+async function reserveRounds(game: GameServer): Promise<number> {
+  let total = 0;
+  for (const clip of await carriedStandardClips(game)) {
+    total += stackOf(await game.entities.detail(clip.id));
+  }
+  return total;
+}
+
+async function cycleAmmo(game: GameServer): Promise<string | null> {
+  await game.input.trigger("CycleAmmo");
+  await game.step({ frames: 2 });
+  return (await game.info()).player.wielded_ammo_type;
+}
+
+test(
+  "cycling a loaded weapon returns its rounds to the backpack",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8414),
+    });
+
+    await game.step({ frames: 5 });
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    const pistol = (await game.info()).player.wielded_entity_id;
+    assert.ok(pistol !== null, "the debug pistol should be wielded");
+    assert.equal((await game.info()).player.wielded_ammo_type, "std");
+
+    const loaded = ammoOf(await game.entities.detail(pistol));
+    assert.ok(loaded > 0, "the debug pistol starts loaded");
+    assert.equal(await reserveRounds(game), 0, "and carries no reserve of its own");
+
+    // --- No matching stack: the ejected rounds mint the clip archetype.
+    assert.equal(await cycleAmmo(game), "ap", "a loaded magazine no longer blocks the swap");
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol)),
+      0,
+      "the magazine is empty until the new type is reloaded",
+    );
+    const minted = await carriedStandardClips(game);
+    assert.equal(minted.length, 1, "the ejected rounds become one carried standard clip");
+    assert.equal(
+      stackOf(await game.entities.detail(minted[0].id)),
+      loaded,
+      "carrying exactly the rounds that came out",
+    );
+
+    // --- Back to standard and reload from the clip that was just ejected: the
+    // rounds are genuinely usable again, not a cosmetic stack.
+    assert.equal(await cycleAmmo(game), "he");
+    assert.equal(await cycleAmmo(game), "std");
+    const spare = await game.player.spawnItem(STD_CLIP);
+    const reserveBeforeReload = await reserveRounds(game);
+    await game.input.trigger("Reload");
+    await game.step({ frames: 2 });
+    const reloaded = ammoOf(await game.entities.detail(pistol));
+    assert.equal(reloaded, loaded, "the pistol refills from its own ejected rounds");
+    assert.equal(
+      await reserveRounds(game),
+      reserveBeforeReload - reloaded,
+      "reserve drains by exactly the rounds loaded",
+    );
+    assert.ok(
+      (await reserveRounds(game)) > 0,
+      "the spare clip leaves a stack behind for the merge case",
+    );
+
+    // --- With a matching stack carried, an eject merges into it instead of
+    // minting a second one.
+    await game.step({ frames: 130 });
+    const stacksBefore = (await carriedStandardClips(game)).length;
+    const reserveBeforeEject = await reserveRounds(game);
+    assert.equal(await cycleAmmo(game), "ap");
+    assert.equal(ammoOf(await game.entities.detail(pistol)), 0);
+    assert.equal(
+      await reserveRounds(game),
+      reserveBeforeEject + reloaded,
+      "the whole magazine came back to reserve",
+    );
+    assert.equal(
+      (await carriedStandardClips(game)).length,
+      stacksBefore,
+      "merging into the carried stack rather than minting another",
+    );
+    assert.ok(spare.entity_id, "the spare clip is the stack that absorbed it");
+
+    // (Save/load of the selection an eject leaves behind is `weapon-reload`'s,
+    // on earth.mis - debug scenes have no serializable level to save into.)
+  },
+);

--- a/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
@@ -7,6 +7,7 @@ import { fireOnce } from "./helpers/weapon.js";
 // End-to-end regression test for ammo-type cycling (InputAction::CycleAmmo). The
 // pistol carries three Projectile links (std / he / ap); cycling advances the
 // selected one and wraps. Observable headlessly via /v1/info.wielded_ammo_type.
+// What a cycle does to a LOADED magazine is weapon-ammo-eject's subject.
 //
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
@@ -23,7 +24,7 @@ function ammoOf(detail: { properties: { name: string; value: string }[] }): numb
 }
 
 test(
-  "cycling requires an empty magazine, then advances and wraps",
+  "cycling advances the selected ammo type and wraps",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -42,13 +43,11 @@ test(
     const pistolId = (await game.info()).player.wielded_entity_id;
     assert.ok(pistolId !== null, "pistol should be wielded");
 
-    // A loaded magazine has an established projectile identity. Cycling it
-    // would otherwise turn standard rounds into AP/HE for free.
+    // Cycling a LOADED magazine ejects it to the backpack first, which is
+    // weapon-ammo-eject's subject. This test is about the selection ORDER, so
+    // fire the magazine off and cycle from empty.
     const loaded = ammoOf(await game.entities.detail(pistolId));
     assert.ok(loaded > 0, "debug pistol starts loaded");
-    await game.input.trigger("CycleAmmo");
-    await game.step({ frames: 2 });
-    assert.equal(await ammoType(game), "std", "loaded pistol cannot change ammo type");
     for (let i = 0; i < loaded; i++) await fireOnce(game);
     assert.equal(ammoOf(await game.entities.detail(pistolId)), 0, "pistol is empty");
 

--- a/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
@@ -114,13 +114,9 @@ test(
       6,
       "reload stops once the magazine is full",
     );
-    await game.input.trigger("CycleAmmo");
-    await game.step({ frames: 2 });
-    assert.equal(
-      (await game.info()).player.wielded_ammo_type,
-      "std",
-      "loaded standard rounds cannot be converted to another ammo type",
-    );
+    // (What a cycle does to this full magazine - eject it back to reserve
+    // rather than convert it - is weapon-ammo-eject's subject; leave the
+    // magazine alone here so the reserve accounting below stays readable.)
 
     // Let the fire-gating animation finish, then exercise a partial reload.
     await game.step({ frames: 130 });


### PR DESCRIPTION
> Stacked on #1144 (`feat/vr-reload-ammo-binding`) - review that first; this PR's base is its branch.

## What

Cycling ammo used to require an **empty** gun, because loaded rounds had nowhere to go: swapping while loaded would have turned standard rounds into AP for free. The cost was that a half-full magazine had to be *fired off* before the type could change - neither what the original does nor anything a player would guess.

`reload::unload_to_reserve` is the reverse of `load_from_reserve`. It returns the loaded rounds to the backpack **as clips of the ammo type they already are**:

- merging into the first compatible reserve stack - which cannot fail, so that case empties the magazine outright; or
- naming the ammo type's canonical clip archetype for the caller to mint, when the player carries no matching stack. Instantiating an entity needs the mission's entity creator, which the module has no access to.

**The rounds are in exactly one place at every instant.** The mint case deliberately leaves the weapon *loaded*; `mission_core::give_ejected_clip` empties the magazine only once the clip is genuinely carried. Nothing has to be rolled back, so there is no undo to forget. `cycle_ammo` then re-reads the magazine and refuses to advance the selection while rounds remain - covering every shortfall (a refused clip, a borrow that did not come through) by construction rather than by enumeration.

`can_cycle_ammo` relaxes to match: two or more projectile links, and - only when the magazine is loaded - rounds that can actually be returned. That second clause is live against shipped data, not theoretical: the **EMP Rifle's** projectiles author no `Clip` relation at all, so its magazine still has to be fired off. The flat HUD's AMMOFULL cycle button and its pointer hotspot both read that same predicate, so they follow automatically.

`GlobalProjectileClips` now orders each projectile's clips **most-derived first**. Ordering became load-bearing the moment an unload started minting `[0]`, and `get_ancestors` is root-first, so a clip inherited from a family archetype could otherwise outrank the projectile's own.

**Capacity is not enforced**, deliberately: reserve stacks have no ceiling anywhere in this port - `load_from_reserve` drains them without one and pickup never caps them - so the merge is unconditional rather than spilling into a second stack.

## Tests

Negative-first, twice over:

- with `can_cycle_ammo` restored to its empty-clip-only rule, the new e2e fails at `a loaded magazine no longer blocks the swap ('std' !== 'ap')`;
- with the clip placement **forced to fail**, the pistol stays on `std` holding its rounds - the free-conversion hole the review found, which previously reported `ap`.

**Unit** (`shock2vr/src/mission/reload.rs`, 9 new): eject with zero loaded is a no-op; eject merges into a matching stack (5 + 6 -> 11); eject with only a *mismatched* stack carried requests `(STD_CLIP, 5)` and leaves the HE reserve alone; a requested clip leaves the magazine loaded until `empty_magazine` runs; eject returns the **selected** type, not the first link (HE selected -> HE stack); a magazine whose projectile has no clip archetype stays loaded; plus the three `can_cycle_ammo` cases - loaded-but-ejectable allowed, loaded-and-unreturnable refused, single-ammo refused.

**e2e** `tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts` (new, 2 scenarios):
1. A loaded swap mints one carried standard clip holding exactly the ejected rounds and leaves the magazine empty; cycling back and reloading refills the pistol *from those very rounds*, draining reserve by exactly that many; a second loaded swap **merges** into the carried stack (reserve grows by the full magazine, stack count unchanged).
2. The minted archetype is the **weapon's own** authored choice, pinned against real data with an inverted case: the pistol's standard bullet authors `[Standard Clip, Small Standard Clip]` while the **Assault Rifle's** authors them the other way round, so the rifle must eject into `Small Standard Clip` (-1358) and *not* the pistol's full-size -31.

The three tests that asserted the old refusal are updated: `weapon-reload` and `weapon-ammo-type` keep their own subjects (reserve accounting; selection order) and stop asserting a refusal that no longer happens, and the VR scenario now makes its first swap on a **loaded** gun so the eject is exercised from the hand too.

- `cargo test -p shock2vr --lib`: **998 passed, 0 failed** (989 on main)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean
- e2e: `weapon-ammo-eject` (2/2), `weapon-reload` (1/1), `weapon-ammo-type` (1/1), `vr-weapon-reload` (2/2), `give-item` + `provisioning` + `inventory` (5/5, covering the `spawn_into_backpack` extraction), `missions` (**23/23**)
- **Oculus cross-compile: `cargo apk check` passes** for `aarch64-linux-android`

## Review

An adversarial pass over this diff found the unconditional-selection-advance bug plus three mediums; all four are fixed in `2480e86e` (the placement/emptying inversion, the zero-stack merge asymmetry, the clip ordering, and the duplicated spawn-and-give block).

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72

## Visuals

![ammo eject demo](https://gist.githubusercontent.com/tommy-xr/c26d0aaf2e5a406ae97e958ca590242f/raw/ammo-eject.gif)

<sub>Flat presentation, `debug_weapons`. The HUD ammo readout (bottom right) goes `12 / STD` to `0 / AP` the moment `CycleAmmo` fires - the swap no longer refuses on a loaded gun. The burned-in caption line carries what the HUD cannot show, the reserve: every number is sampled live over HTTP at capture time (`/v1/entities/<pistol>` `Ammo`, `/v1/info` `wielded_ammo_type`, and the carried `template_id -31` clip's `StackCount` via `/v1/player/inventory`). Sequence: loaded 12/12 std, then `CycleAmmo` ejects the magazine as a Standard Clip x12 in the backpack and switches to AP, cycle back to std, `Reload` refills 12/12 from those very rounds (reserve drains to 0), and one more `CycleAmmo` sends them straight back out. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

Still - magazine empty, the ejected rounds sitting in the backpack:

![ejected clip in backpack](https://gist.githubusercontent.com/tommy-xr/c26d0aaf2e5a406ae97e958ca590242f/raw/ammo-eject.png)

