### PR TITLE
feat(vr): open the cyber interface onto the log reader

### DIFF
--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -143,9 +143,7 @@ impl ActionDispatcher {
             effects.push(Effect::ToggleMap);
         }
         if state.just_triggered(InputAction::ReadLastUnreadLog) {
-            effects.push(Effect::ReadLastUnreadLog {
-                head_rotation: input_context.head.rotation,
-            });
+            effects.push(Effect::ReadLastUnreadLog);
         }
         // `InputAction::TogglePauseMenu` deliberately produces no effect: the
         // pause overlay is owned by `Game`, which reads the action directly
@@ -168,20 +166,13 @@ mod tests {
     }
 
     #[test]
-    fn audio_log_reader_carries_the_current_head_rotation() {
-        use cgmath::{Deg, Rotation3};
-
+    fn audio_log_reader_action_maps_to_the_reader_effect() {
         let mut state = InputActionState::new();
         state.trigger(InputAction::ReadLastUnreadLog);
-        let mut input = InputContext::default();
-        input.head.rotation = cgmath::Quaternion::from_angle_y(Deg(37.0));
 
-        let effects = ActionDispatcher::dispatch(&state, &input);
+        let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
 
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::ReadLastUnreadLog { head_rotation }] if *head_rotation == input.head.rotation
-        ));
+        assert!(matches!(effects.as_slice(), [Effect::ReadLastUnreadLog]));
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -386,13 +386,6 @@ fn backpack_accepts_deposit(world: &World) -> bool {
 /// scales the unusually wide 15-column strip so all of it fits at arm's reach.
 const VR_BACKPACK_WORLD_SCALE: f32 = 0.55;
 
-/// Head-relative authored-space placement for the narrow portrait reader.
-/// After Dark's scale conversion the panel center is 1.5 world units forward
-/// and 1.4 units above the player origin, keeping its 0.75 x 1.18 canvas fully
-/// framed and within ordinary controller reach.
-const VR_MEDIA_FORWARD: f32 = 3.75;
-const VR_MEDIA_UP: f32 = 3.5;
-
 /// The use-mode ("cyber interface") open/close sting: the shipped gamesys's
 /// own `UI_SCH` schema pair for opening/closing the game's main panel
 /// (`cargo dq templates 610`/`611`) - a faithful "interface open/close"
@@ -1563,6 +1556,15 @@ pub struct MissionCore {
     /// dismissed as soon as that gun stops being wielded.
     weapon_settings_gun: Option<EntityId>,
 
+    /// Whether this use-mode session was opened by the VR log-reader shortcut
+    /// (Quest Y / `Effect::ReadLastUnreadLog`) rather than a deliberate
+    /// `ToggleUseMode`. It makes Y a true inverse of itself: the press that
+    /// dismisses the reader closes the whole interface when Y is what opened
+    /// it, and only puts the reader away - back to the inventory strip - when
+    /// the player was already in the interface. Transient like `use_mode`
+    /// itself (not serialized: a load leaves the mode closed).
+    use_mode_from_log_reader: bool,
+
     /// Entry/exit feel for `use_mode`: one eased 0..1 ramp driving the rim
     /// vignette (both presentations), the VR comfort dim's strength, and the
     /// flat FOV pull - see [`crate::ui::entry_ramp`]. Advanced every update
@@ -2479,6 +2481,7 @@ impl MissionCore {
             flat_melee_anim: None,
             use_mode: false,
             weapon_settings_gun: None,
+            use_mode_from_log_reader: false,
             use_mode_ramp: crate::ui::entry_ramp::EntryExitRamp::new(),
             vr_use_mode_anchor: crate::ui::FrontendPanelAnchor::new(),
             vr_use_mode_head: crate::ui::world_dim::UNTRACKED_HEAD,
@@ -5331,6 +5334,13 @@ impl MissionCore {
         self.use_mode = false;
         self.flat_ui.take_cursor_item();
         self.flat_ui.set_strip(None);
+        // The mode owns the whole canvas, panel slot included: leaving it with
+        // a panel still bound would keep the log reader alive and reported by
+        // `/v1/ui` with nothing presenting it. Inert on flat's Tab path (that
+        // branch dismisses an open panel first and never reaches here with one
+        // bound) and already what `CloseUseMode` does explicitly.
+        self.flat_ui.close();
+        self.use_mode_from_log_reader = false;
         // VR weapon-safe exit: a trigger still held from inside the mode must
         // be released before the hands see it again, or leaving the cyber
         // interface would fire the wielded weapon on a stale press. Inert in
@@ -5353,7 +5363,17 @@ impl MissionCore {
     /// the player's `internal_inventory` entity (whose GuiScript already
     /// emits SetUI every frame). Shared by both presentations - the strip
     /// canvas is the mode; only where it is presented differs.
-    fn enter_use_mode(&mut self) -> Effect {
+    /// Place the VR cyber-interface panel from the pose of *this* entry, not
+    /// wherever the player stood last time - and let the anchor wait out an
+    /// untracked (zero-quaternion) head rather than locking in a garbage
+    /// placement (rules 3 and 7 of the vr-ui-design skill). Shared by every
+    /// way into the mode so no entry can forget it; inert in flat.
+    fn reset_vr_use_mode_placement(&mut self) {
+        self.vr_use_mode_anchor = crate::ui::FrontendPanelAnchor::new();
+        self.vr_use_mode_head = crate::ui::world_dim::UNTRACKED_HEAD;
+    }
+
+    fn enter_use_mode(&mut self, ramp: crate::ui::entry_ramp::RampParams) -> Effect {
         self.use_mode = true;
         let strip_entity = self
             .world
@@ -5366,8 +5386,10 @@ impl MissionCore {
         // a held press must never read as a click on whatever the pointer first
         // crosses (rule 6 of the vr-ui-design skill).
         self.flat_ui.guard_held_press();
-        self.use_mode_ramp
-            .open(crate::ui::entry_ramp::DEFAULT_ENTRY_EXIT);
+        // `ramp` is how strong/long this particular entry feels: the
+        // deliberate inventory open and the Y-to-log-reader shortcut are the
+        // same mode reached with different intent.
+        self.use_mode_ramp.open(ramp);
         Effect::PlaySound {
             handle: AudioHandle::new(),
             source: None,
@@ -5632,7 +5654,9 @@ impl MissionCore {
                             } else if self.use_mode {
                                 effects.push_front(self.leave_use_mode());
                             } else {
-                                effects.push_front(self.enter_use_mode());
+                                effects.push_front(
+                                    self.enter_use_mode(crate::ui::entry_ramp::DEFAULT_ENTRY_EXIT),
+                                );
                             }
                         }
                         crate::PresentationMode::Vr => {
@@ -5653,14 +5677,10 @@ impl MissionCore {
                                 // open, and a level transition replaces this
                                 // scene (taking the mission-owned mode state
                                 // with it).
-                                effects.push_front(self.enter_use_mode());
-                                // Place the panel from the pose of *this*
-                                // entry, not wherever the player stood last
-                                // time - and let the anchor wait out an
-                                // untracked (zero-quaternion) head rather than
-                                // locking in a garbage placement.
-                                self.vr_use_mode_anchor = crate::ui::FrontendPanelAnchor::new();
-                                self.vr_use_mode_head = crate::ui::world_dim::UNTRACKED_HEAD;
+                                effects.push_front(
+                                    self.enter_use_mode(crate::ui::entry_ramp::DEFAULT_ENTRY_EXIT),
+                                );
+                                self.reset_vr_use_mode_placement();
                             }
                         }
                     }
@@ -5797,7 +5817,7 @@ impl MissionCore {
                     self.consume_log_pickup(entity_id);
                 }
 
-                Effect::ReadLastUnreadLog { head_rotation } => {
+                Effect::ReadLastUnreadLog => {
                     let panel_entity = self
                         .world
                         .borrow::<UniqueView<MediaPanelEntity>>()
@@ -5808,18 +5828,32 @@ impl MissionCore {
                         continue;
                     };
 
+                    let is_vr = game_options.presentation_mode == crate::PresentationMode::Vr;
+
                     // Y is also the production dismiss affordance in VR. The
                     // next press re-enters this path, re-resolves and replays
                     // the latest collected log even when it is already read.
-                    if game_options.presentation_mode == crate::PresentationMode::Vr
-                        && self.gui.active_panel() == Some(panel_entity)
-                    {
-                        self.gui.close_panel(
-                            &mut self.world,
-                            &mut self.physics,
-                            &mut self.script_world,
-                            &mut self.id_to_physics,
-                        );
+                    // Y is a true inverse of itself: it puts back exactly what
+                    // it brought up - the whole interface when Y opened it,
+                    // just the reader (leaving the inventory strip) when the
+                    // player was already inside.
+                    if is_vr && self.flat_ui.active_panel() == Some(panel_entity) {
+                        if self.use_mode_from_log_reader {
+                            effects.push_front(self.leave_use_mode());
+                        } else {
+                            self.flat_ui.close();
+                        }
+                        // The log's audio is deliberately left playing - the
+                        // reader is a transcript of a recording, not its
+                        // transport.
+                        continue;
+                    }
+
+                    // Edge policy: no cyber interface over the death sequence,
+                    // the same rule `ToggleUseMode` applies - that moment
+                    // belongs to the game-over flow. Flat is untouched: its
+                    // reader is an MFD, not a mode.
+                    if is_vr && !self.use_mode && !self.player_is_alive() {
                         continue;
                     }
 
@@ -5868,47 +5902,23 @@ impl MissionCore {
                         payload: MessagePayload::PanelOpened,
                     });
 
-                    match game_options.presentation_mode {
-                        crate::PresentationMode::Flat => self.flat_ui.open_unbound(panel_entity),
-                        crate::PresentationMode::Vr => {
-                            let (player_position, player_rotation) = {
-                                let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-                                (player.pos, player.rotation * head_rotation)
-                            };
-                            let offset = player_rotation
-                                * vec3(
-                                    0.0,
-                                    VR_MEDIA_UP / SCALE_FACTOR,
-                                    -VR_MEDIA_FORWARD / SCALE_FACTOR,
-                                );
-                            let panel_position = player_position + offset;
-                            let panel_rotation =
-                                Quaternion::from_angle_y(cgmath::Deg(180.0)) * player_rotation;
-                            self.world.add_component(
-                                panel_entity,
-                                PropPosition {
-                                    position: panel_position,
-                                    rotation: panel_rotation,
-                                    cell: 0,
-                                },
-                            );
-                            self.world.add_component(
-                                panel_entity,
-                                RuntimePropTransform(
-                                    Matrix4::from_translation(panel_position)
-                                        * Matrix4::from(panel_rotation),
-                                ),
-                            );
-                            self.gui.open_panel(
-                                panel_entity,
-                                false,
-                                &mut self.world,
-                                &mut self.physics,
-                                &mut self.script_world,
-                                &mut self.id_to_physics,
-                            );
-                        }
+                    // One canvas, two presenters: the reader is bound into the
+                    // same host slot in both presentations, docked in the MFD
+                    // on screen and carried on the head-anchored cyber-
+                    // interface panel in VR. `open_unbound` because the reader
+                    // is player-owned and has no world object to walk away
+                    // from - it closes only explicitly.
+                    if is_vr && !self.use_mode {
+                        // Y is a shortcut into the interface, not a second
+                        // interface: enter the one mode, with a lighter ramp
+                        // than the deliberate open (see `LOG_READER_ENTRY_EXIT`).
+                        effects.push_front(
+                            self.enter_use_mode(crate::ui::entry_ramp::LOG_READER_ENTRY_EXIT),
+                        );
+                        self.reset_vr_use_mode_placement();
+                        self.use_mode_from_log_reader = true;
                     }
+                    self.flat_ui.open_unbound(panel_entity);
 
                     // Only after a localized reader is bound to the active
                     // presentation do read state and audio advance together.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1563,6 +1563,11 @@ pub struct MissionCore {
     /// it, and only puts the reader away - back to the inventory strip - when
     /// the player was already in the interface. Transient like `use_mode`
     /// itself (not serialized: a load leaves the mode closed).
+    ///
+    /// Only Y consults it. Dismissing the reader with the canvas's own close
+    /// button is the host's generic "put this panel away" and leaves the
+    /// interface up on the inventory strip however it was opened; X or Y
+    /// still exits from there.
     use_mode_from_log_reader: bool,
 
     /// Entry/exit feel for `use_mode`: one eased 0..1 ramp driving the rim
@@ -5716,14 +5721,23 @@ impl MissionCore {
                     // mode retains its historical all-panels presentation.
                     match game_options.presentation_mode {
                         crate::PresentationMode::Flat => self.flat_ui.open(entity),
-                        crate::PresentationMode::Vr => self.gui.open_panel(
-                            entity,
-                            game_options.experimental_features.contains("gui"),
-                            &mut self.world,
-                            &mut self.physics,
-                            &mut self.script_world,
-                            &mut self.id_to_physics,
-                        ),
+                        crate::PresentationMode::Vr => {
+                            // The other half of "one UI at a time": a world
+                            // panel replaces an open log reader, exactly as the
+                            // reader replaces a world panel. Both used to share
+                            // `GuiManager`'s single slot, so this was free; now
+                            // the reader lives in the flat host and the
+                            // symmetry has to be written down.
+                            self.flat_ui.close();
+                            self.gui.open_panel(
+                                entity,
+                                game_options.experimental_features.contains("gui"),
+                                &mut self.world,
+                                &mut self.physics,
+                                &mut self.script_world,
+                                &mut self.id_to_physics,
+                            )
+                        }
                     }
                     // Give the gui its per-open state (the reader's scroll
                     // reset) however the panel was reached.
@@ -5849,11 +5863,16 @@ impl MissionCore {
                         continue;
                     }
 
-                    // Edge policy: no cyber interface over the death sequence,
-                    // the same rule `ToggleUseMode` applies - that moment
-                    // belongs to the game-over flow. Flat is untouched: its
-                    // reader is an MFD, not a mode.
-                    if is_vr && !self.use_mode && !self.player_is_alive() {
+                    // Edge policy: nothing new over the death sequence - the
+                    // same rule `ToggleUseMode` applies, that moment belongs to
+                    // the game-over flow. This sits *after* the dismiss branch
+                    // on purpose: a player who died with the reader up must
+                    // still be able to put it away. It also covers dying while
+                    // already inside the interface, where binding a fresh
+                    // reader would mark a log read and start its audio over the
+                    // death sequence. Flat is untouched: its reader is an MFD,
+                    // not a mode.
+                    if is_vr && !self.player_is_alive() {
                         continue;
                     }
 
@@ -5912,26 +5931,26 @@ impl MissionCore {
                         // The reader replaces whatever world quad was up - the
                         // corpse the log was just looted from - rather than
                         // hanging in front of it. It is the same "one UI at a
-                        // time" contract the world-quad reader had when it
-                        // took the `GuiManager` slot itself.
-                        if self.gui.active_panel().is_some() {
-                            self.gui.close_panel(
-                                &mut self.world,
-                                &mut self.physics,
-                                &mut self.script_world,
-                                &mut self.id_to_physics,
-                            );
-                        }
-                    }
-                    if is_vr && !self.use_mode {
-                        // Y is a shortcut into the interface, not a second
-                        // interface: enter the one mode, with a lighter ramp
-                        // than the deliberate open (see `LOG_READER_ENTRY_EXIT`).
-                        effects.push_front(
-                            self.enter_use_mode(crate::ui::entry_ramp::LOG_READER_ENTRY_EXIT),
+                        // time" contract the world-quad reader had when it took
+                        // the `GuiManager` slot itself (a no-op when nothing is
+                        // open).
+                        self.gui.close_panel(
+                            &mut self.world,
+                            &mut self.physics,
+                            &mut self.script_world,
+                            &mut self.id_to_physics,
                         );
-                        self.reset_vr_use_mode_placement();
-                        self.use_mode_from_log_reader = true;
+                        if !self.use_mode {
+                            // Y is a shortcut into the interface, not a second
+                            // interface: enter the one mode, with a lighter
+                            // ramp than the deliberate open (see
+                            // `LOG_READER_ENTRY_EXIT`).
+                            effects.push_front(
+                                self.enter_use_mode(crate::ui::entry_ramp::LOG_READER_ENTRY_EXIT),
+                            );
+                            self.reset_vr_use_mode_placement();
+                            self.use_mode_from_log_reader = true;
+                        }
                     }
                     self.flat_ui.open_unbound(panel_entity);
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5908,6 +5908,21 @@ impl MissionCore {
                     // interface panel in VR. `open_unbound` because the reader
                     // is player-owned and has no world object to walk away
                     // from - it closes only explicitly.
+                    if is_vr {
+                        // The reader replaces whatever world quad was up - the
+                        // corpse the log was just looted from - rather than
+                        // hanging in front of it. It is the same "one UI at a
+                        // time" contract the world-quad reader had when it
+                        // took the `GuiManager` slot itself.
+                        if self.gui.active_panel().is_some() {
+                            self.gui.close_panel(
+                                &mut self.world,
+                                &mut self.physics,
+                                &mut self.script_world,
+                                &mut self.id_to_physics,
+                            );
+                        }
+                    }
                     if is_vr && !self.use_mode {
                         // Y is a shortcut into the interface, not a second
                         // interface: enter the one mode, with a lighter ramp

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -310,12 +310,11 @@ pub enum Effect {
     /// once all are read. Opens the localized player-owned reader before
     /// marking it read and playing its `LOG<dd><nn>` audio. No-op only when the
     /// collection is empty or the authored transcript is unavailable.
-    ReadLastUnreadLog {
-        /// Head rotation at the input edge. VR uses it to place the
-        /// player-owned reader comfortably in the player's current gaze;
-        /// flat presentation ignores it.
-        head_rotation: Quaternion<f32>,
-    },
+    /// Carries no payload: both presentations place the reader from state
+    /// they already own - flat's MFD slot, and VR's head-anchored cyber-
+    /// interface anchor, which tracks the live head pose rather than a
+    /// rotation sampled at the input edge.
+    ReadLastUnreadLog,
 
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key, `kOverlayMap 26`). Opens the wide map MFD bound to the

--- a/shock2vr/src/ui/entry_ramp.rs
+++ b/shock2vr/src/ui/entry_ramp.rs
@@ -29,6 +29,19 @@ pub const DEFAULT_ENTRY_EXIT: RampParams = RampParams {
     fov_pull_deg: 6.0,
 };
 
+/// Opening straight onto the log reader (Quest's Y button): the same
+/// interface, but reached in passing rather than deliberately jacked into.
+/// Reading a log is something the player does mid-corridor, often repeatedly,
+/// so the ramp is shorter and lighter than [`DEFAULT_ENTRY_EXIT`] on every
+/// axis - enough to say "the world stepped back", not enough to feel like a
+/// scene change each time.
+pub const LOG_READER_ENTRY_EXIT: RampParams = RampParams {
+    attack_secs: 0.18,
+    release_secs: 0.14,
+    vignette_peak: 0.28,
+    fov_pull_deg: 3.0,
+};
+
 /// The rim tint blended in for the cyber interface - a cool cyan rather than
 /// [`crate::hit_feedback`]'s arterial red, so the two read as different
 /// things when they land on screen together.
@@ -274,6 +287,34 @@ mod tests {
         assert_eq!(ramp.progress(), before);
         ramp.update(0.0);
         assert_eq!(ramp.progress(), before);
+    }
+
+    /// The log-reader shortcut must actually be the softer, shorter variant -
+    /// if it ever equals the deliberate open, the "different `RampParams`"
+    /// the caller builds is decoration.
+    #[test]
+    fn the_log_reader_ramp_is_shorter_and_softer_than_the_deliberate_open() {
+        assert!(LOG_READER_ENTRY_EXIT.attack_secs < DEFAULT_ENTRY_EXIT.attack_secs);
+        assert!(LOG_READER_ENTRY_EXIT.release_secs < DEFAULT_ENTRY_EXIT.release_secs);
+        assert!(LOG_READER_ENTRY_EXIT.vignette_peak < DEFAULT_ENTRY_EXIT.vignette_peak);
+        assert!(LOG_READER_ENTRY_EXIT.fov_pull_deg < DEFAULT_ENTRY_EXIT.fov_pull_deg);
+        assert!(LOG_READER_ENTRY_EXIT.attack_secs > 0.0);
+        assert!(LOG_READER_ENTRY_EXIT.release_secs > 0.0);
+    }
+
+    /// And the ramp must honor those params rather than the default it was
+    /// constructed with: half a log-reader attack is already past half a
+    /// *default* attack.
+    #[test]
+    fn opening_with_the_log_reader_params_uses_their_timing() {
+        let mut ramp = EntryExitRamp::new();
+        ramp.open(LOG_READER_ENTRY_EXIT);
+        ramp.update(LOG_READER_ENTRY_EXIT.attack_secs);
+        assert_eq!(ramp.progress(), 1.0);
+        assert_eq!(
+            ramp.vignette_intensity(),
+            LOG_READER_ENTRY_EXIT.vignette_peak
+        );
     }
 
     #[test]

--- a/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
@@ -228,6 +228,23 @@ test(
     await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
     await assertAmanpourReader(game);
+    // X out with the reader still bound: leaving the mode must release the
+    // panel slot too, or `/v1/ui` keeps reporting a reader nothing presents.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const exited = await game.ui.state();
+    assert.equal(exited.mode, "shooter");
+    assert.equal(
+      exited.active_panel,
+      null,
+      "leaving the interface must not orphan the reader in the panel slot",
+    );
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    await assertAmanpourReader(game);
     await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
     const backToStrip = await game.ui.state();

--- a/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
@@ -12,11 +12,15 @@ import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 //   corpse 1680 --Contains(0)--> Amanpour Log 1608
 //   hand trigger -> corpse ContainerGui world panel
 //   hand trigger on the rendered slot -> LogDiscScript collection
-//   Quest Y's semantic action -> player-owned MediaGui world panel
+//   Quest Y's semantic action -> the cyber interface, opened onto the reader
 //
 // Negative-first on PR #967's head: collection auto-plays LOG0220, the semantic
 // action marks it read and plays it again, but the corpse panel stays active and
 // no VR transcript ever renders. There is also no Oculus Y binding.
+//
+// Negative-first again for the cyber-interface surface: before that change Y
+// spawned a bespoke reader world quad, so `ui.mode` stayed "shooter" and the
+// reader carried its own `ui` collision body - both asserted against below.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const AMANPOUR_CORPSE = 1680;
@@ -108,8 +112,19 @@ async function collectAmanpourThroughVrCorpse(game: GameServer): Promise<void> {
 }
 
 async function assertAmanpourReader(game: GameServer): Promise<UiPanel> {
-  const panel = (await game.ui.state()).active_panel;
+  const ui = await game.ui.state();
+  const panel = ui.active_panel;
   assert.ok(panel, "ReadLastUnreadLog must expose the active VR MediaGui panel");
+  assert.equal(
+    ui.mode,
+    "use",
+    "Y must open the cyber interface, not a bespoke reader quad",
+  );
+  assert.ok(ui.strip, "the cyber interface binds the inventory strip either way in");
+  assert.ok(
+    ui.panel_pose,
+    "the reader must ride the head-anchored cyber-interface panel",
+  );
   assert.equal(panel.template_id, -1, "the reader must use its player-owned host");
   const text = panelText(panel);
   assert.ok(text.includes("45100"), `reader transcript must visibly contain 45100: ${text}`);
@@ -120,7 +135,11 @@ async function assertAmanpourReader(game: GameServer): Promise<UiPanel> {
   assert.ok(textures.includes("iface/log.pcx"));
   assert.ok(textures.includes("amanpour.pcx") || textures.includes("amanpour.png"));
   assert.ok(textures.includes("medicon.pcx") || textures.includes("medicon.png"));
-  assert.equal((await uiBodies(game)).length, 1, "reader must replace, not overlap, corpse UI");
+  assert.equal(
+    (await uiBodies(game)).length,
+    0,
+    "the reader is the shared canvas on the cyber-interface panel - no world quad",
+  );
   return panel;
 }
 
@@ -151,16 +170,29 @@ test(
     assert.equal(await log0220Count(game), beforeCollectionAudio + 1);
     await game.screenshot("vr-amanpour-reader-45100.png");
 
-    // Quest Y toggles the reader closed, then reopens/replays the latest entry
-    // even though it is already read.
+    // Quest Y toggles the reader closed. Y opened the interface, so Y closes
+    // all of it - and the log's audio is left playing rather than cut.
     await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
-    assert.equal((await game.ui.state()).active_panel, null);
+    const closed = await game.ui.state();
+    assert.equal(closed.active_panel, null);
+    assert.equal(closed.mode, "shooter", "Y-again must close the interface Y opened");
+    assert.equal(closed.strip, null);
     assert.equal((await uiBodies(game)).length, 0);
+    assert.equal(
+      await log0220Count(game),
+      beforeCollectionAudio + 1,
+      "closing the reader must not stop or restart the log audio",
+    );
+
+    // Reopens/replays the latest entry even though it is already read.
     await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
     await assertAmanpourReader(game);
     assert.equal(await log0220Count(game), beforeCollectionAudio + 2);
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).mode, "shooter");
 
     const saveName = `issue921_vr_log_${Date.now()}`;
     assert.equal((await game.save(saveName)).success, true);
@@ -177,16 +209,36 @@ test(
     await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
     await assertAmanpourReader(game);
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).mode, "shooter");
 
-    // Left-X (now the cyber-interface use-mode toggle - the world-quad
-    // backpack it used to open is gone) stays independent of Y: it brings up
-    // the use-mode strip without disturbing the reader lifecycle, and
-    // toggles away cleanly.
+    // Left-X (the cyber-interface use-mode toggle) opens the same interface
+    // deliberately, onto the inventory rather than a reader.
     await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 5 });
-    const ui = await game.ui.state();
-    assert.equal(ui.mode, "use", "Quest X must open the cyber interface");
-    assert.ok(ui.strip, "the cyber interface must bind the inventory strip");
+    const opened = await game.ui.state();
+    assert.equal(opened.mode, "use", "Quest X must open the cyber interface");
+    assert.ok(opened.strip, "the cyber interface must bind the inventory strip");
+    assert.equal(opened.active_panel, null, "X opens onto the inventory, not a reader");
+
+    // Edge policy: Y inside an interface the player already opened switches the
+    // panel slot to the reader (flat's semantics - the reader is an MFD over the
+    // strip), and Y again puts only the reader away, leaving the interface up.
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    await assertAmanpourReader(game);
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    const backToStrip = await game.ui.state();
+    assert.equal(backToStrip.active_panel, null, "Y-again dismisses the reader");
+    assert.equal(
+      backToStrip.mode,
+      "use",
+      "an interface the player opened with X must survive dismissing the reader",
+    );
+    assert.ok(backToStrip.strip);
+
     await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 5 });
     assert.equal((await game.ui.state()).mode, "shooter");


### PR DESCRIPTION
Stacked on #1165 (`feat/vr-clip-insert-reload`) — review that first.

## What

Quest's **Y** (`ReadLastUnreadLog`) now opens the **cyber interface directly onto the log reader** instead of spawning a bespoke VR world quad for it. Owner decision (cyber-interface plan, 2026-08-22, option A).

Before, the reader existed twice: flat docked the `MediaGui` canvas in its MFD slot via `flat_ui.open_unbound`, while VR built its own head-relative `PropPosition`/`RuntimePropTransform` placement and handed the same entity to `GuiManager` as a physical world quad — a second presentation of a canvas that already had one, with its own placement maths and its own dismiss path. Now **both presentations bind the reader into the same `FlatUiHost` panel slot** (decision 5: one canvas, two presenters), and VR simply brings the interface up around it. Flat behavior is unchanged.

Because reading a log is a mid-corridor act rather than a deliberate "jacking in", the entry uses a lighter ramp — exactly the second `RampParams` caller `entry_ramp.rs` was structured for in #1113:

| | attack | release | vignette peak | FOV pull |
|---|---|---|---|---|
| `DEFAULT_ENTRY_EXIT` (X, deliberate) | 0.35 s | 0.25 s | 0.45 | 6.0° |
| `LOG_READER_ENTRY_EXIT` (Y, shortcut) | 0.18 s | 0.14 s | 0.28 | 3.0° |

## Edge policy (vr-ui-design rule 10)

| Y pressed... | Behavior |
|---|---|
| no collected log / no resolvable transcript | logged no-op — unchanged, and it happens *before* any mode change, so a failed read never opens the interface |
| reader host unavailable | logged no-op, unchanged |
| while dead | ignored, whether or not the interface is already up — the death sequence belongs to the game-over flow (same rule `ToggleUseMode` applies). Dismissing a reader that is already open still works. |
| while a VR world panel (corpse/container) is up | the world panel closes; the reader replaces it rather than hanging in front of it. The reverse holds too — `OpenPanel` now releases the reader's slot, so a frob with a free hand can't leave both up |
| while the interface is already open on the inventory | switches the panel slot to the reader over the strip — flat's own semantics (the reader is an MFD) |
| again, when **Y** opened the interface | closes the whole interface |
| again, when **X** opened it | dismisses only the reader, back to the inventory strip |
| audio on close | keeps playing — the reader is a transcript, not a transport |
| the canvas's own close button | generic "put this panel away": leaves the interface up on the inventory strip however it was opened (documented on the flag) |
| while paused / mid-transition | unreachable, as for `ToggleUseMode`: the pause menu clears triggered actions and forces `CloseUseMode`; a level transition replaces the scene |

`leave_use_mode` now also releases the panel slot, so the mode can no longer be left with a reader still bound but nothing presenting it. `Effect::ReadLastUnreadLog`'s `head_rotation` payload is dropped — the head-anchored panel tracks the live head pose, so there was no longer an edge-sampled rotation to place anything with (`VR_MEDIA_FORWARD`/`VR_MEDIA_UP` go with it).

## Tests

- **Unit** (`ui/entry_ramp.rs`): the log-reader params are shorter/softer than the deliberate open on every axis, and the ramp honors them. Negative-first: neither compiles on base.
- **e2e** (`vr-audio-log-reader.e2e.test.ts`): the existing MedSci Amanpour chain now asserts `/v1/ui` reports `mode: "use"`, a bound strip, a `panel_pose`, the 45100 transcript in the panel slot, **and zero `ui` collision bodies** — the world quad it used to be. Both dismiss cases are covered, plus the audio-keeps-playing assertion. Negative-first: on base `mode` is `"shooter"` and the reader has a `ui` body.
- **e2e, added after review**: leaving use mode with the reader still bound must not orphan it in the panel slot — verified failing without `leave_use_mode`'s `flat_ui.close()`, passing with it.
- Regression, all green (foreground runs; the full 196-test suite was not run end to end — these are `missions.e2e.test.ts` plus every suite touching the shared UI host, use mode, VR panels and the log reader): 62/62 across `vr-cyber-interface{,-deposit,-frob,-pointer}` , `vr-clip-insert-reload` (the base PR's), `vr-audio-log-reader`, `vr-container-world-panel`, `earth-vr-world-panel-arbitration`, `hydro3-vr-desk-loot`, `hydro2-vr-keycard`, `medsci2-vr-released-item`, `vr-held-model`, `vr-frontend-panel-anchor`, `flat-ui-plumbing`, `flat-hud`, `container-loot`, `elevator-panel`, `always-collected-categories`, `door-frob`, `cyber-modules`, `dev-menu`, `earth-log-reader`, `log-pickup-consumption`, `log-quest-bit`, and missions **23/23**.
- Known baseline (pre-existing, unrelated): `log-reader.e2e.test.ts` "hydro3 Korenchkin double-spaced transcript".

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p shock2vr --lib` 1122 passed; `cargo fmt --check` clean.

https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72


## Visuals

![VR log reader on the cyber interface](https://gist.githubusercontent.com/tommy-xr/bc953640efc7122be1d5775d5f4e3a75/raw/demo.gif)

<sub>medsci1 in VR mode: Quest Y (`ReadLastUnreadLog`) opens the head-anchored cyber interface with the audio-log reader canvas on it — the vignette + world dim ease in over the short entry ramp — and Y again closes it back to the plain world. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![Reader panel open with transcript](https://gist.githubusercontent.com/tommy-xr/bc953640efc7122be1d5775d5f4e3a75/raw/still.png)

<sub>Reader fully open on the interface: Amanpour 07.JUL.14 "Re: New code" transcript legible beside the inventory strip.</sub>

<sub>After-only (net-new VR surface); no before/after capture, as the base ref would need a second checkout.</sub>


