### PR TITLE
feat(debug): stock debug_weapons with the full arsenal, ammo, and maxed stats

### DIFF
--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cgmath::{Deg, Matrix4, Quaternion, Rotation3, Vector2, Vector3, vec3};
+use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector2, Vector3, vec3};
 use dark::{
     SCALE_FACTOR,
     importers::TEXTURE_IMPORTER,
@@ -23,6 +23,7 @@ use crate::{
     input_context::InputContext,
     mission::{
         AbstractMission, AlwaysVisible, GlobalContext, SpawnLocation,
+        entity_creator::CreateEntityOptions,
         entity_populator::empty_entity_populator::EmptyEntityPopulator, mission_core::MissionCore,
     },
     quest_info::QuestInfo,
@@ -657,5 +658,20 @@ impl DebugSceneFloor {
         .build();
 
         (vec![floor_object], collider)
+    }
+}
+
+/// `Effect::CreateEntity` at a world position with identity orientation - the
+/// spawn shape every populate hook wants.
+pub fn spawn_at(template_id: i32, position: Point3<f32>) -> Effect {
+    Effect::CreateEntity {
+        template_id,
+        position,
+        orientation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        // Identity, not `from_translation(position)`: the root transform is
+        // applied *on top of* `position`, so passing the position twice lands
+        // the entity at double the offset.
+        root_transform: Matrix4::identity(),
+        options: CreateEntityOptions::default(),
     }
 }

--- a/shock2vr/src/scenes/debug_melee.rs
+++ b/shock2vr/src/scenes/debug_melee.rs
@@ -20,7 +20,7 @@
 //! between them is the calibration error, and it is only visible with both on
 //! screen at once.
 
-use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3, vec3};
+use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, Vector3, vec3};
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -32,12 +32,9 @@ use shipyard::EntityId;
 use crate::{
     GameOptions, dev_params,
     game_scene::GameScene,
-    mission::{
-        GlobalContext, SpawnLocation, entity_creator::CreateEntityOptions,
-        mission_core::MissionCore,
-    },
+    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene, spawn_at,
     },
     scripts::Effect,
 };
@@ -252,19 +249,5 @@ impl DebugSceneHooks for MeleeHooks {
             asset_cache,
             audio_context,
         );
-    }
-}
-
-fn spawn_at(template_id: i32, position: Point3<f32>) -> Effect {
-    Effect::CreateEntity {
-        template_id,
-        position,
-        orientation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        // Identity, not `from_translation(position)`: the root transform is
-        // applied *on top of* `position`, so passing the position twice lands
-        // the entity at double the offset (`debug_ragdoll` does this and its
-        // hybrid spawns twice as far out as its own focus point claims).
-        root_transform: Matrix4::identity(),
-        options: CreateEntityOptions::default(),
     }
 }

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -1,4 +1,4 @@
-//! Debug scene for first-person weapon work (viewmodel framing + aim).
+//! Debug scene for first-person weapon work (viewmodel framing, aim, reload).
 //!
 //! A clean, controlled environment: the player stands on a floor facing a flat
 //! wall a known distance straight ahead. Cycle weapons with `DebugCycleWeapon`
@@ -6,8 +6,14 @@
 //! shots land on the wall as hit-spangs, so it's easy to see whether a weapon's
 //! barrel and its projectiles track the crosshair - without a real mission's
 //! cluttered geometry hiding the viewmodel or swallowing the shot.
+//!
+//! A bench on the player's left (out of the firing lane, so wall shots and
+//! staged VR gestures are unaffected) carries the full player gun arsenal and
+//! one box of every ammo type each gun takes, and the character sheet is maxed
+//! on entry - so reload, ammo cycling, and the VR clip-insert gesture can all
+//! be exercised without provisioning anything first.
 
-use cgmath::{Deg, Matrix4, Quaternion, Rotation3, vec3};
+use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, vec3};
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -18,14 +24,66 @@ use shipyard::EntityId;
 
 use crate::{
     GameOptions,
-    mission::{GlobalContext, SpawnLocation},
+    game_scene::{DebugPlayerStatsRequest, DebugSkillLevelsRequest, DebuggableScene, GameScene},
+    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
+    scenes::debug_common::{DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, spawn_at},
+    scripts::Effect,
+    scripts::gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP},
 };
-
-use super::debug_common::{DebugScene, DebugSceneBuildOptions, DebugSceneBuilder};
 
 /// Distance (world units) from the player to the test wall, straight ahead (-X,
 /// the default-view forward).
 const WALL_DISTANCE: f32 = 12.0;
+
+/// Every player-obtainable gun, in bench order - grouped
+/// so each gun sits near its ammo row entry below.
+const BENCH_GUNS: &[(i32, &str)] = &[
+    (-17, "Pistol"),
+    (-18, "Assault Rifle"),
+    (-19, "Shotgun"),
+    (-21, "Gren Launcher"),
+    (-22, "Laser Pistol"),
+    (-23, "EMP Rifle"),
+    (-25, "Stasis Field Generator"),
+    (-26, "Fusion Cannon"),
+    (-27, "Worm Launcher"),
+    (-29, "Viral Prolif"),
+    (-247, "Psi Amp"),
+];
+
+/// One pickup of every ammo type the guns above take (the world clip/box
+/// templates the `Clip` relation resolves to). Energy weapons (laser, EMP) and
+/// the psi amp have no ammo items - they recharge / draw psi points.
+const BENCH_AMMO: &[(i32, &str)] = &[
+    (-31, "Standard Clip"),
+    (-32, "HE Clip"),
+    (-307, "AP Clip"),
+    (-42, "Pellet Shot Box"),
+    (-43, "Rifled Slug Box"),
+    (-36, "Frag Grenade"),
+    (-39, "Prox Grenade"),
+    (-38, "Incend Grenade"),
+    (-37, "EMP Grenade"),
+    (-40, "Disruption Grenade"),
+    (-41, "Small Prism"),
+    (-44, "Large Prism"),
+    (-48, "Small Worm Beaker"),
+    (-1264, "Large Worm Beaker"),
+];
+
+/// The bench sits beside the firing lane on the player's left (+Z with the -X
+/// forward), long axis along X: guns on the outer row, ammo on the inner row.
+const BENCH_HEIGHT: f32 = 1.1;
+const BENCH_Z: f32 = 3.0;
+const BENCH_HALF_LENGTH: f32 = 4.6;
+const BENCH_HALF_WIDTH: f32 = 1.2;
+/// X of the bench slot nearest the player; items step -X-ward from here.
+const BENCH_NEAR_X: f32 = 1.6;
+const GUN_SPACING: f32 = 0.8;
+const AMMO_SPACING: f32 = 0.6;
+/// Height of the retaining lip above the bench top.
+const BENCH_LIP_HEIGHT: f32 = 0.5;
+const BENCH_LIP_THICKNESS: f32 = 0.08;
 
 fn cube_object(
     color: cgmath::Vector3<f32>,
@@ -45,50 +103,216 @@ pub fn create_debug_weapons_scene(
     game_options: &GameOptions,
     asset_cache: &mut AssetCache,
     audio_context: &mut AudioContext<EntityId, String>,
-) -> DebugScene {
-    // Visual floor (under the player) + a vertical wall straight ahead. The unit
-    // cube spans [-0.5, 0.5], so a `cuboid` collider half-extent matches a
-    // nonuniform scale of 2x the half-extent.
-    let floor = cube_object(
-        vec3(0.18, 0.18, 0.22),
-        vec3(0.0, -0.5, 0.0),
-        vec3(40.0, 1.0, 40.0),
+) -> Box<dyn GameScene> {
+    // Visual floor (under the player) + a vertical wall straight ahead + the
+    // weapons bench on the left. The unit cube spans [-0.5, 0.5], so a `cuboid`
+    // collider half-extent matches a nonuniform scale of 2x the half-extent.
+    let bench_center_x = BENCH_NEAR_X - BENCH_HALF_LENGTH + 0.4;
+    // Growing either roster past the bench pushes a spawn into the static lip
+    // collider - exactly the interpenetration launch the drop heights dodge.
+    debug_assert!(
+        BENCH_NEAR_X - (BENCH_GUNS.len() - 1) as f32 * GUN_SPACING
+            > bench_center_x - BENCH_HALF_LENGTH + 0.4
     );
-    let wall = cube_object(
-        vec3(0.45, 0.45, 0.5),
-        vec3(-WALL_DISTANCE, 5.0, 0.0),
-        vec3(1.0, 30.0, 30.0),
+    debug_assert!(
+        BENCH_NEAR_X - (BENCH_AMMO.len() - 1) as f32 * AMMO_SPACING
+            > bench_center_x - BENCH_HALF_LENGTH + 0.4
     );
+    // Raised lip around the bench top: grenades and prisms are rolling bodies
+    // and a flat table sheds them onto the floor within seconds.
+    let lip_color = vec3(0.36, 0.31, 0.24);
+    let lip_top = BENCH_HEIGHT + BENCH_LIP_HEIGHT / 2.0;
+    let boxes: &[(
+        cgmath::Vector3<f32>,
+        cgmath::Vector3<f32>,
+        cgmath::Vector3<f32>,
+    )] = &[
+        // floor
+        (
+            vec3(0.18, 0.18, 0.22),
+            vec3(0.0, -0.5, 0.0),
+            vec3(40.0, 1.0, 40.0),
+        ),
+        // wall
+        (
+            vec3(0.45, 0.45, 0.5),
+            vec3(-WALL_DISTANCE, 5.0, 0.0),
+            vec3(1.0, 30.0, 30.0),
+        ),
+        // weapons bench
+        (
+            vec3(0.30, 0.26, 0.20),
+            vec3(bench_center_x, BENCH_HEIGHT / 2.0, BENCH_Z),
+            vec3(
+                2.0 * BENCH_HALF_LENGTH,
+                BENCH_HEIGHT,
+                2.0 * BENCH_HALF_WIDTH,
+            ),
+        ),
+        // lip: long sides (inner/outer edges) ...
+        (
+            lip_color,
+            vec3(bench_center_x, lip_top, BENCH_Z - BENCH_HALF_WIDTH),
+            vec3(
+                2.0 * BENCH_HALF_LENGTH,
+                BENCH_LIP_HEIGHT,
+                BENCH_LIP_THICKNESS,
+            ),
+        ),
+        (
+            lip_color,
+            vec3(bench_center_x, lip_top, BENCH_Z + BENCH_HALF_WIDTH),
+            vec3(
+                2.0 * BENCH_HALF_LENGTH,
+                BENCH_LIP_HEIGHT,
+                BENCH_LIP_THICKNESS,
+            ),
+        ),
+        // ... and short ends
+        (
+            lip_color,
+            vec3(bench_center_x - BENCH_HALF_LENGTH, lip_top, BENCH_Z),
+            vec3(
+                BENCH_LIP_THICKNESS,
+                BENCH_LIP_HEIGHT,
+                2.0 * BENCH_HALF_WIDTH,
+            ),
+        ),
+        (
+            lip_color,
+            vec3(bench_center_x + BENCH_HALF_LENGTH, lip_top, BENCH_Z),
+            vec3(
+                BENCH_LIP_THICKNESS,
+                BENCH_LIP_HEIGHT,
+                2.0 * BENCH_HALF_WIDTH,
+            ),
+        ),
+    ];
 
-    // One static compound collider (floor + wall) in the ALL_COLLIDABLE group,
-    // so the wall stops shots (hitscan checks WORLD) and shows hit-spangs.
-    let collider = ColliderBuilder::compound(vec![
-        (
-            Isometry::translation(0.0, -0.5, 0.0),
-            SharedShape::cuboid(20.0, 0.5, 20.0),
-        ),
-        (
-            Isometry::translation(-WALL_DISTANCE, 5.0, 0.0),
-            SharedShape::cuboid(0.5, 15.0, 15.0),
-        ),
-    ])
+    let scene_objects = boxes
+        .iter()
+        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
+        .collect::<Vec<_>>();
+    let collider = ColliderBuilder::compound(
+        boxes
+            .iter()
+            .map(|(_, translation, scale)| {
+                (
+                    Isometry::translation(translation.x, translation.y, translation.z),
+                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
+                )
+            })
+            .collect(),
+    )
     .build();
 
     // Spawn at the floor with identity yaw: the default view forward is -X, so
-    // the wall sits dead ahead.
-    let builder = DebugSceneBuilder::new("debug_weapons")
+    // the wall sits dead ahead and the bench is a quarter-turn to the left.
+    let mut builder = DebugSceneBuilder::new("debug_weapons")
         .with_spawn_location(SpawnLocation::PositionRotation(
             vec3(0.0, 2.0, 0.0),
             Quaternion::from_angle_y(Deg(0.0)),
         ))
-        .with_physics_geometry(collider)
-        .add_scene_object(floor)
-        .add_scene_object(wall);
+        .with_physics_geometry(collider);
+    for scene_object in scene_objects {
+        builder = builder.add_scene_object(scene_object);
+    }
 
-    builder.build(DebugSceneBuildOptions {
-        global_context,
-        game_options,
-        asset_cache,
-        audio_context,
-    })
+    println!(
+        "[debug_weapons] The wall ahead catches shots as hit-spangs; cycle flat\n\
+         viewmodels with the `DebugCycleWeapon` input action (`B` on desktop).\n\
+         The bench on the left carries every player gun and one box of each ammo\n\
+         type, and the character sheet is maxed - grab (VR) or frob (flat) and go."
+    );
+
+    builder.build_with_hooks(
+        DebugSceneBuildOptions {
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        },
+        ArsenalHooks::default(),
+    )
+}
+
+#[derive(Default)]
+struct ArsenalHooks {
+    populated: bool,
+}
+
+impl DebugSceneHooks for ArsenalHooks {
+    fn before_handle_effects(
+        &mut self,
+        core: &mut MissionCore,
+        _effects: &mut Vec<Effect>,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if self.populated {
+            return;
+        }
+        self.populated = true;
+
+        // "Full stats": max the character sheet through the same provisioning
+        // path as `POST /v1/player/stats`, so nothing (skill gates, psi tiers)
+        // stands between the tester and any weapon on the bench.
+        let request = DebugPlayerStatsRequest {
+            strength: Some(STAT_CAP),
+            endurance: Some(STAT_CAP),
+            agility: Some(STAT_CAP),
+            psionic_ability: Some(STAT_CAP),
+            cyber_affinity: Some(STAT_CAP),
+            skills: DebugSkillLevelsRequest {
+                standard_weapons: Some(SKILL_CAP),
+                energy_weapons: Some(SKILL_CAP),
+                heavy_weapons: Some(SKILL_CAP),
+                exotic_weapons: Some(SKILL_CAP),
+                hack: Some(SKILL_CAP),
+                repair: Some(SKILL_CAP),
+                modify: Some(SKILL_CAP),
+                maintenance: Some(SKILL_CAP),
+                research: Some(SKILL_CAP),
+            },
+            psi_tier: Some(PSI_TIER_CAP),
+            cyber_modules: None,
+        };
+        if let Err(err) = core.set_player_stats(&request) {
+            tracing::warn!("[debug_weapons] failed to max player stats: {err}");
+        }
+
+        // Guns on the outer row, ammo on the inner row. Drop heights are
+        // load-bearing: a big gun's collider extends below its origin, and a
+        // spawn that interpenetrates the tabletop gets solver-launched across
+        // the room (+0.05 sent grenades 15 units away) - while a *high* drop
+        // makes the bouncy grenades hop the lip. Small ammo drops low, guns
+        // higher.
+        let mut effects = Vec::new();
+        for (index, (template_id, _)) in BENCH_GUNS.iter().enumerate() {
+            let x = BENCH_NEAR_X - index as f32 * GUN_SPACING;
+            effects.push(spawn_at(
+                *template_id,
+                Point3::new(x, BENCH_HEIGHT + 0.4, BENCH_Z + 0.5),
+            ));
+        }
+        for (index, (template_id, _)) in BENCH_AMMO.iter().enumerate() {
+            let x = BENCH_NEAR_X - index as f32 * AMMO_SPACING;
+            // Zigzag so a bouncing neighbor can't billiard the whole row.
+            let z = BENCH_Z - 0.55 - 0.25 * (index % 2) as f32;
+            effects.push(spawn_at(
+                *template_id,
+                Point3::new(x, BENCH_HEIGHT + 0.15, z),
+            ));
+        }
+
+        core.handle_effects(
+            effects,
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        );
+    }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -156,9 +156,7 @@ const DEBUG_SCENES: &[(&str, DebugSceneCtor)] = &[
     ("debug_minimal", |global, options, assets, audio| {
         Box::new(DebugMinimalScene::create(global, options, assets, audio))
     }),
-    ("debug_weapons", |global, options, assets, audio| {
-        Box::new(create_debug_weapons_scene(global, options, assets, audio))
-    }),
+    ("debug_weapons", create_debug_weapons_scene),
     ("debug_melee", create_debug_melee_scene),
     ("debug_psi", create_debug_psi_scene),
     ("debug_teleport", |global, options, assets, audio| {

--- a/tools/shock2-sdk/test/helpers/weapon.ts
+++ b/tools/shock2-sdk/test/helpers/weapon.ts
@@ -1,4 +1,4 @@
-import type { GameServer } from "../../src/index.js";
+import type { EntitySummary, GameServer } from "../../src/index.js";
 
 /** Fire one round: edge-triggered pull (fires on the rising edge), then release,
  * stepping a frame for each so the next pull is a fresh edge. */
@@ -7,4 +7,29 @@ export async function fireOnce(game: GameServer): Promise<void> {
   await game.step({ frames: 1 });
   await game.input.set("right_hand.trigger", 0.0);
   await game.step({ frames: 1 });
+}
+
+/** Trigger `DebugCycleWeapon` until it spawns an entity matching `match`, and
+ * return that freshly created entity. The lookup is diffed against the entity
+ * list before each trigger: the `debug_weapons` bench stocks one of every gun,
+ * so a by-name or by-template search over the whole scene is ambiguous.
+ * Debug-scene scale only: /v1/entities sorts by distance and truncates at the
+ * limit, so in a large mission a far-away spawn could fall off the list. */
+export async function cycleToWeapon(
+  game: GameServer,
+  match: (e: EntitySummary) => boolean,
+  { cycles = 16, settleFrames = 10 }: { cycles?: number; settleFrames?: number } = {},
+): Promise<EntitySummary> {
+  for (let i = 0; i < cycles; i += 1) {
+    const before = new Set(
+      (await game.entities.list({ limit: 300 })).entities.map((e) => e.id),
+    );
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: settleFrames });
+    const spawned = (await game.entities.list({ limit: 300 })).entities.find(
+      (e) => !before.has(e.id) && match(e),
+    );
+    if (spawned) return spawned;
+  }
+  throw new Error("DebugCycleWeapon did not spawn a matching weapon");
 }

--- a/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
+++ b/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
 import type { EntitySummary, Vec3 } from "../src/index.js";
 
 // End-to-end regression test for "muzzle flash follows the weapon" (the generic
@@ -35,13 +36,9 @@ test(
 
     // debug_weapons starts unarmed; DebugCycleWeapon spawns and wields the pistol.
     await game.step({ frames: 5 });
-    await game.input.trigger("DebugCycleWeapon");
-    await game.step({ frames: 5 });
-
-    // The wielded-entity field (new /v1/info player data) should report the pistol.
-    const before = (await game.entities.list({ limit: 60 })).entities;
-    const pistolId = before.find((e) => e.name === "Pistol")?.id;
-    assert.ok(pistolId !== undefined, "the pistol should exist after DebugCycleWeapon");
+    const pistolId = (
+      await cycleToWeapon(game, (e) => e.name === "Pistol", { settleFrames: 5 })
+    ).id;
     const info = await game.info();
     assert.equal(
       info.player.wielded_entity_id,
@@ -54,8 +51,8 @@ test(
     await game.input.set("right_hand.trigger", 1.0);
     await game.step({ frames: 1 });
 
-    const listA = (await game.entities.list({ limit: 60 })).entities;
-    const pistolA = posOf(listA, "Pistol");
+    const listA = (await game.entities.list({ limit: 200 })).entities;
+    const pistolA = listA.find((e) => e.id === pistolId)?.position;
     const flashA = posOf(listA, "Assault Flash");
     assert.ok(pistolA, "pistol present after firing");
     assert.ok(flashA, "muzzle flash should spawn on fire");
@@ -66,8 +63,8 @@ test(
     await game.input.set("head.look", [30, 0]);
     await game.step({ frames: 1 });
 
-    const listB = (await game.entities.list({ limit: 60 })).entities;
-    const pistolB = posOf(listB, "Pistol");
+    const listB = (await game.entities.list({ limit: 200 })).entities;
+    const pistolB = listB.find((e) => e.id === pistolId)?.position;
     const flashB = posOf(listB, "Assault Flash");
     assert.ok(pistolB, "pistol present after turning");
     assert.ok(flashB, "muzzle flash should still be alive after the turn");

--- a/tools/shock2-sdk/test/vr-cyber-interface.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface.e2e.test.ts
@@ -2,7 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntitySummary, Vec3 } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+import type { Vec3 } from "../src/index.js";
 import { aimVrHandAt, normalize, quatFromTo } from "./helpers/vr-hand.js";
 
 // The VR cyber interface (use-mode skeleton): in VR presentation
@@ -136,13 +137,7 @@ test(
 
     // DebugCycleWeapon drops each weapon in front of the player in VR; grab
     // the laser pistol (self-recharging - no ammo bookkeeping in the way).
-    let laser: EntitySummary | undefined;
-    for (let cycle = 0; cycle < 12 && !laser; cycle += 1) {
-      await game.input.trigger("DebugCycleWeapon");
-      await game.step({ frames: 10 });
-      laser = (await game.entities.list()).entities.find((e) => e.template_id === LASER_PISTOL);
-    }
-    assert.ok(laser, "DebugCycleWeapon must spawn the Laser Pistol");
+    const laser = await cycleToWeapon(game, (e) => e.template_id === LASER_PISTOL);
     await aimVrHandAt(game, laser.position as Vec3, 0.3);
     await game.input.set("right_hand.squeeze", 1);
     await game.step({ frames: 8 });

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { GameServer, findRepoRoot } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
 
 // End-to-end regression tests for held-weapon models: on a 25AE install the
 // remastered first-person gun models (obj/*_h.bin in mods/sshock2ee.kpf) are
@@ -34,13 +35,9 @@ test(
     // DebugCycleWeapon spawns the pistol; VR wield is a no-op so it drops to the
     // floor in front of the player.
     await game.step({ frames: 10 });
-    await game.input.trigger("DebugCycleWeapon");
-    await game.step({ frames: 90 });
-
-    const pistol = (await game.entities.list({ limit: 100 })).entities.find(
-      (e) => e.name === "Pistol",
-    );
-    assert.ok(pistol, "pistol should have spawned");
+    const pistol = await cycleToWeapon(game, (e) => e.name === "Pistol", {
+      settleFrames: 90,
+    });
     assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_w");
 
     // Grab it: park the right hand on the pistol's forward raycast axis
@@ -94,7 +91,7 @@ test(
     for (let i = 0; i < 20 && !wrench; i++) {
       await game.input.trigger("DebugCycleWeapon");
       await game.step({ frames: 5 });
-      wrench = (await game.entities.list({ limit: 100 })).entities.find(
+      wrench = (await game.entities.list({ limit: 200 })).entities.find(
         (e) => e.name === "Wrench",
       );
     }
@@ -105,7 +102,7 @@ test(
     // Grab it: put the hand at the settled wrench's live position (pawn-local)
     // and squeeze.
     const pawn = (await game.info()).player.position;
-    const settled = (await game.entities.list({ limit: 100 })).entities.find(
+    const settled = (await game.entities.list({ limit: 200 })).entities.find(
       (e) => e.id === wrench!.id,
     )!;
     const [px, py, pz] = settled.position;
@@ -152,7 +149,7 @@ test(
     for (let i = 0; i < 20 && !sword; i++) {
       await game.input.trigger("DebugCycleWeapon");
       await game.step({ frames: 5 });
-      sword = (await game.entities.list({ limit: 100 })).entities.find(
+      sword = (await game.entities.list({ limit: 200 })).entities.find(
         (e) => e.name === "PsiSword",
       );
     }
@@ -160,7 +157,7 @@ test(
     await game.step({ frames: 60 });
 
     const pawn = (await game.info()).player.position;
-    const settled = (await game.entities.list({ limit: 100 })).entities.find(
+    const settled = (await game.entities.list({ limit: 200 })).entities.find(
       (e) => e.id === sword!.id,
     )!;
     const [px, py, pz] = settled.position;
@@ -228,7 +225,7 @@ test(
     for (let i = 0; i < 20 && !wrench; i++) {
       await game.input.trigger("DebugCycleWeapon");
       await game.step({ frames: 5 });
-      wrench = (await game.entities.list({ limit: 100 })).entities.find(
+      wrench = (await game.entities.list({ limit: 200 })).entities.find(
         (e) => e.name === "Wrench",
       );
     }
@@ -237,7 +234,6 @@ test(
 
     // One pose, used for both hands, so the two results are comparable.
     const held: Record<string, number[]> = {};
-    const pawn = (await game.info()).player.position;
     const holdAt: [number, number, number] = [-1.7, 0.95, -0.2];
     const yaw45: [number, number, number, number] = [
       0, 0.3826834, 0, 0.9238795,
@@ -247,7 +243,11 @@ test(
       const other = hand === "right" ? "left" : "right";
       await game.input.set(`${other}_hand.position`, [3, -3, 3]);
 
-      const resting = (await game.entities.list({ limit: 100 })).entities.find(
+      // Hand channels are pawn-relative, and the pawn drifts slightly while a
+      // held weapon's body shoves the capsule around - read it fresh per hand,
+      // or the second hand is staged against a stale origin and misses.
+      const pawn = (await game.info()).player.position;
+      const resting = (await game.entities.list({ limit: 200 })).entities.find(
         (e) => e.id === wrench!.id,
       )!.position;
       await game.input.set(`${hand}_hand.position`, [
@@ -270,7 +270,7 @@ test(
       await game.input.set(`${hand}_hand.position`, holdAt);
       await game.step({ frames: 20 });
 
-      held[hand] = (await game.entities.list({ limit: 100 })).entities.find(
+      held[hand] = (await game.entities.list({ limit: 200 })).entities.find(
         (e) => e.id === wrench!.id,
       )!.position;
 
@@ -386,13 +386,7 @@ test(
     // In flat, DebugCycleWeapon spawns AND wields (sends Hold), which swaps the
     // model to the atek_h viewmodel for the first-person weapon path.
     await game.step({ frames: 5 });
-    await game.input.trigger("DebugCycleWeapon");
-    await game.step({ frames: 10 });
-
-    const pistol = (await game.entities.list({ limit: 100 })).entities.find(
-      (e) => e.name === "Pistol",
-    );
-    assert.ok(pistol, "pistol should be wielded");
+    const pistol = await cycleToWeapon(game, (e) => e.name === "Pistol");
     assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_h");
   },
 );

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
 import type { EntitySummary, Vec3 } from "../src/index.js";
 import {
   add,
@@ -186,13 +187,7 @@ test(
     await game.step({ frames: 30 });
 
     // DebugCycleWeapon drops each weapon in front of the player in VR.
-    let laser: EntitySummary | undefined;
-    for (let cycle = 0; cycle < 12 && !laser; cycle += 1) {
-      await game.input.trigger("DebugCycleWeapon");
-      await game.step({ frames: 10 });
-      laser = (await game.entities.list()).entities.find((e) => e.template_id === LASER_PISTOL);
-    }
-    assert.ok(laser, "DebugCycleWeapon must spawn the Laser Pistol");
+    const laser = await cycleToWeapon(game, (e) => e.template_id === LASER_PISTOL);
 
     await grabWithRightHand(game, laser.position as Vec3);
     const held = await game.info();

--- a/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
 import type { SceneObjectSummary, Vec3 } from "../src/types.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
 
@@ -79,12 +80,9 @@ test(
     // DebugCycleWeapon spawns the pistol; the VR path has no auto-wield, so it
     // drops to the floor for the hands to pick up.
     await game.step({ frames: 10 });
-    await game.input.trigger("DebugCycleWeapon");
-    await game.step({ frames: 90 });
-    const pistol = (await game.entities.list({ limit: 200 })).entities.find(
-      (entity) => entity.name === "Pistol",
-    );
-    assert.ok(pistol, "pistol should have spawned");
+    const pistol = await cycleToWeapon(game, (e) => e.name === "Pistol", {
+      settleFrames: 90,
+    });
 
     // Reserve rounds for the reload. `spawn-item` enters the backpack in both
     // presentations, so this needs no VR inventory interaction.

--- a/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, PlayedSound, Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
-import { fireOnce } from "./helpers/weapon.js";
+import { fireOnce, cycleToWeapon } from "./helpers/weapon.js";
 
 // End-to-end coverage for gun handling from a VR-HELD weapon. The reload and
 // ammo-cycle machinery is presentation-shared, but until the Quest face-button
@@ -63,10 +63,7 @@ function tagValue(sound: PlayedSound, tag: string): string | undefined {
 async function grabPistol(game: GameServer): Promise<EntitySummary> {
   // In VR `wield` is a no-op, so DebugCycleWeapon drops each weapon in front of
   // the player as a world pickup. The pistol is the first roster entry.
-  await game.input.trigger("DebugCycleWeapon");
-  await game.step({ frames: 10 });
-  const pistol = (await game.entities.list()).entities.find((e) => e.template_id === PISTOL);
-  assert.ok(pistol, "DebugCycleWeapon must spawn the Pistol");
+  const pistol = await cycleToWeapon(game, (e) => e.template_id === PISTOL);
 
   await aimVrHandAt(game, pistol.position as Vec3, 0.3);
   await game.input.set("right_hand.squeeze", 1);

--- a/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntitySummary } from "../src/index.js";
-import { fireOnce } from "./helpers/weapon.js";
+import { cycleToWeapon, fireOnce } from "./helpers/weapon.js";
 
 // End-to-end regression test for weapon ammo (PropGunState): a weapon limited by
 // its clip decrements one round per shot and dry-fires (no projectile) at empty.
@@ -36,13 +36,9 @@ test(
 
     // debug_weapons starts unarmed; DebugCycleWeapon spawns + wields the pistol.
     await game.step({ frames: 5 });
-    await game.input.trigger("DebugCycleWeapon");
-    await game.step({ frames: 5 });
-
-    const pistolId = (await game.entities.list({ limit: 60 })).entities.find(
-      (e) => e.name === "Pistol",
-    )?.id;
-    assert.ok(pistolId !== undefined, "pistol should be wielded");
+    const pistolId = (
+      await cycleToWeapon(game, (e) => e.name === "Pistol", { settleFrames: 5 })
+    ).id;
 
     const startAmmo = ammoOf(await game.entities.detail(pistolId));
     assert.ok(startAmmo > 0, `pistol should start with rounds (got ${startAmmo})`);


### PR DESCRIPTION
## What

`debug_weapons` becomes the weapons-feel workbench: a lipped bench beside the firing lane carries **every player-obtainable gun** (11, psi amp included) and **one pickup of every ammo type** they take (14 - clips, shells, all five grenades, prisms, worm beakers), and the character sheet is **maxed on entry** (stats/skills 6, psi tier 5) through the same provisioning path as `POST /v1/player/stats`. VR reload/ammo gestures and flat reload/cycling are exercisable with zero setup.

The firing lane is untouched: the bench sits at +Z, out of the -X shot path, so the existing aim/spang tests and staged VR gestures behave exactly as before.

## Physics of a stocked bench (the non-obvious part)

- Spawn heights are load-bearing: a big gun's collider extends below its origin, and a spawn that interpenetrates the tabletop gets **solver-launched across the room** (+0.05 above the top sent grenades 15 units). A high drop instead makes the frictionless, perfectly-elastic grenade spheres hop the lip. Small ammo drops low (+0.15), guns higher (+0.4).
- Gun and ammo rows are ~1u apart: the stasis/fusion colliders reach far enough to eject a neighboring grenade at spawn.
- The lip contains rollers; a `debug_assert` guards that growing either roster can't push a spawn into the lip collider.
- Verified by stepping 10s headlessly and asserting no item leaves the bench.

## Test fallout (and hardening)

The bench stocks one of every gun, so e2e lookups like `find(e => e.name === "Pistol")` after `DebugCycleWeapon` became ambiguous (they only passed by distance-sort luck). New `cycleToWeapon` helper tracks the entity the trigger *created*; all six call sites use it. `muzzle-flash` now pins both position snapshots to the captured id. The left-hand wield test also re-reads the pawn per hand - hand channels are pawn-relative and the pawn drifts while a held weapon's body shoves the capsule, so the second hand was staged against a stale origin.

`spawn_at` was hoisted to `debug_common` (it was a verbatim copy in `debug_melee`), and the scene now uses `build_with_hooks` instead of open-coding it.

## Not done here

- The boxes-to-collider scaffolding is now cloned across three debug scenes (`debug_weapons`/`debug_melee`/`debug_psi`); a `with_boxes` builder entry point would collapse it - left out to keep this diff scoped.
- Open PR #1165 (clip-insert reload) stages its e2e in this scene; the bench is out of its staging area, but it should re-verify on rebase.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo fmt`
- Headless settle check: all 25 items remain on the bench after 10s
- e2e: all 12 debug_weapons-based suites green (vr-held-model 6/6, weapon-ammo, muzzle-flash, vr-cyber-interface, vr-muzzle-origin, vr-weapon-reload, vr-weapon-handedness, weapon-ammo-type, weapon-ammo-eject, weapon-reload-animation, projectile trio)
- xreview (Claude + Codex + de-dup pass): all Critical/High-free; every Medium finding fixed in this diff

![debug_weapons bench pan](https://gist.githubusercontent.com/tommy-xr/4fff884fd096f3ba3e17b828cce4adfb/raw/bench_pan.gif)

<sub>Slow camera dolly along the stocked bench: all 11 player guns in the outer row, 14 ammo pickups in the inner row. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

Full bench, settled:

![debug_weapons bench](https://gist.githubusercontent.com/tommy-xr/4fff884fd096f3ba3e17b828cce4adfb/raw/bench_still.png)

<sub>No before/after: the bench is purely additive - that area of `debug_weapons` was empty floor beforehand.</sub>
