### PR TITLE
fix(build): allow rustc 1.98's suspicious-runtime-symbol lint in vendored ffmpeg-sys

### DIFF
--- a/vendor/ffmpeg-sys-next/src/lib.rs
+++ b/vendor/ffmpeg-sys-next/src/lib.rs
@@ -9,6 +9,14 @@
 #![allow(clippy::ptr_offset_with_cast)]
 #![allow(unpredictable_function_pointer_comparisons)]
 #![allow(unnecessary_transmutes)]
+// bindgen emits declarations for the libc string/memory routines pulled in by
+// ffmpeg's headers (memcpy, memset, strlen, ...) typed with `libc::c_ulong`
+// rather than `usize`. Newer rustc flags that as a mismatched redeclaration of
+// a runtime symbol the standard library owns; the types are layout-identical,
+// so allow it. `unknown_lints` keeps older toolchains (which do not know the
+// lint name) from failing on the allow itself under `-D warnings`.
+#![allow(unknown_lints)]
+#![allow(suspicious_runtime_symbol_definitions)]
 
 extern crate libc;
 


### PR DESCRIPTION
## Problem

Linux CI started failing on unrelated PRs (e.g. #1160, [run 33255781305](https://github.com/tommy-xr/shock2quest/actions/runs/33255781305/job/99109109103)):

```
error: suspicious definition of the runtime `memcpy` symbol used by the standard library
    --> target/release/build/ffmpeg-sys-next-*/out/bindings.rs:3702:5
     = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void`
             found    `unsafe extern "C" fn(*mut c_void, *const c_void, u64) -> *mut c_void`
     = note: `-D suspicious-runtime-symbol-definitions` implied by `-D warnings`
error: could not compile `ffmpeg-sys-next` (lib) due to 6 previous errors
```

## Root cause

Environmental, not code: the runner image picked up Rust 1.98.0 (released 2026-08-18; last green build was Aug 25 on 1.97). 1.98 adds the deny-by-default `suspicious_runtime_symbol_definitions` lint. bindgen's ffmpeg bindings redeclare `memcpy`/`memmove`/`memset`/`memcmp`/`strlen`/`bcmp` with `libc::c_ulong` instead of `usize`. Because `ffmpeg-sys-next` is vendored as a **path** dependency it does not get cargo's `--cap-lints allow`, so CI's `RUSTFLAGS="-D warnings"` promotes the lint to hard errors. Any PR (and `main`) hits it.

## Fix

Allow the lint in `vendor/ffmpeg-sys-next/src/lib.rs` — the types are layout-identical (`c_ulong` == `usize` on the affected targets). Paired with `#![allow(unknown_lints)]` so toolchains older than 1.98 don't fail on the allow itself under `-D warnings`. Same shape as the existing `unpredictable_function_pointer_comparisons` / `unnecessary_transmutes` allows a few lines above.

## Verification

Installed Rust 1.98.0 locally and reproduced/fixed both directions:

- without the allows: `RUSTFLAGS="-D warnings" rustup run stable cargo check -p ffmpeg-sys-next` → the same 6 errors
- with the allows: clean
- `RUSTFLAGS="-D warnings" rustup run stable cargo check -p engine -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command` (CI's package set) → no other 1.98 warnings
- `cargo fmt --all -- --check` clean

https://claude.ai/code/session_01DhLkpxkkcvm3y4JEs4fCMi