### PR TITLE
feat(cutscene): signal completion and chain to a follow-on effect

### DIFF
--- a/engine_ffmpeg/src/video_player.rs
+++ b/engine_ffmpeg/src/video_player.rs
@@ -131,7 +131,13 @@ impl VideoPlayer {
     }
 
     pub fn advance_by_time(&mut self, time: Duration) {
-        self.current_time = (self.current_time + time).min(self.duration);
+        self.current_time += time;
+        // A stream that reported no duration must not be clamped to zero, or it
+        // would never decode a second frame and so never reach EOF - the only
+        // completion signal such a stream has.
+        if !self.duration.is_zero() {
+            self.current_time = self.current_time.min(self.duration);
+        }
         let target_frame_index =
             (self.current_time.as_secs_f64() * self.frames_per_second).floor() as usize;
 
@@ -256,5 +262,33 @@ mod tests {
                 "{fixture_name} should be finished after its duration elapses"
             );
         }
+    }
+
+    /// A container that reports no duration has only EOF to signal completion,
+    /// so playback must still advance frame by frame and finish.
+    #[test]
+    fn a_duration_less_stream_still_advances_to_completion() {
+        crate::init().unwrap();
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("streaming-test.avi");
+
+        let mut player = VideoPlayer::from_filename(fixture.to_str().unwrap()).unwrap();
+        player.duration = Duration::ZERO;
+        let first_frame = player.get_current_frame();
+
+        player.advance_by_time(Duration::from_millis(500));
+        assert!(
+            player.current_frame_index > 0,
+            "a duration-less stream should still decode past its first frame"
+        );
+        assert_ne!(player.get_current_frame().bytes, first_frame.bytes);
+        assert!(!player.is_finished());
+
+        player.advance_by_time(Duration::from_secs(60));
+        assert!(
+            player.is_finished(),
+            "a duration-less stream should finish once its frames run out"
+        );
     }
 }

--- a/engine_ffmpeg/src/video_player.rs
+++ b/engine_ffmpeg/src/video_player.rs
@@ -148,9 +148,12 @@ impl VideoPlayer {
                     self.frames_exhausted = true;
                     break;
                 }
+                // Deliberately not latched: a bad packet mid-video would
+                // otherwise mark the whole stream finished and truncate the
+                // cutscene. Breaking lets the next advance retry, and a stream
+                // that reported a duration still completes on its timeline.
                 Err(error) => {
                     eprintln!("cutscene video decode failed: {error}");
-                    self.frames_exhausted = true;
                     break;
                 }
             }

--- a/engine_ffmpeg/src/video_player.rs
+++ b/engine_ffmpeg/src/video_player.rs
@@ -23,6 +23,7 @@ pub struct VideoPlayer {
     decoder: ffmpeg::decoder::Video,
     scaler: ffmpeg::software::scaling::Context,
     sent_eof: bool,
+    frames_exhausted: bool,
 }
 
 impl VideoPlayer {
@@ -86,6 +87,7 @@ impl VideoPlayer {
             decoder,
             scaler,
             sent_eof: false,
+            frames_exhausted: false,
         };
         if !player.decode_next_frame()? {
             return Err(ffmpeg::Error::InvalidData);
@@ -136,9 +138,13 @@ impl VideoPlayer {
         while self.current_frame_index < target_frame_index {
             match self.decode_next_frame() {
                 Ok(true) => self.current_frame_index += 1,
-                Ok(false) => break,
+                Ok(false) => {
+                    self.frames_exhausted = true;
+                    break;
+                }
                 Err(error) => {
                     eprintln!("cutscene video decode failed: {error}");
+                    self.frames_exhausted = true;
                     break;
                 }
             }
@@ -147,6 +153,19 @@ impl VideoPlayer {
 
     pub fn get_current_frame(&self) -> RawTextureData {
         self.current_frame.clone()
+    }
+
+    /// Playback length of the video stream. Zero when neither the stream nor
+    /// the container reported one.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// True once playback has reached the end: either the timeline caught up
+    /// with the reported duration, or the decoder drained (which is the only
+    /// signal available for a stream that reports no duration).
+    pub fn is_finished(&self) -> bool {
+        self.frames_exhausted || (!self.duration.is_zero() && self.current_time >= self.duration)
     }
 }
 
@@ -203,6 +222,38 @@ mod tests {
             assert!(
                 retained_frame_bytes(&player) <= one_rgb_frame,
                 "reaching EOF in {fixture_name} retained prior decoded frames"
+            );
+        }
+    }
+
+    #[test]
+    fn playback_is_finished_only_once_the_video_ends() {
+        crate::init().unwrap();
+        let testdata = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata");
+
+        for fixture_name in ["streaming-test.avi", "streaming-test.ogv"] {
+            let fixture = testdata.join(fixture_name);
+            let mut player = VideoPlayer::from_filename(fixture.to_str().unwrap()).unwrap();
+
+            assert!(
+                !player.duration().is_zero(),
+                "{fixture_name} should report a duration"
+            );
+            assert!(
+                !player.is_finished(),
+                "{fixture_name} should not be finished before it plays"
+            );
+
+            player.advance_by_time(player.duration() / 2);
+            assert!(
+                !player.is_finished(),
+                "{fixture_name} should not be finished halfway through"
+            );
+
+            player.advance_by_time(player.duration());
+            assert!(
+                player.is_finished(),
+                "{fixture_name} should be finished after its duration elapses"
             );
         }
     }

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -769,7 +769,8 @@ pub struct FrameSnapshot {
     pub frame_index: u64,
     pub time: TimeInfo,
     pub mission: String,
-    /// True once the retail finale has entered its terminal ending cutscene.
+    /// True while the retail finale is playing its terminal ending cutscene;
+    /// false again once the chain reaches the main menu.
     pub campaign_completed: bool,
     /// True once a scene has asked the runtime to quit (the main menu's Quit).
     /// The debug runtime deliberately stays up - an automation session must not

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1827,29 +1827,52 @@ impl Game {
             GlobalEffect::PlayerHit { damage } => {
                 self.hit_feedback.trigger(damage);
             }
+            GlobalEffect::PlayCutscene { video, then } => {
+                // A scene swap like the frontend ones: no ledger write-back, and
+                // any pending transition is abandoned.
+                self.pending_transition = None;
+                let follow_on = then.map_or(GlobalEffect::ShowMainMenu, |effect| *effect);
+                let path_string = scenes::resolve_cutscene_path(&video)
+                    .to_string_lossy()
+                    .into_owned();
+                match CutscenePlayerScene::new(
+                    video.clone(),
+                    path_string.clone(),
+                    follow_on.clone(),
+                    &mut self.audio_context,
+                ) {
+                    Ok(cutscene) => self.set_active_scene(Box::new(cutscene)),
+                    Err(error) => {
+                        // An install missing a movie must not strand the player
+                        // on the scene the cutscene was replacing.
+                        warn!(
+                            "Failed to initialize cutscene '{}' from '{}': {} - skipping it",
+                            video, path_string, error
+                        );
+                        self.handle_global_effect(follow_on);
+                    }
+                }
+            }
             GlobalEffect::CompleteCampaign => {
                 // Preserve the destroyed head and the rest of the finale state
                 // in the in-memory mission ledger before the cutscene replaces
                 // the active world.
                 self.save_active_scene();
 
-                let (cutscene_name, cutscene_path) = resolve_ending_cutscene();
-                let path_string = cutscene_path.to_string_lossy().into_owned();
-                let cutscene = CutscenePlayerScene::new(
-                    cutscene_name.clone(),
-                    path_string.clone(),
-                    &mut self.audio_context,
-                )
-                .unwrap_or_else(|error| {
-                    panic!(
-                        "Failed to initialize ending cutscene '{}' from '{}': {}",
-                        cutscene_name, path_string, error
-                    )
-                });
+                let ending_name = resolve_ending_cutscene();
+                let after_ending = match scenes::resolve_credits_cutscene() {
+                    Some(credits_name) => GlobalEffect::PlayCutscene {
+                        video: credits_name,
+                        then: Some(Box::new(GlobalEffect::ShowMainMenu)),
+                    },
+                    None => GlobalEffect::ShowMainMenu,
+                };
 
-                self.pending_transition = None;
-                self.set_active_scene(Box::new(cutscene));
                 self.campaign_completed = true;
+                self.handle_global_effect(GlobalEffect::PlayCutscene {
+                    video: ending_name,
+                    then: Some(Box::new(after_ending)),
+                });
             }
             GlobalEffect::Quit => {
                 self.should_quit = true;

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -900,7 +900,8 @@ impl Game {
         self.should_quit
     }
 
-    /// Whether the retail campaign finale has entered its terminal cutscene.
+    /// Whether the retail campaign finale is playing its terminal cutscene.
+    /// Clears again when the chain reaches the main menu.
     pub fn campaign_completed(&self) -> bool {
         self.campaign_completed
     }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1799,6 +1799,10 @@ impl Game {
             }
             GlobalEffect::ShowMainMenu => {
                 self.pending_transition = None;
+                // The flag means "the finale is on screen", so reaching the menu
+                // ends it - the ending cutscene now finishes rather than holding
+                // its last frame forever.
+                self.campaign_completed = false;
                 self.set_active_scene(Box::new(MainMenuScene::new()));
             }
             GlobalEffect::ShowDeveloper => {
@@ -1831,7 +1835,7 @@ impl Game {
                 // A scene swap like the frontend ones: no ledger write-back, and
                 // any pending transition is abandoned.
                 self.pending_transition = None;
-                let follow_on = then.map_or(GlobalEffect::ShowMainMenu, |effect| *effect);
+                let follow_on = *then;
                 match CutscenePlayerScene::new(video, follow_on.clone(), &mut self.audio_context) {
                     Ok(cutscene) => self.set_active_scene(Box::new(cutscene)),
                     Err(error) => {
@@ -1848,19 +1852,12 @@ impl Game {
                 // the active world.
                 self.save_active_scene();
 
-                let ending_name = resolve_ending_cutscene();
-                let after_ending = match scenes::resolve_credits_cutscene() {
-                    Some(credits_name) => GlobalEffect::PlayCutscene {
-                        video: credits_name,
-                        then: Some(Box::new(GlobalEffect::ShowMainMenu)),
-                    },
-                    None => GlobalEffect::ShowMainMenu,
-                };
+                let after_ending = scenes::finale_follow_on(scenes::resolve_credits_cutscene());
 
                 self.campaign_completed = true;
                 self.handle_global_effect(GlobalEffect::PlayCutscene {
-                    video: ending_name,
-                    then: Some(Box::new(after_ending)),
+                    video: resolve_ending_cutscene(),
+                    then: Box::new(after_ending),
                 });
             }
             GlobalEffect::Quit => {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1832,23 +1832,12 @@ impl Game {
                 // any pending transition is abandoned.
                 self.pending_transition = None;
                 let follow_on = then.map_or(GlobalEffect::ShowMainMenu, |effect| *effect);
-                let path_string = scenes::resolve_cutscene_path(&video)
-                    .to_string_lossy()
-                    .into_owned();
-                match CutscenePlayerScene::new(
-                    video.clone(),
-                    path_string.clone(),
-                    follow_on.clone(),
-                    &mut self.audio_context,
-                ) {
+                match CutscenePlayerScene::new(video, follow_on.clone(), &mut self.audio_context) {
                     Ok(cutscene) => self.set_active_scene(Box::new(cutscene)),
                     Err(error) => {
                         // An install missing a movie must not strand the player
                         // on the scene the cutscene was replacing.
-                        warn!(
-                            "Failed to initialize cutscene '{}' from '{}': {} - skipping it",
-                            video, path_string, error
-                        );
+                        warn!("{error} - skipping it");
                         self.handle_global_effect(follow_on);
                     }
                 }

--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -14,9 +14,9 @@ use crate::{
     game_scene::GameScene,
     input_context::InputContext,
     inventory::PlayerInventoryEntity,
-    mission::{GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo},
+    mission::{GlobalContext, GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo},
     quest_info::QuestInfo,
-    scripts::Effect,
+    scripts::{Effect, GlobalEffect},
     time::Time,
 };
 
@@ -37,14 +37,27 @@ pub struct CutscenePlayerScene {
     screen_vertical_offset: f32,
     video_name: String,
     total_time: Duration,
+    /// Dispatched once, when playback ends. Without it a finished cutscene
+    /// would hold its last frame forever.
+    on_complete: GlobalEffect,
+    completion_emitted: bool,
+    #[cfg(feature = "ffmpeg")]
+    audio_handle: engine::audio::AudioHandle,
     #[cfg(feature = "ffmpeg")]
     video_player: VideoPlayer,
 }
+
+/// How long the non-ffmpeg stub shows its placeholder before completing. There
+/// is no decoder to ask, so a build without video still has to move on rather
+/// than sit on a blank panel forever.
+#[cfg(not(feature = "ffmpeg"))]
+const STUB_PLAYBACK_DURATION: Duration = Duration::from_secs(2);
 
 impl CutscenePlayerScene {
     pub fn new(
         video_name: String,
         video_path: String,
+        on_complete: GlobalEffect,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let world = Self::initialize_world();
@@ -55,7 +68,8 @@ impl CutscenePlayerScene {
 
             let video_player = VideoPlayer::from_filename(&video_path)?;
             let audio_clip = Rc::new(AudioPlayer::from_filename(&video_path)?);
-            play_audio(audio_context, AudioHandle::new(), None, audio_clip);
+            let audio_handle = AudioHandle::new();
+            play_audio(audio_context, audio_handle.clone(), None, audio_clip);
 
             return Ok(Self {
                 world,
@@ -67,6 +81,9 @@ impl CutscenePlayerScene {
                 screen_vertical_offset: 1.5 / dark::SCALE_FACTOR,
                 video_name,
                 total_time: Duration::ZERO,
+                on_complete,
+                completion_emitted: false,
+                audio_handle,
                 video_player,
             });
         }
@@ -85,6 +102,8 @@ impl CutscenePlayerScene {
                 screen_vertical_offset: 1.5 / dark::SCALE_FACTOR,
                 video_name,
                 total_time: Duration::ZERO,
+                on_complete,
+                completion_emitted: false,
             })
         }
     }
@@ -212,6 +231,18 @@ impl CutscenePlayerScene {
             )
         }
     }
+
+    fn playback_is_finished(&self) -> bool {
+        #[cfg(feature = "ffmpeg")]
+        {
+            self.video_player.is_finished()
+        }
+
+        #[cfg(not(feature = "ffmpeg"))]
+        {
+            self.total_time >= STUB_PLAYBACK_DURATION
+        }
+    }
 }
 
 impl GameScene for CutscenePlayerScene {
@@ -240,6 +271,13 @@ impl GameScene for CutscenePlayerScene {
             self.video_player.advance_by_time(time.elapsed);
         }
 
+        // Latched: the scene keeps updating until `Game` swaps it out, and a
+        // repeated completion effect would re-enter the follow-on every frame.
+        if !self.completion_emitted && self.playback_is_finished() {
+            self.completion_emitted = true;
+            return vec![Effect::GlobalEffect(self.on_complete.clone())];
+        }
+
         Vec::new()
     }
 
@@ -250,6 +288,33 @@ impl GameScene for CutscenePlayerScene {
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let screen = self.build_screen_object();
         (vec![screen], self.player_position, self.player_rotation)
+    }
+
+    fn handle_effects(
+        &mut self,
+        effects: Vec<Effect>,
+        _global_context: &GlobalContext,
+        _game_options: &GameOptions,
+        _asset_cache: &mut AssetCache,
+        _audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Vec<GlobalEffect> {
+        effects
+            .into_iter()
+            .filter_map(|effect| match effect {
+                Effect::GlobalEffect(global) => Some(global),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        // The soundtrack is one clip for the whole video; without this it keeps
+        // playing over whatever scene follows until it drains.
+        #[cfg(feature = "ffmpeg")]
+        engine::audio::stop_audio(audio_context, self.audio_handle.clone());
+
+        #[cfg(not(feature = "ffmpeg"))]
+        let _ = audio_context;
     }
 
     fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {

--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, rc::Rc, time::Duration};
+use std::{collections::HashMap, rc::Rc};
+
+#[cfg(not(feature = "ffmpeg"))]
+use std::time::Duration;
 
 use cgmath::{InnerSpace, Matrix3, Matrix4, Quaternion, Vector3, vec3};
 use engine::{
@@ -36,6 +39,8 @@ pub struct CutscenePlayerScene {
     screen_distance: f32,
     screen_vertical_offset: f32,
     video_name: String,
+    /// Only the stub has no decoder to ask how far playback has got.
+    #[cfg(not(feature = "ffmpeg"))]
     total_time: Duration,
     /// Dispatched once, when playback ends. Without it a finished cutscene
     /// would hold its last frame forever.
@@ -90,7 +95,6 @@ impl CutscenePlayerScene {
                 screen_distance: 6.0 / dark::SCALE_FACTOR,
                 screen_vertical_offset: 1.5 / dark::SCALE_FACTOR,
                 video_name,
-                total_time: Duration::ZERO,
                 on_complete,
                 completion_emitted: false,
                 audio_handle,
@@ -272,7 +276,6 @@ impl GameScene for CutscenePlayerScene {
         self.head_rotation = input_context.head.rotation;
         self.player_position = vec3(0.0, 0.0, 0.0);
         self.player_rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        self.total_time += time.elapsed;
         self.update_player_info();
 
         #[cfg(feature = "ffmpeg")]
@@ -280,8 +283,14 @@ impl GameScene for CutscenePlayerScene {
             self.video_player.advance_by_time(time.elapsed);
         }
 
-        // Latched: the scene keeps updating until `Game` swaps it out, and a
-        // repeated completion effect would re-enter the follow-on every frame.
+        #[cfg(not(feature = "ffmpeg"))]
+        {
+            self.total_time += time.elapsed;
+        }
+
+        // Latched because not every `on_complete` replaces this scene - a
+        // follow-on like `Quit` leaves it running, and re-emitting would then
+        // repeat the effect every frame.
         if !self.completion_emitted && self.playback_is_finished() {
             self.completion_emitted = true;
             return vec![Effect::GlobalEffect(self.on_complete.clone())];

--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -54,9 +54,11 @@ pub struct CutscenePlayerScene {
 const STUB_PLAYBACK_DURATION: Duration = Duration::from_secs(2);
 
 impl CutscenePlayerScene {
+    /// `video_name` is a cutscene name, resolved to a file here so every caller
+    /// selects the same one (see [`super::resolve_cutscene_path`]). The error
+    /// names both, so a caller only has to report it.
     pub fn new(
         video_name: String,
-        video_path: String,
         on_complete: GlobalEffect,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -66,8 +68,16 @@ impl CutscenePlayerScene {
         {
             use engine::audio::{AudioHandle, play_audio};
 
-            let video_player = VideoPlayer::from_filename(&video_path)?;
-            let audio_clip = Rc::new(AudioPlayer::from_filename(&video_path)?);
+            let video_path = super::resolve_cutscene_path(&video_name)
+                .to_string_lossy()
+                .into_owned();
+            let describe = |error: &dyn std::fmt::Display| {
+                format!("cutscene '{video_name}' could not be opened from '{video_path}': {error}")
+            };
+            let video_player =
+                VideoPlayer::from_filename(&video_path).map_err(|error| describe(&error))?;
+            let audio_clip =
+                Rc::new(AudioPlayer::from_filename(&video_path).map_err(|error| describe(&error))?);
             let audio_handle = AudioHandle::new();
             play_audio(audio_context, audio_handle.clone(), None, audio_clip);
 
@@ -91,7 +101,6 @@ impl CutscenePlayerScene {
         #[cfg(not(feature = "ffmpeg"))]
         {
             let _ = audio_context;
-            let _ = video_path;
             Ok(Self {
                 world,
                 head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -464,26 +464,52 @@ fn find_file_ignoring_ascii_case(path: &Path) -> Option<PathBuf> {
 /// and classic (`cs3.avi`) installs.
 pub(crate) fn resolve_ending_cutscene() -> String {
     first_present_cutscene(ENDING_CUTSCENE_CANDIDATES)
-        .map(|(name, _)| name)
         .unwrap_or_else(|| ENDING_CUTSCENE_CANDIDATES[0].to_string())
 }
 
 /// The credits roll that follows the ending, or `None` on an install that ships
 /// without one (the finale then returns straight to the menu).
 pub(crate) fn resolve_credits_cutscene() -> Option<String> {
-    first_present_cutscene(CREDITS_CUTSCENE_CANDIDATES).map(|(name, _)| name)
+    first_present_cutscene(CREDITS_CUTSCENE_CANDIDATES)
 }
 
-fn first_present_cutscene(candidates: &[&str]) -> Option<(String, PathBuf)> {
+/// What the ending cutscene hands off to: the credits roll when the install
+/// ships one, then the main menu either way.
+pub(crate) fn finale_follow_on(credits: Option<String>) -> GlobalEffect {
+    match credits {
+        Some(video) => GlobalEffect::PlayCutscene {
+            video,
+            then: Box::new(GlobalEffect::ShowMainMenu),
+        },
+        None => GlobalEffect::ShowMainMenu,
+    }
+}
+
+fn first_present_cutscene(candidates: &[&str]) -> Option<String> {
     candidates
         .iter()
-        .map(|name| ((*name).to_string(), resolve_cutscene_path(name)))
-        .find(|(_, path)| path.is_file())
+        .find(|name| resolve_cutscene_path(name).is_file())
+        .map(|name| (*name).to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The finale always ends up at the menu, through the credits when the
+    /// install has them and directly when it does not.
+    #[test]
+    fn the_finale_chains_through_the_credits_only_when_they_are_installed() {
+        match finale_follow_on(Some("enhanced/credits.ogv".to_string())) {
+            GlobalEffect::PlayCutscene { video, then } => {
+                assert_eq!(video, "enhanced/credits.ogv");
+                assert!(matches!(*then, GlobalEffect::ShowMainMenu));
+            }
+            other => panic!("expected the credits to play, got {other:?}"),
+        }
+
+        assert!(matches!(finale_follow_on(None), GlobalEffect::ShowMainMenu));
+    }
 
     /// The launcher offers exactly what the dispatcher can build, and every
     /// name is a distinct `debug_` name the CLI accepts too.

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -218,20 +218,11 @@ pub fn create_initial_scene(
 ) -> SceneInitResult {
     if is_cutscene_file(&options.mission) {
         let mission_name = options.mission.clone();
-        let cutscene_path = resolve_cutscene_path(&mission_name);
-        let cutscene_path_string = cutscene_path.to_string_lossy().into_owned();
-        let cutscene = CutscenePlayerScene::new(
-            mission_name.clone(),
-            cutscene_path_string.clone(),
-            GlobalEffect::ShowMainMenu,
-            audio_context,
-        )
-        .unwrap_or_else(|err| {
-            panic!(
-                "Failed to initialize cutscene '{}' from '{}': {}",
-                mission_name, cutscene_path_string, err
-            )
-        });
+        let cutscene =
+            CutscenePlayerScene::new(mission_name, GlobalEffect::ShowMainMenu, audio_context)
+                // An explicitly requested cutscene that cannot be opened is a
+                // bad invocation, so fail loudly rather than boot elsewhere.
+                .unwrap_or_else(|err| panic!("{err}"));
         return SceneInitResult {
             scene: Box::new(cutscene),
             mission_save_data: HashMap::new(),

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     paths,
     save_load::{EntitySaveData, HeldItemSaveData, SaveData},
+    scripts::GlobalEffect,
 };
 
 pub mod cutscene_player;
@@ -110,7 +111,12 @@ pub struct SceneInitResult {
     pub mission_save_data: HashMap<String, EntitySaveData>,
 }
 
+// Movie names are not present in the mission or gamesys data - the original
+// picked them in its engine/game-script code - so the finale's videos are named
+// here.
 const ENDING_CUTSCENE_CANDIDATES: &[&str] = &["enhanced/cs3.ogv", "cs3.avi", "cs3.ogv"];
+const CREDITS_CUTSCENE_CANDIDATES: &[&str] =
+    &["enhanced/credits.ogv", "credits.avi", "credits.ogv"];
 const ANNIVERSARY_CUTSCENE_LAYERS: &[&str] = &["enhanced", "original", "kex"];
 
 /// How a debug scene is built. Every entry in [`DEBUG_SCENES`] has this shape,
@@ -217,6 +223,7 @@ pub fn create_initial_scene(
         let cutscene = CutscenePlayerScene::new(
             mission_name.clone(),
             cutscene_path_string.clone(),
+            GlobalEffect::ShowMainMenu,
             audio_context,
         )
         .unwrap_or_else(|err| {
@@ -464,16 +471,23 @@ fn find_file_ignoring_ascii_case(path: &Path) -> Option<PathBuf> {
 
 /// Resolve the retail ending for both 25th Anniversary (`enhanced/cs3.ogv`)
 /// and classic (`cs3.avi`) installs.
-pub(crate) fn resolve_ending_cutscene() -> (String, PathBuf) {
-    ENDING_CUTSCENE_CANDIDATES
+pub(crate) fn resolve_ending_cutscene() -> String {
+    first_present_cutscene(ENDING_CUTSCENE_CANDIDATES)
+        .map(|(name, _)| name)
+        .unwrap_or_else(|| ENDING_CUTSCENE_CANDIDATES[0].to_string())
+}
+
+/// The credits roll that follows the ending, or `None` on an install that ships
+/// without one (the finale then returns straight to the menu).
+pub(crate) fn resolve_credits_cutscene() -> Option<String> {
+    first_present_cutscene(CREDITS_CUTSCENE_CANDIDATES).map(|(name, _)| name)
+}
+
+fn first_present_cutscene(candidates: &[&str]) -> Option<(String, PathBuf)> {
+    candidates
         .iter()
         .map(|name| ((*name).to_string(), resolve_cutscene_path(name)))
         .find(|(_, path)| path.is_file())
-        .unwrap_or_else(|| {
-            let name = ENDING_CUTSCENE_CANDIDATES[0].to_string();
-            let path = resolve_cutscene_path(&name);
-            (name, path)
-        })
 }
 
 #[cfg(test)]

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -78,9 +78,9 @@ pub enum GlobalEffect {
     },
 
     /// Play `video` full-screen, replacing whatever scene is active, and
-    /// dispatch `then` once it finishes (defaulting to the main menu). The name
-    /// is resolved by `scenes::resolve_cutscene_path`; a video that cannot be
-    /// opened is skipped straight to `then` rather than stranding the player.
+    /// dispatch `then` once it finishes. The name is resolved by
+    /// `scenes::resolve_cutscene_path`; a video that cannot be opened is skipped
+    /// straight to `then` rather than stranding the player.
     ///
     /// Handling this does *not* write the outgoing mission back to the
     /// in-memory level ledger, because the cutscene's own empty world would be
@@ -89,7 +89,7 @@ pub enum GlobalEffect {
     /// resumes gameplay depends on that having happened.
     PlayCutscene {
         video: String,
-        then: Option<Box<GlobalEffect>>,
+        then: Box<GlobalEffect>,
     },
 
     /// Play the retail ending and enter the campaign's terminal state.

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -77,6 +77,15 @@ pub enum GlobalEffect {
         name: String,
     },
 
+    /// Play `video` full-screen, replacing whatever scene is active, and
+    /// dispatch `then` once it finishes (defaulting to the main menu). The name
+    /// is resolved by `scenes::resolve_cutscene_path`; a video that cannot be
+    /// opened is skipped straight to `then` rather than stranding the player.
+    PlayCutscene {
+        video: String,
+        then: Option<Box<GlobalEffect>>,
+    },
+
     /// Play the retail ending and enter the campaign's terminal state.
     CompleteCampaign,
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -81,6 +81,12 @@ pub enum GlobalEffect {
     /// dispatch `then` once it finishes (defaulting to the main menu). The name
     /// is resolved by `scenes::resolve_cutscene_path`; a video that cannot be
     /// opened is skipped straight to `then` rather than stranding the player.
+    ///
+    /// Handling this does *not* write the outgoing mission back to the
+    /// in-memory level ledger, because the cutscene's own empty world would be
+    /// what got saved. A caller that interrupts live gameplay is responsible for
+    /// preserving it first (as `CompleteCampaign` does), and any `then` that
+    /// resumes gameplay depends on that having happened.
     PlayCutscene {
         video: String,
         then: Option<Box<GlobalEffect>>,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -591,7 +591,8 @@ export interface FrameSnapshot {
   frame_index: number;
   time: { total: number; delta: number };
   mission: string;
-  /** True once the retail finale has entered its terminal ending cutscene. */
+  /** True while the retail finale is playing its terminal ending cutscene;
+   * false again once the chain reaches the main menu. */
   campaign_completed: boolean;
   /** True once a scene asked the runtime to quit (the main menu's Quit). The
    * debug runtime stays up regardless, so this is how the quit path is

--- a/tools/shock2-sdk/test/cutscene-completion.e2e.test.ts
+++ b/tools/shock2-sdk/test/cutscene-completion.e2e.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { test } from "node:test";
+import { join } from "node:path";
+
+import { GameServer, findRepoRoot } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// A short authored clip, so the test can step past its whole duration. The
+// runtime's own resolver takes the bare classic name through the Anniversary
+// layers, so both installs play the same scene.
+const SHORT_CUTSCENE = "landing.avi";
+const CUTSCENE_LAYERS = ["", "enhanced", "original", "kex"];
+
+function dataRoot(): string {
+  return (
+    process.env.DARK_ASSET_PATH ??
+    join(findRepoRoot(process.cwd()) ?? process.cwd(), "Data")
+  );
+}
+
+/** Whether any install layer actually ships the clip this test plays. */
+function cutsceneIsInstalled(): boolean {
+  return CUTSCENE_LAYERS.some((layer) =>
+    ["avi", "ogv"].some((extension) =>
+      existsSync(
+        join(
+          dataRoot(),
+          "cutscenes",
+          layer,
+          `${SHORT_CUTSCENE.replace(/\.avi$/, "")}.${extension}`,
+        ),
+      ),
+    ),
+  );
+}
+
+test(
+  "a cutscene signals completion and hands off to its follow-on scene",
+  { skip: !e2eEnabled, timeout: 300_000 },
+  async () => {
+    if (!cutsceneIsInstalled()) {
+      // Nothing to assert on an install without the clip; skipping beats a
+      // failure that says nothing about the change.
+      return;
+    }
+
+    await using game = await GameServer.launch({ mission: SHORT_CUTSCENE });
+
+    // Mid-playback the cutscene must still own the screen, or "it ended" would
+    // be indistinguishable from "it never started".
+    await game.step({ frames: 60 });
+    const playing = (await game.info()).mission;
+    assert.match(
+      playing,
+      /landing\.(avi|ogv)$/i,
+      "the cutscene should be the active scene while it plays",
+    );
+
+    // landing is under 5s; 12s of fixed-timestep stepping clears it with room
+    // for a slower re-encode.
+    await game.step({ frames: 12 * 60 });
+
+    assert.equal(
+      (await game.info()).mission,
+      "main_menu",
+      "a finished cutscene should hand off to the main menu",
+    );
+    assert.equal((await game.health()).status, "ok");
+  },
+);

--- a/tools/shock2-sdk/test/cutscene-completion.e2e.test.ts
+++ b/tools/shock2-sdk/test/cutscene-completion.e2e.test.ts
@@ -13,28 +13,37 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 // layers, so both installs play the same scene.
 const SHORT_CUTSCENE = "landing.avi";
 const CUTSCENE_STEM = "landing";
-const CUTSCENE_LAYERS = ["", "enhanced", "original", "kex"];
+const ANNIVERSARY_LAYERS = ["enhanced", "original", "kex"];
 
 /**
- * Whether any install layer ships the clip this test plays, matching the
- * runtime resolver's case-insensitive name comparison (its Anniversary layers
- * are `.ogv` while a classic install has `.avi`).
+ * Whether the runtime would resolve this test's clip to a real file. Mirrors
+ * `resolve_cutscene_path` exactly, including that it is case-insensitive and
+ * that its Anniversary layer fallback only ever tries `<stem>.ogv` - accepting
+ * a layered `.avi` here would report "installed" for a name the runtime then
+ * fails to open.
  */
 function installedCutscene(): string | null {
-  for (const layer of CUTSCENE_LAYERS) {
+  const found = (layer: string, names: string[]): string | null => {
     let entries: string[];
     try {
       entries = readdirSync(join(dataRoot(), "cutscenes", layer));
     } catch {
-      continue;
+      return null;
     }
+    const wanted = names.map((name) => name.toLowerCase());
     const match = entries.find((entry) =>
-      ["avi", "ogv"].some(
-        (extension) =>
-          entry.toLowerCase() === `${CUTSCENE_STEM}.${extension}`.toLowerCase(),
-      ),
+      wanted.includes(entry.toLowerCase()),
     );
-    if (match) return join(layer, match);
+    return match ? join(layer, match) : null;
+  };
+
+  // The bare `cutscenes/` root takes the requested name, or its `.ogv` twin.
+  const rooted = found("", [`${CUTSCENE_STEM}.avi`, `${CUTSCENE_STEM}.ogv`]);
+  if (rooted) return rooted;
+
+  for (const layer of ANNIVERSARY_LAYERS) {
+    const layered = found(layer, [`${CUTSCENE_STEM}.ogv`]);
+    if (layered) return layered;
   }
   return null;
 }

--- a/tools/shock2-sdk/test/cutscene-completion.e2e.test.ts
+++ b/tools/shock2-sdk/test/cutscene-completion.e2e.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { test } from "node:test";
 import { join } from "node:path";
 
-import { GameServer, findRepoRoot } from "../src/index.js";
+import { GameServer } from "../src/index.js";
+import { dataRoot } from "./helpers/crf.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
@@ -11,38 +12,42 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 // runtime's own resolver takes the bare classic name through the Anniversary
 // layers, so both installs play the same scene.
 const SHORT_CUTSCENE = "landing.avi";
+const CUTSCENE_STEM = "landing";
 const CUTSCENE_LAYERS = ["", "enhanced", "original", "kex"];
 
-function dataRoot(): string {
-  return (
-    process.env.DARK_ASSET_PATH ??
-    join(findRepoRoot(process.cwd()) ?? process.cwd(), "Data")
-  );
-}
-
-/** Whether any install layer actually ships the clip this test plays. */
-function cutsceneIsInstalled(): boolean {
-  return CUTSCENE_LAYERS.some((layer) =>
-    ["avi", "ogv"].some((extension) =>
-      existsSync(
-        join(
-          dataRoot(),
-          "cutscenes",
-          layer,
-          `${SHORT_CUTSCENE.replace(/\.avi$/, "")}.${extension}`,
-        ),
+/**
+ * Whether any install layer ships the clip this test plays, matching the
+ * runtime resolver's case-insensitive name comparison (its Anniversary layers
+ * are `.ogv` while a classic install has `.avi`).
+ */
+function installedCutscene(): string | null {
+  for (const layer of CUTSCENE_LAYERS) {
+    let entries: string[];
+    try {
+      entries = readdirSync(join(dataRoot(), "cutscenes", layer));
+    } catch {
+      continue;
+    }
+    const match = entries.find((entry) =>
+      ["avi", "ogv"].some(
+        (extension) =>
+          entry.toLowerCase() === `${CUTSCENE_STEM}.${extension}`.toLowerCase(),
       ),
-    ),
-  );
+    );
+    if (match) return join(layer, match);
+  }
+  return null;
 }
 
 test(
   "a cutscene signals completion and hands off to its follow-on scene",
   { skip: !e2eEnabled, timeout: 300_000 },
-  async () => {
-    if (!cutsceneIsInstalled()) {
-      // Nothing to assert on an install without the clip; skipping beats a
-      // failure that says nothing about the change.
+  async (t) => {
+    const installed = installedCutscene();
+    if (!installed) {
+      // Nothing to assert on an install without the clip. Skip visibly - a
+      // silent pass would hide the whole test.
+      t.skip(`no ${CUTSCENE_STEM} cutscene installed under ${dataRoot()}`);
       return;
     }
 
@@ -51,10 +56,9 @@ test(
     // Mid-playback the cutscene must still own the screen, or "it ended" would
     // be indistinguishable from "it never started".
     await game.step({ frames: 60 });
-    const playing = (await game.info()).mission;
     assert.match(
-      playing,
-      /landing\.(avi|ogv)$/i,
+      (await game.info()).mission,
+      new RegExp(`${CUTSCENE_STEM}\\.(avi|ogv)$`, "i"),
       "the cutscene should be the active scene while it plays",
     );
 


### PR DESCRIPTION
Stacks on #1194 (PR A). Base: `feat/cutscene-followups-a-loading-screen-default`.

A cutscene held its last frame forever: `CutscenePlayerScene::update` accumulated `total_time` but never read it, returned no effects, and had no `handle_effects`.

## Changes

- `VideoPlayer::duration()` / `is_finished()` — finished when the timeline reaches the reported duration, or when the decoder drains (the only signal for a stream that reports no duration).
- `GlobalEffect::PlayCutscene { video, then }` — swaps in the cutscene scene and dispatches `then` when it ends. A video that cannot be opened is **skipped straight to `then`** rather than stranding the player.
- `CutscenePlayerScene::new` takes a cutscene *name* and an `on_complete: GlobalEffect`; it resolves the path itself, and emits the effect **once** (latched, because a follow-on need not replace the scene) through `handle_effects`.
- Entry points: `--mission <video>` → main menu on finish; `CompleteCampaign` → cs3 → credits → main menu via `scenes::finale_follow_on`, with credits resolved through the same layered candidate list and tolerated missing.
- Non-ffmpeg stub completes after a fixed 2s so those builds don't sit on a blank panel.
- `on_exit` now stops the cutscene soundtrack — previously moot (the scene never exited), now load-bearing or the audio bleeds into the next scene.

Out of scope (later PRs): skip input, `TransitionLevel` wiring, audio streaming.

## Review findings

Two independent adversarial reviewers (Claude + Codex) plus a dedicated duplication pass. Fixed:

- **High** — `advance_by_time` clamped `current_time` to a *zero* duration, so a container reporting none never decoded a second frame and never reached EOF, its only completion signal. Clamped only when the duration is known; covered by `a_duration_less_stream_still_advances_to_completion` (negative-verified).
- **Medium** — `campaign_completed` outlived the cutscene it documents ("the finale has entered its terminal cutscene"): the chain now *ends*, and `ShowMainMenu` didn't clear the flag, so `/v1/info` read `true` while sitting on the menu. Cleared in the `ShowMainMenu` arm.
- **Low/correctness** — a decode *error* was latched as EOF, so one bad packet mid-video would silently truncate the finale and jump to the menu. Only true EOF latches now.
- **Coverage** — the actually-new branching (ending → credits → menu, and the credits-missing arm) had no test. Extracted `scenes::finale_follow_on` and unit-tested both arms host-side, no assets or runtime needed.
- **Duplication (`reuse`)** — both call sites repeated `resolve_cutscene_path` → stringify → `new(name, path, ..)`, and `new` never got a path from anywhere else. Folded into the constructor; the error names both name and resolved path.
- **Simplicity** — `then` is a plain `Box` (no call site constructed `None`); `first_present_cutscene` returns just the name both callers wanted; `total_time` is `cfg`'d to the stub that reads it; the latch comment now describes what it actually guards rather than a per-frame re-entry that cannot happen (`handle_global_effect` runs in the same `Game::update`).
- **Test rigour** — the e2e returned early (reporting a pass) when the clip was absent, and its install probe was a *superset* of the resolver (a layer only ever yields `<stem>.ogv`), so a layered `.avi` would have claimed "installed" for a name the runtime then fails to open. Now `t.skip(...)` with a probe that mirrors the resolver.

Justified, not changed:

- **`PlayCutscene` performs no level-ledger write-back** (the cutscene's own empty world is what would get saved). Every `then` here is a frontend continuation that never reads the ledger, and `CompleteCampaign` still does its own `save_active_scene` first. Documented on the variant so PR C's `TransitionLevel` wiring inherits the contract explicitly.
- **`create_initial_scene` still panics** on an unopenable video while `PlayCutscene` warns and falls through. Deliberately different: `--mission <video>` is a CLI argument error worth failing loudly on; an in-game chain must never strand a player. Both sites now say so.
- **The finale is 9m27s of unskippable video** (cs3 172s + credits 395s on 25AE) and cutscenes aren't pausable. Worth flagging: it is still a strict improvement over the previous behavior (frozen on the last frame *forever*, with the same absence of an exit), and skip input is the next PR in this stack. If you'd rather not ship the credits leg before skip exists, `scenes::finale_follow_on` is the one place to change.
- **`handle_effects`' `filter_map(Effect::GlobalEffect)` body is the sixth verbatim copy** across `scenes/*.rs`. A shared `forward_global_effects` helper is the right fix, but converting the five pre-existing frontend scenes is unrelated churn in a stacked cutscene PR.

## Testing

- `engine_ffmpeg`: 4/4. `cargo test -p shock2vr`: 1148 passed (incl. the new finale-chain test).
- New e2e `tools/shock2-sdk/test/cutscene-completion.e2e.test.ts`: launches `--mission landing.avi`, asserts the cutscene owns the screen mid-playback, steps past its duration, asserts `main_menu`. **Negative test verified** — on the stack base it fails with `actual: 'landing.avi'`.
- `cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; also `-p shock2vr --no-default-features` (the stub path).

No visual change: the cutscene renders identically; only its ending behavior changes.
