### PR TITLE
feat(skills): add audit-our-commands token-usage audit skill

### DIFF
--- a/.claude/skills/audit-our-commands/SKILL.md
+++ b/.claude/skills/audit-our-commands/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: audit-our-commands
+description: >-
+  Audit Claude Code session transcripts to measure which tool calls / commands
+  consume the most result tokens, find waste patterns (re-paging files, wide
+  greps, full diffs, oversized screenshots, duplicate invocations), and
+  recommend optimizations. Use when asked to audit token usage, measure command
+  output cost, or find token-efficiency opportunities in recent sessions.
+---
+
+# audit-our-commands
+
+Measure where tool-result tokens go across recent Claude Code sessions, then
+characterize the waste and recommend fixes, ranked by estimated savings.
+
+## Step 1 — Quantitative pass (cheap, run inline)
+
+Run the bundled analyzer over the relevant transcript directories (transcripts
+live under `~/.claude/projects/<escaped-project-path>/`; one dir per checkout
+or worktree, so glob broadly):
+
+```bash
+python3 .claude/skills/audit-our-commands/tool_token_audit.py \
+  --days 30 --top 50 --samples ~/.claude/projects/*<project-pattern>*
+```
+
+It joins `tool_use` → `tool_result` in every session JSONL (subagent files
+included), estimates tokens as chars/4, strips `cd X &&` / env-var / `timeout`
+prefixes, and aggregates by command category — `sed`, `grep`, `git diff`,
+`curl /v1/<endpoint>`, `cargo dq <sub>`, `[Read text]`, `[Read image]`, etc.
+Output: per-category call count, estimated tokens, share, avg, max, and (with
+`--samples`) the biggest single result per top category with its exact command.
+
+**Image caveat:** the analyzer uses a flat ~1600 tokens/image. Real cost is
+`ceil(w/28) * ceil(h/28)` tokens (standard tier caps the long edge at 1568 px
+≈ 1568 tokens; high-resolution tier at 2576 px ≈ 4784 tokens). Check actual
+PNG dimensions (`sips -g pixelWidth -g pixelHeight`) before trusting the flat
+estimate — HiDPI capture can silently double dimensions.
+
+## Step 2 — Qualitative pass (delegate to one subagent)
+
+For the top 4–6 categories, spawn ONE agent to extract the largest actual
+results from the JSONL (with a small python script — never Read the raw
+multi-MB session files directly) and characterize the waste:
+
+- **Paging/re-reading**: `sed -n 'A,Bp'` used as a pager, whole-file Reads,
+  repeat reads of the same path within one session, paging self-generated
+  diff dumps.
+- **Wide greps**: `-A/-B/-C` context, unanchored patterns returning hundreds
+  of hits, `grep -n "" file` used as cat.
+- **Full diffs**: `git diff` without `--stat` first, `| head -N` with large N.
+- **Duplicates**: hash identical `(tool, command)` per session and total the
+  rerun token cost.
+
+If a token-filtering proxy like `rtk` is installed, have the agent measure
+native-vs-wrapped output on 2–3 sampled commands and judge whether the
+filtering would have lost information the session actually needed. Findings
+from the 2026-08 audit of this repo: `rtk grep` saved 86–96% on wide greps but
+caps output at 200 hits / 80 chars per line (a net loss on small greps — don't
+wrap those, and don't trust it when the hit *count* matters); `rtk read -l
+aggressive` is a good outline reader (~84%) but its `-m N` mode renumbers
+lines; `rtk git diff` drops hunks — never use it as a review artifact.
+
+## Step 3 — Recommend, ranked by estimated tokens/month
+
+For each recommendation give the mechanism (guidance line, wrapper, code fix),
+the estimated monthly savings computed from the Step 1 numbers, and the risk
+(especially silent truncation). Recurring winners: outline-before-page for
+large files, `git diff --stat` first, never re-read what is already in
+context, and downscaling images at the capture source.

--- a/.claude/skills/audit-our-commands/tool_token_audit.py
+++ b/.claude/skills/audit-our-commands/tool_token_audit.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Audit Claude Code transcripts: token cost of tool results, grouped by command category.
+
+Usage: tool_token_audit.py [--days N] [--top N] [--samples] DIR [DIR...]
+Scans *.jsonl session files (including subagent files) in each DIR.
+Token estimate: chars/4 (close enough for ranking; matches rtk's heuristic).
+"""
+import json, sys, os, re, glob, time, argparse
+from collections import defaultdict
+
+def strip_prefixes(c):
+    # peel off env assignments, `cd X &&`, `VAR=...;`, timeout, leading parens
+    prev = None
+    while prev != c:
+        prev = c
+        c = re.sub(r"^\(", "", c).strip()
+        c = re.sub(r"^cd\s+(?:\"[^\"]*\"|'[^']*'|\S+)\s*(?:&&|;)\s*", "", c)
+        c = re.sub(r"^[A-Za-z_][A-Za-z0-9_]*=(?:\"[^\"]*\"|'[^']*'|\S*)\s*(?:&&|;)?\s*", "", c)
+        c = re.sub(r"^(?:timeout\s+\d+\s+|command\s+|exec\s+|sudo\s+)", "", c)
+    return c
+
+def categorize(tool, inp):
+    if tool == "Read":
+        p = ((inp or {}).get("file_path") or "").lower()
+        if re.search(r"\.(png|jpe?g|gif|webp|bmp)$", p):
+            return "[Read image]", p
+        return "[Read text]", p
+    if tool != "Bash":
+        return f"[{tool}]", None
+    cmd = (inp or {}).get("command", "") or ""
+    c = strip_prefixes(cmd.strip())
+    # debug runtime HTTP
+    m = re.search(r"curl[^|;&]*?/v1/([a-zA-Z_/]+)", c)
+    if m:
+        return f"curl /v1/{m.group(1).rstrip('/')}", cmd
+    if "curl" in c:
+        return "curl (other)", cmd
+    m = re.match(r"cargo\s+(dq|dbgr|dv|dr|bn|dbgc)\b\s*(\S*)", c)
+    if m:
+        sub = m.group(2) if m.group(1) in ("dq", "bn") else ""
+        return f"cargo {m.group(1)} {sub}".strip(), cmd
+    m = re.match(r"(?:RUSTFLAGS=\S*\s+)?cargo\s+(check|build|test|clippy|fmt|run)\b", c)
+    if m:
+        return f"cargo {m.group(1)}", cmd
+    m = re.match(r"(?:cd\s+\S+\s*(?:&&|;)\s*)?npm\s+(?:run\s+)?(\S+)", c)
+    if m:
+        return f"npm {m.group(1)}", cmd
+    m = re.match(r"(git|gh)\s+(\S+)", c)
+    if m:
+        return f"{m.group(1)} {m.group(2)}", cmd
+    first = c.split()[0] if c.split() else "(empty)"
+    return first, cmd
+
+def content_len(content):
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        n = 0
+        for b in content:
+            if isinstance(b, dict):
+                if b.get("type") == "text":
+                    n += len(b.get("text", ""))
+                elif b.get("type") == "image":
+                    n += 1600 * 4  # rough: ~1600 tokens per screenshot-sized image
+        return n
+    return 0
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dirs", nargs="+")
+    ap.add_argument("--days", type=float, default=30)
+    ap.add_argument("--top", type=int, default=40)
+    ap.add_argument("--samples", action="store_true", help="print biggest single results per top category")
+    args = ap.parse_args()
+
+    cutoff = time.time() - args.days * 86400
+    files = []
+    for d in args.dirs:
+        for f in glob.glob(os.path.join(d, "**", "*.jsonl"), recursive=True):
+            if "/memory/" in f:
+                continue
+            if os.path.getmtime(f) >= cutoff:
+                files.append(f)
+
+    stats = defaultdict(lambda: {"count": 0, "chars": 0, "max": 0, "max_cmd": "", "max_file": ""})
+    total_chars = 0
+    nfiles = 0
+    for f in files:
+        nfiles += 1
+        pending = {}  # tool_use_id -> (category, cmd)
+        try:
+            with open(f, "r", errors="replace") as fh:
+                for line in fh:
+                    try:
+                        e = json.loads(line)
+                    except Exception:
+                        continue
+                    msg = e.get("message") or {}
+                    content = msg.get("content")
+                    if not isinstance(content, list):
+                        continue
+                    for b in content:
+                        if not isinstance(b, dict):
+                            continue
+                        if b.get("type") == "tool_use":
+                            cat, cmd = categorize(b.get("name", "?"), b.get("input"))
+                            pending[b.get("id")] = (cat, cmd)
+                        elif b.get("type") == "tool_result":
+                            cat, cmd = pending.pop(b.get("tool_use_id"), ("[unmatched]", None))
+                            n = content_len(b.get("content"))
+                            s = stats[cat]
+                            s["count"] += 1
+                            s["chars"] += n
+                            total_chars += n
+                            if n > s["max"]:
+                                s["max"], s["max_cmd"], s["max_file"] = n, (cmd or "")[:200], f
+        except Exception as ex:
+            print(f"warn: {f}: {ex}", file=sys.stderr)
+
+    rows = sorted(stats.items(), key=lambda kv: -kv[1]["chars"])
+    est_total = total_chars // 4
+    print(f"# {nfiles} session files (last {args.days:g} days), total tool-result ~{est_total/1e6:.1f}M est-tokens\n")
+    print(f"{'category':<42} {'calls':>6} {'est-tok':>10} {'%':>5} {'avg':>7} {'max':>8}")
+    for cat, s in rows[: args.top]:
+        tok = s["chars"] // 4
+        print(f"{cat:<42} {s['count']:>6} {tok:>10,} {100*s['chars']/max(total_chars,1):>4.1f}% {tok//max(s['count'],1):>7,} {s['max']//4:>8,}")
+    if args.samples:
+        print("\n## biggest single result per top-10 category")
+        for cat, s in rows[:10]:
+            print(f"\n### {cat}  (max {s['max']//4:,} est-tok)\n  cmd: {s['max_cmd']}\n  file: {s['max_file']}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `.claude/skills/audit-our-commands/`: a skill for auditing Claude Code session transcripts to measure which tool calls / commands consume the most result tokens, plus a bundled analyzer script (`tool_token_audit.py`) that joins `tool_use` → `tool_result` across session JSONL files and aggregates estimated tokens by command category.

## Why

Sessions that iterate heavily (playtests, reviews, debug-runtime loops) burn tokens on tool output. A first 30-day audit (~14.2M est tool-result tokens across 458 sessions) showed the cost is **not** where suspected:

| Category | Share |
|---|---|
| `sed -n` used as a file pager | 20% |
| Screenshots (image reads) | 15–24% |
| Whole-file Reads | 14% |
| `grep` (mostly wide/context greps) | 13% |
| Full `git diff`/`show` | 9% |
| Identical rerun commands | 6% |
| Debug-runtime `curl /v1/*` | ~1.5% |

The skill packages that measurement + a qualitative-waste playbook so it can be re-run after guidance changes (companion PRs: HiDPI screenshot capture fix, CLAUDE.md token-efficiency rules).

## Verification

Analyzer run over `~/.claude/projects/*shock2quest*` (30 days): produced the table above; category totals sum to the corpus total. Docs-only + a standalone python script — no game code touched.

https://claude.ai/code/session_015xd647M4JPqgcuhLoas3Cu