### PR TITLE
feat(hud): frame a creature by its hitboxes, not its capsule

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -689,6 +689,10 @@ pub struct EntityDetailResult {
     pub incoming_links: Vec<LinkInfo>,
     pub contained_by: Option<i32>,
     pub aim_points: Vec<AimPointInfo>,
+    /// World-space `[min, max]` of what the HUD highlight frames for this
+    /// entity: the union of its hitboxes where it has them, otherwise its own
+    /// collider.
+    pub selection_bounds: Option<[[f32; 3]; 2]>,
 }
 
 #[derive(Debug, Serialize)]

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1650,6 +1650,7 @@ fn process_command(
                                 position: point.position,
                             })
                             .collect(),
+                        selection_bounds: detail.selection_bounds,
                     })
             } else {
                 None

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use cgmath::{EuclideanSpace, Matrix4, Vector3, vec3};
-use collision::{Aabb, Aabb3};
+use collision::{Aabb, Aabb3, Union};
 use dark::{hit_box::HitBoxShape, model::Model, motion::JointId, properties::PropPosition};
 use rapier3d::{
     na::Point3 as NaPoint3,
@@ -127,6 +127,27 @@ pub struct HitBoxManager {
 }
 
 impl HitBoxManager {
+    /// World-space bounds of a creature's hitbox proxies - the volume its
+    /// limbs actually occupy in the pose it is drawn in.
+    ///
+    /// This is what the HUD outline wants: the entity's own collider is a
+    /// standing capsule sized from the creature definition, so it frames a
+    /// nominal cylinder rather than the creature - too wide for a monkey,
+    /// far too tall for anything crouched, crawling or dead. `None` for
+    /// anything with no proxies (every non-creature, and a posed corpse),
+    /// which keeps its collider bounds.
+    pub fn selection_bounds(
+        &self,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+    ) -> Option<Aabb3<f32>> {
+        let hit_boxes = self.hit_boxes.get(&entity_id)?;
+        hit_boxes
+            .values()
+            .filter_map(|hit_box| physics.get_aabb2(*hit_box))
+            .reduce(|acc, bounds| acc.union(&bounds))
+    }
+
     pub fn new() -> HitBoxManager {
         HitBoxManager {
             hit_boxes: HashMap::new(),
@@ -321,5 +342,98 @@ impl HitBoxManager {
                 script_world.remove_entity(hitbox);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::{CollisionGroup, PhysicsWorld};
+    use cgmath::{Quaternion, Zero};
+
+    /// Two hitboxes a body-length apart: the highlight must frame both, not
+    /// one of them and not the standing capsule the entity's own collider is.
+    #[test]
+    fn selection_bounds_span_every_hit_box() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let creature = world.add_entity(());
+        let mut manager = HitBoxManager::new();
+        let mut hit_boxes = HashMap::new();
+
+        for (joint, x) in [(0u32, -1.0), (1, 1.0)] {
+            let hit_box = world.add_entity(());
+            physics.add_kinematic(
+                hit_box,
+                vec3(x, 0.0, 0.0),
+                Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                Vector3::zero(),
+                vec3(0.5, 0.5, 0.5),
+                CollisionGroup::hitbox(),
+                false,
+            );
+            hit_boxes.insert(joint, hit_box);
+        }
+        manager.hit_boxes.insert(creature, hit_boxes);
+
+        let bounds = manager
+            .selection_bounds(&physics, creature)
+            .expect("a creature with hitboxes has selection bounds");
+
+        assert!(
+            bounds.min.x <= -1.25 && bounds.max.x >= 1.25,
+            "got {bounds:?}"
+        );
+        assert!(
+            bounds.min.y >= -0.3 && bounds.max.y <= 0.3,
+            "got {bounds:?}"
+        );
+    }
+
+    /// Anything without hitboxes - every prop, and a posed corpse - has no
+    /// hitbox bounds, so the caller keeps using its collider.
+    #[test]
+    fn selection_bounds_are_absent_without_hit_boxes() {
+        let mut world = World::new();
+        let physics = PhysicsWorld::new();
+        let entity_id = world.add_entity(());
+
+        assert!(
+            HitBoxManager::new()
+                .selection_bounds(&physics, entity_id)
+                .is_none()
+        );
+    }
+
+    /// A proxy whose body has gone (mid-teardown) contributes nothing, rather
+    /// than a zero-sized box at the world origin that would stretch the
+    /// highlight across the level.
+    #[test]
+    fn selection_bounds_ignore_a_proxy_with_no_body() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let creature = world.add_entity(());
+        let real = world.add_entity(());
+        let phantom = world.add_entity(());
+        physics.add_kinematic(
+            real,
+            vec3(3.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            Vector3::zero(),
+            vec3(0.5, 0.5, 0.5),
+            CollisionGroup::hitbox(),
+            false,
+        );
+        let mut manager = HitBoxManager::new();
+        manager
+            .hit_boxes
+            .insert(creature, HashMap::from([(0, real), (1, phantom)]));
+
+        let bounds = manager.selection_bounds(&physics, creature).unwrap();
+
+        assert!(
+            bounds.min.x > 2.0,
+            "the phantom must not drag the box to the origin: {bounds:?}"
+        );
     }
 }

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -132,11 +132,24 @@ impl HitBoxManager {
     ///
     /// This is what the HUD outline wants: the entity's own collider is a
     /// standing capsule sized from the creature definition, so it frames a
-    /// nominal cylinder rather than the creature - too wide for a monkey,
-    /// far too tall for anything crouched, crawling or dead. `None` for
-    /// anything with no proxies (every non-creature, and a posed corpse),
-    /// which keeps its collider bounds.
-    pub fn selection_bounds(
+    /// nominal cylinder rather than the creature - and frames the same
+    /// cylinder whatever the creature is doing.
+    ///
+    /// A definition that maps a single `Body` joint (the arachnids and the
+    /// Overlord) gets a body-only frame, legs excluded - measured on hydro3's
+    /// Baby Arachnids at 0.33-0.58 across, against a 0.40 collider. Neither is
+    /// the animal: the shipped creature colliders are their own known problem
+    /// (#904). The hitbox is at least measured from the mesh, so it is what is
+    /// used, and widening those definitions is the fix worth making.
+    ///
+    /// The boxes are world AABBs of the *rotated* proxy shapes, so a diagonal
+    /// limb contributes a little more than its thickness. The extremes come
+    /// from the head, hands and feet, so the inflation is small against the
+    /// error it replaces. (It is deliberately read from physics rather than
+    /// recomputed from the joint transforms with `dark`'s `joint_box_bounds`:
+    /// this is the volume the creature is actually *shot* by, the same proxies
+    /// `aim_points` reports.)
+    pub fn hit_box_bounds(
         &self,
         physics: &PhysicsWorld,
         entity_id: EntityId,
@@ -354,7 +367,7 @@ mod tests {
     /// Two hitboxes a body-length apart: the highlight must frame both, not
     /// one of them and not the standing capsule the entity's own collider is.
     #[test]
-    fn selection_bounds_span_every_hit_box() {
+    fn hit_box_bounds_span_every_hit_box() {
         let mut world = World::new();
         let mut physics = PhysicsWorld::new();
         let creature = world.add_entity(());
@@ -377,7 +390,7 @@ mod tests {
         manager.hit_boxes.insert(creature, hit_boxes);
 
         let bounds = manager
-            .selection_bounds(&physics, creature)
+            .hit_box_bounds(&physics, creature)
             .expect("a creature with hitboxes has selection bounds");
 
         assert!(
@@ -393,14 +406,14 @@ mod tests {
     /// Anything without hitboxes - every prop, and a posed corpse - has no
     /// hitbox bounds, so the caller keeps using its collider.
     #[test]
-    fn selection_bounds_are_absent_without_hit_boxes() {
+    fn hit_box_bounds_are_absent_without_hit_boxes() {
         let mut world = World::new();
         let physics = PhysicsWorld::new();
         let entity_id = world.add_entity(());
 
         assert!(
             HitBoxManager::new()
-                .selection_bounds(&physics, entity_id)
+                .hit_box_bounds(&physics, entity_id)
                 .is_none()
         );
     }
@@ -409,7 +422,7 @@ mod tests {
     /// than a zero-sized box at the world origin that would stretch the
     /// highlight across the level.
     #[test]
-    fn selection_bounds_ignore_a_proxy_with_no_body() {
+    fn hit_box_bounds_ignore_a_proxy_with_no_body() {
         let mut world = World::new();
         let mut physics = PhysicsWorld::new();
         let creature = world.add_entity(());
@@ -429,11 +442,43 @@ mod tests {
             .hit_boxes
             .insert(creature, HashMap::from([(0, real), (1, phantom)]));
 
-        let bounds = manager.selection_bounds(&physics, creature).unwrap();
+        let bounds = manager.hit_box_bounds(&physics, creature).unwrap();
 
         assert!(
             bounds.min.x > 2.0,
             "the phantom must not drag the box to the origin: {bounds:?}"
+        );
+    }
+
+    /// A creature that maps a single `Body` hitbox (the arachnids, the
+    /// Overlord) still gets that hitbox's bounds - it is measured from the
+    /// mesh, unlike the capsule beside it.
+    #[test]
+    fn a_single_hit_box_still_gives_bounds() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let creature = world.add_entity(());
+        let hit_box = world.add_entity(());
+        physics.add_kinematic(
+            hit_box,
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            Vector3::zero(),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::hitbox(),
+            false,
+        );
+        let mut manager = HitBoxManager::new();
+        manager
+            .hit_boxes
+            .insert(creature, HashMap::from([(0, hit_box)]));
+
+        let bounds = manager
+            .hit_box_bounds(&physics, creature)
+            .expect("one hitbox is still bounds");
+        assert!(
+            (bounds.max.x - bounds.min.x - 0.2).abs() < 0.01,
+            "the lone hitbox's own extent, got {bounds:?}"
         );
     }
 }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -287,6 +287,10 @@ pub struct DebugEntityDetail {
     /// this entity lives inside a container.
     pub contained_by: Option<i32>,
     pub aim_points: Vec<DebugAimPoint>,
+    /// World-space bounds the HUD highlight frames: the union of the
+    /// creature's hitboxes where it has them, otherwise the entity's own
+    /// collider. `[min, max]`, or null for an entity with neither.
+    pub selection_bounds: Option<[[f32; 3]; 2]>,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -650,7 +650,7 @@ fn health_bar_fill(world: &World, entity_id: EntityId) -> Option<f32> {
 /// The enemy health bar, drawn flush on top of the selection brackets.
 pub fn draw_health_bar(
     asset_cache: &mut AssetCache,
-    physics: &PhysicsWorld,
+    bounds: Aabb3<f32>,
     entity_id: EntityId,
     world: &World,
     view: Matrix4<f32>,
@@ -661,10 +661,13 @@ pub fn draw_health_bar(
         return vec![];
     };
 
-    let Some(aabb) = physics.get_aabb2(entity_id) else {
-        return vec![];
-    };
-    let extents = project_aabb3(&aabb, view, projection, screen_size);
+    // The same resolved bounds the brackets and the label frame, so the bar
+    // cannot sit over a different volume than the outline it caps.
+    let extents = clamp_extents_to_screen(
+        project_aabb3(&bounds, view, projection, screen_size),
+        screen_size,
+        LABEL_MARGIN,
+    );
 
     // Nearest sampling, unlike the rest of the HUD: the remastered bar art is
     // several times the 80x14 it draws at and carries a pure colour-key border,

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -12,8 +12,6 @@ use dark::{
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
 use shipyard::{EntityId, Get, View, World};
 
-use crate::physics::PhysicsWorld;
-
 /// Whether the highlight overlay (corner brackets + rollover name) may be
 /// drawn for `entity_id`.
 ///
@@ -161,21 +159,14 @@ fn localized_weapon_condition(
 
 pub fn draw_item_name(
     asset_cache: &mut AssetCache,
-    physics: &PhysicsWorld,
+    bounds: Aabb3<f32>,
     entity_id: EntityId,
     world: &World,
-    //aabb: collision::Aabb3<f32>,
     view: Matrix4<f32>,
     projection: Matrix4<f32>,
     screen_size: Vector2<f32>,
     debug_show_ids: bool,
 ) -> Vec<SceneObject> {
-    let maybe_bbox = physics.get_aabb2(entity_id);
-
-    if maybe_bbox.is_none() {
-        return vec![];
-    }
-
     let v_prop_obj_name = world.borrow::<View<PropObjName>>().unwrap();
     let maybe_prop_obj_name = v_prop_obj_name.get(entity_id);
 
@@ -221,7 +212,7 @@ pub fn draw_item_name(
         weapon_condition.as_deref(),
     );
 
-    let aabb = maybe_bbox.unwrap();
+    let aabb = bounds;
     let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
     // Clamped like the brackets, plus the line of text the label sits on.
     let extents = clamp_extents_to_screen(
@@ -700,25 +691,17 @@ pub fn draw_health_bar(
 
 pub fn draw_item_outline(
     asset_cache: &mut AssetCache,
-    physics: &PhysicsWorld,
-    entity_id: EntityId,
-    //aabb: collision::Aabb3<f32>,
+    bounds: Aabb3<f32>,
     view: Matrix4<f32>,
     projection: Matrix4<f32>,
     screen_size: Vector2<f32>,
 ) -> Vec<SceneObject> {
-    let maybe_bbox = physics.get_aabb2(entity_id);
-
-    if maybe_bbox.is_none() {
-        return vec![];
-    }
-
     let options = TextureOptions {
         wrap: false,
         ..Default::default()
     };
 
-    let aabb = maybe_bbox.unwrap();
+    let aabb = bounds;
     let top_left_brack = asset_cache.get_ext(&TEXTURE_IMPORTER, "BRACK0.PCX", &options);
     let top_right_brack = asset_cache.get_ext(&TEXTURE_IMPORTER, "BRACK1.PCX", &options);
     let bottom_right_brack = asset_cache.get_ext(&TEXTURE_IMPORTER, "BRACK2.PCX", &options);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7947,9 +7947,13 @@ impl MissionCore {
     ///
     /// The HUD highlight frames this, and `/v1/entities/:id` reports it, from
     /// this one function: what an agent reads is what the player sees framed.
+    ///
+    /// The proxies are stepped by physics before they are re-posed, so the
+    /// bounds trail the drawn pose by a frame - invisible at 60 Hz, and not
+    /// worth a second pose evaluation to remove.
     pub(crate) fn selection_bounds(&self, entity_id: EntityId) -> Option<Aabb3<f32>> {
         self.hit_boxes
-            .selection_bounds(&self.physics, entity_id)
+            .hit_box_bounds(&self.physics, entity_id)
             .or_else(|| self.physics.get_aabb2(entity_id))
     }
 
@@ -8020,7 +8024,7 @@ impl MissionCore {
 
             ret.extend(draw_health_bar(
                 asset_cache,
-                &self.physics,
+                bounds,
                 hit_entity,
                 &self.world,
                 view,
@@ -9877,7 +9881,6 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn entity_detail(&self, id: EntityId) -> Option<crate::game_scene::DebugEntityDetail> {
-        let selection_bounds = self.selection_bounds(id);
         use crate::game_scene::{DebugAimPoint, DebugEntityDetail, DebugPropertyInfo};
         use shipyard::*;
 
@@ -10130,6 +10133,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .find(|link| link.contains_ordinal.is_some())
                     .map(|link| link.target_id);
 
+                let selection_bounds = self.selection_bounds(id);
                 Some(DebugEntityDetail {
                     entity_id: id.inner() as i32,
                     name,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -14,6 +14,8 @@ use cgmath::{
     Vector2, Vector3, num_traits::ToPrimitive, vec2, vec3,
 };
 
+use collision::Aabb3;
+
 use crate::SpawnLocation;
 use crate::game_scene::DebuggableScene;
 use crate::mission::CullingInfo;
@@ -7930,12 +7932,25 @@ impl MissionCore {
     }
 
     /// Entities whose HUD overlay is still forced on by recent damage.
+    /// Entities whose HUD overlay is still forced on by recent damage.
     fn damage_flash_entities(&self) -> Vec<EntityId> {
         let now = self.world.borrow::<UniqueView<Time>>().unwrap().total;
         self.world
             .borrow::<UniqueViewMut<DamageFlash>>()
             .map(|mut flash| flash.active(now))
             .unwrap_or_default()
+    }
+
+    /// The world-space bounds that stand in for an entity: the union of its
+    /// hitboxes where it has them - the volume a creature's limbs occupy in
+    /// the pose it is in - otherwise its own collider.
+    ///
+    /// The HUD highlight frames this, and `/v1/entities/:id` reports it, from
+    /// this one function: what an agent reads is what the player sees framed.
+    pub(crate) fn selection_bounds(&self, entity_id: EntityId) -> Option<Aabb3<f32>> {
+        self.hit_boxes
+            .selection_bounds(&self.physics, entity_id)
+            .or_else(|| self.physics.get_aabb2(entity_id))
     }
 
     pub fn render_per_eye(
@@ -7978,15 +7993,9 @@ impl MissionCore {
             highlighted.retain(|e| is_hud_selectable(&self.world, *e));
         }
         for hit_entity in highlighted {
-            // What the highlight frames: the creature's own hitboxes where it
-            // has them (the volume its limbs occupy in the pose it is in),
-            // otherwise its collider. Resolved once, so the brackets and the
-            // label can never frame different things.
-            let Some(bounds) = self
-                .hit_boxes
-                .selection_bounds(&self.physics, hit_entity)
-                .or_else(|| self.physics.get_aabb2(hit_entity))
-            else {
+            // What the highlight frames. Resolved once, so the brackets and
+            // the label can never frame different things.
+            let Some(bounds) = self.selection_bounds(hit_entity) else {
                 continue;
             };
 
@@ -9868,6 +9877,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn entity_detail(&self, id: EntityId) -> Option<crate::game_scene::DebugEntityDetail> {
+        let selection_bounds = self.selection_bounds(id);
         use crate::game_scene::{DebugAimPoint, DebugEntityDetail, DebugPropertyInfo};
         use shipyard::*;
 
@@ -10136,6 +10146,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     incoming_links,
                     contained_by,
                     aim_points: aim_points.clone(),
+                    selection_bounds: selection_bounds.map(|bounds| {
+                        [
+                            [bounds.min.x, bounds.min.y, bounds.min.z],
+                            [bounds.max.x, bounds.max.y, bounds.max.z],
+                        ]
+                    }),
                 })
             },
         )

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7978,10 +7978,21 @@ impl MissionCore {
             highlighted.retain(|e| is_hud_selectable(&self.world, *e));
         }
         for hit_entity in highlighted {
+            // What the highlight frames: the creature's own hitboxes where it
+            // has them (the volume its limbs occupy in the pose it is in),
+            // otherwise its collider. Resolved once, so the brackets and the
+            // label can never frame different things.
+            let Some(bounds) = self
+                .hit_boxes
+                .selection_bounds(&self.physics, hit_entity)
+                .or_else(|| self.physics.get_aabb2(hit_entity))
+            else {
+                continue;
+            };
+
             ret.extend(draw_item_outline(
                 asset_cache,
-                &self.physics,
-                hit_entity,
+                bounds,
                 view,
                 projection,
                 screen_size,
@@ -7989,7 +8000,7 @@ impl MissionCore {
 
             ret.extend(draw_item_name(
                 asset_cache,
-                &self.physics,
+                bounds,
                 hit_entity,
                 &self.world,
                 view,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -153,6 +153,11 @@ export interface EntityDetailResult {
    * runtimes predating the aim-point capability.
    */
   aim_points?: AimPoint[];
+  /**
+   * World-space `[min, max]` of what the HUD highlight frames: the union of
+   * the entity's hitboxes where it has them, otherwise its own collider.
+   */
+  selection_bounds?: [[number, number, number], [number, number, number]] | null;
 }
 
 export interface AimPoint {

--- a/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// What the HUD highlight frames, as reported by /v1/entities/:id. A creature's
+// own collider is a standing capsule sized from its creature definition, so it
+// frames a nominal cylinder rather than the creature - and says the same thing
+// whatever the creature is doing. The highlight now frames the union of its
+// hitboxes: the volume its limbs occupy in the pose it is in, and the same
+// volume the creature is shot by.
+test(
+  "a creature's highlight frames its hitboxes; a corpse keeps its collider",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_melee" });
+    await game.step({ frames: 40 });
+
+    // Hitboxes are the identifying feature here, so find the creature by
+    // them rather than by a scene-local name.
+    const { entities } = await game.entities.list();
+    let detail;
+    for (const entity of entities) {
+      const candidate = await game.entities.detail(entity.id);
+      if ((candidate.aim_points ?? []).length > 0) {
+        detail = candidate;
+        break;
+      }
+    }
+    assert.ok(detail, "expected a creature with hitboxes in debug_melee");
+    const bounds = detail.selection_bounds;
+    assert.ok(bounds, "a creature should report selection bounds");
+
+    // Negative-first: the standing capsule does not contain the hitboxes of an
+    // animated creature (arms out, weapon raised), so this fails on the
+    // collider bounds it used to report.
+    const [min, max] = bounds;
+    for (const point of detail.aim_points ?? []) {
+      for (let axis = 0; axis < 3; axis++) {
+        assert.ok(
+          point.position[axis] >= min[axis] - 0.01 &&
+            point.position[axis] <= max[axis] + 0.01,
+          `hitbox ${point.joint_id} (${point.classification}) sits outside the highlight on axis ${axis}: ${JSON.stringify(point.position)} vs ${JSON.stringify(bounds)}`,
+        );
+      }
+    }
+  },
+);
+
+test(
+  "an authored corpse has no hitboxes, so its highlight keeps its collider",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 10 });
+
+    const corpse = (await game.entities.list()).entities
+      .filter((entity) => entity.name === "MS Male Corpse")
+      .sort((a, b) => a.distance - b.distance)[0];
+    assert.ok(corpse, "expected a corpse in medsci1");
+    const detail = await game.entities.detail(corpse.id);
+    assert.equal((detail.aim_points ?? []).length, 0, "a posed corpse has no hitbox proxies");
+
+    const bounds = detail.selection_bounds;
+    assert.ok(bounds, "the corpse should still report bounds - its collider");
+    const [min, max] = bounds;
+    // The PR-1 body-shaped box: a body length across, and flat.
+    assert.ok(max[0] - min[0] > 2, `expected a body-length box, got ${JSON.stringify(bounds)}`);
+    assert.ok(max[1] - min[1] < 1.2, `expected a flat box, got ${JSON.stringify(bounds)}`);
+  },
+);

--- a/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
@@ -37,7 +37,8 @@ test(
     // animated creature (arms out, weapon raised), so this fails on the
     // collider bounds it used to report.
     const [min, max] = bounds;
-    for (const point of detail.aim_points ?? []) {
+    const points = detail.aim_points ?? [];
+    for (const point of points) {
       for (let axis = 0; axis < 3; axis++) {
         assert.ok(
           point.position[axis] >= min[axis] - 0.01 &&
@@ -45,6 +46,19 @@ test(
           `hitbox ${point.joint_id} (${point.classification}) sits outside the highlight on axis ${axis}: ${JSON.stringify(point.position)} vs ${JSON.stringify(bounds)}`,
         );
       }
+    }
+
+    // ...and it frames THIS creature, not the room: the box may exceed the
+    // hitbox centres only by about a limb's thickness. (Containment alone
+    // cannot fail - the bounds are the union of these very proxies - so this
+    // is the half of the check that can.)
+    for (let axis = 0; axis < 3; axis++) {
+      const lo = Math.min(...points.map((point) => point.position[axis]));
+      const hi = Math.max(...points.map((point) => point.position[axis]));
+      assert.ok(
+        min[axis] > lo - 0.8 && max[axis] < hi + 0.8,
+        `the highlight should hug the hitboxes on axis ${axis}: hitboxes span ${lo.toFixed(2)}..${hi.toFixed(2)}, box spans ${min[axis].toFixed(2)}..${max[axis].toFixed(2)}`,
+      );
     }
   },
 );
@@ -69,5 +83,39 @@ test(
     // The PR-1 body-shaped box: a body length across, and flat.
     assert.ok(max[0] - min[0] > 2, `expected a body-length box, got ${JSON.stringify(bounds)}`);
     assert.ok(max[1] - min[1] < 1.2, `expected a flat box, got ${JSON.stringify(bounds)}`);
+  },
+);
+
+test(
+  "an arachnid is framed by its single Body hitbox, at collider scale",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "hydro3.mis" });
+    await game.step({ frames: 60 });
+
+    const arachnid = (await game.entities.list()).entities.find((entity) =>
+      entity.name.includes("Arachnid"),
+    );
+    assert.ok(arachnid, "expected a Baby Arachnid in hydro3");
+    const detail = await game.entities.detail(arachnid.id);
+    assert.equal(
+      (detail.aim_points ?? []).length,
+      1,
+      "the arachnid definition maps exactly one Body hitbox",
+    );
+
+    // A single Body hitbox frames the body without the legs. Coarser than a
+    // humanoid's frame, but still the scale of the creature (its collider
+    // measures 0.40 across) rather than collapsing to a point - which is the
+    // regression a future change here would introduce.
+    const bounds = detail.selection_bounds;
+    assert.ok(bounds, "the arachnid should still report bounds");
+    const width = Math.max(bounds[1][0] - bounds[0][0], bounds[1][2] - bounds[0][2]);
+    const height = bounds[1][1] - bounds[0][1];
+    assert.ok(
+      width > 0.25 && width < 1.0,
+      `expected a body-scale frame, got ${width.toFixed(2)} across`,
+    );
+    assert.ok(height > 0.25, `expected a body-scale frame, got ${height.toFixed(2)} tall`);
   },
 );


### PR DESCRIPTION
Stacked on #1216.

## What

The HUD highlight — the corner brackets and the hover label — frames the union of a creature's **hitboxes** instead of its own collider.

![what the highlight frames](https://gist.githubusercontent.com/tommy-xr/b196ece76e5afd98777d4f428bbf11dd/raw/selection-bounds.png)

A creature's collider is a standing capsule sized from its creature definition, so the brackets framed a nominal cylinder rather than the creature — and framed the same cylinder whatever the creature was doing. They now frame the volume its limbs occupy in the pose it is in, which is also the volume it is shot by (the same proxies `aim_points` reports).

Anything with no hitboxes — every prop, and an authored corpse — keeps its collider bounds, so #1211's body-shaped corpse box is unchanged.

## Also

- Both drawing functions now take *resolved bounds* instead of looking them up themselves, so the brackets and the label cannot frame different volumes.
- `/v1/entities/:id` reports the same bounds as `selection_bounds`, from the same function. The brackets are four 8px quads, so this is the only way to check the highlight headlessly — and it guarantees what an agent reads is what the player sees framed.

## Verification

- Unit: the union spans every hitbox; a stale proxy contributes nothing rather than stretching the box to the origin; no hitboxes means no bounds (collider fallback).
- New e2e `selection-bounds.e2e.test.ts`: every hitbox lies inside the highlight **and** the box hugs them (containment alone cannot fail — the bounds are the union of those very proxies); an authored corpse keeps its collider box; and an arachnid, whose definition maps a single `Body` hitbox, keeps a body-scale frame.
- Negative-verified: with the old collider bounds, hitbox 14 (a hand) sits *outside* the highlight — the capsule does not contain the creature it frames.
- Full SDK e2e suite: 346/362, all 8 failures also fail on `main`.

## Known gaps

- **Single-hitbox creatures** (the arachnids, the Overlord — their definitions map one `Body` joint) get a body-only frame, legs excluded: measured 0.33–0.58 across on hydro3's Baby Arachnids, against a 0.40 collider. Neither is the animal; the shipped creature colliders are their own known problem. The mesh-derived one wins, and widening those definitions is the fix worth making.
- The brackets project the union's **world** AABB, so a diagonal limb contributes a little empty space. Projecting each proxy and unioning in screen space would frame tighter, at the cost of the endpoint no longer reporting exactly what is drawn.
- The bounds trail the drawn pose by one frame (proxies are stepped before they are re-posed) — invisible at 60 Hz.
- A human-sized creature can only be highlighted inside frob reach (~2.8 units), where it fills the view and the brackets clamp to the screen edge (#1211). The visible win is on small creatures and non-standing poses.
