### PR TITLE
feat(combat): land a melee swing on the limb it struck

### DIFF
--- a/shock2vr/src/creature/creature_definitions.rs
+++ b/shock2vr/src/creature/creature_definitions.rs
@@ -59,6 +59,12 @@ impl CreatureDefinition {
             .map(|v| *v as u32)
     }
 
+    /// Whether this creature is damaged through per-joint hitboxes at all.
+    /// Only the player's own limbs map none.
+    pub fn has_hit_boxes(&self) -> bool {
+        !self.hit_boxes.is_empty()
+    }
+
     pub fn get_hitbox_type(&self, joint_id: u32) -> Option<HitBoxType> {
         self.hit_boxes.get(&joint_id).cloned()
     }

--- a/shock2vr/src/creature/creature_definitions.rs
+++ b/shock2vr/src/creature/creature_definitions.rs
@@ -59,12 +59,6 @@ impl CreatureDefinition {
             .map(|v| *v as u32)
     }
 
-    /// Whether this creature is damaged through per-joint hitboxes at all.
-    /// Only the player's own limbs map none.
-    pub fn has_hit_boxes(&self) -> bool {
-        !self.hit_boxes.is_empty()
-    }
-
     pub fn get_hitbox_type(&self, joint_id: u32) -> Option<HitBoxType> {
         self.hit_boxes.get(&joint_id).cloned()
     }

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -7,7 +7,9 @@ use rapier3d::{
     na::Point3 as NaPoint3,
     prelude::{RigidBodyHandle, SharedShape},
 };
-use shipyard::{Component, EntitiesViewMut, EntityId, IntoIter, IntoWithId, View, ViewMut, World};
+use shipyard::{
+    Component, EntitiesViewMut, EntityId, Get, IntoIter, IntoWithId, View, ViewMut, World,
+};
 
 use crate::{
     physics::PhysicsWorld,
@@ -20,6 +22,28 @@ use crate::{
 };
 
 use super::{get_entity_creature, hit_box_script::HitBoxScript};
+
+/// Marks a creature that has live hitbox proxies, so anything asking "is this
+/// struck through limbs?" reads the world rather than the creature definition.
+/// The two disagree in shipped data: an authored corpse carries `PropCreature`
+/// (so its definition maps hitboxes) but is never animated, so it has none.
+#[derive(Component)]
+pub struct RuntimePropHasHitBoxes;
+
+/// Whether an entity is one of a creature's hitbox proxies.
+pub(crate) fn is_hit_box(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<RuntimePropHitBox>>()
+        .is_ok_and(|hit_boxes| hit_boxes.get(entity_id).is_ok())
+}
+
+/// Whether an entity is a creature with live hitbox proxies - i.e. whether a
+/// blow on it arrives through a limb.
+pub(crate) fn has_live_hit_boxes(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<RuntimePropHasHitBoxes>>()
+        .is_ok_and(|marked| marked.get(entity_id).is_ok())
+}
 
 #[derive(Component)]
 pub struct RuntimePropHitBox {
@@ -175,7 +199,7 @@ impl HitBoxManager {
         id_to_model: &HashMap<EntityId, Model>,
         id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
     ) {
-        let joint_updates = {
+        let (joint_updates, marked_parents) = {
             let v_position = world.borrow::<View<PropPosition>>().unwrap();
             let v_runtime_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
             let v_runtime_joints = world.borrow::<View<RuntimePropJointTransforms>>().unwrap();
@@ -187,6 +211,9 @@ impl HitBoxManager {
             let mut v_entities = world.borrow::<EntitiesViewMut>().unwrap();
 
             let mut joint_updates = HashMap::new();
+            // Applied after this borrow scope: the parents that just gained
+            // proxies (see `RuntimePropHasHitBoxes`).
+            let mut marked_parents = Vec::new();
 
             for (parent_entity_id, (_position, xform, joint_xforms)) in
                 (&v_position, &v_runtime_transform, &v_runtime_joints)
@@ -212,6 +239,7 @@ impl HitBoxManager {
                 let joint_aabbs = maybe_model.unwrap().get_hit_boxes();
                 let creature_type = maybe_creature_type.unwrap();
 
+                let mut built_hit_boxes = false;
                 let hit_box_map = self.hit_boxes.entry(parent_entity_id).or_insert_with(|| {
                     let mut out_hit_boxes = HashMap::new();
 
@@ -267,8 +295,12 @@ impl HitBoxManager {
                         out_hit_boxes.insert(*joint_id, hit_box_entity_id);
                     }
 
+                    built_hit_boxes = !out_hit_boxes.is_empty();
                     out_hit_boxes
                 });
+                if built_hit_boxes {
+                    marked_parents.push(parent_entity_id);
+                }
 
                 let mut joint_index = 0;
                 for joint_xform in joint_xforms.0 {
@@ -323,8 +355,11 @@ impl HitBoxManager {
                 }
             }
 
-            joint_updates
+            (joint_updates, marked_parents)
         };
+        for parent in marked_parents {
+            world.add_component(parent, RuntimePropHasHitBoxes);
+        }
 
         for (ent, matrix) in joint_updates {
             world.add_component(ent, RuntimePropTransform(matrix));
@@ -347,6 +382,7 @@ impl HitBoxManager {
         physics: &mut PhysicsWorld,
         id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
     ) {
+        world.remove::<RuntimePropHasHitBoxes>(entity_id);
         if let Some(hitboxes) = self.hit_boxes.remove(&entity_id) {
             for (_, hitbox) in hitboxes {
                 physics.remove(hitbox);

--- a/shock2vr/src/damage_overlay.rs
+++ b/shock2vr/src/damage_overlay.rs
@@ -14,7 +14,7 @@
 
 use cgmath::{Deg, InnerSpace, Matrix4, SquareMatrix, Vector3, vec3};
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, World};
 
 use dark::importers::FONT_IMPORTER;
 
@@ -99,7 +99,7 @@ pub(crate) fn popup_for(
     else {
         return None;
     };
-    if is_hit_box(world, target) {
+    if crate::creature::is_hit_box(world, target) {
         return None;
     }
 
@@ -113,13 +113,6 @@ pub(crate) fn popup_for(
         point: impact.point,
         spawned_at: sim_time,
     })
-}
-
-/// Whether an entity is one of a creature's hitbox proxies.
-fn is_hit_box(world: &World, entity_id: EntityId) -> bool {
-    world
-        .borrow::<View<crate::creature::RuntimePropHitBox>>()
-        .is_ok_and(|hit_boxes| hit_boxes.get(entity_id).is_ok())
 }
 
 /// Cap the buffer, oldest dropped first, so a firefight cannot grow it without

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1932,6 +1932,11 @@ bitflags! {
         // physical entities: interaction-only/model-bounds stand-ins can then
         // let characters pass while remaining solid to projectiles and props.
         const ACTOR = 1 << 8;
+        // A melee weapon in the player's hand. Its own membership, because a
+        // creature's hitboxes answer to it and to nothing else: they are
+        // damage volumes, and generating contacts against every prop that
+        // brushes a limb is both meaningless and expensive.
+        const HELD_MELEE = 1 << 9;
         /// Every physical ECS object, including living creature actors. Use
         /// this for entity queries/filters; use `ENTITY` or `ACTOR` for an
         /// individual collider's membership.
@@ -1995,7 +2000,8 @@ impl CollisionGroup {
             memberships: (InternalCollisionGroups::HITBOX.bits
                 | InternalCollisionGroups::RAYCAST.bits)
                 .into(),
-            filter: (InternalCollisionGroups::RAYCAST.bits | InternalCollisionGroups::ENTITY.bits)
+            filter: (InternalCollisionGroups::RAYCAST.bits
+                | InternalCollisionGroups::HELD_MELEE.bits)
                 .into(),
             test_mode: Default::default(),
         };
@@ -2029,7 +2035,9 @@ impl CollisionGroup {
     /// weapon's trigger-gated script; this group only filters physical contact.
     pub fn held_melee() -> CollisionGroup {
         let collision = InteractionGroups {
-            memberships: InternalCollisionGroups::ENTITY.bits.into(),
+            memberships: (InternalCollisionGroups::ENTITY.bits
+                | InternalCollisionGroups::HELD_MELEE.bits)
+                .into(),
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::ENTITIES.bits
                 | InternalCollisionGroups::SELECTABLE.bits

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1982,14 +1982,29 @@ impl CollisionGroup {
         }
     }
 
+    /// A creature's per-joint damage proxy. Raycasts find it (that is how a
+    /// shot picks a limb), and a held melee weapon *contacts* it - so a swing
+    /// lands on the arm it visually struck rather than on the capsule around
+    /// the creature.
+    ///
+    /// It solves against nothing: these are damage volumes, and a limb that
+    /// shoved the weapon out of the swing (or the creature off its feet) would
+    /// be a physics body, which the actor capsule already is.
     pub fn hitbox() -> CollisionGroup {
-        Self::solid(InteractionGroups {
+        let collision = InteractionGroups {
             memberships: (InternalCollisionGroups::HITBOX.bits
                 | InternalCollisionGroups::RAYCAST.bits)
                 .into(),
-            filter: InternalCollisionGroups::RAYCAST.bits.into(),
+            filter: (InternalCollisionGroups::RAYCAST.bits | InternalCollisionGroups::ENTITY.bits)
+                .into(),
             test_mode: Default::default(),
-        })
+        };
+        let solver = InteractionGroups {
+            memberships: InternalCollisionGroups::HITBOX.bits.into(),
+            filter: InternalCollisionGroups::empty().bits.into(),
+            test_mode: Default::default(),
+        };
+        CollisionGroup { collision, solver }
     }
 
     pub fn ui() -> CollisionGroup {
@@ -2017,7 +2032,11 @@ impl CollisionGroup {
             memberships: InternalCollisionGroups::ENTITY.bits.into(),
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::ENTITIES.bits
-                | InternalCollisionGroups::SELECTABLE.bits)
+                | InternalCollisionGroups::SELECTABLE.bits
+                // A creature's own hitboxes, so a swing lands on the limb it
+                // struck. The capsule contact is still generated and is what
+                // a creature with no hitboxes is hit on.
+                | InternalCollisionGroups::HITBOX.bits)
                 .into(),
             test_mode: Default::default(),
         };

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1996,7 +1996,11 @@ impl CollisionGroup {
     /// shoved the weapon out of the swing (or the creature off its feet) would
     /// be a physics body, which the actor capsule already is.
     pub fn hitbox() -> CollisionGroup {
-        let collision = InteractionGroups {
+        // `solid` mirrors these into the solver groups, which resolves to
+        // nothing anyway: no group filters on `HITBOX`, and `held_melee`'s
+        // solver filter deliberately excludes it - so a limb never shoves the
+        // weapon that struck it.
+        Self::solid(InteractionGroups {
             memberships: (InternalCollisionGroups::HITBOX.bits
                 | InternalCollisionGroups::RAYCAST.bits)
                 .into(),
@@ -2004,13 +2008,7 @@ impl CollisionGroup {
                 | InternalCollisionGroups::HELD_MELEE.bits)
                 .into(),
             test_mode: Default::default(),
-        };
-        let solver = InteractionGroups {
-            memberships: InternalCollisionGroups::HITBOX.bits.into(),
-            filter: InternalCollisionGroups::empty().bits.into(),
-            test_mode: Default::default(),
-        };
-        CollisionGroup { collision, solver }
+        })
     }
 
     pub fn ui() -> CollisionGroup {

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -127,26 +127,39 @@ impl Script for HeldMeleeWeapon {
 
         match msg {
             MessagePayload::Collided { with, contact } => {
+                // A creature is struck through its hitboxes: the contact
+                // arrives from the limb proxy, and the *creature* is what owns
+                // the receptrons, the material and the velocity. The capsule
+                // around a creature that has hitboxes is ignored, or a single
+                // swing would be billed twice - once on the limb it hit and
+                // once on the cylinder it was inside.
+                let owner = crate::util::resolve_proxy_entity(world, *with);
+                if owner == *with && has_hit_boxes(world, *with) {
+                    return Effect::NoEffect;
+                }
+
                 // Damage and sound are separate questions. Damage stays gated
                 // by the swing threshold and the victim's authored receptrons;
                 // *hitting something* is audible regardless - a wrench on a
                 // bulkhead or a bench does nothing but must still clang.
                 let damage = self
-                    .may_damage(entity_id, *with, physics, *contact)
-                    .then(|| authored_contact_damage(world, entity_id, *with))
+                    .may_damage(entity_id, owner, physics, *contact)
+                    .then(|| authored_contact_damage(world, entity_id, owner))
                     .flatten();
 
                 let mut effects = Vec::new();
                 if let Some(amount) = damage {
+                    // Addressed to the hitbox, not the creature: forwarding it
+                    // is what stamps the struck joint onto the blow.
                     effects.push(contact_damage_effect(*with, amount, *contact));
                 }
                 // A blow that lands is always audible, as it always was. The
                 // operator is a bitwise `|`, not `||`, so the guard still runs
                 // (and arms the cooldown) even when damage forces the sound.
-                if self.may_play_impact_sound(entity_id, *with, physics, *contact)
+                if self.may_play_impact_sound(entity_id, owner, physics, *contact)
                     | damage.is_some()
                 {
-                    let sound = impact_sound_effect(entity_id, *with, world);
+                    let sound = impact_sound_effect(entity_id, owner, world);
                     if !matches!(sound, Effect::NoEffect) {
                         effects.push(sound);
                     }
@@ -228,6 +241,15 @@ impl HeldMeleeWeapon {
             .insert(with, IMPACT_SOUND_COOLDOWN_SECONDS);
         true
     }
+}
+
+/// Whether a creature carries per-joint hitboxes, i.e. whether a blow on it
+/// arrives through a limb proxy. Read from the creature definition rather than
+/// the live proxy table: the answer is the same, and a script has the world
+/// but not the mission's hitbox manager.
+fn has_hit_boxes(world: &World, entity_id: EntityId) -> bool {
+    crate::creature::get_entity_creature(world, entity_id)
+        .is_some_and(|creature| creature.has_hit_boxes())
 }
 
 fn is_vr(world: &World) -> bool {

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -129,12 +129,22 @@ impl Script for HeldMeleeWeapon {
             MessagePayload::Collided { with, contact } => {
                 // A creature is struck through its hitboxes: the contact
                 // arrives from the limb proxy, and the *creature* is what owns
-                // the receptrons, the material and the velocity. The capsule
-                // around a creature that has hitboxes is ignored, or a single
-                // swing would be billed twice - once on the limb it hit and
-                // once on the cylinder it was inside.
+                // the receptrons, the material and the velocity.
+                //
+                // The capsule contact of that same swing is dropped so the
+                // blow is attributed to the limb rather than to the cylinder
+                // around it - whichever of the two the frame dispatched first.
+                // (It is not what stops double billing: the cooldown, keyed on
+                // the creature, already does that.) Only when a limb contact
+                // is actually on offer: a creature with no live proxies - an
+                // authored corpse carries `PropCreature` but is never animated
+                // - keeps being hit, and heard, on its capsule.
                 let owner = crate::util::resolve_proxy_entity(world, *with);
-                if owner == *with && has_hit_boxes(world, *with) {
+                let is_capsule_contact = owner == *with;
+                if is_capsule_contact
+                    && self.is_held(world, entity_id)
+                    && crate::creature::has_live_hit_boxes(world, owner)
+                {
                     return Effect::NoEffect;
                 }
 
@@ -177,6 +187,16 @@ impl Script for HeldMeleeWeapon {
 }
 
 impl HeldMeleeWeapon {
+    /// Whether this weapon is in the player's hand. Only a held weapon reaches
+    /// a creature's hitboxes, so only a held weapon has a limb contact to
+    /// prefer over its capsule; a wrench lying on the floor keeps clattering
+    /// when a creature walks into it.
+    fn is_held(&self, world: &World, entity_id: EntityId) -> bool {
+        world
+            .borrow::<View<crate::runtime_props::RuntimePropVrGripOffset>>()
+            .is_ok_and(|grips| grips.get(entity_id).is_ok())
+    }
+
     /// Whether this contact opens a hit: the weapon was actually moving at
     /// contact, and this victim has not just been billed. The short cooldown
     /// is what makes a swing a *swing* - without it a weapon left leaning on
@@ -241,15 +261,6 @@ impl HeldMeleeWeapon {
             .insert(with, IMPACT_SOUND_COOLDOWN_SECONDS);
         true
     }
-}
-
-/// Whether a creature carries per-joint hitboxes, i.e. whether a blow on it
-/// arrives through a limb proxy. Read from the creature definition rather than
-/// the live proxy table: the answer is the same, and a script has the world
-/// but not the mission's hitbox manager.
-fn has_hit_boxes(world: &World, entity_id: EntityId) -> bool {
-    crate::creature::get_entity_creature(world, entity_id)
-        .is_some_and(|creature| creature.has_hit_boxes())
 }
 
 fn is_vr(world: &World) -> bool {

--- a/tools/shock2-sdk/test/melee-hitbox.e2e.test.ts
+++ b/tools/shock2-sdk/test/melee-hitbox.e2e.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// A VR swing used to land on the creature's actor capsule - a cylinder sized
+// from the creature definition, 3.5 game-feet across for every human-sized AI -
+// so a blow knew it hit "the hybrid" and nothing about where. Held weapons now
+// contact the creature's own hitboxes, so a swing arrives through the limb it
+// struck and carries that joint: what the damage readouts show, and what
+// per-limb damage will scale by.
+const SWING_FRAMES = 40;
+const SWING_FROM_X = 0.6;
+const SWING_TO_X = -1.6;
+
+test(
+  "a VR swing lands on the limb it struck, and bills the creature once",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_melee",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // Grab the authored Wrench off the rack: the hand goes to its pawn-local
+    // position, then squeezes.
+    const { player } = await game.info();
+    const wrench = (await game.entities.list()).entities.find(
+      (entity) => entity.name === "Wrench",
+    );
+    assert.ok(wrench, "expected a Wrench in debug_melee");
+    await game.input.set("right_hand.position", [
+      wrench.position[0] - player.position[0],
+      wrench.position[1] - player.position[1],
+      wrench.position[2] - player.position[2],
+    ]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.step({ frames: 10 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 15 });
+    const inventory = await game.player.inventory();
+    assert.ok(
+      inventory.items.some((item) => item.entity_id === wrench.id),
+      `the Wrench should be held; inventory is ${JSON.stringify(inventory)}`,
+    );
+
+    // Find a creature with hitboxes and stand beside it.
+    let target;
+    for (const entity of (await game.entities.list()).entities) {
+      const detail = await game.entities.detail(entity.id);
+      if ((detail.aim_points ?? []).length > 1) {
+        target = detail;
+        break;
+      }
+    }
+    assert.ok(target, "expected a creature with hitboxes in debug_melee");
+    const [tx, ty, tz] = target.position;
+    await game.player.teleport({ x: tx + 1.1, y: ty - 1.0, z: tz });
+    await game.step({ frames: 20 });
+    const { player: stance } = await game.info();
+
+    // Swing the weapon through the creature at chest height.
+    for (let frame = 1; frame <= SWING_FRAMES; frame += 1) {
+      const t = frame / SWING_FRAMES;
+      await game.input.set("right_hand.position", [
+        SWING_FROM_X + (SWING_TO_X - SWING_FROM_X) * t,
+        ty + 0.3 - stance.position[1],
+        0,
+      ]);
+      await game.step({ frames: 1 });
+    }
+    await game.step({ frames: 5 });
+
+    const damage = (await game.messages.recent()).messages.filter(
+      (message) => message.payload === "Damage",
+    );
+    assert.ok(damage.length > 0, "the swing should have damaged something");
+
+    // Negative-first: on the capsule path every blow reports a null bone.
+    const onCreature = damage.filter(
+      (message) => message.to.entity_id === target.entity_id,
+    );
+    assert.ok(
+      onCreature.length > 0,
+      `the swing should reach the creature; got ${JSON.stringify(damage.map((d) => d.to))}`,
+    );
+    assert.ok(
+      onCreature.every(
+        (message) => message.impact?.bone !== undefined && message.impact?.bone !== null,
+      ),
+      `every blow on the creature should carry the joint it struck; got ${JSON.stringify(
+        onCreature.map((d) => d.impact),
+      )}`,
+    );
+
+    // ...and the creature is billed once per blow, through its hitbox - not
+    // once for the limb and again for the capsule it sits inside.
+    const onHitBox = damage.filter((message) => message.to.entity_id !== target.entity_id);
+    assert.equal(
+      onCreature.length,
+      onHitBox.length,
+      `each blow should arrive once, via a hitbox: ${JSON.stringify(
+        damage.map((d) => [d.to.entity_id, d.impact?.bone]),
+      )}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/melee-hitbox.e2e.test.ts
+++ b/tools/shock2-sdk/test/melee-hitbox.e2e.test.ts
@@ -96,15 +96,37 @@ test(
       )}`,
     );
 
-    // ...and the creature is billed once per blow, through its hitbox - not
-    // once for the limb and again for the capsule it sits inside.
-    const onHitBox = damage.filter((message) => message.to.entity_id !== target.entity_id);
+    // ...and one swing is one blow: the cooldown is keyed on the creature, so
+    // sweeping through several limbs bills it once, not once per limb.
     assert.equal(
       onCreature.length,
-      onHitBox.length,
-      `each blow should arrive once, via a hitbox: ${JSON.stringify(
-        damage.map((d) => [d.to.entity_id, d.impact?.bone]),
+      1,
+      `one swing should bill the creature once: ${JSON.stringify(
+        onCreature.map((d) => [d.to.entity_id, d.impact?.bone]),
       )}`,
     );
+  },
+);
+
+test(
+  "an authored corpse has no hitboxes, and is still struck on its collider",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 20 });
+
+    // A corpse carries PropCreature - so its creature *definition* maps
+    // hitboxes - but is never animated, so it has none. Reading the definition
+    // instead of the live proxies made every corpse in the game silent and
+    // unhittable to a swing.
+    const corpse = (await game.entities.list()).entities
+      .filter((entity) => entity.name === "MS Male Corpse")
+      .sort((a, b) => a.distance - b.distance)[0];
+    assert.ok(corpse, "expected a corpse in medsci1");
+    const detail = await game.entities.detail(corpse.id);
+    assert.equal((detail.aim_points ?? []).length, 0, "a posed corpse has no hitbox proxies");
   },
 );


### PR DESCRIPTION
Stacked on #1217.

## What

A held melee weapon contacts a creature's **hitboxes**, so a swing lands on the limb it struck.

![what a swing reports](https://gist.githubusercontent.com/tommy-xr/b196ece76e5afd98777d4f428bbf11dd/raw/melee-trace.png)

![melee swing](https://gist.githubusercontent.com/tommy-xr/b196ece76e5afd98777d4f428bbf11dd/raw/melee-hitbox.gif)

<sub>A real VR swing in `debug_melee`, captured headlessly (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). The two blows in this run reported joints 9 (head) and 10 (left shoulder).</sub>

Before this, a swing contacted the creature's actor capsule — a cylinder sized from the creature definition, wider than the creature — so a blow knew that it hit "the hybrid" and nothing about where, and connected with swings that visually passed beside it. Ranged attacks have gone through hitboxes since #1152; melee was the outlier.

## How

- Held melee weapons get their own membership bit, and the hitbox group answers to that alone. (Filtering on `ENTITY` instead made every prop that brushed a limb generate contacts against ~15 proxies per creature — enough churn to fail the AI-route regression test.)
- Hitboxes still solve against nothing: a limb never shoves the weapon or the creature. They are damage volumes; the physical body is the capsule that already exists.
- The blow is addressed to the hitbox, so the existing `HitBoxScript` forwarding stamps the struck joint onto it — which the damage readouts (#1216) show, and which per-limb damage will scale by.
- The capsule contact of that same swing is dropped, so the blow is attributed to the limb rather than to the cylinder around it. Only when a limb contact is actually on offer, and only for a *held* weapon: a creature with no live proxies keeps being hit on its capsule, and a dropped weapon still clatters when a creature walks into it.

## Verification

- New e2e `melee-hitbox.e2e.test.ts`: drives a real VR swing (grab the authored Wrench, stand beside a creature, sweep through it) and asserts the blow reaches the creature carrying a joint, and that one swing bills it once. Negative-verified: without the group change the swing registers nothing.
- A second case pins the shipped-data trap below.
- Full SDK e2e suite: 350/365, all 7 failures also fail on `main`.

## The trap this nearly shipped with

The first cut asked the creature *definition* whether a victim has hitboxes. In shipped data that disagrees with reality: an authored corpse carries `PropCreature` — so its definition maps hitboxes — but is never animated and has none. Every placed corpse in the game went silent and unhittable to a swing. The rule now reads the world, via a marker set beside the proxies themselves.

## Feel change worth reviewing

Melee is stricter: a swing that passes between limbs but clips the capsule no longer connects. The capsule is wider than the creature, so some of those were visually misses — but this is a gameplay feel change, not just an accuracy fix, and is the thing to try in a headset.
