### PR TITLE
feat(audio): player footsteps paced by distance walked

### DIFF
--- a/dark/src/gamesys/env_sound_query.rs
+++ b/dark/src/gamesys/env_sound_query.rs
@@ -14,6 +14,13 @@ pub struct EnvSoundQueryItem {
 #[derive(Clone, Debug)]
 pub struct EnvSoundQuery {
     items: Vec<EnvSoundQueryItem>,
+    /// Take the *deepest* schema node the query reached rather than the
+    /// shallowest. The schema is a specificity tree and a match collects every
+    /// node along the path, so a query that refines an already-resolving node
+    /// (`material=metal` -> `landing=true`) otherwise resolves to the parent's
+    /// samples and the refinement is silently inert. Off by default so
+    /// existing lookups keep resolving exactly as they did.
+    prefer_most_specific: bool,
 }
 
 impl EnvSoundQueryItem {
@@ -28,11 +35,17 @@ impl EnvSoundQueryItem {
 
 impl EnvSoundQuery {
     pub fn new() -> Self {
-        Self { items: Vec::new() }
+        Self {
+            items: Vec::new(),
+            prefer_most_specific: false,
+        }
     }
 
     pub fn from_items(items: Vec<EnvSoundQueryItem>) -> Self {
-        Self { items }
+        Self {
+            items,
+            prefer_most_specific: false,
+        }
     }
 
     pub fn from_tag_values(items: Vec<(&str, &str)>) -> Self {
@@ -41,7 +54,19 @@ impl EnvSoundQuery {
                 .into_iter()
                 .map(|(tag, value)| EnvSoundQueryItem::new(tag, value))
                 .collect(),
+            prefer_most_specific: false,
         }
+    }
+
+    /// Resolve to the deepest matched schema node instead of the shallowest -
+    /// see [`EnvSoundQuery::prefer_most_specific`].
+    pub fn most_specific(mut self) -> Self {
+        self.prefer_most_specific = true;
+        self
+    }
+
+    pub fn prefers_most_specific(&self) -> bool {
+        self.prefer_most_specific
     }
 
     /// The (tag, value) pairs of this query, e.g. for logging/introspection.

--- a/dark/src/gamesys/env_sound_query.rs
+++ b/dark/src/gamesys/env_sound_query.rs
@@ -14,12 +14,14 @@ pub struct EnvSoundQueryItem {
 #[derive(Clone, Debug)]
 pub struct EnvSoundQuery {
     items: Vec<EnvSoundQueryItem>,
-    /// Take the *deepest* schema node the query reached rather than the
-    /// shallowest. The schema is a specificity tree and a match collects every
-    /// node along the path, so a query that refines an already-resolving node
+    /// Take the *last* schema node the match visited rather than the first.
+    /// The schema is a specificity tree and a match collects every node it
+    /// reaches, so a query that refines an already-resolving node
     /// (`material=metal` -> `landing=true`) otherwise resolves to the parent's
-    /// samples and the refinement is silently inert. Off by default so
-    /// existing lookups keep resolving exactly as they did.
+    /// samples and the refinement is silently inert. Only meaningful for a
+    /// fully-specified query that descends one path (see
+    /// `Gamesys::get_random_environmental_sound`). Off by default so existing
+    /// lookups keep resolving exactly as they did.
     prefer_most_specific: bool,
 }
 

--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -29,11 +29,16 @@ impl Gamesys {
     ) -> Option<ResolvedSoundSchema> {
         let tag_query = query.to_tag_query(&self.speech_db.tag_map, &self.speech_db.value_map);
         let result = self.env_tag_map.query_match_all(&tag_query);
-        if result.is_empty() {
-            return None;
-        }
+        // `query_match_all` appends the data of every node it matched on the
+        // way down, so the path's shallowest match is first and its most
+        // specific one last.
+        let id = if query.prefers_most_specific() {
+            result.last()
+        } else {
+            result.first()
+        }?;
 
-        self.sound_schema.resolve_id(result[0])
+        self.sound_schema.resolve_id(*id)
     }
 
     pub fn speech_db(&self) -> &SpeechDB {

--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -29,9 +29,12 @@ impl Gamesys {
     ) -> Option<ResolvedSoundSchema> {
         let tag_query = query.to_tag_query(&self.speech_db.tag_map, &self.speech_db.value_map);
         let result = self.env_tag_map.query_match_all(&tag_query);
-        // `query_match_all` appends the data of every node it matched on the
-        // way down, so the path's shallowest match is first and its most
-        // specific one last.
+        // `query_match_all` appends the data of every node it matched, in
+        // depth-first order, so the shallowest match on the path comes first
+        // and the deepest-visited one last. With a fully-specified query that
+        // descends a single path - which is what `most_specific` is for - the
+        // last id is that path's refinement; it is NOT a general "most
+        // specific" selector across several matching sibling branches.
         let id = if query.prefers_most_specific() {
             result.last()
         } else {

--- a/projects/footstep-sounds.md
+++ b/projects/footstep-sounds.md
@@ -114,7 +114,35 @@ geometry (`script_util::DEFAULT_IMPACT_MATERIAL`), so `material2` is the default
 bulkhead metal. For hybrids that resolves `ft_ogm*` rather than `ft_og*`, which
 is right for most of the ship and wrong on Hydroponics carpet/soil. See §4.
 
-## 3. The player — plan, not implemented
+## 3. The player — implemented
+
+Built as designed below (`shock2vr/src/mission/player_footsteps.rs`), with
+four corrections the plan did not anticipate:
+
+- **`landing=true` was inert.** The schema authors it, but the resolver takes
+  the *shallowest* matched node, so a landing query resolved to the ordinary
+  `ftmet1..4` rather than `ftmetj`. `EnvSoundQuery::most_specific()` is an
+  opt-in selector used only by the landing query.
+- **Ladders.** A ladder descent is neither walking nor falling, but the climb
+  branch reports ungrounded with a negative per-frame `y`, so a descent
+  accrued the whole shaft as fall distance and thudded at the bottom.
+  `PlayerHandle::is_climbing()` gates both the stride and the fall.
+- **The carry is not folded in by every branch.** Only the walk pass adds the
+  platform carry to its translation; the scripted mantle, top-out and ladder
+  branches do not, so each branch reports its own `self_translation` rather
+  than the caller subtracting a carry that was never applied.
+- **An arrival can be in mid-air.** A spawn point above the floor (or a
+  teleport onto a lip) settles after the relocation, which read as a fall, so
+  `reset()` also swallows the next touchdown.
+
+Cadence is calibrated from `PLAYER_MOVE_SPEED` and a named target of 3.5
+footsteps/second: the port's player moves at ~9.7 world units/second in the
+open, which is a run rather than a stroll. Beware measuring that speed by
+walking a mission for several seconds - the player spends most of it pressed
+against geometry, which reads as ~1.8 wu/s and mis-calibrates the stride by
+5x.
+
+### The original plan
 
 The player has no creature animation, so there is no foot flag to consume. A
 footstep has to be derived from locomotion. Rough size: **a day** for a good

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1523,6 +1523,12 @@ pub struct MissionCore {
     /// next weapon in `DEBUG_WEAPONS` (flat-mode aim/viewmodel testing).
     pub debug_weapon_index: usize,
 
+    /// Distance-paced player footsteps, fed by the movement call below. The
+    /// player has no locomotion animation to hang foot-plant flags on, so
+    /// their footsteps are derived from how far they walked - see
+    /// [`crate::mission::player_footsteps`].
+    player_footsteps: crate::mission::player_footsteps::PlayerFootsteps,
+
     /// First-person animation for the flat melee viewmodel: the wielded melee
     /// entity and its motion player (loops the player-melee idle; a swing is
     /// queued on attack and auto-returns to idle). `None` for guns / no weapon.
@@ -2396,6 +2402,7 @@ impl MissionCore {
             pathfinding_test: crate::mission::pathfinding_test::PathfindingTest::new(),
             debug_pose_index: 0,
             debug_weapon_index: 0,
+            player_footsteps: crate::mission::player_footsteps::PlayerFootsteps::new(),
             flat_melee_anim: None,
             use_mode: false,
             use_mode_ramp: crate::ui::entry_ramp::EntryExitRamp::new(),
@@ -2900,6 +2907,26 @@ impl MissionCore {
                 )
             )
         };
+
+        // Player footsteps, paced by the distance the player just walked under
+        // their own power (platform carry already removed). Only on a frame
+        // that actually ran the movement pass: a paused frame moved nobody,
+        // and `self_translation` still holds the last real frame's travel.
+        if !time.elapsed.is_zero() {
+            let footstep =
+                self.player_footsteps
+                    .update(crate::mission::player_footsteps::FootstepFrame {
+                        self_translation: self.player_handle.self_translation(),
+                        is_grounded: self.player_handle.is_grounded(),
+                        is_crouched: self.player_handle.is_crouched(),
+                    });
+            if let Some(footstep) = footstep {
+                effects.push(crate::mission::player_footsteps::player_footstep_effect(
+                    footstep,
+                    new_character_pos,
+                ));
+            }
+        }
 
         if !time.elapsed.is_zero() {
             let player_id = self
@@ -6899,6 +6926,11 @@ impl MissionCore {
                 } => {
                     self.physics
                         .set_player_translation(position, &mut self.player_handle);
+                    // Teleport locomotion, level load and quickload all land
+                    // here, and none of them ran a movement frame: forget the
+                    // stride and the fall in progress so the arrival is silent
+                    // rather than a burst of steps or a phantom thud.
+                    self.player_footsteps.reset();
                     if is_teleport {
                         self.world
                             .add_component(player_entity, PropTeleported::with_source(source))
@@ -10069,6 +10101,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         // Apply the teleportation using the same logic as Effect::SetPlayerPosition
         self.physics
             .set_player_translation(position, &mut self.player_handle);
+        self.player_footsteps.reset();
 
         // Keep PlayerInfo.pos consistent with the body immediately. It otherwise
         // only re-syncs from the physics body on the next update(), so a query

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2908,17 +2908,19 @@ impl MissionCore {
             )
         };
 
-        // Player footsteps, paced by the distance the player just walked under
-        // their own power (platform carry already removed). Only on a frame
-        // that actually ran the movement pass: a paused frame moved nobody,
-        // and `self_translation` still holds the last real frame's travel.
         if !time.elapsed.is_zero() {
+            // Player footsteps, paced by the distance the player just walked
+            // under their own power (platform carry already removed). Only on
+            // a frame that actually ran the movement pass: a paused frame
+            // moved nobody, and `self_translation` still holds the last real
+            // frame's travel.
             let footstep =
                 self.player_footsteps
                     .update(crate::mission::player_footsteps::FootstepFrame {
                         self_translation: self.player_handle.self_translation(),
                         is_grounded: self.player_handle.is_grounded(),
                         is_crouched: self.player_handle.is_crouched(),
+                        is_climbing: self.player_handle.is_climbing(),
                     });
             if let Some(footstep) = footstep {
                 effects.push(crate::mission::player_footsteps::player_footstep_effect(
@@ -2926,9 +2928,7 @@ impl MissionCore {
                     new_character_pos,
                 ));
             }
-        }
 
-        if !time.elapsed.is_zero() {
             let player_id = self
                 .world
                 .borrow::<UniqueView<PlayerInfo>>()

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -5,6 +5,7 @@ pub mod flat_ui_host;
 pub mod mission_core;
 pub mod pathfinding_debug;
 pub mod pathfinding_test;
+pub mod player_footsteps;
 pub(crate) mod reload;
 pub mod spatial_query;
 mod spawn_location;

--- a/shock2vr/src/mission/player_footsteps.rs
+++ b/shock2vr/src/mission/player_footsteps.rs
@@ -26,11 +26,12 @@ use engine::audio::AudioHandle;
 
 use crate::scripts::Effect;
 
-/// How far the player walks per footstep, in Dark units. Paired with
-/// `PLAYER_MOVE_SPEED` (25 Dark units/second) this paces a full-speed walk at
-/// roughly 3.5 steps/second - the same cadence the creature half measured for
-/// a jogging hybrid.
-const STRIDE_DISTANCE: f32 = 7.0 / SCALE_FACTOR;
+/// How far the player walks per footstep, in Dark units. Full-speed walking
+/// measured at ~1.8 world units/second in medsci1 (one world unit is 2.5 Dark
+/// units, so that is a real walking pace of ~1.4 m/s), which this paces at
+/// ~1.8 footsteps/second - a human's cadence at that speed, and the same
+/// order as the ~3.5/s the creature half measured for a *jogging* hybrid.
+const STRIDE_DISTANCE: f32 = 2.5 / SCALE_FACTOR;
 
 /// Crouched stride multiplier. Crouching does not slow the player down in this
 /// port, and the schema authors no quieter crouch sample (and volume is

--- a/shock2vr/src/mission/player_footsteps.rs
+++ b/shock2vr/src/mission/player_footsteps.rs
@@ -15,23 +15,31 @@
 //! the body without running a movement frame at all - cannot burst a run of
 //! footsteps out of one frame.
 //!
-//! Known gap: room-scale VR walking never moves the capsule (headset
-//! translation only places the camera), so physically stepping in the
-//! playspace is silent. That is deliberate - the deck is not moving under the
-//! player - rather than an oversight.
+//! Two known gaps, both deliberate. Room-scale VR walking never moves the
+//! capsule (headset translation only places the camera), so physically
+//! stepping in the playspace is silent - the deck is not moving under the
+//! player. And "own power" here means only "not carried by a platform": motion
+//! the walk pass produces without the player asking for it - sliding down a
+//! slope, being shoved by a door - still paces steps.
 
 use cgmath::{InnerSpace, Vector3};
 use dark::SCALE_FACTOR;
 use engine::audio::AudioHandle;
 
-use crate::scripts::Effect;
+use crate::{mission::PLAYER_MOVE_SPEED, scripts::Effect, scripts::script_util};
 
-/// How far the player walks per footstep, in Dark units. Full-speed walking
-/// measured at ~1.8 world units/second in medsci1 (one world unit is 2.5 Dark
-/// units, so that is a real walking pace of ~1.4 m/s), which this paces at
-/// ~1.8 footsteps/second - a human's cadence at that speed, and the same
-/// order as the ~3.5/s the creature half measured for a *jogging* hybrid.
-const STRIDE_DISTANCE: f32 = 2.5 / SCALE_FACTOR;
+/// Footsteps per second the stride below is calibrated for, at unobstructed
+/// full-speed movement. The port's player travels ~9.7 world units/second
+/// (measured walking medsci1 in the open), which is a run rather than a walk,
+/// so this matches the ~3.5/s the creature half measured for a jogging hybrid
+/// rather than a strolling pace.
+const TARGET_FOOTSTEPS_PER_SECOND: f32 = 3.5;
+
+/// How far the player walks per footstep, in world units. Derived from the
+/// movement speed so the cadence cannot drift if that is retuned; a player
+/// moving at any other speed simply steps proportionally more or less often,
+/// which is the whole point of pacing on distance.
+const STRIDE_DISTANCE: f32 = PLAYER_MOVE_SPEED / SCALE_FACTOR / TARGET_FOOTSTEPS_PER_SECOND;
 
 /// Crouched stride multiplier. Crouching does not slow the player down in this
 /// port, and the schema authors no quieter crouch sample (and volume is
@@ -44,12 +52,6 @@ const CROUCH_STRIDE_MULTIPLIER: f32 = 1.6;
 /// `landing=true` sample, in Dark units. Below this a landing is just the
 /// player walking off a lip and is left to the ordinary stride.
 const LANDING_MIN_FALL: f32 = 2.0 / SCALE_FACTOR;
-
-/// Material tag every player footstep resolves under until world geometry
-/// carries a per-texture material (`RayCastResult` has no surface id - see
-/// `projects/footstep-sounds.md` §4). The ship is mostly metal bulkheads, so
-/// this is right more often than not and wrong on carpet and soil.
-const DEFAULT_GROUND_MATERIAL: &str = "metal";
 
 /// What the accumulator decided this frame.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -68,6 +70,10 @@ pub struct FootstepFrame {
     pub self_translation: Vector3<f32>,
     pub is_grounded: bool,
     pub is_crouched: bool,
+    /// A ladder climb or a scripted mantle. Such a player is holding a
+    /// surface rather than walking on one - and, crucially, is not falling
+    /// however far down the shaft they travel.
+    pub is_climbing: bool,
 }
 
 /// Distance-paced player footsteps. Purely derived per-frame state: a save
@@ -79,6 +85,11 @@ pub struct PlayerFootsteps {
     /// Downward distance travelled since leaving the ground, in world units.
     fall_distance: f32,
     was_grounded: bool,
+    /// Swallow the next touchdown. Set by [`PlayerFootsteps::reset`], because
+    /// a relocation can put the player in the air (a spawn point above the
+    /// floor, a teleport onto a lip) and the settle that follows is the
+    /// engine placing them, not a fall they took.
+    suppress_next_landing: bool,
 }
 
 impl PlayerFootsteps {
@@ -90,6 +101,7 @@ impl PlayerFootsteps {
             // not have their first movement frame read as a touchdown, which
             // would swallow the first stride.
             was_grounded: true,
+            suppress_next_landing: true,
         }
     }
 
@@ -99,8 +111,10 @@ impl PlayerFootsteps {
     pub fn reset(&mut self) {
         self.distance = 0.0;
         self.fall_distance = 0.0;
-        // Assume grounded so the arrival frame is not read as a landing.
+        // Assume grounded so the arrival frame is not read as a landing, and
+        // swallow the touchdown that follows an arrival made in mid-air.
         self.was_grounded = true;
+        self.suppress_next_landing = true;
     }
 
     /// Advance one movement frame, returning the footstep it produced (at most
@@ -108,6 +122,16 @@ impl PlayerFootsteps {
     pub fn update(&mut self, frame: FootstepFrame) -> Option<PlayerFootstep> {
         let was_grounded = self.was_grounded;
         self.was_grounded = frame.is_grounded;
+
+        if frame.is_climbing {
+            // A ladder is held, not walked or fallen down. Without this a
+            // descent accrues the whole shaft as fall distance and thuds at
+            // the bottom, and a climb past a grounded pose near the foot of
+            // the ladder paces strides out of vertical travel.
+            self.fall_distance = 0.0;
+            self.distance = 0.0;
+            return None;
+        }
 
         if !frame.is_grounded {
             // Airborne: a jump or a fall keeps accruing horizontal distance,
@@ -123,9 +147,12 @@ impl PlayerFootsteps {
             // Touchdown. Either way the stride restarts here, so a landing is
             // not immediately followed by a half-stride step.
             let fall_distance = self.fall_distance;
+            let suppressed = self.suppress_next_landing;
             self.fall_distance = 0.0;
             self.distance = 0.0;
-            return (fall_distance >= LANDING_MIN_FALL).then_some(PlayerFootstep::Landing);
+            self.suppress_next_landing = false;
+            return (!suppressed && fall_distance >= LANDING_MIN_FALL)
+                .then_some(PlayerFootstep::Landing);
         }
 
         let stride = if frame.is_crouched {
@@ -133,17 +160,22 @@ impl PlayerFootsteps {
         } else {
             STRIDE_DISTANCE
         };
+        // Walking proves the player is on the floor: whatever arrival the
+        // reset was guarding against is over, so a later fall thuds normally.
+        self.suppress_next_landing = false;
         let horizontal =
             cgmath::vec2(frame.self_translation.x, frame.self_translation.z).magnitude();
         self.distance += horizontal;
         if self.distance < stride {
             return None;
         }
-        // Subtract rather than zero, so a frame long enough to cross a whole
-        // stride does not lose the remainder and drift the cadence. One step
-        // per frame is plenty - a single frame covering several strides is a
-        // hitch, and a burst of footsteps is the wrong way to report one.
-        self.distance = (self.distance - stride).min(stride);
+        // Subtract rather than zero, so an ordinary frame does not lose its
+        // remainder and drift the cadence. One step per frame is plenty - a
+        // single frame covering several strides is a hitch, and a burst of
+        // footsteps is the wrong way to report one - so a remainder bigger
+        // than the stride is banked as a *part* stride rather than kept whole,
+        // which would fire again on the very next frame that moves at all.
+        self.distance = (self.distance - stride).min(stride * 0.5);
         Some(PlayerFootstep::Step)
     }
 }
@@ -161,7 +193,7 @@ pub fn player_footstep_effect(footstep: PlayerFootstep, position: Vector3<f32>) 
     let mut tags = vec![
         ("event", "footstep"),
         ("creaturetype", "player"),
-        ("material", DEFAULT_GROUND_MATERIAL),
+        ("material", script_util::DEFAULT_IMPACT_MATERIAL),
     ];
     if footstep == PlayerFootstep::Landing {
         tags.push(("landing", "true"));
@@ -190,6 +222,42 @@ mod tests {
             self_translation: vec3(0.0, 0.0, distance),
             is_grounded: true,
             is_crouched: false,
+            is_climbing: false,
+        }
+    }
+
+    fn crouch_walking(distance: f32) -> FootstepFrame {
+        FootstepFrame {
+            is_crouched: true,
+            ..walking(distance)
+        }
+    }
+
+    /// One airborne frame dropping `drop` world units.
+    fn falling(drop: f32) -> FootstepFrame {
+        FootstepFrame {
+            self_translation: vec3(0.0, -drop, 0.0),
+            is_grounded: false,
+            is_crouched: false,
+            is_climbing: false,
+        }
+    }
+
+    /// The frame that touches down at the end of a `drop`-unit descent.
+    fn landed(drop: f32) -> FootstepFrame {
+        FootstepFrame {
+            is_grounded: true,
+            ..falling(drop)
+        }
+    }
+
+    /// One frame of ladder climbing, moving `travel` world units vertically.
+    fn climbing(travel: f32) -> FootstepFrame {
+        FootstepFrame {
+            self_translation: vec3(0.0, travel, 0.0),
+            is_grounded: false,
+            is_crouched: false,
+            is_climbing: true,
         }
     }
 
@@ -208,6 +276,19 @@ mod tests {
         let mut footsteps = PlayerFootsteps::new();
         let steps = count_steps(&mut footsteps, 11, STRIDE_DISTANCE / 10.0);
         assert_eq!(steps, 1);
+    }
+
+    #[test]
+    fn full_speed_walking_paces_the_target_cadence() {
+        // The absolute check: one second of unobstructed full-speed movement,
+        // fed frame by frame exactly as `MissionCore::update` builds it.
+        let mut footsteps = PlayerFootsteps::new();
+        let per_frame = PLAYER_MOVE_SPEED / SCALE_FACTOR / 60.0;
+        let steps = count_steps(&mut footsteps, 60, per_frame);
+        assert!(
+            (3..=4).contains(&steps),
+            "expected ~{TARGET_FOOTSTEPS_PER_SECOND} footsteps in a second of full-speed walking, got {steps}"
+        );
     }
 
     #[test]
@@ -232,12 +313,7 @@ mod tests {
         // A rider standing still on a moving platform has a zero SELF
         // translation, however far the world moves them.
         let mut footsteps = PlayerFootsteps::new();
-        let carried = FootstepFrame {
-            self_translation: vec3(0.0, 0.0, 0.0),
-            is_grounded: true,
-            is_crouched: false,
-        };
-        assert!((0..600).all(|_| footsteps.update(carried).is_none()));
+        assert!((0..600).all(|_| footsteps.update(walking(0.0)).is_none()));
     }
 
     #[test]
@@ -247,6 +323,7 @@ mod tests {
             self_translation: vec3(0.0, 0.1, STRIDE_DISTANCE),
             is_grounded: false,
             is_crouched: false,
+            is_climbing: false,
         };
         assert!((0..60).all(|_| footsteps.update(jumping).is_none()));
     }
@@ -254,19 +331,14 @@ mod tests {
     #[test]
     fn landing_after_a_fall_fires_once() {
         let mut footsteps = PlayerFootsteps::new();
-        let falling = FootstepFrame {
-            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
-            is_grounded: false,
-            is_crouched: false,
-        };
-        assert_eq!(footsteps.update(falling), None);
-
-        let landed = FootstepFrame {
-            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
-            is_grounded: true,
-            is_crouched: false,
-        };
-        assert_eq!(footsteps.update(landed), Some(PlayerFootstep::Landing));
+        // Walk first: an arrival is only suppressed until the player is seen
+        // standing on something.
+        assert_eq!(footsteps.update(walking(0.0)), None);
+        assert_eq!(footsteps.update(falling(LANDING_MIN_FALL)), None);
+        assert_eq!(
+            footsteps.update(landed(LANDING_MIN_FALL)),
+            Some(PlayerFootstep::Landing)
+        );
         // The next grounded frame is an ordinary standing frame, not a second
         // landing.
         assert_eq!(footsteps.update(walking(0.0)), None);
@@ -275,12 +347,8 @@ mod tests {
     #[test]
     fn stepping_off_a_lip_does_not_thud() {
         let mut footsteps = PlayerFootsteps::new();
-        let hop = FootstepFrame {
-            self_translation: vec3(0.0, -LANDING_MIN_FALL * 0.2, 0.0),
-            is_grounded: false,
-            is_crouched: false,
-        };
-        assert_eq!(footsteps.update(hop), None);
+        assert_eq!(footsteps.update(walking(0.0)), None);
+        assert_eq!(footsteps.update(falling(LANDING_MIN_FALL * 0.2)), None);
         assert_eq!(footsteps.update(walking(0.0)), None);
     }
 
@@ -289,20 +357,35 @@ mod tests {
         let mut footsteps = PlayerFootsteps::new();
         // Almost a full stride, then a fall.
         assert_eq!(footsteps.update(walking(STRIDE_DISTANCE * 0.9)), None);
-        let falling = FootstepFrame {
-            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
-            is_grounded: false,
-            is_crouched: false,
-        };
-        assert_eq!(footsteps.update(falling), None);
-        let landed = FootstepFrame {
-            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
-            is_grounded: true,
-            is_crouched: false,
-        };
-        assert_eq!(footsteps.update(landed), Some(PlayerFootstep::Landing));
+        assert_eq!(footsteps.update(falling(LANDING_MIN_FALL)), None);
+        assert_eq!(
+            footsteps.update(landed(LANDING_MIN_FALL)),
+            Some(PlayerFootstep::Landing)
+        );
         // The banked 0.9 stride is gone, so one more short frame is silent.
         assert_eq!(footsteps.update(walking(STRIDE_DISTANCE * 0.2)), None);
+    }
+
+    #[test]
+    fn a_hitch_frame_does_not_fire_twice_in_a_row() {
+        // A frame covering several strides reports one footstep, and does not
+        // leave a full stride banked that fires again immediately.
+        let mut footsteps = PlayerFootsteps::new();
+        assert_eq!(
+            footsteps.update(walking(STRIDE_DISTANCE * 5.0)),
+            Some(PlayerFootstep::Step)
+        );
+        assert_eq!(footsteps.update(walking(STRIDE_DISTANCE * 0.1)), None);
+    }
+
+    #[test]
+    fn climbing_a_ladder_neither_steps_nor_thuds() {
+        let mut footsteps = PlayerFootsteps::new();
+        assert_eq!(footsteps.update(walking(0.0)), None);
+        // A long descent: without the climb gate this accrues the whole shaft
+        // as fall distance and thuds when the player reaches the bottom.
+        assert!((0..120).all(|_| footsteps.update(climbing(-LANDING_MIN_FALL)).is_none()));
+        assert_eq!(footsteps.update(walking(0.0)), None);
     }
 
     #[test]
@@ -313,11 +396,8 @@ mod tests {
         let mut crouched = PlayerFootsteps::new();
         let crouched_steps = (0..1005)
             .filter(|_| {
-                crouched.update(FootstepFrame {
-                    self_translation: vec3(0.0, 0.0, STRIDE_DISTANCE / 100.0),
-                    is_grounded: true,
-                    is_crouched: true,
-                }) == Some(PlayerFootstep::Step)
+                crouched.update(crouch_walking(STRIDE_DISTANCE / 100.0))
+                    == Some(PlayerFootstep::Step)
             })
             .count();
 
@@ -336,16 +416,20 @@ mod tests {
     }
 
     #[test]
-    fn a_reset_mid_fall_does_not_thud_on_arrival() {
+    fn a_relocation_that_lands_in_mid_air_does_not_thud_on_arrival() {
+        // Level load / quickload / a teleport onto a lip: the settle that
+        // follows the arrival is the engine placing the player, not a fall.
         let mut footsteps = PlayerFootsteps::new();
-        let falling = FootstepFrame {
-            self_translation: vec3(0.0, -LANDING_MIN_FALL * 10.0, 0.0),
-            is_grounded: false,
-            is_crouched: false,
-        };
-        assert_eq!(footsteps.update(falling), None);
         footsteps.reset();
+        assert!((0..30).all(|_| footsteps.update(falling(LANDING_MIN_FALL)).is_none()));
+        assert_eq!(footsteps.update(landed(LANDING_MIN_FALL)), None);
+        // A genuine fall afterwards still thuds.
         assert_eq!(footsteps.update(walking(0.0)), None);
+        assert_eq!(footsteps.update(falling(LANDING_MIN_FALL)), None);
+        assert_eq!(
+            footsteps.update(landed(LANDING_MIN_FALL)),
+            Some(PlayerFootstep::Landing)
+        );
     }
 
     #[test]

--- a/shock2vr/src/mission/player_footsteps.rs
+++ b/shock2vr/src/mission/player_footsteps.rs
@@ -1,0 +1,376 @@
+//! Player footstep pacing.
+//!
+//! Creatures get their footsteps from authored animation flags
+//! (`MotionFlags::LEFT_FOOT_STEP`, see `script_util::play_footstep_sound`).
+//! The player has no locomotion animation, so theirs are derived from how far
+//! they actually walked: a **horizontal distance accumulator**, not a timer.
+//! Distance gives a slower cadence when moving slowly and a faster one when
+//! running with no speed tiers, is frame-rate independent (Quest and desktop
+//! run at different rates), and cannot tick while standing still.
+//!
+//! The accumulator is fed the player's *own* per-frame translation
+//! (`PlayerHandle::self_translation`), which already has the moving-platform
+//! carry removed, so a rider standing on an elevator accrues nothing. It is
+//! also never fed a world-position delta, so a teleport hop - which relocates
+//! the body without running a movement frame at all - cannot burst a run of
+//! footsteps out of one frame.
+//!
+//! Known gap: room-scale VR walking never moves the capsule (headset
+//! translation only places the camera), so physically stepping in the
+//! playspace is silent. That is deliberate - the deck is not moving under the
+//! player - rather than an oversight.
+
+use cgmath::{InnerSpace, Vector3};
+use dark::SCALE_FACTOR;
+use engine::audio::AudioHandle;
+
+use crate::scripts::Effect;
+
+/// How far the player walks per footstep, in Dark units. Paired with
+/// `PLAYER_MOVE_SPEED` (25 Dark units/second) this paces a full-speed walk at
+/// roughly 3.5 steps/second - the same cadence the creature half measured for
+/// a jogging hybrid.
+const STRIDE_DISTANCE: f32 = 7.0 / SCALE_FACTOR;
+
+/// Crouched stride multiplier. Crouching does not slow the player down in this
+/// port, and the schema authors no quieter crouch sample (and volume is
+/// authored per-sample, so it cannot be attenuated at the call site), so
+/// spacing the steps further apart is the only lever that makes sneaking read
+/// as quieter than walking.
+const CROUCH_STRIDE_MULTIPLIER: f32 = 1.6;
+
+/// How far the player must fall before touchdown plays the heavier
+/// `landing=true` sample, in Dark units. Below this a landing is just the
+/// player walking off a lip and is left to the ordinary stride.
+const LANDING_MIN_FALL: f32 = 2.0 / SCALE_FACTOR;
+
+/// Material tag every player footstep resolves under until world geometry
+/// carries a per-texture material (`RayCastResult` has no surface id - see
+/// `projects/footstep-sounds.md` §4). The ship is mostly metal bulkheads, so
+/// this is right more often than not and wrong on carpet and soil.
+const DEFAULT_GROUND_MATERIAL: &str = "metal";
+
+/// What the accumulator decided this frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlayerFootstep {
+    /// An ordinary stride while walking.
+    Step,
+    /// Touchdown at the end of a meaningful fall (`landing=true`).
+    Landing,
+}
+
+/// One frame of player locomotion, as the footstep pacer sees it.
+#[derive(Clone, Copy, Debug)]
+pub struct FootstepFrame {
+    /// The player's own translation this frame, platform carry already
+    /// removed (`PlayerHandle::self_translation`).
+    pub self_translation: Vector3<f32>,
+    pub is_grounded: bool,
+    pub is_crouched: bool,
+}
+
+/// Distance-paced player footsteps. Purely derived per-frame state: a save
+/// restores mid-stride at worst, which is inaudible.
+#[derive(Debug)]
+pub struct PlayerFootsteps {
+    /// Horizontal distance walked since the last step, in world units.
+    distance: f32,
+    /// Downward distance travelled since leaving the ground, in world units.
+    fall_distance: f32,
+    was_grounded: bool,
+}
+
+impl PlayerFootsteps {
+    pub fn new() -> Self {
+        Self {
+            distance: 0.0,
+            fall_distance: 0.0,
+            // Start grounded: a player who spawns standing on the deck must
+            // not have their first movement frame read as a touchdown, which
+            // would swallow the first stride.
+            was_grounded: true,
+        }
+    }
+
+    /// Forget the stride and the fall in progress. Called on any direct
+    /// relocation (teleport locomotion, level load, quickload) so the player
+    /// never arrives owing a footstep from wherever they were before.
+    pub fn reset(&mut self) {
+        self.distance = 0.0;
+        self.fall_distance = 0.0;
+        // Assume grounded so the arrival frame is not read as a landing.
+        self.was_grounded = true;
+    }
+
+    /// Advance one movement frame, returning the footstep it produced (at most
+    /// one per frame).
+    pub fn update(&mut self, frame: FootstepFrame) -> Option<PlayerFootstep> {
+        let was_grounded = self.was_grounded;
+        self.was_grounded = frame.is_grounded;
+
+        if !frame.is_grounded {
+            // Airborne: a jump or a fall keeps accruing horizontal distance,
+            // so the stride has to stop rather than play a step at the top of
+            // the arc. Track the drop instead, for the landing below.
+            if frame.self_translation.y < 0.0 {
+                self.fall_distance -= frame.self_translation.y;
+            }
+            return None;
+        }
+
+        if !was_grounded {
+            // Touchdown. Either way the stride restarts here, so a landing is
+            // not immediately followed by a half-stride step.
+            let fall_distance = self.fall_distance;
+            self.fall_distance = 0.0;
+            self.distance = 0.0;
+            return (fall_distance >= LANDING_MIN_FALL).then_some(PlayerFootstep::Landing);
+        }
+
+        let stride = if frame.is_crouched {
+            STRIDE_DISTANCE * CROUCH_STRIDE_MULTIPLIER
+        } else {
+            STRIDE_DISTANCE
+        };
+        let horizontal =
+            cgmath::vec2(frame.self_translation.x, frame.self_translation.z).magnitude();
+        self.distance += horizontal;
+        if self.distance < stride {
+            return None;
+        }
+        // Subtract rather than zero, so a frame long enough to cross a whole
+        // stride does not lose the remainder and drift the cadence. One step
+        // per frame is plenty - a single frame covering several strides is a
+        // hitch, and a burst of footsteps is the wrong way to report one.
+        self.distance = (self.distance - stride).min(stride);
+        Some(PlayerFootstep::Step)
+    }
+}
+
+/// The `Effect` for a player footstep at `position` (the pawn origin, which is
+/// at the player's feet).
+///
+/// The player carries no `PropClassTag`, so `get_environmental_sound_query`
+/// returns `None` for them and the schema query is built directly. The
+/// landing variant asks for the most specific match: `landing=true` refines a
+/// node that already resolves (`material=metal` -> `ftmet1..4`), and the
+/// default shallowest-match resolution would hand back the ordinary footstep
+/// and drop the thud.
+pub fn player_footstep_effect(footstep: PlayerFootstep, position: Vector3<f32>) -> Effect {
+    let mut tags = vec![
+        ("event", "footstep"),
+        ("creaturetype", "player"),
+        ("material", DEFAULT_GROUND_MATERIAL),
+    ];
+    if footstep == PlayerFootstep::Landing {
+        tags.push(("landing", "true"));
+    }
+    let query = dark::EnvSoundQuery::from_tag_values(tags);
+    let query = if footstep == PlayerFootstep::Landing {
+        query.most_specific()
+    } else {
+        query
+    };
+
+    Effect::PlayEnvironmentalSound {
+        audio_handle: AudioHandle::new(),
+        query,
+        position,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::vec3;
+
+    fn walking(distance: f32) -> FootstepFrame {
+        FootstepFrame {
+            self_translation: vec3(0.0, 0.0, distance),
+            is_grounded: true,
+            is_crouched: false,
+        }
+    }
+
+    /// Run `frames` movement frames of `per_frame` forward travel, counting
+    /// the footsteps they produced.
+    fn count_steps(footsteps: &mut PlayerFootsteps, frames: usize, per_frame: f32) -> usize {
+        (0..frames)
+            .filter(|_| footsteps.update(walking(per_frame)) == Some(PlayerFootstep::Step))
+            .count()
+    }
+
+    #[test]
+    fn walking_a_stride_plays_one_footstep() {
+        // Slightly over a stride, so the count does not hinge on a sum of
+        // tenths landing exactly on it.
+        let mut footsteps = PlayerFootsteps::new();
+        let steps = count_steps(&mut footsteps, 11, STRIDE_DISTANCE / 10.0);
+        assert_eq!(steps, 1);
+    }
+
+    #[test]
+    fn footstep_cadence_scales_with_distance_not_frames() {
+        // Ten strides in ten frames and in a thousand frames both produce ten
+        // footsteps: the pacer is distance-driven, not per-frame.
+        let mut coarse = PlayerFootsteps::new();
+        assert_eq!(count_steps(&mut coarse, 10, STRIDE_DISTANCE), 10);
+
+        let mut fine = PlayerFootsteps::new();
+        assert_eq!(count_steps(&mut fine, 1005, STRIDE_DISTANCE / 100.0), 10);
+    }
+
+    #[test]
+    fn standing_still_is_silent() {
+        let mut footsteps = PlayerFootsteps::new();
+        assert_eq!(count_steps(&mut footsteps, 600, 0.0), 0);
+    }
+
+    #[test]
+    fn a_player_carried_by_an_elevator_is_silent() {
+        // A rider standing still on a moving platform has a zero SELF
+        // translation, however far the world moves them.
+        let mut footsteps = PlayerFootsteps::new();
+        let carried = FootstepFrame {
+            self_translation: vec3(0.0, 0.0, 0.0),
+            is_grounded: true,
+            is_crouched: false,
+        };
+        assert!((0..600).all(|_| footsteps.update(carried).is_none()));
+    }
+
+    #[test]
+    fn airborne_travel_plays_no_footstep() {
+        let mut footsteps = PlayerFootsteps::new();
+        let jumping = FootstepFrame {
+            self_translation: vec3(0.0, 0.1, STRIDE_DISTANCE),
+            is_grounded: false,
+            is_crouched: false,
+        };
+        assert!((0..60).all(|_| footsteps.update(jumping).is_none()));
+    }
+
+    #[test]
+    fn landing_after_a_fall_fires_once() {
+        let mut footsteps = PlayerFootsteps::new();
+        let falling = FootstepFrame {
+            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
+            is_grounded: false,
+            is_crouched: false,
+        };
+        assert_eq!(footsteps.update(falling), None);
+
+        let landed = FootstepFrame {
+            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
+            is_grounded: true,
+            is_crouched: false,
+        };
+        assert_eq!(footsteps.update(landed), Some(PlayerFootstep::Landing));
+        // The next grounded frame is an ordinary standing frame, not a second
+        // landing.
+        assert_eq!(footsteps.update(walking(0.0)), None);
+    }
+
+    #[test]
+    fn stepping_off_a_lip_does_not_thud() {
+        let mut footsteps = PlayerFootsteps::new();
+        let hop = FootstepFrame {
+            self_translation: vec3(0.0, -LANDING_MIN_FALL * 0.2, 0.0),
+            is_grounded: false,
+            is_crouched: false,
+        };
+        assert_eq!(footsteps.update(hop), None);
+        assert_eq!(footsteps.update(walking(0.0)), None);
+    }
+
+    #[test]
+    fn a_landing_restarts_the_stride() {
+        let mut footsteps = PlayerFootsteps::new();
+        // Almost a full stride, then a fall.
+        assert_eq!(footsteps.update(walking(STRIDE_DISTANCE * 0.9)), None);
+        let falling = FootstepFrame {
+            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
+            is_grounded: false,
+            is_crouched: false,
+        };
+        assert_eq!(footsteps.update(falling), None);
+        let landed = FootstepFrame {
+            self_translation: vec3(0.0, -LANDING_MIN_FALL, 0.0),
+            is_grounded: true,
+            is_crouched: false,
+        };
+        assert_eq!(footsteps.update(landed), Some(PlayerFootstep::Landing));
+        // The banked 0.9 stride is gone, so one more short frame is silent.
+        assert_eq!(footsteps.update(walking(STRIDE_DISTANCE * 0.2)), None);
+    }
+
+    #[test]
+    fn crouching_spaces_footsteps_further_apart() {
+        let mut standing = PlayerFootsteps::new();
+        let standing_steps = count_steps(&mut standing, 1005, STRIDE_DISTANCE / 100.0);
+
+        let mut crouched = PlayerFootsteps::new();
+        let crouched_steps = (0..1005)
+            .filter(|_| {
+                crouched.update(FootstepFrame {
+                    self_translation: vec3(0.0, 0.0, STRIDE_DISTANCE / 100.0),
+                    is_grounded: true,
+                    is_crouched: true,
+                }) == Some(PlayerFootstep::Step)
+            })
+            .count();
+
+        assert!(
+            crouched_steps < standing_steps,
+            "crouched {crouched_steps} should be quieter than standing {standing_steps}"
+        );
+    }
+
+    #[test]
+    fn a_reset_forgets_the_stride_in_progress() {
+        let mut footsteps = PlayerFootsteps::new();
+        assert_eq!(footsteps.update(walking(STRIDE_DISTANCE * 0.9)), None);
+        footsteps.reset();
+        assert_eq!(footsteps.update(walking(STRIDE_DISTANCE * 0.2)), None);
+    }
+
+    #[test]
+    fn a_reset_mid_fall_does_not_thud_on_arrival() {
+        let mut footsteps = PlayerFootsteps::new();
+        let falling = FootstepFrame {
+            self_translation: vec3(0.0, -LANDING_MIN_FALL * 10.0, 0.0),
+            is_grounded: false,
+            is_crouched: false,
+        };
+        assert_eq!(footsteps.update(falling), None);
+        footsteps.reset();
+        assert_eq!(footsteps.update(walking(0.0)), None);
+    }
+
+    #[test]
+    fn the_landing_query_asks_for_the_most_specific_match() {
+        let effect = player_footstep_effect(PlayerFootstep::Landing, vec3(0.0, 0.0, 0.0));
+        let Effect::PlayEnvironmentalSound { query, .. } = effect else {
+            panic!("expected an environmental sound");
+        };
+        assert!(query.prefers_most_specific());
+        assert!(
+            query
+                .tag_values()
+                .contains(&("landing".to_owned(), "true".to_owned()))
+        );
+    }
+
+    #[test]
+    fn the_step_query_names_the_player_and_a_material() {
+        let effect = player_footstep_effect(PlayerFootstep::Step, vec3(0.0, 0.0, 0.0));
+        let Effect::PlayEnvironmentalSound { query, .. } = effect else {
+            panic!("expected an environmental sound");
+        };
+        let tags = query.tag_values();
+        assert!(tags.contains(&("event".to_owned(), "footstep".to_owned())));
+        assert!(tags.contains(&("creaturetype".to_owned(), "player".to_owned())));
+        // A player query with no material resolves to nothing at all.
+        assert!(tags.iter().any(|(tag, _)| tag == "material"));
+    }
+}

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -666,6 +666,16 @@ struct ClimbTopOut {
 
 struct PlayerMovement {
     movement: EffectiveCharacterMovement,
+    /// `movement.translation` with the moving-platform carry removed, i.e.
+    /// what the player did under their own power. Only the ordinary walk pass
+    /// folds a carry in at all, so the scripted mantle and ladder branches
+    /// report their translation unchanged - subtracting a carry there would
+    /// fabricate motion the player never made.
+    self_translation: Vector<Real>,
+    /// This frame was a ladder climb or a scripted mantle rather than walking
+    /// on a floor. The player is on a surface they are holding, so they are
+    /// neither striding nor free-falling however far they travel.
+    is_climbing: bool,
     top_out: Option<ClimbTopOut>,
     /// Horizontal part of a gravity-induced slope slide, carried into the
     /// next gravity pass so a seam does not erase the player's momentum.
@@ -1224,6 +1234,8 @@ fn plan_climb_top_out(
 
     Some(PlayerMovement {
         movement: scripted_character_movement(first_step),
+        self_translation: first_step,
+        is_climbing: true,
         top_out: Some(ClimbTopOut {
             waypoints,
             next_waypoint: 0,
@@ -1488,8 +1500,11 @@ fn plan_jump_mantle(
         }
     }
 
+    let first_movement = first_movement?;
     Some(PlayerMovement {
-        movement: scripted_character_movement(first_movement?),
+        movement: scripted_character_movement(first_movement),
+        self_translation: first_movement,
+        is_climbing: true,
         top_out: Some(ClimbTopOut {
             waypoints,
             next_waypoint: 0,
@@ -1669,7 +1684,9 @@ fn step_player_movement(
         let climbed = mvt.translation.y * climb.y.signum();
         if climbed > CLIMB_MIN_PROGRESS_FRACTION * climb.y.abs() {
             return PlayerMovement {
+                self_translation: mvt.translation,
                 movement: mvt,
+                is_climbing: true,
                 top_out: None,
                 slope_displacement: Vector::zeros(),
                 actor_collisions: Vec::new(),
@@ -1856,7 +1873,9 @@ fn step_player_movement(
     // measures from the carried pose) is done.
     mvt.translation += carried;
     PlayerMovement {
+        self_translation: mvt.translation - carried,
         movement: mvt,
+        is_climbing: false,
         top_out: None,
         slope_displacement: next_slope_displacement,
         actor_collisions: walk_collisions,
@@ -2268,6 +2287,9 @@ pub struct PlayerHandle {
     // standing still on an elevator reports zero. Purely derived per-frame
     // state, recomputed by every `move_player`, so nothing saves it.
     self_translation: Vector3<f32>,
+    // Whether that frame was a ladder climb or a scripted mantle rather than
+    // ordinary walking. Also purely derived per-frame state.
+    is_climbing: bool,
 }
 
 /// The physical-hand seam for one held melee weapon. `target` is an invisible
@@ -2321,6 +2343,13 @@ impl PlayerHandle {
     /// frame), contributes nothing.
     pub fn self_translation(&self) -> Vector3<f32> {
         self.self_translation
+    }
+
+    /// Whether the last movement frame was a ladder climb or a scripted
+    /// mantle. Such a player is holding a surface: they are neither striding
+    /// along a floor nor falling, however far they travel vertically.
+    pub fn is_climbing(&self) -> bool {
+        self.is_climbing
     }
 }
 
@@ -3976,6 +4005,7 @@ impl PhysicsWorld {
             jump_velocity: None,
             jump_was_pressed: false,
             self_translation: Vector3::new(0.0, 0.0, 0.0),
+            is_climbing: false,
         }
     }
 
@@ -4657,7 +4687,9 @@ impl PhysicsWorld {
                     self.integration_parameters.dt,
                 );
                 PlayerMovement {
+                    self_translation: movement.translation,
                     movement,
+                    is_climbing: true,
                     top_out,
                     slope_displacement: Vector::zeros(),
                     actor_collisions: Vec::new(),
@@ -4709,6 +4741,11 @@ impl PhysicsWorld {
             }
         });
         let was_top_out = player_handle.top_out.is_some();
+        // Recorded by whichever branch produced the movement, because only the
+        // walk pass folds the platform carry in (see `PlayerMovement`).
+        let self_translation = player_movement.self_translation;
+        player_handle.self_translation = nvec_to_cgmath(self_translation);
+        player_handle.is_climbing = player_movement.is_climbing;
         player_handle.top_out = player_movement.top_out;
         player_handle.slope_displacement = player_movement.slope_displacement;
         let is_top_out = player_handle.top_out.is_some();
@@ -4808,7 +4845,7 @@ impl PhysicsWorld {
             player_handle.is_grounded = false;
         } else if let Some(mut velocity) = player_handle.jump_velocity {
             let requested_vertical = velocity * self.integration_parameters.dt;
-            let applied_vertical = mvt.translation.y - carry.y;
+            let applied_vertical = self_translation.y;
             if mvt.grounded && requested_vertical <= 0.0 {
                 player_handle.jump_velocity = None;
                 player_handle.is_grounded = true;
@@ -4827,11 +4864,6 @@ impl PhysicsWorld {
         } else {
             player_handle.is_grounded = mvt.grounded;
         }
-
-        // `mvt.translation` includes the platform carry applied first inside
-        // `step_player_movement`; remove it so what is left is what the player
-        // did under their own power (see `PlayerHandle::self_translation`).
-        player_handle.self_translation = nvec_to_cgmath(mvt.translation - carry);
 
         // Edges already observed along a swept `move_player_validated` hop come
         // first: they happened before this frame's pose. They also leave

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2263,6 +2263,11 @@ pub struct PlayerHandle {
     jump_velocity: Option<Real>,
     // Held-button edge state: one press launches at most one jump.
     jump_was_pressed: bool,
+    // The player's OWN translation from the last movement frame - this
+    // frame's total travel minus the moving-support carry - so a rider
+    // standing still on an elevator reports zero. Purely derived per-frame
+    // state, recomputed by every `move_player`, so nothing saves it.
+    self_translation: Vector3<f32>,
 }
 
 /// The physical-hand seam for one held melee weapon. `target` is an invisible
@@ -2300,6 +2305,22 @@ impl PlayerHandle {
     /// the requested input.
     pub fn is_crouched(&self) -> bool {
         self.is_crouched
+    }
+
+    /// Ground contact reported by the last movement frame. Unlike a support
+    /// probe this includes immutable level terrain, so it is what "standing on
+    /// the deck" means.
+    pub fn is_grounded(&self) -> bool {
+        self.is_grounded
+    }
+
+    /// How far the player moved themselves on the last movement frame, with
+    /// any moving-platform carry removed (see [`PlayerSupport`]). This is the
+    /// displacement footstep pacing accumulates: a player carried by an
+    /// elevator, or relocated by a teleport (which never runs a movement
+    /// frame), contributes nothing.
+    pub fn self_translation(&self) -> Vector3<f32> {
+        self.self_translation
     }
 }
 
@@ -3954,6 +3975,7 @@ impl PhysicsWorld {
             is_grounded: false,
             jump_velocity: None,
             jump_was_pressed: false,
+            self_translation: Vector3::new(0.0, 0.0, 0.0),
         }
     }
 
@@ -4805,6 +4827,11 @@ impl PhysicsWorld {
         } else {
             player_handle.is_grounded = mvt.grounded;
         }
+
+        // `mvt.translation` includes the platform carry applied first inside
+        // `step_player_movement`; remove it so what is left is what the player
+        // did under their own power (see `PlayerHandle::self_translation`).
+        player_handle.self_translation = nvec_to_cgmath(mvt.translation - carry);
 
         // Edges already observed along a swept `move_player_validated` hop come
         // first: they happened before this frame's pose. They also leave

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -818,7 +818,7 @@ pub fn play_environmental_sound(
 /// resolvable material. World geometry has no per-texture material lookup in
 /// the port yet, so terrain hits (and entities without material tags) all
 /// sound like the ship's metal bulkheads.
-const DEFAULT_IMPACT_MATERIAL: &str = "metal";
+pub const DEFAULT_IMPACT_MATERIAL: &str = "metal";
 
 /// The collision-schema material tag ("fleshtarget", "metal", ...) for
 /// whatever was hit: the victim's inherited `PropMaterial` (a tag string like


### PR DESCRIPTION
Player footstep audio, the other half of #1156. Creatures got footsteps from authored animation flags; the player has no locomotion animation, so theirs are derived from locomotion. Built to the design in `projects/footstep-sounds.md`, which held up — the sizing (a day), the shape (a distance accumulator, not a timer), the trap list, and the "build it as a small module fed once per frame from `MissionCore::update`" placement were all right.

## What it does

`shock2vr/src/mission/player_footsteps.rs` — a **horizontal distance accumulator** over the player's *own* per-frame translation, plus a grounded gate and a touchdown edge:

- **Stride** derived from `PLAYER_MOVE_SPEED` and a named `TARGET_FOOTSTEPS_PER_SECOND = 3.5`, so the cadence cannot drift if movement speed is retuned. Distance rather than a timer means slow movement steps slowly, fast movement steps quickly, with no speed tiers, and it is frame-rate independent (Quest and desktop run at different rates).
- **Landing thud** (`landing=true` → `ftmetj`) on the grounded false→true edge when the fall was meaningful; the stride restarts there so a thud is not chased by a half-stride step.
- **Crouch** spaces steps 1.6x further apart. Crouching does not slow the player in this port and the schema authors no quieter crouch sample — volume is authored per-sample, so spacing is the only lever that makes sneaking read as quieter.
- Sound is expressed as a returned `Effect::PlayEnvironmentalSound`, applied centrally like every other effect.

The player carries no `PropClassTag`, so `get_environmental_sound_query` returns `None` for them and the query is built directly, as the design predicted. Everything downstream is #1156's plumbing.

## What the player actually hears

**One material everywhere: metal.** There is no per-texture material lookup for world geometry — `RayCastResult` carries no surface id — so the ground material is `script_util::DEFAULT_IMPACT_MATERIAL`. Every player footstep resolves `ftmet1..4` and every landing `ftmetj`, on carpet and soil as much as on bulkhead. That gap is **deliberately out of scope**: fixing it upgrades footsteps, bullet impacts and melee impacts at once and deserves its own change (`projects/footstep-sounds.md` §4). Water (`medialevel`) is likewise unavailable — the port has no immersion state to key it on.

## Traps, and how each is handled

| Trap | Handling |
| --- | --- |
| **Elevators / moving platforms** | The accumulator is fed `PlayerHandle::self_translation()` — the frame's travel with the support carry already removed — so a rider standing still on a lift accrues nothing. |
| **Teleport locomotion** | Driven by the movement pass's own translation, never a world-position delta, so a hop contributes zero. `SetPlayerPosition` / `teleport_player` also `reset()` the accumulator (covers level load and quickload). Verified: 3 hops totalling 8.6 wu → 0 footsteps. |
| **Airborne** | No stride while ungrounded; the touchdown edge is what plays `landing=true`. |
| **Ladders** *(not in the design doc)* | A descent is ungrounded with a negative per-frame `y`, so it accrued the whole shaft as fall distance and thudded at the bottom. `PlayerHandle::is_climbing()` now gates both the stride and the fall. |
| **Mid-air arrivals** *(not in the design doc)* | A spawn above the floor settles after the relocation, which read as a fall. `reset()` swallows the next touchdown. |
| **Schema volumes** | Authored per sample (−1000 to −1500 mB); nothing is attenuated a second time. |
| **Room-scale VR walking** | Still silent — headset translation never reaches `move_player`. Agreed with the design doc that this is correct for now: the deck is not moving under the player, so a footstep would be wrong. Addressing it cheaply is not possible without inventing a stride from head bob, which is a worse sound than none. |

## The one behavior change outside the player

`landing=true` refines a schema node that already resolves, and `get_random_environmental_sound` took the **shallowest** matched node — so the thud was inert and resolved to an ordinary footstep. `EnvSoundQuery` grows an opt-in `most_specific()` used only by the landing query; every existing lookup keeps `first()`, i.e. exactly the old `result[0]`.

## Audio evidence

`/v1/audio/recent`-backed counts in `medsci1.mis`, **flat and `--vr`, identical in both**:

| | flat | `--vr` |
| --- | --- | --- |
| Standing still, 5 s | **0** footsteps | **0** |
| Walking 1 s (5.72 wu) | **2** — one per **2.86 wu**, exactly the stride | **2** — one per 2.86 wu |
| Crouch-walking 1 s (3.45 wu) | **1** — spaced further apart | **1** |
| One jump | **1** `ftmetj`, no extras | **1** |
| 3 teleport hops, 8.6 wu | **0** | — |

At the unobstructed ~9.7 wu/s the port actually moves, that stride is **~3.4 footsteps/second** — the same order as the ~3.5/s #1156 measured for a jogging hybrid, and nothing like the 60/s a per-frame implementation would give.

## Tests

13 unit tests on the accumulator (`cargo test -p shock2vr --lib player_footsteps`). Each guard was confirmed to have a test that **fails without it**, by mutating the source: dropping the airborne gate fails `airborne_travel_plays_no_footstep` / `landing_after_a_fall_fires_once` / `a_landing_restarts_the_stride`; pacing on a timer instead of distance fails `standing_still_is_silent`, `a_player_carried_by_an_elevator_is_silent`, `walking_a_stride_plays_one_footstep`, `footstep_cadence_scales_with_distance_not_frames` and `crouching_spaces_footsteps_further_apart`; dropping `most_specific()` fails `the_landing_query_asks_for_the_most_specific_match`; dropping the climb gate fails `climbing_a_ladder_neither_steps_nor_thuds`; dropping the landing suppression fails `a_relocation_that_lands_in_mid_air_does_not_thud_on_arrival`; restoring the old clamp fails `a_hitch_frame_does_not_fire_twice_in_a_row`; a 10/s target fails `full_speed_walking_paces_the_target_cadence`.

`cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr --lib` (1115 pass, was 1112 on main), `cargo test -p dark --lib` (119 pass), and the SDK e2e suite (all 23 missions load).

## Review

`/xreview`'s Codex engine is out of quota, so two independent Claude reviewers ran instead (correctness/simplicity + duplication). Both found real defects, all fixed in b7119ede — most importantly the stride was originally calibrated from a walking-speed measurement taken while the player was pressed against geometry (1.8 wu/s instead of 9.7), which would have shipped a ~10/s machine-gun cadence. No visuals: this change is audio-only.

https://claude.ai/code/session_017cm626D5M4tAz7yLPWPMFb
