### PR TITLE
feat(cutscene): play authored videos at campaign transitions

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -465,6 +465,19 @@ fn transition_ready(frames_shown: u32, parse_done_frame: Option<u32>) -> bool {
         && frames_shown >= MIN_LOADING_FRAMES
 }
 
+/// What a scene hands to the level that follows it: the quest bits, the items
+/// in hand and (unless the destination initializes them) the player's vitals.
+///
+/// A transition normally captures this from the scene that queued it, but a
+/// cutscene played in between replaces that scene first - so the cutscene's own
+/// empty world would be what got carried, wiping the player's career, training
+/// year, inventory and health.
+struct PreservedSceneState {
+    quest_info: QuestInfo,
+    held_data: HeldItemSaveData,
+    player_vitals: Option<PlayerVitals>,
+}
+
 pub struct Game {
     options: GameOptions,
     pub asset_cache: AssetCache,
@@ -474,6 +487,9 @@ pub struct Game {
     active_game_scene: Box<dyn GameScene>,
     /// Set while a deferred transition is in flight (loading screen showing).
     pending_transition: Option<PendingTransition>,
+    /// Set while a cutscene stands in for the scene that queued the transition
+    /// following it. See [`PreservedSceneState`].
+    preserved_scene_state: Option<PreservedSceneState>,
     // physics: PhysicsWorld,
     // script_world: ScriptWorld,
     audio_context: AudioContext<EntityId, String>,
@@ -756,7 +772,7 @@ impl Game {
     /// Capture the outgoing scene's save data (so its state survives the transition)
     /// and return the context the new mission needs. Must run while the outgoing scene
     /// is still active.
-    fn save_active_scene(&mut self) -> (QuestInfo, HeldItemSaveData, Option<PlayerVitals>) {
+    fn save_active_scene(&mut self) -> PreservedSceneState {
         let current_quest_info = self
             .active_game_scene
             .world()
@@ -781,7 +797,11 @@ impl Game {
 
         let player_vitals = save_load::capture_player_vitals(self.active_game_scene.world());
 
-        (current_quest_info, held_data, player_vitals)
+        PreservedSceneState {
+            quest_info: current_quest_info,
+            held_data,
+            player_vitals,
+        }
     }
 
     /// Start a background transition: save the outgoing scene, spawn the GL-free level
@@ -810,7 +830,16 @@ impl Game {
             "[loading-screen] begin_transition -> {} (background parse)",
             level_name
         );
-        let (quest_info, held_data, mut player_vitals) = self.save_active_scene();
+        // A cutscene playing ahead of this transition already captured the scene
+        // that queued it; its own empty world is not what should carry forward.
+        let PreservedSceneState {
+            quest_info,
+            held_data,
+            mut player_vitals,
+        } = match self.preserved_scene_state.take() {
+            Some(preserved) => preserved,
+            None => self.save_active_scene(),
+        };
         if vitals_transition == PlayerVitalsTransition::InitializeFromDestination {
             player_vitals = None;
         }
@@ -1261,6 +1290,7 @@ impl Game {
             audio_context,
             active_game_scene,
             pending_transition: None,
+            preserved_scene_state: None,
             global_context: Arc::new(global_context),
             last_music_cue: None,
             last_env_sound: None,
@@ -1833,26 +1863,40 @@ impl Game {
                 self.hit_feedback.trigger(damage);
             }
             GlobalEffect::PlayCutscene { video, then } => {
-                // A scene swap like the frontend ones: no ledger write-back, and
-                // any pending transition is abandoned.
+                // Any pending transition is abandoned, as for the frontend swaps.
                 self.pending_transition = None;
                 let follow_on = *then;
+                // Capture the scene the cutscene is about to replace, so a
+                // follow-on transition carries the player's state and not the
+                // cutscene's empty world. A cutscene chaining into another keeps
+                // what the first captured - the empty world it would capture now
+                // is exactly what must not win.
+                let preserved = match self.preserved_scene_state.take() {
+                    Some(carried) => carried,
+                    None => self.save_active_scene(),
+                };
                 match CutscenePlayerScene::new(video, follow_on.clone(), &mut self.audio_context) {
-                    Ok(cutscene) => self.set_active_scene(Box::new(cutscene)),
+                    Ok(cutscene) => {
+                        self.set_active_scene(Box::new(cutscene));
+                        // After the swap: `set_active_scene` clears this.
+                        self.preserved_scene_state = Some(preserved);
+                    }
                     Err(error) => {
                         // An install missing a movie must not strand the player
                         // on the scene the cutscene was replacing.
                         warn!("{error} - skipping it");
+                        // The follow-on still needs what was captured: the scene
+                        // is unchanged here, but in a chain this is the state of
+                        // the gameplay scene an earlier cutscene replaced.
+                        self.preserved_scene_state = Some(preserved);
                         self.handle_global_effect(follow_on);
                     }
                 }
             }
             GlobalEffect::CompleteCampaign => {
-                // Preserve the destroyed head and the rest of the finale state
-                // in the in-memory mission ledger before the cutscene replaces
-                // the active world.
-                self.save_active_scene();
-
+                // The destroyed head and the rest of the finale state reach the
+                // in-memory mission ledger through `PlayCutscene`, which saves
+                // the scene it replaces.
                 let after_ending = scenes::finale_follow_on(scenes::resolve_credits_cutscene());
 
                 self.campaign_completed = true;
@@ -1872,6 +1916,11 @@ impl Game {
     /// scene swap goes through here so that hook cannot be forgotten.
     fn set_active_scene(&mut self, scene: Box<dyn GameScene>) {
         self.active_game_scene.on_exit(&mut self.audio_context);
+        // Only a cutscene standing in for a scene carries state on its behalf,
+        // and `PlayCutscene` re-arms this straight after the swap. Clearing it
+        // for every other swap means a chain that ends anywhere but a
+        // transition cannot leak the old scene's state into a later one.
+        self.preserved_scene_state = None;
         self.active_game_scene = scene;
         // Whatever hurt the player belongs to the scene being left: a quickload
         // taken mid-fight must not open on a red rim, and the main menu must

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -819,6 +819,9 @@ impl Game {
         // and vitals, and filing a bogus "loading" entry in the mission ledger.
         // Nothing in-game can reach this (the loading scene runs no scripts),
         // but an external caller can, so refuse rather than corrupt.
+        // Taken before the refusal below, so a rejected transition cannot leave
+        // a cutscene's carried state behind for an unrelated later one.
+        let preserved = self.preserved_scene_state.take();
         if self.pending_transition.is_some() {
             warn!(
                 "Ignoring transition to '{}': a level transition is already in flight",
@@ -836,7 +839,7 @@ impl Game {
             quest_info,
             held_data,
             mut player_vitals,
-        } = match self.preserved_scene_state.take() {
+        } = match preserved {
             Some(preserved) => preserved,
             None => self.save_active_scene(),
         };

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1900,10 +1900,7 @@ impl Game {
                 let after_ending = scenes::finale_follow_on(scenes::resolve_credits_cutscene());
 
                 self.campaign_completed = true;
-                self.handle_global_effect(GlobalEffect::PlayCutscene {
-                    video: resolve_ending_cutscene(),
-                    then: Box::new(after_ending),
-                });
+                self.handle_global_effect(after_ending.after_cutscene(&resolve_ending_cutscene()));
             }
             GlobalEffect::Quit => {
                 self.should_quit = true;

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -50,6 +50,10 @@ use std::collections::HashMap;
 
 /// Mission loaded when the player chooses "New Game".
 const NEW_GAME_MISSION: &str = "earth.mis";
+/// The intro movie the original played on New Game, before the first level.
+/// Only this button gets it - the developer launcher boots the same level with
+/// no cutscene, and a load resumes straight into the save.
+const NEW_GAME_CUTSCENE: &str = "cs1.avi";
 
 /// The menu is authored on the original 640x480 `MAIN.PCX` canvas.
 const CANVAS_W: f32 = 640.0;
@@ -319,9 +323,10 @@ impl GameScene for MainMenuScene {
 
         match action {
             Some(MenuAction::NewGame) => {
-                vec![Effect::GlobalEffect(GlobalEffect::new_game_transition(
-                    NEW_GAME_MISSION.to_owned(),
-                ))]
+                vec![Effect::GlobalEffect(
+                    GlobalEffect::new_game_transition(NEW_GAME_MISSION.to_owned())
+                        .after_cutscene(NEW_GAME_CUTSCENE),
+                )]
             }
             Some(MenuAction::LoadGame) => {
                 vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -477,10 +477,7 @@ pub(crate) fn resolve_credits_cutscene() -> Option<String> {
 /// ships one, then the main menu either way.
 pub(crate) fn finale_follow_on(credits: Option<String>) -> GlobalEffect {
     match credits {
-        Some(video) => GlobalEffect::PlayCutscene {
-            video,
-            then: Box::new(GlobalEffect::ShowMainMenu),
-        },
+        Some(video) => GlobalEffect::ShowMainMenu.after_cutscene(&video),
         None => GlobalEffect::ShowMainMenu,
     }
 }

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -6,24 +6,36 @@ use crate::{career::Career, physics::PhysicsWorld, quest_info::QuestInfo};
 
 use super::{Effect, MessagePayload, Script};
 
-/// The boarding of the Von Braun, played once as chargen hands off to the
-/// campaign. Movie names are not present in the mission or gamesys data - the
-/// original picked them in its engine/game-script code.
-const DEPLOY_CUTSCENE: &str = "cs2.avi";
-
 pub struct ChooseMissionScript {}
 
 impl ChooseMissionScript {
-    /// The shuttle clip that plays as the player leaves on the tour advancing
-    /// them to `new_year` (2, 3 and 4 are the three tours of duty). `None` for
-    /// any other year, which no authored marker produces.
-    fn tour_cutscene(new_year: u32) -> Option<&'static str> {
+    /// The clips that play, in this order, as the player leaves on the tour
+    /// advancing them to `new_year` (2, 3 and 4 are the three tours of duty).
+    /// The last tour is also the deploy, so it ends with the boarding of the
+    /// Von Braun. Empty for any year no authored marker produces, so a repeat
+    /// trigger past the deploy replays nothing.
+    ///
+    /// Movie names are not present in the mission or gamesys data - the original
+    /// picked them in its engine/game-script code.
+    fn departure_cutscenes(new_year: u32) -> &'static [&'static str] {
         match new_year {
-            2 => Some("shuttle1.avi"),
-            3 => Some("shuttle2.avi"),
-            4 => Some("shuttle3.avi"),
-            _ => None,
+            2 => &["shuttle1.avi"],
+            3 => &["shuttle2.avi"],
+            4 => &["shuttle3.avi", "cs2.avi"],
+            _ => &[],
         }
+    }
+
+    /// `transition`, behind the clips that play on the way to `new_year`. Each
+    /// wrap goes in front of what it wraps, so they are applied back to front.
+    fn behind_departure_cutscenes(
+        transition: super::GlobalEffect,
+        new_year: u32,
+    ) -> super::GlobalEffect {
+        Self::departure_cutscenes(new_year)
+            .iter()
+            .rev()
+            .fold(transition, |effect, video| effect.after_cutscene(video))
     }
 
     pub fn new() -> ChooseMissionScript {
@@ -130,15 +142,15 @@ impl Script for ChooseMissionScript {
                             .unwrap_or_default()
                     };
 
-                    let mut transition = super::GlobalEffect::TransitionLevel {
-                        level_file: "station.mis".to_string(),
-                        loc: None,
-                        entities_to_trigger,
-                        vitals_transition: super::PlayerVitalsTransition::Preserve,
-                    };
-                    if let Some(video) = Self::tour_cutscene(new_year) {
-                        transition = transition.after_cutscene(video);
-                    }
+                    let transition = Self::behind_departure_cutscenes(
+                        super::GlobalEffect::TransitionLevel {
+                            level_file: "station.mis".to_string(),
+                            loc: None,
+                            entities_to_trigger,
+                            vitals_transition: super::PlayerVitalsTransition::Preserve,
+                        },
+                        new_year,
+                    );
 
                     Effect::Multiple(vec![
                         set_year_effect,
@@ -156,19 +168,15 @@ impl Script for ChooseMissionScript {
                     let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
                     let dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
 
-                    // The last tour's shuttle plays, then the boarding of the
-                    // Von Braun. Each wrap goes in front of what it wraps, so
-                    // the outermost is what the player sees first.
-                    let mut transition = super::GlobalEffect::TransitionLevel {
-                        level_file,
-                        loc: dest_loc,
-                        entities_to_trigger: vec![],
-                        vitals_transition: super::PlayerVitalsTransition::Preserve,
-                    }
-                    .after_cutscene(DEPLOY_CUTSCENE);
-                    if let Some(video) = Self::tour_cutscene(new_year) {
-                        transition = transition.after_cutscene(video);
-                    }
+                    let transition = Self::behind_departure_cutscenes(
+                        super::GlobalEffect::TransitionLevel {
+                            level_file,
+                            loc: dest_loc,
+                            entities_to_trigger: vec![],
+                            vitals_transition: super::PlayerVitalsTransition::Preserve,
+                        },
+                        new_year,
+                    );
 
                     Effect::Multiple(vec![
                         set_year_effect,
@@ -185,17 +193,50 @@ impl Script for ChooseMissionScript {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::scripts::GlobalEffect;
 
-    /// One shuttle per tour of duty, in order, and nothing for a year no
-    /// authored marker can reach - a repeat trigger past the deploy must not
-    /// replay the last tour's video.
+    /// One shuttle per tour of duty, in order, the last tour also boarding the
+    /// Von Braun - and nothing at all for a year no authored marker can reach,
+    /// so a repeat trigger past the deploy replays neither.
     #[test]
-    fn each_tour_of_duty_has_its_own_shuttle_clip() {
-        assert_eq!(ChooseMissionScript::tour_cutscene(2), Some("shuttle1.avi"));
-        assert_eq!(ChooseMissionScript::tour_cutscene(3), Some("shuttle2.avi"));
-        assert_eq!(ChooseMissionScript::tour_cutscene(4), Some("shuttle3.avi"));
+    fn each_tour_of_duty_departs_on_its_own_clips() {
+        assert_eq!(
+            ChooseMissionScript::departure_cutscenes(2),
+            ["shuttle1.avi"]
+        );
+        assert_eq!(
+            ChooseMissionScript::departure_cutscenes(3),
+            ["shuttle2.avi"]
+        );
+        assert_eq!(
+            ChooseMissionScript::departure_cutscenes(4),
+            ["shuttle3.avi", "cs2.avi"]
+        );
 
-        assert_eq!(ChooseMissionScript::tour_cutscene(1), None);
-        assert_eq!(ChooseMissionScript::tour_cutscene(5), None);
+        assert!(ChooseMissionScript::departure_cutscenes(1).is_empty());
+        assert!(ChooseMissionScript::departure_cutscenes(5).is_empty());
+    }
+
+    /// The clips wrap the transition in the order they are shown, and a year
+    /// with no clips leaves the transition exactly as it was.
+    #[test]
+    fn the_deploy_plays_its_clips_in_order_before_the_transition() {
+        let transition = GlobalEffect::new_game_transition("medsci1.mis".to_string());
+
+        let wrapped = ChooseMissionScript::behind_departure_cutscenes(transition.clone(), 4);
+        let GlobalEffect::PlayCutscene { video, then } = wrapped else {
+            panic!("the deploy should play a movie first");
+        };
+        assert_eq!(video, "shuttle3.avi");
+        let GlobalEffect::PlayCutscene { video, then } = *then else {
+            panic!("the shuttle should hand off to the boarding movie");
+        };
+        assert_eq!(video, "cs2.avi");
+        assert!(matches!(*then, GlobalEffect::TransitionLevel { .. }));
+
+        assert!(matches!(
+            ChooseMissionScript::behind_departure_cutscenes(transition, 5),
+            GlobalEffect::TransitionLevel { .. }
+        ));
     }
 }

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -6,9 +6,26 @@ use crate::{career::Career, physics::PhysicsWorld, quest_info::QuestInfo};
 
 use super::{Effect, MessagePayload, Script};
 
+/// The boarding of the Von Braun, played once as chargen hands off to the
+/// campaign. Movie names are not present in the mission or gamesys data - the
+/// original picked them in its engine/game-script code.
+const DEPLOY_CUTSCENE: &str = "cs2.avi";
+
 pub struct ChooseMissionScript {}
 
 impl ChooseMissionScript {
+    /// The shuttle clip that plays as the player leaves on the tour advancing
+    /// them to `new_year` (2, 3 and 4 are the three tours of duty). `None` for
+    /// any other year, which no authored marker produces.
+    fn tour_cutscene(new_year: u32) -> Option<&'static str> {
+        match new_year {
+            2 => Some("shuttle1.avi"),
+            3 => Some("shuttle2.avi"),
+            4 => Some("shuttle3.avi"),
+            _ => None,
+        }
+    }
+
     pub fn new() -> ChooseMissionScript {
         ChooseMissionScript {}
     }
@@ -113,15 +130,20 @@ impl Script for ChooseMissionScript {
                             .unwrap_or_default()
                     };
 
+                    let mut transition = super::GlobalEffect::TransitionLevel {
+                        level_file: "station.mis".to_string(),
+                        loc: None,
+                        entities_to_trigger,
+                        vitals_transition: super::PlayerVitalsTransition::Preserve,
+                    };
+                    if let Some(video) = Self::tour_cutscene(new_year) {
+                        transition = transition.after_cutscene(video);
+                    }
+
                     Effect::Multiple(vec![
                         set_year_effect,
                         grant_effect,
-                        Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                            level_file: "station.mis".to_string(),
-                            loc: None,
-                            entities_to_trigger,
-                            vitals_transition: super::PlayerVitalsTransition::Preserve,
-                        }),
+                        Effect::GlobalEffect(transition),
                     ])
                 } else {
                     // For year 4: go to PropDestLevel (final destination)
@@ -134,19 +156,46 @@ impl Script for ChooseMissionScript {
                     let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
                     let dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
 
+                    // The last tour's shuttle plays, then the boarding of the
+                    // Von Braun. Each wrap goes in front of what it wraps, so
+                    // the outermost is what the player sees first.
+                    let mut transition = super::GlobalEffect::TransitionLevel {
+                        level_file,
+                        loc: dest_loc,
+                        entities_to_trigger: vec![],
+                        vitals_transition: super::PlayerVitalsTransition::Preserve,
+                    }
+                    .after_cutscene(DEPLOY_CUTSCENE);
+                    if let Some(video) = Self::tour_cutscene(new_year) {
+                        transition = transition.after_cutscene(video);
+                    }
+
                     Effect::Multiple(vec![
                         set_year_effect,
                         grant_effect,
-                        Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                            level_file,
-                            loc: dest_loc,
-                            entities_to_trigger: vec![],
-                            vitals_transition: super::PlayerVitalsTransition::Preserve,
-                        }),
+                        Effect::GlobalEffect(transition),
                     ])
                 }
             }
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One shuttle per tour of duty, in order, and nothing for a year no
+    /// authored marker can reach - a repeat trigger past the deploy must not
+    /// replay the last tour's video.
+    #[test]
+    fn each_tour_of_duty_has_its_own_shuttle_clip() {
+        assert_eq!(ChooseMissionScript::tour_cutscene(2), Some("shuttle1.avi"));
+        assert_eq!(ChooseMissionScript::tour_cutscene(3), Some("shuttle2.avi"));
+        assert_eq!(ChooseMissionScript::tour_cutscene(4), Some("shuttle3.avi"));
+
+        assert_eq!(ChooseMissionScript::tour_cutscene(1), None);
+        assert_eq!(ChooseMissionScript::tour_cutscene(5), None);
     }
 }

--- a/shock2vr/src/scripts/choose_service.rs
+++ b/shock2vr/src/scripts/choose_service.rs
@@ -25,6 +25,11 @@ use super::{Effect, GlobalEffect, MessagePayload, Script};
 /// `crate::career` + `MissionCore::load`) - and then transitions to the marker's
 /// own destination (the station recruit deck). The three branches are mutually
 /// exclusive: selecting one clears the others.
+/// The ride to the recruit station, played once as the player leaves Earth for
+/// the tour selection. Movie names are not present in the mission or gamesys
+/// data - the original picked them in its engine/game-script code.
+const ENLISTMENT_CUTSCENE: &str = "starport.avi";
+
 pub struct ChooseServiceScript {}
 impl ChooseServiceScript {
     pub fn new() -> ChooseServiceScript {
@@ -59,12 +64,15 @@ impl Script for ChooseServiceScript {
                 if let Ok(dest_level) = v_dest_level.get(entity_id) {
                     let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
                     let dest_loc = v_dest_loc.get(entity_id).ok().map(|l| l.0);
-                    effects.push(Effect::GlobalEffect(GlobalEffect::TransitionLevel {
+                    let transition = GlobalEffect::TransitionLevel {
                         level_file: format!("{}.mis", dest_level.0),
                         loc: dest_loc,
                         entities_to_trigger: vec![career.station_start_trigger(1)],
                         vitals_transition: super::PlayerVitalsTransition::InitializeFromDestination,
-                    }));
+                    };
+                    effects.push(Effect::GlobalEffect(
+                        transition.after_cutscene(ENLISTMENT_CUTSCENE),
+                    ));
                 }
 
                 Effect::Multiple(effects)

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -82,11 +82,11 @@ pub enum GlobalEffect {
     /// `scenes::resolve_cutscene_path`; a video that cannot be opened is skipped
     /// straight to `then` rather than stranding the player.
     ///
-    /// Handling this does *not* write the outgoing mission back to the
-    /// in-memory level ledger, because the cutscene's own empty world would be
-    /// what got saved. A caller that interrupts live gameplay is responsible for
-    /// preserving it first (as `CompleteCampaign` does), and any `then` that
-    /// resumes gameplay depends on that having happened.
+    /// Handling this saves the scene being replaced - to the in-memory level
+    /// ledger, and as the quest bits / held items / vitals a `then` transition
+    /// carries forward. Without that the cutscene's own empty world would be
+    /// what a chargen transition handed the next level, wiping the player's
+    /// career, training year, inventory and health.
     PlayCutscene {
         video: String,
         then: Box<GlobalEffect>,
@@ -109,6 +109,18 @@ pub enum GlobalEffect {
 }
 
 impl GlobalEffect {
+    /// Play `video` first and dispatch `self` when it ends.
+    ///
+    /// Movie names are not present in the mission or gamesys data - the original
+    /// picked them in its engine/game-script code - so each authored moment
+    /// names its own video at the site that emits the transition.
+    pub fn after_cutscene(self, video: &str) -> Self {
+        GlobalEffect::PlayCutscene {
+            video: video.to_owned(),
+            then: Box::new(self),
+        }
+    }
+
     /// The new-game boot into `level_file`: map-default spawn, no triggers,
     /// vitals initialized from the destination. Shared by the main menu's New
     /// Game and the developer launcher's Missions tab so the two boots cannot

--- a/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
+++ b/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { isCutsceneScene, stepPastCutscenes } from "./helpers/cutscenes.js";
+import { menuEntry } from "./helpers/frontend-menu.js";
+
+// The authored campaign moments play their movie before the level they lead to.
+// Negative-first: before the wiring each of these transitions swapped straight
+// to its destination, so every "the cutscene owns the screen" assertion below
+// failed with the destination level's name.
+//
+// Movie names are not present in the mission or gamesys data - the original
+// picked them in its engine/game-script code - so this test is also what pins
+// the names the code chose.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** New Game is the first of the six main-menu entries. */
+const NEW_GAME_ENTRY = menuEntry(0);
+
+// The earth.mis Marine career-door tripwire volume: teleporting onto it fires
+// the same ENTER trigger as walking in, running the real TrapNewTripwire ->
+// ChooseService chain. Mission-file positions are stable across runs; runtime
+// entity ids are not. (See station-flow.e2e.test.ts for the full chain.)
+const MARINE_CAREER_DOOR: Vec3 = [-2.4990878, 24.0, 68.16256];
+
+test(
+  "New Game plays the intro movie before the first level loads",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({ mission: "main_menu" });
+    await game.step({ frames: 10 });
+
+    // Clicks are rising-edge, so the press has to start on a frame where the
+    // previous one was unpressed.
+    await game.input.set("pointer.position", NEW_GAME_ENTRY);
+    await game.step({ frames: 5 });
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 5 });
+
+    // The intro runs for minutes, so this stops at "the movie is what is on
+    // screen, and earth.mis is not loaded yet" rather than playing it out.
+    assert.equal(
+      (await game.info()).mission,
+      "cs1.avi",
+      "New Game should show the intro movie before booting the first level",
+    );
+  },
+);
+
+test(
+  "enlisting plays the ride to the recruit station and carries the career through it",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "earth.mis" });
+    await game.step({ frames: 5 });
+
+    await game.player.teleport({
+      x: MARINE_CAREER_DOOR[0],
+      y: MARINE_CAREER_DOOR[1],
+      z: MARINE_CAREER_DOOR[2],
+    });
+    await game.step({ frames: 15 });
+
+    const duringCutscene = await game.info();
+    assert.equal(
+      duringCutscene.mission,
+      "starport.avi",
+      "enlisting should play the ride to the recruit station before loading it",
+    );
+    assert.ok(isCutsceneScene(duringCutscene.mission));
+
+    assert.deepEqual(
+      await stepPastCutscenes(game),
+      ["starport.avi"],
+      "exactly one movie should stand between the career door and the station",
+    );
+
+    const arrival = await game.info();
+    assert.equal(
+      arrival.mission.toLowerCase(),
+      "station.mis",
+      "the finished movie should hand off to the recruit station",
+    );
+
+    // The movie replaces the scene that queued the transition, so its own empty
+    // world is what the station would have been handed without the state the
+    // cutscene carries: no career bit and no career loadout.
+    assert.equal(
+      await game.quests.get("career_marine"),
+      "complete",
+      "the career chosen before the movie should survive it",
+    );
+    assert.equal(
+      arrival.player.max_hit_points,
+      45,
+      "the Marine loadout should still be applied on the other side of the movie",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
+++ b/tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { isCutsceneScene, stepPastCutscenes } from "./helpers/cutscenes.js";
-import { menuEntry } from "./helpers/frontend-menu.js";
+import { clickMenuEntry } from "./helpers/frontend-menu.js";
 
 // The authored campaign moments play their movie before the level they lead to.
 // Negative-first: before the wiring each of these transitions swapped straight
@@ -17,7 +17,7 @@ import { menuEntry } from "./helpers/frontend-menu.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 /** New Game is the first of the six main-menu entries. */
-const NEW_GAME_ENTRY = menuEntry(0);
+const NEW_GAME_ENTRY = 0;
 
 // The earth.mis Marine career-door tripwire volume: teleporting onto it fires
 // the same ENTER trigger as walking in, running the real TrapNewTripwire ->
@@ -32,14 +32,7 @@ test(
     await using game = await GameServer.launch({ mission: "main_menu" });
     await game.step({ frames: 10 });
 
-    // Clicks are rising-edge, so the press has to start on a frame where the
-    // previous one was unpressed.
-    await game.input.set("pointer.position", NEW_GAME_ENTRY);
-    await game.step({ frames: 5 });
-    await game.input.set("pointer.pressed", 1);
-    await game.step({ frames: 2 });
-    await game.input.set("pointer.pressed", 0);
-    await game.step({ frames: 5 });
+    await clickMenuEntry(game, NEW_GAME_ENTRY);
 
     // The intro runs for minutes, so this stops at "the movie is what is on
     // screen, and earth.mis is not loaded yet" rather than playing it out.

--- a/tools/shock2-sdk/test/helpers/cutscenes.ts
+++ b/tools/shock2-sdk/test/helpers/cutscenes.ts
@@ -5,7 +5,11 @@ import type { GameServer } from "../../src/index.js";
 // reports the requested video name (not the file the install resolves it to),
 // which is how a cutscene is told apart from a level here.
 
-/** Whether `mission` names a cutscene rather than a level or debug scene. */
+/**
+ * Whether `mission` names a cutscene rather than a level or debug scene. Mirrors
+ * the runtime's `scenes::is_cutscene_file`, which is what decides the same thing
+ * there; keep the extensions in step with it.
+ */
 export function isCutsceneScene(mission: string): boolean {
   return /\.(avi|ogv)$/i.test(mission);
 }

--- a/tools/shock2-sdk/test/helpers/cutscenes.ts
+++ b/tools/shock2-sdk/test/helpers/cutscenes.ts
@@ -28,8 +28,10 @@ export async function stepPastCutscenes(
   const seen: string[] = [];
   for (let stepped = 0; stepped <= timeoutSeconds * 60; stepped += chunkFrames) {
     const { mission } = await game.info();
-    if (!isCutsceneScene(mission)) return seen;
-    if (seen[seen.length - 1] !== mission) seen.push(mission);
+    // "loading" is the transition the last cutscene handed off to, so keep
+    // stepping: a caller wants the destination, not the loading screen.
+    if (!isCutsceneScene(mission) && mission !== "loading") return seen;
+    if (isCutsceneScene(mission) && seen[seen.length - 1] !== mission) seen.push(mission);
     await game.step({ frames: chunkFrames });
   }
   throw new Error(

--- a/tools/shock2-sdk/test/helpers/cutscenes.ts
+++ b/tools/shock2-sdk/test/helpers/cutscenes.ts
@@ -1,0 +1,34 @@
+import type { GameServer } from "../../src/index.js";
+
+// The authored campaign moments play a movie before the level they lead to, so
+// a test that triggers one lands on the cutscene scene first. `info().mission`
+// reports the requested video name (not the file the install resolves it to),
+// which is how a cutscene is told apart from a level here.
+
+/** Whether `mission` names a cutscene rather than a level or debug scene. */
+export function isCutsceneScene(mission: string): boolean {
+  return /\.(avi|ogv)$/i.test(mission);
+}
+
+/**
+ * Step until no cutscene is on screen, and return the videos seen in order.
+ *
+ * Stepping is a fixed 60 Hz, so this advances real playback time - a chunk at a
+ * time rather than one huge step, because the authored clips run from ten
+ * seconds to nearly three minutes and a caller should not have to know which.
+ */
+export async function stepPastCutscenes(
+  game: GameServer,
+  { timeoutSeconds = 400, chunkFrames = 120 } = {},
+): Promise<string[]> {
+  const seen: string[] = [];
+  for (let stepped = 0; stepped <= timeoutSeconds * 60; stepped += chunkFrames) {
+    const { mission } = await game.info();
+    if (!isCutsceneScene(mission)) return seen;
+    if (seen[seen.length - 1] !== mission) seen.push(mission);
+    await game.step({ frames: chunkFrames });
+  }
+  throw new Error(
+    `cutscene(s) ${JSON.stringify(seen)} did not finish within ${timeoutSeconds}s of stepping`,
+  );
+}

--- a/tools/shock2-sdk/test/helpers/frontend-menu.ts
+++ b/tools/shock2-sdk/test/helpers/frontend-menu.ts
@@ -1,4 +1,5 @@
 import { PLAYER_EYE_HEIGHT_WORLD } from "../../src/index.js";
+import type { GameServer } from "../../src/index.js";
 
 /** The frontend screens are authored on the original 640x480 UI canvas. */
 export const CANVAS_W = 640;
@@ -14,6 +15,19 @@ export const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y
  */
 export const menuEntry = (index: number): [number, number] =>
   norm(400 + 179 / 2, 20 + index * 76 + 60 / 2);
+
+/**
+ * Click one main-menu entry with the flat pointer. Clicks are rising-edge, so
+ * the press has to start on a frame where the previous one was unpressed.
+ */
+export async function clickMenuEntry(game: GameServer, index: number): Promise<void> {
+  await game.input.set("pointer.position", menuEntry(index));
+  await game.step({ frames: 5 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 5 });
+}
 
 // The VR menu is the same canvas on a world-space panel, driven by a controller
 // ray instead of a cursor. The runtime's VR head yaw is +90 degrees (the camera

--- a/tools/shock2-sdk/test/menu-quit.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-quit.e2e.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import { AIM_AT_PANEL, menuEntry, panelPoint } from "./helpers/frontend-menu.js";
+import { AIM_AT_PANEL, clickMenuEntry, menuEntry, panelPoint } from "./helpers/frontend-menu.js";
 
 // End-to-end test for the main menu's Quit entry: clicking it must reach
 // `Game::should_quit`, which is what every runtime shuts down on (the desktop
@@ -17,7 +17,8 @@ import { AIM_AT_PANEL, menuEntry, panelPoint } from "./helpers/frontend-menu.js"
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 /** Quit is the last of the six main-menu entries. */
-const QUIT_ENTRY = menuEntry(5);
+const QUIT_INDEX = 5;
+const QUIT_ENTRY = menuEntry(QUIT_INDEX);
 
 test(
   "clicking Quit in the flat menu requests a quit without killing the runtime",
@@ -32,14 +33,7 @@ test(
       "nothing has asked to quit yet",
     );
 
-    // Clicks are rising-edge, so the press has to start on a frame where the
-    // previous one was unpressed.
-    await game.input.set("pointer.position", QUIT_ENTRY);
-    await game.step({ frames: 5 });
-    await game.input.set("pointer.pressed", 1);
-    await game.step({ frames: 2 });
-    await game.input.set("pointer.pressed", 0);
-    await game.step({ frames: 5 });
+    await clickMenuEntry(game, QUIT_INDEX);
 
     assert.equal(
       (await game.info()).quit_requested,

--- a/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
+import { stepPastCutscenes } from "./helpers/cutscenes.js";
 
 // End-to-end test for career (Marine/Navy/OSA) branching. Requires game assets
 // in Data/ and compiles the runtime on first run, so it is opt-in:
@@ -79,6 +80,9 @@ async function playCareer(
 
   await game.entities.sendMessage(marker.id, { type: "TurnOn" });
   await game.step({ frames: 3 });
+  // Enlisting plays its authored movie first (campaign-cutscenes.e2e.test.ts);
+  // this test is about the loadout waiting on the other side of it.
+  await stepPastCutscenes(game);
   // The marker's own transition ships the player to the recruit station.
   assert.equal(
     (await game.info()).mission,

--- a/tools/shock2-sdk/test/station-career.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { stepPastCutscenes } from "./helpers/cutscenes.js";
 
 // End-to-end test for the station training-year progression. Requires game
 // assets in Data/ and compiles the runtime on first run, so it is opt-in:
@@ -38,6 +39,9 @@ test(
         type: "TurnOn",
       } as unknown as Parameters<typeof game.entities.sendMessage>[1]);
       await game.step({ frames: 20 });
+      // Each tour leaves on its authored shuttle movie
+      // (campaign-cutscenes.e2e.test.ts); the year only advances on the far side.
+      await stepPastCutscenes(game);
       mission = (await game.info()).mission;
     }
 

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -110,10 +110,10 @@ async function teleportTo(game: GameServer, [x, y, z]: Vec3): Promise<void> {
  * for the mapping), so the destination is only on screen once those finish;
  * this test is about what survives the chain, not about the movies.
  */
-async function tripAndArrive(game: GameServer, at: Vec3, frames: number): Promise<void> {
+async function tripAndArrive(game: GameServer, at: Vec3, frames: number): Promise<string[]> {
   await teleportTo(game, at);
   await game.step({ frames });
-  await stepPastCutscenes(game);
+  return stepPastCutscenes(game);
 }
 
 /** The set of `training_year_N` bits currently COMPLETE, sorted ascending. */
@@ -264,7 +264,12 @@ test(
     // Step 3: the third tour advances to year 4, grants the Marine Y3 T0 reward
     // (Mission7: +1 Maintenance), and deploys to MedSci1 - stats survive the
     // level transition.
-    await tripAndArrive(game, TOUR_TRIP, 20);
+    // The deploy is the one moment that plays two movies, shuttle then boarding.
+    assert.deepEqual(
+      await tripAndArrive(game, TOUR_TRIP, 20),
+      ["shuttle3.avi", "cs2.avi"],
+      "the deploy should play the last shuttle, then the boarding of the Von Braun",
+    );
     info = await game.info();
     assert.equal(
       info.mission.toLowerCase(),

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
+import { stepPastCutscenes } from "./helpers/cutscenes.js";
 
 // End-to-end test for the HONEST character-creation chain the player walks at
 // game start: earth.mis (pick a career) -> station.mis three training tours ->
@@ -103,6 +104,18 @@ async function teleportTo(game: GameServer, [x, y, z]: Vec3): Promise<void> {
   await game.player.teleport({ x, y, z });
 }
 
+/**
+ * Trip a chargen tripwire and arrive at its destination. Each of these
+ * transitions plays its authored movie first (see campaign-cutscenes.e2e.test.ts
+ * for the mapping), so the destination is only on screen once those finish;
+ * this test is about what survives the chain, not about the movies.
+ */
+async function tripAndArrive(game: GameServer, at: Vec3, frames: number): Promise<void> {
+  await teleportTo(game, at);
+  await game.step({ frames });
+  await stepPastCutscenes(game);
+}
+
 /** The set of `training_year_N` bits currently COMPLETE, sorted ascending. */
 async function completeTrainingYears(game: GameServer): Promise<string[]> {
   const { quests } = await game.quests.list();
@@ -125,8 +138,7 @@ test(
     // Step 1: enlist as a Marine by walking through the Marine career door.
     // Teleport ONTO its tripwire volume (equivalent to walking in: fires the same
     // ENTER trigger) and let the real TrapNewTripwire -> ChooseService chain run.
-    await teleportTo(game, CAREER_DOORS.marine.trip);
-    await game.step({ frames: 15 });
+    await tripAndArrive(game, CAREER_DOORS.marine.trip, 15);
 
     let info = await game.info();
     assert.equal(
@@ -189,8 +201,7 @@ test(
     // back to station.mis, and grant the tour-0 reward for that Marine year
     // (#453). hp/psi are unchanged by these grants (they touch STR/skills), so
     // the loadout stays 45/20 - the observable change is now in player.stats.
-    await teleportTo(game, TOUR_TRIP);
-    await game.step({ frames: 20 });
+    await tripAndArrive(game, TOUR_TRIP, 20);
     info = await game.info();
     assert.equal(info.mission.toLowerCase(), "station.mis", "tour 1 (year < 4) should loop back to station.mis");
     assert.deepEqual(
@@ -212,8 +223,7 @@ test(
       "#497 START_02 Marine choice",
     );
 
-    await teleportTo(game, TOUR_TRIP);
-    await game.step({ frames: 20 });
+    await tripAndArrive(game, TOUR_TRIP, 20);
     info = await game.info();
     assert.equal(info.mission.toLowerCase(), "station.mis", "tour 2 (year < 4) should loop back to station.mis");
     assert.deepEqual(
@@ -254,8 +264,7 @@ test(
     // Step 3: the third tour advances to year 4, grants the Marine Y3 T0 reward
     // (Mission7: +1 Maintenance), and deploys to MedSci1 - stats survive the
     // level transition.
-    await teleportTo(game, TOUR_TRIP);
-    await game.step({ frames: 20 });
+    await tripAndArrive(game, TOUR_TRIP, 20);
     info = await game.info();
     assert.equal(
       info.mission.toLowerCase(),
@@ -303,8 +312,7 @@ async function enlist(
   await using game = await GameServer.launch({ mission: "earth.mis" });
   await game.step({ frames: 5 });
 
-  await teleportTo(game, door.trip);
-  await game.step({ frames: 15 });
+  await tripAndArrive(game, door.trip, 15);
 
   const info = await game.info();
   assert.equal(


### PR DESCRIPTION
Stacked on #1195 (`feat/cutscene-followups-b-completion-signal`).

PR B gave us `GlobalEffect::PlayCutscene { video, then }`. This one uses it: the campaign's authored movie moments now play at the transitions they belong to.

## Mapping wired

Movie names are not present in the mission or gamesys data - the original picked them in its engine/game-script code - so each moment names its video at the site that emits the transition.

| Moment | Video | Emit site |
| --- | --- | --- |
| New Game | `cs1.avi` | `scenes/main_menu.rs` (the button only - the developer launcher boots `earth.mis` with no movie) |
| Enlisting: Earth -> recruit station | `starport.avi` | `scripts/choose_service.rs` |
| Tour of duty 1 / 2 / 3 | `shuttle1/2/3.avi` | `scripts/choose_mission.rs` (`departure_cutscenes`, keyed on the training year the tour advances to) |
| Chargen -> campaign (boarding the Von Braun) | `cs2.avi` | `scripts/choose_mission.rs`, after `shuttle3` on the year-4 deploy |

The names go through the layer-aware `resolve_cutscene_path`, so a bare classic name resolves to `enhanced/*.ogv` on 25AE and `*.avi` on a classic install.

Deliberately left out:
- **Nothing gets a cutscene on a repeat visit.** `level_change_button` / `trap_trip_level` / elevators are untouched; only the authored one-time chargen moments and the New Game button emit one. `departure_cutscenes` is empty for any year an authored marker cannot produce, so a re-trigger past the deploy replays neither the shuttle nor the boarding.
- `landing.avi` stays unused (it is unused in retail).
- `intro` / `credits` / `cs3` were already handled.

Judgment call worth a look: `starport` is placed on the Earth -> station transition, i.e. the moment chargen opens. And `shuttle3` and `cs2` both land on the third tour, because in our chain that single transition *is* both the third tour and the deploy - they play in that order.

## The part that is not just wrapping

A transition captures the quest bits, held items and vitals from the scene that queued it. A cutscene replaces that scene *before* the transition runs, so wrapping a chargen transition naively hands the next level the cutscene's own empty world - the player arrives with no career, no training year, no inventory and default health.

So `Game` now preserves the outgoing scene's state when a cutscene stands in for it (`PreservedSceneState`), and `begin_transition` prefers it over re-capturing. A cutscene chaining into another keeps what the first captured. `set_active_scene` clears it, so a chain that ends anywhere but a transition cannot leak state into a later one. `CompleteCampaign`'s explicit `save_active_scene()` is now redundant (`PlayCutscene` does it) and is gone.

Verified negative: with the preservation removed, the new e2e test reports `career_marine` = `unknown` at the recruit station.

## Testing

- `tools/shock2-sdk/test/campaign-cutscenes.e2e.test.ts` (new): New Game shows `cs1.avi` before `earth.mis` loads; enlisting shows `starport.avi`, then completes into `station.mis` with the career bit and Marine loadout intact.
- `test/helpers/cutscenes.ts` (new): `stepPastCutscenes`, used by the existing chargen tests, which now step past the movies - `station-flow`, `station-career`, `station-career-attributes`.
- Unit: `ChooseMissionScript::departure_cutscenes` / `behind_departure_cutscenes` (one shuttle per tour, the deploy's two clips in the order shown, nothing outside 2..=4).

Green: `campaign-cutscenes`, `station-flow`, `station-career`, `station-career-attributes`, `missions` (all 23), `transition-level`, `transitions-trigger`, `transition-revisit`, `simple-level-change-button`, `save-load`, `cutscene-completion`, `menu-quit`. `cargo test -p shock2vr` (1149) and `cargo fmt` / `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` (+ `-p shock2vr --no-default-features`).

Not run: the full multi-hour e2e suite - that is owed once at the stack tip.

The full chargen chain including `shuttle3` + `cs2` costs ~74s of stepping in `station-flow`; decoding runs about 4x faster than playback.


## Review

`/xreview` ran with the Claude engines only - Codex was out of usage. Applied: the deploy movie was replaying past the last tour (it is now behind the same year guard as the shuttles, and unit-tested); `begin_transition` could leave carried state behind when it refused a transition; one spelling (`after_cutscene`) for wrapping an effect in a cutscene, now also used by the finale; `stepPastCutscenes` keeps stepping through `loading`; the deploy's two-movie order is asserted in `station-flow`; a shared `clickMenuEntry` test helper.

Checked and not reproduced: a save taken during a cutscene, and `DebugReloadLevel` during one, were both flagged as writing junk / crashing - both are already refused by `player_standing_transform`'s `NoPlayer`. Verified live against a runtime parked on `starport.avi`: the save comes back `no_player_pose` with no file written, and the reload leaves the runtime up on the cutscene.

Not fixed here: **cutscenes cannot be skipped** (#1200). Real, and this change makes it matter - about six minutes of unskippable video now sits on a fresh playthrough's critical path - but a skip path is its own change.

Also declined: folding `PendingTransition`'s three carry fields into the new `PreservedSceneState`. It is genuine overlap, but `PendingTransition` also holds the level name, spawn loc and parse handle, so nesting three of its fields rewrites `finish_transition` for no behavior change.

`landing.avi` ships in the install and is deliberately wired nowhere - it is unused in retail.
