### PR TITLE
test(items): match the restored nanite pile by its exact name

### DIFF
--- a/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
+++ b/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
@@ -126,7 +126,7 @@ test(
 
     // Entity ids do not survive the reload; find the restored pile by name.
     const carried = (await game.player.inventory()).items;
-    const pile = carried.find((item) => item.name?.includes("Nanites"));
+    const pile = carried.find((item) => item.name === NANITE_PILE);
     assert.ok(pile, `the reloaded backpack must still hold the pile: ${JSON.stringify(carried)}`);
 
     await game.input.trigger("ToggleUseMode");


### PR DESCRIPTION
Follow-up to #1147, which merged one commit short.

The save/load round-trip in `always-collected-categories.e2e.test.ts` looks up the reloaded backpack item by name (entity ids do not survive a reload). It searched for `"Nanites"`, but the item staged from the `Big Nanite Pile` template comes back named exactly that — so `assert.ok(pile, ...)` could never pass and the scenario failed on every run.

Verified: both scenarios in the file now pass against `main`.

```
ok 1 - medsci1 VR: squeezing a disc out of a loot panel files the log instead of holding it
ok 2 - medsci1 flat: clicking an already-inventoried nanite pile in the strip credits it
```

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72