### PR TITLE
feat(hud): retail enemy health bar above the selection brackets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,22 @@ interaction, deterministic fixed-timestep), assembles the GIF, hosts the
 binaries in a gist, and embeds them in the PR body. Run the capture in a
 subagent when the active agent supports delegation; otherwise run it inline.
 
-### 5. Token-Efficient Tool Output
+### 5. Save Compatibility Is Not a Concern Before v1
+
+**Do not spend effort keeping pre-existing save files working.** Until v1 ships,
+a change is free to add a property, rename a field, or alter the serialized
+shape without a migration, and "this breaks saves made before this commit" is
+not a valid review finding. Re-saving is the expected fix.
+
+This specifically covers the `restore_missing_component!` backfill list in
+`shock2vr/src/mission/entity_populator/save_file_entity_populator.rs`: a newly
+parsed property does **not** need an entry there just because old saves predate
+it. Add one only when a save in active use would otherwise break.
+
+Saves must still round-trip correctly *within* a build — a save written by the
+current code must load in the current code.
+
+### 6. Token-Efficient Tool Output
 
 A 30-day audit of agent sessions (the `audit-our-commands` skill) showed most
 tool-result tokens go to *reading habits*, not to game tooling — `sed`-paging

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -500,6 +500,13 @@ pub struct PropLocalPlayer {}
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropHUDSelect(pub bool);
 
+/// "ShowHP" ("Show HP?"): opt-in for the hit-point bar drawn above the
+/// selection brackets. Separate from [`PropHUDSelect`], which only gates the
+/// brackets themselves - the shipped data sets this on the creature families
+/// so loot and set dressing stay bar-less.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropShowHP(pub bool);
+
 /// "AI_Patrol": when true, the AI patrols a route of patrol-point objects
 /// chained by `Link::AIPatrol`, walking point to point while idle.
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
@@ -1515,6 +1522,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$HUDSelect",
             |reader, _len| read_bool(reader),
             PropHUDSelect,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$ShowHP",
+            |reader, _len| read_bool(reader),
+            PropShowHP,
             accumulator::latest,
         ),
         define_prop(

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -117,37 +117,39 @@ pub struct SceneObject {
 }
 
 impl SceneObject {
+    /// Places a unit quad at `position` with `size`, in screen pixels with the
+    /// origin at the top-left. Shared by every screen-space quad constructor so
+    /// they cannot drift apart on where a rect lands.
+    fn screen_space_quad_object(
+        material: Box<dyn Material>,
+        position: Vector2<f32>,
+        size: Vector2<f32>,
+    ) -> SceneObject {
+        let xform = Matrix4::from_translation(vec3(position.x, position.y, 0.0))
+            * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
+            * Matrix4::from_translation(vec3(0.5, 0.5, 0.0));
+        let mut ret = Self::new(material, Box::new(quad::create()));
+        ret.set_local_transform(xform);
+        ret
+    }
+
     pub fn screen_space_quad2(
         texture: Rc<dyn TextureTrait>,
         position: Vector2<f32>,
         size: Vector2<f32>,
         opacity: f32,
     ) -> SceneObject {
-        let mesh = quad::create();
         let material =
             materials::ScreenSpaceMaterial::create(texture, vec4(1.0, 1.0, 1.0, opacity));
-
-        let xform = Matrix4::from_translation(vec3(position.x, position.y, 0.0))
-            * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
-            * Matrix4::from_translation(vec3(0.5, 0.5, 0.0));
-        let mut ret = Self::new(material, Box::new(mesh));
-        ret.set_local_transform(xform);
-        ret
+        Self::screen_space_quad_object(material, position, size)
     }
     pub fn screen_space_quad(
         texture: Rc<dyn TextureTrait>,
         position: Vector2<f32>,
         size: Vector2<f32>,
     ) -> SceneObject {
-        let mesh = quad::create();
         let material = materials::ScreenSpaceMaterial::create(texture, vec4(1.0, 1.0, 1.0, 1.0));
-
-        let xform = Matrix4::from_translation(vec3(position.x, position.y, 0.0))
-            * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
-            * Matrix4::from_translation(vec3(0.5, 0.5, 0.0));
-        let mut ret = Self::new(material, Box::new(mesh));
-        ret.set_local_transform(xform);
-        ret
+        Self::screen_space_quad_object(material, position, size)
     }
     /// A screen-space quad whose texture is *clipped* at `clip` (0..1) of its
     /// width rather than scaled to it: the bitmap draws at `size` and
@@ -161,12 +163,7 @@ impl SceneObject {
         clip: f32,
     ) -> SceneObject {
         let material = crate::scene::clipped_screen_material::create_screen_space(texture, clip);
-        let xform = Matrix4::from_translation(vec3(position.x, position.y, 0.0))
-            * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
-            * Matrix4::from_translation(vec3(0.5, 0.5, 0.0));
-        let mut ret = Self::new(material, Box::new(quad::create()));
-        ret.set_local_transform(xform);
-        ret
+        Self::screen_space_quad_object(material, position, size)
     }
 
     /// Glyph quads for `str` at `font_size`, laid out from `origin` as the

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -149,6 +149,26 @@ impl SceneObject {
         ret.set_local_transform(xform);
         ret
     }
+    /// A screen-space quad whose texture is *clipped* at `clip` (0..1) of its
+    /// width rather than scaled to it: the bitmap draws at `size` and
+    /// everything past `clip` is discarded. This is what a fill bar wants -
+    /// the artwork's right-hand border disappears as the bar drains instead of
+    /// sliding inwards.
+    pub fn screen_space_clipped_quad(
+        texture: Rc<dyn TextureTrait>,
+        position: Vector2<f32>,
+        size: Vector2<f32>,
+        clip: f32,
+    ) -> SceneObject {
+        let material = crate::scene::clipped_screen_material::create_screen_space(texture, clip);
+        let xform = Matrix4::from_translation(vec3(position.x, position.y, 0.0))
+            * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
+            * Matrix4::from_translation(vec3(0.5, 0.5, 0.0));
+        let mut ret = Self::new(material, Box::new(quad::create()));
+        ret.set_local_transform(xform);
+        ret
+    }
+
     /// Glyph quads for `str` at `font_size`, laid out from `origin` as the
     /// **top-left of the line**, x growing right and y growing down.
     ///

--- a/engine/src/texture.rs
+++ b/engine/src/texture.rs
@@ -123,6 +123,17 @@ pub fn bind(texture: &Texture) {
     bind0(texture);
 }
 
+/// How a texture is sampled when it does not map 1:1 to pixels.
+#[derive(Hash, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TextureFilter {
+    /// Blend neighbouring texels. Right for world and scaled-up art.
+    Linear,
+    /// Snap to the nearest texel. Right for colour-keyed HUD bitmaps drawn
+    /// minified: blending across the key boundary turns it into a visible
+    /// fringe that no colour-key test can then recognize.
+    Nearest,
+}
+
 #[derive(Hash)]
 pub struct TextureOptions {
     pub wrap: bool,
@@ -130,6 +141,7 @@ pub struct TextureOptions {
     /// (PCX). Dark bitmap sprites (particles) are keyed this way; wall/UI
     /// textures are not, so this is opt-in.
     pub transparent_index_0: bool,
+    pub filter: TextureFilter,
 }
 
 impl Default for TextureOptions {
@@ -137,6 +149,7 @@ impl Default for TextureOptions {
         TextureOptions {
             wrap: true,
             transparent_index_0: false,
+            filter: TextureFilter::Linear,
         }
     }
 }
@@ -163,8 +176,12 @@ pub fn init_from_memory2(raw_texture_data: RawTextureData, options: &TextureOpti
         // gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as i32);
 
         // set texture filtering parameters
-        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR as i32);
-        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR as i32);
+        let filter = match options.filter {
+            TextureFilter::Linear => gl::LINEAR,
+            TextureFilter::Nearest => gl::NEAREST,
+        };
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, filter as i32);
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, filter as i32);
     }
 
     let pixel_format = match raw_texture_data.format {

--- a/shock2vr/src/hud/damage_flash.rs
+++ b/shock2vr/src/hud/damage_flash.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use shipyard::{EntityId, Unique};
+
+/// How long a damaged creature keeps showing its brackets and health bar with
+/// nothing highlighting it. The original marks the object with a `HUDTime`
+/// expiry when it takes damage, which is why a creature you shoot from cover
+/// stays legible for a moment afterwards.
+pub const DAMAGE_FLASH_DURATION: Duration = Duration::from_secs(5);
+
+/// Entities whose HUD overlay is currently forced on by recent damage, keyed by
+/// the elapsed mission time at which the overlay stops.
+#[derive(Unique, Default)]
+pub struct DamageFlash {
+    expiry: HashMap<EntityId, Duration>,
+}
+
+impl DamageFlash {
+    pub fn arm(&mut self, entity_id: EntityId, now: Duration) {
+        self.expiry.insert(entity_id, now + DAMAGE_FLASH_DURATION);
+    }
+
+    /// The entities still flashing at `now`. Expired entries are dropped here
+    /// rather than on a timer, so the map cannot grow with every creature the
+    /// player has ever shot.
+    pub fn active(&mut self, now: Duration) -> Vec<EntityId> {
+        self.expiry.retain(|_, expiry| *expiry > now);
+        self.expiry.keys().copied().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shipyard::World;
+
+    fn entity() -> EntityId {
+        World::new().add_entity(())
+    }
+
+    #[test]
+    fn damage_shows_the_overlay_for_five_seconds() {
+        let (mut flash, id) = (DamageFlash::default(), entity());
+        flash.arm(id, Duration::from_secs(10));
+
+        assert_eq!(flash.active(Duration::from_secs(14)), vec![id]);
+        assert!(flash.active(Duration::from_secs(15)).is_empty());
+    }
+
+    #[test]
+    fn a_second_hit_restarts_the_window() {
+        let (mut flash, id) = (DamageFlash::default(), entity());
+        flash.arm(id, Duration::from_secs(10));
+        flash.arm(id, Duration::from_secs(14));
+
+        assert_eq!(flash.active(Duration::from_secs(18)), vec![id]);
+    }
+}

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -236,21 +236,26 @@ pub fn draw_item_name(
         .map(|template_id| (template_id, entity_id.inner()));
     let text_content = format_hover_label(&item_name, hit_points, debug_identity);
 
-    // Above the rect, lifted clear of the health bar - the original reserves
-    // the strip immediately above the rect for the bar (`draw_health_bar`).
+    // Above the rect, and lifted by a further bar-height only when this entity
+    // actually draws one - an ordinary item with no health bar keeps the label
+    // tight to its brackets rather than floating a gap above nothing.
     //
     // This position is ours, not the original's: there the rollover name is
     // not anchored to the rect at all, but drawn in a fixed frame at the top
     // centre of the screen, and the slot below the rect belongs to a separate
     // "HUD Use" hint string ("Search container") that this port does not yet
     // read. Keeping the name by the object is the interim.
+    let label_lift = match health_bar_fill(world, entity_id) {
+        Some(_) => HP_BAR_HEIGHT + LABEL_HEIGHT,
+        None => LABEL_HEIGHT,
+    };
     let text_obj_0_0 = SceneObject::screen_space_text(
         &text_content,
         font.clone(),
         10.0,
         0.5,
         extents.min.x,
-        extents.min.y - HP_BAR_HEIGHT - LABEL_HEIGHT,
+        extents.min.y - label_lift,
     );
 
     vec![text_obj_0_0]
@@ -479,6 +484,37 @@ mod tests {
         assert!(shows_hit_points(&world, id));
     }
 
+    /// The label's lift is driven by whether a bar is actually drawn, not by
+    /// the entity merely being a creature: an item with no bar keeps its label
+    /// tight to the brackets, and a corpse at zero hit points draws no bar and
+    /// so gets no gap either.
+    #[test]
+    fn only_an_entity_with_a_bar_reserves_the_strip_above_the_rect() {
+        let mut world = World::new();
+
+        let item = world.add_entity(PropHUDSelect(true));
+        assert_eq!(health_bar_fill(&world, item), None, "no ShowHP, no bar");
+
+        let creature = world.add_entity((
+            PropShowHP(true),
+            PropHitPoints { hit_points: 6 },
+            PropMaxHitPoints { hit_points: 12 },
+        ));
+        // Biased, like every other ratio here: (6+2)/(12+2).
+        assert_eq!(health_bar_fill(&world, creature), Some(8.0 / 14.0));
+
+        let corpse = world.add_entity((
+            PropShowHP(true),
+            PropHitPoints { hit_points: 0 },
+            PropMaxHitPoints { hit_points: 12 },
+        ));
+        assert_eq!(health_bar_fill(&world, corpse), None, "dead: no bar");
+
+        // Opted in but with no pool to read - nothing to draw.
+        let poolless = world.add_entity(PropShowHP(true));
+        assert_eq!(health_bar_fill(&world, poolless), None);
+    }
+
     #[test]
     fn decimal_placeholder_is_preserved_without_a_stack_count() {
         assert_eq!(
@@ -546,6 +582,20 @@ fn hit_point_pool(world: &World, entity_id: EntityId) -> Option<(i32, u32)> {
     Some((hit_points, max_hit_points))
 }
 
+/// The bar's fill ratio when `entity_id` will draw one at all, else `None`.
+///
+/// The single answer to "is there a bar here?", so the label's offset in
+/// [`draw_item_name`] and the bar itself cannot disagree about whether the
+/// strip above the rect is occupied.
+fn health_bar_fill(world: &World, entity_id: EntityId) -> Option<f32> {
+    if !shows_hit_points(world, entity_id) {
+        return None;
+    }
+    let (hit_points, max_hit_points) = hit_point_pool(world, entity_id)?;
+    let ratio = health_bar_ratio(hit_points, max_hit_points);
+    (ratio > 0.0).then_some(ratio)
+}
+
 /// The enemy health bar, drawn flush on top of the selection brackets.
 pub fn draw_health_bar(
     asset_cache: &mut AssetCache,
@@ -556,18 +606,9 @@ pub fn draw_health_bar(
     projection: Matrix4<f32>,
     screen_size: Vector2<f32>,
 ) -> Vec<SceneObject> {
-    if !shows_hit_points(world, entity_id) {
-        return vec![];
-    }
-
-    let Some((hit_points, max_hit_points)) = hit_point_pool(world, entity_id) else {
+    let Some(ratio) = health_bar_fill(world, entity_id) else {
         return vec![];
     };
-
-    let ratio = health_bar_ratio(hit_points, max_hit_points);
-    if ratio <= 0.0 {
-        return vec![];
-    }
 
     let Some(aabb) = physics.get_aabb2(entity_id) else {
         return vec![];

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -37,6 +37,9 @@ pub(crate) fn is_hud_selectable(world: &World, entity_id: EntityId) -> bool {
 
 const LOG_UNSET: u32 = 33;
 
+/// Side of each corner-bracket glyph, in screen pixels.
+const BRACKET_SIZE: f32 = 8.0;
+
 fn resolve_localized_property_string(raw: &str, strings: &HashMap<String, String>) -> String {
     let (key, fallback) = match raw.split_once(':') {
         Some((key, remainder)) => {
@@ -231,14 +234,16 @@ pub fn draw_item_name(
     let text_content = format_hover_label(&item_name, hit_points, debug_identity);
 
     // Below the brackets, as the original draws it: the strip directly above
-    // the rect belongs to the health bar (`draw_health_bar`).
+    // the rect belongs to the health bar (`draw_health_bar`). Cleared by a
+    // full bracket glyph, since the text anchors on its top edge and the
+    // bottom brackets hang below the rect.
     let text_obj_0_0 = SceneObject::screen_space_text(
         &text_content,
         font.clone(),
         10.0,
         0.5,
         extents.min.x,
-        extents.max.y + 4.0,
+        extents.max.y + BRACKET_SIZE,
     );
 
     vec![text_obj_0_0]
@@ -479,7 +484,7 @@ mod tests {
 /// The original biases the health ratio by a couple of points at both ends, so
 /// a creature on its last hit point still shows a sliver of bar rather than
 /// nothing, and a full pool always reads as exactly full.
-const HP_BUFFER: i32 = 2;
+const HP_BUFFER: f32 = 2.0;
 /// Three bar bitmaps, `HPBAR0` (red) through `HPBAR2` (green).
 const HP_BAR_COUNT: i32 = 3;
 /// Authored size of the bar bitmaps, in canvas pixels.
@@ -491,7 +496,7 @@ fn health_bar_ratio(hit_points: i32, max_hit_points: u32) -> f32 {
     if hit_points <= 0 || max_hit_points == 0 {
         return 0.0;
     }
-    ((hit_points + HP_BUFFER) as f32 / (max_hit_points as i32 + HP_BUFFER) as f32).clamp(0.0, 1.0)
+    ((hit_points as f32 + HP_BUFFER) / (max_hit_points as f32 + HP_BUFFER)).clamp(0.0, 1.0)
 }
 
 /// Colour is quantized where width is not: the bar is one of three bitmaps
@@ -562,8 +567,13 @@ pub fn draw_health_bar(
     };
     let extents = project_aabb3(&aabb, view, projection, screen_size);
 
+    // Nearest sampling, unlike the rest of the HUD: the remastered bar art is
+    // several times the 80x14 it draws at and carries a pure colour-key border,
+    // so linear minification blends key into art and leaves a teal fringe along
+    // the bar's top and bottom edges that the shader's key test cannot catch.
     let options = TextureOptions {
         wrap: false,
+        filter: engine::texture::TextureFilter::Nearest,
         ..Default::default()
     };
     let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, health_bar_texture(ratio), &options);
@@ -606,7 +616,7 @@ pub fn draw_item_outline(
     let bottom_right_brack = asset_cache.get_ext(&TEXTURE_IMPORTER, "BRACK2.PCX", &options);
     let bottom_left_brack = asset_cache.get_ext(&TEXTURE_IMPORTER, "BRACK3.PCX", &options);
 
-    let size = vec2(8.0, 8.0);
+    let size = vec2(BRACKET_SIZE, BRACKET_SIZE);
     let extents = project_aabb3(&aabb, view, projection, screen_size);
     let top_left_brack_obj =
         SceneObject::screen_space_quad(top_left_brack, vec2(extents.min.x, extents.min.y), size);

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -5,8 +5,8 @@ use collision::{Aabb2, Aabb3};
 use dark::{
     importers::{FONT_IMPORTER, STRINGS_IMPORTER, TEXTURE_IMPORTER},
     properties::{
-        ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropObjName,
-        PropObjectNameType, PropStackCount, PropTemplateId,
+        ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
+        PropObjName, PropObjectNameType, PropShowHP, PropStackCount, PropTemplateId,
     },
 };
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
@@ -230,13 +230,15 @@ pub fn draw_item_name(
         .map(|template_id| (template_id, entity_id.inner()));
     let text_content = format_hover_label(&item_name, hit_points, debug_identity);
 
+    // Below the brackets, as the original draws it: the strip directly above
+    // the rect belongs to the health bar (`draw_health_bar`).
     let text_obj_0_0 = SceneObject::screen_space_text(
         &text_content,
         font.clone(),
         10.0,
         0.5,
         extents.min.x,
-        extents.min.y - 10.0,
+        extents.max.y + 4.0,
     );
 
     vec![text_obj_0_0]
@@ -430,6 +432,41 @@ mod tests {
         );
     }
 
+    /// The bias means a full pool reads as exactly full and a creature on its
+    /// last point still shows a sliver, rather than a bar that vanishes one
+    /// hit before death.
+    #[test]
+    fn health_ratio_is_biased_at_both_ends() {
+        assert_eq!(health_bar_ratio(10, 10), 1.0);
+        assert_eq!(health_bar_ratio(1, 10), 0.25);
+        assert_eq!(health_bar_ratio(0, 10), 0.0);
+        assert_eq!(health_bar_ratio(-5, 10), 0.0);
+        assert_eq!(health_bar_ratio(10, 0), 0.0);
+    }
+
+    /// Colour steps in thirds and swaps outright - full health must not land
+    /// on a fourth, nonexistent bitmap.
+    #[test]
+    fn health_bar_bitmap_steps_in_thirds() {
+        assert_eq!(health_bar_texture(1.0), "HPBAR2.PCX");
+        assert_eq!(health_bar_texture(2.0 / 3.0), "HPBAR2.PCX");
+        assert_eq!(health_bar_texture(0.65), "HPBAR1.PCX");
+        assert_eq!(health_bar_texture(1.0 / 3.0), "HPBAR1.PCX");
+        assert_eq!(health_bar_texture(0.32), "HPBAR0.PCX");
+        assert_eq!(health_bar_texture(0.0), "HPBAR0.PCX");
+    }
+
+    /// `P$ShowHP` is the bar's own opt-in: brackets are not enough.
+    #[test]
+    fn health_bar_needs_its_own_opt_in() {
+        let mut world = World::new();
+        let id = world.add_entity(PropHUDSelect(true));
+        assert!(!shows_hit_points(&world, id));
+
+        world.add_component(id, PropShowHP(true));
+        assert!(shows_hit_points(&world, id));
+    }
+
     #[test]
     fn decimal_placeholder_is_preserved_without_a_stack_count() {
         assert_eq!(
@@ -437,6 +474,110 @@ mod tests {
             r#"Nanites: "%d nanites.""#,
         );
     }
+}
+
+/// The original biases the health ratio by a couple of points at both ends, so
+/// a creature on its last hit point still shows a sliver of bar rather than
+/// nothing, and a full pool always reads as exactly full.
+const HP_BUFFER: i32 = 2;
+/// Three bar bitmaps, `HPBAR0` (red) through `HPBAR2` (green).
+const HP_BAR_COUNT: i32 = 3;
+/// Authored size of the bar bitmaps, in canvas pixels.
+const HP_BAR_WIDTH: f32 = 80.0;
+const HP_BAR_HEIGHT: f32 = 14.0;
+
+/// `0.0` when dead or when the pool is meaningless, `1.0` at full health.
+fn health_bar_ratio(hit_points: i32, max_hit_points: u32) -> f32 {
+    if hit_points <= 0 || max_hit_points == 0 {
+        return 0.0;
+    }
+    ((hit_points + HP_BUFFER) as f32 / (max_hit_points as i32 + HP_BUFFER) as f32).clamp(0.0, 1.0)
+}
+
+/// Colour is quantized where width is not: the bar is one of three bitmaps
+/// chosen by which *third* of the ratio it falls in, and it swaps outright
+/// rather than blending, so red means "nearly dead" at a glance.
+fn health_bar_texture(ratio: f32) -> &'static str {
+    match ((ratio * HP_BAR_COUNT as f32) as i32).clamp(0, HP_BAR_COUNT - 1) {
+        0 => "HPBAR0.PCX",
+        1 => "HPBAR1.PCX",
+        _ => "HPBAR2.PCX",
+    }
+}
+
+/// Whether `entity_id` opts in to the health bar.
+///
+/// This is `P$ShowHP` ("Show HP?"), which is a *separate* opt-in from
+/// [`is_hud_selectable`]'s `P$HUDSelect`: the shipped data sets it on the
+/// creature families and leaves it off everything else, so a damageable crate
+/// draws brackets without advertising its hit points.
+pub(crate) fn shows_hit_points(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropShowHP>>()
+        .map(|v| v.get(entity_id).map(|p| p.0).unwrap_or(false))
+        .unwrap_or(false)
+}
+
+fn hit_point_pool(world: &World, entity_id: EntityId) -> Option<(i32, u32)> {
+    let hit_points = world
+        .borrow::<View<PropHitPoints>>()
+        .ok()?
+        .get(entity_id)
+        .ok()?
+        .hit_points;
+    let max_hit_points = world
+        .borrow::<View<PropMaxHitPoints>>()
+        .ok()?
+        .get(entity_id)
+        .ok()?
+        .hit_points;
+    Some((hit_points, max_hit_points))
+}
+
+/// The enemy health bar, drawn flush on top of the selection brackets.
+pub fn draw_health_bar(
+    asset_cache: &mut AssetCache,
+    physics: &PhysicsWorld,
+    entity_id: EntityId,
+    world: &World,
+    view: Matrix4<f32>,
+    projection: Matrix4<f32>,
+    screen_size: Vector2<f32>,
+) -> Vec<SceneObject> {
+    if !shows_hit_points(world, entity_id) {
+        return vec![];
+    }
+
+    let Some((hit_points, max_hit_points)) = hit_point_pool(world, entity_id) else {
+        return vec![];
+    };
+
+    let ratio = health_bar_ratio(hit_points, max_hit_points);
+    if ratio <= 0.0 {
+        return vec![];
+    }
+
+    let Some(aabb) = physics.get_aabb2(entity_id) else {
+        return vec![];
+    };
+    let extents = project_aabb3(&aabb, view, projection, screen_size);
+
+    let options = TextureOptions {
+        wrap: false,
+        ..Default::default()
+    };
+    let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, health_bar_texture(ratio), &options);
+
+    // Clipped, not scaled: the bar is drawn at its authored width and cut off
+    // at `ratio`, so a half-health bar is the left half of the artwork - the
+    // right-hand border vanishes rather than sliding in. Left-aligned to the
+    // rect and exactly one bar-height above it, sitting on the brackets.
+    vec![SceneObject::screen_space_clipped_quad(
+        texture,
+        vec2(extents.min.x, extents.min.y - HP_BAR_HEIGHT),
+        vec2(HP_BAR_WIDTH, HP_BAR_HEIGHT),
+        ratio,
+    )]
 }
 
 pub fn draw_item_outline(

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -40,6 +40,9 @@ const LOG_UNSET: u32 = 33;
 /// Side of each corner-bracket glyph, in screen pixels.
 const BRACKET_SIZE: f32 = 8.0;
 
+/// Line height of the rollover label, in screen pixels.
+const LABEL_HEIGHT: f32 = 10.0;
+
 fn resolve_localized_property_string(raw: &str, strings: &HashMap<String, String>) -> String {
     let (key, fallback) = match raw.split_once(':') {
         Some((key, remainder)) => {
@@ -233,17 +236,21 @@ pub fn draw_item_name(
         .map(|template_id| (template_id, entity_id.inner()));
     let text_content = format_hover_label(&item_name, hit_points, debug_identity);
 
-    // Below the brackets, as the original draws it: the strip directly above
-    // the rect belongs to the health bar (`draw_health_bar`). Cleared by a
-    // full bracket glyph, since the text anchors on its top edge and the
-    // bottom brackets hang below the rect.
+    // Above the rect, lifted clear of the health bar - the original reserves
+    // the strip immediately above the rect for the bar (`draw_health_bar`).
+    //
+    // This position is ours, not the original's: there the rollover name is
+    // not anchored to the rect at all, but drawn in a fixed frame at the top
+    // centre of the screen, and the slot below the rect belongs to a separate
+    // "HUD Use" hint string ("Search container") that this port does not yet
+    // read. Keeping the name by the object is the interim.
     let text_obj_0_0 = SceneObject::screen_space_text(
         &text_content,
         font.clone(),
         10.0,
         0.5,
         extents.min.x,
-        extents.max.y + BRACKET_SIZE,
+        extents.min.y - HP_BAR_HEIGHT - LABEL_HEIGHT,
     );
 
     vec![text_obj_0_0]

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -1,3 +1,6 @@
+mod damage_flash;
+pub use damage_flash::*;
+
 mod item_outline;
 pub use item_outline::*;
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -79,7 +79,7 @@ use crate::{
     game_scene::AmbientAudioState,
     game_scene::PlayerSavePoseError,
     gui::GuiManager,
-    hud::{draw_item_name, draw_item_outline, is_hud_selectable},
+    hud::{DamageFlash, draw_health_bar, draw_item_name, draw_item_outline, is_hud_selectable},
     input_context::{self, InputContext},
     interaction::{FlatInteraction, InteractionContext, PlayerInteraction, VrInteraction},
     inventory::PlayerInventoryEntity,
@@ -1887,6 +1887,7 @@ impl MissionCore {
         world.add_unique(crate::psi::ActivePsiPowers::default());
         world.add_unique(crate::scripts::healing_item::ActiveHealing::default());
         world.add_unique(crate::scripts::radiation::ActiveRadiation::default());
+        world.add_unique(DamageFlash::default());
 
         // ** Entity creation
 
@@ -5313,6 +5314,19 @@ impl MissionCore {
                                 });
                             }
                         }
+                        // Show the overlay on anything the player just hurt.
+                        // Gated on the same opt-in the bar itself reads, so
+                        // the map only ever holds creatures.
+                        if entity_id != player_entity
+                            && hp < previous
+                            && crate::hud::shows_hit_points(&self.world, entity_id)
+                        {
+                            let now = self.world.borrow::<UniqueView<Time>>().unwrap().total;
+                            self.world
+                                .borrow::<UniqueViewMut<DamageFlash>>()
+                                .unwrap()
+                                .arm(entity_id, now);
+                        }
                         if entity_id == player_entity && previous > 0 && hp == 0 {
                             for death_effect in self.begin_player_death() {
                                 effects.push_back(death_effect);
@@ -7902,6 +7916,15 @@ impl MissionCore {
         }
     }
 
+    /// Entities whose HUD overlay is still forced on by recent damage.
+    fn damage_flash_entities(&self) -> Vec<EntityId> {
+        let now = self.world.borrow::<UniqueView<Time>>().unwrap().total;
+        self.world
+            .borrow::<UniqueViewMut<DamageFlash>>()
+            .map(|mut flash| flash.active(now))
+            .unwrap_or_default()
+    }
+
     pub fn render_per_eye(
         &mut self,
         asset_cache: &mut AssetCache,
@@ -7925,6 +7948,13 @@ impl MissionCore {
         if !options.debug_show_ids {
             highlighted.retain(|e| is_hud_selectable(&self.world, *e));
         }
+        // Recently-damaged creatures show the same overlay without being
+        // looked at, so a shot that lands off to the side still reads.
+        for flashed in self.damage_flash_entities() {
+            if !highlighted.contains(&flashed) {
+                highlighted.push(flashed);
+            }
+        }
         for hit_entity in highlighted {
             ret.extend(draw_item_outline(
                 asset_cache,
@@ -7944,6 +7974,16 @@ impl MissionCore {
                 projection,
                 screen_size,
                 options.debug_show_ids,
+            ));
+
+            ret.extend(draw_health_bar(
+                asset_cache,
+                &self.physics,
+                hit_entity,
+                &self.world,
+                view,
+                projection,
+                screen_size,
             ));
         }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3513,6 +3513,7 @@ impl MissionCore {
                                         // palette index 0 (the magenta color
                                         // key only covers some of them).
                                         transparent_index_0: true,
+                                        ..Default::default()
                                     },
                                 ) {
                                     system = system
@@ -5314,9 +5315,13 @@ impl MissionCore {
                                 });
                             }
                         }
-                        // Show the overlay on anything the player just hurt.
-                        // Gated on the same opt-in the bar itself reads, so
-                        // the map only ever holds creatures.
+                        // Show the overlay on anything that just took damage -
+                        // this is the one applier every source of damage flows
+                        // through, so an AI burned by a fire or shot by a
+                        // turret flashes too, not only the player's own hits.
+                        // Narrowed to the bar's own opt-in, which the original
+                        // does not do: it keeps the map to creatures, and an
+                        // object with no bar to show has nothing to reveal.
                         if entity_id != player_entity
                             && hp < previous
                             && crate::hud::shows_hit_points(&self.world, entity_id)
@@ -7945,15 +7950,24 @@ impl MissionCore {
         // is most needed for exactly the fixtures the gate excludes - so the
         // debug overlay deliberately bypasses it.
         let mut highlighted = self.interaction.highlighted_entities();
-        if !options.debug_show_ids {
-            highlighted.retain(|e| is_hud_selectable(&self.world, *e));
-        }
         // Recently-damaged creatures show the same overlay without being
         // looked at, so a shot that lands off to the side still reads.
+        //
+        // Visibility is the load-bearing gate here, not decoration: the
+        // reticle pick is a raycast and so is always unoccluded and in front
+        // of the camera, but a damaged entity is any entity - one behind the
+        // player projects to a mirrored on-screen position, and one through a
+        // wall would advertise its health through the geometry.
         for flashed in self.damage_flash_entities() {
-            if !highlighted.contains(&flashed) {
+            if self.visibility_engine.is_visible(flashed) && !highlighted.contains(&flashed) {
                 highlighted.push(flashed);
             }
+        }
+        // One gate for the whole overlay, applied to hover and damage alike,
+        // so an entity cannot acquire brackets by being shot that it could
+        // never get by being looked at.
+        if !options.debug_show_ids {
+            highlighted.retain(|e| is_hud_selectable(&self.world, *e));
         }
         for hit_entity in highlighted {
             ret.extend(draw_item_outline(

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -879,20 +879,13 @@ impl UiCanvas<()> {
     }
 }
 
-/// Replicate `SceneObject::screen_space_quad`'s transform so a manually-built
-/// screen-space object (e.g. the clipped bar material) maps to the same pixels.
-fn screen_space_quad_transform(position: Vector2<f32>, size: Vector2<f32>) -> Matrix4<f32> {
-    Matrix4::from_translation(vec3(position.x, position.y, 0.0))
-        * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
-        * Matrix4::from_translation(vec3(0.5, 0.5, 0.0))
-}
-
 /// How a `kind`'s art is sampled. Shared so layout and the presenters key the
 /// asset cache the same way.
 fn texture_options(kind: ImageKind) -> TextureOptions {
     TextureOptions {
         wrap: false,
         transparent_index_0: kind.transparent_index_0(),
+        ..Default::default()
     }
 }
 
@@ -1007,16 +1000,12 @@ fn present_screen(
         PlacedContent::Bar { texture, fill } => {
             let texture =
                 asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options(ImageKind::Ui));
-            let material = engine::scene::clipped_screen_material::create_screen_space(
+            SceneObject::screen_space_clipped_quad(
                 texture.clone() as Rc<dyn TextureTrait>,
-                *fill,
-            );
-            let mut object = SceneObject::new(material, Box::new(engine::scene::quad::create()));
-            object.set_local_transform(screen_space_quad_transform(
                 vec2(rect.x, rect.y),
                 vec2(rect.w, rect.h),
-            ));
-            object
+                *fill,
+            )
         }
         PlacedContent::Text { text, font, .. } => {
             let font_obj = resolve_font(asset_cache, font);


### PR DESCRIPTION
Draws the original's enemy health bar above the HUD selection brackets, using the shipped `HPBAR0/1/2` art.

![enemy health bar draining green to yellow to red](https://gist.githubusercontent.com/tommy-xr/c6a3973055ae8eea22bf4c869344f1cd/raw/health-bar.gif)

<sub>`debug_melee`: a hybrid taking one point of damage at a time, 12 HP down to 1. The bar steps green -> yellow -> red at thirds and is clipped, not scaled, to the health ratio. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![health bar at partial health](https://gist.githubusercontent.com/tommy-xr/c6a3973055ae8eea22bf4c869344f1cd/raw/health-bar-still.png)

<sub>Half health: the bar is the left half of the 80x14 artwork, its right-hand border gone rather than slid inwards. The rollover name is lifted clear of the bar's strip.</sub>

## Behavior

Matches the original's `ShockHUDDrawRect`:

- **Ratio** — `(hp + 2) / (maxhp + 2)`, zero when `hp <= 0`. The bias means a full pool always reads as exactly full and a creature on its last point still shows a sliver instead of nothing.
- **Colour** — one of three bitmaps by `int(ratio * 3)` clamped to `0..2`: `HPBAR0` red, `HPBAR1` yellow, `HPBAR2` green. A hard swap at thirds, no blending.
- **Width** — the 80x14 bitmap is *clipped* at `ratio` of its width, not scaled to it, so the art's right-hand border disappears as the bar drains rather than sliding inwards.
- **Placement** — left-aligned to the bracket rect and exactly one bar-height above it.
- **Gating** — the new `P$ShowHP` ("Show HP?") plus both `P$HitPoints` and `P$MaxHitPoints`. This is a *separate* opt-in from `P$HUDSelect`, which gates the brackets: the shipped data sets `ShowHP` on the creature families and explicitly false on the `Tech` family, so a damageable console draws brackets without advertising hit points.
- **Damage flash** — taking damage shows the overlay for 5 seconds unhovered, so a shot that lands off to the side still reads. This is the original's `HUDTime` marker.

The rollover name label stays above the rect but is lifted by the bar's height, since the strip immediately above the rect is the bar's.

## Before -> after

The rollover label sits above the bracket rect, and is now lifted by a further
bar-height **only when a bar is actually drawn** — 24 px above the rect (the bar's
14 px plus the label's 10 px line height) for a creature that shows hit points,
and the unchanged 10 px for an ordinary item, which draws no bar and so keeps its
label tight to its brackets. Items are untouched by this PR.

![rollover label before and after](https://gist.githubusercontent.com/tommy-xr/c6a3973055ae8eea22bf4c869344f1cd/raw/label-before-after.png)

<sub>`debug_melee`, identical request sequence on `e2bed184` (before) and this branch (after): the same hybrid damaged to 6/12 HP, crops around the bracket rect with a red line on the rect's top edge. Before, the damaged creature draws no overlay at all — no bar, and no rollover label either, since flat mode only reaches a creature through this PR's damage flash. After: the bar occupies y 477-505 px, flush on the rect's top edge at y 505, and the label's glyph ink tops out at y 462 px, clear above it (1600x1200 capture). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Notes

- The label's position is **ours, not the original's**. There the rollover name is not anchored to the bracket rect at all — it is drawn in a fixed 255x17 frame at the top centre of the screen (`ShockMiniFrameDraw` / `DrawObjName`), and the slot below the rect belongs to a separate `P$HUDUse` hint string ("Search container", "Press button") that this port does not read. Keeping the name by the object is the interim; #1213 and #1214 track the real behaviour.

- `ClippedScreenMaterial` already existed unused, with a colour-key discard tuned to the exact cyan the `HPBAR` art keys on. It was evidently written for this feature and never wired up; this hooks it up via a new `SceneObject::screen_space_clipped_quad`, and routes the UI canvas's existing bar through the same constructor (deleting `screen_space_quad_transform`, whose doc comment said it existed to replicate precisely that).
- `TextureFilter::Nearest` is new. The bar needs it: the remastered art is several times its 80x14 draw size and carries a pure colour-key border, so linear minification blended key into art and left a teal fringe along the bar's top and bottom edges that the shader's key test cannot recognize. Measured before/after on the edge rows: blue `143 -> 64` and `117 -> 66`, back inside the bar art's own `b=24..60` range.
- The damage flash is gated on `visibility_engine.is_visible`. The reticle pick is a raycast and so always unoccluded and in front of the camera, but a *damaged* entity is any entity — one behind the player projects to a mirrored on-screen position, and one through a wall would advertise its health through the geometry. The original was implicitly safe here because its overlay was queued from the per-rendered-object render callback.
- Flat mode currently reaches the bar only through the damage flash: `FlatPlayerController` narrows the reticle highlight to frobbable entities within ~2.8 units, so creatures do not highlight on hover. Pre-existing, and widening it touches frob targeting; left for a follow-up.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; 39 `hud::` unit tests pass, covering the ratio bias, the thirds stepping (full health must not index a fourth, nonexistent bitmap), and the `ShowHP` gate.
- Full SDK e2e suite: 358 tests, 341 pass, 9 fail — each of the 9 re-run on `origin/main` and failing identically there.
- Bar measured in-game against the shipped palettes: widths within a pixel of `ratio * 80` at three health levels, and the cross glyph's column signature is identical across the 73 px and 40 px bars, confirming clipping rather than squeezing.
- Visibility gate measured across the live 5-second window: 98 bar px facing the creature, 0 bar px and 0 bracket px facing away at two later timestamps, 133 bar px on turning back — the return proves the blanks were the gate, not expiry.

Reviewed with `/xreview` (Claude + Codex + a duplication pass); all High and Medium findings are fixed in the second commit, except old-save backfill, which is out of scope per the save-compatibility policy this PR adds as AGENTS.md section 5.




