### PR TITLE
fix(physics): size a corpse's selection box from its posed mesh

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -79,12 +79,12 @@ pub struct AnimatedModel {
     /// rather than joint-local space. Holds `bind_inverse[j] * bind_correction`,
     /// so the posed palette becomes `pose[j] * bind[j]`.
     bind: Option<Rc<[Matrix4<f32>; MAX_SKINNED_JOINTS]>>,
-    /// Global joint transforms of the pose baked into `scene_objects`, set when
-    /// a model is statically posed (`animate`/`pose`). The skeleton itself stays
-    /// at rest - only the skinning palette is baked - so this is the only record
-    /// of the pose the model is actually drawn in, and [`bounding_box`] needs it
-    /// to bound a lying corpse rather than the standing rest pose.
-    posed_joints: Option<Rc<[Matrix4<f32>; 40]>>,
+    /// Model-space bounds of the pose baked into `scene_objects`, set when a
+    /// model is statically posed (`animate`/`pose`). Posing bakes only the
+    /// skinning palette - the skeleton itself stays at rest - so without this
+    /// there is no record of the pose the model is actually drawn in, and a
+    /// corpse lying flat would be bounded by the standing rest skeleton.
+    posed_bounds: Option<Aabb3<f32>>,
 }
 
 /// Build the render palette, undoing the bind pose first when the geometry needs
@@ -110,38 +110,40 @@ fn build_palette(
     }
 }
 
-impl AnimatedModel {
-    /// Model-space bounds of the pose this model is drawn in - the baked pose
-    /// for a statically posed model (an authored corpse), the rest pose
-    /// otherwise. Each joint's vertex AABB is authored in that joint's own
-    /// frame, so it is carried into model space by that joint's transform
-    /// before the union. `None` when the mesh has no per-joint boxes at all (a
-    /// jointed object mesh, a GLB).
-    ///
-    /// The joint boxes are the coarse per-joint vertex AABBs (they cluster at
-    /// the joint origins), not a fit of the skinned vertices - enough for the
-    /// selection volume this feeds, and the same source the damage hitboxes
-    /// use.
-    fn bounding_box(&self) -> Option<Aabb3<f32>> {
-        let joints = self
-            .posed_joints
-            .as_ref()
-            .map(|posed| **posed)
-            .unwrap_or_else(|| self.skeleton.get_transforms());
-        let mut bounds: Option<Aabb3<f32>> = None;
-        for (joint_id, aabb) in self.hit_boxes.iter() {
-            let Some(transform) = joints.get(*joint_id as usize) else {
-                continue;
-            };
-            for corner in aabb.to_corners() {
-                let point = transform.transform_point(corner);
-                bounds = Some(match bounds {
-                    None => Aabb3::new(point, point),
-                    Some(bounds) => bounds.grow(point),
-                });
-            }
+/// Union of per-joint vertex AABBs, each carried into model space by that
+/// joint's transform. `None` when the mesh has no per-joint boxes at all (a
+/// jointed object mesh, a GLB).
+///
+/// The joint boxes are the coarse per-joint vertex AABBs (they cluster at the
+/// joint origins), not a fit of the skinned vertices - enough for the selection
+/// volume this feeds, and the same source the damage hitboxes use.
+fn joint_box_bounds(
+    joints: &[Matrix4<f32>; 40],
+    hit_boxes: &HashMap<u32, Aabb3<f32>>,
+) -> Option<Aabb3<f32>> {
+    let mut bounds: Option<Aabb3<f32>> = None;
+    for (joint_id, aabb) in hit_boxes.iter() {
+        let Some(transform) = joints.get(*joint_id as usize) else {
+            continue;
+        };
+        for corner in aabb.to_corners() {
+            let point = transform.transform_point(corner);
+            bounds = Some(match bounds {
+                None => Aabb3::new(point, point),
+                Some(bounds) => bounds.grow(point),
+            });
         }
-        bounds
+    }
+    bounds
+}
+
+impl AnimatedModel {
+    /// Model-space bounds of the pose this model is drawn in: the baked pose
+    /// for a statically posed model (an authored corpse), the rest pose
+    /// otherwise.
+    fn bounding_box(&self) -> Option<Aabb3<f32>> {
+        self.posed_bounds
+            .or_else(|| joint_box_bounds(&self.skeleton.get_transforms(), &self.hit_boxes))
     }
 
     fn to_scene_objects(&self) -> &Vec<SceneObject> {
@@ -199,7 +201,7 @@ impl AnimatedModel {
             vhots: self.vhots.clone(),
             sub_objects: self.sub_objects.clone(),
             bind: self.bind.clone(),
-            posed_joints: Some(Rc::new(animated_skeleton.get_transforms())),
+            posed_bounds: joint_box_bounds(&animated_skeleton.get_transforms(), &self.hit_boxes),
         }
     }
 
@@ -223,7 +225,7 @@ impl AnimatedModel {
             vhots: model.vhots.clone(),
             sub_objects: model.sub_objects.clone(),
             bind: model.bind.clone(),
-            posed_joints: model.posed_joints.clone(),
+            posed_bounds: model.posed_bounds,
         }
     }
 
@@ -279,7 +281,7 @@ impl Model {
                     vhots: static_mesh.vhots.clone(),
                     sub_objects,
                     bind: None,
-                    posed_joints: None,
+                    posed_bounds: None,
                 }),
             }
         } else {
@@ -349,7 +351,7 @@ impl Model {
                 vhots: vec![],
                 sub_objects: vec![],
                 bind,
-                posed_joints: None,
+                posed_bounds: None,
             }),
         }
     }
@@ -376,7 +378,7 @@ impl Model {
                     vhots: vec![],
                     sub_objects: vec![],
                     bind: None,
-                    posed_joints: None,
+                    posed_bounds: None,
                 }),
             }
         } else {
@@ -667,6 +669,7 @@ mod tests {
         bones: Vec<Bone>,
         posed_joints: Option<[Matrix4<f32>; 40]>,
     ) -> Model {
+        let posed_bounds = posed_joints.and_then(|joints| joint_box_bounds(&joints, &hit_boxes));
         Model {
             transform: Matrix4::identity(),
             inner: InnerModel::Animated(AnimatedModel {
@@ -677,7 +680,7 @@ mod tests {
                 vhots: Vec::new(),
                 sub_objects: Vec::new(),
                 bind: None,
-                posed_joints: posed_joints.map(Rc::new),
+                posed_bounds,
             }),
         }
     }

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -7,8 +7,8 @@ use crate::{
     ss2_bin_obj_loader::{self, SystemShock2ObjectMesh, Vhot},
     ss2_skeleton::{self, AnimationInfo, Bone, Skeleton},
 };
-use cgmath::{Matrix4, SquareMatrix, Vector2};
-use collision::Aabb3;
+use cgmath::{Matrix4, SquareMatrix, Transform, Vector2};
+use collision::{Aabb, Aabb3};
 use engine::{
     assets::asset_cache::AssetCache,
     scene::{FrontFaceWinding, MAX_SKINNED_JOINTS, SKINNING_PALETTE_SIZE, SceneObject},
@@ -105,6 +105,30 @@ fn build_palette(
 }
 
 impl AnimatedModel {
+    /// Model-space bounds in the skeleton's rest pose - the pose an
+    /// un-animated model draws in (an authored corpse, a posed prop). Each
+    /// joint's vertex AABB is authored in that joint's own frame, so it is
+    /// carried into model space by that joint's rest transform before the
+    /// union. `None` when the mesh has no per-joint boxes at all (a jointed
+    /// object mesh, a GLB).
+    fn bounding_box(&self) -> Option<Aabb3<f32>> {
+        let rest = self.skeleton.get_transforms();
+        let mut bounds: Option<Aabb3<f32>> = None;
+        for (joint_id, aabb) in self.hit_boxes.iter() {
+            let Some(transform) = rest.get(*joint_id as usize) else {
+                continue;
+            };
+            for corner in aabb.to_corners() {
+                let point = transform.transform_point(corner);
+                bounds = Some(match bounds {
+                    None => Aabb3::new(point, point),
+                    Some(bounds) => bounds.grow(point),
+                });
+            }
+        }
+        bounds
+    }
+
     fn to_scene_objects(&self) -> &Vec<SceneObject> {
         &self.scene_objects
     }
@@ -424,7 +448,7 @@ impl Model {
 
     pub fn bounding_box(&self) -> Option<Aabb3<f32>> {
         match &self.inner {
-            InnerModel::Animated(_animated_model) => None,
+            InnerModel::Animated(animated_model) => animated_model.bounding_box(),
             InnerModel::Static(static_model) => Some(static_model.bounding_box),
         }
     }
@@ -609,6 +633,68 @@ mod tests {
                 sub_objects: Vec::new(),
             }),
         }
+    }
+
+    /// A skinned corpse or posed prop is one joint chain: its bounds are the
+    /// per-joint boxes placed by the rest pose, not the joint-local boxes
+    /// themselves.
+    fn animated_model(hit_boxes: HashMap<u32, Aabb3<f32>>, bones: Vec<Bone>) -> Model {
+        Model {
+            transform: Matrix4::identity(),
+            inner: InnerModel::Animated(AnimatedModel {
+                skeleton: Rc::new(Skeleton::create_from_bones(bones)),
+                scene_objects: Vec::new(),
+                hit_boxes: Rc::new(hit_boxes),
+                hit_box_shapes: Rc::new(HashMap::new()),
+                vhots: Vec::new(),
+                bind: None,
+            }),
+        }
+    }
+
+    fn unit_box() -> Aabb3<f32> {
+        Aabb3::new(Point3::new(-0.5, -0.5, -0.5), Point3::new(0.5, 0.5, 0.5))
+    }
+
+    /// Negative-first: an animated model used to report no bounds at all, so
+    /// every consumer (the frob/selection collider a corpse is picked by) fell
+    /// back to a default-sized box at the object's origin.
+    #[test]
+    fn an_animated_model_has_the_bounds_of_its_posed_joint_boxes() {
+        let bones = vec![
+            Bone {
+                joint_id: 0,
+                parent_id: None,
+                local_transform: Matrix4::identity(),
+            },
+            Bone {
+                joint_id: 1,
+                parent_id: Some(0),
+                local_transform: Matrix4::from_translation(vec3(4.0, 0.0, 0.0)),
+            },
+        ];
+        let hit_boxes = HashMap::from([(0, unit_box()), (1, unit_box())]);
+
+        let bounds = animated_model(hit_boxes, bones)
+            .bounding_box()
+            .expect("an animated model with joint boxes has bounds");
+
+        // The second joint sits 4 units along +x, so the union spans it -
+        // taking the joint-local boxes as-is would give a 1-unit cube.
+        assert_eq!(bounds.min, Point3::new(-0.5, -0.5, -0.5));
+        assert_eq!(bounds.max, Point3::new(4.5, 0.5, 0.5));
+    }
+
+    /// A jointed object mesh (`from_obj_bin`'s animated branch) carries no
+    /// per-joint boxes; reporting an empty box would be worse than reporting
+    /// nothing, which callers already handle.
+    #[test]
+    fn an_animated_model_without_joint_boxes_has_no_bounds() {
+        assert!(
+            animated_model(HashMap::new(), Vec::new())
+                .bounding_box()
+                .is_none()
+        );
     }
 
     fn winding(model: &Model) -> Option<FrontFaceWinding> {

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -79,6 +79,12 @@ pub struct AnimatedModel {
     /// rather than joint-local space. Holds `bind_inverse[j] * bind_correction`,
     /// so the posed palette becomes `pose[j] * bind[j]`.
     bind: Option<Rc<[Matrix4<f32>; MAX_SKINNED_JOINTS]>>,
+    /// Global joint transforms of the pose baked into `scene_objects`, set when
+    /// a model is statically posed (`animate`/`pose`). The skeleton itself stays
+    /// at rest - only the skinning palette is baked - so this is the only record
+    /// of the pose the model is actually drawn in, and [`bounding_box`] needs it
+    /// to bound a lying corpse rather than the standing rest pose.
+    posed_joints: Option<Rc<[Matrix4<f32>; 40]>>,
 }
 
 /// Build the render palette, undoing the bind pose first when the geometry needs
@@ -105,17 +111,26 @@ fn build_palette(
 }
 
 impl AnimatedModel {
-    /// Model-space bounds in the skeleton's rest pose - the pose an
-    /// un-animated model draws in (an authored corpse, a posed prop). Each
-    /// joint's vertex AABB is authored in that joint's own frame, so it is
-    /// carried into model space by that joint's rest transform before the
-    /// union. `None` when the mesh has no per-joint boxes at all (a jointed
-    /// object mesh, a GLB).
+    /// Model-space bounds of the pose this model is drawn in - the baked pose
+    /// for a statically posed model (an authored corpse), the rest pose
+    /// otherwise. Each joint's vertex AABB is authored in that joint's own
+    /// frame, so it is carried into model space by that joint's transform
+    /// before the union. `None` when the mesh has no per-joint boxes at all (a
+    /// jointed object mesh, a GLB).
+    ///
+    /// The joint boxes are the coarse per-joint vertex AABBs (they cluster at
+    /// the joint origins), not a fit of the skinned vertices - enough for the
+    /// selection volume this feeds, and the same source the damage hitboxes
+    /// use.
     fn bounding_box(&self) -> Option<Aabb3<f32>> {
-        let rest = self.skeleton.get_transforms();
+        let joints = self
+            .posed_joints
+            .as_ref()
+            .map(|posed| **posed)
+            .unwrap_or_else(|| self.skeleton.get_transforms());
         let mut bounds: Option<Aabb3<f32>> = None;
         for (joint_id, aabb) in self.hit_boxes.iter() {
-            let Some(transform) = rest.get(*joint_id as usize) else {
+            let Some(transform) = joints.get(*joint_id as usize) else {
                 continue;
             };
             for corner in aabb.to_corners() {
@@ -184,6 +199,7 @@ impl AnimatedModel {
             vhots: self.vhots.clone(),
             sub_objects: self.sub_objects.clone(),
             bind: self.bind.clone(),
+            posed_joints: Some(Rc::new(animated_skeleton.get_transforms())),
         }
     }
 
@@ -207,6 +223,7 @@ impl AnimatedModel {
             vhots: model.vhots.clone(),
             sub_objects: model.sub_objects.clone(),
             bind: model.bind.clone(),
+            posed_joints: model.posed_joints.clone(),
         }
     }
 
@@ -262,6 +279,7 @@ impl Model {
                     vhots: static_mesh.vhots.clone(),
                     sub_objects,
                     bind: None,
+                    posed_joints: None,
                 }),
             }
         } else {
@@ -331,6 +349,7 @@ impl Model {
                 vhots: vec![],
                 sub_objects: vec![],
                 bind,
+                posed_joints: None,
             }),
         }
     }
@@ -357,6 +376,7 @@ impl Model {
                     vhots: vec![],
                     sub_objects: vec![],
                     bind: None,
+                    posed_joints: None,
                 }),
             }
         } else {
@@ -639,6 +659,14 @@ mod tests {
     /// per-joint boxes placed by the rest pose, not the joint-local boxes
     /// themselves.
     fn animated_model(hit_boxes: HashMap<u32, Aabb3<f32>>, bones: Vec<Bone>) -> Model {
+        posed_model(hit_boxes, bones, None)
+    }
+
+    fn posed_model(
+        hit_boxes: HashMap<u32, Aabb3<f32>>,
+        bones: Vec<Bone>,
+        posed_joints: Option<[Matrix4<f32>; 40]>,
+    ) -> Model {
         Model {
             transform: Matrix4::identity(),
             inner: InnerModel::Animated(AnimatedModel {
@@ -647,7 +675,9 @@ mod tests {
                 hit_boxes: Rc::new(hit_boxes),
                 hit_box_shapes: Rc::new(HashMap::new()),
                 vhots: Vec::new(),
+                sub_objects: Vec::new(),
                 bind: None,
+                posed_joints: posed_joints.map(Rc::new),
             }),
         }
     }
@@ -660,7 +690,7 @@ mod tests {
     /// every consumer (the frob/selection collider a corpse is picked by) fell
     /// back to a default-sized box at the object's origin.
     #[test]
-    fn an_animated_model_has_the_bounds_of_its_posed_joint_boxes() {
+    fn an_animated_model_has_the_bounds_of_its_rest_posed_joint_boxes() {
         let bones = vec![
             Bone {
                 joint_id: 0,
@@ -683,6 +713,28 @@ mod tests {
         // taking the joint-local boxes as-is would give a 1-unit cube.
         assert_eq!(bounds.min, Point3::new(-0.5, -0.5, -0.5));
         assert_eq!(bounds.max, Point3::new(4.5, 0.5, 0.5));
+    }
+
+    /// A statically posed model (an authored corpse) is drawn in its baked
+    /// pose, not the skeleton's rest pose: its bounds must follow the pose, or
+    /// a body lying on the floor is bounded by the standing rest skeleton.
+    #[test]
+    fn a_posed_model_is_bounded_by_the_pose_it_is_drawn_in() {
+        let bones = vec![Bone {
+            joint_id: 0,
+            parent_id: None,
+            local_transform: Matrix4::identity(),
+        }];
+        // The pose lays the single joint down 5 units along +x.
+        let mut posed = [Matrix4::identity(); 40];
+        posed[0] = Matrix4::from_translation(vec3(5.0, 0.0, 0.0));
+
+        let bounds = posed_model(HashMap::from([(0, unit_box())]), bones, Some(posed))
+            .bounding_box()
+            .expect("a posed model with joint boxes has bounds");
+
+        assert_eq!(bounds.min, Point3::new(4.5, -0.5, -0.5));
+        assert_eq!(bounds.max, Point3::new(5.5, 0.5, 0.5));
     }
 
     /// A jointed object mesh (`from_obj_bin`'s animated branch) carries no

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -43,6 +43,10 @@ const BRACKET_SIZE: f32 = 8.0;
 /// Line height of the rollover label, in screen pixels.
 const LABEL_HEIGHT: f32 = 10.0;
 
+/// Screen inset for the hover label: the bracket it sits beside plus the line
+/// of text drawn above it.
+const LABEL_MARGIN: f32 = BRACKET_SIZE + LABEL_HEIGHT;
+
 fn resolve_localized_property_string(raw: &str, strings: &HashMap<String, String>) -> String {
     let (key, fallback) = match raw.split_once(':') {
         Some((key, remainder)) => {
@@ -219,7 +223,12 @@ pub fn draw_item_name(
 
     let aabb = maybe_bbox.unwrap();
     let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
-    let extents = project_aabb3(&aabb, view, projection, screen_size);
+    // Clamped like the brackets, plus the line of text the label sits on.
+    let extents = clamp_extents_to_screen(
+        project_aabb3(&aabb, view, projection, screen_size),
+        screen_size,
+        LABEL_MARGIN,
+    );
 
     let v_prop_hitpoints = world.borrow::<View<PropHitPoints>>().unwrap();
     let hit_points = v_prop_hitpoints.get(entity_id).map(|hp| hp.hit_points).ok();
@@ -264,6 +273,57 @@ pub fn draw_item_name(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const SCREEN: Vector2<f32> = Vector2::new(800.0, 600.0);
+
+    fn extents(min: (f32, f32), max: (f32, f32)) -> Aabb2<f32> {
+        Aabb2 {
+            min: point2(min.0, min.1),
+            max: point2(max.0, max.1),
+        }
+    }
+
+    /// Negative-first: a corpse frobbed from arm's length projects past every
+    /// edge, and unclamped its brackets and name are drawn off-screen - the
+    /// object looks un-highlighted while the player is looting it.
+    #[test]
+    fn an_oversized_extent_is_pulled_back_onto_the_screen() {
+        let clamped =
+            clamp_extents_to_screen(extents((-400.0, -300.0), (1200.0, 900.0)), SCREEN, 8.0);
+
+        assert_eq!(clamped.min, point2(8.0, 8.0));
+        assert_eq!(clamped.max, point2(792.0, 592.0));
+    }
+
+    /// An extent already on screen is untouched: the clamp must not nudge the
+    /// brackets off the object they frame.
+    #[test]
+    fn an_onscreen_extent_is_left_alone() {
+        let original = extents((100.0, 120.0), (300.0, 260.0));
+
+        assert_eq!(
+            clamp_extents_to_screen(original, SCREEN, 8.0).min,
+            original.min
+        );
+        assert_eq!(
+            clamp_extents_to_screen(original, SCREEN, 8.0).max,
+            original.max
+        );
+    }
+
+    /// Something entirely off screen (behind the camera, or past its edge) is
+    /// left alone too - clamping it would pin a marker to the edge for an
+    /// object the player cannot see.
+    #[test]
+    fn a_fully_offscreen_extent_is_not_pinned_to_the_edge() {
+        let offscreen = extents((-500.0, -400.0), (-100.0, -50.0));
+
+        assert_eq!(
+            clamp_extents_to_screen(offscreen, SCREEN, 8.0).min,
+            offscreen.min
+        );
+    }
+
     use crate::flat_player_controller::is_frobbable;
     use dark::properties::{FrobFlag, ObjectNameType, PropFrobInfo};
 
@@ -665,7 +725,14 @@ pub fn draw_item_outline(
     let bottom_left_brack = asset_cache.get_ext(&TEXTURE_IMPORTER, "BRACK3.PCX", &options);
 
     let size = vec2(BRACKET_SIZE, BRACKET_SIZE);
-    let extents = project_aabb3(&aabb, view, projection, screen_size);
+    // A body-sized volume seen from arm's length projects past every edge of
+    // the screen; without the clamp all four brackets land off-view and the
+    // object reads as un-highlighted while it is being frobbed.
+    let extents = clamp_extents_to_screen(
+        project_aabb3(&aabb, view, projection, screen_size),
+        screen_size,
+        size.x,
+    );
     let top_left_brack_obj =
         SceneObject::screen_space_quad(top_left_brack, vec2(extents.min.x, extents.min.y), size);
     let top_right_brack_obj =
@@ -683,6 +750,36 @@ pub fn draw_item_outline(
         bottom_right_brack_obj,
         top_right_brack_obj,
     ]
+}
+
+/// Keep a projected extent on screen, so an object bigger than the view still
+/// shows where it is instead of throwing its brackets and label off-view. Every
+/// edge is inset by `margin` (the bracket size), and a fully off-screen extent
+/// is left alone - clamping that would pin a marker to the edge for something
+/// behind the camera.
+pub fn clamp_extents_to_screen(
+    extents: Aabb2<f32>,
+    screen_size: Vector2<f32>,
+    margin: f32,
+) -> Aabb2<f32> {
+    let (max_x, max_y) = (screen_size.x - margin, screen_size.y - margin);
+    if extents.max.x < margin
+        || extents.max.y < margin
+        || extents.min.x > max_x
+        || extents.min.y > max_y
+    {
+        return extents;
+    }
+    Aabb2 {
+        min: point2(
+            extents.min.x.clamp(margin, max_x),
+            extents.min.y.clamp(margin, max_y),
+        ),
+        max: point2(
+            extents.max.x.clamp(margin, max_x),
+            extents.max.y.clamp(margin, max_y),
+        ),
+    }
 }
 
 pub fn project_aabb3(

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1016,20 +1016,27 @@ fn create_physics_representation_with_options(
 
     let min_size = 0.5 / SCALE_FACTOR;
     let min_size_vec = vec3(min_size, min_size, min_size);
+    // Model bounds in world units: the mesh is drawn at `PropScale`, so both the
+    // size and the centre of a box that stands in for it take that scale. The
+    // render bakes the scale's absolute value (see `create_model`), so a
+    // mirrored model keeps its box on the same side as its mesh.
+    let model_scale = vec3(
+        model_scale.x.abs(),
+        model_scale.y.abs(),
+        model_scale.z.abs(),
+    );
     let model_bounds = maybe_model.as_ref().and_then(|model| model.bounding_box());
     let dimensions = model_bounds
         .map(|bbox| bbox.dim())
         .unwrap_or(default_size_vec);
     let abs_dimensions = vec3(
-        dimensions.x.abs().max(min_size_vec.x),
-        dimensions.y.abs().max(min_size_vec.y),
-        dimensions.z.abs().max(min_size_vec.z),
+        (dimensions.x * model_scale.x).abs().max(min_size_vec.x),
+        (dimensions.y * model_scale.y).abs().max(min_size_vec.y),
+        (dimensions.z * model_scale.z).abs().max(min_size_vec.z),
     );
     // Model bounds are not centred on the object's origin - a skinned corpse
-    // lies away from its root joint - so the selection box has to be carried
-    // to the bounds' centre, or it covers empty space beside the mesh. The
-    // centre follows the model's own scale (which `abs_dimensions` above has
-    // never applied) so a scaled mesh keeps its box.
+    // lies away from its root joint - so the selection box has to be carried to
+    // the bounds' centre, or it covers empty space beside the mesh.
     let model_bounds_center = model_bounds
         .map(|bbox| {
             let center = bbox.center().to_vec();
@@ -1058,7 +1065,10 @@ fn create_physics_representation_with_options(
     // every load. Preserve the live creature's dynamic capsule geometry and
     // material, place it at the exact saved transform, then start it asleep.
     // The corpse group keeps it on the world and selectable for looting without
-    // leaving a player-blocking creature capsule behind.
+    // leaving a player-blocking creature capsule behind. This capsule is also
+    // why a death pose needs no model bounds: it is posed at draw time from an
+    // `AnimationPlayer`, which bakes no bounds, so it would otherwise fall
+    // through to the rest-pose box below.
     if v_death_pose.get(entity_id).is_ok() {
         if let (Ok(pos), Ok(creature_type)) = (v_pos.get(entity_id), v_creature.get(entity_id)) {
             let creature_def = get_creature_definition(creature_type.0).unwrap();
@@ -2003,6 +2013,41 @@ mod tests {
         entity_id
     }
 
+    /// The mesh is drawn at `PropScale`, so its stand-in box takes that scale -
+    /// in both size and placement, and by the scale's absolute value, which is
+    /// what the render bakes (a mirrored model must not have its box flipped to
+    /// the other side of the object).
+    #[test]
+    fn a_frob_collider_takes_the_models_scale() {
+        for scale in [vec3(2.0, 2.0, 2.0), vec3(-2.0, 2.0, 2.0)] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity_id = add_wall_fixture(&mut world, None);
+            world.add_component(entity_id, PropScale(scale));
+            let model = Model::from_glb(
+                vec![],
+                Aabb3::new(Point3::new(2.0, -0.5, -0.5), Point3::new(4.0, 0.5, 0.5)),
+                None,
+            );
+
+            create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+                .expect("a frobbable fixture should always get a frob collider");
+
+            let aabb = physics
+                .get_aabb2(entity_id)
+                .expect("the frob collider has bounds");
+            let center = aabb.min + (aabb.max - aabb.min) / 2.0;
+            assert!(
+                (center.x - 6.0).abs() < 0.01,
+                "scale {scale:?}: the box should sit at the scaled bounds centre, got {center:?}"
+            );
+            assert!(
+                ((aabb.max.x - aabb.min.x) - 4.0).abs() < 0.01,
+                "scale {scale:?}: the box should be the scaled bounds size, got {aabb:?}"
+            );
+        }
+    }
+
     /// An authored corpse is a posed creature: it inherits a `PhysType`, so the
     /// #801 guard below does not fire, but its selection box is now the whole
     /// body - solid, it would fence off the floor around every body in the
@@ -2037,14 +2082,17 @@ mod tests {
             !physics.collider_blocks_actor(handle),
             "a corpse's frob box must not block actors"
         );
-        let bodies = physics.debug_list_bodies();
+        let body = physics
+            .debug_list_bodies()
+            .into_iter()
+            .find(|body| body.entity_id == Some(entity_id.inner() as i32))
+            .expect("the corpse's body should be listed");
         assert!(
-            bodies[0]
-                .collision_groups
+            body.collision_groups
                 .iter()
                 .any(|g| g == "entity" || g == "selectable"),
             "the corpse must stay selectable, got {:?}",
-            bodies[0].collision_groups
+            body.collision_groups
         );
     }
 

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -13,7 +13,7 @@ use cgmath::{
     EuclideanSpace, Matrix4, Point3, Quaternion, SquareMatrix, Transform, Vector3, Zero,
     num_traits::abs, vec3,
 };
-use collision::Aabb3;
+use collision::{Aabb, Aabb3};
 use dark::{
     BitmapAnimation, SCALE_FACTOR,
     importers::{ANIMATION_CLIP_IMPORTER, BITMAP_ANIMATION_IMPORTER, MODELS_IMPORTER},
@@ -978,6 +978,14 @@ fn create_physics_representation_with_options(
         .unwrap()
         .contains(entity_id);
 
+    // Read alone: the borrow tuple below is already at shipyard's arity limit.
+    let model_scale = world
+        .borrow::<View<PropScale>>()
+        .unwrap()
+        .get(entity_id)
+        .map(|scale| scale.0)
+        .unwrap_or_else(|_| vec3(1.0, 1.0, 1.0));
+
     let (
         v_pos,
         v_phys_attr,
@@ -1008,9 +1016,9 @@ fn create_physics_representation_with_options(
 
     let min_size = 0.5 / SCALE_FACTOR;
     let min_size_vec = vec3(min_size, min_size, min_size);
-    let dimensions = maybe_model
-        .as_ref()
-        .and_then(|model| model.bounding_box().map(|bbox| bbox.max - bbox.min))
+    let model_bounds = maybe_model.as_ref().and_then(|model| model.bounding_box());
+    let dimensions = model_bounds
+        .map(|bbox| bbox.dim())
         .unwrap_or(default_size_vec);
     let abs_dimensions = vec3(
         dimensions.x.abs().max(min_size_vec.x),
@@ -1019,11 +1027,18 @@ fn create_physics_representation_with_options(
     );
     // Model bounds are not centred on the object's origin - a skinned corpse
     // lies away from its root joint - so the selection box has to be carried
-    // to the bounds' centre, or it covers empty space beside the mesh.
-    let model_bounds_center = maybe_model
-        .as_ref()
-        .and_then(|model| model.bounding_box())
-        .map(|bbox| bbox.min.to_vec() + (bbox.max - bbox.min) / 2.0)
+    // to the bounds' centre, or it covers empty space beside the mesh. The
+    // centre follows the model's own scale (which `abs_dimensions` above has
+    // never applied) so a scaled mesh keeps its box.
+    let model_bounds_center = model_bounds
+        .map(|bbox| {
+            let center = bbox.center().to_vec();
+            vec3(
+                center.x * model_scale.x,
+                center.y * model_scale.y,
+                center.z * model_scale.z,
+            )
+        })
         .unwrap_or_else(Vector3::zero);
 
     let dynamics_options = if let Ok(phys_attr) = v_phys_attr.get(entity_id) {
@@ -1250,7 +1265,12 @@ fn create_physics_representation_with_options(
             // walk-in fixtures - the hydro2 Resurrection Station alcove is a
             // 2.2 x 4.0 x 2.5 box the player must stand inside - and wedges
             // the capsule against its faces with no way out (#801).
-            if v_phys_type.get(entity_id).is_err() {
+            //
+            // An authored corpse is the same story from the other side: it is
+            // a posed creature, so it *does* inherit a `PhysType`, but its box
+            // is now the whole body and a solid one would fence off the floor
+            // around it. Retail lets the player walk over a body.
+            if v_phys_type.get(entity_id).is_err() || v_creature_pose.get(entity_id).is_ok() {
                 frob_group = frob_group.non_solid_to_characters();
             }
             rigid_body_handle = physics.add_kinematic(
@@ -1981,6 +2001,51 @@ mod tests {
             );
         }
         entity_id
+    }
+
+    /// An authored corpse is a posed creature: it inherits a `PhysType`, so the
+    /// #801 guard below does not fire, but its selection box is now the whole
+    /// body - solid, it would fence off the floor around every body in the
+    /// level. Retail lets the player walk over a corpse.
+    ///
+    /// Negative-first: with the body-sized box and no pose guard this blocks.
+    #[test]
+    fn a_posed_corpse_frob_box_does_not_block_characters() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_wall_fixture(&mut world, Some(PhysicsModelType::ORIENTED_BOUNDING_BOX));
+        world.add_component(
+            entity_id,
+            PropCreaturePose {
+                pose_type: PoseType::MOTION_NAME,
+                motion_or_tag_name: "humdie3c".to_owned(),
+                scale: 1.0,
+                ballistic: true,
+            },
+        );
+        let model = ladder_model();
+
+        let handle =
+            create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+                .expect("a posed corpse should still get its frob collider");
+
+        assert!(
+            !physics.collider_blocks_player(handle),
+            "a corpse's frob box must not block the player"
+        );
+        assert!(
+            !physics.collider_blocks_actor(handle),
+            "a corpse's frob box must not block actors"
+        );
+        let bodies = physics.debug_list_bodies();
+        assert!(
+            bodies[0]
+                .collision_groups
+                .iter()
+                .any(|g| g == "entity" || g == "selectable"),
+            "the corpse must stay selectable, got {:?}",
+            bodies[0].collision_groups
+        );
     }
 
     /// The selection collider has to cover the *mesh*, wherever the mesh sits

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1017,6 +1017,14 @@ fn create_physics_representation_with_options(
         dimensions.y.abs().max(min_size_vec.y),
         dimensions.z.abs().max(min_size_vec.z),
     );
+    // Model bounds are not centred on the object's origin - a skinned corpse
+    // lies away from its root joint - so the selection box has to be carried
+    // to the bounds' centre, or it covers empty space beside the mesh.
+    let model_bounds_center = maybe_model
+        .as_ref()
+        .and_then(|model| model.bounding_box())
+        .map(|bbox| bbox.min.to_vec() + (bbox.max - bbox.min) / 2.0)
+        .unwrap_or_else(Vector3::zero);
 
     let dynamics_options = if let Ok(phys_attr) = v_phys_attr.get(entity_id) {
         DynamicPhysicsOptions {
@@ -1214,7 +1222,7 @@ fn create_physics_representation_with_options(
             physics.add_interaction_cuboid(
                 rigid_body_handle,
                 entity_id,
-                Vector3::zero(),
+                model_bounds_center,
                 abs_dimensions,
                 frob_group,
             );
@@ -1249,7 +1257,7 @@ fn create_physics_representation_with_options(
                 entity_id,
                 pos.position,
                 qrotation,
-                Vector3::zero(),
+                model_bounds_center,
                 abs_dimensions,
                 // TODO: Kinematic experiment
                 //is_sensor,
@@ -1973,6 +1981,38 @@ mod tests {
             );
         }
         entity_id
+    }
+
+    /// The selection collider has to cover the *mesh*, wherever the mesh sits
+    /// relative to the object's origin. A skinned corpse's bounds lie a body
+    /// length away from its root joint, so an origin-centred box misses it.
+    ///
+    /// Negative-first: before the fix the collider was always centred on the
+    /// object's position.
+    #[test]
+    fn a_frob_collider_is_centred_on_the_model_bounds() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_wall_fixture(&mut world, None);
+        // Bounds offset 3 units along +x, as a lying corpse's are from its
+        // root joint.
+        let model = Model::from_glb(
+            vec![],
+            Aabb3::new(Point3::new(2.0, -0.5, -0.5), Point3::new(4.0, 0.5, 0.5)),
+            None,
+        );
+
+        create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+            .expect("a frobbable fixture should always get a frob collider");
+
+        let aabb = physics
+            .get_aabb2(entity_id)
+            .expect("the frob collider has bounds");
+        let center = aabb.min + (aabb.max - aabb.min) / 2.0;
+        assert!(
+            (center.x - 3.0).abs() < 0.01,
+            "collider should sit at the model bounds centre, got {center:?}"
+        );
     }
 
     /// A frobbable fixture's collider comes from its model bounding box, not

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1016,27 +1016,31 @@ fn create_physics_representation_with_options(
 
     let min_size = 0.5 / SCALE_FACTOR;
     let min_size_vec = vec3(min_size, min_size, min_size);
-    // Model bounds in world units: the mesh is drawn at `PropScale`, so both the
-    // size and the centre of a box that stands in for it take that scale. The
-    // render bakes the scale's absolute value (see `create_model`), so a
-    // mirrored model keeps its box on the same side as its mesh.
+    // The render bakes the *absolute* value of `PropScale` (see `create_model`),
+    // so anything derived from the model's bounds follows the same.
     let model_scale = vec3(
         model_scale.x.abs(),
         model_scale.y.abs(),
         model_scale.z.abs(),
     );
     let model_bounds = maybe_model.as_ref().and_then(|model| model.bounding_box());
+    // Deliberately unscaled, as it always has been. Scaling the model-bounds
+    // *size* here resizes the selection volume of every scaled object in the
+    // game, and measurably moves what the crosshair picks (it took earth's
+    // Interrogation Room door pick with it), so it wants its own pass.
     let dimensions = model_bounds
         .map(|bbox| bbox.dim())
         .unwrap_or(default_size_vec);
     let abs_dimensions = vec3(
-        (dimensions.x * model_scale.x).abs().max(min_size_vec.x),
-        (dimensions.y * model_scale.y).abs().max(min_size_vec.y),
-        (dimensions.z * model_scale.z).abs().max(min_size_vec.z),
+        dimensions.x.abs().max(min_size_vec.x),
+        dimensions.y.abs().max(min_size_vec.y),
+        dimensions.z.abs().max(min_size_vec.z),
     );
     // Model bounds are not centred on the object's origin - a skinned corpse
     // lies away from its root joint - so the selection box has to be carried to
-    // the bounds' centre, or it covers empty space beside the mesh.
+    // the bounds' centre, or it covers empty space beside the mesh. The centre
+    // *is* scaled: it says where the mesh is, and a scaled mesh is somewhere
+    // else.
     let model_bounds_center = model_bounds
         .map(|bbox| {
             let center = bbox.center().to_vec();
@@ -2013,10 +2017,11 @@ mod tests {
         entity_id
     }
 
-    /// The mesh is drawn at `PropScale`, so its stand-in box takes that scale -
-    /// in both size and placement, and by the scale's absolute value, which is
-    /// what the render bakes (a mirrored model must not have its box flipped to
-    /// the other side of the object).
+    /// A scaled mesh sits somewhere else, so the box follows `PropScale` to the
+    /// scaled bounds centre - by the scale's absolute value, which is what the
+    /// render bakes (a mirrored model must not have its box flipped to the
+    /// other side of the object). The box's *size* is deliberately left
+    /// unscaled: see the comment at the call site.
     #[test]
     fn a_frob_collider_takes_the_models_scale() {
         for scale in [vec3(2.0, 2.0, 2.0), vec3(-2.0, 2.0, 2.0)] {
@@ -2042,8 +2047,8 @@ mod tests {
                 "scale {scale:?}: the box should sit at the scaled bounds centre, got {center:?}"
             );
             assert!(
-                ((aabb.max.x - aabb.min.x) - 4.0).abs() < 0.01,
-                "scale {scale:?}: the box should be the scaled bounds size, got {aabb:?}"
+                ((aabb.max.x - aabb.min.x) - 2.0).abs() < 0.01,
+                "scale {scale:?}: the box keeps the unscaled bounds size, got {aabb:?}"
             );
         }
     }

--- a/tools/shock2-sdk/test/corpse-body-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/corpse-body-frob.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// An authored corpse is a posed creature, not a live one: it carries
+// PropCreature + PropCreaturePose and a skinned mesh, and its collider is the
+// model-bounds box every frobbable fixture gets. An animated model used to
+// report no bounds at all, so that box collapsed to the 0.2-unit default at
+// the corpse's root joint - the body was unfrobbable except for one spot over
+// its hip, and the wrench inside it was unreachable.
+//
+// Negative-first: before the fix the squeeze below opens no panel, and the
+// footprint probe finds the corpse under a single sample instead of dozens.
+const MEDSCI_CORPSE_NAME = "MS Male Corpse";
+const STANDING_SPOT = { x: -37.27, y: -4.4, z: 30.2 };
+
+test(
+  "medsci1: a corpse is frobbed by aiming anywhere along its body",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 10 });
+
+    const { entities } = await game.entities.list();
+    const corpses = entities.filter((entity) => entity.name === MEDSCI_CORPSE_NAME);
+    const corpse = corpses.sort((a, b) => a.distance - b.distance)[0];
+    assert.ok(corpse, `expected a ${MEDSCI_CORPSE_NAME} in medsci1`);
+    const [cx, cy, cz] = corpse.position;
+
+    // The selection collider must span the body, not sit on its origin. Probe
+    // straight down on a grid and count the samples that land on the corpse.
+    const probe = async (dx: number, dz: number) =>
+      game.raycast({
+        start: [cx + dx, cy + 3, cz + dz],
+        end: [cx + dx, cy - 1, cz + dz],
+        collision_groups: ["world", "entity", "selectable", "raycast", "hitbox"],
+      });
+    let onBody = 0;
+    for (let i = -6; i <= 6; i++) {
+      for (let j = -2; j <= 2; j++) {
+        const hit = await probe(i * 0.2, j * 0.2);
+        if (hit.entity_id === corpse.id) onBody++;
+      }
+    }
+    assert.ok(
+      onBody > 20,
+      `the corpse's selection collider should cover its body; only ${onBody} of 65 samples hit it`,
+    );
+
+    // Production interaction: aim at a point a half body-length off the root
+    // joint - the part of the corpse the old point-sized collider missed.
+    await teleportVerified(game, STANDING_SPOT);
+    await game.step({ frames: 10 });
+    await game.input.lookAtWorldPoint([cx + 0.6, cy + 0.2, cz]);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+
+    const ui = await game.ui.state();
+    assert.ok(
+      ui.active_panel,
+      `aiming along the corpse and squeezing should open its loot MFD (got ${JSON.stringify(ui)})`,
+    );
+    assert.equal(
+      ui.active_panel.entity_id,
+      corpse.id,
+      "the active panel should be bound to the corpse entity",
+    );
+    await game.screenshot("medsci1-corpse-body-frob.png");
+  },
+);

--- a/tools/shock2-sdk/test/corpse-body-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/corpse-body-frob.e2e.test.ts
@@ -51,6 +51,25 @@ test(
       `the corpse's selection collider should cover its body; only ${onBody} of 65 samples hit it`,
     );
 
+    // ...and be the shape of the pose it is DRAWN in. Bounding the skeleton's
+    // standing rest pose instead gives a body-height slab standing on end over
+    // a body lying flat, which passes the footprint probe above but fences off
+    // the air above the corpse.
+    const top = await probe(0, 0);
+    assert.equal(top.entity_id, corpse.id, "expected the probe over the origin to hit the corpse");
+    const height = top.hit_point![1] - cy;
+    assert.ok(
+      height < 0.8,
+      `a corpse lies flat: its collider should top out just above its origin, got ${height}`,
+    );
+
+    // The collider must be solid to nothing: it is a selection volume, and a
+    // body-sized solid box would fence off the floor around every corpse.
+    const [body] = (await game.physics.bodies({ entityId: corpse.id })).bodies;
+    assert.ok(body, "the corpse should have a physics body");
+    assert.equal(body.blocks_player, false, "a corpse must not block the player");
+    assert.equal(body.blocks_actor, false, "a corpse must not block actors");
+
     // Production interaction: aim at a point a half body-length off the root
     // joint - the part of the corpse the old point-sized collider missed.
     await teleportVerified(game, STANDING_SPOT);


### PR DESCRIPTION
## Problem

The first corpse in medsci1 (and every other authored corpse) was effectively unlootable: its frob/selection hit area was a **0.2-unit cube at the object's root joint**, so the crosshair had to land on one spot over its hip to open the body.

Authored corpses are *posed creatures* — `PropCreature` + `PropCreaturePose`, a skinned mesh, `ContainerScript`. They take the model-bounds collider path every frobbable fixture takes, and `Model::bounding_box()` returned `None` for **every animated model**, so that box fell back to the default size.

![corpse frob demo](https://gist.githubusercontent.com/tommy-xr/e622c0b5ff244e5d7fc7bc83f097b973/raw/corpse-frob.gif)

<sub>The crosshair sweeps the length of the body — highlighted throughout — and frobbing opens the corpse's SEARCH panel with its wrench. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Change

- `AnimatedModel::bounding_box()` — the union of the per-joint vertex AABBs, each carried into model space by that joint's transform. Those joint boxes are the same source the damage hitboxes use.
- The bounds follow the **pose the model is drawn in**. Posing bakes only the skinning palette, leaving the skeleton at rest, so `animate` now records the posed bounds; without that a body lying flat was bounded by the standing rest skeleton (a 3-unit-tall slab on its end).
- The frob/selection collider is centred on those bounds (at the model's absolute `PropScale`). A lying body's mesh is a body length from its origin, so an origin-centred box misses it. The box's *size* stays unscaled, as it always has been: scaling it resizes the selection volume of every scaled object in the game and measurably moved what the crosshair picks (it took earth's Interrogation Room door pick with it).
- A posed corpse's box is **not solid**. It is a selection volume; body-sized and solid, it would fence off the floor around every corpse. The existing #801 guard did not cover this — a posed creature inherits a `PhysType`.
- The HUD brackets and hover label clamp to the viewport. A body-sized box seen from frob range projects past every edge, which drew all four brackets and the name off-screen — the body read as un-highlighted while being frobbed.

## Before → after

![outline before/after](https://gist.githubusercontent.com/tommy-xr/e622c0b5ff244e5d7fc7bc83f097b973/raw/corpse-outline.png)

<sub>Same standing spot, same aim at the corpse's hip (the one spot the old build highlights at all), `main` vs this branch.</sub>

![loot panel before/after](https://gist.githubusercontent.com/tommy-xr/e622c0b5ff244e5d7fc7bc83f097b973/raw/corpse-beforeafter.png)

<sub>Same aim, same use button: nothing happens on `main`, the body opens here.</sub>

![selection footprint](https://gist.githubusercontent.com/tommy-xr/e622c0b5ff244e5d7fc7bc83f097b973/raw/corpse-footprint.png)

<sub>The collider itself, probed with downward raycasts — and 0.31 tall rather than the 3.0-unit standing slab the rest pose would give.</sub>

## Verification

- `dark`: rest-pose union, posed-pose union, and the no-joint-boxes `None` case.
- `shock2vr`: the frob collider is centred on the model bounds; it takes the absolute scale; a posed corpse's box blocks neither player nor actors; the HUD extent clamp (oversized, on-screen, and fully-off-screen cases).
- New e2e `corpse-body-frob.e2e.test.ts`: probes the collider's footprint and height, checks it is non-solid, then aims off-origin along the body and frobs — the loot panel opens with the corpse's wrench. Every assertion was verified to fail without its own fix.
- Full SDK e2e suite: 344/359, and all 7 remaining failures also fail on `main`. (A door-pick regression found mid-review was bisected to the size-scaling hunk and reverted.)

## Known gaps (not this PR)

- The `FrobFlag::MOVE` dynamic branch still centres its model-bounds collider on the origin.
- The box is the AABB of a sprawled pose, so it overhangs the body at the corners. Tightening the selection volume to the fitted per-joint shapes is the next PR in this stack.

