### PR TITLE
fix(ui): fill the loading bar from the deferred transition's checkpoints

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -864,6 +864,15 @@ fn run_game_blocking(
             }
             accumulated_time
         } else {
+            // Pace the paused deferred-transition pump to the fixed frame rate.
+            // Without this the loop spins zero-dt updates flat out, racing the
+            // loading screen's frame-counted minimum/hold through in about a
+            // millisecond (and pinning a core) - so its progress checkpoints
+            // could never be observed via /v1/screenshot, unlike on the real
+            // runtimes where update runs once per presented frame.
+            if game.has_pending_transition() {
+                thread::sleep(Duration::from_secs_f32(FIXED_STEP_DT));
+            }
             // When paused, use zero delta time to prevent any updates
             let zero_time = Time {
                 elapsed: Duration::from_secs_f32(0.0),

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -869,7 +869,9 @@ fn run_game_blocking(
             // loading screen's frame-counted minimum/hold through in about a
             // millisecond (and pinning a core) - so its progress checkpoints
             // could never be observed via /v1/screenshot, unlike on the real
-            // runtimes where update runs once per presented frame.
+            // runtimes where update runs once per presented frame. Trade-off:
+            // commands are polled at the top of the loop, so any /v1 request
+            // arriving mid-transition waits up to one fixed step extra.
             if game.has_pending_transition() {
                 thread::sleep(Duration::from_secs_f32(FIXED_STEP_DT));
             }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -424,11 +424,35 @@ struct PendingTransition {
     /// the debug runtime's zero-dt stepping). A minimum display so the loading screen is
     /// shown for a perceptible moment even if the parse finishes very quickly.
     frames_shown: u32,
+    /// `frames_shown` when the worker parse was first observed finished. Drives the
+    /// coarse checkpoint fill of the loading bar ([`transition_progress`]).
+    parse_done_frame: Option<u32>,
 }
 
 /// Minimum number of frames to show the loading screen before swapping to the mission,
 /// even if the background parse finished sooner. ~0.4s at 60fps.
 const MIN_LOADING_FRAMES: u32 = 24;
+
+/// Coarse checkpoint fill for the loading bar. The transition has two real phases -
+/// the worker-thread parse and the main-thread build - and the original art draws
+/// "% Transfer Completed" with no numeric readout, so a stepped fill is faithful.
+const PROGRESS_PARSING: f32 = 0.25;
+const PROGRESS_PARSE_DONE: f32 = 0.65;
+/// Shown just before the blocking build, which submits no frames; the bar sits here
+/// until the built mission swaps in.
+const PROGRESS_BUILDING: f32 = 0.9;
+/// Frames the parse-done fill is held (and rendered) before the build is allowed to
+/// start, so the bar's advance is visible instead of swallowed by the frozen build.
+const PARSE_DONE_HOLD_FRAMES: u32 = 6;
+
+/// Map the deferred transition's checkpoints to the loading-bar fill.
+fn transition_progress(frames_shown: u32, parse_done_frame: Option<u32>) -> f32 {
+    match parse_done_frame {
+        None => PROGRESS_PARSING,
+        Some(done) if frames_shown < done + PARSE_DONE_HOLD_FRAMES => PROGRESS_PARSE_DONE,
+        Some(_) => PROGRESS_BUILDING,
+    }
+}
 
 pub struct Game {
     options: GameOptions,
@@ -848,6 +872,7 @@ impl Game {
             player_vitals,
             parse_handle,
             frames_shown: 0,
+            parse_done_frame: None,
         });
     }
 
@@ -1346,11 +1371,25 @@ impl Game {
         // has shown for its minimum, run the main-thread build and swap to the mission.
         if let Some(pending) = self.pending_transition.as_mut() {
             pending.frames_shown += 1;
-            let ready =
-                pending.parse_handle.is_finished() && pending.frames_shown >= MIN_LOADING_FRAMES;
+            if pending.parse_done_frame.is_none() && pending.parse_handle.is_finished() {
+                pending.parse_done_frame = Some(pending.frames_shown);
+            }
+            let progress = transition_progress(pending.frames_shown, pending.parse_done_frame);
+            // Build only after the parse-done fill has been held on screen (see
+            // PARSE_DONE_HOLD_FRAMES) and the minimum display has elapsed.
+            let ready = pending
+                .parse_done_frame
+                .is_some_and(|done| pending.frames_shown > done + PARSE_DONE_HOLD_FRAMES)
+                && pending.frames_shown >= MIN_LOADING_FRAMES;
             if ready {
                 let pending = self.pending_transition.take().unwrap();
                 self.finish_transition(pending);
+            } else if let Some(scene) = self
+                .active_game_scene
+                .as_any_mut()
+                .and_then(|scene| scene.downcast_mut::<LoadingScene>())
+            {
+                scene.set_progress(progress);
             }
         }
 
@@ -2289,6 +2328,26 @@ mod tests {
 
     fn features(list: &[&str]) -> HashSet<String> {
         list.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The bar steps through the coarse transition checkpoints (#1005): parsing,
+    /// parse done (held so it renders), then just-before-build.
+    #[test]
+    fn transition_progress_steps_through_checkpoints() {
+        // Worker parse still running.
+        assert_eq!(transition_progress(1, None), PROGRESS_PARSING);
+        assert_eq!(transition_progress(500, None), PROGRESS_PARSING);
+        // Parse finished at frame 10: held at the parse-done fill...
+        assert_eq!(transition_progress(10, Some(10)), PROGRESS_PARSE_DONE);
+        assert_eq!(
+            transition_progress(10 + PARSE_DONE_HOLD_FRAMES - 1, Some(10)),
+            PROGRESS_PARSE_DONE
+        );
+        // ...then the build fill once the hold elapses.
+        assert_eq!(
+            transition_progress(10 + PARSE_DONE_HOLD_FRAMES, Some(10)),
+            PROGRESS_BUILDING
+        );
     }
 
     /// On by default on every platform since the Quest measurement (#1022).

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -439,11 +439,14 @@ const MIN_LOADING_FRAMES: u32 = 24;
 const PROGRESS_PARSING: f32 = 0.25;
 const PROGRESS_PARSE_DONE: f32 = 0.65;
 /// Shown just before the blocking build, which submits no frames; the bar sits here
-/// until the built mission swaps in.
+/// until the built mission swaps in. It stays visible only because the build blocks
+/// presentation, so the last rendered frame persists (the desktop window keeps it,
+/// the Quest compositor reprojects it).
 const PROGRESS_BUILDING: f32 = 0.9;
 /// Frames the parse-done fill is held (and rendered) before the build is allowed to
-/// start, so the bar's advance is visible instead of swallowed by the frozen build.
-/// ~0.2s at 60fps.
+/// start. A deliberate ~0.2s (at 60fps) added to every transition: without at least
+/// one rendered frame per later checkpoint, `finish_transition` would run the same
+/// frame the parse ends and the frozen build would display the parsing fill forever.
 const PARSE_DONE_HOLD_FRAMES: u32 = 12;
 
 /// Map the deferred transition's checkpoints to the loading-bar fill.
@@ -453,6 +456,14 @@ fn transition_progress(frames_shown: u32, parse_done_frame: Option<u32>) -> f32 
         Some(done) if frames_shown < done + PARSE_DONE_HOLD_FRAMES => PROGRESS_PARSE_DONE,
         Some(_) => PROGRESS_BUILDING,
     }
+}
+
+/// Whether the deferred transition may run its blocking build this frame. Strictly
+/// *after* the hold, not at it: the frame at `done + PARSE_DONE_HOLD_FRAMES` must
+/// still render, because it is the one that shows [`PROGRESS_BUILDING`].
+fn transition_ready(frames_shown: u32, parse_done_frame: Option<u32>) -> bool {
+    parse_done_frame.is_some_and(|done| frames_shown > done + PARSE_DONE_HOLD_FRAMES)
+        && frames_shown >= MIN_LOADING_FRAMES
 }
 
 pub struct Game {
@@ -863,7 +874,12 @@ impl Game {
             Mission::parse(&**asset_paths, &base_path, &parse_name, &global_context)
         });
 
-        self.set_active_scene(Box::new(LoadingScene::new()));
+        // Start the bar at the parsing fill: `begin_transition` runs after this
+        // frame's pending-transition block, so a fresh scene's 0.0 would render
+        // for one frame before the first checkpoint lands.
+        let mut loading_scene = LoadingScene::new();
+        loading_scene.set_progress(PROGRESS_PARSING);
+        self.set_active_scene(Box::new(loading_scene));
         self.pending_transition = Some(PendingTransition {
             level_name,
             spawn_loc,
@@ -1376,12 +1392,7 @@ impl Game {
                 pending.parse_done_frame = Some(pending.frames_shown);
             }
             let progress = transition_progress(pending.frames_shown, pending.parse_done_frame);
-            // Build only after the parse-done fill has been held on screen (see
-            // PARSE_DONE_HOLD_FRAMES) and the minimum display has elapsed.
-            let ready = pending
-                .parse_done_frame
-                .is_some_and(|done| pending.frames_shown > done + PARSE_DONE_HOLD_FRAMES)
-                && pending.frames_shown >= MIN_LOADING_FRAMES;
+            let ready = transition_ready(pending.frames_shown, pending.parse_done_frame);
             if ready {
                 let pending = self.pending_transition.take().unwrap();
                 self.finish_transition(pending);
@@ -2349,6 +2360,25 @@ mod tests {
             transition_progress(10 + PARSE_DONE_HOLD_FRAMES, Some(10)),
             PROGRESS_BUILDING
         );
+    }
+
+    /// The build checkpoint must actually render: the last frame before
+    /// `transition_ready` fires shows PROGRESS_BUILDING. Weakening `ready`'s
+    /// strict `>` to `>=` would silently delete the 0.9 state (#1005).
+    #[test]
+    fn the_build_fill_renders_before_the_transition_finishes() {
+        let done = MIN_LOADING_FRAMES; // parse finished after the minimum display
+        let last_shown = done + PARSE_DONE_HOLD_FRAMES;
+        assert!(!transition_ready(last_shown, Some(done)));
+        assert_eq!(
+            transition_progress(last_shown, Some(done)),
+            PROGRESS_BUILDING
+        );
+        assert!(transition_ready(last_shown + 1, Some(done)));
+        // The minimum display still gates a fast parse.
+        assert!(!transition_ready(MIN_LOADING_FRAMES - 1, Some(1)));
+        // And an unfinished parse is never ready.
+        assert!(!transition_ready(1000, None));
     }
 
     /// On by default on every platform since the Quest measurement (#1022).

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -443,7 +443,8 @@ const PROGRESS_PARSE_DONE: f32 = 0.65;
 const PROGRESS_BUILDING: f32 = 0.9;
 /// Frames the parse-done fill is held (and rendered) before the build is allowed to
 /// start, so the bar's advance is visible instead of swallowed by the frozen build.
-const PARSE_DONE_HOLD_FRAMES: u32 = 6;
+/// ~0.2s at 60fps.
+const PARSE_DONE_HOLD_FRAMES: u32 = 12;
 
 /// Map the deferred transition's checkpoints to the loading-bar fill.
 fn transition_progress(frames_shown: u32, parse_done_frame: Option<u32>) -> f32 {

--- a/shock2vr/src/scenes/loading.rs
+++ b/shock2vr/src/scenes/loading.rs
@@ -12,7 +12,8 @@
 //!
 //! The rotation is driven by the frame clock (always animates). The bar fill is
 //! driven by `progress`: `new_demo()` sweeps it for visual inspection via the
-//! `debug_loading` scene; real background loading (PR 3) calls `set_progress`.
+//! `debug_loading` scene; a real transition sets it from the deferred-transition
+//! checkpoints (`Game::update` via `set_progress`).
 
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
 use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
@@ -107,7 +108,7 @@ impl LoadingScene {
         }
     }
 
-    /// Set the load progress (0..=1). Used by the background loader in PR 3.
+    /// Set the load progress (0..=1). Driven by the deferred transition's checkpoints.
     pub fn set_progress(&mut self, progress: f32) {
         self.progress = progress.clamp(0.0, 1.0);
     }
@@ -240,6 +241,12 @@ impl GameScene for LoadingScene {
 
     fn scene_name(&self) -> &str {
         &self.scene_name
+    }
+
+    /// So `Game::update` can reach [`LoadingScene::set_progress`] through the
+    /// active-scene box during a deferred transition.
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
     }
 }
 


### PR DESCRIPTION
Fixes #1005

The real transition path never called `LoadingScene::set_progress`, so the "% Transfer Completed" bar sat empty for every real load — only `debug_loading`'s demo sweep ever filled it. This drives the bar from the coarse checkpoints the deferred transition already has (the original art has no numeric readout, so a stepped fill is faithful):

| Checkpoint | Fill |
| --- | --- |
| worker-thread parse running | 0.25 |
| parse finished (held ~0.2 s so it renders) | 0.65 |
| just before the blocking main-thread build | 0.90 |

- `transition_progress` / `transition_ready` are pure functions (unit-tested, including the invariant that the 0.9 fill renders on the last frame before the build — `ready`'s strict `>` is what buys that frame).
- The fresh `LoadingScene` is seeded at the parsing fill so the first frame doesn't flash an empty bar.
- The `PARSE_DONE_HOLD_FRAMES` hold is a deliberate ~0.2 s added per transition: without at least one rendered frame per later checkpoint, `finish_transition` would run the same frame the parse ends and the frozen build would show the parsing fill forever.
- The debug runtime's paused transition pump previously spun zero-dt updates flat out (racing the loading screen's frame-counted timing through in ~1 ms while pinning a core); it now sleeps one fixed step per pumped frame, so the checkpoints are observable via `/v1/screenshot` like on the real runtimes.

The build phase itself submits no frames, so the bar necessarily freezes at 0.9 until the mission swaps in — the 0.9 frame persists on screen (desktop keeps the last frame, Quest reprojects it).

Verified headlessly in **both presentations** (flat and `--vr`): `DebugReloadLevel` on medsci1 with `--experimental loading_screen`, rapid `/v1/screenshot` sampling. Measured fill extents step 78 px → 201 px → 278 px of the 308 px bar (= 0.25 / 0.65 / 0.90) in both, identical fractions flat vs VR; on `main` the same run measures an empty bar. Unit tests pass, loading e2e tests pass (`vr-loading-panel`, `transition-level`), and all 23 missions load (`missions.e2e`).

![loading bar filling during a real reload](https://gist.githubusercontent.com/tommy-xr/91b448755e044feba912594d54e08230/raw/demo.gif)

<sub>A real `DebugReloadLevel` transition of medsci1 (flat): 25% while the worker parse runs, 65% once it finishes, 90% just before the build, then the mission. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/91b448755e044feba912594d54e08230/raw/beforeafter.png)

## Checkpoints, flat and VR

![checkpoints in both presentations](https://gist.githubusercontent.com/tommy-xr/91b448755e044feba912594d54e08230/raw/checkpoints.png)
