### PR TITLE
feat(dark_explorer): preview .fon fonts with sample strings

### DIFF
--- a/dark/src/font.rs
+++ b/dark/src/font.rs
@@ -16,7 +16,7 @@ use engine::{
     texture_atlas::{TexturePackResult, TexturePacker},
 };
 use image::ImageBuffer;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::ss2_common::{read_bytes, read_i16, read_u8, read_u16, read_u32};
 
@@ -131,23 +131,27 @@ pub struct FontBitmap {
     bitmap: Vec<u8>,
 }
 
-/// Horizontal gap between glyphs, in the font's native pixels.
-const GLYPH_SPACING: usize = SPACING as usize;
-
 impl FontBitmap {
     pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> FontBitmap {
-        // The bitmap strip runs to end-of-file, so measure the file first.
+        // The bitmap strip runs to end-of-file, so read the whole file once.
         let mut all = Vec::new();
-        reader.read_to_end(&mut all).unwrap();
-        let end_bytes = reader.stream_position().unwrap();
         reader.seek(io::SeekFrom::Start(0)).unwrap();
+        reader.read_to_end(&mut all).unwrap();
 
-        let metrics = FontMetrics::read(reader);
-        reader
-            .seek(io::SeekFrom::Start(metrics.bitmap_offset as u64))
-            .unwrap();
-        let bitmap_size = end_bytes.saturating_sub(metrics.bitmap_offset as u64);
-        let bitmap = read_bytes(reader, bitmap_size as usize);
+        let metrics = FontMetrics::read(&mut io::Cursor::new(&all));
+        let bitmap = all
+            .get(metrics.bitmap_offset as usize..)
+            .unwrap_or(&[])
+            .to_vec();
+        let expected = metrics.row_width as usize * metrics.height as usize;
+        if bitmap.len() < expected {
+            // Reads past the strip decode as transparent, so say so rather than
+            // letting a bad asset render as silently blank glyphs.
+            warn!(
+                "font bitmap truncated: {} of {expected} bytes",
+                bitmap.len()
+            );
+        }
 
         FontBitmap { metrics, bitmap }
     }
@@ -189,8 +193,10 @@ impl FontBitmap {
     }
 
     /// Rasterize `text` at native size into `(width, height, alpha)`, laying
-    /// glyphs out left to right exactly as the in-game text mesh does (one
-    /// pixel of spacing). Characters the font does not define are skipped.
+    /// glyphs out left to right on their advances with nothing added between
+    /// them (side bearings are baked into the glyph cells), as the UI's
+    /// `measure_text_width` does. Characters the font does not define are
+    /// skipped.
     pub fn render_string(&self, text: &str) -> (usize, usize, Vec<u8>) {
         let height = self.metrics.height as usize;
         let glyphs: Vec<(usize, Vec<u8>)> = text
@@ -201,8 +207,10 @@ impl FontBitmap {
         if glyphs.is_empty() || height == 0 {
             return (0, 0, Vec::new());
         }
-        let width: usize =
-            glyphs.iter().map(|(w, _)| w).sum::<usize>() + GLYPH_SPACING * (glyphs.len() - 1);
+        let width: usize = glyphs.iter().map(|(w, _)| w).sum();
+        if width == 0 {
+            return (0, 0, Vec::new());
+        }
 
         let mut out = vec![0u8; width * height];
         let mut pen = 0usize;
@@ -212,7 +220,7 @@ impl FontBitmap {
                 out[dst..dst + glyph_width]
                     .copy_from_slice(&alpha[y * glyph_width..(y + 1) * glyph_width]);
             }
-            pen += glyph_width + GLYPH_SPACING;
+            pen += glyph_width;
         }
         (width, height, out)
     }
@@ -488,17 +496,17 @@ mod tests {
     }
 
     #[test]
-    fn format1_glyphs_scale_coverage_and_lay_out_with_spacing() {
+    fn format1_glyphs_scale_coverage_and_lay_out_on_advances() {
         // Two 2x1 glyphs, format 1 (coverage 0..=15), row_width = 4 bytes.
         let bytes = with_bitmap(synth_font(65, 66, 1, &[0, 2, 4], 1), &[15, 0, 8, 15]);
         let font = FontBitmap::read(&mut Cursor::new(bytes));
 
         assert_eq!(font.glyph_alpha(65), Some((2, vec![255, 0])));
         assert_eq!(font.glyph_alpha(66), Some((2, vec![136, 255])));
-        // Glyphs run left to right with one transparent pixel between them.
-        assert_eq!(font.render_string("AB"), (5, 1, vec![255, 0, 0, 136, 255]));
+        // Glyphs run left to right on their advances, nothing added between.
+        assert_eq!(font.render_string("AB"), (4, 1, vec![255, 0, 136, 255]));
         // Undefined characters are dropped rather than rendered as blanks.
-        assert_eq!(font.render_string("AZB").0, 5);
+        assert_eq!(font.render_string("AZB").0, 4);
         assert_eq!(font.render_string("ZZ"), (0, 0, vec![]));
     }
 

--- a/dark/src/font.rs
+++ b/dark/src/font.rs
@@ -83,6 +83,17 @@ impl FontMetrics {
         Some(self.columns[i + 1] - self.columns[i])
     }
 
+    /// Human-readable name of the bitmap encoding, for tools reporting which
+    /// variant a file uses.
+    pub fn format_label(&self) -> &'static str {
+        match self.format {
+            0 => "0 (packed, 1 bit per pixel)",
+            1 => "1 (antialiased, 16 coverage levels)",
+            0xcccc => "0xcccc (antialiased, 8-bit alpha)",
+            _ => "unknown (treated as 8-bit alpha)",
+        }
+    }
+
     pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> FontMetrics {
         let header = FontHeader::read(reader);
         assert!(header.palette == 0);
@@ -108,6 +119,102 @@ impl FontMetrics {
             bitmap_offset: header.bitmap_offset,
             columns,
         }
+    }
+}
+
+/// A `.FON` decoded to CPU-side glyph coverage: the metrics plus the raw
+/// bitmap strip, with no texture atlas and no GL. [`Font::read`] builds its
+/// atlas from this, and headless tools (dark_explorer's font preview) rasterize
+/// sample strings from it.
+pub struct FontBitmap {
+    pub metrics: FontMetrics,
+    bitmap: Vec<u8>,
+}
+
+/// Horizontal gap between glyphs, in the font's native pixels.
+const GLYPH_SPACING: usize = SPACING as usize;
+
+impl FontBitmap {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> FontBitmap {
+        // The bitmap strip runs to end-of-file, so measure the file first.
+        let mut all = Vec::new();
+        reader.read_to_end(&mut all).unwrap();
+        let end_bytes = reader.stream_position().unwrap();
+        reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+        let metrics = FontMetrics::read(reader);
+        reader
+            .seek(io::SeekFrom::Start(metrics.bitmap_offset as u64))
+            .unwrap();
+        let bitmap_size = end_bytes.saturating_sub(metrics.bitmap_offset as u64);
+        let bitmap = read_bytes(reader, bitmap_size as usize);
+
+        FontBitmap { metrics, bitmap }
+    }
+
+    /// Alpha of one pixel of the bitmap strip, in strip coordinates. Reads past
+    /// the strip (a truncated file) yield transparent rather than panicking.
+    fn pixel_alpha(&self, x: u32, y: u32) -> u8 {
+        let row_width = self.metrics.row_width as u32;
+        if self.metrics.format == 0 {
+            // Packed: each byte holds 8 horizontally adjacent pixels, MSB first.
+            let byte = *self
+                .bitmap
+                .get((y * row_width + x / 8) as usize)
+                .unwrap_or(&0);
+            if byte >> (7 - (x % 8)) & 1 == 1 {
+                255
+            } else {
+                0
+            }
+        } else {
+            let byte = *self.bitmap.get((y * row_width + x) as usize).unwrap_or(&0);
+            unpacked_byte_alpha(self.metrics.format, byte)
+        }
+    }
+
+    /// Coverage mask for one glyph: `(width, alpha)` with `alpha` row-major
+    /// `width * height`. `None` for a code the font does not define.
+    pub fn glyph_alpha(&self, code: i16) -> Option<(usize, Vec<u8>)> {
+        let width = self.metrics.glyph_width(code)? as u32;
+        let column = self.metrics.columns[(code - self.metrics.first_char) as usize] as u32;
+        let height = self.metrics.height as u32;
+        let mut alpha = Vec::with_capacity((width * height) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                alpha.push(self.pixel_alpha(column + x, y));
+            }
+        }
+        Some((width as usize, alpha))
+    }
+
+    /// Rasterize `text` at native size into `(width, height, alpha)`, laying
+    /// glyphs out left to right exactly as the in-game text mesh does (one
+    /// pixel of spacing). Characters the font does not define are skipped.
+    pub fn render_string(&self, text: &str) -> (usize, usize, Vec<u8>) {
+        let height = self.metrics.height as usize;
+        let glyphs: Vec<(usize, Vec<u8>)> = text
+            .chars()
+            .filter_map(|c| i16::try_from(c as u32).ok())
+            .filter_map(|code| self.glyph_alpha(code))
+            .collect();
+        if glyphs.is_empty() || height == 0 {
+            return (0, 0, Vec::new());
+        }
+        let width: usize =
+            glyphs.iter().map(|(w, _)| w).sum::<usize>() + GLYPH_SPACING * (glyphs.len() - 1);
+
+        let mut out = vec![0u8; width * height];
+        let mut pen = 0usize;
+        for (glyph_width, alpha) in &glyphs {
+            for y in 0..height {
+                let dst = y * width + pen;
+                out[dst..dst + glyph_width]
+                    .copy_from_slice(&alpha[y * glyph_width..(y + 1) * glyph_width]);
+            }
+            pen += glyph_width + GLYPH_SPACING;
+        }
+        (width, height, out)
     }
 }
 
@@ -219,70 +326,25 @@ impl Font {
         mesh::create(vertices)
     }
     pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> Font {
-        // Get total length of file
-        // Needed so we can get the size of the bitmap
-        let mut _vec = Vec::new();
-        let _end = reader.read_to_end(&mut _vec).unwrap();
-        let end_bytes = reader.stream_position().unwrap();
-
-        // Then rewind and start reading...
-        reader.seek(io::SeekFrom::Start(0)).unwrap();
-
-        let metrics = FontMetrics::read(reader);
+        let font_bitmap = FontBitmap::read(reader);
+        let metrics = &font_bitmap.metrics;
 
         info!("Loading font with metrics: {:?}", metrics);
 
         let num_chars = metrics.num_chars();
-
-        // Read bitmap data
-        reader
-            .seek(io::SeekFrom::Start(metrics.bitmap_offset as u64))
-            .unwrap();
-
-        let bitmap_size = end_bytes - metrics.bitmap_offset as u64;
-        let bitmap = read_bytes(reader, bitmap_size as usize);
 
         let mut char_to_info = HashMap::new();
         let mut texture_packer = TexturePacker::<image::Rgba<u8>>::new_rgba(512, 512);
         for n in 0..num_chars {
             let code = metrics.first_char + n as i16;
             let ascii = char::from_u32(code as u32).unwrap();
-            let idx = n;
 
-            let column = metrics.columns[idx];
-            let width = metrics.columns[idx + 1] - metrics.columns[idx];
+            let (width, alpha) = font_bitmap.glyph_alpha(code).unwrap();
 
-            // Generate the image corresponding to the character:
+            // White glyphs; the bitmap only carries coverage.
             let img: ImageBuffer<image::Rgba<u8>, std::vec::Vec<u8>> =
                 image::ImageBuffer::from_fn(width as u32, metrics.height as u32, |x, y| {
-                    let adj_x = x + (column as u32);
-                    if metrics.format == 0 {
-                        // This is a little gnarly... what is happening here is that each pixel
-                        // is compacted horizontally. Each 'byte' value actually corresponds to 8
-                        // pixels - each bit tracking whether the pixel is on or off.
-
-                        // First, get the byte-index of the pixel
-                        let idx_packed = adj_x / 8;
-                        let byte_index = (y * metrics.row_width as u32 + idx_packed) as usize;
-
-                        // This gives us the full byte value
-                        let packed_val = bitmap[byte_index];
-
-                        // Now, we need to figure out whether the 'bit' corresponding to the pixel
-                        // is on or off. We grab the remainder to find the relevant bit:
-                        let x_remainder = 7 - (adj_x % 8);
-                        // and then check if it is on:
-                        let is_on = packed_val >> x_remainder & 1 == 1;
-
-                        let alpha = if is_on { 255u8 } else { 0u8 };
-
-                        image::Rgba([255, 255, 255, alpha])
-                    } else {
-                        // Unpacked formats: one byte per pixel.
-                        let idx = (y * metrics.row_width as u32 + adj_x) as usize;
-                        let alpha = unpacked_byte_alpha(metrics.format, bitmap[idx]);
-                        image::Rgba([255, 255, 255, alpha])
-                    }
+                    image::Rgba([255, 255, 255, alpha[(y as usize) * width + x as usize]])
                 });
 
             let texture_pack_result = texture_packer.pack(&img);
@@ -352,7 +414,7 @@ impl engine::Font for Font {
 
 #[cfg(test)]
 mod tests {
-    use super::FontMetrics;
+    use super::{FontBitmap, FontMetrics};
     use std::io::Cursor;
 
     /// Build a minimal, valid Dark `.FON` byte buffer for `first..=last` with
@@ -399,6 +461,54 @@ mod tests {
         // Out-of-range codes have no glyph.
         assert_eq!(m.glyph_width(47), None);
         assert_eq!(m.glyph_width(50), None);
+    }
+
+    /// `synth_font` leaves the bitmap strip zeroed; overwrite it with `pixels`.
+    fn with_bitmap(mut bytes: Vec<u8>, pixels: &[u8]) -> Vec<u8> {
+        let start = bytes.len() - pixels.len();
+        bytes[start..].copy_from_slice(pixels);
+        bytes
+    }
+
+    #[test]
+    fn packed_glyph_unpacks_one_bit_per_pixel() {
+        // One 3x2 glyph 'A'; row_width = 3 bytes (synth uses the last column).
+        // Row 0 = 1 0 1, row 1 = 0 1 0.
+        let bytes = with_bitmap(
+            synth_font(65, 65, 2, &[0, 3], 0),
+            &[0b1010_0000, 0, 0, 0b0100_0000, 0, 0],
+        );
+        let font = FontBitmap::read(&mut Cursor::new(bytes));
+
+        assert_eq!(
+            font.glyph_alpha(65),
+            Some((3, vec![255, 0, 255, 0, 255, 0]))
+        );
+        assert_eq!(font.glyph_alpha(66), None);
+    }
+
+    #[test]
+    fn format1_glyphs_scale_coverage_and_lay_out_with_spacing() {
+        // Two 2x1 glyphs, format 1 (coverage 0..=15), row_width = 4 bytes.
+        let bytes = with_bitmap(synth_font(65, 66, 1, &[0, 2, 4], 1), &[15, 0, 8, 15]);
+        let font = FontBitmap::read(&mut Cursor::new(bytes));
+
+        assert_eq!(font.glyph_alpha(65), Some((2, vec![255, 0])));
+        assert_eq!(font.glyph_alpha(66), Some((2, vec![136, 255])));
+        // Glyphs run left to right with one transparent pixel between them.
+        assert_eq!(font.render_string("AB"), (5, 1, vec![255, 0, 0, 136, 255]));
+        // Undefined characters are dropped rather than rendered as blanks.
+        assert_eq!(font.render_string("AZB").0, 5);
+        assert_eq!(font.render_string("ZZ"), (0, 0, vec![]));
+    }
+
+    #[test]
+    fn truncated_bitmap_reads_as_transparent_instead_of_panicking() {
+        let mut bytes = with_bitmap(synth_font(65, 65, 2, &[0, 3], 1), &[9; 6]);
+        bytes.truncate(bytes.len() - 4);
+        let font = FontBitmap::read(&mut Cursor::new(bytes));
+
+        assert_eq!(font.glyph_alpha(65), Some((3, vec![153, 153, 0, 0, 0, 0])));
     }
 
     /// Locate a game asset by data-root-relative path (fonts live under both

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -167,6 +167,13 @@ enum PreviewKind {
     Motion {
         clip: ClipInfo,
     },
+    /// A `.fon` bitmap font: its header metadata plus a sample string
+    /// rasterized from the font's own glyphs.
+    Font {
+        summary: Vec<(&'static str, String)>,
+        sample: egui::ColorImage,
+        texture: Option<egui::TextureHandle>,
+    },
     /// A `.mi` motion-info header, parsed standalone.
     MotionInfo {
         info: dark::motion::MotionInfo,
@@ -780,6 +787,13 @@ fn decode_preview(
             Err(reason) => raw_fallback(&bytes, reason),
         };
     }
+    if ext == "fon" {
+        return match quiet_catch(|| decode_font(&bytes)) {
+            Ok(Ok(kind)) => kind,
+            Ok(Err(reason)) => raw_fallback(&bytes, reason),
+            Err(msg) => raw_fallback(&bytes, format!(".fon parse failed: {msg}")),
+        };
+    }
     if ext == "mi" {
         let parsed =
             quiet_catch(|| dark::motion::MotionInfo::read(&mut std::io::Cursor::new(&bytes)));
@@ -792,6 +806,47 @@ fn decode_preview(
         };
     }
     raw_fallback(&bytes, format!("cannot render .{ext} files"))
+}
+
+/// Sample text drawn with a previewed `.fon`, chosen to cover both cases and
+/// the digits.
+const FONT_SAMPLE: &str = "The quick brown fox jumps over the lazy dog 0123456789";
+/// Integer scales the sample is drawn at (the fonts are bitmaps, so only whole
+/// multiples of their native height are meaningful).
+const FONT_SAMPLE_SCALES: &[usize] = &[1, 2, 3];
+
+/// Rasterize the sample string with the font's own glyphs, plus the header
+/// metadata rows. Glyph coverage becomes the alpha of white pixels, so the
+/// sample reads against the panel background.
+fn decode_font(bytes: &[u8]) -> Result<PreviewKind, String> {
+    let font = dark::font::FontBitmap::read(&mut std::io::Cursor::new(bytes));
+    let metrics = &font.metrics;
+    let summary = vec![
+        ("Format", metrics.format_label().to_string()),
+        (
+            "Glyphs",
+            format!(
+                "{} (codes {}..={})",
+                metrics.num_chars(),
+                metrics.first_char,
+                metrics.last_char
+            ),
+        ),
+        ("Height", format!("{} px", metrics.height)),
+        ("Row width", format!("{} bytes", metrics.row_width)),
+    ];
+
+    let (width, height, alpha) = font.render_string(FONT_SAMPLE);
+    if width == 0 || height == 0 {
+        return Err("font defines none of the sample characters".to_string());
+    }
+    let rgba: Vec<u8> = alpha.iter().flat_map(|&a| [255, 255, 255, a]).collect();
+    let sample = egui::ColorImage::from_rgba_unmultiplied([width, height], &rgba);
+    Ok(PreviewKind::Font {
+        summary,
+        sample,
+        texture: None,
+    })
 }
 
 /// Decode image bytes to a `ColorImage` under the panic guard (Ok(None) = no
@@ -1690,6 +1745,37 @@ impl ExplorerApp {
                     self.screenshot.is_some(),
                 );
                 host.show(ui, frame, &model_key, &PreviewScene::Skeleton(clip_name));
+            }
+            PreviewKind::Font {
+                summary,
+                sample,
+                texture,
+            } => {
+                egui::Grid::new("font_info").num_columns(2).show(ui, |ui| {
+                    for (label, value) in summary.iter() {
+                        ui.label(*label);
+                        ui.label(value);
+                        ui.end_row();
+                    }
+                });
+                ui.separator();
+                let [width, height] = sample.size;
+                let texture = texture.get_or_insert_with(|| {
+                    ui.ctx().load_texture(
+                        format!("font_sample:{}", preview.key),
+                        sample.clone(),
+                        egui::TextureOptions::NEAREST,
+                    )
+                });
+                egui::ScrollArea::both().show(ui, |ui| {
+                    for scale in FONT_SAMPLE_SCALES {
+                        ui.label(format!("{scale}x ({} px)", height * scale));
+                        let display =
+                            egui::Vec2::new((width * scale) as f32, (height * scale) as f32);
+                        ui.image((texture.id(), display));
+                        ui.add_space(4.0);
+                    }
+                });
             }
             PreviewKind::MotionInfo { info, hex } => {
                 egui::Grid::new("motion_info_file")


### PR DESCRIPTION
Selecting a `.FON` in `cargo dx` showed a hex dump. It now shows what the font *is*: the header metadata (format variant, glyph count and code range, height, row width) and a pangram rasterized from the font's own glyphs at 1x/2x/3x — the fonts are bitmaps, so whole multiples of the native height are the only meaningful "sizes".

The preview reuses the shipping parser rather than adding a second one. The glyph pixel decode moves out of `Font::read` into a new no-GL `FontBitmap` in `dark/src/font.rs` (metrics + bitmap strip, `glyph_alpha`, `render_string`); `Font::read` now builds its texture atlas from that, so the in-game text path and the preview decode pixels through one function.

All three shipped variants render: packed format 0 (`MAINFONT.FON`), format 1 antialias-16 (`METAFONT.FON` — the variant that has bitten before), and 0xCCCC 8-bit alpha (`MAINAA.FON`). A format the parser does not specially handle is labeled "unknown (treated as 8-bit alpha)" rather than silently mislabeled. Reads past a truncated bitmap strip now yield transparent instead of panicking.

## Visuals

`MAINFONT.FON` — format 0, packed 1bpp:

![mainfont](https://gist.githubusercontent.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/font-preview-mainfont.png)

`METAFONT.FON` — format 1, antialias-16:

![metafont](https://gist.githubusercontent.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/font-preview-metafont.png)

`MAINAA.FON` — format 0xCCCC, 8-bit alpha (dimmer because the shared decoder's `> 205 -> 0` clamp is faithful to what the game draws):

![mainaa](https://gist.githubusercontent.com/tommy-xr/d1665b465f43ca14461315a12990acb0/raw/font-preview-mainaa.png)

No GIF: the preview is static.

## Verification

- `cargo test -p dark --lib font` — 8 tests green, including three new ones for the rasterizer (packed 1bpp unpacking, format-1 coverage scaling + glyph spacing, truncated-strip safety).
- `RUSTFLAGS="-D warnings" cargo check -p dark -p dark_explorer -p shock2vr`.
- Screenshots above captured headlessly: `cargo dx ui --select iface/fonts/mainfont.fon --screenshot <out>.png` (likewise `intrface/metafont.fon`, `iface/fonts/mainaa.fon`).

- In-game text path re-verified after the `Font::read` refactor: the main menu (METAFONT) still renders correctly through the debug runtime, and the SDK e2e suite was run.

## Review

`/xreview` (Claude + Codex + a de-dup pass): **no Critical/High**. Applied: the sample now lays out on glyph advances (the UI's `measure_text_width` adds nothing between glyphs — only the dark_viewer-only `Font::get_mesh` uses `SPACING`), the file is read once instead of twice, and a truncated bitmap strip logs a warning.

Both engines flagged that reads past a truncated strip now decode as transparent where `Font::read` previously panicked. Kept deliberately: the explorer must tolerate whatever file the user clicked, and the leniency never fires on real data (every shipped font's strip is exactly `row_width * height`) — the new `warn!` makes a bad asset visible in the log instead of silently blank.

Continues the dark_explorer campaign (stack #1193, now merged); branches from `main`.
