### PR TITLE
fix(items): mint the ejected clip archetype whose authored size fits the rounds

### DIFF
--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -62,15 +62,15 @@ impl GlobalProjectileClips {
         // Resolve each clip archetype's authored stack size - "Small Standard
         // Clip" holds 6, "Standard Clip" 12 - which is what an eject sizes its
         // minted clip against.
+        let unique_clips: std::collections::HashSet<i32> =
+            projectile_clips.values().flatten().copied().collect();
         let mut clip_sizes = HashMap::new();
-        for clip in projectile_clips.values().flatten() {
-            if !clip_sizes.contains_key(clip) {
-                if let Some(stack) = crate::scripts::script_util::hydrate_template_component::<
-                    PropStackCount,
-                >(*clip, entity_info)
-                {
-                    clip_sizes.insert(*clip, stack.0);
-                }
+        for clip in unique_clips {
+            if let Some(stack) = crate::scripts::script_util::hydrate_template_component::<
+                PropStackCount,
+            >(clip, entity_info)
+            {
+                clip_sizes.insert(clip, stack.0);
             }
         }
 
@@ -826,20 +826,34 @@ mod tests {
         entity_info
             .entity_to_properties
             .insert(STD_CLIP, vec![Arc::new(Box::new(PropStackCount(12)))]);
+        entity_info
+            .entity_to_properties
+            .insert(SMALL_STD_CLIP, vec![Arc::new(Box::new(PropStackCount(6)))]);
         entity_info.template_to_links.insert(
             STD_PROJECTILE,
             dark::properties::TemplateLinks {
-                to_links: vec![ToTemplateLink {
-                    link: Link::Clip,
-                    to_template_id: STD_CLIP,
-                }],
+                to_links: vec![
+                    ToTemplateLink {
+                        link: Link::Clip,
+                        to_template_id: SMALL_STD_CLIP,
+                    },
+                    ToTemplateLink {
+                        link: Link::Clip,
+                        to_template_id: STD_CLIP,
+                    },
+                ],
             },
         );
 
         let clips = GlobalProjectileClips::from_entity_info(&entity_info);
 
-        assert_eq!(clips.clips.get(&STD_PROJECTILE), Some(&vec![STD_CLIP]));
+        assert_eq!(
+            clips.clips.get(&STD_PROJECTILE),
+            Some(&vec![SMALL_STD_CLIP, STD_CLIP]),
+            "the authored order is preserved - the mint's tie-break and fallback"
+        );
         assert_eq!(clips.clip_sizes.get(&STD_CLIP), Some(&12));
+        assert_eq!(clips.clip_sizes.get(&SMALL_STD_CLIP), Some(&6));
     }
 
     #[test]

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -7,9 +7,14 @@ use dark::{
 use shipyard::{EntityId, Get, Unique, UniqueView, View, ViewMut, World};
 
 /// Projectile archetype -> compatible ammo-clip archetypes, authored by the
-/// Dark engine's `Clip` relation.
+/// Dark engine's `Clip` relation, plus each clip archetype's authored stack
+/// size (its effective `P$StackCount`) so an eject can mint the box that
+/// actually fits the rounds.
 #[derive(Unique, Clone, Default)]
-pub(crate) struct GlobalProjectileClips(pub HashMap<i32, Vec<i32>>);
+pub(crate) struct GlobalProjectileClips {
+    pub clips: HashMap<i32, Vec<i32>>,
+    pub clip_sizes: HashMap<i32, i32>,
+}
 
 impl GlobalProjectileClips {
     pub fn from_entity_info(entity_info: &SystemShock2EntityInfo) -> Self {
@@ -20,15 +25,13 @@ impl GlobalProjectileClips {
         // relation for every archetype so a concrete projectile child can use a
         // relation authored on its family archetype.
         //
-        // MOST-DERIVED FIRST, and that order is load-bearing: an unload mints
-        // `[0]` as the ammo type's canonical clip, so a projectile's OWN
-        // authored clip must outrank anything it merely inherits, and the
-        // data's own preference must be preserved within a template (the
-        // pistol's standard bullet lists the full Standard Clip first, the
-        // assault rifle's lists the Small Standard Clip first - each weapon
-        // family's intended default). `get_ancestors` is root-first, so it is
-        // reversed here. Compatibility checks elsewhere only test membership
-        // and are indifferent to the order.
+        // MOST-DERIVED FIRST, and that order is load-bearing: it is an unload's
+        // tie-break and its fallback when no clip has an authored size (see
+        // [`mint_clip_template`]), so a projectile's OWN authored clip must
+        // outrank anything it merely inherits, and the data's own preference
+        // must be preserved within a template. `get_ancestors` is root-first,
+        // so it is reversed here. Compatibility checks elsewhere only test
+        // membership and are indifferent to the order.
         for template_id in entity_info.entity_to_properties.keys() {
             let mut lineage = vec![*template_id];
             lineage.extend(
@@ -56,7 +59,25 @@ impl GlobalProjectileClips {
             }
         }
 
-        Self(projectile_clips)
+        // Resolve each clip archetype's authored stack size - "Small Standard
+        // Clip" holds 6, "Standard Clip" 12 - which is what an eject sizes its
+        // minted clip against.
+        let mut clip_sizes = HashMap::new();
+        for clip in projectile_clips.values().flatten() {
+            if !clip_sizes.contains_key(clip) {
+                if let Some(stack) = crate::scripts::script_util::hydrate_template_component::<
+                    PropStackCount,
+                >(*clip, entity_info)
+                {
+                    clip_sizes.insert(*clip, stack.0);
+                }
+            }
+        }
+
+        Self {
+            clips: projectile_clips,
+            clip_sizes,
+        }
     }
 }
 
@@ -84,7 +105,7 @@ fn selected_clip_templates(world: &World, weapon: EntityId) -> Option<Vec<i32>> 
     world
         .borrow::<UniqueView<GlobalProjectileClips>>()
         .ok()
-        .and_then(|clips| clips.0.get(&projectile_template).cloned())
+        .and_then(|clips| clips.clips.get(&projectile_template).cloned())
         .filter(|clips| !clips.is_empty())
 }
 
@@ -244,10 +265,13 @@ pub(crate) fn unload_to_reserve(world: &World, weapon: EntityId) -> UnloadOutcom
         .next();
 
     let Some(item) = destination else {
-        // The most-derived authored clip is the ammo type's canonical archetype.
+        let template = world
+            .borrow::<UniqueView<GlobalProjectileClips>>()
+            .map(|clips| mint_clip_template(&compatible_clip_templates, &clips.clip_sizes, loaded))
+            .unwrap_or(compatible_clip_templates[0]);
         return UnloadOutcome {
             rounds_unloaded: 0,
-            spawn_clip: Some((compatible_clip_templates[0], loaded)),
+            spawn_clip: Some((template, loaded)),
         };
     };
 
@@ -265,6 +289,33 @@ pub(crate) fn unload_to_reserve(world: &World, weapon: EntityId) -> UnloadOutcom
         rounds_unloaded: loaded,
         spawn_clip: None,
     }
+}
+
+/// The clip archetype to mint for `rounds` ejected rounds: the smallest
+/// authored box that holds them all, so the label matches the contents - an
+/// assault rifle's 30 rounds must not come back as a "Small Standard Clip"
+/// (issue #1171). When even the largest box cannot hold them, the largest is
+/// minted holding them all anyway: reserve stacks have no capacity ceiling in
+/// this port. The data's authored order breaks ties and stands in for
+/// archetypes with no authored size.
+fn mint_clip_template(clip_templates: &[i32], sizes: &HashMap<i32, i32>, rounds: i32) -> i32 {
+    let mut fitting: Option<(i32, i32)> = None;
+    let mut largest: Option<(i32, i32)> = None;
+    for &clip in clip_templates {
+        let Some(&size) = sizes.get(&clip) else {
+            continue;
+        };
+        if size >= rounds && fitting.is_none_or(|(_, best)| size < best) {
+            fitting = Some((clip, size));
+        }
+        if largest.is_none_or(|(_, best)| size > best) {
+            largest = Some((clip, size));
+        }
+    }
+    fitting
+        .or(largest)
+        .map(|(clip, _)| clip)
+        .unwrap_or(clip_templates[0])
 }
 
 /// Zero `weapon`'s magazine, once its rounds are safely somewhere else.
@@ -354,12 +405,22 @@ mod tests {
                 right_hand_entity_id: None,
                 inventory_entity_id: inventory,
             });
-            world.add_unique(GlobalProjectileClips(HashMap::from([
-                (STD_PROJECTILE, vec![STD_CLIP, SMALL_STD_CLIP]),
-                (ASSAULT_STD_PROJECTILE, vec![SMALL_STD_CLIP, STD_CLIP]),
-                (HE_PROJECTILE, vec![HE_CLIP]),
-                (PRISM_PROJECTILE, vec![SMALL_PRISM, LARGE_PRISM]),
-            ])));
+            world.add_unique(GlobalProjectileClips {
+                clips: HashMap::from([
+                    (STD_PROJECTILE, vec![STD_CLIP, SMALL_STD_CLIP]),
+                    (ASSAULT_STD_PROJECTILE, vec![SMALL_STD_CLIP, STD_CLIP]),
+                    (HE_PROJECTILE, vec![HE_CLIP]),
+                    (PRISM_PROJECTILE, vec![SMALL_PRISM, LARGE_PRISM]),
+                ]),
+                // The shipped archetypes' authored sizes.
+                clip_sizes: HashMap::from([
+                    (STD_CLIP, 12),
+                    (SMALL_STD_CLIP, 6),
+                    (HE_CLIP, 12),
+                    (SMALL_PRISM, 10),
+                    (LARGE_PRISM, 20),
+                ]),
+            });
             world.add_unique(GlobalTemplateHierarchy(HashMap::from([
                 (SMALL_STD_CLIP, vec![STD_CLIP]),
                 (EARTH_SMALL_STD_CLIP, vec![SMALL_STD_CLIP]),
@@ -683,8 +744,9 @@ mod tests {
             UnloadOutcome {
                 // Nothing has moved yet - this is a request, not a completed
                 // unload, so the rounds are still counted in the magazine.
+                // 5 rounds fit the small box, so that is the one requested.
                 rounds_unloaded: 0,
-                spawn_clip: Some((STD_CLIP, 5)),
+                spawn_clip: Some((SMALL_STD_CLIP, 5)),
             }
         );
         assert_eq!(fixture.rounds(mismatched), 6, "HE reserve is untouched");
@@ -700,11 +762,84 @@ mod tests {
 
         let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
 
-        assert_eq!(outcome.spawn_clip, Some((STD_CLIP, 5)));
+        assert_eq!(outcome.spawn_clip, Some((SMALL_STD_CLIP, 5)));
         assert_eq!(fixture.ammo(), 5, "still loaded until the clip is carried");
 
         empty_magazine(&fixture.world, fixture.weapon);
         assert_eq!(fixture.ammo(), 0);
+    }
+
+    #[test]
+    fn ejecting_more_rounds_than_any_box_holds_mints_the_largest_archetype() {
+        // Issue #1171's headline case: the assault rifle's data prefers the
+        // SMALL standard clip, but 30 rounds fit neither the 6- nor the
+        // 12-round box, so the largest must absorb them rather than labeling
+        // 30 rounds a "Small Standard Clip".
+        let mut fixture = Fixture::new(30, 0);
+        fixture.set_standard_projectile(ASSAULT_STD_PROJECTILE);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(outcome.spawn_clip, Some((STD_CLIP, 30)));
+    }
+
+    #[test]
+    fn ejecting_exactly_a_full_box_mints_that_box() {
+        // 12 rounds are exactly a full Standard Clip, even for the assault
+        // rifle whose authored order prefers the small one.
+        let mut fixture = Fixture::new(12, 0);
+        fixture.set_standard_projectile(ASSAULT_STD_PROJECTILE);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(outcome.spawn_clip, Some((STD_CLIP, 12)));
+    }
+
+    #[test]
+    fn ejecting_fewer_rounds_than_the_smallest_box_mints_the_smallest() {
+        // 6 rounds fit the Small Standard Clip exactly, even for the pistol
+        // whose authored order prefers the full-size one.
+        let fixture = Fixture::new(6, 0);
+
+        let outcome = unload_to_reserve(&fixture.world, fixture.weapon);
+
+        assert_eq!(outcome.spawn_clip, Some((SMALL_STD_CLIP, 6)));
+    }
+
+    #[test]
+    fn minting_without_authored_sizes_falls_back_to_the_authored_order() {
+        assert_eq!(
+            mint_clip_template(&[SMALL_STD_CLIP, STD_CLIP], &HashMap::new(), 7),
+            SMALL_STD_CLIP
+        );
+    }
+
+    #[test]
+    fn from_entity_info_records_each_clip_archetypes_authored_size() {
+        use dark::properties::ToTemplateLink;
+        use std::sync::Arc;
+
+        let mut entity_info = SystemShock2EntityInfo::empty();
+        entity_info
+            .entity_to_properties
+            .insert(STD_PROJECTILE, vec![]);
+        entity_info
+            .entity_to_properties
+            .insert(STD_CLIP, vec![Arc::new(Box::new(PropStackCount(12)))]);
+        entity_info.template_to_links.insert(
+            STD_PROJECTILE,
+            dark::properties::TemplateLinks {
+                to_links: vec![ToTemplateLink {
+                    link: Link::Clip,
+                    to_template_id: STD_CLIP,
+                }],
+            },
+        );
+
+        let clips = GlobalProjectileClips::from_entity_info(&entity_info);
+
+        assert_eq!(clips.clips.get(&STD_PROJECTILE), Some(&vec![STD_CLIP]));
+        assert_eq!(clips.clip_sizes.get(&STD_CLIP), Some(&12));
     }
 
     #[test]

--- a/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-eject.e2e.test.ts
@@ -22,11 +22,11 @@ import type { EntitySummary } from "../src/index.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-/** The pistol's standard clip - the archetype an ejected std magazine becomes. */
+/** The full-size standard clip (authored size 12). */
 const STD_CLIP = -31;
-/** The Assault Rifle's *first* authored standard clip, which is the SMALL one -
- * the reverse of the pistol's preference, and the case that catches an eject
- * minting a family-wide default instead of the weapon's own authored choice. */
+/** The small standard clip (authored size 6) - the Assault Rifle's *first*
+ * authored choice, which must NOT win when the ejected rounds don't fit its
+ * authored size (issue #1171). */
 const SMALL_STD_CLIP = -1358;
 
 function propOf(
@@ -161,15 +161,15 @@ test(
 );
 
 test(
-  "the ejected clip is the weapon's own authored archetype, not a family default",
+  "the ejected clip is the archetype whose authored size fits the rounds",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    // The pistol's standard bullet authors [Standard Clip, Small Standard Clip];
-    // the ASSAULT RIFLE's authors those two the other way round. Each weapon's
-    // own first choice must win, so an eject that reached for a shared family
-    // default - or that let an inherited relation outrank the projectile's own -
-    // would mint the wrong archetype here while still looking right for the
-    // pistol.
+    // The Assault Rifle's standard bullet authors [Small Standard Clip,
+    // Standard Clip] - small first. Its magazine holds far more than the small
+    // box's authored 6, so minting the data's first choice would label the
+    // ejected rounds a "Small Standard Clip" (issue #1171). The eject must
+    // instead mint the smallest archetype that holds the count - and the
+    // largest when, topped past every box size, nothing does.
     await using game = await GameServer.launch({
       mission: "debug_weapons",
     });
@@ -184,8 +184,19 @@ test(
     const rifle = (await game.info()).player.wielded_entity_id;
     assert.ok(rifle !== null, "the assault rifle should be wielded");
     assert.equal((await game.info()).player.wielded_ammo_type, "std");
+
+    // Top the rifle up past the largest box's authored size (12): a small
+    // spare clip reloads on top of the starting magazine.
+    await game.player.spawnItem(SMALL_STD_CLIP);
+    await game.input.trigger("Reload");
+    await game.step({ frames: 2 });
     const loaded = ammoOf(await game.entities.detail(rifle));
-    assert.ok(loaded > 0, "the debug assault rifle starts loaded");
+    assert.ok(loaded > 12, `the rifle holds more than any box (${loaded})`);
+    assert.equal(
+      (await carriedClips(game, SMALL_STD_CLIP)).length,
+      0,
+      "the spare was consumed - the eject has nothing to merge into",
+    );
 
     await game.input.trigger("CycleAmmo");
     await game.step({ frames: 2 });
@@ -194,11 +205,11 @@ test(
     const small = await carriedClips(game, SMALL_STD_CLIP);
     const full = await carriedClips(game, STD_CLIP);
     assert.equal(
-      full.length,
+      small.length,
       0,
-      "the pistol's full-size Standard Clip is NOT the assault rifle's choice",
+      "the rifle's first authored choice, the small box, cannot hold the rounds",
     );
-    assert.equal(small.length, 1, "the assault rifle ejects into its own Small Standard Clip");
-    assert.equal(stackOf(await game.entities.detail(small[0].id)), loaded);
+    assert.equal(full.length, 1, "the largest box absorbs the whole magazine");
+    assert.equal(stackOf(await game.entities.detail(full[0].id)), loaded);
   },
 );


### PR DESCRIPTION
Fixes #1171

## Choice: (a) mint the smallest archetype whose authored size fits — extended with "largest when none fits"

The three options from the issue, against the shipped data (each bullet family authors a small and a full box: Standard/AP/HE 6 and 12, prisms 10 and 20):

- **(a) prefer the smallest archetype that fits the count** — chosen. It is the smallest faithful change: the mint site already picks from the projectile's authored `Clip` relation; it just picked by authored order instead of by size. Since a full assault-rifle magazine (36, starts at 12 and reloads well past 12) exceeds even the largest bullet box, (a) needs one extension: when nothing fits, mint the **largest** archetype holding all the rounds anyway.
- **(b) split into multiple minted clips** would contradict the port's reserve model everywhere else — reserve stacks have no capacity ceiling (pickup never caps them, `load_from_reserve` drains without one, an eject **merges unconditionally** into an existing stack, deliberately, per #1145). Minting three entities where a merge would have made one stack also clutters the backpack and adds entity churn for no player benefit.
- **(c) restyle the label** treats the symptom: the entity would still *be* the wrong archetype (wrong sym-name, wrong identity for anything that filters by template).

So the overflow case still over-stuffs one box (a "Standard Clip" holding 18) — exactly as an eject into an existing reserve stack already does, and the displayed name interpolates the true count (`"%d standard bullets"`).

## What changed

- `GlobalProjectileClips` now also records each clip archetype's authored stack size (its effective `P$StackCount`, resolved through template inheritance via `hydrate_template_component`).
- New `mint_clip_template`: smallest authored box that holds the ejected rounds; largest when none does; the data's authored order breaks ties and stands in for archetypes with no authored size.
- `unload_to_reserve`'s mint branch selects through it instead of taking `compatible_clip_templates[0]`. The merge path, reload path, and `give_ejected_clip` are untouched.

## Tests

Negative-first: the three new unit tests fail on main (`left: Some((-1358, 30))` — 30 rounds minted as the 6-round Small Standard Clip) and pass with the fix:

- eject 30 (more than any box) with the assault rifle's small-first authored order → full `Standard Clip`;
- eject exactly 12 → the 12-round box, small-first order notwithstanding;
- eject 6 on the pistol (full-first order) → `Small Standard Clip`;
- plus: sizeless archetypes fall back to authored order, and a `from_entity_info` test pinning the recorded sizes.

Two prior tests asserting a 5-round eject requested the full-size clip now expect the small one — that flip *is* the fix.

**e2e** (`weapon-ammo-eject`): the archetype-pinning scenario inverted — it previously asserted the buggy behavior (rifle ejects into `Small Standard Clip` because that is its first authored choice). It now tops the rifle past every box size (spawn a small clip, reload → 18 loaded), ejects, and asserts one full `Standard Clip` holding all 18 and zero small clips.

- `cargo test -p shock2vr --lib`: 1135 passed, 0 failed (1130 on main)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean
- e2e: `weapon-ammo-eject` 2/2, `weapon-reload` 1/1, `weapon-ammo-type` 1/1, `vr-weapon-reload` 2/2, `missions` **23/23**

## Review

xreview ran with the Claude adversarial reviewer plus the dedicated de-dup pass (the Codex engine was unavailable - usage limit). No Critical/High findings; de-dup pass: no actionable duplication. Mediums addressed as follows:

- *"Smallest-that-fits downgrades a 5-round pistol eject to the small clip"* - deliberate, this is exactly option (a) from the issue; the archetype now describes the contents instead of the weapon's default, and reload accepts either sibling.
- *"The merge path can still grow a Small Standard Clip past 6"* - pre-existing, deliberate reserve semantics from #1145 (uncapped stacks, unconditional merge); the mint fix doesn't change it, and re-picking merge targets by size would shuffle stacks the player already carries.
- *"Authored-order coverage weakened"* - the order is now the tie-break/fallback rather than the choice; it stays pinned by the extended `from_entity_info` test and the sizeless-fallback test.
- Two Lows fixed in the follow-up commit (hydrate each clip archetype once, not per referencing projectile; test-order pinning above); the unreachable-`unwrap_or` note kept as harmless defense.
