### PR TITLE
feat(ui): launch missions from the developer menu

### DIFF
--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -118,10 +118,14 @@ pub enum SceneTab {
 impl SceneTab {
     const ALL: [SceneTab; 2] = [SceneTab::Missions, SceneTab::DebugScenes];
 
+    /// Both labels together must fit the 202px header the tabs split -
+    /// "Debug Scenes" measured ~139px in the menu font and overprinted its
+    /// neighbour, hence the short form (drawn `_fit` besides, so a wide label
+    /// can never spill into the other tab again).
     fn label(self) -> &'static str {
         match self {
             SceneTab::Missions => "Missions",
-            SceneTab::DebugScenes => "Debug Scenes",
+            SceneTab::DebugScenes => "Debug",
         }
     }
 }
@@ -357,8 +361,6 @@ impl DeveloperScene {
             page: DeveloperPage::Params,
             tab: SceneTab::Missions,
             missions: Vec::new(),
-            // Preselect the first entry so "Launch" is immediately meaningful,
-            // the way the load screen preselects the most recent save.
             scene_scroll: 0,
             selected_scene: None,
         }
@@ -442,8 +444,11 @@ impl DeveloperScene {
                 for tab in SceneTab::ALL {
                     let active =
                         self.tab == tab || hovered == Some(DeveloperAction::SelectTab(tab));
+                    // `_fit` so a label stays inside its own half of the
+                    // header - drawn wider it would overprint the other tab
+                    // while the rect-based hit test kept the boundary.
                     canvas
-                        .text_native(
+                        .text_native_fit(
                             tab_rect(self.panel_rects, tab),
                             tab.label(),
                             MENU_FONT,
@@ -455,14 +460,20 @@ impl DeveloperScene {
 
                 let len = self.tab_list_len();
                 let rows = scene_visible_rows(self.panel_rects, len, self.scene_scroll);
-                for slot in 0..rows.len() {
-                    let Some(name) = self.tab_name(rows.start + slot) else {
-                        break;
-                    };
+                // The visible page's names, resolved once (not per row).
+                let names: Vec<String> = match self.tab {
+                    SceneTab::Missions => self.missions[rows.clone()].to_vec(),
+                    SceneTab::DebugScenes => super::debug_scene_names()
+                        .skip(rows.start)
+                        .take(rows.len())
+                        .map(str::to_owned)
+                        .collect(),
+                };
+                for (slot, name) in names.iter().enumerate() {
                     canvas
                         .text_native_fit(
                             scene_text_rect(self.panel_rects, len, slot),
-                            &name,
+                            name,
                             LIST_FONT,
                             HAlign::Left,
                             VAlign::Middle,
@@ -542,13 +553,9 @@ impl DeveloperScene {
                     // launching from here is the new-game boot with the level
                     // swapped: default spawn, vitals from the destination map.
                     SceneTab::Missions => {
-                        vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
-                            level_file: name,
-                            loc: None,
-                            entities_to_trigger: vec![],
-                            vitals_transition:
-                                crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
-                        })]
+                        vec![Effect::GlobalEffect(GlobalEffect::new_game_transition(
+                            name,
+                        ))]
                     }
                     SceneTab::DebugScenes => {
                         vec![Effect::GlobalEffect(GlobalEffect::LaunchDebugScene {
@@ -1018,7 +1025,11 @@ mod tests {
                 "tab {tab:?}"
             );
         }
-        assert!(tab_rect(rects, SceneTab::Missions).x < tab_rect(rects, SceneTab::DebugScenes).x);
+        // The halves are disjoint - a draw kept inside its own rect (`_fit`)
+        // can therefore never overprint the other tab or its click target.
+        let missions = tab_rect(rects, SceneTab::Missions);
+        let debug = tab_rect(rects, SceneTab::DebugScenes);
+        assert!(missions.x + missions.w <= debug.x);
 
         let mut scene = DeveloperScene::new();
         scene.page = DeveloperPage::Scenes;

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -338,23 +338,12 @@ pub struct DeveloperScene {
     selected_scene: Option<usize>,
 }
 
-/// The `*.mis` files in the data root, sorted by name. Read when the launcher
-/// opens, so a changed install shows up without a restart.
+/// The install's missions, sorted by name - loose `.mis` files on a classic
+/// install, the archived `data/*.mis` entries on a 25AE one
+/// ([`crate::data_files::mission_names`]). Read when the launcher opens, so a
+/// changed install shows up without a restart.
 fn mission_files() -> Vec<String> {
-    let mut names: Vec<String> = std::fs::read_dir(crate::paths::data_root())
-        .into_iter()
-        .flatten()
-        .flatten()
-        .filter_map(|entry| {
-            let name = entry.file_name().into_string().ok()?;
-            std::path::Path::new(&name)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("mis"))
-                .then_some(name)
-        })
-        .collect();
-    names.sort_by_key(|name| name.to_ascii_lowercase());
-    names
+    crate::data_files::mission_names(&crate::paths::data_root())
 }
 
 impl DeveloperScene {

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -7,12 +7,14 @@
 //! pause overlay hosts the very same builder as its Developer page, so the
 //! screen is identical whichever way it is reached.
 //!
-//! The screen has a second page: a list of the debug scenes, reached from the
-//! upper framed button (the load screen's "Load" frame) and returning to the
-//! parameters with its own "Done". It exists because a headset picks its scene
-//! from a file read at startup, so without an in-game entry point every change
-//! of debug scene - or every death inside one - costs an APK relaunch. The
-//! names come from the same registry `--mission debug_x` dispatches from
+//! The screen has a second page: a launcher, reached from the upper framed
+//! button (the load screen's "Load" frame) and returning to the parameters
+//! with its own "Done". It exists because a headset picks its scene from a
+//! file read at startup, so without an in-game entry point every change of
+//! scene - or every death inside one - costs an APK relaunch. Two tabs share
+//! the one list: "Missions" enumerates the `*.mis` files in the data root and
+//! launches through the same `TransitionLevel` the main menu's New Game uses;
+//! "Debug Scenes" lists the registry `--mission debug_x` dispatches from
 //! ([`crate::scenes::debug_scene_names`]), so the launcher cannot drift from
 //! what the game can actually start.
 //!
@@ -88,7 +90,6 @@ const DISABLED_OPACITY: f32 = 0.3;
 const IDLE_OPACITY: f32 = 0.65;
 const ACTIVE_OPACITY: f32 = 1.0;
 
-const SCENES_HEADER_LABEL: &str = "Select a debug scene.";
 /// The upper framed button: the launcher's door on the parameters page, and
 /// the launch itself on the launcher page.
 const OPEN_SCENES_LABEL: &str = "Scenes";
@@ -100,8 +101,29 @@ const DONE_LABEL: &str = "Done";
 pub enum DeveloperPage {
     /// The tunable parameter rows ([`dev_params_panel`]).
     Params,
-    /// The debug-scene launcher.
+    /// The mission / debug-scene launcher.
     Scenes,
+}
+
+/// Which list the launcher shows. The tabs live in the header rect, so they
+/// cost no pane space and the list machinery below them is shared.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SceneTab {
+    /// The `*.mis` files in the data root.
+    Missions,
+    /// The debug-scene registry.
+    DebugScenes,
+}
+
+impl SceneTab {
+    const ALL: [SceneTab; 2] = [SceneTab::Missions, SceneTab::DebugScenes];
+
+    fn label(self) -> &'static str {
+        match self {
+            SceneTab::Missions => "Missions",
+            SceneTab::DebugScenes => "Debug Scenes",
+        }
+    }
 }
 
 /// What a click on the screen asks for, whichever page it landed on.
@@ -109,11 +131,13 @@ pub enum DeveloperPage {
 pub enum DeveloperAction {
     /// Something on the parameter page: a step, its scroll, or "Done".
     Param(DevParamsEvent),
-    /// Open the debug-scene launcher.
+    /// Open the launcher.
     OpenScenes,
-    /// Highlight the debug scene at this index in the registry.
+    /// Show this tab's list in the launcher.
+    SelectTab(SceneTab),
+    /// Highlight the entry at this index in the showing tab's list.
     SelectScene(usize),
-    /// Launch the highlighted debug scene.
+    /// Launch the highlighted entry.
     LaunchScene,
     /// Scroll the launcher's list.
     ScrollScenes(ScrollHalf),
@@ -130,9 +154,12 @@ struct ScreenState {
     rects: PanelRects,
     /// Registry index drawn in the parameter pane's top row.
     scroll: usize,
-    /// Registry index drawn in the launcher's top row.
+    /// How many entries the launcher's showing tab lists - the only thing the
+    /// shared list geometry needs to know about the data source.
+    list_len: usize,
+    /// List index drawn in the launcher's top row.
     scene_scroll: usize,
-    /// Whether a scene row is highlighted - "Launch" is inert without one,
+    /// Whether a row is highlighted - "Launch" is inert without one,
     /// exactly as the load screen's "Load" is.
     has_selection: bool,
 }
@@ -146,27 +173,47 @@ fn scene_rows_per_page(rects: PanelRects) -> usize {
     list_scroll::rows_per_page(rects.list_rect(), FIELD_TOP_Y, SCENE_ROW_H)
 }
 
-fn scene_max_scroll(rects: PanelRects) -> usize {
-    list_scroll::max_scroll(scene_count(), scene_rows_per_page(rects))
+fn scene_max_scroll(rects: PanelRects, len: usize) -> usize {
+    list_scroll::max_scroll(len, scene_rows_per_page(rects))
 }
 
-/// The registry indices on screen at `scene_scroll`, clamped to the page.
-fn scene_visible_rows(rects: PanelRects, scene_scroll: usize) -> std::ops::Range<usize> {
-    list_scroll::visible_rows(scene_count(), scene_rows_per_page(rects), scene_scroll)
+/// The list indices on screen at `scene_scroll`, clamped to the page.
+fn scene_visible_rows(
+    rects: PanelRects,
+    len: usize,
+    scene_scroll: usize,
+) -> std::ops::Range<usize> {
+    list_scroll::visible_rows(len, scene_rows_per_page(rects), scene_scroll)
 }
 
 /// The launcher's scroll rocker, in the gutter down the pane's right edge -
 /// the very same one the parameter page scrolls with.
-fn scene_rocker(rects: PanelRects) -> Option<list_scroll::Rocker> {
-    list_scroll::rocker(rects.list_rect(), FIELD_TOP_Y, scene_max_scroll(rects) > 0)
+fn scene_rocker(rects: PanelRects, len: usize) -> Option<list_scroll::Rocker> {
+    list_scroll::rocker(
+        rects.list_rect(),
+        FIELD_TOP_Y,
+        scene_max_scroll(rects, len) > 0,
+    )
+}
+
+/// The canvas rect of the tab header for `tab`: the header rect split in two,
+/// so the tabs ride the backdrop's authored header line in both presentations.
+fn tab_rect(rects: PanelRects, tab: SceneTab) -> Rect {
+    let header = rects.header_rect();
+    let half = header.w / 2.0;
+    let x = match tab {
+        SceneTab::Missions => header.x,
+        SceneTab::DebugScenes => header.x + half,
+    };
+    Rect::new(x, header.y, half, header.h)
 }
 
 /// The canvas rect of the launcher's `slot`-th visible row. The rows stop
 /// short of the scroll gutter whenever it is in use, so a row and the rocker
 /// can never claim the same point.
-fn scene_row_rect(rects: PanelRects, slot: usize) -> Rect {
+fn scene_row_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
     let list = rects.list_rect();
-    let gutter = if scene_max_scroll(rects) > 0 {
+    let gutter = if scene_max_scroll(rects, len) > 0 {
         list_scroll::GUTTER_W
     } else {
         0.0
@@ -179,9 +226,9 @@ fn scene_row_rect(rects: PanelRects, slot: usize) -> Rect {
     )
 }
 
-/// The rect a scene name is drawn in: the row, inset on both edges.
-fn scene_text_rect(rects: PanelRects, slot: usize) -> Rect {
-    let row = scene_row_rect(rects, slot);
+/// The rect a row's name is drawn in: the row, inset on both edges.
+fn scene_text_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
+    let row = scene_row_rect(rects, len, slot);
     Rect::new(
         row.x + SCENE_TEXT_INSET,
         row.y,
@@ -202,6 +249,12 @@ fn hit(state: ScreenState, point: Vector2<f32>) -> Option<DeveloperAction> {
             dev_params_panel::hit(state.rects, state.scroll, point).map(DeveloperAction::Param)
         }
         DeveloperPage::Scenes => {
+            if let Some(tab) = SceneTab::ALL
+                .into_iter()
+                .find(|tab| tab_rect(state.rects, *tab).contains(point))
+            {
+                return Some(DeveloperAction::SelectTab(tab));
+            }
             // "Launch" is inert with nothing selected rather than launching
             // whatever happens to be first.
             if state.has_selection && state.rects.action_rect().contains(point) {
@@ -210,19 +263,22 @@ fn hit(state: ScreenState, point: Vector2<f32>) -> Option<DeveloperAction> {
             if state.rects.done_rect().contains(point) {
                 return Some(DeveloperAction::CloseScenes);
             }
-            let rows = scene_visible_rows(state.rects, state.scene_scroll);
-            if let Some(rocker) = scene_rocker(state.rects) {
-                if let Some(half) =
-                    list_scroll::hit(&rocker, rows.start, scene_max_scroll(state.rects), point)
-                {
+            let rows = scene_visible_rows(state.rects, state.list_len, state.scene_scroll);
+            if let Some(rocker) = scene_rocker(state.rects, state.list_len) {
+                if let Some(half) = list_scroll::hit(
+                    &rocker,
+                    rows.start,
+                    scene_max_scroll(state.rects, state.list_len),
+                    point,
+                ) {
                     return Some(DeveloperAction::ScrollScenes(half));
                 }
             }
-            // Rows carry the index of the scene scrolled into that slot, never
-            // the slot itself: a positional index would launch whatever scene
+            // Rows carry the index of the entry scrolled into that slot, never
+            // the slot itself: a positional index would launch whatever entry
             // *used* to be in the row the moment the list scrolls.
             (0..rows.len())
-                .find(|slot| scene_row_rect(state.rects, *slot).contains(point))
+                .find(|slot| scene_row_rect(state.rects, state.list_len, *slot).contains(point))
                 .map(|slot| DeveloperAction::SelectScene(rows.start + slot))
         }
     }
@@ -271,10 +327,34 @@ pub struct DeveloperScene {
     scroll: usize,
     /// Which page is showing.
     page: DeveloperPage,
-    /// Index of the debug scene drawn in the launcher's top row.
+    /// Which of the launcher's tabs is showing.
+    tab: SceneTab,
+    /// The `*.mis` files the Missions tab lists, enumerated from the data
+    /// root when the launcher opens.
+    missions: Vec<String>,
+    /// Index of the entry drawn in the launcher's top row.
     scene_scroll: usize,
-    /// The highlighted debug scene, as an index into the registry.
+    /// The highlighted entry, as an index into the showing tab's list.
     selected_scene: Option<usize>,
+}
+
+/// The `*.mis` files in the data root, sorted by name. Read when the launcher
+/// opens, so a changed install shows up without a restart.
+fn mission_files() -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(crate::paths::data_root())
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().into_string().ok()?;
+            std::path::Path::new(&name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("mis"))
+                .then_some(name)
+        })
+        .collect();
+    names.sort_by_key(|name| name.to_ascii_lowercase());
+    names
 }
 
 impl DeveloperScene {
@@ -286,11 +366,37 @@ impl DeveloperScene {
             panel_rects: PanelRects::default(),
             scroll: 0,
             page: DeveloperPage::Params,
-            // Preselect the first scene so "Launch" is immediately meaningful,
+            tab: SceneTab::Missions,
+            missions: Vec::new(),
+            // Preselect the first entry so "Launch" is immediately meaningful,
             // the way the load screen preselects the most recent save.
             scene_scroll: 0,
-            selected_scene: (scene_count() > 0).then_some(0),
+            selected_scene: None,
         }
+    }
+
+    /// How many entries the showing tab lists.
+    fn tab_list_len(&self) -> usize {
+        match self.tab {
+            SceneTab::Missions => self.missions.len(),
+            SceneTab::DebugScenes => scene_count(),
+        }
+    }
+
+    /// The name of the showing tab's `index`-th entry.
+    fn tab_name(&self, index: usize) -> Option<String> {
+        match self.tab {
+            SceneTab::Missions => self.missions.get(index).cloned(),
+            SceneTab::DebugScenes => super::debug_scene_names().nth(index).map(str::to_owned),
+        }
+    }
+
+    /// Reset the launcher's list to its top with the first entry highlighted -
+    /// on opening it and on switching tabs, so a stale index can never point
+    /// into the other tab's list.
+    fn reset_list(&mut self) {
+        self.scene_scroll = 0;
+        self.selected_scene = (self.tab_list_len() > 0).then_some(0);
     }
 
     /// Everything a click on this frame depends on, in one value shared by the
@@ -300,6 +406,7 @@ impl DeveloperScene {
             page: self.page,
             rects: self.panel_rects,
             scroll: self.scroll,
+            list_len: self.tab_list_len(),
             scene_scroll: self.scene_scroll,
             has_selection: self.selected_scene.is_some(),
         }
@@ -341,24 +448,32 @@ impl DeveloperScene {
                 );
             }
             DeveloperPage::Scenes => {
-                canvas.text_native(
-                    self.panel_rects.header_rect(),
-                    SCENES_HEADER_LABEL,
-                    MENU_FONT,
-                    HAlign::Center,
-                    VAlign::Middle,
-                );
+                // The tabs ride the header line: the showing one at full
+                // opacity, the other at the buttons' idle level.
+                for tab in SceneTab::ALL {
+                    let active =
+                        self.tab == tab || hovered == Some(DeveloperAction::SelectTab(tab));
+                    canvas
+                        .text_native(
+                            tab_rect(self.panel_rects, tab),
+                            tab.label(),
+                            MENU_FONT,
+                            HAlign::Center,
+                            VAlign::Middle,
+                        )
+                        .opacity(if active { ACTIVE_OPACITY } else { IDLE_OPACITY });
+                }
 
-                let rows = scene_visible_rows(self.panel_rects, self.scene_scroll);
-                for (slot, name) in super::debug_scene_names()
-                    .skip(rows.start)
-                    .take(rows.len())
-                    .enumerate()
-                {
+                let len = self.tab_list_len();
+                let rows = scene_visible_rows(self.panel_rects, len, self.scene_scroll);
+                for slot in 0..rows.len() {
+                    let Some(name) = self.tab_name(rows.start + slot) else {
+                        break;
+                    };
                     canvas
                         .text_native_fit(
-                            scene_text_rect(self.panel_rects, slot),
-                            name,
+                            scene_text_rect(self.panel_rects, len, slot),
+                            &name,
                             LIST_FONT,
                             HAlign::Left,
                             VAlign::Middle,
@@ -370,12 +485,12 @@ impl DeveloperScene {
                         });
                 }
 
-                if let Some(rocker) = scene_rocker(self.panel_rects) {
+                if let Some(rocker) = scene_rocker(self.panel_rects, len) {
                     list_scroll::draw(
                         &mut canvas,
                         &rocker,
                         rows.start,
-                        scene_max_scroll(self.panel_rects),
+                        scene_max_scroll(self.panel_rects, len),
                         match hovered {
                             Some(DeveloperAction::ScrollScenes(half)) => Some(half),
                             _ => None,
@@ -412,23 +527,46 @@ impl DeveloperScene {
                     return vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)];
                 }
             }
-            DeveloperAction::OpenScenes => self.page = DeveloperPage::Scenes,
+            DeveloperAction::OpenScenes => {
+                self.page = DeveloperPage::Scenes;
+                self.missions = mission_files();
+                self.reset_list();
+            }
             DeveloperAction::CloseScenes => self.page = DeveloperPage::Params,
-            DeveloperAction::SelectScene(index) => self.selected_scene = Some(index),
-            DeveloperAction::ScrollScenes(half) => list_scroll::apply(
-                half,
-                &mut self.scene_scroll,
-                scene_max_scroll(self.panel_rects),
-            ),
-            DeveloperAction::LaunchScene => {
-                if let Some(name) = self
-                    .selected_scene
-                    .and_then(|index| super::debug_scene_names().nth(index))
-                {
-                    return vec![Effect::GlobalEffect(GlobalEffect::LaunchDebugScene {
-                        name: name.to_owned(),
-                    })];
+            DeveloperAction::SelectTab(tab) => {
+                if self.tab != tab {
+                    self.tab = tab;
+                    self.reset_list();
                 }
+            }
+            DeveloperAction::SelectScene(index) => self.selected_scene = Some(index),
+            DeveloperAction::ScrollScenes(half) => {
+                let max = scene_max_scroll(self.panel_rects, self.tab_list_len());
+                list_scroll::apply(half, &mut self.scene_scroll, max)
+            }
+            DeveloperAction::LaunchScene => {
+                let Some(name) = self.selected_scene.and_then(|index| self.tab_name(index)) else {
+                    return Vec::new();
+                };
+                return match self.tab {
+                    // The very same effect the main menu's New Game emits, so
+                    // launching from here is the new-game boot with the level
+                    // swapped: default spawn, vitals from the destination map.
+                    SceneTab::Missions => {
+                        vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
+                            level_file: name,
+                            loc: None,
+                            entities_to_trigger: vec![],
+                            vitals_transition:
+                                crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
+                        })]
+                    }
+                    SceneTab::DebugScenes => {
+                        vec![Effect::GlobalEffect(GlobalEffect::LaunchDebugScene {
+                            name,
+                        })]
+                    }
+                };
             }
         }
         Vec::new()
@@ -569,20 +707,31 @@ mod tests {
             page: DeveloperPage::Params,
             rects: PanelRects::default(),
             scroll,
+            list_len: scene_count(),
             scene_scroll: 0,
             has_selection: true,
         }
     }
 
-    /// The debug-scene launcher at `scene_scroll`.
-    fn scenes_state(scene_scroll: usize, has_selection: bool) -> ScreenState {
+    /// The launcher at `scene_scroll`, showing a list of `len` entries.
+    fn scenes_state(scene_scroll: usize, has_selection: bool, len: usize) -> ScreenState {
         ScreenState {
             page: DeveloperPage::Scenes,
             rects: PanelRects::default(),
             scroll: 0,
+            list_len: len,
             scene_scroll,
             has_selection,
         }
+    }
+
+    /// A launcher scene showing the debug-scene tab, as a click would reach
+    /// it: opened (which enumerates missions), then tabbed over.
+    fn debug_tab_scene() -> DeveloperScene {
+        let mut scene = DeveloperScene::new();
+        scene.handle_action(DeveloperAction::OpenScenes);
+        scene.handle_action(DeveloperAction::SelectTab(SceneTab::DebugScenes));
+        scene
     }
 
     fn pointer_at(canvas_point: Vector2<f32>, pressed: bool) -> Option<Pointer2D> {
@@ -776,20 +925,21 @@ mod tests {
         let names: Vec<&str> = super::super::debug_scene_names().collect();
         assert!(!names.is_empty(), "there are debug scenes to launch");
         let rects = PanelRects::default();
+        let len = names.len();
         for (index, name) in names.iter().enumerate() {
             // Scrolling to a scene's own index always shows it (clamped when
             // it is inside the last page).
-            let rows = scene_visible_rows(rects, index);
+            let rows = scene_visible_rows(rects, len, index);
             assert!(rows.contains(&index), "scene {name} is off screen");
-            let row = scene_row_rect(rects, index - rows.start);
+            let row = scene_row_rect(rects, len, index - rows.start);
             assert_eq!(
-                hit(scenes_state(index, true), row.center()),
+                hit(scenes_state(index, true, len), row.center()),
                 Some(DeveloperAction::SelectScene(index)),
                 "row for {name}"
             );
 
             // ...and selecting it launches *that* scene.
-            let mut scene = DeveloperScene::new();
+            let mut scene = debug_tab_scene();
             scene.handle_action(DeveloperAction::SelectScene(index));
             assert_eq!(
                 launched_scene(scene.handle_action(DeveloperAction::LaunchScene)),
@@ -799,18 +949,140 @@ mod tests {
         }
     }
 
+    #[test]
+    fn every_mission_is_reachable_and_launches_its_own_file() {
+        // The list is data the fs hands the scene, so the mapping is tested on
+        // a fake install; the enumeration itself is thin (`mission_files`).
+        let missions: Vec<String> = (1..=23).map(|n| format!("level{n:02}.mis")).collect();
+        let rects = PanelRects::default();
+        let len = missions.len();
+        for (index, name) in missions.iter().enumerate() {
+            let rows = scene_visible_rows(rects, len, index);
+            assert!(rows.contains(&index), "mission {name} is off screen");
+            let row = scene_row_rect(rects, len, index - rows.start);
+            assert_eq!(
+                hit(scenes_state(index, true, len), row.center()),
+                Some(DeveloperAction::SelectScene(index)),
+                "row for {name}"
+            );
+
+            let mut scene = DeveloperScene::new();
+            scene.page = DeveloperPage::Scenes;
+            scene.missions = missions.clone();
+            scene.handle_action(DeveloperAction::SelectScene(index));
+            match global_effect(scene.handle_action(DeveloperAction::LaunchScene)) {
+                Some(GlobalEffect::TransitionLevel {
+                    level_file,
+                    loc,
+                    entities_to_trigger,
+                    ..
+                }) => {
+                    assert_eq!(&level_file, name);
+                    assert_eq!(loc, None, "map-default spawn");
+                    assert!(entities_to_trigger.is_empty());
+                }
+                other => panic!("launch of {name} produced {other:?}"),
+            }
+        }
+    }
+
+    /// The negative test the tabs demand: the very same Launch click must emit
+    /// a mission transition on one tab and a debug-scene launch on the other -
+    /// never the wrong one.
+    #[test]
+    fn launch_follows_the_showing_tab() {
+        let mut scene = DeveloperScene::new();
+        scene.page = DeveloperPage::Scenes;
+        scene.missions = vec!["earth.mis".to_owned()];
+        scene.reset_list();
+        assert_eq!(scene.tab, SceneTab::Missions);
+        let effect = global_effect(scene.handle_action(DeveloperAction::LaunchScene));
+        assert!(
+            matches!(
+                effect,
+                Some(GlobalEffect::TransitionLevel { ref level_file, .. }) if level_file == "earth.mis"
+            ),
+            "Missions tab must emit TransitionLevel, got {effect:?}"
+        );
+
+        scene.handle_action(DeveloperAction::SelectTab(SceneTab::DebugScenes));
+        assert!(matches!(
+            global_effect(scene.handle_action(DeveloperAction::LaunchScene)),
+            Some(GlobalEffect::LaunchDebugScene { .. })
+        ));
+    }
+
+    /// Switching tabs resets the scroll and the selection - a stale index
+    /// would point into the other tab's list. Re-clicking the showing tab
+    /// keeps the selection.
+    #[test]
+    fn the_tabs_share_the_header_and_reset_the_list() {
+        let rects = PanelRects::default();
+        let header = rects.header_rect();
+        // Both tabs sit on the authored header line, side by side.
+        for tab in SceneTab::ALL {
+            let r = tab_rect(rects, tab);
+            assert_eq!(r.y, header.y);
+            assert_eq!(
+                hit(scenes_state(0, true, scene_count()), r.center()),
+                Some(DeveloperAction::SelectTab(tab)),
+                "tab {tab:?}"
+            );
+        }
+        assert!(tab_rect(rects, SceneTab::Missions).x < tab_rect(rects, SceneTab::DebugScenes).x);
+
+        let mut scene = DeveloperScene::new();
+        scene.page = DeveloperPage::Scenes;
+        scene.missions = vec!["earth.mis".to_owned(), "station.mis".to_owned()];
+        scene.reset_list();
+        scene.handle_action(DeveloperAction::SelectScene(1));
+        // Re-clicking the showing tab is a no-op.
+        scene.handle_action(DeveloperAction::SelectTab(SceneTab::Missions));
+        assert_eq!(scene.selected_scene, Some(1));
+        // Switching resets to the other list's first entry.
+        scene.handle_action(DeveloperAction::SelectTab(SceneTab::DebugScenes));
+        assert_eq!(scene.tab, SceneTab::DebugScenes);
+        assert_eq!(scene.scene_scroll, 0);
+        assert_eq!(scene.selected_scene, Some(0));
+    }
+
+    /// Opening the launcher enumerates the install's missions and lands on the
+    /// Missions tab with its first entry preselected.
+    #[test]
+    fn opening_the_launcher_enumerates_missions() {
+        let mut scene = DeveloperScene::new();
+        scene.handle_action(DeveloperAction::OpenScenes);
+        assert_eq!(scene.tab, SceneTab::Missions);
+        assert_eq!(scene.missions, mission_files());
+        assert_eq!(
+            scene.selected_scene,
+            (!scene.missions.is_empty()).then_some(0)
+        );
+        // The enumeration is sorted and lists only `*.mis` files.
+        let mut sorted = scene.missions.clone();
+        sorted.sort_by_key(|name| name.to_ascii_lowercase());
+        assert_eq!(scene.missions, sorted);
+        assert!(
+            scene
+                .missions
+                .iter()
+                .all(|name| name.to_ascii_lowercase().ends_with(".mis"))
+        );
+    }
+
     /// The bug a scrolling list invites: the rows move but the hit test still
     /// indexes positionally, so clicking a row launches whatever scene *used*
     /// to be there.
     #[test]
     fn the_launcher_hit_test_follows_its_scroll() {
         let rects = PanelRects::default();
-        let max = scene_max_scroll(rects);
+        let len = scene_count();
+        let max = scene_max_scroll(rects, len);
         assert!(max > 0, "the shipped scene list must scroll to test this");
         for scroll in 1..=max {
-            let slot0 = scene_row_rect(rects, 0);
+            let slot0 = scene_row_rect(rects, len, 0);
             assert_eq!(
-                hit(scenes_state(scroll, true), slot0.center()),
+                hit(scenes_state(scroll, true, len), slot0.center()),
                 Some(DeveloperAction::SelectScene(scroll)),
                 "top row at scroll {scroll}"
             );
@@ -820,23 +1092,26 @@ mod tests {
     #[test]
     fn the_launchers_rocker_scrolls_and_stops_at_both_ends() {
         let rects = PanelRects::default();
-        let rocker = scene_rocker(rects).expect("the shipped scene list scrolls");
-        let max = scene_max_scroll(rects);
+        let len = scene_count();
+        let rocker = scene_rocker(rects, len).expect("the shipped scene list scrolls");
+        let max = scene_max_scroll(rects, len);
 
         // At the top the "Up" half is inert; at the bottom, "Dn" is.
-        assert_eq!(hit(scenes_state(0, true), rocker.up.center()), None);
+        assert_eq!(hit(scenes_state(0, true, len), rocker.up.center()), None);
         assert_eq!(
-            hit(scenes_state(0, true), rocker.down.center()),
+            hit(scenes_state(0, true, len), rocker.down.center()),
             Some(DeveloperAction::ScrollScenes(ScrollHalf::Down))
         );
-        assert_eq!(hit(scenes_state(max, true), rocker.down.center()), None);
         assert_eq!(
-            hit(scenes_state(max, true), rocker.up.center()),
+            hit(scenes_state(max, true, len), rocker.down.center()),
+            None
+        );
+        assert_eq!(
+            hit(scenes_state(max, true, len), rocker.up.center()),
             Some(DeveloperAction::ScrollScenes(ScrollHalf::Up))
         );
 
-        let mut scene = DeveloperScene::new();
-        scene.page = DeveloperPage::Scenes;
+        let mut scene = debug_tab_scene();
         for _ in 0..max + 3 {
             scene.handle_action(DeveloperAction::ScrollScenes(ScrollHalf::Down));
         }
@@ -845,18 +1120,22 @@ mod tests {
         assert_eq!(scene.scene_scroll, max - 1);
 
         // A row's text must never run under the rocker it shares the pane with.
-        assert!(scene_text_rect(rects, 0).x + scene_text_rect(rects, 0).w <= rocker.up.x);
+        let text = scene_text_rect(rects, len, 0);
+        assert!(text.x + text.w <= rocker.up.x);
     }
 
     #[test]
     fn launch_requires_a_selection() {
         assert_eq!(
-            hit(scenes_state(0, true), action_point()),
+            hit(scenes_state(0, true, scene_count()), action_point()),
             Some(DeveloperAction::LaunchScene)
         );
         // With nothing selected the button is inert rather than launching
         // whatever happens to be first.
-        assert_eq!(hit(scenes_state(0, false), action_point()), None);
+        assert_eq!(
+            hit(scenes_state(0, false, scene_count()), action_point()),
+            None
+        );
         let mut scene = DeveloperScene::new();
         scene.selected_scene = None;
         assert!(scene.handle_action(DeveloperAction::LaunchScene).is_empty());
@@ -866,7 +1145,7 @@ mod tests {
     fn done_leaves_the_launcher_for_the_parameters_not_the_main_menu() {
         let done = PanelRects::default().done_rect().center();
         assert_eq!(
-            hit(scenes_state(0, true), done),
+            hit(scenes_state(0, true, scene_count()), done),
             Some(DeveloperAction::CloseScenes)
         );
         let mut scene = DeveloperScene::new();
@@ -894,11 +1173,11 @@ mod tests {
             Some(DeveloperAction::Param(_))
         ));
         assert!(!matches!(
-            hit(scenes_state(0, true), arrow),
+            hit(scenes_state(0, true, scene_count()), arrow),
             Some(DeveloperAction::Param(_))
         ));
         // And the launcher's rows are not on the parameters page.
-        let row = scene_row_rect(PanelRects::default(), 0);
+        let row = scene_row_rect(PanelRects::default(), scene_count(), 0);
         assert!(!matches!(
             hit(params_state(0), row.center()),
             Some(DeveloperAction::SelectScene(_))
@@ -933,16 +1212,42 @@ mod tests {
             Some(DeveloperAction::OpenScenes)
         );
         assert_eq!(
-            resolve_click_at(scenes_state(0, true), Some(point), pressed, false).0,
+            resolve_click_at(
+                scenes_state(0, true, scene_count()),
+                Some(point),
+                pressed,
+                false
+            )
+            .0,
             Some(DeveloperAction::LaunchScene)
         );
 
         // A row on the launcher, through the same ray.
-        let row = scene_row_rect(PanelRects::default(), 2).center();
+        let row = scene_row_rect(PanelRects::default(), scene_count(), 2).center();
         let (point, pressed) = aim(row);
         assert_eq!(
-            resolve_click_at(scenes_state(0, true), Some(point), pressed, false).0,
+            resolve_click_at(
+                scenes_state(0, true, scene_count()),
+                Some(point),
+                pressed,
+                false
+            )
+            .0,
             Some(DeveloperAction::SelectScene(2))
+        );
+
+        // ...and a tab, through the same ray - the parity the tabs must keep.
+        let tab = tab_rect(PanelRects::default(), SceneTab::Missions).center();
+        let (point, pressed) = aim(tab);
+        assert_eq!(
+            resolve_click_at(
+                scenes_state(0, true, scene_count()),
+                Some(point),
+                pressed,
+                false
+            )
+            .0,
+            Some(DeveloperAction::SelectTab(SceneTab::Missions))
         );
     }
 
@@ -951,12 +1256,13 @@ mod tests {
     #[test]
     fn the_launchers_rows_stay_inside_the_pane() {
         let rects = PanelRects::default();
+        let len = scene_count();
         let list = rects.list_rect();
-        let rows = scene_visible_rows(rects, 0);
+        let rows = scene_visible_rows(rects, len, 0);
         assert!(rows.len() >= 10, "the pane should show a useful page");
-        let last = scene_row_rect(rects, rows.len() - 1);
+        let last = scene_row_rect(rects, len, rows.len() - 1);
         assert!(last.y + last.h <= FIELD_TOP_Y);
         assert!(last.y + last.h <= list.y + list.h);
-        assert_eq!(scene_row_rect(rects, 0).x, list.x);
+        assert_eq!(scene_row_rect(rects, len, 0).x, list.x);
     }
 }

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -529,6 +529,9 @@ impl DeveloperScene {
             }
             DeveloperAction::OpenScenes => {
                 self.page = DeveloperPage::Scenes;
+                // The launcher always opens on the Missions tab, whatever tab
+                // it was left on.
+                self.tab = SceneTab::Missions;
                 self.missions = mission_files();
                 self.reset_list();
             }
@@ -1047,10 +1050,12 @@ mod tests {
     }
 
     /// Opening the launcher enumerates the install's missions and lands on the
-    /// Missions tab with its first entry preselected.
+    /// Missions tab with its first entry preselected - even when it was left
+    /// on the Debug Scenes tab last time.
     #[test]
     fn opening_the_launcher_enumerates_missions() {
         let mut scene = DeveloperScene::new();
+        scene.tab = SceneTab::DebugScenes;
         scene.handle_action(DeveloperAction::OpenScenes);
         assert_eq!(scene.tab, SceneTab::Missions);
         assert_eq!(scene.missions, mission_files());

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -319,13 +319,9 @@ impl GameScene for MainMenuScene {
 
         match action {
             Some(MenuAction::NewGame) => {
-                vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
-                    level_file: NEW_GAME_MISSION.to_owned(),
-                    loc: None,
-                    entities_to_trigger: vec![],
-                    vitals_transition:
-                        crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
-                })]
+                vec![Effect::GlobalEffect(GlobalEffect::new_game_transition(
+                    NEW_GAME_MISSION.to_owned(),
+                ))]
             }
             Some(MenuAction::LoadGame) => {
                 vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -93,6 +93,21 @@ pub enum GlobalEffect {
     Quit,
 }
 
+impl GlobalEffect {
+    /// The new-game boot into `level_file`: map-default spawn, no triggers,
+    /// vitals initialized from the destination. Shared by the main menu's New
+    /// Game and the developer launcher's Missions tab so the two boots cannot
+    /// drift.
+    pub fn new_game_transition(level_file: String) -> Self {
+        GlobalEffect::TransitionLevel {
+            level_file,
+            loc: None,
+            entities_to_trigger: vec![],
+            vitals_transition: PlayerVitalsTransition::InitializeFromDestination,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum AIPropertyUpdate {
     Alertness {

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -316,13 +316,15 @@ test(
     await click(game, TAB_MISSIONS);
     await click(game, sceneRow(MEDSCI1_ROW));
     await click(game, ACTION);
-    // Row 9 is medsci1.mis on the canonical 23-mission install; another
-    // install may sort a different mission into that row, so the hard
-    // assertion is "a real mission booted", not which one.
-    const mission = (await game.info()).mission;
-    assert.ok(
-      mission.toLowerCase().endsWith(".mis"),
-      `Launch on the Missions tab must boot the selected mission, got ${mission}`,
+    // Row 9 is medsci1.mis on the canonical 23-mission install (the same
+    // assumption missions.e2e.test.ts hardcodes). Asserting the exact name
+    // proves the row CLICK picked the mission - the preselected row 0 would
+    // boot command1.mis, so a looser ".mis booted" check could pass without
+    // the selection ever moving.
+    assert.equal(
+      (await game.info()).mission,
+      "medsci1.mis",
+      "Launch on the Missions tab must boot the clicked row's mission (canonical install assumed)",
     );
 
     // ...and it is a real world, not just a scene-name swap.

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -309,16 +309,20 @@ test(
     await click(game, [489, 202]);
     assert.equal((await game.info()).mission, "developer");
 
-    // The launcher opens on the Missions tab; row 9 of the sorted install
-    // is medsci1.mis. Clicking Missions again is a no-op (it is showing).
+    // The launcher opens on the Missions tab; tab over to Debug Scenes and
+    // back, so the round trip is exercised end to end, then pick a row.
     await click(game, ACTION);
+    await click(game, TAB_DEBUG_SCENES);
     await click(game, TAB_MISSIONS);
     await click(game, sceneRow(MEDSCI1_ROW));
     await click(game, ACTION);
-    assert.equal(
-      (await game.info()).mission,
-      "medsci1.mis",
-      "Launch on the Missions tab must boot the selected mission",
+    // Row 9 is medsci1.mis on the canonical 23-mission install; another
+    // install may sort a different mission into that row, so the hard
+    // assertion is "a real mission booted", not which one.
+    const mission = (await game.info()).mission;
+    assert.ok(
+      mission.toLowerCase().endsWith(".mis"),
+      `Launch on the Missions tab must boot the selected mission, got ${mission}`,
     );
 
     // ...and it is a real world, not just a scene-name swap.

--- a/tools/shock2-sdk/test/dev-menu.e2e.test.ts
+++ b/tools/shock2-sdk/test/dev-menu.e2e.test.ts
@@ -43,12 +43,22 @@ const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
 // launch itself on the launcher page.
 const ACTION: [number, number] = [527 + 96 / 2, 161 + 62 / 2];
 /**
+ * The launcher's tabs ride the header line (GAMELODR.BIN rect 0: 261,31
+ * 202x20), split in half: Missions on the left, Debug Scenes on the right.
+ * The launcher opens on Missions.
+ */
+const TAB_MISSIONS: [number, number] = [261 + 202 / 4, 41];
+const TAB_DEBUG_SCENES: [number, number] = [261 + (3 * 202) / 4, 41];
+/**
  * A row of the launcher's list: 19px rows from the pane top (y=54), x well
- * inside the pane and clear of the scroll gutter. Row 2 is `debug_minimal` -
- * the cheapest scene to actually start.
+ * inside the pane and clear of the scroll gutter. On the Debug Scenes tab
+ * row 2 is `debug_minimal` - the cheapest scene to actually start. On the
+ * Missions tab (the sorted *.mis files of the canonical install) row 9 is
+ * `medsci1.mis`.
  */
 const sceneRow = (index: number): [number, number] => [330, 54 + index * 19 + 9];
 const DEBUG_MINIMAL_ROW = 2;
+const MEDSCI1_ROW = 9;
 
 /** SIMR.BIN pause entries: five 179x76 buttons at x=400, top 20, 92px pitch. */
 const pauseEntry = (index: number): [number, number] =>
@@ -277,8 +287,9 @@ test(
     );
     await click(game, ROW0_DECREMENT);
 
-    // Select a scene and launch it.
+    // Select a scene on the Debug Scenes tab and launch it.
     await click(game, ACTION);
+    await click(game, TAB_DEBUG_SCENES);
     await click(game, sceneRow(DEBUG_MINIMAL_ROW));
     await click(game, ACTION);
     assert.equal(
@@ -286,6 +297,33 @@ test(
       "debug_minimal",
       "Launch must start the selected scene",
     );
+  },
+);
+
+test(
+  "the flat Developer screen launches a full mission from the Missions tab",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "main_menu" });
+    await game.step({ frames: 10 });
+    await click(game, [489, 202]);
+    assert.equal((await game.info()).mission, "developer");
+
+    // The launcher opens on the Missions tab; row 9 of the sorted install
+    // is medsci1.mis. Clicking Missions again is a no-op (it is showing).
+    await click(game, ACTION);
+    await click(game, TAB_MISSIONS);
+    await click(game, sceneRow(MEDSCI1_ROW));
+    await click(game, ACTION);
+    assert.equal(
+      (await game.info()).mission,
+      "medsci1.mis",
+      "Launch on the Missions tab must boot the selected mission",
+    );
+
+    // ...and it is a real world, not just a scene-name swap.
+    const { entities } = await game.entities.list({ limit: 200 });
+    assert.ok(entities.length > 100, `expected a populated mission, got ${entities.length}`);
   },
 );
 
@@ -307,6 +345,7 @@ test(
     await game.step({ frames: 5 });
     await game.screenshot("dev-scenes-vr.png");
 
+    await vrClick(game, TAB_DEBUG_SCENES);
     await vrClick(game, sceneRow(DEBUG_MINIMAL_ROW));
     await vrClick(game, ACTION);
     assert.equal((await game.info()).mission, "debug_minimal");


### PR DESCRIPTION
The developer screen's launcher page grows two tabs on its header line: **Missions** (the install's `.mis` files, via `data_files::mission_names` so both classic loose files and 25AE kpf archives enumerate) and **Debug Scenes** (the existing registry list). Same list/scroll/launch machinery, laid out once in canvas pixels for both presentations.

Launching a mission emits the same `TransitionLevel` the main menu's New Game does (`loc: None` map-default spawn, vitals initialized from the destination), so it is the new-game boot with the level swapped.

Covered by unit tests (tab/list/launch action mapping, negative: Missions-tab launch must emit `TransitionLevel`, not `LaunchDebugScene`) and the `dev-menu` SDK e2e suite, which now launches `medsci1.mis` from the menu flat and `debug_minimal` through the VR ray.

## Visuals

![launcher demo](https://gist.githubusercontent.com/tommy-xr/d8bf89ee7a16ec8db8d6438300b31d18/raw/launcher-demo.gif)

<sub>Flat: launcher opens on the **Missions** tab → clicking `medsci1.mis` moves the selection highlight → **Launch** loads the mission (in-game frames at the end). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Flat / VR parity (Missions tab)

![FLAT | VR parity](https://gist.githubusercontent.com/tommy-xr/d8bf89ee7a16ec8db8d6438300b31d18/raw/launcher-parity.png)

<sub>Tab labels, list rows, Launch and Done sit in the same place relative to the panel art in both presentations (layout resolved once in canvas pixels).</sub>

<details><summary>Individual stills (both tabs, both presentations)</summary>

| | Missions | Debug Scenes |
|---|---|---|
| **Flat** | ![missions flat](https://gist.githubusercontent.com/tommy-xr/d8bf89ee7a16ec8db8d6438300b31d18/raw/launcher-missions-flat.png) | ![debug flat](https://gist.githubusercontent.com/tommy-xr/d8bf89ee7a16ec8db8d6438300b31d18/raw/launcher-debug-flat.png) |
| **VR** | ![missions vr](https://gist.githubusercontent.com/tommy-xr/d8bf89ee7a16ec8db8d6438300b31d18/raw/launcher-missions-vr.png) | ![debug vr](https://gist.githubusercontent.com/tommy-xr/d8bf89ee7a16ec8db8d6438300b31d18/raw/launcher-debug-vr.png) |

</details>
