### PR TITLE
feat(combat): a shot resolves to the limb it crossed

### DIFF
--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -37,6 +37,19 @@ pub(crate) fn is_hit_box(world: &World, entity_id: EntityId) -> bool {
         .is_ok_and(|hit_boxes| hit_boxes.get(entity_id).is_ok())
 }
 
+/// Whether a creature's hitboxes stand in for its *body*, i.e. whether missing
+/// all of them means the shot missed the creature.
+///
+/// A definition that maps one `Body` joint (`SPIDER_HIT_BOXES`,
+/// `OVERLORD_HIT_BOXES`) leaves the legs and limbs with no proxy at all, so
+/// treating a miss on that one blob as a miss on the animal would make whole
+/// bands of it unshootable. Those creatures keep their capsule; widening their
+/// definitions is what would let them join the rule.
+pub(crate) fn hit_boxes_cover_body(world: &World, entity_id: EntityId) -> bool {
+    crate::creature::get_entity_creature(world, entity_id)
+        .is_some_and(|creature| creature.hit_boxes.len() > 1)
+}
+
 /// Whether an entity is a creature with live hitbox proxies - i.e. whether a
 /// blow on it arrives through a limb.
 pub(crate) fn has_live_hit_boxes(world: &World, entity_id: EntityId) -> bool {

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -335,13 +335,6 @@ pub(crate) fn is_entity_door(world: &shipyard::World, entity_id: shipyard::Entit
     v_door_prop.contains(entity_id)
 }
 
-pub(crate) fn does_entity_have_hitboxes(world: &World, entity_id: EntityId) -> bool {
-    let v_creature_prop = world.borrow::<View<PropCreature>>().unwrap();
-
-    // If the entity has a creature prop, we use hitboxes for damage
-    v_creature_prop.contains(entity_id)
-}
-
 /// Fire Ranged Weapon
 ///
 /// Handles firing a projectile through the AIRangedWeapon link, which is a proxy between the main entity link

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -173,14 +173,20 @@ impl Script for InternalFastProjectileScript {
     }
 }
 
+/// Whether a collider is one of this creature's own hitboxes. Read from the
+/// proxy's `parent_entity_id` - the fact that says whose limb this is - rather
+/// than from the generic proxy link `resolve_proxy_entity` follows.
 fn hitbox_belongs_to_entity(world: &World, hitbox_entity: EntityId, parent: EntityId) -> bool {
     world
         .borrow::<View<RuntimePropHitBox>>()
-        .is_ok_and(|hitboxes| {
-            hitboxes
+        .ok()
+        .and_then(|hit_boxes| {
+            hit_boxes
                 .get(hitbox_entity)
-                .is_ok_and(|hitbox| hitbox.parent_entity_id == parent)
+                .ok()
+                .map(|hb| hb.parent_entity_id)
         })
+        == Some(parent)
 }
 
 /// Whether the shot started inside this entity's own bounds - a weapon pressed
@@ -202,6 +208,12 @@ fn fired_from_inside(
 /// unusual; this only bounds the work.
 const MAX_PASS_THROUGH: usize = 4;
 
+/// How far a shot reaches, in world units. The shipped value: `ray_cast`
+/// normalizes its direction and caps the cast at 100, so the caller's nominal
+/// 1000 never applied. Kept explicit here so the range stays what it has
+/// always been rather than becoming ten times longer by accident.
+const MAX_RANGE: f32 = 100.0;
+
 fn projectile_ray_cast(
     start_point: Point3<f32>,
     forward: cgmath::Vector3<f32>,
@@ -215,6 +227,7 @@ fn projectile_ray_cast(
     } else {
         InternalCollisionGroups::empty()
     };
+    let distance = distance.min(MAX_RANGE);
     let coarse_groups = InternalCollisionGroups::ENTITIES
         // Sometimes, the hitbox can stick out past the bounding box...
         // so we should still check for it here
@@ -223,10 +236,11 @@ fn projectile_ray_cast(
         | InternalCollisionGroups::SELECTABLE
         | InternalCollisionGroups::WORLD;
 
-    // Creatures whose capsule the shot has already passed through: they had no
-    // limb on this line, so they are not what it hit.
+    // Creatures whose *capsule* the shot has already passed through: it found
+    // no limb of theirs on this line. Their proxies stay in play - if a later
+    // pass finds one, that is a genuine limb hit and wins.
     let mut passed_through: Vec<EntityId> = Vec::new();
-    for _ in 0..MAX_PASS_THROUGH {
+    for pass in 0..=MAX_PASS_THROUGH {
         let is_not_passed_through = |entity_id: EntityId| !passed_through.contains(&entity_id);
         let maybe_hit_spot = physics.ray_cast2_with_entity_filter(
             start_point,
@@ -248,6 +262,10 @@ fn projectile_ray_cast(
         // carries `PropCreature` but is never animated and has none. Reading
         // the definition would refine against hitboxes that do not exist and
         // then pass the shot straight through the body.
+        // Out of passes: take the nearest thing that is left, capsule or not.
+        if pass == MAX_PASS_THROUGH {
+            return maybe_hit_spot;
+        }
         if !crate::creature::has_live_hit_boxes(world, hit_entity_id) {
             return maybe_hit_spot;
         }
@@ -274,6 +292,15 @@ fn projectile_ray_cast(
             // the damage.
             return refined_hit;
         }
+        if !crate::creature::hit_boxes_cover_body(world, hit_entity_id) {
+            // The creature's hitboxes do not stand in for its body: the
+            // arachnids and the Overlord map a single `Body` joint, so their
+            // legs and limbs have no proxy at all. Passing through would make
+            // whole bands of them unshootable, so the capsule keeps the shot
+            // (with no joint to report). Widening those definitions is the fix
+            // that would let them join the rule above.
+            return maybe_hit_spot;
+        }
         if fired_from_inside(physics, start_point, hit_entity_id) {
             // Point blank, with the capsule around the muzzle: the proxies may
             // all be behind the origin, and a shot pressed into a creature
@@ -285,16 +312,7 @@ fn projectile_ray_cast(
         // creature, so the shot carries on to whatever is behind it.
         passed_through.push(hit_entity_id);
     }
-    // Too many creatures deep: take the nearest thing that is left.
-    physics.ray_cast2_with_entity_filter(
-        start_point,
-        forward,
-        distance,
-        coarse_groups,
-        None,
-        true,
-        &|entity_id: EntityId| !passed_through.contains(&entity_id),
-    )
+    None
 }
 
 #[cfg(test)]
@@ -304,6 +322,7 @@ mod tests {
     use crate::physics::PhysicsWorld;
     use cgmath::{Quaternion, point3, vec3};
     use dark::SCALE_FACTOR;
+    use dark::properties::PropCreature;
     use shipyard::{EntityId, World};
 
     #[test]
@@ -381,8 +400,10 @@ mod tests {
         let mut physics = PhysicsWorld::new();
         let mut world = World::new();
 
-        // The creature's capsule spans the line of fire...
-        let creature = world.add_entity(crate::creature::RuntimePropHasHitBoxes);
+        // The creature's capsule spans the line of fire...  Creature type 0 is
+        // HUMAN, whose definition maps fifteen joints, so its hitboxes stand
+        // in for its body.
+        let creature = world.add_entity((crate::creature::RuntimePropHasHitBoxes, PropCreature(0)));
         physics.add_kinematic(
             creature,
             vec3(0.0, 0.0, 5.0),
@@ -449,7 +470,7 @@ mod tests {
         let mut physics = PhysicsWorld::new();
         let mut world = World::new();
 
-        let creature = world.add_entity(crate::creature::RuntimePropHasHitBoxes);
+        let creature = world.add_entity((crate::creature::RuntimePropHasHitBoxes, PropCreature(0)));
         physics.add_kinematic(
             creature,
             vec3(0.0, 0.0, 0.0),
@@ -502,6 +523,73 @@ mod tests {
             hit.and_then(|result| result.maybe_entity_id),
             Some(creature),
             "a muzzle inside the creature keeps its coarse hit",
+        );
+    }
+
+    /// The arachnids and the Overlord map a single `Body` joint, so their legs
+    /// and limbs have no proxy at all. A shot that misses that one blob has
+    /// not missed the animal - passing through would leave whole bands of it
+    /// unshootable - so those creatures keep their capsule.
+    ///
+    /// Negative-first: without the coverage gate this shot reaches the wall.
+    #[test]
+    fn a_sparse_hitbox_creature_is_still_hit_on_its_capsule() {
+        let mut physics = PhysicsWorld::new();
+        let mut world = World::new();
+
+        // Creature type 6 is ARACHNID: one mapped joint.
+        let creature = world.add_entity((crate::creature::RuntimePropHasHitBoxes, PropCreature(6)));
+        physics.add_kinematic(
+            creature,
+            vec3(0.0, 0.0, 5.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(3.0, 3.0, 1.0),
+            crate::physics::CollisionGroup::actor(),
+            false,
+        );
+        let hit_box = world.add_entity(RuntimePropHitBox {
+            parent_entity_id: creature,
+            hit_box_type: HitBoxType::Body,
+            joint_id: 0,
+        });
+        // Off to the side, as an arachnid's body blob is from its legs.
+        physics.add_kinematic(
+            hit_box,
+            vec3(1.2, 0.0, 5.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.4, 0.4, 0.4),
+            crate::physics::CollisionGroup::hitbox(),
+            false,
+        );
+        let wall = world.add_entity(());
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 0.0, 9.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(6.0, 6.0, 1.0),
+            crate::physics::CollisionGroup::selectable(),
+            false,
+        );
+        let mut player =
+            physics.create_player(vec3(0.0, 0.0, -50.0), EntityId::from_inner(9).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let hit = projectile_ray_cast(
+            point3(0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 1.0),
+            &physics,
+            20.0,
+            &world,
+            false,
+        );
+
+        assert_eq!(
+            hit.and_then(|result| result.maybe_entity_id),
+            Some(creature),
+            "a creature whose hitboxes do not cover it keeps taking capsule hits",
         );
     }
 

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -2,6 +2,7 @@ use cgmath::{
     Deg, EuclideanSpace, InnerSpace, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3,
     vec3, vec4,
 };
+use collision::Contains;
 use dark::SCALE_FACTOR;
 
 use shipyard::{EntityId, Get, View, World};
@@ -13,7 +14,6 @@ use crate::{
     runtime_props::{RuntimePropProjectileRayOrigin, RuntimePropTransform},
     scripts::{
         Message,
-        ai::ai_util::does_entity_have_hitboxes,
         script_util::{choose_impact_spang, play_impact_sound},
     },
     time::Time,
@@ -183,6 +183,25 @@ fn hitbox_belongs_to_entity(world: &World, hitbox_entity: EntityId, parent: Enti
         })
 }
 
+/// Whether the shot started inside this entity's own bounds - a weapon pressed
+/// against a creature. Its limb proxies can then all lie behind the muzzle,
+/// so the coarse capsule hit is the only thing left that means "I shot the
+/// creature I am standing in".
+fn fired_from_inside(
+    physics: &PhysicsWorld,
+    start_point: Point3<f32>,
+    entity_id: EntityId,
+) -> bool {
+    physics
+        .get_aabb2(entity_id)
+        .is_some_and(|bounds| bounds.contains(&start_point))
+}
+
+/// How many creature capsules one shot may pass through before it gives up and
+/// keeps whatever it last hit. A shot threading two creatures' gaps is already
+/// unusual; this only bounds the work.
+const MAX_PASS_THROUGH: usize = 4;
+
 fn projectile_ray_cast(
     start_point: Point3<f32>,
     forward: cgmath::Vector3<f32>,
@@ -196,53 +215,86 @@ fn projectile_ray_cast(
     } else {
         InternalCollisionGroups::empty()
     };
-    let mut maybe_hit_spot = physics.ray_cast(
-        start_point,
-        forward * distance,
-        InternalCollisionGroups::ENTITIES
-            // Sometimes, the hitbox can stick out past the bounding box...
-            // so we should still check for it here
-            | InternalCollisionGroups::HITBOX
-            | player_group
-            | InternalCollisionGroups::SELECTABLE
-            | InternalCollisionGroups::WORLD,
-    );
+    let coarse_groups = InternalCollisionGroups::ENTITIES
+        // Sometimes, the hitbox can stick out past the bounding box...
+        // so we should still check for it here
+        | InternalCollisionGroups::HITBOX
+        | player_group
+        | InternalCollisionGroups::SELECTABLE
+        | InternalCollisionGroups::WORLD;
 
-    // If we hit an entity with a hitbox, scan again for the hitbox
-    if let Some(hit_spot) = &maybe_hit_spot {
-        //let hit_spot = &maybe_hit_spot.unwrap();
+    // Creatures whose capsule the shot has already passed through: they had no
+    // limb on this line, so they are not what it hit.
+    let mut passed_through: Vec<EntityId> = Vec::new();
+    for _ in 0..MAX_PASS_THROUGH {
+        let is_not_passed_through = |entity_id: EntityId| !passed_through.contains(&entity_id);
+        let maybe_hit_spot = physics.ray_cast2_with_entity_filter(
+            start_point,
+            forward,
+            distance,
+            coarse_groups,
+            None,
+            true,
+            &is_not_passed_through,
+        );
 
-        if let Some(hit_entity_id) = &hit_spot.maybe_entity_id {
-            if does_entity_have_hitboxes(world, *hit_entity_id) {
-                let refined_hit = physics.ray_cast(
-                    start_point,
-                    forward * distance,
-                    InternalCollisionGroups::HITBOX
-                        | InternalCollisionGroups::SELECTABLE
-                        | InternalCollisionGroups::WORLD,
-                );
-                // Prefer the authored damage proxy when the ray intersects one.
-                // If the coarse creature capsule surrounds the ray origin but
-                // its proxies do not cover that exact line, retain the coarse
-                // entity hit instead of turning a contact-range shot into a
-                // terrain impact beyond the creature.
-                let refined_hits_target_hitbox = refined_hit
-                    .as_ref()
-                    .and_then(|hit| hit.maybe_entity_id)
-                    .is_some_and(|entity_id| {
-                        hitbox_belongs_to_entity(world, entity_id, *hit_entity_id)
-                    });
-                if refined_hits_target_hitbox {
-                    maybe_hit_spot = refined_hit;
-                }
-            }
+        let Some(hit_spot) = &maybe_hit_spot else {
+            return maybe_hit_spot;
+        };
+        let Some(hit_entity_id) = hit_spot.maybe_entity_id else {
+            return maybe_hit_spot;
+        };
+        // Live proxies, not the creature definition: an authored corpse
+        // carries `PropCreature` but is never animated and has none. Reading
+        // the definition would refine against hitboxes that do not exist and
+        // then pass the shot straight through the body.
+        if !crate::creature::has_live_hit_boxes(world, hit_entity_id) {
+            return maybe_hit_spot;
         }
+
+        // The coarse hit is a creature's capsule; the shot really landed on
+        // whichever of its hitboxes the line crosses.
+        let refined_hit = physics.ray_cast2_with_entity_filter(
+            start_point,
+            forward,
+            distance,
+            InternalCollisionGroups::HITBOX
+                | InternalCollisionGroups::SELECTABLE
+                | InternalCollisionGroups::WORLD,
+            None,
+            true,
+            &is_not_passed_through,
+        );
+        let refined_hits_target_hitbox = refined_hit
+            .as_ref()
+            .and_then(|hit| hit.maybe_entity_id)
+            .is_some_and(|entity_id| hitbox_belongs_to_entity(world, entity_id, hit_entity_id));
+        if refined_hits_target_hitbox {
+            // Found the limb: that is the hit, and its joint rides along on
+            // the damage.
+            return refined_hit;
+        }
+        if fired_from_inside(physics, start_point, hit_entity_id) {
+            // Point blank, with the capsule around the muzzle: the proxies may
+            // all be behind the origin, and a shot pressed into a creature
+            // must not become a terrain impact past it. Keep the coarse hit.
+            return maybe_hit_spot;
+        }
+        // The line crossed the capsule without touching a limb - between the
+        // arm and the ribs, say. The capsule is a movement volume, not the
+        // creature, so the shot carries on to whatever is behind it.
+        passed_through.push(hit_entity_id);
     }
-
-    // TODO: If we missed the entity in the hitbox, we should still raycast through to see if we hit anything else
-    // This should be called recursively with some limit (ie, depth=3) to handle those cases
-
-    maybe_hit_spot
+    // Too many creatures deep: take the nearest thing that is left.
+    physics.ray_cast2_with_entity_filter(
+        start_point,
+        forward,
+        distance,
+        coarse_groups,
+        None,
+        true,
+        &|entity_id: EntityId| !passed_through.contains(&entity_id),
+    )
 }
 
 #[cfg(test)]
@@ -315,6 +367,191 @@ mod tests {
             hit.and_then(|result| result.maybe_entity_id),
             Some(target),
             "a shot fired from the player's own eye must reach the target, not the shooter",
+        );
+    }
+
+    /// A creature whose capsule the shot crosses without touching a limb is
+    /// not what the shot hit: the capsule is a movement volume, wider than the
+    /// creature. The shot carries on to the wall behind it.
+    ///
+    /// Negative-first: keeping the coarse hit bills the creature for a shot
+    /// that passed beside it, with no joint to show for it.
+    #[test]
+    fn a_shot_through_the_gap_beside_a_limb_passes_the_creature_by() {
+        let mut physics = PhysicsWorld::new();
+        let mut world = World::new();
+
+        // The creature's capsule spans the line of fire...
+        let creature = world.add_entity(crate::creature::RuntimePropHasHitBoxes);
+        physics.add_kinematic(
+            creature,
+            vec3(0.0, 0.0, 5.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(3.0, 3.0, 1.0),
+            crate::physics::CollisionGroup::actor(),
+            false,
+        );
+        // ...but its one hitbox sits well off to the side of it.
+        let hit_box = world.add_entity(RuntimePropHitBox {
+            parent_entity_id: creature,
+            hit_box_type: HitBoxType::Body,
+            joint_id: 1,
+        });
+        physics.add_kinematic(
+            hit_box,
+            vec3(1.2, 0.0, 5.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.4, 0.4, 0.4),
+            crate::physics::CollisionGroup::hitbox(),
+            false,
+        );
+        // The wall behind.
+        let wall = world.add_entity(());
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 0.0, 9.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(6.0, 6.0, 1.0),
+            crate::physics::CollisionGroup::selectable(),
+            false,
+        );
+
+        // A step so the broad phase sees the fresh bodies. The player is
+        // parked far behind the muzzle and never on the line of fire.
+        let mut player =
+            physics.create_player(vec3(0.0, 0.0, -50.0), EntityId::from_inner(9).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let hit = projectile_ray_cast(
+            point3(0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 1.0),
+            &physics,
+            20.0,
+            &world,
+            false,
+        );
+
+        assert_eq!(
+            hit.and_then(|result| result.maybe_entity_id),
+            Some(wall),
+            "a shot that crossed the capsule but no limb should reach the wall behind",
+        );
+    }
+
+    /// ...unless the muzzle is inside the creature. Its limbs can all lie
+    /// behind the ray origin, and a shot pressed into a body must not become a
+    /// terrain impact past it.
+    #[test]
+    fn a_point_blank_shot_still_hits_the_creature_it_is_pressed_into() {
+        let mut physics = PhysicsWorld::new();
+        let mut world = World::new();
+
+        let creature = world.add_entity(crate::creature::RuntimePropHasHitBoxes);
+        physics.add_kinematic(
+            creature,
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(3.0, 3.0, 3.0),
+            crate::physics::CollisionGroup::actor(),
+            false,
+        );
+        let hit_box = world.add_entity(RuntimePropHitBox {
+            parent_entity_id: creature,
+            hit_box_type: HitBoxType::Body,
+            joint_id: 1,
+        });
+        // Behind the muzzle, so the refining cast cannot find it.
+        physics.add_kinematic(
+            hit_box,
+            vec3(0.0, 0.0, -1.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.4, 0.4, 0.4),
+            crate::physics::CollisionGroup::hitbox(),
+            false,
+        );
+        let wall = world.add_entity(());
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 0.0, 9.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(6.0, 6.0, 1.0),
+            crate::physics::CollisionGroup::selectable(),
+            false,
+        );
+
+        let mut player =
+            physics.create_player(vec3(0.0, 0.0, -50.0), EntityId::from_inner(9).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let hit = projectile_ray_cast(
+            point3(0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 1.0),
+            &physics,
+            20.0,
+            &world,
+            false,
+        );
+
+        assert_eq!(
+            hit.and_then(|result| result.maybe_entity_id),
+            Some(creature),
+            "a muzzle inside the creature keeps its coarse hit",
+        );
+    }
+
+    /// An authored corpse carries `PropCreature` - so the creature definition
+    /// says "hitboxes" - but is never animated and has none. Refining against
+    /// hitboxes that do not exist would pass every shot straight through the
+    /// body.
+    #[test]
+    fn a_body_with_no_live_hitboxes_still_stops_the_shot() {
+        let mut physics = PhysicsWorld::new();
+        let mut world = World::new();
+
+        // No `RuntimePropHasHitBoxes`: the proxies were never built.
+        let corpse = world.add_entity(());
+        physics.add_kinematic(
+            corpse,
+            vec3(0.0, 0.0, 5.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(3.0, 3.0, 1.0),
+            crate::physics::CollisionGroup::selectable(),
+            false,
+        );
+        let wall = world.add_entity(());
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 0.0, 9.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(6.0, 6.0, 1.0),
+            crate::physics::CollisionGroup::selectable(),
+            false,
+        );
+        let mut player =
+            physics.create_player(vec3(0.0, 0.0, -50.0), EntityId::from_inner(9).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let hit = projectile_ray_cast(
+            point3(0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 1.0),
+            &physics,
+            20.0,
+            &world,
+            false,
+        );
+
+        assert_eq!(
+            hit.and_then(|result| result.maybe_entity_id),
+            Some(corpse),
+            "a body with no hitboxes is hit on its own collider, as it always was",
         );
     }
 

--- a/tools/shock2-sdk/test/ranged-hitbox.e2e.test.ts
+++ b/tools/shock2-sdk/test/ranged-hitbox.e2e.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// A shot resolves to the limb it crossed. The creature's capsule is a movement
+// volume - wider than the creature - so a shot that crossed it without touching
+// a limb used to damage the creature anyway, reporting no joint. It now carries
+// on to whatever is actually behind it.
+//
+// The exception is a muzzle pressed into a creature: its limbs can all lie
+// behind the ray origin, and a point-blank shot must not become a terrain
+// impact past the body.
+const LATERAL_OFFSETS = [0, 0.2, 0.35, 0.5, 0.65];
+
+test(
+  "every shot that damages a creature names the limb it hit",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_melee" });
+    await game.step({ frames: 30 });
+
+    await game.player.spawnItem("Pistol");
+    await game.player.spawnItem("Small Standard Clip");
+    await game.step({ frames: 5 });
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 20 });
+
+    // Every creature in the scene, so a shot passing through one and hitting
+    // the next is still checked.
+    const creatures = new Map<number, number>();
+    let target;
+    for (const entity of (await game.entities.list()).entities) {
+      const detail = await game.entities.detail(entity.id);
+      const points = (detail.aim_points ?? []).length;
+      if (points > 1) {
+        creatures.set(detail.entity_id, points);
+        target ??= detail;
+      }
+    }
+    assert.ok(target, "expected a creature with hitboxes in debug_melee");
+
+    const [tx, ty, tz] = target.position;
+    await game.player.teleport({ x: tx + 3.0, y: ty - 1.0, z: tz });
+    await game.step({ frames: 20 });
+
+    const seen: Array<[number, number | null | undefined]> = [];
+    for (const dz of LATERAL_OFFSETS) {
+      const before = (await game.messages.recent()).messages.length;
+      await game.input.lookAtWorldPoint([tx, ty + 0.2, tz + dz]);
+      await game.step({ frames: 5 });
+      await game.input.set("right_hand.trigger", 1);
+      await game.step({ frames: 3 });
+      await game.input.set("right_hand.trigger", 0);
+      await game.step({ frames: 12 });
+
+      for (const message of (await game.messages.recent()).messages.slice(before)) {
+        if (message.payload !== "Damage") continue;
+        if (!creatures.has(message.to.entity_id)) continue;
+        seen.push([message.to.entity_id, message.impact?.bone]);
+      }
+    }
+
+    assert.ok(seen.length > 0, "the shots should have damaged a creature");
+    // Negative-first: the capsule fallback billed creatures with bone null.
+    assert.ok(
+      seen.every(([, bone]) => bone !== undefined && bone !== null),
+      `every creature hit should name a joint; got ${JSON.stringify(seen)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ranged-hitbox.e2e.test.ts
+++ b/tools/shock2-sdk/test/ranged-hitbox.e2e.test.ts
@@ -63,6 +63,12 @@ test(
       }
     }
 
+    // The centred shot must land: this rule may only reroute shots that
+    // missed every limb, never make a creature harder to hit.
+    assert.ok(
+      seen.some(([entity]) => entity === target.entity_id),
+      `the centred shot should have damaged the creature; got ${JSON.stringify(seen)}`,
+    );
     assert.ok(seen.length > 0, "the shots should have damaged a creature");
     // Negative-first: the capsule fallback billed creatures with bone null.
     assert.ok(


### PR DESCRIPTION
Stacked on #1218.

## What

A shot resolves to the **limb it crossed** — and a shot that crossed no limb is not a hit on that creature.

![what a shot reports](https://gist.githubusercontent.com/tommy-xr/b196ece76e5afd98777d4f428bbf11dd/raw/ranged-trace.png)

Ranged already refined a coarse hit to the creature's hitboxes (#1152), but kept the coarse **capsule** hit whenever the refined ray found no limb. The capsule is a movement volume, wider than the creature, so a shot threading the gap between an arm and the ribs still damaged the creature and reported no joint. Such a shot now carries on to whatever is actually behind it, refining again at each creature it crosses — the file's own long-standing TODO.

## The two things it must not do

Both pinned by tests, both found the hard way:

- **A creature whose hitboxes don't stand in for its body keeps its capsule.** The arachnids and the Overlord map a *single* `Body` joint (`SPIDER_HIT_BOXES`, `OVERLORD_HIT_BOXES`), so their legs and limbs have no proxy at all — treating a miss on that one blob as a miss on the animal would leave whole bands of it unshootable. Widening those definitions is what would let them join the rule.
- **A body with no live hitboxes is still hit on its own collider.** This is where the predicate was wrong: `does_entity_have_hitboxes` asked the creature *definition*, which is true for every authored corpse in the game while the runtime gives them no proxies. Left alone, every shot would have passed straight through corpses. It now reads the world, and the old predicate (no other callers) is gone.

Plus a muzzle pressed into a creature keeps its coarse hit: its limbs can all lie behind the ray origin.

## Also

The rewrite reached **ten times further** than the shipped range before review caught it: `ray_cast` normalizes its direction and capped the cast at 100 units, so the caller's nominal 1000 never applied. Pinned at 100, explicitly.

## Verification

- 7 unit tests in `internal_fast_projectile.rs`, four of them new: pass-through, point-blank, no-live-hitboxes, and the sparse-hitbox creature.
- New e2e `ranged-hitbox.e2e.test.ts`: fires across a lateral spread and asserts every creature hit names a joint, *and* that the centred shot still lands — this rule may only reroute shots that missed every limb, never make a creature harder to hit.
- Full SDK e2e suite: 350/366. Seven failures also fail on `main`; the eighth (`baby-arachnid`) passes 3/3 in isolation here and also appears in full-suite runs on the earlier branches in this stack, so it is load flake, not this change.
