### PR TITLE
fix(gameplay): recharge station charges a held item once per interaction

### DIFF
--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use dark::{
     EnvSoundQuery,
     properties::{PropClassTag, PropPosition},
@@ -12,36 +14,44 @@ use super::{Effect, Message, MessagePayload, Script};
 
 /// How long (seconds) a charged item must stay out of contact before holding
 /// it to the station charges it again. Also absorbs single-frame raycast
-/// jitter so a wobbling hand doesn't re-trigger the charge.
+/// jitter (and re-fired Collided edges from a held item resting against the
+/// station) so a wobbling hand doesn't re-trigger the charge.
 const CONTACT_RELEASE_SECONDS: f32 = 0.5;
 
 pub struct EnergyStation {
-    // VR hover/contact latch: the item currently pressed to the station, and
-    // how long since its contact was last seen. Hover arrives every frame the
-    // hand ray touches the station, so without the latch the charge + sound
-    // replay per frame. Transient proximity state - deliberately not saved:
-    // after a load the worst case is one extra charge of an already-full item.
-    contact_target: Option<EntityId>,
-    seconds_since_contact: f32,
+    // VR hover/contact latch: each item currently pressed to the station,
+    // keyed per item (both hands can press one item each) with the seconds
+    // since its contact was last seen. Hover arrives every frame the hand ray
+    // touches the station, so without the latch the charge + sound replay per
+    // frame. Transient proximity state - deliberately not saved: after a load
+    // the worst case is one extra charge of an already-full item.
+    contacts: HashMap<EntityId, f32>,
 }
 impl EnergyStation {
     pub fn new() -> EnergyStation {
         EnergyStation {
-            contact_target: None,
-            seconds_since_contact: 0.0,
+            contacts: HashMap::new(),
         }
     }
 
     /// Charge `with` once per continuous interaction: first contact charges,
-    /// repeated contact only renews the latch until the item leaves.
+    /// repeated contact only renews the latch until the item leaves. A fresh
+    /// item arriving while another contact is still fresh charges *quietly* -
+    /// the activate sound already played for this interaction (this covers
+    /// the charged cell that replaces a dead one mid-hold, and a second held
+    /// item pressed alongside the first).
     fn contact_recharge(&mut self, world: &World, entity_id: EntityId, with: &EntityId) -> Effect {
-        let renewed = self.contact_target == Some(*with);
-        self.contact_target = Some(*with);
-        self.seconds_since_contact = 0.0;
+        let other_contact_fresh = self.contacts.keys().any(|item| item != with);
+        let renewed = self.contacts.insert(*with, 0.0).is_some();
         if renewed {
             Effect::NoEffect
+        } else if other_contact_fresh {
+            recharge_message(with)
         } else {
-            do_recharge(world, entity_id, with)
+            Effect::combine(vec![
+                recharge_message(with),
+                activate_sound(world, entity_id),
+            ])
         }
     }
 }
@@ -54,11 +64,12 @@ impl Script for EnergyStation {
         _physics: &PhysicsWorld,
         time: &Time,
     ) -> Effect {
-        if self.contact_target.is_some() {
-            self.seconds_since_contact += time.elapsed.as_secs_f32();
-            if self.seconds_since_contact > CONTACT_RELEASE_SECONDS {
-                self.contact_target = None;
-            }
+        if !self.contacts.is_empty() {
+            let dt = time.elapsed.as_secs_f32();
+            self.contacts.retain(|_, age| {
+                *age += dt;
+                *age <= CONTACT_RELEASE_SECONDS
+            });
         }
         Effect::NoEffect
     }
@@ -100,15 +111,19 @@ impl Script for EnergyStation {
 fn do_recharge_all(world: &World, entity_id: EntityId) -> Effect {
     let mut effects: Vec<Effect> = super::script_util::player_carried_items(world)
         .into_iter()
-        .map(|item| Effect::Send {
-            msg: Message {
-                to: item,
-                payload: MessagePayload::Recharge,
-            },
-        })
+        .map(|item| recharge_message(&item))
         .collect();
     effects.push(activate_sound(world, entity_id));
     Effect::combine(effects)
+}
+
+fn recharge_message(to: &EntityId) -> Effect {
+    Effect::Send {
+        msg: Message {
+            to: *to,
+            payload: MessagePayload::Recharge,
+        },
+    }
 }
 
 fn activate_sound(world: &World, entity_id: EntityId) -> Effect {
@@ -126,16 +141,6 @@ fn activate_sound(world: &World, entity_id: EntityId) -> Effect {
         query: EnvSoundQuery::from_tag_values(query),
         position: pos.position,
     }
-}
-
-fn do_recharge(world: &World, entity_id: EntityId, with: &EntityId) -> Effect {
-    let recharge_effect = Effect::Send {
-        msg: Message {
-            to: *with,
-            payload: MessagePayload::Recharge,
-        },
-    };
-    Effect::combine(vec![recharge_effect, activate_sound(world, entity_id)])
 }
 
 #[cfg(test)]
@@ -251,6 +256,50 @@ mod tests {
         tick(&mut script, station, &world, 1.0);
         let again = charge_events(script.handle_message(station, &world, &physics, &hover(item)));
         assert_eq!(again, (1, 1), "latch re-arms once contact lapses");
+    }
+
+    #[test]
+    fn alternating_items_each_charge_once_with_one_sound() {
+        // Two hands holding two items at the station: Hover alternates targets
+        // every frame. Each item charges once; the sound plays once for the
+        // whole interaction (the second item joins an already-audible charge).
+        let (mut world, station, item_a) = make_world();
+        let item_b = world.add_entity(());
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+
+        let mut totals = (0, 0);
+        for _ in 0..60 {
+            for item in [item_a, item_b] {
+                let (r, s) =
+                    charge_events(script.handle_message(station, &world, &physics, &hover(item)));
+                totals.0 += r;
+                totals.1 += s;
+            }
+            tick(&mut script, station, &world, 1.0 / 60.0);
+        }
+
+        assert_eq!(totals, (2, 1), "each item charges once, one sound total");
+    }
+
+    #[test]
+    fn replacement_item_charges_quietly_mid_hold() {
+        // Recharging a dead power cell replaces it with a NEW entity still in
+        // the hand; that fresh id must not replay the activate sound.
+        let (mut world, station, dead_cell) = make_world();
+        let charged_cell = world.add_entity(());
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+
+        let first =
+            charge_events(script.handle_message(station, &world, &physics, &hover(dead_cell)));
+        assert_eq!(first, (1, 1));
+
+        // Next frame the hand holds the replacement entity.
+        tick(&mut script, station, &world, 1.0 / 60.0);
+        let second =
+            charge_events(script.handle_message(station, &world, &physics, &hover(charged_cell)));
+        assert_eq!(second, (1, 0), "recharge sent, sound not replayed");
     }
 
     #[test]

--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -6,17 +6,63 @@ use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
+use crate::time::Time;
 
 use super::{Effect, Message, MessagePayload, Script};
 
-pub struct EnergyStation;
+/// How long (seconds) a charged item must stay out of contact before holding
+/// it to the station charges it again. Also absorbs single-frame raycast
+/// jitter so a wobbling hand doesn't re-trigger the charge.
+const CONTACT_RELEASE_SECONDS: f32 = 0.5;
+
+pub struct EnergyStation {
+    // VR hover/contact latch: the item currently pressed to the station, and
+    // how long since its contact was last seen. Hover arrives every frame the
+    // hand ray touches the station, so without the latch the charge + sound
+    // replay per frame. Transient proximity state - deliberately not saved:
+    // after a load the worst case is one extra charge of an already-full item.
+    contact_target: Option<EntityId>,
+    seconds_since_contact: f32,
+}
 impl EnergyStation {
     pub fn new() -> EnergyStation {
-        EnergyStation
+        EnergyStation {
+            contact_target: None,
+            seconds_since_contact: 0.0,
+        }
+    }
+
+    /// Charge `with` once per continuous interaction: first contact charges,
+    /// repeated contact only renews the latch until the item leaves.
+    fn contact_recharge(&mut self, world: &World, entity_id: EntityId, with: &EntityId) -> Effect {
+        let renewed = self.contact_target == Some(*with);
+        self.contact_target = Some(*with);
+        self.seconds_since_contact = 0.0;
+        if renewed {
+            Effect::NoEffect
+        } else {
+            do_recharge(world, entity_id, with)
+        }
     }
 }
 
 impl Script for EnergyStation {
+    fn update(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        if self.contact_target.is_some() {
+            self.seconds_since_contact += time.elapsed.as_secs_f32();
+            if self.seconds_since_contact > CONTACT_RELEASE_SECONDS {
+                self.contact_target = None;
+            }
+        }
+        Effect::NoEffect
+    }
+
     fn handle_message(
         &mut self,
         entity_id: EntityId,
@@ -33,18 +79,18 @@ impl Script for EnergyStation {
                 hand: _,
             } => {
                 if let Some(with) = held_entity_id {
-                    do_recharge(world, entity_id, with)
+                    self.contact_recharge(world, entity_id, with)
                 } else {
                     Effect::NoEffect
                 }
             }
-            MessagePayload::Collided { with, .. } => do_recharge(world, entity_id, with),
-            // Flat presentation: frobbing the station sends Recharge to every
-            // item the player carries at once (there is no
-            // hold-one-item-near-the-station step - that is VR-only, handled by
-            // Hover/Collided above). Each item self-handles Recharge, so only
-            // responders react - dead power cells replace themselves with charged
-            // cells, while energy weapons replenish their internal charge.
+            MessagePayload::Collided { with, .. } => self.contact_recharge(world, entity_id, with),
+            // Frobbing the station (flat click, or a VR empty-hand trigger
+            // press) sends Recharge to every item the player carries at once.
+            // Each item self-handles Recharge, so only responders react - dead
+            // power cells replace themselves with charged cells, while energy
+            // weapons replenish their internal charge. The VR-only
+            // hold-one-item-to-the-station step is Hover/Collided above.
             MessagePayload::Frob => do_recharge_all(world, entity_id),
             _ => Effect::NoEffect,
         }
@@ -90,4 +136,138 @@ fn do_recharge(world: &World, entity_id: EntityId, with: &EntityId) -> Effect {
         },
     };
     Effect::combine(vec![recharge_effect, activate_sound(world, entity_id)])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::PropPosition;
+    use shipyard::{EntityId, World};
+
+    use crate::{physics::PhysicsWorld, time::Time, vr_config::Handedness};
+
+    use super::{Effect, EnergyStation, MessagePayload, Script};
+
+    fn make_world() -> (World, EntityId, EntityId) {
+        let mut world = World::new();
+        let station = world.add_entity((PropPosition {
+            position: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            cell: 0,
+        },));
+        let item = world.add_entity(());
+        (world, station, item)
+    }
+
+    fn hover(item: EntityId) -> MessagePayload {
+        MessagePayload::Hover {
+            held_entity_id: Some(item),
+            world_position: vec3(0.0, 0.0, 0.0),
+            is_triggered: false,
+            is_grabbing: true,
+            hand: Handedness::Right,
+        }
+    }
+
+    /// Count (recharge sends, sounds) in one returned effect tree.
+    fn charge_events(effect: Effect) -> (usize, usize) {
+        let flat = Effect::flatten(vec![effect]);
+        let recharges = flat
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Effect::Send {
+                        msg: super::Message {
+                            payload: MessagePayload::Recharge,
+                            ..
+                        }
+                    }
+                )
+            })
+            .count();
+        let sounds = flat
+            .iter()
+            .filter(|e| matches!(e, Effect::PlayEnvironmentalSound { .. }))
+            .count();
+        (recharges, sounds)
+    }
+
+    fn tick(script: &mut EnergyStation, station: EntityId, world: &World, seconds: f32) {
+        let time = Time {
+            elapsed: Duration::from_secs_f32(seconds),
+            total: Duration::ZERO,
+        };
+        script.update(station, world, &PhysicsWorld::new(), &time);
+    }
+
+    #[test]
+    fn continuous_hover_charges_once() {
+        let (world, station, item) = make_world();
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+
+        // Hover arrives every frame while the held item points at the station.
+        let mut totals = (0, 0);
+        for _ in 0..120 {
+            let (r, s) =
+                charge_events(script.handle_message(station, &world, &physics, &hover(item)));
+            totals.0 += r;
+            totals.1 += s;
+            tick(&mut script, station, &world, 1.0 / 60.0);
+        }
+
+        assert_eq!(totals, (1, 1), "one charge + one sound per interaction");
+    }
+
+    #[test]
+    fn collided_spam_charges_once() {
+        let (world, station, item) = make_world();
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+        let collided = MessagePayload::Collided {
+            with: item,
+            contact: None,
+        };
+
+        let first = charge_events(script.handle_message(station, &world, &physics, &collided));
+        let second = charge_events(script.handle_message(station, &world, &physics, &collided));
+        assert_eq!(first, (1, 1));
+        assert_eq!(second, (0, 0));
+    }
+
+    #[test]
+    fn recharges_again_after_item_leaves() {
+        let (world, station, item) = make_world();
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+
+        let first = charge_events(script.handle_message(station, &world, &physics, &hover(item)));
+        assert_eq!(first, (1, 1));
+
+        // Pull the item away for over the release window, then bring it back.
+        tick(&mut script, station, &world, 1.0);
+        let again = charge_events(script.handle_message(station, &world, &physics, &hover(item)));
+        assert_eq!(again, (1, 1), "latch re-arms once contact lapses");
+    }
+
+    #[test]
+    fn frob_is_not_latched() {
+        let (world, station, _item) = make_world();
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+
+        // Frob is already edge-triggered upstream; each deliberate use plays.
+        for _ in 0..2 {
+            let (_, sounds) = charge_events(script.handle_message(
+                station,
+                &world,
+                &physics,
+                &MessagePayload::Frob,
+            ));
+            assert_eq!(sounds, 1);
+        }
+    }
 }

--- a/tools/shock2-sdk/test/recharge-hover-once.e2e.test.ts
+++ b/tools/shock2-sdk/test/recharge-hover-once.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
 
 // VR recharge-station regression coverage: holding an item to a Recharging
 // Station must charge it ONCE per interaction, not every frame.
@@ -9,34 +10,17 @@ import { GameServer } from "../src/index.js";
 // The station receives a Hover message every frame the hand ray touches it;
 // before the contact latch in energy_station.rs, each of those replayed the
 // charge + "recharge" activate sound (60/s of sound spam). Negative-first:
-// reverting the latch makes the steady-state assertion below fail with ~180
-// extra recharge sounds in the 3-second hover window.
+// reverting the latch makes the assertions below fail (~56 charge events in
+// the contact second, and steady spam in the 3-second hover window).
 //
 // The setup drives the real VR interaction: physically grab a world Dead
 // Power Cell with the simulated right hand, then aim the held item at the
 // station and hold it there.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-type Vec3 = [number, number, number];
-
-const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
-const norm = (v: Vec3): Vec3 => {
-  const len = Math.hypot(...v);
-  return [v[0] / len, v[1] / len, v[2] / len];
-};
-
-/** Quaternion [x,y,z,w] rotating the hand ray axis (0,0,-1) onto `dir`. */
-function aimQuat(dir: Vec3): [number, number, number, number] {
-  const a: Vec3 = [0, 0, -1];
-  const d = norm(dir);
-  // q = (w: 1 + a.d, xyz: a x d), normalized.
-  const w = 1 + (a[0] * d[0] + a[1] * d[1] + a[2] * d[2]);
-  const x = a[1] * d[2] - a[2] * d[1];
-  const y = a[2] * d[0] - a[0] * d[2];
-  const z = a[0] * d[1] - a[1] * d[0];
-  const len = Math.hypot(x, y, z, w);
-  return [x / len, y / len, z / len, w / len];
-}
+// Mission object id (stable across runs, exposed as `template_id`) of one of
+// medsci1's three Recharging Stations.
+const STATION_OBJ = 506;
 
 test(
   "medsci1.mis (VR): holding an item to the Recharging Station charges once, not per frame",
@@ -62,16 +46,8 @@ test(
     });
     await game.step({ frames: 30 });
 
-    const settled = (await game.entities.detail(cell.id)).position as Vec3;
-    const p0 = await game.player.position();
-    const playerPos: Vec3 = [p0.x, p0.y, p0.z];
-
-    // Hand channels are pawn-local; put the hand half a unit above the cell
-    // pointing straight down, then squeeze to grab.
-    const local = sub(settled, playerPos);
-    await game.input.set("right_hand.position", [local[0], local[1] + 0.5, local[2]]);
-    await game.input.set("right_hand.rotation", [-Math.SQRT1_2, 0, 0, Math.SQRT1_2]);
-    await game.step({ frames: 5 });
+    const settled = (await game.entities.detail(cell.id)).position;
+    await aimVrHandAt(game, settled, 0.5);
     await game.input.set("right_hand.squeeze", 1.0);
     await game.step({ frames: 10 });
 
@@ -81,36 +57,16 @@ test(
     assert.ok(held, "the Dead Power Cell should be grabbed into the right hand");
     assert.equal(held.name, "Dead Power Cell");
 
-    // --- Hold the item to a Recharging Station. ---
-    // Pin one specific station by mission object id (stable across runs):
-    // obj 506 faces pawn +X, matching the stand-and-aim geometry below.
-    const stations = (
-      await game.entities.list({ filter: "Recharging Station", limit: 10 })
-    ).entities;
-    const station = stations.find((s) => s.template_id === 506);
-    assert.ok(station, "medsci1 should contain Recharging Station obj 506");
-
-    // Stand pawn-forward (-X) of the station; aim the held hand at it.
+    // --- Hold the item to the Recharging Station. ---
+    const station = (await game.entities.byTemplate(STATION_OBJ)).find(
+      (s) => s.name === "Recharging Station",
+    );
+    assert.ok(station, `medsci1 should contain Recharging Station obj ${STATION_OBJ}`);
     await game.player.teleport({
       x: station.position[0] + 3,
       y: station.position[1],
       z: station.position[2],
     });
-    const p1 = await game.player.position();
-    const pawn: Vec3 = [p1.x, p1.y, p1.z];
-    const handLocal: Vec3 = [-0.55, 1.0, -0.2];
-    const handWorld: Vec3 = [
-      pawn[0] + handLocal[0],
-      pawn[1] + handLocal[1],
-      pawn[2] + handLocal[2],
-    ];
-    const target: Vec3 = [
-      station.position[0],
-      station.position[1],
-      station.position[2],
-    ];
-    await game.input.set("right_hand.position", handLocal);
-    await game.input.set("right_hand.rotation", aimQuat(sub(target, handWorld)));
 
     // The audio log is a bounded ring buffer, so window by sequence snapshots.
     const lastSequence = async () =>
@@ -120,15 +76,21 @@ test(
         (s) => s.sequence > sequence && s.sample === "recharge",
       ).length;
 
-    // Contact second: the charge event fires. The charge replaces the dead
-    // cell with a charged one (a new entity), which is itself charged once as
-    // a fresh contact - so allow up to 2 events, but nothing per-frame.
+    // Snapshot BEFORE aiming: aimVrHandAt steps a few frames itself, and the
+    // first of those already delivers the Hover that charges the item.
     const beforeContact = await lastSequence();
+    // Keep the squeeze so the cell stays held while the hand re-aims.
+    await aimVrHandAt(game, station.position, 1.5, /* squeeze */ 1);
+
+    // Contact second: exactly one audible charge event. (The charge replaces
+    // the dead cell with a charged one - a new entity - which is charged
+    // quietly: the station suppresses the sound while a contact is fresh.)
     await game.step({ frames: 60 });
     const duringContact = await rechargesSince(beforeContact);
-    assert.ok(
-      duringContact >= 1 && duringContact <= 2,
-      `expected 1-2 charge events at contact, saw ${duringContact}`,
+    assert.equal(
+      duringContact,
+      1,
+      `expected exactly 1 audible charge event at contact, saw ${duringContact}`,
     );
     const heldAfter = (await game.player.inventory()).items.find(
       (i) => i.location === "right_hand",

--- a/tools/shock2-sdk/test/recharge-hover-once.e2e.test.ts
+++ b/tools/shock2-sdk/test/recharge-hover-once.e2e.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// VR recharge-station regression coverage: holding an item to a Recharging
+// Station must charge it ONCE per interaction, not every frame.
+//
+// The station receives a Hover message every frame the hand ray touches it;
+// before the contact latch in energy_station.rs, each of those replayed the
+// charge + "recharge" activate sound (60/s of sound spam). Negative-first:
+// reverting the latch makes the steady-state assertion below fail with ~180
+// extra recharge sounds in the 3-second hover window.
+//
+// The setup drives the real VR interaction: physically grab a world Dead
+// Power Cell with the simulated right hand, then aim the held item at the
+// station and hold it there.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+type Vec3 = [number, number, number];
+
+const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const norm = (v: Vec3): Vec3 => {
+  const len = Math.hypot(...v);
+  return [v[0] / len, v[1] / len, v[2] / len];
+};
+
+/** Quaternion [x,y,z,w] rotating the hand ray axis (0,0,-1) onto `dir`. */
+function aimQuat(dir: Vec3): [number, number, number, number] {
+  const a: Vec3 = [0, 0, -1];
+  const d = norm(dir);
+  // q = (w: 1 + a.d, xyz: a x d), normalized.
+  const w = 1 + (a[0] * d[0] + a[1] * d[1] + a[2] * d[2]);
+  const x = a[1] * d[2] - a[2] * d[1];
+  const y = a[2] * d[0] - a[0] * d[2];
+  const z = a[0] * d[1] - a[1] * d[0];
+  const len = Math.hypot(x, y, z, w);
+  return [x / len, y / len, z / len, w / len];
+}
+
+test(
+  "medsci1.mis (VR): holding an item to the Recharging Station charges once, not per frame",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    // --- Grab a world Dead Power Cell with the right hand. ---
+    const cells = (await game.entities.list({ filter: "Dead Power Cell", limit: 20 }))
+      .entities;
+    assert.ok(cells.length >= 1, "medsci1 should contain a Dead Power Cell");
+    const cell = cells[0];
+
+    // Stand near the cell and let it (and the player) settle.
+    await game.player.teleport({
+      x: cell.position[0],
+      y: cell.position[1] + 1.6,
+      z: cell.position[2] + 1.8,
+    });
+    await game.step({ frames: 30 });
+
+    const settled = (await game.entities.detail(cell.id)).position as Vec3;
+    const p0 = await game.player.position();
+    const playerPos: Vec3 = [p0.x, p0.y, p0.z];
+
+    // Hand channels are pawn-local; put the hand half a unit above the cell
+    // pointing straight down, then squeeze to grab.
+    const local = sub(settled, playerPos);
+    await game.input.set("right_hand.position", [local[0], local[1] + 0.5, local[2]]);
+    await game.input.set("right_hand.rotation", [-Math.SQRT1_2, 0, 0, Math.SQRT1_2]);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 10 });
+
+    const held = (await game.player.inventory()).items.find(
+      (i) => i.location === "right_hand",
+    );
+    assert.ok(held, "the Dead Power Cell should be grabbed into the right hand");
+    assert.equal(held.name, "Dead Power Cell");
+
+    // --- Hold the item to a Recharging Station. ---
+    // Pin one specific station by mission object id (stable across runs):
+    // obj 506 faces pawn +X, matching the stand-and-aim geometry below.
+    const stations = (
+      await game.entities.list({ filter: "Recharging Station", limit: 10 })
+    ).entities;
+    const station = stations.find((s) => s.template_id === 506);
+    assert.ok(station, "medsci1 should contain Recharging Station obj 506");
+
+    // Stand pawn-forward (-X) of the station; aim the held hand at it.
+    await game.player.teleport({
+      x: station.position[0] + 3,
+      y: station.position[1],
+      z: station.position[2],
+    });
+    const p1 = await game.player.position();
+    const pawn: Vec3 = [p1.x, p1.y, p1.z];
+    const handLocal: Vec3 = [-0.55, 1.0, -0.2];
+    const handWorld: Vec3 = [
+      pawn[0] + handLocal[0],
+      pawn[1] + handLocal[1],
+      pawn[2] + handLocal[2],
+    ];
+    const target: Vec3 = [
+      station.position[0],
+      station.position[1],
+      station.position[2],
+    ];
+    await game.input.set("right_hand.position", handLocal);
+    await game.input.set("right_hand.rotation", aimQuat(sub(target, handWorld)));
+
+    // The audio log is a bounded ring buffer, so window by sequence snapshots.
+    const lastSequence = async () =>
+      Math.max(0, ...(await game.audio.recent()).sounds.map((s) => s.sequence));
+    const rechargesSince = async (sequence: number) =>
+      (await game.audio.recent()).sounds.filter(
+        (s) => s.sequence > sequence && s.sample === "recharge",
+      ).length;
+
+    // Contact second: the charge event fires. The charge replaces the dead
+    // cell with a charged one (a new entity), which is itself charged once as
+    // a fresh contact - so allow up to 2 events, but nothing per-frame.
+    const beforeContact = await lastSequence();
+    await game.step({ frames: 60 });
+    const duringContact = await rechargesSince(beforeContact);
+    assert.ok(
+      duringContact >= 1 && duringContact <= 2,
+      `expected 1-2 charge events at contact, saw ${duringContact}`,
+    );
+    const heldAfter = (await game.player.inventory()).items.find(
+      (i) => i.location === "right_hand",
+    );
+    assert.equal(heldAfter?.name, "Power Cell", "held dead cell should charge in place");
+
+    // Steady state: three more seconds of continuous hover must charge nothing.
+    const beforeSteady = await lastSequence();
+    await game.step({ frames: 180 });
+    const steadyState = await rechargesSince(beforeSteady);
+    assert.equal(
+      steadyState,
+      0,
+      `continuous hover replayed the recharge ${steadyState} more times`,
+    );
+  },
+);


### PR DESCRIPTION
## Problem

Holding an item to a recharge station in VR "goes crazy": the `EnergyStation` script recharged and played the activate sound on **every** `Hover` message, and `VirtualHand` emits `Hover` every frame the hand ray touches the station — 60 charge events/sounds per second.

**Before (repro evidence):**
- unit: 120 hover frames → 120 charge sends + 120 sounds
- e2e (latch reverted): 56 audible charge events in the first contact second

## Fix

`shock2vr/src/scripts/energy_station.rs`: latch contacts in script-private state, keyed **per item** (both hands can press one item each; the charged cell that replaces a dead one mid-hold is a new `EntityId`). One charge + one sound per continuous interaction; a fresh item arriving while another contact is still fresh charges *quietly*; the latch re-arms 0.5 s after contact ends. `Frob` stays unlatched (already edge-triggered upstream). Transient proximity state — deliberately not saved (worst case after a load: one extra charge of an already-full item).

**After:** hover held for 180 frames → 1 charge, 1 sound, 0 replays (unit, e2e, and manual `--vr` debug-runtime run all agree).

## Frobbing the station (bug 2)

Verified in `--vr` mode: frobbing the station (VR empty-hand trigger sends the same `MessagePayload::Frob` as a flat click) recharges **all** carried items — a Dead Power Cell in the backpack becomes a charged Power Cell with one sound. This already worked (#518/#535); the stale "flat-only" comment is updated and `powercell-recharge.e2e.test.ts` still covers it.

## Tests

- 6 unit tests on returned `Effect`s (hover spam, Collided spam, re-arm, two-hand alternation, quiet replacement charge, frob unlatched) — the spam tests fail without the latch
- new `recharge-hover-once.e2e.test.ts`: real VR interaction (grab a world Dead Power Cell with the simulated hand via the shared `vr-hand.ts` helpers, hold it to the station), asserts exactly 1 audible charge then 0 over 3 s, and the held cell charges in place
- xreview run; both Medium findings (two-hand latch ping-pong, `ReplaceEntity` double sound) fixed and re-validated
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr` (1136 pass), SDK `npm test` (32 pass), recharge e2e suite (3 pass)

## Deferred

Charging visual (bolt/particle stream from station to item): the mission data already authors `RechargeFX` entities `ParticleAttachement`-linked to each station — a proper visual should activate those rather than invent a new effect; left as a follow-up.
