### PR TITLE
feat(vr): physical clip-insert reload gesture

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,7 +119,7 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 | --- | ------ | ----- |
 | `P` | `PathfindingTestCycle` | set start → set goal → show path |
 | `B` | `DebugCycleWeapon` | spawns and wields the next weapon (unlike the number row) |
-| `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | |
+| `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | no Quest binding - in VR ammo is swapped by inserting a clip of the other type |
 | `F` | `CycleGunSetting` | switch the wielded gun's fire mode (e.g. NORM / BURST); flat only |
 | `U` | `ReadLastUnreadLog` | Quest: left `Y` |
 | `M` | `ToggleMap` | flat only |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `Tab` / `I` - toggle the cyber interface ("use" mode): a cursor-driven UI over the 3D view
 - `Alt+S` / `Alt+L` - quick save / quick load
 - Quest VR: press the left controller's `X` button to toggle the cyber interface.
+- Quest VR: reload by hand. Pull a clip out of the cyber interface's inventory
+  strip with your free hand and bring it to the gun the other hand is holding -
+  the clip goes in and the weapon is loaded. A clip of a different ammo type
+  swaps the type over, returning the rounds already loaded to your pack.
 - Quest VR: press the left controller's `Y` button to open the newest unread
   audio log. Press `Y` again to close it; after every log is read, `Y` replays
   the most recently collected log.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - Quest VR: reload by hand. Pull a clip out of the cyber interface's inventory
   strip with your free hand and bring it to the gun the other hand is holding -
   the clip goes in and the weapon is loaded. A clip of a different ammo type
-  swaps the type over, returning the rounds already loaded to your pack.
+  swaps the type over, returning the rounds already loaded to your pack - that
+  insert is the only way to change ammo type in the headset, so the types you
+  can select are the ones you are carrying clips for. There is no reload or
+  ammo-swap button on the controllers; the gesture is the control.
 - Quest VR: press the left controller's `Y` button to open the newest unread
   audio log. Press `Y` again to close it; after every log is read, `Y` replays
   the most recently collected log.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -363,14 +363,20 @@ fn main() {
         .create_action::<bool>("menu", "Pause Menu", &[])
         .unwrap();
 
-    // The gun hand's two face buttons: A reloads, B swaps ammo type.
-    let reload_action = action_set
-        .create_action::<bool>("reload", "Reload Weapon", &[])
+    // The right controller's two face buttons. Nothing binds them singly - VR
+    // reloading is the physical clip-insert gesture - so they exist only as the
+    // two halves of the free-camera chord.
+    let free_camera_a_action = action_set
+        .create_action::<bool>("free_camera_a", "Free Camera Chord (A)", &[])
         .unwrap();
 
-    let cycle_ammo_action = action_set
-        .create_action::<bool>("cycle_ammo", "Cycle Ammo Type", &[])
+    let free_camera_b_action = action_set
+        .create_action::<bool>("free_camera_b", "Free Camera Chord (B)", &[])
         .unwrap();
+
+    let free_camera_chord = shock2vr::input::InputAction::ToggleFreeCamera
+        .quest_touch_chord_paths()
+        .expect("Quest free-camera chord binding");
 
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
@@ -484,24 +490,12 @@ fn main() {
                         .unwrap(),
                 ),
                 xr::Binding::new(
-                    &reload_action,
-                    xr_instance
-                        .string_to_path(
-                            shock2vr::input::InputAction::Reload
-                                .quest_touch_click_path()
-                                .expect("Quest reload binding"),
-                        )
-                        .unwrap(),
+                    &free_camera_a_action,
+                    xr_instance.string_to_path(free_camera_chord.0).unwrap(),
                 ),
                 xr::Binding::new(
-                    &cycle_ammo_action,
-                    xr_instance
-                        .string_to_path(
-                            shock2vr::input::InputAction::CycleAmmo
-                                .quest_touch_click_path()
-                                .expect("Quest cycle-ammo binding"),
-                        )
-                        .unwrap(),
+                    &free_camera_b_action,
+                    xr_instance.string_to_path(free_camera_chord.1).unwrap(),
                 ),
             ],
         )
@@ -809,8 +803,12 @@ fn main() {
         let use_mode_state = use_mode_action.state(&session, xr::Path::NULL).unwrap();
         let audio_log_state = audio_log_action.state(&session, xr::Path::NULL).unwrap();
         let menu_state = menu_action.state(&session, xr::Path::NULL).unwrap();
-        let reload_state = reload_action.state(&session, xr::Path::NULL).unwrap();
-        let cycle_ammo_state = cycle_ammo_action.state(&session, xr::Path::NULL).unwrap();
+        let free_camera_a_state = free_camera_a_action
+            .state(&session, xr::Path::NULL)
+            .unwrap();
+        let free_camera_b_state = free_camera_b_action
+            .state(&session, xr::Path::NULL)
+            .unwrap();
         // Only edge-detect while the action is live: with the session merely
         // VISIBLE (system overlay up), current_state reads false even though
         // the button may still be physically held, and treating that as a
@@ -839,38 +837,12 @@ fn main() {
             menu_state.changed_since_last_sync,
             menu_state.current_state,
         );
-        // Right A and B carry two meanings: on their own they reload and swap
-        // ammo (#1144), and together they toggle the free camera. There is no
-        // unbound button left on the Touch to give the camera, so it shares
-        // these - and only while its developer option is on, which is the one
-        // time the player is deliberately debugging rather than shooting.
+        // Right A and B are the free camera's chord and nothing else: gun
+        // handling in VR is the physical clip-insert gesture, so neither button
+        // carries an action of its own and pressing one alone does nothing.
+        // (That is what retires #1144's second-press suppression - there is no
+        // longer an ammo swap for completing the chord to trigger.)
         //
-        // While the gate is on, a button whose partner is ALREADY held is
-        // suppressed, so completing the chord cannot also swap your ammo. The
-        // first button pressed still fires its own action (its edge lands
-        // before the chord exists), which is why the pair is A-reloads-first
-        // rather than B: an extra reload costs nothing, an ammo swap is a
-        // change you have to undo. With the option off, both behave exactly as
-        // #1144 defines them.
-        let free_camera_gate = shock2vr::free_camera::FreeCamera::is_enabled();
-        let suppress_reload = free_camera_gate && cycle_ammo_state.current_state;
-        let suppress_cycle_ammo = free_camera_gate && reload_state.current_state;
-        if !suppress_reload {
-            action_state.sync_discrete_button(
-                shock2vr::input::InputAction::Reload,
-                reload_state.is_active,
-                reload_state.changed_since_last_sync,
-                reload_state.current_state,
-            );
-        }
-        if !suppress_cycle_ammo {
-            action_state.sync_discrete_button(
-                shock2vr::input::InputAction::CycleAmmo,
-                cycle_ammo_state.is_active,
-                cycle_ammo_state.changed_since_last_sync,
-                cycle_ammo_state.current_state,
-            );
-        }
         // A chord is edge-detected from the pair's raw states, so it takes
         // them directly rather than through `sync_discrete_button`. Activity
         // is passed through rather than folded into the button states: while
@@ -879,9 +851,9 @@ fn main() {
         // the same hazard the latched crouch above guards against.
         action_state.sync_chord(
             shock2vr::input::InputAction::ToggleFreeCamera,
-            reload_state.is_active && cycle_ammo_state.is_active,
-            reload_state.current_state,
-            cycle_ammo_state.current_state,
+            free_camera_a_state.is_active && free_camera_b_state.is_active,
+            free_camera_a_state.current_state,
+            free_camera_b_state.current_state,
         );
 
         let left_trigger_value = left_trigger

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -200,10 +200,12 @@ impl InputAction {
             // The right controller's menu button is reserved by the Quest
             // system UI; the left one is the app's.
             InputAction::TogglePauseMenu => Some("/user/hand/left/input/menu/click"),
-            // The right controller holds the gun, so its two face buttons own
-            // the two gun-handling actions - A reloads, B swaps ammo type.
-            InputAction::Reload => Some("/user/hand/right/input/a/click"),
-            InputAction::CycleAmmo => Some("/user/hand/right/input/b/click"),
+            // `Reload` and `CycleAmmo` deliberately have NO Quest binding: in
+            // VR reloading is the physical clip-insert gesture, which is
+            // unambiguous per weapon and therefore works while dual wielding,
+            // where a face button on one controller cannot say which gun it
+            // meant. Both actions remain reachable everywhere else (flat keys,
+            // HTTP, the SDK).
             _ => None,
         }
     }
@@ -211,18 +213,12 @@ impl InputAction {
     /// Production Meta Quest Touch binding for actions reached by a two-button
     /// **chord** rather than a button of their own.
     ///
-    /// The Touch has no button left to give: `X`, `Y` and the left `Menu` are
-    /// taken, both thumbstick clicks are jump and crouch, right `A` and `B`
-    /// are reload and swap-ammo, and the right `Menu` belongs to the Quest
-    /// system UI. So a debug toggle *shares* a pair rather than owning one -
-    /// here right `A`+`B`, whose own actions only matter with a weapon in
-    /// hand. The pair's edge is resolved by [`InputActionState::sync_chord`].
-    ///
-    /// Sharing is safe because the chord is dead unless the free camera's
-    /// developer option is on. While it IS on, `oculus_runtime` suppresses
-    /// whichever button is pressed *second*, so completing the chord cannot
-    /// also swap your ammo; the first press still fires its own action, which
-    /// is why the harmless one (`Reload`) is the natural opener.
+    /// The Touch has few buttons to give: `X`, `Y` and the left `Menu` are
+    /// taken, both thumbstick clicks are jump and crouch, and the right `Menu`
+    /// belongs to the Quest system UI. A debug toggle takes a *pair* rather
+    /// than a scarce single button - here right `A`+`B`, which the physical
+    /// clip-insert reload freed of the gun-handling actions they used to
+    /// carry. The pair's edge is resolved by [`InputActionState::sync_chord`].
     ///
     /// [`InputActionState::sync_chord`]: crate::input::InputActionState::sync_chord
     pub fn quest_touch_chord_paths(&self) -> Option<(&'static str, &'static str)> {
@@ -308,24 +304,12 @@ mod tests {
     /// The free camera is a chord, not a button, and must never quietly
     /// become one: a single-path binding here would consume a face button the
     /// Touch does not have to spare.
-    ///
-    /// Its two halves deliberately DO collide with `Reload` and `CycleAmmo`
-    /// (#1144) - there is no unbound button left - which is exactly why
-    /// `oculus_runtime` suppresses the second press while the developer
-    /// option is on. Pinning that here means a future rebinding of either gun
-    /// action has to come back and re-read the suppression rule rather than
-    /// silently making the chord fire both.
     #[test]
-    fn the_free_camera_chord_shares_the_two_gun_buttons() {
+    fn the_free_camera_chord_owns_the_right_face_buttons() {
         assert_eq!(InputAction::ToggleFreeCamera.quest_touch_click_path(), None);
         let (first, second) = InputAction::ToggleFreeCamera
             .quest_touch_chord_paths()
             .expect("free camera chord binding");
-        assert_eq!(first, InputAction::Reload.quest_touch_click_path().unwrap());
-        assert_eq!(
-            second,
-            InputAction::CycleAmmo.quest_touch_click_path().unwrap()
-        );
         assert_eq!(first, "/user/hand/right/input/a/click");
         assert_eq!(second, "/user/hand/right/input/b/click");
     }
@@ -342,16 +326,20 @@ mod tests {
         }
     }
 
+    /// Gun handling is a GESTURE in VR, not a button. A face button lives on
+    /// one controller, so it cannot say which of two wielded guns it meant;
+    /// carrying a clip to a magazine always can. Both actions stay fully
+    /// drivable elsewhere - flat keys, HTTP, the SDK - which is what the e2e
+    /// coverage uses.
     #[test]
-    fn quest_touch_assigns_the_right_face_buttons_to_gun_handling() {
-        assert_eq!(
-            InputAction::Reload.quest_touch_click_path(),
-            Some("/user/hand/right/input/a/click")
-        );
-        assert_eq!(
-            InputAction::CycleAmmo.quest_touch_click_path(),
-            Some("/user/hand/right/input/b/click")
-        );
+    fn quest_touch_leaves_gun_handling_to_the_clip_insert_gesture() {
+        assert_eq!(InputAction::Reload.quest_touch_click_path(), None);
+        assert_eq!(InputAction::CycleAmmo.quest_touch_click_path(), None);
+        assert!(InputAction::Reload.quest_touch_chord_paths().is_none());
+        assert!(InputAction::CycleAmmo.quest_touch_chord_paths().is_none());
+        // Still first-class actions, just not Quest-bound ones.
+        assert!(InputAction::all().contains(&InputAction::Reload));
+        assert!(InputAction::all().contains(&InputAction::CycleAmmo));
     }
 
     #[test]

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -130,10 +130,21 @@ pub struct CanvasPointer {
     pub canvas_pos: Option<Vector2<f32>>,
     /// The click button: flat LMB, VR trigger.
     pub pressed: bool,
-    /// The grab gesture: the VR squeeze. Flat has none, so it is always false
-    /// there - the same `GUIHover` field the hand ray fills, which is what lets
-    /// a squeeze on a panel item pull it into the hand.
+    /// The grab gesture: the VR squeeze, for the hand this pointer belongs to.
+    /// Flat has none, so it is always false there - the same `GUIHover` field
+    /// the hand ray fills, which is what lets a squeeze on a panel item pull it
+    /// into the hand.
     pub grabbing: bool,
+    /// BOTH controllers' squeeze this frame, indexed by
+    /// [`crate::mission::mission_core::hand_slot`].
+    ///
+    /// The panel edge-detects each hand separately, and it needs both hands to
+    /// do it: a VR player holds a gun by holding that hand's squeeze DOWN, so a
+    /// single shared latch reads "already grabbing" forever and the other
+    /// hand's fresh squeeze on a slot never registers an edge - which is
+    /// exactly the reach for a clip that the physical reload is made of.
+    /// Flat has no grab gesture, so it passes `[false; 2]`.
+    pub grabbing_hands: [bool; 2],
     /// Which hand the gesture belongs to, for the panel's per-hand edge
     /// tracking and for `GrabEntity`'s destination hand. Flat reports `Right`.
     pub hand: Handedness,
@@ -161,14 +172,19 @@ pub fn vr_canvas_pointer(
         .active_ray()
         .map(|ray| ray.handedness)
         .unwrap_or(Handedness::Right);
-    let input_hand = match hand {
-        Handedness::Left => &input_context.left_hand,
-        Handedness::Right => &input_context.right_hand,
+    let squeezing = |input_hand: &crate::input_context::Hand| {
+        input_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD
     };
+    let mut grabbing_hands = [false; 2];
+    grabbing_hands[crate::mission::mission_core::hand_slot(Handedness::Left)] =
+        squeezing(&input_context.left_hand);
+    grabbing_hands[crate::mission::mission_core::hand_slot(Handedness::Right)] =
+        squeezing(&input_context.right_hand);
     CanvasPointer {
         canvas_pos: pass.point(),
         pressed: pass.pressed,
-        grabbing: input_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD,
+        grabbing: grabbing_hands[crate::mission::mission_core::hand_slot(hand)],
+        grabbing_hands,
         hand,
         bare_view: BareViewPress::Ignore,
     }
@@ -235,7 +251,7 @@ pub struct FlatUiHost {
     /// is level-triggered (`GuiComponent::get_event` reads `is_grabbed`
     /// directly), so a squeeze held while the ray swept the grid would take
     /// every slot it crossed.
-    last_pointer_grabbing: bool,
+    last_pointer_grabbing: [bool; 2],
     /// Last known render-target size, for pointer->canvas letterbox mapping
     /// (updated every rendered frame; 4:3 default until the first render).
     screen_size: Vector2<f32>,
@@ -266,7 +282,7 @@ impl FlatUiHost {
             hover_close: false,
             last_pointer_pressed: false,
             last_pointer: None,
-            last_pointer_grabbing: false,
+            last_pointer_grabbing: [false; 2],
             screen_size: CANVAS_SIZE,
         }
     }
@@ -568,6 +584,7 @@ impl FlatUiHost {
             ),
             pressed: pointer.pressed,
             grabbing: false,
+            grabbing_hands: [false; 2],
             hand: Handedness::Right,
             bare_view: BareViewPress::Exit,
         });
@@ -584,10 +601,17 @@ impl FlatUiHost {
         pointer: Option<CanvasPointer>,
     ) -> (Vec<Message>, Vec<FlatUiDragAction>) {
         // Edge-detect the grab before anything can return early, so a squeeze
-        // held across frames is one gesture wherever the ray goes.
-        let grabbing = pointer.map(|p| p.grabbing).unwrap_or(false);
-        let grab_edge = grabbing && !self.last_pointer_grabbing;
-        self.last_pointer_grabbing = grabbing;
+        // held across frames is one gesture wherever the ray goes. Both hands
+        // are latched every frame, and the edge that reaches the panel is the
+        // POINTING hand's own: the other hand's squeeze is very often held for
+        // the whole session (that is how a VR player keeps hold of a gun) and
+        // must not stand in for a gesture it did not make.
+        let grabbing_hands = pointer.map(|p| p.grabbing_hands).unwrap_or([false; 2]);
+        let grab_edge = pointer.is_some_and(|p| {
+            let slot = crate::mission::mission_core::hand_slot(p.hand);
+            grabbing_hands[slot] && !self.last_pointer_grabbing[slot]
+        });
+        self.last_pointer_grabbing = grabbing_hands;
         // `/v1/ui` reports the gesture as the player is making it (held or
         // not); only what reaches the panel is reduced to the edge.
         self.last_pointer = pointer;
@@ -2396,6 +2420,73 @@ mod tests {
         }
     }
 
+    /// A VR player keeps hold of a gun by keeping that hand's squeeze DOWN, so
+    /// the other hand's squeeze on a slot is the ONLY way to get a clip out of
+    /// the strip - the reach the physical reload is made of. A single shared
+    /// grab latch reads the gun hand's permanently-held squeeze as "already
+    /// grabbing" and swallows the free hand's rising edge forever.
+    #[test]
+    fn a_squeeze_held_in_the_other_hand_does_not_swallow_this_ones_grab() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        let slot = vec2(23.5, 34.0);
+        // The gun hand: off the panel, squeezing, and never letting go.
+        let holding_right = Hand {
+            squeeze_value: 1.0,
+            ..test_support::hand_aimed_away(0.0)
+        };
+        let frame = |left_squeeze: f32| {
+            let input = InputContext {
+                right_hand: holding_right.clone(),
+                left_hand: Hand {
+                    squeeze_value: left_squeeze,
+                    ..test_support::hand_aimed_at(CANVAS_SIZE, slot, 0.0)
+                },
+                ..InputContext::default()
+            };
+            let pass = crate::ui::vr_pointer_pass(
+                &input,
+                CANVAS_SIZE,
+                &test_support::test_panel(),
+                crate::ui::PointerEngagement::TriggerOrGrab,
+            );
+            vr_canvas_pointer(&pass, &input)
+        };
+        let grabs = |msgs: Vec<Message>| {
+            msgs.iter()
+                .filter(|m| {
+                    matches!(
+                        m.payload,
+                        MessagePayload::GUIHover {
+                            is_grabbing: true,
+                            ..
+                        }
+                    )
+                })
+                .count()
+        };
+
+        // Several frames with the gun hand already squeezing, so a shared latch
+        // has every chance to settle on "grabbing".
+        host.update_canvas(&world, Some(frame(0.0)));
+        host.update_canvas(&world, Some(frame(0.0)));
+
+        let (grabbed, _) = host.update_canvas(&world, Some(frame(1.0)));
+        assert_eq!(
+            grabs(grabbed),
+            1,
+            "the free hand's fresh squeeze must reach the slot"
+        );
+        assert!(
+            host.cursor_debug().is_none(),
+            "a squeeze pulls the item into the HAND, not onto the cursor"
+        );
+        let _ = wrench;
+
+        // ...and it is still one gesture: holding it must not re-grab.
+        let (held, _) = host.update_canvas(&world, Some(frame(1.0)));
+        assert_eq!(grabs(held), 0, "the held squeeze must not grab again");
+    }
+
     /// The panel's grab handler is level-triggered, so a squeeze held while the
     /// ray sweeps the grid would take every slot it crossed. Only the rising
     /// edge reaches the panel.
@@ -2406,6 +2497,7 @@ mod tests {
             canvas_pos: Some(vec2(canvas.0, canvas.1)),
             pressed: false,
             grabbing: true,
+            grabbing_hands: [false, true],
             hand: Handedness::Right,
             bare_view: BareViewPress::Ignore,
         };

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -136,7 +136,7 @@ pub struct CanvasPointer {
     /// into the hand.
     pub grabbing: bool,
     /// BOTH controllers' squeeze this frame, indexed by
-    /// [`crate::mission::mission_core::hand_slot`].
+    /// [`crate::vr_config::hand_slot`].
     ///
     /// The panel edge-detects each hand separately, and it needs both hands to
     /// do it: a VR player holds a gun by holding that hand's squeeze DOWN, so a
@@ -176,14 +176,14 @@ pub fn vr_canvas_pointer(
         input_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD
     };
     let mut grabbing_hands = [false; 2];
-    grabbing_hands[crate::mission::mission_core::hand_slot(Handedness::Left)] =
+    grabbing_hands[crate::vr_config::hand_slot(Handedness::Left)] =
         squeezing(&input_context.left_hand);
-    grabbing_hands[crate::mission::mission_core::hand_slot(Handedness::Right)] =
+    grabbing_hands[crate::vr_config::hand_slot(Handedness::Right)] =
         squeezing(&input_context.right_hand);
     CanvasPointer {
         canvas_pos: pass.point(),
         pressed: pass.pressed,
-        grabbing: grabbing_hands[crate::mission::mission_core::hand_slot(hand)],
+        grabbing: grabbing_hands[crate::vr_config::hand_slot(hand)],
         grabbing_hands,
         hand,
         bare_view: BareViewPress::Ignore,
@@ -606,12 +606,21 @@ impl FlatUiHost {
         // POINTING hand's own: the other hand's squeeze is very often held for
         // the whole session (that is how a VR player keeps hold of a gun) and
         // must not stand in for a gesture it did not make.
-        let grabbing_hands = pointer.map(|p| p.grabbing_hands).unwrap_or([false; 2]);
-        let grab_edge = pointer.is_some_and(|p| {
-            let slot = crate::mission::mission_core::hand_slot(p.hand);
-            grabbing_hands[slot] && !self.last_pointer_grabbing[slot]
-        });
-        self.last_pointer_grabbing = grabbing_hands;
+        //
+        // A frame with NO pointer at all (the VR pass is still coming up, flat
+        // with the cursor off the window) leaves the latches ALONE rather than
+        // clearing them: a hand that has been squeezing throughout would
+        // otherwise read as a rising edge on the first frame a pointer exists
+        // and grab whatever slot it happened to be over.
+        let grab_edge = match pointer {
+            Some(pointer) => {
+                let slot = crate::vr_config::hand_slot(pointer.hand);
+                let edge = pointer.grabbing_hands[slot] && !self.last_pointer_grabbing[slot];
+                self.last_pointer_grabbing = pointer.grabbing_hands;
+                edge
+            }
+            None => false,
+        };
         // `/v1/ui` reports the gesture as the player is making it (held or
         // not); only what reaches the panel is reduced to the edge.
         self.last_pointer = pointer;
@@ -2398,7 +2407,9 @@ mod tests {
             &input,
             CANVAS_SIZE,
             &test_support::test_panel(),
-            crate::ui::PointerEngagement::TriggerOrGrab,
+            crate::ui::PointerEngagement::TriggerOrGrab {
+                carrying: [false; 2],
+            },
         );
         let pointer = vr_canvas_pointer(&pass, &input);
         assert_eq!(pointer.hand, Handedness::Left);
@@ -2447,7 +2458,9 @@ mod tests {
                 &input,
                 CANVAS_SIZE,
                 &test_support::test_panel(),
-                crate::ui::PointerEngagement::TriggerOrGrab,
+                crate::ui::PointerEngagement::TriggerOrGrab {
+                    carrying: [false; 2],
+                },
             );
             vr_canvas_pointer(&pass, &input)
         };

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -163,7 +163,7 @@ const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
 /// Index of a hand in the per-hand `[left, right]` arrays this module keeps
 /// (the VR grab swallow, the on-panel arbitration). One conversion, so the two
 /// sides of a latch can never disagree about which slot a hand owns.
-fn hand_slot(hand: crate::vr_config::Handedness) -> usize {
+pub(crate) fn hand_slot(hand: crate::vr_config::Handedness) -> usize {
     match hand {
         crate::vr_config::Handedness::Left => 0,
         crate::vr_config::Handedness::Right => 1,
@@ -8124,16 +8124,18 @@ impl MissionCore {
         )]
     }
 
-    /// The insert-refused cue: the gun's own dry-fire click, the refusal sound
-    /// the player already associates with "this weapon will not do that".
+    /// The insert-refused cue: `repfail`, the game's own "that request is not
+    /// going to happen" chime (the replicator plays it for an unaffordable
+    /// purchase). Deliberately NOT the weapon's dry-fire schema - most guns,
+    /// the pistol included, author no `dryfire` event at all, so the refusal
+    /// would be silent on exactly the weapons a player reloads most.
     fn refuse_clip_insert(&self, weapon: EntityId) -> Effect {
-        crate::scripts::script_util::play_environmental_sound(
-            &self.world,
-            weapon,
-            "dryfire",
-            vec![],
-            AudioHandle::new(),
-        )
+        Effect::PlaySound {
+            handle: AudioHandle::new(),
+            source: Some(weapon),
+            name: "repfail".to_owned(),
+            spatial: false,
+        }
     }
 
     /// Cycle `weapon` to its next ammo type (next `Projectile` link). No-op when

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -161,14 +161,9 @@ fn resolve_optional_log_art_texture(
 const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
 
 /// Index of a hand in the per-hand `[left, right]` arrays this module keeps
-/// (the VR grab swallow, the on-panel arbitration). One conversion, so the two
-/// sides of a latch can never disagree about which slot a hand owns.
-pub(crate) fn hand_slot(hand: crate::vr_config::Handedness) -> usize {
-    match hand {
-        crate::vr_config::Handedness::Left => 0,
-        crate::vr_config::Handedness::Right => 1,
-    }
-}
+/// (the VR grab swallow, the on-panel arbitration). The crate-wide conversion,
+/// so a per-hand array built here reads correctly wherever it is consumed.
+use crate::vr_config::hand_slot;
 
 /// Advance the VR grab swallow one frame, per hand (see
 /// [`MissionCore::vr_squeeze_swallow`]).
@@ -1626,6 +1621,11 @@ pub struct MissionCore {
     /// other hand's weapon magazine zone. The physical reload fires on the
     /// rising edge of this - see [`update_clip_insert_gesture`] - so a clip
     /// resting against the gun inserts once rather than every frame.
+    ///
+    /// Not saved, like its neighbours above: a save taken with a clip already
+    /// touching the gun restores with the latch clear and inserts on the first
+    /// frame. That is the same insert the player was one frame away from
+    /// making, so it is left as the cheaper behaviour rather than persisted.
     ///
     /// [`update_clip_insert_gesture`]: MissionCore::update_clip_insert_gesture
     vr_clip_insert_engaged: [bool; 2],
@@ -3211,13 +3211,18 @@ impl MissionCore {
             );
             // The VR ray plays the role of the mouse: one pass resolves where
             // each controller lands on the panel and which one owns it.
+            let (left_carrying, right_carrying) = self.interaction.held_entities();
+            let mut carrying = [false; 2];
+            carrying[hand_slot(crate::vr_config::Handedness::Left)] = left_carrying.is_some();
+            carrying[hand_slot(crate::vr_config::Handedness::Right)] = right_carrying.is_some();
             self.vr_use_mode_pointer = Some(crate::ui::vr_pointer_pass(
                 input_context,
                 crate::mission::flat_ui_host::CANVAS_SIZE,
                 &panel,
                 // A squeeze claims the panel here, unlike on a frontend screen:
-                // it is how a hand takes an item out of a slot.
-                crate::ui::PointerEngagement::TriggerOrGrab,
+                // it is how a hand takes an item out of a slot - but only from a
+                // hand that is not already using its squeeze to hold something.
+                crate::ui::PointerEngagement::TriggerOrGrab { carrying },
             ));
         }
         if self.vr_trigger_swallow && !self.use_mode {
@@ -8010,13 +8015,13 @@ impl MissionCore {
             // holds a gun, so dual wielding inserts into the gun the clip
             // actually reached.
             let pair = match (held[slot], held[1 - slot]) {
-                (Some(clip), Some(weapon)) if self.magazine_capacity(weapon).is_some() => {
-                    Some((clip, weapon))
-                }
+                (Some(clip), Some(weapon)) => self
+                    .magazine_capacity(weapon)
+                    .map(|capacity| (clip, weapon, capacity)),
                 _ => None,
             };
             let engaged = pair
-                .and_then(|(clip, weapon)| {
+                .and_then(|(clip, weapon, _)| {
                     let clip_position = self.entity_world_position(clip)?;
                     let weapon_position = self.entity_world_position(weapon)?;
                     Some(crate::mission::reload::clip_insert_zone_engaged(
@@ -8027,8 +8032,8 @@ impl MissionCore {
                 .unwrap_or(false);
             let entered = engaged && !self.vr_clip_insert_engaged[slot];
             self.vr_clip_insert_engaged[slot] = engaged;
-            if let (true, Some((clip, weapon))) = (entered, pair) {
-                cues.extend(self.insert_held_clip(asset_cache, weapon, clip));
+            if let (true, Some((clip, weapon, capacity))) = (entered, pair) {
+                cues.extend(self.insert_held_clip(asset_cache, weapon, clip, capacity));
             }
         }
         cues
@@ -8062,17 +8067,23 @@ impl MissionCore {
         asset_cache: &mut AssetCache,
         weapon: EntityId,
         clip: EntityId,
+        capacity: i32,
     ) -> Vec<Effect> {
         if !crate::mission::reload::is_ammo_clip(&self.world, clip) {
             return Vec::new();
         }
-        let Some(capacity) = self.magazine_capacity(weapon) else {
-            return Vec::new();
-        };
         let Some(index) = crate::mission::reload::clip_projectile_index(&self.world, weapon, clip)
         else {
             return vec![self.refuse_clip_insert(weapon)];
         };
+        // Nothing below may run unless rounds could actually MOVE. Both halves
+        // of the swap - the eject and the selection change - are committed
+        // before the load, so a gun that cannot hold a round (`clip: 0`) or an
+        // empty clip entity would otherwise dump the magazine and switch the
+        // ammo type having loaded nothing at all.
+        if capacity <= 0 || crate::mission::reload::clip_rounds(&self.world, clip) <= 0 {
+            return vec![self.refuse_clip_insert(weapon)];
+        }
 
         if index != crate::mission::reload::selected_ammo_index(&self.world, weapon) {
             // A different ammo type: the loaded rounds go back to the backpack

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1622,6 +1622,14 @@ pub struct MissionCore {
     /// never made. See [`latch_trigger_safe`].
     vr_trigger_safe_latch: [Option<bool>; 2],
 
+    /// Whether each hand (indexed by [`hand_slot`]) is currently inside the
+    /// other hand's weapon magazine zone. The physical reload fires on the
+    /// rising edge of this - see [`update_clip_insert_gesture`] - so a clip
+    /// resting against the gun inserts once rather than every frame.
+    ///
+    /// [`update_clip_insert_gesture`]: MissionCore::update_clip_insert_gesture
+    vr_clip_insert_engaged: [bool; 2],
+
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
     /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
     /// `GuiManager` for the corresponding object-bound world panel.
@@ -2478,6 +2486,7 @@ impl MissionCore {
             vr_use_mode_pointer: None,
             vr_squeeze_swallow: [false; 2],
             vr_trigger_safe_latch: [None; 2],
+            vr_clip_insert_engaged: [false; 2],
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
@@ -3386,6 +3395,14 @@ impl MissionCore {
         });
         rewrite_strip_release(&mut interaction_msgs, &store, &collect);
         self.process_virtual_hand_effects(asset_cache, interaction_msgs);
+
+        // The physical VR reload: a clip carried into the other hand's weapon
+        // loads it. Runs after the hands have been updated so the held pair is
+        // this frame's.
+        if game_options.presentation_mode == crate::PresentationMode::Vr {
+            let cues = self.update_clip_insert_gesture(asset_cache);
+            effects.extend(cues);
+        }
 
         // Tag the wielded weapon with the flat camera/crosshair fire ray so its
         // firing scripts spawn projectiles along the crosshair (camera-origin
@@ -7962,6 +7979,158 @@ impl MissionCore {
             &self.world,
             weapon,
             "reload",
+            vec![],
+            AudioHandle::new(),
+        )
+    }
+
+    /// The physical VR reload (R3a): a clip carried in one hand into the
+    /// magazine zone of the weapon held in the other loads it instantly.
+    ///
+    /// **Proximity while held, not release.** The insert fires the moment the
+    /// clip ENTERS the zone, which is both what the motion reads like
+    /// physically (you push the magazine home, you do not let go of it inside
+    /// the gun) and what keeps this clear of the release gestures that already
+    /// exist: a clip opened over the cyber-interface strip must still deposit
+    /// there (#1138/#1158), and claiming releases near a weapon would swallow
+    /// exactly those.
+    ///
+    /// The motion IS the reload cost, so there is no authored `reload_time`
+    /// hold on this path - only the weapon's authored "reload" cue, which is
+    /// the sole feedback a VR player gets (the flat reload's viewmodel pitch is
+    /// never rendered for a hand-held gun).
+    ///
+    /// Returns the audible cues to apply.
+    fn update_clip_insert_gesture(&mut self, asset_cache: &mut AssetCache) -> Vec<Effect> {
+        let (left_held, right_held) = self.interaction.held_entities();
+        let held = [left_held, right_held];
+        let mut cues = Vec::new();
+        for slot in 0..2 {
+            // Per weapon, not per player: the zone belongs to whichever hand
+            // holds a gun, so dual wielding inserts into the gun the clip
+            // actually reached.
+            let pair = match (held[slot], held[1 - slot]) {
+                (Some(clip), Some(weapon)) if self.magazine_capacity(weapon).is_some() => {
+                    Some((clip, weapon))
+                }
+                _ => None,
+            };
+            let engaged = pair
+                .and_then(|(clip, weapon)| {
+                    let clip_position = self.entity_world_position(clip)?;
+                    let weapon_position = self.entity_world_position(weapon)?;
+                    Some(crate::mission::reload::clip_insert_zone_engaged(
+                        self.vr_clip_insert_engaged[slot],
+                        (clip_position - weapon_position).magnitude(),
+                    ))
+                })
+                .unwrap_or(false);
+            let entered = engaged && !self.vr_clip_insert_engaged[slot];
+            self.vr_clip_insert_engaged[slot] = engaged;
+            if let (true, Some((clip, weapon))) = (entered, pair) {
+                cues.extend(self.insert_held_clip(asset_cache, weapon, clip));
+            }
+        }
+        cues
+    }
+
+    /// How many rounds `weapon`'s magazine holds, or `None` when it is not a
+    /// gun that takes one.
+    fn magazine_capacity(&self, weapon: EntityId) -> Option<i32> {
+        crate::scripts::script_util::active_gun_setting(&self.world, weapon).map(|d| d.clip)
+    }
+
+    /// The world position of `entity`'s live transform.
+    fn entity_world_position(&self, entity: EntityId) -> Option<Vector3<f32>> {
+        use cgmath::Transform as _;
+        let transforms = self.world.borrow::<View<RuntimePropTransform>>().ok()?;
+        let transform = transforms.get(entity).ok()?;
+        Some(crate::util::point3_to_vec3(
+            transform.0.transform_point(Point3::new(0.0, 0.0, 0.0)),
+        ))
+    }
+
+    /// Load a held `clip` into `weapon`, swapping the loaded ammo type if the
+    /// clip is a different one. Returns the gesture's audible cues.
+    ///
+    /// A clip of a type the weapon does not take earns the refusal cue and
+    /// changes nothing; an item that is not ammo at all passes through in
+    /// silence, since the zone is a volume around a gun the player carries
+    /// everything else past.
+    fn insert_held_clip(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        weapon: EntityId,
+        clip: EntityId,
+    ) -> Vec<Effect> {
+        if !crate::mission::reload::is_ammo_clip(&self.world, clip) {
+            return Vec::new();
+        }
+        let Some(capacity) = self.magazine_capacity(weapon) else {
+            return Vec::new();
+        };
+        let Some(index) = crate::mission::reload::clip_projectile_index(&self.world, weapon, clip)
+        else {
+            return vec![self.refuse_clip_insert(weapon)];
+        };
+
+        if index != crate::mission::reload::selected_ammo_index(&self.world, weapon) {
+            // A different ammo type: the loaded rounds go back to the backpack
+            // as what they already are, exactly as an ammo-cycle ejects them.
+            if let Some((clip_template, rounds)) =
+                crate::mission::reload::unload_to_reserve(&self.world, weapon).spawn_clip
+            {
+                self.give_ejected_clip(asset_cache, weapon, clip_template, rounds);
+            }
+            // The swap is earned by an empty magazine, never assumed - see
+            // `cycle_ammo`. Rounds that could not be returned stay loaded, and
+            // switching over them would convert them for free.
+            let still_loaded = self
+                .world
+                .borrow::<View<dark::properties::PropGunState>>()
+                .ok()
+                .and_then(|states| states.get(weapon).ok().map(|state| state.ammo > 0))
+                .unwrap_or(false);
+            if still_loaded {
+                return vec![self.refuse_clip_insert(weapon)];
+            }
+            self.world
+                .add_component(weapon, RuntimePropSelectedAmmo(index));
+        }
+
+        let outcome =
+            crate::mission::reload::load_from_held_clip(&self.world, weapon, clip, capacity);
+        if outcome.rounds_loaded == 0 {
+            // A magazine already at capacity: nothing moved, and a cue for a
+            // reload that did not happen would be a lie.
+            return Vec::new();
+        }
+        // A clip drained to nothing leaves the hand with it - the hand is
+        // released by `on_entity_destroyed`. A clip with rounds left over stays
+        // held, and the zone's exit radius keeps it from re-inserting in place.
+        for item in outcome.depleted_items {
+            self.interaction.on_entity_destroyed(item);
+            self.flat_ui.on_entity_destroyed(item);
+            self.remove_incoming_contains_links(item);
+            self.remove_entity(item);
+        }
+
+        vec![crate::scripts::script_util::play_environmental_sound(
+            &self.world,
+            weapon,
+            "reload",
+            vec![],
+            AudioHandle::new(),
+        )]
+    }
+
+    /// The insert-refused cue: the gun's own dry-fire click, the refusal sound
+    /// the player already associates with "this weapon will not do that".
+    fn refuse_clip_insert(&self, weapon: EntityId) -> Effect {
+        crate::scripts::script_util::play_environmental_sound(
+            &self.world,
+            weapon,
+            "dryfire",
             vec![],
             AudioHandle::new(),
         )

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -96,17 +96,161 @@ fn selected_clip_templates(world: &World, weapon: EntityId) -> Option<Vec<i32>> 
     if projectiles.is_empty() {
         return None;
     }
-    let selected = world
-        .borrow::<View<crate::runtime_props::RuntimePropSelectedAmmo>>()
-        .ok()
-        .and_then(|selected| selected.get(weapon).ok().map(|selected| selected.0))
-        .unwrap_or(0);
-    let projectile_template = projectiles[selected % projectiles.len()].0;
+    clip_templates_for_projectile(world, projectiles[selected_ammo_index(world, weapon)].0)
+}
+
+/// The clip archetypes authored for one projectile archetype.
+fn clip_templates_for_projectile(world: &World, projectile_template: i32) -> Option<Vec<i32>> {
     world
         .borrow::<UniqueView<GlobalProjectileClips>>()
         .ok()
         .and_then(|clips| clips.clips.get(&projectile_template).cloned())
         .filter(|clips| !clips.is_empty())
+}
+
+/// Which of `weapon`'s projectile links is currently selected, already wrapped
+/// into range. A weapon with no `RuntimePropSelectedAmmo` is on its first.
+pub(crate) fn selected_ammo_index(world: &World, weapon: EntityId) -> usize {
+    let count = crate::scripts::script_util::ordered_projectile_links(world, weapon).len();
+    if count == 0 {
+        return 0;
+    }
+    world
+        .borrow::<View<crate::runtime_props::RuntimePropSelectedAmmo>>()
+        .ok()
+        .and_then(|selected| selected.get(weapon).ok().map(|selected| selected.0))
+        .unwrap_or(0)
+        % count
+}
+
+/// Whether `item`'s class descends from any clip archetype the data authors a
+/// `Clip` relation to - "this is ammo", regardless of which gun it fits.
+///
+/// The physical insert gesture needs this separately from
+/// [`clip_projectile_index`]: an item that is not ammo at all must pass through
+/// the magazine zone in silence, while ammo the gun cannot take earns a
+/// refusal.
+pub(crate) fn is_ammo_clip(world: &World, item: EntityId) -> bool {
+    let Some(class_template_id) =
+        crate::scripts::script_util::entity_class_template_id(world, item)
+    else {
+        return false;
+    };
+    let (Ok(projectile_clips), Ok(hierarchy)) = (
+        world.borrow::<UniqueView<GlobalProjectileClips>>(),
+        world.borrow::<UniqueView<crate::mission::GlobalTemplateHierarchy>>(),
+    ) else {
+        return false;
+    };
+    projectile_clips
+        .clips
+        .values()
+        .flatten()
+        .any(|clip_template| hierarchy.is_or_descends_from(class_template_id, *clip_template))
+}
+
+/// Which of `weapon`'s ammo types the clip entity `clip` loads, as an index
+/// into its ordered projectile links. `None` when the weapon takes no such
+/// clip at all.
+///
+/// The CURRENTLY selected type is tested first, so a clip that fits more than
+/// one of a weapon's projectiles (a family archetype two ammo types both
+/// inherit) tops the loaded type off rather than silently swapping it.
+pub(crate) fn clip_projectile_index(
+    world: &World,
+    weapon: EntityId,
+    clip: EntityId,
+) -> Option<usize> {
+    let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
+    if projectiles.is_empty() {
+        return None;
+    }
+    let class_template_id = crate::scripts::script_util::entity_class_template_id(world, clip)?;
+    let hierarchy = world
+        .borrow::<UniqueView<crate::mission::GlobalTemplateHierarchy>>()
+        .ok()?;
+    let selected = selected_ammo_index(world, weapon);
+    let order = std::iter::once(selected).chain((0..projectiles.len()).filter(|i| *i != selected));
+    order.into_iter().find(|index| {
+        clip_templates_for_projectile(world, projectiles[*index].0).is_some_and(|clip_templates| {
+            clip_templates.iter().any(|clip_template| {
+                hierarchy.is_or_descends_from(class_template_id, *clip_template)
+            })
+        })
+    })
+}
+
+/// Move rounds from ONE clip entity the player is physically holding into
+/// `weapon`'s magazine - the physical VR reload's counterpart to
+/// [`load_from_reserve`], which draws from the backpack instead.
+///
+/// Only as many rounds as the magazine is missing move, so a fuller clip keeps
+/// its remainder and stays in the hand. A clip drained to zero is reported in
+/// `depleted_items` for the caller to destroy, exactly as a reserve stack is.
+pub(crate) fn load_from_held_clip(
+    world: &World,
+    weapon: EntityId,
+    clip: EntityId,
+    capacity: i32,
+) -> ReloadOutcome {
+    let current_ammo = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|states| states.get(weapon).ok().map(|state| state.ammo));
+    let Some(current_ammo) = current_ammo else {
+        return ReloadOutcome::default();
+    };
+    let rounds_needed = (capacity.max(0) - current_ammo.max(0)).max(0);
+    if rounds_needed == 0 {
+        return ReloadOutcome::default();
+    }
+
+    let mut outcome = ReloadOutcome::default();
+    {
+        let Ok(mut stacks) = world.borrow::<ViewMut<PropStackCount>>() else {
+            return outcome;
+        };
+        let Ok(stack) = (&mut stacks).get(clip) else {
+            return outcome;
+        };
+        let consumed = stack.0.min(rounds_needed).max(0);
+        if consumed == 0 {
+            return outcome;
+        }
+        stack.0 -= consumed;
+        outcome.rounds_loaded = consumed;
+        if stack.0 == 0 {
+            outcome.depleted_items.push(clip);
+        }
+    }
+
+    let mut states = world.borrow::<ViewMut<PropGunState>>().unwrap();
+    if let Ok(state) = (&mut states).get(weapon) {
+        state.ammo = (state.ammo.max(0) + outcome.rounds_loaded).min(capacity.max(0));
+    }
+    outcome
+}
+
+/// Enter/exit radii (world units) of a weapon's magazine zone - the volume a
+/// held clip is inserted by entering. One world unit is ~0.76 m, so this is a
+/// generous ~19 cm sphere around the weapon's origin, entered deliberately but
+/// not requiring the player to thread a needle in mid-air.
+///
+/// v1 centres the zone on the weapon's own transform; a per-model magazine
+/// anchor is a follow-up.
+pub(crate) const CLIP_INSERT_ENTER_RADIUS: f32 = 0.25;
+pub(crate) const CLIP_INSERT_EXIT_RADIUS: f32 = 0.35;
+
+/// Whether the magazine zone is engaged this frame, given whether it was
+/// engaged last frame. The two radii are deliberately different: a single
+/// threshold flickers on hand jitter right at the boundary, and every flicker
+/// is another insert attempt.
+pub(crate) fn clip_insert_zone_engaged(was_engaged: bool, distance: f32) -> bool {
+    if was_engaged {
+        distance <= CLIP_INSERT_EXIT_RADIUS
+    } else {
+        distance <= CLIP_INSERT_ENTER_RADIUS
+    }
 }
 
 /// The backpack's stackable items whose class descends from one of
@@ -473,6 +617,14 @@ mod tests {
                     to_template_id: concrete_template_id,
                 });
             item
+        }
+
+        /// A clip the player is physically holding: an ordinary stackable
+        /// entity with NO `Contains` link, since a grabbed item has left the
+        /// backpack.
+        fn held_clip(&mut self, template_id: i32, rounds: i32) -> EntityId {
+            self.world
+                .add_entity((PropTemplateId { template_id }, PropStackCount(rounds)))
         }
 
         fn set_standard_projectile(&mut self, template_id: i32) {
@@ -899,6 +1051,132 @@ mod tests {
         fixture.set_standard_projectile(CLIPLESS_PROJECTILE);
 
         assert!(!can_cycle_ammo(&fixture.world, fixture.weapon));
+    }
+
+    // --- the physical VR insert gesture (a clip carried to the magazine) ---
+
+    #[test]
+    fn a_held_clip_of_the_selected_type_loads_that_type() {
+        let mut fixture = Fixture::new(0, 0);
+        let clip = fixture.held_clip(EARTH_SMALL_STD_CLIP, 6);
+
+        assert_eq!(
+            clip_projectile_index(&fixture.world, fixture.weapon, clip),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn a_held_clip_of_another_carried_type_names_that_types_projectile() {
+        // Standard is selected and HE is what the hand brought: the gesture has
+        // to name index 1 so the caller ejects and swaps to it.
+        let mut fixture = Fixture::new(0, 0);
+        let clip = fixture.held_clip(HE_CLIP, 4);
+
+        assert_eq!(
+            clip_projectile_index(&fixture.world, fixture.weapon, clip),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn a_clip_this_weapon_does_not_take_has_no_projectile_index() {
+        // Real ammo (a prism), but for a gun the pistol's projectiles never
+        // link - the refusal case, as distinct from carrying a medkit past.
+        let mut fixture = Fixture::new(0, 0);
+        let clip = fixture.held_clip(SMALL_PRISM, 10);
+
+        assert!(is_ammo_clip(&fixture.world, clip));
+        assert_eq!(
+            clip_projectile_index(&fixture.world, fixture.weapon, clip),
+            None
+        );
+    }
+
+    #[test]
+    fn an_item_that_is_not_ammo_at_all_is_not_a_clip() {
+        const A_MEDKIT: i32 = -9999;
+        let mut fixture = Fixture::new(0, 0);
+        let item = fixture.held_clip(A_MEDKIT, 1);
+
+        assert!(!is_ammo_clip(&fixture.world, item));
+    }
+
+    #[test]
+    fn inserting_a_held_clip_fills_the_magazine_and_empties_the_clip() {
+        let mut fixture = Fixture::new(0, 0);
+        let clip = fixture.held_clip(EARTH_SMALL_STD_CLIP, 12);
+
+        let outcome = load_from_held_clip(&fixture.world, fixture.weapon, clip, 12);
+
+        assert_eq!(fixture.ammo(), 12);
+        assert_eq!(fixture.rounds(clip), 0);
+        assert_eq!(outcome.rounds_loaded, 12);
+        assert_eq!(
+            outcome.depleted_items,
+            vec![clip],
+            "a spent clip is the caller's to destroy - it leaves the hand with it"
+        );
+    }
+
+    #[test]
+    fn a_fuller_clip_keeps_its_remainder_in_the_hand() {
+        let mut fixture = Fixture::new(0, 0);
+        let clip = fixture.held_clip(STD_CLIP, 20);
+
+        let outcome = load_from_held_clip(&fixture.world, fixture.weapon, clip, 12);
+
+        assert_eq!(fixture.ammo(), 12);
+        assert_eq!(fixture.rounds(clip), 8, "the remainder stays on the clip");
+        assert_eq!(outcome.rounds_loaded, 12);
+        assert!(
+            outcome.depleted_items.is_empty(),
+            "a clip with rounds left is not destroyed"
+        );
+    }
+
+    #[test]
+    fn a_partly_loaded_magazine_is_topped_off_from_the_held_clip() {
+        let mut fixture = Fixture::new(7, 0);
+        let clip = fixture.held_clip(EARTH_SMALL_STD_CLIP, 6);
+
+        let outcome = load_from_held_clip(&fixture.world, fixture.weapon, clip, 12);
+
+        assert_eq!(fixture.ammo(), 12);
+        assert_eq!(fixture.rounds(clip), 1);
+        assert_eq!(outcome.rounds_loaded, 5);
+    }
+
+    #[test]
+    fn inserting_into_a_full_magazine_moves_nothing() {
+        // The rounds must not be silently burned: a full gun simply refuses the
+        // clip, and the player still carries it.
+        let mut fixture = Fixture::new(12, 0);
+        let clip = fixture.held_clip(EARTH_SMALL_STD_CLIP, 6);
+
+        let outcome = load_from_held_clip(&fixture.world, fixture.weapon, clip, 12);
+
+        assert_eq!(outcome, ReloadOutcome::default());
+        assert_eq!(fixture.ammo(), 12);
+        assert_eq!(fixture.rounds(clip), 6);
+    }
+
+    #[test]
+    fn the_magazine_zone_needs_a_closer_approach_than_it_needs_to_hold() {
+        // Hysteresis: without it, hand jitter right at the boundary re-enters
+        // the zone every few frames, and every entry is another insert.
+        let between = (CLIP_INSERT_ENTER_RADIUS + CLIP_INSERT_EXIT_RADIUS) / 2.0;
+
+        assert!(!clip_insert_zone_engaged(false, between));
+        assert!(clip_insert_zone_engaged(true, between));
+        assert!(clip_insert_zone_engaged(
+            false,
+            CLIP_INSERT_ENTER_RADIUS - 0.01
+        ));
+        assert!(!clip_insert_zone_engaged(
+            true,
+            CLIP_INSERT_EXIT_RADIUS + 0.01
+        ));
     }
 
     #[test]

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -180,6 +180,15 @@ pub(crate) fn clip_projectile_index(
     })
 }
 
+/// How many rounds a clip entity still carries (0 for anything with no stack).
+pub(crate) fn clip_rounds(world: &World, clip: EntityId) -> i32 {
+    world
+        .borrow::<View<PropStackCount>>()
+        .ok()
+        .and_then(|stacks| stacks.get(clip).ok().map(|stack| stack.0))
+        .unwrap_or(0)
+}
+
 /// Move rounds from ONE clip entity the player is physically holding into
 /// `weapon`'s magazine - the physical VR reload's counterpart to
 /// [`load_from_reserve`], which draws from the backpack instead.

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -56,15 +56,27 @@ fn grabbing(hand: &Hand) -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PointerEngagement {
     Trigger,
-    TriggerOrGrab,
+    TriggerOrGrab {
+        /// Which hands are already CARRYING something, by
+        /// [`crate::vr_config::hand_slot`].
+        ///
+        /// A carrying hand squeezes to keep hold of its object, for as long as
+        /// it carries it - that squeeze is not a gesture aimed at the panel and
+        /// must not claim it, or a player with a gun in one hand can never
+        /// reach the inventory strip with the other. Its TRIGGER still claims
+        /// the panel normally.
+        carrying: [bool; 2],
+    },
 }
 
 impl PointerEngagement {
-    /// Whether `hand` is actively working the panel under this policy.
-    fn engaged(self, hand: &Hand) -> bool {
+    /// Whether `hand` is making a gesture the panel should listen to.
+    fn engaged(self, hand: &Hand, handedness: Handedness) -> bool {
         match self {
             Self::Trigger => held(hand),
-            Self::TriggerOrGrab => held(hand) || grabbing(hand),
+            Self::TriggerOrGrab { carrying } => {
+                held(hand) || (grabbing(hand) && !carrying[crate::vr_config::hand_slot(handedness)])
+            }
         }
     }
 }
@@ -208,7 +220,7 @@ pub fn vr_pointer_pass(
     // flight for an idle hand to land.
     let working_the_panel = |slot: usize| {
         held(hands[slot])
-            || (engagement.engaged(hands[slot])
+            || (engagement.engaged(hands[slot], handedness[slot])
                 && ray_of_hand[slot].is_some_and(|index| rays[index].canvas_hit.is_some()))
     };
     let any_engaged = working_the_panel(0) || working_the_panel(1);
@@ -404,7 +416,9 @@ mod tests {
             &vr_input(carrying_right, reaching_left),
             CANVAS,
             &test_panel(),
-            PointerEngagement::TriggerOrGrab,
+            PointerEngagement::TriggerOrGrab {
+                carrying: [false; 2],
+            },
         );
 
         assert_eq!(
@@ -413,6 +427,68 @@ mod tests {
             "the free hand must own the panel"
         );
         assert!(pass.point().is_some(), "and it must supply a point");
+    }
+
+    /// The harder half of the same problem: the panel is head-anchored, so the
+    /// gun hand's ray crosses it constantly. Its permanently-held squeeze must
+    /// not claim the panel THERE either, or the free hand loses the tie (the
+    /// right hand wins ties) and can still never reach a slot.
+    #[test]
+    fn a_carrying_hand_does_not_claim_the_panel_its_ray_happens_to_cross() {
+        let slot = vec2(23.5, 34.0);
+        let carrying_right = Hand {
+            squeeze_value: 1.0,
+            ..hand_aimed_at(CANVAS, vec2(400.0, 200.0), 0.0)
+        };
+        let reaching_left = Hand {
+            squeeze_value: 1.0,
+            ..hand_aimed_at(CANVAS, slot, 0.0)
+        };
+        let mut carrying = [false; 2];
+        carrying[crate::vr_config::hand_slot(Handedness::Right)] = true;
+
+        let pass = vr_pointer_pass(
+            &vr_input(carrying_right, reaching_left),
+            CANVAS,
+            &test_panel(),
+            PointerEngagement::TriggerOrGrab { carrying },
+        );
+
+        assert_eq!(
+            pass.active_ray().map(|ray| ray.handedness),
+            Some(Handedness::Left),
+            "the empty hand's squeeze must outrank the carrying hand's"
+        );
+        let point = pass.point().expect("the free hand must supply a point");
+        assert!(
+            (point.x - slot.x).abs() < 1.0 && (point.y - slot.y).abs() < 1.0,
+            "and it must be the slot it aimed at, got {point:?}"
+        );
+    }
+
+    /// ...but a hand carrying nothing keeps its squeeze claim, which is what
+    /// takes an item out of a slot in the first place.
+    #[test]
+    fn an_empty_hands_squeeze_still_claims_the_panel() {
+        let pass = vr_pointer_pass(
+            &vr_input(
+                Hand {
+                    squeeze_value: 1.0,
+                    ..hand_aimed_at(CANVAS, vec2(23.5, 34.0), 0.0)
+                },
+                hand_aimed_at(CANVAS, vec2(400.0, 200.0), 0.0),
+            ),
+            CANVAS,
+            &test_panel(),
+            PointerEngagement::TriggerOrGrab {
+                carrying: [false; 2],
+            },
+        );
+
+        assert_eq!(
+            pass.active_ray().map(|ray| ray.handedness),
+            Some(Handedness::Right)
+        );
     }
 
     /// The trigger half is the opposite: a press in flight is reported for
@@ -428,7 +504,9 @@ mod tests {
             ),
             CANVAS,
             &test_panel(),
-            PointerEngagement::TriggerOrGrab,
+            PointerEngagement::TriggerOrGrab {
+                carrying: [false; 2],
+            },
         );
 
         assert_eq!(pass.point(), None);

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -192,8 +192,27 @@ pub fn vr_pointer_pass(
         }
     }
 
-    let any_engaged = engagement.engaged(hands[0]) || engagement.engaged(hands[1]);
-    let order = if engagement.engaged(hands[1]) && !engagement.engaged(hands[0]) {
+    // Which hand is claiming the panel this frame.
+    //
+    // A held TRIGGER claims it wherever it points: `pressed` below is reported
+    // for either hand, so letting an idle hand supply the point while a press
+    // is in flight would land that press on whatever the idle hand happens to
+    // hover.
+    //
+    // A held SQUEEZE claims it only while actually pointing at it. Under
+    // `TriggerOrGrab` the squeeze is also how a VR player keeps HOLD of an
+    // object - a hand carrying a gun squeezes for as long as it carries it - so
+    // treating that as working the panel hands it the panel from across the
+    // room, and the free hand cannot so much as hover a slot. The grab is
+    // edge-detected per hand downstream, so an off-panel squeeze has nothing in
+    // flight for an idle hand to land.
+    let working_the_panel = |slot: usize| {
+        held(hands[slot])
+            || (engagement.engaged(hands[slot])
+                && ray_of_hand[slot].is_some_and(|index| rays[index].canvas_hit.is_some()))
+    };
+    let any_engaged = working_the_panel(0) || working_the_panel(1);
+    let order = if working_the_panel(1) && !working_the_panel(0) {
         [1, 0]
     } else {
         [0, 1]
@@ -205,7 +224,7 @@ pub fn vr_pointer_pass(
         // point: otherwise an idle hand resting on the panel would report
         // "not pressed" and clear the held state, so sweeping the pressed hand
         // onto a button would read as a fresh edge and click it.
-        if any_engaged && !engagement.engaged(hands[slot]) {
+        if any_engaged && !working_the_panel(slot) {
             continue;
         }
         let Some(index) = ray_of_hand[slot] else {
@@ -367,6 +386,53 @@ mod tests {
             point, None,
             "the idle hand must not supply a point while the other is pressed"
         );
+    }
+
+    /// The squeeze half of `TriggerOrGrab` is not a gesture aimed at the panel
+    /// - it is also how a VR player keeps hold of whatever is in that hand. A
+    /// hand carrying a gun at their side must not own the cyber interface, or
+    /// the free hand can never reach the inventory strip (which is how a clip
+    /// gets out of it, and therefore how the physical reload starts).
+    #[test]
+    fn a_hand_squeezing_a_carried_object_off_panel_does_not_own_the_interface() {
+        let carrying_right = Hand {
+            squeeze_value: 1.0,
+            ..hand_aimed_away(0.0)
+        };
+        let reaching_left = hand_aimed_at(CANVAS, vec2(23.5, 34.0), 0.0);
+        let pass = vr_pointer_pass(
+            &vr_input(carrying_right, reaching_left),
+            CANVAS,
+            &test_panel(),
+            PointerEngagement::TriggerOrGrab,
+        );
+
+        assert_eq!(
+            pass.active_ray().map(|ray| ray.handedness),
+            Some(Handedness::Left),
+            "the free hand must own the panel"
+        );
+        assert!(pass.point().is_some(), "and it must supply a point");
+    }
+
+    /// The trigger half is the opposite: a press in flight is reported for
+    /// either hand (`pressed` below), so a hand holding one owns the panel
+    /// wherever it points - otherwise the idle hand's hover would take a click
+    /// the pressing hand aimed somewhere else entirely.
+    #[test]
+    fn a_hand_holding_a_trigger_off_panel_still_owns_the_interface() {
+        let pass = vr_pointer_pass(
+            &vr_input(
+                hand_aimed_at(CANVAS, vec2(23.5, 34.0), 0.0),
+                hand_aimed_away(1.0),
+            ),
+            CANVAS,
+            &test_panel(),
+            PointerEngagement::TriggerOrGrab,
+        );
+
+        assert_eq!(pass.point(), None);
+        assert!(pass.pressed);
     }
 
     #[test]

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -51,6 +51,19 @@ impl Handedness {
     }
 }
 
+/// The index a hand occupies in a `[_; 2]` of per-hand state.
+///
+/// One conversion, crate-wide, so per-hand arrays built in one module can be
+/// read in another. Anything that pairs the hands in an array (latches,
+/// per-hand gestures) uses THIS ordering; a local array in some other order
+/// must not be indexed with it.
+pub fn hand_slot(hand: Handedness) -> usize {
+    match hand {
+        Handedness::Left => 0,
+        Handedness::Right => 1,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct VRHandModelPerHandAdjustments {
     pub offset: Vector3<f32>,

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -274,8 +274,12 @@ test(
     await game.step({ frames: 30 });
 
     const pistol = await grabPistol(game);
+    // The debug pistol spawns with a FULL magazine, so what it holds now is its
+    // capacity - the number the insert has to restore. Pinned as a precondition
+    // rather than assumed, so a data change fails here and not three asserts
+    // later with a confusing count.
     const capacity = ammoOf(await game.entities.detail(pistol.id));
-    assert.ok(capacity > 0, "the debug pistol starts loaded");
+    assert.ok(capacity > 0, "the debug pistol starts loaded, and starts full");
 
     // Empty it, so the insert has somewhere to put rounds.
     for (let shot = 0; shot < 40; shot += 1) {
@@ -438,15 +442,20 @@ test(
       "the magazine holds the new type's rounds",
     );
 
-    // The standard rounds that were loaded come BACK as standard ammo - the
-    // swap costs a reload, it does not convert them.
+    // The standard rounds that were loaded come BACK as standard ammo, all of
+    // them - the swap costs a reload, it neither converts nor loses rounds.
     const inventory = await game.player.inventory();
     const returned = inventory.items.filter((item) =>
       (item.name ?? "").includes("Standard"),
     );
-    assert.ok(
-      returned.length > 0,
-      `the ejected standard rounds must be in the pack: ${JSON.stringify(inventory.items)}`,
+    let returnedRounds = 0;
+    for (const item of returned) {
+      returnedRounds += stackOf(await game.entities.detail(item.entity_id));
+    }
+    assert.equal(
+      returnedRounds,
+      loaded,
+      `every ejected standard round must be in the pack: ${JSON.stringify(inventory.items)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -1,0 +1,452 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, PlayedSound, Vec3 } from "../src/index.js";
+import {
+  aimVrHandAt,
+  aimVrHandAtCanvas,
+  add,
+  quatConjugate,
+  quatRotate,
+  sub,
+  type Quat,
+} from "./helpers/vr-hand.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// The physical VR reload (R3a): a clip pulled out of the cyber-interface strip
+// with the free hand and carried to the gun the other hand holds loads it -
+// instantly, because the motion is the reload cost.
+//
+// Negative-first: on the parent every scenario here fails at the insert. The
+// clip simply rests against the gun, the magazine stays where it was, and
+// nothing is consumed - VR had no reload at all except the Quest's face
+// button, which this change removes.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8636);
+
+/** The debug pistol and the ammo the scenarios carry to it. */
+const PISTOL = -17;
+const STD_CLIP = -31;
+const HE_CLIP = -32;
+/** Shotgun shells: real ammo, but nothing the pistol's projectiles link to. */
+const PELLET_SHOT_BOX = -42;
+
+/** Mirrors `reload::CLIP_INSERT_EXIT_RADIUS` - what the clip must start
+ * OUTSIDE of for the insert to be a genuine entry into the magazine zone. */
+const CLIP_INSERT_EXIT_RADIUS = 0.35;
+
+function propOf(
+  detail: { properties: { name: string; value: string }[] },
+  name: string,
+): number | undefined {
+  const p = detail.properties.find((x) => x.name === name);
+  return p === undefined ? undefined : Number(p.value);
+}
+
+function ammoOf(detail: {
+  properties: { name: string; value: string }[];
+}): number {
+  const value = propOf(detail, "Ammo");
+  assert.ok(value !== undefined, "a weapon should expose an Ammo property");
+  return value;
+}
+
+function stackOf(detail: {
+  properties: { name: string; value: string }[];
+}): number {
+  const value = propOf(detail, "StackCount");
+  assert.ok(value !== undefined, "a clip should expose a StackCount property");
+  return value;
+}
+
+/**
+ * What the OFF hand is holding.
+ *
+ * `PlayerInfo` carries two hand slots and the snapshot spells the LEFT one
+ * `wielded_entity_id` - flatscreen wields into that slot, so the name is right
+ * there and merely unhelpful here (see `shock2vr::wielded_weapon`). These
+ * scenarios put the gun in the right hand and the clip in the left, so this is
+ * the clip hand.
+ */
+function offHandEntityId(info: {
+  player: { wielded_entity_id: number | null };
+}): number | null {
+  return info.player.wielded_entity_id;
+}
+
+function tagValue(sound: PlayedSound, tag: string): string | undefined {
+  return sound.tags.find(([t]) => t === tag)?.[1];
+}
+
+/** The sound-schema events played since `sequence`. */
+async function eventsSince(
+  game: GameServer,
+  sequence: number,
+): Promise<string[]> {
+  return (await game.audio.recent()).sounds
+    .filter((sound) => sound.sequence > sequence)
+    .map((sound) => tagValue(sound, "event") ?? "")
+    .filter((event) => event !== "");
+}
+
+async function lastSound(game: GameServer): Promise<number> {
+  return (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+}
+
+const magnitude = (v: Vec3): number => Math.hypot(v[0], v[1], v[2]);
+
+async function entityById(
+  game: GameServer,
+  id: number,
+): Promise<EntitySummary | undefined> {
+  return (await game.entities.list()).entities.find((e) => e.id === id);
+}
+
+/** Spawn the debug pistol and take hold of it with the VR RIGHT hand, then turn
+ * that hand off the cyber-interface panel so the free left hand owns the canvas
+ * pointer when the interface opens. */
+async function grabPistol(game: GameServer): Promise<EntitySummary> {
+  await game.input.trigger("DebugCycleWeapon");
+  await game.step({ frames: 10 });
+  const pistol = (await game.entities.list()).entities.find(
+    (e) => e.template_id === PISTOL,
+  );
+  assert.ok(pistol, "DebugCycleWeapon must spawn the Pistol");
+
+  await aimVrHandAt(game, pistol.position as Vec3, 0.3);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    pistol.id,
+    "the VR right hand must hold the pistol",
+  );
+
+  // Point the gun hand down and away: a hand aimed at the head-anchored panel
+  // would compete for the canvas pointer the clip hand needs.
+  await game.input.set("right_hand.rotation", [0.5, 0, 0, 0.866]);
+  await game.step({ frames: 5 });
+  return pistol;
+}
+
+/**
+ * Move `hand` until the clip it holds sits at `target` (world space).
+ *
+ * Closed loop rather than an offset table: a held item hangs off its hand by a
+ * per-model grip offset this test has no business knowing, so it reads where
+ * the clip actually IS and corrects the hand by that world delta (rotated into
+ * the pawn space `/v1/control/input` speaks). Returns the hand position it left
+ * the controller at, and whether the clip survived the trip.
+ */
+async function steerHeldClip(
+  game: GameServer,
+  hand: "left" | "right",
+  handPosition: Vec3,
+  clipId: number,
+  target: () => Promise<Vec3>,
+): Promise<{ handPosition: Vec3; consumed: boolean }> {
+  let position = handPosition;
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const clip = await entityById(game, clipId);
+    if (!clip) return { handPosition: position, consumed: true };
+    const delta = sub(await target(), clip.position as Vec3);
+    if (magnitude(delta) <= 0.03) return { handPosition: position, consumed: false };
+    const pawnRotation = (await game.info()).player.rotation as Quat;
+    position = add(position, quatRotate(quatConjugate(pawnRotation), delta));
+    await game.input.set(`${hand}_hand.position`, position);
+    await game.step({ frames: 3 });
+  }
+  return { handPosition: position, consumed: false };
+}
+
+/**
+ * The player-facing half of the gesture: open the cyber interface, squeeze the
+ * clip out of its inventory-strip slot into the LEFT hand, close the interface,
+ * and park the clip well clear of the gun.
+ *
+ * The parking step is what makes the insert that follows a genuine ZONE ENTRY
+ * rather than an accident of where the strip grab happened to leave the hand.
+ */
+async function takeClipIntoOffHand(
+  game: GameServer,
+  clipId: number,
+  weaponId: number,
+): Promise<Vec3> {
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 5 });
+  const ui = await game.ui.state();
+  assert.equal(ui.mode, "use", "the cyber interface must be open");
+  assert.ok(ui.panel_pose, "the open interface must report its panel pose");
+  const slot = ui.strip?.elements.find((e) => e.entity_id === clipId);
+  assert.ok(
+    slot,
+    `the clip must have a strip slot: ${JSON.stringify(ui.strip?.elements)}`,
+  );
+
+  await aimVrHandAtCanvas(
+    game,
+    ui.panel_pose,
+    [slot.rect[0] + slot.rect[2] / 2, slot.rect[1] + slot.rect[3] / 2],
+    { hand: "left", squeeze: 0 },
+  );
+  // Point first, THEN squeeze: the panel edge-detects each hand's grab, and an
+  // edge needs a frame of that hand merely hovering to be an edge from.
+  await game.step({ frames: 4 });
+  await game.input.set("left_hand.squeeze", 1);
+  await game.step({ frames: 6 });
+  assert.equal(
+    offHandEntityId(await game.info()),
+    clipId,
+    `a squeeze on the strip slot must pull the clip into the off hand (pointer ${JSON.stringify(
+      (await game.ui.state()).pointer,
+    )}, right hand ${(await game.info()).player.right_hand_entity_id})`,
+  );
+
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 5 });
+  assert.equal(
+    offHandEntityId(await game.info()),
+    clipId,
+    "closing the interface must not take the clip back",
+  );
+
+  // Park it a comfortable arm's drop below the gun.
+  const weaponPosition = async (): Promise<Vec3> => {
+    const weapon = await entityById(game, weaponId);
+    assert.ok(weapon, "the weapon must still be held");
+    return weapon.position as Vec3;
+  };
+  const parked = await steerHeldClip(
+    game,
+    "left",
+    [0, 0, 0],
+    clipId,
+    async () => add(await weaponPosition(), [0, -1.2, 0]),
+  );
+  assert.equal(parked.consumed, false, "parking the clip must not insert it");
+
+  const clip = await entityById(game, clipId);
+  assert.ok(clip);
+  assert.ok(
+    magnitude(sub(clip.position as Vec3, await weaponPosition())) >
+      CLIP_INSERT_EXIT_RADIUS,
+    "the clip must start outside the magazine zone, or the insert proves nothing",
+  );
+  return parked.handPosition;
+}
+
+/** Carry the parked clip into the weapon's magazine zone. */
+async function insertClip(
+  game: GameServer,
+  handPosition: Vec3,
+  clipId: number,
+  weaponId: number,
+): Promise<void> {
+  await steerHeldClip(game, "left", handPosition, clipId, async () => {
+    const weapon = await entityById(game, weaponId);
+    assert.ok(weapon, "the weapon must still be held");
+    return weapon.position as Vec3;
+  });
+  await game.step({ frames: 5 });
+}
+
+/** Spawn a clip archetype into the backpack and report its authored stack. */
+async function spawnClip(
+  game: GameServer,
+  template: number,
+): Promise<{ id: number; rounds: number }> {
+  const spawned = await game.player.spawnItem(template);
+  const rounds = stackOf(await game.entities.detail(spawned.entity_id));
+  assert.ok(rounds > 0, "a spawned clip carries rounds");
+  return { id: spawned.entity_id, rounds };
+}
+
+test(
+  "carrying a clip into a VR-held weapon's magazine loads it",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = await grabPistol(game);
+    const capacity = ammoOf(await game.entities.detail(pistol.id));
+    assert.ok(capacity > 0, "the debug pistol starts loaded");
+
+    // Empty it, so the insert has somewhere to put rounds.
+    for (let shot = 0; shot < 40; shot += 1) {
+      if (ammoOf(await game.entities.detail(pistol.id)) === 0) break;
+      await fireOnce(game);
+    }
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0);
+
+    const clip = await spawnClip(game, STD_CLIP);
+    assert.ok(
+      clip.rounds >= capacity,
+      `this scenario needs a clip that can fill the magazine (${clip.rounds} vs ${capacity})`,
+    );
+    const parked = await takeClipIntoOffHand(game, clip.id, pistol.id);
+    const before = await lastSound(game);
+
+    await insertClip(game, parked, clip.id, pistol.id);
+
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      capacity,
+      "the insert must fill the magazine",
+    );
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "std",
+      "a standard clip loads standard rounds",
+    );
+    assert.equal(
+      await entityById(game, clip.id),
+      undefined,
+      "a clip emptied into the gun is consumed",
+    );
+    assert.equal(
+      offHandEntityId(await game.info()),
+      null,
+      "the consumed clip must leave the hand",
+    );
+    assert.equal(
+      (await game.info()).player.reloading,
+      false,
+      "the gesture loads instantly - the motion is the reload cost",
+    );
+    const played = await eventsSince(game, before);
+    assert.ok(
+      played.includes("reload"),
+      `the insert must play the weapon's reload cue, got ${JSON.stringify(played)}`,
+    );
+
+    // Second leg: a partly-spent magazine is TOPPED OFF, and the clip keeps the
+    // rounds the gun did not need.
+    const spent = 5;
+    for (let shot = 0; shot < spent; shot += 1) await fireOnce(game);
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), capacity - spent);
+
+    const second = await spawnClip(game, STD_CLIP);
+    const parkedAgain = await takeClipIntoOffHand(game, second.id, pistol.id);
+    await insertClip(game, parkedAgain, second.id, pistol.id);
+
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      capacity,
+      "the top-off must reach capacity",
+    );
+    assert.equal(
+      offHandEntityId(await game.info()),
+      second.id,
+      "a clip with rounds left over stays in the hand",
+    );
+    assert.equal(
+      stackOf(await game.entities.detail(second.id)),
+      second.rounds - spent,
+      "only the missing rounds leave the clip",
+    );
+  },
+);
+
+test(
+  "a clip the weapon does not take is refused, not swallowed",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = await grabPistol(game);
+    const loaded = ammoOf(await game.entities.detail(pistol.id));
+    const ammoType = (await game.info()).player.wielded_ammo_type;
+
+    const shells = await spawnClip(game, PELLET_SHOT_BOX);
+    const parked = await takeClipIntoOffHand(game, shells.id, pistol.id);
+    const before = await lastSound(game);
+
+    await insertClip(game, parked, shells.id, pistol.id);
+
+    assert.equal(
+      offHandEntityId(await game.info()),
+      shells.id,
+      "a refused clip stays in the hand",
+    );
+    assert.equal(
+      stackOf(await game.entities.detail(shells.id)),
+      shells.rounds,
+      "a refused clip keeps every round",
+    );
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      loaded,
+      "the magazine is untouched",
+    );
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      ammoType,
+      "the loaded ammo type is untouched",
+    );
+    const played = (await game.audio.recent()).sounds.filter(
+      (sound) => sound.sequence > before,
+    );
+    // `repfail`, the game's refusal chime, resolves to the `noinvrm` sample.
+    assert.deepEqual(
+      played.map((sound) => sound.sample),
+      ["noinvrm"],
+      "the refusal must be audible, and nothing else must have happened",
+    );
+  },
+);
+
+test(
+  "inserting a clip of another ammo type ejects the loaded rounds and swaps",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 2,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = await grabPistol(game);
+    const loaded = ammoOf(await game.entities.detail(pistol.id));
+    assert.ok(loaded > 0, "the swap must be made over a LOADED magazine");
+    assert.equal((await game.info()).player.wielded_ammo_type, "std");
+
+    const he = await spawnClip(game, HE_CLIP);
+    const parked = await takeClipIntoOffHand(game, he.id, pistol.id);
+
+    await insertClip(game, parked, he.id, pistol.id);
+
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "he",
+      "the inserted clip's type becomes the loaded type",
+    );
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      Math.min(he.rounds, loaded),
+      "the magazine holds the new type's rounds",
+    );
+
+    // The standard rounds that were loaded come BACK as standard ammo - the
+    // swap costs a reload, it does not convert them.
+    const inventory = await game.player.inventory();
+    const returned = inventory.items.filter((item) =>
+      (item.name ?? "").includes("Standard"),
+    );
+    assert.ok(
+      returned.length > 0,
+      `the ejected standard rounds must be in the pack: ${JSON.stringify(inventory.items)}`,
+    );
+  },
+);


### PR DESCRIPTION
Rebased onto main b443ff86: the clip-insert gesture's `magazine_capacity` now reads the wielded gun's *active fire setting* (`script_util::active_gun_setting`), since `PropBaseGunDesc.clip` moved into the per-setting records; DEVELOPMENT.md's key table keeps both the new `F` / `CycleGunSetting` row and this PR's `T` / `Y` note.

Rebased onto main d693a5a4: `is_ammo_clip` now reads `GlobalProjectileClips::clips` (main #1184 turned the tuple struct into named fields), and the new `hand_slot` helper sits alongside main's `impl Handedness` in `vr_config.rs`.

## What

Reloading in VR is now a **physical gesture**. Squeeze a clip out of the cyber
interface's inventory strip with your free hand, bring it to the gun the other
hand is holding, and the clip goes in - **instantly**. The motion is the reload
cost, so there is no authored `reload_time` hold on this path; the weapon's own
"reload" cue (from #1144) is the confirmation.

- **A clip of a different ammo type swaps the type over**, ejecting the loaded
  rounds back to the pack as what they already are, through #1145's
  `unload_to_reserve` machinery - and only if that eject actually emptied the
  magazine, so rounds are never converted for free.
- **A clip the weapon does not take is refused** with `repfail`, the game's own
  refusal chime, and stays in your hand. An item that is not ammo at all passes
  through in silence.
- **Partial clips** load `min(stack, missing)` and keep the remainder in hand.
- **Per weapon, not per player**: the clip goes into whichever wielded gun it
  reached, so this works while dual wielding.

![clip-insert reload demo](https://gist.githubusercontent.com/tommy-xr/ef5200a08baed95c348f081901f6f5e5/raw/clip-insert-demo.gif)

<sub>The clip carried into the pistol's magazine zone: it is consumed on contact and the magazine goes 0 -> 12. Ammo counts burned in from `/v1/entities` (VR has no on-screen counter here). Captured headlessly through the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep), framed with the detached debug camera.</sub>

### After the insert

![loaded weapon, off hand empty](https://gist.githubusercontent.com/tommy-xr/ef5200a08baed95c348f081901f6f5e5/raw/clip-insert-still.png)

## Zone and trigger

The magazine zone is a sphere on the weapon's own transform: **enter at 0.25
world units (~19 cm), exit at 0.35**. Two radii, because a single threshold
flickers on hand jitter right at the boundary and every flicker is another
insert attempt.

The insert fires on **proximity while held (entering the zone), not on
release**. Two reasons:

1. It reads like the motion it is - you push a magazine home, you do not let go
   of it inside the gun.
2. Release is already spoken for. A clip opened over the inventory strip must
   still deposit there (#1138 / #1158); claiming releases near a weapon would
   swallow exactly those. Nothing about #1126's trigger-safe latch or #1119's
   debounce is touched either - this reads no buttons at all.

A generous default radius on the weapon origin is v1; see follow-ups.

## Quest bindings removed

`Reload` and `CycleAmmo` lose their Quest right-A / right-B bindings (added in
#1144). A face button lives on ONE controller, so it cannot say which gun it
means once both hands hold one; carrying a clip to a magazine always can. Right
A and B now exist only as the two halves of the free-camera chord, which lets
its second-press suppression go with them.

**The actions themselves are untouched** - flat keys, the dispatcher,
`POST /v1/input/action` and the SDK all still drive them, which is what the
existing reload e2e coverage uses.

## Two blockers this had to clear first

Both only bite once one hand is carrying something, because **a VR player holds
an object by holding that hand's squeeze down**, for as long as they carry it:

1. **Pointer arbitration** treated that permanent squeeze as "working the panel"
   under `TriggerOrGrab`, so the gun hand owned the cyber interface from across
   the room and the free hand could not so much as hover a slot. A held squeeze
   now claims the panel only while actually pointing at it. A held *trigger*
   still claims it wherever it points - `pressed` is reported for either hand,
   so a press in flight must not land on whatever the idle hand hovers.
2. **The panel's grab latch was shared between the hands**, so the gun hand's
   held squeeze read as "already grabbing" and swallowed the free hand's rising
   edge forever. Each hand is latched separately now.

Without these, the first move of the gesture - getting a clip out of the strip
with a gun in the other hand - was simply impossible.

## Tests

Negative-first throughout (each was watched failing before the change):

- **Unit** (`mission/reload.rs`): clip -> projectile index (selected type
  preferred, so a shared archetype tops off rather than swapping), an
  incompatible clip vs. an item that is not ammo, fill / top-off / remainder /
  full-magazine, and the zone's hysteresis.
- **Unit** (`ui/frontend_pointer.rs`, `mission/flat_ui_host.rs`): the two
  blockers above, each verified red with the old rule restored.
- **e2e** (`vr-clip-insert-reload.e2e.test.ts`, VR `debug_weapons`): the whole
  gesture through the production hand ray - strip squeeze into the off hand,
  carry to the gun, ammo/consumption/cue asserted; the wrong-type refusal; and
  the ammo-type swap with the ejected rounds landing back in the pack. All
  three fail on the parent.

Verification run (foreground):

- `cargo test -p shock2vr --lib` - 1120 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` - clean
- `cargo apk check` (Oculus) - clean (confirmed it really type-checks the crate by injecting an error)
- e2e: new suite 3/3; `missions` 23/23; `vr-weapon-reload`, `weapon-reload`,
  `weapon-ammo-eject`, `vr-cyber-interface-deposit` 10/10; the VR interface,
  inventory, frontend-menu, weapon, pickup/container and save-load groups all
  green. `bio-ammo-full` fails - **verified failing on `origin/main` too**
  (pre-existing, not this change).

## Review

An adversarial review pass found and this branch fixes:

- **Critical** - the Quest runtime was never actually updated: an earlier `git
  checkout` (undoing a deliberate compile-error probe) silently reverted the
  binding edits, leaving right A/B still bound to `Reload`/`CycleAmmo` *and*
  calling `.expect()` on their now-`None` click paths - a panic on every Quest
  launch that no host-side check or unit test could see. Redone properly and
  re-verified with `cargo apk check`.
- **High** - the pointer fix was half a fix. Gating a squeeze on "its ray is on
  the panel" is not enough, because the interface is head-anchored and the gun
  hand's ray crosses it constantly (and the right hand wins ties). A hand that
  is *carrying* something now never claims the panel by squeeze at all.
- **Medium** - a frame with no pointer cleared both grab latches, so the first
  frame a pass existed read a session-long squeeze as a rising edge.
- **Medium** - the ammo-type swap committed the eject and the selection change
  before knowing the load could move anything (`clip: 0` gun, empty clip
  entity). Both refused up front now.
- Plus the Low items: `hand_slot` unified into `vr_config`, the capacity passed
  through instead of looked up twice, the unsaved latch documented, and the e2e
  swap scenario now asserts the ejected rounds come back *in full*.

## Follow-ups

- **Per-model magazine-zone anchors.** v1 centres the zone on the weapon's
  transform origin; a per-model anchor table (the pattern #1091 introduces)
  would put it at each weapon's actual magazine well.
- **Ammo type in VR is now clip-driven only.** With the face buttons gone there is no `CycleAmmo` in the headset: you switch types by inserting a clip of that type, so you cannot select a type you carry no clip for. That is the intended physical reading (you cannot load ammo you do not have), and the README says so - flagging it as a deliberate consequence.
- **R3b: waist pouch** - reaching to the hip for a clip instead of opening the
  cyber interface.

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72



