### PR TITLE
feat(tools): LGMD sub-object/vhot articulation overlay in dark_explorer

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -22,11 +22,21 @@ fn flip_winding(winding: FrontFaceWinding) -> FrontFaceWinding {
     }
 }
 
+/// One LGMD sub-object: a named part of a static `.bin` (the pieces an in-game
+/// tweq rotates or translates - a gun slide, a door leaf) and its pivot in
+/// model space. Empty for LGMM/AI and GLB models, which articulate via joints.
+#[derive(Clone, Debug)]
+pub struct SubObject {
+    pub name: String,
+    pub transform: Matrix4<f32>,
+}
+
 #[derive(Clone)]
 pub struct StaticModel {
     scene_objects: Vec<SceneObject>,
     bounding_box: Aabb3<f32>,
     vhots: Vec<Vhot>,
+    sub_objects: Vec<SubObject>,
 }
 
 impl StaticModel {
@@ -52,6 +62,7 @@ impl StaticModel {
             scene_objects: new_scene_objects,
             bounding_box: model.bounding_box,
             vhots: model.vhots.clone(),
+            sub_objects: model.sub_objects.clone(),
         }
     }
 }
@@ -63,6 +74,7 @@ pub struct AnimatedModel {
     hit_boxes: Rc<HashMap<u32, Aabb3<f32>>>,
     hit_box_shapes: Rc<HashMap<u32, HitBoxShape>>,
     vhots: Vec<Vhot>,
+    sub_objects: Vec<SubObject>,
     /// Set only for a `PMNM` mesh, whose vertices are in bind-pose model space
     /// rather than joint-local space. Holds `bind_inverse[j] * bind_correction`,
     /// so the posed palette becomes `pose[j] * bind[j]`.
@@ -146,6 +158,7 @@ impl AnimatedModel {
             hit_boxes: self.hit_boxes.clone(),
             hit_box_shapes: self.hit_box_shapes.clone(),
             vhots: self.vhots.clone(),
+            sub_objects: self.sub_objects.clone(),
             bind: self.bind.clone(),
         }
     }
@@ -168,6 +181,7 @@ impl AnimatedModel {
             hit_boxes: model.hit_boxes.clone(),
             hit_box_shapes: model.hit_box_shapes.clone(),
             vhots: model.vhots.clone(),
+            sub_objects: model.sub_objects.clone(),
             bind: model.bind.clone(),
         }
     }
@@ -198,6 +212,18 @@ impl Model {
             ss2_bin_obj_loader::to_scene_objects(&static_mesh, asset_cache);
         let bounding_box = static_mesh.bounding_box;
 
+        // Sub-object pivots, in model space: the skeleton the obj loader just
+        // built from the sub-object tree is exactly that hierarchy resolved.
+        let sub_objects = static_mesh
+            .sub_objects
+            .iter()
+            .enumerate()
+            .map(|(index, sub_object)| SubObject {
+                name: sub_object.name.clone(),
+                transform: skeleton.global_transform(&(index as u32)),
+            })
+            .collect::<Vec<SubObject>>();
+
         if skeleton.bone_count() > 1 {
             let hit_boxes = HashMap::new();
             Model {
@@ -208,6 +234,7 @@ impl Model {
                     hit_boxes: Rc::new(hit_boxes),
                     hit_box_shapes: Rc::new(HashMap::new()),
                     vhots: static_mesh.vhots.clone(),
+                    sub_objects,
                     bind: None,
                 }),
             }
@@ -218,6 +245,7 @@ impl Model {
                     scene_objects,
                     bounding_box,
                     vhots: static_mesh.vhots.clone(),
+                    sub_objects,
                 }),
             }
         }
@@ -275,6 +303,7 @@ impl Model {
                 hit_boxes: Rc::new(hit_boxes),
                 hit_box_shapes: Rc::new(hit_box_shapes),
                 vhots: vec![],
+                sub_objects: vec![],
                 bind,
             }),
         }
@@ -300,6 +329,7 @@ impl Model {
                     hit_boxes: Rc::new(hit_boxes),
                     hit_box_shapes: Rc::new(HashMap::new()),
                     vhots: vec![],
+                    sub_objects: vec![],
                     bind: None,
                 }),
             }
@@ -312,6 +342,7 @@ impl Model {
                     scene_objects,
                     bounding_box,
                     vhots: vec![],
+                    sub_objects: vec![],
                 }),
             }
         }
@@ -347,6 +378,15 @@ impl Model {
         match &self.inner {
             InnerModel::Animated(animated_model) => animated_model.vhots.clone(),
             InnerModel::Static(static_model) => static_model.vhots.clone(),
+        }
+    }
+
+    /// The LGMD sub-object pivots (see [`SubObject`]). Empty unless this model
+    /// came from an object `.bin`.
+    pub fn sub_objects(&self) -> &[SubObject] {
+        match &self.inner {
+            InnerModel::Animated(animated_model) => &animated_model.sub_objects,
+            InnerModel::Static(static_model) => &static_model.sub_objects,
         }
     }
 
@@ -564,6 +604,7 @@ mod tests {
                 scene_objects: vec![object],
                 bounding_box: Aabb3::new(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 1.0)),
                 vhots: Vec::new(),
+                sub_objects: Vec::new(),
             }),
         }
     }

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -214,6 +214,8 @@ impl Model {
 
         // Sub-object pivots, in model space: the skeleton the obj loader just
         // built from the sub-object tree is exactly that hierarchy resolved.
+        // Same pairs as `ss2_bin_obj_loader::sub_object_transforms` - keep them
+        // in step.
         let sub_objects = static_mesh
             .sub_objects
             .iter()

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -969,8 +969,7 @@ pub struct SubObjectHeader {
     idx: u32,
     #[allow(dead_code)]
     parent_idx: i32,
-    #[allow(dead_code)]
-    name: String,
+    pub name: String,
     transform: Matrix4<f32>,
     #[allow(dead_code)]
     min_range: f32,

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -1239,6 +1239,41 @@ mod tests {
         }
     }
 
+    fn sub_object(name: &str, local: Vector3<f32>, child: i16, next: i16) -> SubObjectHeader {
+        SubObjectHeader {
+            idx: 0,
+            parent_idx: -1,
+            name: name.to_owned(),
+            transform: Matrix4::from_translation(local),
+            min_range: 0.0,
+            max_range: 0.0,
+            child_sub_obj_idx: child,
+            next_sub_obj_idx: next,
+            point_start: 0,
+            point_stop: 0,
+        }
+    }
+
+    /// A sub-object's authored transform is relative to its parent, so a pivot
+    /// is only right once the chain is composed - this is what
+    /// `Model::sub_objects` (which needs GL, hence the test at this level)
+    /// hands the articulation overlay.
+    #[test]
+    fn sub_object_transforms_compose_the_parent_chain() {
+        let mut mesh = mesh_with(vec![], vec![]);
+        mesh.sub_objects = vec![
+            sub_object("parent", vec3(1.0, 0.0, 0.0), 1, -1),
+            sub_object("child", vec3(0.0, 1.0, 0.0), -1, -1),
+        ];
+
+        let transforms = sub_object_transforms(&mesh);
+
+        assert_eq!(transforms[0].0, "parent");
+        assert_eq!(transforms[0].1.w.truncate(), vec3(1.0, 0.0, 0.0));
+        assert_eq!(transforms[1].0, "child");
+        assert_eq!(transforms[1].1.w.truncate(), vec3(1.0, 1.0, 0.0));
+    }
+
     #[test]
     fn retain_materials_keeps_only_the_selected_slots() {
         let mesh = mesh_with(

--- a/tools/dark_explorer/src/main.rs
+++ b/tools/dark_explorer/src/main.rs
@@ -68,6 +68,11 @@ enum Commands {
         #[arg(long)]
         hitboxes: bool,
 
+        /// Start the 3D model preview with the LGMD articulation overlay on
+        /// (sub-object pivots + vhots)
+        #[arg(long)]
+        articulation: bool,
+
         /// Open the Archetypes tab with this archetype selected (name or template id)
         #[arg(long)]
         archetype: Option<String>,
@@ -221,6 +226,7 @@ fn main() {
             grid,
             skeletons,
             hitboxes,
+            articulation,
             archetype,
             clip,
             advance,
@@ -233,6 +239,7 @@ fn main() {
             grid,
             skeletons,
             hitboxes,
+            articulation,
             archetype,
             clip,
             advance,

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -71,14 +71,19 @@ pub struct ModelPreview {
     engine: Box<dyn Engine>,
     asset_cache: AssetCache,
     /// What the current scene (or error) was built for: (key, scene, skeletons,
-    /// hitboxes). Guards against rebuilding — or re-panicking — every frame.
-    built_for: Option<(String, PreviewScene, bool, bool)>,
+    /// hitboxes, articulation). Guards against rebuilding — or re-panicking —
+    /// every frame.
+    built_for: Option<(String, PreviewScene, bool, bool, bool)>,
     scene: Option<Box<dyn ToolScene>>,
     /// The scene plays an animation clip, so it re-renders every frame.
     animated: bool,
     error: Option<String>,
     pub debug_skeletons: bool,
     pub debug_hit_boxes: bool,
+    pub debug_articulation: bool,
+    /// (sub-object, vhot) counts of the loaded LGMD model, when it has any -
+    /// what the articulation overlay would draw.
+    articulation: Option<(usize, usize)>,
     /// Suspend the per-frame wall-clock tick of an animated scene, so
     /// `advance()` is the only time source - `--screenshot` runs set this to
     /// capture a deterministic pose.
@@ -113,6 +118,8 @@ impl ModelPreview {
             error: None,
             debug_skeletons: false,
             debug_hit_boxes: false,
+            debug_articulation: false,
+            articulation: None,
             paused: false,
             yaw: 65.0,
             pitch: 75.0,
@@ -151,6 +158,11 @@ impl ModelPreview {
             if !matches!(scene, PreviewScene::Skeleton(_)) {
                 ui.checkbox(&mut self.debug_skeletons, "Skeleton");
                 ui.checkbox(&mut self.debug_hit_boxes, "Hitboxes");
+            }
+            // Only an object (LGMD) .bin has sub-objects/vhots to show.
+            if let Some((sub_objects, vhots)) = self.articulation {
+                ui.checkbox(&mut self.debug_articulation, "Articulation");
+                ui.label(format!("({sub_objects} sub-objects, {vhots} vhots)"));
             }
             ui.label("(drag to orbit, scroll to zoom)");
         });
@@ -203,6 +215,7 @@ impl ModelPreview {
             scene.clone(),
             self.debug_skeletons,
             self.debug_hit_boxes,
+            self.debug_articulation,
         );
         if self.built_for.as_ref() == Some(&wanted) {
             return;
@@ -212,6 +225,7 @@ impl ModelPreview {
         self.scene = None;
         self.animated = false;
         self.error = None;
+        self.articulation = None;
         // Load the model eagerly under catch_unwind — the scene itself defers
         // loading to render, and Dark parsers panic on malformed input; a
         // failure becomes an error label instead of a crash. The key resolves
@@ -233,6 +247,7 @@ impl ModelPreview {
                 &self.asset_cache,
                 self.debug_skeletons,
                 self.debug_hit_boxes,
+                self.debug_articulation,
             )
             .map(|scene| Box::new(scene) as Box<dyn ToolScene>)
             .map_err(|err| err.to_string()),
@@ -263,6 +278,13 @@ impl ModelPreview {
             })
             .and_then(|r| r),
         };
+        // Offer the articulation toggle only where there is something to draw.
+        if matches!(scene, PreviewScene::Model) {
+            let counts = (model.sub_objects().len(), model.vhots().len());
+            if counts != (0, 0) {
+                self.articulation = Some(counts);
+            }
+        }
         match built {
             Ok(built) => {
                 self.scene = Some(built);

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -285,6 +285,15 @@ impl ModelPreview {
                 self.articulation = Some(counts);
             }
         }
+        // No toggle means no way to turn it back off, so don't carry a hidden
+        // "on" over from the previous model. Keep `built_for` in step or the
+        // next frame rebuilds the scene for nothing.
+        if self.articulation.is_none() {
+            self.debug_articulation = false;
+            if let Some(built_for) = &mut self.built_for {
+                built_for.4 = false;
+            }
+        }
         match built {
             Ok(built) => {
                 self.scene = Some(built);

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -37,6 +37,7 @@ pub struct UiOptions {
     /// `--screenshot` run can capture the debug overlays).
     pub skeletons: bool,
     pub hitboxes: bool,
+    pub articulation: bool,
     /// Open the Archetypes tab with this archetype selected (name or
     /// template id), optionally playing `clip`, advanced by `advance` seconds
     /// of simulation time before a `--screenshot` capture.
@@ -257,7 +258,7 @@ pub struct ExplorerApp {
     /// every family's archives and creates the engine render host.
     model_preview: Option<ModelPreview>,
     /// Initial overlay toggles for the model preview (from the CLI).
-    initial_overlays: (bool, bool),
+    initial_overlays: (bool, bool, bool),
     frames_rendered: u32,
     /// Whether the screenshot viewport command was already sent (grid mode
     /// delays it until the visible thumbnails have decoded).
@@ -346,7 +347,7 @@ impl ExplorerApp {
             audio_error: None,
             screenshot: options.screenshot,
             model_preview: None,
-            initial_overlays: (options.skeletons, options.hitboxes),
+            initial_overlays: (options.skeletons, options.hitboxes, options.articulation),
             frames_rendered: 0,
             screenshot_sent: false,
             scroll_frames: 0,
@@ -1786,13 +1787,14 @@ impl ExplorerApp {
 /// time source (a deterministic pose per invocation).
 fn preview_host(
     model_preview: &mut Option<ModelPreview>,
-    (skeletons, hitboxes): (bool, bool),
+    (skeletons, hitboxes, articulation): (bool, bool, bool),
     paused: bool,
 ) -> &mut ModelPreview {
     model_preview.get_or_insert_with(|| {
         let mut host = ModelPreview::new();
         host.debug_skeletons = skeletons;
         host.debug_hit_boxes = hitboxes;
+        host.debug_articulation = articulation;
         host.paused = paused;
         host
     })

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -83,6 +83,10 @@ struct Cli {
     /// Overlay the fitted per-joint hit-box shapes (capsules/boxes) for AI meshes (.bin).
     #[arg(long)]
     debug_hitboxes: bool,
+
+    /// Overlay LGMD sub-object pivots and vhots for object meshes (.bin).
+    #[arg(long)]
+    debug_articulation: bool,
 }
 
 use dark_viewer::normalize_clip_name;
@@ -175,6 +179,7 @@ fn create_scene(
     asset_cache: &mut engine::assets::asset_cache::AssetCache,
     debug_skeletons: bool,
     debug_hit_boxes: bool,
+    debug_articulation: bool,
 ) -> Result<Box<dyn ToolScene>, Box<dyn std::error::Error>> {
     let lower = filename.to_ascii_lowercase();
     if is_cutscene_file(&lower) {
@@ -198,6 +203,7 @@ fn create_scene(
                 asset_cache,
                 debug_skeletons,
                 debug_hit_boxes,
+                debug_articulation,
             )?;
             Ok(Box::new(scene))
         } else {
@@ -331,6 +337,7 @@ pub fn main() {
             &mut game.asset_cache,
             debug_skeletons,
             debug_hit_boxes,
+            cli.debug_articulation,
         ) {
             Ok(_) => println!("Scene creation succeeded."),
             Err(err) => println!("Error creating scene: {err}"),
@@ -346,6 +353,7 @@ pub fn main() {
         &mut game.asset_cache,
         debug_skeletons,
         debug_hit_boxes,
+        cli.debug_articulation,
     ) {
         Ok(scene) => scene,
         Err(err) => {

--- a/tools/dark_viewer/src/scenes/bin_ai_viewer.rs
+++ b/tools/dark_viewer/src/scenes/bin_ai_viewer.rs
@@ -100,18 +100,16 @@ impl ToolScene for BinAiViewerScene {
     }
 
     fn render(&self, asset_cache: &mut AssetCache) -> Scene {
-        let mut objects = self.model.to_animated_scene_objects(&self.animation_player);
+        let objects = self.model.to_animated_scene_objects(&self.animation_player);
 
-        // Add ground plane
-        objects.push(create_ground_plane(asset_cache));
-
-        // Add axes gizmo
-        objects.extend(create_axes_gizmo(asset_cache));
+        let mut decorations = vec![create_ground_plane(asset_cache)];
+        decorations.extend(create_axes_gizmo(asset_cache));
 
         build_model_scene_with_debug_skeletons(
             self.model.as_ref(),
             Some(&self.animation_player),
             objects,
+            decorations,
             self.debug_skeletons,
             self.debug_hit_boxes,
             // LGMM meshes carry no sub-objects or vhots.

--- a/tools/dark_viewer/src/scenes/bin_ai_viewer.rs
+++ b/tools/dark_viewer/src/scenes/bin_ai_viewer.rs
@@ -114,6 +114,8 @@ impl ToolScene for BinAiViewerScene {
             objects,
             self.debug_skeletons,
             self.debug_hit_boxes,
+            // LGMM meshes carry no sub-objects or vhots.
+            false,
         )
     }
 }

--- a/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
+++ b/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
@@ -69,18 +69,16 @@ impl ToolScene for BinObjViewerScene {
 
     fn render(&self, asset_cache: &mut AssetCache) -> Scene {
         let turret = asset_cache.get(&MODELS_IMPORTER, &self.model_name);
-        let mut turret_scene_objects = turret.to_animated_scene_objects(&self.animation_player);
+        let turret_scene_objects = turret.to_animated_scene_objects(&self.animation_player);
 
-        // Add ground plane
-        turret_scene_objects.push(create_ground_plane(asset_cache));
-
-        // Add axes gizmo
-        turret_scene_objects.extend(create_axes_gizmo(asset_cache));
+        let mut decorations = vec![create_ground_plane(asset_cache)];
+        decorations.extend(create_axes_gizmo(asset_cache));
 
         build_model_scene_with_debug_skeletons(
             turret.as_ref(),
             Some(&self.animation_player),
             turret_scene_objects,
+            decorations,
             self.debug_skeletons,
             self.debug_hit_boxes,
             self.debug_articulation,

--- a/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
+++ b/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
@@ -19,6 +19,7 @@ pub struct BinObjViewerScene {
     animation_player: AnimationPlayer,
     debug_skeletons: bool,
     debug_hit_boxes: bool,
+    debug_articulation: bool,
 }
 
 impl BinObjViewerScene {
@@ -27,6 +28,7 @@ impl BinObjViewerScene {
         _asset_cache: &AssetCache,
         debug_skeletons: bool,
         debug_hit_boxes: bool,
+        debug_articulation: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         // We don't load the model here, we'll load it during render using the asset cache
         let animation_player = AnimationPlayer::empty();
@@ -42,6 +44,7 @@ impl BinObjViewerScene {
             animation_player,
             debug_skeletons,
             debug_hit_boxes,
+            debug_articulation,
         })
     }
 }
@@ -80,6 +83,7 @@ impl ToolScene for BinObjViewerScene {
             turret_scene_objects,
             self.debug_skeletons,
             self.debug_hit_boxes,
+            self.debug_articulation,
         )
     }
 }

--- a/tools/dark_viewer/src/scenes/render_helpers.rs
+++ b/tools/dark_viewer/src/scenes/render_helpers.rs
@@ -1,4 +1,4 @@
-use cgmath::{Matrix4, Vector3};
+use cgmath::{EuclideanSpace, Matrix4, Vector3};
 use dark::{importers::TEXTURE_IMPORTER, model::Model, motion::AnimationPlayer};
 use engine::assets::asset_cache::AssetCache;
 use engine::scene::{
@@ -8,6 +8,44 @@ use engine::scene::{
 
 /// Color of the fitted hit-box wireframe overlay (bright green).
 const HIT_BOX_OVERLAY_COLOR: Vector3<f32> = Vector3::new(0.2, 1.0, 0.3);
+
+/// Articulation overlay: LGMD sub-object pivots (magenta) and vhots (yellow).
+const SUB_OBJECT_COLOR: Vector3<f32> = Vector3::new(1.0, 0.2, 0.85);
+const VHOT_COLOR: Vector3<f32> = Vector3::new(1.0, 0.85, 0.1);
+const SUB_OBJECT_MARKER_SIZE: f32 = 0.05;
+const VHOT_MARKER_SIZE: f32 = 0.035;
+
+/// How much of the mesh shows through under an overlay (0 = opaque).
+const OVERLAY_GHOST_TRANSPARENCY: f32 = 0.35;
+
+/// Markers for a static `.bin`'s articulation points: one cube per sub-object
+/// pivot (the parts tweqs rotate/translate) and one per vhot (attachment
+/// points - muzzle, light, particle origins). Empty for LGMM/GLB models.
+pub fn articulation_overlay(model: &Model) -> Vec<SceneObject> {
+    let model_transform = model.get_transform();
+    let marker = |color: Vector3<f32>, at: Matrix4<f32>, size: f32| {
+        let mut obj = SceneObject::new(color_material::create(color), Box::new(cube::create()));
+        obj.set_transform(model_transform * at * Matrix4::from_scale(size));
+        obj
+    };
+
+    let mut objects = model
+        .sub_objects()
+        .iter()
+        .map(|sub_object| {
+            // Pivot only: the sub-object's rotation would skew the cube.
+            let at = Matrix4::from_translation(sub_object.transform.w.truncate());
+            marker(SUB_OBJECT_COLOR, at, SUB_OBJECT_MARKER_SIZE)
+        })
+        .collect::<Vec<SceneObject>>();
+
+    objects.extend(model.vhots().iter().map(|vhot| {
+        let at = Matrix4::from_translation(vhot.point.to_vec());
+        marker(VHOT_COLOR, at, VHOT_MARKER_SIZE)
+    }));
+
+    objects
+}
 
 /// The model's joint palette in world space: each joint transform with the
 /// model transform applied, as the debug skeleton and hit-box overlays want it.
@@ -20,43 +58,62 @@ pub fn world_joint_transforms(model: &Model, player: &AnimationPlayer) -> Vec<Ma
         .collect()
 }
 
-/// Compose a scene for a model, optionally overlaying debug skeletons and/or the
-/// fitted per-joint hit-box shapes (`dark::hit_box`). The hit-box overlay renders
-/// exactly what `fit_hit_box_shapes` produced, transformed by the live joint
-/// transforms - so it tracks the animated mesh and reveals fit/mapping issues
-/// independent of the physics ragdoll.
+/// Compose a scene for a model, optionally overlaying debug skeletons, the
+/// fitted per-joint hit-box shapes (`dark::hit_box`), and/or the LGMD
+/// articulation markers. The hit-box overlay renders exactly what
+/// `fit_hit_box_shapes` produced, transformed by the live joint transforms - so
+/// it tracks the animated mesh and reveals fit/mapping issues independent of the
+/// physics ragdoll.
 pub fn build_model_scene_with_debug_skeletons(
     model: &Model,
     animation_player: Option<&AnimationPlayer>,
     mut objects: Vec<SceneObject>,
     debug_skeletons: bool,
     debug_hit_boxes: bool,
+    debug_articulation: bool,
 ) -> Scene {
+    let mut overlay = Vec::new();
+
     if (debug_skeletons || debug_hit_boxes) && model.is_animated() {
         if let Some(player) = animation_player {
-            objects.iter_mut().for_each(|obj| {
-                obj.set_depth_write(false);
-                obj.set_skinned_transparency(Some(0.35));
-            });
-
             let world_joints = world_joint_transforms(model, player);
 
             if debug_skeletons {
-                let mut debug_skeleton = model.draw_debug_skeleton(&world_joints);
-                objects.append(&mut debug_skeleton);
+                overlay.append(&mut model.draw_debug_skeleton(&world_joints));
             }
 
             if debug_hit_boxes {
-                let mut debug_hit_boxes = dark::hit_box::draw_debug_hit_box_shapes(
+                overlay.append(&mut dark::hit_box::draw_debug_hit_box_shapes(
                     &model.hit_box_shapes(),
                     &world_joints,
                     HIT_BOX_OVERLAY_COLOR,
-                );
-                objects.append(&mut debug_hit_boxes);
+                ));
             }
         }
     }
 
+    // Ghost the mesh so overlay geometry buried inside it still reads.
+    if !overlay.is_empty() {
+        objects.iter_mut().for_each(|obj| {
+            obj.set_depth_write(false);
+            obj.set_skinned_transparency(Some(OVERLAY_GHOST_TRANSPARENCY));
+        });
+    }
+
+    if debug_articulation {
+        let mut markers = articulation_overlay(model);
+        if !markers.is_empty() {
+            // An LGMD mesh is not skinned, so ghosting it takes the per-object
+            // transparency override instead of the material one above.
+            objects.iter_mut().for_each(|obj| {
+                obj.set_depth_write(false);
+                obj.set_transparency(Some(OVERLAY_GHOST_TRANSPARENCY));
+            });
+            overlay.append(&mut markers);
+        }
+    }
+
+    objects.append(&mut overlay);
     Scene::from_objects(objects)
 }
 

--- a/tools/dark_viewer/src/scenes/render_helpers.rs
+++ b/tools/dark_viewer/src/scenes/render_helpers.rs
@@ -39,6 +39,8 @@ pub fn articulation_overlay(model: &Model) -> Vec<SceneObject> {
         })
         .collect::<Vec<SceneObject>>();
 
+    // These coincide with the small blue cubes the LGMD loader itself bakes in
+    // at every vhot (`ss2_bin_obj_loader::to_scene_objects`) - see issue #1208.
     objects.extend(model.vhots().iter().map(|vhot| {
         let at = Matrix4::from_translation(vhot.point.to_vec());
         marker(VHOT_COLOR, at, VHOT_MARKER_SIZE)
@@ -64,10 +66,14 @@ pub fn world_joint_transforms(model: &Model, player: &AnimationPlayer) -> Vec<Ma
 /// `fit_hit_box_shapes` produced, transformed by the live joint transforms - so
 /// it tracks the animated mesh and reveals fit/mapping issues independent of the
 /// physics ragdoll.
+///
+/// `decorations` (ground plane, axes gizmo) are kept apart from the model's own
+/// objects so that ghosting under an overlay touches only the mesh.
 pub fn build_model_scene_with_debug_skeletons(
     model: &Model,
     animation_player: Option<&AnimationPlayer>,
-    mut objects: Vec<SceneObject>,
+    mut model_objects: Vec<SceneObject>,
+    mut decorations: Vec<SceneObject>,
     debug_skeletons: bool,
     debug_hit_boxes: bool,
     debug_articulation: bool,
@@ -92,29 +98,22 @@ pub fn build_model_scene_with_debug_skeletons(
         }
     }
 
-    // Ghost the mesh so overlay geometry buried inside it still reads.
+    if debug_articulation {
+        overlay.append(&mut articulation_overlay(model));
+    }
+
+    // Ghost the model (and only the model - not the grid) so overlay geometry
+    // buried inside the mesh still reads.
     if !overlay.is_empty() {
-        objects.iter_mut().for_each(|obj| {
+        model_objects.iter_mut().for_each(|obj| {
             obj.set_depth_write(false);
-            obj.set_skinned_transparency(Some(OVERLAY_GHOST_TRANSPARENCY));
+            obj.set_transparency(Some(OVERLAY_GHOST_TRANSPARENCY));
         });
     }
 
-    if debug_articulation {
-        let mut markers = articulation_overlay(model);
-        if !markers.is_empty() {
-            // An LGMD mesh is not skinned, so ghosting it takes the per-object
-            // transparency override instead of the material one above.
-            objects.iter_mut().for_each(|obj| {
-                obj.set_depth_write(false);
-                obj.set_transparency(Some(OVERLAY_GHOST_TRANSPARENCY));
-            });
-            overlay.append(&mut markers);
-        }
-    }
-
-    objects.append(&mut overlay);
-    Scene::from_objects(objects)
+    model_objects.append(&mut decorations);
+    model_objects.append(&mut overlay);
+    Scene::from_objects(model_objects)
 }
 
 /// Create a ground plane SceneObject with grid texture and proper scaling


### PR DESCRIPTION
Adds an **Articulation** toggle to the 3D model preview: for LGMD static models it overlays each sub-object pivot (magenta) and each vhot (yellow) — making a weapon's slide joint and muzzle attachment point visible.

- `dark` (additive): `Model::sub_objects()` (name + pivot transform, read off the skeleton the loader already builds) and `SubObjectHeader::name` made pub; unit test pins the parent-chain composition.
- The checkbox appears only when the model actually has sub-objects/vhots, with the counts beside it; `--articulation` (dark_explorer) and `--debug-articulation` (dark_viewer) for captures.
- Ghosting now applies to the model only — the ground plane/axes no longer change when overlays toggle (fixed for the pre-existing skeleton path too).
- Filed #1208: the loader bakes unconditional blue debug cubes at every vhot, in-game included — likely unintended, left for its own pass.
- Missions e2e re-run after the `dark` change: 23/23 pass.

### Screenshots (atek_h.bin — the pistol viewmodel)
| Articulation ON | OFF | Marker close-up |
|---|---|---|
| ![on](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/ee84a76cd75f4f9040f2ddcbbef8b44f9d00961a/atek_on_v2.png) | ![off](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/ee84a76cd75f4f9040f2ddcbbef8b44f9d00961a/atek_off_v2.png) | ![crop](https://gist.github.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/ee84a76cd75f4f9040f2ddcbbef8b44f9d00961a/crop_a_atek_articulation_on.png) |

Reviewed (Claude reviewer): no Critical/High; both Mediums (decoration ghosting, doubled vhot cubes → issue #1208 + comment) and Lows fixed and re-verified (grid pixel-identical across the toggle).