### PR TITLE
feat(cutscene): hang the movie where a menu hangs, and list all cutscenes

### DIFF
--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, rc::Rc};
 #[cfg(not(feature = "ffmpeg"))]
 use std::time::Duration;
 
-use cgmath::{InnerSpace, Matrix3, Matrix4, Quaternion, Vector2, Vector3, vec2, vec3};
+use cgmath::{Matrix3, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -13,7 +13,7 @@ use engine::{
 use shipyard::{EntityId, UniqueViewMut, World};
 
 use crate::{
-    GameOptions,
+    GameOptions, PresentationMode,
     game_scene::GameScene,
     input_context::InputContext,
     inventory::PlayerInventoryEntity,
@@ -21,7 +21,10 @@ use crate::{
     quest_info::QuestInfo,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{HAlign, Rect, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, WorldPanel},
+    ui::{
+        FRONTEND_PANEL_SIZE, FrontendPanelAnchor, HAlign, Rect, UiCanvas, VAlign,
+        VR_COMPONENT_Z_STEP, WorldPanel, frontend_panel_distance,
+    },
 };
 
 use super::cutscene_skip::{self, SkipHold};
@@ -35,12 +38,16 @@ use engine::texture_format::{PixelFormat, RawTextureData};
 /// Displays a flat panel in front of the player and plays back a video file.
 pub struct CutscenePlayerScene {
     world: World,
-    head_rotation: Quaternion<f32>,
     player_position: Vector3<f32>,
     player_rotation: Quaternion<f32>,
-    head_height: f32,
-    screen_distance: f32,
-    screen_vertical_offset: f32,
+    /// Where the screen hangs in VR: the same head-anchored placement the
+    /// frontend panels use - placed once from the head's yaw, world-locked
+    /// afterward, lazily recentered when the player turns away and stays away.
+    panel_anchor: FrontendPanelAnchor,
+    /// The live head pose, which is what flatscreen hangs the screen off (see
+    /// [`Self::screen_panel`]).
+    head_position: Vector3<f32>,
+    head_rotation: Quaternion<f32>,
     video_name: String,
     /// Only the stub has no decoder to ask how far playback has got.
     #[cfg(not(feature = "ffmpeg"))]
@@ -60,42 +67,61 @@ pub struct CutscenePlayerScene {
     video_player: VideoPlayer,
 }
 
-/// Where the video screen hangs, and the viewer-facing basis it is built on.
+/// Where the video screen hangs: the panel it is drawn on, and the height the
+/// video occupies inside it once letterboxed.
 struct ScreenBasis {
-    center: Vector3<f32>,
-    /// In-plane horizontal axis. It points to the viewer's *left*: the
-    /// billboard basis below is mirrored, and this is the axis that mirroring
-    /// is built from - it is not a "right" to offset something sideways by.
-    screen_x: Vector3<f32>,
-    up: Vector3<f32>,
-    /// From the screen back toward the viewer.
-    look_dir: Vector3<f32>,
+    panel: WorldPanel,
     height: f32,
 }
 
 impl ScreenBasis {
     /// Orientation for a raw quad drawn on the screen. Decoded frames are
-    /// top-row-first while a quad maps v=0 to its bottom edge, and the
-    /// billboard basis faces the quad's back toward the player - so the quad
-    /// is turned half a turn in its own plane, which corrects both at once.
-    /// The generated ring art shares the row order, so it shares this basis.
+    /// top-row-first while a quad maps v=0 to its bottom edge, and the panel
+    /// basis faces the quad's back toward the player - so the quad is turned
+    /// half a turn about its own x axis, which corrects both at once. The
+    /// generated ring art shares the row order, so it shares this basis.
     fn billboard_rotation(&self) -> Matrix3<f32> {
-        Matrix3::from_cols(self.screen_x, self.up, -self.look_dir)
-            * Matrix3::from_angle_z(cgmath::Deg(180.0))
+        Matrix3::from(self.panel.rotation) * Matrix3::from_angle_x(cgmath::Deg(180.0))
     }
 
-    /// Orientation for a [`WorldPanel`] on the screen: the honest basis the
-    /// canvas path expects (+x the viewer's right, +y up, +z back at the
-    /// viewer), which is what facing the viewer means.
-    fn panel_rotation(&self) -> Quaternion<f32> {
-        crate::util::get_rotation_from_forward_vector(self.look_dir)
+    /// In-plane up: the panel's own, since a placement is gravity-aligned.
+    fn up(&self) -> Vector3<f32> {
+        self.panel.rotation.rotate_vector(vec3(0.0, 1.0, 0.0))
     }
 
     /// Off the screen plane toward the viewer, so an overlay never z-fights the
     /// video it sits on.
     fn toward_viewer(&self, fraction_of_height: f32) -> Vector3<f32> {
-        self.look_dir * (self.height * fraction_of_height)
+        self.panel.normal() * (self.height * fraction_of_height)
     }
+}
+
+/// The screen the video is drawn on, fitted inside `panel`.
+fn screen_basis(panel: WorldPanel, aspect_ratio: f32) -> ScreenBasis {
+    let height = fitted_screen_height(panel.size, aspect_ratio);
+    ScreenBasis { panel, height }
+}
+
+/// A panel hung squarely in front of a head pose, pitch included.
+///
+/// Flatscreen's counterpart to the VR anchor: there is no tracked head there,
+/// only the mouse-look camera, so a world-locked screen would slide out of
+/// frame on the first look and (below the anchor's recenter threshold) never
+/// come back. Keeping it on the view is what "full-screen" means on a monitor.
+fn head_locked_panel(head_position: Vector3<f32>, head_rotation: Quaternion<f32>) -> WorldPanel {
+    let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+    WorldPanel {
+        center: head_position + forward * frontend_panel_distance(),
+        rotation: crate::util::get_rotation_from_forward_vector(-forward),
+        size: FRONTEND_PANEL_SIZE,
+    }
+}
+
+/// The video's height once fitted inside the panel's rect, letterboxed rather
+/// than cropped or stretched: wide videos are limited by the panel's width,
+/// tall ones by its height.
+fn fitted_screen_height(panel_size: Vector2<f32>, aspect_ratio: f32) -> f32 {
+    (panel_size.x / aspect_ratio.max(1e-3)).min(panel_size.y)
 }
 
 /// The skip ring's diameter and its center height, both as a fraction of the
@@ -152,12 +178,11 @@ impl CutscenePlayerScene {
 
             return Ok(Self {
                 world,
-                head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
                 player_position: vec3(0.0, 0.0, 0.0),
                 player_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-                head_height: 4.0 / dark::SCALE_FACTOR,
-                screen_distance: 6.0 / dark::SCALE_FACTOR,
-                screen_vertical_offset: 1.5 / dark::SCALE_FACTOR,
+                panel_anchor: FrontendPanelAnchor::new(),
+                head_position: vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0),
+                head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
                 video_name,
                 on_complete,
                 completion_emitted: false,
@@ -173,12 +198,11 @@ impl CutscenePlayerScene {
             let _ = audio_context;
             Ok(Self {
                 world,
-                head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
                 player_position: vec3(0.0, 0.0, 0.0),
                 player_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-                head_height: 4.0 / dark::SCALE_FACTOR,
-                screen_distance: 6.0 / dark::SCALE_FACTOR,
-                screen_vertical_offset: 1.5 / dark::SCALE_FACTOR,
+                panel_anchor: FrontendPanelAnchor::new(),
+                head_position: vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0),
+                head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
                 video_name,
                 total_time: Duration::ZERO,
                 on_complete,
@@ -216,10 +240,6 @@ impl CutscenePlayerScene {
         world
     }
 
-    fn head_base(&self) -> Vector3<f32> {
-        self.player_position + vec3(0.0, self.head_height, 0.0)
-    }
-
     fn update_player_info(&mut self) {
         if let Ok(mut player_info) = self.world.borrow::<UniqueViewMut<PlayerInfo>>() {
             player_info.pos = self.player_position;
@@ -227,49 +247,33 @@ impl CutscenePlayerScene {
         }
     }
 
-    /// Where the video screen hangs and how it is oriented. The skip affordance
-    /// is anchored to the same basis, so it rides the screen in flatscreen and
-    /// in VR alike rather than being placed twice.
-    fn screen_basis(&self) -> ScreenBasis {
-        let forward = self.head_rotation * vec3(0.0, 0.0, -1.0);
-        let base = self.head_base();
-        let mut screen_position = base + forward * self.screen_distance;
-        screen_position.y += self.screen_vertical_offset;
-
-        let mut look_dir = base - screen_position;
-        if look_dir.magnitude2() < 1e-6 {
-            look_dir = vec3(0.0, 0.0, 1.0);
-        } else {
-            look_dir = look_dir.normalize();
-        }
-
-        let mut up = vec3(0.0, 1.0, 0.0);
-        let mut right = look_dir.cross(up);
-        if right.magnitude2() < 1e-6 {
-            up = vec3(0.0, 0.0, 1.0);
-            right = look_dir.cross(up);
-        }
-        right = right.normalize();
-        let true_up = right.cross(look_dir).normalize();
-
-        ScreenBasis {
-            center: screen_position,
-            screen_x: right,
-            up: true_up,
-            look_dir,
-            height: 2.0 / dark::SCALE_FACTOR,
+    /// The panel the video screen is drawn on, per presentation.
+    ///
+    /// In VR that is the frontend panels' own placement - gravity-aligned,
+    /// world-locked, lazily recentered - so a cutscene hangs where a menu
+    /// would instead of riding the gaze (which tilts with every glance and
+    /// cannot be looked at). Flatscreen keeps the screen on the view; see
+    /// [`head_locked_panel`].
+    fn screen_panel(&self, presentation: PresentationMode) -> WorldPanel {
+        match presentation {
+            PresentationMode::Vr => self.panel_anchor.panel(),
+            PresentationMode::Flat => head_locked_panel(self.head_position, self.head_rotation),
         }
     }
 
-    fn build_screen_object(&self, basis: &ScreenBasis) -> SceneObject {
-        let (texture, aspect_ratio) = self.build_video_texture();
+    fn build_screen_object(
+        &self,
+        basis: &ScreenBasis,
+        texture: Rc<dyn TextureTrait>,
+        aspect_ratio: f32,
+    ) -> SceneObject {
         let material = basic_material::create(texture, 1.0, 0.0);
         let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
 
         let screen_height = basis.height;
         let screen_width = screen_height * aspect_ratio;
 
-        let transform = Matrix4::from_translation(basis.center)
+        let transform = Matrix4::from_translation(basis.panel.center)
             * Matrix4::from(basis.billboard_rotation())
             * Matrix4::from_nonuniform_scale(screen_width, screen_height, 1.0);
         quad.set_transform(transform);
@@ -305,8 +309,8 @@ impl CutscenePlayerScene {
         let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
 
         let size = basis.height * RING_SIZE;
-        let center = basis.center
-            + basis.up * (RING_CENTER_HEIGHT * basis.height)
+        let center = basis.panel.center
+            + basis.up() * (RING_CENTER_HEIGHT * basis.height)
             + basis.toward_viewer(OVERLAY_DEPTH);
 
         quad.set_transform(
@@ -326,10 +330,10 @@ impl CutscenePlayerScene {
         alpha: f32,
     ) -> Vec<SceneObject> {
         let panel = WorldPanel {
-            center: basis.center
-                + basis.up * (HINT_CENTER_HEIGHT * basis.height)
+            center: basis.panel.center
+                + basis.up() * (HINT_CENTER_HEIGHT * basis.height)
                 + basis.toward_viewer(OVERLAY_DEPTH),
-            rotation: basis.panel_rotation(),
+            rotation: basis.panel.rotation,
             size: vec2(basis.height * HINT_WIDTH, basis.height * HINT_HEIGHT),
         };
 
@@ -422,7 +426,13 @@ impl GameScene for CutscenePlayerScene {
             *world_time = time.clone();
         }
 
+        self.head_position = input_context.head.position;
         self.head_rotation = input_context.head.rotation;
+        self.panel_anchor.update(
+            input_context.head.position,
+            input_context.head.rotation,
+            time.elapsed,
+        );
         self.player_position = vec3(0.0, 0.0, 0.0);
         self.player_rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
         self.update_player_info();
@@ -461,12 +471,13 @@ impl GameScene for CutscenePlayerScene {
     fn render(
         &mut self,
         asset_cache: &mut AssetCache,
-        _options: &GameOptions,
+        options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         // One world-space list for both presentations: the affordance is
         // anchored to the video screen, so flatscreen and VR place it alike.
-        let basis = self.screen_basis();
-        let mut objects = vec![self.build_screen_object(&basis)];
+        let (texture, aspect_ratio) = self.build_video_texture();
+        let basis = screen_basis(self.screen_panel(options.presentation_mode), aspect_ratio);
+        let mut objects = vec![self.build_screen_object(&basis, texture, aspect_ratio)];
         let alpha = self.skip_hold.alpha();
         if alpha > 0.01 {
             objects.push(self.build_skip_ring(&basis, alpha));
@@ -512,5 +523,99 @@ impl GameScene for CutscenePlayerScene {
 
     fn scene_name(&self) -> &str {
         &self.video_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input_context::DEFAULT_HEAD_HEIGHT;
+    use cgmath::{Deg, InnerSpace, Rotation3};
+    use std::time::Duration;
+
+    fn eye() -> Vector3<f32> {
+        vec3(0.0, DEFAULT_HEAD_HEIGHT, 0.0)
+    }
+
+    /// A head pitched at the floor: VR hangs the screen upright at eye level
+    /// (the frontend placement), while flatscreen keeps it squarely on the
+    /// view - a world-locked screen there would slide out of frame on the
+    /// first mouse-look and never come back.
+    #[test]
+    fn vr_hangs_the_screen_upright_while_flat_keeps_it_on_the_view() {
+        let pitched = Quaternion::from_angle_y(Deg(90.0)) * Quaternion::from_angle_x(Deg(-70.0));
+
+        let mut anchor = FrontendPanelAnchor::new();
+        let vr = anchor.update(eye(), pitched, Duration::from_millis(16));
+        assert!(
+            (vr.center.y - eye().y).abs() < 1e-4,
+            "VR screen should hang at eye level, got {:?}",
+            vr.center
+        );
+        let vr_up = vr.rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+        assert!(
+            vr_up.dot(vec3(0.0, 1.0, 0.0)) > 0.999,
+            "VR screen is upright"
+        );
+
+        let flat = head_locked_panel(eye(), pitched);
+        let gaze = pitched.rotate_vector(vec3(0.0, 0.0, -1.0));
+        let to_screen = (flat.center - eye()).normalize();
+        assert!(
+            to_screen.dot(gaze) > 0.999,
+            "flat screen should sit on the gaze, got {to_screen:?} vs {gaze:?}"
+        );
+        assert!(
+            flat.normal().dot(-gaze) > 0.999,
+            "flat screen faces the eye"
+        );
+    }
+
+    /// A turned head leaves the VR screen where it was placed (it is
+    /// world-locked, like a menu) - the property the whole anchor exists for.
+    #[test]
+    fn turning_the_head_does_not_drag_the_vr_screen_along() {
+        let mut anchor = FrontendPanelAnchor::new();
+        let placed = anchor.update(
+            eye(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            Duration::from_millis(16),
+        );
+        let after_glance = anchor.update(
+            eye(),
+            Quaternion::from_angle_y(Deg(30.0)),
+            Duration::from_millis(16),
+        );
+        assert!((after_glance.center - placed.center).magnitude() < 1e-4);
+    }
+
+    /// The quad's basis flips the decoded frame's row order (top-row-first art
+    /// on a quad whose v=0 is its bottom edge) without mirroring it sideways.
+    #[test]
+    fn the_billboard_basis_flips_rows_and_nothing_else() {
+        let basis = screen_basis(
+            head_locked_panel(eye(), Quaternion::new(1.0, 0.0, 0.0, 0.0)),
+            16.0 / 9.0,
+        );
+        let quad = basis.billboard_rotation();
+        let right = basis.panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
+        assert!(quad.x.dot(right) > 0.999, "not mirrored sideways");
+        assert!(quad.y.dot(basis.up()) < -0.999, "rows are flipped");
+    }
+
+    /// The video is letterboxed into the frontend panel's rect: a wide clip is
+    /// bounded by the panel's width, a tall one by its height. Getting this
+    /// backwards would hang a screen wider or taller than the menus.
+    #[test]
+    fn the_video_is_fitted_inside_the_panel_rect() {
+        let panel = FRONTEND_PANEL_SIZE;
+
+        let wide = fitted_screen_height(panel, 16.0 / 9.0);
+        assert!((wide - panel.x / (16.0 / 9.0)).abs() < 1e-4);
+        assert!(wide <= panel.y);
+
+        let tall = fitted_screen_height(panel, 0.5);
+        assert!((tall - panel.y).abs() < 1e-4);
+        assert!(tall * 0.5 <= panel.x);
     }
 }

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -113,19 +113,26 @@ pub enum SceneTab {
     Missions,
     /// The debug-scene registry.
     DebugScenes,
+    /// The cutscene videos the install ships.
+    Cutscenes,
 }
 
 impl SceneTab {
-    const ALL: [SceneTab; 2] = [SceneTab::Missions, SceneTab::DebugScenes];
+    const ALL: [SceneTab; 3] = [
+        SceneTab::Missions,
+        SceneTab::DebugScenes,
+        SceneTab::Cutscenes,
+    ];
 
-    /// Both labels together must fit the 202px header the tabs split -
-    /// "Debug Scenes" measured ~139px in the menu font and overprinted its
-    /// neighbour, hence the short form (drawn `_fit` besides, so a wide label
-    /// can never spill into the other tab again).
+    /// Each label must fit its third of the ~202px header the tabs split -
+    /// about five glyphs of the menu font, so the labels are short forms.
+    /// They are drawn `_fit` besides, which ellipsizes rather than spilling
+    /// into the neighbouring tab: a longer word reads as "Missi..." here.
     fn label(self) -> &'static str {
         match self {
-            SceneTab::Missions => "Missions",
+            SceneTab::Missions => "Maps",
             SceneTab::DebugScenes => "Debug",
+            SceneTab::Cutscenes => "Video",
         }
     }
 }
@@ -200,16 +207,20 @@ fn scene_rocker(rects: PanelRects, len: usize) -> Option<list_scroll::Rocker> {
     )
 }
 
-/// The canvas rect of the tab header for `tab`: the header rect split in two,
-/// so the tabs ride the backdrop's authored header line in both presentations.
+/// The canvas rect of the tab header for `tab`: the header rect split evenly
+/// between the tabs, so they ride the backdrop's authored header line in both
+/// presentations.
 fn tab_rect(rects: PanelRects, tab: SceneTab) -> Rect {
     let header = rects.header_rect();
-    let half = header.w / 2.0;
-    let x = match tab {
-        SceneTab::Missions => header.x,
-        SceneTab::DebugScenes => header.x + half,
+    let width = header.w / SceneTab::ALL.len() as f32;
+    // Explicit, so a new variant is a compile error here rather than a tab
+    // that silently shares the first one's rect (and its click target).
+    let index = match tab {
+        SceneTab::Missions => 0,
+        SceneTab::DebugScenes => 1,
+        SceneTab::Cutscenes => 2,
     };
-    Rect::new(x, header.y, half, header.h)
+    Rect::new(header.x + index as f32 * width, header.y, width, header.h)
 }
 
 /// The canvas rect of the launcher's `slot`-th visible row. The rows stop
@@ -336,6 +347,8 @@ pub struct DeveloperScene {
     /// The `*.mis` files the Missions tab lists, enumerated from the data
     /// root when the launcher opens.
     missions: Vec<String>,
+    /// The cutscene videos the Video tab lists, enumerated alongside them.
+    cutscenes: Vec<String>,
     /// Index of the entry drawn in the launcher's top row.
     scene_scroll: usize,
     /// The highlighted entry, as an index into the showing tab's list.
@@ -361,6 +374,7 @@ impl DeveloperScene {
             page: DeveloperPage::Params,
             tab: SceneTab::Missions,
             missions: Vec::new(),
+            cutscenes: Vec::new(),
             scene_scroll: 0,
             selected_scene: None,
         }
@@ -371,6 +385,7 @@ impl DeveloperScene {
         match self.tab {
             SceneTab::Missions => self.missions.len(),
             SceneTab::DebugScenes => scene_count(),
+            SceneTab::Cutscenes => self.cutscenes.len(),
         }
     }
 
@@ -379,6 +394,7 @@ impl DeveloperScene {
         match self.tab {
             SceneTab::Missions => self.missions.get(index).cloned(),
             SceneTab::DebugScenes => super::debug_scene_names().nth(index).map(str::to_owned),
+            SceneTab::Cutscenes => self.cutscenes.get(index).cloned(),
         }
     }
 
@@ -468,6 +484,7 @@ impl DeveloperScene {
                         .take(rows.len())
                         .map(str::to_owned)
                         .collect(),
+                    SceneTab::Cutscenes => self.cutscenes[rows.clone()].to_vec(),
                 };
                 for (slot, name) in names.iter().enumerate() {
                     canvas
@@ -533,6 +550,7 @@ impl DeveloperScene {
                 // it was left on.
                 self.tab = SceneTab::Missions;
                 self.missions = mission_files();
+                self.cutscenes = super::cutscene_names();
                 self.reset_list();
             }
             DeveloperAction::CloseScenes => self.page = DeveloperPage::Params,
@@ -565,6 +583,12 @@ impl DeveloperScene {
                             name,
                         })]
                     }
+                    // Back to this screen when the video ends (on its parameters
+                    // page, where `ShowDeveloper` always lands) rather than to
+                    // whatever the cutscene replaced.
+                    SceneTab::Cutscenes => vec![Effect::GlobalEffect(
+                        GlobalEffect::ShowDeveloper.after_cutscene(&name),
+                    )],
                 };
             }
         }
@@ -986,13 +1010,14 @@ mod tests {
     }
 
     /// The negative test the tabs demand: the very same Launch click must emit
-    /// a mission transition on one tab and a debug-scene launch on the other -
-    /// never the wrong one.
+    /// a mission transition on one tab, a debug-scene launch on the next and a
+    /// cutscene on the third - never the wrong one.
     #[test]
     fn launch_follows_the_showing_tab() {
         let mut scene = DeveloperScene::new();
         scene.page = DeveloperPage::Scenes;
         scene.missions = vec!["earth.mis".to_owned()];
+        scene.cutscenes = vec!["cs1.avi".to_owned()];
         scene.reset_list();
         assert_eq!(scene.tab, SceneTab::Missions);
         let effect = global_effect(scene.handle_action(DeveloperAction::LaunchScene));
@@ -1009,6 +1034,16 @@ mod tests {
             global_effect(scene.handle_action(DeveloperAction::LaunchScene)),
             Some(GlobalEffect::LaunchDebugScene { .. })
         ));
+
+        // A movie plays and comes back to this screen when it ends.
+        scene.handle_action(DeveloperAction::SelectTab(SceneTab::Cutscenes));
+        match global_effect(scene.handle_action(DeveloperAction::LaunchScene)) {
+            Some(GlobalEffect::PlayCutscene { video, then }) => {
+                assert_eq!(video, "cs1.avi");
+                assert!(matches!(*then, GlobalEffect::ShowDeveloper));
+            }
+            other => panic!("Video tab must emit PlayCutscene, got {other:?}"),
+        }
     }
 
     /// Switching tabs resets the scroll and the selection - a stale index
@@ -1018,7 +1053,7 @@ mod tests {
     fn the_tabs_share_the_header_and_reset_the_list() {
         let rects = PanelRects::default();
         let header = rects.header_rect();
-        // Both tabs sit on the authored header line, side by side.
+        // Every tab sits on the authored header line, side by side.
         for tab in SceneTab::ALL {
             let r = tab_rect(rects, tab);
             assert_eq!(r.y, header.y);
@@ -1028,11 +1063,13 @@ mod tests {
                 "tab {tab:?}"
             );
         }
-        // The halves are disjoint - a draw kept inside its own rect (`_fit`)
-        // can therefore never overprint the other tab or its click target.
-        let missions = tab_rect(rects, SceneTab::Missions);
-        let debug = tab_rect(rects, SceneTab::DebugScenes);
-        assert!(missions.x + missions.w <= debug.x);
+        // The slots are disjoint - a draw kept inside its own rect (`_fit`)
+        // can therefore never overprint another tab or its click target.
+        for pair in SceneTab::ALL.windows(2) {
+            let left = tab_rect(rects, pair[0]);
+            let right = tab_rect(rects, pair[1]);
+            assert!(left.x + left.w <= right.x, "{pair:?} overlap");
+        }
 
         let mut scene = DeveloperScene::new();
         scene.page = DeveloperPage::Scenes;

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -483,6 +483,43 @@ pub(crate) fn finale_follow_on(credits: Option<String>) -> GlobalEffect {
     }
 }
 
+/// Every cutscene the install ships, as bare names ready for
+/// [`resolve_cutscene_path`] (e.g. `cs1.avi`), sorted and deduplicated.
+///
+/// A 25th Anniversary install layers the same clip under `enhanced/`,
+/// `original/` and `kex/`, so the layers are folded into one entry per stem and
+/// the bare name lets the resolver pick its preferred layer at playback -
+/// exactly what an authored moment gets.
+pub(crate) fn cutscene_names() -> Vec<String> {
+    cutscene_names_from(&paths::data_root())
+}
+
+fn cutscene_names_from(data_root: &Path) -> Vec<String> {
+    let root = data_root.join("cutscenes");
+    let mut stems: Vec<String> = std::iter::once(root.clone())
+        .chain(
+            ANNIVERSARY_CUTSCENE_LAYERS
+                .iter()
+                .map(|layer| root.join(layer)),
+        )
+        .filter_map(|dir| dir.read_dir().ok())
+        .flatten()
+        .filter_map(Result::ok)
+        .filter(|entry| is_cutscene_file(&entry.file_name().to_string_lossy()))
+        .filter_map(|entry| {
+            Path::new(&entry.file_name())
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().to_ascii_lowercase())
+        })
+        .collect();
+    stems.sort();
+    stems.dedup();
+    stems
+        .into_iter()
+        .map(|stem| format!("{stem}.avi"))
+        .collect()
+}
+
 fn first_present_cutscene(candidates: &[&str]) -> Option<String> {
     candidates
         .iter()
@@ -493,6 +530,32 @@ fn first_present_cutscene(candidates: &[&str]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The launcher's list folds an Anniversary install's layers into one
+    /// entry per clip and hands back names the resolver understands - a name
+    /// per layer would offer the same movie three times.
+    #[test]
+    fn the_cutscene_list_folds_the_anniversary_layers_into_one_entry_each() {
+        let root = crate::test_support::TempDir::new("cutscenes");
+        let cutscenes = root.path().join("cutscenes");
+        for (layer, name) in [
+            ("enhanced", "cs1.ogv"),
+            ("original", "cs1.ogv"),
+            ("kex", "Kex.ogv"),
+            ("", "intro.avi"),
+            // Not a video: the list must not offer it.
+            ("", "notes.txt"),
+        ] {
+            let dir = cutscenes.join(layer);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join(name), b"").unwrap();
+        }
+
+        assert_eq!(
+            cutscene_names_from(root.path()),
+            vec!["cs1.avi", "intro.avi", "kex.avi"]
+        );
+    }
 
     /// The finale always ends up at the menu, through the credits when the
     /// install has them and directly when it does not.


### PR DESCRIPTION
Two cutscene follow-ups.

## 1. Placement: the movie hangs where a menu hangs

The video screen rode the **live head pose, pitch included**, so a cutscene entered while looking down hung tilted at the player's feet, and it could never be looked *at* - it moved exactly as fast as the eye.

VR now places it with `FrontendPanelAnchor`, the frontend panels' own policy:

- placed **once** from the head's **yaw only**, so it is gravity-aligned and upright however the head was pitched on entry;
- **world-locked** afterward, so turning the head moves it *in view* like a menu;
- **lazily recentered** after ~1s of sustained divergence (>60 degrees of yaw, or 1 unit of movement), eased over 0.3s.

The video is letterboxed inside `FRONTEND_PANEL_SIZE` at the `panel_distance` dev param, so a movie and a menu share their size, distance and tuning.

**Flat is the exception, and deliberately so.** There is no tracked head on a monitor - `head.rotation` *is* the mouse-look camera - so a world-locked screen slides out of frame on the first look and, below the 60-degree recenter threshold, never comes back. `head_locked_panel` keeps it squarely on the view, which is what "full-screen" means there. This was caught in review and reproduced before fixing (see below).

Net effect on the file: the hand-rolled orthonormal billboard basis and its three tuning fields (`head_height`, `screen_distance`, `screen_vertical_offset`) are gone, replaced by the shared anchor.

## 2. A Video tab in the Developer launcher

The scene launcher gains a third tab listing every cutscene the install ships - the 25AE `enhanced`/`original`/`kex` layers folded into one entry per clip, filtered to names the resolver can actually open. Launching plays the movie and returns to the Developer screen.

Labels shorten to **Maps / Debug / Video**: each tab gets a third of the ~202px header, and the menu font ellipsizes anything longer ("Missi...", "Movi...").

## Visual verification

![VR world-lock and lazy recenter demo](https://gist.githubusercontent.com/tommy-xr/46681276b9705fb156e8893b16960704/raw/demo.gif)

<sub>VR, current branch: centered -> a 30-degree glance slides the screen in view (it is world-locked, like a menu) -> a turn past the 60-degree threshold takes it out of view -> after ~1s of sustained divergence it eases back, centered. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before -> after: VR, level gaze

![VR before/after, level gaze](https://gist.githubusercontent.com/tommy-xr/46681276b9705fb156e8893b16960704/raw/vr-beforeafter.png)

<sub>Identical request sequence from a fresh launch on `main` vs this branch, at a level gaze. Before: the screen hangs high and small - it is glued to the live head pose and carries a fixed vertical offset, so the movie rides off the top of the view. After: `FrontendPanelAnchor` hangs it at eye level at the menus' size and distance, centered and upright.</sub>

### Before -> after: flat, pitched mouse-look

![Flat before/after, pitched head](https://gist.githubusercontent.com/tommy-xr/46681276b9705fb156e8893b16960704/raw/flat-beforeafter.png)

<sub>Same pitched mouse-look (25 degrees) from a fresh launch on `main` vs this branch. Flat gains the same sizing and the loss of the vertical offset, so the movie is centered and full-size instead of clipped against the top edge - while `head_locked_panel` keeps it on the view at any pitch, as it was.</sub>

### Developer launcher: Video tab

![Developer Scenes launcher, Video tab selected](https://gist.githubusercontent.com/tommy-xr/46681276b9705fb156e8893b16960704/raw/video-tab.png)

<sub>Developer -> Scenes -> Video, listing the install's cutscenes (atari.avi, credits.avi, cs1-3.avi, intro.avi, kex.avi, landing.avi, nightdive.avi, shuttle1-3.avi, starport.avi).</sub>

## Verification

- 1173 unit tests (7 new), including "a pitched head yields an upright VR screen while flat keeps it on the view", "turning the head does not drag the VR screen along", and the billboard row-flip basis.
- e2e: `campaign-cutscenes` + `missions` (all 23 missions load) = 25 pass; `cutscene-completion` + `cutscene-skip` = 3 pass.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, also `--no-default-features` (no-ffmpeg stub path).
- Driven live in the debug runtime in **both** presentations: flat stays centered under mouse-look yaw+pitch; VR world-locks on a 25-degree glance and recenters after a held 65-degree turn; the Video tab lists all 13 clips and one plays and returns.

