### PR TITLE
feat(cutscene): hold trigger to skip, with radial progress

### DIFF
--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -51,6 +51,9 @@ pub struct CutscenePlayerScene {
     completion_emitted: bool,
     /// Holding either trigger finishes the cutscene early.
     skip_hold: SkipHold,
+    /// The generated progress-ring art, keyed on the fill step it was built
+    /// for, so a held trigger does not re-upload it every frame.
+    ring_art: Option<(u32, Rc<dyn TextureTrait>)>,
     #[cfg(feature = "ffmpeg")]
     audio_handle: engine::audio::AudioHandle,
     #[cfg(feature = "ffmpeg")]
@@ -60,8 +63,10 @@ pub struct CutscenePlayerScene {
 /// Where the video screen hangs, and the viewer-facing basis it is built on.
 struct ScreenBasis {
     center: Vector3<f32>,
-    /// Perpendicular to the view on the screen plane, and `up` with it.
-    right: Vector3<f32>,
+    /// In-plane horizontal axis. It points to the viewer's *left*: the
+    /// billboard basis below is mirrored, and this is the axis that mirroring
+    /// is built from - it is not a "right" to offset something sideways by.
+    screen_x: Vector3<f32>,
     up: Vector3<f32>,
     /// From the screen back toward the viewer.
     look_dir: Vector3<f32>,
@@ -75,15 +80,21 @@ impl ScreenBasis {
     /// is turned half a turn in its own plane, which corrects both at once.
     /// The generated ring art shares the row order, so it shares this basis.
     fn billboard_rotation(&self) -> Matrix3<f32> {
-        Matrix3::from_cols(self.right, self.up, -self.look_dir)
+        Matrix3::from_cols(self.screen_x, self.up, -self.look_dir)
             * Matrix3::from_angle_z(cgmath::Deg(180.0))
     }
 
-    /// Orientation for a [`WorldPanel`] on the screen: an honest basis with +x
-    /// the viewer's right, +y up and +z at the viewer, which is what the canvas
-    /// path expects (it applies its own canvas-y flip).
+    /// Orientation for a [`WorldPanel`] on the screen: the honest basis the
+    /// canvas path expects (+x the viewer's right, +y up, +z back at the
+    /// viewer), which is what facing the viewer means.
     fn panel_rotation(&self) -> Quaternion<f32> {
-        Matrix3::from_cols(-self.right, self.up, self.look_dir).into()
+        crate::util::get_rotation_from_forward_vector(self.look_dir)
+    }
+
+    /// Off the screen plane toward the viewer, so an overlay never z-fights the
+    /// video it sits on.
+    fn toward_viewer(&self, fraction_of_height: f32) -> Vector3<f32> {
+        self.look_dir * (self.height * fraction_of_height)
     }
 }
 
@@ -95,6 +106,8 @@ const RING_CENTER_HEIGHT: f32 = -0.28;
 const HINT_WIDTH: f32 = 0.6;
 const HINT_HEIGHT: f32 = 0.075;
 const HINT_CENTER_HEIGHT: f32 = -0.42;
+/// How far the affordance floats off the screen plane, in the same units.
+const OVERLAY_DEPTH: f32 = 0.01;
 /// Canvas the caption is authored on - only its aspect matters, since the panel
 /// scales it to `HINT_WIDTH` x `HINT_HEIGHT`.
 const HINT_CANVAS: Vector2<f32> = Vector2 { x: 320.0, y: 40.0 };
@@ -146,6 +159,7 @@ impl CutscenePlayerScene {
                 on_complete,
                 completion_emitted: false,
                 skip_hold: SkipHold::default(),
+                ring_art: None,
                 audio_handle,
                 video_player,
             });
@@ -167,6 +181,7 @@ impl CutscenePlayerScene {
                 on_complete,
                 completion_emitted: false,
                 skip_hold: SkipHold::default(),
+                ring_art: None,
             })
         }
     }
@@ -236,19 +251,18 @@ impl CutscenePlayerScene {
 
         ScreenBasis {
             center: screen_position,
-            right,
+            screen_x: right,
             up: true_up,
             look_dir,
             height: 2.0 / dark::SCALE_FACTOR,
         }
     }
 
-    fn build_screen_object(&self) -> SceneObject {
+    fn build_screen_object(&self, basis: &ScreenBasis) -> SceneObject {
         let (texture, aspect_ratio) = self.build_video_texture();
         let material = basic_material::create(texture, 1.0, 0.0);
         let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
 
-        let basis = self.screen_basis();
         let screen_height = basis.height;
         let screen_width = screen_height * aspect_ratio;
 
@@ -260,20 +274,26 @@ impl CutscenePlayerScene {
     }
 
     /// The radial hold-to-skip progress ring, drawn on the video screen while
-    /// the trigger is touched. `None` once it has faded out.
-    fn build_skip_ring(&self) -> Option<SceneObject> {
-        let alpha = self.skip_hold.alpha();
-        if alpha <= 0.01 {
-            return None;
-        }
+    /// the trigger is touched.
+    fn build_skip_ring(&mut self, basis: &ScreenBasis, alpha: f32) -> SceneObject {
+        // The art changes only when the fill crosses a step, so a held trigger
+        // rasterizes and uploads a few dozen textures rather than one a frame.
+        let step = cutscene_skip::ring_step(self.skip_hold.progress());
+        let texture = match &self.ring_art {
+            Some((cached_step, texture)) if *cached_step == step => texture.clone(),
+            _ => {
+                let texture: Rc<dyn TextureTrait> = Rc::new(init_from_memory2(
+                    cutscene_skip::ring_texture_for_step(step),
+                    &TextureOptions {
+                        wrap: false,
+                        ..Default::default()
+                    },
+                ));
+                self.ring_art = Some((step, texture.clone()));
+                texture
+            }
+        };
 
-        let texture: Rc<dyn TextureTrait> = Rc::new(init_from_memory2(
-            cutscene_skip::ring_texture(self.skip_hold.progress()),
-            &TextureOptions {
-                wrap: false,
-                ..Default::default()
-            },
-        ));
         // Held just under fully opaque: the material only joins the blended
         // pass when it is transparent at all, and the ring is nothing but
         // per-pixel alpha.
@@ -281,39 +301,36 @@ impl CutscenePlayerScene {
         let material = basic_material::create(texture, 1.0, transparency);
         let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
 
-        let basis = self.screen_basis();
         let size = basis.height * RING_SIZE;
-        let center = basis.center + basis.up * (RING_CENTER_HEIGHT * basis.height)
-            // Off the screen plane toward the viewer, so it never z-fights the
-            // video it sits on.
-            + basis.look_dir * (size * 0.05);
+        let center = basis.center
+            + basis.up * (RING_CENTER_HEIGHT * basis.height)
+            + basis.toward_viewer(OVERLAY_DEPTH);
 
         quad.set_transform(
             Matrix4::from_translation(center)
                 * Matrix4::from(basis.billboard_rotation())
                 * Matrix4::from_nonuniform_scale(size, size, 1.0),
         );
-        Some(quad)
+        quad
     }
 
     /// The "hold to skip" caption under the ring, on its own world panel so the
     /// text goes through the shared UI path rather than a bespoke one.
-    fn build_skip_hint(&self, asset_cache: &mut AssetCache) -> Vec<SceneObject> {
-        let alpha = self.skip_hold.alpha();
-        if alpha <= 0.01 {
-            return Vec::new();
-        }
-
-        let basis = self.screen_basis();
+    fn build_skip_hint(
+        &self,
+        asset_cache: &mut AssetCache,
+        basis: &ScreenBasis,
+        alpha: f32,
+    ) -> Vec<SceneObject> {
         let panel = WorldPanel {
             center: basis.center
                 + basis.up * (HINT_CENTER_HEIGHT * basis.height)
-                + basis.look_dir * (basis.height * 0.01),
+                + basis.toward_viewer(OVERLAY_DEPTH),
             rotation: basis.panel_rotation(),
             size: vec2(basis.height * HINT_WIDTH, basis.height * HINT_HEIGHT),
         };
 
-        let mut canvas = UiCanvas::new(vec2(HINT_CANVAS.x, HINT_CANVAS.y));
+        let mut canvas = UiCanvas::new(HINT_CANVAS);
         canvas.text_native(
             Rect::new(0.0, 0.0, HINT_CANVAS.x, HINT_CANVAS.y),
             "HOLD TO SKIP",
@@ -445,9 +462,13 @@ impl GameScene for CutscenePlayerScene {
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         // One world-space list for both presentations: the affordance is
         // anchored to the video screen, so flatscreen and VR place it alike.
-        let mut objects = vec![self.build_screen_object()];
-        objects.extend(self.build_skip_ring());
-        objects.extend(self.build_skip_hint(asset_cache));
+        let basis = self.screen_basis();
+        let mut objects = vec![self.build_screen_object(&basis)];
+        let alpha = self.skip_hold.alpha();
+        if alpha > 0.01 {
+            objects.push(self.build_skip_ring(&basis, alpha));
+            objects.extend(self.build_skip_hint(asset_cache, &basis, alpha));
+        }
         (objects, self.player_position, self.player_rotation)
     }
 

--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, rc::Rc};
 #[cfg(not(feature = "ffmpeg"))]
 use std::time::Duration;
 
-use cgmath::{InnerSpace, Matrix3, Matrix4, Quaternion, Vector3, vec3};
+use cgmath::{InnerSpace, Matrix3, Matrix4, Quaternion, Vector2, Vector3, vec2, vec3};
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -21,7 +21,10 @@ use crate::{
     quest_info::QuestInfo,
     scripts::{Effect, GlobalEffect},
     time::Time,
+    ui::{HAlign, Rect, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, WorldPanel},
 };
+
+use super::cutscene_skip::{self, SkipHold};
 
 #[cfg(feature = "ffmpeg")]
 use engine_ffmpeg::{AudioPlayer, VideoPlayer};
@@ -46,11 +49,56 @@ pub struct CutscenePlayerScene {
     /// would hold its last frame forever.
     on_complete: GlobalEffect,
     completion_emitted: bool,
+    /// Holding either trigger finishes the cutscene early.
+    skip_hold: SkipHold,
     #[cfg(feature = "ffmpeg")]
     audio_handle: engine::audio::AudioHandle,
     #[cfg(feature = "ffmpeg")]
     video_player: VideoPlayer,
 }
+
+/// Where the video screen hangs, and the viewer-facing basis it is built on.
+struct ScreenBasis {
+    center: Vector3<f32>,
+    /// Perpendicular to the view on the screen plane, and `up` with it.
+    right: Vector3<f32>,
+    up: Vector3<f32>,
+    /// From the screen back toward the viewer.
+    look_dir: Vector3<f32>,
+    height: f32,
+}
+
+impl ScreenBasis {
+    /// Orientation for a raw quad drawn on the screen. Decoded frames are
+    /// top-row-first while a quad maps v=0 to its bottom edge, and the
+    /// billboard basis faces the quad's back toward the player - so the quad
+    /// is turned half a turn in its own plane, which corrects both at once.
+    /// The generated ring art shares the row order, so it shares this basis.
+    fn billboard_rotation(&self) -> Matrix3<f32> {
+        Matrix3::from_cols(self.right, self.up, -self.look_dir)
+            * Matrix3::from_angle_z(cgmath::Deg(180.0))
+    }
+
+    /// Orientation for a [`WorldPanel`] on the screen: an honest basis with +x
+    /// the viewer's right, +y up and +z at the viewer, which is what the canvas
+    /// path expects (it applies its own canvas-y flip).
+    fn panel_rotation(&self) -> Quaternion<f32> {
+        Matrix3::from_cols(-self.right, self.up, self.look_dir).into()
+    }
+}
+
+/// The skip ring's diameter and its center height, both as a fraction of the
+/// video screen's height (center height is signed, up from the screen center).
+const RING_SIZE: f32 = 0.18;
+const RING_CENTER_HEIGHT: f32 = -0.28;
+/// The caption's panel: size and center height, in the same units.
+const HINT_WIDTH: f32 = 0.6;
+const HINT_HEIGHT: f32 = 0.075;
+const HINT_CENTER_HEIGHT: f32 = -0.42;
+/// Canvas the caption is authored on - only its aspect matters, since the panel
+/// scales it to `HINT_WIDTH` x `HINT_HEIGHT`.
+const HINT_CANVAS: Vector2<f32> = Vector2 { x: 320.0, y: 40.0 };
+const HINT_FONT: &str = "metafont.fon";
 
 /// How long the non-ffmpeg stub shows its placeholder before completing. There
 /// is no decoder to ask, so a build without video still has to move on rather
@@ -97,6 +145,7 @@ impl CutscenePlayerScene {
                 video_name,
                 on_complete,
                 completion_emitted: false,
+                skip_hold: SkipHold::default(),
                 audio_handle,
                 video_player,
             });
@@ -117,6 +166,7 @@ impl CutscenePlayerScene {
                 total_time: Duration::ZERO,
                 on_complete,
                 completion_emitted: false,
+                skip_hold: SkipHold::default(),
             })
         }
     }
@@ -159,11 +209,10 @@ impl CutscenePlayerScene {
         }
     }
 
-    fn build_screen_object(&self) -> SceneObject {
-        let (texture, aspect_ratio) = self.build_video_texture();
-        let material = basic_material::create(texture, 1.0, 0.0);
-        let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
-
+    /// Where the video screen hangs and how it is oriented. The skip affordance
+    /// is anchored to the same basis, so it rides the screen in flatscreen and
+    /// in VR alike rather than being placed twice.
+    fn screen_basis(&self) -> ScreenBasis {
         let forward = self.head_rotation * vec3(0.0, 0.0, -1.0);
         let base = self.head_base();
         let mut screen_position = base + forward * self.screen_distance;
@@ -184,21 +233,101 @@ impl CutscenePlayerScene {
         }
         right = right.normalize();
         let true_up = right.cross(look_dir).normalize();
-        let rotation_matrix = Matrix3::from_cols(right, true_up, -look_dir);
 
-        let screen_height = 2.0 / dark::SCALE_FACTOR;
+        ScreenBasis {
+            center: screen_position,
+            right,
+            up: true_up,
+            look_dir,
+            height: 2.0 / dark::SCALE_FACTOR,
+        }
+    }
+
+    fn build_screen_object(&self) -> SceneObject {
+        let (texture, aspect_ratio) = self.build_video_texture();
+        let material = basic_material::create(texture, 1.0, 0.0);
+        let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
+
+        let basis = self.screen_basis();
+        let screen_height = basis.height;
         let screen_width = screen_height * aspect_ratio;
 
-        // Decoded frames are top-row-first while the quad maps v=0 to its
-        // bottom edge, and the billboard basis faces the quad's back toward
-        // the player - together the video showed rotated 180 degrees. Spinning
-        // the quad half a turn in its own plane corrects both at once.
-        let transform = Matrix4::from_translation(screen_position)
-            * Matrix4::from(rotation_matrix)
-            * Matrix4::from_angle_z(cgmath::Deg(180.0))
+        let transform = Matrix4::from_translation(basis.center)
+            * Matrix4::from(basis.billboard_rotation())
             * Matrix4::from_nonuniform_scale(screen_width, screen_height, 1.0);
         quad.set_transform(transform);
         quad
+    }
+
+    /// The radial hold-to-skip progress ring, drawn on the video screen while
+    /// the trigger is touched. `None` once it has faded out.
+    fn build_skip_ring(&self) -> Option<SceneObject> {
+        let alpha = self.skip_hold.alpha();
+        if alpha <= 0.01 {
+            return None;
+        }
+
+        let texture: Rc<dyn TextureTrait> = Rc::new(init_from_memory2(
+            cutscene_skip::ring_texture(self.skip_hold.progress()),
+            &TextureOptions {
+                wrap: false,
+                ..Default::default()
+            },
+        ));
+        // Held just under fully opaque: the material only joins the blended
+        // pass when it is transparent at all, and the ring is nothing but
+        // per-pixel alpha.
+        let transparency = (1.0 - alpha).max(0.02);
+        let material = basic_material::create(texture, 1.0, transparency);
+        let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
+
+        let basis = self.screen_basis();
+        let size = basis.height * RING_SIZE;
+        let center = basis.center + basis.up * (RING_CENTER_HEIGHT * basis.height)
+            // Off the screen plane toward the viewer, so it never z-fights the
+            // video it sits on.
+            + basis.look_dir * (size * 0.05);
+
+        quad.set_transform(
+            Matrix4::from_translation(center)
+                * Matrix4::from(basis.billboard_rotation())
+                * Matrix4::from_nonuniform_scale(size, size, 1.0),
+        );
+        Some(quad)
+    }
+
+    /// The "hold to skip" caption under the ring, on its own world panel so the
+    /// text goes through the shared UI path rather than a bespoke one.
+    fn build_skip_hint(&self, asset_cache: &mut AssetCache) -> Vec<SceneObject> {
+        let alpha = self.skip_hold.alpha();
+        if alpha <= 0.01 {
+            return Vec::new();
+        }
+
+        let basis = self.screen_basis();
+        let panel = WorldPanel {
+            center: basis.center
+                + basis.up * (HINT_CENTER_HEIGHT * basis.height)
+                + basis.look_dir * (basis.height * 0.01),
+            rotation: basis.panel_rotation(),
+            size: vec2(basis.height * HINT_WIDTH, basis.height * HINT_HEIGHT),
+        };
+
+        let mut canvas = UiCanvas::new(vec2(HINT_CANVAS.x, HINT_CANVAS.y));
+        canvas.text_native(
+            Rect::new(0.0, 0.0, HINT_CANVAS.x, HINT_CANVAS.y),
+            "HOLD TO SKIP",
+            HINT_FONT,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+        canvas.render_world_space(
+            asset_cache,
+            panel.transform(),
+            None,
+            Some(alpha),
+            VR_COMPONENT_Z_STEP,
+        )
     }
 
     fn build_video_texture(&self) -> (Rc<dyn TextureTrait>, f32) {
@@ -288,10 +417,20 @@ impl GameScene for CutscenePlayerScene {
             self.total_time += time.elapsed;
         }
 
+        // Contextual, not an `InputAction`: the hold needs the analog value, and
+        // either hand can give it.
+        let trigger = input_context
+            .left_hand
+            .trigger_value
+            .max(input_context.right_hand.trigger_value);
+        let skipped = self.skip_hold.update(trigger, time.elapsed);
+
         // Latched because not every `on_complete` replaces this scene - a
         // follow-on like `Quit` leaves it running, and re-emitting would then
-        // repeat the effect every frame.
-        if !self.completion_emitted && self.playback_is_finished() {
+        // repeat the effect every frame. A skip finishes the cutscene through
+        // this same path, so the follow-on (and the audio stop in `on_exit`)
+        // cannot differ between ending early and playing out.
+        if !self.completion_emitted && (skipped || self.playback_is_finished()) {
             self.completion_emitted = true;
             return vec![Effect::GlobalEffect(self.on_complete.clone())];
         }
@@ -301,11 +440,15 @@ impl GameScene for CutscenePlayerScene {
 
     fn render(
         &mut self,
-        _asset_cache: &mut AssetCache,
+        asset_cache: &mut AssetCache,
         _options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
-        let screen = self.build_screen_object();
-        (vec![screen], self.player_position, self.player_rotation)
+        // One world-space list for both presentations: the affordance is
+        // anchored to the video screen, so flatscreen and VR place it alike.
+        let mut objects = vec![self.build_screen_object()];
+        objects.extend(self.build_skip_ring());
+        objects.extend(self.build_skip_hint(asset_cache));
+        (objects, self.player_position, self.player_rotation)
     }
 
     fn handle_effects(

--- a/shock2vr/src/scenes/cutscene_skip.rs
+++ b/shock2vr/src/scenes/cutscene_skip.rs
@@ -1,0 +1,214 @@
+//! Hold-to-skip for the cutscene player: the hold latch and the radial progress
+//! art it draws. Both are pure, so the timing rule and the ring are testable
+//! without a running game.
+
+use std::time::Duration;
+
+use engine::texture_format::{PixelFormat, RawTextureData};
+
+/// How long either trigger must be held to skip. Long enough that a trigger
+/// brushed on the way into a cutscene does not dismiss it.
+pub const SKIP_HOLD_DURATION: Duration = Duration::from_millis(1500);
+
+/// Analog triggers rest a little above zero, so a resting hand must not read as
+/// a hold - nor light up the affordance.
+const TRIGGER_TOUCH: f32 = 0.2;
+
+/// How fast the affordance fades in and back out, in alpha per second.
+const FADE_RATE: f32 = 4.0;
+
+/// The trigger hold that skips a cutscene: it accumulates while either trigger
+/// is held past [`TRIGGER_TOUCH`] and resets the moment it is released.
+#[derive(Default)]
+pub struct SkipHold {
+    held: Duration,
+    /// Opacity of the affordance, so releasing fades it out rather than
+    /// blinking it away.
+    alpha: f32,
+}
+
+impl SkipHold {
+    /// Advance the hold by one frame's `elapsed` and return whether the hold is
+    /// now complete - i.e. the cutscene should skip.
+    pub fn update(&mut self, trigger_value: f32, elapsed: Duration) -> bool {
+        let touched = trigger_value >= TRIGGER_TOUCH;
+        if touched {
+            self.held = (self.held + elapsed).min(SKIP_HOLD_DURATION);
+        } else {
+            self.held = Duration::ZERO;
+        }
+
+        let target = if touched { 1.0 } else { 0.0 };
+        let step = FADE_RATE * elapsed.as_secs_f32();
+        self.alpha += (target - self.alpha).clamp(-step, step);
+
+        self.is_complete()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.held >= SKIP_HOLD_DURATION
+    }
+
+    /// Hold progress, 0.0 to 1.0.
+    pub fn progress(&self) -> f32 {
+        self.held.as_secs_f32() / SKIP_HOLD_DURATION.as_secs_f32()
+    }
+
+    /// Opacity of the affordance; 0.0 means it should not be drawn at all.
+    pub fn alpha(&self) -> f32 {
+        self.alpha
+    }
+}
+
+/// Edge length of the generated ring texture. Small: the ring is a thin arc on
+/// a quad a few degrees wide, and it is rebuilt every frame it is visible.
+const RING_TEXTURE_SIZE: usize = 96;
+/// Inner and outer radius of the ring, in units of half the texture edge.
+const RING_INNER: f32 = 0.66;
+const RING_OUTER: f32 = 0.86;
+/// Alpha of the part of the ring the hold has not reached yet - present enough
+/// to read as a track for the fill to run around.
+const TRACK_ALPHA: u8 = 60;
+
+/// The radial progress ring for a hold `progress` in 0.0..=1.0: a white arc
+/// filling clockwise from twelve o'clock over a faint full-circle track,
+/// transparent everywhere else.
+pub fn ring_texture(progress: f32) -> RawTextureData {
+    let progress = progress.clamp(0.0, 1.0);
+    let size = RING_TEXTURE_SIZE;
+    let half = size as f32 / 2.0;
+    let mut bytes = Vec::with_capacity(size * size * 4);
+
+    for y in 0..size {
+        for x in 0..size {
+            // Pixel centers, in -1..1 with +y up (the quad's v axis).
+            let dx = (x as f32 + 0.5 - half) / half;
+            let dy = -(y as f32 + 0.5 - half) / half;
+            let radius = (dx * dx + dy * dy).sqrt();
+
+            let alpha = if !(RING_INNER..=RING_OUTER).contains(&radius) {
+                0
+            } else if angle_fraction(dx, dy) <= progress {
+                255
+            } else {
+                TRACK_ALPHA
+            };
+
+            bytes.extend_from_slice(&[255, 255, 255, alpha]);
+        }
+    }
+
+    RawTextureData {
+        width: size as u32,
+        height: size as u32,
+        bytes,
+        format: PixelFormat::RGBA,
+    }
+}
+
+/// Where a point sits around the ring: 0.0 at twelve o'clock, rising clockwise
+/// to 1.0 back at the top.
+fn angle_fraction(dx: f32, dy: f32) -> f32 {
+    let angle = dx.atan2(dy); // -PI..PI, zero pointing up
+    let turns = angle / std::f32::consts::TAU;
+    if turns < 0.0 { turns + 1.0 } else { turns }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FRAME: Duration = Duration::from_millis(100);
+
+    #[test]
+    fn a_held_trigger_completes_only_after_the_hold_duration() {
+        let mut hold = SkipHold::default();
+        let mut elapsed = Duration::ZERO;
+
+        while elapsed + FRAME < SKIP_HOLD_DURATION {
+            assert!(!hold.update(1.0, FRAME), "skipped early at {elapsed:?}");
+            elapsed += FRAME;
+        }
+
+        assert!(hold.update(1.0, FRAME + FRAME));
+        assert!(hold.is_complete());
+        assert_eq!(hold.progress(), 1.0);
+    }
+
+    #[test]
+    fn releasing_the_trigger_resets_the_hold() {
+        let mut hold = SkipHold::default();
+        hold.update(1.0, SKIP_HOLD_DURATION - FRAME);
+        assert!(hold.progress() > 0.9);
+
+        hold.update(0.0, FRAME);
+        assert_eq!(hold.progress(), 0.0);
+
+        // A fresh hold must run the full duration again.
+        assert!(!hold.update(1.0, SKIP_HOLD_DURATION - FRAME));
+    }
+
+    /// A resting analog trigger reads slightly above zero on real hardware.
+    #[test]
+    fn a_barely_touched_trigger_does_not_accumulate() {
+        let mut hold = SkipHold::default();
+        hold.update(0.05, SKIP_HOLD_DURATION);
+        assert_eq!(hold.progress(), 0.0);
+        assert_eq!(hold.alpha(), 0.0);
+    }
+
+    #[test]
+    fn the_affordance_fades_in_while_held_and_out_after_release() {
+        let mut hold = SkipHold::default();
+        hold.update(1.0, FRAME);
+        let faded_in = hold.alpha();
+        assert!(faded_in > 0.0);
+
+        hold.update(1.0, Duration::from_secs(1));
+        assert_eq!(hold.alpha(), 1.0);
+
+        hold.update(0.0, FRAME);
+        assert!(hold.alpha() < 1.0 && hold.alpha() > 0.0);
+
+        hold.update(0.0, Duration::from_secs(1));
+        assert_eq!(hold.alpha(), 0.0);
+    }
+
+    /// Alpha of the ring pixel at the given angle in turns clockwise from the
+    /// top, sampled mid-band.
+    fn sample(texture: &RawTextureData, turns: f32) -> u8 {
+        let size = texture.width as f32;
+        let radius = (RING_INNER + RING_OUTER) / 2.0;
+        let angle = turns * std::f32::consts::TAU;
+        let x = (size / 2.0 + angle.sin() * radius * size / 2.0) as u32;
+        let y = (size / 2.0 - angle.cos() * radius * size / 2.0) as u32;
+        texture.bytes[((y * texture.width + x) * 4 + 3) as usize]
+    }
+
+    #[test]
+    fn the_ring_fills_clockwise_from_the_top() {
+        let quarter = ring_texture(0.25);
+
+        assert_eq!(sample(&quarter, 0.1), 255, "just past the top is filled");
+        assert_eq!(sample(&quarter, 0.2), 255, "the first quarter is filled");
+        assert_eq!(
+            sample(&quarter, 0.4),
+            TRACK_ALPHA,
+            "past the fill only the track shows"
+        );
+        assert_eq!(sample(&quarter, 0.9), TRACK_ALPHA);
+
+        let full = ring_texture(1.0);
+        for turns in [0.1, 0.35, 0.6, 0.85] {
+            assert_eq!(sample(&full, turns), 255, "a complete hold fills the ring");
+        }
+    }
+
+    #[test]
+    fn the_ring_is_transparent_off_the_band() {
+        let texture = ring_texture(1.0);
+        let center = ((texture.height / 2) * texture.width + texture.width / 2) * 4 + 3;
+        assert_eq!(texture.bytes[center as usize], 0, "hollow center");
+        assert_eq!(texture.bytes[3], 0, "transparent corner");
+    }
+}

--- a/shock2vr/src/scenes/cutscene_skip.rs
+++ b/shock2vr/src/scenes/cutscene_skip.rs
@@ -68,7 +68,7 @@ const RING_INNER: f32 = 0.66;
 const RING_OUTER: f32 = 0.86;
 /// Alpha of the part of the ring the hold has not reached yet - present enough
 /// to read as a track for the fill to run around.
-const TRACK_ALPHA: u8 = 60;
+const TRACK_ALPHA: u8 = 90;
 
 /// The radial progress ring for a hold `progress` in 0.0..=1.0: a white arc
 /// filling clockwise from twelve o'clock over a faint full-circle track,

--- a/shock2vr/src/scenes/cutscene_skip.rs
+++ b/shock2vr/src/scenes/cutscene_skip.rs
@@ -11,7 +11,10 @@ use engine::texture_format::{PixelFormat, RawTextureData};
 pub const SKIP_HOLD_DURATION: Duration = Duration::from_millis(1500);
 
 /// Analog triggers rest a little above zero, so a resting hand must not read as
-/// a hold - nor light up the affordance.
+/// a hold - nor light up the affordance. Deliberately below the shared
+/// press threshold ([`crate::ui::VR_TRIGGER_THRESHOLD`]): this is "the trigger
+/// is being touched", which is when the affordance should appear, not "the
+/// trigger is pressed".
 const TRIGGER_TOUCH: f32 = 0.2;
 
 /// How fast the affordance fades in and back out, in alpha per second.
@@ -25,6 +28,11 @@ pub struct SkipHold {
     /// Opacity of the affordance, so releasing fades it out rather than
     /// blinking it away.
     alpha: f32,
+    /// The trigger has been seen released since the cutscene began. A cutscene
+    /// is often started by a trigger - a frobbed panel, a menu click - and that
+    /// press is frequently still down as the movie opens; counting it would
+    /// dismiss the movie the player just started.
+    armed: bool,
 }
 
 impl SkipHold {
@@ -32,6 +40,8 @@ impl SkipHold {
     /// now complete - i.e. the cutscene should skip.
     pub fn update(&mut self, trigger_value: f32, elapsed: Duration) -> bool {
         let touched = trigger_value >= TRIGGER_TOUCH;
+        self.armed |= !touched;
+        let touched = touched && self.armed;
         if touched {
             self.held = (self.held + elapsed).min(SKIP_HOLD_DURATION);
         } else {
@@ -60,9 +70,25 @@ impl SkipHold {
     }
 }
 
-/// Edge length of the generated ring texture. Small: the ring is a thin arc on
-/// a quad a few degrees wide, and it is rebuilt every frame it is visible.
-const RING_TEXTURE_SIZE: usize = 96;
+/// Edge length of the generated ring texture. Small: the ring draws a few dozen
+/// pixels across, so anything larger is only oversampling.
+const RING_TEXTURE_SIZE: usize = 64;
+
+/// Steps the fill is drawn in. The art changes only when the arc crosses one, so
+/// a caller keyed on [`ring_step`] rebuilds and re-uploads the texture this many
+/// times over a hold rather than once per frame.
+pub const RING_STEPS: u32 = 48;
+
+/// Which step `progress` falls in - the cache key for [`ring_texture`].
+pub fn ring_step(progress: f32) -> u32 {
+    (progress.clamp(0.0, 1.0) * RING_STEPS as f32).round() as u32
+}
+
+/// The ring art for a step from [`ring_step`].
+pub fn ring_texture_for_step(step: u32) -> RawTextureData {
+    ring_texture(step as f32 / RING_STEPS as f32)
+}
+
 /// Inner and outer radius of the ring, in units of half the texture edge.
 const RING_INNER: f32 = 0.66;
 const RING_OUTER: f32 = 0.86;
@@ -120,9 +146,28 @@ mod tests {
 
     const FRAME: Duration = Duration::from_millis(100);
 
+    /// Release the trigger for a frame, which is what arms a fresh hold.
+    fn armed() -> SkipHold {
+        let mut hold = SkipHold::default();
+        hold.update(0.0, FRAME);
+        hold
+    }
+
+    /// The trigger that started the cutscene is often still down as it opens.
+    #[test]
+    fn a_trigger_already_held_at_the_start_does_not_skip() {
+        let mut hold = SkipHold::default();
+        assert!(!hold.update(1.0, SKIP_HOLD_DURATION * 3));
+        assert_eq!(hold.progress(), 0.0);
+
+        // Once released, a fresh hold counts as normal.
+        hold.update(0.0, FRAME);
+        assert!(hold.update(1.0, SKIP_HOLD_DURATION));
+    }
+
     #[test]
     fn a_held_trigger_completes_only_after_the_hold_duration() {
-        let mut hold = SkipHold::default();
+        let mut hold = armed();
         let mut elapsed = Duration::ZERO;
 
         while elapsed + FRAME < SKIP_HOLD_DURATION {
@@ -137,7 +182,7 @@ mod tests {
 
     #[test]
     fn releasing_the_trigger_resets_the_hold() {
-        let mut hold = SkipHold::default();
+        let mut hold = armed();
         hold.update(1.0, SKIP_HOLD_DURATION - FRAME);
         assert!(hold.progress() > 0.9);
 
@@ -151,7 +196,7 @@ mod tests {
     /// A resting analog trigger reads slightly above zero on real hardware.
     #[test]
     fn a_barely_touched_trigger_does_not_accumulate() {
-        let mut hold = SkipHold::default();
+        let mut hold = armed();
         hold.update(0.05, SKIP_HOLD_DURATION);
         assert_eq!(hold.progress(), 0.0);
         assert_eq!(hold.alpha(), 0.0);
@@ -159,7 +204,7 @@ mod tests {
 
     #[test]
     fn the_affordance_fades_in_while_held_and_out_after_release() {
-        let mut hold = SkipHold::default();
+        let mut hold = armed();
         hold.update(1.0, FRAME);
         let faded_in = hold.alpha();
         assert!(faded_in > 0.0);

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 
 pub mod cutscene_player;
+pub mod cutscene_skip;
 pub mod debug_camera;
 pub mod debug_common;
 pub mod debug_gloves;

--- a/tools/shock2-sdk/test/cutscene-skip.e2e.test.ts
+++ b/tools/shock2-sdk/test/cutscene-skip.e2e.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Holding either trigger skips the movie. Negative-first: before the skip, both
+// tests below sat on "cs1.avi" for the whole 400-frame budget (the intro runs
+// for minutes), so the "playback ended early" assertions failed.
+//
+// Booting the runtime straight into a cutscene gives it `ShowMainMenu` as its
+// follow-on, so the menu appearing is the observable skip.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The intro movie, ~2:40 long - far longer than anything stepped here. */
+const INTRO = "cs1.avi";
+/** Matches `SKIP_HOLD_DURATION` (1.5s) with room for the frame it lands on. */
+const HOLD_FRAMES = 120;
+
+test(
+  "holding a trigger skips a cutscene to its follow-on",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: INTRO });
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).mission, INTRO, "the movie should be playing");
+
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: HOLD_FRAMES });
+
+    assert.equal(
+      (await game.info()).mission,
+      "main_menu",
+      "a held trigger should end the movie early and hand off to its follow-on",
+    );
+  },
+);
+
+test(
+  "a released trigger restarts the hold, and a movie left alone keeps playing",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: INTRO });
+    await game.step({ frames: 10 });
+
+    // Two 1s holds: enough to skip if the hold survived the release, since the
+    // threshold is 1.5s.
+    await game.input.set("left_hand.trigger", 1.0);
+    await game.step({ frames: 60 });
+    await game.input.set("left_hand.trigger", 0.0);
+    await game.step({ frames: 10 });
+    await game.input.set("left_hand.trigger", 1.0);
+    await game.step({ frames: 60 });
+
+    assert.equal(
+      (await game.info()).mission,
+      INTRO,
+      "two part-holds should not add up to a skip",
+    );
+
+    // ... and untouched, the movie plays on rather than being dismissed by the
+    // resting trigger value.
+    await game.input.set("left_hand.trigger", 0.0);
+    await game.step({ frames: 300 });
+    assert.equal(
+      (await game.info()).mission,
+      INTRO,
+      "an untouched movie should still be playing",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #1200

Holding either trigger for 1.5s finishes a cutscene early, through the same one-shot `on_complete` latch the natural end uses - so the follow-on transition and the `on_exit` soundtrack stop are identical whether a movie plays out or is skipped.

The affordance appears on first trigger touch and fades out on release: a faint track ring with a white arc filling clockwise from twelve o'clock, plus a "HOLD TO SKIP" caption. Both are anchored to the video screen's own billboard basis, so flatscreen and VR place them identically by construction.

- `scenes/cutscene_skip.rs` - the hold latch (accumulate / reset on release / threshold, plus the fade) and the ring art, both pure and unit-tested. The ring is a small CPU-generated RGBA texture (alpha by radius band and `atan2` angle vs progress), rebuilt only when the fill crosses one of 48 steps, so a hold uploads a few dozen textures rather than one a frame - no new material or arc primitive needed.
- Input is contextual, not an `InputAction`: it reads `InputContext`'s analog `trigger_value` (left or right). Desktop already maps LMB to `right_hand.trigger_value`; the debug runtime drives it with the existing `right_hand.trigger` / `left_hand.trigger` channels, so it is headlessly testable with no new wiring.
- The hold arms only after the trigger has been seen released: a cutscene is usually started *by* a trigger (a frobbed panel, a menu click) and that press is often still down as the movie opens.

## Visuals

![Hold to skip demo](https://gist.githubusercontent.com/tommy-xr/62281ff1fa28ecdc16e52b0d590151ed/raw/demo.gif)

<sub>Holding the trigger during `cs1.avi` fills the ring clockwise from twelve o'clock over 1.5s; the cutscene skips once it completes. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Testing

- `tools/shock2-sdk/test/cutscene-skip.e2e.test.ts` - negative-verified: with the skip removed, "holding a trigger skips a cutscene to its follow-on" fails (the intro just keeps playing). Also covers that two part-holds either side of a release do not add up to a skip, and that an untouched movie keeps playing.
- `cargo test -p shock2vr` (hold timing, fade, ring fill direction and transparency), `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` and `-p shock2vr --no-default-features`.

