### PR TITLE
feat(lighting): parse the object light table and per-cell light lists

### DIFF
--- a/dark/src/mission/cell.rs
+++ b/dark/src/mission/cell.rs
@@ -33,6 +33,11 @@ pub struct Cell {
     pub planes: Vec<Plane>,
     pub vertices: Vec<Vector3<f32>>,
     pub lights: Vec<LightInfo>,
+    /// Indices into the mission's object-light table naming the lights that
+    /// reach this cell - the candidate set for lighting any object standing
+    /// here. Authored at level-build time, so it is not derivable from the
+    /// lights' radii.
+    pub light_indices: Vec<u16>,
 }
 
 impl Cell {
@@ -99,7 +104,7 @@ impl Cell {
             planes.push(plane);
         }
 
-        let lights = read_lights(
+        let (lights, light_indices) = read_lights(
             packer,
             cell_idx,
             reader,
@@ -122,6 +127,7 @@ impl Cell {
             planes,
             vertices,
             lights,
+            light_indices,
         };
         cell
     }
@@ -331,7 +337,7 @@ fn read_lights<T: io::Read>(
     num_lights: u8,
     num_lightmaps: u8,
     light_size: u8,
-) -> Vec<LightInfo> {
+) -> (Vec<LightInfo>, Vec<u16>) {
     // Cell-local order for the animated-light bits on each face. A set bit in
     // `LightInfo::animation_flags` means the following layer belongs to the
     // light number at the same index in this table.
@@ -378,12 +384,19 @@ fn read_lights<T: io::Read>(
         }
     }
 
-    let light_count = reader.read_u32::<byteorder::LittleEndian>().unwrap();
-    for _ in 0..light_count {
-        let _ = reader.read_u16::<byteorder::LittleEndian>().unwrap();
+    // The cell's object-light list: a count, then that count of entries whose
+    // first element repeats the count.
+    let light_index_count = reader.read_u32::<byteorder::LittleEndian>().unwrap();
+    let mut light_indices = Vec::new();
+    for i in 0..light_index_count {
+        let index = reader.read_u16::<byteorder::LittleEndian>().unwrap();
+        // The first entry repeats the count; only the rest are light indices.
+        if i > 0 {
+            light_indices.push(index);
+        }
     }
 
-    light_infos
+    (light_infos, light_indices)
 }
 
 fn set_bit_indices(flags: u32) -> impl Iterator<Item = usize> {

--- a/dark/src/mission/cell.rs
+++ b/dark/src/mission/cell.rs
@@ -384,16 +384,21 @@ fn read_lights<T: io::Read>(
         }
     }
 
-    // The cell's object-light list: a count, then that count of entries whose
-    // first element repeats the count.
+    // The cell's object-light list. The u32 counts the u16s that follow, and
+    // the first of those is itself the number of real indices behind it.
     let light_index_count = reader.read_u32::<byteorder::LittleEndian>().unwrap();
     let mut light_indices = Vec::new();
     for i in 0..light_index_count {
         let index = reader.read_u16::<byteorder::LittleEndian>().unwrap();
-        // The first entry repeats the count; only the rest are light indices.
-        if i > 0 {
-            light_indices.push(index);
+        if i == 0 {
+            debug_assert_eq!(
+                u32::from(index) + 1,
+                light_index_count,
+                "cell {poly_idx}: leading light-list entry should count the rest"
+            );
+            continue;
         }
+        light_indices.push(index);
     }
 
     (light_infos, light_indices)

--- a/dark/src/mission/light_table.rs
+++ b/dark/src/mission/light_table.rs
@@ -1,0 +1,277 @@
+///
+/// light_table.rs
+///
+/// The object-lighting light table, stored in the mission's world-rep chunk
+/// right after the BSP tree. This is a second light database, parallel to the
+/// baked lightmaps: lightmaps light world geometry, this table lights *objects*
+/// (props, creatures, held items). Each cell carries a list of indices into it
+/// (`Cell::light_indices`) naming the lights that reach that cell, so lighting
+/// an object is "find its cell, evaluate that cell's lights".
+///
+/// The table is a fixed-size array regardless of how many lights the mission
+/// actually uses; `num_static` names the used prefix and the dynamic lights the
+/// engine appends at runtime live directly above it.
+use byteorder::ReadBytesExt;
+use cgmath::{Vector3, vec3};
+
+use std::io;
+
+use crate::SCALE_FACTOR;
+use crate::ss2_common::{read_single, read_vec3};
+
+/// The table is always written at full size, used entries or not.
+pub const LIGHT_TABLE_LEN: usize = 768;
+
+/// A scratch array of the same record type follows the table and carries no
+/// meaning - it is whatever the writer happened to have in its working buffer.
+const SCRATCH_LEN: usize = 32;
+
+/// Bytes per record: position, direction, rgb brightness, two cone cosines and
+/// a radius.
+const RECORD_SIZE: usize = 48;
+
+/// Sentinel in `inner`: this light is an omni, not a spotlight.
+const NOT_A_SPOTLIGHT: f32 = -1.0;
+
+/// One light as it lights objects. Brightness arrives pre-divided by the
+/// engine's light scale, so it is already in the 0..1-ish range the shader
+/// wants rather than the authored brightness.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WorldLight {
+    pub position: Vector3<f32>,
+    /// Direction the cone points. Meaningless unless [`WorldLight::is_spotlight`].
+    pub direction: Vector3<f32>,
+    pub brightness: Vector3<f32>,
+    /// Cosine of the cone angle at which the light is still at full strength.
+    pub inner: f32,
+    /// Cosine of the cone angle at which the light has fallen to nothing.
+    pub outer: f32,
+    /// Hard cutoff distance. Zero means the light has no distance cutoff at all
+    /// (the common case - most authored lights rely on falloff instead).
+    pub radius: f32,
+}
+
+impl WorldLight {
+    pub fn is_spotlight(&self) -> bool {
+        self.inner != NOT_A_SPOTLIGHT
+    }
+
+    /// Whether this light can reach `position` at all. Only the radius cutoff -
+    /// cone and falloff are the renderer's business.
+    pub fn reaches(&self, position: Vector3<f32>) -> bool {
+        if self.radius == 0.0 {
+            return true;
+        }
+        let delta = position - self.position;
+        cgmath::dot(delta, delta) <= self.radius * self.radius
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LightTable {
+    lights: Vec<WorldLight>,
+    num_static: u32,
+    num_dynamic: u32,
+}
+
+impl LightTable {
+    pub fn read<T: io::Read>(reader: &mut T, num_static: u32, num_dynamic: u32) -> LightTable {
+        let mut lights = Vec::with_capacity(LIGHT_TABLE_LEN);
+        for _ in 0..LIGHT_TABLE_LEN {
+            lights.push(read_light(reader));
+        }
+
+        for _ in 0..(SCRATCH_LEN * RECORD_SIZE) {
+            let _ = reader.read_u8();
+        }
+
+        LightTable {
+            lights,
+            num_static,
+            num_dynamic,
+        }
+    }
+
+    /// An empty table, for scenes with no world rep of their own.
+    pub fn empty() -> LightTable {
+        LightTable {
+            lights: Vec::new(),
+            num_static: 0,
+            num_dynamic: 0,
+        }
+    }
+
+    /// Look up a light by the index a cell's light list carries. Out-of-range
+    /// indices return `None` rather than panicking: the lists are authored data.
+    pub fn get(&self, index: u16) -> Option<&WorldLight> {
+        self.lights.get(index as usize)
+    }
+
+    /// The used prefix of the table - the lights the mission actually authored.
+    pub fn static_lights(&self) -> &[WorldLight] {
+        let end = (self.num_static as usize).min(self.lights.len());
+        &self.lights[..end]
+    }
+
+    pub fn num_static(&self) -> u32 {
+        self.num_static
+    }
+
+    pub fn num_dynamic(&self) -> u32 {
+        self.num_dynamic
+    }
+}
+
+fn read_light<T: io::Read>(reader: &mut T) -> WorldLight {
+    let position = read_vec3(reader) / SCALE_FACTOR;
+    let direction = read_vec3(reader);
+    // Stored in the same three-float shape as a position, but it is a colour -
+    // reading it as a vector would swizzle the channels and negate red.
+    let brightness = vec3(
+        read_single(reader),
+        read_single(reader),
+        read_single(reader),
+    );
+    let inner = read_single(reader);
+    let outer = read_single(reader);
+    let radius = read_single(reader) / SCALE_FACTOR;
+
+    WorldLight {
+        position,
+        direction,
+        brightness,
+        inner,
+        outer,
+        radius,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use byteorder::{LittleEndian, WriteBytesExt};
+    use cgmath::vec3;
+
+    fn record(marker: f32, inner: f32, radius: f32) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // position, direction, brightness - all marked so a stride error shows
+        // up as the wrong field rather than as plausible-looking numbers.
+        for value in [
+            marker,
+            marker + 1.0,
+            marker + 2.0,
+            0.0,
+            0.0,
+            -1.0,
+            0.5,
+            0.25,
+            0.125,
+        ] {
+            bytes.write_f32::<LittleEndian>(value).unwrap();
+        }
+        bytes.write_f32::<LittleEndian>(inner).unwrap();
+        bytes.write_f32::<LittleEndian>(0.7).unwrap();
+        bytes.write_f32::<LittleEndian>(radius).unwrap();
+        assert_eq!(bytes.len(), RECORD_SIZE);
+        bytes
+    }
+
+    fn table_bytes() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend(record(10.0, NOT_A_SPOTLIGHT, 0.0));
+        bytes.extend(record(20.0, 0.9, 32.0));
+        for _ in 2..LIGHT_TABLE_LEN {
+            bytes.extend(record(0.0, NOT_A_SPOTLIGHT, 0.0));
+        }
+        // The scratch array the table is followed by.
+        for _ in 0..SCRATCH_LEN {
+            bytes.extend(record(999.0, NOT_A_SPOTLIGHT, 0.0));
+        }
+        bytes
+    }
+
+    #[test]
+    fn reads_a_light_record_field_by_field() {
+        let bytes = table_bytes();
+        let table = LightTable::read(&mut io::Cursor::new(bytes), 2, 0);
+
+        // Positions and directions come back in engine axes: the file's
+        // (x, y, z) is read as (-x, z, y), and positions are scaled.
+        let light = table.get(0).expect("light 0 must parse");
+        assert_eq!(light.position, vec3(-10.0, 12.0, 11.0) / SCALE_FACTOR);
+        assert_eq!(light.direction, vec3(0.0, -1.0, 0.0));
+        assert_eq!(light.brightness, vec3(0.5, 0.25, 0.125));
+        assert_eq!(light.outer, 0.7);
+        assert!(!light.is_spotlight(), "inner -1.0 means omni");
+        assert_eq!(light.radius, 0.0);
+    }
+
+    /// The stride check: light 1 is only where we expect it if the record is
+    /// exactly 48 bytes.
+    #[test]
+    fn later_records_land_at_the_right_stride() {
+        let bytes = table_bytes();
+        let table = LightTable::read(&mut io::Cursor::new(bytes), 2, 0);
+
+        let light = table.get(1).expect("light 1 must parse");
+        assert_eq!(light.position, vec3(-20.0, 22.0, 21.0) / SCALE_FACTOR);
+        assert!(light.is_spotlight());
+        assert_eq!(light.inner, 0.9);
+        assert_eq!(light.radius, 32.0 / SCALE_FACTOR);
+    }
+
+    /// The table is fixed-length and the scratch array that follows it is not
+    /// part of it, so the last slot must be a real record and the marker value
+    /// from the scratch array must never appear.
+    #[test]
+    fn table_is_fixed_length_and_excludes_the_scratch_array() {
+        let bytes = table_bytes();
+        let consumed = bytes.len();
+        let mut cursor = io::Cursor::new(bytes);
+        let table = LightTable::read(&mut cursor, 2, 0);
+
+        assert!(table.get(LIGHT_TABLE_LEN as u16 - 1).is_some());
+        assert!(table.get(LIGHT_TABLE_LEN as u16).is_none());
+        assert!(
+            table
+                .static_lights()
+                .iter()
+                .all(|l| l.position.x != -999.0 / SCALE_FACTOR)
+        );
+        assert_eq!(
+            cursor.position() as usize,
+            consumed,
+            "the scratch array must be consumed too, or every chunk after the \
+             world rep reads from the wrong offset"
+        );
+    }
+
+    #[test]
+    fn static_lights_are_the_used_prefix() {
+        let bytes = table_bytes();
+        let table = LightTable::read(&mut io::Cursor::new(bytes), 2, 4);
+
+        assert_eq!(table.static_lights().len(), 2);
+        assert_eq!(table.num_dynamic(), 4);
+    }
+
+    #[test]
+    fn radius_zero_reaches_everywhere() {
+        let omni = WorldLight {
+            position: vec3(0.0, 0.0, 0.0),
+            direction: vec3(0.0, 0.0, -1.0),
+            brightness: vec3(1.0, 1.0, 1.0),
+            inner: NOT_A_SPOTLIGHT,
+            outer: 0.0,
+            radius: 0.0,
+        };
+        assert!(omni.reaches(vec3(1000.0, 0.0, 0.0)));
+
+        let bounded = WorldLight {
+            radius: 10.0,
+            ..omni
+        };
+        assert!(bounded.reaches(vec3(9.0, 0.0, 0.0)));
+        assert!(!bounded.reaches(vec3(11.0, 0.0, 0.0)));
+    }
+}

--- a/dark/src/mission/light_table.rs
+++ b/dark/src/mission/light_table.rs
@@ -8,10 +8,10 @@
 /// (`Cell::light_indices`) naming the lights that reach that cell, so lighting
 /// an object is "find its cell, evaluate that cell's lights".
 ///
-/// The table is a fixed-size array regardless of how many lights the mission
-/// actually uses; `num_static` names the used prefix and the dynamic lights the
-/// engine appends at runtime live directly above it.
-use byteorder::ReadBytesExt;
+/// The world rep declares how many lights it holds; the array on disk is longer
+/// than that and its full length varies by mission (WRRGB and WREXT missions
+/// differ), so read only the declared count - everything past it is unrelated
+/// data that would decode as plausible-looking junk.
 use cgmath::{Vector3, vec3};
 
 use std::io;
@@ -19,23 +19,17 @@ use std::io;
 use crate::SCALE_FACTOR;
 use crate::ss2_common::{read_single, read_vec3};
 
-/// The table is always written at full size, used entries or not.
-pub const LIGHT_TABLE_LEN: usize = 768;
-
-/// A scratch array of the same record type follows the table and carries no
-/// meaning - it is whatever the writer happened to have in its working buffer.
-const SCRATCH_LEN: usize = 32;
-
 /// Bytes per record: position, direction, rgb brightness, two cone cosines and
 /// a radius.
-const RECORD_SIZE: usize = 48;
+pub const RECORD_SIZE: usize = 48;
 
 /// Sentinel in `inner`: this light is an omni, not a spotlight.
 const NOT_A_SPOTLIGHT: f32 = -1.0;
 
 /// One light as it lights objects. Brightness arrives pre-divided by the
-/// engine's light scale, so it is already in the 0..1-ish range the shader
-/// wants rather than the authored brightness.
+/// engine's light scale, so it is much smaller than the authored brightness -
+/// but it is NOT normalized: values run past 1.0 (up to ~12.5 on medsci1), so
+/// whatever consumes this has to scale or tone-map rather than assume 0..1.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct WorldLight {
     pub position: Vector3<f32>,
@@ -53,51 +47,42 @@ pub struct WorldLight {
 
 impl WorldLight {
     pub fn is_spotlight(&self) -> bool {
-        self.inner != NOT_A_SPOTLIGHT
-    }
-
-    /// Whether this light can reach `position` at all. Only the radius cutoff -
-    /// cone and falloff are the renderer's business.
-    pub fn reaches(&self, position: Vector3<f32>) -> bool {
-        if self.radius == 0.0 {
-            return true;
-        }
-        let delta = position - self.position;
-        cgmath::dot(delta, delta) <= self.radius * self.radius
+        self.inner > NOT_A_SPOTLIGHT
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct LightTable {
+    /// The static lights, then the dynamic ones the engine keeps above them.
     lights: Vec<WorldLight>,
-    num_static: u32,
-    num_dynamic: u32,
+    num_static: usize,
 }
 
 impl LightTable {
-    pub fn read<T: io::Read>(reader: &mut T, num_static: u32, num_dynamic: u32) -> LightTable {
-        let mut lights = Vec::with_capacity(LIGHT_TABLE_LEN);
-        for _ in 0..LIGHT_TABLE_LEN {
-            lights.push(read_light(reader));
+    /// Reads the declared lights. `max_records` bounds the read to what is left
+    /// in the world-rep chunk, so a mission whose counts overstate its table is
+    /// short rather than a read past the end of the file.
+    pub fn read<T: io::Read>(
+        reader: &mut T,
+        num_static: u32,
+        num_dynamic: u32,
+        max_records: usize,
+    ) -> LightTable {
+        let declared = num_static as usize + num_dynamic as usize;
+        let to_read = declared.min(max_records);
+        if to_read < declared {
+            tracing::warn!(
+                "Light table declares {} lights but only {} fit in the world rep",
+                declared,
+                to_read
+            );
         }
 
-        for _ in 0..(SCRATCH_LEN * RECORD_SIZE) {
-            let _ = reader.read_u8();
-        }
+        let lights = (0..to_read).map(|_| read_light(reader)).collect();
 
         LightTable {
             lights,
-            num_static,
-            num_dynamic,
-        }
-    }
-
-    /// An empty table, for scenes with no world rep of their own.
-    pub fn empty() -> LightTable {
-        LightTable {
-            lights: Vec::new(),
-            num_static: 0,
-            num_dynamic: 0,
+            num_static: (num_static as usize).min(to_read),
         }
     }
 
@@ -107,18 +92,10 @@ impl LightTable {
         self.lights.get(index as usize)
     }
 
-    /// The used prefix of the table - the lights the mission actually authored.
+    /// The lights authored into the level, which is what the cells' index lists
+    /// address.
     pub fn static_lights(&self) -> &[WorldLight] {
-        let end = (self.num_static as usize).min(self.lights.len());
-        &self.lights[..end]
-    }
-
-    pub fn num_static(&self) -> u32 {
-        self.num_static
-    }
-
-    pub fn num_dynamic(&self) -> u32 {
-        self.num_dynamic
+        &self.lights[..self.num_static]
     }
 }
 
@@ -176,15 +153,16 @@ mod tests {
         bytes
     }
 
-    fn table_bytes() -> Vec<u8> {
+    /// A table of `count` records, followed by unrelated data that must never
+    /// be decoded as a light.
+    fn table_bytes(count: usize) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend(record(10.0, NOT_A_SPOTLIGHT, 0.0));
         bytes.extend(record(20.0, 0.9, 32.0));
-        for _ in 2..LIGHT_TABLE_LEN {
+        for _ in 2..count {
             bytes.extend(record(0.0, NOT_A_SPOTLIGHT, 0.0));
         }
-        // The scratch array the table is followed by.
-        for _ in 0..SCRATCH_LEN {
+        for _ in 0..4 {
             bytes.extend(record(999.0, NOT_A_SPOTLIGHT, 0.0));
         }
         bytes
@@ -192,8 +170,7 @@ mod tests {
 
     #[test]
     fn reads_a_light_record_field_by_field() {
-        let bytes = table_bytes();
-        let table = LightTable::read(&mut io::Cursor::new(bytes), 2, 0);
+        let table = LightTable::read(&mut io::Cursor::new(table_bytes(8)), 8, 0, usize::MAX);
 
         // Positions and directions come back in engine axes: the file's
         // (x, y, z) is read as (-x, z, y), and positions are scaled.
@@ -210,8 +187,7 @@ mod tests {
     /// exactly 48 bytes.
     #[test]
     fn later_records_land_at_the_right_stride() {
-        let bytes = table_bytes();
-        let table = LightTable::read(&mut io::Cursor::new(bytes), 2, 0);
+        let table = LightTable::read(&mut io::Cursor::new(table_bytes(8)), 8, 0, usize::MAX);
 
         let light = table.get(1).expect("light 1 must parse");
         assert_eq!(light.position, vec3(-20.0, 22.0, 21.0) / SCALE_FACTOR);
@@ -220,43 +196,38 @@ mod tests {
         assert_eq!(light.radius, 32.0 / SCALE_FACTOR);
     }
 
-    /// The table is fixed-length and the scratch array that follows it is not
-    /// part of it, so the last slot must be a real record and the marker value
-    /// from the scratch array must never appear.
+    /// The array on disk runs past the declared count, and what follows is not
+    /// lights - so reading more than was declared yields junk.
     #[test]
-    fn table_is_fixed_length_and_excludes_the_scratch_array() {
-        let bytes = table_bytes();
-        let consumed = bytes.len();
-        let mut cursor = io::Cursor::new(bytes);
-        let table = LightTable::read(&mut cursor, 2, 0);
+    fn reads_only_the_declared_lights() {
+        let table = LightTable::read(&mut io::Cursor::new(table_bytes(8)), 8, 0, usize::MAX);
 
-        assert!(table.get(LIGHT_TABLE_LEN as u16 - 1).is_some());
-        assert!(table.get(LIGHT_TABLE_LEN as u16).is_none());
-        assert!(
-            table
-                .static_lights()
-                .iter()
-                .all(|l| l.position.x != -999.0 / SCALE_FACTOR)
-        );
-        assert_eq!(
-            cursor.position() as usize,
-            consumed,
-            "the scratch array must be consumed too, or every chunk after the \
-             world rep reads from the wrong offset"
-        );
+        assert_eq!(table.static_lights().len(), 8);
+        assert!(table.get(8).is_none(), "must not decode past the count");
+    }
+
+    /// Dynamic lights sit above the static ones and are not part of the prefix
+    /// the cells' index lists address.
+    #[test]
+    fn dynamic_lights_follow_the_static_ones() {
+        let table = LightTable::read(&mut io::Cursor::new(table_bytes(8)), 6, 2, usize::MAX);
+
+        assert_eq!(table.static_lights().len(), 6);
+        assert!(table.get(7).is_some());
+        assert!(table.get(8).is_none());
+    }
+
+    /// A mission whose counts overstate its table must come back short rather
+    /// than reading off the end of the chunk.
+    #[test]
+    fn a_short_chunk_bounds_the_read() {
+        let table = LightTable::read(&mut io::Cursor::new(table_bytes(4)), 900, 0, 4);
+
+        assert_eq!(table.static_lights().len(), 4);
     }
 
     #[test]
-    fn static_lights_are_the_used_prefix() {
-        let bytes = table_bytes();
-        let table = LightTable::read(&mut io::Cursor::new(bytes), 2, 4);
-
-        assert_eq!(table.static_lights().len(), 2);
-        assert_eq!(table.num_dynamic(), 4);
-    }
-
-    #[test]
-    fn radius_zero_reaches_everywhere() {
+    fn the_spotlight_sentinel_is_the_only_omni_case() {
         let omni = WorldLight {
             position: vec3(0.0, 0.0, 0.0),
             direction: vec3(0.0, 0.0, -1.0),
@@ -265,13 +236,15 @@ mod tests {
             outer: 0.0,
             radius: 0.0,
         };
-        assert!(omni.reaches(vec3(1000.0, 0.0, 0.0)));
-
-        let bounded = WorldLight {
-            radius: 10.0,
-            ..omni
-        };
-        assert!(bounded.reaches(vec3(9.0, 0.0, 0.0)));
-        assert!(!bounded.reaches(vec3(11.0, 0.0, 0.0)));
+        assert!(!omni.is_spotlight());
+        assert!(
+            !WorldLight {
+                inner: NOT_A_SPOTLIGHT - 0.0001,
+                ..omni
+            }
+            .is_spotlight(),
+            "a value below the sentinel is not a cone"
+        );
+        assert!(WorldLight { inner: 0.5, ..omni }.is_spotlight());
     }
 }

--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -1,6 +1,7 @@
 mod bsp_tree;
 mod cell;
 mod cell_portal;
+pub mod light_table;
 mod map_params;
 pub mod path_database;
 mod plane;
@@ -14,6 +15,7 @@ pub mod texture_list;
 pub use bsp_tree::*;
 pub use cell::*;
 pub use cell_portal::*;
+pub use light_table::{LightTable, WorldLight};
 pub use map_params::MapParams;
 pub use path_database::{CellDoor, PathDatabase};
 pub use plane::*;
@@ -87,6 +89,9 @@ pub struct SystemShock2Level {
     pub map_params: MapParams,
     pub bsp_tree: BspTree,
     pub path_database: Option<PathDatabase>,
+    /// Lights that shade *objects*, as opposed to the baked lightmaps that
+    /// shade world geometry.
+    pub light_table: LightTable,
 }
 
 // Capstone for the loading-screen "foundation track" (projects/loading-screen.md, PR
@@ -211,10 +216,14 @@ pub fn read<T: io::Read + io::Seek>(
 
     let num_static_lights = read_u32(reader);
     let num_dynamic_lights = read_u32(reader);
+    let light_table = LightTable::read(reader, num_static_lights, num_dynamic_lights);
+    let cell_light_refs: usize = cells.iter().map(|c| c.light_indices.len()).sum();
     tracing::debug!(
-        "Mission lights - static: {} dynamic: {}",
+        "Mission lights - static: {} dynamic: {} first: {:?} cell refs: {}",
         num_static_lights,
-        num_dynamic_lights
+        num_dynamic_lights,
+        light_table.static_lights().first(),
+        cell_light_refs,
     );
 
     let (obj_map, obj_texture_families) = read_obj_map(&table_of_contents, reader);
@@ -280,6 +289,7 @@ pub fn read<T: io::Read + io::Seek>(
         song_params,
         map_params,
         path_database,
+        light_table,
     }
 }
 

--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -216,14 +216,21 @@ pub fn read<T: io::Read + io::Seek>(
 
     let num_static_lights = read_u32(reader);
     let num_dynamic_lights = read_u32(reader);
-    let light_table = LightTable::read(reader, num_static_lights, num_dynamic_lights);
-    let cell_light_refs: usize = cells.iter().map(|c| c.light_indices.len()).sum();
-    tracing::debug!(
-        "Mission lights - static: {} dynamic: {} first: {:?} cell refs: {}",
+    // The light array on disk is longer than the declared count and its length
+    // varies by mission, so bound the read by what is left in the chunk.
+    let wr_chunk_end = wr_chunk.offset + wr_chunk.length;
+    let max_light_records = wr_chunk_end.saturating_sub(reader.stream_position().unwrap()) as usize
+        / light_table::RECORD_SIZE;
+    let light_table = LightTable::read(
+        reader,
         num_static_lights,
         num_dynamic_lights,
-        light_table.static_lights().first(),
-        cell_light_refs,
+        max_light_records,
+    );
+    tracing::debug!(
+        "Mission lights - static: {} dynamic: {}",
+        num_static_lights,
+        num_dynamic_lights
     );
 
     let (obj_map, obj_texture_families) = read_obj_map(&table_of_contents, reader);


### PR DESCRIPTION
Objects in a mission receive no scene lighting at all. Every prop, creature and
held item is shaded `texColor * 0.5 + emissivity + Σ(6 spotlight slots)`, and the
only thing that ever fills those slots is the player's hand spotlights - so a
corpse in a black corridor is exactly as bright as one under a lamp, and
switching a room dark changes the walls but not the props in it.

The data to fix that is already in the mission and we were walking past it. The
original engine lights objects from a second light database, parallel to the
baked lightmaps: a light table in the world rep, plus a per-cell list of the
lights that reach that cell. Lighting an object is "find its cell, evaluate that
cell's lights".

This PR parses both. **No behavior change** - it is the data for the per-object
lighting slices that follow.

- `dark/src/mission/light_table.rs` (new) - reads the light records (position,
  direction, rgb brightness, cone cosines, radius) that sit after the BSP tree,
  where we previously read two counts and jumped away via the chunk TOC.
- `dark/src/mission/cell.rs` - retains the per-cell light index list that
  `read_lights` was reading into a discard.

## Verification

Real-mission checks, since the `dark` integration harness can't reach data that
lives inside `.kpf` archives:

| Check | Result |
|---|---|
| Record stride / field alignment | `inner` reads **exactly -1.0** on omni lights - the not-a-spotlight sentinel. A wrong stride would essentially never land on that value. |
| Cell indices address the table | medsci1 indices span **0..367** against **368** static lights - exactly the used prefix. |
| Leading `u16` of each cell list | Equals `count - 1` on every cell in medsci1, hydro2 and shodan; now enforced by a `debug_assert`. |
| WRRGB **and** WREXT missions | medsci1 368, hydro2 493, shodan 460 static lights - all coherent, no warnings. |
| Full mission suite | `missions.e2e.test.ts` **23/23 pass**. |
| Unit | 128 `dark` unit + 11 integration tests, `-D warnings` clean. |

## Review notes (`/xreview`)

Two bugs the reviewers caught, both fixed in the second commit:

- **A fixed 768-record table length is a WRRGB-ism.** hydro2 and shodan are
  WREXT and their arrays differ, so a fixed read decoded following data as ~240
  junk lights and could run past EOF on a short file. Now reads only
  `num_static + num_dynamic`, bounded by the chunk end - which retires the
  length question entirely.
- **The trailing array I called "scratch" isn't.** On medsci1 it holds coherent
  light records (plausibly the animated lights - a known gap for the consumer
  slice). Nothing downstream reads sequentially, so the skip and the test whose
  justification was false are both gone.

Also from review: brightness is **not** normalized (0..12.5 on medsci1), so the
doc says so rather than promising 0..1; the spotlight sentinel compares with `>`;
and the speculative `reaches()`/`empty()` helpers are dropped - `reaches()`
encoded an unvalidated radius semantic that disagreed with
`SpotLight::affects_position` about what a zero radius means.

Codex was unavailable (usage limit), so this had no cross-engine agreement - the
findings are single-engine, though verified against the shipped archives.

Design notes and the remaining slices: per-object light selection lands behind
`--experimental object_lighting`, since it is per-drawn-object per-frame work and
Quest is the binding constraint.