### PR TITLE
feat(debug): floating damage readouts at the point of impact

### DIFF
--- a/shock2vr/src/damage_overlay.rs
+++ b/shock2vr/src/damage_overlay.rs
@@ -9,13 +9,12 @@
 //! Recorded from the one place every script message is dispatched
 //! (`ScriptWorld::update`), so it sees melee, projectiles, hitbox-forwarded
 //! damage and script-injected damage alike - anything that reaches a script as
-//! `MessagePayload::Damage` with an impact point.
-
-use std::sync::Mutex;
+//! `MessagePayload::Damage` with an impact point. The readouts live on the
+//! `ScriptWorld` that records them, so they die with their scene.
 
 use cgmath::{Deg, InnerSpace, Matrix4, SquareMatrix, Vector3, vec3};
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
-use shipyard::{EntityId, World};
+use shipyard::{EntityId, Get, View, World};
 
 use dark::importers::FONT_IMPORTER;
 
@@ -27,26 +26,21 @@ const LIFETIME_SECS: f64 = 1.6;
 const RISE: f32 = 0.6;
 /// World-space height of a line of text.
 const TEXT_HEIGHT: f32 = 0.22;
-/// Nominal glyph width as a fraction of the line height, for sizing the quad
-/// the normalized text is stretched onto.
-const CHAR_ASPECT: f32 = 0.55;
 /// Older readouts are dropped rather than accumulating in a firefight.
 const MAX_POPUPS: usize = 32;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct DamagePopup {
+pub(crate) struct DamagePopup {
     pub text: String,
     pub point: Vector3<f32>,
     pub spawned_at: f64,
 }
 
-static POPUPS: Mutex<Vec<DamagePopup>> = Mutex::new(Vec::new());
-
 /// The readout for one blow: how much, and where it landed. The hitbox name
 /// comes from the struck joint, which only a hitbox-forwarded hit carries - a
 /// blow that landed on the entity's own collider says nothing about limbs
 /// rather than guessing "Body".
-pub fn popup_text(amount: f32, hit_box: Option<HitBoxType>) -> String {
+pub(crate) fn popup_text(amount: f32, hit_box: Option<HitBoxType>) -> String {
     let amount = format!("-{} HP", format_amount(amount));
     match hit_box {
         Some(hit_box) => format!("{amount}  {}", hit_box_label(hit_box)),
@@ -76,56 +70,74 @@ fn hit_box_label(hit_box: HitBoxType) -> &'static str {
 }
 
 /// Remaining life of a readout as a 0..1 ramp, `None` once it has expired.
-pub fn fade(spawned_at: f64, now: f64) -> Option<f32> {
+pub(crate) fn fade(spawned_at: f64, now: f64) -> Option<f32> {
     let age = now - spawned_at;
     (age >= 0.0 && age < LIFETIME_SECS).then(|| 1.0 - (age / LIFETIME_SECS) as f32)
 }
 
-/// Record a dispatched message, keeping the ones that are damage with a known
-/// impact point. A no-op while the overlay is off, so nothing accumulates.
-pub fn record(world: &World, sim_time: f64, target: EntityId, payload: &MessagePayload) {
+/// The readout a dispatched message earns, if any: damage that knows where it
+/// landed, while the overlay is on.
+///
+/// A hit forwarded by a hitbox is dispatched twice - once to the hitbox entity
+/// and once to the creature it belongs to, both carrying the same impact point
+/// - so the proxy delivery is skipped. Recording both would stack an unlabeled
+/// readout under the labeled one on every real limb hit, which is exactly the
+/// ambiguity this overlay exists to remove.
+pub(crate) fn popup_for(
+    world: &World,
+    sim_time: f64,
+    target: EntityId,
+    payload: &MessagePayload,
+) -> Option<DamagePopup> {
     if !crate::dev_params::get_bool(crate::dev_params::DAMAGE_NUMBERS) {
-        return;
+        return None;
     }
     let MessagePayload::Damage {
         amount,
         impact: Some(impact),
     } = payload
     else {
-        return;
+        return None;
     };
+    if is_hit_box(world, target) {
+        return None;
+    }
 
     let hit_box = impact.bone.and_then(|bone| {
         crate::creature::get_entity_creature(world, target)
             .and_then(|creature| creature.get_hitbox_type(bone))
     });
 
-    let mut popups = POPUPS.lock().unwrap();
-    if popups.len() >= MAX_POPUPS {
-        popups.remove(0);
-    }
-    popups.push(DamagePopup {
+    Some(DamagePopup {
         text: popup_text(*amount, hit_box),
         point: impact.point,
         spawned_at: sim_time,
-    });
+    })
 }
 
-/// Live readouts, oldest first. Expired ones are dropped as a side effect, so
-/// the buffer drains on its own even if nothing is rendering.
-pub fn live(now: f64) -> Vec<(DamagePopup, f32)> {
-    let mut popups = POPUPS.lock().unwrap();
+/// Whether an entity is one of a creature's hitbox proxies.
+fn is_hit_box(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<crate::creature::RuntimePropHitBox>>()
+        .is_ok_and(|hit_boxes| hit_boxes.get(entity_id).is_ok())
+}
+
+/// Cap the buffer, oldest dropped first, so a firefight cannot grow it without
+/// bound before the next render ages it out.
+pub(crate) fn trim(popups: &mut Vec<DamagePopup>) {
+    if popups.len() > MAX_POPUPS {
+        popups.drain(..popups.len() - MAX_POPUPS);
+    }
+}
+
+/// Drop expired readouts, and report those still alive with their remaining
+/// life as a 0..1 ramp.
+pub(crate) fn live(popups: &mut Vec<DamagePopup>, now: f64) -> Vec<(DamagePopup, f32)> {
     popups.retain(|popup| fade(popup.spawned_at, now).is_some());
     popups
         .iter()
         .filter_map(|popup| fade(popup.spawned_at, now).map(|fade| (popup.clone(), fade)))
         .collect()
-}
-
-/// Drop every readout. Called on a level transition, where the world the points
-/// referred to is gone.
-pub fn clear() {
-    POPUPS.lock().unwrap().clear();
 }
 
 /// The readouts as world-space text, turned to face the camera and drifting up
@@ -134,12 +146,25 @@ pub fn clear() {
 /// Billboarded about the vertical only, toward `camera_pos`: a readout stays
 /// upright, which is what makes it readable, and it needs only the camera's
 /// position - so the same call serves the flat camera and either VR eye.
-pub fn render(
+///
+/// `camera_pos` is the player's own eye. A *detached* free camera therefore
+/// sees the readouts edge-on: the free camera's pose is resolved by `Game`
+/// after this scene is built, and is deliberately not plumbed in here - a
+/// spectator camera showing the body's instruments from the body's point of
+/// view is the same rule the HUD already follows.
+pub(crate) fn render(
     asset_cache: &mut AssetCache,
+    popups: &mut Vec<DamagePopup>,
     camera_pos: Vector3<f32>,
     now: f64,
 ) -> Vec<SceneObject> {
-    let live = live(now);
+    if !crate::dev_params::get_bool(crate::dev_params::DAMAGE_NUMBERS) {
+        // Turning the overlay off takes the readouts with it, rather than
+        // leaving the last second and a half of them hanging in the world.
+        popups.clear();
+        return Vec::new();
+    }
+    let live = live(popups, now);
     if live.is_empty() {
         return Vec::new();
     }
@@ -155,9 +180,9 @@ pub fn render(
                     * facing_rotation(position, camera_pos)
                     * Matrix4::from_nonuniform_scale(
                         // `world_space_text` normalizes its glyphs into a unit
-                        // square, so the caller owns the aspect: width is the
-                        // line height times the character count.
-                        TEXT_HEIGHT * popup.text.chars().count() as f32 * CHAR_ASPECT,
+                        // square, so the caller owns the aspect: the font's own
+                        // measurement of this string at unit line height.
+                        TEXT_HEIGHT * engine::measure_text_width(&**font, &popup.text, 1.0),
                         TEXT_HEIGHT,
                         1.0,
                     )

--- a/shock2vr/src/damage_overlay.rs
+++ b/shock2vr/src/damage_overlay.rs
@@ -1,0 +1,265 @@
+//! Floating damage readouts: a short-lived "-7 HP" at the point a blow landed,
+//! labeled with the hitbox it struck.
+//!
+//! This is the instrument for the hitbox work: without it, "did that shot hit
+//! the head or the arm, and for how much?" can only be answered by reading the
+//! victim's hit points before and after. Off by default, behind the
+//! `damage_numbers` dev param, so a headset can turn it on without a rebuild.
+//!
+//! Recorded from the one place every script message is dispatched
+//! (`ScriptWorld::update`), so it sees melee, projectiles, hitbox-forwarded
+//! damage and script-injected damage alike - anything that reaches a script as
+//! `MessagePayload::Damage` with an impact point.
+
+use std::sync::Mutex;
+
+use cgmath::{Deg, InnerSpace, Matrix4, SquareMatrix, Vector3, vec3};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+use shipyard::{EntityId, World};
+
+use dark::importers::FONT_IMPORTER;
+
+use crate::{creature::HitBoxType, scripts::MessagePayload};
+
+/// How long a readout stays up.
+const LIFETIME_SECS: f64 = 1.6;
+/// How far it drifts upward over that life, in world units.
+const RISE: f32 = 0.6;
+/// World-space height of a line of text.
+const TEXT_HEIGHT: f32 = 0.22;
+/// Nominal glyph width as a fraction of the line height, for sizing the quad
+/// the normalized text is stretched onto.
+const CHAR_ASPECT: f32 = 0.55;
+/// Older readouts are dropped rather than accumulating in a firefight.
+const MAX_POPUPS: usize = 32;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DamagePopup {
+    pub text: String,
+    pub point: Vector3<f32>,
+    pub spawned_at: f64,
+}
+
+static POPUPS: Mutex<Vec<DamagePopup>> = Mutex::new(Vec::new());
+
+/// The readout for one blow: how much, and where it landed. The hitbox name
+/// comes from the struck joint, which only a hitbox-forwarded hit carries - a
+/// blow that landed on the entity's own collider says nothing about limbs
+/// rather than guessing "Body".
+pub fn popup_text(amount: f32, hit_box: Option<HitBoxType>) -> String {
+    let amount = format!("-{} HP", format_amount(amount));
+    match hit_box {
+        Some(hit_box) => format!("{amount}  {}", hit_box_label(hit_box)),
+        None => amount,
+    }
+}
+
+/// Damage is authored in whole points but arrives scaled (armor, difficulty),
+/// so a fractional value keeps one decimal instead of reading as an integer it
+/// is not.
+fn format_amount(amount: f32) -> String {
+    if (amount - amount.round()).abs() < 0.05 {
+        format!("{}", amount.round() as i64)
+    } else {
+        format!("{amount:.1}")
+    }
+}
+
+fn hit_box_label(hit_box: HitBoxType) -> &'static str {
+    match hit_box {
+        HitBoxType::Head => "head",
+        HitBoxType::Body => "body",
+        HitBoxType::Limb => "limb",
+        HitBoxType::Extremity => "extremity",
+        HitBoxType::NoDamage => "no-damage",
+    }
+}
+
+/// Remaining life of a readout as a 0..1 ramp, `None` once it has expired.
+pub fn fade(spawned_at: f64, now: f64) -> Option<f32> {
+    let age = now - spawned_at;
+    (age >= 0.0 && age < LIFETIME_SECS).then(|| 1.0 - (age / LIFETIME_SECS) as f32)
+}
+
+/// Record a dispatched message, keeping the ones that are damage with a known
+/// impact point. A no-op while the overlay is off, so nothing accumulates.
+pub fn record(world: &World, sim_time: f64, target: EntityId, payload: &MessagePayload) {
+    if !crate::dev_params::get_bool(crate::dev_params::DAMAGE_NUMBERS) {
+        return;
+    }
+    let MessagePayload::Damage {
+        amount,
+        impact: Some(impact),
+    } = payload
+    else {
+        return;
+    };
+
+    let hit_box = impact.bone.and_then(|bone| {
+        crate::creature::get_entity_creature(world, target)
+            .and_then(|creature| creature.get_hitbox_type(bone))
+    });
+
+    let mut popups = POPUPS.lock().unwrap();
+    if popups.len() >= MAX_POPUPS {
+        popups.remove(0);
+    }
+    popups.push(DamagePopup {
+        text: popup_text(*amount, hit_box),
+        point: impact.point,
+        spawned_at: sim_time,
+    });
+}
+
+/// Live readouts, oldest first. Expired ones are dropped as a side effect, so
+/// the buffer drains on its own even if nothing is rendering.
+pub fn live(now: f64) -> Vec<(DamagePopup, f32)> {
+    let mut popups = POPUPS.lock().unwrap();
+    popups.retain(|popup| fade(popup.spawned_at, now).is_some());
+    popups
+        .iter()
+        .filter_map(|popup| fade(popup.spawned_at, now).map(|fade| (popup.clone(), fade)))
+        .collect()
+}
+
+/// Drop every readout. Called on a level transition, where the world the points
+/// referred to is gone.
+pub fn clear() {
+    POPUPS.lock().unwrap().clear();
+}
+
+/// The readouts as world-space text, turned to face the camera and drifting up
+/// as they fade.
+///
+/// Billboarded about the vertical only, toward `camera_pos`: a readout stays
+/// upright, which is what makes it readable, and it needs only the camera's
+/// position - so the same call serves the flat camera and either VR eye.
+pub fn render(
+    asset_cache: &mut AssetCache,
+    camera_pos: Vector3<f32>,
+    now: f64,
+) -> Vec<SceneObject> {
+    let live = live(now);
+    if live.is_empty() {
+        return Vec::new();
+    }
+    let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
+
+    let mut objects = live
+        .into_iter()
+        .map(|(popup, fade)| {
+            let position = popup.point + vec3(0.0, RISE * (1.0 - fade), 0.0);
+            let mut object = SceneObject::world_space_text(&popup.text, font.clone(), 1.0 - fade);
+            object.set_transform(
+                Matrix4::from_translation(position)
+                    * facing_rotation(position, camera_pos)
+                    * Matrix4::from_nonuniform_scale(
+                        // `world_space_text` normalizes its glyphs into a unit
+                        // square, so the caller owns the aspect: width is the
+                        // line height times the character count.
+                        TEXT_HEIGHT * popup.text.chars().count() as f32 * CHAR_ASPECT,
+                        TEXT_HEIGHT,
+                        1.0,
+                    )
+                    // The glyph mesh is built in the canvas's y-down space, so
+                    // world-space text is stood upright by the same half turn
+                    // about x the UI panels use (`ui::world_element_transform`).
+                    // Without it the readout renders upside down, which at a
+                    // glance reads as mirrored.
+                    * Matrix4::from_angle_x(Deg(180.0)),
+            );
+            object
+        })
+        .collect::<Vec<_>>();
+    crate::util::tag_render_source(&mut objects, crate::util::render_source::DAMAGE_NUMBERS);
+    objects
+}
+
+/// The rotation that stands text at `position` up facing `camera_pos`.
+///
+/// Built as an explicit basis rather than a yaw angle, so the glyph quad's
+/// local +x is the direction the *viewer* calls right and its +z points at the
+/// viewer: a yaw alone leaves the convention of the text mesh's facing to
+/// chance, and getting it wrong renders every number mirrored.
+fn facing_rotation(position: Vector3<f32>, camera_pos: Vector3<f32>) -> Matrix4<f32> {
+    let up = vec3(0.0, 1.0, 0.0);
+    let to_camera = camera_pos - position;
+    // Level the text: a readout above a corpse should not pitch down at a
+    // player standing over it.
+    let to_camera = vec3(to_camera.x, 0.0, to_camera.z);
+    if to_camera.magnitude2() < 1.0e-6 {
+        // Directly overhead or underneath: any facing is as good as another.
+        return Matrix4::identity();
+    }
+    let forward = to_camera.normalize();
+    let right = up.cross(forward);
+    Matrix4::from_cols(
+        right.extend(0.0),
+        up.extend(0.0),
+        forward.extend(0.0),
+        cgmath::vec4(0.0, 0.0, 0.0, 1.0),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_readout_names_the_hitbox_it_struck() {
+        assert_eq!(popup_text(7.0, Some(HitBoxType::Head)), "-7 HP  head");
+        assert_eq!(popup_text(12.0, Some(HitBoxType::Limb)), "-12 HP  limb");
+    }
+
+    /// A blow that landed on the entity's own collider carries no joint, and
+    /// must not claim one.
+    #[test]
+    fn a_readout_without_a_hitbox_is_just_the_amount() {
+        assert_eq!(popup_text(3.0, None), "-3 HP");
+    }
+
+    /// Scaled damage (armor, difficulty) is not a whole number; rounding it to
+    /// one would make the overlay disagree with the hit points it explains.
+    #[test]
+    fn a_fractional_amount_keeps_a_decimal() {
+        assert_eq!(popup_text(4.5, None), "-4.5 HP");
+        assert_eq!(popup_text(6.02, None), "-6 HP");
+    }
+
+    /// The text stands up facing the camera: +z at the viewer, +x the way the
+    /// viewer reads, +y up. Any other basis renders the number mirrored, or
+    /// tipped over when the player stands above the body.
+    #[test]
+    fn a_readout_stands_up_facing_the_camera() {
+        let at = vec3(0.0, 0.0, 0.0);
+        let rotation = facing_rotation(at, vec3(5.0, 3.0, 0.0));
+
+        // +z points at the camera, horizontally - the camera's height is not
+        // allowed to tip the text.
+        assert_eq!(rotation.z.truncate(), vec3(1.0, 0.0, 0.0));
+        assert_eq!(rotation.y.truncate(), vec3(0.0, 1.0, 0.0));
+        // ...and +x is the viewer's right (looking along -x, that is -z).
+        assert_eq!(rotation.x.truncate(), vec3(0.0, 0.0, -1.0));
+    }
+
+    /// A camera directly overhead has no bearing to face; the text must not
+    /// come out as a degenerate (zero-scaled) transform.
+    #[test]
+    fn a_readout_under_the_camera_keeps_a_valid_rotation() {
+        let rotation = facing_rotation(vec3(0.0, 0.0, 0.0), vec3(0.0, 5.0, 0.0));
+
+        assert_eq!(rotation, Matrix4::identity());
+    }
+
+    #[test]
+    fn a_readout_fades_over_its_lifetime_and_then_expires() {
+        assert_eq!(fade(10.0, 10.0), Some(1.0));
+        assert!(fade(10.0, 10.0 + LIFETIME_SECS / 2.0).unwrap() < 0.55);
+        // Faded out by the end of its life (the exact boundary is float
+        // noise, so the expiry is checked just past it).
+        assert!(fade(10.0, 10.0 + LIFETIME_SECS).unwrap_or(0.0) < 0.001);
+        assert_eq!(fade(10.0, 10.0 + LIFETIME_SECS + 0.01), None);
+        // A readout from a previous level (clock reset) is not live.
+        assert_eq!(fade(10.0, 1.0), None);
+    }
+}

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -191,6 +191,12 @@ dev_params! {
     /// weapon is". Read out of Rapier at the collider's own isometry, so it
     /// shows what is actually simulated rather than what the wield intended.
     MELEE_VOLUMES = float("melee_volumes", "Show hurtbox", 0.0, 0.0, 1.0, 1.0),
+    /// Draw a floating "-7 HP" at the point each blow lands, labeled with the
+    /// hitbox it struck.
+    ///
+    /// The readout for the hitbox work: which limb a shot or swing actually
+    /// hit, and for how much, without reading hit points before and after.
+    DAMAGE_NUMBERS = bool("damage_numbers", "Damage numbers", false),
     /// Uniform scale applied to a wielded melee `_h` view model, about the
     /// baked fist so the grip stays on the controller.
     ///

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -1048,6 +1048,12 @@ pub enum DebugEntityMessage {
         direction: Option<[f32; 3]>,
         #[serde(default)]
         point: Option<[f32; 3]>,
+        /// Skeleton joint id of the hitbox that was struck, as a real
+        /// hitbox-forwarded hit carries. Lets a test exercise the per-limb
+        /// paths (damage readouts, ragdoll reaction) without having to land a
+        /// live shot on a chosen limb.
+        #[serde(default)]
+        bone: Option<u32>,
     },
     /// Frob (use) the entity.
     Frob,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -15,6 +15,7 @@ pub mod time;
 
 pub mod career;
 pub mod creature;
+pub mod damage_overlay;
 pub mod data_files;
 pub mod death_camera;
 pub mod dev_params;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1616,6 +1616,9 @@ pub struct MissionCore {
     /// no input context - so it is recorded here each update rather than
     /// threaded through the effect path.
     last_head_rotation: Quaternion<f32>,
+    /// The eye's offset within the pawn, as last reported by the input
+    /// context: eye height in flat, plus the roomscale offset in VR.
+    last_head_position: Vector3<f32>,
 
     /// The fall to the floor that plays while the player is dying, or `None`
     /// while they are alive. Runtime-only, like [`PlayerLifeState`] itself: a
@@ -2418,6 +2421,7 @@ impl MissionCore {
             screen_fade_alpha: 0.0,
             screen_fade_texture,
             last_head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            last_head_position: vec3(0.0, 0.0, 0.0),
             death_camera: None,
         };
         for (index, entity_id) in backpack_load_remap.overflow.into_iter().enumerate() {
@@ -2709,6 +2713,10 @@ impl MissionCore {
                 .unwrap_or(false)
         };
         self.last_head_rotation = input_context.head.rotation;
+        // Where the eye is within the pawn, so the damage readouts face the
+        // viewer rather than the pawn origin (they differ by the roomscale
+        // offset in VR, and by eye height in both).
+        self.last_head_position = input_context.head.position;
         let mut life_state_effects = Vec::new();
         if self.player_is_alive() && player_health_depleted {
             life_state_effects.append(&mut self.begin_player_death());
@@ -8672,9 +8680,11 @@ impl MissionCore {
             .borrow::<UniqueView<Time>>()
             .map(|time| time.total.as_secs_f64())
             .unwrap_or(0.0);
+        let eye = player.pos + player.rotation * self.last_head_position;
         scene.extend(crate::damage_overlay::render(
             asset_cache,
-            player.pos,
+            self.script_world.damage_popups(),
+            eye,
             sim_time,
         ));
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8664,6 +8664,20 @@ impl MissionCore {
             scene.extend(use_mode_objects);
         }
 
+        // Floating damage readouts, in the shared world pass so flat and VR
+        // show the identical overlay - and so they depth-test against the
+        // world instead of floating over it like the per-eye HUD.
+        let sim_time = self
+            .world
+            .borrow::<UniqueView<Time>>()
+            .map(|time| time.total.as_secs_f64())
+            .unwrap_or(0.0);
+        scene.extend(crate::damage_overlay::render(
+            asset_cache,
+            player.pos,
+            sim_time,
+        ));
+
         // Note: Hand spotlights for enhanced lighting are now handled in the runtime
         // via get_hand_spotlights() method - they're added to the Scene's lighting system
 
@@ -10958,6 +10972,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 amount,
                 direction,
                 point,
+                bone,
             } => MessagePayload::Damage {
                 amount,
                 // A directional debug blow mirrors what a projectile hit
@@ -10981,7 +10996,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     Some(crate::scripts::DamageImpact {
                         direction: d.normalize(),
                         point,
-                        bone: None,
+                        bone,
                     })
                 }),
             },

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -836,14 +836,25 @@ pub struct ScriptWorld {
     entity_has_initialized: HashMap<EntityId, bool>,
     entity_to_scripts: HashMap<EntityId, Vec<ScriptInstance>>,
     message_queue: Vec<Message>,
+    /// Floating damage readouts earned by the messages dispatched here, drawn
+    /// by the mission's render pass. Owned by the script world so they die
+    /// with their scene - a readout is a world point in one level.
+    damage_popups: Vec<crate::damage_overlay::DamagePopup>,
 }
 
 impl ScriptWorld {
+    /// The floating damage readouts recorded so far, for the render pass to
+    /// draw and age out.
+    pub(crate) fn damage_popups(&mut self) -> &mut Vec<crate::damage_overlay::DamagePopup> {
+        &mut self.damage_popups
+    }
+
     pub fn new() -> ScriptWorld {
         ScriptWorld {
             entity_has_initialized: HashMap::new(),
             entity_to_scripts: HashMap::new(),
             message_queue: Vec::new(),
+            damage_popups: Vec::new(),
         }
     }
 
@@ -1332,6 +1343,9 @@ impl ScriptWorld {
 
         // Process any incoming messages
         let mut slayed_entities: HashSet<EntityId> = HashSet::new();
+        // Collected here and appended after the loop: the queue is borrowed
+        // for the duration of it.
+        let mut new_damage_popups = Vec::new();
         let span = span!(Level::INFO, "messages");
         let _ = span.enter();
         for msg in &self.message_queue {
@@ -1353,12 +1367,14 @@ impl ScriptWorld {
             // Same choke point feeds the floating damage readouts, so they see
             // every damage path (melee contact, projectiles, hitbox-forwarded
             // hits, script injection) rather than one of them.
-            crate::damage_overlay::record(
+            if let Some(popup) = crate::damage_overlay::popup_for(
                 world,
                 time.total.as_secs_f64(),
                 to_entity_id,
                 &msg.payload,
-            );
+            ) {
+                new_damage_popups.push(popup);
+            }
 
             let mut is_turn_on = false;
             match msg.payload {
@@ -1396,6 +1412,8 @@ impl ScriptWorld {
         }
 
         self.message_queue.clear();
+        self.damage_popups.extend(new_damage_popups);
+        crate::damage_overlay::trim(&mut self.damage_popups);
 
         for (entity_id, scripts) in self.entity_to_scripts.iter_mut() {
             for instance in scripts.iter_mut() {

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -1350,6 +1350,15 @@ impl ScriptWorld {
                 to_entity_id,
                 &msg.payload,
             );
+            // Same choke point feeds the floating damage readouts, so they see
+            // every damage path (melee contact, projectiles, hitbox-forwarded
+            // hits, script injection) rather than one of them.
+            crate::damage_overlay::record(
+                world,
+                time.total.as_secs_f64(),
+                to_entity_id,
+                &msg.payload,
+            );
 
             let mut is_turn_on = false;
             match msg.payload {

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -360,6 +360,8 @@ pub mod render_source {
     pub const USE_MODE_POINTER: &str = "use_mode_pointer";
     /// The red rim tint shown for a moment after the player takes damage.
     pub const HIT_FEEDBACK: &str = "hit_feedback";
+    /// Floating damage readouts, when the `damage_numbers` dev param is on.
+    pub const DAMAGE_NUMBERS: &str = "damage_numbers";
     /// The cyber interface's own rim vignette, eased in/out with its
     /// entry/exit ramp - layered alongside (not merged with) [`HIT_FEEDBACK`],
     /// so a hit still reads while the interface is open.

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -92,6 +92,12 @@ export type DebugEntityMessage =
       direction?: [number, number, number];
       /** Optional world-space hit point (defaults to the victim's position). */
       point?: [number, number, number];
+      /**
+       * Optional skeleton joint id of the hitbox struck, as a real
+       * hitbox-forwarded hit carries - exercises the per-limb paths (damage
+       * readouts, ragdoll reaction) without landing a live shot on a limb.
+       */
+      bone?: number;
     }
   | { type: "Frob" }
   | { type: "Signal"; name: string }

--- a/tools/shock2-sdk/test/damage-overlay.e2e.test.ts
+++ b/tools/shock2-sdk/test/damage-overlay.e2e.test.ts
@@ -12,8 +12,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const OVERLAY_SOURCE = "damage_numbers";
 
 async function overlayCount(game: GameServer): Promise<number> {
-  const { objects } = await game.scene.objects();
-  return objects.filter((object) => object.source === OVERLAY_SOURCE).length;
+  return (await game.scene.fromSource(OVERLAY_SOURCE)).length;
 }
 
 test(
@@ -28,13 +27,12 @@ test(
     );
     assert.ok(creature, "expected a damageable creature in debug_melee");
     const [x, y, z] = creature.position;
-    const damage = (bone?: number) =>
+    const damage = () =>
       game.entities.sendMessage(creature.id, {
         type: "Damage",
         amount: 7,
         point: [x, y + 1.2, z],
         direction: [0, 0, 1],
-        bone,
       });
 
     // Off by default: damage draws nothing.
@@ -55,15 +53,37 @@ test(
     await game.step({ frames: 150 });
     assert.equal(await overlayCount(game), 0, "the readout should expire");
 
-    // A hitbox-forwarded hit carries the struck joint, and the readout names
-    // it - the whole point of the overlay for the hitbox work. Joint 9 is the
-    // humanoid head (`creature_definitions::HUMANOID_HIT_BOXES`).
-    await damage(9);
+    // A blow landing on a real hitbox collider is dispatched TWICE - once to
+    // the hitbox entity, once forwarded to the creature with the struck joint
+    // attached - and both carry the same impact point. It must draw exactly
+    // one readout, the labeled one; recording both stacks an unlabeled
+    // duplicate underneath every real limb hit.
+    //
+    // Negative-first: without the proxy skip this is 2.
+    const hitBoxBody = (await game.physics.bodies({ limit: 5000 })).bodies.find((body) =>
+      body.collision_groups.includes("hitbox"),
+    );
+    assert.ok(hitBoxBody?.entity_id, "expected the creature to have hitbox proxies");
+    await game.entities.sendMessage(hitBoxBody.entity_id, {
+      type: "Damage",
+      amount: 9,
+      point: [x, y + 1.5, z],
+      direction: [0, 0, 1],
+    });
     await game.step({ frames: 6 });
+    assert.equal(
+      await overlayCount(game),
+      1,
+      "a hitbox hit should draw one readout, not one per dispatch",
+    );
+
+    // ...and it is the labeled one: the forwarded copy carries the joint.
     const traced = (await game.messages.recent()).messages
       .filter((message) => message.payload === "Damage")
       .at(-1);
-    assert.equal(traced?.impact?.bone, 9, "the injected blow should carry its joint");
-    assert.equal(await overlayCount(game), 1, "the labeled blow should draw its readout");
+    assert.ok(
+      traced?.impact?.bone !== undefined && traced?.impact?.bone !== null,
+      `the forwarded blow should carry its joint, got ${JSON.stringify(traced?.impact)}`,
+    );
   },
 );

--- a/tools/shock2-sdk/test/damage-overlay.e2e.test.ts
+++ b/tools/shock2-sdk/test/damage-overlay.e2e.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// The floating damage readouts are the instrument for the hitbox work: they
+// answer "which limb did that hit, and for how much" without reading hit points
+// before and after. They are dev-param gated, drawn in the world pass, and
+// tagged `damage_numbers` in /v1/scene so this can assert on them.
+const OVERLAY_SOURCE = "damage_numbers";
+
+async function overlayCount(game: GameServer): Promise<number> {
+  const { objects } = await game.scene.objects();
+  return objects.filter((object) => object.source === OVERLAY_SOURCE).length;
+}
+
+test(
+  "damage numbers appear at the impact point, only while the dev param is on",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_melee" });
+    await game.step({ frames: 20 });
+
+    const creature = (await game.entities.list()).entities.find((entity) =>
+      entity.name.startsWith("Entity_"),
+    );
+    assert.ok(creature, "expected a damageable creature in debug_melee");
+    const [x, y, z] = creature.position;
+    const damage = (bone?: number) =>
+      game.entities.sendMessage(creature.id, {
+        type: "Damage",
+        amount: 7,
+        point: [x, y + 1.2, z],
+        direction: [0, 0, 1],
+        bone,
+      });
+
+    // Off by default: damage draws nothing.
+    await damage();
+    await game.step({ frames: 6 });
+    assert.equal(
+      await overlayCount(game),
+      0,
+      "no readout should be drawn while `damage_numbers` is off",
+    );
+
+    await game.devParams.set("damage_numbers", 1);
+    await damage();
+    await game.step({ frames: 6 });
+    assert.equal(await overlayCount(game), 1, "the blow should draw one readout");
+
+    // ...and it is short-lived, so a firefight does not paper the level over.
+    await game.step({ frames: 150 });
+    assert.equal(await overlayCount(game), 0, "the readout should expire");
+
+    // A hitbox-forwarded hit carries the struck joint, and the readout names
+    // it - the whole point of the overlay for the hitbox work. Joint 9 is the
+    // humanoid head (`creature_definitions::HUMANOID_HIT_BOXES`).
+    await damage(9);
+    await game.step({ frames: 6 });
+    const traced = (await game.messages.recent()).messages
+      .filter((message) => message.payload === "Damage")
+      .at(-1);
+    assert.equal(traced?.impact?.bone, 9, "the injected blow should carry its joint");
+    assert.equal(await overlayCount(game), 1, "the labeled blow should draw its readout");
+  },
+);


### PR DESCRIPTION
Stacked on #1211.

## What

A floating `-9 HP  head` at the point each blow lands, for 1.6 seconds, drifting up as it fades.

![damage overlay](https://gist.githubusercontent.com/tommy-xr/b196ece76e5afd98777d4f428bbf11dd/raw/damage-overlay.gif)

<sub>Three blows to a hybrid at different joints. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![damage overlay still](https://gist.githubusercontent.com/tommy-xr/b196ece76e5afd98777d4f428bbf11dd/raw/damage-overlay.png)

## Why

This is the instrument the rest of the hitbox work needs. "Did that shot hit the head or the arm, and for how much?" is currently only answerable by reading the victim's hit points before and after — which says nothing about *where* it landed. The next PRs in this stack (outline from the hitbox union, melee through hitboxes, per-limb multipliers) are all judged by exactly that question.

## How

- Recorded at the one place every script message is dispatched, so it covers melee contact, projectiles, hitbox-forwarded hits and script injection alike.
- The hitbox name comes from the struck joint, so it appears on hitbox-forwarded hits only; a blow that landed on an entity's own collider prints just the amount rather than guessing "body".
- **One readout per blow.** A hitbox-forwarded hit is dispatched *twice* — to the hitbox proxy, then to the creature with the joint attached, both carrying the same impact point — so the proxy delivery is skipped. Recording both stacked an unlabeled readout under the labeled one on every real limb hit.
- The readouts live on the `ScriptWorld` that records them, so they die with their scene: no global, no mutex on the dispatch path, and no clear-hook to forget on the transition paths that would have bypassed it.
- Drawn in the shared world pass, so flat and VR show the identical overlay and it depth-tests against the world (the per-eye path has its render layer rewritten to `SceneUi`, which would float the numbers over geometry).
- Off by default behind the `damage_numbers` dev param; the recorder is a no-op while it is off, and turning it off clears what is on screen.

The debug damage message gains an optional `bone`, so a test can exercise a chosen limb without landing a live shot on it.

## Verification

- Unit: the readout text (labeled, unlabeled, fractional damage), the fade/expiry ramp, and the billboard basis (the wrong one renders every number mirrored or tips it over).
- New e2e `damage-overlay.e2e.test.ts`: nothing drawn while the param is off; one readout per injected blow; it expires; and — the case both reviewers asked for — a blow landing on a **real hitbox proxy** draws exactly one readout, the labeled one. Verified to fail (at 2) without the proxy skip.
- Full SDK e2e suite: 344/360, all 8 failures also fail on `main`.

## Known gaps

- **Damage type is not shown.** `MessagePayload::Damage` carries only `{amount, impact{direction, point, bone}}` — the stim/receptron type is resolved before the message is sent, so showing it needs new plumbing rather than a readout change.
- A *detached* free camera sees the readouts edge-on: they face the player's eye, and the free camera's pose is resolved after the scene is built.
