### PR TITLE
docs: add token-efficient tool-output rules for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,36 @@ interaction, deterministic fixed-timestep), assembles the GIF, hosts the
 binaries in a gist, and embeds them in the PR body. Run the capture in a
 subagent when the active agent supports delegation; otherwise run it inline.
 
+### 5. Token-Efficient Tool Output
+
+A 30-day audit of agent sessions (the `audit-our-commands` skill) showed most
+tool-result tokens go to *reading habits*, not to game tooling — `sed`-paging
+source files (much of it re-paging files already read that session), whole-file
+reads, wide greps, and full diffs. The debug runtime's HTTP responses and
+`dark_query` are already cheap. Rules, ranked by measured savings:
+
+- **Outline before paging any file over ~800 lines.** Grep its structure first
+  (`grep -nE '^\s*(pub )?(fn|struct|impl|enum|trait)' <file>`), then make one
+  targeted Read with `offset`/`limit` at the section you need. Don't page
+  through a large file in serial `sed -n 'A,Bp'` windows — on `mission_core.rs`
+  an outline is ~30x smaller than the file, and serial paging tends to re-fetch
+  the same regions.
+- **Never re-read what is already in context.** Repeat Reads of the same path,
+  repeat searches, and `cat` followed by `cat -n` of the same file measured at
+  ~6% of all tool-result tokens. If you saved a diff/log to a file yourself,
+  grep it for what you need — don't page your own dump back into context.
+- **`git diff --stat` first.** Only after the stat, diff the specific files you
+  care about. Never `git diff | head -1200`-style truncation — you pay for the
+  head and still might not see the file you needed.
+- **Keep greps narrow.** `-A/-B/-C` context and unanchored patterns are where
+  grep cost concentrates; scope by path and tighten the pattern before adding
+  context lines. Never `grep -n "" file` as a substitute for reading a range.
+  If the `rtk` proxy is installed, `rtk grep` is a large win for deliberately
+  wide greps (it caps at 200 hits / 80-char lines, so don't use it when the
+  exact hit count or long lines matter, and skip it for small greps — it's
+  measurably worse there). Do **not** use `rtk git diff` for review — it drops
+  hunks.
+
 ## Project Documentation
 
 ### Essential Reading


### PR DESCRIPTION
## What

Adds **Core Principle 5: Token-Efficient Tool Output** to `AGENTS.md` — four rules for agents, ranked by measured savings:

1. **Outline before paging** any file over ~800 lines (grep its `fn/struct/impl` structure, then one targeted read) — attacks the biggest bucket: serial `sed -n 'A,Bp'` paging was 20% of all tool-result tokens, 58% of it re-paging files already read in the same session (`mission_core.rs` alone absorbed 3.6× its own size in reads).
2. **Never re-read what's already in context** — identical rerun commands measured at ~6% of tool-result tokens; includes paging your own saved diff dumps.
3. **`git diff --stat` first**, then per-file diffs — full diffs averaged ~2k tokens each, 9% of the total.
4. **Keep greps narrow** — `-A/-B/-C` calls were 28% of grep cost; includes measured guidance on when `rtk grep` helps (86–96% on wide greps) and when it's unsafe (200-hit cap, small greps, `rtk git diff` drops hunks).

## Why

30-day audit of ~14.2M est tool-result tokens across 458 agent sessions (methodology + analyzer in PR #1148, the `audit-our-commands` skill). The suspected culprits — debug-runtime HTTP responses and `cargo dq` — were already cheap (~2.5% combined); reading habits dominate. Realistic ceiling for these rules: ~2.6–3.4M tokens/month (18–24%).

Companion PRs: #1148 (audit skill this section references), and the HiDPI screenshot capture fix (separate PR — screenshots were another 15–24%).

Docs-only change.

https://claude.ai/code/session_015xd647M4JPqgcuhLoas3Cu