### PR TITLE
feat(ui): draw scroll rockers with the original arrow art

### DIFF
--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -1101,7 +1101,7 @@ mod tests {
         let rocker = scene_rocker(rects, len).expect("the shipped scene list scrolls");
         let max = scene_max_scroll(rects, len);
 
-        // At the top the "Up" half is inert; at the bottom, "Dn" is.
+        // At the top the up half is inert; at the bottom, the down half is.
         assert_eq!(hit(scenes_state(0, true, len), rocker.up.center()), None);
         assert_eq!(
             hit(scenes_state(0, true, len), rocker.down.center()),

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -246,7 +246,7 @@ fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
     list_scroll::visible_rows(dev_params::PARAMS.len(), rows_per_page(rects), scroll)
 }
 
-/// The scroll rocker's two halves - "Up" and "Down" - in a gutter down the
+/// The scroll rocker's two halves - up and down arrows - in a gutter down the
 /// list pane's right edge, beside the rows they scroll. `None` when the whole
 /// registry fits on one page.
 ///
@@ -534,7 +534,7 @@ mod tests {
         let (up, down) = scroll_rects(rects).expect("the shipped registry scrolls");
         let mut scroll = 0;
 
-        // At the top the "Up" half is inert - and stays inert if activated.
+        // At the top the up half is inert - and stays inert if activated.
         assert_eq!(hit(rects, scroll, up.center()), None);
         assert_eq!(
             hit(rects, scroll, down.center()),

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -164,7 +164,7 @@ const ARROW_W: f32 = 20.0;
 /// Width of the value readout between the arrows.
 const VALUE_W: f32 = 48.0;
 /// The scroll gutter down the list pane's right edge. The rocker itself - its
-/// geometry, its labels and its "an end that cannot move is inert" rule - is
+/// geometry, its arrow art and its "an end that cannot move is inert" rule - is
 /// [`list_scroll`]'s, shared with the debug-scene launcher.
 const SCROLL_GUTTER_W: f32 = list_scroll::GUTTER_W;
 

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -204,12 +204,15 @@ fn row_rects(rects: PanelRects, index: usize) -> RowRects {
     // Leave the scroll gutter clear whenever it is in use, so a row's `>`
     // never sits under the rocker (they resolve through one hit test, so an
     // overlap is a genuine ambiguity, not just a visual one).
-    let gutter = if max_scroll(rects) > 0 {
+    // The gutter subsumes the right inset: the rocker's own art carries a dark
+    // margin either side of its arrow, so charging the row for both as well
+    // costs label width and ellipsizes names that otherwise fit.
+    let right_margin = if max_scroll(rects) > 0 {
         SCROLL_GUTTER_W
     } else {
-        0.0
+        TEXT_INSET
     };
-    let right = list.x + list.w - TEXT_INSET - gutter;
+    let right = list.x + list.w - right_margin;
     let increment_x = right - ARROW_W;
     let value_x = increment_x - VALUE_W;
     let decrement_x = value_x - ARROW_W;
@@ -586,11 +589,13 @@ mod tests {
         );
         assert!(max_scroll(tall) > 0);
         assert!(scroll_rects(tall).is_some());
-        // Scrolling means the gutter is reserved: a row's increment stops
-        // short of the pane's inset by the gutter width.
+        // Scrolling means the gutter is reserved: a row's increment stops at
+        // the rocker's left edge. The gutter replaces the right inset rather
+        // than adding to it, so reserving it costs the label no width it did
+        // not already lose.
         assert_eq!(
             row_rects(tall, 0).increment.x + ARROW_W,
-            tall.list.x + tall.list.w - TEXT_INSET - SCROLL_GUTTER_W
+            tall.list.x + tall.list.w - SCROLL_GUTTER_W
         );
         assert_eq!(visible_rows(tall, 0), 0..cap);
     }

--- a/shock2vr/src/ui/list_scroll.rs
+++ b/shock2vr/src/ui/list_scroll.rs
@@ -22,12 +22,41 @@ use super::{Rect, UiCanvas};
 pub const GUTTER_W: f32 = 32.0;
 const BUTTON_H: f32 = 16.0;
 
-/// The original scroll-arrow art. Each half has three states, and the art
-/// itself carries the shading, so the rocker draws fully opaque throughout:
-/// `_NORM` idle, `_HLIT` under the pointer, `_DOWN` (the darkened plate) for a
-/// half that cannot move.
-const UP_ART: [&str; 3] = ["BUP_NORM.PCX", "BUP_HLIT.PCX", "BUP_DOWN.PCX"];
-const DOWN_ART: [&str; 3] = ["BDN_NORM.PCX", "BDN_HLIT.PCX", "BDN_DOWN.PCX"];
+/// The original scroll-arrow art for one half. The art carries the shading, so
+/// the rocker draws fully opaque and picks a state instead of an opacity.
+struct ArrowArt {
+    /// Idle.
+    norm: &'static str,
+    /// Under the pointer.
+    hlit: &'static str,
+    /// A half that cannot move. This is the original's *pressed* plate; the
+    /// rocker has no press-and-hold visual of its own, and its darkened arrow
+    /// reads as unavailable, so it doubles as the inert state.
+    down: &'static str,
+}
+
+const UP_ART: ArrowArt = ArrowArt {
+    norm: "BUP_NORM.PCX",
+    hlit: "BUP_HLIT.PCX",
+    down: "BUP_DOWN.PCX",
+};
+const DOWN_ART: ArrowArt = ArrowArt {
+    norm: "BDN_NORM.PCX",
+    hlit: "BDN_HLIT.PCX",
+    down: "BDN_DOWN.PCX",
+};
+
+/// The art a half shows. Named rather than positional so a state can't
+/// silently swap with its neighbour.
+fn art_for(art: &ArrowArt, enabled: bool, hovered: bool) -> &'static str {
+    if !enabled {
+        art.down
+    } else if hovered {
+        art.hlit
+    } else {
+        art.norm
+    }
+}
 
 /// Which half of the rocker a point is over.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -120,17 +149,15 @@ pub fn draw(
     hovered: Option<ScrollHalf>,
 ) {
     for (half, rect, art, enabled) in [
-        (ScrollHalf::Up, rocker.up, UP_ART, scroll > 0),
-        (ScrollHalf::Down, rocker.down, DOWN_ART, scroll < max_scroll),
+        (ScrollHalf::Up, rocker.up, &UP_ART, scroll > 0),
+        (
+            ScrollHalf::Down,
+            rocker.down,
+            &DOWN_ART,
+            scroll < max_scroll,
+        ),
     ] {
-        let texture = if !enabled {
-            art[2]
-        } else if hovered == Some(half) {
-            art[1]
-        } else {
-            art[0]
-        };
-        canvas.image(rect, texture);
+        canvas.image(rect, art_for(art, enabled, hovered == Some(half)));
     }
 }
 
@@ -197,6 +224,19 @@ mod tests {
 
     fn rocker_none() -> Option<Rocker> {
         rocker(LIST, FIELD_TOP_Y, false)
+    }
+
+    #[test]
+    fn each_half_shows_the_art_for_its_state() {
+        assert_eq!(art_for(&UP_ART, true, false), "BUP_NORM.PCX");
+        assert_eq!(art_for(&UP_ART, true, true), "BUP_HLIT.PCX");
+        assert_eq!(art_for(&DOWN_ART, true, false), "BDN_NORM.PCX");
+        assert_eq!(art_for(&DOWN_ART, true, true), "BDN_HLIT.PCX");
+        // A half that cannot move shows the darkened plate whether or not the
+        // pointer is over it - it is not hit-testable either.
+        assert_eq!(art_for(&UP_ART, false, false), "BUP_DOWN.PCX");
+        assert_eq!(art_for(&UP_ART, false, true), "BUP_DOWN.PCX");
+        assert_eq!(art_for(&DOWN_ART, false, true), "BDN_DOWN.PCX");
     }
 
     #[test]

--- a/shock2vr/src/ui/list_scroll.rs
+++ b/shock2vr/src/ui/list_scroll.rs
@@ -22,6 +22,10 @@ use super::{Rect, UiCanvas};
 pub const GUTTER_W: f32 = 32.0;
 const BUTTON_H: f32 = 16.0;
 
+/// Breathing room between the down arrow and the line the page stops at, so
+/// the arrow reads as sitting in the pane rather than resting on its edge.
+const BOTTOM_GAP: f32 = 6.0;
+
 /// The original scroll-arrow art for one half. The art carries the shading, so
 /// the rocker draws fully opaque and picks a state instead of an opacity.
 struct ArrowArt {
@@ -107,7 +111,7 @@ pub fn rocker(list: Rect, bottom_limit: f32, needed: bool) -> Option<Rocker> {
         let bottom = (list.y + list.h).min(bottom_limit);
         Rocker {
             up: Rect::new(x, list.y, GUTTER_W, BUTTON_H),
-            down: Rect::new(x, bottom - BUTTON_H, GUTTER_W, BUTTON_H),
+            down: Rect::new(x, bottom - BUTTON_H - BOTTOM_GAP, GUTTER_W, BUTTON_H),
         }
     })
 }
@@ -203,7 +207,7 @@ mod tests {
         assert_eq!(rocker.up.x, LIST.x + LIST.w - GUTTER_W);
         assert_eq!(rocker.up.y, LIST.y);
         assert_eq!(rocker.down.x, rocker.up.x);
-        assert_eq!(rocker.down.y + BUTTON_H, FIELD_TOP_Y);
+        assert_eq!(rocker.down.y + BUTTON_H + BOTTOM_GAP, FIELD_TOP_Y);
 
         let max = 4;
         assert_eq!(hit(&rocker, 0, max, rocker.up.center()), None);

--- a/shock2vr/src/ui/list_scroll.rs
+++ b/shock2vr/src/ui/list_scroll.rs
@@ -4,7 +4,7 @@
 //! of them bounded by the backdrop art, and - when the contents outrun the page
 //! - a two-button rocker in a gutter down the pane's right edge. This module
 //! owns that geometry, its enablement rule ("a half that cannot move is inert,
-//! not just dimmed") and its labels, so the Developer parameter list and the
+//! not just dimmed") and its arrow art, so the Developer parameter list and the
 //! debug-scene launcher scroll the same way rather than each growing their own.
 //!
 //! Everything here is in canvas pixels and presentation-free: hosts hand the
@@ -15,26 +15,19 @@ use std::ops::Range;
 
 use cgmath::Vector2;
 
-use super::{HAlign, Rect, UiCanvas, VAlign};
+use super::{Rect, UiCanvas};
 
-/// The gutter the rocker lives in, and the height of each of its halves.
-pub const GUTTER_W: f32 = 26.0;
-const BUTTON_H: f32 = 20.0;
+/// The gutter the rocker lives in, and the height of each of its halves -
+/// the authored 32x16 size of the arrow art, so it draws unstretched.
+pub const GUTTER_W: f32 = 32.0;
+const BUTTON_H: f32 = 16.0;
 
-/// The small data font, and "Dn" rather than "Down": `text_native` does not
-/// shrink to its rect, so the display font's labels overhung the gutter and
-/// drew across the rows beside them.
-const LABEL_FONT: &str = "mainfont.fon";
-const UP_LABEL: &str = "Up";
-const DOWN_LABEL: &str = "Dn";
-
-/// Opacity for a half that cannot move any further - which is also not
-/// hit-testable.
-const DISABLED_OPACITY: f32 = 0.3;
-/// Opacity for a movable half the pointer is not over.
-const IDLE_OPACITY: f32 = 0.65;
-/// Opacity for the half under the pointer.
-const HOVER_OPACITY: f32 = 1.0;
+/// The original scroll-arrow art. Each half has three states, and the art
+/// itself carries the shading, so the rocker draws fully opaque throughout:
+/// `_NORM` idle, `_HLIT` under the pointer, `_DOWN` (the darkened plate) for a
+/// half that cannot move.
+const UP_ART: [&str; 3] = ["BUP_NORM.PCX", "BUP_HLIT.PCX", "BUP_DOWN.PCX"];
+const DOWN_ART: [&str; 3] = ["BDN_NORM.PCX", "BDN_HLIT.PCX", "BDN_DOWN.PCX"];
 
 /// Which half of the rocker a point is over.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -126,24 +119,18 @@ pub fn draw(
     max_scroll: usize,
     hovered: Option<ScrollHalf>,
 ) {
-    for (half, rect, text, enabled) in [
-        (ScrollHalf::Up, rocker.up, UP_LABEL, scroll > 0),
-        (
-            ScrollHalf::Down,
-            rocker.down,
-            DOWN_LABEL,
-            scroll < max_scroll,
-        ),
+    for (half, rect, art, enabled) in [
+        (ScrollHalf::Up, rocker.up, UP_ART, scroll > 0),
+        (ScrollHalf::Down, rocker.down, DOWN_ART, scroll < max_scroll),
     ] {
-        canvas
-            .text_native(rect, text, LABEL_FONT, HAlign::Center, VAlign::Middle)
-            .opacity(if !enabled {
-                DISABLED_OPACITY
-            } else if hovered == Some(half) {
-                HOVER_OPACITY
-            } else {
-                IDLE_OPACITY
-            });
+        let texture = if !enabled {
+            art[2]
+        } else if hovered == Some(half) {
+            art[1]
+        } else {
+            art[0]
+        };
+        canvas.image(rect, texture);
     }
 }
 


### PR DESCRIPTION
The frontend scrolling-list rocker labelled its halves `Up` / `Dn` in the small
data font. Draw the shipped original button art instead.

- `BUP_NORM/HLIT/DOWN` and `BDN_NORM/HLIT/DOWN` (`res/intrface/`, all six 32x16),
  so `GUTTER_W` 26 -> 32 and the half height 20 -> 16 and the art blits
  unstretched. Both hosts already subtract `GUTTER_W` from row width, so a row's
  `>` still cannot share a point with the rocker.
- The wider gutter first cost the dev-param rows label width and ellipsized two
  names (`Panel distance` -> `Panel distan...`). `row_rects` was charging the row
  for both `TEXT_INSET` and the gutter; the rocker art carries its own dark
  margin either side of its arrow, so the gutter now replaces the inset rather
  than adding to it and the labels come out 2px wider than before.
- State comes from the art, not an opacity ramp: `_NORM` idle, `_HLIT` under the
  pointer, `_DOWN` for a half that cannot move. `_DOWN` is the original's
  *pressed* plate; the rocker has no press-and-hold visual of its own, and the
  darkened arrow reads as unavailable, so it doubles as the inert state.
- `art_for` names the three states rather than indexing a triple, and a test
  pins each mapping - a swap was previously invisible.

Both screens that use `list_scroll` pick this up: the standalone Developer
scene's launcher and the pause menu's Developer page.

![scroll rocker states](https://gist.githubusercontent.com/tommy-xr/08a208db7e55ab828c7e980116a01f92/raw/rocker.gif)

<sub>Developer screen, flatscreen. Idle at scroll 0 (the up half is the inert `_DOWN` plate), the down half lights `_HLIT` under the pointer, two clicks scroll the list and bring the up half live, the up half lights on hover, then two more clicks reach the bottom and the down half goes inert. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![both halves live](https://gist.githubusercontent.com/tommy-xr/08a208db7e55ab828c7e980116a01f92/raw/still_flat_both_live.png)

<sub>Scrolled mid-list: both halves idle `_NORM`.</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/08a208db7e55ab828c7e980116a01f92/raw/beforeafter.png)

## VR

![flat vs VR](https://gist.githubusercontent.com/tommy-xr/08a208db7e55ab828c7e980116a01f92/raw/flat_vs_vr.png)

<sub>Same screen in both presentations (AGENTS.md §3): the rocker sits in the same place relative to its pane and shows the same art. Hover was verified in VR too - aiming the controller ray at the down half swaps `_NORM` -> `_HLIT` exactly as the flat pointer does.</sub>

