### PR TITLE
feat(hud): psi and overload meters on the wielded psi amp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -630,18 +630,31 @@ The project supports experimental flags for gating in-progress features during d
   default is the only reachable setting without a rebuild. Tell-tale log line:
   `high-detail (PMNM) meshes: true|false`.
 
-- **`ambient_meters`**: prototype VR ambient-meter model (flat HUD untouched).
-  The ammo readout moves onto the wielded weapon - the compact AMMOBACK square
-  (round count + ammo type, the same gauge the flat HUD shows outside use
-  mode), anchored to the weapon's live transform and facing the shooter like a
-  rear-sight status tag - and the right-forearm ammo panel is retired while the
-  flag is on. The left-forearm health panel stays but renders only when the
-  wrist is glanced at (panel normal vs eye vector, with hysteresis; untracked
-  poses hide it). Panel shape/tilt/size and the glance thresholds live in
+- **`ambient_meters`**: prototype ambient-meter model. In VR, the ammo readout
+  moves onto the wielded weapon - the compact AMMOBACK square (round count +
+  ammo type, the same gauge the flat HUD shows outside use mode), anchored to
+  the weapon's live transform and facing the shooter like a rear-sight status
+  tag - and the right-forearm ammo panel is retired while the flag is on. The
+  left-forearm health panel stays but renders only when the wrist is glanced
+  at (panel normal vs eye vector, with hysteresis; untracked poses hide it).
+  Panel shape/tilt/size and the glance thresholds live in
   `shock2vr/src/hud/ammo_panel.rs` + `shock2vr/src/hud/ambient_meters.rs`; the
   per-weapon anchor (where the tag hangs in the weapon's own frame) lives in
-  `vr_config::weapon_meter_anchor_*`, beside the grip-offset table. Without the
-  flag, both forearm panels render exactly as before.
+  `vr_config::weapon_meter_anchor_*`, beside the grip-offset table. Without
+  the flag, both forearm panels render exactly as before.
+
+  The flag also puts a psi pool bar + hold-to-overload meter directly on the
+  wielded psi amp, in **both** presentations (flat's existing bio-monitor psi
+  bar and center-screen overload meter are unaffected - this is additive).
+  Layout lives in `shock2vr/src/hud/psi_amp_panel.rs`; placement in
+  `hud::ambient_meters::amp_meter_transform`/`amp_psi_meter_root` (flat
+  premultiplies the same root transform by the viewmodel's FOV `squish`, VR
+  hangs it directly off the amp). The amp's hold-to-overload charge is itself
+  gated to `is_flat || ambient_meters_enabled` in `PsiAmpScript` (a
+  `GlobalAmbientMetersEnabled` Unique resource next to
+  `GlobalPresentationMode`) - VR only gets the real hold gesture where a
+  meter exists to show it, or a player would charge (and risk a damaging
+  burnout) with no feedback.
 
 #### Adding New Experimental Features
 

--- a/shock2vr/src/hud/ambient_meters.rs
+++ b/shock2vr/src/hud/ambient_meters.rs
@@ -1,11 +1,15 @@
 //! Prototype "ambient meters" (experimental flag [`FEATURE`]): ammo lives on
 //! the wielded weapon, health stays on the left wrist but only shows when the
-//! wrist is glanced at (rotated toward the face).
+//! wrist is glanced at (rotated toward the face), and the psi amp carries its
+//! own pool/overload meter.
 //!
-//! Layout/placement decisions live HERE (and in [`super::ammo_panel`], which
-//! authors the readout's pixels) - a presentation supplies only a root
-//! transform (AGENTS.md section 3). Only the VR presentation consumes these
-//! today; the flat HUD is untouched by the flag.
+//! Layout/placement decisions live HERE (and in [`super::ammo_panel`] /
+//! [`super::psi_amp_panel`], which author the readouts' pixels) - a
+//! presentation supplies only a root transform (AGENTS.md section 3). The
+//! on-weapon ammo tag and glance-gated wrist health are VR-only (the flat HUD
+//! is untouched by the flag for those); the on-amp psi meter draws in BOTH
+//! presentations - see [`amp_psi_meter_root`] and `mission_core`'s flat
+//! viewmodel draw.
 
 use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation, Vector3, vec3};
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
@@ -15,6 +19,7 @@ use crate::runtime_props::RuntimePropTransform;
 use crate::vr_config::Handedness;
 
 use super::ammo_panel;
+use super::psi_amp_panel;
 use super::virtual_arms;
 use virtual_arms::OVERLAY_Z_OFFSET;
 
@@ -55,6 +60,88 @@ pub(crate) fn weapon_meter_transform(
         * Matrix4::from_angle_y(Deg(90.0))
         * Matrix4::from_angle_x(WEAPON_METER_TILT)
         * Matrix4::from_nonuniform_scale(WEAPON_METER_WIDTH, WEAPON_METER_HEIGHT, 1.0)
+}
+
+// --- On-amp psi meter placement -------------------------------------------
+//
+// The psi pool / overload meter hangs directly below the on-weapon tag
+// (which already shows the amp's selected tier - `create_weapon_ammo_meter`
+// draws for the amp too, since `AmmoReadout::psi_power` replaces the ammo
+// clip). Same weapon-local frame and anchor table entry (`amp_h` in
+// `vr_config::WEAPON_METER_ANCHORS`) as the tag; only the vertical offset and
+// panel aspect differ.
+
+/// Gap between the tag's bottom edge and the psi meter's top edge.
+const AMP_METER_GAP: f32 = 0.015;
+/// Same width as the on-weapon tag, so the two stack flush.
+const AMP_METER_WIDTH: f32 = WEAPON_METER_WIDTH;
+const AMP_METER_HEIGHT: f32 = AMP_METER_WIDTH * (psi_amp_panel::PANEL_H / psi_amp_panel::PANEL_W);
+
+/// Root transform for the on-amp psi meter: the same weapon-local frame and
+/// tag anchor as [`weapon_meter_transform`], shifted down by the tag's own
+/// height plus a gap so the two panels stack without overlapping.
+pub(crate) fn amp_meter_transform(
+    weapon_transform: Matrix4<f32>,
+    tag_anchor: Vector3<f32>,
+) -> Matrix4<f32> {
+    let anchor = tag_anchor
+        - vec3(
+            0.0,
+            WEAPON_METER_HEIGHT / 2.0 + AMP_METER_GAP + AMP_METER_HEIGHT / 2.0,
+            0.0,
+        );
+    weapon_transform
+        * Matrix4::from_translation(anchor)
+        * Matrix4::from_angle_y(Deg(90.0))
+        * Matrix4::from_angle_x(WEAPON_METER_TILT)
+        * Matrix4::from_nonuniform_scale(AMP_METER_WIDTH, AMP_METER_HEIGHT, 1.0)
+}
+
+/// The on-amp psi meter's root transform, or `None` when the psi amp is not
+/// wielded, has nothing to show, or has no transform. Shared by both
+/// presentations - VR hangs it directly off the amp; flat premultiplies it by
+/// the viewmodel's FOV `squish` (see `mission_core`'s flat viewmodel draw).
+pub(crate) fn amp_psi_meter_root(
+    world: &World,
+) -> Option<(psi_amp_panel::PsiAmpReadout, Matrix4<f32>)> {
+    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
+    if !crate::wielded_weapon::is_psi_amp(world, weapon) {
+        return None;
+    }
+    let readout = psi_amp_panel::PsiAmpReadout::from_world(world);
+    if readout.is_empty() {
+        return None;
+    }
+    let weapon_transform = world
+        .borrow::<View<RuntimePropTransform>>()
+        .ok()?
+        .get(weapon)
+        .ok()?
+        .0;
+
+    let tag_anchor = crate::vr_config::weapon_meter_anchor_from_entity(world, weapon);
+    let root = amp_meter_transform(without_scale(weapon_transform), tag_anchor);
+    Some((readout, root))
+}
+
+/// The on-amp psi meter: the psi pool bar and (while charging) the
+/// hold-to-overload meter, laid out once in [`psi_amp_panel`], hung off the
+/// wielded psi amp's live `RuntimePropTransform` below its ammo/tier tag.
+/// Empty when the psi amp is not wielded or has no transform.
+pub(crate) fn create_amp_psi_meter(
+    asset_cache: &mut AssetCache,
+    world: &World,
+) -> Vec<SceneObject> {
+    let Some((readout, root)) = amp_psi_meter_root(world) else {
+        return Vec::new();
+    };
+    psi_amp_panel::build_readout_canvas(&readout).render_world_space(
+        asset_cache,
+        root,
+        None,
+        None,
+        OVERLAY_Z_OFFSET,
+    )
 }
 
 /// A transform's translation + rotation with any (positive) scale stripped:
@@ -246,5 +333,32 @@ mod tests {
         // ...and the panel's world width stays the authored width.
         let width_axis = root * vec4(1.0, 0.0, 0.0, 0.0);
         assert!((width_axis.truncate().magnitude() - WEAPON_METER_WIDTH).abs() < 1e-5);
+    }
+
+    #[test]
+    fn the_amp_meter_hangs_below_the_tag_not_on_top_of_it() {
+        // Negative-first: at the tag's own anchor, the amp meter's centre
+        // must NOT coincide with it - the two panels would overlap.
+        let tag_anchor = vec3(0.15, 0.34, 0.0);
+        let tag_root = weapon_meter_transform(Matrix4::identity(), tag_anchor);
+        let amp_root = amp_meter_transform(Matrix4::identity(), tag_anchor);
+        let tag_center = vec3(tag_root.w.x, tag_root.w.y, tag_root.w.z);
+        let amp_center = vec3(amp_root.w.x, amp_root.w.y, amp_root.w.z);
+        assert_ne!(tag_center, amp_center);
+        // The amp meter sits strictly below the tag (lower weapon-local Y)...
+        assert!(amp_center.y < tag_center.y);
+        // ...separated by at least both panels' half-heights plus the gap, so
+        // they never overlap.
+        let min_gap = WEAPON_METER_HEIGHT / 2.0 + AMP_METER_GAP + AMP_METER_HEIGHT / 2.0;
+        assert!((tag_center.y - amp_center.y - min_gap).abs() < 1e-5);
+    }
+
+    #[test]
+    fn the_amp_meter_preserves_its_authored_aspect() {
+        let root = amp_meter_transform(Matrix4::identity(), vec3(0.0, 0.0, 0.0));
+        let width_axis = (root * vec4(1.0, 0.0, 0.0, 0.0)).truncate().magnitude();
+        let height_axis = (root * vec4(0.0, 1.0, 0.0, 0.0)).truncate().magnitude();
+        assert!((width_axis - AMP_METER_WIDTH).abs() < 1e-5);
+        assert!((height_axis - AMP_METER_HEIGHT).abs() < 1e-5);
     }
 }

--- a/shock2vr/src/hud/ambient_meters.rs
+++ b/shock2vr/src/hud/ambient_meters.rs
@@ -64,34 +64,24 @@ pub(crate) fn weapon_meter_transform(
 
 // --- On-amp psi meter placement -------------------------------------------
 //
-// The psi pool / overload meter hangs directly below the on-weapon tag
-// (which already shows the amp's selected tier - `create_weapon_ammo_meter`
-// draws for the amp too, since `AmmoReadout::psi_power` replaces the ammo
-// clip). Same weapon-local frame and anchor table entry (`amp_h` in
-// `vr_config::WEAPON_METER_ANCHORS`) as the tag; only the vertical offset and
-// panel aspect differ.
+// The amp_h model is a compact sphere (not an elongated gun body), so the
+// psi meter gets its own anchor rather than reusing the on-weapon tag's -
+// tuned directly against the amp mesh: level with its lit indicator strip
+// and just off its near side, so it reads like a status readout on the
+// device itself.
 
-/// Gap between the tag's bottom edge and the psi meter's top edge.
-const AMP_METER_GAP: f32 = 0.015;
-/// Same width as the on-weapon tag, so the two stack flush.
-const AMP_METER_WIDTH: f32 = WEAPON_METER_WIDTH;
+const AMP_METER_ANCHOR: Vector3<f32> = vec3(-0.03, 0.05, 0.0);
+/// Panel size in world units, preserving the psi panel's authored 80x32
+/// aspect.
+const AMP_METER_WIDTH: f32 = 0.08;
 const AMP_METER_HEIGHT: f32 = AMP_METER_WIDTH * (psi_amp_panel::PANEL_H / psi_amp_panel::PANEL_W);
 
-/// Root transform for the on-amp psi meter: the same weapon-local frame and
-/// tag anchor as [`weapon_meter_transform`], shifted down by the tag's own
-/// height plus a gap so the two panels stack without overlapping.
-pub(crate) fn amp_meter_transform(
-    weapon_transform: Matrix4<f32>,
-    tag_anchor: Vector3<f32>,
-) -> Matrix4<f32> {
-    let anchor = tag_anchor
-        - vec3(
-            0.0,
-            WEAPON_METER_HEIGHT / 2.0 + AMP_METER_GAP + AMP_METER_HEIGHT / 2.0,
-            0.0,
-        );
+/// Root transform for the on-amp psi meter: same canvas convention as
+/// [`weapon_meter_transform`] (+Z at the viewer), hung at [`AMP_METER_ANCHOR`]
+/// in the amp's local frame.
+pub(crate) fn amp_meter_transform(weapon_transform: Matrix4<f32>) -> Matrix4<f32> {
     weapon_transform
-        * Matrix4::from_translation(anchor)
+        * Matrix4::from_translation(AMP_METER_ANCHOR)
         * Matrix4::from_angle_y(Deg(90.0))
         * Matrix4::from_angle_x(WEAPON_METER_TILT)
         * Matrix4::from_nonuniform_scale(AMP_METER_WIDTH, AMP_METER_HEIGHT, 1.0)
@@ -119,8 +109,7 @@ pub(crate) fn amp_psi_meter_root(
         .ok()?
         .0;
 
-    let tag_anchor = crate::vr_config::weapon_meter_anchor_from_entity(world, weapon);
-    let root = amp_meter_transform(without_scale(weapon_transform), tag_anchor);
+    let root = amp_meter_transform(without_scale(weapon_transform));
     Some((readout, root))
 }
 
@@ -336,26 +325,18 @@ mod tests {
     }
 
     #[test]
-    fn the_amp_meter_hangs_below_the_tag_not_on_top_of_it() {
-        // Negative-first: at the tag's own anchor, the amp meter's centre
-        // must NOT coincide with it - the two panels would overlap.
-        let tag_anchor = vec3(0.15, 0.34, 0.0);
-        let tag_root = weapon_meter_transform(Matrix4::identity(), tag_anchor);
-        let amp_root = amp_meter_transform(Matrix4::identity(), tag_anchor);
-        let tag_center = vec3(tag_root.w.x, tag_root.w.y, tag_root.w.z);
-        let amp_center = vec3(amp_root.w.x, amp_root.w.y, amp_root.w.z);
-        assert_ne!(tag_center, amp_center);
-        // The amp meter sits strictly below the tag (lower weapon-local Y)...
-        assert!(amp_center.y < tag_center.y);
-        // ...separated by at least both panels' half-heights plus the gap, so
-        // they never overlap.
-        let min_gap = WEAPON_METER_HEIGHT / 2.0 + AMP_METER_GAP + AMP_METER_HEIGHT / 2.0;
-        assert!((tag_center.y - amp_center.y - min_gap).abs() < 1e-5);
+    fn the_amp_meter_hangs_at_its_anchor() {
+        let root = amp_meter_transform(Matrix4::identity());
+        assert_eq!(
+            vec3(root.w.x, root.w.y, root.w.z),
+            AMP_METER_ANCHOR,
+            "panel centre must sit at the amp-local anchor"
+        );
     }
 
     #[test]
     fn the_amp_meter_preserves_its_authored_aspect() {
-        let root = amp_meter_transform(Matrix4::identity(), vec3(0.0, 0.0, 0.0));
+        let root = amp_meter_transform(Matrix4::identity());
         let width_axis = (root * vec4(1.0, 0.0, 0.0, 0.0)).truncate().magnitude();
         let height_axis = (root * vec4(0.0, 1.0, 0.0, 0.0)).truncate().magnitude();
         assert!((width_axis - AMP_METER_WIDTH).abs() < 1e-5);

--- a/shock2vr/src/hud/ambient_meters.rs
+++ b/shock2vr/src/hud/ambient_meters.rs
@@ -66,9 +66,9 @@ pub(crate) fn weapon_meter_transform(
 //
 // The amp_h model is a compact sphere (not an elongated gun body), so the
 // psi meter gets its own anchor rather than reusing the on-weapon tag's -
-// tuned directly against the amp mesh: level with its lit indicator strip
-// and just off its near side, so it reads like a status readout on the
-// device itself.
+// tuned directly against the amp mesh, near its cable/base on the side
+// facing the shooter, so it reads like a status readout on the device
+// itself rather than a tag floating off it.
 
 const AMP_METER_ANCHOR: Vector3<f32> = vec3(-0.03, 0.05, 0.0);
 /// Panel size in world units, preserving the psi panel's authored 80x32

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -6,6 +6,7 @@ pub use virtual_arms::*;
 
 pub(crate) mod ambient_meters;
 pub(crate) mod ammo_panel;
+pub(crate) mod psi_amp_panel;
 
 mod flat_hud;
 pub(crate) use flat_hud::*;

--- a/shock2vr/src/hud/psi_amp_panel.rs
+++ b/shock2vr/src/hud/psi_amp_panel.rs
@@ -1,0 +1,185 @@
+//! The on-amp psi meter's layout - decided ONCE, in panel pixels, the same
+//! way [`super::ammo_panel`] lays out the on-weapon ammo tag. A psi pool bar
+//! (PSIBAR.PCX, the same fill art the flat bio-monitor uses) plus the
+//! hold-to-overload meter (LOADBACK/LOADMETR/LOADGOOD/LOADBURN) - the latter
+//! was flat-only before this (`flat_hud.rs`'s `OVERLOAD_METER`, no VR
+//! consumer); this closes that parity gap by drawing it here too, on the amp
+//! itself. Both presentations emit this readout from [`emit`], so it lands in
+//! the same place relative to the amp in the headset as the fraction would on
+//! screen (AGENTS.md section 3).
+//!
+//! Rects are panel-local: (0,0) is the panel's upper-left corner.
+
+use cgmath::{Vector2, vec2};
+use shipyard::World;
+
+use crate::runtime_props::{PsiChargePhase, RuntimePropPsiCharge};
+use crate::ui::{Rect, UiCanvas};
+
+/// The panel's authored pixel size: two stacked bars, each the same 80x14 the
+/// flat bio-monitor's HPBAR/PSIBAR fills use.
+pub(crate) const PANEL_W: f32 = 80.0;
+pub(crate) const PANEL_H: f32 = 32.0;
+pub(crate) const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
+
+/// Psi pool level - always shown while the amp is wielded.
+pub(crate) const PSI_BAR: Rect = Rect::new(0.0, 0.0, 80.0, 14.0);
+/// Hold-to-overload progress - shown only while a charge is in progress or
+/// its result is still flashing (`readout.charge.is_some()`).
+pub(crate) const OVERLOAD_BAR: Rect = Rect::new(0.0, 18.0, 80.0, 14.0);
+
+/// What the on-amp psi meter says this frame. Presentation-agnostic: both the
+/// flat viewmodel and the VR amp-mounted panel build one of these from the
+/// world.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PsiAmpReadout {
+    /// Whether the psi amp is the wielded weapon - the panel draws nothing at
+    /// all otherwise.
+    pub wielded: bool,
+    /// Psi pool fraction (0..1).
+    pub psi_fraction: f32,
+    /// The hold-to-overload meter's state, or `None` when no charge is in
+    /// progress (or nothing is wielded).
+    pub charge: Option<RuntimePropPsiCharge>,
+}
+
+impl PsiAmpReadout {
+    /// Read the wielded amp's readout from the world.
+    pub(crate) fn from_world(world: &World) -> Self {
+        let wielded = crate::wielded_weapon::wielded_weapon(world)
+            .is_some_and(|weapon| crate::wielded_weapon::is_psi_amp(world, weapon));
+        Self {
+            wielded,
+            psi_fraction: super::get_psi_percentage(world),
+            charge: super::get_wielded_psi_charge(world),
+        }
+    }
+
+    /// Nothing to say - the amp is not wielded. Neither presentation draws
+    /// the panel at all when this is true.
+    pub(crate) fn is_empty(&self) -> bool {
+        !self.wielded
+    }
+}
+
+/// Emit the readout's elements into `canvas`, with the panel's upper-left
+/// corner at `origin`. Every placement decision lives here.
+pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &PsiAmpReadout) {
+    if !readout.wielded {
+        return;
+    }
+    let at = |rect: Rect| Rect::new(origin.x + rect.x, origin.y + rect.y, rect.w, rect.h);
+    canvas.bar(at(PSI_BAR), "PSIBAR.PCX", readout.psi_fraction);
+    if let Some(charge) = &readout.charge {
+        match charge.phase {
+            PsiChargePhase::Charging => {
+                canvas.image(at(OVERLOAD_BAR), "LOADBACK.PCX").bar(
+                    at(OVERLOAD_BAR),
+                    "LOADMETR.PCX",
+                    charge.fraction,
+                );
+            }
+            PsiChargePhase::Overloaded => {
+                canvas.image(at(OVERLOAD_BAR), "LOADGOOD.PCX");
+            }
+            PsiChargePhase::Burnout => {
+                canvas.image(at(OVERLOAD_BAR), "LOADBURN.PCX");
+            }
+        }
+    }
+}
+
+/// The readout as a panel-sized canvas, the shape the amp-mounted panel lays
+/// over its own root transform. Pure (no asset/GL access), so it is
+/// unit-testable like `ammo_panel::build_readout_canvas`.
+pub(crate) fn build_readout_canvas(readout: &PsiAmpReadout) -> UiCanvas {
+    let mut canvas = UiCanvas::new(PANEL_SIZE);
+    emit(&mut canvas, vec2(0.0, 0.0), readout);
+    canvas
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unwielded_amp_draws_nothing() {
+        // Negative case: no amp wielded, the panel is bare.
+        let readout = PsiAmpReadout::default();
+        assert!(readout.is_empty());
+        assert_eq!(build_readout_canvas(&readout).element_count(), 0);
+    }
+
+    #[test]
+    fn a_wielded_amp_shows_its_psi_pool() {
+        let readout = PsiAmpReadout {
+            wielded: true,
+            psi_fraction: 0.5,
+            charge: None,
+        };
+        assert!(!readout.is_empty());
+        assert_eq!(build_readout_canvas(&readout).element_count(), 1);
+    }
+
+    #[test]
+    fn no_charge_means_no_overload_meter() {
+        let readout = PsiAmpReadout {
+            wielded: true,
+            psi_fraction: 1.0,
+            charge: None,
+        };
+        let canvas = build_readout_canvas(&readout);
+        assert_eq!(canvas.element_count(), 1, "only the psi bar should draw");
+    }
+
+    #[test]
+    fn charging_adds_the_track_and_fill() {
+        let readout = PsiAmpReadout {
+            wielded: true,
+            psi_fraction: 0.75,
+            charge: Some(RuntimePropPsiCharge {
+                fraction: 0.4,
+                phase: PsiChargePhase::Charging,
+            }),
+        };
+        // Psi bar + overload track + overload fill = 3.
+        assert_eq!(build_readout_canvas(&readout).element_count(), 3);
+    }
+
+    #[test]
+    fn a_flashed_result_shows_a_single_image_not_a_bar() {
+        for phase in [PsiChargePhase::Overloaded, PsiChargePhase::Burnout] {
+            let readout = PsiAmpReadout {
+                wielded: true,
+                psi_fraction: 0.2,
+                charge: Some(RuntimePropPsiCharge {
+                    fraction: 1.0,
+                    phase,
+                }),
+            };
+            // Psi bar + one result image = 2.
+            assert_eq!(build_readout_canvas(&readout).element_count(), 2);
+        }
+    }
+
+    #[test]
+    fn placing_the_panel_offsets_position_but_not_size() {
+        let mut canvas = UiCanvas::new(PANEL_SIZE);
+        emit(
+            &mut canvas,
+            vec2(10.0, 20.0),
+            &PsiAmpReadout {
+                wielded: true,
+                psi_fraction: 0.5,
+                charge: None,
+            },
+        );
+        match &canvas.elements()[0] {
+            crate::ui::UiElement::Bar { position, size, .. } => {
+                assert_eq!(*position, vec2(10.0 + PSI_BAR.x, 20.0 + PSI_BAR.y));
+                assert_eq!(*size, vec2(PSI_BAR.w, PSI_BAR.h));
+            }
+            other => panic!("expected a Bar element, got {other:?}"),
+        }
+    }
+}

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -257,6 +257,10 @@ impl PlayerInteraction for VrInteraction {
         ));
         if ambient {
             let mut meter = ambient_meters::create_weapon_ammo_meter(asset_cache, world);
+            meter.append(&mut ambient_meters::create_amp_psi_meter(
+                asset_cache,
+                world,
+            ));
             // Same label as the forearm panels, so the pause menu's
             // player-hands suppression covers the meter too.
             crate::util::tag_render_source(&mut meter, crate::util::render_source::PLAYER_HANDS);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1312,6 +1312,14 @@ pub struct DebugOptions {
 #[derive(Unique, Clone, Copy)]
 pub struct GlobalPresentationMode(pub crate::PresentationMode);
 
+/// Whether the `ambient_meters` experimental flag is on, accessible from
+/// scripts via UniqueView. `PsiAmpScript` needs this: hold-to-overload must
+/// only run where a meter can render it (flat always has one; VR only draws
+/// the on-amp psi meter behind this flag), or a VR player would charge -
+/// and possibly burn out - completely blind.
+#[derive(Unique, Clone, Copy)]
+pub struct GlobalAmbientMetersEnabled(pub bool);
+
 /// Pathfinding service accessible from scripts (steering strategies) via
 /// UniqueView. None when the mission has no AIPATH data (e.g. debug scenes).
 #[derive(Unique, Clone)]
@@ -1786,6 +1794,11 @@ impl MissionCore {
             debug_ai: game_options.debug_ai,
         });
         world.add_unique(GlobalPresentationMode(game_options.presentation_mode));
+        world.add_unique(GlobalAmbientMetersEnabled(
+            game_options
+                .experimental_features
+                .contains(crate::hud::ambient_meters::FEATURE),
+        ));
         let template_class_tags = create_template_class_tag_map(&entity_info_rc);
         world.add_unique(GlobalTemplateClassTags(template_class_tags));
         world.add_unique(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8086,6 +8086,30 @@ impl MissionCore {
                             }
                         }
                     }
+
+                    // On-amp psi meter (experimental `ambient_meters`): drawn
+                    // with the same FOV `squish` as the viewmodel above, so it
+                    // hangs on the amp instead of floating off it - see
+                    // `hud::ambient_meters::amp_psi_meter_root`'s doc comment.
+                    if options
+                        .experimental_features
+                        .contains(crate::hud::ambient_meters::FEATURE)
+                    {
+                        if let Some((readout, root)) =
+                            crate::hud::ambient_meters::amp_psi_meter_root(&self.world)
+                        {
+                            ret.extend(
+                                crate::hud::psi_amp_panel::build_readout_canvas(&readout)
+                                    .render_world_space(
+                                        asset_cache,
+                                        squish * root,
+                                        None,
+                                        None,
+                                        crate::hud::OVERLAY_Z_OFFSET,
+                                    ),
+                            );
+                        }
+                    }
                 }
             }
 

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -84,16 +84,21 @@ impl Script for PsiAmpScript {
                     game_log!(INFO, "Psi power {} is not trained", power.name);
                     return Effect::NoEffect;
                 }
-                // Hold-to-overload runs only in flat presentation (the meter
-                // renders on the flat HUD; a flat-aimed amp carries
-                // RuntimePropFlatAim). In VR the amp keeps cast-on-pull until
-                // a VR meter exists - charging blind would spend points with
-                // no feedback.
+                // Hold-to-overload runs wherever a meter can render it: flat
+                // always has one (the HUD's `OVERLOAD_METER`); VR only draws
+                // the on-amp psi meter behind the `ambient_meters`
+                // experimental flag, so VR keeps the old cast-on-pull
+                // fallback while it is off - charging blind would spend
+                // points (and risk a damaging burnout) with no feedback.
                 let is_flat = world
                     .borrow::<View<crate::runtime_props::RuntimePropFlatAim>>()
                     .map(|v| v.get(entity_id).is_ok())
                     .unwrap_or(false);
-                if power.overloadable && is_flat {
+                let ambient_meters_enabled = world
+                    .borrow::<UniqueView<crate::mission::GlobalAmbientMetersEnabled>>()
+                    .map(|flag| flag.0)
+                    .unwrap_or(false);
+                if power.overloadable && (is_flat || ambient_meters_enabled) {
                     // No points, no charge: gate up front so a broke caster
                     // can't charge into a burnout (which spends points and
                     // deals damage) they couldn't afford as a cast.


### PR DESCRIPTION
## Summary
- Add the on-amp psi pool bar and hold-to-overload meter, under the `ambient_meters` experimental flag (stacked on #1091's on-weapon ammo tag / glance-gated wrist health prototype).
- New `hud::psi_amp_panel` module (readout + layout, mirroring `hud::ammo_panel`), hung off the wielded psi amp's live `RuntimePropTransform` via `hud::ambient_meters::amp_psi_meter_root`, tuned to sit beside the amp's lit indicator strip.
- Draws in **both** presentations - VR hangs it directly off the amp; flat premultiplies the same root transform by the viewmodel's FOV `squish` so it stays pinned to the amp instead of floating off it.
- Closes a flat/VR parity gap: the hold-to-overload charge was gated to flat-only in game logic (`PsiAmpScript`, not just the HUD) with a comment that VR should keep cast-on-pull "until a VR meter exists". Now that a VR meter exists, the gate is `is_flat || ambient_meters_enabled` (a new `GlobalAmbientMetersEnabled` Unique resource next to the existing `GlobalPresentationMode`), so VR only gets the real hold-to-overload gesture where a meter can show it - never blind.
- Kept the flat bio-monitor's existing psi bar (owner decision) - this adds the on-amp meter alongside it.

## Visuals

![on-amp psi meter charging](https://gist.githubusercontent.com/tommy-xr/cb79d0d2c5a60362b18173f538baa03d/raw/demo.gif)

<sub>Flat presentation, `debug_psi`: the small red psi-pool bar and green/yellow hold-to-overload bar sit right on the wielded amp, next to its lit indicator strip, alongside the existing center-screen overload meter. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![on-amp psi meter steady state](https://gist.githubusercontent.com/tommy-xr/cb79d0d2c5a60362b18173f538baa03d/raw/steady.png)

<sub>Steady state (no charge in progress): just the psi-pool bar.</sub>

The same root transform (premultiplied by the flat viewmodel's FOV `squish`) drives the VR presentation - verified manually via `cargo dbgr --mission debug_psi --experimental ambient_meters --vr` with the amp grabbed and a free-camera framing: the meter lands in the same relative spot on the amp, and holding the trigger fills the same overload bar.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [x] `cargo fmt`
- [x] `cargo test -p shock2vr --lib` (1143 passed)
- [x] Manual verification in `debug_psi`, both `cargo dbgr --mission debug_psi --experimental ambient_meters` and `--vr`: meter appears on the amp, psi bar reflects the pool, overload bar fills while holding the trigger on Cryokinesis (overloadable), in both presentations.
- [x] Targeted SDK e2e regressions (foreground, per-file): `missions.e2e` (23/23), `psi.e2e` + `psi-overload.e2e` + `psi-sustained.e2e` + `psi-trained.e2e` + `flat-hud.e2e` (7/7), `vr-weapon-handedness.e2e` + `weapon-ammo.e2e` + `weapon-ammo-type.e2e` + `vr-weapon-reload.e2e` + `vr-held-model.e2e` (10/10) - all green.

Claude-Session: https://claude.ai/code/session_01CcZQxbiYUsaLJrJJaRAM72
