### PR TITLE
feat(tools): list all modeled templates in dark_explorer's Archetypes tab

### DIFF
--- a/tools/dark_explorer/src/archetypes.rs
+++ b/tools/dark_explorer/src/archetypes.rs
@@ -1,6 +1,6 @@
-//! Gamesys creature archetypes: templates that resolve (inheritance-aware) to
-//! a model + creature type, arranged in their MetaProp hierarchy, plus the
-//! motion-database clip list for each archetype's actor type.
+//! Gamesys archetypes: every template that resolves (inheritance-aware) to a
+//! model, arranged in its MetaProp hierarchy. Creature templates additionally
+//! carry an actor type and the motion-database clip list it can play.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -34,17 +34,25 @@ pub struct Archetype {
     pub name: String,
     /// Model base name from `PropModelName` (lowercased, no extension).
     pub model_name: String,
-    pub creature_type: u32,
+    /// `PropCreature`, or None for a non-creature template (weapon, prop, ...).
+    pub creature_type: Option<u32>,
     /// The motion database's creature category, from the creature definition.
     pub actor_type: Option<ActorType>,
 }
 
 impl Archetype {
+    pub fn is_creature(&self) -> bool {
+        self.creature_type.is_some()
+    }
+
     pub fn creature_type_name(&self) -> String {
+        let Some(creature_type) = self.creature_type else {
+            return "-".to_string();
+        };
         CREATURE_TYPE_NAMES
-            .get(self.creature_type as usize)
-            .map(|n| format!("{n} ({})", self.creature_type))
-            .unwrap_or_else(|| format!("unknown ({})", self.creature_type))
+            .get(creature_type as usize)
+            .map(|n| format!("{n} ({creature_type})"))
+            .unwrap_or_else(|| format!("unknown ({creature_type})"))
     }
 
     pub fn actor_type_name(&self) -> String {
@@ -129,6 +137,9 @@ impl ArchetypeDb {
     /// Clip names playable by this archetype's actor type.
     pub fn clips_for(&self, archetype: &Archetype) -> Result<Vec<String>, String> {
         let motion_db = self.motion_db.as_ref().map_err(|e| e.clone())?;
+        if !archetype.is_creature() {
+            return Err(format!("'{}' is not a creature", archetype.name));
+        }
         let actor = archetype.actor_type.clone().ok_or_else(|| {
             format!(
                 "no creature definition for {}",
@@ -197,7 +208,7 @@ impl ArchetypeDb {
             return if self.archetypes.contains_key(&id) {
                 Ok(id)
             } else {
-                Err(format!("no creature archetype with template id {id}"))
+                Err(format!("no archetype with template id {id}"))
             };
         }
         let needle = wanted.to_ascii_lowercase();
@@ -217,13 +228,18 @@ impl ArchetypeDb {
         }
         match matches.as_slice() {
             [id] => Ok(*id),
-            [] => Err(format!("no creature archetype matching '{wanted}'")),
+            [] => Err(format!("no archetype matching '{wanted}'")),
+            // Substring hits can run to dozens now that every modeled template
+            // is here; list a sample rather than a wall of names.
             many => Err(format!(
-                "'{wanted}' is ambiguous: {}",
+                "'{wanted}' is ambiguous ({} matches): {}{}",
+                many.len(),
                 many.iter()
+                    .take(10)
                     .map(|id| self.name_of(*id))
                     .collect::<Vec<_>>()
-                    .join(", ")
+                    .join(", "),
+                if many.len() > 10 { ", ..." } else { "" }
             )),
         }
     }
@@ -261,10 +277,12 @@ fn load_impl() -> Result<ArchetypeDb, String> {
             if let Ok(name) = v_name.get(entity) {
                 names.insert(template_id, name.0.clone());
             }
-            let (Ok(model), Ok(creature)) = (v_model.get(entity), v_creature.get(entity)) else {
+            let Ok(model) = v_model.get(entity) else {
                 continue;
             };
-            let actor_type = shock2vr::creature::get_creature_definition(creature.0)
+            let creature_type = v_creature.get(entity).ok().map(|c| c.0);
+            let actor_type = creature_type
+                .and_then(shock2vr::creature::get_creature_definition)
                 .map(|def| def.actor_type.clone());
             archetypes.insert(
                 template_id,
@@ -275,7 +293,7 @@ fn load_impl() -> Result<ArchetypeDb, String> {
                         .cloned()
                         .unwrap_or_else(|| format!("Template {template_id}")),
                     model_name: model.0.to_ascii_lowercase(),
-                    creature_type: creature.0,
+                    creature_type,
                     actor_type,
                 },
             );

--- a/tools/dark_explorer/src/archetypes.rs
+++ b/tools/dark_explorer/src/archetypes.rs
@@ -326,10 +326,11 @@ fn load_impl() -> Result<ArchetypeDb, String> {
             .unwrap_or_else(|| format!("Template {id}"))
             .to_ascii_lowercase()
     };
+    // Tie-break same-named templates on id so tree order is reproducible.
     for siblings in children.values_mut() {
-        siblings.sort_by_key(name_of);
+        siblings.sort_by_key(|id| (name_of(id), *id));
     }
-    roots.sort_by_key(name_of);
+    roots.sort_by_key(|id| (name_of(id), *id));
 
     let motion_db = quiet_catch(|| {
         let mut reader = shock2vr::data_files::open_data_file("motiondb.bin")

--- a/tools/dark_explorer/src/main.rs
+++ b/tools/dark_explorer/src/main.rs
@@ -68,7 +68,7 @@ enum Commands {
         #[arg(long)]
         hitboxes: bool,
 
-        /// Open the Archetypes tab with this creature selected (name or template id)
+        /// Open the Archetypes tab with this archetype selected (name or template id)
         #[arg(long)]
         archetype: Option<String>,
 

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -1406,7 +1406,7 @@ impl ExplorerApp {
                         .values()
                         .filter(|a| a.name.to_ascii_lowercase().contains(&needle))
                         .collect();
-                    matches.sort_by_key(|a| a.name.to_ascii_lowercase());
+                    matches.sort_by_key(|a| (a.name.to_ascii_lowercase(), a.template_id));
                     for archetype in &matches {
                         let is_selected = selected == Some(archetype.template_id);
                         if ui.selectable_label(is_selected, &archetype.name).clicked() {

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -37,7 +37,7 @@ pub struct UiOptions {
     /// `--screenshot` run can capture the debug overlays).
     pub skeletons: bool,
     pub hitboxes: bool,
-    /// Open the Archetypes tab with this creature selected (name or
+    /// Open the Archetypes tab with this archetype selected (name or
     /// template id), optionally playing `clip`, advanced by `advance` seconds
     /// of simulation time before a `--screenshot` capture.
     pub archetype: Option<String>,
@@ -1370,7 +1370,7 @@ impl ExplorerApp {
         show_flat_results(ui, rows, *total, ':', selected.as_ref(), clicked);
     }
 
-    /// Left panel, Archetypes tab: search box + creature template tree (or a
+    /// Left panel, Archetypes tab: search box + modeled-template tree (or a
     /// flat filtered list while searching).
     fn show_archetype_panel(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
@@ -1447,7 +1447,7 @@ impl ExplorerApp {
                 return;
             }
         };
-        if self.archetype_clips.as_ref().map(|(i, _)| *i) != Some(id) {
+        if archetype.is_creature() && self.archetype_clips.as_ref().map(|(i, _)| *i) != Some(id) {
             let clips = match &self.archetype_db {
                 Some(Ok(db)) => db.clips_for(&archetype),
                 _ => Err("archetype data not loaded".to_string()),
@@ -1465,44 +1465,52 @@ impl ExplorerApp {
                 ui.label("Model");
                 ui.label(archetype.model_key());
                 ui.end_row();
-                ui.label("Creature type");
-                ui.label(archetype.creature_type_name());
-                ui.end_row();
-                ui.label("Actor type");
-                ui.label(archetype.actor_type_name());
-                ui.end_row();
+                // Creature rows are meaningless for a weapon or prop.
+                if archetype.is_creature() {
+                    ui.label("Creature type");
+                    ui.label(archetype.creature_type_name());
+                    ui.end_row();
+                    ui.label("Actor type");
+                    ui.label(archetype.actor_type_name());
+                    ui.end_row();
+                }
             });
         ui.separator();
 
-        egui::Panel::right(egui::Id::new("clip_list"))
-            .resizable(true)
-            .default_size(220.0)
-            .show(ui, |ui| {
-                ui.label("Clips (click to play)");
-                ui.separator();
-                match &self.archetype_clips {
-                    Some((_, Ok(clips))) => {
-                        if clips.is_empty() {
-                            ui.label("(no clips for this actor type)");
-                        }
-                        egui::ScrollArea::vertical()
-                            .auto_shrink([false, false])
-                            .show(ui, |ui| {
-                                for clip in clips {
-                                    let is_playing = self.selected_clip.as_deref() == Some(clip);
-                                    if ui.selectable_label(is_playing, clip).clicked() {
-                                        // Click toggles: re-clicking stops it.
-                                        self.selected_clip = (!is_playing).then(|| clip.clone());
+        // Only creatures animate; non-creatures get the full pane for the model.
+        if archetype.is_creature() {
+            egui::Panel::right(egui::Id::new("clip_list"))
+                .resizable(true)
+                .default_size(220.0)
+                .show(ui, |ui| {
+                    ui.label("Clips (click to play)");
+                    ui.separator();
+                    match &self.archetype_clips {
+                        Some((_, Ok(clips))) => {
+                            if clips.is_empty() {
+                                ui.label("(no clips for this actor type)");
+                            }
+                            egui::ScrollArea::vertical()
+                                .auto_shrink([false, false])
+                                .show(ui, |ui| {
+                                    for clip in clips {
+                                        let is_playing =
+                                            self.selected_clip.as_deref() == Some(clip);
+                                        if ui.selectable_label(is_playing, clip).clicked() {
+                                            // Click toggles: re-clicking stops it.
+                                            self.selected_clip =
+                                                (!is_playing).then(|| clip.clone());
+                                        }
                                     }
-                                }
-                            });
+                                });
+                        }
+                        Some((_, Err(err))) => {
+                            ui.label(format!("Cannot list clips: {err}"));
+                        }
+                        None => {}
                     }
-                    Some((_, Err(err))) => {
-                        ui.label(format!("Cannot list clips: {err}"));
-                    }
-                    None => {}
-                }
-            });
+                });
+        }
 
         let host = preview_host(
             &mut self.model_preview,
@@ -1510,8 +1518,8 @@ impl ExplorerApp {
             self.screenshot.is_some(),
         );
         let scene = match &self.selected_clip {
-            Some(clip) => PreviewScene::Clip(clip.clone()),
-            None => PreviewScene::Model,
+            Some(clip) if archetype.is_creature() => PreviewScene::Clip(clip.clone()),
+            _ => PreviewScene::Model,
         };
         host.show(ui, frame, &archetype.model_key(), &scene);
     }
@@ -1791,7 +1799,7 @@ fn preview_host(
 }
 
 /// One node of the archetype tree: a collapsible header where the template has
-/// children (with a selectable "(this)" row when it is itself a creature),
+/// children (with a selectable "(this)" row when it is itself an archetype),
 /// else a selectable leaf.
 fn show_archetype_node(
     ui: &mut egui::Ui,


### PR DESCRIPTION
The Archetypes tab now lists **every** template with an inheritance-aware `PropModelName` — weapons, items, props, projectiles — not just creatures (1666 archetypes, 81 of them creatures). Creature templates keep their clip list; non-creatures show the model with no clip panel.

- `Archetype.creature_type` is `Option<u32>` (+ `is_creature()`, used uniformly); `--clip` on a non-creature exits 2 with a clear message.
- `--archetype Pistol` resolves to template -17 (`atek_w.bin`) and renders it headlessly.
- Sorts tie-break on template id so tree/search order is reproducible at this scale.

### Screenshots
| Pistol archetype (no clip panel) | Creature regression (clip playing) |
|---|---|
| ![pistol](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/a34bd9ccc4f83c61d2c0f866edb7517a3cbc3b8c/pistol.png) | ![creature](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/a34bd9ccc4f83c61d2c0f866edb7517a3cbc3b8c/creature_clip.png) |

Reviewed (Claude reviewer): verdict clean — no correctness defects; both Low findings addressed (deterministic sort tie-break; the duplicate screenshot was dropped from evidence).