### PR TITLE
fix(creature): build selection/damage hitboxes from fitted per-joint shapes

### DIFF
--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
-use cgmath::{EuclideanSpace, Matrix4, vec3};
-use collision::{Aabb, Aabb3};
-use dark::{model::Model, motion::JointId, properties::PropPosition};
-use rapier3d::prelude::RigidBodyHandle;
+use cgmath::{EuclideanSpace, Matrix4, Vector3};
+use collision::Aabb;
+use dark::{hit_box::HitBoxShape, model::Model, motion::JointId, properties::PropPosition};
+use rapier3d::{
+    na::Point3 as NaPoint3,
+    prelude::{RigidBodyHandle, SharedShape},
+};
 use shipyard::{Component, EntitiesViewMut, EntityId, IntoIter, IntoWithId, View, ViewMut, World};
 
 use crate::{
@@ -33,6 +36,71 @@ pub enum HitBoxType {
     Extremity,
     #[allow(dead_code)]
     NoDamage,
+}
+
+/// Minimum collider half-extent, so a degenerate joint shape (e.g. a joint with
+/// a single skinned vertex) still yields a valid, non-zero box.
+const MIN_HALF_EXTENT: f32 = 0.01;
+
+/// The per-joint collision shapes to build hitbox proxies from: the *fitted*
+/// shapes (capsule spanning the bone toward its child, box otherwise) shared
+/// with the ragdoll, falling back to the raw per-joint vertex AABB for any joint
+/// (or model) that has no fitted shape.
+///
+/// Fitted shapes matter here because these proxies are what melee/projectile
+/// damage AND frob/selection raycasts hit: per-joint AABBs cluster around the
+/// joint origins and leave the bone segments between them uncovered, which made
+/// creatures - corpses especially - fiddly to aim at and to loot.
+fn joint_hit_box_shapes(model: &Model) -> HashMap<JointId, HitBoxShape> {
+    let mut out: HashMap<JointId, HitBoxShape> = model
+        .get_hit_boxes()
+        .iter()
+        .map(|(joint_id, bbox)| {
+            let half = bbox.dim() * 0.5;
+            (
+                *joint_id,
+                HitBoxShape::Cuboid {
+                    half_extents: half,
+                    center: bbox.center().to_vec(),
+                },
+            )
+        })
+        .collect();
+
+    for (joint_id, shape) in model.hit_box_shapes().iter() {
+        out.insert(*joint_id, shape.clone());
+    }
+
+    out
+}
+
+/// Centroid of a fitted shape, in joint-local space.
+fn shape_center(shape: &HitBoxShape) -> Vector3<f32> {
+    match shape {
+        HitBoxShape::Cuboid { center, .. } => *center,
+        HitBoxShape::Capsule { a, b, .. } => (*a + *b) * 0.5,
+    }
+}
+
+/// The rapier collider for a fitted shape, expressed relative to `center` (the
+/// proxy body's origin).
+fn shape_to_collider(shape: &HitBoxShape, center: Vector3<f32>) -> SharedShape {
+    match shape {
+        HitBoxShape::Cuboid { half_extents, .. } => SharedShape::cuboid(
+            half_extents.x.max(MIN_HALF_EXTENT),
+            half_extents.y.max(MIN_HALF_EXTENT),
+            half_extents.z.max(MIN_HALF_EXTENT),
+        ),
+        HitBoxShape::Capsule { a, b, radius } => {
+            let a = *a - center;
+            let b = *b - center;
+            SharedShape::capsule(
+                NaPoint3::new(a.x, a.y, a.z),
+                NaPoint3::new(b.x, b.y, b.z),
+                radius.max(MIN_HALF_EXTENT),
+            )
+        }
+    }
 }
 
 pub struct HitBoxManager {
@@ -83,13 +151,13 @@ impl HitBoxManager {
                     continue;
                 }
 
-                let hit_boxes = maybe_model.unwrap().get_hit_boxes();
+                let hit_boxes = joint_hit_box_shapes(maybe_model.unwrap());
                 let creature_type = maybe_creature_type.unwrap();
 
                 let hit_box_map = self.hit_boxes.entry(parent_entity_id).or_insert_with(|| {
                     let mut out_hit_boxes = HashMap::new();
 
-                    for (joint_id, _bbox) in hit_boxes.iter() {
+                    for (joint_id, _shape) in hit_boxes.iter() {
                         let maybe_hitbox_type = creature_type.get_hitbox_type(*joint_id);
                         if maybe_hitbox_type.is_none() {
                             continue;
@@ -146,11 +214,7 @@ impl HitBoxManager {
 
                 let mut joint_index = 0;
                 for joint_xform in joint_xforms.0 {
-                    let bbox = hit_boxes
-                        .get(&joint_index)
-                        .copied()
-                        .unwrap_or(Aabb3::zero());
-                    let sizes = bbox.dim() * 1.0;
+                    let maybe_shape = hit_boxes.get(&joint_index);
 
                     let maybe_hitbox_type = creature_type.get_hitbox_type(joint_index);
 
@@ -165,22 +229,27 @@ impl HitBoxManager {
                         continue;
                     };
                     let hit_box_entry = maybe_entry.unwrap();
-                    let joint_xform =
-                        xform.0 * joint_xform * Matrix4::from_translation(bbox.center().to_vec());
-                    //* Matrix4::from_nonuniform_scale(sizes.x, sizes.y, sizes.z);
+                    let Some(shape) = maybe_shape else {
+                        joint_index += 1;
+                        continue;
+                    };
+                    // The proxy body sits at the fitted shape's centroid (as it
+                    // used to sit at the joint AABB's center) so a debug aim
+                    // point keeps pointing at the middle of the volume; the
+                    // collider is then built centered on that origin.
+                    let center = shape_center(shape);
+                    let joint_xform = xform.0 * joint_xform * Matrix4::from_translation(center);
 
                     let pos = point3_to_vec3(get_position_from_matrix(&joint_xform));
                     let rotation = get_rotation_from_matrix(&joint_xform);
                     // If there is not a physics entity yet, create one
                     if !id_to_physics.contains_key(hit_box_entry) {
-                        let physics_handle = physics.add_kinematic(
+                        let physics_handle = physics.add_kinematic_shape(
                             *hit_box_entry,
                             pos,
                             rotation,
-                            vec3(0.0, 0.0, 0.0),
-                            vec3(sizes.x, sizes.y, sizes.z),
+                            shape_to_collider(shape, center),
                             crate::physics::CollisionGroup::hitbox(),
-                            false,
                         );
                         id_to_physics.insert(*hit_box_entry, physics_handle);
                     } else {

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use cgmath::{EuclideanSpace, Matrix4, Vector3};
-use collision::Aabb;
+use cgmath::{EuclideanSpace, Matrix4, Vector3, vec3};
+use collision::{Aabb, Aabb3};
 use dark::{hit_box::HitBoxShape, model::Model, motion::JointId, properties::PropPosition};
 use rapier3d::{
     na::Point3 as NaPoint3,
@@ -38,40 +38,38 @@ pub enum HitBoxType {
     NoDamage,
 }
 
-/// Minimum collider half-extent, so a degenerate joint shape (e.g. a joint with
-/// a single skinned vertex) still yields a valid, non-zero box.
-const MIN_HALF_EXTENT: f32 = 0.01;
+/// Floor for the AABB fallback's half-extents: a degenerate joint AABB (a joint
+/// with a single skinned vertex) is zero-sized, and a zero-extent collider makes
+/// parry's ray-AABB test overflow. The *fitted* shapes are already clamped where
+/// they are produced (`dark::hit_box`).
+const FALLBACK_MIN_HALF_EXTENT: f32 = 0.01;
 
-/// The per-joint collision shapes to build hitbox proxies from: the *fitted*
-/// shapes (capsule spanning the bone toward its child, box otherwise) shared
-/// with the ragdoll, falling back to the raw per-joint vertex AABB for any joint
-/// (or model) that has no fitted shape.
+/// The collision shape for one joint: the *fitted* shape (capsule spanning the
+/// bone toward its child, box otherwise) shared with the ragdoll, falling back
+/// to the raw per-joint vertex AABB for a joint (or model) that has none.
 ///
 /// Fitted shapes matter here because these proxies are what melee/projectile
 /// damage AND frob/selection raycasts hit: per-joint AABBs cluster around the
 /// joint origins and leave the bone segments between them uncovered, which made
 /// creatures - corpses especially - fiddly to aim at and to loot.
-fn joint_hit_box_shapes(model: &Model) -> HashMap<JointId, HitBoxShape> {
-    let mut out: HashMap<JointId, HitBoxShape> = model
-        .get_hit_boxes()
-        .iter()
-        .map(|(joint_id, bbox)| {
-            let half = bbox.dim() * 0.5;
-            (
-                *joint_id,
-                HitBoxShape::Cuboid {
-                    half_extents: half,
-                    center: bbox.center().to_vec(),
-                },
-            )
-        })
-        .collect();
-
-    for (joint_id, shape) in model.hit_box_shapes().iter() {
-        out.insert(*joint_id, shape.clone());
+fn joint_shape(
+    fitted: &HashMap<JointId, HitBoxShape>,
+    aabbs: &HashMap<JointId, Aabb3<f32>>,
+    joint_id: JointId,
+) -> Option<HitBoxShape> {
+    if let Some(shape) = fitted.get(&joint_id) {
+        return Some(shape.clone());
     }
-
-    out
+    let bbox = aabbs.get(&joint_id)?;
+    let half = bbox.dim() * 0.5;
+    Some(HitBoxShape::Cuboid {
+        half_extents: vec3(
+            half.x.max(FALLBACK_MIN_HALF_EXTENT),
+            half.y.max(FALLBACK_MIN_HALF_EXTENT),
+            half.z.max(FALLBACK_MIN_HALF_EXTENT),
+        ),
+        center: bbox.center().to_vec(),
+    })
 }
 
 /// Centroid of a fitted shape, in joint-local space.
@@ -83,24 +81,44 @@ fn shape_center(shape: &HitBoxShape) -> Vector3<f32> {
 }
 
 /// The rapier collider for a fitted shape, expressed relative to `center` (the
-/// proxy body's origin).
+/// proxy body's origin). Non-finite geometry degenerates to a small box rather
+/// than reaching parry, whose broad-phase panics on a NaN AABB.
 fn shape_to_collider(shape: &HitBoxShape, center: Vector3<f32>) -> SharedShape {
+    let min_box = || {
+        SharedShape::cuboid(
+            FALLBACK_MIN_HALF_EXTENT,
+            FALLBACK_MIN_HALF_EXTENT,
+            FALLBACK_MIN_HALF_EXTENT,
+        )
+    };
     match shape {
-        HitBoxShape::Cuboid { half_extents, .. } => SharedShape::cuboid(
-            half_extents.x.max(MIN_HALF_EXTENT),
-            half_extents.y.max(MIN_HALF_EXTENT),
-            half_extents.z.max(MIN_HALF_EXTENT),
-        ),
+        HitBoxShape::Cuboid { half_extents, .. } => {
+            if !is_finite(*half_extents) {
+                return min_box();
+            }
+            SharedShape::cuboid(
+                half_extents.x.max(FALLBACK_MIN_HALF_EXTENT),
+                half_extents.y.max(FALLBACK_MIN_HALF_EXTENT),
+                half_extents.z.max(FALLBACK_MIN_HALF_EXTENT),
+            )
+        }
         HitBoxShape::Capsule { a, b, radius } => {
             let a = *a - center;
             let b = *b - center;
+            if !is_finite(a) || !is_finite(b) || !radius.is_finite() {
+                return min_box();
+            }
             SharedShape::capsule(
                 NaPoint3::new(a.x, a.y, a.z),
                 NaPoint3::new(b.x, b.y, b.z),
-                radius.max(MIN_HALF_EXTENT),
+                radius.max(FALLBACK_MIN_HALF_EXTENT),
             )
         }
     }
+}
+
+fn is_finite(v: Vector3<f32>) -> bool {
+    v.x.is_finite() && v.y.is_finite() && v.z.is_finite()
 }
 
 pub struct HitBoxManager {
@@ -151,13 +169,19 @@ impl HitBoxManager {
                     continue;
                 }
 
-                let hit_boxes = joint_hit_box_shapes(maybe_model.unwrap());
+                // Fitted shapes first, per-joint vertex AABBs as the fallback.
+                // Both are `Rc` handles owned by the model - no per-frame
+                // rebuild - and both are keyed by the same joints (a joint only
+                // gets either when it has skinned vertices), so the AABB map is
+                // the authoritative key set for which joints get a proxy.
+                let fitted_shapes = maybe_model.unwrap().hit_box_shapes();
+                let joint_aabbs = maybe_model.unwrap().get_hit_boxes();
                 let creature_type = maybe_creature_type.unwrap();
 
                 let hit_box_map = self.hit_boxes.entry(parent_entity_id).or_insert_with(|| {
                     let mut out_hit_boxes = HashMap::new();
 
-                    for (joint_id, _shape) in hit_boxes.iter() {
+                    for joint_id in joint_aabbs.keys() {
                         let maybe_hitbox_type = creature_type.get_hitbox_type(*joint_id);
                         if maybe_hitbox_type.is_none() {
                             continue;
@@ -214,8 +238,6 @@ impl HitBoxManager {
 
                 let mut joint_index = 0;
                 for joint_xform in joint_xforms.0 {
-                    let maybe_shape = hit_boxes.get(&joint_index);
-
                     let maybe_hitbox_type = creature_type.get_hitbox_type(joint_index);
 
                     if maybe_hitbox_type.is_none() {
@@ -229,7 +251,9 @@ impl HitBoxManager {
                         continue;
                     };
                     let hit_box_entry = maybe_entry.unwrap();
-                    let Some(shape) = maybe_shape else {
+                    // Always `Some` for a joint that has a proxy - the proxies
+                    // are created from this same key set above.
+                    let Some(shape) = joint_shape(&fitted_shapes, &joint_aabbs, joint_index) else {
                         joint_index += 1;
                         continue;
                     };
@@ -237,7 +261,7 @@ impl HitBoxManager {
                     // used to sit at the joint AABB's center) so a debug aim
                     // point keeps pointing at the middle of the volume; the
                     // collider is then built centered on that origin.
-                    let center = shape_center(shape);
+                    let center = shape_center(&shape);
                     let joint_xform = xform.0 * joint_xform * Matrix4::from_translation(center);
 
                     let pos = point3_to_vec3(get_position_from_matrix(&joint_xform));
@@ -248,8 +272,10 @@ impl HitBoxManager {
                             *hit_box_entry,
                             pos,
                             rotation,
-                            shape_to_collider(shape, center),
+                            shape_to_collider(&shape, center),
+                            vec3(0.0, 0.0, 0.0),
                             crate::physics::CollisionGroup::hitbox(),
+                            false,
                         );
                         id_to_physics.insert(*hit_box_entry, physics_handle);
                     } else {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3571,30 +3571,20 @@ impl PhysicsWorld {
         collision_groups: CollisionGroup,
         is_sensor: bool,
     ) -> RigidBodyHandle {
-        //for (pos, size, facing, id, is_sensor) in &phys_objs {
-        let handle = self.add_kinematic_anchor(entity_id, pos, facing);
         let size = sanitize_collider_size(entity_id, "add_kinematic", size);
-        let mut collider = ColliderBuilder::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0)
-            //.rotation(vector!(angles.0, angles.1, angles.2))
-            //.rotation(vector!(facing.z, facing.x, facing.y))
-            .translation(vec_to_nvec(offset))
-            //.position(test)
-            .restitution(0.7)
-            .build();
-
-        collider.set_enabled(true);
-        collider.set_sensor(is_sensor);
-        collider.user_data = entity_id.inner() as u128;
-        collider.set_collision_groups(collision_groups.collision);
-        collider.set_solver_groups(collision_groups.solver);
-
-        self.collider_set
-            .insert_with_parent(collider, handle, &mut self.rigid_body_set);
-        handle
+        self.add_kinematic_shape(
+            entity_id,
+            pos,
+            facing,
+            SharedShape::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0),
+            offset,
+            collision_groups,
+            is_sensor,
+        )
     }
 
-    /// Create a kinematic body carrying an arbitrary shape, instead of the
-    /// axis-aligned cuboid `add_kinematic` builds. The creature hitbox proxies
+    /// Create a kinematic body carrying an arbitrary shape, rather than the
+    /// axis-aligned cuboid `add_kinematic` passes. The creature hitbox proxies
     /// use it so their collider is the *fitted* per-joint shape (capsule along
     /// the bone / box) shared with the ragdoll, which covers the body far
     /// better than a per-joint AABB.
@@ -3604,12 +3594,18 @@ impl PhysicsWorld {
         pos: Vector3<f32>,
         facing: Quaternion<f32>,
         shape: SharedShape,
+        offset: Vector3<f32>,
         collision_groups: CollisionGroup,
+        is_sensor: bool,
     ) -> RigidBodyHandle {
         let handle = self.add_kinematic_anchor(entity_id, pos, facing);
-        let mut collider = ColliderBuilder::new(shape).restitution(0.7).build();
+        let mut collider = ColliderBuilder::new(shape)
+            .translation(vec_to_nvec(offset))
+            .restitution(0.7)
+            .build();
 
         collider.set_enabled(true);
+        collider.set_sensor(is_sensor);
         collider.user_data = entity_id.inner() as u128;
         collider.set_collision_groups(collision_groups.collision);
         collider.set_solver_groups(collision_groups.solver);

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3593,6 +3593,32 @@ impl PhysicsWorld {
         handle
     }
 
+    /// Create a kinematic body carrying an arbitrary shape, instead of the
+    /// axis-aligned cuboid `add_kinematic` builds. The creature hitbox proxies
+    /// use it so their collider is the *fitted* per-joint shape (capsule along
+    /// the bone / box) shared with the ragdoll, which covers the body far
+    /// better than a per-joint AABB.
+    pub fn add_kinematic_shape(
+        &mut self,
+        entity_id: EntityId,
+        pos: Vector3<f32>,
+        facing: Quaternion<f32>,
+        shape: SharedShape,
+        collision_groups: CollisionGroup,
+    ) -> RigidBodyHandle {
+        let handle = self.add_kinematic_anchor(entity_id, pos, facing);
+        let mut collider = ColliderBuilder::new(shape).restitution(0.7).build();
+
+        collider.set_enabled(true);
+        collider.user_data = entity_id.inner() as u128;
+        collider.set_collision_groups(collision_groups.collision);
+        collider.set_solver_groups(collision_groups.solver);
+
+        self.collider_set
+            .insert_with_parent(collider, handle, &mut self.rigid_body_set);
+        handle
+    }
+
     /// Create a kinematic transform anchor without collision geometry.
     ///
     /// Zero-volume PhysAttach objects (notably `Lift 1 Walls`) still own a

--- a/tools/shock2-sdk/test/hitbox-coverage.e2e.test.ts
+++ b/tools/shock2-sdk/test/hitbox-coverage.e2e.test.ts
@@ -13,9 +13,9 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
  * clean through it, which is why corpses were so fiddly to aim at and loot.
  *
  * Sweep horizontal rays up the standing creature and require an unbroken run of
- * hits from just above the knees to over the head. With the old AABB proxies
- * this fails immediately (the lower band is empty); with the fitted
- * capsule/box shapes the whole body is covered.
+ * hits from the thighs to the chest. With the old AABB proxies this fails
+ * immediately (the lower band is empty); with the fitted capsule/box shapes the
+ * body is covered continuously.
  */
 test(
   "creature hitbox proxies cover the whole body, with no gaps between joints",
@@ -41,12 +41,15 @@ test(
     const proxyIds = new Set((detail.aim_points ?? []).map((p) => p.proxy_entity_id));
     assert.ok(proxyIds.size > 0, "creature should expose per-joint hitbox proxies");
 
-    // Heights relative to the creature origin: roughly mid-thigh up to above the
-    // head. The origin sits about a metre above the feet.
+    // Heights relative to the creature origin, stepped in integers to avoid
+    // float drift. The band runs from the thighs up to the chest - the column
+    // of the body that unambiguously has mesh at the creature's own x, so a
+    // miss means a genuine hole between joints rather than a ray that slipped
+    // past an outstretched limb.
     const misses: string[] = [];
     const hits: number[] = [];
-    for (let offset = -1.05; offset <= 1.45 + 1e-6; offset += 0.05) {
-      const y = cy + offset;
+    for (let step = 0; step <= 28; step += 1) {
+      const y = cy - 1.05 + step * 0.05;
       const hit = await game.raycast({
         start: [cx, y, cz - 3.0],
         end: [cx, y, cz + 3.0],
@@ -66,6 +69,6 @@ test(
       [],
       `every height along the creature should hit one of its own hitbox proxies; uncovered: ${misses.join(", ")}`,
     );
-    assert.ok(hits.length >= 50, `expected a dense sweep, got ${hits.length} samples`);
+    assert.equal(hits.length, 29, "the whole band should have been sampled");
   },
 );

--- a/tools/shock2-sdk/test/hitbox-coverage.e2e.test.ts
+++ b/tools/shock2-sdk/test/hitbox-coverage.e2e.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/**
+ * A creature's per-joint hitbox proxies are what melee, projectiles AND
+ * frob/selection raycasts actually hit. When they were the raw per-joint vertex
+ * AABBs they clustered around the joint origins, leaving the bone segments
+ * between joints uncovered - a horizontal ray through a hybrid's thigh passed
+ * clean through it, which is why corpses were so fiddly to aim at and loot.
+ *
+ * Sweep horizontal rays up the standing creature and require an unbroken run of
+ * hits from just above the knees to over the head. With the old AABB proxies
+ * this fails immediately (the lower band is empty); with the fitted
+ * capsule/box shapes the whole body is covered.
+ */
+test(
+  "creature hitbox proxies cover the whole body, with no gaps between joints",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_melee",
+      port: Number(process.env.SHOCK2_E2E_HITBOX_COVERAGE_PORT ?? 8393),
+    });
+    // Hitbox proxies are built (and their bodies registered with the query
+    // pipeline) on the first updates.
+    await game.step({ frames: 30 });
+
+    const creatures = await game.entities.list({ filter: "OG-Pipe" });
+    assert.ok(
+      creatures.entities.length > 0,
+      "debug_melee should contain OG-Pipe hybrids to swing at",
+    );
+    const creature = creatures.entities[0];
+    const [cx, cy, cz] = creature.position;
+
+    const detail = await game.entities.detail(creature.id);
+    const proxyIds = new Set((detail.aim_points ?? []).map((p) => p.proxy_entity_id));
+    assert.ok(proxyIds.size > 0, "creature should expose per-joint hitbox proxies");
+
+    // Heights relative to the creature origin: roughly mid-thigh up to above the
+    // head. The origin sits about a metre above the feet.
+    const misses: string[] = [];
+    const hits: number[] = [];
+    for (let offset = -1.05; offset <= 1.45 + 1e-6; offset += 0.05) {
+      const y = cy + offset;
+      const hit = await game.raycast({
+        start: [cx, y, cz - 3.0],
+        end: [cx, y, cz + 3.0],
+        collision_groups: ["hitbox"],
+      });
+      if (hit.hit && hit.entity_id !== null && proxyIds.has(hit.entity_id)) {
+        hits.push(y);
+      } else {
+        misses.push(
+          `y=${y.toFixed(2)} (${hit.hit ? `hit ${hit.entity_id}` : "no hit"})`,
+        );
+      }
+    }
+
+    assert.deepEqual(
+      misses,
+      [],
+      `every height along the creature should hit one of its own hitbox proxies; uncovered: ${misses.join(", ")}`,
+    );
+    assert.ok(hits.length >= 50, `expected a dense sweep, got ${hits.length} samples`);
+  },
+);


### PR DESCRIPTION
## What

Creature/corpse **selection and damage hitboxes** are now built from the *fitted* per-joint shapes (`Model::hit_box_shapes()` — capsule spanning the bone toward its child, box otherwise) instead of the raw per-joint vertex AABBs.

Those AABBs are computed from joint-local skinned vertices, so they cluster around the joint *origins* and leave the bone segments *between* joints uncovered. Since the per-joint proxies are what melee, projectiles **and** frob/selection raycasts hit, that showed up as a patchy, disconnected hit surface — you could point straight at a limb and hit nothing.

The fitted shapes are already the ragdoll's collision rig, and `dark::hit_box` documents them as the shared source of truth for the damage hitboxes too — this change makes the hitboxes actually use them.

## Visuals

A dense probe of what the hitboxes cover: 3773 parallel rays fired through a standing medsci1 hybrid (world frozen, `hitbox` collision group only), one per cell of a vertical plane. Green = that ray resolves to one of the creature's own hitbox proxies. Before, the body is a set of disconnected blobs with the arm floating free; after, it is a continuous silhouette.

![hitbox coverage before/after](https://gist.githubusercontent.com/tommy-xr/a1f0e862baacdeaaf2e60162d0a4ed99/raw/hitbox-coverage.gif)

<sub>Blink comparator, same probe: **1306 → 1925 of 3773 rays** hit a hitbox (+47%). Captured headlessly via the debug runtime (`/v1/step` + `/v1/physics/raycast` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![coverage panels](https://gist.githubusercontent.com/tommy-xr/a1f0e862baacdeaaf2e60162d0a4ed99/raw/hitbox-coverage.png)

And in play, sweeping the flat crosshair the length of a corpse (quicksaved world, replayed identically on both builds, 24 sample points along the body): the frob/selection ray resolves to the corpse at **21/24 points before, 24/24 after**. One of the three recovered points:

![crosshair on a corpse](https://gist.githubusercontent.com/tommy-xr/a1f0e862baacdeaaf2e60162d0a4ed99/raw/hitbox-selection.png)

<sub>The badge is the result of the player's own frob-ray collision groups, run at that frame.</sub>

## How

- `PhysicsWorld::add_kinematic_shape` — a kinematic body carrying an arbitrary `SharedShape`. `add_kinematic` now delegates to it with a cuboid instead of duplicating the collider wiring.
- `HitBoxManager::update` builds each proxy's collider from the joint's fitted shape, looked up in the model's existing `Rc` maps (no per-frame rebuild). The proxy body still sits at the shape's **centroid** (as it previously sat at the AABB center), so debug aim points still point at the middle of each volume and the capsule endpoints are expressed relative to that origin.
- Joints (or models) with no fitted shape fall back to the old AABB-derived box, clamped so a degenerate joint can't produce a zero-extent collider; non-finite geometry degenerates to a small box rather than handing a NaN to parry.

**Damage attribution is unchanged**: the proxy entity, its `RuntimePropHitBox { parent_entity_id, hit_box_type, joint_id }`, the `HitBoxScript` that forwards `Damage` to the parent stamped with the struck joint, and `CollisionGroup::hitbox()` are all untouched. Only the collider geometry changed — the same 15 proxies with the same head/torso/limb/extremity classification before and after.

## Deliberate divergence from retail

Retail picked frob targets from a screen-space bounding box, so it never had a "gap between the bones" problem to begin with. This port raycasts against physics proxies, and the intent here is that **every part of a creature or corpse you can see is selectable** — a usability decision, not a fidelity one. It also widens the melee/projectile hit surface, which is the same coverage argument that motivated the ragdoll using these shapes.

## Testing

- `cargo fmt --all`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; `cargo test -p shock2vr` (1064 passed).
- New e2e `tools/shock2-sdk/test/hitbox-coverage.e2e.test.ts`: sweeps horizontal rays up a standing hybrid in `debug_melee` and requires every height from the thighs to the chest to hit one of that creature's own hitbox proxies. **Negative-checked**: on `origin/main` it fails with 9 of 29 sample heights passing clean through the body; it passes with this change.
- Melee/death e2e green: `vr-melee-contact` (4 tests), `melee-impact-sound`, `flat-melee-animation-event`, `monster-death`, `ragdoll-death`.
- `creature-loot.e2e.test.ts` still fails — **identically on `origin/main`** (`reading the looted disc should open the reader MFD bound to it`, `-1 !== 251`), a pre-existing failure unrelated to this change. It gets *past* the looting steps in both.
