### PR TITLE
feat(gameplay): play authored RechargeFX when a station charges

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3452,9 +3452,9 @@ impl MissionCore {
                         .iter()
                         .with_id()
                 {
-                    // Dormant groups (authored inactive) do not emit. There is
-                    // no runtime activation toggle yet; when one exists this
-                    // should flip the system on rather than skip it. A
+                    // Dormant groups (authored inactive, or switched off via
+                    // Effect::SetParticleActive - which also drops the live
+                    // system, see the effect applier) do not emit. A
                     // transient (fire-and-forget) entity that is dormant would
                     // never finish a burst, so reap it immediately instead of
                     // leaking an invisible entity.
@@ -6994,6 +6994,20 @@ impl MissionCore {
                         .unwrap_or(false);
                     if is_alive {
                         self.world.add_component(entity_id, PropObjState(state));
+                    }
+                }
+                Effect::SetParticleActive { entity_id, active } => {
+                    self.world.run(|mut v_pg: ViewMut<PropParticleGroup>| {
+                        if let Ok(pg) = (&mut v_pg).get(entity_id) {
+                            pg.is_active = active;
+                        }
+                    });
+                    // Drop the live system on deactivate: the render pass
+                    // draws whatever systems exist, so a lingering system
+                    // would keep showing its last frame. Rebuilding on the
+                    // next activation also restarts the burst from scratch.
+                    if !active {
+                        self.id_to_particle_system.remove(&entity_id);
                     }
                 }
                 Effect::SetAnimatedLight {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -619,6 +619,15 @@ pub enum Effect {
         state: ObjectState,
     },
 
+    /// Turn one authored particle group (`P$ParticleG`) on or off - e.g. the
+    /// recharge station pulsing its attached `RechargeFX` while it charges.
+    /// Deactivating also clears the live particle system, so the next
+    /// activation restarts the burst from scratch.
+    SetParticleActive {
+        entity_id: EntityId,
+        active: bool,
+    },
+
     /// Persistently switch one authored animated light and update the matching
     /// world-representation lightmap layers. `intensity` is normalized against
     /// the light's authored maximum; `inactive` is stored in `P$AnimLight` so

--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -35,25 +35,19 @@ pub struct EnergyStation {
     /// Seconds left on the current RechargeFX pulse; <= 0 means the FX is off.
     /// Transient like `contacts` - a pulse lost to a save/load is cosmetic.
     fx_seconds_left: f32,
-    /// The mission data authors the FX group `is_active: true`, so it would
-    /// otherwise glow forever; the first update turns it off. False again
-    /// after a load, which re-normalizes the restored state.
-    fx_normalized: bool,
 }
 impl EnergyStation {
     pub fn new() -> EnergyStation {
         EnergyStation {
             contacts: HashMap::new(),
             fx_seconds_left: 0.0,
-            fx_normalized: false,
         }
     }
 
-    /// Start (or extend) the charge FX pulse on the station's attached
-    /// particle group.
+    /// Start a charge FX pulse on the station's attached particle group (one
+    /// per interaction - a held contact renews the latch, not the pulse).
     fn begin_fx_pulse(&mut self, world: &World, entity_id: EntityId) -> Effect {
         self.fx_seconds_left = FX_PULSE_SECONDS;
-        self.fx_normalized = true;
         set_attached_fx_active(world, entity_id, true)
     }
 
@@ -84,6 +78,13 @@ impl EnergyStation {
 }
 
 impl Script for EnergyStation {
+    // The mission data authors the FX group `is_active: true` (it would glow
+    // forever) - switch it off until a charge pulses it. Runs fresh and after
+    // every load (the pulse timer is transient), re-normalizing restored state.
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        set_attached_fx_active(world, entity_id, false)
+    }
+
     fn update(
         &mut self,
         entity_id: EntityId,
@@ -97,14 +98,6 @@ impl Script for EnergyStation {
                 *age += dt;
                 *age <= CONTACT_RELEASE_SECONDS
             });
-        }
-        // The authored FX group ships active - switch it off until a charge
-        // pulses it (and after a load, re-normalize the restored state).
-        if !self.fx_normalized {
-            self.fx_normalized = true;
-            if self.fx_seconds_left <= 0.0 {
-                return set_attached_fx_active(world, entity_id, false);
-            }
         }
         // Expire the charge pulse.
         if self.fx_seconds_left > 0.0 {
@@ -165,7 +158,9 @@ fn do_recharge_all(world: &World, entity_id: EntityId) -> Effect {
 /// Toggle the particle groups attached to this station. The mission data
 /// authors one `RechargeFX` entity per station, linked BY the FX entity via a
 /// concrete `ParticleAttachement` link (FX -> station), so the FX is found by
-/// scanning incoming links.
+/// scanning incoming links. This assumes a mission-placed station: a
+/// runtime-created host gets its riders attached without `Links`, but every
+/// energy station ships placed in the level.
 fn set_attached_fx_active(world: &World, station_id: EntityId, active: bool) -> Effect {
     let v_links = world.borrow::<View<Links>>().unwrap();
     let effects: Vec<Effect> = v_links
@@ -455,16 +450,16 @@ mod tests {
     }
 
     #[test]
-    fn first_update_turns_authored_fx_off() {
+    fn initialize_turns_authored_fx_off() {
         // The mission data authors the FX group active; the station normalizes
-        // it off before any charge.
+        // it off before any charge, and plain updates don't re-emit it.
         let (mut world, station, _item) = make_world();
         let fx = add_fx(&mut world, station);
         let mut script = EnergyStation::new();
 
-        let first = fx_toggles(tick(&mut script, station, &world, 1.0 / 60.0));
-        assert_eq!(first, vec![(fx, false)]);
-        let second = fx_toggles(tick(&mut script, station, &world, 1.0 / 60.0));
-        assert_eq!(second, vec![], "normalization happens once");
+        let init = fx_toggles(script.initialize(station, &world));
+        assert_eq!(init, vec![(fx, false)]);
+        let update = fx_toggles(tick(&mut script, station, &world, 1.0 / 60.0));
+        assert_eq!(update, vec![], "idle update emits nothing");
     }
 }

--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 
 use dark::{
     EnvSoundQuery,
-    properties::{PropClassTag, PropPosition},
+    properties::{Link, Links, PropClassTag, PropPosition},
 };
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
 
 use crate::physics::PhysicsWorld;
 use crate::time::Time;
@@ -18,6 +18,12 @@ use super::{Effect, Message, MessagePayload, Script};
 /// station) so a wobbling hand doesn't re-trigger the charge.
 const CONTACT_RELEASE_SECONDS: f32 = 0.5;
 
+/// How long (seconds) the station's attached `RechargeFX` particle group
+/// plays after a charge. The mission data authors the group as a continuous
+/// emitter with no duration of its own, so the station pulses it: on at each
+/// charge, off when this expires (roughly the activate sound's length).
+const FX_PULSE_SECONDS: f32 = 2.0;
+
 pub struct EnergyStation {
     // VR hover/contact latch: each item currently pressed to the station,
     // keyed per item (both hands can press one item each) with the seconds
@@ -26,12 +32,29 @@ pub struct EnergyStation {
     // frame. Transient proximity state - deliberately not saved: after a load
     // the worst case is one extra charge of an already-full item.
     contacts: HashMap<EntityId, f32>,
+    /// Seconds left on the current RechargeFX pulse; <= 0 means the FX is off.
+    /// Transient like `contacts` - a pulse lost to a save/load is cosmetic.
+    fx_seconds_left: f32,
+    /// The mission data authors the FX group `is_active: true`, so it would
+    /// otherwise glow forever; the first update turns it off. False again
+    /// after a load, which re-normalizes the restored state.
+    fx_normalized: bool,
 }
 impl EnergyStation {
     pub fn new() -> EnergyStation {
         EnergyStation {
             contacts: HashMap::new(),
+            fx_seconds_left: 0.0,
+            fx_normalized: false,
         }
+    }
+
+    /// Start (or extend) the charge FX pulse on the station's attached
+    /// particle group.
+    fn begin_fx_pulse(&mut self, world: &World, entity_id: EntityId) -> Effect {
+        self.fx_seconds_left = FX_PULSE_SECONDS;
+        self.fx_normalized = true;
+        set_attached_fx_active(world, entity_id, true)
     }
 
     /// Charge `with` once per continuous interaction: first contact charges,
@@ -46,11 +69,15 @@ impl EnergyStation {
         if renewed {
             Effect::NoEffect
         } else if other_contact_fresh {
-            recharge_message(with)
+            Effect::combine(vec![
+                recharge_message(with),
+                self.begin_fx_pulse(world, entity_id),
+            ])
         } else {
             Effect::combine(vec![
                 recharge_message(with),
                 activate_sound(world, entity_id),
+                self.begin_fx_pulse(world, entity_id),
             ])
         }
     }
@@ -59,17 +86,32 @@ impl EnergyStation {
 impl Script for EnergyStation {
     fn update(
         &mut self,
-        _entity_id: EntityId,
-        _world: &World,
+        entity_id: EntityId,
+        world: &World,
         _physics: &PhysicsWorld,
         time: &Time,
     ) -> Effect {
+        let dt = time.elapsed.as_secs_f32();
         if !self.contacts.is_empty() {
-            let dt = time.elapsed.as_secs_f32();
             self.contacts.retain(|_, age| {
                 *age += dt;
                 *age <= CONTACT_RELEASE_SECONDS
             });
+        }
+        // The authored FX group ships active - switch it off until a charge
+        // pulses it (and after a load, re-normalize the restored state).
+        if !self.fx_normalized {
+            self.fx_normalized = true;
+            if self.fx_seconds_left <= 0.0 {
+                return set_attached_fx_active(world, entity_id, false);
+            }
+        }
+        // Expire the charge pulse.
+        if self.fx_seconds_left > 0.0 {
+            self.fx_seconds_left -= dt;
+            if self.fx_seconds_left <= 0.0 {
+                return set_attached_fx_active(world, entity_id, false);
+            }
         }
         Effect::NoEffect
     }
@@ -102,7 +144,10 @@ impl Script for EnergyStation {
             // power cells replace themselves with charged cells, while energy
             // weapons replenish their internal charge. The VR-only
             // hold-one-item-to-the-station step is Hover/Collided above.
-            MessagePayload::Frob => do_recharge_all(world, entity_id),
+            MessagePayload::Frob => Effect::combine(vec![
+                do_recharge_all(world, entity_id),
+                self.begin_fx_pulse(world, entity_id),
+            ]),
             _ => Effect::NoEffect,
         }
     }
@@ -114,6 +159,29 @@ fn do_recharge_all(world: &World, entity_id: EntityId) -> Effect {
         .map(|item| recharge_message(&item))
         .collect();
     effects.push(activate_sound(world, entity_id));
+    Effect::combine(effects)
+}
+
+/// Toggle the particle groups attached to this station. The mission data
+/// authors one `RechargeFX` entity per station, linked BY the FX entity via a
+/// concrete `ParticleAttachement` link (FX -> station), so the FX is found by
+/// scanning incoming links.
+fn set_attached_fx_active(world: &World, station_id: EntityId, active: bool) -> Effect {
+    let v_links = world.borrow::<View<Links>>().unwrap();
+    let effects: Vec<Effect> = v_links
+        .iter()
+        .with_id()
+        .filter(|(_, links)| {
+            links.to_links.iter().any(|l| {
+                matches!(l.link, Link::ParticleAttachement(_))
+                    && l.to_entity_id.map(|e| e.0) == Some(station_id)
+            })
+        })
+        .map(|(id, _)| Effect::SetParticleActive {
+            entity_id: id,
+            active,
+        })
+        .collect();
     Effect::combine(effects)
 }
 
@@ -148,7 +216,9 @@ mod tests {
     use std::time::Duration;
 
     use cgmath::{Quaternion, vec3};
-    use dark::properties::PropPosition;
+    use dark::properties::{
+        Link, Links, ParticleAttachOptions, PropPosition, ToLink, WrappedEntityId,
+    };
     use shipyard::{EntityId, World};
 
     use crate::{physics::PhysicsWorld, time::Time, vr_config::Handedness};
@@ -200,12 +270,40 @@ mod tests {
         (recharges, sounds)
     }
 
-    fn tick(script: &mut EnergyStation, station: EntityId, world: &World, seconds: f32) {
+    fn tick(script: &mut EnergyStation, station: EntityId, world: &World, seconds: f32) -> Effect {
         let time = Time {
             elapsed: Duration::from_secs_f32(seconds),
             total: Duration::ZERO,
         };
-        script.update(station, world, &PhysicsWorld::new(), &time);
+        script.update(station, world, &PhysicsWorld::new(), &time)
+    }
+
+    /// Add a mission-style RechargeFX entity: a concrete ParticleAttachement
+    /// link from the FX entity to its station.
+    fn add_fx(world: &mut World, station: EntityId) -> EntityId {
+        world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(station)),
+                link: Link::ParticleAttachement(ParticleAttachOptions {
+                    attach_type: 0,
+                    vhot: 0,
+                    joint: 0,
+                    submodel: 0,
+                }),
+            }],
+        })
+    }
+
+    /// Collect (entity, active) from every SetParticleActive in the tree.
+    fn fx_toggles(effect: Effect) -> Vec<(EntityId, bool)> {
+        Effect::flatten(vec![effect])
+            .into_iter()
+            .filter_map(|e| match e {
+                Effect::SetParticleActive { entity_id, active } => Some((entity_id, active)),
+                _ => None,
+            })
+            .collect()
     }
 
     #[test]
@@ -318,5 +416,55 @@ mod tests {
             ));
             assert_eq!(sounds, 1);
         }
+    }
+
+    #[test]
+    fn charge_pulses_attached_fx_once_per_interaction() {
+        let (mut world, station, item) = make_world();
+        let fx = add_fx(&mut world, station);
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+
+        // First contact turns the FX on...
+        let first = fx_toggles(script.handle_message(station, &world, &physics, &hover(item)));
+        assert_eq!(first, vec![(fx, true)]);
+
+        // ...latched repeat contacts don't re-emit it...
+        tick(&mut script, station, &world, 1.0 / 60.0);
+        let repeat = fx_toggles(script.handle_message(station, &world, &physics, &hover(item)));
+        assert_eq!(repeat, vec![], "latched contact must not re-pulse the FX");
+
+        // ...and the pulse expires back to off.
+        let mut offs = Vec::new();
+        for _ in 0..180 {
+            offs.extend(fx_toggles(tick(&mut script, station, &world, 1.0 / 60.0)));
+        }
+        assert_eq!(offs, vec![(fx, false)], "pulse turns off exactly once");
+    }
+
+    #[test]
+    fn frob_pulses_attached_fx() {
+        let (mut world, station, _item) = make_world();
+        let fx = add_fx(&mut world, station);
+        let mut script = EnergyStation::new();
+        let physics = PhysicsWorld::new();
+
+        let toggles =
+            fx_toggles(script.handle_message(station, &world, &physics, &MessagePayload::Frob));
+        assert_eq!(toggles, vec![(fx, true)]);
+    }
+
+    #[test]
+    fn first_update_turns_authored_fx_off() {
+        // The mission data authors the FX group active; the station normalizes
+        // it off before any charge.
+        let (mut world, station, _item) = make_world();
+        let fx = add_fx(&mut world, station);
+        let mut script = EnergyStation::new();
+
+        let first = fx_toggles(tick(&mut script, station, &world, 1.0 / 60.0));
+        assert_eq!(first, vec![(fx, false)]);
+        let second = fx_toggles(tick(&mut script, station, &world, 1.0 / 60.0));
+        assert_eq!(second, vec![], "normalization happens once");
     }
 }


### PR DESCRIPTION
Stacks on #1180 (`fix/recharge-spam`).

The mission data already authors a `RechargeFX` particle entity at every recharging station, tied to it by a concrete `ParticleAttachement` link (FX -> station). The group ships `is_active: true` with no duration, so in the port it glowed 24/7 in the station's coil slot - and never reacted to a charge.

This activates the authored effect properly:

- **`Effect::SetParticleActive`** - flips `PropParticleGroup.is_active` on one entity; deactivating also drops the live `ParticleSystem`, so the render pass stops drawing it and the next activation restarts the burst.
- **`EnergyStation`** pulses its attached FX for 2 s per charge event - one pulse per contact-latch interaction (VR held-item charge) and per frob (flat charge-all) - and normalizes the authored always-on group OFF on its first update (re-normalizing after a load; the pulse timer is transient script state like the contact latch).
- FX entities are found by scanning incoming `ParticleAttachement` links, so this works in every mission without hardcoding.

## Verification

- Unit tests: FX pulses once per interaction (not on latched repeat contacts), frob pulses, first update turns the authored group off exactly once.
- `cargo test -p shock2vr` (1139 pass), `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt`.
- e2e: `recharge-hover-once`, `powercell-recharge`, `energy-weapon-recharge`, `missions` all pass.
- Headless render verification on `medsci1.mis`: idle -> frob -> 2 s glow -> off (screenshots below; before the change the glow was permanently on).


## Demo

![recharge FX pulse demo](https://gist.githubusercontent.com/tommy-xr/20fa57b60f17512a72b96c5c2471808c/raw/recharge_fx.gif)

<sub>Frob charges the station: the authored RechargeFX glows in the coil slot for 2 s, then goes dark. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) on `medsci1.mis`.</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/20fa57b60f17512a72b96c5c2471808c/raw/beforeafter.png)

<sub>Before: the authored `is_active: true` group glowed permanently at every station. After: dark when idle, glowing only while charging.</sub>
