### PR TITLE
test(sdk): let every e2e test take an ephemeral port

### DIFF
--- a/tools/shock2-sdk/scripts/reliability.mjs
+++ b/tools/shock2-sdk/scripts/reliability.mjs
@@ -1,7 +1,6 @@
 // Repeatedly runs the e2e suite to surface flakiness in timing-sensitive tests
 // (e.g. the muzzle-flash tracking test, whose flash is alive only a couple of
-// deterministic frames). Each run gets a unique port so leftover runtimes can't
-// collide. Exits non-zero on the first failing run.
+// deterministic frames). Exits non-zero on the first failing run.
 //
 // Usage (build first, or rely on the npm script which runs `tsc`):
 //   node scripts/reliability.mjs [count] [namePattern]
@@ -30,7 +29,7 @@ if (files.length === 0) {
 let passed = 0;
 for (let i = 1; i <= count; i++) {
   // Serialize files (--test-concurrency=1): each e2e test spawns its own heavy
-  // debug runtime, so running them one at a time avoids port/resource contention.
+  // debug runtime, so running them one at a time avoids resource contention.
   const args = ["--test", "--test-concurrency=1"];
   if (pattern) args.push(`--test-name-pattern=${pattern}`);
   args.push(...files);
@@ -38,7 +37,7 @@ for (let i = 1; i <= count; i++) {
   console.log(`=== run ${i}/${count} ===`);
   const res = spawnSync("node", args, {
     stdio: "inherit",
-    env: { ...process.env, SHOCK2_E2E: "1", SHOCK2_E2E_PORT: String(8200 + i) },
+    env: { ...process.env, SHOCK2_E2E: "1" },
   });
 
   if (res.status === 0) {

--- a/tools/shock2-sdk/test/ai-alertness.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-alertness.e2e.test.ts
@@ -26,7 +26,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
@@ -37,7 +37,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8592),
     });
 
     await game.step({ frames: 10 });
@@ -180,7 +179,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT_SCAN ?? 8593),
     });
 
     await game.step({ frames: 60 });

--- a/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
+++ b/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
@@ -28,7 +28,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8105),
       experimental: ["nav_bridges"],
     });
 

--- a/tools/shock2-sdk/test/ally-line-of-fire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ally-line-of-fire.e2e.test.ts
@@ -25,7 +25,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8146),
       experimental: ["nav_bridges"],
     });
 

--- a/tools/shock2-sdk/test/animation-nan-source.e2e.test.ts
+++ b/tools/shock2-sdk/test/animation-nan-source.e2e.test.ts
@@ -33,7 +33,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "station.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8344),
     });
     await game.step({ frames: 30 }); // settle
 
@@ -138,7 +137,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "station.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8344) + 1,
     });
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/audio-message-diagnostics.e2e.test.ts
+++ b/tools/shock2-sdk/test/audio-message-diagnostics.e2e.test.ts
@@ -18,7 +18,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8193),
     });
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/auto-install-soft.e2e.test.ts
+++ b/tools/shock2-sdk/test/auto-install-soft.e2e.test.ts
@@ -33,7 +33,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9241),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
+++ b/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
@@ -6,7 +6,6 @@ import type { EntityDetailResult, EntitySummary } from "../src/index.js";
 import { fireOnce } from "./helpers/weapon.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8491);
 
 // Stable Hydro3 mission object/template ids, never runtime entity ids.
 const NORTH_ARACHNID = 372;
@@ -36,7 +35,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro3.mis",
-      port: basePort,
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
+++ b/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
@@ -34,7 +34,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8159),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -37,7 +37,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8100),
     });
 
     // Wield the pistol (first DebugCycleWeapon roster entry).

--- a/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
+++ b/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
@@ -26,7 +26,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
     });
 
     const bulletHoles = async () =>

--- a/tools/shock2-sdk/test/camera-alert-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/camera-alert-save.e2e.test.ts
@@ -17,8 +17,6 @@ import type { EntityDetailResult, EntitySummary } from "../src/index.js";
 // fails (the runtime never comes back with the restored mission).
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8203);
-
 // medsci1 object 102 - a Security Camera (`cameraalert` script) with a clear
 // line of sight to the vantage point used below. Template ids are stable
 // across runs; runtime entity ids are not.
@@ -44,7 +42,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "medsci1.mis",
-        port: basePort,
       });
       await game.step({ frames: 10 });
 
@@ -79,7 +76,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "eng1.mis",
-        port: basePort + 1,
       });
       await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/camera-aware-delay.e2e.test.ts
+++ b/tools/shock2-sdk/test/camera-aware-delay.e2e.test.ts
@@ -5,7 +5,6 @@ import { GameServer } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8223);
 
 // MedSci1 object 102 is a Security Camera with an unobstructed view from the
 // authored floor position used below. Runtime entity ids vary between runs.
@@ -21,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
     });
 
     const [camera] = await game.entities.byTemplate(CAMERA_TEMPLATE_ID);

--- a/tools/shock2-sdk/test/chase-last-seen.e2e.test.ts
+++ b/tools/shock2-sdk/test/chase-last-seen.e2e.test.ts
@@ -30,7 +30,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8110),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -37,7 +37,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
     });
     await game.step({ frames: 5 });
 
@@ -101,7 +100,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rick1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/close-range-projectile.e2e.test.ts
+++ b/tools/shock2-sdk/test/close-range-projectile.e2e.test.ts
@@ -16,7 +16,6 @@ import { fireOnce } from "./helpers/weapon.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const TRAINING_DROID = 593;
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8469);
 
 function hitPoints(detail: EntityDetailResult): number {
   const property = detail.properties.find(
@@ -67,7 +66,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: basePort,
     });
     await game.step({ frames: 5 });
 
@@ -118,7 +116,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
     });
     await game.step({ frames: 5 });
 
@@ -184,7 +181,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 2,
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/comestible.e2e.test.ts
+++ b/tools/shock2-sdk/test/comestible.e2e.test.ts
@@ -75,7 +75,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8225),
       repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
     });
     await game.step({ frames: 5 });
@@ -158,7 +157,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8226),
       repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
       debugFlags: ["--vr"],
     });

--- a/tools/shock2-sdk/test/command-locked-card-relay.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-locked-card-relay.e2e.test.ts
@@ -65,7 +65,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8157),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/command-resonator.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-resonator.e2e.test.ts
@@ -102,7 +102,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9440),
       rustLog: "debug_runtime=info,shock2vr=debug",
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/command-shuttle-destroy.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-shuttle-destroy.e2e.test.ts
@@ -44,7 +44,6 @@ test(
     const saveName = `command_shuttle_b_destroyed_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8618),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/command-tram.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-tram.e2e.test.ts
@@ -33,7 +33,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8184),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/concurrent-step.e2e.test.ts
+++ b/tools/shock2-sdk/test/concurrent-step.e2e.test.ts
@@ -15,7 +15,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_minimal",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8115),
     });
 
     // Keep the rejection handled from the moment the request is launched:

--- a/tools/shock2-sdk/test/container-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/container-loot.e2e.test.ts
@@ -49,7 +49,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8119),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/creature-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/creature-loot.e2e.test.ts
@@ -43,7 +43,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8177),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/cross-mode-held-load.e2e.test.ts
+++ b/tools/shock2-sdk/test/cross-mode-held-load.e2e.test.ts
@@ -64,7 +64,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8530),
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/crouch-load-headroom.e2e.test.ts
+++ b/tools/shock2-sdk/test/crouch-load-headroom.e2e.test.ts
@@ -55,7 +55,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8237),
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
+++ b/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
@@ -41,7 +41,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8116),
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
 

--- a/tools/shock2-sdk/test/cyber-modules.e2e.test.ts
+++ b/tools/shock2-sdk/test/cyber-modules.e2e.test.ts
@@ -18,7 +18,6 @@ import type { EntitySummary } from "../src/types.js";
 // Negative-first: on main, info().stats has no `cyber_modules` field (undefined,
 // so the `=== 0` baseline assert fails) and TurnOn'ing the trap changes nothing.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8169);
 
 /** Read the property `name`'s integer value from an entity's detail, or null. */
 async function propInt(
@@ -43,7 +42,6 @@ test(
     const saveName = `cyber_modules_e2e_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/damage-alert.e2e.test.ts
+++ b/tools/shock2-sdk/test/damage-alert.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/death-links.e2e.test.ts
+++ b/tools/shock2-sdk/test/death-links.e2e.test.ts
@@ -15,7 +15,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8131),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/debris-wedge.e2e.test.ts
+++ b/tools/shock2-sdk/test/debris-wedge.e2e.test.ts
@@ -42,7 +42,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8213),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -255,7 +255,7 @@ test(
   "the flat Developer screen launches a debug scene and can back out of the list",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
   async () => {
-    await using game = await GameServer.launch({ mission: "main_menu", port: 8134 });
+    await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 10 });
     await click(game, [489, 202]);
     assert.equal((await game.info()).mission, "developer");
@@ -295,7 +295,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8135,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -78,7 +78,7 @@ test(
   "the flat Developer screen steps a param with < and > and leaves with Done",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
   async () => {
-    await using game = await GameServer.launch({ mission: "main_menu", port: 8131 });
+    await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 10 });
 
     // The repurposed Options slot now swaps to the Developer scene.
@@ -156,7 +156,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8132,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });
@@ -200,7 +199,7 @@ test(
   "the pause overlay's Developer page tunes without leaving the mission",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
   async () => {
-    await using game = await GameServer.launch({ mission: "medsci1.mis", port: 8133 });
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
     await game.step({ frames: 30 });
 
     await game.input.trigger("TogglePauseMenu");

--- a/tools/shock2-sdk/test/dev-params.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-params.e2e.test.ts
@@ -39,7 +39,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/docile-alert-cap.e2e.test.ts
+++ b/tools/shock2-sdk/test/docile-alert-cap.e2e.test.ts
@@ -32,7 +32,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8144),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/docile-training-droid.e2e.test.ts
+++ b/tools/shock2-sdk/test/docile-training-droid.e2e.test.ts
@@ -29,7 +29,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8138),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/door-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/door-frob.e2e.test.ts
@@ -28,7 +28,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8146),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
@@ -27,7 +27,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8155),
       rustLog: "debug_runtime=info,shock2vr=debug",
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/earth-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-log-reader.e2e.test.ts
@@ -33,13 +33,9 @@ const panelText = (panel: UiPanel): string =>
     .map((element) => element.text)
     .join(" ");
 
-async function verifyEarthLogReader(
-  presentation: "flat" | "vr",
-  port: number,
-): Promise<void> {
+async function verifyEarthLogReader(presentation: "flat" | "vr"): Promise<void> {
   await using game = await GameServer.launch({
     mission: "earth.mis",
-    port,
     debugFlags: presentation === "vr" ? ["--vr"] : [],
   });
   await game.step({ frames: 5 });
@@ -96,13 +92,7 @@ test(
   "25AE Earth log 1/24 collects, reads and renders in flat and VR",
   { skip: !has25thScp, timeout: 600_000 },
   async () => {
-    await verifyEarthLogReader(
-      "flat",
-      Number(process.env.SHOCK2_E2E_PORT ?? 8861),
-    );
-    await verifyEarthLogReader(
-      "vr",
-      Number(process.env.SHOCK2_E2E_PORT ?? 8862),
-    );
+    await verifyEarthLogReader("flat");
+    await verifyEarthLogReader("vr");
   },
 );

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -145,7 +145,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8201),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
@@ -332,7 +331,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8200),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
@@ -394,7 +392,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8201),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
@@ -42,7 +42,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8156),
       rustLog: "debug_runtime=info,shock2vr=debug",
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/earth-replicator-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-hacking.e2e.test.ts
@@ -51,7 +51,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8157),
       rustLog: "debug_runtime=info,shock2vr=debug",
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/earth-training-droid-respawn.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-training-droid-respawn.e2e.test.ts
@@ -4,7 +4,6 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8534);
 
 // earth.mis's basic-training stand:
 //
@@ -32,7 +31,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: basePort,
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/earth-training-narration.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-training-narration.e2e.test.ts
@@ -37,7 +37,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8194),
     });
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/earth-tram-exit.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-tram-exit.e2e.test.ts
@@ -23,7 +23,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8112),
     });
     await game.step({ frames: 30 }); // settle onto the tram floor
 

--- a/tools/shock2-sdk/test/earth-vr-live-creature-offer.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-vr-live-creature-offer.e2e.test.ts
@@ -66,7 +66,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/earth-vr-world-panel-arbitration.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-vr-world-panel-arbitration.e2e.test.ts
@@ -196,7 +196,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8202),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
@@ -68,7 +68,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8163),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/elevator-reroute.e2e.test.ts
+++ b/tools/shock2-sdk/test/elevator-reroute.e2e.test.ts
@@ -5,7 +5,6 @@ import { GameServer } from "../src/index.js";
 import type { EntitySummary, Vec3 } from "../src/types.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const PORT = Number(process.env.SHOCK2_E2E_PORT ?? 8147);
 
 function onlyEntity(entities: EntitySummary[], authoredId: number): EntitySummary {
   assert.equal(
@@ -31,7 +30,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: PORT,
     });
 
     // Runtime ids vary every launch; resolve all four mission objects from

--- a/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
+++ b/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
@@ -28,7 +28,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8127),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/energy-weapon-recharge.e2e.test.ts
+++ b/tools/shock2-sdk/test/energy-weapon-recharge.e2e.test.ts
@@ -70,7 +70,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8174),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/eng2-many-ride.e2e.test.ts
+++ b/tools/shock2-sdk/test/eng2-many-ride.e2e.test.ts
@@ -38,7 +38,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "eng2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8158),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/entity-containment-links.e2e.test.ts
+++ b/tools/shock2-sdk/test/entity-containment-links.e2e.test.ts
@@ -18,7 +18,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/entity-list-sort.e2e.test.ts
+++ b/tools/shock2-sdk/test/entity-list-sort.e2e.test.ts
@@ -22,7 +22,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8105),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/entity-recycled-slot.e2e.test.ts
+++ b/tools/shock2-sdk/test/entity-recycled-slot.e2e.test.ts
@@ -26,7 +26,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8115),
       experimental: ["ragdoll"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/explosion.e2e.test.ts
+++ b/tools/shock2-sdk/test/explosion.e2e.test.ts
@@ -41,7 +41,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8114),
     });
 
     await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/flat-hud.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-hud.e2e.test.ts
@@ -19,7 +19,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8093),
       // Flatscreen is the debug runtime's default presentation now.
     });
 

--- a/tools/shock2-sdk/test/flat-melee-animation-event.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-melee-animation-event.e2e.test.ts
@@ -28,7 +28,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8951),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/flat-ui-plumbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-ui-plumbing.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8115),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/flat-world-pickup.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-world-pickup.e2e.test.ts
@@ -12,7 +12,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8138),
     });
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/flinderize.e2e.test.ts
+++ b/tools/shock2-sdk/test/flinderize.e2e.test.ts
@@ -38,7 +38,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8112),
     });
 
     // Let the mission load and initialize scripts.

--- a/tools/shock2-sdk/test/force-chase.e2e.test.ts
+++ b/tools/shock2-sdk/test/force-chase.e2e.test.ts
@@ -27,7 +27,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
       experimental: ["nav_bridges"],
     });
 

--- a/tools/shock2-sdk/test/give-item.e2e.test.ts
+++ b/tools/shock2-sdk/test/give-item.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
     });
     await game.step({ frames: 5 });
 
@@ -89,7 +88,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/gravshaft.e2e.test.ts
+++ b/tools/shock2-sdk/test/gravshaft.e2e.test.ts
@@ -26,7 +26,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8306),
     });
     await game.step({ frames: 30 }); // settle
 

--- a/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
+++ b/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
@@ -137,7 +137,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9101),
       rustLog: "debug_runtime=info,shock2vr=debug",
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/healing-items.e2e.test.ts
+++ b/tools/shock2-sdk/test/healing-items.e2e.test.ts
@@ -149,7 +149,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8668),
       repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
       debugFlags: ["--vr"],
     });
@@ -362,7 +361,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8669),
       repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
     });
     await game.step({ frames: 5 });
@@ -442,7 +440,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8670),
       repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/health.e2e.test.ts
+++ b/tools/shock2-sdk/test/health.e2e.test.ts
@@ -37,7 +37,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8092),
     });
 
     // Let the mission load and initialize scripts.

--- a/tools/shock2-sdk/test/hostile-ranged-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/hostile-ranged-damage.e2e.test.ts
@@ -11,7 +11,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_turret",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8574),
     });
 
     const hpBefore = (await game.info()).player.hit_points;

--- a/tools/shock2-sdk/test/hydro-research.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro-research.e2e.test.ts
@@ -129,7 +129,6 @@ test(
     const saveName = `hydro_research_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
     });
     await game.step({ frames: 5 });
     const supportedSavePosition = await game.player.position();

--- a/tools/shock2-sdk/test/hydro2-corpse-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-corpse-frob.e2e.test.ts
@@ -25,7 +25,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8231),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/hydro2-keycard-gates.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-keycard-gates.e2e.test.ts
@@ -55,7 +55,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-vr-keycard.e2e.test.ts
@@ -134,7 +134,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8620),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
@@ -170,7 +169,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8622),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
@@ -34,7 +34,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro3.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8600),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
@@ -39,7 +39,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
     });
 
     // Wield the pistol (first DebugCycleWeapon roster entry).

--- a/tools/shock2-sdk/test/info-inputs.e2e.test.ts
+++ b/tools/shock2-sdk/test/info-inputs.e2e.test.ts
@@ -13,7 +13,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_minimal",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9370),
     });
 
     for (const [channel, value] of [

--- a/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
@@ -31,7 +31,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8156),
     });
     await game.step({ frames: 5 });
 
@@ -219,7 +218,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8158),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/inventory-strength.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-strength.e2e.test.ts
@@ -13,7 +13,6 @@ import { teleportVerified } from "./helpers/teleport.js";
 // BLOCK art, and stores the four column-major items at 0,15,30,1 rather than
 // the Strength-1 width's 0,10,20,1.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8608);
 
 const isBlock = (element: UiElement) =>
   element.kind === "image" &&
@@ -64,7 +63,6 @@ test(
     const saveName = `inventory_strength_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
     });
     await game.step({ frames: 5 });
 
@@ -144,7 +142,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 1,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
@@ -179,7 +176,6 @@ test(
     const saveName = `inventory_pack_rat_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: basePort + 2,
     });
     await game.step({ frames: 5 });
     await Promise.all([

--- a/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
@@ -39,7 +39,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8133),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102),
     });
     // Let the scene auto-equip the amp.
     await game.step({ frames: 20 });
@@ -47,7 +46,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102) + 1,
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -33,7 +33,6 @@ test(
   async (t) => {
     await using game = await GameServer.launch({
       mission: "eng2.mis",
-      port: Number(process.env.SHOCK2_E2E_ENG2_CEILING_PORT ?? 8140),
     });
     await game.step({ frames: 5 });
 
@@ -179,7 +178,6 @@ test(
   async (t) => {
     await using game = await GameServer.launch({
       mission: "eng1.mis",
-      port: Number(process.env.SHOCK2_E2E_ENG1_OG_PIPE_PORT ?? 8141),
     });
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/jump.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8136),
     });
     await game.step({ frames: 5 });
 
@@ -221,7 +220,6 @@ test(
   async (t) => {
     await using game = await GameServer.launch({
       mission: "eng2.mis",
-      port: Number(process.env.SHOCK2_E2E_ENG2_JUMP_PORT ?? 8138),
     });
     await game.step({ frames: 5 });
 
@@ -337,7 +335,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_LOG_PORT ?? 8137),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/keypad.e2e.test.ts
+++ b/tools/shock2-sdk/test/keypad.e2e.test.ts
@@ -31,7 +31,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8118),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/launch-failure.e2e.test.ts
+++ b/tools/shock2-sdk/test/launch-failure.e2e.test.ts
@@ -16,10 +16,6 @@ test(
     await assert.rejects(
       GameServer.launch({
         mission: "doesnotexist.mis",
-        // The e2e suite runs serially (`--test-concurrency=1`), so ports don't
-        // collide across files; a unique default is just belt-and-suspenders for
-        // anyone running this file alongside others by hand.
-        port: Number(process.env.SHOCK2_E2E_PORT ?? 8095),
       }),
       (error: Error) => {
         assert.match(error.message, /debug_runtime failed to start/);

--- a/tools/shock2-sdk/test/lift-wall-attachment.e2e.test.ts
+++ b/tools/shock2-sdk/test/lift-wall-attachment.e2e.test.ts
@@ -33,7 +33,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8216),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
+++ b/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
@@ -48,8 +48,8 @@ async function entityCount(game: GameServer): Promise<number> {
  * save directory, so a machine that has never saved would otherwise show
  * "< EMPTY >" and the load assertions would be vacuous.
  */
-async function seedSave(port: number): Promise<void> {
-  await using game = await GameServer.launch({ mission: "medsci1.mis", port });
+async function seedSave(): Promise<void> {
+  await using game = await GameServer.launch({ mission: "medsci1.mis" });
   await game.step({ frames: 30 });
   await game.input.trigger("QuickSave");
   await game.step({ frames: 30 });
@@ -59,8 +59,8 @@ test(
   "the load screen opens from the menu and Done returns to it",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
   async () => {
-    await seedSave(8120);
-    await using game = await GameServer.launch({ mission: "main_menu", port: 8121 });
+    await seedSave();
+    await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 5 });
 
     // A frontend scene has no world entities.
@@ -94,8 +94,8 @@ test(
   "loading a save from the list restores a mission",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
   async () => {
-    await seedSave(8123);
-    await using game = await GameServer.launch({ mission: "main_menu", port: 8122 });
+    await seedSave();
+    await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 5 });
     assert.equal(await entityCount(game), 0);
 

--- a/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
@@ -16,7 +16,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8247),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/log-quest-bit.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-quest-bit.e2e.test.ts
@@ -28,7 +28,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops3.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8221),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -38,7 +38,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8166),
     });
     await game.step({ frames: 5 });
 
@@ -240,7 +239,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
     });
     await game.step({ frames: 5 });
 
@@ -292,7 +290,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro3.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8252),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/map.e2e.test.ts
+++ b/tools/shock2-sdk/test/map.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8167),
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -18,7 +18,6 @@ import { aimVrHandAt } from "./helpers/vr-hand.js";
 // identity split that made the campaign weapon physically shove creatures
 // without sending Damage.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8585);
 
 const MEDSCI1_WRENCH = 990;
 const WRENCH_CORPSE = 1177;
@@ -590,7 +589,6 @@ test(
     {
       await using control = await GameServer.launch({
         mission: "medsci2.mis",
-        port: basePort + 1,
         debugFlags: ["--vr"],
         echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
       });
@@ -617,7 +615,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
@@ -729,7 +726,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 2,
       repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
       debugFlags: ["--vr"],
       experimental: ["ragdoll"],

--- a/tools/shock2-sdk/test/medsci-sight-occlusion.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-sight-occlusion.e2e.test.ts
@@ -5,7 +5,6 @@ import { GameServer } from "../src/index.js";
 import type { EntityDetailResult, EntitySummary, Vec3 } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8560);
 
 // Stable MedSci2 mission-object identities. Runtime entity ids are assigned
 // afresh on every launch and are deliberately discovered below.
@@ -55,7 +54,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: basePort,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
@@ -145,7 +143,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: basePort + 1,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/medsci-threaten-og.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-threaten-og.e2e.test.ts
@@ -33,7 +33,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8206),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/medsci2-vr-released-item.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-vr-released-item.e2e.test.ts
@@ -137,7 +137,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8602),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
+++ b/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
@@ -53,7 +53,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8601),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/menu-audio.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-audio.e2e.test.ts
@@ -54,7 +54,7 @@ test(
   "the frontend plays the original hum, rollover and select sounds",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
   async () => {
-    await using game = await GameServer.launch({ mission: "main_menu", port: 8122 });
+    await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 10 });
 
     // The bed starts with the screen and loops under it.
@@ -116,7 +116,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8123,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });
@@ -157,7 +156,7 @@ test(
   "the bed stops when the menu is replaced without going through a click",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
   async () => {
-    await using game = await GameServer.launch({ mission: "main_menu", port: 8124 });
+    await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 10 });
 
     const before = (await played(game)).find((s) => s.sample === HUM);
@@ -187,7 +186,7 @@ test(
   "the pause overlay uses the same hum, rollover and select lifecycle",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
   async () => {
-    await using game = await GameServer.launch({ mission: "debug_minimal", port: 8125 });
+    await using game = await GameServer.launch({ mission: "debug_minimal" });
     await game.step({ frames: 10 });
 
     // Open over empty backdrop so the bed can be observed separately from a

--- a/tools/shock2-sdk/test/menu-quit.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-quit.e2e.test.ts
@@ -23,7 +23,7 @@ test(
   "clicking Quit in the flat menu requests a quit without killing the runtime",
   { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
   async () => {
-    await using game = await GameServer.launch({ mission: "main_menu", port: 8126 });
+    await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 10 });
 
     assert.equal(
@@ -61,7 +61,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8127,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/missions.e2e.test.ts
+++ b/tools/shock2-sdk/test/missions.e2e.test.ts
@@ -37,16 +37,13 @@ const MISSIONS = [
   "shodan.mis",
 ];
 
-const BASE_PORT = Number(process.env.SHOCK2_E2E_PORT ?? 8100);
-
-MISSIONS.forEach((mission, index) => {
+MISSIONS.forEach((mission) => {
   test(
     `mission loads: ${mission}`,
     { skip: !e2eEnabled, timeout: 300_000 },
     async () => {
       await using game = await GameServer.launch({
         mission,
-        port: BASE_PORT + index,
       });
 
       // Simulation advances without crashing.

--- a/tools/shock2-sdk/test/model-bounds-colliders.e2e.test.ts
+++ b/tools/shock2-sdk/test/model-bounds-colliders.e2e.test.ts
@@ -60,7 +60,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "station.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8188),
     });
     await game.step({ frames: 2 });
 
@@ -74,7 +73,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8189),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -50,7 +50,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
     });
 
     await game.step({ frames: 10 });
@@ -150,7 +149,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/montage-teleport-loop.e2e.test.ts
+++ b/tools/shock2-sdk/test/montage-teleport-loop.e2e.test.ts
@@ -39,7 +39,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/motion-query-tags.e2e.test.ts
+++ b/tools/shock2-sdk/test/motion-query-tags.e2e.test.ts
@@ -29,7 +29,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
     });
 
     await game.step({ frames: 10 });
@@ -61,7 +60,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/moving-terrain-carry.e2e.test.ts
+++ b/tools/shock2-sdk/test/moving-terrain-carry.e2e.test.ts
@@ -38,7 +38,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8188),
     });
     await game.step({ frames: 5 });
 
@@ -111,7 +110,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8189),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
+++ b/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
@@ -31,7 +31,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8094),
     });
 
     // debug_weapons starts unarmed; DebugCycleWeapon spawns and wields the pistol.

--- a/tools/shock2-sdk/test/nanite-player-stat.e2e.test.ts
+++ b/tools/shock2-sdk/test/nanite-player-stat.e2e.test.ts
@@ -24,7 +24,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8194),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/nanite-stack-label.e2e.test.ts
+++ b/tools/shock2-sdk/test/nanite-stack-label.e2e.test.ts
@@ -12,7 +12,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8193),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/nonfinite-body-report.e2e.test.ts
+++ b/tools/shock2-sdk/test/nonfinite-body-report.e2e.test.ts
@@ -32,7 +32,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "station.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8340),
     });
     await game.step({ frames: 30 }); // settle
 

--- a/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
@@ -48,7 +48,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8128),
     });
     await game.step({ frames: 2 });
     assert.equal(await game.quests.get("ShodanRoom"), "unknown");
@@ -80,7 +79,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8129),
     });
     await game.step({ frames: 2 });
 
@@ -136,7 +134,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8125),
     });
     await game.step({ frames: 2 });
     assert.equal(
@@ -173,7 +170,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops3.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8126),
     });
     await game.step({ frames: 2 });
 
@@ -204,7 +200,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops4.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8127),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/ops2-aim-visibility.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-aim-visibility.e2e.test.ts
@@ -11,7 +11,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8221),
     });
     const midwife = (
       await game.entities.list({ filter: "Midwife", limit: 20 })

--- a/tools/shock2-sdk/test/ops2-corpse-corridor.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-corpse-corridor.e2e.test.ts
@@ -22,7 +22,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8491),
     });
 
     const loaded = await game.load(saveName!);

--- a/tools/shock2-sdk/test/ops2-trigger-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-trigger-damage.e2e.test.ts
@@ -31,7 +31,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8486),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/ops4-door-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-door-save.e2e.test.ts
@@ -4,7 +4,6 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8184);
 
 test(
   "ops4.mis: tripwire door 676 stays open across a fresh-process save load",
@@ -16,7 +15,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "ops4.mis",
-        port: basePort,
       });
       await game.step({ frames: 5 });
       const door = (
@@ -43,7 +41,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "ops1.mis",
-        port: basePort + 1,
       });
       assert.equal((await game.load(saveName)).success, true);
       assert.equal((await game.info()).mission, "ops4.mis");

--- a/tools/shock2-sdk/test/ops4-trigger-destroy.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-trigger-destroy.e2e.test.ts
@@ -11,7 +11,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "ops4.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8176),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/ops4-tweq-emitter.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-tweq-emitter.e2e.test.ts
@@ -4,7 +4,6 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8188);
 
 const TRIPWIRE = 662;
 const EMITTER = 682;
@@ -35,7 +34,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "ops4.mis",
-        port: basePort,
       });
       await game.step({ frames: 5 });
 
@@ -123,7 +121,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "ops1.mis",
-        port: basePort + 1,
       });
       assert.equal((await game.load(midBurstSave)).success, true);
       assert.equal((await game.info()).mission, "ops4.mis");
@@ -157,7 +154,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "ops1.mis",
-        port: basePort + 2,
       });
       assert.equal((await game.load(completedSave)).success, true);
       assert.equal((await game.entities.byTemplate(EMITTER)).length, 0);

--- a/tools/shock2-sdk/test/os-traits.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-traits.e2e.test.ts
@@ -20,7 +20,6 @@ import { teleportVerified } from "./helpers/teleport.js";
 // medsci2's Trait Machine (mission id 133) opens nothing, so the "panel
 // opened" assertion fails.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8171);
 
 /** Find the level's Trait Machine by stable mission object id. */
 async function findMachine(game: GameServer, missionId: number) {
@@ -74,7 +73,6 @@ test(
     const saveName = `os_traits_e2e_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: basePort,
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/pathfinding-budget.e2e.test.ts
+++ b/tools/shock2-sdk/test/pathfinding-budget.e2e.test.ts
@@ -18,7 +18,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/pathfinding.e2e.test.ts
+++ b/tools/shock2-sdk/test/pathfinding.e2e.test.ts
@@ -15,7 +15,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8091),
     });
 
     // Give the mission a couple of frames to settle.

--- a/tools/shock2-sdk/test/patrol.e2e.test.ts
+++ b/tools/shock2-sdk/test/patrol.e2e.test.ts
@@ -52,7 +52,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "eng1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8161),
     });
 
     // Let the level's AIs instantiate.
@@ -143,7 +142,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8163),
     });
     // Leave the player at the authored spawn in the sealed cryo recovery room:
     // it has valid walkable support and is isolated from this patrol route.
@@ -242,7 +240,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8162),
     });
 
     // Move the player off the deck before anything can be seen, so the run is
@@ -347,7 +344,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "eng1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8164),
     });
 
     // Keep the player far away: this is about an AI nobody ever alerted.

--- a/tools/shock2-sdk/test/pause-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/pause-menu.e2e.test.ts
@@ -19,7 +19,6 @@ import { GameServer } from "../src/index.js";
 // keeps `Game::render` gated the world stops drawing - which is the VR
 // comfort/compositor bug (#1002/#1003) this design exists to avoid.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8210);
 
 const CANVAS_W = 640;
 const CANVAS_H = 480;
@@ -57,7 +56,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
     });
     await game.step({ frames: 30 });
 
@@ -113,7 +111,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 1,
     });
     await game.step({ frames: 30 });
 
@@ -146,7 +143,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_minimal",
-      port: basePort + 2,
     });
     await game.step({ frames: 30 });
 
@@ -172,7 +168,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 3,
     });
     await game.step({ frames: 30 });
 
@@ -218,7 +213,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 4,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -281,7 +275,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 5,
     });
     await game.step({ frames: 30 });
     await game.input.trigger("TogglePauseMenu");

--- a/tools/shock2-sdk/test/picture-swap.e2e.test.ts
+++ b/tools/shock2-sdk/test/picture-swap.e2e.test.ts
@@ -58,7 +58,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rec1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8153),
     });
     await game.step({ frames: 5 });
     const supportedSavePosition = await game.player.position();

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -5,7 +5,6 @@ import { GameServer } from "../src/index.js";
 import { carriedNaniteTotal } from "./helpers/earth-replicator.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8198);
 
 const RESURRECTION_BUTTON = 909;
 const RESURRECTION_TARGET = 187;
@@ -35,7 +34,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
     });
     await game.step({ frames: 5 });
 
@@ -80,7 +78,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 4,
     });
     await game.step({ frames: 5 });
 
@@ -147,7 +144,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 6,
     });
     await game.step({ frames: 5 });
     await game.input.set("head.look", [0, 0]);
@@ -195,7 +191,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "medsci1.mis",
-        port: basePort + 7,
       });
       await game.step({ frames: 30 });
       const sceneUi = async () =>
@@ -217,7 +212,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "medsci1.mis",
-        port: basePort + 8,
         debugFlags: ["--vr"],
       });
       await game.step({ frames: 30 });
@@ -243,7 +237,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 5,
     });
     await game.step({ frames: 5 });
 
@@ -284,7 +277,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 1,
     });
     await game.step({ frames: 5 });
 
@@ -360,7 +352,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 2,
     });
     await game.step({ frames: 5 });
 
@@ -416,7 +407,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 3,
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-hit-feedback.e2e.test.ts
@@ -18,7 +18,6 @@ import { GameServer } from "../src/index.js";
 // Negative-first: without the feature, (1) and (3) both fail - `/v1/scene` has
 // no `hit_feedback` object at all and the damage plays no sound whatsoever.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8101);
 
 const HIT_FEEDBACK_SOURCE = "hit_feedback";
 
@@ -54,7 +53,6 @@ for (const presentation of ["flat", "vr"] as const) {
     async () => {
       await using game = await GameServer.launch({
         mission: "medsci1.mis",
-        port: basePort,
         debugFlags: presentation === "vr" ? ["--vr"] : [],
       });
       await game.step({ frames: 60 });
@@ -107,7 +105,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 1,
     });
     await game.step({ frames: 60 });
 
@@ -142,7 +139,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 2,
     });
     await game.step({ frames: 60 });
 

--- a/tools/shock2-sdk/test/player-move.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-move.e2e.test.ts
@@ -28,7 +28,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
     });
     await game.step({ frames: 2 });
 
@@ -146,7 +145,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/powercell-recharge.e2e.test.ts
+++ b/tools/shock2-sdk/test/powercell-recharge.e2e.test.ts
@@ -35,7 +35,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8161),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/projectile-trail.e2e.test.ts
+++ b/tools/shock2-sdk/test/projectile-trail.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8101),
     });
 
     // Cycle to the laser pistol (4th roster entry).

--- a/tools/shock2-sdk/test/protocol-droid-self-destruct.e2e.test.ts
+++ b/tools/shock2-sdk/test/protocol-droid-self-destruct.e2e.test.ts
@@ -30,7 +30,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_protocol_droid",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/provisioning.e2e.test.ts
+++ b/tools/shock2-sdk/test/provisioning.e2e.test.ts
@@ -38,7 +38,6 @@ test(
     // state is a fresh character with nothing.
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8348),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/psi-overload.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-overload.e2e.test.ts
@@ -23,7 +23,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8098),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
@@ -48,7 +48,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8120),
     });
 
     // The scene auto-equips the Psi Amp on the first update.
@@ -95,7 +94,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "debug_camera",
-        port: Number(process.env.SHOCK2_E2E_PORT ?? 8121),
       });
       await game.step({ frames: 10 });
       const camera = (await game.entities.list({ filter: "Security Camera", limit: 5 }))
@@ -121,7 +119,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "debug_camera",
-        port: Number(process.env.SHOCK2_E2E_PORT ?? 8122),
       });
       await game.step({ frames: 10 });
       const camera = (await game.entities.list({ filter: "Security Camera", limit: 5 }))

--- a/tools/shock2-sdk/test/psi-trained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-trained.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8110),
     });
 
     await game.step({ frames: 10 });
@@ -48,7 +47,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT2 ?? 8111),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/psi.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8097),
     });
 
     // The scene auto-equips the Psi Amp on the first update.

--- a/tools/shock2-sdk/test/qbr-alcove-clearance.e2e.test.ts
+++ b/tools/shock2-sdk/test/qbr-alcove-clearance.e2e.test.ts
@@ -17,7 +17,6 @@ import { carriedNaniteTotal } from "./helpers/earth-replicator.js";
 // Negative-first: on main both the raw-input and bounded-move assertions below
 // report 0 at the wedge coordinates from the issue.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8206);
 
 // Stable mission-object ids (`template_id`), not runtime entity ids.
 const RESURRECTION_STATION = 423;
@@ -82,7 +81,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: basePort,
     });
     await game.step({ frames: 5 });
 
@@ -142,7 +140,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: basePort + 1,
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/quests.e2e.test.ts
+++ b/tools/shock2-sdk/test/quests.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8101),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/quickload-missing.e2e.test.ts
+++ b/tools/shock2-sdk/test/quickload-missing.e2e.test.ts
@@ -33,7 +33,6 @@ test(
     try {
       await using game = await GameServer.launch({
         mission: "debug_minimal",
-        port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
       });
 
       await game.input.trigger("QuickLoad");

--- a/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
       experimental: ["ragdoll"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
@@ -117,7 +116,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
       experimental: ["ragdoll"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/raycast-groups.e2e.test.ts
+++ b/tools/shock2-sdk/test/raycast-groups.e2e.test.ts
@@ -22,7 +22,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_RAYCAST_PORT ?? 8260),
     });
     // The first physics update populates Rapier's query broad phase.
     await game.step({ frames: 1 });

--- a/tools/shock2-sdk/test/rec-arrival-room.e2e.test.ts
+++ b/tools/shock2-sdk/test/rec-arrival-room.e2e.test.ts
@@ -86,7 +86,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rec1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8198),
     });
     assert.ok(arrivalSave);
     assert.equal((await game.load(arrivalSave)).success, true);
@@ -182,7 +181,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8198),
     });
     assert.ok(commandArrivalSave);
     assert.equal((await game.load(commandArrivalSave)).success, true);

--- a/tools/shock2-sdk/test/rec-dynamic-lights.e2e.test.ts
+++ b/tools/shock2-sdk/test/rec-dynamic-lights.e2e.test.ts
@@ -30,7 +30,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rec1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8588),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/rick1-quest-container.e2e.test.ts
+++ b/tools/shock2-sdk/test/rick1-quest-container.e2e.test.ts
@@ -39,7 +39,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rick1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8523),
     });
 
     const loaded = await game.load(saveName!);

--- a/tools/shock2-sdk/test/rick1-rumbler-junction.e2e.test.ts
+++ b/tools/shock2-sdk/test/rick1-rumbler-junction.e2e.test.ts
@@ -83,7 +83,6 @@ test(
     );
     await using game = await GameServer.launch({
       mission: "rick1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8290),
       debugFlags: ["--save-file", reproSave],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
       repoRoot: process.env.SHOCK2_REPO_ROOT,

--- a/tools/shock2-sdk/test/root-motion-velocity.e2e.test.ts
+++ b/tools/shock2-sdk/test/root-motion-velocity.e2e.test.ts
@@ -15,7 +15,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8108),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/save-load.e2e.test.ts
+++ b/tools/shock2-sdk/test/save-load.e2e.test.ts
@@ -22,8 +22,6 @@ import { earthWorldUse } from "./helpers/earth-world-use.js";
 // restored - which is impossible without the endpoints (the save call 404s).
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8101);
-
 interface PlayerVitals {
   hitPoints: number;
   maxHitPoints: number;
@@ -86,7 +84,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "medsci1.mis",
-        port: basePort,
       });
 
       await game.step({ frames: 2 });
@@ -120,7 +117,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "eng1.mis",
-        port: basePort + 1,
       });
 
       await game.step({ frames: 2 });
@@ -199,7 +195,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 2,
     });
     await game.step({ frames: 2 });
 
@@ -238,7 +233,6 @@ test(
 
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 5,
     });
     await game.step({ frames: 5 });
 
@@ -298,7 +292,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "earth.mis",
-        port: basePort + 3,
       });
       await game.step({ frames: 5 });
 
@@ -346,7 +339,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "eng1.mis",
-        port: basePort + 4,
       });
       await game.step({ frames: 2 });
       assert.equal((await game.info()).mission, "eng1.mis");

--- a/tools/shock2-sdk/test/search-behavior.e2e.test.ts
+++ b/tools/shock2-sdk/test/search-behavior.e2e.test.ts
@@ -30,7 +30,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8108),
     });
 
     await game.step({ frames: 10 });
@@ -91,7 +90,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/security-ecology.e2e.test.ts
+++ b/tools/shock2-sdk/test/security-ecology.e2e.test.ts
@@ -5,7 +5,6 @@ import { GameServer } from "../src/index.js";
 import type { EntityDetailResult, EntitySummary } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8482);
 
 // One complete authored medsci1 security ecology:
 //
@@ -51,7 +50,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/shodan-avatar-ecology.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-avatar-ecology.e2e.test.ts
@@ -72,7 +72,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8474),
     });
     await game.step({ frames: 10 });
 
@@ -93,7 +92,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8474) + 1,
     });
     await game.load(avatarSave!);
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/shodan-computer-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-computer-hacking.e2e.test.ts
@@ -253,7 +253,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8249),
       rustLog: "debug_runtime=info,shock2vr=debug",
     });
     assert.ok(bossSave);

--- a/tools/shock2-sdk/test/shodan-corpse-drift.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-corpse-drift.e2e.test.ts
@@ -26,7 +26,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8460),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/shodan-ending.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-ending.e2e.test.ts
@@ -22,7 +22,6 @@ test(
     assert.ok(endingSave);
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8251),
       debugFlags: ["--save-file", endingSave],
       rustLog: "debug_runtime=info,shock2vr=debug",
     });

--- a/tools/shock2-sdk/test/shodan-live-assassin-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-live-assassin-support.e2e.test.ts
@@ -24,7 +24,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8471),
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/shodan-start.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-start.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
 
@@ -74,7 +73,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "shodan.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233) + 1,
     });
 
     // Resume the reviewed campaign frontier immediately before the portal.

--- a/tools/shock2-sdk/test/simple-level-change-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/simple-level-change-button.e2e.test.ts
@@ -31,7 +31,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rec1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
     });
     await game.step({ frames: 2 });
     assert.equal(
@@ -68,7 +67,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rick3.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8124),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/slow-projectile-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/slow-projectile-spang.e2e.test.ts
@@ -24,7 +24,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
     });
 
     // Cycle to the laser pistol (4th roster entry).

--- a/tools/shock2-sdk/test/sound-awareness.e2e.test.ts
+++ b/tools/shock2-sdk/test/sound-awareness.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
     });
 
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/spawn-drop-to-floor.e2e.test.ts
+++ b/tools/shock2-sdk/test/spawn-drop-to-floor.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8131),
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
 

--- a/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
@@ -47,9 +47,8 @@ function dist2(a: Vec3, b: Vec3): number {
  */
 async function playCareer(
   branch: keyof typeof MARKERS,
-  port: number,
 ): Promise<{ maxHp: number; maxPsi: number }> {
-  await using game = await GameServer.launch({ mission: "earth.mis", port });
+  await using game = await GameServer.launch({ mission: "earth.mis" });
   await game.step({ frames: 5 });
 
   // Guard: selection must go through station's own entities, not the removed
@@ -104,10 +103,9 @@ test(
   "career: branches chosen at the recruitment intro deploy with distinct attributes",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8117);
-    const marine = await playCareer("marine", basePort);
-    const navy = await playCareer("navy", basePort + 1);
-    const osa = await playCareer("osa", basePort + 2);
+    const marine = await playCareer("marine");
+    const navy = await playCareer("navy");
+    const osa = await playCareer("osa");
 
     // Hit points differ across all three branches (Marines tankiest, OSA least).
     assert.notEqual(marine.maxHp, navy.maxHp, "Marine vs Navy HP should differ");

--- a/tools/shock2-sdk/test/station-career.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career.e2e.test.ts
@@ -22,7 +22,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "station.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -118,7 +118,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8130),
     });
     await game.step({ frames: 5 });
     await game.screenshot("station-flow-earth.png");
@@ -293,7 +292,6 @@ test(
  */
 async function enlist(
   branch: keyof typeof CAREER_DOORS,
-  port: number,
 ): Promise<{
   bit: string;
   hitPoints: number | null;
@@ -302,7 +300,7 @@ async function enlist(
   maxPsi: number | null;
 }> {
   const door = CAREER_DOORS[branch];
-  await using game = await GameServer.launch({ mission: "earth.mis", port });
+  await using game = await GameServer.launch({ mission: "earth.mis" });
   await game.step({ frames: 5 });
 
   await teleportTo(game, door.trip);
@@ -327,18 +325,16 @@ test(
   "station flow: Navy and OSA doors map to the correct career bit and loadout",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8131);
-
     // Navy: the door whose tripwire switches the mislabeled "SendToMarines"
     // marker (P$Service=1). Correct engine behavior yields the Navy career.
-    const navy = await enlist("navy", basePort);
+    const navy = await enlist("navy");
     assert.equal(navy.bit, "complete", "Navy door should set career_navy (despite the 'SendToMarines' misnomer)");
     assert.equal(navy.hitPoints, CAREER_DOORS.navy.maxHp, "Navy starts at full career HP");
     assert.equal(navy.maxHp, CAREER_DOORS.navy.maxHp, "Navy deploys with 35 max HP");
     assert.equal(navy.psiPoints, CAREER_DOORS.navy.maxPsi, "Navy starts at full career psi");
     assert.equal(navy.maxPsi, CAREER_DOORS.navy.maxPsi, "Navy deploys with 35 max psi");
 
-    const osa = await enlist("osa", basePort + 1);
+    const osa = await enlist("osa");
     assert.equal(osa.bit, "complete", "OSA door should set career_osa");
     assert.equal(osa.hitPoints, CAREER_DOORS.osa.maxHp, "OSA starts at full career HP");
     assert.equal(osa.maxHp, CAREER_DOORS.osa.maxHp, "OSA deploys with 30 max HP");

--- a/tools/shock2-sdk/test/teleport-position.e2e.test.ts
+++ b/tools/shock2-sdk/test/teleport-position.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
     });
     await game.step({ frames: 2 });
 

--- a/tools/shock2-sdk/test/trainer.e2e.test.ts
+++ b/tools/shock2-sdk/test/trainer.e2e.test.ts
@@ -19,7 +19,6 @@ import { teleportVerified } from "./helpers/teleport.js";
 // intentional SkillTrainerScript no-op stub (#424) - /v1/ui reports no active
 // panel, so the "panel opened" assertion fails.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8170);
 
 test(
   "trainer MFD: Strength expands inventory and Endurance raises max HP persistently",
@@ -28,7 +27,6 @@ test(
     const saveName = `trainer_e2e_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/transition-level.e2e.test.ts
+++ b/tools/shock2-sdk/test/transition-level.e2e.test.ts
@@ -20,7 +20,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8099),
     });
 
     await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/transition-revisit.e2e.test.ts
+++ b/tools/shock2-sdk/test/transition-revisit.e2e.test.ts
@@ -51,7 +51,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8118),
     });
 
     await game.step({ frames: 2 });
@@ -81,7 +80,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8118),
     });
 
     await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/transitions-trigger.e2e.test.ts
+++ b/tools/shock2-sdk/test/transitions-trigger.e2e.test.ts
@@ -21,7 +21,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
+++ b/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
@@ -85,7 +85,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "eng1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
     });
     await game.step({ frames: 10 });
 

--- a/tools/shock2-sdk/test/tripwire-crossing.e2e.test.ts
+++ b/tools/shock2-sdk/test/tripwire-crossing.e2e.test.ts
@@ -27,7 +27,6 @@ import type { Position } from "../src/index.js";
 // grants the Note_6_1 objective. Entities are discovered by stable mission
 // object id / name - runtime entity ids differ every launch.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8222);
 
 const TRIPWIRE_OBJECT_ID = 2308;
 const OBJECTIVE = "note_6_1";
@@ -97,7 +96,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: basePort,
     });
     const { wire, start } = await arriveAtTripwire(game);
 
@@ -128,7 +126,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: basePort + 1,
     });
     const { wire, start } = await arriveAtTripwire(game);
 
@@ -163,7 +160,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: basePort + 2,
     });
     const { wire, start } = await arriveAtTripwire(game);
 

--- a/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
@@ -161,7 +161,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
     });
     await game.step({ frames: 5 });
 
@@ -216,7 +215,6 @@ for (const advanced of ADVANCED_EXITS) {
     async () => {
       await using game = await GameServer.launch({
         mission: "earth.mis",
-        port: Number(process.env.SHOCK2_E2E_PORT ?? 8197),
       });
       await game.step({ frames: 5 });
 
@@ -248,7 +246,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8198),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
@@ -130,7 +130,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8571),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
@@ -29,7 +29,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8540),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/vr-cyber-interface-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-frob.e2e.test.ts
@@ -15,7 +15,6 @@ import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
 // Negative-first: on the parent this fails at the "collected" assertion -
 // the pile is still sitting there with the stat unchanged.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8577);
 
 /** Stable earth.mis mission object: a "Big Nanite Pile" (see
  * nanite-player-stat.e2e.test.ts). Collecting it moves a known amount into
@@ -30,7 +29,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: basePort,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -100,7 +98,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: basePort + 1,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
@@ -14,7 +14,6 @@ import { aimVrHandAtCanvas } from "./helpers/vr-hand.js";
 // reports no `panel_pose` and no `pointer`, so aiming at a slot changes
 // nothing and every assertion below fails there.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8581);
 
 const center = (el: UiElement): [number, number] => [
   el.rect[0] + el.rect[2] / 2,
@@ -57,7 +56,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -150,7 +148,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort + 1,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-cyber-interface.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface.e2e.test.ts
@@ -15,7 +15,6 @@ import { aimVrHandAt, normalize, quatFromTo } from "./helpers/vr-hand.js";
 // mode stays "shooter" and no strip appears, so the first assertion of each
 // scenario fails there.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8571);
 
 /** Weapon template cycled by DebugCycleWeapon (mission_core DEBUG_WEAPONS). */
 const LASER_PISTOL = -22;
@@ -35,7 +34,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: basePort,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -132,7 +130,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-elevator-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-elevator-world-panel.e2e.test.ts
@@ -99,7 +99,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "rec1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8541),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/vr-frontend-panel-anchor.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-frontend-panel-anchor.e2e.test.ts
@@ -131,7 +131,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8171,
       debugFlags: ["--vr"],
     });
     // Scene entry places the panel from the default head (yaw 0).
@@ -166,7 +165,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8172,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });
@@ -203,7 +201,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "main_menu",
-      port: 8173,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -28,7 +28,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102),
       debugFlags: ["--vr"],
     });
 
@@ -85,7 +84,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
       debugFlags: ["--vr"],
     });
 
@@ -142,7 +140,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
       debugFlags: ["--vr"],
     });
 
@@ -232,7 +229,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "earth.mis",
-        port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
       });
       await game.step({ frames: 10 });
 
@@ -263,7 +259,6 @@ test(
     // Without that dispatch the restored pistol keeps its saved world model.
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8105),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
@@ -286,7 +281,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
     });
 
     // In flat, DebugCycleWeapon spawns AND wields (sends Hold), which swaps the

--- a/tools/shock2-sdk/test/vr-loading-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-loading-panel.e2e.test.ts
@@ -66,7 +66,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
       experimental: ["loading_screen"],
       debugFlags: ["--vr"],
     });
@@ -108,7 +107,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT_FLAT ?? 8104),
       experimental: ["loading_screen"],
       debugFlags: [],
     });

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -72,7 +72,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8138),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
@@ -229,7 +228,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT_SAVE ?? 8139),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });
@@ -305,7 +303,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT_HELD_RAY ?? 8140),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -29,7 +29,6 @@ import type { Quat } from "./helpers/vr-hand.js";
 // Requires a 25th Anniversary install (DARK_ASSET_PATH): the vhots below are
 // the remastered `mods/sshock2ee.kpf` view models', which is what VR wields.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8102);
 
 /** Weapon templates cycled by DebugCycleWeapon (mission_core DEBUG_WEAPONS). */
 const LASER_PISTOL = -22;
@@ -182,7 +181,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -226,7 +224,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: basePort + 1,
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
@@ -73,7 +73,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
       debugFlags: ["--vr"],
     });
 

--- a/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
@@ -88,7 +88,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8414),
     });
 
     await game.step({ frames: 5 });
@@ -173,7 +172,6 @@ test(
     // pistol.
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8415),
     });
 
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
@@ -29,7 +29,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8099),
     });
 
     // Unarmed: no ammo type.

--- a/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
@@ -30,7 +30,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8096),
       // Flat is the debug runtime's default presentation; the flat path drives
       // the first-person fire loop.
     });

--- a/tools/shock2-sdk/test/weapon-cycle-authenticity.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-cycle-authenticity.e2e.test.ts
@@ -11,7 +11,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8379),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/weapon-reload-animation.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-reload-animation.e2e.test.ts
@@ -26,7 +26,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8098),
     });
 
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
@@ -31,7 +31,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8097),
     });
 
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/weapon-selection.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-selection.e2e.test.ts
@@ -36,7 +36,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8364),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/weapon-swap-holster.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-swap-holster.e2e.test.ts
@@ -26,7 +26,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8523),
     });
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/world-aim.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-aim.e2e.test.ts
@@ -23,7 +23,6 @@ test(
     // no corresponding mission asset exists.
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8221),
     });
     await game.step({ frames: 5 });
     // Provision and auto-wield the same loaded pistol used by the debug action.

--- a/tools/shock2-sdk/test/world-frob-pickup.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-frob-pickup.e2e.test.ts
@@ -17,7 +17,6 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "eng1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8192),
     });
     await game.step({ frames: 2 });
 


### PR DESCRIPTION
Completes the sequence started by #1130 (runtime reports its bound port) and
#1132 (SDK reads it instead of guessing). Those made ephemeral ports *possible*;
this makes the suite actually use them.

## Why

**178 of ~183 e2e files passed a fixed `port:`**, so they opted out of the
ephemeral default — and after #1132 they became *less* forgiving, because a
squatted port now fails the launch loudly instead of drifting to the next one.

That is not hypothetical. Several agents and sessions share this machine, and a
full `missions.e2e` run had `rec2.mis` (8114) and `command1.mis` (8116) fail,
then pass on four subsequent runs — consistent with another runtime holding
those ports.

## What

`port:` is **deleted**, not replaced with a helper. After #1132 the correct
behaviour is what you get by writing nothing, so a helper would be a new API to
misuse and a way to keep hardcoding ports. `game.baseUrl` already tells a
debugging human where the runtime actually landed.

The `process.env.SHOCK2_E2E_PORT ?? <literal>` wrappers go too: their purpose
was overriding a hardcoded default, and there is no longer a default to
override.

Derived ports (`… + 1`, `basePort`) marked tests that launch two runtimes and
were hand-separating them; those simply get two ephemeral ports now.

**Second commit** sweeps four files that landed *after* this branch was cut —
`melee-impact-sound`, `hydro3-vr-desk-loot`, `weapon-ammo-eject`, `dev-menu` —
which were written while a fixed port was still the convention and would have
reintroduced the problem on the day this merged.

Two `port:` occurrences deliberately survive, both correct:
`runtime-lifecycle`'s `port: 0` is the test's own squatter binding an ephemeral
port, and `unit.test.ts`'s `54321` is a parser fixture. Neither is a launch.

## Verification

Full suite, one clean run on a quiet machine: **330 passed, 4 failed, 8 skipped
(342 total).**

All four failures are **pre-existing on `main`**, not caused by this change —
which is easy to state with confidence here, because **this branch touches no
source whatsoever** (`git diff origin/main...HEAD -- tools/shock2-sdk/src/
shock2vr/ runtimes/` is empty). It is test files only.

- `creature loot`, `Earth hackable keypad`, `hydro3 Korenchkin log` — the three
  already documented as failing on main.
- `use mode exposes AMMOFULL ammo-cycle` — not previously in that list, so I
  triaged it: it reproduces in isolation, and it fails **identically** when the
  test file is reverted to main's own copy (fixed port and all). Pre-existing,
  and worth its own issue.

`./node_modules/.bin/tsc` clean · `npm test` 32/32.

https://claude.ai/code/session_017cm626D5M4tAz7yLPWPMFb
