### PR TITLE
feat(debug): developer cheat pad (X+Y empty-hand chord, weapon/nanite rain)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,6 +128,7 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 | `Alt+G` | `DebugForceChase` | every monster hunts the player, pinned |
 | `Alt+C` | `DebugCalmAll` | clears the pin |
 | `Alt+V` | `ToggleFreeCamera` | requires the **Free camera** developer option; Quest: right `A`+`B` together |
+| `Alt+K` | `ToggleCheatPad` | requires the **Cheats** developer option; Quest: left `X`+`Y` together, on an empty left hand |
 
 Every action is also triggerable without a keyboard - over HTTP on the debug
 runtime (`POST /v1/input/action`) or through the SDK (`game.input.trigger(...)`).
@@ -150,6 +151,14 @@ shows exactly what the *player's* viewpoint decided to draw. Turn on **Cull
 from cam** when you would rather just look at things. The developer option is
 the gate: while it is off the `Alt+V` / `A`+`B` toggle does nothing, and turning
 it off while detached re-attaches the camera.
+
+**Cheats** arms the developer cheat pad: a two-button panel (`Alt+K`, or left
+`X`+`Y` on the Quest with nothing in that hand) that rains a spread of weapons
+and ammo, or of cyber modules and nanites, down around the player so a test
+situation can be set up without playing the game up to it. Like the free
+camera, the developer option is the gate - with it off the toggle does nothing
+from any input path, HTTP injection included, and turning it off while the pad
+is up closes it.
 
 Flying uses the ordinary locomotion controls, so they are the ones your hands
 already know - and while the camera has them, the player stands still rather

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -189,6 +189,13 @@ impl DesktopInputMapper {
                 modifier: Modifier::Alt,
                 action: InputAction::ToggleFreeCamera,
             },
+            // Open/close the developer cheat pad. Alt-modified and gated on
+            // the `cheats` dev param, exactly like the free camera above.
+            Binding {
+                key: Key::K,
+                modifier: Modifier::Alt,
+                action: InputAction::ToggleCheatPad,
+            },
         ];
 
         Self {

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -821,16 +821,35 @@ fn main() {
             }
             crouch_button_was_pressed = crouch_state.current_state;
         }
-        action_state.sync_discrete_button(
-            shock2vr::input::InputAction::ToggleUseMode,
-            use_mode_state.is_active,
-            use_mode_state.changed_since_last_sync,
+        // Left X and Y carry two meanings, on the same terms right A and B do
+        // below: alone they toggle the cyber interface and play the last audio
+        // log, together they toggle the developer cheat pad. The sharing is
+        // dead unless the `cheats` developer option is on, and while it is on
+        // the button whose partner is ALREADY held is suppressed so completing
+        // the chord cannot also open the interface.
+        let cheats_gate = shock2vr::dev_params::get_bool(shock2vr::dev_params::CHEATS);
+        let suppress_use_mode = cheats_gate && audio_log_state.current_state;
+        let suppress_audio_log = cheats_gate && use_mode_state.current_state;
+        if !suppress_use_mode {
+            action_state.sync_discrete_button(
+                shock2vr::input::InputAction::ToggleUseMode,
+                use_mode_state.is_active,
+                use_mode_state.changed_since_last_sync,
+                use_mode_state.current_state,
+            );
+        }
+        if !suppress_audio_log {
+            action_state.sync_discrete_button(
+                shock2vr::input::InputAction::ReadLastUnreadLog,
+                audio_log_state.is_active,
+                audio_log_state.changed_since_last_sync,
+                audio_log_state.current_state,
+            );
+        }
+        action_state.sync_chord(
+            shock2vr::input::InputAction::ToggleCheatPad,
+            use_mode_state.is_active && audio_log_state.is_active,
             use_mode_state.current_state,
-        );
-        action_state.sync_discrete_button(
-            shock2vr::input::InputAction::ReadLastUnreadLog,
-            audio_log_state.is_active,
-            audio_log_state.changed_since_last_sync,
             audio_log_state.current_state,
         );
         action_state.sync_discrete_button(

--- a/shock2vr/src/cheat_pad.rs
+++ b/shock2vr/src/cheat_pad.rs
@@ -3,10 +3,13 @@
 //! A two-button panel that rains useful items around the player, for setting
 //! up a test situation without playing the game up to it. Like
 //! [`crate::pause_menu`] it is an overlay owned by [`crate::Game`] rather than
-//! a [`GameScene`](crate::game_scene::GameScene), so every gameplay scene -
-//! missions and the `debug_*` scenes alike - gets it for free, the world keeps
-//! rendering behind it (a frozen submit is a VR comfort problem), and only the
-//! scene's `update` is skipped while it is up.
+//! a [`GameScene`](crate::game_scene::GameScene), so it draws over any pausable
+//! scene without that scene implementing anything, the world keeps rendering
+//! behind it (a frozen submit is a VR comfort problem), and only the scene's
+//! `update` is skipped while it is up. The *rain* still needs a scene that
+//! handles [`Effect::RainItems`] - missions and the `debug_*` scenes built on
+//! `MissionCore` do; a scene using the trait's default effect handler (e.g.
+//! `debug_hud`) shows the pad but drops the spawn.
 //!
 //! It is gated on the `cheats` developer parameter: with that off the open
 //! action is never even read, so neither a stray controller chord nor an HTTP

--- a/shock2vr/src/cheat_pad.rs
+++ b/shock2vr/src/cheat_pad.rs
@@ -1,0 +1,492 @@
+//! The developer cheat pad.
+//!
+//! A two-button panel that rains useful items around the player, for setting
+//! up a test situation without playing the game up to it. Like
+//! [`crate::pause_menu`] it is an overlay owned by [`crate::Game`] rather than
+//! a [`GameScene`](crate::game_scene::GameScene), so every gameplay scene -
+//! missions and the `debug_*` scenes alike - gets it for free, the world keeps
+//! rendering behind it (a frozen submit is a VR comfort problem), and only the
+//! scene's `update` is skipped while it is up.
+//!
+//! It is gated on the `cheats` developer parameter: with that off the open
+//! action is never even read, so neither a stray controller chord nor an HTTP
+//! injection can conjure free weapons into an ordinary run.
+//!
+//! The page rides [`dev_params_panel`]'s authored widget rects (`GAMELODR.BIN`
+//! over `GAMELOD.PCX`), so its placement is resolved once, in canvas pixels,
+//! and flatscreen and VR draw the identical canvas (AGENTS.md section 3).
+
+use cgmath::{Matrix4, Quaternion, Vector2, Vector3, vec2};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext, scene::SceneObject};
+use shipyard::EntityId;
+
+use crate::ui::world_dim::{UNTRACKED_HEAD, dim_distance, dim_pose, world_dim_layer};
+use crate::{
+    GameOptions,
+    input_context::InputContext,
+    scripts::Effect,
+    ui::{
+        FrontendCanvasPresenter, FrontendMenu, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
+        dev_params_panel::{self, PanelRects},
+    },
+};
+
+/// The page is authored on the original 640x480 canvas, like every other
+/// frontend screen.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+/// The archive frame the Developer page uses, shared so the two developer
+/// pages read as one screen family.
+const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
+const MENU_FONT: &str = "metafont.fon";
+const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
+
+/// Opacity for a button the pointer is not over, and for the one it is.
+/// Matches [`dev_params_panel`]'s pair so the two pages highlight alike.
+const IDLE_OPACITY: f32 = 0.65;
+const HOVER_OPACITY: f32 = 1.0;
+
+/// Button geometry inside the panel's list pane: a horizontal inset matching
+/// the parameter rows', and rows tall enough to be an easy VR ray target.
+const BUTTON_INSET: f32 = 8.0;
+const BUTTON_H: f32 = 40.0;
+const BUTTON_PITCH: f32 = 56.0;
+
+/// Templates rained by [`CheatButton::RainWeapons`]: the four workhorse
+/// weapons plus a clip for each gun that takes one. Resolved from the gamesys
+/// (`cargo dq entities medsci1.mis --filter "*Clip*"`).
+const WEAPON_TEMPLATES: &[i32] = &[
+    -928,  // Wrench
+    -17,   // Pistol
+    -19,   // Shotgun
+    -18,   // Assault Rifle
+    -1358, // Small Standard Clip
+    -1358, // Small Standard Clip
+    -1360, // Small AP Clip
+    -42,   // Pellet Shot Box (shotgun shells)
+];
+
+/// Templates rained by [`CheatButton::RainModules`]: cyber modules and
+/// nanites, the two things a test situation is usually short of.
+const MODULE_TEMPLATES: &[i32] = &[
+    -938, // EXP Cookies (cyber modules)
+    -938, -938, -938, //
+    -89,  // 20 Nanites
+    -89, -89, -89,
+];
+
+/// What a click on the pad does.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheatButton {
+    RainWeapons,
+    RainModules,
+    /// Close the pad and let the simulation run again.
+    Done,
+}
+
+impl CheatButton {
+    /// The two rain buttons, top to bottom. `Done` is not here: it rides the
+    /// backdrop's own "Done" rect rather than a list row.
+    const ROWS: [(CheatButton, &'static str); 2] = [
+        (CheatButton::RainWeapons, "Rain weapons"),
+        (CheatButton::RainModules, "Rain modules + nanites"),
+    ];
+
+    /// The effect this button asks the scene for; `None` for `Done`, which
+    /// only closes the pad.
+    pub fn effect(self) -> Option<Effect> {
+        let templates = match self {
+            CheatButton::RainWeapons => WEAPON_TEMPLATES,
+            CheatButton::RainModules => MODULE_TEMPLATES,
+            CheatButton::Done => return None,
+        };
+        Some(Effect::RainItems {
+            template_ids: templates.to_vec(),
+        })
+    }
+}
+
+/// The canvas rect of the `index`th list row.
+fn button_rect(rects: PanelRects, index: usize) -> Rect {
+    let list = rects.list_rect();
+    Rect::new(
+        list.x + BUTTON_INSET,
+        list.y + BUTTON_INSET + index as f32 * BUTTON_PITCH,
+        list.w - 2.0 * BUTTON_INSET,
+        BUTTON_H,
+    )
+}
+
+/// The button at a canvas point, if any. Both the click and the hover
+/// highlight go through this, so the two can never disagree.
+fn hit(rects: PanelRects, point: Vector2<f32>) -> Option<CheatButton> {
+    for (index, (button, _)) in CheatButton::ROWS.iter().enumerate() {
+        if button_rect(rects, index).contains(point) {
+            return Some(*button);
+        }
+    }
+    rects
+        .done_rect()
+        .contains(point)
+        .then_some(CheatButton::Done)
+}
+
+/// Describe the pad onto a canvas: backdrop, header, the two rain buttons and
+/// "Done". One description for both presentations.
+fn build_canvas(rects: PanelRects, pointer_canvas: Option<Vector2<f32>>) -> UiCanvas {
+    let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+    canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
+
+    let hovered = pointer_canvas.and_then(|point| hit(rects, point));
+    let opacity = |button: CheatButton| {
+        if hovered == Some(button) {
+            HOVER_OPACITY
+        } else {
+            IDLE_OPACITY
+        }
+    };
+
+    canvas.text_native(
+        rects.header_rect(),
+        "Cheats",
+        MENU_FONT,
+        HAlign::Center,
+        VAlign::Middle,
+    );
+
+    for (index, (button, label)) in CheatButton::ROWS.iter().enumerate() {
+        // Fitted, not plain: "Rain modules + nanites" is wider than the pane
+        // at METAFONT's native cell, and `text_native` does not shrink.
+        canvas
+            .text_native_fit(
+                button_rect(rects, index),
+                label,
+                MENU_FONT,
+                HAlign::Center,
+                VAlign::Middle,
+            )
+            .opacity(opacity(*button));
+    }
+
+    canvas
+        .text_native(
+            rects.done_rect(),
+            "Done",
+            MENU_FONT,
+            HAlign::Center,
+            VAlign::Middle,
+        )
+        .opacity(opacity(CheatButton::Done));
+
+    canvas
+}
+
+/// The cheat overlay. Closed by default; [`CheatPad::open`] arms it.
+pub struct CheatPad {
+    open: bool,
+    menu: FrontendMenu<CheatButton>,
+    /// The head pose from the latest update, for the comfort dim (which
+    /// follows the gaze rather than the world-locked panel).
+    head: (Vector3<f32>, Quaternion<f32>),
+    /// Set when a click closed the pad, and cleared once that click is
+    /// released. See [`CheatPad::suspends_scene`].
+    closed_under_a_held_press: bool,
+    /// The panel's widget rects, re-resolved each update (the render path
+    /// takes `&self`, so it reads them here).
+    rects: PanelRects,
+}
+
+impl Default for CheatPad {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CheatPad {
+    pub fn new() -> Self {
+        Self {
+            open: false,
+            menu: FrontendMenu::new(vec2(CANVAS_W, CANVAS_H), SCALE_MODE),
+            head: UNTRACKED_HEAD,
+            closed_under_a_held_press: false,
+            rects: PanelRects::default(),
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Whether the active scene must stay frozen this frame. Wider than
+    /// [`is_open`](Self::is_open) by one beat, for the same reason the pause
+    /// menu's is: the press that closed the pad is still down, and
+    /// `VirtualHand` - never advanced while the pad was up - would read it as
+    /// a fresh rising edge and fire the held weapon the instant the world came
+    /// back.
+    pub fn suspends_scene(&self) -> bool {
+        self.open || self.closed_under_a_held_press
+    }
+
+    /// Clear the post-close latch once nothing is pressed any more.
+    pub fn poll_release(&mut self, input_context: &InputContext) {
+        if !self.closed_under_a_held_press {
+            return;
+        }
+        let hand_held = |hand: &crate::input_context::Hand| {
+            hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD
+        };
+        let pressed = hand_held(&input_context.right_hand)
+            || hand_held(&input_context.left_hand)
+            || input_context.pointer.is_some_and(|p| p.pressed);
+        if !pressed {
+            self.closed_under_a_held_press = false;
+        }
+    }
+
+    /// Open the pad in front of the player. `last_pressed` starts `true` (via
+    /// `reset_on_entry`) so the very chord that opened it cannot read as a
+    /// rising edge over a button on the first frame.
+    pub fn open(&mut self) {
+        self.open = true;
+        self.menu.reset_on_entry();
+        // Forget the previous session's head: a stale pose would hang the dim
+        // where the player stood last time if `render` beats the first
+        // `update`.
+        self.head = UNTRACKED_HEAD;
+    }
+
+    /// Close because a button was clicked - the press that did it is still
+    /// held, so latch the scene shut until it is released.
+    pub fn close_after_click(&mut self) {
+        self.closed_under_a_held_press = true;
+        self.close();
+    }
+
+    pub fn close(&mut self) {
+        self.open = false;
+        self.menu.clear_pointer();
+    }
+
+    pub fn pump_sfx(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        self.menu.pump_sfx(asset_cache, audio_context);
+    }
+
+    pub fn stop_sfx(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        self.menu.stop_sfx(audio_context);
+    }
+
+    /// Advance the overlay and report the button that was clicked, if any.
+    /// A no-op returning `None` while closed.
+    pub fn update(
+        &mut self,
+        elapsed: std::time::Duration,
+        input_context: &InputContext,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+    ) -> Option<CheatButton> {
+        if !self.open {
+            return None;
+        }
+        self.rects = dev_params_panel::rects(asset_cache);
+        self.head = (input_context.head.position, input_context.head.rotation);
+
+        let rects = self.rects;
+        self.menu.update(
+            elapsed,
+            input_context,
+            options.presentation_mode,
+            |point| hit(rects, point),
+            |point| hit(rects, point),
+        )
+    }
+
+    /// World-space presentation: the canvas on a panel in front of the player.
+    /// Empty when closed or flat. `pawn_to_world` maps the tracked play space
+    /// (where the head, the hands and therefore the panel live) into world
+    /// coordinates, exactly as the pause menu does.
+    pub fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+        pawn_to_world: Matrix4<f32>,
+    ) -> Vec<SceneObject> {
+        if !self.open {
+            return Vec::new();
+        }
+        FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_world_space(
+            || {
+                let panel = self.menu.panel();
+                let canvas = build_canvas(self.rects, self.menu.pointer_canvas());
+                let (dim_position, dim_forward) = dim_pose(self.head.0, self.head.1, &panel);
+                let mut objects = vec![world_dim_layer(
+                    dim_position,
+                    dim_forward,
+                    dim_distance(dim_position, &panel),
+                    crate::util::render_source::PAUSE_DIM,
+                )];
+                objects.extend(self.menu.render_world_space(
+                    asset_cache,
+                    canvas,
+                    options.presentation_mode,
+                ));
+                for object in &mut objects {
+                    object.set_transform(pawn_to_world * object.get_transform());
+                }
+                objects
+            },
+        )
+    }
+
+    /// Screen-space presentation. Empty when closed or in VR (where a
+    /// screen-space copy would paste the canvas over both eyes).
+    pub fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        screen_size: Vector2<f32>,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        if !self.open {
+            return Vec::new();
+        }
+        FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_screen_space(
+            || {
+                let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
+                let canvas = build_canvas(self.rects, pointer_canvas);
+                self.menu.render_screen_space(
+                    asset_cache,
+                    canvas,
+                    screen_size,
+                    options.presentation_mode,
+                )
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every button is reachable, and the two rain rows do not overlap each
+    /// other or the "Done" rect they share a backdrop with.
+    #[test]
+    fn each_button_hit_tests_to_itself() {
+        let rects = PanelRects::default();
+        assert_eq!(
+            hit(rects, button_rect(rects, 0).center()),
+            Some(CheatButton::RainWeapons)
+        );
+        assert_eq!(
+            hit(rects, button_rect(rects, 1).center()),
+            Some(CheatButton::RainModules)
+        );
+        assert_eq!(
+            hit(rects, rects.done_rect().center()),
+            Some(CheatButton::Done)
+        );
+    }
+
+    #[test]
+    fn the_rain_rows_stay_inside_the_list_pane() {
+        let rects = PanelRects::default();
+        let list = rects.list_rect();
+        for index in 0..CheatButton::ROWS.len() {
+            let row = button_rect(rects, index);
+            assert!(
+                row.x >= list.x && row.x + row.w <= list.x + list.w,
+                "{row:?}"
+            );
+            assert!(
+                row.y >= list.y && row.y + row.h <= list.y + list.h,
+                "{row:?}"
+            );
+            assert_eq!(hit(rects, row.center()), Some(CheatButton::ROWS[index].0));
+        }
+    }
+
+    /// The pad's whole point: each rain button asks for a spread of items, and
+    /// the two spreads are different.
+    #[test]
+    fn each_rain_button_asks_for_a_spread_of_items() {
+        let rained = |button: CheatButton| match button.effect() {
+            Some(Effect::RainItems { template_ids }) => template_ids,
+            other => panic!("{button:?} produced {other:?}"),
+        };
+        for button in [CheatButton::RainWeapons, CheatButton::RainModules] {
+            let ids = rained(button);
+            assert!(
+                (6..=10).contains(&ids.len()),
+                "{button:?} rains {} items - a modest shower, not a physics stress test",
+                ids.len()
+            );
+            assert!(ids.iter().all(|id| *id < 0), "templates are negative ids");
+        }
+        assert_ne!(
+            rained(CheatButton::RainWeapons),
+            rained(CheatButton::RainModules)
+        );
+        assert!(CheatButton::Done.effect().is_none());
+    }
+
+    /// The press that clicked a button is still held on the frame the pad
+    /// closes; resuming into it would read as a fresh trigger pull.
+    #[test]
+    fn the_scene_stays_suspended_until_the_selecting_press_is_released() {
+        let mut pad = CheatPad::new();
+        pad.open();
+        assert!(pad.suspends_scene());
+
+        pad.close_after_click();
+        assert!(!pad.is_open());
+        assert!(pad.suspends_scene(), "the click is still held");
+
+        let mut held = InputContext::default();
+        held.right_hand.trigger_value = 1.0;
+        pad.poll_release(&held);
+        assert!(pad.suspends_scene());
+
+        pad.poll_release(&InputContext::default());
+        assert!(!pad.suspends_scene(), "released: the world may run again");
+    }
+
+    /// Closing with the chord has nothing held to wait for, so it must not
+    /// strand the simulation.
+    #[test]
+    fn closing_with_the_toggle_resumes_immediately() {
+        let mut pad = CheatPad::new();
+        pad.open();
+        pad.close();
+        assert!(!pad.suspends_scene());
+    }
+
+    /// The chord that opens the pad is a press: without `reset_on_entry`'s
+    /// armed latch it would read as a rising edge over whatever the VR ray
+    /// crossed on the very first frame.
+    #[test]
+    fn the_press_that_opens_the_pad_cannot_click_a_button() {
+        let rects = PanelRects::default();
+        let mut pad = CheatPad::new();
+        pad.open();
+        pad.rects = rects;
+        let point = Some(button_rect(rects, 0).center());
+
+        assert_eq!(
+            pad.menu
+                .resolve_pointer(point, true, |p| hit(rects, p), |p| hit(rects, p)),
+            None,
+            "a press carried in from the opening chord must not rain items"
+        );
+        // Releasing and pressing again is a real click.
+        pad.menu
+            .resolve_pointer(point, false, |p| hit(rects, p), |p| hit(rects, p));
+        assert_eq!(
+            pad.menu
+                .resolve_pointer(point, true, |p| hit(rects, p), |p| hit(rects, p)),
+            Some(CheatButton::RainWeapons)
+        );
+    }
+}

--- a/shock2vr/src/cheat_pad.rs
+++ b/shock2vr/src/cheat_pad.rs
@@ -1,7 +1,7 @@
 //! The developer cheat pad.
 //!
-//! A two-button panel that rains useful items around the player, for setting
-//! up a test situation without playing the game up to it. Like
+//! A scrolling list of cheats that rain useful items around the player, for
+//! setting up a test situation without playing the game up to it. Like
 //! [`crate::pause_menu`] it is an overlay owned by [`crate::Game`] rather than
 //! a [`GameScene`](crate::game_scene::GameScene), so it draws over any pausable
 //! scene without that scene implementing anything, the world keeps rendering
@@ -16,8 +16,11 @@
 //! injection can conjure free weapons into an ordinary run.
 //!
 //! The page rides [`dev_params_panel`]'s authored widget rects (`GAMELODR.BIN`
-//! over `GAMELOD.PCX`), so its placement is resolved once, in canvas pixels,
-//! and flatscreen and VR draw the identical canvas (AGENTS.md section 3).
+//! over `GAMELOD.PCX`) and scrolls with the shared [`list_scroll`] rocker, so
+//! it is the same list the Developer screen's parameter page and debug-scene
+//! launcher are: placement is resolved once, in canvas pixels, and flatscreen
+//! and VR draw the identical canvas (AGENTS.md section 3). Adding a cheat is
+//! one line in [`CHEATS`] - the page grows and starts scrolling on its own.
 
 use cgmath::{Matrix4, Quaternion, Vector2, Vector3, vec2};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext, scene::SceneObject};
@@ -30,7 +33,8 @@ use crate::{
     scripts::Effect,
     ui::{
         FrontendCanvasPresenter, FrontendMenu, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
-        dev_params_panel::{self, PanelRects},
+        dev_params_panel::{self, FIELD_TOP_Y, PanelRects},
+        list_scroll::{self, ScrollHalf},
     },
 };
 
@@ -42,110 +46,164 @@ const CANVAS_H: f32 = 480.0;
 /// pages read as one screen family.
 const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
 const MENU_FONT: &str = "metafont.fon";
-/// The smaller face the Developer page's rows use. The display font
-/// ellipsizes "Rain modules + nanites" inside the 202px pane.
+/// The face the Developer screen's own lists use, at their row pitch, so a
+/// cheat row and a debug-scene row are the same row.
 const ROW_FONT: &str = "mainfont.fon";
+const ROW_H: f32 = 19.0;
+/// Horizontal inset of a row's text from the row, matching the launcher's.
+const TEXT_INSET: f32 = 8.0;
 const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 
-/// Opacity for a button the pointer is not over, and for the one it is.
+/// Opacity for a row the pointer is not over, and for the one it is.
 /// Matches [`dev_params_panel`]'s pair so the two pages highlight alike.
 const IDLE_OPACITY: f32 = 0.65;
 const HOVER_OPACITY: f32 = 1.0;
 
-/// Button geometry inside the panel's list pane: a horizontal inset matching
-/// the parameter rows', and rows tall enough to be an easy VR ray target.
-const BUTTON_INSET: f32 = 8.0;
-const BUTTON_H: f32 = 40.0;
-const BUTTON_PITCH: f32 = 56.0;
+/// One entry in the list: the row's label and the templates it rains.
+pub struct Cheat {
+    pub label: &'static str,
+    templates: &'static [i32],
+}
 
-/// Templates rained by [`CheatButton::RainWeapons`]: the four workhorse
-/// weapons plus a clip for each gun that takes one. Resolved from the gamesys
-/// (`cargo dq entities medsci1.mis --filter "*Clip*"`).
-const WEAPON_TEMPLATES: &[i32] = &[
-    -928,  // Wrench
-    -17,   // Pistol
-    -19,   // Shotgun
-    -18,   // Assault Rifle
-    -1358, // Small Standard Clip
-    -1358, // Small Standard Clip
-    -1360, // Small AP Clip
-    -42,   // Pellet Shot Box (shotgun shells)
+/// Every cheat, in screen order. Template ids come from `cargo dq` against the
+/// gamesys; a new cheat is one line here and nothing else - the list pages and
+/// grows a scroll rocker on its own once the entries outrun the pane.
+pub static CHEATS: &[Cheat] = &[
+    Cheat {
+        label: "Rain weapons",
+        // The four workhorse weapons, plus a clip for each gun that takes one.
+        templates: &[
+            -928,  // Wrench
+            -17,   // Pistol
+            -19,   // Shotgun
+            -18,   // Assault Rifle
+            -1358, // Small Standard Clip
+            -1358, // Small Standard Clip
+            -1360, // Small AP Clip
+            -42,   // Pellet Shot Box (shotgun shells)
+        ],
+    },
+    Cheat {
+        label: "Rain modules + nanites",
+        // The two things a test situation is usually short of.
+        templates: &[
+            -938, // EXP Cookies (cyber modules)
+            -938, -938, -938, //
+            -89,  // 20 Nanites
+            -89, -89, -89,
+        ],
+    },
 ];
 
-/// Templates rained by [`CheatButton::RainModules`]: cyber modules and
-/// nanites, the two things a test situation is usually short of.
-const MODULE_TEMPLATES: &[i32] = &[
-    -938, // EXP Cookies (cyber modules)
-    -938, -938, -938, //
-    -89,  // 20 Nanites
-    -89, -89, -89,
-];
+impl Cheat {
+    /// The effect this row asks the scene for.
+    pub fn effect(&self) -> Effect {
+        Effect::RainItems {
+            template_ids: self.templates.to_vec(),
+        }
+    }
+}
 
-/// What a click on the pad does.
+/// What a click on the pad resolves to. `Cheat` carries the index of the entry
+/// scrolled into that row, never the row's own slot: a positional index would
+/// rain whatever entry *used* to sit there the moment the list scrolls.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CheatButton {
-    RainWeapons,
-    RainModules,
+enum CheatEvent {
+    Cheat(usize),
+    Scroll(ScrollHalf),
     /// Close the pad and let the simulation run again.
     Done,
 }
 
-impl CheatButton {
-    /// The two rain buttons, top to bottom. `Done` is not here: it rides the
-    /// backdrop's own "Done" rect rather than a list row.
-    const ROWS: [(CheatButton, &'static str); 2] = [
-        (CheatButton::RainWeapons, "Rain weapons"),
-        (CheatButton::RainModules, "Rain modules + nanites"),
-    ];
-
-    /// The effect this button asks the scene for; `None` for `Done`, which
-    /// only closes the pad.
-    pub fn effect(self) -> Option<Effect> {
-        let templates = match self {
-            CheatButton::RainWeapons => WEAPON_TEMPLATES,
-            CheatButton::RainModules => MODULE_TEMPLATES,
-            CheatButton::Done => return None,
-        };
-        Some(Effect::RainItems {
-            template_ids: templates.to_vec(),
-        })
-    }
+/// What the owning `Game` must act on. Scrolling never reaches it - the pad
+/// absorbs that itself, exactly as [`dev_params_panel::activate`] absorbs a
+/// parameter step.
+pub enum CheatOutcome {
+    Rain(Effect),
+    Close,
 }
 
-/// The canvas rect of the `index`th list row.
-fn button_rect(rects: PanelRects, index: usize) -> Rect {
+// The list geometry, all of it `list_scroll`'s. Parameterised by `len` rather
+// than reading `CHEATS` directly so the paging and scroll behaviour is testable
+// against a list longer than the two entries shipped today.
+
+fn rows_per_page(rects: PanelRects) -> usize {
+    list_scroll::rows_per_page(rects.list_rect(), FIELD_TOP_Y, ROW_H)
+}
+
+fn max_scroll(rects: PanelRects, len: usize) -> usize {
+    list_scroll::max_scroll(len, rows_per_page(rects))
+}
+
+fn visible_rows(rects: PanelRects, len: usize, scroll: usize) -> std::ops::Range<usize> {
+    list_scroll::visible_rows(len, rows_per_page(rects), scroll)
+}
+
+fn rocker(rects: PanelRects, len: usize) -> Option<list_scroll::Rocker> {
+    list_scroll::rocker(rects.list_rect(), FIELD_TOP_Y, max_scroll(rects, len) > 0)
+}
+
+/// The canvas rect of the `slot`-th visible row. Rows stop short of the scroll
+/// gutter whenever it is in use, so a row and the rocker can never claim the
+/// same point.
+fn row_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
     let list = rects.list_rect();
+    let gutter = if max_scroll(rects, len) > 0 {
+        list_scroll::GUTTER_W
+    } else {
+        0.0
+    };
     Rect::new(
-        list.x + BUTTON_INSET,
-        list.y + BUTTON_INSET + index as f32 * BUTTON_PITCH,
-        list.w - 2.0 * BUTTON_INSET,
-        BUTTON_H,
+        list.x,
+        list.y + slot as f32 * ROW_H,
+        (list.w - gutter).max(0.0),
+        ROW_H,
     )
 }
 
-/// The button at a canvas point, if any. Both the click and the hover
-/// highlight go through this, so the two can never disagree.
-fn hit(rects: PanelRects, point: Vector2<f32>) -> Option<CheatButton> {
-    for (index, (button, _)) in CheatButton::ROWS.iter().enumerate() {
-        if button_rect(rects, index).contains(point) {
-            return Some(*button);
-        }
-    }
-    rects
-        .done_rect()
-        .contains(point)
-        .then_some(CheatButton::Done)
+/// The rect a row's label is drawn in: the row, inset on both edges.
+fn text_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
+    let row = row_rect(rects, len, slot);
+    Rect::new(
+        row.x + TEXT_INSET,
+        row.y,
+        (row.w - 2.0 * TEXT_INSET).max(0.0),
+        row.h,
+    )
 }
 
-/// Describe the pad onto a canvas: backdrop, header, the two rain buttons and
-/// "Done". One description for both presentations.
-fn build_canvas(rects: PanelRects, pointer_canvas: Option<Vector2<f32>>) -> UiCanvas {
+/// What is at a canvas point, if any. Both the click and the hover highlight go
+/// through this, so the two can never disagree.
+fn hit(rects: PanelRects, len: usize, scroll: usize, point: Vector2<f32>) -> Option<CheatEvent> {
+    if rects.done_rect().contains(point) {
+        return Some(CheatEvent::Done);
+    }
+    let rows = visible_rows(rects, len, scroll);
+    if let Some(rocker) = rocker(rects, len) {
+        if let Some(half) = list_scroll::hit(&rocker, rows.start, max_scroll(rects, len), point) {
+            return Some(CheatEvent::Scroll(half));
+        }
+    }
+    (0..rows.len())
+        .find(|slot| row_rect(rects, len, *slot).contains(point))
+        .map(|slot| CheatEvent::Cheat(rows.start + slot))
+}
+
+/// Describe the pad onto a canvas: backdrop, header, the scrolled rows, the
+/// rocker if the list needs one, and "Done". One description for both
+/// presentations.
+fn build_canvas(
+    rects: PanelRects,
+    len: usize,
+    scroll: usize,
+    pointer_canvas: Option<Vector2<f32>>,
+) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
     canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
-    let hovered = pointer_canvas.and_then(|point| hit(rects, point));
-    let opacity = |button: CheatButton| {
-        if hovered == Some(button) {
+    let hovered = pointer_canvas.and_then(|point| hit(rects, len, scroll, point));
+    let opacity = |event: CheatEvent| {
+        if hovered == Some(event) {
             HOVER_OPACITY
         } else {
             IDLE_OPACITY
@@ -160,19 +218,33 @@ fn build_canvas(rects: PanelRects, pointer_canvas: Option<Vector2<f32>>) -> UiCa
         VAlign::Middle,
     );
 
-    for (index, (button, label)) in CheatButton::ROWS.iter().enumerate() {
+    let rows = visible_rows(rects, len, scroll);
+    for (slot, index) in rows.clone().enumerate() {
         // Fitted, not plain: `text_native` does not shrink to its rect, so a
-        // label that outgrows the pane would run over the frame instead of
-        // ellipsizing inside it.
+        // label that outgrows the pane would run over the frame - and over the
+        // scroll gutter - instead of ellipsizing inside it.
         canvas
             .text_native_fit(
-                button_rect(rects, index),
-                label,
+                text_rect(rects, len, slot),
+                CHEATS[index].label,
                 ROW_FONT,
-                HAlign::Center,
+                HAlign::Left,
                 VAlign::Middle,
             )
-            .opacity(opacity(*button));
+            .opacity(opacity(CheatEvent::Cheat(index)));
+    }
+
+    if let Some(rocker) = rocker(rects, len) {
+        list_scroll::draw(
+            &mut canvas,
+            &rocker,
+            rows.start,
+            max_scroll(rects, len),
+            match hovered {
+                Some(CheatEvent::Scroll(half)) => Some(half),
+                _ => None,
+            },
+        );
     }
 
     canvas
@@ -183,7 +255,7 @@ fn build_canvas(rects: PanelRects, pointer_canvas: Option<Vector2<f32>>) -> UiCa
             HAlign::Center,
             VAlign::Middle,
         )
-        .opacity(opacity(CheatButton::Done));
+        .opacity(opacity(CheatEvent::Done));
 
     canvas
 }
@@ -191,7 +263,7 @@ fn build_canvas(rects: PanelRects, pointer_canvas: Option<Vector2<f32>>) -> UiCa
 /// The cheat overlay. Closed by default; [`CheatPad::open`] arms it.
 pub struct CheatPad {
     open: bool,
-    menu: FrontendMenu<CheatButton>,
+    menu: FrontendMenu<CheatEvent>,
     /// The head pose from the latest update, for the comfort dim (which
     /// follows the gaze rather than the world-locked panel).
     head: (Vector3<f32>, Quaternion<f32>),
@@ -201,6 +273,8 @@ pub struct CheatPad {
     /// The panel's widget rects, re-resolved each update (the render path
     /// takes `&self`, so it reads them here).
     rects: PanelRects,
+    /// Index of the cheat in the top row.
+    scroll: usize,
 }
 
 impl Default for CheatPad {
@@ -217,6 +291,7 @@ impl CheatPad {
             head: UNTRACKED_HEAD,
             closed_under_a_held_press: false,
             rects: PanelRects::default(),
+            scroll: 0,
         }
     }
 
@@ -252,18 +327,21 @@ impl CheatPad {
 
     /// Open the pad in front of the player. `last_pressed` starts `true` (via
     /// `reset_on_entry`) so the very chord that opened it cannot read as a
-    /// rising edge over a button on the first frame.
+    /// rising edge over a row on the first frame.
     pub fn open(&mut self) {
         self.open = true;
         self.menu.reset_on_entry();
+        // Always land at the top of the list: reopening part-way down one the
+        // player forgot they had scrolled would read as a broken page.
+        self.scroll = 0;
         // Forget the previous session's head: a stale pose would hang the dim
         // where the player stood last time if `render` beats the first
         // `update`.
         self.head = UNTRACKED_HEAD;
     }
 
-    /// Close because a button was clicked - the press that did it is still
-    /// held, so latch the scene shut until it is released.
+    /// Close because a row was clicked - the press that did it is still held,
+    /// so latch the scene shut until it is released.
     pub fn close_after_click(&mut self) {
         self.closed_under_a_held_press = true;
         self.close();
@@ -286,29 +364,42 @@ impl CheatPad {
         self.menu.stop_sfx(audio_context);
     }
 
-    /// Advance the overlay and report the button that was clicked, if any.
-    /// A no-op returning `None` while closed.
+    /// Advance the overlay and report what the owning `Game` must act on, if
+    /// anything. A no-op returning `None` while closed.
     pub fn update(
         &mut self,
         elapsed: std::time::Duration,
         input_context: &InputContext,
         asset_cache: &mut AssetCache,
         options: &GameOptions,
-    ) -> Option<CheatButton> {
+    ) -> Option<CheatOutcome> {
         if !self.open {
             return None;
         }
         self.rects = dev_params_panel::rects(asset_cache);
         self.head = (input_context.head.position, input_context.head.rotation);
 
-        let rects = self.rects;
-        self.menu.update(
+        let (rects, len, scroll) = (self.rects, CHEATS.len(), self.scroll);
+        let event = self.menu.update(
             elapsed,
             input_context,
             options.presentation_mode,
-            |point| hit(rects, point),
-            |point| hit(rects, point),
-        )
+            |point| hit(rects, len, scroll, point),
+            |point| hit(rects, len, scroll, point),
+        );
+        self.activate(event)
+    }
+
+    /// Apply a clicked event: scrolling is absorbed here, the rest goes up.
+    fn activate(&mut self, event: Option<CheatEvent>) -> Option<CheatOutcome> {
+        match event? {
+            CheatEvent::Cheat(index) => Some(CheatOutcome::Rain(CHEATS[index].effect())),
+            CheatEvent::Scroll(half) => {
+                list_scroll::apply(half, &mut self.scroll, max_scroll(self.rects, CHEATS.len()));
+                None
+            }
+            CheatEvent::Done => Some(CheatOutcome::Close),
+        }
     }
 
     /// World-space presentation: the canvas on a panel in front of the player.
@@ -327,7 +418,12 @@ impl CheatPad {
         FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_world_space(
             || {
                 let panel = self.menu.panel();
-                let canvas = build_canvas(self.rects, self.menu.pointer_canvas());
+                let canvas = build_canvas(
+                    self.rects,
+                    CHEATS.len(),
+                    self.scroll,
+                    self.menu.pointer_canvas(),
+                );
                 let (dim_position, dim_forward) = dim_pose(self.head.0, self.head.1, &panel);
                 let mut objects = vec![world_dim_layer(
                     dim_position,
@@ -362,7 +458,7 @@ impl CheatPad {
         FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_screen_space(
             || {
                 let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
-                let canvas = build_canvas(self.rects, pointer_canvas);
+                let canvas = build_canvas(self.rects, CHEATS.len(), self.scroll, pointer_canvas);
                 self.menu.render_screen_space(
                     asset_cache,
                     canvas,
@@ -378,31 +474,40 @@ impl CheatPad {
 mod tests {
     use super::*;
 
-    /// Every button is reachable, and the two rain rows do not overlap each
-    /// other or the "Done" rect they share a backdrop with.
+    /// A list long enough to outrun the pane, for the scrolling assertions.
+    /// The shipped `CHEATS` fits on one page today - which is the point of
+    /// parameterising the geometry on `len` rather than reading it.
+    fn long_list(rects: PanelRects) -> usize {
+        rows_per_page(rects) + 5
+    }
+
     #[test]
-    fn each_button_hit_tests_to_itself() {
+    fn every_shipped_cheat_is_reachable_and_hit_tests_to_itself() {
         let rects = PanelRects::default();
-        assert_eq!(
-            hit(rects, button_rect(rects, 0).center()),
-            Some(CheatButton::RainWeapons)
+        let len = CHEATS.len();
+        assert!(
+            len <= rows_per_page(rects),
+            "the shipped list fits one page"
         );
+        for index in 0..len {
+            assert_eq!(
+                hit(rects, len, 0, row_rect(rects, len, index).center()),
+                Some(CheatEvent::Cheat(index)),
+            );
+        }
         assert_eq!(
-            hit(rects, button_rect(rects, 1).center()),
-            Some(CheatButton::RainModules)
-        );
-        assert_eq!(
-            hit(rects, rects.done_rect().center()),
-            Some(CheatButton::Done)
+            hit(rects, len, 0, rects.done_rect().center()),
+            Some(CheatEvent::Done)
         );
     }
 
     #[test]
-    fn the_rain_rows_stay_inside_the_list_pane() {
+    fn the_rows_stay_inside_the_list_pane() {
         let rects = PanelRects::default();
+        let len = CHEATS.len();
         let list = rects.list_rect();
-        for index in 0..CheatButton::ROWS.len() {
-            let row = button_rect(rects, index);
+        for slot in 0..len {
+            let row = row_rect(rects, len, slot);
             assert!(
                 row.x >= list.x && row.x + row.w <= list.x + list.w,
                 "{row:?}"
@@ -411,36 +516,111 @@ mod tests {
                 row.y >= list.y && row.y + row.h <= list.y + list.h,
                 "{row:?}"
             );
-            assert_eq!(hit(rects, row.center()), Some(CheatButton::ROWS[index].0));
         }
     }
 
-    /// The pad's whole point: each rain button asks for a spread of items, and
-    /// the two spreads are different.
+    /// The list is meant to grow. Once it outruns the pane a rocker appears,
+    /// the rows make room for its gutter, and a row reports the entry
+    /// *scrolled into* it rather than its own slot.
     #[test]
-    fn each_rain_button_asks_for_a_spread_of_items() {
-        let rained = |button: CheatButton| match button.effect() {
-            Some(Effect::RainItems { template_ids }) => template_ids,
-            other => panic!("{button:?} produced {other:?}"),
+    fn a_list_that_outruns_the_pane_scrolls_and_rows_follow_the_offset() {
+        let rects = PanelRects::default();
+        let len = long_list(rects);
+        let max = max_scroll(rects, len);
+        assert_eq!(max, 5);
+
+        let no_gutter = row_rect(rects, CHEATS.len(), 0);
+        let with_gutter = row_rect(rects, len, 0);
+        assert_eq!(
+            with_gutter.w,
+            no_gutter.w - list_scroll::GUTTER_W,
+            "rows must clear the rocker's gutter once it appears"
+        );
+
+        // Unscrolled the top row is entry 0; scrolled by 3 it is entry 3.
+        assert_eq!(
+            hit(rects, len, 0, row_rect(rects, len, 0).center()),
+            Some(CheatEvent::Cheat(0))
+        );
+        assert_eq!(
+            hit(rects, len, 3, row_rect(rects, len, 0).center()),
+            Some(CheatEvent::Cheat(3))
+        );
+        // An over-scroll cannot walk the list off its end.
+        assert_eq!(
+            hit(rects, len, 99, row_rect(rects, len, 0).center()),
+            Some(CheatEvent::Cheat(max))
+        );
+    }
+
+    /// A short list has no rocker at all, so nothing can steal a row's clicks.
+    #[test]
+    fn a_list_that_fits_has_no_rocker() {
+        let rects = PanelRects::default();
+        assert!(rocker(rects, CHEATS.len()).is_none());
+        assert!(rocker(rects, long_list(rects)).is_some());
+    }
+
+    /// The rocker's ends are inert, and clicking it scrolls rather than
+    /// reaching `Game` - the pad absorbs it.
+    #[test]
+    fn the_rocker_scrolls_and_stops_at_both_ends() {
+        let rects = PanelRects::default();
+        let len = long_list(rects);
+        let max = max_scroll(rects, len);
+        let rocker = rocker(rects, len).expect("this list scrolls");
+
+        // At the top, "up" is inert and "down" scrolls.
+        assert_eq!(hit(rects, len, 0, rocker.up.center()), None);
+        assert_eq!(
+            hit(rects, len, 0, rocker.down.center()),
+            Some(CheatEvent::Scroll(ScrollHalf::Down))
+        );
+
+        let mut pad = CheatPad::new();
+        pad.rects = rects;
+        // `activate` scrolls against the SHIPPED list, which fits, so its max
+        // is zero - assert the absorption, then the walk on the long list.
+        assert!(matches!(
+            pad.activate(Some(CheatEvent::Scroll(ScrollHalf::Down))),
+            None
+        ));
+
+        let mut scroll = 0;
+        for _ in 0..max + 3 {
+            list_scroll::apply(ScrollHalf::Down, &mut scroll, max);
+        }
+        assert_eq!(scroll, max);
+        assert_eq!(hit(rects, len, max, rocker.down.center()), None);
+        assert_eq!(
+            hit(rects, len, max, rocker.up.center()),
+            Some(CheatEvent::Scroll(ScrollHalf::Up))
+        );
+    }
+
+    /// The pad's whole point: each cheat asks for a spread of items, and the
+    /// spreads differ.
+    #[test]
+    fn each_cheat_asks_for_a_spread_of_items() {
+        let rained = |cheat: &Cheat| match cheat.effect() {
+            Effect::RainItems { template_ids } => template_ids,
+            other => panic!("{} produced {other:?}", cheat.label),
         };
-        for button in [CheatButton::RainWeapons, CheatButton::RainModules] {
-            let ids = rained(button);
+        for cheat in CHEATS {
+            let ids = rained(cheat);
             assert!(
                 (6..=10).contains(&ids.len()),
-                "{button:?} rains {} items - a modest shower, not a physics stress test",
+                "{} rains {} items - a modest shower, not a physics stress test",
+                cheat.label,
                 ids.len()
             );
             assert!(ids.iter().all(|id| *id < 0), "templates are negative ids");
         }
-        assert_ne!(
-            rained(CheatButton::RainWeapons),
-            rained(CheatButton::RainModules)
-        );
-        assert!(CheatButton::Done.effect().is_none());
+        assert_ne!(rained(&CHEATS[0]), rained(&CHEATS[1]));
     }
 
-    /// The press that clicked a button is still held on the frame the pad
-    /// closes; resuming into it would read as a fresh trigger pull.
+    /// The press that clicked a row is still held on the frame the pad closes;
+    /// resuming into it would read as a fresh trigger pull.
     #[test]
     fn the_scene_stays_suspended_until_the_selecting_press_is_released() {
         let mut pad = CheatPad::new();
@@ -470,30 +650,40 @@ mod tests {
         assert!(!pad.suspends_scene());
     }
 
+    /// Reopening lands at the top of the list rather than wherever it was left.
+    #[test]
+    fn reopening_resets_the_scroll() {
+        let mut pad = CheatPad::new();
+        pad.open();
+        pad.scroll = 4;
+        pad.close();
+        pad.open();
+        assert_eq!(pad.scroll, 0);
+    }
+
     /// The chord that opens the pad is a press: without `reset_on_entry`'s
     /// armed latch it would read as a rising edge over whatever the VR ray
     /// crossed on the very first frame.
     #[test]
-    fn the_press_that_opens_the_pad_cannot_click_a_button() {
+    fn the_press_that_opens_the_pad_cannot_click_a_row() {
         let rects = PanelRects::default();
+        let len = CHEATS.len();
         let mut pad = CheatPad::new();
         pad.open();
         pad.rects = rects;
-        let point = Some(button_rect(rects, 0).center());
+        let point = Some(row_rect(rects, len, 0).center());
+        let at = |p| hit(rects, len, 0, p);
 
         assert_eq!(
-            pad.menu
-                .resolve_pointer(point, true, |p| hit(rects, p), |p| hit(rects, p)),
+            pad.menu.resolve_pointer(point, true, at, at),
             None,
             "a press carried in from the opening chord must not rain items"
         );
         // Releasing and pressing again is a real click.
-        pad.menu
-            .resolve_pointer(point, false, |p| hit(rects, p), |p| hit(rects, p));
+        pad.menu.resolve_pointer(point, false, at, at);
         assert_eq!(
-            pad.menu
-                .resolve_pointer(point, true, |p| hit(rects, p), |p| hit(rects, p)),
-            Some(CheatButton::RainWeapons)
+            pad.menu.resolve_pointer(point, true, at, at),
+            Some(CheatEvent::Cheat(0))
         );
     }
 }

--- a/shock2vr/src/cheat_pad.rs
+++ b/shock2vr/src/cheat_pad.rs
@@ -39,6 +39,9 @@ const CANVAS_H: f32 = 480.0;
 /// pages read as one screen family.
 const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
 const MENU_FONT: &str = "metafont.fon";
+/// The smaller face the Developer page's rows use. The display font
+/// ellipsizes "Rain modules + nanites" inside the 202px pane.
+const ROW_FONT: &str = "mainfont.fon";
 const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 
 /// Opacity for a button the pointer is not over, and for the one it is.
@@ -155,13 +158,14 @@ fn build_canvas(rects: PanelRects, pointer_canvas: Option<Vector2<f32>>) -> UiCa
     );
 
     for (index, (button, label)) in CheatButton::ROWS.iter().enumerate() {
-        // Fitted, not plain: "Rain modules + nanites" is wider than the pane
-        // at METAFONT's native cell, and `text_native` does not shrink.
+        // Fitted, not plain: `text_native` does not shrink to its rect, so a
+        // label that outgrows the pane would run over the frame instead of
+        // ellipsizing inside it.
         canvas
             .text_native_fit(
                 button_rect(rects, index),
                 label,
-                MENU_FONT,
+                ROW_FONT,
                 HAlign::Center,
                 VAlign::Middle,
             )

--- a/shock2vr/src/cheat_pad.rs
+++ b/shock2vr/src/cheat_pad.rs
@@ -34,7 +34,7 @@ use crate::{
     ui::{
         FrontendCanvasPresenter, FrontendMenu, HAlign, Rect, ScaleMode, UiCanvas, VAlign,
         dev_params_panel::{self, FIELD_TOP_Y, PanelRects},
-        list_scroll::{self, ScrollHalf},
+        list_scroll::{self, ListGeometry, ListHit, ScrollHalf},
     },
 };
 
@@ -60,15 +60,15 @@ const IDLE_OPACITY: f32 = 0.65;
 const HOVER_OPACITY: f32 = 1.0;
 
 /// One entry in the list: the row's label and the templates it rains.
-pub struct Cheat {
-    pub label: &'static str,
+struct Cheat {
+    label: &'static str,
     templates: &'static [i32],
 }
 
 /// Every cheat, in screen order. Template ids come from `cargo dq` against the
-/// gamesys; a new cheat is one line here and nothing else - the list pages and
+/// gamesys; a new cheat is one entry here and nothing else - the list pages and
 /// grows a scroll rocker on its own once the entries outrun the pane.
-pub static CHEATS: &[Cheat] = &[
+static CHEATS: &[Cheat] = &[
     Cheat {
         label: "Rain weapons",
         // The four workhorse weapons, plus a clip for each gun that takes one.
@@ -97,18 +97,17 @@ pub static CHEATS: &[Cheat] = &[
 
 impl Cheat {
     /// The effect this row asks the scene for.
-    pub fn effect(&self) -> Effect {
+    fn effect(&self) -> Effect {
         Effect::RainItems {
             template_ids: self.templates.to_vec(),
         }
     }
 }
 
-/// What a click on the pad resolves to. `Cheat` carries the index of the entry
-/// scrolled into that row, never the row's own slot: a positional index would
-/// rain whatever entry *used* to sit there the moment the list scrolls.
+/// What a click on the pad resolves to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CheatEvent {
+    /// The index of the cheat scrolled into the clicked row.
     Cheat(usize),
     Scroll(ScrollHalf),
     /// Close the pad and let the simulation run again.
@@ -123,70 +122,38 @@ pub enum CheatOutcome {
     Close,
 }
 
-// The list geometry, all of it `list_scroll`'s. Parameterised by `len` rather
-// than reading `CHEATS` directly so the paging and scroll behaviour is testable
-// against a list longer than the two entries shipped today.
-
-fn rows_per_page(rects: PanelRects) -> usize {
-    list_scroll::rows_per_page(rects.list_rect(), FIELD_TOP_Y, ROW_H)
-}
-
-fn max_scroll(rects: PanelRects, len: usize) -> usize {
-    list_scroll::max_scroll(len, rows_per_page(rects))
-}
-
-fn visible_rows(rects: PanelRects, len: usize, scroll: usize) -> std::ops::Range<usize> {
-    list_scroll::visible_rows(len, rows_per_page(rects), scroll)
-}
-
-fn rocker(rects: PanelRects, len: usize) -> Option<list_scroll::Rocker> {
-    list_scroll::rocker(rects.list_rect(), FIELD_TOP_Y, max_scroll(rects, len) > 0)
-}
-
-/// The canvas rect of the `slot`-th visible row. Rows stop short of the scroll
-/// gutter whenever it is in use, so a row and the rocker can never claim the
-/// same point.
-fn row_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
-    let list = rects.list_rect();
-    let gutter = if max_scroll(rects, len) > 0 {
-        list_scroll::GUTTER_W
-    } else {
-        0.0
-    };
-    Rect::new(
-        list.x,
-        list.y + slot as f32 * ROW_H,
-        (list.w - gutter).max(0.0),
-        ROW_H,
-    )
-}
-
-/// The rect a row's label is drawn in: the row, inset on both edges.
-fn text_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
-    let row = row_rect(rects, len, slot);
-    Rect::new(
-        row.x + TEXT_INSET,
-        row.y,
-        (row.w - 2.0 * TEXT_INSET).max(0.0),
-        row.h,
-    )
+/// The list's geometry, shared with every other frontend list. The pane and
+/// the line the rows stop at are the Developer page's own; the pitch and inset
+/// are the debug-scene launcher's, so a cheat row and a scene row are the same
+/// row.
+fn geometry(rects: PanelRects) -> ListGeometry {
+    ListGeometry {
+        pane: rects.list_rect(),
+        bottom_limit: FIELD_TOP_Y,
+        row_h: ROW_H,
+        text_inset: TEXT_INSET,
+    }
 }
 
 /// What is at a canvas point, if any. Both the click and the hover highlight go
 /// through this, so the two can never disagree.
-fn hit(rects: PanelRects, len: usize, scroll: usize, point: Vector2<f32>) -> Option<CheatEvent> {
+///
+/// Takes the entries rather than a count so the rows and the labels drawn in
+/// them are the same object: a length parameter would let a caller hit-test a
+/// row that has no cheat behind it.
+fn hit(
+    rects: PanelRects,
+    cheats: &[Cheat],
+    scroll: usize,
+    point: Vector2<f32>,
+) -> Option<CheatEvent> {
     if rects.done_rect().contains(point) {
         return Some(CheatEvent::Done);
     }
-    let rows = visible_rows(rects, len, scroll);
-    if let Some(rocker) = rocker(rects, len) {
-        if let Some(half) = list_scroll::hit(&rocker, rows.start, max_scroll(rects, len), point) {
-            return Some(CheatEvent::Scroll(half));
-        }
+    match geometry(rects).hit(cheats.len(), scroll, point)? {
+        ListHit::Row(index) => Some(CheatEvent::Cheat(index)),
+        ListHit::Scroll(half) => Some(CheatEvent::Scroll(half)),
     }
-    (0..rows.len())
-        .find(|slot| row_rect(rects, len, *slot).contains(point))
-        .map(|slot| CheatEvent::Cheat(rows.start + slot))
 }
 
 /// Describe the pad onto a canvas: backdrop, header, the scrolled rows, the
@@ -194,14 +161,16 @@ fn hit(rects: PanelRects, len: usize, scroll: usize, point: Vector2<f32>) -> Opt
 /// presentations.
 fn build_canvas(
     rects: PanelRects,
-    len: usize,
+    cheats: &[Cheat],
     scroll: usize,
     pointer_canvas: Option<Vector2<f32>>,
 ) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
     canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
-    let hovered = pointer_canvas.and_then(|point| hit(rects, len, scroll, point));
+    let list = geometry(rects);
+    let len = cheats.len();
+    let hovered = pointer_canvas.and_then(|point| hit(rects, cheats, scroll, point));
     let opacity = |event: CheatEvent| {
         if hovered == Some(event) {
             HOVER_OPACITY
@@ -218,15 +187,15 @@ fn build_canvas(
         VAlign::Middle,
     );
 
-    let rows = visible_rows(rects, len, scroll);
+    let rows = list.visible_rows(len, scroll);
     for (slot, index) in rows.clone().enumerate() {
         // Fitted, not plain: `text_native` does not shrink to its rect, so a
         // label that outgrows the pane would run over the frame - and over the
         // scroll gutter - instead of ellipsizing inside it.
         canvas
             .text_native_fit(
-                text_rect(rects, len, slot),
-                CHEATS[index].label,
+                list.text_rect(len, slot),
+                cheats[index].label,
                 ROW_FONT,
                 HAlign::Left,
                 VAlign::Middle,
@@ -234,12 +203,12 @@ fn build_canvas(
             .opacity(opacity(CheatEvent::Cheat(index)));
     }
 
-    if let Some(rocker) = rocker(rects, len) {
+    if let Some(rocker) = list.rocker(len) {
         list_scroll::draw(
             &mut canvas,
             &rocker,
             rows.start,
-            max_scroll(rects, len),
+            list.max_scroll(len),
             match hovered {
                 Some(CheatEvent::Scroll(half)) => Some(half),
                 _ => None,
@@ -379,13 +348,13 @@ impl CheatPad {
         self.rects = dev_params_panel::rects(asset_cache);
         self.head = (input_context.head.position, input_context.head.rotation);
 
-        let (rects, len, scroll) = (self.rects, CHEATS.len(), self.scroll);
+        let (rects, scroll) = (self.rects, self.scroll);
         let event = self.menu.update(
             elapsed,
             input_context,
             options.presentation_mode,
-            |point| hit(rects, len, scroll, point),
-            |point| hit(rects, len, scroll, point),
+            |point| hit(rects, CHEATS, scroll, point),
+            |point| hit(rects, CHEATS, scroll, point),
         );
         self.activate(event)
     }
@@ -395,7 +364,11 @@ impl CheatPad {
         match event? {
             CheatEvent::Cheat(index) => Some(CheatOutcome::Rain(CHEATS[index].effect())),
             CheatEvent::Scroll(half) => {
-                list_scroll::apply(half, &mut self.scroll, max_scroll(self.rects, CHEATS.len()));
+                list_scroll::apply(
+                    half,
+                    &mut self.scroll,
+                    geometry(self.rects).max_scroll(CHEATS.len()),
+                );
                 None
             }
             CheatEvent::Done => Some(CheatOutcome::Close),
@@ -418,12 +391,8 @@ impl CheatPad {
         FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_world_space(
             || {
                 let panel = self.menu.panel();
-                let canvas = build_canvas(
-                    self.rects,
-                    CHEATS.len(),
-                    self.scroll,
-                    self.menu.pointer_canvas(),
-                );
+                let canvas =
+                    build_canvas(self.rects, CHEATS, self.scroll, self.menu.pointer_canvas());
                 let (dim_position, dim_forward) = dim_pose(self.head.0, self.head.1, &panel);
                 let mut objects = vec![world_dim_layer(
                     dim_position,
@@ -458,7 +427,7 @@ impl CheatPad {
         FrontendCanvasPresenter::new(options.presentation_mode, SCALE_MODE).present_screen_space(
             || {
                 let pointer_canvas = self.menu.screen_pointer_canvas(screen_size);
-                let canvas = build_canvas(self.rects, CHEATS.len(), self.scroll, pointer_canvas);
+                let canvas = build_canvas(self.rects, CHEATS, self.scroll, pointer_canvas);
                 self.menu.render_screen_space(
                     asset_cache,
                     canvas,
@@ -474,82 +443,73 @@ impl CheatPad {
 mod tests {
     use super::*;
 
-    /// A list long enough to outrun the pane, for the scrolling assertions.
-    /// The shipped `CHEATS` fits on one page today - which is the point of
-    /// parameterising the geometry on `len` rather than reading it.
-    fn long_list(rects: PanelRects) -> usize {
-        rows_per_page(rects) + 5
+    /// A synthesized list long enough to outrun the pane. The shipped `CHEATS`
+    /// fits on one page today, which is exactly why the geometry takes the
+    /// entries rather than reading the global.
+    fn long_list(rects: PanelRects) -> Vec<Cheat> {
+        let len = geometry(rects).rows_per_page() + 5;
+        (0..len)
+            .map(|_| Cheat {
+                label: "test cheat",
+                templates: &[-17],
+            })
+            .collect()
     }
 
     #[test]
     fn every_shipped_cheat_is_reachable_and_hit_tests_to_itself() {
         let rects = PanelRects::default();
-        let len = CHEATS.len();
+        let list = geometry(rects);
         assert!(
-            len <= rows_per_page(rects),
+            CHEATS.len() <= list.rows_per_page(),
             "the shipped list fits one page"
         );
-        for index in 0..len {
+        for index in 0..CHEATS.len() {
             assert_eq!(
-                hit(rects, len, 0, row_rect(rects, len, index).center()),
+                hit(
+                    rects,
+                    CHEATS,
+                    0,
+                    list.row_rect(CHEATS.len(), index).center()
+                ),
                 Some(CheatEvent::Cheat(index)),
             );
         }
         assert_eq!(
-            hit(rects, len, 0, rects.done_rect().center()),
+            hit(rects, CHEATS, 0, rects.done_rect().center()),
             Some(CheatEvent::Done)
         );
     }
 
-    #[test]
-    fn the_rows_stay_inside_the_list_pane() {
-        let rects = PanelRects::default();
-        let len = CHEATS.len();
-        let list = rects.list_rect();
-        for slot in 0..len {
-            let row = row_rect(rects, len, slot);
-            assert!(
-                row.x >= list.x && row.x + row.w <= list.x + list.w,
-                "{row:?}"
-            );
-            assert!(
-                row.y >= list.y && row.y + row.h <= list.y + list.h,
-                "{row:?}"
-            );
-        }
-    }
-
-    /// The list is meant to grow. Once it outruns the pane a rocker appears,
-    /// the rows make room for its gutter, and a row reports the entry
-    /// *scrolled into* it rather than its own slot.
+    /// The list is meant to grow. Once it outruns the pane a rocker appears and
+    /// a row reports the entry *scrolled into* it rather than its own slot.
+    /// (The geometry itself is `list_scroll`'s and tested there; this pins that
+    /// the pad is wired to it, and that "Done" still wins over a row.)
     #[test]
     fn a_list_that_outruns_the_pane_scrolls_and_rows_follow_the_offset() {
         let rects = PanelRects::default();
-        let len = long_list(rects);
-        let max = max_scroll(rects, len);
+        let cheats = long_list(rects);
+        let list = geometry(rects);
+        let max = list.max_scroll(cheats.len());
         assert_eq!(max, 5);
 
-        let no_gutter = row_rect(rects, CHEATS.len(), 0);
-        let with_gutter = row_rect(rects, len, 0);
-        assert_eq!(
-            with_gutter.w,
-            no_gutter.w - list_scroll::GUTTER_W,
-            "rows must clear the rocker's gutter once it appears"
-        );
-
-        // Unscrolled the top row is entry 0; scrolled by 3 it is entry 3.
-        assert_eq!(
-            hit(rects, len, 0, row_rect(rects, len, 0).center()),
-            Some(CheatEvent::Cheat(0))
-        );
-        assert_eq!(
-            hit(rects, len, 3, row_rect(rects, len, 0).center()),
-            Some(CheatEvent::Cheat(3))
-        );
+        let row0 = list.row_rect(cheats.len(), 0).center();
+        assert_eq!(hit(rects, &cheats, 0, row0), Some(CheatEvent::Cheat(0)));
+        assert_eq!(hit(rects, &cheats, 3, row0), Some(CheatEvent::Cheat(3)));
         // An over-scroll cannot walk the list off its end.
+        assert_eq!(hit(rects, &cheats, 99, row0), Some(CheatEvent::Cheat(max)));
+
+        let rocker = list.rocker(cheats.len()).expect("this list scrolls");
         assert_eq!(
-            hit(rects, len, 99, row_rect(rects, len, 0).center()),
-            Some(CheatEvent::Cheat(max))
+            hit(rects, &cheats, 0, rocker.down.center()),
+            Some(CheatEvent::Scroll(ScrollHalf::Down))
+        );
+        assert_eq!(hit(rects, &cheats, 0, rocker.up.center()), None);
+        // "Done" is resolved before the list, so a pane that ever grew over it
+        // could not swallow the way out.
+        assert_eq!(
+            hit(rects, &cheats, 0, rects.done_rect().center()),
+            Some(CheatEvent::Done)
         );
     }
 
@@ -557,45 +517,21 @@ mod tests {
     #[test]
     fn a_list_that_fits_has_no_rocker() {
         let rects = PanelRects::default();
-        assert!(rocker(rects, CHEATS.len()).is_none());
-        assert!(rocker(rects, long_list(rects)).is_some());
+        assert!(geometry(rects).rocker(CHEATS.len()).is_none());
+        assert!(geometry(rects).rocker(long_list(rects).len()).is_some());
     }
 
-    /// The rocker's ends are inert, and clicking it scrolls rather than
-    /// reaching `Game` - the pad absorbs it.
+    /// Clicking the rocker scrolls the pad rather than reaching `Game`.
     #[test]
-    fn the_rocker_scrolls_and_stops_at_both_ends() {
-        let rects = PanelRects::default();
-        let len = long_list(rects);
-        let max = max_scroll(rects, len);
-        let rocker = rocker(rects, len).expect("this list scrolls");
-
-        // At the top, "up" is inert and "down" scrolls.
-        assert_eq!(hit(rects, len, 0, rocker.up.center()), None);
-        assert_eq!(
-            hit(rects, len, 0, rocker.down.center()),
-            Some(CheatEvent::Scroll(ScrollHalf::Down))
-        );
-
+    fn a_scroll_click_is_absorbed_by_the_pad() {
         let mut pad = CheatPad::new();
-        pad.rects = rects;
-        // `activate` scrolls against the SHIPPED list, which fits, so its max
-        // is zero - assert the absorption, then the walk on the long list.
-        assert!(matches!(
-            pad.activate(Some(CheatEvent::Scroll(ScrollHalf::Down))),
-            None
-        ));
-
-        let mut scroll = 0;
-        for _ in 0..max + 3 {
-            list_scroll::apply(ScrollHalf::Down, &mut scroll, max);
-        }
-        assert_eq!(scroll, max);
-        assert_eq!(hit(rects, len, max, rocker.down.center()), None);
-        assert_eq!(
-            hit(rects, len, max, rocker.up.center()),
-            Some(CheatEvent::Scroll(ScrollHalf::Up))
+        pad.rects = PanelRects::default();
+        assert!(
+            pad.activate(Some(CheatEvent::Scroll(ScrollHalf::Down)))
+                .is_none()
         );
+        // The shipped list fits, so its max is zero and the offset stays put.
+        assert_eq!(pad.scroll, 0);
     }
 
     /// The pad's whole point: each cheat asks for a spread of items, and the
@@ -667,12 +603,11 @@ mod tests {
     #[test]
     fn the_press_that_opens_the_pad_cannot_click_a_row() {
         let rects = PanelRects::default();
-        let len = CHEATS.len();
         let mut pad = CheatPad::new();
         pad.open();
         pad.rects = rects;
-        let point = Some(row_rect(rects, len, 0).center());
-        let at = |p| hit(rects, len, 0, p);
+        let point = Some(geometry(rects).row_rect(CHEATS.len(), 0).center());
+        let at = |p| hit(rects, CHEATS, 0, p);
 
         assert_eq!(
             pad.menu.resolve_pointer(point, true, at, at),

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -213,6 +213,12 @@ dev_params! {
     /// making the arm exactly life-size (0.79) would leave the Wrench at 52,
     /// and making the Wrench right (~0.5) would leave a child's arm.
     MELEE_WIELD_SCALE = float("melee_scale", "Melee scale", 0.7, 0.25, 1.5, 0.05),
+    /// Enables the developer cheat pad. Like [`FREE_CAMERA`] this is a *gate*,
+    /// not the pad's own open/closed state: while it is false the open action
+    /// is not even read, so neither a stray controller chord nor an HTTP
+    /// injection can conjure free weapons into an ordinary run. Turning it off
+    /// while the pad is up also closes it, so the switch is always a way out.
+    CHEATS = bool("cheats", "Cheats", false),
     /// Enables the detached debug ("free") camera. This is the *gate*, not
     /// the camera's own on/off: while it is false the toggle input is not
     /// even read, so a stray `Alt+V` (or controller chord) during normal play

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -16,6 +16,7 @@ use crate::{
     quest_info::QuestInfo,
     scripts::{Effect, GlobalEffect, ScriptWorld},
     time::Time,
+    vr_config::Handedness,
 };
 
 /// Why the player's current state cannot be represented by a durable save.
@@ -149,6 +150,16 @@ pub trait GameScene {
     /// stacked menus; they keep the default.
     fn is_pausable(&self) -> bool {
         false
+    }
+
+    /// Whether the given VR hand is holding nothing.
+    ///
+    /// Gates the cheat pad's controller chord, which shares its two face
+    /// buttons with the actions worth reaching for *while holding something*.
+    /// Scenes with no virtual hands keep the default, so the gate is inert
+    /// rather than blocking there.
+    fn hand_is_empty(&self, _hand: Handedness) -> bool {
+        true
     }
 
     /// Whether the player's collider is currently crouched (the *actual*

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -97,6 +97,12 @@ pub enum InputAction {
     /// stray press during normal play cannot detach the view.
     ToggleFreeCamera,
 
+    /// Toggle the developer cheat pad. Consumed by `Game` itself for the same
+    /// reason `TogglePauseMenu` is: the pad is a `Game`-owned overlay that
+    /// suspends the scene, so an effect routed through the scene could never
+    /// close it again. Inert unless the `cheats` developer option is on.
+    ToggleCheatPad,
+
     /// Open/play the newest unread audio log (the original's
     /// `play_unread_log`), or replay the newest collected log once all are read.
     /// Collecting a disc only files it in the PDA, so this is how it is read.
@@ -141,6 +147,7 @@ impl InputAction {
             InputAction::ToggleMap,
             InputAction::TogglePauseMenu,
             InputAction::ToggleFreeCamera,
+            InputAction::ToggleCheatPad,
         ]
     }
 
@@ -179,6 +186,7 @@ impl InputAction {
             InputAction::ToggleMap => "ToggleMap",
             InputAction::TogglePauseMenu => "TogglePauseMenu",
             InputAction::ToggleFreeCamera => "ToggleFreeCamera",
+            InputAction::ToggleCheatPad => "ToggleCheatPad",
         }
     }
 
@@ -225,6 +233,16 @@ impl InputAction {
             InputAction::ToggleFreeCamera => Some((
                 "/user/hand/right/input/a/click",
                 "/user/hand/right/input/b/click",
+            )),
+            // The cheat pad takes the LEFT controller's face pair, because the
+            // right one is already the free camera's. Same sharing argument:
+            // the chord is dead unless the `cheats` developer option is on,
+            // and `Game` additionally refuses it while the left hand is
+            // holding something - the state in which X (the cyber interface)
+            // and Y (play last log) are worth reaching for on their own.
+            InputAction::ToggleCheatPad => Some((
+                "/user/hand/left/input/x/click",
+                "/user/hand/left/input/y/click",
             )),
             _ => None,
         }
@@ -323,6 +341,34 @@ mod tests {
         );
         assert_eq!(first, "/user/hand/right/input/a/click");
         assert_eq!(second, "/user/hand/right/input/b/click");
+    }
+
+    /// The cheat pad shares the LEFT face pair, because the right one is
+    /// already the free camera's. Pinning both chords here means a future
+    /// rebinding of either has to come back and re-read `oculus_runtime`'s
+    /// suppression rule rather than silently making one chord fire the other.
+    #[test]
+    fn the_cheat_pad_chord_shares_the_two_left_face_buttons() {
+        assert_eq!(InputAction::ToggleCheatPad.quest_touch_click_path(), None);
+        let (first, second) = InputAction::ToggleCheatPad
+            .quest_touch_chord_paths()
+            .expect("cheat pad chord binding");
+        assert_eq!(
+            first,
+            InputAction::ToggleUseMode.quest_touch_click_path().unwrap()
+        );
+        assert_eq!(
+            second,
+            InputAction::ReadLastUnreadLog
+                .quest_touch_click_path()
+                .unwrap()
+        );
+        // ...and it is a different pair from the free camera's, so completing
+        // one chord can never also complete the other.
+        assert_ne!(
+            InputAction::ToggleCheatPad.quest_touch_chord_paths(),
+            InputAction::ToggleFreeCamera.quest_touch_chord_paths()
+        );
     }
 
     /// Every action is reachable by exactly one kind of binding, or none.

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1042,10 +1042,11 @@ impl Game {
             || self.active_game_scene.wants_pointer()
     }
 
-    /// Whether the in-game pause menu is up (and therefore the simulation is
-    /// frozen). Automation reads this to tell "paused" from "stuck".
+    /// Whether a `Game`-owned overlay is up (and therefore the simulation is
+    /// frozen). Automation reads this to tell "paused" from "stuck", so it must
+    /// name every overlay that suspends the scene, not just the pause menu.
     pub fn is_paused(&self) -> bool {
-        self.pause_menu.is_open()
+        self.overlay_is_open()
     }
 
     /// Name of the currently active scene (e.g. "medsci1.mis"), tracking
@@ -1648,11 +1649,13 @@ impl Game {
     ) {
         self.cheat_pad.poll_release(input_context);
 
-        if actions.just_triggered(InputAction::ToggleCheatPad) && self.cheats_are_allowed() {
+        if actions.just_triggered(InputAction::ToggleCheatPad) {
+            // Only *opening* is gated: a pad that is already up must always be
+            // closable by the same chord, whatever the gate says about it now.
             if self.cheat_pad.is_open() {
                 self.close_cheat_pad(false);
-            } else {
-                self.cheat_pad.open();
+            } else if self.cheats_are_allowed() {
+                self.open_cheat_pad();
             }
         }
 
@@ -1700,6 +1703,24 @@ impl Game {
         }
     }
 
+    /// Open the pad, taking the screen over from the flat metagame (Tab/MFD)
+    /// mode exactly as [`Self::open_pause_menu`] does - and for the same reason
+    /// on the Quest, where the first half of the `X`+`Y` chord fires `X`'s own
+    /// action and opens the cyber interface a frame before the pad appears.
+    fn open_cheat_pad(&mut self) {
+        let global_effects = self.active_game_scene.handle_effects(
+            vec![Effect::CloseUseMode],
+            &self.global_context,
+            &self.options,
+            &mut self.asset_cache,
+            &mut self.audio_context,
+        );
+        for effect in global_effects {
+            self.handle_global_effect(effect);
+        }
+        self.cheat_pad.open();
+    }
+
     fn close_cheat_pad(&mut self, after_click: bool) {
         if after_click {
             self.cheat_pad.close_after_click();
@@ -1719,6 +1740,12 @@ impl Game {
     }
 
     fn open_pause_menu(&mut self) {
+        // At most one overlay is up at a time. Without this the pause menu
+        // would open *behind* an already-open cheat pad - the pad's opaque
+        // backdrop drawn last, but the pause menu the only one consuming
+        // clicks - so the player would blind-press "Quit to Main Menu"
+        // through the panel they can actually see.
+        self.close_cheat_pad(false);
         // Taking over the screen suspends the flat metagame (Tab/MFD) mode, so
         // the player is not left with a cursor-driven overlay under the pause
         // panel. Effects reach a scene through `handle_effects`, which stays

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1678,16 +1678,13 @@ impl Game {
         );
         self.cheat_pad
             .pump_sfx(&mut self.asset_cache, &mut self.audio_context);
-        let Some(button) = clicked else {
-            return;
-        };
-        // The pad stays up across a rain (pressing both buttons is the common
-        // case); only "Done" closes it. `handle_effects` stays callable while
-        // the scene's `update` is skipped, which is how the spawn reaches a
-        // suspended world at all - the items hang until the world resumes and
-        // then fall.
-        match button.effect() {
-            Some(effect) => {
+        // The pad stays up across a rain (using more than one cheat is the
+        // common case); only "Done" closes it, and scrolling never gets here
+        // at all. `handle_effects` stays callable while the scene's `update`
+        // is skipped, which is how the spawn reaches a suspended world at all
+        // - the items hang until the world resumes and then fall.
+        match clicked {
+            Some(cheat_pad::CheatOutcome::Rain(effect)) => {
                 let global_effects = self.active_game_scene.handle_effects(
                     vec![effect],
                     &self.global_context,
@@ -1699,7 +1696,8 @@ impl Game {
                     self.handle_global_effect(effect);
                 }
             }
-            None => self.close_cheat_pad(true),
+            Some(cheat_pad::CheatOutcome::Close) => self.close_cheat_pad(true),
+            None => {}
         }
     }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -14,6 +14,7 @@ pub mod teleport;
 pub mod time;
 
 pub mod career;
+pub mod cheat_pad;
 pub mod creature;
 pub mod data_files;
 pub mod death_camera;
@@ -602,6 +603,11 @@ pub struct Game {
     /// so the paused scene keeps rendering while its update is skipped.
     pause_menu: pause_menu::PauseMenu,
 
+    /// The developer cheat pad, a second `Game`-owned overlay for the same
+    /// reasons the pause menu is one. Gated on the `cheats` developer
+    /// parameter; see [`cheat_pad`].
+    cheat_pad: cheat_pad::CheatPad,
+
     /// Wall-clock time spent with the simulation suspended, subtracted from the
     /// clock the scene sees. See [`Game::scene_time`].
     time_suspended: std::time::Duration,
@@ -1031,7 +1037,9 @@ impl Game {
     pub fn wants_pointer(&self) -> bool {
         // The pause menu is pointer-driven in flat presentation, and it is
         // drawn over scenes that otherwise capture the mouse for look.
-        self.pause_menu.is_open() || self.active_game_scene.wants_pointer()
+        self.pause_menu.is_open()
+            || self.cheat_pad.is_open()
+            || self.active_game_scene.wants_pointer()
     }
 
     /// Whether the in-game pause menu is up (and therefore the simulation is
@@ -1318,6 +1326,7 @@ impl Game {
             should_quit: false,
             campaign_completed: false,
             pause_menu: pause_menu::PauseMenu::new(),
+            cheat_pad: cheat_pad::CheatPad::new(),
             time_suspended: std::time::Duration::ZERO,
             hit_feedback: hit_feedback::HitFeedback::new(),
             head_pose: (
@@ -1394,7 +1403,12 @@ impl Game {
         // scene is not updated at all, so a scene-routed effect could never
         // close the menu again.
         self.update_pause_menu(time, input_context, actions);
-        if self.pause_menu.suspends_scene() {
+        // The cheat pad is a second Game-owned overlay, driven only while the
+        // pause menu is not (two stacked panels would both own the pointer).
+        if !self.pause_menu.suspends_scene() {
+            self.update_cheat_pad(time, input_context, actions);
+        }
+        if self.pause_menu.suspends_scene() || self.cheat_pad.suspends_scene() {
             // Paused: the scene is not updated (nothing simulates, and
             // `VirtualHand` is never advanced, so hands are inert but keep
             // whatever they were holding). It is still *rendered* every frame
@@ -1601,6 +1615,98 @@ impl Game {
             }
             None => {}
         }
+    }
+
+    /// Whether a `Game`-owned panel is covering the view. The scene's own
+    /// hands, viewmodel and HUD are dropped while one is, so they cannot draw
+    /// a second pair of hands inside the panel's or bleed through it.
+    fn overlay_is_open(&self) -> bool {
+        self.pause_menu.is_open() || self.cheat_pad.is_open()
+    }
+
+    /// Whether the cheat pad may open right now: the developer gate is on, the
+    /// scene is one that can be frozen, and - in VR only - the hand carrying
+    /// the opening chord is empty. Flat has no motion controllers, so
+    /// "an empty hand" has no meaning there and its key binding is
+    /// unambiguous on its own.
+    fn cheats_are_allowed(&self) -> bool {
+        if !dev_params::get_bool(dev_params::CHEATS) || !self.pause_is_allowed() {
+            return false;
+        }
+        self.options.presentation_mode != PresentationMode::Vr
+            || self
+                .active_game_scene
+                .hand_is_empty(vr_config::Handedness::Left)
+    }
+
+    /// Apply the cheat-pad toggle and, while open, drive the overlay.
+    fn update_cheat_pad(
+        &mut self,
+        time: &Time,
+        input_context: &input_context::InputContext,
+        actions: &input::InputActionState,
+    ) {
+        self.cheat_pad.poll_release(input_context);
+
+        if actions.just_triggered(InputAction::ToggleCheatPad) && self.cheats_are_allowed() {
+            if self.cheat_pad.is_open() {
+                self.close_cheat_pad(false);
+            } else {
+                self.cheat_pad.open();
+            }
+        }
+
+        if !self.cheat_pad.is_open() {
+            return;
+        }
+        // A pad that lost its gate mid-session (the option was switched off, a
+        // transition started, the player died) closes rather than stranding
+        // them on a panel over a screen that has taken over.
+        if !dev_params::get_bool(dev_params::CHEATS) || !self.pause_is_allowed() {
+            self.close_cheat_pad(false);
+            return;
+        }
+
+        let clicked = self.cheat_pad.update(
+            time.elapsed,
+            input_context,
+            &mut self.asset_cache,
+            &self.options,
+        );
+        self.cheat_pad
+            .pump_sfx(&mut self.asset_cache, &mut self.audio_context);
+        let Some(button) = clicked else {
+            return;
+        };
+        // The pad stays up across a rain (pressing both buttons is the common
+        // case); only "Done" closes it. `handle_effects` stays callable while
+        // the scene's `update` is skipped, which is how the spawn reaches a
+        // suspended world at all - the items hang until the world resumes and
+        // then fall.
+        match button.effect() {
+            Some(effect) => {
+                let global_effects = self.active_game_scene.handle_effects(
+                    vec![effect],
+                    &self.global_context,
+                    &self.options,
+                    &mut self.asset_cache,
+                    &mut self.audio_context,
+                );
+                for effect in global_effects {
+                    self.handle_global_effect(effect);
+                }
+            }
+            None => self.close_cheat_pad(true),
+        }
+    }
+
+    fn close_cheat_pad(&mut self, after_click: bool) {
+        if after_click {
+            self.cheat_pad.close_after_click();
+        } else {
+            self.cheat_pad.close();
+        }
+        self.cheat_pad.stop_sfx(&mut self.audio_context);
     }
 
     fn close_pause_menu(&mut self, after_click: bool) {
@@ -1984,7 +2090,7 @@ impl Game {
         // The lights belong to the hands: with the hands suppressed they would
         // be two pools cast by nothing - and, being world lighting, they light
         // the scene *before* the pause dim and show straight through it.
-        if self.pause_menu.is_open() {
+        if self.overlay_is_open() {
             return Vec::new();
         }
         self.active_game_scene.get_hand_spotlights(&self.options)
@@ -2093,7 +2199,7 @@ impl Game {
         // left latched when the menu closes. The same `is_open()` gate drops the
         // scene's screen-space UI in `render_per_eye`.
         // The same drop covers the death camera - see `player_visuals_hidden`.
-        if self.pause_menu.is_open() || self.player_visuals_hidden() {
+        if self.overlay_is_open() || self.player_visuals_hidden() {
             scene.retain(|object| {
                 object.debug_tag().and_then(|tag| tag.source.as_deref())
                     != Some(util::render_source::PLAYER_HANDS)
@@ -2167,13 +2273,18 @@ impl Game {
             scene.push(layer);
         }
 
-        let mut pause_objects =
+        let mut overlay_objects =
             self.pause_menu
                 .render(&mut self.asset_cache, &self.options, pawn_to_world);
-        for object in &mut pause_objects {
+        overlay_objects.extend(self.cheat_pad.render(
+            &mut self.asset_cache,
+            &self.options,
+            pawn_to_world,
+        ));
+        for object in &mut overlay_objects {
             object.set_render_layer(RenderLayer::SystemOverlay);
         }
-        scene.extend(pause_objects);
+        scene.extend(overlay_objects);
 
         // let font = File::open(resource_path("res/fonts/mainfont.FON")).unwrap();
         // let mut font_reader = BufReader::new(font);
@@ -2227,7 +2338,7 @@ impl Game {
         // with a gun welded to their face while the camera rolled onto the
         // floor - the two presentations diverging on exactly the beat this
         // feature exists for (AGENTS.md section 3).
-        let mut objs = if self.pause_menu.is_open() || self.player_visuals_hidden() {
+        let mut objs = if self.overlay_is_open() || self.player_visuals_hidden() {
             Vec::new()
         } else {
             self.active_game_scene.render_per_eye(
@@ -2244,13 +2355,18 @@ impl Game {
             }
         }
 
-        let mut pause_objects =
+        let mut overlay_objects =
             self.pause_menu
                 .render_per_eye(&mut self.asset_cache, screen_size, &self.options);
-        for object in &mut pause_objects {
+        overlay_objects.extend(self.cheat_pad.render_per_eye(
+            &mut self.asset_cache,
+            screen_size,
+            &self.options,
+        ));
+        for object in &mut overlay_objects {
             object.set_render_layer(RenderLayer::SystemOverlay);
         }
-        objs.extend(pause_objects);
+        objs.extend(overlay_objects);
 
         let world_position = vec3(0.0, 1.0, 0.0);
         let screen_width = screen_size.x;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -123,9 +123,11 @@ pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
 
 /// Where `Effect::RainItems` puts its spawns: a ring of this radius, this far
-/// above the player's feet. Wide enough that neighbours do not start
-/// interpenetrating (which the solver resolves by flinging them apart), low
-/// enough to stay under an ordinary ceiling.
+/// above the player's origin - both in **world** units, not the pre-scale SS2
+/// units the neighbouring spawn handlers divide by `SCALE_FACTOR`. Wide enough
+/// that neighbours do not start interpenetrating (which the solver resolves by
+/// flinging them apart), low enough to stay under an ordinary ceiling. A spawn
+/// that still lands inside geometry is simply ejected by the solver.
 const RAIN_RADIUS: f32 = 0.8;
 const RAIN_HEIGHT: f32 = 2.5;
 
@@ -7584,7 +7586,7 @@ impl MissionCore {
                     // (which would fling them apart), and high enough that
                     // they visibly fall. Deterministic, not random - a capture
                     // or an e2e assertion must be able to repeat the layout.
-                    let count = template_ids.len().max(1) as f32;
+                    let count = template_ids.len() as f32;
                     for (index, template_id) in template_ids.iter().enumerate() {
                         let angle = std::f32::consts::TAU * index as f32 / count;
                         let offset = vec3(
@@ -8757,6 +8759,19 @@ impl MissionCore {
 
     /// Actual crouch state of the player collider (stand-up can be refused
     /// for lack of headroom, so this can lag the crouch input).
+    /// Whether the given VR hand is holding nothing. See
+    /// [`crate::game_scene::GameScene::hand_is_empty`]; inherent so the
+    /// `Mission` / `DebugScene` wrappers can delegate to it (without this they
+    /// silently keep the trait default, which would leave the cheat pad's
+    /// empty-hand gate inert everywhere `Game` actually runs).
+    pub fn hand_is_empty(&self, hand: crate::vr_config::Handedness) -> bool {
+        let (left, right) = self.interaction.held_entities();
+        match hand {
+            crate::vr_config::Handedness::Left => left.is_none(),
+            crate::vr_config::Handedness::Right => right.is_none(),
+        }
+    }
+
     pub fn player_is_crouched(&self) -> bool {
         self.player_handle.is_crouched()
     }
@@ -12436,10 +12451,6 @@ impl crate::game_scene::GameScene for MissionCore {
     }
 
     fn hand_is_empty(&self, hand: crate::vr_config::Handedness) -> bool {
-        let (left, right) = self.interaction.held_entities();
-        match hand {
-            crate::vr_config::Handedness::Left => left.is_none(),
-            crate::vr_config::Handedness::Right => right.is_none(),
-        }
+        self.hand_is_empty(hand)
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -122,6 +122,13 @@ pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 /// trimesh (see `spawn_ragdoll`).
 const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
 
+/// Where `Effect::RainItems` puts its spawns: a ring of this radius, this far
+/// above the player's feet. Wide enough that neighbours do not start
+/// interpenetrating (which the solver resolves by flinging them apart), low
+/// enough to stay under an ordinary ceiling.
+const RAIN_RADIUS: f32 = 0.8;
+const RAIN_HEIGHT: f32 = 2.5;
+
 /// Resolve optional media-reader portrait/icon art before it becomes a shared
 /// UI image. STR tables author extension-less PCX-era names, while replacement
 /// layers may provide the same art under a modern encoding (SCP's Earth
@@ -7567,6 +7574,34 @@ impl MissionCore {
                         self.process_virtual_hand_effects(asset_cache, msgs);
                     }
                 }
+                Effect::RainItems { template_ids } => {
+                    let (pos, rot) = {
+                        let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+                        (vec3_to_point3(player.pos), player.rotation)
+                    };
+                    // A ring above head height, one item per slot: spread out
+                    // so the spawns do not interpenetrate on the first step
+                    // (which would fling them apart), and high enough that
+                    // they visibly fall. Deterministic, not random - a capture
+                    // or an e2e assertion must be able to repeat the layout.
+                    let count = template_ids.len().max(1) as f32;
+                    for (index, template_id) in template_ids.iter().enumerate() {
+                        let angle = std::f32::consts::TAU * index as f32 / count;
+                        let offset = vec3(
+                            RAIN_RADIUS * angle.cos(),
+                            RAIN_HEIGHT,
+                            RAIN_RADIUS * angle.sin(),
+                        );
+                        self.create_entity_with_position(
+                            asset_cache,
+                            *template_id,
+                            pos + offset,
+                            rot,
+                            Matrix4::identity(),
+                            CreateEntityOptions::default(),
+                        );
+                    }
+                }
                 Effect::DebugCycleWeapon { head_rotation } => {
                     // The SS2 player-weapon roster (templates with PropPlayerGun),
                     // cycled for flat-mode aim/viewmodel testing.
@@ -12398,5 +12433,13 @@ impl crate::game_scene::GameScene for MissionCore {
 
     fn wants_pointer(&self) -> bool {
         self.wants_pointer()
+    }
+
+    fn hand_is_empty(&self, hand: crate::vr_config::Handedness) -> bool {
+        let (left, right) = self.interaction.held_entities();
+        match hand {
+            crate::vr_config::Handedness::Left => left.is_none(),
+            crate::vr_config::Handedness::Right => right.is_none(),
+        }
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -122,14 +122,18 @@ pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 /// trimesh (see `spawn_ragdoll`).
 const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
 
-/// Where `Effect::RainItems` puts its spawns: a ring of this radius, this far
-/// above the player's origin - both in **world** units, not the pre-scale SS2
-/// units the neighbouring spawn handlers divide by `SCALE_FACTOR`. Wide enough
-/// that neighbours do not start interpenetrating (which the solver resolves by
-/// flinging them apart), low enough to stay under an ordinary ceiling. A spawn
-/// that still lands inside geometry is simply ejected by the solver.
-const RAIN_RADIUS: f32 = 0.8;
-const RAIN_HEIGHT: f32 = 2.5;
+/// Where `Effect::RainItems` puts its spawns, relative to the player's body
+/// ORIGIN (which is the capsule centre, three feet off the floor - not the
+/// feet). Written in SS2 feet over `SCALE_FACTOR`, like the spawn handlers
+/// beside it, because the profile these clear is authored in feet: the
+/// standing capsule's crown is 3 ft above the origin and its radius is 1.2 ft.
+///
+/// So the ring drops items from just over head height, at arm's length: high
+/// enough to fall visibly and to miss the player, low enough to stay under a
+/// corridor ceiling. Height was 6.25 ft here at first and the rain landed on
+/// top of the ceiling geometry instead of reaching the player.
+const RAIN_RADIUS: f32 = 2.0 / SCALE_FACTOR;
+const RAIN_HEIGHT: f32 = 3.5 / SCALE_FACTOR;
 
 /// Resolve optional media-reader portrait/icon art before it becomes a shared
 /// UI image. STR tables author extension-less PCX-era names, while replacement

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -262,6 +262,10 @@ impl crate::game_scene::GameScene for Mission {
         self.mission_core.wants_pointer()
     }
 
+    fn hand_is_empty(&self, hand: crate::vr_config::Handedness) -> bool {
+        self.mission_core.hand_is_empty(hand)
+    }
+
     fn player_is_crouched(&self) -> bool {
         self.mission_core.player_is_crouched()
     }

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -267,6 +267,10 @@ impl GameScene for DebugScene {
         self.core.queue_entity_trigger(entity_name)
     }
 
+    fn hand_is_empty(&self, hand: crate::vr_config::Handedness) -> bool {
+        self.core.hand_is_empty(hand)
+    }
+
     fn player_is_crouched(&self) -> bool {
         self.core.player_is_crouched()
     }
@@ -497,6 +501,10 @@ impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
 
     fn queue_entity_trigger(&mut self, entity_name: String) {
         self.core.queue_entity_trigger(entity_name)
+    }
+
+    fn hand_is_empty(&self, hand: crate::vr_config::Handedness) -> bool {
+        self.core.hand_is_empty(hand)
     }
 
     fn player_is_crouched(&self) -> bool {

--- a/shock2vr/src/scenes/developer.rs
+++ b/shock2vr/src/scenes/developer.rs
@@ -173,31 +173,23 @@ fn scene_count() -> usize {
     super::debug_scene_names().count()
 }
 
-fn scene_rows_per_page(rects: PanelRects) -> usize {
-    list_scroll::rows_per_page(rects.list_rect(), FIELD_TOP_Y, SCENE_ROW_H)
+/// The launcher list's geometry - paging, the gutter rocker and the
+/// slot-to-entry mapping - shared with every other frontend list.
+fn scene_list(rects: PanelRects) -> list_scroll::ListGeometry {
+    list_scroll::ListGeometry {
+        pane: rects.list_rect(),
+        bottom_limit: FIELD_TOP_Y,
+        row_h: SCENE_ROW_H,
+        text_inset: SCENE_TEXT_INSET,
+    }
 }
 
-fn scene_max_scroll(rects: PanelRects, len: usize) -> usize {
-    list_scroll::max_scroll(len, scene_rows_per_page(rects))
-}
-
-/// The list indices on screen at `scene_scroll`, clamped to the page.
 fn scene_visible_rows(
     rects: PanelRects,
     len: usize,
     scene_scroll: usize,
 ) -> std::ops::Range<usize> {
-    list_scroll::visible_rows(len, scene_rows_per_page(rects), scene_scroll)
-}
-
-/// The launcher's scroll rocker, in the gutter down the pane's right edge -
-/// the very same one the parameter page scrolls with.
-fn scene_rocker(rects: PanelRects, len: usize) -> Option<list_scroll::Rocker> {
-    list_scroll::rocker(
-        rects.list_rect(),
-        FIELD_TOP_Y,
-        scene_max_scroll(rects, len) > 0,
-    )
+    scene_list(rects).visible_rows(len, scene_scroll)
 }
 
 /// The canvas rect of the tab header for `tab`: the header rect split in two,
@@ -212,33 +204,16 @@ fn tab_rect(rects: PanelRects, tab: SceneTab) -> Rect {
     Rect::new(x, header.y, half, header.h)
 }
 
-/// The canvas rect of the launcher's `slot`-th visible row. The rows stop
-/// short of the scroll gutter whenever it is in use, so a row and the rocker
-/// can never claim the same point.
+/// The canvas rect of the launcher's `slot`-th visible row. Production code
+/// reaches rows through `scene_list(..).hit(..)`; the tests still name them.
+#[cfg(test)]
 fn scene_row_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
-    let list = rects.list_rect();
-    let gutter = if scene_max_scroll(rects, len) > 0 {
-        list_scroll::GUTTER_W
-    } else {
-        0.0
-    };
-    Rect::new(
-        list.x,
-        list.y + slot as f32 * SCENE_ROW_H,
-        (list.w - gutter).max(0.0),
-        SCENE_ROW_H,
-    )
+    scene_list(rects).row_rect(len, slot)
 }
 
 /// The rect a row's name is drawn in: the row, inset on both edges.
 fn scene_text_rect(rects: PanelRects, len: usize, slot: usize) -> Rect {
-    let row = scene_row_rect(rects, len, slot);
-    Rect::new(
-        row.x + SCENE_TEXT_INSET,
-        row.y,
-        (row.w - 2.0 * SCENE_TEXT_INSET).max(0.0),
-        row.h,
-    )
+    scene_list(rects).text_rect(len, slot)
 }
 
 /// What is at a canvas point, on whichever page is showing. Shared by the
@@ -267,23 +242,14 @@ fn hit(state: ScreenState, point: Vector2<f32>) -> Option<DeveloperAction> {
             if state.rects.done_rect().contains(point) {
                 return Some(DeveloperAction::CloseScenes);
             }
-            let rows = scene_visible_rows(state.rects, state.list_len, state.scene_scroll);
-            if let Some(rocker) = scene_rocker(state.rects, state.list_len) {
-                if let Some(half) = list_scroll::hit(
-                    &rocker,
-                    rows.start,
-                    scene_max_scroll(state.rects, state.list_len),
-                    point,
-                ) {
-                    return Some(DeveloperAction::ScrollScenes(half));
-                }
-            }
             // Rows carry the index of the entry scrolled into that slot, never
             // the slot itself: a positional index would launch whatever entry
-            // *used* to be in the row the moment the list scrolls.
-            (0..rows.len())
-                .find(|slot| scene_row_rect(state.rects, state.list_len, *slot).contains(point))
-                .map(|slot| DeveloperAction::SelectScene(rows.start + slot))
+            // *used* to be in the row the moment the list scrolls. That rule,
+            // and the inert-rocker-end one, live in `list_scroll`.
+            match scene_list(state.rects).hit(state.list_len, state.scene_scroll, point)? {
+                list_scroll::ListHit::Row(index) => Some(DeveloperAction::SelectScene(index)),
+                list_scroll::ListHit::Scroll(half) => Some(DeveloperAction::ScrollScenes(half)),
+            }
         }
     }
 }
@@ -485,12 +451,12 @@ impl DeveloperScene {
                         });
                 }
 
-                if let Some(rocker) = scene_rocker(self.panel_rects, len) {
+                if let Some(rocker) = scene_list(self.panel_rects).rocker(len) {
                     list_scroll::draw(
                         &mut canvas,
                         &rocker,
                         rows.start,
-                        scene_max_scroll(self.panel_rects, len),
+                        scene_list(self.panel_rects).max_scroll(len),
                         match hovered {
                             Some(DeveloperAction::ScrollScenes(half)) => Some(half),
                             _ => None,
@@ -544,7 +510,7 @@ impl DeveloperScene {
             }
             DeveloperAction::SelectScene(index) => self.selected_scene = Some(index),
             DeveloperAction::ScrollScenes(half) => {
-                let max = scene_max_scroll(self.panel_rects, self.tab_list_len());
+                let max = scene_list(self.panel_rects).max_scroll(self.tab_list_len());
                 list_scroll::apply(half, &mut self.scene_scroll, max)
             }
             DeveloperAction::LaunchScene => {
@@ -1082,7 +1048,7 @@ mod tests {
     fn the_launcher_hit_test_follows_its_scroll() {
         let rects = PanelRects::default();
         let len = scene_count();
-        let max = scene_max_scroll(rects, len);
+        let max = scene_list(rects).max_scroll(len);
         assert!(max > 0, "the shipped scene list must scroll to test this");
         for scroll in 1..=max {
             let slot0 = scene_row_rect(rects, len, 0);
@@ -1098,8 +1064,10 @@ mod tests {
     fn the_launchers_rocker_scrolls_and_stops_at_both_ends() {
         let rects = PanelRects::default();
         let len = scene_count();
-        let rocker = scene_rocker(rects, len).expect("the shipped scene list scrolls");
-        let max = scene_max_scroll(rects, len);
+        let rocker = scene_list(rects)
+            .rocker(len)
+            .expect("the shipped scene list scrolls");
+        let max = scene_list(rects).max_scroll(len);
 
         // At the top the up half is inert; at the bottom, the down half is.
         assert_eq!(hit(scenes_state(0, true, len), rocker.up.center()), None);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -832,6 +832,13 @@ pub enum Effect {
         auto_wield: bool,
     },
 
+    /// Developer cheat: rain a spread of template instances down around the
+    /// player, one per id, so they fall and settle as ordinary world pickups.
+    /// Player position is resolved by the effect handler.
+    RainItems {
+        template_ids: Vec<i32>,
+    },
+
     /// Debug: spawn the next player weapon in front of the player and wield it
     /// as the flat viewmodel (holstering the previously wielded one). Cycles
     /// the SS2 weapon roster for aim/viewmodel testing.

--- a/shock2vr/src/ui/dev_params_panel.rs
+++ b/shock2vr/src/ui/dev_params_panel.rs
@@ -225,17 +225,30 @@ fn row_rects(rects: PanelRects, index: usize) -> RowRects {
     }
 }
 
+/// This page's list geometry - the paging and the gutter rocker every other
+/// frontend list uses, at the parameter rows' own pitch. The rows themselves
+/// are built by [`row_rects`] rather than the shared `row_rect`, because a
+/// parameter row is not one target but four columns (label, `<`, value, `>`).
+fn list(rects: PanelRects) -> list_scroll::ListGeometry {
+    list_scroll::ListGeometry {
+        pane: rects.list,
+        bottom_limit: FIELD_TOP_Y,
+        row_h: ROW_PITCH,
+        text_inset: TEXT_INSET,
+    }
+}
+
 /// How many rows fit in the pane above the backdrop's painted field - the
 /// size of one page of the list, however long the registry is.
 fn rows_per_page(rects: PanelRects) -> usize {
-    list_scroll::rows_per_page(rects.list, FIELD_TOP_Y, ROW_PITCH)
+    list(rects).rows_per_page()
 }
 
 /// The furthest the list can scroll: the first-row index that puts the tail
 /// of the registry against the bottom of the pane. Zero when everything fits
 /// at once, which is also what hides the scroll rocker.
 fn max_scroll(rects: PanelRects) -> usize {
-    list_scroll::max_scroll(dev_params::PARAMS.len(), rows_per_page(rects))
+    list(rects).max_scroll(dev_params::PARAMS.len())
 }
 
 /// The registry indices on screen at `scroll`, with `scroll` clamped to what
@@ -246,7 +259,7 @@ fn max_scroll(rects: PanelRects) -> usize {
 /// *step* another's - the failure a positional row index invites the moment
 /// the list scrolls.
 fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
-    list_scroll::visible_rows(dev_params::PARAMS.len(), rows_per_page(rects), scroll)
+    list(rects).visible_rows(dev_params::PARAMS.len(), scroll)
 }
 
 /// The scroll rocker's two halves - up and down arrows - in a gutter down the
@@ -259,7 +272,7 @@ fn visible_rows(rects: PanelRects, scroll: usize) -> Range<usize> {
 /// anyway - a scrollbar's place is beside what it scrolls, not across the
 /// screen from it.
 fn rocker(rects: PanelRects) -> Option<list_scroll::Rocker> {
-    list_scroll::rocker(rects.list, FIELD_TOP_Y, max_scroll(rects) > 0)
+    list(rects).rocker(dev_params::PARAMS.len())
 }
 
 #[cfg(test)]

--- a/shock2vr/src/ui/list_scroll.rs
+++ b/shock2vr/src/ui/list_scroll.rs
@@ -135,10 +135,106 @@ pub fn hit(
 }
 
 /// Move `scroll` by one row, stopping at either end.
+///
+/// The offset is clamped into range *before* it moves, so an offset left over
+/// from a longer list (or a taller pane) does not need several dead `Up`
+/// clicks to unstick: the display already clamps via [`visible_rows`], and
+/// this keeps the stored offset agreeing with what is drawn.
 pub fn apply(half: ScrollHalf, scroll: &mut usize, max_scroll: usize) {
+    *scroll = (*scroll).min(max_scroll);
     match half {
         ScrollHalf::Up => *scroll = scroll.saturating_sub(1),
         ScrollHalf::Down => *scroll = (*scroll + 1).min(max_scroll),
+    }
+}
+
+/// What a point on a list pane landed on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ListHit {
+    /// The item index scrolled into the row under the point - never the row's
+    /// own slot, which would act on whatever *used* to sit there.
+    Row(usize),
+    Scroll(ScrollHalf),
+}
+
+/// One list pane's geometry: everything a screen needs to turn "a pane, a row
+/// height and a number of items" into rows, a rocker and a hit test.
+///
+/// The primitives above are shared; this is the *composition* of them, which
+/// was written out once per screen until three lists had their own copy. A
+/// screen now states its pane and its pitch and gets the same paging, the same
+/// gutter, and the same slot-to-index mapping as every other list.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ListGeometry {
+    /// The pane the rows live in, from the backdrop's authored layout.
+    pub pane: Rect,
+    /// The y the rows must stop at - where the backdrop starts painting
+    /// something they have to clear.
+    pub bottom_limit: f32,
+    /// Distance between row tops, and each row's height.
+    pub row_h: f32,
+    /// Horizontal inset of a row's text from the row.
+    pub text_inset: f32,
+}
+
+impl ListGeometry {
+    pub fn rows_per_page(&self) -> usize {
+        rows_per_page(self.pane, self.bottom_limit, self.row_h)
+    }
+
+    pub fn max_scroll(&self, len: usize) -> usize {
+        max_scroll(len, self.rows_per_page())
+    }
+
+    pub fn visible_rows(&self, len: usize, scroll: usize) -> Range<usize> {
+        visible_rows(len, self.rows_per_page(), scroll)
+    }
+
+    pub fn rocker(&self, len: usize) -> Option<Rocker> {
+        rocker(self.pane, self.bottom_limit, self.max_scroll(len) > 0)
+    }
+
+    /// The `slot`-th visible row. Rows stop short of the scroll gutter exactly
+    /// when [`Self::rocker`] is `Some` - the same expression decides both, so a
+    /// row and the rocker can never claim the same point.
+    pub fn row_rect(&self, len: usize, slot: usize) -> Rect {
+        let gutter = if self.max_scroll(len) > 0 {
+            GUTTER_W
+        } else {
+            0.0
+        };
+        Rect::new(
+            self.pane.x,
+            self.pane.y + slot as f32 * self.row_h,
+            (self.pane.w - gutter).max(0.0),
+            self.row_h,
+        )
+    }
+
+    /// The rect a row's text is drawn in: the row, inset on both edges.
+    pub fn text_rect(&self, len: usize, slot: usize) -> Rect {
+        let row = self.row_rect(len, slot);
+        Rect::new(
+            row.x + self.text_inset,
+            row.y,
+            (row.w - 2.0 * self.text_inset).max(0.0),
+            row.h,
+        )
+    }
+
+    /// What is at a canvas point: a row's item index, a live rocker half, or
+    /// nothing. The rocker is tested first, and a half that cannot move is
+    /// inert rather than falling through to the row beneath it.
+    pub fn hit(&self, len: usize, scroll: usize, point: Vector2<f32>) -> Option<ListHit> {
+        let rows = self.visible_rows(len, scroll);
+        if let Some(rocker) = self.rocker(len) {
+            if let Some(half) = hit(&rocker, rows.start, self.max_scroll(len), point) {
+                return Some(ListHit::Scroll(half));
+            }
+        }
+        (0..rows.len())
+            .find(|slot| self.row_rect(len, *slot).contains(point))
+            .map(|slot| ListHit::Row(rows.start + slot))
     }
 }
 
@@ -241,6 +337,74 @@ mod tests {
         assert_eq!(art_for(&UP_ART, false, false), "BUP_DOWN.PCX");
         assert_eq!(art_for(&UP_ART, false, true), "BUP_DOWN.PCX");
         assert_eq!(art_for(&DOWN_ART, false, true), "BDN_DOWN.PCX");
+    }
+
+    const GEOMETRY: ListGeometry = ListGeometry {
+        pane: LIST,
+        bottom_limit: FIELD_TOP_Y,
+        row_h: 19.0,
+        text_inset: 8.0,
+    };
+
+    /// The composition every list shares: rows page, the gutter appears with
+    /// the rocker, and a row reports the item scrolled into it.
+    #[test]
+    fn the_geometry_maps_slots_to_the_scrolled_item() {
+        let short = GEOMETRY.rows_per_page() - 1;
+        let long = GEOMETRY.rows_per_page() + 5;
+
+        // A list that fits: no rocker, and rows span the full pane.
+        assert!(GEOMETRY.rocker(short).is_none());
+        assert_eq!(GEOMETRY.row_rect(short, 0).w, LIST.w);
+        assert_eq!(
+            GEOMETRY.hit(short, 0, GEOMETRY.row_rect(short, 0).center()),
+            Some(ListHit::Row(0))
+        );
+
+        // A list that does not: the rows make room for the gutter...
+        assert!(GEOMETRY.rocker(long).is_some());
+        assert_eq!(GEOMETRY.row_rect(long, 0).w, LIST.w - GUTTER_W);
+        // ...the top row follows the offset...
+        assert_eq!(
+            GEOMETRY.hit(long, 3, GEOMETRY.row_rect(long, 0).center()),
+            Some(ListHit::Row(3))
+        );
+        // ...an over-scroll clamps rather than walking off the end...
+        assert_eq!(
+            GEOMETRY.hit(long, 99, GEOMETRY.row_rect(long, 0).center()),
+            Some(ListHit::Row(GEOMETRY.max_scroll(long)))
+        );
+        // ...and the rocker takes its own gutter, with inert ends.
+        let rocker = GEOMETRY.rocker(long).unwrap();
+        assert_eq!(
+            GEOMETRY.hit(long, 0, rocker.down.center()),
+            Some(ListHit::Scroll(ScrollHalf::Down))
+        );
+        assert_eq!(GEOMETRY.hit(long, 0, rocker.up.center()), None);
+    }
+
+    /// Every row of a full page clears the painted field, not just the pane.
+    #[test]
+    fn a_full_page_of_rows_stays_above_the_field() {
+        let len = GEOMETRY.rows_per_page() + 5;
+        for slot in 0..GEOMETRY.rows_per_page() {
+            let row = GEOMETRY.row_rect(len, slot);
+            assert!(row.y >= LIST.y, "{row:?}");
+            assert!(row.y + row.h <= FIELD_TOP_Y, "slot {slot}: {row:?}");
+        }
+    }
+
+    /// An offset stranded past the end (a shorter list, a shallower pane)
+    /// must not need dead clicks to unstick.
+    #[test]
+    fn an_over_scroll_is_clamped_before_it_moves() {
+        let mut scroll = 40;
+        apply(ScrollHalf::Up, &mut scroll, 5);
+        assert_eq!(scroll, 4, "one Up from a stranded offset must move a row");
+
+        let mut scroll = 40;
+        apply(ScrollHalf::Down, &mut scroll, 5);
+        assert_eq!(scroll, 5);
     }
 
     #[test]

--- a/tools/shock2-sdk/test/cheat-pad.e2e.test.ts
+++ b/tools/shock2-sdk/test/cheat-pad.e2e.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// The developer cheat pad (`shock2vr::cheat_pad`) is a Game-owned overlay
+// gated on the `cheats` dev param. Two buttons rain items around the player.
+//
+// Negative-first: with the gate off, the open action and every click that
+// follows it must do nothing at all - which is the first half of this test,
+// and which fails against a build that opens the pad unconditionally.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+// The pad rides the Developer page's authored widget rects (GAMELODR.BIN,
+// fallback list pane 261,54,202,290 and Done 527,405,95,62), with 40px rows
+// inset 8px on a 56px pitch - see `cheat_pad::button_rect`.
+const row = (index: number): [number, number] => [
+  (261 + 202 / 2) / CANVAS_W,
+  (54 + 8 + index * 56 + 40 / 2) / CANVAS_H,
+];
+const RAIN_WEAPONS = row(0);
+const RAIN_MODULES = row(1);
+const DONE: [number, number] = [(527 + 95 / 2) / CANVAS_W, (405 + 62 / 2) / CANVAS_H];
+
+/** Click a canvas point with the flat pointer, as a real rising edge. */
+async function click(game: GameServer, [u, v]: [number, number]): Promise<void> {
+  await game.input.set("pointer.position", [u, v]);
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 3 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 3 });
+}
+
+async function count(game: GameServer, filter: string): Promise<number> {
+  return (await game.entities.list({ filter, limit: 200 })).entities.length;
+}
+
+test(
+  "the cheat pad is unreachable until the cheats option is on, then rains items",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 30 });
+
+    const { params } = await game.devParams.list();
+    const cheats = params.find((p) => p.key === "cheats");
+    assert.ok(cheats, "the `cheats` gate must be registered");
+    assert.equal(cheats.kind, "bool");
+    assert.equal(cheats.value, 0, "cheats must be off by default");
+
+    const wrenchesBefore = await count(game, "Wrench");
+    const modulesBefore = await count(game, "EXP");
+    const nanitesBefore = await count(game, "Nanites");
+
+    // NEGATIVE: gate off. The action is accepted by HTTP but must be inert,
+    // so a click where the button would be changes nothing in the world.
+    await game.input.trigger("ToggleCheatPad");
+    await game.step({ frames: 5 });
+    await click(game, RAIN_WEAPONS);
+    assert.equal(
+      await count(game, "Wrench"),
+      wrenchesBefore,
+      "an ungated cheat pad must not rain anything",
+    );
+
+    // Gate on: now the pad opens and its buttons work.
+    await game.devParams.set("cheats", 1);
+    await game.input.trigger("ToggleCheatPad");
+    await game.step({ frames: 5 });
+
+    await click(game, RAIN_WEAPONS);
+    const wrenchesAfter = await count(game, "Wrench");
+    assert.ok(
+      wrenchesAfter > wrenchesBefore,
+      `rain weapons should have added a wrench (${wrenchesBefore} -> ${wrenchesAfter})`,
+    );
+
+    // The rained weapon is a real dynamic pickup: it owns a physics body,
+    // and once the pad closes and the world runs again it settles.
+    const wrench = (await game.entities.list({ filter: "Wrench", limit: 200 })).entities
+      .filter((e) => e.template_id === -928)
+      .at(0);
+    assert.ok(wrench, "the rained wrench should be the -928 template");
+    const spawned = await game.physics.bodies({ entityId: wrench.id });
+    assert.ok(spawned.bodies.length > 0, "a rained item should own a physics body");
+    assert.equal(spawned.bodies[0].body_type, "dynamic");
+
+    await click(game, DONE);
+    await game.step({ frames: 180 });
+    const settled = (await game.physics.bodies({ entityId: wrench.id })).bodies[0];
+    const speed = Math.hypot(...settled.velocity);
+    assert.ok(speed < 0.5, `the rained wrench should have settled, moving at ${speed}`);
+
+    // Reopening reaches the second button, which rains a different spread.
+    await game.input.trigger("ToggleCheatPad");
+    await game.step({ frames: 5 });
+    await click(game, RAIN_MODULES);
+    assert.equal(
+      await count(game, "EXP"),
+      modulesBefore + 4,
+      "rain modules should have added four cyber-module stacks",
+    );
+    assert.equal(
+      await count(game, "Nanites"),
+      nanitesBefore + 4,
+      "rain modules should have added four nanite piles",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/cheat-pad.e2e.test.ts
+++ b/tools/shock2-sdk/test/cheat-pad.e2e.test.ts
@@ -2,31 +2,29 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { norm } from "./helpers/frontend-menu.js";
 
 // The developer cheat pad (`shock2vr::cheat_pad`) is a Game-owned overlay
 // gated on the `cheats` dev param. Two buttons rain items around the player.
 //
 // Negative-first: with the gate off, the open action and every click that
-// follows it must do nothing at all - which is the first half of this test,
-// and which fails against a build that opens the pad unconditionally.
+// follows it must do nothing at all - which is the first half of this test.
+// Verified by removing both gate checks: the test then fails.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-const CANVAS_W = 640;
-const CANVAS_H = 480;
-// The pad rides the Developer page's authored widget rects (GAMELODR.BIN,
-// fallback list pane 261,54,202,290 and Done 527,405,95,62), with 40px rows
-// inset 8px on a 56px pitch - see `cheat_pad::button_rect`.
-const row = (index: number): [number, number] => [
-  (261 + 202 / 2) / CANVAS_W,
-  (54 + 8 + index * 56 + 40 / 2) / CANVAS_H,
-];
+// The pad rides the Developer page's authored widget rects (GAMELODR.BIN:
+// list pane 261,54 202x290 and Done 527,405 95x62), with 40px rows inset 8px
+// on a 56px pitch - see `cheat_pad::button_rect`.
+const row = (index: number): [number, number] => [261 + 202 / 2, 54 + 8 + index * 56 + 40 / 2];
 const RAIN_WEAPONS = row(0);
 const RAIN_MODULES = row(1);
-const DONE: [number, number] = [(527 + 95 / 2) / CANVAS_W, (405 + 62 / 2) / CANVAS_H];
+const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];
+/** SIMR.BIN pause entries: five 179x76 buttons at x=400, top 20, 92px pitch. */
+const PAUSE_CONTINUE: [number, number] = [400 + 179 / 2, 20 + 76 / 2];
 
 /** Click a canvas point with the flat pointer, as a real rising edge. */
-async function click(game: GameServer, [u, v]: [number, number]): Promise<void> {
-  await game.input.set("pointer.position", [u, v]);
+async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
+  await game.input.set("pointer.position", norm(x, y));
   await game.input.set("pointer.pressed", 0);
   await game.step({ frames: 3 });
   await game.input.set("pointer.pressed", 1);
@@ -35,8 +33,9 @@ async function click(game: GameServer, [u, v]: [number, number]): Promise<void> 
   await game.step({ frames: 3 });
 }
 
-async function count(game: GameServer, filter: string): Promise<number> {
-  return (await game.entities.list({ filter, limit: 200 })).entities.length;
+async function ids(game: GameServer, filter: string): Promise<Set<number>> {
+  const { entities } = await game.entities.list({ filter, limit: 200 });
+  return new Set(entities.map((e) => e.id));
 }
 
 test(
@@ -52,9 +51,9 @@ test(
     assert.equal(cheats.kind, "bool");
     assert.equal(cheats.value, 0, "cheats must be off by default");
 
-    const wrenchesBefore = await count(game, "Wrench");
-    const modulesBefore = await count(game, "EXP");
-    const nanitesBefore = await count(game, "Nanites");
+    const wrenchesBefore = await ids(game, "Wrench");
+    const modulesBefore = (await ids(game, "EXP")).size;
+    const nanitesBefore = (await ids(game, "Nanites")).size;
 
     // NEGATIVE: gate off. The action is accepted by HTTP but must be inert,
     // so a click where the button would be changes nothing in the world.
@@ -62,8 +61,8 @@ test(
     await game.step({ frames: 5 });
     await click(game, RAIN_WEAPONS);
     assert.equal(
-      await count(game, "Wrench"),
-      wrenchesBefore,
+      (await ids(game, "Wrench")).size,
+      wrenchesBefore.size,
       "an ungated cheat pad must not rain anything",
     );
 
@@ -71,27 +70,25 @@ test(
     await game.devParams.set("cheats", 1);
     await game.input.trigger("ToggleCheatPad");
     await game.step({ frames: 5 });
-
-    await click(game, RAIN_WEAPONS);
-    const wrenchesAfter = await count(game, "Wrench");
-    assert.ok(
-      wrenchesAfter > wrenchesBefore,
-      `rain weapons should have added a wrench (${wrenchesBefore} -> ${wrenchesAfter})`,
+    assert.equal(
+      (await game.info()).paused,
+      true,
+      "an open cheat pad suspends the scene, so automation must see it as paused",
     );
 
-    // The rained weapon is a real dynamic pickup: it owns a physics body,
-    // and once the pad closes and the world runs again it settles.
-    const wrench = (await game.entities.list({ filter: "Wrench", limit: 200 })).entities
-      .filter((e) => e.template_id === -928)
-      .at(0);
-    assert.ok(wrench, "the rained wrench should be the -928 template");
-    const spawned = await game.physics.bodies({ entityId: wrench.id });
-    assert.ok(spawned.bodies.length > 0, "a rained item should own a physics body");
-    assert.equal(spawned.bodies[0].body_type, "dynamic");
+    await click(game, RAIN_WEAPONS);
+    const rained = [...(await ids(game, "Wrench"))].filter((id) => !wrenchesBefore.has(id));
+    assert.equal(rained.length, 1, `rain weapons should have added exactly one wrench`);
+
+    // The rained weapon is a real dynamic pickup: it owns a physics body, and
+    // once the pad closes and the world runs again it settles.
+    const { bodies } = await game.physics.bodies({ entityId: rained[0] });
+    assert.ok(bodies.length > 0, "a rained item should own a physics body");
+    assert.equal(bodies[0].body_type, "dynamic");
 
     await click(game, DONE);
     await game.step({ frames: 180 });
-    const settled = (await game.physics.bodies({ entityId: wrench.id })).bodies[0];
+    const settled = (await game.physics.bodies({ entityId: rained[0] })).bodies[0];
     const speed = Math.hypot(...settled.velocity);
     assert.ok(speed < 0.5, `the rained wrench should have settled, moving at ${speed}`);
 
@@ -100,14 +97,32 @@ test(
     await game.step({ frames: 5 });
     await click(game, RAIN_MODULES);
     assert.equal(
-      await count(game, "EXP"),
+      (await ids(game, "EXP")).size,
       modulesBefore + 4,
       "rain modules should have added four cyber-module stacks",
     );
     assert.equal(
-      await count(game, "Nanites"),
+      (await ids(game, "Nanites")).size,
       nanitesBefore + 4,
       "rain modules should have added four nanite piles",
     );
+
+    // At most one Game overlay is up at a time: opening the pause menu over
+    // the pad must take the pad down, or the pad's opaque backdrop would hide
+    // the menu that is actually consuming the clicks (and "Quit to Main Menu"
+    // sits under the pad's own rows).
+    await game.input.trigger("TogglePauseMenu");
+    await game.step({ frames: 5 });
+    const afterPause = (await ids(game, "EXP")).size;
+    await click(game, RAIN_WEAPONS);
+    assert.equal(
+      (await ids(game, "EXP")).size,
+      afterPause,
+      "the cheat pad must be gone once the pause menu takes over",
+    );
+    // ...and the pause menu really is the one on screen: its Continue button
+    // resumes the world.
+    await click(game, PAUSE_CONTINUE);
+    assert.equal((await game.info()).paused, false, "Continue should resume the mission");
   },
 );

--- a/tools/shock2-sdk/test/cheat-pad.e2e.test.ts
+++ b/tools/shock2-sdk/test/cheat-pad.e2e.test.ts
@@ -12,10 +12,12 @@ import { norm } from "./helpers/frontend-menu.js";
 // Verified by removing both gate checks: the test then fails.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-// The pad rides the Developer page's authored widget rects (GAMELODR.BIN:
-// list pane 261,54 202x290 and Done 527,405 95x62), with 40px rows inset 8px
-// on a 56px pitch - see `cheat_pad::button_rect`.
-const row = (index: number): [number, number] => [261 + 202 / 2, 54 + 8 + index * 56 + 40 / 2];
+// The pad is a `list_scroll` list on the Developer page's authored widget
+// rects (GAMELODR.BIN: list pane 261,54 202x290 and Done 527,405 95x62), at
+// the same 19px row pitch the debug-scene launcher uses - see
+// `cheat_pad::row_rect`. The two shipped cheats fit one page, so there is no
+// scroll gutter and rows span the full pane width.
+const row = (index: number): [number, number] => [261 + 202 / 2, 54 + index * 19 + 19 / 2];
 const RAIN_WEAPONS = row(0);
 const RAIN_MODULES = row(1);
 const DONE: [number, number] = [527 + 95 / 2, 405 + 62 / 2];


### PR DESCRIPTION
Adds a small developer cheat pad: a two-button overlay that rains useful items around the player, so a test situation can be set up without playing the game up to it.

## What

- **Gate**: a new `cheats` bool dev param (`shock2vr/src/dev_params.rs`). With it off the open action is never read, so neither a stray controller chord nor an HTTP injection can conjure free weapons into an ordinary run. Turning it off while the pad is up closes it.
- **Open**: `InputAction::ToggleCheatPad` - `Alt+K` on desktop, left `X`+`Y` chord on the Quest, gated in VR on that hand being **empty** (`GameScene::hand_is_empty`). Same chord, or the pad's `Done` button, dismisses it.
- **UI**: a `Game`-owned overlay modelled on `pause_menu` (so every pausable scene gets it, the world keeps rendering behind it, only `update` is skipped). The page is a **scrolling list** built on `ui::list_scroll` - the same paging, gutter rocker, inert-end rule and arrow art the Developer screen's parameter page and debug-scene launcher use - at the launcher's 19px row pitch and font, on the Developer page's authored widget rects (`GAMELODR.BIN` over `GAMELOD.PCX`). Placement is decided once in canvas pixels, so flat and VR draw the identical canvas (AGENTS.md section 3).
- **Adding a cheat is one entry in `CHEATS`.** The list pages and grows a scroll rocker on its own once the entries outrun the pane; rows carry the index of the entry *scrolled into* them, never their own slot.
- **Effect**: one new `Effect::RainItems { template_ids }`, applied in `mission_core` as a deterministic ring 2.5 units above the player.

Templates (from `cargo dq`): weapons rain `-928` Wrench, `-17` Pistol, `-19` Shotgun, `-18` Assault Rifle, `-1358` x2 / `-1360` Small Standard/AP Clip, `-42` Pellet Shot Box. Modules rain `-938` EXP Cookies x4 and `-89` 20 Nanites x4.

## Verification

- `cargo test -p shock2vr --lib`: 1175 pass, including new unit tests for the hit test, the chord binding, and the press-edge rule (the chord that opens the pad must not click a button on the first frame).
- New `tools/shock2-sdk/test/cheat-pad.e2e.test.ts`: gate off -> the action and a click on the button are inert; gate on -> the pad opens, rain-weapons adds a wrench that owns a dynamic body and settles, rain-modules adds exactly 4 module stacks + 4 nanite piles. **Negative-verified**: removing both gate checks makes it fail, restoring them makes it pass.
- Rendered and photographed in **both** presentations (below): labels land in the same place relative to their widgets.
- `cargo apk check` passes for `oculus_runtime` (the chord wiring lives there).
- `/xreview` (Claude + Codex + a de-dup pass) run and its Critical/High findings fixed:
  - the pause menu could open *behind* an already-open cheat pad, so the pad's opaque backdrop hid the menu that was actually taking the clicks (and "Quit to Main Menu" sits under the pad's own rows) &mdash; one overlay is up at a time now, asserted in the e2e test;
  - `hand_is_empty` was implemented on `MissionCore` only, but `Game` holds the `Mission` / `DebugScene` wrappers, which kept the trait default `true` and left the empty-hand gate inert everywhere it actually runs;
  - opening the pad now closes use mode, as the pause menu does &mdash; on the Quest the first half of the `X`+`Y` chord fires `X`'s own action first;
  - `is_paused()` reports every overlay that suspends the scene, so automation cannot read a frozen sim as running;
  - the *close* branch of the toggle is ungated, so a pad that is up is always closable by the chord that opened it.
- Capturing the GIF also caught a real bug the tests had not: the ring spawned 6.25 ft above the player's body origin, high enough to land **on top of corridor ceiling geometry** instead of reaching the player. It is now 3.5 ft over the origin (just above the standing capsule's 3 ft crown), written in SS2 feet over `SCALE_FACTOR` like the spawn handlers beside it.

## Revision: the list UI

Per maintainer feedback the pad was reworked from two fixed-rect buttons into a scrollable list, so it scales as cheats are added. Gating, chord, `RainItems` and the two entries are unchanged.

**What was reused:** `shock2vr/src/ui/list_scroll.rs` — already the shared home for the Developer screen's two lists. Its *primitives* (`rows_per_page` / `max_scroll` / `visible_rows` / `rocker` / `hit` / `apply` / the arrow art) dropped straight in.

**The friction, and what it turned into:** review caught that reusing the primitives still left me copying the *composition* around them — `rows_per_page`/`max_scroll`/`visible_rows`/`rocker`/`row_rect`/`text_rect` were character-for-character the debug-scene launcher's `scene_*` helpers, which are themselves a near-copy at a third pitch inside `dev_params_panel`. A third copy would have made "the lists scroll the same way" a convention rather than a fact, which is the opposite of the ask. So `list_scroll::ListGeometry` now owns that composition — including the slot-to-item mapping and the rule that a row clears the gutter *exactly* when the rocker exists — and all three lists go through it. Net: the launcher and the parameter page each lost their copy.

Two more review fixes rode along: `list_scroll::apply` now clamps a stranded offset before it moves (an over-scroll previously needed dead `Up` clicks to unstick), and the pad's `hit`/`build_canvas` take the cheat entries rather than a length, so a row cannot be hit-tested without a cheat behind it.

**One player-visible change** beyond the layout: rows are the launcher's 19px rather than the old 40px buttons, so the VR ray target is smaller. That is the pitch the launcher already ships with in VR, and the VR still below is a fresh capture of the list — but it is a real tradeoff, noted rather than hidden.

## Gaps

- The VR *click* was not exercised headlessly: the offscreen `--vr` runtime's controller ray could not be steered onto a row from HTTP (patched hand rotations stick but the rendered ray does not follow). The panel and its aim ray render correctly, and the hit test is the same shared function the flat path clicks through, but a real headset press is unverified.
- Raining twice onto the same spot piles items on each other and the solver flings them apart; a single press settles cleanly.
- The empty-hand gate itself has no automated test &mdash; filling a VR hand headlessly is expensive. Its wiring is the piece review caught, so it is worth a follow-up.
- `dev_params_panel` keeps its own four-column `row_rects` (a parameter row is a label plus `<`/value/`>`, not one target), so only its paging moved to `ListGeometry`.
- Codex hit its API usage limit part-way through the revision's `/xreview`, so that delta pass is single-engine (the Claude reviewer) rather than cross-engine.
- Deferred de-dup findings, all deliberate to keep this diff small: `cheat_pad` repeats `pause_menu`'s overlay shell (open / close / held-press latch / render), and `Game` repeats its update-and-close pair &mdash; extracting a shared `FrontendOverlay<T>` would cut ~150 lines and make the "two overlays open at once" bug structurally impossible, but it is a refactor of shipped UI code rather than part of this feature. Same for the two near-identical chorded-pair blocks in `oculus_runtime`, and the `click` helper this e2e test shares verbatim with `dev-menu.e2e.test.ts`.

## Visuals

![cheat pad demo](https://gist.githubusercontent.com/tommy-xr/268134bef680c10da1caca635cece670/raw/demo.gif)

<sub>Flat, captured headlessly on the debug runtime: the pad (now a list) opens, "Rain weapons" is pressed, "Done" closes it, and the spread drops and settles at the player's feet.</sub>

![flat cheat pad open](https://gist.githubusercontent.com/tommy-xr/268134bef680c10da1caca635cece670/raw/still_flat_padopen.png)

<sub>Flat &mdash; the pad</sub>

![the rained weapons](https://gist.githubusercontent.com/tommy-xr/268134bef680c10da1caca635cece670/raw/still_flat_rain.png)

<sub>Flat &mdash; one press of "Rain weapons", settled</sub>

![VR cheat pad open](https://gist.githubusercontent.com/tommy-xr/268134bef680c10da1caca635cece670/raw/still_vr_padopen.png)

<sub>VR &mdash; the same list canvas on a world-space panel, with the controller aim ray and its hit dot. Rows land in the same place relative to the pane as they do flat.</sub>


## Full e2e suite

`SHOCK2_E2E=1 npm run test:e2e` on this branch (`ea2ba14`): **126 pass / 4 fail**.

- `Earth hackable keypad ...` and `creature loot: ... Watts yields the 12451 disc` &mdash; already known to fail on `main`.
- `Hydro3 Baby Arachnids can be pushed aside and hit by normal weapons` and `use mode exposes AMMOFULL ammo-cycle for an empty multi-ammo weapon` &mdash; **verified pre-existing**, not caused by this branch. Re-ran both against `origin/main` (`9c4b3f66`, fresh `cargo build -p debug_runtime`) in isolation and they fail identically:
  - baby-arachnid: `an aimed wrench swing should damage the Baby Arachnid` &mdash; `expected: true, actual: false`
  - bio-ammo-full: `loaded magazine must not expose a conversion control` &mdash; `expected: true, actual: false`

All 4 failures are pre-existing on `main`; none are caused by this PR.
