### PR TITLE
feat(items): reject pickups into a full backpack

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -717,7 +717,11 @@ fn move_live_entity_into_container_at_cell(
     target_cell: (usize, usize),
 ) -> bool {
     let grid = crate::inventory::grid_for(world, container_entity_id);
-    let occupied = crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    let mut occupied =
+        crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    // See `move_live_entity_into_container_at_slot`: a re-grab can still show
+    // the dropped entity occupying its own old cell here.
+    occupied.remove_entity(dropped_entity_id);
     let dims = world
         .borrow::<View<dark::properties::PropInventoryDimensions>>()
         .ok()
@@ -815,7 +819,11 @@ fn container_can_accept_item(
         return false;
     }
     let grid = crate::inventory::grid_for(world, container_entity_id);
-    let occupied = crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    let mut occupied =
+        crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    // See `move_live_entity_into_container_at_slot`: a re-grab can still show
+    // the dropped entity occupying its own old cell here.
+    occupied.remove_entity(dropped_entity_id);
     let dims = world
         .borrow::<View<dark::properties::PropInventoryDimensions>>()
         .ok()
@@ -847,15 +855,19 @@ fn move_live_entity_into_container_at_slot(
     }
 
     // Give the item a cell in the container's grid, so it stays where it
-    // was put instead of being repacked on every draw. Computed before
-    // the borrow below, and *after* the item's own links are irrelevant -
-    // it is not in the container yet, so it cannot occupy a cell here.
+    // was put instead of being repacked on every draw.
     let slot = match requested_slot {
         Some(slot) => slot,
         None => {
             let grid = crate::inventory::grid_for(world, container_entity_id);
-            let occupied =
+            let mut occupied =
                 crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+            // A re-grab (e.g. a flat wield-swap's double-click pull from the
+            // backpack) can still show the dropped entity's own OLD cell as
+            // occupied here - its `Contains` link is not removed until below.
+            // Uncount it so the capacity check reflects the cell it is about
+            // to vacate, not phantom occupancy by itself.
+            occupied.remove_entity(dropped_entity_id);
             let dims = world
                 .borrow::<View<dark::properties::PropInventoryDimensions>>()
                 .ok()
@@ -8982,6 +8994,7 @@ impl MissionCore {
                     });
                     if !stored {
                         deferred.push(backpack_full_feedback(entity_id));
+                        self.restore_refused_store_to_world(entity_id);
                     }
                 }
                 VirtualHandEffect::StoreItemAtCell { entity_id, cell } => {
@@ -8995,32 +9008,59 @@ impl MissionCore {
                     });
                     if !stored {
                         deferred.push(backpack_full_feedback(entity_id));
+                        self.restore_refused_store_to_world(entity_id);
                     }
                 }
                 VirtualHandEffect::DropItem { entity_id } => {
-                    if !restore_live_entity_world_refs(&mut self.world, entity_id) {
-                        continue;
-                    }
-                    if self.is_vr_melee_weapon(entity_id) {
-                        // Recreate from authored physics so the released item
-                        // is an ordinary dynamic, harmless loose prop again.
-                        self.make_un_physical(entity_id);
-                    }
-                    // After the body is gone (so this writes the entity's
-                    // transform rather than pushing the outgoing kinematic
-                    // body around) and before the loose prop is rebuilt from
-                    // it.
-                    self.return_held_entity_to_the_hand(entity_id);
-                    self.make_physical(entity_id);
-
-                    self.script_world.dispatch(Message {
-                        payload: MessagePayload::Drop,
-                        to: entity_id,
-                    });
+                    self.drop_held_item_into_world(entity_id);
                 }
             }
         }
         deferred
+    }
+
+    /// Restore a HELD item's ordinary world presence (refs, physics body, and
+    /// the `Drop` script signal) - the shared tail for an explicit VR release
+    /// (`DropItem`) and a `StoreItem`/`StoreItemAtCell` deposit refused for
+    /// lack of backpack room. A held item (a wield swap's displaced weapon, a
+    /// grabbed item) has already had its world refs stripped and its physics
+    /// removed by the time it reaches a store attempt, so a plain refusal
+    /// would otherwise leave it with no container link, no physics, and no
+    /// hand - gone. A no-op if the entity was destroyed in between.
+    fn drop_held_item_into_world(&mut self, entity_id: EntityId) {
+        if !restore_live_entity_world_refs(&mut self.world, entity_id) {
+            return;
+        }
+        if self.is_vr_melee_weapon(entity_id) {
+            // Recreate from authored physics so the released item is an
+            // ordinary dynamic, harmless loose prop again.
+            self.make_un_physical(entity_id);
+        }
+        // After the body is gone (so this writes the entity's transform
+        // rather than pushing the outgoing kinematic body around) and before
+        // the loose prop is rebuilt from it.
+        self.return_held_entity_to_the_hand(entity_id);
+        self.make_physical(entity_id);
+
+        self.script_world.dispatch(Message {
+            payload: MessagePayload::Drop,
+            to: entity_id,
+        });
+    }
+
+    /// A `StoreItem`/`StoreItemAtCell` deposit was refused (no room): if the
+    /// item still has an ordinary physics body it was never picked up out of
+    /// the world (the flat "loot goes straight to the backpack" path), and
+    /// `drop_entity_into_container`'s failure already left it untouched -
+    /// nothing to do. Otherwise it left the world when it was grabbed/held
+    /// (a wield-swap's displaced weapon, a VR hand's held item whose strip
+    /// release was claimed but then lost the room race), and must be
+    /// restored rather than vanish.
+    fn restore_refused_store_to_world(&mut self, entity_id: EntityId) {
+        if self.id_to_physics.contains_key(&entity_id) {
+            return;
+        }
+        self.drop_held_item_into_world(entity_id);
     }
 
     fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -362,24 +362,44 @@ fn rewrite_strip_release(
     *effects = rewritten;
 }
 
-/// Whether the player's backpack can actually take a deposit right now.
+/// UI feedback for a backpack deposit the capacity check refused: retail's
+/// MISC.STR `InvFull` ("No room in inventory.") message. The port has no
+/// player-facing text facility yet (see the `SoftUseless`/`SoftUpgrade`
+/// handling above, which hits the same gap), so the text goes to the game
+/// log; the audible half is the same `repfail` UI chime other refused player
+/// actions already reuse (a replicator purchase without enough nanites).
+fn backpack_full_feedback(entity_id: EntityId) -> Effect {
+    game_log!(
+        INFO,
+        "{:?} refused: no room in inventory (MISC.STR InvFull)",
+        entity_id
+    );
+    Effect::PlaySound {
+        handle: AudioHandle::new(),
+        source: None,
+        name: "repfail".to_owned(),
+        spatial: false,
+    }
+}
+
+/// Whether the player's backpack can actually take `dropped_entity_id` right
+/// now.
 ///
 /// This is exactly [`move_live_entity_into_container`]'s success condition for
 /// a live item: a container without `Links` has nowhere to record the new
-/// `Contains`, and the transfer silently does nothing. Claiming a release the
-/// backpack cannot accept would suppress the world drop for an item that then
-/// lands nowhere at all, so the claim is gated on it and an unusable backpack
-/// simply leaves the ordinary world drop alone.
-fn backpack_accepts_deposit(world: &World) -> bool {
+/// `Contains`, and a full grid with nothing to merge into leaves the item
+/// unplaced. Claiming a release the backpack cannot accept would suppress the
+/// world drop for an item that then lands nowhere at all, so the claim is
+/// gated on it and an unusable/full backpack simply leaves the ordinary world
+/// drop alone (the VR "held item can't stay mid-air" fallback).
+fn backpack_accepts_deposit(world: &World, dropped_entity_id: EntityId) -> bool {
     let Ok(inventory_entity) = world
         .borrow::<UniqueView<PlayerInfo>>()
         .map(|player| player.inventory_entity_id)
     else {
         return false;
     };
-    world
-        .borrow::<View<Links>>()
-        .is_ok_and(|links| links.get(inventory_entity).is_ok())
+    container_can_accept_item(world, inventory_entity, dropped_entity_id)
 }
 
 /// Head-relative authored-space placement for the wide VR backpack canvas.
@@ -748,6 +768,68 @@ fn matching_stack_at_cell(
         .map(|_| occupant)
 }
 
+/// Any occupant of `container_entity_id`'s grid sharing `dropped_entity_id`'s
+/// template and both carrying a `PropStackCount` - the merge target a deposit
+/// falls back to when the container has no free cell for a new item at all,
+/// mirroring [`matching_stack_at_cell`] but searching the whole grid instead
+/// of one specific cell.
+fn find_mergeable_stack_anywhere(
+    world: &World,
+    container_entity_id: EntityId,
+    dropped_entity_id: EntityId,
+) -> Option<EntityId> {
+    let grid = crate::inventory::grid_for(world, container_entity_id);
+    let occupied = crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    let v_template = world
+        .borrow::<View<dark::properties::PropTemplateId>>()
+        .ok()?;
+    let v_stacks = world
+        .borrow::<View<dark::properties::PropStackCount>>()
+        .ok()?;
+    v_stacks.get(dropped_entity_id).ok()?;
+    let dropped_template = v_template.get(dropped_entity_id).ok()?.template_id;
+    occupied.all_items().find_map(|item| {
+        (item.entity != dropped_entity_id
+            && v_template.get(item.entity).ok().map(|t| t.template_id) == Some(dropped_template)
+            && v_stacks.get(item.entity).is_ok())
+        .then_some(item.entity)
+    })
+}
+
+/// Whether `container_entity_id` can accept a deposit of `dropped_entity_id`
+/// right now, without mutating anything: the container exists (has `Links` to
+/// record the transfer) and either has a free cell for the item's authored
+/// footprint or holds a stack it can merge into instead. Mirrors
+/// [`move_live_entity_into_container`]/[`MissionCore::drop_entity_into_container`]'s
+/// success condition for a live item, so a release can be pre-checked before
+/// it is claimed as a store (see [`backpack_accepts_deposit`]).
+fn container_can_accept_item(
+    world: &World,
+    container_entity_id: EntityId,
+    dropped_entity_id: EntityId,
+) -> bool {
+    if !world
+        .borrow::<View<Links>>()
+        .is_ok_and(|links| links.get(container_entity_id).is_ok())
+    {
+        return false;
+    }
+    let grid = crate::inventory::grid_for(world, container_entity_id);
+    let occupied = crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+    let dims = world
+        .borrow::<View<dark::properties::PropInventoryDimensions>>()
+        .ok()
+        .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
+        .unwrap_or((1, 1));
+    if occupied
+        .first_free_slot(dims.0 as usize, dims.1 as usize)
+        .is_some()
+    {
+        return true;
+    }
+    find_mergeable_stack_anywhere(world, container_entity_id, dropped_entity_id).is_some()
+}
+
 /// Shared placement body for [`move_live_entity_into_container`] and
 /// [`move_live_entity_into_container_at_cell`]: `requested_slot` names the
 /// exact ordinal to claim, or `None` for the first free cell.
@@ -779,11 +861,15 @@ fn move_live_entity_into_container_at_slot(
                 .ok()
                 .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
                 .unwrap_or((1, 1));
-            // A full container still takes the item (the drop is already
-            // permitted by the caller); it just has no cell to remember.
-            occupied
-                .first_free_slot(dims.0 as usize, dims.1 as usize)
-                .unwrap_or(0)
+            // No free cell: retail rejects the transfer rather than stacking
+            // items invisibly on top of each other (#backpack-capacity). The
+            // caller is responsible for trying a merge into an existing stack
+            // first (see `find_mergeable_stack_anywhere`) - this is the true
+            // "nowhere left to put it" case.
+            match occupied.first_free_slot(dims.0 as usize, dims.1 as usize) {
+                Some(slot) => slot,
+                None => return false,
+            }
         }
     };
 
@@ -1191,6 +1277,145 @@ mod cell_deposit_tests {
             0,
             "falls back to the first free cell, (0,0)"
         );
+    }
+}
+
+#[cfg(test)]
+mod capacity_enforcement_tests {
+    use dark::properties::{PropStackCount, PropTemplateId};
+
+    use super::*;
+
+    /// A container whose entire `CONTAINER_GRID` is occupied by distinct
+    /// (non-stackable) items - no free cell anywhere, and nothing a deposit
+    /// could merge into.
+    fn full_container() -> (World, EntityId) {
+        let mut world = World::new();
+        let (width, height) = crate::inventory::CONTAINER_GRID;
+        let to_links = (0..width * height)
+            .map(|slot| {
+                let occupant = world.add_entity((PropHasRefs(false),));
+                ToLink {
+                    link: Link::Contains(slot as u32),
+                    to_entity_id: Some(WrappedEntityId(occupant)),
+                    to_template_id: 0,
+                }
+            })
+            .collect();
+        let container = world.add_entity(Links { to_links });
+        (world, container)
+    }
+
+    /// The reported bug: a full backpack must refuse a first-free deposit
+    /// (retail's "no room in inventory") instead of silently absorbing it
+    /// with no cell to remember. Fails on main, where the fallback forces
+    /// slot 0 regardless of capacity.
+    #[test]
+    fn a_full_container_refuses_a_first_free_deposit() {
+        let (mut world, container) = full_container();
+        let item = world.add_entity(PropHasRefs(false));
+
+        assert!(
+            !move_live_entity_into_container(&mut world, container, item),
+            "a full container must refuse the deposit"
+        );
+        assert!(
+            world
+                .borrow::<View<Links>>()
+                .unwrap()
+                .get(container)
+                .unwrap()
+                .to_links
+                .iter()
+                .all(|link| link.to_entity_id.map(|w| w.0) != Some(item)),
+            "the refused item must not be linked into the container"
+        );
+    }
+
+    /// A full container still has nowhere for a stackable deposit to merge
+    /// into if nothing already inside shares its template - the "OR can
+    /// merge" half of the capacity check isn't a blanket pass.
+    #[test]
+    fn find_mergeable_stack_anywhere_is_none_without_a_matching_stack() {
+        let (mut world, container) = full_container();
+        let dropped = world.add_entity((
+            PropHasRefs(false),
+            PropTemplateId { template_id: 99 },
+            PropStackCount(1),
+        ));
+
+        assert_eq!(
+            find_mergeable_stack_anywhere(&world, container, dropped),
+            None
+        );
+    }
+
+    /// A full container that DOES hold a matching stack (template + both
+    /// stackable) offers it as a merge target anywhere in the grid, not just
+    /// at one specific cell - `matching_stack_at_cell`'s general-purpose
+    /// sibling, used by the ordinary (non-cell-targeted) deposit path.
+    #[test]
+    fn find_mergeable_stack_anywhere_finds_a_matching_stack() {
+        let (mut world, container) = full_container();
+        // Retarget one of the sixteen filler occupants to share the dropped
+        // item's template and carry a stack count, so it becomes the merge
+        // candidate.
+        let occupant = world
+            .borrow::<View<Links>>()
+            .unwrap()
+            .get(container)
+            .unwrap()
+            .to_links[3]
+            .to_entity_id
+            .unwrap()
+            .0;
+        world.add_component(occupant, PropTemplateId { template_id: 42 });
+        world.add_component(occupant, PropStackCount(3));
+        let dropped = world.add_entity((
+            PropHasRefs(false),
+            PropTemplateId { template_id: 42 },
+            PropStackCount(2),
+        ));
+
+        assert_eq!(
+            find_mergeable_stack_anywhere(&world, container, dropped),
+            Some(occupant)
+        );
+    }
+
+    /// The composed capacity check a release is gated on: a full container
+    /// with no mergeable stack cannot accept the deposit.
+    #[test]
+    fn container_can_accept_item_is_false_when_full_and_unmergeable() {
+        let (mut world, container) = full_container();
+        let dropped = world.add_entity((PropHasRefs(false),));
+
+        assert!(!container_can_accept_item(&world, container, dropped));
+    }
+
+    /// ...but a full container that holds a matching stack still accepts it,
+    /// via the merge fallback rather than a free cell.
+    #[test]
+    fn container_can_accept_item_is_true_when_full_but_mergeable() {
+        let (mut world, container) = full_container();
+        let occupant = world
+            .borrow::<View<Links>>()
+            .unwrap()
+            .get(container)
+            .unwrap()
+            .to_links[0]
+            .to_entity_id
+            .unwrap()
+            .0;
+        world.add_component(occupant, PropTemplateId { template_id: 7 });
+        world.add_component(occupant, PropStackCount(1));
+        let dropped = world.add_entity((
+            PropHasRefs(false),
+            PropTemplateId { template_id: 7 },
+            PropStackCount(1),
+        ));
+
+        assert!(container_can_accept_item(&world, container, dropped));
     }
 }
 
@@ -2415,7 +2640,9 @@ impl MissionCore {
         for (index, entity_id) in backpack_load_remap.overflow.into_iter().enumerate() {
             mission_core.spill_backpack_overflow(entity_id, index);
         }
-        mission_core.process_virtual_hand_effects(asset_cache, held_restore_effects);
+        // Restoring held items on load only emits `HoldItem`, never a store
+        // that could be refused - nothing to forward here.
+        let _ = mission_core.process_virtual_hand_effects(asset_cache, held_restore_effects);
         // Re-run each restored held item's Hold script. Only a fresh world
         // grab dispatches Hold (see `restore_held_item_physics` for the same
         // restore gap), so without this a save/load or level transition loses
@@ -3261,18 +3488,17 @@ impl MissionCore {
             })
         };
         // A stored item needs backpack room, so nothing is claimed unless the
-        // backpack can actually take it - a release is never suppressed into an
-        // item that lands nowhere. A collected one never enters the pack (its
-        // Frob awards and destroys it), so it is claimed either way.
-        let store: Vec<(EntityId, Option<(usize, usize)>)> =
-            if backpack_accepts_deposit(&self.world) {
-                store
-                    .into_iter()
-                    .map(|entity_id| (*entity_id, cell_for(*entity_id)))
-                    .collect()
-            } else {
-                Vec::new()
-            };
+        // backpack can actually take *that* item - a release is never
+        // suppressed into an item that lands nowhere. Checked per item (a
+        // full pack can still take a stackable that merges), so a two-hand
+        // release can claim one item and leave the other to its ordinary
+        // world drop. A collected one never enters the pack (its Frob awards
+        // and destroys it), so it is claimed either way.
+        let store: Vec<(EntityId, Option<(usize, usize)>)> = store
+            .into_iter()
+            .filter(|entity_id| backpack_accepts_deposit(&self.world, **entity_id))
+            .map(|entity_id| (*entity_id, cell_for(*entity_id)))
+            .collect();
 
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.
@@ -3286,7 +3512,7 @@ impl MissionCore {
             eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
         });
         rewrite_strip_release(&mut interaction_msgs, &store, &collect);
-        self.process_virtual_hand_effects(asset_cache, interaction_msgs);
+        effects.extend(self.process_virtual_hand_effects(asset_cache, interaction_msgs));
 
         // Tag the wielded weapon with the flat camera/crosshair fire ray so its
         // firing scripts spawn projectiles along the crosshair (camera-origin
@@ -4295,11 +4521,40 @@ impl MissionCore {
         self.id_to_physics.remove(&entity_id);
     }
 
+    /// Increment `occupant`'s stack by `dropped_entity_id`'s count and destroy
+    /// the now-redundant dropped entity - the shared merge tail for both the
+    /// cell-targeted deposit and the ordinary first-free deposit's
+    /// full-container fallback.
+    fn merge_dropped_stack(&mut self, occupant: EntityId, dropped_entity_id: EntityId) {
+        let dropped_count = self
+            .world
+            .borrow::<View<dark::properties::PropStackCount>>()
+            .unwrap()
+            .get(dropped_entity_id)
+            .unwrap()
+            .0;
+        if let Ok(mut stacks) = self
+            .world
+            .borrow::<ViewMut<dark::properties::PropStackCount>>()
+        {
+            if let Ok(occupant_stack) = (&mut stacks).get(occupant) {
+                occupant_stack.0 += dropped_count;
+            }
+        }
+        self.destroy_entity(dropped_entity_id);
+    }
+
     /// Move `dropped_entity_id` into `container_entity_id` (e.g. the player's
     /// inventory): drop any prior `Contains` links to it, add a fresh one from
     /// the container, mark it referenced, and remove it from the physical world.
-    /// Returns false if the container entity has no `Links` (so nothing was
-    /// added). Shared by the `DropEntityInfo` effect and the debug give lever.
+    ///
+    /// Returns false, leaving the item's prior links untouched, if the
+    /// container has no `Links` (nowhere to record the transfer) or has no
+    /// free cell for it and nothing to merge it into - a full backpack
+    /// refuses the deposit, retail-style, rather than absorbing it invisibly.
+    /// A full container that still holds a matching stack merges into it
+    /// instead of refusing (see [`find_mergeable_stack_anywhere`]). Shared by
+    /// the `DropEntityInfo` effect and the debug give lever.
     pub fn drop_entity_into_container(
         &mut self,
         container_entity_id: EntityId,
@@ -4312,8 +4567,15 @@ impl MissionCore {
         );
         if moved {
             self.make_un_physical(dropped_entity_id);
+            return true;
         }
-        moved
+        if let Some(occupant) =
+            find_mergeable_stack_anywhere(&self.world, container_entity_id, dropped_entity_id)
+        {
+            self.merge_dropped_stack(occupant, dropped_entity_id);
+            return true;
+        }
+        false
     }
 
     /// Like [`Self::drop_entity_into_container`], but targets `target_cell`
@@ -4324,7 +4586,9 @@ impl MissionCore {
     /// entity is consumed rather than claiming a cell of its own - matching
     /// the retail "drop onto a like stack" behavior. Any other occupied cell,
     /// or a cell off the grid, falls back to the ordinary first-free
-    /// placement (no swap semantics for a VR release).
+    /// placement (no swap semantics for a VR release); a full grid with no
+    /// free cell anywhere still merges into a matching stack wherever it sits,
+    /// and only refuses (returning false, untouched) when neither exists.
     pub fn drop_entity_into_container_at_cell(
         &mut self,
         container_entity_id: EntityId,
@@ -4337,22 +4601,7 @@ impl MissionCore {
             dropped_entity_id,
             target_cell,
         ) {
-            let dropped_count = self
-                .world
-                .borrow::<View<dark::properties::PropStackCount>>()
-                .unwrap()
-                .get(dropped_entity_id)
-                .unwrap()
-                .0;
-            if let Ok(mut stacks) = self
-                .world
-                .borrow::<ViewMut<dark::properties::PropStackCount>>()
-            {
-                if let Ok(occupant_stack) = (&mut stacks).get(occupant) {
-                    occupant_stack.0 += dropped_count;
-                }
-            }
-            self.destroy_entity(dropped_entity_id);
+            self.merge_dropped_stack(occupant, dropped_entity_id);
             return true;
         }
 
@@ -4364,8 +4613,15 @@ impl MissionCore {
         );
         if moved {
             self.make_un_physical(dropped_entity_id);
+            return true;
         }
-        moved
+        if let Some(occupant) =
+            find_mergeable_stack_anywhere(&self.world, container_entity_id, dropped_entity_id)
+        {
+            self.merge_dropped_stack(occupant, dropped_entity_id);
+            return true;
+        }
+        false
     }
 
     /// Re-encode the backpack's stored cells after effective Strength changes.
@@ -6057,7 +6313,9 @@ impl MissionCore {
                     parent_entity_id,
                     dropped_entity_id,
                 } => {
-                    self.drop_entity_into_container(parent_entity_id, dropped_entity_id);
+                    if !self.drop_entity_into_container(parent_entity_id, dropped_entity_id) {
+                        effects.push_front(backpack_full_feedback(dropped_entity_id));
+                    }
                 }
 
                 Effect::EquipCarriedWeapon { class_template_id } => {
@@ -6091,7 +6349,7 @@ impl MissionCore {
                     // grabs into an occupied hand no-op, so nothing is
                     // displaced there.
                     let grab_effects = self.interaction.grab(&self.world, entity_id, hand);
-                    self.process_virtual_hand_effects(asset_cache, grab_effects);
+                    effects.extend(self.process_virtual_hand_effects(asset_cache, grab_effects));
 
                     if self.interaction.is_holding(entity_id) {
                         // A grab routed through this effect (equip a carried
@@ -7484,7 +7742,7 @@ impl MissionCore {
                         && !self.interaction.is_wielding()
                     {
                         let msgs = self.interaction.wield(info.entity_id);
-                        self.process_virtual_hand_effects(asset_cache, msgs);
+                        effects.extend(self.process_virtual_hand_effects(asset_cache, msgs));
                     }
                 }
                 Effect::DebugCycleWeapon { head_rotation } => {
@@ -7532,7 +7790,7 @@ impl MissionCore {
                     // previously held weapon into the backpack, so each cycle
                     // swaps the viewmodel. No-op in VR (wield returns nothing).
                     let msgs = self.interaction.wield(info.entity_id);
-                    self.process_virtual_hand_effects(asset_cache, msgs);
+                    effects.extend(self.process_virtual_hand_effects(asset_cache, msgs));
                 }
                 Effect::TurnOffTweqs { entity_id } => {
                     self.world.run_with_data(turn_off_tweqs, entity_id);
@@ -8650,11 +8908,18 @@ impl MissionCore {
     /// Apply the effects produced by an interaction controller (the VR hands or
     /// the flat first-person controller). Shared so both presentations go
     /// through one path.
+    /// Returns any follow-up `Effect`s the batch produced (currently just UI
+    /// feedback for a refused backpack deposit) - the caller either has an
+    /// in-flight `effects` deque to extend (inside `handle_effects`) or its
+    /// own returned `Vec<Effect>` for the frame (`update`), and either way
+    /// they still reach `handle_effects`'s `Effect::PlaySound` handler this
+    /// frame.
     fn process_virtual_hand_effects(
         &mut self,
         asset_cache: &mut AssetCache,
         msgs: Vec<VirtualHandEffect>,
-    ) {
+    ) -> Vec<Effect> {
+        let mut deferred = Vec::new();
         for msg in msgs {
             match msg {
                 VirtualHandEffect::OutMessage { message } => self.script_world.dispatch(message),
@@ -8712,8 +8977,11 @@ impl MissionCore {
                         .borrow::<UniqueView<PlayerInfo>>()
                         .map(|player| player.inventory_entity_id)
                         .ok();
-                    if let Some(inventory_entity) = inventory_entity {
-                        self.drop_entity_into_container(inventory_entity, entity_id);
+                    let stored = inventory_entity.is_some_and(|inventory_entity| {
+                        self.drop_entity_into_container(inventory_entity, entity_id)
+                    });
+                    if !stored {
+                        deferred.push(backpack_full_feedback(entity_id));
                     }
                 }
                 VirtualHandEffect::StoreItemAtCell { entity_id, cell } => {
@@ -8722,8 +8990,11 @@ impl MissionCore {
                         .borrow::<UniqueView<PlayerInfo>>()
                         .map(|player| player.inventory_entity_id)
                         .ok();
-                    if let Some(inventory_entity) = inventory_entity {
-                        self.drop_entity_into_container_at_cell(inventory_entity, entity_id, cell);
+                    let stored = inventory_entity.is_some_and(|inventory_entity| {
+                        self.drop_entity_into_container_at_cell(inventory_entity, entity_id, cell)
+                    });
+                    if !stored {
+                        deferred.push(backpack_full_feedback(entity_id));
                     }
                 }
                 VirtualHandEffect::DropItem { entity_id } => {
@@ -8749,6 +9020,7 @@ impl MissionCore {
                 }
             }
         }
+        deferred
     }
 
     fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {
@@ -11580,12 +11852,12 @@ mod strip_deposit_tests {
             inventory_entity_id,
         });
         assert!(
-            !backpack_accepts_deposit(&world),
+            !backpack_accepts_deposit(&world, entity_id),
             "a backpack with no Links cannot take a deposit"
         );
 
         world.add_component(inventory_entity_id, Links::empty());
-        assert!(backpack_accepts_deposit(&world));
+        assert!(backpack_accepts_deposit(&world, entity_id));
     }
 }
 

--- a/tools/shock2-sdk/test/backpack-capacity.e2e.test.ts
+++ b/tools/shock2-sdk/test/backpack-capacity.e2e.test.ts
@@ -317,3 +317,57 @@ test(
     );
   },
 );
+
+test(
+  "a full backpack returns a wield-swap's displaced weapon to the world instead of losing it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // A wield swap holsters the previously-wielded weapon via the same
+    // `VirtualHandEffect::StoreItem` a world pickup uses - but that weapon
+    // already left the world (unphysical, refs stripped) the moment it was
+    // first wielded. A refusal here has nowhere to "leave it be": without a
+    // world-drop fallback the displaced weapon is destroyed nowhere - not in
+    // the backpack, not in the world, not held.
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 5,
+    });
+    await game.step({ frames: 30 });
+
+    await fillBackpackWithWrenches(game);
+
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    const firstWeapon = (await game.info()).player.wielded_entity_id;
+    assert.ok(firstWeapon, "the first cycle should wield a spawned weapon");
+    // A wielded item is itself listed (location "left_hand"), so this is the
+    // baseline to compare against after the swap - not zero.
+    const beforeCount = (await game.player.inventory()).count;
+
+    // The second cycle wields a different weapon, displacing the first -
+    // exactly the swap that must not lose it with a full backpack.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    const secondWeapon = (await game.info()).player.wielded_entity_id;
+    assert.ok(secondWeapon && secondWeapon !== firstWeapon, "the swap must wield a new weapon");
+
+    assert.equal(
+      (await game.player.inventory()).items.find((i) => i.entity_id === firstWeapon),
+      undefined,
+      "the displaced weapon must not enter the full backpack",
+    );
+    // Wrenches unchanged, one weapon still wielded (now `secondWeapon`) - the
+    // count itself doesn't distinguish "vanished" from "back in the world"
+    // (neither is counted), so it's a sanity check; the body check below is
+    // the one that actually catches the vanish.
+    assert.equal(
+      (await game.player.inventory()).count,
+      beforeCount,
+      "wrench count plus exactly one wielded weapon, unchanged",
+    );
+    assert.ok(
+      (await game.physics.bodies({ entityId: firstWeapon! })).bodies.length > 0,
+      "the displaced weapon must fall back into the world instead of vanishing",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/backpack-capacity.e2e.test.ts
+++ b/tools/shock2-sdk/test/backpack-capacity.e2e.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, HttpError } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
+
+// Retail parity: a full backpack REJECTS a transfer into it (panel Take,
+// flat/VR world pickup, VR strip deposit) rather than silently absorbing the
+// item with no cell to remember it by. The item stays exactly where it was.
+// A full container that still holds a matching stack (same template, both
+// stackable) merges into it instead of refusing.
+//
+// Negative-first: on the parent, `move_live_entity_into_container`'s
+// first-free fallback forces slot 0 regardless of capacity, so every "must
+// stay put" assertion below fails - the item lands in the backpack anyway.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** Gamesys templates (negative ids, stable across runs). */
+const WRENCH_TEMPLATE = -928; // 1x3 footprint, not stackable - fills a whole column.
+const CLIP_TEMPLATE = -1358; // "Small Standard Clip", 1x1, stackable.
+
+/** earth.mis stable mission-object ids (see flat-world-pickup.e2e.test.ts,
+ * nanite-player-stat.e2e.test.ts, vr-cyber-interface-deposit.e2e.test.ts). */
+const EARTH_CLIP_OBJ = 249; // Standard Clip, template -1358 - a world pickup.
+const EARTH_NANITE_PILE_OBJ = 257; // Big Nanite Pile - always-collected.
+
+/** medsci1.mis stable mission-object id (see container-loot.e2e.test.ts). */
+const MEDSCI_WRENCH_CORPSE = 1177; // MS Male Corpse -> Contains -> Wrench.
+
+/**
+ * Fill the player's backpack completely with non-stackable Wrenches (1x3):
+ * each spawn claims a whole grid column, so once every column is taken the
+ * next spawn has nowhere to go and genuinely refuses - independent of the
+ * backpack's actual width (Strength-dependent), no hardcoded cell count.
+ */
+async function fillBackpackWithWrenches(game: GameServer): Promise<number> {
+  let count = 0;
+  for (let i = 0; i < 40; i++) {
+    try {
+      await game.player.spawnItem(WRENCH_TEMPLATE);
+      count++;
+    } catch (error) {
+      assert.ok(
+        error instanceof HttpError && error.status === 400,
+        `expected a refusal (400), got ${error}`,
+      );
+      return count;
+    }
+  }
+  throw new Error("backpack never became full after 40 wrenches");
+}
+
+test(
+  "a full backpack still merges a matching stackable instead of refusing it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501),
+    });
+    await game.step({ frames: 2 });
+
+    // Spawn 1x1 Standard Clips one at a time until the backpack stops
+    // growing a new distinct item - the point at which every cell is
+    // already a Standard Clip stack and the next one can only merge. On the
+    // parent this loop never plateaus (a "full" backpack still silently
+    // takes every item at slot 0), so it exhausts its budget and throws.
+    let previousCount = (await game.player.inventory()).count;
+    let plateaued = false;
+    for (let i = 0; i < 60 && !plateaued; i++) {
+      await game.player.spawnItem(CLIP_TEMPLATE);
+      const currentCount = (await game.player.inventory()).count;
+      if (currentCount === previousCount) {
+        plateaued = true;
+      } else {
+        previousCount = currentCount;
+      }
+    }
+    assert.ok(
+      plateaued,
+      "the backpack should fill with distinct clip stacks and then start merging",
+    );
+    assert.ok(previousCount >= 10, `expected a plausible backpack size, got ${previousCount}`);
+
+    // The merge must not have refused the deposit: the spawned entity was
+    // consumed into an existing stack, so the item count is unchanged and
+    // every carried item is still a Standard Clip.
+    const inventory = await game.player.inventory();
+    assert.equal(inventory.count, previousCount);
+    assert.ok(
+      inventory.items.every((item) => item.name?.includes("Clip")),
+      `expected every carried item to be a Clip, got ${JSON.stringify(inventory.items)}`,
+    );
+  },
+);
+
+test(
+  "a full backpack refuses a panel Take: the item stays in its container",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 1,
+    });
+    await game.step({ frames: 5 });
+
+    const filled = await fillBackpackWithWrenches(game);
+    assert.ok(filled > 0, "expected at least one wrench to fit initially");
+    const beforeCount = (await game.player.inventory()).count;
+
+    const [corpse] = await game.entities.byTemplate(MEDSCI_WRENCH_CORPSE);
+    assert.ok(corpse, "expected MS Male Corpse 1177");
+    const containsBefore = (await game.entities.detail(corpse.id)).outgoing_links.filter(
+      (l) => l.link_type.startsWith("Contains"),
+    );
+    assert.equal(containsBefore.length, 1, "corpse 1177 should contain exactly the Wrench");
+    const lootWrenchId = containsBefore[0].target_id;
+
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.0,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.0,
+    });
+    await game.entities.sendMessage(corpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "frobbing the corpse should open its loot MFD panel");
+    const wrenchElement = panel!.elements.find(
+      (e: UiElement) => e.kind === "button" && e.entity_id === lootWrenchId,
+    );
+    assert.ok(
+      wrenchElement,
+      `loot panel should list the Wrench: ${JSON.stringify(panel!.elements)}`,
+    );
+
+    const [x, y, w, h] = wrenchElement.screen_rect;
+    const center: [number, number] = [x + w / 2, y + h / 2];
+    await game.input.set("pointer.position", center);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 5 });
+
+    // The refused item must NOT be in the backpack, count unchanged, and it
+    // must still be exactly where it was: contained by the corpse, no world
+    // physics presence, still listed in the (still open) loot panel.
+    assert.equal(
+      (await game.player.inventory()).items.find((i) => i.entity_id === lootWrenchId),
+      undefined,
+      "a refused Take must not add the item to the backpack",
+    );
+    assert.equal((await game.player.inventory()).count, beforeCount, "item count must be unchanged");
+    const containsAfter = (await game.entities.detail(corpse.id)).outgoing_links.filter(
+      (l) => l.link_type.startsWith("Contains"),
+    );
+    assert.equal(
+      containsAfter.length,
+      1,
+      "the refused Wrench must still be contained by the corpse",
+    );
+    assert.equal(containsAfter[0].target_id, lootWrenchId);
+    assert.equal(
+      (await game.physics.bodies({ entityId: lootWrenchId })).bodies.length,
+      0,
+      "the refused item stays contained, not spilled into the world",
+    );
+    const stillOpen = (await game.ui.state()).active_panel;
+    assert.ok(
+      stillOpen?.elements.some((e) => e.entity_id === lootWrenchId),
+      "the refused Wrench must still be listed in the loot panel",
+    );
+  },
+);
+
+test(
+  "a full backpack refuses a flat world pickup: the item stays in the world",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 2,
+    });
+    await game.step({ frames: 30 });
+
+    await fillBackpackWithWrenches(game);
+    const beforeCount = (await game.player.inventory()).count;
+
+    const entities = (await game.entities.list()).entities;
+    const clip = entities.find(
+      (entity) => entity.template_id === EARTH_CLIP_OBJ && entity.name.includes("Standard Clip"),
+    );
+    assert.ok(clip, "expected earth Weapons Training standard clip 249");
+
+    await earthWorldUse(game, clip!);
+
+    assert.equal(
+      (await game.player.inventory()).items.find((i) => i.entity_id === clip!.id),
+      undefined,
+      "the refused clip must not enter the backpack",
+    );
+    assert.equal((await game.player.inventory()).count, beforeCount, "item count must be unchanged");
+    assert.ok(
+      (await game.physics.bodies({ entityId: clip!.id })).bodies.length > 0,
+      "the refused clip must remain a loose world prop",
+    );
+  },
+);
+
+test(
+  "a full backpack still collects an always-collected nanite pile",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 3,
+    });
+    await game.step({ frames: 2 });
+
+    await fillBackpackWithWrenches(game);
+    const statsBefore = (await game.info()).player.stats;
+    assert.equal(statsBefore?.nanites ?? 0, 0, "a fresh earth character starts with no nanites");
+
+    const [pile] = await game.entities.byTemplate(EARTH_NANITE_PILE_OBJ);
+    assert.ok(pile, "expected earth mission object 257 (Big Nanite Pile)");
+    const stackProp = (await game.entities.detail(pile.id)).properties.find((p) =>
+      p.name.includes("StackCount"),
+    );
+    const expectedNanites = Number(stackProp?.value ?? "0");
+    assert.ok(expectedNanites > 0, "expected a positive authored stack count");
+
+    await game.entities.sendMessage(pile.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.info()).player.stats?.nanites,
+      expectedNanites,
+      "the pile must still collect as a stat even with a full backpack",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.find((i) => i.entity_id === pile.id),
+      undefined,
+      "a collected nanite pile must never enter the inventory grid",
+    );
+  },
+);
+
+test(
+  "a full backpack forces a VR strip release back to the ordinary world drop",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 4,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    await fillBackpackWithWrenches(game);
+    const beforeCount = (await game.player.inventory()).count;
+
+    const clip = (await game.entities.list()).entities.find(
+      (entity) => entity.template_id === EARTH_CLIP_OBJ,
+    );
+    assert.ok(clip, "expected earth mission object 249 (Standard Clip)");
+    assert.ok(
+      (await game.physics.bodies({ entityId: clip!.id })).bodies.length > 0,
+      "the clip must start as a physical world prop",
+    );
+
+    const [x, y, z] = clip!.position;
+    await game.player.teleport({ x: x + 1.2, y: y - 0.8, z: z + 1.2 });
+    await game.step({ frames: 30 });
+    const aim = await game.player.aimAt(clip!.id, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+    await aimVrHandAt(game, aim.world_point, 0.35, 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      clip!.id,
+      "the world squeeze must put the clip in the hand",
+    );
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const pose = (await game.ui.state()).panel_pose!;
+    assert.ok(pose, "the open interface must report its panel pose");
+
+    // Aim the holding hand at the strip and release - the deposit target -
+    // with a full backpack behind it.
+    const STRIP_CANVAS: [number, number] = [320, 60];
+    await aimVrHandAtCanvas(game, pose, STRIP_CANVAS, { squeeze: 1 });
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    // The hand must still empty (the item leaves it either way), but a full
+    // backpack means this is the ordinary world drop, not a deposit: no
+    // backpack entry, and the item lands back in the world with a body.
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.equal(
+      (await game.player.inventory()).items.find((i) => i.entity_id === clip!.id),
+      undefined,
+      "a refused strip deposit must not add the item to the backpack",
+    );
+    assert.equal((await game.player.inventory()).count, beforeCount, "item count must be unchanged");
+    assert.ok(
+      (await game.physics.bodies({ entityId: clip!.id })).bodies.length > 0,
+      "a refused strip release must fall back to the ordinary world drop",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Retail parity: a full backpack now **rejects** a pickup/deposit instead of
silently absorbing it with no cell to remember it by. The refused item stays
exactly where it was:

- **Panel Take** (loot MFD / cyber-interface strip) — item stays in its
  container, panel keeps listing it.
- **Flat/VR world pickup** — item stays in the world as a loose prop.
- **VR strip deposit** (targeted-cell or first-free) — item stays wherever it
  was; a *held* item can't stay mid-air, so that one case falls back to the
  ordinary world drop instead.

A full container that already holds a **matching stack** (same template, both
carrying a stack count) still merges into it — "has a free slot OR can
merge," not just free-slot. Always-collected items (keycards, cyber modules,
nanites, logs) are unaffected: they never occupy a slot and are exempt by
construction.

**Feedback on refusal:** retail's `MISC.STR` `InvFull` ("No room in
inventory.") to the game log — the port has no player-facing HUD text
facility yet (matching the existing `SoftUpgrade`/`SoftUseless` precedent) —
plus the `repfail` UI chime already reused for other refused player actions
(e.g. an unaffordable replicator purchase).

**Adversarial-review fix folded in:** a `StoreItem`/`StoreItemAtCell` refused
for an already-*held* item (a wield swap's displaced weapon, a re-grab) had
already left the world - refs stripped, physics removed - by the time the
deposit was attempted; refusing with only a feedback sound left it nowhere
(not backpack, not physical, not held). It now falls back to the same
world-restore path an ordinary VR release uses. Also fixed: the capacity scan
could undercount free cells by one when re-grabbing an item that still showed
its own stale slot as occupied.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [x] `cargo fmt --check -p shock2vr`
- [x] `cargo test -p shock2vr --lib` — 1092 passed (negative-first: new
      capacity/merge/wield-swap unit + e2e tests fail on `main` when the
      fixes are reverted, verified locally)
- [x] `tools/shock2-sdk` e2e (`SHOCK2_E2E=1`):
  - [x] new `backpack-capacity.e2e.test.ts` (6 scenarios) — merge-into-full,
        panel Take refusal, flat world-pickup refusal, always-collected
        nanite pile still collects, VR strip release world-drop fallback,
        wield-swap displaced-weapon world-drop fallback
  - [x] `missions.e2e.test.ts` — 23/23 missions load
  - [x] regression: `vr-cyber-interface-deposit`, `container-loot`,
        `inventory`, `inventory-drag`, `inventory-strength`,
        `hydro2-vr-keycard`, `nanite-player-stat`, `nanite-stack-label`,
        `flat-world-pickup` — all green
  - [x] full suite run once: reached 134/full with the only failure being
        the pre-existing documented baseline flake (`log-reader hydro3`,
        unrelated to this change); the run was then killed by unrelated
        resource contention from other concurrent sessions on the shared
        build machine, not by a test failure

## Before → after

![backpack-full panel Take before/after](https://gist.githubusercontent.com/tommy-xr/4bf865c21e8503e644de515c136f9806/raw/beforeafter.png)

<sub>medsci1.mis, MS Male Corpse's Wrench, backpack filled to capacity: on
`main` clicking Take silently removes it from the loot panel (absorbed into
the full pack with no cell); on this branch it stays listed. Captured
headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`,
deterministic fixed-timestep).</sub>

Claude-Session: https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72

