### PR TITLE
feat(ui): drop items into the pointed-at inventory cell

### DIFF
--- a/shock2vr/src/inventory/mod.rs
+++ b/shock2vr/src/inventory/mod.rs
@@ -376,6 +376,15 @@ impl Inventory {
         true
     }
 
+    /// The entity occupying `(x, y)`, if any - including a cell a multi-cell
+    /// item merely extends into, not just its anchor.
+    pub fn entity_at(&self, x: usize, y: usize) -> Option<EntityId> {
+        if x >= self.width || y >= self.height {
+            return None;
+        }
+        self.grid[self.get_index(x, y)]
+    }
+
     pub fn remove_entity(&mut self, entity: EntityId) {
         for item in self.grid.iter_mut() {
             if let Some(contained_entity) = item {

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -292,6 +292,26 @@ impl FlatUiHost {
             .is_some_and(|rect| rect.contains(canvas_pos))
     }
 
+    /// The backpack grid cell `canvas_pos` lands in, or `None` when it is off
+    /// the strip (including a blocked/strength-capped column) - the deposit
+    /// target for a VR release aimed at the strip (see
+    /// `MissionCore::strip_deposit_entities`). The strip is drawn at 1:1
+    /// scale onto the canvas (`strip_canvas_rect` reuses `size_px` directly),
+    /// so the canvas offset alone recovers the panel-local pixel position
+    /// [`crate::scripts::gui::backpack_cell_at`] lays items out in - the same
+    /// inverse the strip's own rendering uses, so the resolved cell can never
+    /// drift from what is drawn.
+    pub fn strip_cell_at(&self, canvas_pos: Vector2<f32>, world: &World) -> Option<(usize, usize)> {
+        let strip = self.strip.as_ref()?;
+        let rect = self.strip_rect()?;
+        if !rect.contains(canvas_pos) {
+            return None;
+        }
+        let panel_pos = canvas_pos - Vector2::new(rect.x, rect.y);
+        let grid = crate::inventory::grid_for(world, strip.entity);
+        crate::scripts::gui::backpack_cell_at(panel_pos, grid)
+    }
+
     /// The item currently held on the cursor mid-drag (for `/v1/ui` `cursor`).
     pub fn cursor_debug(&self) -> Option<crate::game_scene::DebugUiCursor> {
         self.cursor_item

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -696,24 +696,20 @@ fn move_live_entity_into_container_at_cell(
     dropped_entity_id: EntityId,
     target_cell: (usize, usize),
 ) -> bool {
-    let fits = {
-        let grid = crate::inventory::grid_for(world, container_entity_id);
-        let occupied =
-            crate::inventory::Inventory::from_container(world, container_entity_id, grid);
-        let dims = world
-            .borrow::<View<dark::properties::PropInventoryDimensions>>()
-            .ok()
-            .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
-            .unwrap_or((1, 1));
-        occupied.has_capacity(
-            target_cell.0,
-            target_cell.1,
-            dims.0 as usize,
-            dims.1 as usize,
-        )
-    };
     let grid = crate::inventory::grid_for(world, container_entity_id);
-    let slot = fits.then(|| (target_cell.1 * grid.0 + target_cell.0) as u32);
+    let occupied = crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    let dims = world
+        .borrow::<View<dark::properties::PropInventoryDimensions>>()
+        .ok()
+        .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
+        .unwrap_or((1, 1));
+    let fits = occupied.has_capacity(
+        target_cell.0,
+        target_cell.1,
+        dims.0 as usize,
+        dims.1 as usize,
+    );
+    let slot = fits.then(|| occupied.slot_at(target_cell.0, target_cell.1));
     move_live_entity_into_container_at_slot(world, container_entity_id, dropped_entity_id, slot)
 }
 
@@ -1031,41 +1027,29 @@ mod cell_deposit_tests {
 
     use super::*;
 
-    fn container_with_item_at(
-        occupant_cell: Option<(u32, u32)>,
-    ) -> (World, EntityId, Option<EntityId>) {
+    fn container_with_item_at(occupant_cell: Option<(u32, u32)>) -> (World, EntityId) {
         let mut world = World::new();
-        let occupant = occupant_cell.map(|_| world.add_entity((PropHasRefs(false),)));
-        let to_links = match (occupant, occupant_cell) {
-            (Some(occupant), Some((x, y))) => vec![ToLink {
-                link: Link::Contains(y * crate::inventory::CONTAINER_GRID.0 as u32 + x),
-                to_entity_id: Some(WrappedEntityId(occupant)),
-                to_template_id: 0,
-            }],
-            _ => Vec::new(),
-        };
+        let to_links = occupant_cell
+            .map(|(x, y)| {
+                let occupant = world.add_entity((PropHasRefs(false),));
+                vec![ToLink {
+                    link: Link::Contains(y * crate::inventory::CONTAINER_GRID.0 as u32 + x),
+                    to_entity_id: Some(WrappedEntityId(occupant)),
+                    to_template_id: 0,
+                }]
+            })
+            .unwrap_or_default();
         let container = world.add_entity(Links { to_links });
-        (world, container, occupant)
+        (world, container)
     }
 
-    /// The reported bug: a targeted deposit over an empty cell must land
-    /// exactly there, not at the grid's first free slot. Fails on main, where
-    /// only `move_live_entity_into_container`'s always-first-free placement
-    /// exists.
-    #[test]
-    fn an_empty_target_cell_is_claimed_exactly() {
-        let (mut world, container, _occupant) = container_with_item_at(None);
-        let item = world.add_entity(PropHasRefs(false));
-
-        assert!(move_live_entity_into_container_at_cell(
-            &mut world,
-            container,
-            item,
-            (3, 1),
-        ));
-
-        let links = world.borrow::<View<Links>>().unwrap();
-        let slot = links
+    /// The `Contains` slot `item` is linked into `container` at, panicking if
+    /// it is not linked at all - the shared assertion every placement test
+    /// below reads its result through.
+    fn contains_slot(world: &World, container: EntityId, item: EntityId) -> u32 {
+        world
+            .borrow::<View<Links>>()
+            .unwrap()
             .get(container)
             .unwrap()
             .to_links
@@ -1078,55 +1062,13 @@ mod cell_deposit_tests {
                         _ => None,
                     })
             })
-            .expect("item should be linked into the container");
-        assert_eq!(
-            slot,
-            1 * crate::inventory::CONTAINER_GRID.0 as u32 + 3,
-            "must land at (3,1), not the first free cell"
-        );
+            .expect("item should be linked into the container")
     }
 
-    /// A cell already claimed by a different (non-matching) item falls back
-    /// to the ordinary first-free placement rather than evicting or swapping.
-    #[test]
-    fn an_occupied_target_cell_falls_back_to_first_free() {
-        let (mut world, container, occupant) = container_with_item_at(Some((0, 0)));
-        let item = world.add_entity(PropHasRefs(false));
-
-        assert!(move_live_entity_into_container_at_cell(
-            &mut world,
-            container,
-            item,
-            (0, 0),
-        ));
-
-        let links = world.borrow::<View<Links>>().unwrap();
-        let slot = links
-            .get(container)
-            .unwrap()
-            .to_links
-            .iter()
-            .find_map(|link| {
-                (link.to_entity_id.map(|w| w.0) == Some(item))
-                    .then_some(link.link.clone())
-                    .and_then(|l| match l {
-                        Link::Contains(slot) => Some(slot),
-                        _ => None,
-                    })
-            })
-            .expect("item should still be linked into the container");
-        assert_ne!(
-            slot, 0,
-            "cell 0 is taken by another item; the deposit must not overwrite it"
-        );
-        assert!(occupant.is_some());
-    }
-
-    /// A target cell holding a same-template stack is a merge candidate, not
-    /// a claim - `MissionCore::drop_entity_into_container_at_cell` sums the
-    /// counts and destroys the dropped entity instead of placing it.
-    #[test]
-    fn a_matching_stack_at_the_cell_is_detected_as_a_merge_target() {
+    /// A container holding one stackable occupant at cell (0,0), plus a
+    /// dropped entity carrying `dropped_template_id` - the shared setup for
+    /// `matching_stack_at_cell`'s matching/non-matching cases.
+    fn stack_world(dropped_template_id: i32) -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
         let occupant = world.add_entity((
             PropHasRefs(false),
@@ -1142,9 +1084,66 @@ mod cell_deposit_tests {
         });
         let dropped = world.add_entity((
             PropHasRefs(false),
-            PropTemplateId { template_id: 42 },
+            PropTemplateId {
+                template_id: dropped_template_id,
+            },
             PropStackCount(2),
         ));
+        (world, container, occupant, dropped)
+    }
+
+    /// The reported bug: a targeted deposit over an empty cell must land
+    /// exactly there, not at the grid's first free slot. Fails on main, where
+    /// only `move_live_entity_into_container`'s always-first-free placement
+    /// exists.
+    #[test]
+    fn an_empty_target_cell_is_claimed_exactly() {
+        let (mut world, container) = container_with_item_at(None);
+        let item = world.add_entity(PropHasRefs(false));
+
+        assert!(move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            item,
+            (3, 1),
+        ));
+
+        assert_eq!(
+            contains_slot(&world, container, item),
+            crate::inventory::CONTAINER_GRID.0 as u32 + 3,
+            "must land at (3,1), not the first free cell"
+        );
+    }
+
+    /// A cell already claimed by a different (non-matching) item falls back
+    /// to the ordinary first-free placement rather than evicting or swapping.
+    #[test]
+    fn an_occupied_target_cell_falls_back_to_first_free() {
+        let (mut world, container) = container_with_item_at(Some((0, 0)));
+        let item = world.add_entity(PropHasRefs(false));
+
+        assert!(move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            item,
+            (0, 0),
+        ));
+
+        // Column-major first-fit skips the occupied (0,0) and lands at
+        // (0,1) - slot 4 in the 4-wide `CONTAINER_GRID`.
+        assert_eq!(
+            contains_slot(&world, container, item),
+            crate::inventory::CONTAINER_GRID.0 as u32,
+            "cell 0 is taken by another item; the deposit must land at the next free cell"
+        );
+    }
+
+    /// A target cell holding a same-template stack is a merge candidate, not
+    /// a claim - `MissionCore::drop_entity_into_container_at_cell` sums the
+    /// counts and destroys the dropped entity instead of placing it.
+    #[test]
+    fn a_matching_stack_at_the_cell_is_detected_as_a_merge_target() {
+        let (world, container, occupant, dropped) = stack_world(42);
 
         assert_eq!(
             matching_stack_at_cell(&world, container, dropped, (0, 0)),
@@ -1157,24 +1156,7 @@ mod cell_deposit_tests {
     /// of silently folding unrelated items together.
     #[test]
     fn a_different_template_at_the_cell_is_not_a_merge_target() {
-        let mut world = World::new();
-        let occupant = world.add_entity((
-            PropHasRefs(false),
-            PropTemplateId { template_id: 42 },
-            PropStackCount(3),
-        ));
-        let container = world.add_entity(Links {
-            to_links: vec![ToLink {
-                link: Link::Contains(0),
-                to_entity_id: Some(WrappedEntityId(occupant)),
-                to_template_id: 0,
-            }],
-        });
-        let dropped = world.add_entity((
-            PropHasRefs(false),
-            PropTemplateId { template_id: 43 },
-            PropStackCount(2),
-        ));
+        let (world, container, _occupant, dropped) = stack_world(43);
 
         assert_eq!(
             matching_stack_at_cell(&world, container, dropped, (0, 0)),
@@ -1186,7 +1168,7 @@ mod cell_deposit_tests {
     /// cannot fit the item's authored footprint is not claimed, even empty.
     #[test]
     fn a_target_cell_too_small_for_the_items_footprint_falls_back() {
-        let (mut world, container, _occupant) = container_with_item_at(None);
+        let (mut world, container) = container_with_item_at(None);
         let item = world.add_entity((
             PropHasRefs(false),
             PropInventoryDimensions {
@@ -1204,22 +1186,11 @@ mod cell_deposit_tests {
             (0, 3),
         ));
 
-        let links = world.borrow::<View<Links>>().unwrap();
-        let slot = links
-            .get(container)
-            .unwrap()
-            .to_links
-            .iter()
-            .find_map(|link| {
-                (link.to_entity_id.map(|w| w.0) == Some(item))
-                    .then_some(link.link.clone())
-                    .and_then(|l| match l {
-                        Link::Contains(slot) => Some(slot),
-                        _ => None,
-                    })
-            })
-            .expect("item should be linked into the container");
-        assert_eq!(slot, 0, "falls back to the first free cell, (0,0)");
+        assert_eq!(
+            contains_slot(&world, container, item),
+            0,
+            "falls back to the first free cell, (0,0)"
+        );
     }
 }
 
@@ -3281,8 +3252,10 @@ impl MissionCore {
         // the strip between resolving `strip_cell` and here, or generally
         // defensive) falls back to `StoreItem`'s first-free placement.
         let cell_for = |entity_id: EntityId| -> Option<(usize, usize)> {
+            // `strip_cell[slot]` is only ever set alongside `on_strip[slot]`
+            // (see above), so matching on it alone is enough.
             (0..2).find_map(|slot| {
-                (on_strip[slot] && [left_hand_held, right_hand_held][slot] == Some(entity_id))
+                ([left_hand_held, right_hand_held][slot] == Some(entity_id))
                     .then_some(strip_cell[slot])
                     .flatten()
             })

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -301,6 +301,11 @@ fn strip_deposit_entities(
 /// rather than stored, so the credential is recorded instead of an inert card
 /// being banked.
 ///
+/// `store` pairs each stored item with the strip cell its release was over,
+/// when one resolved - the deposit becomes a [`VirtualHandEffect::StoreItemAtCell`]
+/// there, falling back to the first-free [`VirtualHandEffect::StoreItem`]
+/// only when no cell resolved.
+///
 /// The `ProvideForConsumption` offer goes too. It is what the hand offers to
 /// whatever its release raycast hit, and because the panel is not physical
 /// that ray reaches straight through it - so a container standing behind the
@@ -308,13 +313,15 @@ fn strip_deposit_entities(
 /// twice. Everything else the hand emitted this frame is untouched.
 fn rewrite_strip_release(
     effects: &mut Vec<VirtualHandEffect>,
-    store: &[EntityId],
+    store: &[(EntityId, Option<(usize, usize)>)],
     collect: &[EntityId],
 ) {
     if store.is_empty() && collect.is_empty() {
         return;
     }
-    let claimed = |entity_id: &EntityId| store.contains(entity_id) || collect.contains(entity_id);
+    let claimed = |entity_id: &EntityId| {
+        store.iter().any(|(item, _)| item == entity_id) || collect.contains(entity_id)
+    };
     let mut rewritten = Vec::with_capacity(effects.len());
     for effect in effects.drain(..) {
         match effect {
@@ -333,7 +340,13 @@ fn rewrite_strip_release(
                         },
                     }
                 } else {
-                    VirtualHandEffect::StoreItem { entity_id }
+                    match store.iter().find(|(item, _)| *item == entity_id) {
+                        Some((_, Some(cell))) => VirtualHandEffect::StoreItemAtCell {
+                            entity_id,
+                            cell: *cell,
+                        },
+                        _ => VirtualHandEffect::StoreItem { entity_id },
+                    }
                 });
             }
             VirtualHandEffect::OutMessage {
@@ -669,6 +682,85 @@ fn move_live_entity_into_container(
     container_entity_id: EntityId,
     dropped_entity_id: EntityId,
 ) -> bool {
+    move_live_entity_into_container_at_slot(world, container_entity_id, dropped_entity_id, None)
+}
+
+/// Like [`move_live_entity_into_container`], but prefers the cell
+/// `target_cell` names when it exists and can fit the item, and falls back to
+/// the first free cell otherwise (a cell held by another item, or outside the
+/// grid entirely) - retail drops an item where the player is pointing rather
+/// than always at the first free slot.
+fn move_live_entity_into_container_at_cell(
+    world: &mut World,
+    container_entity_id: EntityId,
+    dropped_entity_id: EntityId,
+    target_cell: (usize, usize),
+) -> bool {
+    let fits = {
+        let grid = crate::inventory::grid_for(world, container_entity_id);
+        let occupied =
+            crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+        let dims = world
+            .borrow::<View<dark::properties::PropInventoryDimensions>>()
+            .ok()
+            .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
+            .unwrap_or((1, 1));
+        occupied.has_capacity(
+            target_cell.0,
+            target_cell.1,
+            dims.0 as usize,
+            dims.1 as usize,
+        )
+    };
+    let grid = crate::inventory::grid_for(world, container_entity_id);
+    let slot = fits.then(|| (target_cell.1 * grid.0 + target_cell.0) as u32);
+    move_live_entity_into_container_at_slot(world, container_entity_id, dropped_entity_id, slot)
+}
+
+/// The occupant of `target_cell` in `container_entity_id`'s grid, if that
+/// occupant shares `dropped_entity_id`'s template and both carry a
+/// `PropStackCount` - the "matching stackable" a targeted deposit merges
+/// into instead of claiming a cell of its own. `None` when the cell is empty,
+/// off the grid, or holds an item that cannot be merged with.
+fn matching_stack_at_cell(
+    world: &World,
+    container_entity_id: EntityId,
+    dropped_entity_id: EntityId,
+    target_cell: (usize, usize),
+) -> Option<EntityId> {
+    let grid = crate::inventory::grid_for(world, container_entity_id);
+    let occupied = crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    let occupant = occupied.entity_at(target_cell.0, target_cell.1)?;
+    if occupant == dropped_entity_id {
+        return None;
+    }
+    let v_template = world
+        .borrow::<View<dark::properties::PropTemplateId>>()
+        .ok()?;
+    let v_stacks = world
+        .borrow::<View<dark::properties::PropStackCount>>()
+        .ok()?;
+    let dropped_template = v_template.get(dropped_entity_id).ok()?.template_id;
+    let occupant_template = v_template.get(occupant).ok()?.template_id;
+    if dropped_template != occupant_template {
+        return None;
+    }
+    v_stacks
+        .get(occupant)
+        .ok()
+        .and_then(|_| v_stacks.get(dropped_entity_id).ok())
+        .map(|_| occupant)
+}
+
+/// Shared placement body for [`move_live_entity_into_container`] and
+/// [`move_live_entity_into_container_at_cell`]: `requested_slot` names the
+/// exact ordinal to claim, or `None` for the first free cell.
+fn move_live_entity_into_container_at_slot(
+    world: &mut World,
+    container_entity_id: EntityId,
+    dropped_entity_id: EntityId,
+    requested_slot: Option<u32>,
+) -> bool {
     let is_alive = world
         .borrow::<EntitiesView>()
         .is_ok_and(|entities| entities.is_alive(dropped_entity_id));
@@ -680,20 +772,23 @@ fn move_live_entity_into_container(
     // was put instead of being repacked on every draw. Computed before
     // the borrow below, and *after* the item's own links are irrelevant -
     // it is not in the container yet, so it cannot occupy a cell here.
-    let slot = {
-        let grid = crate::inventory::grid_for(world, container_entity_id);
-        let occupied =
-            crate::inventory::Inventory::from_container(world, container_entity_id, grid);
-        let dims = world
-            .borrow::<View<dark::properties::PropInventoryDimensions>>()
-            .ok()
-            .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
-            .unwrap_or((1, 1));
-        // A full container still takes the item (the drop is already
-        // permitted by the caller); it just has no cell to remember.
-        occupied
-            .first_free_slot(dims.0 as usize, dims.1 as usize)
-            .unwrap_or(0)
+    let slot = match requested_slot {
+        Some(slot) => slot,
+        None => {
+            let grid = crate::inventory::grid_for(world, container_entity_id);
+            let occupied =
+                crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+            let dims = world
+                .borrow::<View<dark::properties::PropInventoryDimensions>>()
+                .ok()
+                .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
+                .unwrap_or((1, 1));
+            // A full container still takes the item (the drop is already
+            // permitted by the caller); it just has no cell to remember.
+            occupied
+                .first_free_slot(dims.0 as usize, dims.1 as usize)
+                .unwrap_or(0)
+        }
     };
 
     let mut was_able_to_drop = false;
@@ -927,6 +1022,204 @@ mod released_item_world_refs_tests {
 
         assert!(!restore_live_entity_world_refs(&mut world, item));
         assert!(!world.borrow::<EntitiesView>().unwrap().is_alive(item));
+    }
+}
+
+#[cfg(test)]
+mod cell_deposit_tests {
+    use dark::properties::{PropInventoryDimensions, PropStackCount, PropTemplateId};
+
+    use super::*;
+
+    fn container_with_item_at(
+        occupant_cell: Option<(u32, u32)>,
+    ) -> (World, EntityId, Option<EntityId>) {
+        let mut world = World::new();
+        let occupant = occupant_cell.map(|_| world.add_entity((PropHasRefs(false),)));
+        let to_links = match (occupant, occupant_cell) {
+            (Some(occupant), Some((x, y))) => vec![ToLink {
+                link: Link::Contains(y * crate::inventory::CONTAINER_GRID.0 as u32 + x),
+                to_entity_id: Some(WrappedEntityId(occupant)),
+                to_template_id: 0,
+            }],
+            _ => Vec::new(),
+        };
+        let container = world.add_entity(Links { to_links });
+        (world, container, occupant)
+    }
+
+    /// The reported bug: a targeted deposit over an empty cell must land
+    /// exactly there, not at the grid's first free slot. Fails on main, where
+    /// only `move_live_entity_into_container`'s always-first-free placement
+    /// exists.
+    #[test]
+    fn an_empty_target_cell_is_claimed_exactly() {
+        let (mut world, container, _occupant) = container_with_item_at(None);
+        let item = world.add_entity(PropHasRefs(false));
+
+        assert!(move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            item,
+            (3, 1),
+        ));
+
+        let links = world.borrow::<View<Links>>().unwrap();
+        let slot = links
+            .get(container)
+            .unwrap()
+            .to_links
+            .iter()
+            .find_map(|link| {
+                (link.to_entity_id.map(|w| w.0) == Some(item))
+                    .then_some(link.link.clone())
+                    .and_then(|l| match l {
+                        Link::Contains(slot) => Some(slot),
+                        _ => None,
+                    })
+            })
+            .expect("item should be linked into the container");
+        assert_eq!(
+            slot,
+            1 * crate::inventory::CONTAINER_GRID.0 as u32 + 3,
+            "must land at (3,1), not the first free cell"
+        );
+    }
+
+    /// A cell already claimed by a different (non-matching) item falls back
+    /// to the ordinary first-free placement rather than evicting or swapping.
+    #[test]
+    fn an_occupied_target_cell_falls_back_to_first_free() {
+        let (mut world, container, occupant) = container_with_item_at(Some((0, 0)));
+        let item = world.add_entity(PropHasRefs(false));
+
+        assert!(move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            item,
+            (0, 0),
+        ));
+
+        let links = world.borrow::<View<Links>>().unwrap();
+        let slot = links
+            .get(container)
+            .unwrap()
+            .to_links
+            .iter()
+            .find_map(|link| {
+                (link.to_entity_id.map(|w| w.0) == Some(item))
+                    .then_some(link.link.clone())
+                    .and_then(|l| match l {
+                        Link::Contains(slot) => Some(slot),
+                        _ => None,
+                    })
+            })
+            .expect("item should still be linked into the container");
+        assert_ne!(
+            slot, 0,
+            "cell 0 is taken by another item; the deposit must not overwrite it"
+        );
+        assert!(occupant.is_some());
+    }
+
+    /// A target cell holding a same-template stack is a merge candidate, not
+    /// a claim - `MissionCore::drop_entity_into_container_at_cell` sums the
+    /// counts and destroys the dropped entity instead of placing it.
+    #[test]
+    fn a_matching_stack_at_the_cell_is_detected_as_a_merge_target() {
+        let mut world = World::new();
+        let occupant = world.add_entity((
+            PropHasRefs(false),
+            PropTemplateId { template_id: 42 },
+            PropStackCount(3),
+        ));
+        let container = world.add_entity(Links {
+            to_links: vec![ToLink {
+                link: Link::Contains(0),
+                to_entity_id: Some(WrappedEntityId(occupant)),
+                to_template_id: 0,
+            }],
+        });
+        let dropped = world.add_entity((
+            PropHasRefs(false),
+            PropTemplateId { template_id: 42 },
+            PropStackCount(2),
+        ));
+
+        assert_eq!(
+            matching_stack_at_cell(&world, container, dropped, (0, 0)),
+            Some(occupant)
+        );
+    }
+
+    /// A same-cell item with a different template is an ordinary occupant,
+    /// not a merge target - the deposit must fall back to first-free instead
+    /// of silently folding unrelated items together.
+    #[test]
+    fn a_different_template_at_the_cell_is_not_a_merge_target() {
+        let mut world = World::new();
+        let occupant = world.add_entity((
+            PropHasRefs(false),
+            PropTemplateId { template_id: 42 },
+            PropStackCount(3),
+        ));
+        let container = world.add_entity(Links {
+            to_links: vec![ToLink {
+                link: Link::Contains(0),
+                to_entity_id: Some(WrappedEntityId(occupant)),
+                to_template_id: 0,
+            }],
+        });
+        let dropped = world.add_entity((
+            PropHasRefs(false),
+            PropTemplateId { template_id: 43 },
+            PropStackCount(2),
+        ));
+
+        assert_eq!(
+            matching_stack_at_cell(&world, container, dropped, (0, 0)),
+            None
+        );
+    }
+
+    /// A multi-cell item's target still respects capacity: a target cell that
+    /// cannot fit the item's authored footprint is not claimed, even empty.
+    #[test]
+    fn a_target_cell_too_small_for_the_items_footprint_falls_back() {
+        let (mut world, container, _occupant) = container_with_item_at(None);
+        let item = world.add_entity((
+            PropHasRefs(false),
+            PropInventoryDimensions {
+                width: 1,
+                height: 3,
+            },
+        ));
+
+        // (0, 3) is the last row of a 4-tall grid - a 1x3 item cannot fit
+        // starting there.
+        assert!(move_live_entity_into_container_at_cell(
+            &mut world,
+            container,
+            item,
+            (0, 3),
+        ));
+
+        let links = world.borrow::<View<Links>>().unwrap();
+        let slot = links
+            .get(container)
+            .unwrap()
+            .to_links
+            .iter()
+            .find_map(|link| {
+                (link.to_entity_id.map(|w| w.0) == Some(item))
+                    .then_some(link.link.clone())
+                    .and_then(|l| match l {
+                        Link::Contains(slot) => Some(slot),
+                        _ => None,
+                    })
+            })
+            .expect("item should be linked into the container");
+        assert_eq!(slot, 0, "falls back to the first free cell, (0,0)");
     }
 }
 
@@ -2870,6 +3163,10 @@ impl MissionCore {
         // the canvas is not a drop target, so a release there stays an
         // ordinary world drop.
         let mut on_strip = [false; 2];
+        // The strip cell each on-strip hand's ray currently lands on, for the
+        // release-deposit below - retail drops the item into the cell the
+        // player is pointing at rather than always the first free one.
+        let mut strip_cell: [Option<(usize, usize)>; 2] = [None; 2];
         if let Some(pass) = self.vr_use_mode_pointer.as_ref() {
             for ray in pass.rays.iter() {
                 let Some(canvas_hit) = ray.canvas_hit else {
@@ -2885,6 +3182,8 @@ impl MissionCore {
                     && self.flat_ui.strip_contains(canvas_hit)
                 {
                     on_strip[hand_slot(ray.handedness)] = true;
+                    strip_cell[hand_slot(ray.handedness)] =
+                        self.flat_ui.strip_cell_at(canvas_hit, &self.world);
                 }
             }
         }
@@ -2977,15 +3276,30 @@ impl MissionCore {
             crate::scripts::script_util::is_always_collected(&self.world, **entity_id)
         });
         let collect: Vec<_> = collect.into_iter().copied().collect();
+        // The cell the depositing hand's ray was over, for a stored item -
+        // whichever on-strip slot actually held it. `None` (a ray gone off
+        // the strip between resolving `strip_cell` and here, or generally
+        // defensive) falls back to `StoreItem`'s first-free placement.
+        let cell_for = |entity_id: EntityId| -> Option<(usize, usize)> {
+            (0..2).find_map(|slot| {
+                (on_strip[slot] && [left_hand_held, right_hand_held][slot] == Some(entity_id))
+                    .then_some(strip_cell[slot])
+                    .flatten()
+            })
+        };
         // A stored item needs backpack room, so nothing is claimed unless the
         // backpack can actually take it - a release is never suppressed into an
         // item that lands nowhere. A collected one never enters the pack (its
         // Frob awards and destroys it), so it is claimed either way.
-        let store: Vec<_> = if backpack_accepts_deposit(&self.world) {
-            store.into_iter().copied().collect()
-        } else {
-            Vec::new()
-        };
+        let store: Vec<(EntityId, Option<(usize, usize)>)> =
+            if backpack_accepts_deposit(&self.world) {
+                store
+                    .into_iter()
+                    .map(|entity_id| (*entity_id, cell_for(*entity_id)))
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.
@@ -4022,6 +4336,58 @@ impl MissionCore {
             &mut self.world,
             container_entity_id,
             dropped_entity_id,
+        );
+        if moved {
+            self.make_un_physical(dropped_entity_id);
+        }
+        moved
+    }
+
+    /// Like [`Self::drop_entity_into_container`], but targets `target_cell`
+    /// (the cyber-interface strip deposit, released over the grid cell the
+    /// player is pointing at) instead of always the first free cell.
+    ///
+    /// A cell already holding a matching stack merges into it - the dropped
+    /// entity is consumed rather than claiming a cell of its own - matching
+    /// the retail "drop onto a like stack" behavior. Any other occupied cell,
+    /// or a cell off the grid, falls back to the ordinary first-free
+    /// placement (no swap semantics for a VR release).
+    pub fn drop_entity_into_container_at_cell(
+        &mut self,
+        container_entity_id: EntityId,
+        dropped_entity_id: EntityId,
+        target_cell: (usize, usize),
+    ) -> bool {
+        if let Some(occupant) = matching_stack_at_cell(
+            &self.world,
+            container_entity_id,
+            dropped_entity_id,
+            target_cell,
+        ) {
+            let dropped_count = self
+                .world
+                .borrow::<View<dark::properties::PropStackCount>>()
+                .unwrap()
+                .get(dropped_entity_id)
+                .unwrap()
+                .0;
+            if let Ok(mut stacks) = self
+                .world
+                .borrow::<ViewMut<dark::properties::PropStackCount>>()
+            {
+                if let Ok(occupant_stack) = (&mut stacks).get(occupant) {
+                    occupant_stack.0 += dropped_count;
+                }
+            }
+            self.destroy_entity(dropped_entity_id);
+            return true;
+        }
+
+        let moved = move_live_entity_into_container_at_cell(
+            &mut self.world,
+            container_entity_id,
+            dropped_entity_id,
+            target_cell,
         );
         if moved {
             self.make_un_physical(dropped_entity_id);
@@ -8363,6 +8729,16 @@ impl MissionCore {
                         self.drop_entity_into_container(inventory_entity, entity_id);
                     }
                 }
+                VirtualHandEffect::StoreItemAtCell { entity_id, cell } => {
+                    let inventory_entity = self
+                        .world
+                        .borrow::<UniqueView<PlayerInfo>>()
+                        .map(|player| player.inventory_entity_id)
+                        .ok();
+                    if let Some(inventory_entity) = inventory_entity {
+                        self.drop_entity_into_container_at_cell(inventory_entity, entity_id, cell);
+                    }
+                }
                 VirtualHandEffect::DropItem { entity_id } => {
                     if !restore_live_entity_world_refs(&mut self.world, entity_id) {
                         continue;
@@ -11062,7 +11438,7 @@ mod strip_deposit_tests {
             VirtualHandEffect::DropItem { entity_id: item },
             VirtualHandEffect::DropItem { entity_id: other },
         ];
-        rewrite_strip_release(&mut effects, &[item], &[]);
+        rewrite_strip_release(&mut effects, &[(item, None)], &[]);
         assert!(
             matches!(
                 effects.as_slice(),
@@ -11078,6 +11454,33 @@ mod strip_deposit_tests {
                         entity_id: untouched
                     },
                 ] if *to == item && *entity_id == item && *untouched == other
+            ),
+            "got {effects:?}"
+        );
+    }
+
+    /// A resolved strip cell becomes a targeted store, not the first-free
+    /// one - retail drops the item into the cell the player is pointing at.
+    #[test]
+    fn a_claimed_release_with_a_resolved_cell_targets_it() {
+        let (_world, item, _other) = two_entities();
+        let mut effects = vec![VirtualHandEffect::DropItem { entity_id: item }];
+        rewrite_strip_release(&mut effects, &[(item, Some((3, 1)))], &[]);
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [
+                    VirtualHandEffect::OutMessage {
+                        message: Message {
+                            payload: MessagePayload::Drop,
+                            ..
+                        }
+                    },
+                    VirtualHandEffect::StoreItemAtCell {
+                        entity_id,
+                        cell: (3, 1)
+                    },
+                ] if *entity_id == item
             ),
             "got {effects:?}"
         );
@@ -11124,7 +11527,7 @@ mod strip_deposit_tests {
                 payload: MessagePayload::ProvideForConsumption { entity: item },
             },
         }];
-        rewrite_strip_release(&mut effects, &[item], &[]);
+        rewrite_strip_release(&mut effects, &[(item, None)], &[]);
         assert!(effects.is_empty(), "got {effects:?}");
     }
 
@@ -11143,7 +11546,7 @@ mod strip_deposit_tests {
             },
             VirtualHandEffect::HoldItem { entity_id: item },
         ];
-        rewrite_strip_release(&mut effects, &[item], &[]);
+        rewrite_strip_release(&mut effects, &[(item, None)], &[]);
         assert!(
             matches!(
                 effects.as_slice(),

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -465,6 +465,49 @@ mod tests {
         FrobFlag, KeyCard, Links, PropFrobInfo, PropHitPoints, PropKeySrc, ToLink, WrappedEntityId,
     };
 
+    /// The load-bearing invariant `backpack_cell_at`'s doc comment claims: it
+    /// must be the exact inverse of the pixel position `get_components` draws
+    /// each cell's item at, or a pointer position and an item's own drawn
+    /// position could resolve to different cells.
+    #[test]
+    fn backpack_cell_at_inverts_the_item_layout_formula() {
+        let grid = (10, 3);
+        for y in 0..grid.1 {
+            for x in 0..grid.0 {
+                // The pixel `get_components` places this cell's item icon at,
+                // offset into the cell's interior so it isn't sitting exactly
+                // on a boundary.
+                let drawn = BACKPACK_GRID_ORIGIN
+                    + Vector2::new(SLOT_PITCH.x * x as f32, SLOT_PITCH.y * y as f32)
+                    + Vector2::new(1.0, 1.0);
+                assert_eq!(
+                    backpack_cell_at(drawn, grid),
+                    Some((x, y)),
+                    "cell ({x},{y})'s own drawn position must resolve back to it"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn backpack_cell_at_rejects_off_grid_and_capped_columns() {
+        let grid = (10, 3);
+        assert_eq!(
+            backpack_cell_at(BACKPACK_GRID_ORIGIN - vec2(1.0, 0.0), grid),
+            None,
+            "left of the grid"
+        );
+        assert_eq!(
+            backpack_cell_at(BACKPACK_GRID_ORIGIN - vec2(0.0, 1.0), grid),
+            None,
+            "above the grid"
+        );
+        // Column 10 is a strength-capped column beyond a 10-wide usable grid,
+        // even though it is still inside the panel's full 15-column art.
+        let capped = BACKPACK_GRID_ORIGIN + Vector2::new(SLOT_PITCH.x * 10.0, 0.0);
+        assert_eq!(backpack_cell_at(capped, grid), None, "capped column");
+    }
+
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
     /// through.

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -85,6 +85,23 @@ const BACKPACK_GRID_ORIGIN: Vector2<f32> = Vector2::new(4.0, 17.0);
 /// leaving the separators in `INVBACK.PCX` visible around it.
 const BLOCK_SIZE: Vector2<f32> = Vector2::new(34.0, 32.0);
 
+/// The backpack grid cell a panel-local pixel position (in `invback.pcx`'s
+/// own 635x120 pixel space, the same space [`get_components`] lays items out
+/// in) lands in - the inverse of that layout, so a pointer position and an
+/// item's own position can never resolve to different cells. `grid` is the
+/// usable width/height from `grid_for` (strength-capped columns are not
+/// targetable). Returns `None` off the grid entirely, including a
+/// blocked/capped column.
+pub fn backpack_cell_at(panel_pos: Vector2<f32>, grid: (usize, usize)) -> Option<(usize, usize)> {
+    let local = panel_pos - BACKPACK_GRID_ORIGIN;
+    if local.x < 0.0 || local.y < 0.0 {
+        return None;
+    }
+    let x = (local.x / SLOT_PITCH.x) as usize;
+    let y = (local.y / SLOT_PITCH.y) as usize;
+    (x < grid.0 && y < grid.1).then_some((x, y))
+}
+
 impl ContainerGui {
     pub fn loot_container() -> ContainerGui {
         ContainerGui {

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -77,6 +77,15 @@ pub enum VirtualHandEffect {
     StoreItem {
         entity_id: EntityId,
     },
+    /// Like [`Self::StoreItem`], but for a VR release aimed at a specific
+    /// backpack grid cell (the cyber-interface strip deposit): retail drops
+    /// the item into the cell the player is pointing at rather than always
+    /// the first free one. Carries the same held-item `Drop`-first contract
+    /// as `StoreItem`.
+    StoreItemAtCell {
+        entity_id: EntityId,
+        cell: (usize, usize),
+    },
     /// Eject an item into the world (it regains physics + its world model).
     /// This is an explicit drop only: VR opening its hand. Losing an item to a
     /// wield swap is a `StoreItem`, not a drop (#777).

--- a/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
@@ -29,6 +29,26 @@ const STRIP_CANVAS: [number, number] = [320, 60];
  * and the case a ray aimed off the panel entirely cannot cover. */
 const BELOW_STRIP_CANVAS: [number, number] = [320, 400];
 
+/** The backpack grid's layout constants (shock2vr's `container.rs`:
+ * `BACKPACK_GRID_ORIGIN` (4, 17), `SLOT_PITCH` (35, 34)), plus the strip's
+ * canvas anchor (2, 0) - mirrored here so the test can compute a cell's
+ * expected canvas rect independently of the code under test. */
+const STRIP_ANCHOR: [number, number] = [2, 0];
+const BACKPACK_GRID_ORIGIN: [number, number] = [4, 17];
+const SLOT_PITCH: [number, number] = [35, 34];
+
+function cellTopLeft(cellX: number, cellY: number): [number, number] {
+  return [
+    STRIP_ANCHOR[0] + BACKPACK_GRID_ORIGIN[0] + SLOT_PITCH[0] * cellX,
+    STRIP_ANCHOR[1] + BACKPACK_GRID_ORIGIN[1] + SLOT_PITCH[1] * cellY,
+  ];
+}
+
+function cellCenter(cellX: number, cellY: number): [number, number] {
+  const [x, y] = cellTopLeft(cellX, cellY);
+  return [x + SLOT_PITCH[0] / 2, y + SLOT_PITCH[1] / 2];
+}
+
 async function launchWithHeldClip(port: number): Promise<{
   game: GameServer;
   clip: EntitySummary;
@@ -260,6 +280,56 @@ test(
       (await game.physics.bodies({ entityId: item })).bodies.length,
       0,
       "the item must not become a loose world prop",
+    );
+  },
+);
+
+test(
+  "releasing a held item over a specific empty strip cell deposits it there, not at the first free slot",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    // Retail drops a dragged item into the cell the player is pointing at.
+    // Negative-first: on the parent this lands at the backpack's first free
+    // cell (0, 0) regardless of where the release ray was aimed.
+    const { game, clip } = await launchWithHeldClip(basePort + 4);
+    await using _game = game;
+    // A middle cell, well clear of (0, 0) - a fresh earth character's
+    // backpack is empty, so first-free would also land at (0, 0).
+    const targetCell: [number, number] = [5, 1];
+
+    const pose = (await game.ui.state()).panel_pose!;
+    await aimVrHandAtCanvas(game, pose, cellCenter(...targetCell), {
+      squeeze: 1,
+    });
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      clip.id,
+      "aiming at the panel must not by itself drop the item",
+    );
+
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (item) => item.entity_id === clip.id,
+      )?.location,
+      "inventory",
+      "the clip must be in the backpack",
+    );
+
+    const strip = (await game.ui.state()).strip;
+    const slot = strip?.elements.find(
+      (element) => element.entity_id === clip.id,
+    );
+    assert.ok(slot, `the deposited clip must have a strip slot: ${JSON.stringify(strip?.elements)}`);
+    const [expectedX, expectedY] = cellTopLeft(...targetCell);
+    assert.deepEqual(
+      [slot.rect[0], slot.rect[1]],
+      [expectedX, expectedY],
+      `the clip must land at cell (${targetCell.join(",")}) = (${expectedX}, ${expectedY}), got rect ${JSON.stringify(slot.rect)}`,
     );
   },
 );


### PR DESCRIPTION
Retail System Shock 2 deposits a dragged/held item into the inventory grid **cell the player is pointing at**. The VR cyber-interface inventory-strip deposit didn't do this: releasing a held item over the strip always dropped it at the first free slot (e.g. cell (0,0)), ignoring where the hand ray was actually aimed.

Now: aiming at strip cell (x,y) and releasing a held item deposits it exactly there. Falls back to first-free only if the aimed cell is occupied by something that isn't a matching stack, or is off-grid.

The targeted-cell logic feeds a shared helper (`backpack_cell_at`/`strip_cell_at`) so cell resolution can't drift from what's actually drawn on screen.

Flat mode's own drag-to-rearrange path was checked and found to use a different mechanism entirely (the lifted item simply keeps its prior cell until placed on a matching/empty target) — it was not exhibiting the first-free bug, so it was left untouched.

## Changes

- `shock2vr/src/mission/mission_core.rs`: `VirtualHandEffect::StoreItemAtCell`, `MissionCore::drop_entity_into_container_at_cell`
- `shock2vr/src/mission/flat_ui_host.rs`: `FlatUiHost::strip_cell_at`
- `shock2vr/src/scripts/gui/container.rs`: `backpack_cell_at`

## Testing

- Unit tests added for the new cell-resolution helpers.
- New VR e2e test: `tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts` — "releasing a held item over a specific empty strip cell deposits it there, not at the first free slot". Negative-first: verified failing against the parent commit (lands at (0,0) regardless of aim), passing on this branch.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo test -p shock2vr` — 1077 passed.

## Demo

Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep): grab the Standard Clip, open the cyber interface, aim at strip cell (5,1), release.

![targeted-cell deposit demo](https://gist.githubusercontent.com/tommy-xr/a65ea74063c17486dd99d0f09f7f96b3/raw/demo.gif)

<sub>Grab the Standard Clip, open the cyber interface, aim at strip cell (5,1), release. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/a65ea74063c17486dd99d0f09f7f96b3/raw/beforeafter.png)

<sub>Same aim, same release, from a fresh launch on each build. Before (parent commit 9b375d61): the clip lands at cell (0,0) regardless of aim. After: it lands at the aimed-at cell (5,1).</sub>

