### PR TITLE
fix(debug): capture screenshots at the declared resolution on HiDPI

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -77,6 +77,10 @@ DARK_ASSET_PATH="$HOME/ss2-25th" cargo dbgr --mission <m>.mis --port <p> --vr
 `/v1/step {frames:N}` after each action so it takes effect (deterministic; no
 sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
 
+Screenshots come back at **800x600** (the declared size, regardless of a HiDPI
+framebuffer) — cheap to read often. Add a large `{"max_width": 4000}` on the rare
+shot where you need the native framebuffer detail; it never upscales.
+
 ### Player-authentic interaction differs by presentation
 
 `POST /v1/entities/:id/message {type:"Frob"}` is a **debug injection**: it drives

--- a/.claude/skills/pr-visuals/SKILL.md
+++ b/.claude/skills/pr-visuals/SKILL.md
@@ -62,6 +62,9 @@ curl -s -X POST http://127.0.0.1:8085/v1/shutdown
 - **The screenshot path must be ABSOLUTE and its directory must already exist** —
   the endpoint won't `mkdir`, and `curl` exits 0 on the error response, so a
   missing dir fails silently. Echo the JSON response instead of `> /dev/null`.
+- **Captures are 800x600** — the declared logical size, regardless of a HiDPI
+  framebuffer. Pass a large `{"max_width": 4000}` when a detail (small HUD text,
+  a thin seam) needs the native framebuffer resolution; it never upscales.
 - `/v1/step` is a **fixed 60 Hz timestep** and blocks until the frames ran;
   `/v1/screenshot` captures the fully-rendered frame. The same request sequence
   from a fresh launch produces **byte-identical** images — that determinism is

--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -230,7 +230,7 @@ GET  /v1/control/input    - Get input state
 POST /v1/control/input    - Set input channel
 POST /v1/player/spawn-item - Provision an item template into the inventory
 POST /v1/player/stats     - Provision skills/stats/psi tier/cyber modules
-POST /v1/screenshot       - Capture screenshot
+POST /v1/screenshot       - Capture screenshot (800x600; {max_width} to override)
 GET  /v1/dev-params       - List live-tunable dev params (key, label, range, value, default)
 POST /v1/dev-params       - Set a dev param {key, value} (clamped + snapped) or restore its exact default {key, reset: true}; 404 on unknown key
 ```
@@ -353,7 +353,10 @@ pass `"ignore_sensors": false` to probe sensor volumes deliberately.
 - Screenshots saved to `/tmp/claude/` directory
 - Input overrides persist until reset
 - Frame counter tracks actual game frames (not wall time)
-- macOS Retina displays: viewport size auto-detected for correct screenshots
+- Screenshots are saved at the declared 800x600, downscaled from a HiDPI
+  framebuffer if there is one, so the file matches the reported `resolution`.
+  Pass `max_width` (aspect-preserving, never upscales) for a different size -
+  a large value such as `4000` gets the native framebuffer back.
 
 ## Input Action Injection ✅ COMPLETE
 

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -238,6 +238,8 @@ pub struct StepResult {
 #[derive(Debug, Deserialize)]
 pub struct ScreenshotSpec {
     pub filename: Option<String>,
+    /// Cap the saved PNG's width (aspect-preserving, never upscales).
+    pub max_width: Option<u32>,
 }
 
 /// Result of taking a screenshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -3353,6 +3353,10 @@ async fn audit_colliders(
 #[derive(serde::Deserialize)]
 struct ScreenshotRequest {
     filename: Option<String>,
+    /// Cap the saved PNG's width (aspect-preserving, never upscales). Omitted,
+    /// the capture is downscaled to the declared logical size (`SCR_WIDTH`), so
+    /// a HiDPI framebuffer doesn't quadruple the pixel count.
+    max_width: Option<u32>,
 }
 
 /// HTTP handler for taking screenshots
@@ -3364,6 +3368,7 @@ async fn take_screenshot(
 
     let spec = ScreenshotSpec {
         filename: request.filename,
+        max_width: request.max_width,
     };
 
     // Send screenshot command to game loop
@@ -3409,13 +3414,13 @@ fn capture_screenshot_to_result(spec: ScreenshotSpec) -> ScreenshotResult {
     });
     let full_path = screenshots_dir.join(&filename);
 
-    match capture_screenshot(&full_path, SCR_WIDTH, SCR_HEIGHT) {
-        Ok(size_bytes) => {
+    match capture_screenshot(&full_path, SCR_WIDTH, SCR_HEIGHT, spec.max_width) {
+        Ok((size_bytes, resolution)) => {
             tracing::info!("Screenshot saved to: {}", full_path.display());
             ScreenshotResult {
                 filename,
                 full_path: full_path.to_string_lossy().to_string(),
-                resolution: [SCR_WIDTH, SCR_HEIGHT],
+                resolution,
                 size_bytes,
             }
         }
@@ -3431,12 +3436,52 @@ fn capture_screenshot_to_result(spec: ScreenshotSpec) -> ScreenshotResult {
     }
 }
 
-/// Capture the current OpenGL framebuffer and save it as a PNG
+/// Pick the dimensions the saved PNG should have.
+///
+/// The framebuffer can be larger than the declared logical size (2x on a HiDPI
+/// display), so by default we shrink back to fit the declared box: what callers
+/// asked for, and a quarter of the pixels (which matters for LLM consumers, who
+/// pay per image pixel). `max_width` replaces that box with a width-only cap.
+/// Aspect is always the framebuffer's, so nothing is distorted, and the result
+/// never exceeds the framebuffer (no upscaling).
+fn screenshot_target_size(
+    fb_width: u32,
+    fb_height: u32,
+    logical_width: u32,
+    logical_height: u32,
+    max_width: Option<u32>,
+) -> (u32, u32) {
+    if fb_width == 0 || fb_height == 0 {
+        return (fb_width, fb_height);
+    }
+
+    // Scale factor that fits the framebuffer into the requested bounds. Without
+    // `max_width` that's the declared box, so a window resized to a different
+    // aspect still lands inside 800x600 rather than only under 800 wide.
+    let scale = match max_width.filter(|w| *w > 0) {
+        Some(max_width) => max_width as f64 / fb_width as f64,
+        None => {
+            (logical_width as f64 / fb_width as f64).min(logical_height as f64 / fb_height as f64)
+        }
+    };
+    if scale >= 1.0 {
+        return (fb_width, fb_height);
+    }
+
+    let target_width = ((fb_width as f64 * scale).round() as u32).max(1);
+    let target_height = ((fb_height as f64 * scale).round() as u32).max(1);
+    (target_width, target_height)
+}
+
+/// Capture the current OpenGL framebuffer and save it as a PNG.
+///
+/// Returns the file size and the true dimensions of the saved image.
 fn capture_screenshot(
     path: &std::path::Path,
     width: u32,
     height: u32,
-) -> Result<u64, Box<dyn std::error::Error>> {
+    max_width: Option<u32>,
+) -> Result<(u64, [u32; 2]), Box<dyn std::error::Error>> {
     unsafe {
         // Ensure all rendering for this frame has completed before reading back,
         // so we never capture a partially-drawn buffer.
@@ -3504,11 +3549,30 @@ fn capture_screenshot(
         let img = image::RgbImage::from_vec(actual_width, actual_height, flipped_pixels)
             .ok_or("Failed to create image from pixel data")?;
 
+        // Downscale to the declared (or requested) size so the saved PNG matches
+        // the resolution we report, even when the framebuffer is HiDPI.
+        // `Triangle` rather than `Lanczos3`: the runtime is normally run from the
+        // dev profile, where the higher-order filter costs the game loop nearly a
+        // second per capture, and this is a plain area reduction where the
+        // difference is not visible.
+        let (target_width, target_height) =
+            screenshot_target_size(actual_width, actual_height, width, height, max_width);
+        let img = if (target_width, target_height) == (actual_width, actual_height) {
+            img
+        } else {
+            image::imageops::resize(
+                &img,
+                target_width,
+                target_height,
+                image::imageops::FilterType::Triangle,
+            )
+        };
+
         img.save(path)?;
 
         // Calculate file size
         let metadata = std::fs::metadata(path)?;
-        Ok(metadata.len())
+        Ok((metadata.len(), [target_width, target_height]))
     }
 }
 
@@ -3841,6 +3905,85 @@ async fn shutdown_signal(command_tx: mpsc::UnboundedSender<RuntimeCommand>) {
 fn request_game_loop_shutdown(command_tx: &mpsc::UnboundedSender<RuntimeCommand>) {
     if command_tx.send(RuntimeCommand::Shutdown).is_err() {
         info!("Game loop already stopped while handling shutdown signal");
+    }
+}
+
+#[cfg(test)]
+mod screenshot_size_tests {
+    use super::screenshot_target_size;
+
+    #[test]
+    fn hidpi_framebuffer_downscales_to_logical_size() {
+        assert_eq!(
+            screenshot_target_size(1600, 1200, 800, 600, None),
+            (800, 600)
+        );
+    }
+
+    #[test]
+    fn non_hidpi_framebuffer_is_untouched() {
+        assert_eq!(screenshot_target_size(800, 600, 800, 600, None), (800, 600));
+    }
+
+    #[test]
+    fn max_width_raises_the_cap_but_never_upscales() {
+        assert_eq!(
+            screenshot_target_size(1600, 1200, 800, 600, Some(1600)),
+            (1600, 1200)
+        );
+        assert_eq!(
+            screenshot_target_size(1600, 1200, 800, 600, Some(4000)),
+            (1600, 1200)
+        );
+        assert_eq!(
+            screenshot_target_size(800, 600, 800, 600, Some(4000)),
+            (800, 600)
+        );
+    }
+
+    #[test]
+    fn max_width_below_logical_size_shrinks_further() {
+        assert_eq!(
+            screenshot_target_size(1600, 1200, 800, 600, Some(400)),
+            (400, 300)
+        );
+    }
+
+    #[test]
+    fn a_resized_window_still_fits_inside_the_declared_box() {
+        // The debug window is resizable, so the framebuffer aspect can differ
+        // from the declared one. Fit inside 800x600 rather than capping width
+        // alone, which would have saved a PNG taller than the declared size.
+        assert_eq!(
+            screenshot_target_size(1600, 2000, 800, 600, None),
+            (480, 600)
+        );
+        // ...and the aspect is never distorted to fill the box exactly.
+        assert_eq!(
+            screenshot_target_size(2000, 1000, 800, 600, None),
+            (800, 400)
+        );
+    }
+
+    #[test]
+    fn max_width_is_a_width_only_cap() {
+        // Asking for a width explicitly means exactly that; the declared height
+        // no longer constrains the result.
+        assert_eq!(
+            screenshot_target_size(1600, 2000, 800, 600, Some(800)),
+            (800, 1000)
+        );
+    }
+
+    #[test]
+    fn degenerate_inputs_do_not_panic() {
+        assert_eq!(screenshot_target_size(0, 0, 800, 600, None), (0, 0));
+        // A zero cap is meaningless, so it falls back to the declared box
+        // rather than writing a 1x1 PNG.
+        assert_eq!(
+            screenshot_target_size(1600, 1200, 800, 600, Some(0)),
+            (800, 600)
+        );
     }
 }
 

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -112,7 +112,8 @@ await game.waitFor(
 );
 
 // Screenshots and physics
-await game.screenshot("test.png");
+await game.screenshot("test.png"); // 800x600; pass a max width for more detail
+await game.screenshot("detail.png", 4000);
 await game.raycast({
   start: [0, 0, 0],
   end: [10, 0, 0],

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -794,8 +794,15 @@ export class Game {
     return this.client.post<StepResult>("/v1/step", spec);
   }
 
-  async screenshot(filename?: string): Promise<ScreenshotResult> {
-    return this.client.post<ScreenshotResult>("/v1/screenshot", { filename });
+  /**
+   * Capture the current frame. Saved at the runtime's declared 800x600 by
+   * default (even on a HiDPI framebuffer); pass `maxWidth` for more detail.
+   */
+  async screenshot(filename?: string, maxWidth?: number): Promise<ScreenshotResult> {
+    return this.client.post<ScreenshotResult>("/v1/screenshot", {
+      filename,
+      max_width: maxWidth,
+    });
   }
 
   async raycast(request: RayCastRequest): Promise<RayCastResult> {


### PR DESCRIPTION
## The bug

`debug_runtime` declares `SCR_WIDTH = 800` / `SCR_HEIGHT = 600`, but `capture_screenshot`
read the *actual* GL viewport via `gl::GetIntegerv(gl::VIEWPORT, ...)` and saved the PNG at
that size. On a Retina/HiDPI host the framebuffer is 2x, so every `/v1/screenshot` PNG came
out **1600x1200** while the JSON response's `resolution` field still claimed `[800, 600]`.

Two problems in one: the reported resolution was a lie, and the images were 4x the pixel
count anyone asked for.

## Why it matters (token cost)

These screenshots are read by LLM agents (`playtest`, `play-through`, `pr-visuals`, e2e
scenario tests). Image token cost scales with pixel count:

| Capture | Image tokens (approx) |
| --- | --- |
| 1600x1200 | ~2494 |
| 800x600 | ~638 |

A playtest session reads dozens of screenshots, so this was roughly a 4x tax on the single
largest consumer of context in those workflows — for detail nobody had asked for.

## The fix

- `capture_screenshot` now downscales the framebuffer readback to fit the **declared logical
  box** before saving, so the saved PNG matches what the API says it is.
- New optional `max_width` on `POST /v1/screenshot`: an aspect-preserving width cap that
  **never upscales**. Pass a large value (e.g. `4000`) to get the native framebuffer back
  when you genuinely need the detail; `0` falls back to the default.
- `resolution` now reports the **true dimensions of the saved PNG**, computed by a new pure
  helper `screenshot_target_size(fb_w, fb_h, logical_w, logical_h, max_width)`.
- The default fits inside the declared *box* (both dimensions), not just the width, because
  the debug window is resizable — so a differently-shaped window can't produce a PNG taller
  than the declared size. Aspect is always the framebuffer's, so nothing is distorted.
- The SDK's `game.screenshot(filename, maxWidth?)` exposes the new parameter.
- Docs: the endpoint/behavior notes in `projects/debug-runtime.md` (which still described the
  old "viewport auto-detected" behavior), the SDK README, and one-line notes in the
  `playtest` / `pr-visuals` skills.

Captures also got **faster**, not slower: the smaller PNG encode more than pays for the
`Triangle` resample (numbers below).

## Before / after

Same scene (`debug_minimal`), same request, shown at native pixel scale — the content is
identical, the pixel count is a quarter:

![before/after screenshot resolution](https://gist.githubusercontent.com/tommy-xr/a422feca62e16d0bccd4011fee0b2458/raw/beforeafter.png)

<sub>No GIF here: this is a static capture-pipeline change with no motion to show, so a
before/after still pair is the right evidence. Captured headlessly via the debug runtime
(`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). Full-size stills:
[before](https://gist.githubusercontent.com/tommy-xr/a422feca62e16d0bccd4011fee0b2458/raw/before.png) ·
[after](https://gist.githubusercontent.com/tommy-xr/a422feca62e16d0bccd4011fee0b2458/raw/after.png)</sub>

## Verification

Negative test first, on the pre-fix binary (`debug_minimal`, HiDPI host):

```
$ curl -sX POST .../v1/screenshot -d '{"filename":"hidpi-before.png"}'
{"filename":"hidpi-before.png",...,"resolution":[800,600],"size_bytes":76749}
$ sips -g pixelWidth -g pixelHeight /tmp/claude/hidpi-before.png
  pixelWidth: 1600
  pixelHeight: 1200      <-- reported 800x600, saved 1600x1200
```

After the fix:

```
-- default --
{"filename":"hidpi-after.png",...,"resolution":[800,600],"size_bytes":31739}
  pixelWidth: 800
  pixelHeight: 600

-- max_width 4000 --
{"filename":"hidpi-after-full.png",...,"resolution":[1600,1200],"size_bytes":76749}
  pixelWidth: 1600
  pixelHeight: 1200      <-- byte-for-byte the old default capture; never upscaled past 1600

-- max_width 400 --
{"filename":"hidpi-after-small.png",...,"resolution":[400,300],"size_bytes":12514}
  pixelWidth: 400
  pixelHeight: 300
```

Per-capture latency (`/v1/screenshot` round-trip, dev profile, same runtime):

| Request | real |
| --- | --- |
| default 800x600 (resamples) | 0.46 / 0.52 / 0.53 s |
| `max_width: 4000` → 1600x1200 (no resample) | 0.54 / 0.54 / 0.61 s |

Checks and tests:

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo fmt` applied; `cargo test -p debug_runtime` — 22 pass, 0 fail.
- New host-side unit tests for `screenshot_target_size` (7 cases: HiDPI downscale, non-HiDPI
  no-op, `max_width` cap / never-upscale, sub-declared `max_width`, resized-window box fit,
  `max_width` as a width-only cap, degenerate 0 / `max_width: 0`).
- SDK unit tests (`npm test`) — 32 pass, 0 fail.
- **Screenshot-relevant e2e only** (the full suite was deliberately not run): the four tests
  asserting on `resolution` / `size_bytes` — `flat-hud`, `nanite-stack-label`,
  `eng2-many-ride`, `earth-log-reader` — all pass, before and after the review fixes.
  (`eng2-many-ride` compares two captures' `size_bytes` ratio, so it exercises the new,
  smaller PNGs rather than just the reported resolution. Those `resolution` asserts used to be
  vacuously true, since the field was hardcoded; they're now load-bearing.)

## Review notes

`/xreview` was run. Codex was unavailable (usage limit), so this had the Claude adversarial
reviewer plus the `dupfinder` duplication pass (S1 lexical + S2 clones — no duplication
signals touching the changed hunks).

Findings addressed:

- **High — resample cost on the game loop.** The first draft used `Lanczos3`, which added
  ~0.7 s per capture in the dev profile that both `cargo dbgr` and `GameServer.launch` use —
  a real tax on 60-shot `video-capture` loops and the e2e suite. Switched to `Triangle`;
  measured above, captures are now net *faster* than before the change.
- **Medium — width-only cap on a resizable window** could save a PNG taller than the declared
  size. The default now fits inside the declared box in both dimensions and uses the `height`
  argument that was previously only a viewport fallback; covered by a new unit test.
- **Low — `max_width: 0`** wrote a 1x1 PNG; it now falls back to the default box.
- **Low — docs.** `projects/debug-runtime.md` still claimed "viewport size auto-detected for
  correct screenshots" and the SDK README had no `maxWidth`; both updated. The skills' "pass
  1600 for full resolution" wording was only true at exactly 2x, so it now says "a large value
  such as 4000".

Considered and not taken:

- **Set `WindowHint::CocoaRetinaFramebuffer(false)`** so the framebuffer is 800x600 to begin
  with (~2 lines instead of this diff). Rejected: it's macOS-only, so it doesn't fix HiDPI
  Linux/Windows hosts, it makes a `--visible` debug window render blurry on a Retina display,
  and it removes any way to ask for a higher-detail capture. Resampling is host-agnostic and,
  as measured, free.
- **`screenshot(filename, { maxWidth })`** to match the object-argument shape of sibling SDK
  methods. Left as a positional optional; not a bug, and changing the shape buys nothing here.

https://claude.ai/code/session_015xd647M4JPqgcuhLoas3Cu
