### PR TITLE
fix(hud): gate the item outline on P$HUDSelect like the original

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -286,9 +286,11 @@ fn out_message(to: EntityId, payload: MessagePayload) -> VirtualHandEffect {
     }
 }
 
-/// Whether an entity is worth highlighting / interacting with (it has frob
-/// info), which excludes plain world geometry the ray also hits.
-fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
+/// Whether an entity is worth *interacting* with (it has frob info), which
+/// excludes plain world geometry the ray also hits. Note this is not the
+/// highlight test: whether the HUD draws brackets over the pick is a separate,
+/// data-driven question answered by `hud::is_hud_selectable` (`P$HUDSelect`).
+pub(crate) fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
     world
         .borrow::<View<PropFrobInfo>>()
         .map(|v| v.get(entity_id).is_ok())

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -2,12 +2,43 @@ use cgmath::{Matrix4, Vector2, point2, vec2, vec3};
 use collision::{Aabb2, Aabb3};
 use dark::{
     importers::{FONT_IMPORTER, TEXTURE_IMPORTER},
-    properties::{PropHitPoints, PropObjName, PropStackCount, PropTemplateId},
+    properties::{PropHUDSelect, PropHitPoints, PropObjName, PropStackCount, PropTemplateId},
 };
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
+
+/// Whether the highlight overlay (corner brackets + rollover name) may be
+/// drawn for `entity_id`.
+///
+/// The original gates the overlay on an opt-in "HUD Selectable?" boolean
+/// (`P$HUDSelect`) rather than on frobbability: the shipped data marks the
+/// families the player is meant to be able to pick out of the scene (weapons,
+/// creatures, loot) `true`, and marks fixed set dressing that is nevertheless
+/// frobbable - the `Tech` family of consoles, force-field emitters and
+/// speakers - explicitly `false`. An object with no `P$HUDSelect` at all
+/// (inheritance-resolved) is *not* highlighted.
+///
+/// This deliberately says nothing about whether the object can be *frobbed*:
+/// frob eligibility stays `P$FrobInfo`-based, so a console with no
+/// `P$HUDSelect` still uses/hacks normally, it just draws no brackets.
+pub fn is_hud_selectable(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropHUDSelect>>()
+        .map(|v| v.get(entity_id).map(|p| p.0).unwrap_or(false))
+        .unwrap_or(false)
+}
+
+/// Narrow the entities picked by the interaction layer (reticle / VR hand
+/// rays) to the ones the HUD may highlight. Applied once, on the shared
+/// render path, so flat and VR cannot diverge.
+pub fn hud_selectable_entities(world: &World, picked: Vec<EntityId>) -> Vec<EntityId> {
+    picked
+        .into_iter()
+        .filter(|e| is_hud_selectable(world, *e))
+        .collect()
+}
 
 fn format_stack_aware_item_name(item_name: &str, stack_count: Option<i32>) -> String {
     match stack_count {
@@ -96,7 +127,61 @@ pub fn draw_item_name(
 
 #[cfg(test)]
 mod tests {
-    use super::format_stack_aware_item_name;
+    use super::*;
+    use dark::properties::{FrobFlag, PropFrobInfo};
+
+    fn frob_info() -> PropFrobInfo {
+        PropFrobInfo {
+            world_action: FrobFlag::SCRIPT,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        }
+    }
+
+    /// A frobbable object with no `P$HUDSelect` (a `Tech`-family console's
+    /// ancestors before the property is authored) must not be highlighted -
+    /// frobbability alone never earned the brackets in the original.
+    #[test]
+    fn frobbable_without_hud_select_is_not_highlighted() {
+        let mut world = World::new();
+        let id = world.add_entity(frob_info());
+        assert!(!is_hud_selectable(&world, id));
+        assert!(hud_selectable_entities(&world, vec![id]).is_empty());
+    }
+
+    #[test]
+    fn hud_select_true_is_highlighted() {
+        let mut world = World::new();
+        let id = world.add_entity(frob_info());
+        world.add_component(id, PropHUDSelect(true));
+        assert!(is_hud_selectable(&world, id));
+        assert_eq!(hud_selectable_entities(&world, vec![id]), vec![id]);
+    }
+
+    /// The shipped `Tech` family sets `P$HUDSelect` explicitly false; an
+    /// explicit false is as unhighlightable as an absent property.
+    #[test]
+    fn hud_select_false_is_not_highlighted() {
+        let mut world = World::new();
+        let id = world.add_entity(frob_info());
+        world.add_component(id, PropHUDSelect(false));
+        assert!(!is_hud_selectable(&world, id));
+        assert!(hud_selectable_entities(&world, vec![id]).is_empty());
+    }
+
+    #[test]
+    fn only_the_hud_selectable_picks_survive() {
+        let mut world = World::new();
+        let console = world.add_entity(frob_info());
+        world.add_component(console, PropHUDSelect(false));
+        let pistol = world.add_entity(frob_info());
+        world.add_component(pistol, PropHUDSelect(true));
+
+        assert_eq!(
+            hud_selectable_entities(&world, vec![console, pistol]),
+            vec![pistol]
+        );
+    }
 
     #[test]
     fn stack_count_replaces_object_name_decimal_placeholder() {

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -23,21 +23,11 @@ use crate::physics::PhysicsWorld;
 /// This deliberately says nothing about whether the object can be *frobbed*:
 /// frob eligibility stays `P$FrobInfo`-based, so a console with no
 /// `P$HUDSelect` still uses/hacks normally, it just draws no brackets.
-pub fn is_hud_selectable(world: &World, entity_id: EntityId) -> bool {
+pub(crate) fn is_hud_selectable(world: &World, entity_id: EntityId) -> bool {
     world
         .borrow::<View<PropHUDSelect>>()
         .map(|v| v.get(entity_id).map(|p| p.0).unwrap_or(false))
         .unwrap_or(false)
-}
-
-/// Narrow the entities picked by the interaction layer (reticle / VR hand
-/// rays) to the ones the HUD may highlight. Applied once, on the shared
-/// render path, so flat and VR cannot diverge.
-pub fn hud_selectable_entities(world: &World, picked: Vec<EntityId>) -> Vec<EntityId> {
-    picked
-        .into_iter()
-        .filter(|e| is_hud_selectable(world, *e))
-        .collect()
 }
 
 fn format_stack_aware_item_name(item_name: &str, stack_count: Option<i32>) -> String {
@@ -128,6 +118,7 @@ pub fn draw_item_name(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::flat_player_controller::is_frobbable;
     use dark::properties::{FrobFlag, PropFrobInfo};
 
     fn frob_info() -> PropFrobInfo {
@@ -138,15 +129,16 @@ mod tests {
         }
     }
 
-    /// A frobbable object with no `P$HUDSelect` (a `Tech`-family console's
-    /// ancestors before the property is authored) must not be highlighted -
-    /// frobbability alone never earned the brackets in the original.
+    /// The false positive this gate removes, and the invariant that makes it
+    /// safe: an object can be frobbable and still not highlightable. A `Tech`
+    /// console keeps working when you use it, it just stops drawing brackets.
     #[test]
     fn frobbable_without_hud_select_is_not_highlighted() {
         let mut world = World::new();
         let id = world.add_entity(frob_info());
+
+        assert!(is_frobbable(&world, id), "frob eligibility is unchanged");
         assert!(!is_hud_selectable(&world, id));
-        assert!(hud_selectable_entities(&world, vec![id]).is_empty());
     }
 
     #[test]
@@ -155,32 +147,29 @@ mod tests {
         let id = world.add_entity(frob_info());
         world.add_component(id, PropHUDSelect(true));
         assert!(is_hud_selectable(&world, id));
-        assert_eq!(hud_selectable_entities(&world, vec![id]), vec![id]);
     }
 
     /// The shipped `Tech` family sets `P$HUDSelect` explicitly false; an
-    /// explicit false is as unhighlightable as an absent property.
+    /// explicit false is as unhighlightable as an absent property, and is
+    /// likewise still frobbable.
     #[test]
-    fn hud_select_false_is_not_highlighted() {
+    fn hud_select_false_is_not_highlighted_but_stays_frobbable() {
         let mut world = World::new();
         let id = world.add_entity(frob_info());
         world.add_component(id, PropHUDSelect(false));
+
+        assert!(is_frobbable(&world, id), "frob eligibility is unchanged");
         assert!(!is_hud_selectable(&world, id));
-        assert!(hud_selectable_entities(&world, vec![id]).is_empty());
     }
 
+    /// Plain world geometry - no frob info, no `P$HUDSelect` - is neither.
     #[test]
-    fn only_the_hud_selectable_picks_survive() {
+    fn world_geometry_is_neither_frobbable_nor_highlighted() {
         let mut world = World::new();
-        let console = world.add_entity(frob_info());
-        world.add_component(console, PropHUDSelect(false));
-        let pistol = world.add_entity(frob_info());
-        world.add_component(pistol, PropHUDSelect(true));
+        let id = world.add_entity(PropHitPoints { hit_points: 1 });
 
-        assert_eq!(
-            hud_selectable_entities(&world, vec![console, pistol]),
-            vec![pistol]
-        );
+        assert!(!is_frobbable(&world, id));
+        assert!(!is_hud_selectable(&world, id));
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -79,7 +79,7 @@ use crate::{
     game_scene::AmbientAudioState,
     game_scene::PlayerSavePoseError,
     gui::GuiManager,
-    hud::{draw_item_name, draw_item_outline},
+    hud::{draw_item_name, draw_item_outline, hud_selectable_entities},
     input_context::{self, InputContext},
     interaction::{FlatInteraction, InteractionContext, PlayerInteraction, VrInteraction},
     inventory::PlayerInventoryEntity,
@@ -7509,7 +7509,13 @@ impl MissionCore {
         options: &crate::GameOptions,
     ) -> Vec<SceneObject> {
         let mut ret = vec![];
-        for hit_entity in self.interaction.highlighted_entities() {
+        // The interaction layer reports what the reticle / hand rays picked;
+        // whether that pick may be *highlighted* is a separate, data-driven
+        // question (`P$HUDSelect`), answered here so flat and VR share one
+        // answer. The pick itself stays frobbable either way.
+        let highlighted =
+            hud_selectable_entities(&self.world, self.interaction.highlighted_entities());
+        for hit_entity in highlighted {
             ret.extend(draw_item_outline(
                 asset_cache,
                 &self.physics,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -79,7 +79,7 @@ use crate::{
     game_scene::AmbientAudioState,
     game_scene::PlayerSavePoseError,
     gui::GuiManager,
-    hud::{draw_item_name, draw_item_outline, hud_selectable_entities},
+    hud::{draw_item_name, draw_item_outline, is_hud_selectable},
     input_context::{self, InputContext},
     interaction::{FlatInteraction, InteractionContext, PlayerInteraction, VrInteraction},
     inventory::PlayerInventoryEntity,
@@ -7511,10 +7511,18 @@ impl MissionCore {
         let mut ret = vec![];
         // The interaction layer reports what the reticle / hand rays picked;
         // whether that pick may be *highlighted* is a separate, data-driven
-        // question (`P$HUDSelect`), answered here so flat and VR share one
-        // answer. The pick itself stays frobbable either way.
-        let highlighted =
-            hud_selectable_entities(&self.world, self.interaction.highlighted_entities());
+        // question (`P$HUDSelect`), answered once here so the flat and VR
+        // presentations cannot give different answers. (Flat additionally
+        // narrows its own pick to frobbable entities, upstream in
+        // `FlatPlayerController`; that is the frob target, not the highlight.)
+        // `debug_show_ids` piggybacks on the rollover label to read out an
+        // object's runtime entity id, which has no other in-world readout and
+        // is most needed for exactly the fixtures the gate excludes - so the
+        // debug overlay deliberately bypasses it.
+        let mut highlighted = self.interaction.highlighted_entities();
+        if !options.debug_show_ids {
+            highlighted.retain(|e| is_hud_selectable(&self.world, *e));
+        }
         for hit_entity in highlighted {
             ret.extend(draw_item_outline(
                 asset_cache,


### PR DESCRIPTION
## Problem

The item highlight overlay — the four corner brackets (`BRACK0-3.PCX`) plus the
rollover name/HP label — was drawn for essentially anything the player pointed at:

- **Flat** (`FlatPlayerController::update`) gated the highlighted entity on
  "has `P$FrobInfo`", i.e. *frobbable ⇒ highlighted*.
- **VR** (`VrInteraction::highlighted_entities`) applied **no filter at all** — every
  entity a hand ray touched got brackets.

So doors, debris, broken railings and other fixed set dressing lit up with loot
brackets, and the two presentations disagreed about what counts as highlightable.

## Root cause

Highlight eligibility was inferred from frobbability. It isn't derived — the
shipped data states it directly.

`P$HUDSelect` is an opt-in boolean ("HUD Selectable?") authored on templates and
resolved through the normal MetaProp inheritance chain. The port already parsed
and registered it (`dark/src/properties/mod.rs`, `define_prop("P$HUDSelect", …)`);
nothing consumed it for the HUD. Confirmed against the shipped gamesys:

```
$ cargo dq templates 12       # sym:Weapon
  PropHUDSelect(true)
$ cargo dq templates 162      # sym:Monsters
  PropHUDSelect(true)
$ cargo dq templates 505      # sym:Tech  (consoles, force fields, speakers)
  PropHUDSelect(false)
```

1245 of the 6097 merged `medsci1.mis` entities carry the property once
inheritance is resolved — a deliberate, curated opt-in list, not an accident of
the data. An object with no `P$HUDSelect` at all is not highlightable.

## Fix

Gate the outline + name on the inheritance-resolved `P$HUDSelect`, applied **once**
on the shared render path (`MissionCore::render_per_eye`) so flat and VR cannot
give different answers:

```rust
let mut highlighted = self.interaction.highlighted_entities();
if !options.debug_show_ids {
    highlighted.retain(|e| is_hud_selectable(&self.world, *e));
}
```

**Frob eligibility is untouched.** The interaction layer still reports the picked
entity exactly as before, and `flat_player_controller::is_frobbable` (`P$FrobInfo`)
still decides what a use-press acts on. The door below still opens — it just draws
no loot brackets. That split matches the original, where the pick and the
highlight are separate questions.

`debug_show_ids` deliberately bypasses the gate: the rollover label is the only
in-world readout of a runtime entity id (which is not stable across runs), and the
fixtures the gate excludes are exactly the ones that most often need identifying.

## Visuals

![item outline gate demo](https://gist.githubusercontent.com/tommy-xr/213679d32a29e45901d974c263a89a9d/raw/demo.gif)

<sub>The same crosshair pan past a `Sci Med Door` in medsci1, on `main` (left) and this PR (right). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) — identical request sequence and identical stand point on both refs, with a raycast asserting the crosshair is on the same object in both runs.</sub>

### Before → after

A door: frobbable, but no `P$HUDSelect` anywhere in its chain. Brackets and the
`Sci Med Door n206: "A door." | ?` label are gone; the door still opens.

![door before/after](https://gist.githubusercontent.com/tommy-xr/213679d32a29e45901d974c263a89a9d/raw/door_before_after.png)

The control — the sick-bay pistol (`Weapon` family, `P$HUDSelect` true) keeps its
brackets, proving the gate didn't just switch the overlay off:

![pistol before/after](https://gist.githubusercontent.com/tommy-xr/213679d32a29e45901d974c263a89a9d/raw/pistol_before_after.png)

## Player-visible effect

Everything the player is meant to pick out of a room keeps its highlight: weapons,
ammo, creatures and corpses, patches/implants, logs, keys, buttons
(`Res_Station_Button`, `Recharger_Button`), opt-in terminals (`OverideComputer`,
the `ops consoles` family), replicators.

In **flat**, the objects that lose it are the 138 medsci1 entities that have
`P$FrobInfo` but no `P$HUDSelect` — overwhelmingly doors and debris:

> Sci Med Door (30), Security Door (8), Airlock Door 1/2 (10), Double Elevator
> Door (5), Cryo Tube door (5), Broken Railing (4), Debris #3/#4/#8 (9),
> space_shield_10x24 (3), Cargo Bay (3), Broken Junction Box (2), Floor Hatch (2), …

In **VR** the change is larger, because VR previously filtered nothing at all:
every wall panel, pipe and light a hand ray crossed drew brackets. Those stop.

Note the `Tech` family (`P$HUDSelect(false)`) was already unhighlighted in flat —
its consoles carry no `P$FrobInfo` — so this PR does not change them there; the
`false` is what keeps them unhighlighted in VR.

## Tests

New unit tests in `shock2vr/src/hud/item_outline.rs`, asserting both halves of the
invariant on the same entity so the "frob eligibility is unchanged" claim is
tested rather than implied:

- frobbable with **no** `P$HUDSelect` → still frobbable, **not** highlighted
  (the false positive this PR fixes),
- `P$HUDSelect(true)` → highlighted,
- explicit `P$HUDSelect(false)` → still frobbable, **not** highlighted,
- plain world geometry → neither.

```
cargo test -p shock2vr -p dark                  1068 + 118 + 11 pass, 0 fail
RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime   clean
cargo fmt --all                                 clean
```

No e2e test: the debug runtime exposes no introspection of the highlighted set, so
there is nothing to assert on headlessly short of pixel-diffing screenshots — which
is what the before/after capture above does (the door stills differ only inside the
door's bounding box; the pistol stills keep their brackets in both).
