### PR TITLE
feat(tools): 3D model preview in dark_explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,9 +1154,13 @@ dependencies = [
 name = "dark_explorer"
 version = "0.1.0"
 dependencies = [
+ "cgmath",
  "clap",
+ "dark",
+ "dark_viewer",
  "eframe",
  "engine",
+ "gl",
  "image 0.24.7",
  "shock2vr",
 ]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -314,6 +314,87 @@ pub fn resource_family_paths(
     AssetPath::combine(mounts)
 }
 
+/// The full mount stack the game resolves assets through, for the current
+/// install layout - shared with tools (dark_explorer's model preview) that
+/// need game-identical asset resolution without a `Game`.
+///
+/// A 25th Anniversary install keeps everything inside KPF archives, so it
+/// needs a different mount list from a pre-remaster install's loose `.crf`s.
+pub fn game_asset_mounts(
+    bundle_storage: Arc<dyn Storage>,
+) -> Box<dyn engine::assets::asset_paths::AbstractAssetPath> {
+    if install::probe_data_root().kind == install::InstallKind::Anniversary {
+        AssetPath::combine(build_25th_anniversary_mounts(bundle_storage.clone()))
+    } else {
+        AssetPath::combine(vec![
+            AssetPath::folder(resource_path("res/mesh")),
+            // AssetPath::folder(resource_path("res/mesh/txt16")),
+            AssetPath::folder(resource_path("res/obj")),
+            // AssetPath::folder(resource_path("res/obj/txt16")),
+            ZipAssetPath::new(resource_path("res/obj.crf")),
+            ZipAssetPath::new(resource_path("res/bitmap.crf")),
+            // Log/email sender portraits + deck icons (the reader panel art).
+            ZipAssetPath::new(resource_path("res/book.crf")),
+            ZipAssetPath::new(resource_path("res/fam.crf")),
+            // The canonical font family. iface.crf also bundles a "fonts/"
+            // subfolder sharing most of these basenames (mostly identical,
+            // but its MAINFONT.FON/MAINAA.FON are stripped copies missing
+            // glyph data for '%' and '&' - a 1px-wide blank cell instead of
+            // the real bitmap), so this must be mounted first to win.
+            ZipAssetPath::new(resource_path("res/fonts.crf")),
+            // Also mounted under the "iface/" namespace: iface.crf shares seven
+            // basenames with the obj/bitmap mounts above (access/block/log/
+            // plant1/repair/stats.pcx + palette1.pal), and first-mount-wins
+            // means those plain names must keep resolving to the model
+            // textures. GUI code that wants the interface art requests the
+            // archive-qualified "iface/<name>" key instead.
+            ZipAssetPath::with_namespace(resource_path("res/iface.crf"), "iface"),
+            ZipAssetPath::new(resource_path("res/intrface.crf")),
+            ZipAssetPath::new(resource_path("res/mesh.crf")),
+            ZipAssetPath::new(resource_path("res/motions.crf")),
+            ZipAssetPath::new(resource_path("res/objicon.crf")),
+            ZipAssetPath::new(resource_path("res/snd.crf")),
+            ZipAssetPath::new(resource_path("res/snd2.crf")),
+            ZipAssetPath::new(resource_path("res/song.crf")),
+            ZipAssetPath::new2(resource_path("res/strings.crf"), false),
+            // Bundle assets
+            BundleAssetPath::new("".to_owned(), bundle_storage),
+            // Textures
+            // AssetPath::folder("res/bitmap".to_owned()),
+            // AssetPath::folder("res/bitmap/txt16".to_owned()),
+            //AssetPath::folder("res/fam".to_owned()),
+            // Models
+            // AssetPath::folder("res/mesh/txt16".to_owned()),
+            // AssetPath::folder("res/obj".to_owned()),
+            // AssetPath::folder("res/mesh".to_owned()),
+            // Animations
+            //AssetPath::folder("res/motions".to_owned()),
+            // Motion db
+            AssetPath::folder("".to_owned()),
+            // Audio
+            // AssetPath::folder("res/snd".to_owned()),
+            // AssetPath::folder("res/snd/amb".to_owned()),
+            // AssetPath::folder("res/snd/Assassin".to_owned()),
+            // AssetPath::folder("res/snd/BBetty".to_owned()),
+            // AssetPath::folder("res/snd/Devices".to_owned()),
+            // AssetPath::folder("res/snd/GRUB".to_owned()),
+            // AssetPath::folder("res/snd/HITS".to_owned()),
+            // AssetPath::folder("res/snd/MaintBot/english".to_owned()),
+            // AssetPath::folder("res/snd/Midwife/english".to_owned()),
+            // AssetPath::folder("res/snd/OGRUNT/english".to_owned()),
+            // AssetPath::folder("res/snd/Overlord/english".to_owned()),
+            // AssetPath::folder("res/snd/SONGS".to_owned()),
+            // AssetPath::folder("res/snd/TurrCam".to_owned()),
+            // AssetPath::folder("res/snd/Weapons".to_owned()),
+            // AssetPath::folder("res/snd2/vBriefs/ENGLISH".to_owned()),
+            // AssetPath::folder("res/snd2/vCs/ENGLISH".to_owned()),
+            // AssetPath::folder("res/snd2/vEmails/english".to_owned()),
+            // AssetPath::folder("res/snd2/vLogs/english".to_owned()),
+            // AssetPath::folder("res/snd2/vTriggers/english".to_owned()),
+        ])
+    }
+}
+
 fn build_25th_anniversary_mounts(
     bundle_storage: Arc<dyn Storage>,
 ) -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
@@ -1133,78 +1214,7 @@ impl Game {
             panic!("cannot load the game: {}", install.summary());
         }
 
-        // A 25th Anniversary install keeps everything inside KPF archives, so it
-        // needs a different mount list from a pre-remaster install's loose `.crf`s.
-        let asset_paths = if install.kind == install::InstallKind::Anniversary {
-            AssetPath::combine(build_25th_anniversary_mounts(bundle_storage.clone()))
-        } else {
-            AssetPath::combine(vec![
-                AssetPath::folder(resource_path("res/mesh")),
-                // AssetPath::folder(resource_path("res/mesh/txt16")),
-                AssetPath::folder(resource_path("res/obj")),
-                // AssetPath::folder(resource_path("res/obj/txt16")),
-                ZipAssetPath::new(resource_path("res/obj.crf")),
-                ZipAssetPath::new(resource_path("res/bitmap.crf")),
-                // Log/email sender portraits + deck icons (the reader panel art).
-                ZipAssetPath::new(resource_path("res/book.crf")),
-                ZipAssetPath::new(resource_path("res/fam.crf")),
-                // The canonical font family. iface.crf also bundles a "fonts/"
-                // subfolder sharing most of these basenames (mostly identical,
-                // but its MAINFONT.FON/MAINAA.FON are stripped copies missing
-                // glyph data for '%' and '&' - a 1px-wide blank cell instead of
-                // the real bitmap), so this must be mounted first to win.
-                ZipAssetPath::new(resource_path("res/fonts.crf")),
-                // Also mounted under the "iface/" namespace: iface.crf shares seven
-                // basenames with the obj/bitmap mounts above (access/block/log/
-                // plant1/repair/stats.pcx + palette1.pal), and first-mount-wins
-                // means those plain names must keep resolving to the model
-                // textures. GUI code that wants the interface art requests the
-                // archive-qualified "iface/<name>" key instead.
-                ZipAssetPath::with_namespace(resource_path("res/iface.crf"), "iface"),
-                ZipAssetPath::new(resource_path("res/intrface.crf")),
-                ZipAssetPath::new(resource_path("res/mesh.crf")),
-                ZipAssetPath::new(resource_path("res/motions.crf")),
-                ZipAssetPath::new(resource_path("res/objicon.crf")),
-                ZipAssetPath::new(resource_path("res/snd.crf")),
-                ZipAssetPath::new(resource_path("res/snd2.crf")),
-                ZipAssetPath::new(resource_path("res/song.crf")),
-                ZipAssetPath::new2(resource_path("res/strings.crf"), false),
-                // Bundle assets
-                BundleAssetPath::new("".to_owned(), bundle_storage),
-                // Textures
-                // AssetPath::folder("res/bitmap".to_owned()),
-                // AssetPath::folder("res/bitmap/txt16".to_owned()),
-                //AssetPath::folder("res/fam".to_owned()),
-                // Models
-                // AssetPath::folder("res/mesh/txt16".to_owned()),
-                // AssetPath::folder("res/obj".to_owned()),
-                // AssetPath::folder("res/mesh".to_owned()),
-                // Animations
-                //AssetPath::folder("res/motions".to_owned()),
-                // Motion db
-                AssetPath::folder("".to_owned()),
-                // Audio
-                // AssetPath::folder("res/snd".to_owned()),
-                // AssetPath::folder("res/snd/amb".to_owned()),
-                // AssetPath::folder("res/snd/Assassin".to_owned()),
-                // AssetPath::folder("res/snd/BBetty".to_owned()),
-                // AssetPath::folder("res/snd/Devices".to_owned()),
-                // AssetPath::folder("res/snd/GRUB".to_owned()),
-                // AssetPath::folder("res/snd/HITS".to_owned()),
-                // AssetPath::folder("res/snd/MaintBot/english".to_owned()),
-                // AssetPath::folder("res/snd/Midwife/english".to_owned()),
-                // AssetPath::folder("res/snd/OGRUNT/english".to_owned()),
-                // AssetPath::folder("res/snd/Overlord/english".to_owned()),
-                // AssetPath::folder("res/snd/SONGS".to_owned()),
-                // AssetPath::folder("res/snd/TurrCam".to_owned()),
-                // AssetPath::folder("res/snd/Weapons".to_owned()),
-                // AssetPath::folder("res/snd2/vBriefs/ENGLISH".to_owned()),
-                // AssetPath::folder("res/snd2/vCs/ENGLISH".to_owned()),
-                // AssetPath::folder("res/snd2/vEmails/english".to_owned()),
-                // AssetPath::folder("res/snd2/vLogs/english".to_owned()),
-                // AssetPath::folder("res/snd2/vTriggers/english".to_owned()),
-            ])
-        };
+        let asset_paths = game_asset_mounts(bundle_storage.clone());
         // Global items
         let base_path = paths::data_root().to_string_lossy().into_owned();
         let mut asset_cache = AssetCache::new(base_path, asset_paths);

--- a/tools/dark_explorer/Cargo.toml
+++ b/tools/dark_explorer/Cargo.toml
@@ -10,6 +10,10 @@ path = "src/main.rs"
 [dependencies]
 engine = { path = "../../engine" }
 shock2vr = { path = "../../shock2vr", default-features = false }
+dark = { path = "../../dark" }
+dark_viewer = { path = "../dark_viewer", default-features = false }
+gl = "0.14.0"
+cgmath = "0.18.0"
 clap = { version = "4.5.4", features = ["derive"] }
 eframe = { version = "=0.36.1", default-features = false, features = ["glow", "default_fonts", "wayland", "x11"] }
 # Same version the engine uses, so the workspace builds one copy.

--- a/tools/dark_explorer/src/main.rs
+++ b/tools/dark_explorer/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use engine::assets::asset_paths::AssetEntry;
 
 mod explorer;
+mod model_preview;
 mod ui;
 
 use explorer::{family_entries, family_names, print_coverage_caveat, short_source};
@@ -52,6 +53,14 @@ enum Commands {
         /// Open with the search box pre-filled with this filter
         #[arg(long)]
         search: Option<String>,
+
+        /// Start the 3D model preview with the skeleton overlay on
+        #[arg(long)]
+        skeletons: bool,
+
+        /// Start the 3D model preview with the hitbox overlay on
+        #[arg(long)]
+        hitboxes: bool,
     },
     /// Show every mount serving an asset name, resolution winner first
     Which {
@@ -181,7 +190,15 @@ fn main() {
             screenshot,
             select,
             search,
-        } => ui::run(screenshot, select, search),
+            skeletons,
+            hitboxes,
+        } => ui::run(ui::UiOptions {
+            screenshot,
+            select,
+            search,
+            skeletons,
+            hitboxes,
+        }),
         Commands::Which { name } => which(name),
     }
 }

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -1,0 +1,357 @@
+//! 3D model preview: renders a `dark_viewer` scene with the game engine into
+//! an offscreen FBO, shown in the preview pane as an egui texture, with an
+//! orbit camera (drag to rotate, scroll to zoom) and the viewer's debug
+//! skeleton/hitbox overlays.
+//!
+//! GL interop: eframe's glow backend owns the GL context; `init_raw_gl` points
+//! the engine's raw `gl` function pointers at the same context via
+//! `cc.get_proc_address`, so the engine can render while eframe's context is
+//! current (it is, throughout `App::ui`). The engine draws into our own FBO
+//! (its render clears whatever framebuffer is bound), and the FBO's color
+//! texture is registered with egui as a native texture.
+
+use std::ffi::CString;
+
+use cgmath::{Quaternion, Rad, Rotation3, vec2, vec3};
+use dark::importers::MODELS_IMPORTER;
+use dark_viewer::scenes::{BinObjViewerScene, ToolScene};
+use eframe::{egui, glow};
+use engine::Engine;
+use engine::assets::asset_cache::AssetCache;
+use engine::assets::asset_paths::{AbstractAssetPath, AssetPath};
+use engine::assets::bundle_asset_path::BundleAssetPath;
+
+use crate::ui::quiet_catch;
+
+/// Load the raw `gl` crate's function pointers from eframe's GL context.
+/// Call once, in the `AppCreator` closure, before any engine rendering.
+pub fn init_raw_gl(cc: &eframe::CreationContext<'_>) {
+    if let Some(get_proc) = cc.get_proc_address.clone() {
+        gl::load_with(move |symbol| match CString::new(symbol) {
+            Ok(symbol) => get_proc(&symbol),
+            Err(_) => std::ptr::null(),
+        });
+    }
+}
+
+/// Offscreen render target whose color texture egui displays.
+struct OffscreenTarget {
+    fbo: u32,
+    depth: u32,
+    size: [i32; 2],
+    egui_texture: egui::TextureId,
+}
+
+pub struct ModelPreview {
+    engine: Box<dyn Engine>,
+    asset_cache: AssetCache,
+    /// What the current scene (or error) was built for: (key, skeletons,
+    /// hitboxes). Guards against rebuilding — or re-panicking — every frame.
+    built_for: Option<(String, bool, bool)>,
+    scene: Option<Box<dyn ToolScene>>,
+    error: Option<String>,
+    pub debug_skeletons: bool,
+    pub debug_hit_boxes: bool,
+    // Orbit camera around `target` (dark_viewer's parameterization: pitch 90
+    // is horizontal, distance along the orbit radius).
+    yaw: f32,
+    pitch: f32,
+    distance: f32,
+    target: cgmath::Vector3<f32>,
+    fbo: Option<OffscreenTarget>,
+}
+
+impl ModelPreview {
+    /// Build the render host: the engine plus one asset cache over the same
+    /// family mounts the game resolves models and textures through.
+    pub fn new() -> ModelPreview {
+        let engine = engine::opengl();
+        let mut mounts: Vec<Box<dyn AbstractAssetPath>> = shock2vr::resource_families()
+            .iter()
+            .map(|family| shock2vr::resource_family_paths(family))
+            .collect();
+        // Engine bundle assets (the grid ground-plane texture).
+        mounts.push(BundleAssetPath::new("".to_owned(), engine.get_storage()));
+        let base_path = shock2vr::paths::data_root().to_string_lossy().into_owned();
+        let asset_cache = AssetCache::new(base_path, AssetPath::combine(mounts));
+        ModelPreview {
+            engine,
+            asset_cache,
+            built_for: None,
+            scene: None,
+            error: None,
+            debug_skeletons: false,
+            debug_hit_boxes: false,
+            yaw: 90.0,
+            pitch: 90.0,
+            distance: 10.0,
+            target: vec3(0.0, 0.0, 0.0),
+            fbo: None,
+        }
+    }
+
+    /// Show the preview for `key` (a `.bin` model): toggles, then the rendered
+    /// viewport filling the remaining space.
+    pub fn show(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame, key: &str) {
+        self.ensure_scene(key);
+        if let Some(error) = &self.error {
+            ui.label(format!("Cannot render this model: {error}"));
+            return;
+        }
+
+        // A toggle change rebuilds on the next frame's ensure_scene (the pane
+        // repaints continuously, so that is immediate in practice).
+        ui.horizontal(|ui| {
+            ui.checkbox(&mut self.debug_skeletons, "Skeleton");
+            ui.checkbox(&mut self.debug_hit_boxes, "Hitboxes");
+            ui.label("(drag to orbit, scroll to zoom)");
+        });
+
+        let available = ui.available_size();
+        let size = egui::vec2(available.x.max(1.0), available.y.max(1.0));
+        let response = ui.allocate_response(size, egui::Sense::drag());
+        self.apply_camera_input(ui, &response);
+
+        // Tick the scene with real time and keep repainting while shown, so an
+        // animated scene advances even without input.
+        let dt = ui.input(|i| i.stable_dt).min(0.1);
+        if let Some(scene) = &mut self.scene {
+            scene.update(dt);
+        }
+        ui.ctx().request_repaint();
+
+        let pixels_per_point = ui.ctx().pixels_per_point();
+        let px = [
+            (size.x * pixels_per_point).round().max(1.0) as i32,
+            (size.y * pixels_per_point).round().max(1.0) as i32,
+        ];
+        self.ensure_target(frame, px);
+        self.render_scene(px);
+
+        if let Some(target) = &self.fbo {
+            // GL renders bottom-up; flip V so egui shows it upright.
+            let uv = egui::Rect::from_min_max(egui::pos2(0.0, 1.0), egui::pos2(1.0, 0.0));
+            ui.painter()
+                .image(target.egui_texture, response.rect, uv, egui::Color32::WHITE);
+        }
+    }
+
+    /// (Re)build the scene when the key or a debug toggle changed, framing the
+    /// camera from the model's bounds where they are known.
+    fn ensure_scene(&mut self, key: &str) {
+        let wanted = (key.to_string(), self.debug_skeletons, self.debug_hit_boxes);
+        if self.built_for.as_ref() == Some(&wanted) {
+            return;
+        }
+        let reframe = self.built_for.as_ref().map(|(k, ..)| k.as_str()) != Some(key);
+        self.built_for = Some(wanted);
+        self.scene = None;
+        self.error = None;
+        // Dark parsers panic on malformed input; fall back to an error label.
+        let built = quiet_catch(|| {
+            BinObjViewerScene::from_model(
+                key.to_string(),
+                &self.asset_cache,
+                self.debug_skeletons,
+                self.debug_hit_boxes,
+            )
+            .map_err(|e| e.to_string())
+        });
+        match built {
+            Ok(Ok(scene)) => {
+                self.scene = Some(Box::new(scene));
+                if reframe {
+                    self.frame_camera(key);
+                }
+            }
+            Ok(Err(msg)) | Err(msg) => self.error = Some(msg),
+        }
+    }
+
+    /// Reset the orbit to frame the model: static models by their bounding
+    /// box, animated (AI) meshes with a standing-creature default.
+    fn frame_camera(&mut self, key: &str) {
+        self.yaw = 90.0;
+        self.pitch = 80.0;
+        let bounds = quiet_catch(|| {
+            let model = self.asset_cache.get(&MODELS_IMPORTER, key);
+            model
+                .bounding_box()
+                .map(|bb| (bb.min, bb.max, model.get_transform()))
+        })
+        .ok()
+        .flatten();
+        match bounds {
+            Some((min, max, transform)) => {
+                // The scene objects render with the model transform applied, so
+                // frame the transformed box center.
+                let center = transform
+                    * cgmath::vec4(
+                        (min.x + max.x) / 2.0,
+                        (min.y + max.y) / 2.0,
+                        (min.z + max.z) / 2.0,
+                        1.0,
+                    );
+                self.target = vec3(center.x, center.y, center.z);
+                let extent = vec3(max.x - min.x, max.y - min.y, max.z - min.z);
+                let radius =
+                    (extent.x * extent.x + extent.y * extent.y + extent.z * extent.z).sqrt() / 2.0;
+                self.distance = (radius * 4.0).clamp(3.0, 150.0);
+            }
+            None => {
+                // Animated (AI) meshes expose no bounds; frame a creature
+                // T-posed around the origin (hips at 0, limbs a few feet out).
+                self.target = vec3(0.0, 0.0, 0.0);
+                self.distance = 12.0;
+            }
+        }
+    }
+
+    fn apply_camera_input(&mut self, ui: &egui::Ui, response: &egui::Response) {
+        if response.dragged() {
+            let delta = response.drag_delta();
+            self.yaw += delta.x * 0.4;
+            self.pitch = (self.pitch + delta.y * 0.4).clamp(5.0, 175.0);
+        }
+        if response.hovered() {
+            let scroll = ui.input(|i| i.smooth_scroll_delta.y);
+            if scroll != 0.0 {
+                self.distance = (self.distance * (-scroll * 0.003).exp()).clamp(0.5, 300.0);
+            }
+        }
+    }
+
+    /// Create (or resize) the offscreen FBO and register its color texture
+    /// with egui. A resize registers a fresh egui texture id.
+    fn ensure_target(&mut self, frame: &mut eframe::Frame, size: [i32; 2]) {
+        if self.fbo.as_ref().is_some_and(|t| t.size == size) {
+            return;
+        }
+        if let Some(old) = self.fbo.take() {
+            unsafe {
+                gl::DeleteFramebuffers(1, &old.fbo);
+                gl::DeleteRenderbuffers(1, &old.depth);
+                // The color texture's ownership passed to egui at registration;
+                // leave deleting it to the painter.
+            }
+        }
+        unsafe {
+            let mut color = 0;
+            gl::GenTextures(1, &mut color);
+            gl::BindTexture(gl::TEXTURE_2D, color);
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR as i32);
+            gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR as i32);
+            gl::TexImage2D(
+                gl::TEXTURE_2D,
+                0,
+                gl::RGBA8 as i32,
+                size[0],
+                size[1],
+                0,
+                gl::RGBA,
+                gl::UNSIGNED_BYTE,
+                std::ptr::null(),
+            );
+            gl::BindTexture(gl::TEXTURE_2D, 0);
+
+            let mut depth = 0;
+            gl::GenRenderbuffers(1, &mut depth);
+            gl::BindRenderbuffer(gl::RENDERBUFFER, depth);
+            gl::RenderbufferStorage(gl::RENDERBUFFER, gl::DEPTH_COMPONENT24, size[0], size[1]);
+            gl::BindRenderbuffer(gl::RENDERBUFFER, 0);
+
+            let mut fbo = 0;
+            gl::GenFramebuffers(1, &mut fbo);
+            gl::BindFramebuffer(gl::FRAMEBUFFER, fbo);
+            gl::FramebufferTexture2D(
+                gl::FRAMEBUFFER,
+                gl::COLOR_ATTACHMENT0,
+                gl::TEXTURE_2D,
+                color,
+                0,
+            );
+            gl::FramebufferRenderbuffer(
+                gl::FRAMEBUFFER,
+                gl::DEPTH_ATTACHMENT,
+                gl::RENDERBUFFER,
+                depth,
+            );
+            let complete = gl::CheckFramebufferStatus(gl::FRAMEBUFFER) == gl::FRAMEBUFFER_COMPLETE;
+            gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
+            if !complete {
+                self.error = Some("offscreen framebuffer incomplete".to_string());
+                gl::DeleteFramebuffers(1, &fbo);
+                gl::DeleteRenderbuffers(1, &depth);
+                gl::DeleteTextures(1, &color);
+                return;
+            }
+
+            let native = glow::NativeTexture(std::num::NonZeroU32::new(color).unwrap());
+            let egui_texture = frame.register_native_glow_texture(native);
+            self.fbo = Some(OffscreenTarget {
+                fbo,
+                depth,
+                size,
+                egui_texture,
+            });
+        }
+    }
+
+    /// Render the scene into the FBO with the engine, restoring the
+    /// framebuffer and viewport egui had bound.
+    fn render_scene(&mut self, size: [i32; 2]) {
+        let Some(target) = &self.fbo else { return };
+        let Some(scene) = &self.scene else { return };
+        let rendered = scene.render(&mut self.asset_cache);
+
+        // dark_viewer's orbit: position on a sphere around `target`, oriented
+        // to look back at it.
+        let yaw_rad = self.yaw.to_radians();
+        let pitch_rad = self.pitch.to_radians();
+        let offset = vec3(
+            self.distance * pitch_rad.sin() * yaw_rad.cos(),
+            self.distance * pitch_rad.cos(),
+            self.distance * pitch_rad.sin() * yaw_rad.sin(),
+        );
+        let pitch_quat = Quaternion::from_angle_x(Rad(pitch_rad - 90.0f32.to_radians()));
+        let yaw_quat = Quaternion::from_angle_y(Rad(-yaw_rad + 90.0f32.to_radians()));
+        let render_context = engine::EngineRenderContext {
+            time: 0.0,
+            camera_offset: self.target + offset,
+            camera_rotation: Quaternion {
+                v: vec3(0.0, 0.0, 0.0),
+                s: 1.0,
+            },
+            head_offset: vec3(0.0, 0.0, 0.0),
+            head_rotation: yaw_quat * pitch_quat,
+            projection_matrix: cgmath::perspective(
+                cgmath::Deg(45.0),
+                size[0] as f32 / size[1] as f32,
+                0.1,
+                1000.0,
+            ),
+            screen_size: vec2(size[0] as f32, size[1] as f32),
+        };
+
+        unsafe {
+            let mut prev_fbo = 0;
+            gl::GetIntegerv(gl::DRAW_FRAMEBUFFER_BINDING, &mut prev_fbo);
+            let mut prev_viewport = [0i32; 4];
+            gl::GetIntegerv(gl::VIEWPORT, prev_viewport.as_mut_ptr());
+            // egui's painter leaves scissoring on; the engine never touches it.
+            gl::Disable(gl::SCISSOR_TEST);
+            gl::BindFramebuffer(gl::FRAMEBUFFER, target.fbo);
+            gl::Viewport(0, 0, size[0], size[1]);
+
+            self.engine.render(&render_context, &rendered);
+
+            gl::BindFramebuffer(gl::FRAMEBUFFER, prev_fbo as u32);
+            gl::Viewport(
+                prev_viewport[0],
+                prev_viewport[1],
+                prev_viewport[2],
+                prev_viewport[3],
+            );
+        }
+    }
+}

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -14,29 +14,34 @@ use std::ffi::CString;
 
 use cgmath::{Quaternion, Rad, Rotation3, vec2, vec3};
 use dark::importers::MODELS_IMPORTER;
+use dark::model::Model;
 use dark_viewer::scenes::{BinObjViewerScene, ToolScene};
 use eframe::{egui, glow};
 use engine::Engine;
 use engine::assets::asset_cache::AssetCache;
-use engine::assets::asset_paths::{AbstractAssetPath, AssetPath};
-use engine::assets::bundle_asset_path::BundleAssetPath;
 
 use crate::ui::quiet_catch;
 
 /// Load the raw `gl` crate's function pointers from eframe's GL context.
 /// Call once, in the `AppCreator` closure, before any engine rendering.
 pub fn init_raw_gl(cc: &eframe::CreationContext<'_>) {
-    if let Some(get_proc) = cc.get_proc_address.clone() {
-        gl::load_with(move |symbol| match CString::new(symbol) {
+    match cc.get_proc_address.clone() {
+        Some(get_proc) => gl::load_with(move |symbol| match CString::new(symbol) {
             Ok(symbol) => get_proc(&symbol),
             Err(_) => std::ptr::null(),
-        });
+        }),
+        // Selecting a model would then die inside the first raw GL call, so
+        // leave a trail (eframe only omits the loader on non-glow backends).
+        None => eprintln!("no GL proc loader from eframe; model preview will not work"),
     }
 }
 
-/// Offscreen render target whose color texture egui displays.
+/// Offscreen render target whose color texture egui displays. Created once;
+/// a resize re-specifies the texture/renderbuffer storage in place, so the
+/// registered egui texture id stays valid for the preview's lifetime.
 struct OffscreenTarget {
     fbo: u32,
+    color: u32,
     depth: u32,
     size: [i32; 2],
     egui_texture: egui::TextureId,
@@ -59,21 +64,20 @@ pub struct ModelPreview {
     distance: f32,
     target: cgmath::Vector3<f32>,
     fbo: Option<OffscreenTarget>,
+    /// The scene is static (animation is out of scope), so the FBO is only
+    /// re-rendered when something changed — scene, camera, or viewport size.
+    needs_render: bool,
 }
 
 impl ModelPreview {
-    /// Build the render host: the engine plus one asset cache over the same
-    /// family mounts the game resolves models and textures through.
+    /// Build the render host: the engine plus one asset cache over the exact
+    /// mount stack the game resolves models and textures through (which also
+    /// carries the engine bundle assets, e.g. the grid ground-plane texture).
     pub fn new() -> ModelPreview {
         let engine = engine::opengl();
-        let mut mounts: Vec<Box<dyn AbstractAssetPath>> = shock2vr::resource_families()
-            .iter()
-            .map(|family| shock2vr::resource_family_paths(family))
-            .collect();
-        // Engine bundle assets (the grid ground-plane texture).
-        mounts.push(BundleAssetPath::new("".to_owned(), engine.get_storage()));
+        let mounts = shock2vr::game_asset_mounts(engine.get_storage());
         let base_path = shock2vr::paths::data_root().to_string_lossy().into_owned();
-        let asset_cache = AssetCache::new(base_path, AssetPath::combine(mounts));
+        let asset_cache = AssetCache::new(base_path, mounts);
         ModelPreview {
             engine,
             asset_cache,
@@ -82,11 +86,12 @@ impl ModelPreview {
             error: None,
             debug_skeletons: false,
             debug_hit_boxes: false,
-            yaw: 90.0,
-            pitch: 90.0,
+            yaw: 65.0,
+            pitch: 75.0,
             distance: 10.0,
             target: vec3(0.0, 0.0, 0.0),
             fbo: None,
+            needs_render: false,
         }
     }
 
@@ -99,8 +104,8 @@ impl ModelPreview {
             return;
         }
 
-        // A toggle change rebuilds on the next frame's ensure_scene (the pane
-        // repaints continuously, so that is immediate in practice).
+        // A toggle change rebuilds on the next frame's ensure_scene (the click
+        // itself triggers that repaint).
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.debug_skeletons, "Skeleton");
             ui.checkbox(&mut self.debug_hit_boxes, "Hitboxes");
@@ -110,25 +115,34 @@ impl ModelPreview {
         let available = ui.available_size();
         let size = egui::vec2(available.x.max(1.0), available.y.max(1.0));
         let response = ui.allocate_response(size, egui::Sense::drag());
-        self.apply_camera_input(ui, &response);
-
-        // Tick the scene with real time and keep repainting while shown, so an
-        // animated scene advances even without input.
-        let dt = ui.input(|i| i.stable_dt).min(0.1);
-        if let Some(scene) = &mut self.scene {
-            scene.update(dt);
+        if self.apply_camera_input(ui, &response) {
+            self.needs_render = true;
         }
-        ui.ctx().request_repaint();
 
         let pixels_per_point = ui.ctx().pixels_per_point();
         let px = [
             (size.x * pixels_per_point).round().max(1.0) as i32,
             (size.y * pixels_per_point).round().max(1.0) as i32,
         ];
-        self.ensure_target(frame, px);
-        self.render_scene(px);
+        if self.ensure_target(frame, px) {
+            self.needs_render = true;
+        }
+
+        if self.needs_render && self.scene.is_some() && self.fbo.is_some() {
+            let dt = ui.input(|i| i.stable_dt).min(0.1);
+            if let Some(scene) = &mut self.scene {
+                scene.update(dt);
+            }
+            self.render_scene(px);
+            self.needs_render = false;
+        }
 
         if let Some(target) = &self.fbo {
+            // Opaque backing: the engine clears to alpha 0 and blends straight
+            // alpha, while egui composites premultiplied — translucent overlay
+            // pixels would tint against the panel otherwise.
+            ui.painter()
+                .rect_filled(response.rect, 0.0, egui::Color32::BLACK);
             // GL renders bottom-up; flip V so egui shows it upright.
             let uv = egui::Rect::from_min_max(egui::pos2(0.0, 1.0), egui::pos2(1.0, 0.0));
             ui.painter()
@@ -147,45 +161,47 @@ impl ModelPreview {
         self.built_for = Some(wanted);
         self.scene = None;
         self.error = None;
-        // Dark parsers panic on malformed input; fall back to an error label.
-        let built = quiet_catch(|| {
-            BinObjViewerScene::from_model(
-                key.to_string(),
-                &self.asset_cache,
-                self.debug_skeletons,
-                self.debug_hit_boxes,
-            )
-            .map_err(|e| e.to_string())
-        });
-        match built {
-            Ok(Ok(scene)) => {
+        // Load the model eagerly under catch_unwind — the scene itself defers
+        // loading to render, and Dark parsers panic on malformed input; a
+        // failure becomes an error label instead of a crash. The key resolves
+        // through the full game mount stack (obj outranks mesh; the two
+        // families currently share no `.bin` basenames).
+        let model = match quiet_catch(|| self.asset_cache.get(&MODELS_IMPORTER, key)) {
+            Ok(model) => model,
+            Err(msg) => {
+                self.error = Some(msg);
+                return;
+            }
+        };
+        match BinObjViewerScene::from_model(
+            key.to_string(),
+            &self.asset_cache,
+            self.debug_skeletons,
+            self.debug_hit_boxes,
+        ) {
+            Ok(scene) => {
                 self.scene = Some(Box::new(scene));
+                self.needs_render = true;
                 if reframe {
-                    self.frame_camera(key);
+                    self.frame_camera(&model);
                 }
             }
-            Ok(Err(msg)) | Err(msg) => self.error = Some(msg),
+            Err(err) => self.error = Some(err.to_string()),
         }
     }
 
     /// Reset the orbit to frame the model: static models by their bounding
-    /// box, animated (AI) meshes with a standing-creature default.
-    fn frame_camera(&mut self, key: &str) {
-        self.yaw = 90.0;
-        self.pitch = 80.0;
-        let bounds = quiet_catch(|| {
-            let model = self.asset_cache.get(&MODELS_IMPORTER, key);
-            model
-                .bounding_box()
-                .map(|bb| (bb.min, bb.max, model.get_transform()))
-        })
-        .ok()
-        .flatten();
-        match bounds {
-            Some((min, max, transform)) => {
+    /// box, animated (AI) meshes with a standing-creature default. The default
+    /// angle is a three-quarter view so flat models are not seen edge-on.
+    fn frame_camera(&mut self, model: &Model) {
+        self.yaw = 65.0;
+        self.pitch = 75.0;
+        match model.bounding_box() {
+            Some(bb) => {
                 // The scene objects render with the model transform applied, so
                 // frame the transformed box center.
-                let center = transform
+                let (min, max) = (bb.min, bb.max);
+                let center = model.get_transform()
                     * cgmath::vec4(
                         (min.x + max.x) / 2.0,
                         (min.y + max.y) / 2.0,
@@ -196,44 +212,68 @@ impl ModelPreview {
                 let extent = vec3(max.x - min.x, max.y - min.y, max.z - min.z);
                 let radius =
                     (extent.x * extent.x + extent.y * extent.y + extent.z * extent.z).sqrt() / 2.0;
-                self.distance = (radius * 4.0).clamp(3.0, 150.0);
+                // r / sin(fovy/2) exactly fills the 45-degree frustum; 2.9r
+                // leaves some margin around it.
+                self.distance = (radius * 2.9).clamp(3.0, 150.0);
             }
             None => {
-                // Animated (AI) meshes expose no bounds; frame a creature
-                // T-posed around the origin (hips at 0, limbs a few feet out).
+                // Animated (AI) meshes expose no bounds; they T-pose around
+                // the origin at the hips (legs below y=0), so aim there.
                 self.target = vec3(0.0, 0.0, 0.0);
-                self.distance = 12.0;
+                self.distance = 11.0;
             }
         }
     }
 
-    fn apply_camera_input(&mut self, ui: &egui::Ui, response: &egui::Response) {
+    /// Returns whether the camera moved.
+    fn apply_camera_input(&mut self, ui: &egui::Ui, response: &egui::Response) -> bool {
+        let mut moved = false;
         if response.dragged() {
             let delta = response.drag_delta();
-            self.yaw += delta.x * 0.4;
-            self.pitch = (self.pitch + delta.y * 0.4).clamp(5.0, 175.0);
+            if delta != egui::Vec2::ZERO {
+                self.yaw += delta.x * 0.4;
+                self.pitch = (self.pitch + delta.y * 0.4).clamp(5.0, 175.0);
+                moved = true;
+            }
         }
         if response.hovered() {
             let scroll = ui.input(|i| i.smooth_scroll_delta.y);
             if scroll != 0.0 {
                 self.distance = (self.distance * (-scroll * 0.003).exp()).clamp(0.5, 300.0);
+                moved = true;
             }
         }
+        moved
     }
 
-    /// Create (or resize) the offscreen FBO and register its color texture
-    /// with egui. A resize registers a fresh egui texture id.
-    fn ensure_target(&mut self, frame: &mut eframe::Frame, size: [i32; 2]) {
-        if self.fbo.as_ref().is_some_and(|t| t.size == size) {
-            return;
-        }
-        if let Some(old) = self.fbo.take() {
-            unsafe {
-                gl::DeleteFramebuffers(1, &old.fbo);
-                gl::DeleteRenderbuffers(1, &old.depth);
-                // The color texture's ownership passed to egui at registration;
-                // leave deleting it to the painter.
+    /// Create the offscreen FBO on first use, or re-specify its texture and
+    /// depth storage on resize (keeping the GL names, and therefore the
+    /// registered egui texture id, stable). Returns whether anything changed.
+    fn ensure_target(&mut self, frame: &mut eframe::Frame, size: [i32; 2]) -> bool {
+        if let Some(target) = &mut self.fbo {
+            if target.size == size {
+                return false;
             }
+            unsafe {
+                gl::BindTexture(gl::TEXTURE_2D, target.color);
+                gl::TexImage2D(
+                    gl::TEXTURE_2D,
+                    0,
+                    gl::RGBA8 as i32,
+                    size[0],
+                    size[1],
+                    0,
+                    gl::RGBA,
+                    gl::UNSIGNED_BYTE,
+                    std::ptr::null(),
+                );
+                gl::BindTexture(gl::TEXTURE_2D, 0);
+                gl::BindRenderbuffer(gl::RENDERBUFFER, target.depth);
+                gl::RenderbufferStorage(gl::RENDERBUFFER, gl::DEPTH_COMPONENT24, size[0], size[1]);
+                gl::BindRenderbuffer(gl::RENDERBUFFER, 0);
+            }
+            target.size = size;
+            return true;
         }
         unsafe {
             let mut color = 0;
@@ -283,18 +323,20 @@ impl ModelPreview {
                 gl::DeleteFramebuffers(1, &fbo);
                 gl::DeleteRenderbuffers(1, &depth);
                 gl::DeleteTextures(1, &color);
-                return;
+                return false;
             }
 
             let native = glow::NativeTexture(std::num::NonZeroU32::new(color).unwrap());
             let egui_texture = frame.register_native_glow_texture(native);
             self.fbo = Some(OffscreenTarget {
                 fbo,
+                color,
                 depth,
                 size,
                 egui_texture,
             });
         }
+        true
     }
 
     /// Render the scene into the FBO with the engine, restoring the
@@ -302,7 +344,16 @@ impl ModelPreview {
     fn render_scene(&mut self, size: [i32; 2]) {
         let Some(target) = &self.fbo else { return };
         let Some(scene) = &self.scene else { return };
-        let rendered = scene.render(&mut self.asset_cache);
+        // Belt-and-braces: the scene loads lazily through the asset cache at
+        // render time too (its own model lookup, the grid texture).
+        let rendered = match quiet_catch(|| scene.render(&mut self.asset_cache)) {
+            Ok(rendered) => rendered,
+            Err(msg) => {
+                self.scene = None;
+                self.error = Some(msg);
+                return;
+            }
+        };
 
         // dark_viewer's orbit: position on a sphere around `target`, oriented
         // to look back at it.

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -1,5 +1,5 @@
 //! Windowed asset browser: family/directory tree + search on the left,
-//! per-asset preview (image/audio/text/hex) on the right.
+//! per-asset preview (image/audio/text/3D model/hex) on the right.
 
 use std::collections::BTreeMap;
 use std::panic::{self, AssertUnwindSafe};
@@ -12,24 +12,38 @@ use engine::audio::{AudioClip, AudioContext, AudioHandle};
 use engine::texture_format::{self, PixelFormat};
 
 use crate::explorer;
+use crate::model_preview::{self, ModelPreview};
 
 const TEXT_EXTENSIONS: &[&str] = &["str", "mtl", "txt", "ini", "cfg", "json"];
 /// Cap on rows the flattened search view renders per frame.
 const SEARCH_RESULT_CAP: usize = 500;
 
-pub fn run(screenshot: Option<PathBuf>, select: Option<String>, search: Option<String>) {
+pub struct UiOptions {
+    pub screenshot: Option<PathBuf>,
+    pub select: Option<String>,
+    pub search: Option<String>,
+    /// Start the model preview with the skeleton / hitbox overlay on (so a
+    /// `--screenshot` run can capture the debug overlays).
+    pub skeletons: bool,
+    pub hitboxes: bool,
+}
+
+pub fn run(options: UiOptions) {
     explorer::print_coverage_caveat();
     let viewport = egui::ViewportBuilder::default()
         .with_inner_size([1150.0, 760.0])
         .with_title("dark_explorer");
-    let options = eframe::NativeOptions {
+    let native_options = eframe::NativeOptions {
         viewport,
         ..Default::default()
     };
     let result = eframe::run_native(
         "dark_explorer",
-        options,
+        native_options,
         Box::new(move |cc| {
+            // Point the engine's raw `gl` bindings at eframe's GL context so
+            // the model preview can render with the game renderer.
+            model_preview::init_raw_gl(cc);
             // No open/close or scroll animation: a `--select` scroll measured
             // against a still-animating CollapsingHeader lands on stale layout,
             // and an animated scroll-to hasn't arrived when `--screenshot`
@@ -38,7 +52,7 @@ pub fn run(screenshot: Option<PathBuf>, select: Option<String>, search: Option<S
                 style.animation_time = 0.0;
                 style.scroll_animation = egui::style::ScrollAnimation::none();
             });
-            Ok(Box::new(ExplorerApp::new(screenshot, select, search)))
+            Ok(Box::new(ExplorerApp::new(options)))
         }),
     );
     if let Err(err) = result {
@@ -110,6 +124,8 @@ enum PreviewKind {
         duration: Option<std::time::Duration>,
     },
     Text(String),
+    /// A `.bin` 3D model, rendered by `ModelPreview` from `Preview::key`.
+    Model,
     /// Undecodable content: the reason plus a hex dump of the leading bytes.
     Raw {
         reason: String,
@@ -138,6 +154,11 @@ pub struct ExplorerApp {
     audio_handle: Option<AudioHandle>,
     audio_error: Option<String>,
     screenshot: Option<PathBuf>,
+    /// Lazily built on the first model selection: constructing it indexes
+    /// every family's archives and creates the engine render host.
+    model_preview: Option<ModelPreview>,
+    /// Initial overlay toggles for the model preview (from the CLI).
+    initial_overlays: (bool, bool),
     frames_rendered: u32,
     /// Frames left in which the tree scrolls to the selected row (a couple of
     /// frames, so the scroll re-applies once layout has settled).
@@ -147,26 +168,24 @@ pub struct ExplorerApp {
 }
 
 impl ExplorerApp {
-    fn new(
-        screenshot: Option<PathBuf>,
-        select: Option<String>,
-        search: Option<String>,
-    ) -> ExplorerApp {
+    fn new(options: UiOptions) -> ExplorerApp {
         let mut app = ExplorerApp {
             family_names: explorer::family_names(),
             families: BTreeMap::new(),
-            search: search.unwrap_or_default(),
+            search: options.search.unwrap_or_default(),
             selected: None,
             preview: None,
             audio: None,
             audio_handle: None,
             audio_error: None,
-            screenshot,
+            screenshot: options.screenshot,
+            model_preview: None,
+            initial_overlays: (options.skeletons, options.hitboxes),
             frames_rendered: 0,
             scroll_frames: 0,
             search_results: None,
         };
-        if let Some(select) = select {
+        if let Some(select) = options.select {
             // Fail loudly on a bad selection: a `--screenshot` run that quietly
             // captured an empty preview would still exit 0 otherwise.
             match select.split_once('/') {
@@ -230,7 +249,7 @@ fn build_preview(family: &str, key: &str, loaded: &LoadedFamily) -> Preview {
         }
     };
     let size = bytes.len();
-    let kind = decode_preview(key, bytes);
+    let kind = decode_preview(family, key, bytes);
     Preview {
         family: family.to_string(),
         key: key.to_string(),
@@ -245,7 +264,7 @@ fn extension(key: &str) -> &str {
     key.rsplit_once('.').map(|(_, ext)| ext).unwrap_or("")
 }
 
-fn decode_preview(key: &str, bytes: Vec<u8>) -> PreviewKind {
+fn decode_preview(family: &str, key: &str, bytes: Vec<u8>) -> PreviewKind {
     let ext = extension(key).to_ascii_lowercase();
     // Dark parsers panic on malformed input, so every decode runs under
     // catch_unwind and falls back to the hex view instead of crashing.
@@ -281,12 +300,17 @@ fn decode_preview(key: &str, bytes: Vec<u8>) -> PreviewKind {
     if TEXT_EXTENSIONS.contains(&ext.as_str()) {
         return PreviewKind::Text(String::from_utf8_lossy(&bytes).into_owned());
     }
+    // Only the model families: `data` also serves `.bin` files (motiondb)
+    // whose parse failure aborts rather than unwinds.
+    if ext == "bin" && matches!(family, "obj" | "mesh") {
+        return PreviewKind::Model;
+    }
     raw_fallback(&bytes, format!("cannot render .{ext} files"))
 }
 
 /// Run a Dark parser under `catch_unwind` with the panic hook silenced (the
 /// format readers panic on malformed input), mapping a panic to its message.
-fn quiet_catch<T>(f: impl FnOnce() -> T) -> Result<T, String> {
+pub(crate) fn quiet_catch<T>(f: impl FnOnce() -> T) -> Result<T, String> {
     let prev = panic::take_hook();
     panic::set_hook(Box::new(|_| {}));
     let res = panic::catch_unwind(AssertUnwindSafe(f));
@@ -335,7 +359,7 @@ fn hex_dump(bytes: &[u8], limit: usize) -> String {
 }
 
 impl eframe::App for ExplorerApp {
-    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
         let mut clicked: Option<(String, String)> = None;
 
@@ -365,7 +389,7 @@ impl eframe::App for ExplorerApp {
             });
 
         egui::CentralPanel::default_margins().show(ui, |ui| {
-            self.show_preview(ui);
+            self.show_preview(ui, frame);
         });
 
         self.scroll_frames = self.scroll_frames.saturating_sub(1);
@@ -452,7 +476,7 @@ impl ExplorerApp {
         }
     }
 
-    fn show_preview(&mut self, ui: &mut egui::Ui) {
+    fn show_preview(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
         let Some(preview) = &mut self.preview else {
             ui.centered_and_justified(|ui| {
                 ui.label("Select an asset to preview it");
@@ -538,6 +562,17 @@ impl ExplorerApp {
                                 .desired_width(f32::INFINITY),
                         );
                     });
+            }
+            PreviewKind::Model => {
+                let key = preview.key.clone();
+                let (skeletons, hitboxes) = self.initial_overlays;
+                let host = self.model_preview.get_or_insert_with(|| {
+                    let mut host = ModelPreview::new();
+                    host.debug_skeletons = skeletons;
+                    host.debug_hit_boxes = hitboxes;
+                    host
+                });
+                host.show(ui, frame, &key);
             }
             PreviewKind::Raw { reason, hex } => {
                 ui.label(format!("Cannot render this file: {reason}"));

--- a/tools/dark_viewer/Cargo.toml
+++ b/tools/dark_viewer/Cargo.toml
@@ -19,7 +19,10 @@ glfw = "0.56.0"
 engine = { path = "../../engine" }
 engine_ffmpeg = { path = "../../engine_ffmpeg", optional = true }
 dark = { path = "../../dark" }
-shock2vr = { path = "../../shock2vr" }
+# default-features off so a dependent with `default-features = false` (the
+# dark_explorer preview) does not get shock2vr/ffmpeg back through feature
+# unification; the crate's own `ffmpeg` feature forwards it.
+shock2vr = { path = "../../shock2vr", default-features = false }
 cgmath = "0.18.0"
 byteorder = "1.4.3"
 pcx = "0.2.3"

--- a/tools/dark_viewer/Cargo.toml
+++ b/tools/dark_viewer/Cargo.toml
@@ -3,6 +3,10 @@ name = "dark_viewer"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+name = "dark_viewer"
+path = "src/lib.rs"
+
 [[bin]]
 name = "dark_viewer"
 path = "src/main.rs"

--- a/tools/dark_viewer/src/lib.rs
+++ b/tools/dark_viewer/src/lib.rs
@@ -1,0 +1,4 @@
+//! Window-free viewer scenes, reusable by other tools (dark_explorer's
+//! model preview embeds them); the `dark_viewer` binary drives them in GLFW.
+
+pub mod scenes;

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -7,7 +7,7 @@ extern crate glfw;
 use clap::Parser;
 use glfw::GlfwReceiver;
 
-mod scenes;
+use dark_viewer::scenes;
 use scenes::{
     BinAiViewerScene, BinObjViewerScene, FontViewerScene, GlbViewerScene, ToolScene,
     VideoPlayerScene,

--- a/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
+++ b/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
@@ -29,7 +29,7 @@ impl BinObjViewerScene {
         debug_hit_boxes: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         // We don't load the model here, we'll load it during render using the asset cache
-        let mut animation_player = AnimationPlayer::empty();
+        let animation_player = AnimationPlayer::empty();
         // animation_player = AnimationPlayer::set_additional_joint_transform(
         //     &animation_player,
         //     2,

--- a/tools/dark_viewer/src/scenes/mod.rs
+++ b/tools/dark_viewer/src/scenes/mod.rs
@@ -3,7 +3,7 @@ use engine::audio::AudioContext;
 use engine::scene::Scene;
 
 pub trait ToolScene {
-    fn init(&mut self, audio_context: &mut AudioContext<(), String>) {
+    fn init(&mut self, _audio_context: &mut AudioContext<(), String>) {
         // Default implementation does nothing
     }
     fn update(&mut self, delta_time: f32);

--- a/tools/dark_viewer/src/scenes/video_player.rs
+++ b/tools/dark_viewer/src/scenes/video_player.rs
@@ -52,11 +52,12 @@ impl VideoPlayerScene {
 }
 
 impl ToolScene for VideoPlayerScene {
-    fn init(&mut self, _audio_context: &mut AudioContext<(), String>) {
+    #[cfg_attr(not(feature = "ffmpeg"), allow(unused_variables))]
+    fn init(&mut self, audio_context: &mut AudioContext<(), String>) {
         #[cfg(feature = "ffmpeg")]
         {
             engine_ffmpeg::init().unwrap();
-            self.init_audio(_audio_context);
+            self.init_audio(audio_context);
         }
     }
 

--- a/tools/dark_viewer/src/scenes/video_player.rs
+++ b/tools/dark_viewer/src/scenes/video_player.rs
@@ -52,11 +52,11 @@ impl VideoPlayerScene {
 }
 
 impl ToolScene for VideoPlayerScene {
-    fn init(&mut self, audio_context: &mut AudioContext<(), String>) {
+    fn init(&mut self, _audio_context: &mut AudioContext<(), String>) {
         #[cfg(feature = "ffmpeg")]
         {
             engine_ffmpeg::init().unwrap();
-            self.init_audio(audio_context);
+            self.init_audio(_audio_context);
         }
     }
 


### PR DESCRIPTION
Adds a live 3D model preview to `cargo dx ui`: selecting a `.bin` in the obj/mesh families renders it with the engine's own renderer inside the egui window.

- GL interop: eframe's glow context feeds `gl::load_with` via `cc.get_proc_address`, so the raw-gl engine renders on the same context into a private FBO; the color texture is registered once with `register_native_glow_texture` (stable TextureId, in-place resize). FBO/viewport state saved and restored around the engine pass.
- Orbit camera (drag rotate, scroll zoom), auto-framing, three-quarter default angle; dark_viewer's grid + axes.
- Skeleton / Hitboxes toggles (checkboxes + `--skeletons`/`--hitboxes` flags so `--screenshot` can capture them). Malformed models degrade to an error label (parse under `catch_unwind`).
- Reuse: dark_viewer gains a lib target exposing its `ToolScene` scenes (binary unchanged); `shock2vr::game_asset_mounts()` extracted from `Game::init` so the preview uses the game's exact mount stack. Missions e2e re-run after the extraction: 23/23 pass.

### Screenshots
| Static prop | Creature mesh | Skeleton + hitboxes |
|---|---|---|
| ![shovel](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/c11960b87a3b020a88e41edcb3cd53fd16937280/shovel_v2.png) | ![grunt](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/c11960b87a3b020a88e41edcb3cd53fd16937280/grunt_v3.png) | ![overlays](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/c11960b87a3b020a88e41edcb3cd53fd16937280/grunt_overlays_v3.png) |

Reviewed with cross-engine xreview; agreed Critical/High findings (bad-model crash guard, texture leak, mount divergence, framing) fixed and re-verified by capture.