### PR TITLE
feat(debug): place and aim the debug camera over HTTP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,26 @@ For debugging visual/rendering changes without a full interactive session:
    # (Teleporting into a trigger volume fires it, same as walking in.)
    curl -X POST http://127.0.0.1:8080/v1/control/input -d '{"right_hand.thumbstick": [0.0, 1.0]}'
 
+   # Place the debug (free) camera anywhere and aim it - the only way to
+   # photograph something the player's own eye cannot see, the player and
+   # whatever they are holding included. `position` is the world-space EYE
+   # position (the head composition is divided back out for you), and
+   # `look_at` aims at a world point; pass `rotation` [w,x,y,z] instead for an
+   # explicit orientation. Then step and screenshot as usual.
+   curl -X POST http://127.0.0.1:8080/v1/camera \
+     -d '{"position": [-32, 1, 21], "look_at": [-35, 0, 21]}'
+   curl http://127.0.0.1:8080/v1/camera            # read it back (eye_position/eye_rotation)
+   curl -X POST http://127.0.0.1:8080/v1/camera -d '{"detached": false}'   # back to the player
+   #
+   # Notes: placing turns the `free_camera` developer option on (nothing else
+   # would keep the placement past the next /v1/step, which re-attaches while
+   # the option is off). The pawn is NOT moved and nothing that reads the
+   # player's position notices - but while detached the locomotion sticks fly
+   # the camera instead of walking the player, so re-attach before driving.
+   # Culling still follows the *player* by default, so a camera placed in
+   # another room may see culled-away geometry; set the `free_camera_cull`
+   # dev param (POST /v1/dev-params) when framing from far away.
+
    # IMPORTANT: Always shut down when done to avoid interfering with user's session
    curl -X POST http://127.0.0.1:8080/v1/shutdown
    ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,10 @@ For debugging visual/rendering changes without a full interactive session:
    # the option is off). The pawn is NOT moved and nothing that reads the
    # player's position notices - but while detached the locomotion sticks fly
    # the camera instead of walking the player, so re-attach before driving.
+   # Aim the head (/v1/control/input head.look) BEFORE placing: the runtime
+   # composes the tracked head onto the camera pose, and the placement divides
+   # out the head as it was at request time, so a later head patch swings the
+   # camera off its look_at. Re-POST the placement if you re-aim.
    # Culling still follows the *player* by default, so a camera placed in
    # another room may see culled-away geometry; set the `free_camera_cull`
    # dev param (POST /v1/dev-params) when framing from far away.

--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -337,15 +337,31 @@ pass `"ignore_sensors": false` to probe sensor volumes deliberately.
 4. **Phase 7: CLI Tool** - Build out `debug_command` with all subcommands
 5. **Error Handling** - Standardize error responses with codes and suggestions
 6. **Documentation** - Add OpenAPI spec and usage examples
-7. **Aimable debug camera** - Let callers point the debug camera at an arbitrary
-   world position/orientation, so agents can frame whatever they're inspecting
-   (e.g. wherever a ragdoll lands) instead of relying on a fixed default view.
-   Either a new `/v1/camera` endpoint (set position + look-at target, or
-   position + rotation) or by honoring the head rotation already present in
-   `POST /v1/control/input`. Today the debug runtime hardcodes the camera head
-   rotation to the desktop default (`default_camera_head_rotation()` in
-   `runtimes/debug_runtime/src/main.rs`, looking toward -X); screenshots are only
-   representative when the subject happens to be in that default view.
+## Aimable Debug Camera ✅ COMPLETE
+
+`POST /v1/camera` places and aims the free (debug) camera, so a capture can
+frame whatever is being inspected - including the player and what they are
+holding, which the player-anchored eye cannot see at all.
+
+```bash
+curl -X POST .../v1/camera -d '{"position": [-32, 1, 21], "look_at": [-35, 0, 21]}'
+curl -X POST .../v1/camera -d '{"position": [-32, 1, 21], "rotation": [1, 0, 0, 0]}'
+curl -X POST .../v1/camera -d '{"detached": false}'   # back to the player
+curl .../v1/camera                                    # read it back
+```
+
+Poses are the world-space **eye** pose. The runtime builds its view as
+`(camera * head)^-1`, so the tracked head offset/rotation is divided back out
+of the request (`shock2vr::free_camera::pose_for_eye`) and multiplied back in
+for the read-back (`eye_for_pose`, reported as `eye_position`/`eye_rotation`) -
+otherwise a placement would render an eye-height above the requested point,
+yawed by the default view rotation.
+
+Placing turns the `free_camera` dev param on, because `Game::update` re-attaches
+the camera every frame while that option is off and there is no human at a
+Developer screen in a headless runtime. Culling still follows the *player*
+(`free_camera_cull`, off by default), so a camera placed in another room can see
+culled-away geometry - flip that dev param when framing from far away.
 
 ## Technical Notes
 

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -112,6 +112,14 @@ pub enum RuntimeCommand {
     /// rendering from when it is.
     GetCameraState(oneshot::Sender<CameraStateSnapshot>),
 
+    /// Place the free (debug) camera, or re-attach it to the player. Replies
+    /// with the resulting state, so a caller can read back what it set in the
+    /// same round trip.
+    SetCameraState {
+        request: SetCameraRequest,
+        reply: oneshot::Sender<Result<CameraStateSnapshot, String>>,
+    },
+
     /// Pathfinding test command (set_start, set_goal, reset)
     PathfindingTest(String, oneshot::Sender<CommandResult>),
 
@@ -719,6 +727,39 @@ pub struct CameraStateSnapshot {
     pub enabled: bool,
     pub position: Option<[f32; 3]>,
     /// Rotation as `[w, x, y, z]`.
+    pub rotation: Option<[f32; 4]>,
+    /// Where the *eye* actually ends up, once the runtime composes its tracked
+    /// head offset/rotation onto the camera pose above. This is the pose
+    /// `POST /v1/camera` takes and the one a screenshot is taken from, so a
+    /// caller reads back what it asked for rather than the compensated pose
+    /// stored underneath (see `shock2vr::free_camera::eye_for_pose`).
+    pub eye_position: Option<[f32; 3]>,
+    /// Eye rotation as `[w, x, y, z]`.
+    pub eye_rotation: Option<[f32; 4]>,
+}
+
+/// `POST /v1/camera`: detach and place the free (debug) camera, or re-attach it.
+///
+/// Every pose is the **eye** pose in world space - where the picture is taken
+/// from - not the internal camera pose the head composition sits on top of.
+///
+/// * `{"detached": false}` re-attaches to the player. No pose field is allowed.
+/// * Otherwise the camera detaches (that is the default) and moves:
+///   - `position` - where to put the eye. Required unless the camera already
+///     has a pose to patch.
+///   - `look_at` - a world point to aim at. The ergonomic primitive: "frame
+///     this entity" is `position` + `look_at`.
+///   - `rotation` - an explicit `[w, x, y, z]` orientation instead of
+///     `look_at`. The two are mutually exclusive.
+///   - Omitting both keeps the current orientation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SetCameraRequest {
+    /// `false` re-attaches. Omitted means "detached", since placing a camera
+    /// that is still attached to the player could not mean anything else.
+    pub detached: Option<bool>,
+    pub position: Option<[f32; 3]>,
+    pub look_at: Option<[f32; 3]>,
+    /// `[w, x, y, z]`, matching what `GET /v1/camera` reports.
     pub rotation: Option<[f32; 4]>,
 }
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1974,11 +1974,8 @@ fn input_snapshot_from_context(input: &InputContext) -> InputSnapshot {
 /// camera the runtime actually rendered from, which is what makes the death
 /// camera observable headlessly, and a second copy of this expression would
 /// drift from the one that matters.
-/// The tracked head this runtime composes onto the camera pose every frame -
-/// the offset `resolved_camera` passes and the rotation the input context
-/// holds. `POST /v1/camera` has to divide it back out (and `GET /v1/camera`
-/// multiply it back in) so the pose a caller names is the pose the picture is
-/// actually taken from.
+/// The *tracked* head this runtime reports: the crouch-aware eye height and
+/// whatever `/v1/control/input` last aimed the head at.
 fn tracked_head(game: &Game, input: &InputContext) -> (Vector3<f32>, Quaternion<f32>) {
     (
         vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
@@ -1986,10 +1983,32 @@ fn tracked_head(game: &Game, input: &InputContext) -> (Vector3<f32>, Quaternion<
     )
 }
 
+/// The head the renderer actually composes onto the camera pose this frame.
+///
+/// Not the tracked pair: while the player is dying the death camera *replaces*
+/// both components with the fallen eye (`death_camera::resolve`), and it does
+/// so with a full position, not a small delta. Dividing out the tracked pair
+/// instead would land a placement made during the fall metres away and have
+/// `GET /v1/camera` confidently report a pose that was never rendered - and
+/// "watch where the ragdoll landed" is exactly when an agent reaches for this.
+///
+/// The pawn is passed as the identity it is relative to, the same trick
+/// `capture_frame_snapshot` uses: `resolve` never touches the pawn half.
+fn composed_head(game: &Game, input: &InputContext) -> (Vector3<f32>, Quaternion<f32>) {
+    let (head_offset, head_rotation) = tracked_head(game, input);
+    let resolved = game.resolve_camera(
+        vec3(0.0, 0.0, 0.0),
+        Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        head_offset,
+        head_rotation,
+    );
+    (resolved.head_offset, resolved.head_rotation)
+}
+
 /// The free camera's state as `GET /v1/camera` (and the reply to a placement)
 /// reports it: the stored camera pose, plus the eye pose it renders as.
 fn camera_snapshot(game: &Game, input: &InputContext) -> CameraStateSnapshot {
-    let (head_offset, head_rotation) = tracked_head(game, input);
+    let (head_offset, head_rotation) = composed_head(game, input);
     let (detached, pose) = game.free_camera_state();
     let eye =
         pose.map(|pose| shock2vr::free_camera::eye_for_pose(pose, head_offset, head_rotation));
@@ -2013,8 +2032,8 @@ fn camera_snapshot(game: &Game, input: &InputContext) -> CameraStateSnapshot {
 /// * **The head composition.** The view is `(camera * head)^-1`, so a pose
 ///   handed straight to the free camera would render an eye-height above the
 ///   requested point, rotated by whatever the head last reported. It is divided
-///   out here (`free_camera::pose_for_eye`) against the same head
-///   `resolved_camera` uses.
+///   out here (`free_camera::pose_for_eye`) against `composed_head` - the head
+///   the renderer really composes, death-camera blend included.
 /// * **The developer gate.** `Game::update` re-attaches the camera every frame
 ///   while the `free_camera` dev param is off, so a placement made without it
 ///   would survive exactly until the next `/v1/step`. There is no human at a
@@ -2022,13 +2041,24 @@ fn camera_snapshot(game: &Game, input: &InputContext) -> CameraStateSnapshot {
 ///   turns the gate on itself (and `GET /v1/camera` reports it as `enabled`).
 ///   Re-attaching deliberately leaves the gate alone: the caller may have set
 ///   it on purpose, and re-attaching is already the full way back to the body.
+///   One consequence worth knowing: the gate stays on for the rest of the
+///   process, so the `ToggleFreeCamera` chord is live from the first placement.
+///
+/// The compensation is a snapshot of a live quantity, so a later
+/// `POST /v1/control/input` that patches `head.rotation` (or a crouch, which
+/// moves the eye height) swings a placed camera off its target - `GET` still
+/// reports the truth, because it recomputes, but the picture is no longer the
+/// one that was asked for. Re-issue the placement after aiming the head.
 fn apply_camera_request(
     game: &mut Game,
     input: &InputContext,
     request: &SetCameraRequest,
 ) -> Result<(), String> {
+    fn all_finite(values: &[f32]) -> bool {
+        values.iter().all(|v| v.is_finite())
+    }
     fn finite(label: &str, values: [f32; 3]) -> Result<Vector3<f32>, String> {
-        if values.iter().any(|v| !v.is_finite()) {
+        if !all_finite(&values) {
             return Err(format!(
                 "'{label}' must be three finite numbers, got {values:?}"
             ));
@@ -2054,7 +2084,7 @@ fn apply_camera_request(
         );
     }
 
-    let (head_offset, head_rotation) = tracked_head(game, input);
+    let (head_offset, head_rotation) = composed_head(game, input);
     // Patch semantics are against the *eye* pose, which is the pose the caller
     // named last time - not the compensated one stored underneath.
     let current_eye = game
@@ -2085,7 +2115,7 @@ fn apply_camera_request(
         })?
     } else if let Some([w, x, y, z]) = request.rotation {
         let quaternion = Quaternion::new(w, x, y, z);
-        if ![w, x, y, z].iter().all(|v| v.is_finite()) || quaternion.magnitude() < 1e-6 {
+        if !all_finite(&[w, x, y, z]) || quaternion.magnitude() < 1e-6 {
             return Err(format!(
                 "'rotation' must be a non-degenerate [w, x, y, z] quaternion, got {:?}",
                 [w, x, y, z]
@@ -2117,12 +2147,12 @@ fn resolved_camera(
     pawn_rotation: Quaternion<f32>,
     input: &InputContext,
 ) -> shock2vr::death_camera::CameraPose {
-    game.resolve_camera(
-        pawn_offset,
-        pawn_rotation,
-        vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
-        input.head.rotation,
-    )
+    // The head pair comes from `tracked_head` rather than being spelled out
+    // again here: `composed_head` - what `POST /v1/camera` divides back out -
+    // is this same pair put through the same `resolve_camera`, and the
+    // placement is only correct while the two agree.
+    let (head_offset, head_rotation) = tracked_head(game, input);
+    game.resolve_camera(pawn_offset, pawn_rotation, head_offset, head_rotation)
 }
 
 /// Capture current game state as a frame snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -33,7 +33,7 @@ use lifecycle::{DEFAULT_IDLE_TIMEOUT_SECS, IDLE_POLL_INTERVAL, IdleWatchdog};
 // Game engine imports
 extern crate glfw;
 use self::glfw::{Context, WindowEvent};
-use cgmath::{Quaternion, Rotation3, vec2, vec3};
+use cgmath::{InnerSpace, Quaternion, Rotation3, vec2, vec3};
 use dark::SCALE_FACTOR;
 use engine::{profile, scene::Scene, util::compute_view_matrix_from_render_context};
 use shock2vr::{
@@ -166,18 +166,6 @@ struct Args {
 /// Instance identifier from --instance-id, echoed by /v1/health
 static INSTANCE_ID: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
 
-/// Default debug-camera head rotation.
-///
-/// Matches the desktop runtime's default view orientation (`cargo dr`): at
-/// `yaw=0, pitch=0` the desktop camera forward is `(1,0,0)` fed through
-/// `look_at_rh`, so it looks toward `-X`. Mirroring it here keeps debug-runtime
-/// screenshots framed the same as what you see interactively on desktop.
-///
-/// TODO(camera-endpoint): make the debug camera aimable over HTTP - either a new
-/// `/v1/camera` endpoint or by honoring the head rotation in `/v1/control/input`
-/// - so an agent can point the camera at an arbitrary world point (e.g. wherever
-/// a ragdoll lands) instead of relying on this fixed default. Tracked in
-/// projects/debug-runtime.md.
 /// Fixed simulation timestep used while stepping (`/v1/step`), so frame- and
 /// time-based stepping advance a deterministic, wall-clock-independent amount of
 /// simulation time (60 Hz, matching the game's target frame rate).
@@ -192,6 +180,17 @@ const FIXED_STEP_DT: f32 = 1.0 / 60.0;
 /// ms is a no-op for automation but returns the core the rest of the time.
 const IDLE_SLEEP: Duration = Duration::from_millis(4);
 
+/// Default debug-camera head rotation.
+///
+/// Matches the desktop runtime's default view orientation (`cargo dr`): at
+/// `yaw=0, pitch=0` the desktop camera forward is `(1,0,0)` fed through
+/// `look_at_rh`, so it looks toward `-X`. Mirroring it here keeps debug-runtime
+/// screenshots framed the same as what you see interactively on desktop.
+///
+/// This is the *starting* value only - it is written once, before the loop, so
+/// `/v1/control/input` can aim the head from there. The same rotation is also
+/// composed onto the free camera's pose every frame, which is why
+/// `POST /v1/camera` divides it back out (see `apply_camera_request`).
 fn default_camera_head_rotation() -> Quaternion<f32> {
     head_rotation_from_yaw_pitch(0.0, 0.0)
 }
@@ -365,6 +364,7 @@ async fn start_http_server(
         .route("/v1/entities/:id/animation", get(get_animation_state))
         .route("/v1/player/position", get(get_player_position))
         .route("/v1/camera", get(get_camera_state))
+        .route("/v1/camera", axum::routing::post(set_camera_state))
         .route("/v1/player/teleport", axum::routing::post(teleport_player))
         .route(
             "/v1/player/move",
@@ -1367,16 +1367,15 @@ fn process_command(
             }
         }
         RuntimeCommand::GetCameraState(reply) => {
-            let (detached, pose) = game.free_camera_state();
-            let snapshot = CameraStateSnapshot {
-                detached,
-                enabled: shock2vr::free_camera::FreeCamera::is_enabled(),
-                position: pose.map(|(position, _)| [position.x, position.y, position.z]),
-                rotation: pose
-                    .map(|(_, rotation)| [rotation.s, rotation.v.x, rotation.v.y, rotation.v.z]),
-            };
-            if reply.send(snapshot).is_err() {
+            if reply.send(camera_snapshot(game, current_input)).is_err() {
                 tracing::warn!("Failed to send camera state - receiver dropped");
+            }
+        }
+        RuntimeCommand::SetCameraState { request, reply } => {
+            let result = apply_camera_request(game, current_input, &request)
+                .map(|()| camera_snapshot(game, current_input));
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send camera placement result - receiver dropped");
             }
         }
         RuntimeCommand::GetPlayerPosition(reply) => {
@@ -1975,6 +1974,143 @@ fn input_snapshot_from_context(input: &InputContext) -> InputSnapshot {
 /// camera the runtime actually rendered from, which is what makes the death
 /// camera observable headlessly, and a second copy of this expression would
 /// drift from the one that matters.
+/// The tracked head this runtime composes onto the camera pose every frame -
+/// the offset `resolved_camera` passes and the rotation the input context
+/// holds. `POST /v1/camera` has to divide it back out (and `GET /v1/camera`
+/// multiply it back in) so the pose a caller names is the pose the picture is
+/// actually taken from.
+fn tracked_head(game: &Game, input: &InputContext) -> (Vector3<f32>, Quaternion<f32>) {
+    (
+        vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
+        input.head.rotation,
+    )
+}
+
+/// The free camera's state as `GET /v1/camera` (and the reply to a placement)
+/// reports it: the stored camera pose, plus the eye pose it renders as.
+fn camera_snapshot(game: &Game, input: &InputContext) -> CameraStateSnapshot {
+    let (head_offset, head_rotation) = tracked_head(game, input);
+    let (detached, pose) = game.free_camera_state();
+    let eye =
+        pose.map(|pose| shock2vr::free_camera::eye_for_pose(pose, head_offset, head_rotation));
+    CameraStateSnapshot {
+        detached,
+        enabled: shock2vr::free_camera::FreeCamera::is_enabled(),
+        position: pose.map(|(position, _)| [position.x, position.y, position.z]),
+        rotation: pose.map(|(_, rotation)| [rotation.s, rotation.v.x, rotation.v.y, rotation.v.z]),
+        eye_position: eye.map(|(position, _)| [position.x, position.y, position.z]),
+        eye_rotation: eye
+            .map(|(_, rotation)| [rotation.s, rotation.v.x, rotation.v.y, rotation.v.z]),
+    }
+}
+
+/// Apply a `POST /v1/camera` request: re-attach, or detach and place the camera
+/// at the requested eye pose.
+///
+/// Two things this has to get right, both of which produce an endpoint that
+/// looks like it works and silently does nothing:
+///
+/// * **The head composition.** The view is `(camera * head)^-1`, so a pose
+///   handed straight to the free camera would render an eye-height above the
+///   requested point, rotated by whatever the head last reported. It is divided
+///   out here (`free_camera::pose_for_eye`) against the same head
+///   `resolved_camera` uses.
+/// * **The developer gate.** `Game::update` re-attaches the camera every frame
+///   while the `free_camera` dev param is off, so a placement made without it
+///   would survive exactly until the next `/v1/step`. There is no human at a
+///   Developer screen in a headless runtime, so placing the camera over HTTP
+///   turns the gate on itself (and `GET /v1/camera` reports it as `enabled`).
+///   Re-attaching deliberately leaves the gate alone: the caller may have set
+///   it on purpose, and re-attaching is already the full way back to the body.
+fn apply_camera_request(
+    game: &mut Game,
+    input: &InputContext,
+    request: &SetCameraRequest,
+) -> Result<(), String> {
+    fn finite(label: &str, values: [f32; 3]) -> Result<Vector3<f32>, String> {
+        if values.iter().any(|v| !v.is_finite()) {
+            return Err(format!(
+                "'{label}' must be three finite numbers, got {values:?}"
+            ));
+        }
+        Ok(vec3(values[0], values[1], values[2]))
+    }
+
+    if request.detached == Some(false) {
+        if request.position.is_some() || request.look_at.is_some() || request.rotation.is_some() {
+            return Err(
+                "'detached: false' re-attaches the camera to the player and takes no pose; \
+                 drop 'position'/'look_at'/'rotation', or set 'detached: true'"
+                    .to_string(),
+            );
+        }
+        game.attach_free_camera();
+        return Ok(());
+    }
+
+    if request.look_at.is_some() && request.rotation.is_some() {
+        return Err(
+            "'look_at' and 'rotation' are two ways to say the same thing; pass one".to_string(),
+        );
+    }
+
+    let (head_offset, head_rotation) = tracked_head(game, input);
+    // Patch semantics are against the *eye* pose, which is the pose the caller
+    // named last time - not the compensated one stored underneath.
+    let current_eye = game
+        .free_camera_state()
+        .1
+        .map(|pose| shock2vr::free_camera::eye_for_pose(pose, head_offset, head_rotation));
+
+    let position = match request.position {
+        Some(position) => finite("position", position)?,
+        None => {
+            current_eye
+                .ok_or_else(|| {
+                    "'position' is required: the camera is not placed yet, so there is nothing \
+                     to patch"
+                        .to_string()
+                })?
+                .0
+        }
+    };
+
+    let rotation = if let Some(target) = request.look_at {
+        let target = finite("look_at", target)?;
+        shock2vr::free_camera::look_at_rotation(position, target).ok_or_else(|| {
+            format!(
+                "'look_at' {:?} is the camera position itself, so there is no direction to aim",
+                [target.x, target.y, target.z]
+            )
+        })?
+    } else if let Some([w, x, y, z]) = request.rotation {
+        let quaternion = Quaternion::new(w, x, y, z);
+        if ![w, x, y, z].iter().all(|v| v.is_finite()) || quaternion.magnitude() < 1e-6 {
+            return Err(format!(
+                "'rotation' must be a non-degenerate [w, x, y, z] quaternion, got {:?}",
+                [w, x, y, z]
+            ));
+        }
+        quaternion.normalize()
+    } else {
+        current_eye
+            .ok_or_else(|| {
+                "'look_at' or 'rotation' is required: the camera is not placed yet, so there is \
+                 no orientation to keep"
+                    .to_string()
+            })?
+            .1
+    };
+
+    shock2vr::dev_params::set(shock2vr::dev_params::FREE_CAMERA, 1.0);
+    game.place_free_camera(shock2vr::free_camera::pose_for_eye(
+        (position, rotation),
+        head_offset,
+        head_rotation,
+    ));
+    Ok(())
+}
+
 fn resolved_camera(
     game: &Game,
     pawn_offset: Vector3<f32>,
@@ -2515,6 +2651,38 @@ async fn get_camera_state(
         Ok(snapshot) => Ok(Json(snapshot)),
         Err(_) => {
             tracing::error!("Failed to receive camera state - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler placing the free (debug) camera, or re-attaching it.
+///
+/// The write side of `GET /v1/camera`: it makes a third-person shot possible at
+/// all - the player and whatever they are holding, framed from outside - which
+/// the player-anchored eye simply cannot see.
+async fn set_camera_state(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<SetCameraRequest>,
+) -> Result<Json<CameraStateSnapshot>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if command_tx
+        .send(RuntimeCommand::SetCameraState {
+            request,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send SetCameraState command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+
+    match reply_rx.await {
+        Ok(Ok(snapshot)) => Ok(Json(snapshot)),
+        Ok(Err(message)) => Err((StatusCode::BAD_REQUEST, message)),
+        Err(_) => {
+            tracing::error!("Failed to receive camera placement result - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/free_camera.rs
+++ b/shock2vr/src/free_camera.rs
@@ -25,7 +25,9 @@
 //! channels are withheld from the scene (see `Game::update`), so the pawn
 //! stands still rather than sleepwalking off while you fly.
 
-use cgmath::{Matrix4, Quaternion, Rotation, Rotation3, SquareMatrix, Vector3, vec3};
+use cgmath::{
+    InnerSpace, Matrix3, Matrix4, Quaternion, Rotation, Rotation3, SquareMatrix, Vector3, vec3,
+};
 
 use crate::dev_params;
 use crate::input_context::InputContext;
@@ -75,6 +77,23 @@ impl FreeCamera {
     pub fn attach(&mut self) {
         self.detached = false;
         self.pose = None;
+    }
+
+    /// Detach the camera and put it at an explicit pose, in one step.
+    ///
+    /// Unlike [`toggle`], this leaves nothing to be captured later: the pose
+    /// is known now, so the very next frame renders from it. This is what an
+    /// out-of-process caller (the debug runtime's `POST /v1/camera`) uses to
+    /// place the camera, since there is no stick to fly it with.
+    ///
+    /// The pose is the *camera* pose, not the eye pose: a runtime composes its
+    /// tracked head offset/rotation on top of it (see [`pose_for_eye`], which
+    /// is how a caller who wants a particular eye pose gets there).
+    ///
+    /// [`toggle`]: Self::toggle
+    pub fn place(&mut self, pose: Pose) {
+        self.detached = true;
+        self.pose = Some(pose);
     }
 
     /// The captured pose, or `None` while attached (or on the single frame
@@ -206,6 +225,68 @@ pub fn without_locomotion(input_context: &InputContext) -> InputContext {
     withheld.jump = false;
     withheld.crouch = false;
     withheld
+}
+
+/// The rotation that aims a camera at `target` from `eye`, with no roll.
+///
+/// The camera convention is the engine's: the camera looks down its own `-Z`
+/// (which is why [`FreeCamera::fly`] walks the stick's forward along `-Z`), so
+/// the returned rotation maps `(0, 0, -1)` onto `normalize(target - eye)`.
+///
+/// `None` when there is no direction to speak of - `target` is `eye`, or one of
+/// them is not finite - rather than a silently arbitrary orientation.
+///
+/// Looking straight up or down has no roll-free "up" to level against, so the
+/// world up is swapped for a horizontal reference there; the result still faces
+/// the target exactly, which is the property callers depend on.
+pub fn look_at_rotation(eye: Vector3<f32>, target: Vector3<f32>) -> Option<Quaternion<f32>> {
+    let delta = target - eye;
+    if !delta.x.is_finite() || !delta.y.is_finite() || !delta.z.is_finite() {
+        return None;
+    }
+    if delta.magnitude2() < 1e-12 {
+        return None;
+    }
+    let forward = delta.normalize();
+    // The camera's own +Z points *backwards* along the view direction.
+    let back = -forward;
+    let world_up = vec3(0.0, 1.0, 0.0);
+    // Straight up/down: `world_up` is parallel to the view, so it cannot
+    // define "right". Level against world -Z instead, which keeps the picture
+    // upright in the same sense as looking at the horizon toward -Z.
+    let reference_up = if forward.cross(world_up).magnitude2() < 1e-6 {
+        vec3(0.0, 0.0, -1.0)
+    } else {
+        world_up
+    };
+    let right = reference_up.cross(back).normalize();
+    let up = back.cross(right);
+    Some(Quaternion::from(Matrix3::from_cols(right, up, back)))
+}
+
+/// The camera pose that renders the eye at exactly `eye`, given the tracked
+/// head offset/rotation the runtime composes on top of the camera pose.
+///
+/// A runtime builds its view as `(camera * head)^-1` (see
+/// `engine::util::compute_view_matrix`), so a caller who names a world pose for
+/// the *eye* - "stand here, look at that" - must have the head composition
+/// divided back out or the camera lands an eye-height above the requested point
+/// and rotated by whatever the head last reported. This is that division, and
+/// [`eye_for_pose`] is its inverse (what the eye actually ends up as).
+pub fn pose_for_eye(eye: Pose, head_offset: Vector3<f32>, head_rotation: Quaternion<f32>) -> Pose {
+    let rotation = eye.1 * head_rotation.invert();
+    (eye.0 - rotation.rotate_vector(head_offset), rotation)
+}
+
+/// Where the eye actually ends up for a camera pose, once the runtime composes
+/// its tracked head offset/rotation on top. The inverse of [`pose_for_eye`],
+/// and what `GET /v1/camera` reports so a caller reads back the pose it asked
+/// for rather than the compensated one stored underneath.
+pub fn eye_for_pose(pose: Pose, head_offset: Vector3<f32>, head_rotation: Quaternion<f32>) -> Pose {
+    (
+        pose.0 + pose.1.rotate_vector(head_offset),
+        pose.1 * head_rotation,
+    )
 }
 
 #[cfg(test)]
@@ -435,5 +516,125 @@ mod tests {
                 "corrected view {corrected:?} != player view {expected:?}"
             );
         }
+    }
+
+    /// A camera looks down its own -Z, so the look-at rotation must map -Z onto
+    /// the direction to the target. A subtly wrong look-at (a sign, or the
+    /// forward/back axis swapped) is invisible in a screenshot of an empty
+    /// corridor, so it is asserted numerically.
+    #[test]
+    fn a_look_at_rotation_points_the_camera_at_its_target() {
+        let eye = vec3(1.0, 2.0, 3.0);
+        for target in [
+            vec3(10.0, 2.0, 3.0),
+            vec3(-4.0, 9.0, 3.0),
+            vec3(1.0, 2.0, -8.0),
+            vec3(-2.5, -6.0, 7.25),
+        ] {
+            let rotation = look_at_rotation(eye, target).expect("a distinct target has a rotation");
+            let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+            let expected = (target - eye).normalize();
+            assert!(
+                (forward - expected).magnitude() < 1e-5,
+                "aimed {forward:?}, wanted {expected:?}"
+            );
+        }
+    }
+
+    /// Level against the horizon: aiming anywhere but straight up/down must
+    /// leave the camera's right axis horizontal, or every framed screenshot
+    /// comes out rolled.
+    #[test]
+    fn a_look_at_rotation_has_no_roll() {
+        let eye = vec3(0.0, 5.0, 0.0);
+        let rotation =
+            look_at_rotation(eye, vec3(12.0, 1.0, -7.0)).expect("a distinct target has a rotation");
+        let right = rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
+        assert!(right.y.abs() < 1e-5, "camera is rolled: right = {right:?}");
+        let up = rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+        assert!(up.y > 0.0, "camera is upside down: up = {up:?}");
+    }
+
+    /// Straight down is the degenerate case for "level against world up". It
+    /// must still aim exactly at the target rather than fall over into a NaN.
+    #[test]
+    fn a_look_at_rotation_survives_looking_straight_down() {
+        let eye = vec3(2.0, 20.0, -3.0);
+        let rotation =
+            look_at_rotation(eye, vec3(2.0, 0.0, -3.0)).expect("a distinct target has a rotation");
+        let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(
+            (forward - vec3(0.0, -1.0, 0.0)).magnitude() < 1e-5,
+            "aimed {forward:?}, wanted straight down"
+        );
+    }
+
+    /// No direction, no answer - rather than an arbitrary one.
+    #[test]
+    fn a_look_at_rotation_refuses_a_target_on_top_of_the_eye() {
+        assert!(look_at_rotation(vec3(1.0, 2.0, 3.0), vec3(1.0, 2.0, 3.0)).is_none());
+        assert!(look_at_rotation(vec3(0.0, 0.0, 0.0), vec3(f32::NAN, 0.0, 1.0)).is_none());
+    }
+
+    /// The whole point of the head compensation: a caller names an eye pose,
+    /// and the view the runtime actually builds - `(camera * head)^-1` - must
+    /// put the eye exactly there. Asserted against the engine's own view
+    /// matrix, not against a re-derivation of it.
+    #[test]
+    fn compensating_for_the_head_puts_the_eye_where_it_was_asked_for() {
+        let head_offset = vec3(0.0, 1.04, 0.0);
+        let head_rotation = Quaternion::from_angle_y(Deg(-90.0_f32));
+        let eye: Pose = (
+            vec3(4.0, 3.0, -6.0),
+            Quaternion::from_angle_y(Deg(20.0_f32)),
+        );
+
+        let pose = pose_for_eye(eye, head_offset, head_rotation);
+        let view = engine::util::compute_view_matrix(pose.0, pose.1, head_offset, head_rotation);
+        // The eye's world transform is the inverse of the view matrix.
+        let eye_to_world = view.invert().expect("a view matrix inverts");
+        let origin = eye_to_world * Vector4::new(0.0, 0.0, 0.0, 1.0);
+        assert!(
+            (vec3(origin.x, origin.y, origin.z) - eye.0).magnitude() < 1e-4,
+            "eye landed at {origin:?}, wanted {:?}",
+            eye.0
+        );
+        let forward = eye_to_world * Vector4::new(0.0, 0.0, -1.0, 0.0);
+        let expected = eye.1.rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(
+            (vec3(forward.x, forward.y, forward.z) - expected).magnitude() < 1e-4,
+            "eye faced {forward:?}, wanted {expected:?}"
+        );
+    }
+
+    /// `eye_for_pose` is what the read-back reports, so it has to be the exact
+    /// inverse of the compensation - otherwise a caller reads a pose it never
+    /// set.
+    #[test]
+    fn the_eye_and_camera_poses_round_trip() {
+        let head_offset = vec3(0.2, 1.7, -0.1);
+        let head_rotation = Quaternion::from_angle_x(Deg(15.0_f32));
+        let eye: Pose = (
+            vec3(-9.0, 2.5, 11.0),
+            Quaternion::from_angle_z(Deg(5.0_f32)),
+        );
+
+        let pose = pose_for_eye(eye, head_offset, head_rotation);
+        let (position, rotation) = eye_for_pose(pose, head_offset, head_rotation);
+        assert!((position - eye.0).magnitude() < 1e-4, "{position:?}");
+        let delta = rotation.rotate_vector(vec3(0.0, 0.0, -1.0))
+            - eye.1.rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(delta.magnitude() < 1e-4);
+    }
+
+    /// Placing is a detach and a pose in one: nothing is left to be captured
+    /// from the player on the next render (which would silently overwrite it).
+    #[test]
+    fn placing_the_camera_detaches_it_at_the_requested_pose() {
+        let mut camera = FreeCamera::new();
+        camera.place(elsewhere());
+        assert!(camera.is_detached());
+        assert_eq!(camera.pose(), Some(elsewhere()));
+        assert_eq!(camera.camera_pose(pawn()), elsewhere());
     }
 }

--- a/shock2vr/src/free_camera.rs
+++ b/shock2vr/src/free_camera.rs
@@ -25,9 +25,7 @@
 //! channels are withheld from the scene (see `Game::update`), so the pawn
 //! stands still rather than sleepwalking off while you fly.
 
-use cgmath::{
-    InnerSpace, Matrix3, Matrix4, Quaternion, Rotation, Rotation3, SquareMatrix, Vector3, vec3,
-};
+use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, Rotation3, SquareMatrix, Vector3, vec3};
 
 use crate::dev_params;
 use crate::input_context::InputContext;
@@ -237,8 +235,15 @@ pub fn without_locomotion(input_context: &InputContext) -> InputContext {
 /// them is not finite - rather than a silently arbitrary orientation.
 ///
 /// Looking straight up or down has no roll-free "up" to level against, so the
-/// world up is swapped for a horizontal reference there; the result still faces
-/// the target exactly, which is the property callers depend on.
+/// basis is leveled against a horizontal reference there instead; the result
+/// still faces the target exactly, which is the property callers depend on.
+///
+/// The basis itself is [`crate::util::get_rotation_from_forward_vector`] - the
+/// repo's one "aim a rotation along a direction" - fed the *negated* direction,
+/// which is the same call the panel anchor and the hit-feedback rim already
+/// make to turn a gaze direction into a camera-convention rotation. All this
+/// adds is the guard: a target on top of the eye has no direction, and a
+/// normalize there would hand back a NaN rotation.
 pub fn look_at_rotation(eye: Vector3<f32>, target: Vector3<f32>) -> Option<Quaternion<f32>> {
     let delta = target - eye;
     if !delta.x.is_finite() || !delta.y.is_finite() || !delta.z.is_finite() {
@@ -247,21 +252,10 @@ pub fn look_at_rotation(eye: Vector3<f32>, target: Vector3<f32>) -> Option<Quate
     if delta.magnitude2() < 1e-12 {
         return None;
     }
-    let forward = delta.normalize();
     // The camera's own +Z points *backwards* along the view direction.
-    let back = -forward;
-    let world_up = vec3(0.0, 1.0, 0.0);
-    // Straight up/down: `world_up` is parallel to the view, so it cannot
-    // define "right". Level against world -Z instead, which keeps the picture
-    // upright in the same sense as looking at the horizon toward -Z.
-    let reference_up = if forward.cross(world_up).magnitude2() < 1e-6 {
-        vec3(0.0, 0.0, -1.0)
-    } else {
-        world_up
-    };
-    let right = reference_up.cross(back).normalize();
-    let up = back.cross(right);
-    Some(Quaternion::from(Matrix3::from_cols(right, up, back)))
+    Some(crate::util::get_rotation_from_forward_vector(
+        -delta.normalize(),
+    ))
 }
 
 /// The camera pose that renders the eye at exactly `eye`, given the tracked

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1896,8 +1896,7 @@ impl Game {
         // outside it entirely. Worse, it strands the player: the frontend
         // panel is pawn-anchored, so a detached camera cannot see the menu it
         // would take to switch the camera back off.
-        self.free_camera.attach();
-        self.free_camera_view_fixup = None;
+        self.attach_free_camera();
     }
 
     /// The free camera's observable state: whether it is detached, and the

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1909,6 +1909,25 @@ impl Game {
         (self.free_camera.is_detached(), self.free_camera.pose())
     }
 
+    /// Detach the free camera and put it at an explicit *camera* pose - the
+    /// write side of [`free_camera_state`], for a caller with no stick to fly
+    /// it with (the debug runtime's `POST /v1/camera`).
+    ///
+    /// The pose is the one a runtime composes its tracked head offset/rotation
+    /// onto, not the eye pose; [`free_camera::pose_for_eye`] converts.
+    ///
+    /// [`free_camera_state`]: Self::free_camera_state
+    pub fn place_free_camera(&mut self, pose: free_camera::Pose) {
+        self.free_camera.place(pose);
+    }
+
+    /// Re-attach the free camera to the player. The pawn never moved, so there
+    /// is nothing to restore beyond dropping the override.
+    pub fn attach_free_camera(&mut self) {
+        self.free_camera.attach();
+        self.free_camera_view_fixup = None;
+    }
+
     /// Get hand spotlights for enhanced lighting when experimental flag is enabled
     pub fn get_hand_spotlights(&self) -> Vec<engine::scene::light::SpotLight> {
         // The lights belong to the hands: with the hands suppressed they would

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -637,6 +637,10 @@ export class CameraApi {
    * `free_camera` developer option on (nothing else would keep the placement
    * past the next step), and while the camera is detached the pawn will not
    * walk - the locomotion sticks fly the camera instead.
+   *
+   * Aim the head AFTER this and the camera swings off its target: the runtime
+   * composes the tracked head onto the camera pose, and this divides out the
+   * head as it is now. Place the camera last, or re-issue the placement.
    */
   async set(placement: CameraPlacement): Promise<CameraState> {
     return this.client.post<CameraState>("/v1/camera", {

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -4,6 +4,7 @@ import type {
   CommandResult,
   DebugEntityMessage,
   DevParamSetResult,
+  CameraPlacement,
   CameraState,
   DevParamsListResult,
   EntityDetailResult,
@@ -620,6 +621,35 @@ export class CameraApi {
    */
   async state(): Promise<CameraState> {
     return this.client.get<CameraState>("/v1/camera");
+  }
+
+  /**
+   * Detach the camera and place it in the world - the only way to photograph
+   * something the player's own eye cannot see, the player themselves included.
+   *
+   * `{ position, lookAt }` is the primitive worth reaching for: stand the
+   * camera off to one side and aim it at the thing under test. The returned
+   * state reports where the eye ended up, so a caller can assert on the pose it
+   * asked for rather than trusting the request.
+   *
+   * The simulation is untouched: the pawn does not move, and everything that
+   * reads the player's position keeps reading the body. Placing does turn the
+   * `free_camera` developer option on (nothing else would keep the placement
+   * past the next step), and while the camera is detached the pawn will not
+   * walk - the locomotion sticks fly the camera instead.
+   */
+  async set(placement: CameraPlacement): Promise<CameraState> {
+    return this.client.post<CameraState>("/v1/camera", {
+      detached: true,
+      position: placement.position,
+      look_at: placement.lookAt,
+      rotation: placement.rotation,
+    });
+  }
+
+  /** Return the view to the player's own eye. */
+  async attach(): Promise<CameraState> {
+    return this.client.post<CameraState>("/v1/camera", { detached: false });
   }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -434,7 +434,11 @@ export interface CameraPlacement {
   position?: [number, number, number];
   /** A world point to aim at - the ergonomic way to frame an entity. */
   lookAt?: [number, number, number];
-  /** An explicit orientation as [w, x, y, z], instead of `lookAt`. */
+  /**
+   * An explicit orientation as **[w, x, y, z]**, instead of `lookAt`. Note the
+   * order: it matches what `camera.state()` reports back, NOT the `[x, y, z, w]`
+   * the `head.rotation` input channel takes.
+   */
   rotation?: [number, number, number, number];
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -411,6 +411,31 @@ export interface CameraState {
   position: [number, number, number] | null;
   /** Rotation as [w, x, y, z]. */
   rotation: [number, number, number, number] | null;
+  /**
+   * Where the *eye* actually ends up, once the runtime composes its tracked
+   * head offset/rotation onto the camera pose above. This is the pose
+   * `camera.set()` takes and the one a screenshot is taken from, so it is the
+   * one to assert against.
+   */
+  eye_position: [number, number, number] | null;
+  /** Eye rotation as [w, x, y, z]. */
+  eye_rotation: [number, number, number, number] | null;
+}
+
+/**
+ * Where to put the free (debug) camera (POST /v1/camera).
+ *
+ * Poses are the *eye* pose in world space - where the picture is taken from.
+ * `lookAt` and `rotation` are two ways to say the same thing; pass one.
+ * Omitting a field keeps what the camera already has, so an already-placed
+ * camera can be re-aimed with `{ lookAt }` alone.
+ */
+export interface CameraPlacement {
+  position?: [number, number, number];
+  /** A world point to aim at - the ergonomic way to frame an entity. */
+  lookAt?: [number, number, number];
+  /** An explicit orientation as [w, x, y, z], instead of `lookAt`. */
+  rotation?: [number, number, number, number];
 }
 
 /** What a POST /v1/dev-params actually applied (after clamp/snap). */

--- a/tools/shock2-sdk/test/free-camera.e2e.test.ts
+++ b/tools/shock2-sdk/test/free-camera.e2e.test.ts
@@ -153,10 +153,8 @@ test("a placed camera renders from where it was put", { skip }, async () => {
     player.y + 2.5,
     player.z + 3,
   ];
-  const placed = await game.camera.set({
-    position: eye,
-    lookAt: [player.x, player.y + 1, player.z],
-  });
+  const target: [number, number, number] = [player.x, player.y + 1, player.z];
+  const placed = await game.camera.set({ position: eye, lookAt: target });
 
   assert.equal(placed.detached, true);
   assert.equal(
@@ -169,6 +167,27 @@ test("a placed camera renders from where it was put", { skip }, async () => {
     assert.ok(
       Math.abs(placed.eye_position[axis] - eye[axis]) < 1e-3,
       `eye landed at ${placed.eye_position}, wanted ${eye}`,
+    );
+  }
+
+  // ...and it is AIMED where it was told. Asserting only the position would
+  // pass a look-at that quietly points somewhere else - the composition
+  // (look_at -> pose_for_eye -> stored -> eye_for_pose) is what this closes.
+  assert.ok(placed.eye_rotation);
+  const [w, qx, qy, qz] = placed.eye_rotation;
+  // Rotate (0, 0, -1) by the reported quaternion - i.e. negate the rotation
+  // matrix's third column - to recover the camera's view direction.
+  const forward = [
+    -2 * (qx * qz + w * qy),
+    -2 * (qy * qz - w * qx),
+    -(1 - 2 * (qx * qx + qy * qy)),
+  ];
+  const toTarget = [target[0] - eye[0], target[1] - eye[1], target[2] - eye[2]];
+  const length = Math.hypot(...toTarget);
+  for (const axis of [0, 1, 2]) {
+    assert.ok(
+      Math.abs(forward[axis] - toTarget[axis] / length) < 1e-3,
+      `camera aimed ${forward}, wanted ${toTarget.map((v) => v / length)}`,
     );
   }
 
@@ -229,8 +248,10 @@ test("a nonsense camera placement is refused, not half-applied", { skip }, async
     /direction/,
   );
 
-  // None of that placed anything.
+  // None of that placed anything - including the developer gate, which is the
+  // side effect that would leak from a request applied halfway.
   const state = await game.camera.state();
   assert.equal(state.detached, false);
   assert.equal(state.position, null);
+  assert.equal(state.enabled, false, "a refused placement must not open the gate");
 });

--- a/tools/shock2-sdk/test/free-camera.e2e.test.ts
+++ b/tools/shock2-sdk/test/free-camera.e2e.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
@@ -117,4 +118,119 @@ test("a level reload re-attaches the camera", { skip }, async () => {
   assert.equal(after.detached, false, "a scene swap must re-attach the camera");
   assert.equal(after.position, null);
   assert.equal(after.enabled, true, "the developer option itself is not reset");
+});
+
+// The write side (POST /v1/camera). What it buys over toggling and flying is
+// that a capture can be *aimed*: an agent investigating something near the
+// player - a held weapon, the player themselves - can stand the camera off to
+// one side and photograph it, which the player-anchored eye cannot do.
+//
+// Negative-first, per assertion:
+//   - "the eye lands where it was asked to" fails without the head
+//     compensation: the runtime composes the tracked head offset/rotation onto
+//     the camera pose, so an uncompensated placement reports (and renders from)
+//     an eye-height above the requested point, yawed by the default view.
+//   - "the screenshot differs from the player's" fails without the developer-
+//     gate write: `Game::update` re-attaches the camera on the very next step,
+//     so the placement is gone by the time the picture is taken and the two
+//     images come back byte-identical (stepping is deterministic).
+//   - the rejection cases fail if a contradictory request is accepted and
+//     silently does half of what was asked.
+test("a placed camera renders from where it was put", { skip }, async () => {
+  await using game = await GameServer.launch({
+    mission: "medsci1.mis",
+    port: 8700,
+  });
+  await game.step({ frames: 30 });
+
+  const playerView = await game.screenshot("free-camera-player-view.png");
+  const player = await game.player.position();
+
+  // Stand off to one side and above, aimed back at the player's head: the
+  // third-person shot the player's own eye cannot take.
+  const eye: [number, number, number] = [
+    player.x + 3,
+    player.y + 2.5,
+    player.z + 3,
+  ];
+  const placed = await game.camera.set({
+    position: eye,
+    lookAt: [player.x, player.y + 1, player.z],
+  });
+
+  assert.equal(placed.detached, true);
+  assert.equal(
+    placed.enabled,
+    true,
+    "placing must turn the gate on, or the next step re-attaches",
+  );
+  assert.ok(placed.eye_position, "a placed camera reports its eye pose");
+  for (const axis of [0, 1, 2]) {
+    assert.ok(
+      Math.abs(placed.eye_position[axis] - eye[axis]) < 1e-3,
+      `eye landed at ${placed.eye_position}, wanted ${eye}`,
+    );
+  }
+
+  await game.step({ frames: 2 });
+  // The pose survives stepping - the gate is on and nothing recaptured it.
+  const held = await game.camera.state();
+  assert.equal(held.detached, true);
+  assert.ok(held.eye_position);
+  assert.ok(
+    Math.hypot(
+      held.eye_position[0] - eye[0],
+      held.eye_position[1] - eye[1],
+      held.eye_position[2] - eye[2],
+    ) < 1e-3,
+    `the camera drifted to ${held.eye_position}`,
+  );
+
+  const cameraView = await game.screenshot("free-camera-placed-view.png");
+  const fromPlayer = readFileSync(playerView.full_path);
+  const fromCamera = readFileSync(cameraView.full_path);
+  assert.ok(
+    !fromPlayer.equals(fromCamera),
+    "the camera view is byte-identical to the player view - the camera never moved",
+  );
+
+  // And back: the point of a spectator camera is that it is borrowable.
+  const attached = await game.camera.attach();
+  assert.equal(attached.detached, false);
+  assert.equal(attached.eye_position, null);
+});
+
+test("a nonsense camera placement is refused, not half-applied", { skip }, async () => {
+  await using game = await GameServer.launch({
+    mission: "medsci1.mis",
+    port: 8701,
+  });
+  await game.step({ frames: 30 });
+
+  // Nothing placed yet: a bare aim has no position to aim from.
+  await assert.rejects(
+    () => game.camera.set({ lookAt: [0, 0, 0] }),
+    /position/,
+    "aiming an unplaced camera must be refused",
+  );
+  // Two ways to say the same thing.
+  await assert.rejects(
+    () =>
+      game.camera.set({
+        position: [0, 0, 0],
+        lookAt: [1, 0, 0],
+        rotation: [1, 0, 0, 0],
+      }),
+    /look_at/,
+  );
+  // Aiming at the camera's own position is not a direction.
+  await assert.rejects(
+    () => game.camera.set({ position: [1, 2, 3], lookAt: [1, 2, 3] }),
+    /direction/,
+  );
+
+  // None of that placed anything.
+  const state = await game.camera.state();
+  assert.equal(state.detached, false);
+  assert.equal(state.position, null);
 });


### PR DESCRIPTION
## The failure this fixes

`GET /v1/camera` could *read* the free (debug) camera, but nothing could *place*
it, so every headless capture was taken from the player's own eye. An agent
investigating physically-held guns could not produce a before/after image of a
gun stopping against a wall: the debug runtime's VR eye sits ~1 m behind the
hand and looks `+Z`, so with the feature off the gun ended up behind the wall,
depth-culled out of frame. It shipped numbers instead of an image. Anything
*near* the player — and the player themselves — had the same problem;
third-person views were simply impossible.

`runtimes/debug_runtime/src/main.rs` carried the `TODO(camera-endpoint)` for
exactly this. It is now satisfied and removed (as is the corresponding
"next step" in `projects/debug-runtime.md`).

## The API

`POST /v1/camera`, beside the existing `GET`:

```bash
curl -X POST .../v1/camera -d '{"position": [-32, 1, 21], "look_at": [-35, 0, 21]}'
curl -X POST .../v1/camera -d '{"position": [-32, 1, 21], "rotation": [1, 0, 0, 0]}'
curl -X POST .../v1/camera -d '{"detached": false}'   # back to the player
```

- **Look-at is the primitive.** "Frame this entity/point" is what the motivating
  failure needed, so `position` + `look_at` is the ergonomic path; `rotation`
  `[w,x,y,z]` is there for a caller that already has an orientation. The two are
  mutually exclusive, and omitting both keeps what the camera already has, so an
  already-placed camera can be re-aimed with `look_at` alone.
- **Poses are the world-space *eye* pose** — where the picture is taken from —
  and the reply is that same pose, so a caller reads back exactly what it set
  and can restore it afterwards. `GET /v1/camera` gained `eye_position` /
  `eye_rotation` beside the raw camera pose it already reported.
- One endpoint rather than overloading `/v1/control/input`: that channel aims
  the *player*, and a spectator camera that swung whenever the player looked
  around would be a worse tool.

Two things had to be got right, both of which produce an endpoint that looks
like it works and silently does nothing:

- **The head composition.** The runtime builds its view as `(camera * head)^-1`,
  composing the head offset (eye height) and `InputContext.head.rotation` onto
  the camera pose *every frame* — `default_camera_head_rotation()` seeds that
  rotation to the desktop-default `-X` view. A pose handed straight to the free
  camera would therefore render an eye-height above the requested point, yawed
  by that default. `free_camera::pose_for_eye` divides the composition back out
  at placement; `eye_for_pose` multiplies it back in for the read-back. It is
  divided out against the head the renderer *actually* composes — the tracked
  pair put through `resolve_camera` — because while the player is dying the
  death camera replaces both components with the fallen eye, and "watch where
  the ragdoll landed" is exactly when an agent reaches for this endpoint. (The
  feared *per-frame overwrite* of `head.rotation` does not exist on `main` —
  that line runs once before the loop — but the per-frame *composition* is the
  real hazard, and it is what this handles.)
- **The developer gate.** `Game::update` re-attaches the camera every frame while
  the `free_camera` dev param is off, so a placement made without it would
  survive exactly until the next `/v1/step`. There is no human at a Developer
  screen in a headless runtime, so placing over HTTP turns the gate on itself and
  reports it back as `enabled`. Re-attaching deliberately leaves the gate alone.

`free_camera_cull` is untouched: culling still follows the **player**, which is
what makes the camera a tool for inspecting visibility rather than a way to make
geometry pop. A camera placed outside the player's own cell therefore sees
culled-away geometry (visible as the dark surround in the capture below) —
documented, with the dev param named as the opt-out.

## Evidence — the view that was impossible

`--mission medsci1.mis --vr`, a Wrench equipped into the VR right hand, same
simulation moment either side:

![before/after](https://gist.githubusercontent.com/tommy-xr/0d2c8f39248f27ceb5f43af049b76528/raw/camera-before-after.png)

Left, the player's own eye: the MedSci cryo bay, a sliver of its own forearm at
the top edge — it can never see itself or what it is holding. Right, the same
frame with `POST /v1/camera` putting the eye 2.2 units to the player's right and
`look_at` on the hand: the right hand and forearm gripping the Wrench, the left
hand beyond it. ([full-size
before](https://gist.githubusercontent.com/tommy-xr/0d2c8f39248f27ceb5f43af049b76528/raw/held-before-player-eye.png)
/ [after](https://gist.githubusercontent.com/tommy-xr/0d2c8f39248f27ceb5f43af049b76528/raw/held-after-third-person.png))

## Tests

- Unit (`shock2vr`, 7 new, 1078 total): the look-at maps `-Z` onto the target for
  a spread of directions, is roll-free, survives straight-down, and refuses a
  degenerate target; the head compensation is asserted against
  `engine::util::compute_view_matrix` itself, not a re-derivation, and
  `eye_for_pose` round-trips it.
- e2e (`tools/shock2-sdk/test/free-camera.e2e.test.ts`, extended): a placed
  camera reports the eye where it was asked for **and aimed at what it was
  aimed at**, holds both across steps, and produces a screenshot that differs
  **byte-for-byte** from the player-view screenshot — stepping is deterministic,
  so an identical image would mean the camera never moved. Plus a rejection test
  (nothing to patch, `look_at` + `rotation` together, aiming at the camera's own
  position) that also asserts a refused request does not open the dev-param gate.

Both halves confirmed failing first:

- Without the head compensation: `eye landed at -32.21,-1.28,20.61, wanted
  -31.97,-2.26,20.86`.
- Without the gate write: `placing must turn the gate on, or the next step
  re-attaches — false !== true`.

## Verification

`cargo fmt --all -- --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p
desktop_runtime -p debug_runtime`; `cargo test -p shock2vr --lib` → 1078 passed;
`tsc` + `npm test` (32) in the SDK; `free-camera.e2e.test.ts` 5/5;
`missions.e2e.test.ts` 23/23.

Reviewed with `/xreview` (Codex was out of quota this run, so a single Claude
reviewer plus the de-dup pass): the death-camera head, the shared look-at basis,
the two respelled helpers, the aim assertion and the gate assertion above are all
review findings, applied and re-validated.

https://claude.ai/code/session_017cm626D5M4tAz7yLPWPMFb
