### PR TITLE
feat(tools): asset enumeration API + dark_explorer CLI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [alias]
 dv = "run -p dark_viewer --"
 dq = "run -p dark_query --"
+dx = "run -p dark_explorer --"
 dr = "run -p desktop_runtime --"
 dbgr = "run -p debug_runtime --"
 dbgc = "run -p debug_command --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dark_explorer"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "engine",
+ "shock2vr",
+]
+
+[[package]]
 name = "dark_query"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "dark",
     "tools/asset_probe",
     "tools/dark_viewer",
+    "tools/dark_explorer",
     "tools/dark_query",
     "tools/debug_command",
     "tools/hitbox_analyzer",

--- a/engine/src/assets/asset_paths.rs
+++ b/engine/src/assets/asset_paths.rs
@@ -13,6 +13,21 @@ pub trait ReadableAndSeekable: io::Read + io::Seek + Send + Sync + 'static {}
 
 impl<T> ReadableAndSeekable for T where T: io::Read + io::Seek + Send + Sync + 'static {}
 
+/// One lookup key a mount can serve, plus where the bytes really live.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetEntry {
+    /// The key `exists`/`get_reader` resolve (lowercased).
+    pub key: String,
+    /// The archive or folder serving it.
+    pub source: String,
+    /// The real entry name inside the source (original case, full path).
+    pub entry_name: String,
+    /// True for a secondary key (collapsed basename, namespace-qualified name)
+    /// pointing at the same bytes as a primary mount-relative key. Filter these
+    /// out to list each file once; keep them to see every resolvable name.
+    pub is_alias: bool,
+}
+
 pub trait AbstractAssetPath: Sync + Send {
     fn exists(&self, base_path: String, asset_name: String) -> bool;
 
@@ -38,6 +53,15 @@ pub trait AbstractAssetPath: Sync + Send {
             .iter()
             .find(|candidate| self.exists(base_path.clone(), (*candidate).to_string()))
             .cloned()
+    }
+
+    /// Every lookup key this mount can serve. Combined mounts concatenate in
+    /// mount-priority order (a key's first occurrence is the mount a lookup
+    /// serves it from); within one mount, keys are unique and unordered.
+    /// Mounts that cannot cheaply enumerate (loose folders, the app bundle)
+    /// report nothing - enumeration is a tooling affordance, not a lookup path.
+    fn entries(&self) -> Vec<AssetEntry> {
+        Vec::new()
     }
 }
 
@@ -85,6 +109,13 @@ impl AbstractAssetPath for MultipleAssetPaths {
             }
         }
         None
+    }
+
+    fn entries(&self) -> Vec<AssetEntry> {
+        self.asset_paths
+            .iter()
+            .flat_map(|asset_path| asset_path.entries())
+            .collect()
     }
 }
 

--- a/shock2vr/src/data_files.rs
+++ b/shock2vr/src/data_files.rs
@@ -147,15 +147,10 @@ mod tests {
 
     /// Write a stand-in for the 25AE archive holding `entries`.
     fn write_archive(root: &Path, entries: &[(&str, &[u8])]) {
-        let file = std::fs::File::create(root.join(crate::install::ANNIVERSARY_SENTINEL)).unwrap();
-        let mut writer = zip::ZipWriter::new(file);
-        for (name, contents) in entries {
-            writer
-                .start_file(*name, zip::write::FileOptions::default())
-                .unwrap();
-            writer.write_all(contents).unwrap();
-        }
-        writer.finish().unwrap();
+        crate::test_support::write_archive(
+            &root.join(crate::install::ANNIVERSARY_SENTINEL),
+            entries,
+        );
     }
 
     fn read(root: &Path, name: &str) -> Option<Vec<u8>> {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -283,6 +283,12 @@ fn anniversary_family_mounts(
     mounts
 }
 
+/// The resource families a lookup consults, in priority order - for tools that
+/// enumerate the mounts family by family (`resource_family_paths`).
+pub fn resource_families() -> &'static [&'static str] {
+    RESOURCE_FAMILIES
+}
+
 /// The mounts for a *single* resource family, for a CLI tool that needs one
 /// family's files without a renderer - `dq maps` reads the map rectangles out
 /// of `intrface`, which a classic install keeps in `res/intrface.crf` and a

--- a/shock2vr/src/test_support.rs
+++ b/shock2vr/src/test_support.rs
@@ -159,3 +159,17 @@ impl Drop for TempDir {
         let _ = std::fs::remove_dir_all(&self.0);
     }
 }
+
+/// Write a zip archive at `path` holding `entries`, for tests that mount one.
+pub fn write_archive(path: &Path, entries: &[(&str, &[u8])]) {
+    use std::io::Write;
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = zip::ZipWriter::new(file);
+    for (name, contents) in entries {
+        writer
+            .start_file(*name, zip::write::FileOptions::default())
+            .unwrap();
+        writer.write_all(contents).unwrap();
+    }
+    writer.finish().unwrap();
+}

--- a/shock2vr/src/zip_asset_path.rs
+++ b/shock2vr/src/zip_asset_path.rs
@@ -6,21 +6,25 @@ use std::{
     sync::Mutex,
 };
 
-use engine::assets::asset_paths::{AbstractAssetPath, ReadableAndSeekable};
+use engine::assets::asset_paths::{AbstractAssetPath, AssetEntry, ReadableAndSeekable};
 use zip::ZipArchive;
 
 pub struct ZipAssetPath {
+    zip_path: String,
     archive: Mutex<ZipArchive<BufReader<File>>>,
     asset_to_path: HashMap<String, String>,
+    /// The (lowercased) mount prefix, kept so `entries()` can tell a primary
+    /// key (the prefix-stripped path) from a registered alias.
+    prefix: String,
 }
 
 impl ZipAssetPath {
     pub fn new(zip_path: String) -> Box<ZipAssetPath> {
-        Self::build(zip_path, true, None)
+        Self::with_prefix_opts(zip_path, "", true, None)
     }
 
     pub fn new2(zip_path: String, collapse_paths: bool) -> Box<ZipAssetPath> {
-        Self::build(zip_path, collapse_paths, None)
+        Self::with_prefix_opts(zip_path, "", collapse_paths, None)
     }
 
     /// Mount like [`ZipAssetPath::new`], but *additionally* register every entry
@@ -30,7 +34,7 @@ impl ZipAssetPath {
     /// basename (e.g. `"iface/log.pcx"` selects iface.crf's 188x296 MFD frame
     /// rather than obj.crf's 64x64 model texture, both named `LOG.PCX`).
     pub fn with_namespace(zip_path: String, namespace: &str) -> Box<ZipAssetPath> {
-        Self::build(zip_path, true, Some(namespace))
+        Self::with_prefix_opts(zip_path, "", true, Some(namespace))
     }
 
     /// Mount only the entries under `prefix`, keyed by the path *relative to*
@@ -99,56 +103,10 @@ impl ZipAssetPath {
             }
         }
         Box::new(ZipAssetPath {
+            zip_path,
             archive: Mutex::new(archive),
             asset_to_path,
-        })
-    }
-
-    fn build(zip_path: String, collapse_paths: bool, namespace: Option<&str>) -> Box<ZipAssetPath> {
-        let file = File::open(zip_path).unwrap();
-        let reader = BufReader::new(file);
-
-        let mut archive = zip::ZipArchive::new(reader).unwrap();
-        let mut asset_to_path = HashMap::new();
-        for i in 0..archive.len() {
-            let file = archive.by_index(i).unwrap();
-            let outpath = match file.enclosed_name() {
-                Some(path) => path,
-                None => {
-                    // println!("Entry {} has a suspicious path", file.name());
-                    continue;
-                }
-            };
-
-            if !(*file.name()).ends_with('/') {
-                let just_file_name = outpath
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_ascii_lowercase();
-
-                asset_to_path.insert(
-                    outpath.to_str().unwrap().to_ascii_lowercase(),
-                    outpath.to_str().unwrap().to_string(),
-                );
-                if collapse_paths {
-                    asset_to_path.insert(
-                        just_file_name.clone(),
-                        outpath.to_str().unwrap().to_string(),
-                    );
-                }
-                if let Some(namespace) = namespace {
-                    asset_to_path.insert(
-                        format!("{}/{}", namespace, just_file_name),
-                        outpath.to_str().unwrap().to_string(),
-                    );
-                }
-            }
-        }
-        Box::new(ZipAssetPath {
-            archive: Mutex::new(archive),
-            asset_to_path,
+            prefix,
         })
     }
 }
@@ -171,12 +129,145 @@ impl AbstractAssetPath for ZipAssetPath {
         file.read_to_end(&mut file_contents).unwrap();
         Some(RefCell::new(Box::new(Cursor::new(file_contents))))
     }
+
+    fn entries(&self) -> Vec<AssetEntry> {
+        // Every registered lookup key, aliases included, so a caller can tell
+        // exactly which names this mount resolves. A key is primary when it is
+        // the prefix-stripped entry path; anything else (collapsed basename,
+        // namespace-qualified) is an alias to the same bytes.
+        self.asset_to_path
+            .iter()
+            .map(|(key, entry_name)| {
+                let primary = entry_name
+                    .to_ascii_lowercase()
+                    .strip_prefix(&self.prefix)
+                    .map(str::to_owned)
+                    .unwrap_or_default();
+                AssetEntry {
+                    key: key.clone(),
+                    source: self.zip_path.clone(),
+                    entry_name: entry_name.clone(),
+                    is_alias: *key != primary,
+                }
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::write_archive;
     use engine::assets::asset_paths::AssetPath;
+
+    /// `entries()` reports every registered lookup key - each file once as a
+    /// primary mount-relative key, plus its basename/namespace aliases marked
+    /// `is_alias` - all pointing at the real archive entry serving the bytes.
+    #[test]
+    fn entries_reports_primary_keys_and_marks_aliases() {
+        let root = crate::test_support::TempDir::new("zip-entries");
+        let archive = root.path().join("mod.kpf");
+        write_archive(
+            &archive,
+            &[
+                ("OBJ/txt16/Foo.PCX", b"pcx bytes"),
+                ("OBJ/foo.bin", b"bin bytes"),
+                ("other/skipped.txt", b"outside the prefix"),
+            ],
+        );
+        let archive = archive.to_string_lossy().into_owned();
+
+        let mount = ZipAssetPath::with_prefix_opts(archive.clone(), "obj/", true, Some("obj"));
+        let mut entries = mount.entries();
+        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        assert_eq!(
+            entries,
+            vec![
+                // "foo.bin" is both the primary key and its own basename, so
+                // there is exactly one (primary) entry for it.
+                AssetEntry {
+                    key: "foo.bin".to_owned(),
+                    source: archive.clone(),
+                    entry_name: "OBJ/foo.bin".to_owned(),
+                    is_alias: false,
+                },
+                AssetEntry {
+                    key: "foo.pcx".to_owned(),
+                    source: archive.clone(),
+                    entry_name: "OBJ/txt16/Foo.PCX".to_owned(),
+                    is_alias: true,
+                },
+                AssetEntry {
+                    key: "obj/foo.bin".to_owned(),
+                    source: archive.clone(),
+                    entry_name: "OBJ/foo.bin".to_owned(),
+                    is_alias: true,
+                },
+                AssetEntry {
+                    key: "obj/foo.pcx".to_owned(),
+                    source: archive.clone(),
+                    entry_name: "OBJ/txt16/Foo.PCX".to_owned(),
+                    is_alias: true,
+                },
+                AssetEntry {
+                    key: "txt16/foo.pcx".to_owned(),
+                    source: archive.clone(),
+                    entry_name: "OBJ/txt16/Foo.PCX".to_owned(),
+                    is_alias: false,
+                },
+            ]
+        );
+    }
+
+    /// A mount that registers no basename aliases (`collapse_paths: false`,
+    /// the `strings` family) must report none - a bare-name query genuinely
+    /// does not resolve there.
+    #[test]
+    fn entries_reports_no_aliases_when_paths_are_not_collapsed() {
+        let root = crate::test_support::TempDir::new("zip-entries-nocollapse");
+        let archive = root.path().join("strings.kpf");
+        write_archive(
+            &archive,
+            &[("strings/german/objshort.str", b"german table")],
+        );
+        let archive = archive.to_string_lossy().into_owned();
+
+        let mount = ZipAssetPath::with_prefix_opts(archive, "strings/", false, None);
+        let entries = mount.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].key, "german/objshort.str");
+        assert!(!entries[0].is_alias);
+        assert!(!mount.exists(String::new(), "objshort.str".to_owned()));
+    }
+
+    /// Combined mounts enumerate in resolution-priority order, so the first
+    /// entry for a key is the mount a lookup would actually serve it from.
+    #[test]
+    fn combined_mounts_enumerate_in_priority_order() {
+        let root = crate::test_support::TempDir::new("zip-entries-priority");
+        let modded = root.path().join("mod.kpf");
+        let base = root.path().join("base.kpf");
+        write_archive(&modded, &[("obj/foo.pcx", b"modded")]);
+        write_archive(&base, &[("data/res/obj/foo.pcx", b"original")]);
+
+        let mounts = AssetPath::combine(vec![
+            ZipAssetPath::with_prefix(modded.to_string_lossy().into_owned(), "obj/"),
+            ZipAssetPath::with_prefix(base.to_string_lossy().into_owned(), "data/res/obj/"),
+        ]);
+        let entries = mounts.entries();
+        let sources: Vec<String> = entries
+            .iter()
+            .filter(|e| e.key == "foo.pcx")
+            .map(|e| e.source.clone())
+            .collect();
+        assert_eq!(
+            sources,
+            vec![
+                modded.to_string_lossy().into_owned(),
+                base.to_string_lossy().into_owned()
+            ]
+        );
+    }
 
     /// `res/iface.crf` bundles its own `fonts/` subfolder sharing most
     /// basenames with `res/fonts.crf` (the canonical font family) - almost all

--- a/tools/dark_explorer/Cargo.toml
+++ b/tools/dark_explorer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "dark_explorer"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "dark_explorer"
+path = "src/main.rs"
+
+[dependencies]
+engine = { path = "../../engine" }
+shock2vr = { path = "../../shock2vr", default-features = false }
+clap = { version = "4.5.4", features = ["derive"] }

--- a/tools/dark_explorer/src/main.rs
+++ b/tools/dark_explorer/src/main.rs
@@ -1,0 +1,214 @@
+use clap::{Parser, Subcommand};
+use engine::assets::asset_paths::AssetEntry;
+
+#[derive(Parser)]
+#[command(name = "dark_explorer")]
+#[command(about = "Explore the mounted game archives (KPF/CRF) without unzipping them")]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List mounted archives per resource family (or one family's assets)
+    Ls {
+        /// Resource family to list assets for (e.g. obj, snd, mesh); omit for an overview
+        family: Option<String>,
+
+        /// Only show keys containing this substring (case-insensitive)
+        #[arg(long)]
+        filter: Option<String>,
+
+        /// Maximum assets to print
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
+    /// Search all families for assets whose key contains a substring
+    Find {
+        /// Case-insensitive substring to match against asset keys
+        pattern: String,
+
+        /// Maximum matches to print
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
+    /// Show every mount serving an asset name, resolution winner first
+    Which {
+        /// A lookup key: mount-relative path, bare filename where the family
+        /// collapses basenames, or a namespace-qualified name like "iface/log.pcx"
+        name: String,
+    },
+}
+
+/// The families the tool enumerates, in the game's lookup priority order:
+/// every family the game consults, plus the raw data files (gamesys, missions,
+/// motiondb) as a pseudo-family, plus `fonts` on a classic install (mounted
+/// from `res/fonts.crf` outside the family list there).
+fn family_names() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = shock2vr::resource_families().to_vec();
+    if !shock2vr::is_25th_anniversary_install() {
+        names.push("fonts");
+    }
+    names.push("data");
+    names
+}
+
+fn family_entries(family: &str) -> Vec<AssetEntry> {
+    if family == "data" {
+        let mounts = engine::assets::asset_paths::AssetPath::combine(
+            shock2vr::data_files::data_file_mounts(shock2vr::paths::data_root()),
+        );
+        // The data mount spans all of `data/`, which contains the res/
+        // families already listed as their own families; keep only the
+        // root-level files (gamesys, missions, motiondb).
+        return mounts
+            .entries()
+            .into_iter()
+            .filter(|entry| !entry.key.contains('/'))
+            .collect();
+    }
+    shock2vr::resource_family_paths(family).entries()
+}
+
+/// Mounts the game consults that this tool cannot enumerate, so results can be
+/// incomplete: a classic install's loose `res/mesh` / `res/obj` folder mounts
+/// (which outrank the archives) and its loose data-root files.
+fn print_coverage_caveat() {
+    if !shock2vr::is_25th_anniversary_install() {
+        eprintln!(
+            "note: classic install - loose res/mesh and res/obj folders (which outrank the \
+             archives) and loose data-root files are not enumerated; results may be incomplete"
+        );
+    }
+}
+
+/// Archive path relative to the data root, for compact display.
+fn short_source(source: &str) -> String {
+    let root = shock2vr::paths::data_root().to_string_lossy().into_owned();
+    source
+        .strip_prefix(&format!("{root}/"))
+        .unwrap_or(source)
+        .to_string()
+}
+
+fn ls(family: Option<String>, filter: Option<String>, limit: usize) {
+    print_coverage_caveat();
+    match family {
+        None => {
+            if filter.is_some() {
+                eprintln!("--filter needs a family (e.g. ls obj --filter door)");
+                std::process::exit(1);
+            }
+            // Overview: per family, per archive, how many files each serves.
+            for family in family_names() {
+                let mut per_source: Vec<(String, usize)> = Vec::new();
+                for entry in family_entries(family) {
+                    if entry.is_alias {
+                        continue;
+                    }
+                    match per_source.iter_mut().find(|(s, _)| *s == entry.source) {
+                        Some((_, count)) => *count += 1,
+                        None => per_source.push((entry.source, 1)),
+                    }
+                }
+                if per_source.is_empty() {
+                    continue;
+                }
+                let total: usize = per_source.iter().map(|(_, count)| count).sum();
+                println!("{family} ({total} assets)");
+                for (source, count) in per_source {
+                    println!("  {} ({count})", short_source(&source));
+                }
+            }
+        }
+        Some(family) => {
+            let known = family_names();
+            if !known.contains(&family.as_str()) {
+                eprintln!("unknown family '{family}' (known: {})", known.join(", "));
+                std::process::exit(1);
+            }
+            let needle = filter.map(|f| f.to_ascii_lowercase());
+            let mut entries: Vec<AssetEntry> = family_entries(&family)
+                .into_iter()
+                .filter(|e| !e.is_alias)
+                .filter(|e| needle.as_ref().is_none_or(|n| e.key.contains(n)))
+                .collect();
+            entries.sort_by(|a, b| a.key.cmp(&b.key));
+            for entry in entries.iter().take(limit) {
+                println!("{}\t{}", entry.key, short_source(&entry.source));
+            }
+            if entries.len() > limit {
+                println!("... {} more (raise --limit)", entries.len() - limit);
+            }
+        }
+    }
+}
+
+fn find(pattern: String, limit: usize) {
+    print_coverage_caveat();
+    let needle = pattern.to_ascii_lowercase();
+    let mut shown = 0;
+    let mut total = 0;
+    for family in family_names() {
+        for entry in family_entries(family) {
+            if entry.is_alias || !entry.key.contains(&needle) {
+                continue;
+            }
+            total += 1;
+            if shown < limit {
+                println!("{family}\t{}\t{}", entry.key, short_source(&entry.source));
+                shown += 1;
+            }
+        }
+    }
+    if total > shown {
+        println!("... {} more (raise --limit)", total - shown);
+    }
+    if total == 0 {
+        println!("no assets matching '{pattern}'");
+    }
+}
+
+fn which(name: String) {
+    print_coverage_caveat();
+    let query = name.to_ascii_lowercase();
+    // The game resolves one combined mount list (families in this same order),
+    // so exactly one match can win; everything after it is shadowed. Aliases
+    // count - they are real lookup keys - but only where the mount actually
+    // registered one (`strings` collapses no basenames, for example).
+    let mut winner_marked = false;
+    for family in family_names() {
+        for entry in family_entries(family) {
+            if entry.key != query {
+                continue;
+            }
+            let marker = if winner_marked { "shadowed" } else { "WINNER" };
+            winner_marked = true;
+            println!(
+                "{family}\t{marker}\t{}\t{} ({})",
+                entry.key,
+                short_source(&entry.source),
+                entry.entry_name
+            );
+        }
+    }
+    if !winner_marked {
+        println!("no mount serves '{name}'");
+        std::process::exit(1);
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Ls {
+            family,
+            filter,
+            limit,
+        } => ls(family, filter, limit),
+        Commands::Find { pattern, limit } => find(pattern, limit),
+        Commands::Which { name } => which(name),
+    }
+}


### PR DESCRIPTION
Adds entries() to AbstractAssetPath: ZipAssetPath reports every registered
lookup key (primary mount-relative keys plus basename/namespace aliases,
marked is_alias) derived on demand from the existing lookup map - no extra
per-mount storage on the game's startup path. MultipleAssetPaths concatenates
in resolution-priority order.

Unifies ZipAssetPath's two constructors: new/new2/with_namespace now delegate
to with_prefix_opts with an empty prefix. That normalizes whole-archive alias
registration to first-entry-wins (was last-entry-wins), matching the
first-mount-wins model the rest of the file documents.

Adds a headless dark_explorer CLI (cargo dx) with ls/find/which over the real
mount set - the first slice of a KPF asset-browser tool. 'which' walks the
families in the game's global lookup order and marks the single entry a
lookup would actually serve, aliases included.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>