### PR TITLE
feat(audio): world geometry resolves its own surface material

### DIFF
--- a/dark/src/gamesys/env_sound_query.rs
+++ b/dark/src/gamesys/env_sound_query.rs
@@ -23,6 +23,10 @@ pub struct EnvSoundQuery {
     /// `Gamesys::get_random_environmental_sound`). Off by default so existing
     /// lookups keep resolving exactly as they did.
     prefer_most_specific: bool,
+    /// Tried, in order, when this query resolves to no sample. The schema does
+    /// not author every (event, material) pair - a pistol round on tile has no
+    /// entry - and silence is a worse answer there than a less specific one.
+    fallback: Option<Box<EnvSoundQuery>>,
 }
 
 impl EnvSoundQueryItem {
@@ -40,6 +44,7 @@ impl EnvSoundQuery {
         Self {
             items: Vec::new(),
             prefer_most_specific: false,
+            fallback: None,
         }
     }
 
@@ -47,6 +52,7 @@ impl EnvSoundQuery {
         Self {
             items,
             prefer_most_specific: false,
+            fallback: None,
         }
     }
 
@@ -57,6 +63,7 @@ impl EnvSoundQuery {
                 .map(|(tag, value)| EnvSoundQueryItem::new(tag, value))
                 .collect(),
             prefer_most_specific: false,
+            fallback: None,
         }
     }
 
@@ -69,6 +76,18 @@ impl EnvSoundQuery {
 
     pub fn prefers_most_specific(&self) -> bool {
         self.prefer_most_specific
+    }
+
+    /// Return this query with a less specific one to fall back on when it
+    /// resolves to nothing.
+    pub fn with_fallback(mut self, fallback: EnvSoundQuery) -> Self {
+        self.fallback = Some(Box::new(fallback));
+        self
+    }
+
+    /// The query to try next when this one resolves to no sample.
+    pub fn fallback(&self) -> Option<&EnvSoundQuery> {
+        self.fallback.as_deref()
     }
 
     /// The (tag, value) pairs of this query, e.g. for logging/introspection.

--- a/dark/src/mission/texture_list.rs
+++ b/dark/src/mission/texture_list.rs
@@ -1,5 +1,5 @@
 use crate::Gamesys;
-use crate::properties::{AnimTexFlags, PropAnimTex, PropRenderType, RenderType};
+use crate::properties::{AnimTexFlags, PropAnimTex, PropMaterial, PropRenderType, RenderType};
 use crate::ss2_chunk_file_reader::ChunkFileTableOfContents;
 use crate::ss2_entity_info::{self, SystemShock2EntityInfo};
 use byteorder::ReadBytesExt;
@@ -24,6 +24,19 @@ pub struct SystemShock2Texture {
     pub texture_filename: String,
     pub render_type: RenderType,
     pub animation_info: Option<TextureAnimationInfo>,
+    /// Sound-schema material tag for this surface ("metal", "fabric", ...),
+    /// from the texture archetype's inherited `PropMaterial`. `None` when the
+    /// texture has no archetype entry, or its material has no tag.
+    pub material: Option<String>,
+}
+
+/// What a texture's `t_fam/<family>/<name>` archetype contributes to the
+/// texture entry it names.
+#[derive(Clone, Debug)]
+struct TextureArchetypeInfo {
+    render_type: RenderType,
+    animation_info: Option<TextureAnimationInfo>,
+    material: Option<String>,
 }
 
 pub struct TextureList(pub Vec<SystemShock2Texture>);
@@ -49,7 +62,7 @@ impl TextureList {
 fn read_txlist_chunk<T: io::Read + io::Seek>(
     table_of_contents: &ChunkFileTableOfContents,
     reader: &mut T,
-    name_to_info: HashMap<String, (RenderType, Option<TextureAnimationInfo>)>,
+    name_to_info: HashMap<String, TextureArchetypeInfo>,
 ) -> TextureList {
     let txlist = table_of_contents
         .get_chunk("TXLIST".to_string())
@@ -84,13 +97,17 @@ fn read_txlist_chunk<T: io::Read + io::Seek>(
 
         let entity_name = format!("t_fam/{}/{}", family, name);
 
-        let (render_type, maybe_animation_info) = {
+        let (render_type, maybe_animation_info, material) = {
             if let Some(info) = name_to_info.get(&entity_name) {
                 info!("texture info for: {} is {:?}", entity_name, info);
-                (info.0.clone(), info.1.clone())
+                (
+                    info.render_type.clone(),
+                    info.animation_info.clone(),
+                    info.material.clone(),
+                )
             } else {
                 warn!("no texture info for: {}", entity_name);
-                (RenderType::Normal, None)
+                (RenderType::Normal, None, None)
             }
         };
 
@@ -99,6 +116,7 @@ fn read_txlist_chunk<T: io::Read + io::Seek>(
             texture_filename: name,
             render_type,
             animation_info: maybe_animation_info,
+            material,
         })
     }
     TextureList(textures)
@@ -108,7 +126,7 @@ fn read_texture_archetypes(
     obj_texture_families: Vec<(String, i32)>,
     entity_info: &SystemShock2EntityInfo,
     gamesys: &Gamesys,
-) -> HashMap<String, (RenderType, Option<TextureAnimationInfo>)> {
+) -> HashMap<String, TextureArchetypeInfo> {
     let mut world = World::new();
     let name_map_override = HashMap::new();
 
@@ -129,6 +147,7 @@ fn read_texture_archetypes(
     for (family_name, id) in &obj_texture_families {
         let v_render_type = world.borrow::<View<PropRenderType>>().unwrap();
         let v_anim_tex = world.borrow::<View<PropAnimTex>>().unwrap();
+        let v_material = world.borrow::<View<PropMaterial>>().unwrap();
 
         let maybe_entity_id = template_to_entity_id.get(id);
         if let Some(entity_id) = maybe_entity_id {
@@ -152,9 +171,21 @@ fn read_texture_archetypes(
                     None
                 }
             };
+            // The hydrated entity carries the *resolved* material: props are
+            // applied most-distant-ancestor first, so a `MatMetal`-style
+            // metaproperty overwrites the `Texture` base archetype's default.
+            let material = v_material
+                .get(*entity_id)
+                .ok()
+                .and_then(|prop_material| prop_material.tag());
+
             name_to_info.insert(
                 family_name.clone(),
-                (render_type, maybe_texture_animation_info),
+                TextureArchetypeInfo {
+                    render_type,
+                    animation_info: maybe_texture_animation_info,
+                    material,
+                },
             );
 
             // if let Ok(anim_tex) = maybe_anim_tex {

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -277,6 +277,22 @@ impl PropMapRef {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropMaterial(pub String);
 
+impl PropMaterial {
+    /// The collision/footstep-schema material tag for this property, e.g.
+    /// `"Material FleshTarget"` -> `"fleshtarget"`. Authored values are a
+    /// `Material <tag>` pair (via archetypes such as `MatFlesh` / `MatMetal`);
+    /// anything that does not follow that shape has no tag.
+    pub fn tag(&self) -> Option<String> {
+        let mut tokens = self.0.split_whitespace();
+        while let Some(token) = tokens.next() {
+            if token.eq_ignore_ascii_case("material") {
+                return tokens.next().map(|value| value.to_ascii_lowercase());
+            }
+        }
+        None
+    }
+}
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropMapText(pub String);
 

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -282,6 +282,8 @@ pub struct RayCastResult {
     pub body_id: Option<u32>,
     pub collision_group: Option<String>,
     pub is_sensor: bool,
+    /// Sound-schema material of the world surface hit, when level geometry.
+    pub surface_material: Option<String>,
 }
 
 /// Scene objects submitted on the last rendered frame

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1048,6 +1048,7 @@ fn process_command(
                     body_id: hit.body_id,
                     collision_group: hit.collision_group,
                     is_sensor: hit.is_sensor,
+                    surface_material: hit.surface_material,
                 }
             } else {
                 tracing::error!("No debug scene available for raycast");
@@ -1061,6 +1062,7 @@ fn process_command(
                     body_id: None,
                     collision_group: None,
                     is_sensor: false,
+                    surface_material: None,
                 }
             };
 
@@ -3341,6 +3343,7 @@ async fn perform_raycast(
             body_id: None,
             collision_group: None,
             is_sensor: false,
+            surface_material: None,
         }));
     }
 
@@ -3359,6 +3362,7 @@ async fn perform_raycast(
                 body_id: None,
                 collision_group: None,
                 is_sensor: false,
+                surface_material: None,
             }))
         }
     }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -330,6 +330,9 @@ pub struct DebugRayHit {
     pub body_id: Option<u32>,
     pub collision_group: Option<String>,
     pub is_sensor: bool,
+    /// Sound-schema material of the world surface hit ("metal", "fabric", ...),
+    /// when the ray landed on level geometry.
+    pub surface_material: Option<String>,
 }
 
 /// Raycast mask for collision group filtering

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -65,7 +65,7 @@ use physics::PhysicsWorld;
 use rand::{
     Rng, distributions::WeightedIndex, prelude::Distribution, seq::SliceRandom, thread_rng,
 };
-use rapier3d::prelude::{Collider, RigidBodyHandle};
+use rapier3d::prelude::RigidBodyHandle;
 use scripts::ScriptWorld;
 
 use shipyard::*;
@@ -1688,7 +1688,7 @@ pub struct AbstractMission {
     pub song_params: SongParams,
     pub room_db: RoomDatabase,
     pub map_params: dark::mission::MapParams,
-    pub physics_geometry: Option<Collider>,
+    pub physics_geometry: Option<crate::physics::LevelGeometry>,
     pub spatial_data: Option<Box<dyn SpatialQueryEngine>>,
     pub entity_info: SystemShock2EntityInfo,
     pub obj_map: HashMap<i32, String>,
@@ -2057,8 +2057,8 @@ impl MissionCore {
         );
 
         let world_entity_id = world.add_entity(RuntimePropDoNotSerialize {});
-        if let Some(collider) = abstract_mission.physics_geometry {
-            physics.add_collider(world_entity_id, collider);
+        if let Some(geometry) = abstract_mission.physics_geometry {
+            physics.add_level_geometry(world_entity_id, geometry);
         }
 
         // Finally, instantiate these entities

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2923,9 +2923,13 @@ impl MissionCore {
                         is_climbing: self.player_handle.is_climbing(),
                     });
             if let Some(footstep) = footstep {
+                // The deck the foot landed on: `new_character_pos` is the pawn
+                // origin, already at the player's feet.
+                let ground_material = self.physics.ground_surface_material(new_character_pos);
                 effects.push(crate::mission::player_footsteps::player_footstep_effect(
                     footstep,
                     new_character_pos,
+                    ground_material,
                 ));
             }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3016,6 +3016,7 @@ impl MissionCore {
                             contact: contact.map(|contact| physics::CollisionContact {
                                 point: contact.point,
                                 normal: -contact.normal,
+                                surface_material: contact.surface_material,
                             }),
                         },
                     });
@@ -9408,7 +9409,20 @@ fn play_environmental_sound(
     audio_handle: AudioHandle,
     position: Vector3<f32>,
 ) {
-    if let Some(resolved) = gamesys.get_random_environmental_sound(&query) {
+    // A query may carry less specific fallbacks (see `EnvSoundQuery::
+    // with_fallback`): the schema authors no bullet sound for glass, and
+    // playing nothing there is worse than playing the default impact.
+    let mut resolved_with_query = None;
+    let mut candidate = Some(&query);
+    while let Some(query) = candidate {
+        if let Some(resolved) = gamesys.get_random_environmental_sound(query) {
+            resolved_with_query = Some((resolved, query));
+            break;
+        }
+        candidate = query.fallback();
+    }
+
+    if let Some((resolved, query)) = resolved_with_query {
         let audio_clip = asset_cache.get(&AUDIO_IMPORTER, &format!("{}.wav", resolved.sample_name));
 
         info!(
@@ -10081,6 +10095,10 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     body_id,
                     collision_group,
                     is_sensor: hit.is_sensor,
+                    surface_material: hit
+                        .surface_material
+                        .and_then(|material| self.physics.surface_material_name(material))
+                        .map(|material| material.to_owned()),
                 }
             }
             None => DebugRayHit {
@@ -10093,6 +10111,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 body_id: None,
                 collision_group: None,
                 is_sensor: false,
+                surface_material: None,
             },
         }
     }

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -18,7 +18,6 @@ pub use spawn_location::*;
 pub use visibility_engine::*;
 
 use cgmath::{Matrix4, Quaternion, Vector2, Vector3};
-use rapier3d::prelude::{Collider, ColliderBuilder};
 
 use engine::{
     assets::{asset_cache::AssetCache, asset_paths::AbstractAssetPath},
@@ -93,7 +92,7 @@ impl Mission {
         let song_params = level.song_params.clone();
         let room_db = level.room_database.clone();
         let map_params = level.map_params;
-        let physics_geometry = create_physics_collider(&level);
+        let physics_geometry = crate::physics::build_level_geometry(&level);
         engine::platform::service_events();
         let spatial_data = LevelSpatialData::from_level(&level);
         engine::platform::service_events();
@@ -462,51 +461,4 @@ impl crate::game_scene::DebuggableScene for Mission {
     ) -> bool {
         self.mission_core.send_entity_message(id, message)
     }
-}
-
-/// Creates a physics collider from level geometry
-/// This allows mission loading code to create physics geometry independently of the physics system
-pub fn create_physics_collider(level: &dark::mission::SystemShock2Level) -> Option<Collider> {
-    if level.all_geometry.is_empty() {
-        return None;
-    }
-
-    let mut vertices = Vec::new();
-    let mut indices = Vec::new();
-
-    for geo in &level.all_geometry {
-        let verts = &geo.verts;
-
-        let mut idx = 0;
-        let len = verts.len();
-
-        while idx < len {
-            let dest_idx = vertices.len() as u32;
-
-            // Convert vertex positions to rapier3d format
-            vertices.push(rapier3d::prelude::Point::new(
-                verts[idx].position.x,
-                verts[idx].position.y,
-                verts[idx].position.z,
-            ));
-            vertices.push(rapier3d::prelude::Point::new(
-                verts[idx + 1].position.x,
-                verts[idx + 1].position.y,
-                verts[idx + 1].position.z,
-            ));
-            vertices.push(rapier3d::prelude::Point::new(
-                verts[idx + 2].position.x,
-                verts[idx + 2].position.y,
-                verts[idx + 2].position.z,
-            ));
-
-            indices.push([dest_idx, dest_idx + 1, dest_idx + 2]);
-
-            idx += 3;
-        }
-    }
-
-    ColliderBuilder::trimesh(vertices, indices)
-        .ok()
-        .map(|builder| builder.build())
 }

--- a/shock2vr/src/mission/player_footsteps.rs
+++ b/shock2vr/src/mission/player_footsteps.rs
@@ -180,6 +180,24 @@ impl PlayerFootsteps {
     }
 }
 
+/// The schema query for one player footstep on `material`.
+fn player_footstep_query(footstep: PlayerFootstep, material: &str) -> dark::EnvSoundQuery {
+    let mut tags = vec![
+        ("event", "footstep"),
+        ("creaturetype", "player"),
+        ("material", material),
+    ];
+    if footstep == PlayerFootstep::Landing {
+        tags.push(("landing", "true"));
+    }
+    let query = dark::EnvSoundQuery::from_tag_values(tags);
+    if footstep == PlayerFootstep::Landing {
+        query.most_specific()
+    } else {
+        query
+    }
+}
+
 /// The `Effect` for a player footstep at `position` (the pawn origin, which is
 /// at the player's feet).
 ///
@@ -189,20 +207,27 @@ impl PlayerFootsteps {
 /// node that already resolves (`material=metal` -> `ftmet1..4`), and the
 /// default shallowest-match resolution would hand back the ordinary footstep
 /// and drop the thud.
-pub fn player_footstep_effect(footstep: PlayerFootstep, position: Vector3<f32>) -> Effect {
-    let mut tags = vec![
-        ("event", "footstep"),
-        ("creaturetype", "player"),
-        ("material", script_util::DEFAULT_IMPACT_MATERIAL),
-    ];
-    if footstep == PlayerFootstep::Landing {
-        tags.push(("landing", "true"));
-    }
-    let query = dark::EnvSoundQuery::from_tag_values(tags);
-    let query = if footstep == PlayerFootstep::Landing {
-        query.most_specific()
-    } else {
+///
+/// `ground_material` is the deck underfoot, from the world geometry's own
+/// texture material - carpet reads `ftcar*`, tile `fttil*`, bulkhead
+/// `ftmet*`. `None` (no ground found, or a surface with no material) keeps the
+/// default. The schema does not author every material for every sub-key, so
+/// the query falls back to the default material rather than going silent on,
+/// say, a landing the schema has no thud for.
+pub fn player_footstep_effect(
+    footstep: PlayerFootstep,
+    position: Vector3<f32>,
+    ground_material: Option<&str>,
+) -> Effect {
+    let material = ground_material.unwrap_or(script_util::DEFAULT_IMPACT_MATERIAL);
+    let query = player_footstep_query(footstep, material);
+    let query = if material == script_util::DEFAULT_IMPACT_MATERIAL {
         query
+    } else {
+        query.with_fallback(player_footstep_query(
+            footstep,
+            script_util::DEFAULT_IMPACT_MATERIAL,
+        ))
     };
 
     Effect::PlayEnvironmentalSound {
@@ -434,7 +459,7 @@ mod tests {
 
     #[test]
     fn the_landing_query_asks_for_the_most_specific_match() {
-        let effect = player_footstep_effect(PlayerFootstep::Landing, vec3(0.0, 0.0, 0.0));
+        let effect = player_footstep_effect(PlayerFootstep::Landing, vec3(0.0, 0.0, 0.0), None);
         let Effect::PlayEnvironmentalSound { query, .. } = effect else {
             panic!("expected an environmental sound");
         };
@@ -446,9 +471,53 @@ mod tests {
         );
     }
 
+    /// The deck underfoot picks the sample: carpet is `ftcar*`, not the
+    /// bulkhead `ftmet*` every step used to resolve. The default stays the
+    /// fallback, so a material the schema never authored for this sub-key
+    /// still makes a sound.
+    #[test]
+    fn a_step_names_the_ground_it_landed_on() {
+        let effect =
+            player_footstep_effect(PlayerFootstep::Step, vec3(0.0, 0.0, 0.0), Some("fabric"));
+        let Effect::PlayEnvironmentalSound { query, .. } = effect else {
+            panic!("expected an environmental sound");
+        };
+        assert!(
+            query
+                .tag_values()
+                .contains(&("material".to_owned(), "fabric".to_owned())),
+            "the real deck is queried first: {:?}",
+            query.tag_values()
+        );
+        let fallback = query.fallback().expect("a fallback query");
+        assert!(
+            fallback
+                .tag_values()
+                .contains(&("material".to_owned(), "metal".to_owned())),
+            "the default material backs it up: {:?}",
+            fallback.tag_values()
+        );
+    }
+
+    /// No ground found (mid-air, or a surface with no material) is the old
+    /// behavior exactly, with no fallback to itself.
+    #[test]
+    fn a_step_with_no_ground_material_keeps_the_default() {
+        let effect = player_footstep_effect(PlayerFootstep::Step, vec3(0.0, 0.0, 0.0), None);
+        let Effect::PlayEnvironmentalSound { query, .. } = effect else {
+            panic!("expected an environmental sound");
+        };
+        assert!(
+            query
+                .tag_values()
+                .contains(&("material".to_owned(), "metal".to_owned())),
+        );
+        assert!(query.fallback().is_none());
+    }
+
     #[test]
     fn the_step_query_names_the_player_and_a_material() {
-        let effect = player_footstep_effect(PlayerFootstep::Step, vec3(0.0, 0.0, 0.0));
+        let effect = player_footstep_effect(PlayerFootstep::Step, vec3(0.0, 0.0, 0.0), None);
         let Effect::PlayEnvironmentalSound { query, .. } = effect else {
             panic!("expected an environmental sound");
         };

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2330,6 +2330,9 @@ impl LevelGeometry {
 }
 
 /// Build a level's collision geometry. `None` when the level has no geometry.
+///
+/// The trimesh and its per-triangle materials are pushed together in one pass,
+/// so "one material entry per triangle" is structural rather than asserted.
 pub fn build_level_geometry(level: &SystemShock2Level) -> Option<LevelGeometry> {
     if level.all_geometry.is_empty() {
         return None;
@@ -2337,13 +2340,24 @@ pub fn build_level_geometry(level: &SystemShock2Level) -> Option<LevelGeometry> 
 
     let mut vertices = Vec::new();
     let mut indices = Vec::new();
-    for geo in &level.all_geometry {
-        let verts = &geo.verts;
+    let mut per_triangle_material = Vec::new();
+    let mut material_names: Vec<String> = Vec::new();
 
+    for geo in &level.all_geometry {
+        let material = intern_surface_material(
+            level
+                .textures
+                .0
+                .get(geo.texture_idx as usize)
+                .and_then(|texture| texture.material.as_deref()),
+            &mut material_names,
+        );
+
+        let verts = &geo.verts;
         let mut idx = 0;
         let len = verts.len();
 
-        while idx < len {
+        while idx + 2 < len {
             let dest_idx = vertices.len() as u32;
 
             vertices.push(vec_to_npoint(verts[idx].position));
@@ -2351,18 +2365,11 @@ pub fn build_level_geometry(level: &SystemShock2Level) -> Option<LevelGeometry> 
             vertices.push(vec_to_npoint(verts[idx + 2].position));
 
             indices.push([dest_idx, dest_idx + 1, dest_idx + 2]);
+            per_triangle_material.push(material);
 
             idx += 3;
         }
     }
-
-    let (per_triangle_material, material_names) =
-        build_surface_material_table(&level.all_geometry, &level.textures.0);
-    assert_eq!(
-        per_triangle_material.len(),
-        indices.len(),
-        "one material entry per level triangle"
-    );
 
     let collider = ColliderBuilder::trimesh(vertices, indices).ok()?.build();
 
@@ -2373,10 +2380,37 @@ pub fn build_level_geometry(level: &SystemShock2Level) -> Option<LevelGeometry> 
     })
 }
 
-/// Build the per-triangle material table for a level's geometry, in the same
-/// order [`PhysicsWorld::add_level_geometry`] pushes triangles into the trimesh.
+/// The table entry for a texture's material, interning its tag in `names`.
 ///
-/// Pure, so the mapping is testable without a physics world.
+/// `NO_SURFACE_MATERIAL` is both the "untagged" entry and the ceiling on how
+/// many distinct materials are addressable, so a level that somehow authored
+/// that many leaves the remainder untagged - falling back to the default
+/// impact material - rather than aliasing onto the sentinel.
+fn intern_surface_material(material: Option<&str>, names: &mut Vec<String>) -> u16 {
+    let Some(material) = material else {
+        return NO_SURFACE_MATERIAL;
+    };
+
+    if let Some(index) = names.iter().position(|name| name == material) {
+        return index as u16;
+    }
+    if names.len() >= NO_SURFACE_MATERIAL as usize {
+        tracing::warn!(
+            "more than {NO_SURFACE_MATERIAL} distinct surface materials; '{material}' untagged"
+        );
+        return NO_SURFACE_MATERIAL;
+    }
+
+    names.push(material.to_owned());
+    (names.len() - 1) as u16
+}
+
+/// The per-triangle material table for a level's geometry, in the same order
+/// [`build_level_geometry`] pushes triangles into the trimesh.
+///
+/// Pure, so the ordering contract is testable without building a trimesh; the
+/// shipped path interleaves the same interning with the trimesh build.
+#[cfg(test)]
 fn build_surface_material_table(
     geometry: &[dark::mission::SystemShock2Geometry],
     textures: &[dark::mission::texture_list::SystemShock2Texture],
@@ -2385,25 +2419,13 @@ fn build_surface_material_table(
     let mut names: Vec<String> = Vec::new();
 
     for geo in geometry {
-        let material = textures
-            .get(geo.texture_idx as usize)
-            .and_then(|texture| texture.material.as_deref());
-        let entry = match material {
-            Some(material) => {
-                let index = names
-                    .iter()
-                    .position(|name| name == material)
-                    .unwrap_or_else(|| {
-                        names.push(material.to_owned());
-                        names.len() - 1
-                    });
-                // More distinct materials than the sentinel allows is not
-                // representable; the shipped data has a handful.
-                u16::try_from(index).unwrap_or(NO_SURFACE_MATERIAL)
-            }
-            None => NO_SURFACE_MATERIAL,
-        };
-        per_triangle.extend(std::iter::repeat_n(entry, geo.verts.len() / 3));
+        let material = intern_surface_material(
+            textures
+                .get(geo.texture_idx as usize)
+                .and_then(|texture| texture.material.as_deref()),
+            &mut names,
+        );
+        per_triangle.extend(std::iter::repeat_n(material, geo.verts.len() / 3));
     }
 
     (per_triangle, names)
@@ -2737,8 +2759,14 @@ impl PhysicsWorld {
     }
 
     /// The sound-schema tag of the world surface directly under `position` -
-    /// what a foot planted there lands on. Casts a short ray down, so a floor
-    /// the creature is standing on answers and open air does not.
+    /// what a foot planted there lands on. Casts a ray down, so a floor the
+    /// creature is standing on answers and open air does not.
+    ///
+    /// World geometry only: a creature riding a lift or standing on a crate
+    /// (entities, not level brushes) names the deck under it rather than the
+    /// thing it is on. Only footstep flavor rides on this, and the deck is a
+    /// better guess than nothing; entities carry their own `PropMaterial` if
+    /// this ever needs to resolve them.
     ///
     /// Shared by every footstep caller so a creature's step and the player's
     /// resolve the same surface the same way.

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2160,6 +2160,9 @@ pub struct RayCastResult {
     pub maybe_entity_id: Option<EntityId>,
     pub maybe_rigid_body_handle: Option<RigidBodyHandle>,
     pub is_sensor: bool,
+    /// The material of the world surface hit, when the hit was level geometry.
+    /// Resolve to a schema tag with [`PhysicsWorld::surface_material_name`].
+    pub surface_material: Option<SurfaceMaterialId>,
     // TODO:
     // entity_id
 }
@@ -2209,6 +2212,128 @@ pub struct CollisionContact {
     pub point: Vector3<f32>,
     /// Unit normal pointing from `entity1_id` toward `entity2_id`.
     pub normal: Vector3<f32>,
+    /// The material of the world surface touched, when one side of the contact
+    /// was level geometry. Resolve to a schema tag with
+    /// [`PhysicsWorld::surface_material_name`].
+    pub surface_material: Option<SurfaceMaterialId>,
+}
+
+/// An interned world-surface material. Copy, so it rides along on contacts and
+/// ray hits; the tag string itself lives in the level's material table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SurfaceMaterialId(u16);
+
+/// How far above a footstep position the ground probe starts, so a foot
+/// planted level with (or slightly inside) the floor still finds it.
+const GROUND_MATERIAL_PROBE_LIFT: f32 = 0.25;
+
+/// How far below a footstep position the ground probe reaches. Generous enough
+/// to cover a creature whose origin floats a little above the deck, short
+/// enough that a creature in mid-air finds nothing.
+const GROUND_MATERIAL_PROBE_DROP: f32 = 1.5;
+
+/// Sentinel triangle entry for "this triangle's texture has no material tag".
+const NO_SURFACE_MATERIAL: u16 = u16::MAX;
+
+/// Per-triangle materials for the one level-geometry trimesh, so a ray hit or a
+/// contact on world geometry can name the surface it touched (carpet, tile,
+/// bulkhead) instead of falling back to a single default.
+///
+/// Keyed by triangle index, which is sound because `add_level_geometry` pushes
+/// exactly one triangle per three vertices in order and parry's `TriMesh::new`
+/// preserves the index buffer verbatim (no merging, welding, or dropping of
+/// degenerate triangles). The build asserts the two stay the same length.
+#[derive(Debug)]
+pub struct LevelSurfaceMaterials {
+    /// The single collider these triangles belong to.
+    collider: ColliderHandle,
+    /// Index into `names` per trimesh triangle, or [`NO_SURFACE_MATERIAL`].
+    per_triangle: Vec<u16>,
+    /// Distinct material tags ("metal", "fabric", ...), already lowercased.
+    names: Vec<String>,
+}
+
+impl LevelSurfaceMaterials {
+    /// The material of `triangle`, folding parry's backface encoding: a hit on
+    /// the back of triangle `i` is reported as `Face(i + triangle_count)`.
+    fn material_for_triangle(&self, triangle: u32) -> Option<SurfaceMaterialId> {
+        let count = self.per_triangle.len() as u32;
+        let index = if triangle >= count {
+            triangle.checked_sub(count)?
+        } else {
+            triangle
+        };
+        match self.per_triangle.get(index as usize).copied() {
+            Some(NO_SURFACE_MATERIAL) | None => None,
+            Some(material) => Some(SurfaceMaterialId(material)),
+        }
+    }
+
+    /// The material of `triangle` when `collider` is the level trimesh.
+    fn material_for_triangle_on(
+        &self,
+        collider: ColliderHandle,
+        triangle: u32,
+    ) -> Option<SurfaceMaterialId> {
+        if collider != self.collider {
+            return None;
+        }
+        self.material_for_triangle(triangle)
+    }
+
+    /// The material a ray hit on `collider` landed on. Anything but a triangle
+    /// face - another collider, or a feature parry could not name - has none.
+    fn material_for_feature(
+        &self,
+        collider: ColliderHandle,
+        feature: FeatureId,
+    ) -> Option<SurfaceMaterialId> {
+        match feature {
+            FeatureId::Face(triangle) => self.material_for_triangle_on(collider, triangle),
+            _ => None,
+        }
+    }
+
+    /// The schema tag for an interned material.
+    fn name(&self, id: SurfaceMaterialId) -> Option<&str> {
+        self.names.get(id.0 as usize).map(|name| name.as_str())
+    }
+}
+
+/// Build the per-triangle material table for a level's geometry, in the same
+/// order [`PhysicsWorld::add_level_geometry`] pushes triangles into the trimesh.
+///
+/// Pure, so the mapping is testable without a physics world.
+fn build_surface_material_table(
+    geometry: &[dark::mission::SystemShock2Geometry],
+    textures: &[dark::mission::texture_list::SystemShock2Texture],
+) -> (Vec<u16>, Vec<String>) {
+    let mut per_triangle = Vec::new();
+    let mut names: Vec<String> = Vec::new();
+
+    for geo in geometry {
+        let material = textures
+            .get(geo.texture_idx as usize)
+            .and_then(|texture| texture.material.as_deref());
+        let entry = match material {
+            Some(material) => {
+                let index = names
+                    .iter()
+                    .position(|name| name == material)
+                    .unwrap_or_else(|| {
+                        names.push(material.to_owned());
+                        names.len() - 1
+                    });
+                // More distinct materials than the sentinel allows is not
+                // representable; the shipped data has a handful.
+                u16::try_from(index).unwrap_or(NO_SURFACE_MATERIAL)
+            }
+            None => NO_SURFACE_MATERIAL,
+        };
+        per_triangle.extend(std::iter::repeat_n(entry, geo.verts.len() / 3));
+    }
+
+    (per_triangle, names)
 }
 
 /// Predicate selecting *only* sensor colliders - the volumes the player's
@@ -2392,6 +2517,11 @@ pub struct PhysicsWorld {
 
     rigid_bodies_with_forces: Vec<RigidBodyHandle>,
 
+    /// Per-triangle materials for the level trimesh, once one has been added.
+    /// Shared with the collision-event handler so contacts and ray hits name
+    /// the same surface. Debug scenes build their own trimeshes and have none.
+    level_surface_materials: Option<std::sync::Arc<LevelSurfaceMaterials>>,
+
     entity_id_to_body: HashMap<EntityId, RigidBodyHandle>,
 
     // Short-lived recovery state created only while a living, gravity-driven
@@ -2532,6 +2662,14 @@ impl PhysicsWorld {
             }
         }
 
+        let (per_triangle, material_names) =
+            build_surface_material_table(&level.all_geometry, &level.textures.0);
+        assert_eq!(
+            per_triangle.len(),
+            indices.len(),
+            "one material entry per level triangle"
+        );
+
         let mut collider = ColliderBuilder::trimesh(vertices, indices)
             .expect("level geometry trimesh")
             .build();
@@ -2541,7 +2679,45 @@ impl PhysicsWorld {
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             test_mode: Default::default(),
         });
-        self.collider_set.insert(collider);
+        let handle = self.collider_set.insert(collider);
+
+        let materials = std::sync::Arc::new(LevelSurfaceMaterials {
+            collider: handle,
+            per_triangle,
+            names: material_names,
+        });
+        self.events.set_level_surface_materials(materials.clone());
+        self.level_surface_materials = Some(materials);
+    }
+
+    /// The sound-schema tag of the world surface directly under `position` -
+    /// what a foot planted there lands on. Casts a short ray down, so a floor
+    /// the creature is standing on answers and open air does not.
+    ///
+    /// Shared by every footstep caller so a creature's step and the player's
+    /// resolve the same surface the same way.
+    pub fn ground_surface_material(&self, position: Vector3<f32>) -> Option<&str> {
+        let hit = self.ray_cast2(
+            point3(
+                position.x,
+                position.y + GROUND_MATERIAL_PROBE_LIFT,
+                position.z,
+            ),
+            vec3(0.0, -1.0, 0.0),
+            GROUND_MATERIAL_PROBE_LIFT + GROUND_MATERIAL_PROBE_DROP,
+            InternalCollisionGroups::WORLD,
+            None,
+            true,
+        )?;
+        self.surface_material_name(hit.surface_material?)
+    }
+
+    /// The sound-schema tag ("metal", "fabric", ...) for a surface material
+    /// reported by a ray hit or a contact.
+    pub fn surface_material_name(&self, id: SurfaceMaterialId) -> Option<&str> {
+        self.level_surface_materials
+            .as_ref()
+            .and_then(|materials| materials.name(id))
     }
 
     pub fn add_collider(&mut self, entity_id: EntityId, mut collider: Collider) {
@@ -4292,6 +4468,7 @@ impl PhysicsWorld {
             ccd_solver,
             rigid_body_set,
             no_bodies: RigidBodySet::new(),
+            level_surface_materials: None,
             rigid_bodies_with_forces: Vec::new(),
             // TODO:
             // physics_hooks: Box::new(physics_hooks),
@@ -5256,10 +5433,16 @@ impl PhysicsWorld {
             //     handle, hit_point, hit_normal, data
             // );
 
+            let surface_material = self
+                .level_surface_materials
+                .as_ref()
+                .and_then(|materials| materials.material_for_feature(handle, intersection.feature));
+
             Some(RayCastResult {
                 hit_point: npoint_to_cgmath(hit_point),
                 hit_normal: nvec_to_cgmath(hit_normal),
                 maybe_entity_id,
+                surface_material,
                 maybe_rigid_body_handle,
                 is_sensor: collider.is_sensor(),
             })
@@ -6515,6 +6698,7 @@ mod tests {
             } if *entity1_id == actor && *entity2_id == weapon => Some(CollisionContact {
                 point: contact.point,
                 normal: -contact.normal,
+                surface_material: contact.surface_material,
             }),
             _ => None,
         });
@@ -10124,6 +10308,139 @@ mod tests {
         assert!(
             capped < 0.1,
             "a step under a low ceiling must be refused, rose {capped}"
+        );
+    }
+
+    // ---- world surface materials ----
+
+    /// Geometry with `triangles` triangles, all textured `texture_idx`.
+    fn geometry_with(texture_idx: u16, triangles: usize) -> dark::mission::SystemShock2Geometry {
+        use engine::scene::VertexPositionTextureLightmapAtlasNormal;
+
+        let vertex = VertexPositionTextureLightmapAtlasNormal {
+            position: vec3(0.0, 0.0, 0.0),
+            uv: cgmath::vec2(0.0, 0.0),
+            lightmap_uv: cgmath::vec2(0.0, 0.0),
+            lightmap_atlas: cgmath::vec4(0.0, 0.0, 0.0, 0.0),
+            normal: vec3(0.0, 1.0, 0.0),
+        };
+        dark::mission::SystemShock2Geometry {
+            verts: vec![vertex; triangles * 3],
+            texture_idx,
+            cell_idx: 0,
+            poly_idx: 0,
+            lightmap_pack_result: engine::texture_atlas::TexturePackResult::DEFAULT,
+        }
+    }
+
+    fn texture_with(material: Option<&str>) -> dark::mission::texture_list::SystemShock2Texture {
+        dark::mission::texture_list::SystemShock2Texture {
+            family: "fam".to_owned(),
+            texture_filename: "tex".to_owned(),
+            render_type: dark::properties::RenderType::Normal,
+            animation_info: None,
+            material: material.map(|material| material.to_owned()),
+        }
+    }
+
+    /// Every triangle gets its own texture's material, in push order - the
+    /// invariant the whole lookup rests on.
+    #[test]
+    fn surface_material_table_follows_triangle_order() {
+        let geometry = vec![
+            geometry_with(0, 2), // metal
+            geometry_with(1, 1), // fabric
+            geometry_with(2, 3), // no material
+        ];
+        let textures = vec![
+            texture_with(Some("metal")),
+            texture_with(Some("fabric")),
+            texture_with(None),
+        ];
+
+        let (per_triangle, names) = build_surface_material_table(&geometry, &textures);
+
+        assert_eq!(per_triangle.len(), 6, "one entry per triangle");
+        assert_eq!(names, vec!["metal".to_owned(), "fabric".to_owned()]);
+        assert_eq!(per_triangle[0], 0);
+        assert_eq!(per_triangle[1], 0);
+        assert_eq!(per_triangle[2], 1);
+        assert_eq!(per_triangle[3], NO_SURFACE_MATERIAL);
+        assert_eq!(per_triangle[5], NO_SURFACE_MATERIAL);
+    }
+
+    /// Parry reports a hit on the *back* of triangle `i` as
+    /// `Face(i + triangle_count)`. Without folding that, every backface hit
+    /// reads out of range and silently loses its material.
+    #[test]
+    fn backface_triangle_resolves_to_the_same_material() {
+        let materials = LevelSurfaceMaterials {
+            collider: ColliderHandle::invalid(),
+            per_triangle: vec![0, NO_SURFACE_MATERIAL, 1],
+            names: vec!["metal".to_owned(), "fabric".to_owned()],
+        };
+
+        let front = materials.material_for_triangle(2).expect("front face");
+        let back = materials.material_for_triangle(2 + 3).expect("back face");
+        assert_eq!(front, back);
+        assert_eq!(materials.name(front), Some("fabric"));
+
+        assert_eq!(materials.material_for_triangle(1), None, "untagged texture");
+        assert_eq!(materials.material_for_triangle(99), None, "out of range");
+    }
+
+    /// The shipped textures really do carry more than one material, and the
+    /// archetype hierarchy really does resolve to the *metaproperty's* value
+    /// (`MatMetal` -> metal) rather than the `Texture` base archetype's
+    /// "plasticrete" default. If inheritance order ever flipped, medsci1 would
+    /// come back all-plasticrete and every surface would sound the same again.
+    #[test]
+    fn medsci_textures_resolve_several_distinct_materials() {
+        let Some(level) = try_load_level("medsci1.mis") else {
+            return;
+        };
+        let (per_triangle, names) =
+            build_surface_material_table(&level.all_geometry, &level.textures.0);
+
+        eprintln!("medsci1 surface materials: {names:?}");
+        assert!(
+            names.len() > 1,
+            "expected several distinct surface materials, got {names:?}"
+        );
+        assert!(
+            names.iter().any(|name| name == "metal"),
+            "expected metal among {names:?}"
+        );
+        let tagged = per_triangle
+            .iter()
+            .filter(|entry| **entry != NO_SURFACE_MATERIAL)
+            .count();
+        assert!(
+            tagged * 2 > per_triangle.len(),
+            "most of the level should have a material, {tagged} of {}",
+            per_triangle.len()
+        );
+    }
+
+    /// End to end through the physics world: a ray down onto MedSci's deck
+    /// names the material of the floor it lands on.
+    #[test]
+    fn ray_onto_medsci_floor_reports_its_material() {
+        let Some(level) = try_load_level("medsci1.mis") else {
+            return;
+        };
+        let mut world = PhysicsWorld::new();
+        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        let mut player = world.create_player(
+            vec3(-22.294, -0.596, -17.1),
+            EntityId::from_inner(2).unwrap(),
+        );
+        step(&mut world, &mut player, 5);
+
+        let material = world.ground_surface_material(vec3(-22.294, -0.596, -17.1));
+        assert!(
+            material.is_some(),
+            "the deck under the player should name a material"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2227,10 +2227,15 @@ pub struct SurfaceMaterialId(u16);
 /// planted level with (or slightly inside) the floor still finds it.
 const GROUND_MATERIAL_PROBE_LIFT: f32 = 0.25;
 
-/// How far below a footstep position the ground probe reaches. Generous enough
-/// to cover a creature whose origin floats a little above the deck, short
-/// enough that a creature in mid-air finds nothing.
-const GROUND_MATERIAL_PROBE_DROP: f32 = 1.5;
+/// How far below a footstep position the ground probe reaches.
+///
+/// Deliberately generous: a footstep is reported at the creature's *origin*,
+/// which sits around body centre - a MedSci hybrid's is ~2.1 above the deck it
+/// is standing on, and larger creatures sit higher still. The probe takes the
+/// nearest hit, so a longer reach never picks the wrong floor; it only lets a
+/// creature that is genuinely airborne name the deck below, which is the right
+/// answer for a foot plant anyway.
+const GROUND_MATERIAL_PROBE_DROP: f32 = 8.0;
 
 /// Sentinel triangle entry for "this triangle's texture has no material tag".
 const NO_SURFACE_MATERIAL: u16 = u16::MAX;
@@ -2298,6 +2303,74 @@ impl LevelSurfaceMaterials {
     fn name(&self, id: SurfaceMaterialId) -> Option<&str> {
         self.names.get(id.0 as usize).map(|name| name.as_str())
     }
+}
+
+/// A level's collision geometry: the world trimesh plus the material of each
+/// of its triangles, built together so the two can never fall out of step.
+///
+/// Built at load time (off the mission's `SystemShock2Level`) and installed
+/// with [`PhysicsWorld::add_level_geometry`].
+pub struct LevelGeometry {
+    collider: Collider,
+    per_triangle_material: Vec<u16>,
+    material_names: Vec<String>,
+}
+
+impl LevelGeometry {
+    /// Collision geometry with no surface materials - a debug scene's floor,
+    /// which has no textures to take a material from. Hits on it fall back to
+    /// the default impact material, exactly as they did before.
+    pub fn untextured(collider: Collider) -> Self {
+        Self {
+            collider,
+            per_triangle_material: Vec::new(),
+            material_names: Vec::new(),
+        }
+    }
+}
+
+/// Build a level's collision geometry. `None` when the level has no geometry.
+pub fn build_level_geometry(level: &SystemShock2Level) -> Option<LevelGeometry> {
+    if level.all_geometry.is_empty() {
+        return None;
+    }
+
+    let mut vertices = Vec::new();
+    let mut indices = Vec::new();
+    for geo in &level.all_geometry {
+        let verts = &geo.verts;
+
+        let mut idx = 0;
+        let len = verts.len();
+
+        while idx < len {
+            let dest_idx = vertices.len() as u32;
+
+            vertices.push(vec_to_npoint(verts[idx].position));
+            vertices.push(vec_to_npoint(verts[idx + 1].position));
+            vertices.push(vec_to_npoint(verts[idx + 2].position));
+
+            indices.push([dest_idx, dest_idx + 1, dest_idx + 2]);
+
+            idx += 3;
+        }
+    }
+
+    let (per_triangle_material, material_names) =
+        build_surface_material_table(&level.all_geometry, &level.textures.0);
+    assert_eq!(
+        per_triangle_material.len(),
+        indices.len(),
+        "one material entry per level triangle"
+    );
+
+    let collider = ColliderBuilder::trimesh(vertices, indices).ok()?.build();
+
+    Some(LevelGeometry {
+        collider,
+        per_triangle_material,
+        material_names,
+    })
 }
 
 /// Build the per-triangle material table for a level's geometry, in the same
@@ -2637,42 +2710,15 @@ fn sanitize_collider_radius(entity_id: EntityId, context: &str, radius: f32) -> 
 }
 
 impl PhysicsWorld {
-    pub fn add_level_geometry(&mut self, entity_id: EntityId, level: &SystemShock2Level) {
-        /* Create the ground. */
-        //let collider = ColliderBuilder::cuboid(100.0, 0.1, 100.0).build();
+    /// Install a level's collision geometry, built at load time by
+    /// [`build_level_geometry`], as the world collider owned by `entity_id`.
+    pub fn add_level_geometry(&mut self, entity_id: EntityId, geometry: LevelGeometry) {
+        let LevelGeometry {
+            mut collider,
+            per_triangle_material,
+            material_names,
+        } = geometry;
 
-        let mut vertices = Vec::new();
-        let mut indices = Vec::new();
-        for geo in &level.all_geometry {
-            let verts = &geo.verts;
-
-            let mut idx = 0;
-            let len = verts.len();
-
-            while idx < len {
-                let dest_idx = vertices.len() as u32;
-
-                vertices.push(vec_to_npoint(verts[idx].position));
-                vertices.push(vec_to_npoint(verts[idx + 1].position));
-                vertices.push(vec_to_npoint(verts[idx + 2].position));
-
-                indices.push([dest_idx, dest_idx + 1, dest_idx + 2]);
-
-                idx += 3;
-            }
-        }
-
-        let (per_triangle, material_names) =
-            build_surface_material_table(&level.all_geometry, &level.textures.0);
-        assert_eq!(
-            per_triangle.len(),
-            indices.len(),
-            "one material entry per level triangle"
-        );
-
-        let mut collider = ColliderBuilder::trimesh(vertices, indices)
-            .expect("level geometry trimesh")
-            .build();
         collider.user_data = entity_id.inner() as u128;
         collider.set_collision_groups(InteractionGroups {
             memberships: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
@@ -2683,7 +2729,7 @@ impl PhysicsWorld {
 
         let materials = std::sync::Arc::new(LevelSurfaceMaterials {
             collider: handle,
-            per_triangle,
+            per_triangle: per_triangle_material,
             names: material_names,
         });
         self.events.set_level_surface_materials(materials.clone());
@@ -10430,7 +10476,10 @@ mod tests {
             return;
         };
         let mut world = PhysicsWorld::new();
-        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        world.add_level_geometry(
+            EntityId::from_inner(1).unwrap(),
+            build_level_geometry(&level).expect("level geometry"),
+        );
         let mut player = world.create_player(
             vec3(-22.294, -0.596, -17.1),
             EntityId::from_inner(2).unwrap(),
@@ -10495,7 +10544,10 @@ mod tests {
             return;
         };
         let mut world = PhysicsWorld::new();
-        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        world.add_level_geometry(
+            EntityId::from_inner(1).unwrap(),
+            build_level_geometry(&level).expect("level geometry"),
+        );
         let mut player = world.create_player(
             vec3(-22.294, -0.596, -17.1),
             EntityId::from_inner(2).unwrap(),
@@ -10688,7 +10740,10 @@ mod tests {
             return;
         };
         let mut world = PhysicsWorld::new();
-        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        world.add_level_geometry(
+            EntityId::from_inner(1).unwrap(),
+            build_level_geometry(&level).expect("level geometry"),
+        );
         let mut player = world.create_player(
             vec3(84.37742, 4.044117, 20.42488),
             EntityId::from_inner(2).unwrap(),
@@ -10731,7 +10786,10 @@ mod tests {
             return;
         };
         let mut world = PhysicsWorld::new();
-        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        world.add_level_geometry(
+            EntityId::from_inner(1).unwrap(),
+            build_level_geometry(&level).expect("level geometry"),
+        );
         let mut player =
             world.create_player(vec3(13.38, -3.8, 6.4), EntityId::from_inner(2).unwrap());
         for _ in 0..30 {

--- a/shock2vr/src/physics/physics_events.rs
+++ b/shock2vr/src/physics/physics_events.rs
@@ -9,20 +9,22 @@ pub struct PhysicsEvents {
     queued_events: Mutex<Vec<super::CollisionEvent>>,
     /// The level's per-triangle materials, so a contact against world geometry
     /// can name the surface it touched. `None` until a level is added (debug
-    /// scenes never add one).
-    level_surface_materials: Mutex<Option<Arc<super::LevelSurfaceMaterials>>>,
+    /// scenes never add one). Written once, under `&mut self`, so it needs no
+    /// lock of its own - unlike `queued_events`, which the handler fills from
+    /// inside the solver.
+    level_surface_materials: Option<Arc<super::LevelSurfaceMaterials>>,
 }
 
 impl PhysicsEvents {
     pub fn new() -> PhysicsEvents {
         PhysicsEvents {
             queued_events: Mutex::new(vec![]),
-            level_surface_materials: Mutex::new(None),
+            level_surface_materials: None,
         }
     }
 
-    pub fn set_level_surface_materials(&self, materials: Arc<super::LevelSurfaceMaterials>) {
-        *self.level_surface_materials.lock().unwrap() = Some(materials);
+    pub fn set_level_surface_materials(&mut self, materials: Arc<super::LevelSurfaceMaterials>) {
+        self.level_surface_materials = Some(materials);
     }
 
     pub fn get_and_clear_events(&self) -> Vec<super::CollisionEvent> {
@@ -60,7 +62,7 @@ impl EventHandler for PhysicsEvents {
                     // manifold normal, which Rapier orients collider1 ->
                     // collider2. Some synthetic/degenerate contacts may have
                     // no solver point, so the payload remains optional.
-                    let level_surface_materials = self.level_surface_materials.lock().unwrap();
+                    let level_surface_materials = self.level_surface_materials.as_ref();
                     let contact = contact_pair
                         .manifolds
                         .iter()
@@ -79,21 +81,19 @@ impl EventHandler for PhysicsEvents {
                             // only one either side of a contact can be), the
                             // manifold's subshape IS the triangle index - so a
                             // wrench on a carpeted floor knows it hit fabric.
-                            surface_material: level_surface_materials.as_ref().and_then(
-                                |materials| {
-                                    materials
-                                        .material_for_triangle_on(
-                                            contact_pair.collider1,
-                                            manifold.subshape1,
+                            surface_material: level_surface_materials.and_then(|materials| {
+                                materials
+                                    .material_for_triangle_on(
+                                        contact_pair.collider1,
+                                        manifold.subshape1,
+                                    )
+                                    .or_else(|| {
+                                        materials.material_for_triangle_on(
+                                            contact_pair.collider2,
+                                            manifold.subshape2,
                                         )
-                                        .or_else(|| {
-                                            materials.material_for_triangle_on(
-                                                contact_pair.collider2,
-                                                manifold.subshape2,
-                                            )
-                                        })
-                                },
-                            ),
+                                    })
+                            }),
                         });
                     self.queued_events.lock().unwrap().push(
                         super::CollisionEvent::CollisionStarted {

--- a/shock2vr/src/physics/physics_events.rs
+++ b/shock2vr/src/physics/physics_events.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use rapier3d::prelude::{ColliderSet, ContactPair, EventHandler, Real, RigidBodySet};
 use shipyard::EntityId;
@@ -7,13 +7,22 @@ use super::util::{npoint_to_cgvec, nvec_to_cgmath};
 
 pub struct PhysicsEvents {
     queued_events: Mutex<Vec<super::CollisionEvent>>,
+    /// The level's per-triangle materials, so a contact against world geometry
+    /// can name the surface it touched. `None` until a level is added (debug
+    /// scenes never add one).
+    level_surface_materials: Mutex<Option<Arc<super::LevelSurfaceMaterials>>>,
 }
 
 impl PhysicsEvents {
     pub fn new() -> PhysicsEvents {
         PhysicsEvents {
             queued_events: Mutex::new(vec![]),
+            level_surface_materials: Mutex::new(None),
         }
+    }
+
+    pub fn set_level_surface_materials(&self, materials: Arc<super::LevelSurfaceMaterials>) {
+        *self.level_surface_materials.lock().unwrap() = Some(materials);
     }
 
     pub fn get_and_clear_events(&self) -> Vec<super::CollisionEvent> {
@@ -51,6 +60,7 @@ impl EventHandler for PhysicsEvents {
                     // manifold normal, which Rapier orients collider1 ->
                     // collider2. Some synthetic/degenerate contacts may have
                     // no solver point, so the payload remains optional.
+                    let level_surface_materials = self.level_surface_materials.lock().unwrap();
                     let contact = contact_pair
                         .manifolds
                         .iter()
@@ -65,6 +75,25 @@ impl EventHandler for PhysicsEvents {
                         .map(|(manifold, contact)| super::CollisionContact {
                             point: npoint_to_cgvec(contact.point),
                             normal: nvec_to_cgmath(manifold.data.normal),
+                            // For a composite shape (the level trimesh is the
+                            // only one either side of a contact can be), the
+                            // manifold's subshape IS the triangle index - so a
+                            // wrench on a carpeted floor knows it hit fabric.
+                            surface_material: level_surface_materials.as_ref().and_then(
+                                |materials| {
+                                    materials
+                                        .material_for_triangle_on(
+                                            contact_pair.collider1,
+                                            manifold.subshape1,
+                                        )
+                                        .or_else(|| {
+                                            materials.material_for_triangle_on(
+                                                contact_pair.collider2,
+                                                manifold.subshape2,
+                                            )
+                                        })
+                                },
+                            ),
                         });
                     self.queued_events.lock().unwrap().push(
                         super::CollisionEvent::CollisionStarted {

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -115,13 +115,15 @@ impl DebugSceneBuilder {
 
     pub fn build_core(self, options: DebugSceneBuildOptions<'_>) -> MissionCore {
         let mut scene_objects = Vec::new();
-        let mut physics_geometry = self.physics_geometry;
+        let mut physics_geometry = self
+            .physics_geometry
+            .map(crate::physics::LevelGeometry::untextured);
 
         if let Some(floor) = self.floor {
             let (mut floor_objects, floor_collider) = floor.build(options.asset_cache);
             scene_objects.append(&mut floor_objects);
             if physics_geometry.is_none() {
-                physics_geometry = Some(floor_collider);
+                physics_geometry = Some(crate::physics::LevelGeometry::untextured(floor_collider));
             }
         }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1425,7 +1425,17 @@ impl Script for AnimatedMonsterAI {
                 let footstep = if motion_flags
                     .intersects(MotionFlags::LEFT_FOOT_STEP | MotionFlags::RIGHT_FOOT_STEP)
                 {
-                    script_util::play_footstep_sound(world, entity_id)
+                    // The deck underfoot, so a hybrid crossing carpet sounds
+                    // different from one crossing bulkhead.
+                    let ground_material = physics.ground_surface_material(
+                        crate::util::get_position_from_transform(
+                            world,
+                            entity_id,
+                            vec3(0.0, 0.0, 0.0),
+                        )
+                        .to_vec(),
+                    );
+                    script_util::play_footstep_sound(world, entity_id, ground_material)
                 } else {
                     Effect::NoEffect
                 };

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -45,7 +45,7 @@ impl Script for InternalCollisionType {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with, .. } => {
+            MessagePayload::Collided { with, contact } => {
                 // Only impact-payload entities (projectiles / fragile props
                 // flagged to slay or destroy themselves on contact) deal
                 // collision damage. A plain BOUNCE creature must not: any two
@@ -133,6 +133,9 @@ impl Script for InternalCollisionType {
                         entity_id,
                         *with,
                         position.to_vec(),
+                        contact
+                            .and_then(|contact| contact.surface_material)
+                            .and_then(|material| physics.surface_material_name(material)),
                     ));
                 }
 

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -85,6 +85,7 @@ impl Script for InternalFastProjectileScript {
             hit_normal,
             maybe_rigid_body_handle: _,
             is_sensor: _,
+            surface_material,
         }) = maybe_hit_spot
         {
             // Effect::SetPosition {
@@ -129,7 +130,13 @@ impl Script for InternalFastProjectileScript {
                 Effect::DestroyEntity { entity_id },
                 // Impact sound: the projectile's collision schema, tagged with
                 // the material of what was hit (flesh thud vs metal clang).
-                play_impact_sound(world, entity_id, hit_entity_id, hit_point.to_vec()),
+                play_impact_sound(
+                    world,
+                    entity_id,
+                    hit_entity_id,
+                    hit_point.to_vec(),
+                    surface_material.and_then(|material| physics.surface_material_name(material)),
+                ),
             ];
 
             // Impact effect, from the projectile's authored spang links

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -167,7 +167,7 @@ impl Script for TriggeredMeleeWeapon {
                 if self.may_play_impact_sound(entity_id, *with, physics, *contact)
                     | damage.is_some()
                 {
-                    let sound = impact_sound_effect(entity_id, *with, world);
+                    let sound = impact_sound_effect(entity_id, *with, world, physics, *contact);
                     if !matches!(sound, Effect::NoEffect) {
                         effects.push(sound);
                     }
@@ -300,7 +300,13 @@ fn contact_damage_effect(
 /// tag + hit material - wrench on metal clangs, on a creature thuds), unless
 /// its collision type opts out. Needs no damage value: unmaterialed surfaces
 /// (world geometry, a bench) fall back to the default material tag.
-fn impact_sound_effect(entity_id: EntityId, with: EntityId, world: &World) -> Effect {
+fn impact_sound_effect(
+    entity_id: EntityId,
+    with: EntityId,
+    world: &World,
+    physics: &PhysicsWorld,
+    contact: Option<crate::physics::CollisionContact>,
+) -> Effect {
     let no_sound = world
         .borrow::<View<PropCollisionType>>()
         .ok()
@@ -310,19 +316,28 @@ fn impact_sound_effect(entity_id: EntityId, with: EntityId, world: &World) -> Ef
         return Effect::NoEffect;
     }
     let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
-    play_impact_sound(world, entity_id, with, position.to_vec())
+    play_impact_sound(
+        world,
+        entity_id,
+        with,
+        position.to_vec(),
+        contact
+            .and_then(|contact| contact.surface_material)
+            .and_then(|material| physics.surface_material_name(material)),
+    )
 }
 
 fn melee_impact(
     entity_id: EntityId,
     with: EntityId,
     world: &World,
+    physics: &PhysicsWorld,
     amount: f32,
     contact: Option<crate::physics::CollisionContact>,
 ) -> Effect {
     Effect::Multiple(vec![
         contact_damage_effect(with, amount, contact),
-        impact_sound_effect(entity_id, with, world),
+        impact_sound_effect(entity_id, with, world, physics, contact),
     ])
 }
 
@@ -331,7 +346,7 @@ impl Script for MeleeWeapon {
         &mut self,
         entity_id: EntityId,
         world: &World,
-        _physics: &PhysicsWorld,
+        physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
         // The legacy literal `wrench` script can still back a VR physical
@@ -344,7 +359,7 @@ impl Script for MeleeWeapon {
         match msg {
             // Legacy literal `wrench` script (Maintenance Tool -2949).
             MessagePayload::Collided { with, contact } => {
-                melee_impact(entity_id, *with, world, 1.0, *contact)
+                melee_impact(entity_id, *with, world, physics, 1.0, *contact)
             }
             _ => Effect::NoEffect,
         }
@@ -574,6 +589,7 @@ mod tests {
                 contact: Some(crate::physics::CollisionContact {
                     point: vec3(2.0, 3.0, 4.0),
                     normal: vec3(1.0, 0.0, 0.0),
+                    surface_material: None,
                 }),
             },
         )
@@ -846,6 +862,7 @@ mod tests {
                 contact: Some(crate::physics::CollisionContact {
                     point: vec3(2.0, 3.0, 4.0),
                     normal: vec3(1.0, 0.0, 0.0),
+                    surface_material: None,
                 }),
             },
         );

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -815,9 +815,9 @@ pub fn play_environmental_sound(
 }
 
 /// Material tag used for impact-schema lookups when the hit surface has no
-/// resolvable material. World geometry has no per-texture material lookup in
-/// the port yet, so terrain hits (and entities without material tags) all
-/// sound like the ship's metal bulkheads.
+/// resolvable material: an entity with no material tag, or world geometry whose
+/// texture archetype names none. The ship is mostly metal, so that is the
+/// truest single guess.
 pub const DEFAULT_IMPACT_MATERIAL: &str = "metal";
 
 /// The collision-schema material tag ("fleshtarget", "metal", ...) for
@@ -830,17 +830,7 @@ fn get_impact_material(world: &World, hit_entity_id: EntityId) -> String {
     world
         .borrow::<View<PropMaterial>>()
         .ok()
-        .and_then(|v_material| {
-            let raw = &v_material.get(victim).ok()?.0;
-            // "Material FleshTarget" -> "fleshtarget"
-            let mut tokens = raw.split_whitespace();
-            while let Some(token) = tokens.next() {
-                if token.eq_ignore_ascii_case("material") {
-                    return tokens.next().map(|value| value.to_ascii_lowercase());
-                }
-            }
-            None
-        })
+        .and_then(|v_material| v_material.get(victim).ok()?.tag())
         .unwrap_or_else(|| DEFAULT_IMPACT_MATERIAL.to_owned())
 }
 
@@ -858,18 +848,90 @@ fn get_impact_material(world: &World, hit_entity_id: EntityId) -> String {
 ///
 /// Creature types the schema authors no footsteps for (swarms, apparitions,
 /// SHODAN) resolve to nothing and fall through silently.
-pub fn play_footstep_sound(world: &World, entity_id: EntityId) -> Effect {
+/// A sound query over `tags`, with a less specific one to fall back on when
+/// `relaxed_tag`'s material has no entry in the schema.
+///
+/// The shipped schema does not author every (event, material) combination -
+/// there is no bullet impact on glass, and no creature footstep on fabric -
+/// so naming the real surface can resolve to *nothing* where the old fixed
+/// `metal` resolved to a sample. A truer material must never buy silence, so
+/// every material-tagged query keeps the default as its fallback.
+fn query_with_material_fallback(
+    world: &World,
+    entity_id: EntityId,
+    event_type: &str,
+    tags: Vec<(&str, &str)>,
+    relaxed_tag: &str,
+) -> Option<EnvSoundQuery> {
+    let query = get_environmental_sound_query(world, entity_id, event_type, tags.clone())?;
+
+    let already_default = tags
+        .iter()
+        .any(|(tag, value)| *tag == relaxed_tag && *value == DEFAULT_IMPACT_MATERIAL);
+    if already_default {
+        return Some(query);
+    }
+
+    let relaxed_tags = tags
+        .into_iter()
+        .map(|(tag, value)| {
+            if tag == relaxed_tag {
+                (tag, DEFAULT_IMPACT_MATERIAL)
+            } else {
+                (tag, value)
+            }
+        })
+        .collect();
+    match get_environmental_sound_query(world, entity_id, event_type, relaxed_tags) {
+        Some(fallback) => Some(query.with_fallback(fallback)),
+        None => Some(query),
+    }
+}
+
+/// Emit an already-built environmental sound query at `entity_id`'s position.
+fn emit_environmental_sound(
+    world: &World,
+    entity_id: EntityId,
+    query: EnvSoundQuery,
+    audio_handle: AudioHandle,
+) -> Effect {
+    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+    let position = v_transform
+        .get(entity_id)
+        .unwrap()
+        .0
+        .transform_point(point3(0.0, 0.0, 0.0));
+    Effect::PlayEnvironmentalSound {
+        audio_handle,
+        query,
+        position: point3_to_vec3(position),
+    }
+}
+
+pub fn play_footstep_sound(
+    world: &World,
+    entity_id: EntityId,
+    ground_material: Option<&str>,
+) -> Effect {
     let own_material = get_impact_material(world, entity_id);
-    play_environmental_sound(
+    let maybe_query = query_with_material_fallback(
         world,
         entity_id,
         "footstep",
         vec![
             ("material", &own_material),
-            ("material2", DEFAULT_IMPACT_MATERIAL),
+            (
+                "material2",
+                ground_material.unwrap_or(DEFAULT_IMPACT_MATERIAL),
+            ),
         ],
-        AudioHandle::new(),
-    )
+        "material2",
+    );
+
+    match maybe_query {
+        Some(query) => emit_environmental_sound(world, entity_id, query, AudioHandle::new()),
+        None => Effect::NoEffect,
+    }
 }
 
 /// Impact/collision sound for `entity_id` (a projectile or melee weapon)
@@ -879,15 +941,27 @@ pub fn play_footstep_sound(world: &World, entity_id: EntityId) -> Effect {
 /// wall resolves (event=collision, ammotype=std, material=metal) -> `bulmet*`,
 /// on a hybrid (event=collision, ammotype=std, material=fleshtarget) ->
 /// `bulftar*`.
+///
+/// `surface_material` is the material of the *world surface* struck, when the
+/// hit came with one (see [`crate::physics::PhysicsWorld::surface_material_name`]).
+/// It only applies to world geometry: an entity with its own `PropMaterial` is
+/// what was hit, whatever it is standing on.
 pub fn play_impact_sound(
     world: &World,
     entity_id: EntityId,
     hit_entity_id: EntityId,
     position: Vector3<f32>,
+    surface_material: Option<&str>,
 ) -> Effect {
-    let material = get_impact_material(world, hit_entity_id);
-    let maybe_query =
-        get_environmental_sound_query(world, entity_id, "collision", vec![("material", &material)]);
+    let entity_material = get_impact_material(world, hit_entity_id);
+    let material = surface_material.unwrap_or(&entity_material);
+    let maybe_query = query_with_material_fallback(
+        world,
+        entity_id,
+        "collision",
+        vec![("material", material)],
+        "material",
+    );
 
     if let Some(query) = maybe_query {
         Effect::PlayEnvironmentalSound {
@@ -1033,6 +1107,91 @@ mod tests {
             RuntimePropTransform(Matrix4::from_translation(at)),
         ));
         (world, entity_id)
+    }
+
+    /// A bullet on a surface whose material the schema has no entry for must
+    /// keep the default material as a fallback - naming the real surface must
+    /// never trade a sound for silence (`bulmet*` on glass, not nothing).
+    #[test]
+    fn a_surface_material_impact_falls_back_to_the_default_material() {
+        use super::play_impact_sound;
+        use dark::properties::PropClassTag;
+
+        let mut world = World::new();
+        let bullet = world.add_entity((PropClassTag::from_string("AmmoType Std"),));
+        let wall = world.add_entity((RuntimePropTransform(Matrix4::from_translation(vec3(
+            0.0, 0.0, 0.0,
+        ))),));
+
+        let effect = play_impact_sound(&world, bullet, wall, vec3(0.0, 0.0, 0.0), Some("glass"));
+
+        let crate::scripts::Effect::PlayEnvironmentalSound { query, .. } = effect else {
+            panic!("expected an environmental sound, got {effect:?}");
+        };
+        assert!(
+            query
+                .tag_values()
+                .contains(&("material".to_owned(), "glass".to_owned())),
+            "the real surface material is queried first: {:?}",
+            query.tag_values()
+        );
+        let fallback = query.fallback().expect("a fallback query");
+        assert!(
+            fallback
+                .tag_values()
+                .contains(&("material".to_owned(), "metal".to_owned())),
+            "the default material backs it up: {:?}",
+            fallback.tag_values()
+        );
+    }
+
+    /// The default material needs no fallback to itself.
+    #[test]
+    fn a_default_material_impact_has_no_fallback() {
+        use super::play_impact_sound;
+        use dark::properties::PropClassTag;
+
+        let mut world = World::new();
+        let bullet = world.add_entity((PropClassTag::from_string("AmmoType Std"),));
+        let wall = world.add_entity((RuntimePropTransform(Matrix4::from_translation(vec3(
+            0.0, 0.0, 0.0,
+        ))),));
+
+        let effect = play_impact_sound(&world, bullet, wall, vec3(0.0, 0.0, 0.0), Some("metal"));
+
+        let crate::scripts::Effect::PlayEnvironmentalSound { query, .. } = effect else {
+            panic!("expected an environmental sound, got {effect:?}");
+        };
+        assert!(query.fallback().is_none());
+    }
+
+    /// Footsteps relax the *ground* (`material2`), not the creature's own
+    /// material: the schema has no `fabric` footstep, so a hybrid on carpet
+    /// must still land on its metal step rather than going silent.
+    #[test]
+    fn a_footstep_falls_back_on_the_ground_material() {
+        use super::play_footstep_sound;
+        use dark::properties::PropClassTag;
+
+        let mut world = World::new();
+        let creature = world.add_entity((
+            PropClassTag::from_string("CreatureType OnceGrunt"),
+            RuntimePropTransform(Matrix4::from_translation(vec3(0.0, 0.0, 0.0))),
+        ));
+
+        let effect = play_footstep_sound(&world, creature, Some("fabric"));
+
+        let crate::scripts::Effect::PlayEnvironmentalSound { query, .. } = effect else {
+            panic!("expected an environmental sound, got {effect:?}");
+        };
+        let fallback = query.fallback().expect("a fallback query");
+        assert!(
+            fallback
+                .tag_values()
+                .contains(&("material2".to_owned(), "metal".to_owned())),
+            "only the ground is relaxed: {:?}",
+            fallback.tag_values()
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -792,25 +792,12 @@ pub fn play_environmental_sound(
     additional_tags: Vec<(&str, &str)>,
     audio_handle: AudioHandle,
 ) -> Effect {
-    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let maybe_env_sound_query =
         get_environmental_sound_query(world, entity_id, event_type, additional_tags);
 
-    // An entity can be animating without owning a physics transform (the
-    // animation players and `id_to_physics` are separate maps, and ownership
-    // changes hands around death), so a missing transform is a silent no-sound
-    // rather than a panic - there is nowhere to place the sound.
-    let (Some(query), Ok(transform)) = (maybe_env_sound_query, v_transform.get(entity_id)) else {
-        return Effect::NoEffect;
-    };
-
-    {
-        let position = transform.0.transform_point(point3(0.0, 0.0, 0.0));
-        Effect::PlayEnvironmentalSound {
-            audio_handle,
-            query,
-            position: point3_to_vec3(position),
-        }
+    match maybe_env_sound_query {
+        Some(query) => emit_environmental_sound(world, entity_id, query, audio_handle),
+        None => Effect::NoEffect,
     }
 }
 
@@ -856,6 +843,13 @@ fn get_impact_material(world: &World, hit_entity_id: EntityId) -> String {
 /// so naming the real surface can resolve to *nothing* where the old fixed
 /// `metal` resolved to a sample. A truer material must never buy silence, so
 /// every material-tagged query keeps the default as its fallback.
+///
+/// The tag layer's own relaxation (`TagQueryItem`'s optional flag, which drops
+/// an item that matches nothing) cannot serve here: the schema branches on
+/// material *before* it reaches a sample, so dropping the tag resolves to
+/// nothing at all - `+event:collision +ammotype:std` and a materialless
+/// footstep both match no sample. Substituting the default is what actually
+/// keeps a sound, and it is the exact sound that played before.
 fn query_with_material_fallback(
     world: &World,
     entity_id: EntityId,
@@ -889,6 +883,12 @@ fn query_with_material_fallback(
 }
 
 /// Emit an already-built environmental sound query at `entity_id`'s position.
+///
+/// An entity can be animating without owning a physics transform (the
+/// animation players and `id_to_physics` are separate maps, and ownership
+/// changes hands around death), so a missing transform is a silent no-sound
+/// rather than a panic - there is nowhere to place the sound. Footsteps come
+/// from foot-plant frames of the death collapse too, so this is a live path.
 fn emit_environmental_sound(
     world: &World,
     entity_id: EntityId,
@@ -896,15 +896,14 @@ fn emit_environmental_sound(
     audio_handle: AudioHandle,
 ) -> Effect {
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
-    let position = v_transform
-        .get(entity_id)
-        .unwrap()
-        .0
-        .transform_point(point3(0.0, 0.0, 0.0));
+    let Ok(transform) = v_transform.get(entity_id) else {
+        return Effect::NoEffect;
+    };
+
     Effect::PlayEnvironmentalSound {
         audio_handle,
         query,
-        position: point3_to_vec3(position),
+        position: point3_to_vec3(transform.0.transform_point(point3(0.0, 0.0, 0.0))),
     }
 }
 
@@ -1163,6 +1162,23 @@ mod tests {
             panic!("expected an environmental sound, got {effect:?}");
         };
         assert!(query.fallback().is_none());
+    }
+
+    /// A creature can plant a foot while it owns no physics transform - the
+    /// animation player and `id_to_physics` are separate maps, and ownership
+    /// changes hands around death. There is nowhere to place the sound, so it
+    /// is silent rather than a panic.
+    #[test]
+    fn a_footstep_without_a_transform_is_silent() {
+        use super::play_footstep_sound;
+        use dark::properties::PropClassTag;
+
+        let mut world = World::new();
+        let creature = world.add_entity((PropClassTag::from_string("CreatureType OnceGrunt"),));
+
+        let effect = play_footstep_sound(&world, creature, Some("plasticrete"));
+
+        assert!(matches!(effect, crate::scripts::Effect::NoEffect));
     }
 
     /// Footsteps relax the *ground* (`material2`), not the creature's own

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -821,20 +821,6 @@ fn get_impact_material(world: &World, hit_entity_id: EntityId) -> String {
         .unwrap_or_else(|| DEFAULT_IMPACT_MATERIAL.to_owned())
 }
 
-/// Footstep sound for a creature whose animation just reached an authored
-/// foot-plant frame (`MotionFlags::LEFT_FOOT_STEP` / `RIGHT_FOOT_STEP`).
-///
-/// The schema keys footsteps on `event=footstep` plus the creature's class
-/// tags (`creaturetype=oncegrunt`, `=monkey`, `=droid`, ...); most creature
-/// types resolve on those alone to a four-sample set (`ft_monk1..4`). Hybrids
-/// (`oncegrunt`) branch further on `material` - the creature's *own* material,
-/// i.e. what its feet are made of - and `material2`, the surface underfoot.
-/// The port has no per-texture lookup for world geometry, so `material2` is
-/// the default bulkhead metal, which is what most of the ship is; on a hybrid
-/// that resolves to `ft_ogm*`.
-///
-/// Creature types the schema authors no footsteps for (swarms, apparitions,
-/// SHODAN) resolve to nothing and fall through silently.
 /// A sound query over `tags`, with a less specific one to fall back on when
 /// `relaxed_tag`'s material has no entry in the schema.
 ///
@@ -907,6 +893,21 @@ fn emit_environmental_sound(
     }
 }
 
+/// Footstep sound for a creature whose animation just reached an authored
+/// foot-plant frame (`MotionFlags::LEFT_FOOT_STEP` / `RIGHT_FOOT_STEP`).
+///
+/// The schema keys footsteps on `event=footstep` plus the creature's class
+/// tags (`creaturetype=oncegrunt`, `=monkey`, `=droid`, ...); most creature
+/// types resolve on those alone to a four-sample set (`ft_monk1..4`). Hybrids
+/// (`oncegrunt`) branch further on `material` - the creature's *own* material,
+/// i.e. what its feet are made of - and `material2`, the surface underfoot,
+/// which is `ground_material`: the deck the foot was planted on, probed from
+/// the world geometry's own texture material. A hybrid on MedSci's plasticrete
+/// deck resolves `ft_og*`, on metal plating `ft_ogm*`. `None` (no ground
+/// found, or a surface with no material) keeps the default bulkhead metal.
+///
+/// Creature types the schema authors no footsteps for (swarms, apparitions,
+/// SHODAN) resolve to nothing and fall through silently.
 pub fn play_footstep_sound(
     world: &World,
     entity_id: EntityId,
@@ -953,14 +954,25 @@ pub fn play_impact_sound(
     surface_material: Option<&str>,
 ) -> Effect {
     let entity_material = get_impact_material(world, hit_entity_id);
-    let material = surface_material.unwrap_or(&entity_material);
-    let maybe_query = query_with_material_fallback(
-        world,
-        entity_id,
-        "collision",
-        vec![("material", material)],
-        "material",
-    );
+    let maybe_query = match surface_material {
+        // A world surface is newly able to name itself, so it keeps the
+        // default it replaced as a fallback.
+        Some(surface_material) => query_with_material_fallback(
+            world,
+            entity_id,
+            "collision",
+            vec![("material", surface_material)],
+            "material",
+        ),
+        // An entity's own material is what was hit, and resolves exactly as it
+        // always has - no fallback, so a hit that was silent stays silent.
+        None => get_environmental_sound_query(
+            world,
+            entity_id,
+            "collision",
+            vec![("material", &entity_material)],
+        ),
+    };
 
     if let Some(query) = maybe_query {
         Effect::PlayEnvironmentalSound {

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -338,6 +338,7 @@ impl VirtualHand {
                 hit_normal: _,
                 maybe_entity_id: Some(to_entity_id),
                 maybe_rigid_body_handle: _,
+                surface_material: _,
                 is_sensor: _,
             }) => effs.push(VirtualHandEffect::OutMessage {
                 message: Message {
@@ -434,6 +435,7 @@ fn handle_empty_hand_state(
             hit_normal: _,
             maybe_entity_id: Some(entity),
             maybe_rigid_body_handle: _,
+            surface_material: _,
             is_sensor: _,
         }) = result
         {
@@ -470,6 +472,7 @@ fn handle_empty_hand_state(
             hit_normal: _,
             maybe_entity_id: Some(entity_id),
             maybe_rigid_body_handle: Some(rigid_body_handle),
+            surface_material: _,
             is_sensor: _,
         }) = result
         {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -298,6 +298,12 @@ export interface RayCastResult {
   body_id?: number | null;
   collision_group: string | null;
   is_sensor: boolean;
+  /**
+   * Sound-schema material of the world surface hit ("metal", "plasticrete",
+   * "glass", "fabric"), when the ray landed on level geometry. Optional when
+   * connected to runtimes predating world surface materials.
+   */
+  surface_material?: string | null;
 }
 
 /** Summary of one rigid body, as reported by GET /v1/physics/bodies. */

--- a/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
+++ b/tools/shock2-sdk/test/melee-impact-sound.e2e.test.ts
@@ -11,7 +11,9 @@ import {
 
 // A VR melee contact with something that takes no authored damage - a wall, a
 // bench, a crate - used to be completely silent, because the impact sound was
-// emitted only from the damage path. This exercises the production path on a
+// emitted only from the damage path. It also checks the surface the contact
+// names: the material comes from the level trimesh triangle the manifold
+// touched, so a deck sounds like its own material rather than the default. This exercises the production path on a
 // real mission's static world geometry (not a debug scene's synthetic
 // collider) and observes the played-sound log, the only headless way to hear
 // anything.
@@ -97,9 +99,12 @@ test(
       impacts.length > 0,
       `hitting world geometry should play a collision sound: ${describe(afterSwing)}`,
     );
+    // The floor names its own material now that world geometry carries one
+    // (command2's deck is plasticrete -> `hwrepla*`, where every surface used
+    // to resolve the blanket metal schema).
     assert.ok(
-      impacts.some((sound) => tagValue(sound, "material") === "metal"),
-      `an unmaterialed surface should resolve the default metal schema: ${describe(impacts)}`,
+      impacts.some((sound) => tagValue(sound, "material") === "plasticrete"),
+      `the deck should resolve its own material schema: ${describe(impacts)}`,
     );
     // The swing crosses the floor over ~0.4 s; the per-surface cooldown caps
     // that at a couple of thuds rather than one per contact frame.

--- a/tools/shock2-sdk/test/world-surface-material.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-surface-material.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { describeSounds as describe, tagValue } from "./helpers/audio.js";
+
+// World geometry carries a material now: each level trimesh triangle knows the
+// material of the texture it was built from (from that texture's `t_fam`
+// archetype), so a ray hit and a footstep name the deck they landed on instead
+// of the blanket "metal" every surface used to report.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** A grid of downward probes over MedSci, returning the materials found. */
+async function floorMaterials(game: GameServer): Promise<Map<string, number>> {
+  const found = new Map<string, number>();
+  for (let x = -40; x <= 40; x += 10) {
+    for (let z = -30; z <= 40; z += 10) {
+      for (const y of [0, -4]) {
+        const hit = await game.raycast({
+          start: [x, y + 3, z],
+          end: [x, y - 4, z],
+          collision_groups: ["world"],
+        });
+        const material = hit.hit ? hit.surface_material : undefined;
+        if (material) {
+          found.set(material, (found.get(material) ?? 0) + 1);
+        }
+      }
+    }
+  }
+  return found;
+}
+
+test(
+  "world geometry reports the material of the surface hit",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 60 });
+
+    const materials = await floorMaterials(game);
+    assert.ok(
+      materials.size > 1,
+      `MedSci's decks are not one material: got ${JSON.stringify([...materials])}`,
+    );
+    // Both of these are authored on medsci1's textures; if archetype
+    // inheritance ever stopped resolving the metaproperty's value, every
+    // surface would collapse to the base archetype's "plasticrete" instead.
+    assert.ok(
+      materials.has("plasticrete") && materials.has("metal"),
+      `expected plasticrete deck and metal plate: ${JSON.stringify([...materials])}`,
+    );
+
+    // The creatures wandering MedSci plant their feet on those same decks, and
+    // the footstep schema keys on what they are standing on: the deck here is
+    // plasticrete (`ft_og*`), not the metal (`ft_ogm*`) every step used to
+    // resolve.
+    await game.step({ frames: 240 });
+    const footsteps = (await game.audio.recent()).sounds.filter(
+      (sound) => tagValue(sound, "event") === "footstep",
+    );
+    assert.ok(
+      footsteps.length > 0,
+      "expected MedSci's creatures to be walking around",
+    );
+    assert.ok(
+      footsteps.some((sound) => tagValue(sound, "material2") !== "metal"),
+      `footsteps should name the deck underfoot: ${describe(footsteps)}`,
+    );
+  },
+);


### PR DESCRIPTION
Closes the shared gap called out in #1163: *"One material everywhere: metal."* Footsteps, bullet impacts and melee impacts all resolved the sound-schema material to a hardcoded `metal`, on carpet and tile as much as on bulkhead, because nothing could get from a hit on world geometry to a material.

## The data was already there

Every world texture is a gamesys template `t_fam/<family>/<NAME>` whose archetype chain carries `PropMaterial`:

```
$ cargo dq templates 4790
├─ Template -636 (sym:MetalTex)
  ├─ Template -583 (sym:MatMetal)
      1. PropMaterial("Material Metal")
    ├─ Template -7 (sym:Texture)
        1. PropMaterial("Material Plasticrete")
```

`texture_list::read_texture_archetypes` **already** hydrates exactly those templates to pick up render type and animation flags; it now reads the material too. medsci1 resolves four distinct surfaces: `["metal", "plasticrete", "glass", "fabric"]`.

Note the two `PropMaterial` values in that tree. The metaproperty (`MatMetal`) has to win over the base archetype (`Texture` → plasticrete), or the whole feature silently collapses to one material again — just a different one. It does win (props apply most-distant-ancestor first, self last), and a test pins it.

## Getting it to the hit

`build_level_geometry` builds the trimesh and a per-triangle material table **in one pass**, so "one entry per triangle" is structural rather than asserted. That's sound because parry's `TriMesh::new` runs with `TriMeshFlags::empty()` — no welding, no dedup, no dropping of degenerates, so the index buffer survives verbatim.

Two different hit paths, because there are two:

| Path | Source of the triangle |
| --- | --- |
| Ray hits (bullets, ground probes) | `FeatureId::Face(i)`, folding parry's backface encoding `i + triangle_count` |
| Contacts (melee, slow projectiles) | the contact manifold's `subshape` index |

Both hand back a `Copy` `SurfaceMaterialId`, so `CollisionContact` stays `Copy` — `melee_weapon.rs` relies on that via `*contact`.

## A truer material must never buy silence

The schema does not author every (event, material) pair, and the old fixed `metal` always resolved:

```
$ cargo dq sound +event:collision +ammotype:std +material:metal   -> bulmet2
$ cargo dq sound +event:collision +ammotype:std +material:glass   -> No matching sounds found
$ cargo dq sound +event:footstep +creaturetype:oncegrunt +material2:fabric -> No matching sounds found
```

So naming the real surface could make a bullet on tile **quieter than the bug it fixes**. Every material-tagged query now carries the default material as a fallback, walked by the effect applier.

The tag layer's own relaxation can't serve here, and it's worth recording why: the schema branches on material *before* it reaches a sample, so dropping the tag resolves to nothing at all (`+event:collision +ammotype:std` matches no sample). Substituting the default is what actually keeps a sound — and it is the exact sound that played before.

## What you actually hear

All observed through `GET /v1/audio/recent` on the running game.

**Player, walking medsci1** — the `ftpoly*` plasticrete set, where every step used to be `ftmet*`:

```
{"ftpoly1","ftpoly2","ftpoly3","ftpoly4"}  material=plasticrete
```

**Creatures, medsci1** — hybrids on the plasticrete deck play `ft_og*`, not `ft_ogm*`:

```
ft_og1..4 material2=plasticrete   (was: ft_ogm* everywhere)
```

**Melee, command2** — the wrench on the deck resolves `hwrepla*` instead of the blanket metal `hmetmet*`. This is the *contact* path proving itself, and is why one assertion in `melee-impact-sound.e2e.test.ts` moved.

**Probes across medsci1** (`POST /v1/physics/raycast`, which now reports `surface_material`):

```
{'plasticrete': 308, 'metal': 48, None: 51}
```

## Two bugs the unit tests could not have caught

Both found by checking the running game, and worth flagging because both were invisible to a green test suite:

1. **Missions never built the table at all.** `add_level_geometry` was only ever called by *tests*: a real mission built its trimesh in a second, duplicated loop (`create_physics_collider`) and installed it with the generic `add_collider`. Every surface still read as the default while the unit tests happily passed. Collision geometry and its materials are now built together and installed through one path, so the two cannot drift apart again — the duplicate loop is gone.
2. **The ground probe was too short.** A footstep is reported at the creature's *origin*, which sits around body centre — a MedSci hybrid's is ~2.1 above the deck — so a 1.5 reach found nothing and every creature still stepped on metal.

## Scope

Deliberately **not** included: water (`medialevel`) still has no immersion state to key on.

Entity materials are untouched — an entity's own `PropMaterial` is what was hit, and resolves exactly as it always has, with no fallback, so a hit that was silent stays silent. Only world surfaces, which are newly able to name themselves, carry the fallback.

## Verification

- `cargo test -p shock2vr --lib` — 1136 pass. **Run with `DARK_ASSET_PATH=$PWD/Data`**: the two data-dependent tests (`medsci_textures_resolve_several_distinct_materials`, `ray_onto_medsci_floor_reports_its_material`) skip silently when the data root has no loose `.mis` files, which is the case for a 25AE install.
- New coverage: the triangle→material ordering contract, the backface fold, real medsci1 archetype resolution (would read all-plasticrete if metaproperty precedence flipped), the fallback queries on both the impact and footstep paths, and a missing-transform footstep that panics without its guard.
- New e2e `world-surface-material.e2e.test.ts`: probes medsci1 for more than one material and asserts creature footsteps name the deck.
- Full e2e suite: 341/356. All 7 failures are pre-existing — `baby-arachnid`, `bio-ammo-full` and `trap-unlock` verified failing on `origin/main` itself; `creature-loot`, `earth-hacking` and `hydro3-log` are the known main-failures; `quickload-missing` passes in isolation (suite-order flake).

`trap-unlock` is worth a note for whoever owns it: it fails on main because the audio log holds `MAX_ENTRIES = 64` and eng1's creature footsteps evict the refusal sound it asserts on. Not this change's doing, but this change makes the flood more legible in the failure output.

No GIF — this change is audible, not visible; the audio-log readings above are the equivalent evidence.
