### PR TITLE
feat(tools): archetype browser tab with clip playback in dark_explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "engine",
  "gl",
  "image 0.24.7",
+ "shipyard",
  "shock2vr",
 ]
 

--- a/dark/src/motion/mod.rs
+++ b/dark/src/motion/mod.rs
@@ -249,6 +249,24 @@ impl MotionDB {
     pub fn get_creature_type_count(&self) -> usize {
         self.tag_databases.len()
     }
+
+    /// Every animation name reachable from one creature type's tag database,
+    /// sorted and de-duplicated.
+    pub fn get_all_motions_for_creature(&self, creature_type: u32) -> Vec<String> {
+        let Some(tag_database) = self.tag_databases.get(creature_type as usize) else {
+            return vec![];
+        };
+        let mut names: Vec<String> = tag_database
+            .collect_all_data_ids()
+            .into_iter()
+            .filter_map(|id| self.tag_value_to_animations.get(&id))
+            .flatten()
+            .cloned()
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
 }
 
 fn load_name_map<T: io::Read + io::Seek>(

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -14,7 +14,7 @@ pub mod teleport;
 pub mod time;
 
 pub mod career;
-mod creature;
+pub mod creature;
 pub mod data_files;
 pub mod death_camera;
 pub mod dev_params;

--- a/tools/dark_explorer/Cargo.toml
+++ b/tools/dark_explorer/Cargo.toml
@@ -13,6 +13,7 @@ shock2vr = { path = "../../shock2vr", default-features = false }
 dark = { path = "../../dark" }
 dark_viewer = { path = "../dark_viewer", default-features = false }
 gl = "0.14.0"
+shipyard = "0.6.2"
 cgmath = "0.18.0"
 clap = { version = "4.5.4", features = ["derive"] }
 eframe = { version = "=0.36.1", default-features = false, features = ["glow", "default_fonts", "wayland", "x11"] }

--- a/tools/dark_explorer/src/archetypes.rs
+++ b/tools/dark_explorer/src/archetypes.rs
@@ -8,6 +8,7 @@ use dark::motion::MotionDB;
 use dark::properties::{PropCreature, PropModelName, PropSymName, PropTemplateId};
 use dark::ss2_entity_info;
 use shipyard::{Get, IntoIter, IntoWithId, View, World};
+use shock2vr::creature::ActorType;
 
 use crate::ui::quiet_catch;
 
@@ -25,9 +26,6 @@ const CREATURE_TYPE_NAMES: &[&str] = &[
     "Shodan",
 ];
 
-/// `ActorType` values, indexing the motion database's tag databases.
-const ACTOR_TYPE_NAMES: &[&str] = &["Human", "PlayerLimb", "Droid", "Overlord", "Arachnid"];
-
 #[derive(Clone)]
 pub struct Archetype {
     pub template_id: i32,
@@ -35,8 +33,8 @@ pub struct Archetype {
     /// Model base name from `PropModelName` (lowercased, no extension).
     pub model_name: String,
     pub creature_type: u32,
-    /// Motion-database creature index, from the creature definition.
-    pub actor_type: Option<u32>,
+    /// The motion database's creature category, from the creature definition.
+    pub actor_type: Option<ActorType>,
 }
 
 impl Archetype {
@@ -48,11 +46,8 @@ impl Archetype {
     }
 
     pub fn actor_type_name(&self) -> String {
-        match self.actor_type {
-            Some(actor) => ACTOR_TYPE_NAMES
-                .get(actor as usize)
-                .map(|n| format!("{n} ({actor})"))
-                .unwrap_or_else(|| format!("unknown ({actor})")),
+        match &self.actor_type {
+            Some(actor) => format!("{actor:?} ({})", actor.clone() as u32),
             None => "unknown".to_string(),
         }
     }
@@ -104,13 +99,13 @@ impl ArchetypeDb {
     /// Clip names playable by this archetype's actor type.
     pub fn clips_for(&self, archetype: &Archetype) -> Result<Vec<String>, String> {
         let motion_db = self.motion_db.as_ref().map_err(|e| e.clone())?;
-        let actor = archetype.actor_type.ok_or_else(|| {
+        let actor = archetype.actor_type.clone().ok_or_else(|| {
             format!(
                 "no creature definition for {}",
                 archetype.creature_type_name()
             )
         })?;
-        Ok(motion_db.get_all_motions_for_creature(actor))
+        Ok(motion_db.get_all_motions_for_creature(actor as u32))
     }
 
     /// Resolve a CLI `--archetype` value: a template id (either sign) or a
@@ -189,7 +184,7 @@ fn load_impl() -> Result<ArchetypeDb, String> {
                 continue;
             };
             let actor_type = shock2vr::creature::get_creature_definition(creature.0)
-                .map(|def| def.actor_type.clone() as u32);
+                .map(|def| def.actor_type.clone());
             archetypes.insert(
                 template_id,
                 Archetype {

--- a/tools/dark_explorer/src/archetypes.rs
+++ b/tools/dark_explorer/src/archetypes.rs
@@ -1,0 +1,255 @@
+//! Gamesys creature archetypes: templates that resolve (inheritance-aware) to
+//! a model + creature type, arranged in their MetaProp hierarchy, plus the
+//! motion-database clip list for each archetype's actor type.
+
+use std::collections::{HashMap, HashSet};
+
+use dark::motion::MotionDB;
+use dark::properties::{PropCreature, PropModelName, PropSymName, PropTemplateId};
+use dark::ss2_entity_info;
+use shipyard::{Get, IntoIter, IntoWithId, View, World};
+
+use crate::ui::quiet_catch;
+
+/// `PropCreature` values, indexed the way `get_creature_definition` is.
+const CREATURE_TYPE_NAMES: &[&str] = &[
+    "Human",
+    "PlayerLimb",
+    "Avatar",
+    "Rumbler",
+    "Droid",
+    "Overlord",
+    "Arachnid",
+    "Monkey",
+    "BabyArachnid",
+    "Shodan",
+];
+
+/// `ActorType` values, indexing the motion database's tag databases.
+const ACTOR_TYPE_NAMES: &[&str] = &["Human", "PlayerLimb", "Droid", "Overlord", "Arachnid"];
+
+#[derive(Clone)]
+pub struct Archetype {
+    pub template_id: i32,
+    pub name: String,
+    /// Model base name from `PropModelName` (lowercased, no extension).
+    pub model_name: String,
+    pub creature_type: u32,
+    /// Motion-database creature index, from the creature definition.
+    pub actor_type: Option<u32>,
+}
+
+impl Archetype {
+    pub fn creature_type_name(&self) -> String {
+        CREATURE_TYPE_NAMES
+            .get(self.creature_type as usize)
+            .map(|n| format!("{n} ({})", self.creature_type))
+            .unwrap_or_else(|| format!("unknown ({})", self.creature_type))
+    }
+
+    pub fn actor_type_name(&self) -> String {
+        match self.actor_type {
+            Some(actor) => ACTOR_TYPE_NAMES
+                .get(actor as usize)
+                .map(|n| format!("{n} ({actor})"))
+                .unwrap_or_else(|| format!("unknown ({actor})")),
+            None => "unknown".to_string(),
+        }
+    }
+
+    pub fn model_key(&self) -> String {
+        format!("{}.bin", self.model_name)
+    }
+}
+
+pub struct ArchetypeDb {
+    pub archetypes: HashMap<i32, Archetype>,
+    /// Display names for every tree node (grouping ancestors included).
+    names: HashMap<i32, String>,
+    /// Tree over archetypes and their ancestors, children name-sorted.
+    pub children: HashMap<i32, Vec<i32>>,
+    pub roots: Vec<i32>,
+    parent: HashMap<i32, i32>,
+    /// The motion database, or why it failed to load.
+    motion_db: Result<MotionDB, String>,
+}
+
+impl ArchetypeDb {
+    /// Parse the gamesys and motion database. Everything runs under
+    /// catch_unwind: a malformed install yields an error string, not a crash.
+    pub fn load() -> Result<ArchetypeDb, String> {
+        quiet_catch(load_impl).and_then(|r| r)
+    }
+
+    pub fn name_of(&self, id: i32) -> String {
+        self.names
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(|| format!("Template {id}"))
+    }
+
+    /// Tree ancestors of `id`, for opening the path to a selection.
+    pub fn ancestors_of(&self, id: i32) -> HashSet<i32> {
+        let mut out = HashSet::new();
+        let mut current = id;
+        while let Some(parent) = self.parent.get(&current) {
+            if !out.insert(*parent) {
+                break;
+            }
+            current = *parent;
+        }
+        out
+    }
+
+    /// Clip names playable by this archetype's actor type.
+    pub fn clips_for(&self, archetype: &Archetype) -> Result<Vec<String>, String> {
+        let motion_db = self.motion_db.as_ref().map_err(|e| e.clone())?;
+        let actor = archetype.actor_type.ok_or_else(|| {
+            format!(
+                "no creature definition for {}",
+                archetype.creature_type_name()
+            )
+        })?;
+        Ok(motion_db.get_all_motions_for_creature(actor))
+    }
+
+    /// Resolve a CLI `--archetype` value: a template id (either sign) or a
+    /// case-insensitive name (exact, else unique substring).
+    pub fn resolve(&self, wanted: &str) -> Result<i32, String> {
+        if let Ok(id) = wanted.parse::<i32>() {
+            let id = -id.abs();
+            return if self.archetypes.contains_key(&id) {
+                Ok(id)
+            } else {
+                Err(format!("no creature archetype with template id {id}"))
+            };
+        }
+        let needle = wanted.to_ascii_lowercase();
+        let mut matches: Vec<i32> = self
+            .archetypes
+            .values()
+            .filter(|a| a.name.to_ascii_lowercase() == needle)
+            .map(|a| a.template_id)
+            .collect();
+        if matches.is_empty() {
+            matches = self
+                .archetypes
+                .values()
+                .filter(|a| a.name.to_ascii_lowercase().contains(&needle))
+                .map(|a| a.template_id)
+                .collect();
+        }
+        match matches.as_slice() {
+            [id] => Ok(*id),
+            [] => Err(format!("no creature archetype matching '{wanted}'")),
+            many => Err(format!(
+                "'{wanted}' is ambiguous: {}",
+                many.iter()
+                    .map(|id| self.name_of(*id))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )),
+        }
+    }
+}
+
+fn load_impl() -> Result<ArchetypeDb, String> {
+    let (properties, links, links_with_data) = dark::properties::get();
+    let mut reader = shock2vr::data_files::open_data_file("shock2.gam").ok_or_else(|| {
+        format!(
+            "shock2.gam not found in the game data at {}",
+            shock2vr::paths::data_root().display()
+        )
+    })?;
+    let gamesys = dark::gamesys::read(&mut reader, &links, &links_with_data, &properties);
+    let entity_info = gamesys.into_entity_info();
+
+    // Materialize every template into a world so property reads below are
+    // inheritance-aware (ancestors' components are applied first).
+    let mut world = World::new();
+    entity_info.initialize_world_with_entities(&mut world, HashMap::new(), |id| id < 0);
+
+    let mut names: HashMap<i32, String> = HashMap::new();
+    let mut archetypes: HashMap<i32, Archetype> = HashMap::new();
+    {
+        let (v_template, v_name, v_model, v_creature) = world
+            .borrow::<(
+                View<PropTemplateId>,
+                View<PropSymName>,
+                View<PropModelName>,
+                View<PropCreature>,
+            )>()
+            .map_err(|e| e.to_string())?;
+        for (entity, template) in v_template.iter().with_id() {
+            let template_id = template.template_id;
+            if let Ok(name) = v_name.get(entity) {
+                names.insert(template_id, name.0.clone());
+            }
+            let (Ok(model), Ok(creature)) = (v_model.get(entity), v_creature.get(entity)) else {
+                continue;
+            };
+            let actor_type = shock2vr::creature::get_creature_definition(creature.0)
+                .map(|def| def.actor_type.clone() as u32);
+            archetypes.insert(
+                template_id,
+                Archetype {
+                    template_id,
+                    name: names
+                        .get(&template_id)
+                        .cloned()
+                        .unwrap_or_else(|| format!("Template {template_id}")),
+                    model_name: model.0.to_ascii_lowercase(),
+                    creature_type: creature.0,
+                    actor_type,
+                },
+            );
+        }
+    }
+
+    // Tree: archetypes plus every ancestor, parented by the first direct
+    // MetaProp parent (multi-parent templates show under one branch).
+    let hierarchy = ss2_entity_info::get_hierarchy(&entity_info);
+    let mut include: HashSet<i32> = archetypes.keys().copied().collect();
+    for id in archetypes.keys() {
+        include.extend(ss2_entity_info::get_ancestors(hierarchy, id));
+    }
+    let mut children: HashMap<i32, Vec<i32>> = HashMap::new();
+    let mut parent_map: HashMap<i32, i32> = HashMap::new();
+    let mut roots: Vec<i32> = Vec::new();
+    for id in &include {
+        match hierarchy.get(id).and_then(|parents| parents.first()) {
+            Some(parent) if include.contains(parent) => {
+                parent_map.insert(*id, *parent);
+                children.entry(*parent).or_default().push(*id)
+            }
+            _ => roots.push(*id),
+        }
+    }
+    let name_of = |id: &i32| {
+        names
+            .get(id)
+            .cloned()
+            .unwrap_or_else(|| format!("Template {id}"))
+            .to_ascii_lowercase()
+    };
+    for siblings in children.values_mut() {
+        siblings.sort_by_key(name_of);
+    }
+    roots.sort_by_key(name_of);
+
+    let motion_db = quiet_catch(|| {
+        let mut reader = shock2vr::data_files::open_data_file("motiondb.bin")
+            .ok_or_else(|| "motiondb.bin not found in the game data".to_string())?;
+        Ok(MotionDB::read(&mut reader))
+    })
+    .and_then(|r| r);
+
+    Ok(ArchetypeDb {
+        archetypes,
+        names,
+        children,
+        roots,
+        parent: parent_map,
+        motion_db,
+    })
+}

--- a/tools/dark_explorer/src/main.rs
+++ b/tools/dark_explorer/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use engine::assets::asset_paths::AssetEntry;
 
+mod archetypes;
 mod explorer;
 mod model_preview;
 mod ui;
@@ -61,6 +62,19 @@ enum Commands {
         /// Start the 3D model preview with the hitbox overlay on
         #[arg(long)]
         hitboxes: bool,
+
+        /// Open the Archetypes tab with this creature selected (name or template id)
+        #[arg(long)]
+        archetype: Option<String>,
+
+        /// Play this animation clip on the selected archetype (needs --archetype)
+        #[arg(long)]
+        clip: Option<String>,
+
+        /// Advance the preview scene by this many simulation seconds before a
+        /// --screenshot capture (for posing an animated clip)
+        #[arg(long)]
+        advance: Option<f32>,
     },
     /// Show every mount serving an asset name, resolution winner first
     Which {
@@ -192,12 +206,18 @@ fn main() {
             search,
             skeletons,
             hitboxes,
+            archetype,
+            clip,
+            advance,
         } => ui::run(ui::UiOptions {
             screenshot,
             select,
             search,
             skeletons,
             hitboxes,
+            archetype,
+            clip,
+            advance,
         }),
         Commands::Which { name } => which(name),
     }

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -15,7 +15,7 @@ use std::ffi::CString;
 use cgmath::{Quaternion, Rad, Rotation3, vec2, vec3};
 use dark::importers::MODELS_IMPORTER;
 use dark::model::Model;
-use dark_viewer::scenes::{BinObjViewerScene, ToolScene};
+use dark_viewer::scenes::{BinAiViewerScene, BinObjViewerScene, ToolScene};
 use eframe::{egui, glow};
 use engine::Engine;
 use engine::assets::asset_cache::AssetCache;
@@ -50,10 +50,12 @@ struct OffscreenTarget {
 pub struct ModelPreview {
     engine: Box<dyn Engine>,
     asset_cache: AssetCache,
-    /// What the current scene (or error) was built for: (key, skeletons,
+    /// What the current scene (or error) was built for: (key, clip, skeletons,
     /// hitboxes). Guards against rebuilding — or re-panicking — every frame.
-    built_for: Option<(String, bool, bool)>,
+    built_for: Option<(String, Option<String>, bool, bool)>,
     scene: Option<Box<dyn ToolScene>>,
+    /// The scene plays an animation clip, so it re-renders every frame.
+    animated: bool,
     error: Option<String>,
     pub debug_skeletons: bool,
     pub debug_hit_boxes: bool,
@@ -64,8 +66,8 @@ pub struct ModelPreview {
     distance: f32,
     target: cgmath::Vector3<f32>,
     fbo: Option<OffscreenTarget>,
-    /// The scene is static (animation is out of scope), so the FBO is only
-    /// re-rendered when something changed — scene, camera, or viewport size.
+    /// A static scene's FBO is only re-rendered when something changed —
+    /// scene, camera, or viewport size; an animated one renders every frame.
     needs_render: bool,
 }
 
@@ -83,6 +85,7 @@ impl ModelPreview {
             asset_cache,
             built_for: None,
             scene: None,
+            animated: false,
             error: None,
             debug_skeletons: false,
             debug_hit_boxes: false,
@@ -96,12 +99,24 @@ impl ModelPreview {
     }
 
     /// Show the preview for `key` (a `.bin` model): toggles, then the rendered
-    /// viewport filling the remaining space.
-    pub fn show(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame, key: &str) {
-        self.ensure_scene(key);
+    /// viewport filling the remaining space. With `clip` (a motion name, no
+    /// extension), the model animates with that clip on loop.
+    pub fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        frame: &mut eframe::Frame,
+        key: &str,
+        clip: Option<&str>,
+    ) {
+        self.ensure_scene(key, clip);
         if let Some(error) = &self.error {
             ui.label(format!("Cannot render this model: {error}"));
             return;
+        }
+        if self.animated {
+            // Tick the playing clip with real dt and keep frames coming.
+            self.needs_render = true;
+            ui.ctx().request_repaint();
         }
 
         // A toggle change rebuilds on the next frame's ensure_scene (the click
@@ -150,16 +165,22 @@ impl ModelPreview {
         }
     }
 
-    /// (Re)build the scene when the key or a debug toggle changed, framing the
-    /// camera from the model's bounds where they are known.
-    fn ensure_scene(&mut self, key: &str) {
-        let wanted = (key.to_string(), self.debug_skeletons, self.debug_hit_boxes);
+    /// (Re)build the scene when the key, clip, or a debug toggle changed,
+    /// framing the camera from the model's bounds where they are known.
+    fn ensure_scene(&mut self, key: &str, clip: Option<&str>) {
+        let wanted = (
+            key.to_string(),
+            clip.map(|c| c.to_string()),
+            self.debug_skeletons,
+            self.debug_hit_boxes,
+        );
         if self.built_for.as_ref() == Some(&wanted) {
             return;
         }
         let reframe = self.built_for.as_ref().map(|(k, ..)| k.as_str()) != Some(key);
         self.built_for = Some(wanted);
         self.scene = None;
+        self.animated = false;
         self.error = None;
         // Load the model eagerly under catch_unwind — the scene itself defers
         // loading to render, and Dark parsers panic on malformed input; a
@@ -173,21 +194,53 @@ impl ModelPreview {
                 return;
             }
         };
-        match BinObjViewerScene::from_model(
-            key.to_string(),
-            &self.asset_cache,
-            self.debug_skeletons,
-            self.debug_hit_boxes,
-        ) {
+        let scene: Result<Box<dyn ToolScene>, String> = match clip {
+            None => BinObjViewerScene::from_model(
+                key.to_string(),
+                &self.asset_cache,
+                self.debug_skeletons,
+                self.debug_hit_boxes,
+            )
+            .map(|scene| Box::new(scene) as Box<dyn ToolScene>)
+            .map_err(|err| err.to_string()),
+            // Clip parsing panics on malformed input too, so it also runs
+            // under the guard. `<name>_.mc` is the clip importer's naming.
+            Some(clip) => quiet_catch(|| {
+                BinAiViewerScene::from_clips(
+                    key.to_string(),
+                    vec![format!("{clip}_.mc")],
+                    &mut self.asset_cache,
+                    self.debug_skeletons,
+                    self.debug_hit_boxes,
+                )
+                .map(|scene| Box::new(scene) as Box<dyn ToolScene>)
+                .map_err(|err| err.to_string())
+            })
+            .and_then(|r| r),
+        };
+        match scene {
             Ok(scene) => {
-                self.scene = Some(Box::new(scene));
+                self.scene = Some(scene);
+                self.animated = clip.is_some();
                 self.needs_render = true;
                 if reframe {
                     self.frame_camera(&model);
                 }
             }
-            Err(err) => self.error = Some(err.to_string()),
+            Err(err) => self.error = Some(err),
         }
+    }
+
+    /// Step the playing scene forward by `seconds` of simulation time (in
+    /// fixed 60 Hz increments), so `--screenshot` runs can capture a pose
+    /// mid-clip.
+    pub fn advance(&mut self, seconds: f32) {
+        let Some(scene) = &mut self.scene else { return };
+        let steps = (seconds * 60.0).round().max(0.0) as u32;
+        for _ in 0..steps {
+            scene.update(1.0 / 60.0);
+        }
+        self.needs_render = true;
     }
 
     /// Reset the orbit to frame the model: static models by their bounding

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -59,6 +59,10 @@ pub struct ModelPreview {
     error: Option<String>,
     pub debug_skeletons: bool,
     pub debug_hit_boxes: bool,
+    /// Suspend the per-frame wall-clock tick of an animated scene, so
+    /// `advance()` is the only time source - `--screenshot` runs set this to
+    /// capture a deterministic pose.
+    pub paused: bool,
     // Orbit camera around `target` (dark_viewer's parameterization: pitch 90
     // is horizontal, distance along the orbit radius).
     yaw: f32,
@@ -89,6 +93,7 @@ impl ModelPreview {
             error: None,
             debug_skeletons: false,
             debug_hit_boxes: false,
+            paused: false,
             yaw: 65.0,
             pitch: 75.0,
             distance: 10.0,
@@ -113,7 +118,7 @@ impl ModelPreview {
             ui.label(format!("Cannot render this model: {error}"));
             return;
         }
-        if self.animated {
+        if self.animated && !self.paused {
             // Tick the playing clip with real dt and keep frames coming.
             self.needs_render = true;
             ui.ctx().request_repaint();
@@ -144,9 +149,11 @@ impl ModelPreview {
         }
 
         if self.needs_render && self.scene.is_some() && self.fbo.is_some() {
-            let dt = ui.input(|i| i.stable_dt).min(0.1);
-            if let Some(scene) = &mut self.scene {
-                scene.update(dt);
+            if !self.paused {
+                let dt = ui.input(|i| i.stable_dt).min(0.1);
+                if let Some(scene) = &mut self.scene {
+                    scene.update(dt);
+                }
             }
             self.render_scene(px);
             self.needs_render = false;
@@ -204,11 +211,11 @@ impl ModelPreview {
             .map(|scene| Box::new(scene) as Box<dyn ToolScene>)
             .map_err(|err| err.to_string()),
             // Clip parsing panics on malformed input too, so it also runs
-            // under the guard. `<name>_.mc` is the clip importer's naming.
+            // under the guard.
             Some(clip) => quiet_catch(|| {
                 BinAiViewerScene::from_clips(
                     key.to_string(),
-                    vec![format!("{clip}_.mc")],
+                    vec![dark_viewer::normalize_clip_name(clip)?],
                     &mut self.asset_cache,
                     self.debug_skeletons,
                     self.debug_hit_boxes,
@@ -236,11 +243,17 @@ impl ModelPreview {
     /// mid-clip.
     pub fn advance(&mut self, seconds: f32) {
         let Some(scene) = &mut self.scene else { return };
-        let steps = (seconds * 60.0).round().max(0.0) as u32;
+        // Cap at 10 minutes of sim time so a typo'd --advance can't hang.
+        let steps = (seconds * 60.0).round().clamp(0.0, 60.0 * 600.0) as u32;
         for _ in 0..steps {
             scene.update(1.0 / 60.0);
         }
         self.needs_render = true;
+    }
+
+    /// Why the current selection could not be shown, if it could not.
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
     }
 
     /// Reset the orbit to frame the model: static models by their bounding

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -11,6 +11,7 @@ use engine::assets::asset_paths::{AbstractAssetPath, AssetEntry};
 use engine::audio::{AudioClip, AudioContext, AudioHandle};
 use engine::texture_format::{self, PixelFormat};
 
+use crate::archetypes::{Archetype, ArchetypeDb};
 use crate::explorer;
 use crate::model_preview::{self, ModelPreview};
 
@@ -26,6 +27,12 @@ pub struct UiOptions {
     /// `--screenshot` run can capture the debug overlays).
     pub skeletons: bool,
     pub hitboxes: bool,
+    /// Open the Archetypes tab with this creature selected (name or
+    /// template id), optionally playing `clip`, advanced by `advance` seconds
+    /// of simulation time before a `--screenshot` capture.
+    pub archetype: Option<String>,
+    pub clip: Option<String>,
+    pub advance: Option<f32>,
 }
 
 pub fn run(options: UiOptions) {
@@ -143,7 +150,14 @@ struct Preview {
     kind: PreviewKind,
 }
 
+#[derive(Clone, Copy, PartialEq)]
+enum Tab {
+    Files,
+    Archetypes,
+}
+
 pub struct ExplorerApp {
+    tab: Tab,
     family_names: Vec<&'static str>,
     families: BTreeMap<String, LoadedFamily>,
     search: String,
@@ -165,11 +179,22 @@ pub struct ExplorerApp {
     scroll_frames: u8,
     /// Flattened search rows, cached per needle: (needle, capped rows, total).
     search_results: Option<(String, Vec<(String, String)>, usize)>,
+    /// Lazily built on first opening the Archetypes tab: parsing the gamesys
+    /// and motion database takes a moment. Err = why it failed, shown inline.
+    archetype_db: Option<Result<ArchetypeDb, String>>,
+    archetype_search: String,
+    selected_archetype: Option<i32>,
+    selected_clip: Option<String>,
+    /// Clip list cached for the selected archetype's template id.
+    archetype_clips: Option<(i32, Result<Vec<String>, String>)>,
+    /// Simulation seconds to step the scene once it exists (from `--advance`).
+    advance_pending: Option<f32>,
 }
 
 impl ExplorerApp {
     fn new(options: UiOptions) -> ExplorerApp {
         let mut app = ExplorerApp {
+            tab: Tab::Files,
             family_names: explorer::family_names(),
             families: BTreeMap::new(),
             search: options.search.unwrap_or_default(),
@@ -184,7 +209,54 @@ impl ExplorerApp {
             frames_rendered: 0,
             scroll_frames: 0,
             search_results: None,
+            archetype_db: None,
+            archetype_search: String::new(),
+            selected_archetype: None,
+            selected_clip: None,
+            archetype_clips: None,
+            advance_pending: options.advance,
         };
+        if let Some(archetype) = options.archetype {
+            // Fail loudly, like --select: a `--screenshot` run that quietly
+            // captured an empty preview would still exit 0 otherwise.
+            let id = {
+                let db = match app.archetype_db().as_ref() {
+                    Ok(db) => db,
+                    Err(err) => {
+                        eprintln!("--archetype: {err}");
+                        std::process::exit(2);
+                    }
+                };
+                let id = match db.resolve(&archetype) {
+                    Ok(id) => id,
+                    Err(err) => {
+                        eprintln!("--archetype: {err}");
+                        std::process::exit(2);
+                    }
+                };
+                if let Some(clip) = &options.clip {
+                    match db.archetypes.get(&id).map(|a| db.clips_for(a)) {
+                        Some(Ok(clips)) if clips.iter().any(|c| c == clip) => {}
+                        Some(Ok(_)) => {
+                            eprintln!("--clip: no clip '{clip}' for that archetype");
+                            std::process::exit(2);
+                        }
+                        Some(Err(err)) => {
+                            eprintln!("--clip: cannot list clips: {err}");
+                            std::process::exit(2);
+                        }
+                        None => unreachable!("resolve returned an unknown archetype"),
+                    }
+                }
+                id
+            };
+            app.tab = Tab::Archetypes;
+            app.selected_archetype = Some(id);
+            app.selected_clip = options.clip;
+        } else if options.clip.is_some() {
+            eprintln!("--clip needs --archetype");
+            std::process::exit(2);
+        }
         if let Some(select) = options.select {
             // Fail loudly on a bad selection: a `--screenshot` run that quietly
             // captured an empty preview would still exit 0 otherwise.
@@ -204,6 +276,10 @@ impl ExplorerApp {
             }
         }
         app
+    }
+
+    fn archetype_db(&mut self) -> &Result<ArchetypeDb, String> {
+        self.archetype_db.get_or_insert_with(ArchetypeDb::load)
     }
 
     fn family(&mut self, name: &str) -> &LoadedFamily {
@@ -369,27 +445,41 @@ impl eframe::App for ExplorerApp {
             .show(ui, |ui| {
                 ui.add_space(4.0);
                 ui.horizontal(|ui| {
-                    ui.label("Search:");
-                    ui.add(
-                        egui::TextEdit::singleline(&mut self.search)
-                            .hint_text("substring of a key")
-                            .desired_width(f32::INFINITY),
-                    );
+                    ui.selectable_value(&mut self.tab, Tab::Files, "Files");
+                    ui.selectable_value(&mut self.tab, Tab::Archetypes, "Archetypes");
                 });
                 ui.separator();
-                egui::ScrollArea::both()
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
-                        if self.search.is_empty() {
-                            self.show_tree(ui, &mut clicked);
-                        } else {
-                            self.show_search_results(ui, &mut clicked);
-                        }
-                    });
+                match self.tab {
+                    Tab::Files => {
+                        ui.horizontal(|ui| {
+                            ui.label("Search:");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut self.search)
+                                    .hint_text("substring of a key")
+                                    .desired_width(f32::INFINITY),
+                            );
+                        });
+                        ui.separator();
+                        egui::ScrollArea::both()
+                            .auto_shrink([false, false])
+                            .show(ui, |ui| {
+                                if self.search.is_empty() {
+                                    self.show_tree(ui, &mut clicked);
+                                } else {
+                                    self.show_search_results(ui, &mut clicked);
+                                }
+                            });
+                    }
+                    Tab::Archetypes => self.show_archetype_panel(ui),
+                }
             });
 
         egui::CentralPanel::default_margins().show(ui, |ui| {
-            self.show_preview(ui, frame);
+            if self.tab == Tab::Archetypes {
+                self.show_archetype_preview(ui, frame);
+            } else {
+                self.show_preview(ui, frame);
+            }
         });
 
         self.scroll_frames = self.scroll_frames.saturating_sub(1);
@@ -474,6 +564,155 @@ impl ExplorerApp {
         if *total == 0 {
             ui.label("no matches");
         }
+    }
+
+    /// Left panel, Archetypes tab: search box + creature template tree (or a
+    /// flat filtered list while searching).
+    fn show_archetype_panel(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.label("Search:");
+            ui.add(
+                egui::TextEdit::singleline(&mut self.archetype_search)
+                    .hint_text("archetype name")
+                    .desired_width(f32::INFINITY),
+            );
+        });
+        ui.separator();
+        let db = match self.archetype_db.get_or_insert_with(ArchetypeDb::load) {
+            Ok(db) => db,
+            Err(err) => {
+                ui.label(format!("Cannot load gamesys: {err}"));
+                return;
+            }
+        };
+        let selected = self.selected_archetype;
+        let mut clicked: Option<i32> = None;
+        egui::ScrollArea::both()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                if self.archetype_search.is_empty() {
+                    let open_path = selected.map(|id| db.ancestors_of(id)).unwrap_or_default();
+                    for root in &db.roots {
+                        show_archetype_node(ui, db, *root, selected, &open_path, &mut clicked);
+                    }
+                } else {
+                    let needle = self.archetype_search.to_ascii_lowercase();
+                    let mut matches: Vec<&Archetype> = db
+                        .archetypes
+                        .values()
+                        .filter(|a| a.name.to_ascii_lowercase().contains(&needle))
+                        .collect();
+                    matches.sort_by_key(|a| a.name.to_ascii_lowercase());
+                    for archetype in &matches {
+                        let is_selected = selected == Some(archetype.template_id);
+                        if ui.selectable_label(is_selected, &archetype.name).clicked() {
+                            clicked = Some(archetype.template_id);
+                        }
+                    }
+                    if matches.is_empty() {
+                        ui.label("no matches");
+                    }
+                }
+            });
+        if let Some(id) = clicked {
+            self.selected_archetype = Some(id);
+            self.selected_clip = None;
+            self.archetype_clips = None;
+        }
+    }
+
+    /// Right pane, Archetypes tab: archetype info, clip list, 3D preview.
+    fn show_archetype_preview(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        let Some(id) = self.selected_archetype else {
+            ui.centered_and_justified(|ui| {
+                ui.label("Select an archetype to preview it");
+            });
+            return;
+        };
+        // The db is loaded whenever a selection exists; guard regardless.
+        let archetype = match &self.archetype_db {
+            Some(Ok(db)) => match db.archetypes.get(&id) {
+                Some(archetype) => archetype.clone(),
+                None => {
+                    ui.label(format!("no archetype with template id {id}"));
+                    return;
+                }
+            },
+            _ => {
+                ui.label("archetype data not loaded");
+                return;
+            }
+        };
+        if self.archetype_clips.as_ref().map(|(i, _)| *i) != Some(id) {
+            let clips = match &self.archetype_db {
+                Some(Ok(db)) => db.clips_for(&archetype),
+                _ => Err("archetype data not loaded".to_string()),
+            };
+            self.archetype_clips = Some((id, clips));
+        }
+
+        ui.heading(&archetype.name);
+        egui::Grid::new("archetype_info")
+            .num_columns(2)
+            .show(ui, |ui| {
+                ui.label("Template id");
+                ui.label(archetype.template_id.to_string());
+                ui.end_row();
+                ui.label("Model");
+                ui.label(archetype.model_key());
+                ui.end_row();
+                ui.label("Creature type");
+                ui.label(archetype.creature_type_name());
+                ui.end_row();
+                ui.label("Actor type");
+                ui.label(archetype.actor_type_name());
+                ui.end_row();
+            });
+        ui.separator();
+
+        egui::Panel::right(egui::Id::new("clip_list"))
+            .resizable(true)
+            .default_size(220.0)
+            .show(ui, |ui| {
+                ui.label("Clips (click to play)");
+                ui.separator();
+                match &self.archetype_clips {
+                    Some((_, Ok(clips))) => {
+                        if clips.is_empty() {
+                            ui.label("(no clips for this actor type)");
+                        }
+                        egui::ScrollArea::vertical()
+                            .auto_shrink([false, false])
+                            .show(ui, |ui| {
+                                for clip in clips {
+                                    let is_playing = self.selected_clip.as_deref() == Some(clip);
+                                    if ui.selectable_label(is_playing, clip).clicked() {
+                                        // Click toggles: re-clicking stops it.
+                                        self.selected_clip = (!is_playing).then(|| clip.clone());
+                                    }
+                                }
+                            });
+                    }
+                    Some((_, Err(err))) => {
+                        ui.label(format!("Cannot list clips: {err}"));
+                    }
+                    None => {}
+                }
+            });
+
+        let (skeletons, hitboxes) = self.initial_overlays;
+        let host = self.model_preview.get_or_insert_with(|| {
+            let mut host = ModelPreview::new();
+            host.debug_skeletons = skeletons;
+            host.debug_hit_boxes = hitboxes;
+            host
+        });
+        host.show(
+            ui,
+            frame,
+            &archetype.model_key(),
+            self.selected_clip.as_deref(),
+        );
     }
 
     fn show_preview(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
@@ -572,7 +811,7 @@ impl ExplorerApp {
                     host.debug_hit_boxes = hitboxes;
                     host
                 });
-                host.show(ui, frame, &key);
+                host.show(ui, frame, &key, None);
             }
             PreviewKind::Raw { reason, hex } => {
                 ui.label(format!("Cannot render this file: {reason}"));
@@ -599,6 +838,13 @@ impl ExplorerApp {
         };
         self.frames_rendered += 1;
         ctx.request_repaint();
+        // The scene exists after the first frame's show; step it before the
+        // capture so `--advance` screenshots a mid-clip pose.
+        if self.frames_rendered == 2 && self.advance_pending.is_some() {
+            if let Some(preview) = self.model_preview.as_mut() {
+                preview.advance(self.advance_pending.take().unwrap());
+            }
+        }
         if self.frames_rendered == 3 {
             ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot(egui::UserData::default()));
         }
@@ -631,6 +877,47 @@ impl ExplorerApp {
         if self.frames_rendered > 300 {
             eprintln!("screenshot never arrived after 300 frames");
             std::process::exit(1);
+        }
+    }
+}
+
+/// One node of the archetype tree: a collapsible header where the template has
+/// children (with a selectable "(this)" row when it is itself a creature),
+/// else a selectable leaf.
+fn show_archetype_node(
+    ui: &mut egui::Ui,
+    db: &ArchetypeDb,
+    id: i32,
+    selected: Option<i32>,
+    open_path: &std::collections::HashSet<i32>,
+    clicked: &mut Option<i32>,
+) {
+    let name = db.name_of(id);
+    let is_archetype = db.archetypes.contains_key(&id);
+    let is_selected = selected == Some(id);
+    match db.children.get(&id) {
+        Some(children) if !children.is_empty() => {
+            egui::CollapsingHeader::new(&name)
+                .id_salt(id)
+                .default_open(open_path.contains(&id))
+                .show(ui, |ui| {
+                    if is_archetype {
+                        if ui
+                            .selectable_label(is_selected, format!("{name} (this)"))
+                            .clicked()
+                        {
+                            *clicked = Some(id);
+                        }
+                    }
+                    for child in children {
+                        show_archetype_node(ui, db, *child, selected, open_path, clicked);
+                    }
+                });
+        }
+        _ => {
+            if ui.selectable_label(is_selected, &name).clicked() && is_archetype {
+                *clicked = Some(id);
+            }
         }
     }
 }

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -700,13 +700,11 @@ impl ExplorerApp {
                 }
             });
 
-        let (skeletons, hitboxes) = self.initial_overlays;
-        let host = self.model_preview.get_or_insert_with(|| {
-            let mut host = ModelPreview::new();
-            host.debug_skeletons = skeletons;
-            host.debug_hit_boxes = hitboxes;
-            host
-        });
+        let host = preview_host(
+            &mut self.model_preview,
+            self.initial_overlays,
+            self.screenshot.is_some(),
+        );
         host.show(
             ui,
             frame,
@@ -804,13 +802,11 @@ impl ExplorerApp {
             }
             PreviewKind::Model => {
                 let key = preview.key.clone();
-                let (skeletons, hitboxes) = self.initial_overlays;
-                let host = self.model_preview.get_or_insert_with(|| {
-                    let mut host = ModelPreview::new();
-                    host.debug_skeletons = skeletons;
-                    host.debug_hit_boxes = hitboxes;
-                    host
-                });
+                let host = preview_host(
+                    &mut self.model_preview,
+                    self.initial_overlays,
+                    self.screenshot.is_some(),
+                );
                 host.show(ui, frame, &key, None);
             }
             PreviewKind::Raw { reason, hex } => {
@@ -846,6 +842,12 @@ impl ExplorerApp {
             }
         }
         if self.frames_rendered == 3 {
+            // A selection that failed to load would capture only its error
+            // label; fail loudly instead so automation can trust exit 0.
+            if let Some(error) = self.model_preview.as_ref().and_then(|p| p.error()) {
+                eprintln!("cannot render the selection: {error}");
+                std::process::exit(2);
+            }
             ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot(egui::UserData::default()));
         }
         let image = ctx.input(|i| {
@@ -879,6 +881,23 @@ impl ExplorerApp {
             std::process::exit(1);
         }
     }
+}
+
+/// The lazily-built 3D preview host. CLI overlays apply on first build, and a
+/// `--screenshot` run pauses wall-clock animation so `--advance` is the only
+/// time source (a deterministic pose per invocation).
+fn preview_host(
+    model_preview: &mut Option<ModelPreview>,
+    (skeletons, hitboxes): (bool, bool),
+    paused: bool,
+) -> &mut ModelPreview {
+    model_preview.get_or_insert_with(|| {
+        let mut host = ModelPreview::new();
+        host.debug_skeletons = skeletons;
+        host.debug_hit_boxes = hitboxes;
+        host.paused = paused;
+        host
+    })
 }
 
 /// One node of the archetype tree: a collapsible header where the template has
@@ -915,7 +934,11 @@ fn show_archetype_node(
                 });
         }
         _ => {
-            if ui.selectable_label(is_selected, &name).clicked() && is_archetype {
+            // A childless grouping node (a multi-parent template's other
+            // ancestor) is not selectable - only archetypes are.
+            if !is_archetype {
+                ui.label(&name);
+            } else if ui.selectable_label(is_selected, &name).clicked() {
                 *clicked = Some(id);
             }
         }

--- a/tools/dark_viewer/src/lib.rs
+++ b/tools/dark_viewer/src/lib.rs
@@ -2,3 +2,22 @@
 //! model preview embeds them); the `dark_viewer` binary drives them in GLFW.
 
 pub mod scenes;
+
+/// Normalize a user-supplied animation name to the `<name>_.mc` asset name
+/// the clip importer expects, accepting a bare name, `name.mc`, or `name_.mc`.
+pub fn normalize_clip_name(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("Animation name may not be empty".to_owned());
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.ends_with("_.mc") {
+        return Ok(trimmed.to_owned());
+    }
+    if lower.ends_with(".mc") {
+        let without_ext = &trimmed[..trimmed.len() - 3];
+        return Ok(format!("{}_.mc", without_ext));
+    }
+    Ok(format!("{}_.mc", trimmed))
+}

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -85,22 +85,7 @@ struct Cli {
     debug_hitboxes: bool,
 }
 
-fn normalize_clip_name(raw: &str) -> Result<String, String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Err("Animation name may not be empty".to_owned());
-    }
-
-    let lower = trimmed.to_ascii_lowercase();
-    if lower.ends_with("_.mc") {
-        return Ok(trimmed.to_owned());
-    }
-    if lower.ends_with(".mc") {
-        let without_ext = &trimmed[..trimmed.len() - 3];
-        return Ok(format!("{}_.mc", without_ext));
-    }
-    Ok(format!("{}_.mc", trimmed))
-}
+use dark_viewer::normalize_clip_name;
 
 fn gather_animation_list(cli: &Cli, filename: &str) -> Result<(Vec<String>, bool), String> {
     let animation_flag_provided = cli.animation.is_some();


### PR DESCRIPTION
Final PR of the dark_explorer stack: an **Archetypes tab** with creature animation playback.

- Left panel gains Files / Archetypes tabs. Archetypes shows the gamesys creature templates in their MetaProp hierarchy (inheritance-aware `PropModelName` + `PropCreature` via a shipyard World), with a name filter.
- Selecting one shows template id / model / creature type / actor type, renders the model in the 3D preview, and lists the motion database's clips for its actor type (new additive `MotionDB::get_all_motions_for_creature`).
- Clicking a clip plays it on the skinned mesh (dark_viewer's `BinAiViewerScene`, ticked with real dt); skeleton/hitbox overlays work during playback. All gamesys/motiondb/clip parsing runs under `catch_unwind`.
- Headless verification: `--archetype <name|id>`, `--clip <name>`, `--advance <seconds>`. Screenshot runs pause the wall-clock tick so `--advance` is the only time source — repeat captures are **byte-identical** (verified with `cmp`), and a selection that fails to load exits 2 instead of screenshotting an error label.

### Screenshots
| Archetype tree + clips | Skeleton overlay mid-clip |
|---|---|
| ![tree](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/a92b1f5f993b05c14cbf18ec910d8bf34e8525d5/arch_tree.png) | ![skel](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/a92b1f5f993b05c14cbf18ec910d8bf34e8525d5/skel.png) |

Same clip (`humcrawl`) at `--advance 0.9` vs `--advance 2.0` — distinct poses:
| t = 0.9s | t = 2.0s |
|---|---|
| ![a](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/a92b1f5f993b05c14cbf18ec910d8bf34e8525d5/det1.png) | ![b](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/a92b1f5f993b05c14cbf18ec910d8bf34e8525d5/det3.png) |

Reviewed with cross-engine xreview (Claude reviewer + de-dup pass; Codex hit its usage quota mid-run). All Medium findings fixed and re-verified; dedup findings applied (shared `normalize_clip_name` in the dark_viewer lib, `ActorType` names from shock2vr instead of a third hand-written table, one preview-host helper). Deferred with a note: a shared gamesys-loader for CLI tools (dark_query has its own copy).