### PR TITLE
feat(items): always collect keycards, modules, nanites, and logs on every path

### DIFF
--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -677,6 +677,22 @@ impl FlatUiHost {
                 // Dropping onto another item swaps by lifting that occupant.
                 self.last_lift = None;
                 match self.strip_item_at(canvas_pos) {
+                    // An always-collected occupant is collected rather than
+                    // swapped onto the cursor - the same rule as a plain click
+                    // below, so the swap can't be a back door into carrying one.
+                    Some(target)
+                        if target != held
+                            && crate::scripts::script_util::is_always_collected(world, target) =>
+                    {
+                        self.cursor_item = None;
+                        return (
+                            vec![Message {
+                                to: target,
+                                payload: MessagePayload::Frob,
+                            }],
+                            Vec::new(),
+                        );
+                    }
                     Some(target) if target != held => {
                         self.cursor_item = Some(make_cursor_item(world, target));
                         self.last_lift = Some(LiftMark {
@@ -1630,6 +1646,28 @@ mod tests {
         }
     }
 
+    /// [`press_edge`], keeping the messages the press emitted as well.
+    fn press_edge_with_messages(
+        host: &mut FlatUiHost,
+        world: &World,
+        canvas: (f32, f32),
+    ) -> (Vec<Message>, Vec<FlatUiDragAction>) {
+        host.update(
+            world,
+            Some(Pointer2D {
+                position: norm(canvas.0, canvas.1),
+                pressed: false,
+            }),
+        );
+        host.update(
+            world,
+            Some(Pointer2D {
+                position: norm(canvas.0, canvas.1),
+                pressed: true,
+            }),
+        )
+    }
+
     fn press_edge(
         host: &mut FlatUiHost,
         world: &World,
@@ -1763,6 +1801,44 @@ mod tests {
         assert!(
             host.cursor_debug().is_some(),
             "ordinary loot must still lift onto the cursor"
+        );
+    }
+
+    /// The swap is the same gesture family as the click above: dropping a held
+    /// item onto an always-collected occupant must collect that occupant, not
+    /// lift it onto the cursor - otherwise the swap is a back door into
+    /// carrying one.
+    #[test]
+    fn swapping_onto_an_always_collected_strip_item_collects_it() {
+        use crate::test_support::{CollectedKind, spawn_collected, spawn_ordinary_loot};
+
+        let mut world = World::new();
+        let held = spawn_ordinary_loot(&mut world);
+        let pickup = spawn_collected(&mut world, CollectedKind::KeyCard);
+        let inventory = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.set_strip(Some(inventory));
+        host.on_set_ui(
+            &world,
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[strip_item(held, 0), strip_item(pickup, 1)],
+        );
+
+        // Lift the ordinary item out of slot 0, then press on slot 1's card.
+        press_edge(&mut host, &world, (23.5, 34.0));
+        assert!(host.cursor_debug().is_some(), "slot 0 lifts as usual");
+        let (msgs, actions) = press_edge_with_messages(&mut host, &world, (58.5, 34.0));
+
+        assert!(
+            msgs.iter()
+                .any(|msg| msg.to == pickup && matches!(msg.payload, MessagePayload::Frob)),
+            "the occupant must be collected, got {msgs:?}"
+        );
+        assert!(actions.is_empty(), "collecting is not a world action");
+        assert!(
+            host.cursor_debug().is_none(),
+            "neither item may stay on the cursor"
         );
     }
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -722,6 +722,22 @@ impl FlatUiHost {
             self.hover_close = false;
             if pressed_edge {
                 if let Some(item) = self.strip_item_at(canvas_pos) {
+                    // An always-collected item is never carried on the cursor:
+                    // it collects, exactly as it would from the world or a loot
+                    // panel. Reachable only for one already sitting in the
+                    // backpack - a save made before its category collected on
+                    // pickup - which is the one way it can be in the grid at
+                    // all, and otherwise the one way it could never be
+                    // collected.
+                    if crate::scripts::script_util::is_always_collected(world, item) {
+                        return (
+                            vec![Message {
+                                to: item,
+                                payload: MessagePayload::Frob,
+                            }],
+                            Vec::new(),
+                        );
+                    }
                     self.cursor_item = Some(make_cursor_item(world, item));
                     self.last_lift = Some(LiftMark {
                         entity: item,
@@ -1676,6 +1692,78 @@ mod tests {
             "the lifted item leaves the strip grid",
         );
         assert_eq!(host.strip_item_at(vec2(23.5, 34.0)), None);
+    }
+
+    /// An always-collected item that an older save left in the backpack is the
+    /// one case where the grid holds one at all - and, before this, the one
+    /// place it could never be collected: the host owns strip clicks as the
+    /// cursor drag, so the click never reached `ContainerGui`'s frob. Clicking
+    /// one collects it instead of lifting it onto the cursor.
+    #[test]
+    fn clicking_an_always_collected_strip_item_collects_it() {
+        use crate::test_support::{CollectedKind, spawn_collected, spawn_ordinary_loot};
+
+        for kind in CollectedKind::ALL {
+            let mut world = World::new();
+            let pickup = spawn_collected(&mut world, kind);
+            let inventory = world.add_entity(());
+            let mut host = FlatUiHost::new();
+            host.set_strip(Some(inventory));
+            host.on_set_ui(
+                &world,
+                inventory,
+                vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+                &[strip_item(pickup, 0)],
+            );
+
+            // Slot 0 center, as in `lmb_on_a_strip_item_lifts_it_onto_the_cursor`.
+            host.update(
+                &world,
+                Some(Pointer2D {
+                    position: norm(23.5, 34.0),
+                    pressed: false,
+                }),
+            );
+            let (msgs, actions) = host.update(
+                &world,
+                Some(Pointer2D {
+                    position: norm(23.5, 34.0),
+                    pressed: true,
+                }),
+            );
+
+            assert!(
+                msgs.iter()
+                    .any(|msg| msg.to == pickup && matches!(msg.payload, MessagePayload::Frob)),
+                "{kind:?} clicked in the strip must be frobbed, got {msgs:?}"
+            );
+            assert!(
+                actions.is_empty(),
+                "{kind:?} must not throw or wield, got {actions:?}"
+            );
+            assert!(
+                host.cursor_debug().is_none(),
+                "{kind:?} must never ride the cursor"
+            );
+        }
+
+        // The control: ordinary loot still lifts onto the cursor.
+        let mut world = World::new();
+        let loot = spawn_ordinary_loot(&mut world);
+        let inventory = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.set_strip(Some(inventory));
+        host.on_set_ui(
+            &world,
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[strip_item(loot, 0)],
+        );
+        press_edge(&mut host, &world, (23.5, 34.0));
+        assert!(
+            host.cursor_debug().is_some(),
+            "ordinary loot must still lift onto the cursor"
+        );
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2905,16 +2905,16 @@ impl MissionCore {
         } else {
             Vec::new()
         };
-        // The keycard exception, the same one `ContainerGui`'s own `Take`
-        // makes on the same predicate: a `PropKeySrc` carries a runtime
-        // `internal_keycard` script whose Frob records the credential, so
-        // banking the card bodily would put an object in the pack that unlocks
-        // nothing. Reachable only for a card restored into a hand by an older
-        // save - grabbing one routes through Frob - which is exactly why
-        // `held_trigger_press_payload` keeps its own keycard arm.
-        let (collect, store): (Vec<_>, Vec<_>) = strip_deposits
-            .iter()
-            .partition(|entity_id| crate::virtual_hand::is_key_source(&self.world, **entity_id));
+        // The always-collected exception, the same one `ContainerGui`'s own
+        // `Take` and squeeze make on the same predicate: a keycard's Frob is
+        // what records the credential, a pile's what credits the nanites, so
+        // banking any of them bodily would put an object in the pack that
+        // unlocks or buys nothing. Reachable only for one restored into a hand
+        // by an older save - acquiring one routes through Frob - which is
+        // exactly why `held_trigger_press_payload` keeps its own arm.
+        let (collect, store): (Vec<_>, Vec<_>) = strip_deposits.iter().partition(|entity_id| {
+            crate::scripts::script_util::is_always_collected(&self.world, **entity_id)
+        });
         let collect: Vec<_> = collect.into_iter().copied().collect();
         let store: Vec<_> = store.into_iter().copied().collect();
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2891,20 +2891,14 @@ impl MissionCore {
         // its squeeze swallowed - `update_squeeze_swallow` drops the latch the
         // moment the hand is full - so this cannot fire on a masked squeeze.)
         //
-        // Nothing is claimed unless the backpack can actually take it, so a
-        // release is never suppressed into an item that lands nowhere.
-        let strip_deposits = if backpack_accepts_deposit(&self.world) {
-            strip_deposit_entities(
-                on_strip,
-                [left_hand_held, right_hand_held],
-                [
-                    hands_input.left_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
-                    hands_input.right_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
-                ],
-            )
-        } else {
-            Vec::new()
-        };
+        let strip_deposits = strip_deposit_entities(
+            on_strip,
+            [left_hand_held, right_hand_held],
+            [
+                hands_input.left_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
+                hands_input.right_hand.squeeze_value < crate::ui::VR_TRIGGER_THRESHOLD,
+            ],
+        );
         // The always-collected exception, the same one `ContainerGui`'s own
         // `Take` and squeeze make on the same predicate: a keycard's Frob is
         // what records the credential, a pile's what credits the nanites, so
@@ -2916,7 +2910,15 @@ impl MissionCore {
             crate::scripts::script_util::is_always_collected(&self.world, **entity_id)
         });
         let collect: Vec<_> = collect.into_iter().copied().collect();
-        let store: Vec<_> = store.into_iter().copied().collect();
+        // A stored item needs backpack room, so nothing is claimed unless the
+        // backpack can actually take it - a release is never suppressed into an
+        // item that lands nowhere. A collected one never enters the pack (its
+        // Frob awards and destroys it), so it is claimed either way.
+        let store: Vec<_> = if backpack_accepts_deposit(&self.world) {
+            store.into_iter().copied().collect()
+        } else {
+            Vec::new()
+        };
 
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.

--- a/shock2vr/src/scripts/exp_cookie.rs
+++ b/shock2vr/src/scripts/exp_cookie.rs
@@ -15,11 +15,21 @@ use super::{Effect, MessagePayload, Script};
 /// engine stores an EXP-cookie pile's module value as its stack count, e.g. the
 /// "10 EXP" pile has stack count 10), falling back to `P$ExP` for any
 /// cookie authored the trap way.
-pub struct ExpCookie {}
+pub struct ExpCookie {
+    // The module is destroyed the same frame it is first collected (effects
+    // apply after the whole message batch), so a second Frob delivered in that
+    // same batch - both VR hands squeezing the same loot-panel icon, or trigger
+    // and squeeze from different hands - would otherwise still see it alive and
+    // award its modules twice while only one DestroyEntity is ever queued.
+    // Latch in-memory on the first award, as `InternalNanitesScript` and
+    // `KeyCardScript` do; the entity is gone by the next frame, so this never
+    // needs to survive a save.
+    collected: bool,
+}
 
 impl ExpCookie {
     pub fn new() -> ExpCookie {
-        ExpCookie {}
+        ExpCookie { collected: false }
     }
 }
 
@@ -32,7 +42,9 @@ impl Script for ExpCookie {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
+            MessagePayload::Frob if !self.collected => {
+                self.collected = true;
+
                 let stack = world
                     .borrow::<View<PropStackCount>>()
                     .unwrap()
@@ -61,5 +73,41 @@ impl Script for ExpCookie {
             }
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Negative-first regression: the destroy effect only applies after the
+    /// whole message batch, so a second Frob in the same batch - both VR hands
+    /// squeezing the same loot-panel module, now that a panel squeeze collects
+    /// - still finds the entity alive. Without the `collected` latch this would
+    /// award the pile's modules twice.
+    #[test]
+    fn a_second_frob_in_the_same_batch_awards_nothing_more() {
+        let mut world = World::new();
+        let entity = world.add_entity(PropStackCount(10));
+        let mut script = ExpCookie::new();
+
+        let first =
+            script.handle_message(entity, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+        let second =
+            script.handle_message(entity, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+
+        let Effect::Combined { effects } = first else {
+            panic!("expected a combined effect, got {first:?}");
+        };
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::AwardXP { amount } if *amount == 10)),
+            "the first Frob should award the pile's modules"
+        );
+        assert!(
+            matches!(second, Effect::NoEffect),
+            "a second Frob in the same batch must award nothing more, got {second:?}"
+        );
     }
 }

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -129,7 +129,7 @@ impl ContainerGui {
 #[derive(Clone, Debug, Default)]
 pub struct ContainerGuiState {}
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ContainerGuiMsg {
     GrabbedWithLeftHand(EntityId),
     GrabbedWithRightHand(EntityId),
@@ -346,6 +346,23 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // need their normal Frob behavior when clicked; they are consumed
             // or recorded in place rather than moved into the backpack.
             ContainerGuiMsg::Take(ent) => {
+                // The always-collected categories are decided before anything
+                // physical is considered: a nanite pile is grabbable metadata-
+                // wise (`MOVE`), so without this it would be banked as an inert
+                // can instead of being credited. Keycards, modules and logs took
+                // the Frob branches below already; routing all four here is what
+                // makes the rule one rule (#583, and the M2 recovery path).
+                if crate::scripts::script_util::is_always_collected(world, *ent) {
+                    return (
+                        state.clone(),
+                        Effect::Send {
+                            msg: Message {
+                                payload: MessagePayload::Frob,
+                                to: *ent,
+                            },
+                        },
+                    );
+                }
                 if !crate::virtual_hand::can_grab_item(world, *ent) {
                     let is_use_only = world
                         .borrow::<View<PropFrobInfo>>()
@@ -370,26 +387,10 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                         (state.clone(), Effect::NoEffect)
                     };
                 }
-                // PropKeySrc gets an `internal_keycard` script even when its
-                // retail frob metadata is just MOVE. Scripted loot must run
-                // that Frob before any generic transfer, or the physical card
-                // reaches the backpack without its unlock credential (#583).
-                // Gated on `is_key_source` specifically (not the broader
-                // `uses_scripted_world_frob`, which also matches authored
-                // MOVE|SCRIPT items like eng1's circuit board) so other
-                // scripted-but-grabbable loot keeps its pre-existing Take
-                // behavior - the same predicate `panel_grab_effect` uses below.
-                if crate::virtual_hand::is_key_source(world, *ent) {
-                    return (
-                        state.clone(),
-                        Effect::Send {
-                            msg: Message {
-                                payload: MessagePayload::Frob,
-                                to: *ent,
-                            },
-                        },
-                    );
-                }
+                // Deliberately *not* gated on the broader
+                // `uses_scripted_world_frob`: that also matches authored
+                // MOVE|SCRIPT items like eng1's circuit board, which keep their
+                // pre-existing Take behavior of moving into the backpack.
                 let inventory_entity = world
                     .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
                     .map(|player| player.inventory_entity_id)
@@ -409,17 +410,19 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
     }
 }
 
-/// A squeeze over a panel normally retrieves the icon into that hand. A
-/// keycard is the one semantic exception: it represents a collected access
-/// credential, so every panel (corpse loot and the backpack alike) must route
-/// the gesture through its derived keycard Frob instead of physically holding
-/// an unregistered object.
+/// A squeeze over a panel normally retrieves the icon into that hand. The
+/// always-collected categories are the semantic exception: a keycard is an
+/// access credential, a pile is currency, a module is an upgrade and a disc is a
+/// PDA entry - none of them is an object you can hold. Every panel (corpse loot,
+/// the backpack, the cyber interface's strip) therefore routes the gesture
+/// through their collecting Frob instead of physically holding an unregistered
+/// object.
 fn panel_grab_effect(
     world: &World,
     entity_id: EntityId,
     hand: crate::vr_config::Handedness,
 ) -> Effect {
-    if crate::virtual_hand::is_key_source(world, entity_id) {
+    if crate::scripts::script_util::is_always_collected(world, entity_id) {
         Effect::Send {
             msg: Message {
                 payload: MessagePayload::Frob,
@@ -624,6 +627,43 @@ mod tests {
             ),
             "ordinary MOVE loot must remain grabbable, got {effect:?}"
         );
+    }
+
+    /// Keycards, nanite piles, cyber modules and audio logs are collected, never
+    /// carried: neither of the panel's two acquisition gestures - the take
+    /// click and the VR squeeze - may put one in the backpack grid or in a hand.
+    /// Their scripts' Frob is the only thing that records the credential,
+    /// credits the nanites, awards the modules or files the log.
+    #[test]
+    fn every_always_collected_category_frobs_from_a_panel() {
+        use crate::test_support::{CollectedKind, spawn_collected};
+
+        for kind in CollectedKind::ALL {
+            let (mut world, container, _item, _inventory) = loot_world();
+            let pickup = spawn_collected(&mut world, kind);
+            let gui = ContainerGui::loot_container();
+
+            for message in [
+                ContainerGuiMsg::Take(pickup),
+                ContainerGuiMsg::GrabbedWithLeftHand(pickup),
+                ContainerGuiMsg::GrabbedWithRightHand(pickup),
+            ] {
+                let (_state, effect) =
+                    gui.handle_msg(container, &world, &ContainerGuiState {}, &message);
+                assert!(
+                    matches!(
+                        effect,
+                        Effect::Send {
+                            msg: Message {
+                                to,
+                                payload: MessagePayload::Frob,
+                            },
+                        } if to == pickup
+                    ),
+                    "{kind:?} via {message:?} must collect, got {effect:?}"
+                );
+            }
+        }
     }
 
     /// Both panels' item grids must land on the cell separators authored into

--- a/shock2vr/src/scripts/gui/hackable_crate.rs
+++ b/shock2vr/src/scripts/gui/hackable_crate.rs
@@ -26,9 +26,9 @@
 //! held item is released onto a target - via [`Gui::on_provide_for_consumption`],
 //! so the pick opens the crate instead of being deposited into it.
 
-use dark::properties::{ObjectState, PropScripts};
+use dark::properties::ObjectState;
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, World};
 
 use crate::gui::{Gui, GuiComponent, GuiConfig, GuiCursor};
 use crate::scripts::Effect;
@@ -117,15 +117,7 @@ fn crate_hack_critical_failure(entity_id: EntityId, _world: &World) -> Effect {
 /// Whether `entity_id` is an ICE Pick - an object the data marks with the
 /// `FreeHack` script.
 fn is_free_hack_tool(world: &World, entity_id: EntityId) -> bool {
-    world
-        .borrow::<View<PropScripts>>()
-        .ok()
-        .and_then(|scripts| scripts.get(entity_id).ok().map(|s| s.scripts.clone()))
-        .is_some_and(|scripts| {
-            scripts
-                .iter()
-                .any(|script| script.eq_ignore_ascii_case(FREE_HACK_SCRIPT))
-        })
+    crate::scripts::script_util::entity_has_script(world, entity_id, FREE_HACK_SCRIPT)
 }
 
 impl Gui<HackableCrateState, HackableCrateMsg> for HackableCrateGui {
@@ -274,6 +266,7 @@ mod tests {
     use super::*;
     use crate::scripts::MessagePayload;
     use cgmath::{Quaternion, vec3};
+    use dark::properties::PropScripts;
     use dark::properties::{
         FrobFlag, Link, Links, PropFrobInfo, PropObjIcon, ToLink, WrappedEntityId,
     };

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -117,6 +117,23 @@ pub(super) fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
 /// Log discs carry `PropLog {deck, email:33, log:N}` - the reader keys off the
 /// `log` field; 33 (the empty-bitmask sentinel) in either field means "not
 /// set", so such a disc has nothing to read.
+/// The data's own name for the disc pickup script; `MediaGui` is bound to it in
+/// `scripts::mod`.
+const LOG_DISC_SCRIPT: &str = "logdiscscript";
+
+/// Whether frobbing `entity_id` files a log in the PDA - it carries the disc
+/// script *and* a readable `(deck, log)`, which is exactly the pair
+/// [`MediaGui::on_frob`] needs to emit `Effect::CollectLog`. Both halves matter:
+/// a disc template with its log slot unset (the gamesys archetypes) frobs to
+/// nothing, so routing it as collected would strand it.
+///
+/// This is the "log" arm of `script_util::is_always_collected`; it lives beside
+/// the frob it predicts so the two cannot drift.
+pub(crate) fn is_collectable_log(world: &World, entity_id: EntityId) -> bool {
+    readable_log(world, entity_id).is_some()
+        && crate::scripts::script_util::entity_has_script(world, entity_id, LOG_DISC_SCRIPT)
+}
+
 fn readable_log(world: &World, entity_id: EntityId) -> Option<(u32, u32)> {
     let v_log = world.borrow::<View<PropLog>>().unwrap();
     match v_log.get(entity_id) {

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -113,10 +113,6 @@ pub(super) fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
     lines
 }
 
-/// The disc's readable `(deck, log)` pair, if its `PropLog` names a real log.
-/// Log discs carry `PropLog {deck, email:33, log:N}` - the reader keys off the
-/// `log` field; 33 (the empty-bitmask sentinel) in either field means "not
-/// set", so such a disc has nothing to read.
 /// The data's own name for the disc pickup script; `MediaGui` is bound to it in
 /// `scripts::mod`.
 const LOG_DISC_SCRIPT: &str = "logdiscscript";
@@ -134,6 +130,10 @@ pub(crate) fn is_collectable_log(world: &World, entity_id: EntityId) -> bool {
         && crate::scripts::script_util::entity_has_script(world, entity_id, LOG_DISC_SCRIPT)
 }
 
+/// The disc's readable `(deck, log)` pair, if its `PropLog` names a real log.
+/// Log discs carry `PropLog {deck, email:33, log:N}` - the reader keys off the
+/// `log` field; 33 (the empty-bitmask sentinel) in either field means "not
+/// set", so such a disc has nothing to read.
 fn readable_log(world: &World, entity_id: EntityId) -> Option<(u32, u32)> {
     let v_log = world.borrow::<View<PropLog>>().unwrap();
     match v_log.get(entity_id) {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -84,6 +84,54 @@ pub(crate) fn is_nanite_pickup(world: &World, entity: EntityId) -> bool {
     is_nanite_pile_template(&hierarchy.0, template_id)
 }
 
+/// Whether `entity`'s object scripts include `script`. Case-insensitive: the
+/// data authors these names in mixed case (`ExpCookie`, `LogDiscScript`) while
+/// the port's own derived scripts are lowercase.
+pub(crate) fn entity_has_script(world: &World, entity: EntityId, script: &str) -> bool {
+    world
+        .borrow::<View<dark::properties::PropScripts>>()
+        .ok()
+        .is_some_and(|scripts| {
+            scripts.get(entity).is_ok_and(|entity_scripts| {
+                entity_scripts
+                    .scripts
+                    .iter()
+                    .any(|name| name.eq_ignore_ascii_case(script))
+            })
+        })
+}
+
+/// The cyber-module pickup script (`scripts::exp_cookie`), authored on the
+/// `EXP Cookies` archetype and inherited by every module pile.
+const EXP_COOKIE_SCRIPT: &str = "expcookie";
+
+/// Whether `entity` is a cyber-module pickup, identified by the pickup script
+/// that actually awards the modules rather than by template ancestry - the
+/// script is the thing whose Frob does the collecting.
+pub(crate) fn is_cyber_module(world: &World, entity: EntityId) -> bool {
+    entity_has_script(world, entity, EXP_COOKIE_SCRIPT)
+}
+
+/// Whether `entity` belongs to a category the game *collects* rather than
+/// carries: keycards, nanite piles, cyber modules and audio/data logs.
+///
+/// These four never become a physically-held prop and never occupy an inventory
+/// slot - their value goes straight into a player stat, the credential list or
+/// the PDA, and their scripts' side effects (SwitchLinks, quest bits, awards)
+/// only fire on Frob. So *every* acquisition gesture, on every path - world
+/// frob, world squeeze, a loot panel's take arm or squeeze, a click on the
+/// inventory strip - must route through Frob instead of a grab or a transfer.
+///
+/// The single predicate all of those sites consult, so the category cannot
+/// drift between them. Each arm delegates to the per-type predicate that owns
+/// that type's identity rather than re-deriving it here.
+pub(crate) fn is_always_collected(world: &World, entity: EntityId) -> bool {
+    crate::virtual_hand::is_key_source(world, entity)
+        || is_nanite_pickup(world, entity)
+        || is_cyber_module(world, entity)
+        || crate::scripts::gui::is_collectable_log(world, entity)
+}
+
 pub fn is_message_turnon_or_turnoff(msg: &MessagePayload) -> bool {
     match msg {
         MessagePayload::TurnOn { from: _ } => true,
@@ -920,8 +968,9 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 #[cfg(test)]
 mod tests {
     use super::{
-        debit_player_nanites, door_blocks_pathfinding, door_is_closed, is_nanite_pickup,
-        plan_stack_payment, player_nanite_total, spend_player_nanites, stat_nanite_balance,
+        debit_player_nanites, door_blocks_pathfinding, door_is_closed, is_always_collected,
+        is_nanite_pickup, plan_stack_payment, player_nanite_total, spend_player_nanites,
+        stat_nanite_balance,
     };
     use crate::mission::PlayerInfo;
     use crate::quest_info::QuestInfo;
@@ -1216,5 +1265,45 @@ mod tests {
         let mut world = World::new();
         let entity = world.add_entity(());
         assert!(!is_nanite_pickup(&world, entity));
+    }
+
+    /// The category, and the world paths that read it: a squeeze at a pickup
+    /// (and the flat crosshair pickup, which shares
+    /// `uses_scripted_world_frob`) must Frob all four rather than grab them.
+    #[test]
+    fn every_always_collected_category_frobs_in_the_world() {
+        use crate::test_support::{CollectedKind, spawn_collected, spawn_ordinary_loot};
+
+        for kind in CollectedKind::ALL {
+            let mut world = World::new();
+            let pickup = spawn_collected(&mut world, kind);
+            assert!(
+                is_always_collected(&world, pickup),
+                "{kind:?} belongs to the always-collected category"
+            );
+            assert!(
+                crate::virtual_hand::uses_scripted_world_frob(&world, pickup),
+                "{kind:?} must be taken through its script in the world"
+            );
+        }
+
+        let mut world = World::new();
+        let loot = spawn_ordinary_loot(&mut world);
+        assert!(!is_always_collected(&world, loot));
+        assert!(!crate::virtual_hand::uses_scripted_world_frob(&world, loot));
+    }
+
+    /// A disc whose log slot is unset - the gamesys archetypes, and anything
+    /// spawned from them without one - frobs to nothing, so it must keep the
+    /// ordinary pickup path instead of being routed at a collect that would
+    /// silently strand it.
+    #[test]
+    fn a_disc_without_a_readable_log_is_not_always_collected() {
+        let mut world = World::new();
+        let disc = world.add_entity(dark::properties::PropScripts {
+            scripts: vec!["LogDiscScript".to_owned()],
+            inherits: true,
+        });
+        assert!(!is_always_collected(&world, disc));
     }
 }

--- a/shock2vr/src/test_support.rs
+++ b/shock2vr/src/test_support.rs
@@ -1,7 +1,126 @@
 //! Helpers shared by unit tests across the crate.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+use dark::properties::{
+    FrobFlag, KeyCard, PropFrobInfo, PropKeySrc, PropLog, PropScripts, PropStackCount,
+    PropTemplateId,
+};
+use shipyard::{EntityId, UniqueView, World};
+
+/// One of the four categories the game *collects* rather than carries. Spawned
+/// the way the shipped data authors them, so a test exercises the same identity
+/// `scripts::script_util::is_always_collected` reads at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollectedKind {
+    /// `PropKeySrc` - gains a derived `internal_keycard` script.
+    KeyCard,
+    /// A nanite pile - identified by descent from the pile templates.
+    NanitePile,
+    /// An `ExpCookie` cyber-module pile.
+    CyberModule,
+    /// A `LogDiscScript` disc with a readable `(deck, log)`.
+    AudioLog,
+}
+
+impl CollectedKind {
+    /// Every category, for the matrix tests that must cover all four.
+    pub const ALL: [CollectedKind; 4] = [
+        CollectedKind::KeyCard,
+        CollectedKind::NanitePile,
+        CollectedKind::CyberModule,
+        CollectedKind::AudioLog,
+    ];
+}
+
+/// Spawn one always-collected pickup of `kind` into `world`.
+///
+/// Every kind carries the frob metadata its archetype does, because the
+/// acquisition paths branch on it: keycards and piles inherit `Goodies`'
+/// grabbable `MOVE` (which is exactly why they must be recognized by category,
+/// not by metadata), while modules and discs override it to `SCRIPT`.
+pub fn spawn_collected(world: &mut World, kind: CollectedKind) -> EntityId {
+    let goodies_frob = PropFrobInfo {
+        world_action: FrobFlag::MOVE,
+        inventory_action: FrobFlag::SCRIPT,
+        tool_action: FrobFlag::empty(),
+    };
+    let script_frob = PropFrobInfo {
+        world_action: FrobFlag::SCRIPT,
+        inventory_action: FrobFlag::SCRIPT,
+        tool_action: FrobFlag::empty(),
+    };
+    let scripts = |name: &str| PropScripts {
+        scripts: vec![name.to_owned()],
+        inherits: true,
+    };
+    match kind {
+        CollectedKind::KeyCard => world.add_entity((
+            goodies_frob,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 128,
+                lock_id: 0,
+            }),
+        )),
+        CollectedKind::NanitePile => {
+            register_nanite_hierarchy(world);
+            world.add_entity((
+                goodies_frob,
+                PropTemplateId {
+                    template_id: NANITE_PILE_TEMPLATE_ID,
+                },
+                PropStackCount(10),
+            ))
+        }
+        CollectedKind::CyberModule => {
+            world.add_entity((script_frob, scripts("ExpCookie"), PropStackCount(10)))
+        }
+        CollectedKind::AudioLog => world.add_entity((
+            script_frob,
+            scripts("LogDiscScript"),
+            PropLog {
+                deck: 2,
+                email: 0,
+                log: 5,
+                note: 0,
+                video: 0,
+            },
+        )),
+    }
+}
+
+/// Ordinary grabbable loot - the control every matrix test needs, to show the
+/// always-collected rule did not swallow the whole inventory.
+pub fn spawn_ordinary_loot(world: &mut World) -> EntityId {
+    world.add_entity(PropFrobInfo {
+        world_action: FrobFlag::MOVE,
+        inventory_action: FrobFlag::empty(),
+        tool_action: FrobFlag::empty(),
+    })
+}
+
+/// `Small Nanite Pile`, one of the base pile templates.
+const NANITE_PILE_TEMPLATE_ID: i32 = -1589;
+
+/// Nanite piles are recognized through the runtime template hierarchy, so a
+/// test world needs one. Registered once per world; adding the unique twice
+/// would clobber another fixture's hierarchy.
+fn register_nanite_hierarchy(world: &mut World) {
+    if world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateHierarchy>>()
+        .is_ok()
+    {
+        return;
+    }
+    let mut hierarchy = HashMap::new();
+    hierarchy.insert(NANITE_PILE_TEMPLATE_ID, Vec::new());
+    world.add_unique(crate::mission::mission_core::GlobalTemplateHierarchy(
+        hierarchy,
+    ));
+}
 
 /// Makes each directory unique regardless of `name`. Without it, uniqueness is
 /// a crate-global convention enforced by nothing, and `new` starts with

--- a/shock2vr/src/test_support.rs
+++ b/shock2vr/src/test_support.rs
@@ -102,8 +102,10 @@ pub fn spawn_ordinary_loot(world: &mut World) -> EntityId {
     })
 }
 
-/// `Small Nanite Pile`, one of the base pile templates.
-const NANITE_PILE_TEMPLATE_ID: i32 = -1589;
+/// One of the base pile templates the predicate under test owns, taken from it
+/// rather than restated - a fixture pinned to a stale id would silently stop
+/// testing a pile.
+const NANITE_PILE_TEMPLATE_ID: i32 = crate::scripts::script_util::NANITE_PILE_TEMPLATE_IDS[0];
 
 /// Nanite piles are recognized through the runtime template hierarchy, so a
 /// test world needs one. Registered once per world; adding the unique twice

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -518,10 +518,11 @@ fn get_held_position_orientation(
 /// protocol even though the Weapon archetype also inherits that inventory
 /// flag. The decision stays tied to Dark's production frob metadata.
 fn held_trigger_press_payload(world: &World, entity_id: EntityId) -> MessagePayload {
-    // PropKeySrc injects `internal_keycard` at runtime even though retail ID
-    // cards do not author an inventory SCRIPT flag. A physical card held by an
-    // older save therefore still needs the production trigger to collect it.
-    if is_key_source(world, entity_id) {
+    // An always-collected item can only be in a hand at all if an older save put
+    // it there, and it must still collect rather than act: PropKeySrc injects
+    // `internal_keycard` at runtime even though retail ID cards author no
+    // inventory SCRIPT flag, so the metadata check below would miss a card.
+    if crate::scripts::script_util::is_always_collected(world, entity_id) {
         return MessagePayload::Frob;
     }
 
@@ -568,11 +569,11 @@ pub(crate) fn is_key_source(world: &World, entity_id: EntityId) -> bool {
 /// Whether taking this world item must go through a script before the physical
 /// transfer. An authored `SCRIPT` world action owns its side effects and item
 /// fate (for example `FrobQB` awards a quest bit and moves the item exactly
-/// once). `PropKeySrc` items also receive an `internal_keycard` script at
-/// runtime even when their authored world action is only `MOVE`, and nanite
-/// piles receive `internal_nanites` the same way (see
-/// `scripts::script_util::is_nanite_pickup`) - both must route through Frob
-/// rather than a physical grab in every presentation.
+/// once). The always-collected categories - keycards, nanite piles, cyber
+/// modules and logs - must route through Frob rather than a physical grab in
+/// every presentation and on every path, even where their authored world action
+/// is only `MOVE` (see `scripts::script_util::is_always_collected`, the shared
+/// predicate every acquisition site consults).
 pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bool {
     let has_authored_world_script = world
         .borrow::<View<PropFrobInfo>>()
@@ -582,9 +583,7 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
                 .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
         })
         .unwrap_or(false);
-    has_authored_world_script
-        || is_key_source(world, entity_id)
-        || crate::scripts::script_util::is_nanite_pickup(world, entity_id)
+    has_authored_world_script || crate::scripts::script_util::is_always_collected(world, entity_id)
 }
 
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or

--- a/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
+++ b/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Keycards, cyber modules, nanite piles and audio/data logs are collected, not
+// carried. This covers the two gestures that used to acquire them the wrong
+// way, on authentic medsci1 data:
+//
+//   1. A VR SQUEEZE on a loot panel's disc. Before, `panel_grab_effect` made
+//      the keycard exception only, so squeezing audio log 251 out of
+//      Invulnerable 734's panel pulled the disc into the hand as a physical
+//      prop and its `(deck 2, log 14)` entry was never filed.
+//   2. A FLAT CLICK on a strip item. The host owns strip clicks as the
+//      cursor-is-the-item drag, so a click never reached ContainerGui's frob:
+//      an always-collected item already in the backpack - which only an old
+//      save, made before its category collected on pickup, can produce - rode
+//      the cursor instead of being collected. (#1097 review finding M2.)
+//
+// The frob paths (world frob/squeeze, the take arm on a disc or module) already
+// collected and stay covered by their own tests; the unit matrix in
+// `scripts::gui::container` and `mission::flat_ui_host` records every cell.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** medsci1: Invulnerable 734 --Contains--> Audio Log 251 (deck 2, log 14). */
+const LOOT_NPC = 734;
+const CONTAINED_LOG = 251;
+const LOG_DECK = 2;
+const LOG_NUMBER = 14;
+
+/** A real pile archetype - `is_always_collected` excludes the FakeNanites decoy. */
+const NANITE_PILE = "Big Nanite Pile";
+
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+/**
+ * Squeeze one element of the VR loot panel with the production hand, by aiming
+ * at the element's own spot on the panel's collider (as `hydro2-vr-keycard`
+ * does).
+ */
+async function squeezeWorldPanelElement(
+  game: GameServer,
+  element: UiElement,
+): Promise<void> {
+  // The open panel's colliders are anonymous quads sharing one pose, so aim at
+  // the pose rather than at a particular body, and confirm the ray lands on one
+  // of them before squeezing.
+  const panels = (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+  assert.ok(panels.length > 0, "the open loot panel must have a UI collider to aim at");
+  const [x, y, width, height] = element.screen_rect;
+  const u = x + width / 2;
+  const v = y + height / 2;
+  const panelSize: Vec3 = [
+    LOOT_PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
+    LOOT_PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
+    0,
+  ];
+  const local: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+  const target = add(panels[0].position, quatRotate(panels[0].rotation, local));
+  const aim = await aimVrHandAt(game, target, 0.35);
+  const hit = await game.raycast({
+    start: aim.start,
+    end: aim.target,
+    collision_groups: ["ui"],
+    max_distance: 1,
+  });
+  assert.ok(
+    panels.some((panel) => panel.entity_id === hit.entity_id),
+    "the production hand ray must land on the panel",
+  );
+
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 4 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+}
+
+test(
+  "medsci1 VR: squeezing a disc out of a loot panel files the log instead of holding it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8631),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const host = only(await game.entities.byTemplate(LOOT_NPC), `medsci1 ${LOOT_NPC}`);
+    const disc = only(await game.entities.byTemplate(CONTAINED_LOG), `audio log ${CONTAINED_LOG}`);
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [],
+      "a fresh medsci1 character has filed no logs",
+    );
+
+    // Open the real loot panel by frobbing its host (an invulnerable posed NPC
+    // is lootable), then squeeze the disc's own button.
+    await teleportVerified(game, {
+      x: host.position[0] + 1.0,
+      y: host.position[1] + 0.5,
+      z: host.position[2] + 1.0,
+    });
+    await game.entities.sendMessage(host.id, { type: "Frob" });
+    await game.step({ frames: 8 });
+    const panel = (await game.ui.state()).active_panel;
+    assert.equal(panel?.entity_id, host.id, `${LOOT_NPC} must open its loot panel`);
+    const discElement = panel.elements.find(
+      (element) => element.kind === "button" && element.entity_id === disc.id,
+    );
+    assert.ok(discElement, "the loot panel must expose a button for the contained disc");
+
+    await squeezeWorldPanelElement(game, discElement);
+
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: LOG_DECK, log: LOG_NUMBER, read: false }],
+      "the squeeze must file the disc's log in the PDA",
+    );
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      null,
+      "a collected disc must never come to rest in the hand",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.find((item) => item.entity_id === disc.id),
+      undefined,
+      "a collected disc must not occupy an inventory slot either",
+    );
+  },
+);
+
+test(
+  "medsci1 flat: clicking an already-inventoried nanite pile in the strip credits it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8632),
+    });
+    await game.step({ frames: 5 });
+
+    // Stage the pile directly in the backpack, bypassing every acquisition path
+    // - the state an old save leaves behind, and the one the strip click had no
+    // way to recover from.
+    const pile = await game.player.spawnItem(NANITE_PILE);
+    const stack = Number(
+      (await game.entities.detail(pile.entity_id)).properties.find(
+        (property) => property.name === "StackCount",
+      )?.value,
+    );
+    assert.ok(stack > 0, "the staged pile must carry an authored stack count");
+    assert.equal(
+      (await game.info()).player.stats?.nanites ?? 0,
+      0,
+      "a fresh medsci1 character starts with no stat nanites",
+    );
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 8 });
+    const ui = await game.ui.state();
+    assert.equal(ui.mode, "use", "ToggleUseMode must raise the inventory strip");
+    const slot = ui.strip?.elements.find((element) => element.entity_id === pile.entity_id);
+    assert.ok(slot, "the staged pile must occupy a strip slot");
+
+    const [x, y, width, height] = slot.screen_rect;
+    const center: [number, number] = [x + width / 2, y + height / 2];
+    await game.input.set("pointer.position", center);
+    await game.step({ frames: 2 }); // an unpressed frame first: the click is an edge
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 6 });
+
+    assert.equal(
+      (await game.info()).player.stats?.nanites,
+      stack,
+      "clicking the pile must credit its stack to the nanite stat",
+    );
+    const after = await game.ui.state();
+    assert.equal(after.cursor, null, "a collected pile must never ride the cursor");
+    assert.equal(
+      after.strip?.elements.find((element) => element.entity_id === pile.entity_id),
+      undefined,
+      "the collected pile must leave the strip grid",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.find((item) => item.entity_id === pile.entity_id),
+      undefined,
+      "the collected pile must leave the backpack",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
+++ b/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
+import type { EntitySummary } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import { LOOT_PANEL_SIZE_PX, squeezeWorldPanelElement } from "./helpers/vr-hand.js";
 
 // Keycards, cyber modules, nanite piles and audio/data logs are collected, not
 // carried. This covers the two gestures that used to acquire them the wrong
@@ -34,56 +34,9 @@ const LOG_NUMBER = 14;
 /** A real pile archetype - `is_always_collected` excludes the FakeNanites decoy. */
 const NANITE_PILE = "Big Nanite Pile";
 
-const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
-const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
-
 function only(matches: EntitySummary[], label: string): EntitySummary {
   assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
   return matches[0];
-}
-
-/**
- * Squeeze one element of the VR loot panel with the production hand, by aiming
- * at the element's own spot on the panel's collider (as `hydro2-vr-keycard`
- * does).
- */
-async function squeezeWorldPanelElement(
-  game: GameServer,
-  element: UiElement,
-): Promise<void> {
-  // The open panel's colliders are anonymous quads sharing one pose, so aim at
-  // the pose rather than at a particular body, and confirm the ray lands on one
-  // of them before squeezing.
-  const panels = (await game.physics.bodies()).bodies.filter((body) =>
-    body.collision_groups.includes("ui"),
-  );
-  assert.ok(panels.length > 0, "the open loot panel must have a UI collider to aim at");
-  const [x, y, width, height] = element.screen_rect;
-  const u = x + width / 2;
-  const v = y + height / 2;
-  const panelSize: Vec3 = [
-    LOOT_PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
-    LOOT_PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
-    0,
-  ];
-  const local: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
-  const target = add(panels[0].position, quatRotate(panels[0].rotation, local));
-  const aim = await aimVrHandAt(game, target, 0.35);
-  const hit = await game.raycast({
-    start: aim.start,
-    end: aim.target,
-    collision_groups: ["ui"],
-    max_distance: 1,
-  });
-  assert.ok(
-    panels.some((panel) => panel.entity_id === hit.entity_id),
-    "the production hand ray must land on the panel",
-  );
-
-  await game.input.set("right_hand.squeeze", 1);
-  await game.step({ frames: 4 });
-  await game.input.set("right_hand.squeeze", 0);
-  await game.step({ frames: 8 });
 }
 
 test(
@@ -121,7 +74,7 @@ test(
     );
     assert.ok(discElement, "the loot panel must expose a button for the contained disc");
 
-    await squeezeWorldPanelElement(game, discElement);
+    await squeezeWorldPanelElement(game, LOOT_PANEL_SIZE_PX, 1, discElement);
 
     assert.deepEqual(
       (await game.info()).player.collected_logs,
@@ -151,12 +104,13 @@ test(
     });
     await game.step({ frames: 5 });
 
-    // Stage the pile directly in the backpack, bypassing every acquisition path
-    // - the state an old save leaves behind, and the one the strip click had no
-    // way to recover from.
-    const pile = await game.player.spawnItem(NANITE_PILE);
+    // Stage the pile directly in the backpack, bypassing every acquisition
+    // path, then round-trip it through a save: the state this recovers is a
+    // *deserialized* backpack item, whose derived `internal_nanites` script is
+    // re-attached at load - so the save/load is the point, not incidental.
+    const staged = await game.player.spawnItem(NANITE_PILE);
     const stack = Number(
-      (await game.entities.detail(pile.entity_id)).properties.find(
+      (await game.entities.detail(staged.entity_id)).properties.find(
         (property) => property.name === "StackCount",
       )?.value,
     );
@@ -166,6 +120,14 @@ test(
       0,
       "a fresh medsci1 character starts with no stat nanites",
     );
+    await game.save("always-collected-strip-e2e");
+    await game.load("always-collected-strip-e2e");
+    await game.step({ frames: 5 });
+
+    // Entity ids do not survive the reload; find the restored pile by name.
+    const carried = (await game.player.inventory()).items;
+    const pile = carried.find((item) => item.name?.includes("Nanites"));
+    assert.ok(pile, `the reloaded backpack must still hold the pile: ${JSON.stringify(carried)}`);
 
     await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 8 });

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -145,3 +145,57 @@ export async function aimVrHandAt(
   await game.step({ frames: 3 });
   return { start: worldHand, target };
 }
+
+/** One canvas pixel of a world panel in world units (`gui::GUI_PIXEL_TO_WORLD_SIZE`). */
+export const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+
+/** The retail MFD canvas the loot panel is drawn on. */
+export const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+
+/**
+ * Squeeze one element of an open world panel with the production VR hand.
+ *
+ * Aims at the element's own spot on the panel's collider - in VR the panel is a
+ * physical quad, so this is the gesture a player makes - and confirms the ray
+ * actually lands on it before squeezing. A panel can carry more than one UI
+ * collider at the same pose, so the check is "the ray hit one of them", not
+ * "there is exactly one".
+ */
+export async function squeezeWorldPanelElement(
+  game: GameServer,
+  panelSizePx: Vec3,
+  worldScale: number,
+  element: { screen_rect: [number, number, number, number] },
+): Promise<void> {
+  const panels = (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+  if (panels.length === 0) {
+    throw new Error("no production VR panel collider to aim at");
+  }
+  const [x, y, width, height] = element.screen_rect;
+  const u = x + width / 2;
+  const v = y + height / 2;
+  const panelSize: Vec3 = [
+    panelSizePx[0] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
+    panelSizePx[1] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
+    0,
+  ];
+  const local: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+  const target = add(panels[0].position, quatRotate(panels[0].rotation, local));
+  const aim = await aimVrHandAt(game, target, 0.35);
+  const hit = await game.raycast({
+    start: aim.start,
+    end: aim.target,
+    collision_groups: ["ui"],
+    max_distance: 1,
+  });
+  if (!panels.some((panel) => panel.entity_id === hit.entity_id)) {
+    throw new Error("the production hand ray must land on the panel");
+  }
+
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 4 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+}

--- a/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
@@ -4,7 +4,12 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, UiElement, UiPanelPose, UiState, Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, aimVrHandAtCanvas, quatRotate } from "./helpers/vr-hand.js";
+import {
+  LOOT_PANEL_SIZE_PX,
+  aimVrHandAt,
+  aimVrHandAtCanvas,
+  squeezeWorldPanelElement,
+} from "./helpers/vr-hand.js";
 
 // Authentic Hydro2 Card B chain for #583:
 //   corpse 754 --Contains--> card 942 (PropKeySrc region 128)
@@ -25,8 +30,6 @@ const CARD = 942;
 const CARD_SLOT = 1120;
 const DOOR = 1127;
 const CARD_ARCHETYPE = -1495;
-const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
-const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 
 function only(matches: EntitySummary[], label: string): EntitySummary {
   assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
@@ -35,41 +38,6 @@ function only(matches: EntitySummary[], label: string): EntitySummary {
 
 function distance(a: Vec3, b: Vec3): number {
   return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
-}
-
-async function squeezeWorldPanelElement(
-  game: GameServer,
-  panelSizePx: Vec3,
-  worldScale: number,
-  element: UiElement,
-): Promise<void> {
-  const panel = (await game.physics.bodies()).bodies.filter((body) =>
-    body.collision_groups.includes("ui"),
-  );
-  assert.equal(panel.length, 1, "expected exactly one production VR panel collider");
-  const [x, y, width, height] = element.screen_rect;
-  const u = x + width / 2;
-  const v = y + height / 2;
-  const panelSize: Vec3 = [
-    panelSizePx[0] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
-    panelSizePx[1] * GUI_PIXEL_TO_WORLD_SIZE * worldScale,
-    0,
-  ];
-  const local: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
-  const target = add(panel[0].position, quatRotate(panel[0].rotation, local));
-  const aim = await aimVrHandAt(game, target, 0.35);
-  const hit = await game.raycast({
-    start: aim.start,
-    end: aim.target,
-    collision_groups: ["ui"],
-    max_distance: 1,
-  });
-  assert.equal(hit.entity_id, panel[0].entity_id, "production hand ray must hit the panel");
-
-  await game.input.set("right_hand.squeeze", 1);
-  await game.step({ frames: 4 });
-  await game.input.set("right_hand.squeeze", 0);
-  await game.step({ frames: 8 });
 }
 
 /** The strip element bound to `entityId`, or undefined once it has left the grid. */


### PR DESCRIPTION
Keycards, cyber modules, nanite piles and audio/data logs are **collected, not carried**: their value goes into a player stat, the credential list or the PDA, and their scripts' side effects (SwitchLinks, quest bits, awards) only fire on Frob. Whether that actually happened depended on which gesture the player used, because every acquisition site carried its own predicate.

### The one predicate

`scripts::script_util::is_always_collected` — each arm delegating to the per-type predicate that owns that type's identity (`is_key_source`, `is_nanite_pickup`, the `ExpCookie` script, and a disc with a readable `(deck, log)`), so the category cannot drift between sites. The five acquisition sites now consult it, each keeping its own effect vocabulary (Frob message vs effect):

| site | predicate before | after |
| --- | --- | --- |
| world frob / squeeze, flat crosshair pickup | `uses_scripted_world_frob` (authored SCRIPT ∪ keycard ∪ pile) | authored SCRIPT ∪ `is_always_collected` |
| loot panel take arm | `is_key_source` | `is_always_collected` |
| loot / strip panel squeeze (`panel_grab_effect`) | `is_key_source` | `is_always_collected` |
| VR strip deposit (#1138) | `is_key_source` | `is_always_collected` |
| flat strip click | *(none — always lifted onto the cursor)* | `is_always_collected` → Frob |

### The matrix (verified by making the tests fail first)

| | world frob | world squeeze | panel take / backpack click | panel squeeze | flat strip click |
| --- | --- | --- | --- | --- | --- |
| keycard | ok | ok | ok | ok | **fixed** |
| nanite pile | ok | ok | **fixed** (was banked as an inert can, uncredited) | **fixed** | **fixed** |
| cyber module | ok | ok | ok | **fixed** (was grabbed into the hand) | **fixed** |
| audio / data log | ok | ok | ok | **fixed** (was grabbed into the hand) | **fixed** |

The strip-click column is #1097 review finding M2, deferred to this slice: the host owns strip clicks as the cursor-is-the-item drag, so the click never reached `ContainerGui`'s frob. An always-collected item can only be in the backpack at all via a save made before its category collected on pickup — and that was the one place it could then never be collected.

### Tests

- Unit matrix over all four categories x every panel gesture (`scripts::gui::container`), the strip click (`mission::flat_ui_host`) and the world paths (`scripts::script_util`), sharing one `test_support` fixture that spawns each category the way the data authors it. Each was confirmed failing on exactly the broken cells first.
- A disc with no readable `(deck, log)` — the gamesys archetypes — stays on the ordinary path rather than being routed at a frob that would strand it.
- e2e `always-collected-categories.e2e.test.ts` (medsci1, authentic data): VR squeeze of audio log 251 out of Invulnerable 734's loot panel files `(deck 2, log 14)`; a flat click on a backpack-staged nanite pile credits its stack. Both fail on main.
- Regressions green: `hydro2-vr-keycard`, `nanite-player-stat`, `vr-cyber-interface-deposit`, `container-loot`, `inventory-strip`, `inventory-drag`; 1033 unit tests.

Behavior for keycards and nanites on the paths that already collected is unchanged.

### Review follow-ups (adversarial pass)

No Critical/High findings. Fixed anyway:

- `ExpCookie` had no `collected` latch, unlike `internal_keycard` and `internal_nanites`. Effects apply after the whole message batch, so two hands squeezing one loot-panel module in a frame both found it alive and awarded twice - newly reachable now that a panel squeeze collects. Same latch, same negative-first test.
- The strip **swap** arm (dropping a held item onto an occupied slot lifts the occupant) stayed a back door into carrying an always-collected item; it now collects the occupant too.
- The VR strip release gated the whole deposit on `backpack_accepts_deposit`, including the collect half. A collected item never enters the pack, so a full backpack no longer drops a released keycard on the floor.
- `is_free_hack_tool` was `entity_has_script` open-coded; it now delegates.
- `squeezeWorldPanelElement` was copied from `hydro2-vr-keycard`; both tests now share one copy in `test/helpers/vr-hand.ts`.

`creature-loot` and `log-reader`'s hydro3 transcript case fail identically on unmodified `main` (verified by building `main` in this worktree and re-running both) - pre-existing, not caused by this change.

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72

## Visuals

VR: squeezing the audio-log disc out of the corpse's loot panel (medsci1, Invulnerable 734 -> Audio Log 251).

![always-collect audio log demo](https://gist.githubusercontent.com/tommy-xr/6c7d926d4c3b72a66a4bc2298f17e5df/raw/demo.gif)

<sub>The disc leaves the panel and is filed in the PDA - the hand stays empty. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep, `--vr`).</sub>

### Before -> after

![before/after](https://gist.githubusercontent.com/tommy-xr/6c7d926d4c3b72a66a4bc2298f17e5df/raw/beforeafter.gif)

![before/after still](https://gist.githubusercontent.com/tommy-xr/6c7d926d4c3b72a66a4bc2298f17e5df/raw/beforeafter.png)

Same request sequence on both sides (base `52dcc0b0`, the commit before this change, built in a throwaway worktree). Observed `/v1/info` while the squeeze is held:

| | `player.right_hand_entity_id` | `player.collected_logs` |
| --- | --- | --- |
| before | `576` (the disc, held in the hand) | `[]` |
| after | `null` | `[{ deck: 2, log: 14, read: false }]` |
