### PR TITLE
fix(cutscene): render video right side up

### DIFF
--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -157,8 +157,13 @@ impl CutscenePlayerScene {
         let screen_height = 2.0 / dark::SCALE_FACTOR;
         let screen_width = screen_height * aspect_ratio;
 
+        // Decoded frames are top-row-first while the quad maps v=0 to its
+        // bottom edge, and the billboard basis faces the quad's back toward
+        // the player - together the video showed rotated 180 degrees. Spinning
+        // the quad half a turn in its own plane corrects both at once.
         let transform = Matrix4::from_translation(screen_position)
             * Matrix4::from(rotation_matrix)
+            * Matrix4::from_angle_z(cgmath::Deg(180.0))
             * Matrix4::from_nonuniform_scale(screen_width, screen_height, 1.0);
         quad.set_transform(transform);
         quad


### PR DESCRIPTION
Stacks on #749 (based on `fix/issue-660-anniversary-cutscenes-4dc00616`; merge that first).

## Problem

Cutscene video has been rendering rotated 180 degrees. Two composed conventions in `CutscenePlayerScene::build_screen_object`:

- decoded frames are top-row-first while `quad::create` maps `v=0` to the quad's **bottom** edge (the shared UI world-panel path corrects the same convention with `Matrix4::from_angle_x(Deg(180.0))` in `world_element_transform`; the cutscene quad had no such correction)
- the billboard basis (`from_cols(right, true_up, -look_dir)` with `look_dir` pointing screen → player) points the quad's **back** at the player, mirroring horizontally

Net effect: a 180-degree rotation. Verified by comparing an in-game capture against an `ffmpeg`-extracted frame of the same video (25AE `original/intro.ogv` Looking Glass logo):

| ffmpeg reference | in-game before (flipped) |
| --- | --- |
| ![reference](https://gist.githubusercontent.com/tommy-xr/c9148f33a137498945db9d76c6b9df74/raw/reference-ffmpeg.png) | ![before](https://gist.githubusercontent.com/tommy-xr/c9148f33a137498945db9d76c6b9df74/raw/before-flipped.png) |

## Fix

One transform: spin the quad half a turn in its own plane (`from_angle_z(Deg(180.0))`), correcting both inversions at once. Rotation (unlike a negative scale) preserves winding and the normal stays a pure flip of the basis, so nothing else changes.

## After

![after gif](https://gist.githubusercontent.com/tommy-xr/c9148f33a137498945db9d76c6b9df74/raw/cutscene-upright.gif)

| flat | `--vr` | enhanced layer (cs1, 1080p) |
| --- | --- | --- |
| ![flat](https://gist.githubusercontent.com/tommy-xr/c9148f33a137498945db9d76c6b9df74/raw/after-upright.png) | ![vr](https://gist.githubusercontent.com/tommy-xr/c9148f33a137498945db9d76c6b9df74/raw/after-vr.png) | ![cs1](https://gist.githubusercontent.com/tommy-xr/c9148f33a137498945db9d76c6b9df74/raw/after-cs1-enhanced.png) |

Flat and `--vr` render identically (single shared world-quad path). Captured headlessly via the debug runtime free camera placed at the player's viewpoint (`/v1/camera` + `/v1/step` + `/v1/screenshot`).

## Verification

- negative first: captured the flipped frame on the base branch (`before-flipped.png` above), then the identical request sequence after the fix matches the ffmpeg reference
- `DARK_ASSET_PATH=~/ss2-25th cargo dbgr --mission Intro.avi` and `--mission cs1.avi`, flat and `--vr` - resolves, plays, no panic, upright
- `cargo check -p shock2vr` clean
