### PR TITLE
feat(lighting): light objects from the lights that reach their cell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,6 +631,19 @@ The project supports experimental flags for gating in-progress features during d
   prop, e.g. shield membranes) are sealed in A* in every mode. Verify AI routing
   with `GET /v1/ai/paths` on the debug runtime.
 
+- **`object_lighting`**: light objects (props, creatures, held items) from the
+  mission's own lights. Without it every object is shaded a flat ambient plus
+  the player's hand lights, so a prop under a lamp and one in a black corridor
+  look identical. With it, each object takes the lights its cell says reach it,
+  ranked and capped at the renderer's slots, and is shaded the way the original
+  did - inverse-*distance* falloff over the mission's authored ambient. Objects
+  are legitimately dimmer than the lightmapped walls behind them; three dev
+  params (`object_light_brightness`, `object_light_ambient`,
+  `object_light_wrap`) tune that live over HTTP. **No-op in `debug_*` scenes**,
+  which have no world rep and therefore no cells to take lights from. Inspect
+  the result with `GET /v1/scene`, whose `lighting` block reports each object's
+  resolved light count and the light it receives.
+
 - **`high_detail_meshes`** / **`no_high_detail_meshes`**: force the 25AE
   high-detail (`PMNM`) creature meshes on or off, overriding the default (on
   everywhere since the Quest 3 measurement in #1022; ~0.3 ms extra combined eye

--- a/dark/src/mission/bsp_tree.rs
+++ b/dark/src/mission/bsp_tree.rs
@@ -58,11 +58,11 @@ bitflags! {
 
 impl BspTree {
     pub fn cell_from_position(&self, position: Vector3<f32>) -> Option<u32> {
-        Self::cell_from_position_recursive(self.root_node.clone(), position)
+        Self::cell_from_position_recursive(&self.root_node, position)
     }
 
-    fn cell_from_position_recursive(node: Arc<BspNode>, position: Vector3<f32>) -> Option<u32> {
-        match node.as_ref() {
+    fn cell_from_position_recursive(node: &BspNode, position: Vector3<f32>) -> Option<u32> {
+        match node {
             BspNode::Leaf { cell_idx } => Some(*cell_idx as u32),
             BspNode::Split {
                 cell_idx: _,
@@ -79,12 +79,15 @@ impl BspTree {
                     + plane.w
                     >= 0.0;
 
-                if is_in_front && front.is_some() {
-                    return Self::cell_from_position_recursive(front.clone().unwrap(), position);
+                // Borrow rather than clone the Arc: this descends once per lit
+                // object per frame, and an atomic refcount round-trip per node
+                // is pure overhead for a read.
+                if is_in_front && let Some(front) = front {
+                    return Self::cell_from_position_recursive(front, position);
                 }
 
-                if !is_in_front && back.is_some() {
-                    return Self::cell_from_position_recursive(back.clone().unwrap(), position);
+                if !is_in_front && let Some(back) = back {
+                    return Self::cell_from_position_recursive(back, position);
                 }
 
                 None

--- a/engine/src/gl_engine.rs
+++ b/engine/src/gl_engine.rs
@@ -127,22 +127,27 @@ impl Engine for OpenGLEngine {
                 // SINGLE-PASS LIGHTING: Opaque pass with all lighting calculated
                 // in shaders.
                 scene.objects_in_layer(layer).for_each(|s| {
+                    // An object's own lights don't replace the scene's - the
+                    // player's hand lights live there, and a torch pointed at a
+                    // prop has to light it.
+                    let merged = s.lights().map(|o| o.merged_with(scene.lights()));
                     s.draw_opaque(
                         self,
                         render_context,
                         &view,
-                        s.lights().unwrap_or(scene.lights()),
+                        merged.as_ref().unwrap_or(scene.lights()),
                     )
                 });
 
                 // Transparent pass with all lighting calculated in shaders
                 gl::DepthMask(gl::FALSE);
                 scene.objects_in_layer(layer).for_each(|s| {
+                    let merged = s.lights().map(|o| o.merged_with(scene.lights()));
                     s.draw_transparent(
                         self,
                         render_context,
                         &view,
-                        s.lights().unwrap_or(scene.lights()),
+                        merged.as_ref().unwrap_or(scene.lights()),
                     )
                 });
                 gl::DepthMask(gl::TRUE);

--- a/engine/src/gl_engine.rs
+++ b/engine/src/gl_engine.rs
@@ -126,15 +126,25 @@ impl Engine for OpenGLEngine {
 
                 // SINGLE-PASS LIGHTING: Opaque pass with all lighting calculated
                 // in shaders.
-                scene
-                    .objects_in_layer(layer)
-                    .for_each(|s| s.draw_opaque(self, render_context, &view, scene.lights()));
+                scene.objects_in_layer(layer).for_each(|s| {
+                    s.draw_opaque(
+                        self,
+                        render_context,
+                        &view,
+                        s.lights().unwrap_or(scene.lights()),
+                    )
+                });
 
                 // Transparent pass with all lighting calculated in shaders
                 gl::DepthMask(gl::FALSE);
-                scene
-                    .objects_in_layer(layer)
-                    .for_each(|s| s.draw_transparent(self, render_context, &view, scene.lights()));
+                scene.objects_in_layer(layer).for_each(|s| {
+                    s.draw_transparent(
+                        self,
+                        render_context,
+                        &view,
+                        s.lights().unwrap_or(scene.lights()),
+                    )
+                });
                 gl::DepthMask(gl::TRUE);
             }
 

--- a/engine/src/scene/basic_material.rs
+++ b/engine/src/scene/basic_material.rs
@@ -537,12 +537,20 @@ mod tests {
     #[test]
     fn shader_source_radius_matches_the_engine_constant() {
         let declared = format!(
-            "const float SOURCE_RADIUS = {:.1};",
+            "const float SOURCE_RADIUS = {};",
             crate::scene::light::LIGHT_SOURCE_RADIUS
         );
-        assert!(
-            UNIFIED_FRAGMENT_SHADER_SOURCE.contains(&declared),
-            "shader must declare `{declared}`"
-        );
+        for (name, source) in [
+            ("basic", UNIFIED_FRAGMENT_SHADER_SOURCE),
+            (
+                "skinned",
+                crate::scene::skinned_material::FRAGMENT_SHADER_SOURCE_FOR_TEST,
+            ),
+        ] {
+            assert!(
+                source.contains(&declared),
+                "{name} shader must declare `{declared}`"
+            );
+        }
     }
 }

--- a/engine/src/scene/basic_material.rs
+++ b/engine/src/scene/basic_material.rs
@@ -60,6 +60,19 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
         uniform float spotlightOuterAngle[6];
         uniform float spotlightRange[6];
 
+        // Light every surface gets before any lamp reaches it.
+        uniform vec3 ambientLight;
+        // 0 = the renderer's smooth curve, 1 = inverse distance (how the
+        // original lit objects - it falls off far more slowly).
+        uniform int lightFalloffMode;
+        // 0 = plain lambert, 1 = half-lambert (light wraps past the terminator).
+        uniform float lambertWrap;
+
+        // Lights are sources of this radius, not points: without a floor the
+        // inverse-distance falloff runs away inside the model a lamp belongs
+        // to. Must equal engine::scene::light::LIGHT_SOURCE_RADIUS.
+        const float SOURCE_RADIUS = 0.8;
+
         // Calculate spotlight contribution
         vec3 calculateSpotlight(int i, vec3 worldPos, vec3 normal, vec3 texColor) {
             // Skip if light has zero intensity
@@ -95,10 +108,17 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
             }
 
             // Distance attenuation
-            float distanceAttenuation = 1.0 / (1.0 + 0.1 * distance + 0.01 * distance * distance);
+            float distanceAttenuation;
+            if (lightFalloffMode == 1) {
+                distanceAttenuation = 1.0 / max(distance, SOURCE_RADIUS);
+            } else {
+                distanceAttenuation = 1.0 / (1.0 + 0.1 * distance + 0.01 * distance * distance);
+            }
 
-            // Diffuse lighting
-            float lambertian = max(dot(normal, lightDir), 0.0);
+            // Diffuse lighting, optionally wrapped past the terminator so a
+            // surface facing away is lifted rather than black.
+            float ndl = dot(normal, lightDir);
+            float lambertian = max((ndl + lambertWrap) / (1.0 + lambertWrap), 0.0);
 
             // Combine all factors
             return texColor * spotlightColorIntensity[i].rgb * spotlightColorIntensity[i].w
@@ -110,7 +130,7 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
             if (texColor.a < 0.1) discard;
 
             // Base material color (ambient)
-            vec3 finalColor = texColor.rgb * 0.5;
+            vec3 finalColor = texColor.rgb * ambientLight;
 
             // Add emissive contribution
             finalColor += texColor.rgb * emissivity;
@@ -142,6 +162,9 @@ struct UnifiedUniforms {
     spotlight_inner_angle_loc: [i32; 6],
     spotlight_outer_angle_loc: [i32; 6],
     spotlight_range_loc: [i32; 6],
+    ambient_light_loc: i32,
+    light_falloff_mode_loc: i32,
+    lambert_wrap_loc: i32,
 }
 
 static UNIFIED_SHADER_PROGRAM: OnceCell<(ShaderProgram, UnifiedUniforms)> = OnceCell::new();
@@ -189,6 +212,23 @@ where
             // Set material properties
             gl::Uniform1f(uniforms.transparency_loc, self.transparency);
             gl::Uniform1f(uniforms.emissivity_loc, self.emissivity);
+
+            // How this array's lights behave: what an unlit surface shows, and
+            // how the lights fall off.
+            gl::Uniform3f(
+                uniforms.ambient_light_loc,
+                lights.ambient.x,
+                lights.ambient.y,
+                lights.ambient.z,
+            );
+            gl::Uniform1f(uniforms.lambert_wrap_loc, lights.lambert_wrap);
+            gl::Uniform1i(
+                uniforms.light_falloff_mode_loc,
+                match lights.falloff {
+                    crate::scene::light::LightFalloff::Smooth => 0,
+                    crate::scene::light::LightFalloff::InverseDistance => 1,
+                },
+            );
 
             // Set spotlight array uniforms
             for i in 0..6 {
@@ -420,6 +460,18 @@ where
                         gl::GetUniformLocation(shader.gl_id, c_str!("spotlightRange[4]").as_ptr()),
                         gl::GetUniformLocation(shader.gl_id, c_str!("spotlightRange[5]").as_ptr()),
                     ],
+                    ambient_light_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("ambientLight").as_ptr(),
+                    ),
+                    light_falloff_mode_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("lightFalloffMode").as_ptr(),
+                    ),
+                    lambert_wrap_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("lambertWrap").as_ptr(),
+                    ),
                 };
                 (shader, uniforms)
             }
@@ -472,4 +524,25 @@ where
         transparency,
         base_transparency: transparency,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shader floors its inverse-distance falloff at a source radius, and
+    /// the light selection ranks with the same floor. They are declared in two
+    /// languages, so pin them to each other: if they drift, the lights chosen
+    /// are not the lights drawn.
+    #[test]
+    fn shader_source_radius_matches_the_engine_constant() {
+        let declared = format!(
+            "const float SOURCE_RADIUS = {:.1};",
+            crate::scene::light::LIGHT_SOURCE_RADIUS
+        );
+        assert!(
+            UNIFIED_FRAGMENT_SHADER_SOURCE.contains(&declared),
+            "shader must declare `{declared}`"
+        );
+    }
 }

--- a/engine/src/scene/light.rs
+++ b/engine/src/scene/light.rs
@@ -226,6 +226,33 @@ impl LightArray {
         self
     }
 
+    /// This array's lights plus as many of `scene`'s as still fit, with the
+    /// scene's taking priority.
+    ///
+    /// The player's hand lights live in the scene array and are added by the
+    /// runtime after the game has resolved per-object lights, so an object that
+    /// carries its own lights would otherwise be invisible to the torch pointed
+    /// at it. The scene's go in first because a light the player is holding is
+    /// the one they expect to see working.
+    ///
+    /// Falloff and ambient come from `self`: they are per-array uniforms, so a
+    /// merged array has to pick one rule, and the object's is the one that
+    /// matches the lights doing most of the work.
+    pub fn merged_with(&self, scene: &LightArray) -> LightArray {
+        let mut merged = LightArray {
+            lights: [None, None, None, None, None, None],
+            ambient: self.ambient,
+            falloff: self.falloff,
+            lambert_wrap: self.lambert_wrap,
+        };
+        for (_, light) in scene.iter_active().chain(self.iter_active()) {
+            if merged.add_light(light.clone()).is_none() {
+                break;
+            }
+        }
+        merged
+    }
+
     /// Clear all lights
     pub fn clear(&mut self) {
         self.lights = [None, None, None, None, None, None];

--- a/engine/src/scene/light.rs
+++ b/engine/src/scene/light.rs
@@ -150,11 +150,42 @@ impl From<PointLight> for SceneLight {
     }
 }
 
+/// How a light's contribution falls off with distance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LightFalloff {
+    /// The renderer's own smooth curve, used by the player's hand lights.
+    Smooth,
+    /// Inverse distance, which is what the original engine used to light
+    /// objects. Falls off far more slowly than an inverse square.
+    InverseDistance,
+}
+
+/// The unlit floor: what a surface shows before any light reaches it.
+pub const DEFAULT_AMBIENT: f32 = 0.5;
+
+/// Treat every light as a source of this radius rather than a point, in world
+/// units. Inverse-distance has no upper bound, so a light sitting inside the
+/// model it belongs to - a lamp lighting its own housing - would otherwise
+/// contribute thousands and, worse, crowd every other light out of the
+/// selection. Shading and ranking MUST use the same floor or the lights chosen
+/// are not the lights drawn; the shader spells it `SOURCE_RADIUS`.
+pub const LIGHT_SOURCE_RADIUS: f32 = 0.8;
+
 /// Container for managing up to 6 lights for single-pass lighting
 #[derive(Debug, Clone)]
 pub struct LightArray {
     /// Array of up to 6 lights (None = disabled slot)
     pub lights: [Option<SceneLight>; 6],
+    /// Light every surface receives regardless of the lights above.
+    pub ambient: Vector3<f32>,
+    /// How the lights in this array attenuate.
+    pub falloff: LightFalloff,
+    /// Wraps diffuse light around the terminator: 0 is plain lambert (a
+    /// surface facing away gets nothing, which is what the original did for
+    /// objects), 1 is half-lambert (what it baked into lightmaps, where a wall
+    /// facing away still catches half). Between the two trades directional
+    /// contrast for lifted shadows.
+    pub lambert_wrap: f32,
 }
 
 impl LightArray {
@@ -162,6 +193,9 @@ impl LightArray {
     pub fn new() -> Self {
         Self {
             lights: [None, None, None, None, None, None],
+            ambient: Vector3::new(DEFAULT_AMBIENT, DEFAULT_AMBIENT, DEFAULT_AMBIENT),
+            falloff: LightFalloff::Smooth,
+            lambert_wrap: 0.0,
         }
     }
 
@@ -181,6 +215,15 @@ impl LightArray {
     /// Get a reference to the light in the specified slot
     pub fn get_light(&self, index: usize) -> Option<&SceneLight> {
         self.lights.get(index).and_then(|slot| slot.as_ref())
+    }
+
+    /// Light everything in this array by the original engine's rule: inverse
+    /// distance, over the mission's own ambient floor.
+    pub fn with_object_lighting(mut self, ambient: Vector3<f32>, lambert_wrap: f32) -> Self {
+        self.ambient = ambient;
+        self.falloff = LightFalloff::InverseDistance;
+        self.lambert_wrap = lambert_wrap;
+        self
     }
 
     /// Clear all lights

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -114,6 +114,11 @@ pub struct SceneObject {
     depth_bias: bool,
     /// Debug-only provenance; `Rc` so cloning an object per frame stays cheap.
     debug_tag: Option<Rc<SceneObjectDebugTag>>,
+    /// Lights for this object alone, overriding the scene's. World geometry is
+    /// lit by baked lightmaps and wants the scene set; an object standing in a
+    /// room wants the lights that actually reach that room. `Rc` so the objects
+    /// of one entity share a resolved set and cloning stays cheap.
+    lights: Option<Rc<crate::scene::light::LightArray>>,
 }
 
 impl SceneObject {
@@ -308,7 +313,18 @@ impl SceneObject {
             debug_tag: None,
             backface_culling: None,
             depth_bias: false,
+            lights: None,
         }
+    }
+
+    /// Light this object with its own set instead of the scene's.
+    pub fn set_lights(&mut self, lights: Option<Rc<crate::scene::light::LightArray>>) {
+        self.lights = lights;
+    }
+
+    /// This object's own lights, if it has them.
+    pub fn lights(&self) -> Option<&crate::scene::light::LightArray> {
+        self.lights.as_deref()
     }
 
     pub fn draw_opaque(
@@ -435,11 +451,13 @@ impl SceneObject {
             debug_tag: None,
             backface_culling: None,
             depth_bias: false,
+            lights: None,
         }
     }
 
     pub fn duplicate(&self) -> SceneObject {
         SceneObject {
+            lights: self.lights.clone(),
             material: self.material.clone(),
             geometry: self.geometry.clone(),
             transform: self.transform,

--- a/engine/src/scene/skinned_material.rs
+++ b/engine/src/scene/skinned_material.rs
@@ -77,7 +77,7 @@ const UNIFIED_VERTEX_SHADER_SOURCE: &str = r#"
         }
 "#;
 
-const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
+pub(crate) const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
         out vec4 fragColor;
 
         in vec2 texCoord;
@@ -609,3 +609,8 @@ impl SkinnedMaterial {
         })
     }
 }
+
+/// The fragment shader source, for the test that pins its SOURCE_RADIUS to the
+/// engine constant. Both lit materials declare it; both must agree.
+#[cfg(test)]
+pub(crate) const FRAGMENT_SHADER_SOURCE_FOR_TEST: &str = UNIFIED_FRAGMENT_SHADER_SOURCE;

--- a/engine/src/scene/skinned_material.rs
+++ b/engine/src/scene/skinned_material.rs
@@ -97,6 +97,19 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
         uniform float spotlightOuterAngle[6];
         uniform float spotlightRange[6];
 
+        // Light every surface gets before any lamp reaches it.
+        uniform vec3 ambientLight;
+        // 0 = the renderer's smooth curve, 1 = inverse distance (how the
+        // original lit objects - it falls off far more slowly).
+        uniform int lightFalloffMode;
+        // 0 = plain lambert, 1 = half-lambert (light wraps past the terminator).
+        uniform float lambertWrap;
+
+        // Lights are sources of this radius, not points: without a floor the
+        // inverse-distance falloff runs away inside the model a lamp belongs
+        // to. Must equal engine::scene::light::LIGHT_SOURCE_RADIUS.
+        const float SOURCE_RADIUS = 0.8;
+
         // Calculate spotlight contribution
         vec3 calculateSpotlight(int i, vec3 worldPos, vec3 normal, vec3 texColor) {
             // Skip if light has zero intensity
@@ -132,10 +145,17 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
             }
 
             // Distance attenuation
-            float distanceAttenuation = 1.0 / (1.0 + 0.1 * distance + 0.01 * distance * distance);
+            float distanceAttenuation;
+            if (lightFalloffMode == 1) {
+                distanceAttenuation = 1.0 / max(distance, SOURCE_RADIUS);
+            } else {
+                distanceAttenuation = 1.0 / (1.0 + 0.1 * distance + 0.01 * distance * distance);
+            }
 
-            // Diffuse lighting
-            float lambertian = max(dot(normal, lightDir), 0.0);
+            // Diffuse lighting, optionally wrapped past the terminator so a
+            // surface facing away is lifted rather than black.
+            float ndl = dot(normal, lightDir);
+            float lambertian = max((ndl + lambertWrap) / (1.0 + lambertWrap), 0.0);
 
             // Combine all factors
             return texColor * spotlightColorIntensity[i].rgb * spotlightColorIntensity[i].w
@@ -147,7 +167,7 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
             if (texColor.a < 0.1) discard;
 
             // Base material color (ambient)
-            vec3 finalColor = texColor.rgb * 0.5;
+            vec3 finalColor = texColor.rgb * ambientLight;
 
             // Add emissive contribution
             finalColor += texColor.rgb * emissivity;
@@ -182,6 +202,9 @@ struct UnifiedUniforms {
     spotlight_inner_angle_loc: [i32; 6],
     spotlight_outer_angle_loc: [i32; 6],
     spotlight_range_loc: [i32; 6],
+    ambient_light_loc: i32,
+    light_falloff_mode_loc: i32,
+    lambert_wrap_loc: i32,
 }
 
 static UNIFIED_SHADER_PROGRAM: OnceCell<(ShaderProgram, UnifiedUniforms)> = OnceCell::new();
@@ -254,6 +277,23 @@ impl SkinnedMaterial {
                 crate::scene::SKINNING_PALETTE_SIZE as i32,
                 gl::FALSE,
                 packed.as_ptr(),
+            );
+
+            // How this array's lights behave: what an unlit surface shows, and
+            // how the lights fall off.
+            gl::Uniform3f(
+                uniforms.ambient_light_loc,
+                lights.ambient.x,
+                lights.ambient.y,
+                lights.ambient.z,
+            );
+            gl::Uniform1f(uniforms.lambert_wrap_loc, lights.lambert_wrap);
+            gl::Uniform1i(
+                uniforms.light_falloff_mode_loc,
+                match lights.falloff {
+                    crate::scene::light::LightFalloff::Smooth => 0,
+                    crate::scene::light::LightFalloff::InverseDistance => 1,
+                },
             );
 
             // Set spotlight array uniforms
@@ -489,6 +529,18 @@ impl Material for SkinnedMaterial {
                         gl::GetUniformLocation(shader.gl_id, c_str!("spotlightRange[4]").as_ptr()),
                         gl::GetUniformLocation(shader.gl_id, c_str!("spotlightRange[5]").as_ptr()),
                     ],
+                    ambient_light_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("ambientLight").as_ptr(),
+                    ),
+                    light_falloff_mode_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("lightFalloffMode").as_ptr(),
+                    ),
+                    lambert_wrap_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("lambertWrap").as_ptr(),
+                    ),
                 };
                 (shader, uniforms)
             }

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -297,7 +297,7 @@ pub struct SceneListResult {
 }
 
 /// One scene object as submitted to the renderer
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct SceneObjectSummary {
     pub entity_id: Option<u64>,
     pub name: Option<String>,
@@ -325,7 +325,7 @@ pub struct SceneObjectSummary {
 }
 
 /// What the object-lighting pass decided for one object.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ObjectLightingSummary {
     /// How many lights were kept for it, out of the renderer's slots.
     pub light_count: usize,

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -319,6 +319,21 @@ pub struct SceneObjectSummary {
     pub clear_depth: bool,
     /// Front-face winding used for culling, or absent when double-sided.
     pub backface_culling: Option<String>,
+    /// Lights resolved for this object alone, when object lighting is on.
+    /// Absent for anything lit by the scene's own lights (world geometry, HUD).
+    pub lighting: Option<ObjectLightingSummary>,
+}
+
+/// What the object-lighting pass decided for one object.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ObjectLightingSummary {
+    /// How many lights were kept for it, out of the renderer's slots.
+    pub light_count: usize,
+    /// Total light arriving at its position, ignoring surface orientation -
+    /// the number to compare between objects to see who is lit and who is not.
+    pub received: f32,
+    /// The unlit floor this object is shaded over.
+    pub ambient: [f32; 3],
 }
 
 /// List of physics rigid bodies

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1026,6 +1026,14 @@ fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneO
                 render_layer: render_layer.as_str().to_owned(),
                 clear_depth: render_layer.clears_depth() && first_in_layer,
                 backface_culling: obj.backface_culling().map(|w| format!("{w:?}")),
+                lighting: obj.lights().map(|lights| {
+                    let position = cgmath::vec3(translation.x, translation.y, translation.z);
+                    commands::ObjectLightingSummary {
+                        light_count: lights.active_count(),
+                        received: shock2vr::object_lighting::received_light(lights, position),
+                        ambient: [lights.ambient.x, lights.ambient.y, lights.ambient.z],
+                    }
+                }),
             }
         })
         .collect()
@@ -1794,6 +1802,14 @@ fn process_command(
                     render_layer: o.render_layer.clone(),
                     clear_depth: o.clear_depth,
                     backface_culling: o.backface_culling.clone(),
+                    lighting: o
+                        .lighting
+                        .as_ref()
+                        .map(|l| commands::ObjectLightingSummary {
+                            light_count: l.light_count,
+                            received: l.received,
+                            ambient: l.ambient,
+                        }),
                 })
                 .collect();
             let result = commands::SceneListResult {

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1790,27 +1790,7 @@ fn process_command(
             let objects = matched
                 .into_iter()
                 .take(limit.unwrap_or(usize::MAX))
-                .map(|o| commands::SceneObjectSummary {
-                    entity_id: o.entity_id,
-                    name: o.name.clone(),
-                    model: o.model.clone(),
-                    source: o.source.clone(),
-                    position: o.position,
-                    transparency: o.transparency,
-                    depth_write: o.depth_write,
-                    depth_bias: o.depth_bias,
-                    render_layer: o.render_layer.clone(),
-                    clear_depth: o.clear_depth,
-                    backface_culling: o.backface_culling.clone(),
-                    lighting: o
-                        .lighting
-                        .as_ref()
-                        .map(|l| commands::ObjectLightingSummary {
-                            light_count: l.light_count,
-                            received: l.received,
-                            ambient: l.ambient,
-                        }),
-                })
+                .cloned()
                 .collect();
             let result = commands::SceneListResult {
                 objects,

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -218,6 +218,25 @@ dev_params! {
     /// even read, so a stray `Alt+V` (or controller chord) during normal play
     /// cannot detach the view. Turning it back off while detached also
     /// re-attaches the camera, so the switch is always a way out.
+    /// Multiplies every object light's brightness. The default 1.0 is the
+    /// faithful value - brightness as authored, divided back down for our
+    /// smaller world units - and exists to be turned up when the authored
+    /// answer reads too dark on a modern display. Objects are legitimately
+    /// dimmer than the walls behind them (lightmapped surfaces never fall
+    /// fully dark, objects do), so this is a taste knob, not a correction.
+    OBJECT_LIGHT_BRIGHTNESS = float("object_light_brightness", "Obj light", 1.0, 0.0, 8.0, 0.1),
+    /// Added to the mission's own ambient for objects only. The mission floor
+    /// is often very low (medsci1 authors 0.078), which is faithful but leaves
+    /// an object with no light on it nearly black; raise this to lift the
+    /// shadows without touching what the lamps do.
+    OBJECT_LIGHT_AMBIENT_BOOST = float("object_light_ambient", "Obj ambient", 0.0, 0.0, 0.5, 0.01),
+    /// How far light wraps past the terminator on objects. 0 is what the
+    /// original did for objects - a face pointing away from a lamp gets
+    /// nothing but ambient. 1 is the half-lambert it baked into *lightmaps*,
+    /// which is why walls never go fully dark and props do. Raising this lifts
+    /// a prop's shadowed side at the cost of the directional read that makes a
+    /// lamp feel like a lamp.
+    OBJECT_LIGHT_WRAP = float("object_light_wrap", "Obj wrap", 0.0, 0.0, 1.0, 0.05),
     FREE_CAMERA = bool("free_camera", "Free camera", false),
     /// Which pose the visibility engine culls from while the free camera is
     /// detached. Off (the default) culls from the *player*, so flying out

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -8,6 +8,7 @@ pub mod input_context;
 pub mod install;
 pub mod inventory;
 pub mod message_trace;
+pub mod object_lighting;
 pub mod save_load;
 pub mod scenes;
 pub mod teleport;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8394,6 +8394,24 @@ impl MissionCore {
                 HashSet::new()
             };
 
+        // Per-object lighting, when enabled: a closure so the render loop pays
+        // nothing (no cell lookup, no light ranking) when the flag is off.
+        let object_lights: Option<Box<dyn Fn(Vector3<f32>) -> engine::scene::light::LightArray>> =
+            if options.experimental_features.contains("object_lighting") {
+                self.spatial_data.as_deref().map(|spatial| {
+                    Box::new(move |position: Vector3<f32>| {
+                        crate::object_lighting::lights_for_position(
+                            spatial,
+                            spatial.get_light_table(),
+                            position,
+                        )
+                    })
+                        as Box<dyn Fn(Vector3<f32>) -> engine::scene::light::LightArray>
+                })
+            } else {
+                None
+            };
+
         // Render models
         for (entity_id, objs) in &self.id_to_model {
             total_model_count += 1;
@@ -8443,10 +8461,18 @@ impl MissionCore {
             });
 
             if let Ok(xform) = v_transform.get(*entity_id).map(|p| p.0) {
+                // One light set per entity, resolved at its origin and shared by
+                // its sub-objects - the lights that reach the room it stands in.
+                let entity_lights = object_lights.as_ref().map(|resolve| {
+                    let position = xform.w.truncate();
+                    Rc::new(resolve(position))
+                });
+
                 for obj in scene_objs {
                     let mut xformed_obj = obj.clone();
                     xformed_obj.set_transform(xform);
                     xformed_obj.set_debug_tag(Some(debug_tag.clone()));
+                    xformed_obj.set_lights(entity_lights.clone());
                     if options.debug_skeletons && is_animated_model {
                         xformed_obj.set_depth_write(false);
                         xformed_obj.set_skinned_transparency(Some(0.35));

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8394,23 +8394,14 @@ impl MissionCore {
                 HashSet::new()
             };
 
-        // Per-object lighting, when enabled: a closure so the render loop pays
-        // nothing (no cell lookup, no light ranking) when the flag is off.
-        let object_lights: Option<Box<dyn Fn(Vector3<f32>) -> engine::scene::light::LightArray>> =
-            if options.experimental_features.contains("object_lighting") {
-                self.spatial_data.as_deref().map(|spatial| {
-                    Box::new(move |position: Vector3<f32>| {
-                        crate::object_lighting::lights_for_position(
-                            spatial,
-                            spatial.get_light_table(),
-                            position,
-                        )
-                    })
-                        as Box<dyn Fn(Vector3<f32>) -> engine::scene::light::LightArray>
-                })
-            } else {
-                None
-            };
+        // Per-object lighting, when enabled. `None` when the flag is off or the
+        // scene has no world rep, so the render loop pays no cell lookup and no
+        // light ranking at all.
+        let object_lights: Option<&dyn SpatialQueryEngine> = options
+            .experimental_features
+            .contains("object_lighting")
+            .then(|| self.spatial_data.as_deref())
+            .flatten();
 
         // Render models
         for (entity_id, objs) in &self.id_to_model {
@@ -8463,9 +8454,11 @@ impl MissionCore {
             if let Ok(xform) = v_transform.get(*entity_id).map(|p| p.0) {
                 // One light set per entity, resolved at its origin and shared by
                 // its sub-objects - the lights that reach the room it stands in.
-                let entity_lights = object_lights.as_ref().map(|resolve| {
-                    let position = xform.w.truncate();
-                    Rc::new(resolve(position))
+                let entity_lights = object_lights.map(|spatial| {
+                    Rc::new(crate::object_lighting::lights_for_position(
+                        spatial,
+                        xform.w.truncate(),
+                    ))
                 });
 
                 for obj in scene_objs {

--- a/shock2vr/src/mission/spatial_query.rs
+++ b/shock2vr/src/mission/spatial_query.rs
@@ -18,6 +18,10 @@ pub trait SpatialQueryEngine {
 
     /// The mission's object-light table, which the cells' light lists index.
     fn get_light_table(&self) -> &LightTable;
+
+    /// The mission's ambient light - the floor an object shows where no light
+    /// reaches it.
+    fn get_ambient_light(&self) -> Vector3<f32>;
 }
 
 /// Lightweight spatial data structure extracted from SystemShock2Level
@@ -26,6 +30,7 @@ pub struct LevelSpatialData {
     pub cells: Vec<Cell>,
     pub bsp_tree: BspTree,
     pub light_table: LightTable,
+    pub ambient_light: Vector3<f32>,
 }
 
 impl SpatialQueryEngine for LevelSpatialData {
@@ -49,6 +54,10 @@ impl SpatialQueryEngine for LevelSpatialData {
     fn get_light_table(&self) -> &LightTable {
         &self.light_table
     }
+
+    fn get_ambient_light(&self) -> Vector3<f32> {
+        self.ambient_light
+    }
 }
 
 impl LevelSpatialData {
@@ -58,6 +67,7 @@ impl LevelSpatialData {
             cells: level.cells.clone(),
             bsp_tree: level.bsp_tree.clone(),
             light_table: level.light_table.clone(),
+            ambient_light: level.render_params.ambient_color,
         }
     }
 }
@@ -83,5 +93,9 @@ impl SpatialQueryEngine for SystemShock2Level {
 
     fn get_light_table(&self) -> &LightTable {
         &self.light_table
+    }
+
+    fn get_ambient_light(&self) -> Vector3<f32> {
+        self.render_params.ambient_color
     }
 }

--- a/shock2vr/src/mission/spatial_query.rs
+++ b/shock2vr/src/mission/spatial_query.rs
@@ -1,5 +1,5 @@
 use cgmath::Vector3;
-use dark::mission::{BspTree, Cell, SystemShock2Level};
+use dark::mission::{BspTree, Cell, LightTable, SystemShock2Level};
 
 /// Spatial query interface for level data
 /// Provides position-based lookups without requiring the full SystemShock2Level
@@ -15,6 +15,9 @@ pub trait SpatialQueryEngine {
 
     /// Get a cell by its index
     fn get_cell_by_index(&self, index: usize) -> Option<&Cell>;
+
+    /// The mission's object-light table, which the cells' light lists index.
+    fn get_light_table(&self) -> &LightTable;
 }
 
 /// Lightweight spatial data structure extracted from SystemShock2Level
@@ -22,6 +25,7 @@ pub trait SpatialQueryEngine {
 pub struct LevelSpatialData {
     pub cells: Vec<Cell>,
     pub bsp_tree: BspTree,
+    pub light_table: LightTable,
 }
 
 impl SpatialQueryEngine for LevelSpatialData {
@@ -41,6 +45,10 @@ impl SpatialQueryEngine for LevelSpatialData {
     fn get_cell_by_index(&self, index: usize) -> Option<&Cell> {
         self.cells.get(index)
     }
+
+    fn get_light_table(&self) -> &LightTable {
+        &self.light_table
+    }
 }
 
 impl LevelSpatialData {
@@ -49,6 +57,7 @@ impl LevelSpatialData {
         Self {
             cells: level.cells.clone(),
             bsp_tree: level.bsp_tree.clone(),
+            light_table: level.light_table.clone(),
         }
     }
 }
@@ -70,5 +79,9 @@ impl SpatialQueryEngine for SystemShock2Level {
 
     fn get_cell_by_index(&self, index: usize) -> Option<&Cell> {
         self.cells.get(index)
+    }
+
+    fn get_light_table(&self) -> &LightTable {
+        &self.light_table
     }
 }

--- a/shock2vr/src/object_lighting.rs
+++ b/shock2vr/src/object_lighting.rs
@@ -14,6 +14,7 @@ use cgmath::{InnerSpace, Vector3, Vector4, vec3};
 use dark::mission::{LightTable, WorldLight};
 use engine::scene::light::{LightArray, PointLight, SpotLight};
 
+use crate::dev_params;
 use crate::mission::spatial_query::SpatialQueryEngine;
 
 /// How many lights the renderer can apply to one object.
@@ -23,13 +24,20 @@ const MAX_OBJECT_LIGHTS: usize = 6;
 /// the remainder cannot meaningfully change the shading.
 const ENERGY_CUTOFF: f32 = 0.95;
 
-/// Distances below this are treated as this, so a light sitting exactly on an
-/// object doesn't divide by zero.
-const MIN_DISTANCE: f32 = 0.01;
+/// Rank lights with the same source radius the shader shades them with. A
+/// light inside its own lamp model would otherwise score in the hundreds and
+/// take the entire energy budget, ejecting every light that actually matters.
+const MIN_DISTANCE: f32 = engine::scene::light::LIGHT_SOURCE_RADIUS;
+
+/// Brightness is authored against the mission's own units, but our world is
+/// `SCALE_FACTOR` smaller - so every distance is smaller by that factor and the
+/// inverse-distance falloff would come out that much brighter. Scale the
+/// brightness back down by the same factor to land where the original did.
+const BRIGHTNESS_SCALE: f32 = 1.0 / dark::SCALE_FACTOR;
 
 /// Perceptual weighting used to rank lights against each other - green carries
 /// most of the apparent brightness.
-fn perceived_brightness(brightness: Vector3<f32>) -> f32 {
+pub fn perceived_brightness(brightness: Vector3<f32>) -> f32 {
     0.25 * brightness.x + 0.5 * brightness.y + 0.25 * brightness.z
 }
 
@@ -60,13 +68,32 @@ fn cone_coverage(light: &WorldLight, position: Vector3<f32>) -> f32 {
     (alignment - light.outer) / (light.inner - light.outer)
 }
 
+/// How much light an object at `position` receives from `lights`, ignoring
+/// which way its surfaces face. This is the scalar the original engine used to
+/// answer "how lit is this object" - including, notably, for whether AI can see
+/// the player - so it is the right summary number for tooling to report.
+pub fn received_light(lights: &LightArray, position: Vector3<f32>) -> f32 {
+    lights
+        .iter_active()
+        .map(|(_, light)| {
+            let color = light.color_intensity();
+            let brightness = vec3(color.x, color.y, color.z) * color.w;
+            let distance = (light.position() - position).magnitude().max(MIN_DISTANCE);
+            perceived_brightness(brightness) / distance
+        })
+        .sum()
+}
+
 /// The lights that shade an object at `position`, strongest first.
 pub fn lights_for_position(
     spatial: &dyn SpatialQueryEngine,
     table: &LightTable,
     position: Vector3<f32>,
 ) -> LightArray {
-    let mut lights = LightArray::new();
+    let ambient_boost = dev_params::get(dev_params::OBJECT_LIGHT_AMBIENT_BOOST);
+    let ambient = spatial.get_ambient_light() + vec3(ambient_boost, ambient_boost, ambient_boost);
+    let mut lights = LightArray::new()
+        .with_object_lighting(ambient, dev_params::get(dev_params::OBJECT_LIGHT_WRAP));
 
     let Some(cell) = spatial.get_cell_from_position(position) else {
         // Outside the world rep (or in a scene with none) - no cell, no lights.
@@ -121,10 +148,11 @@ pub fn lights_for_position(
 /// stored as cosines and the renderer wants radians; a light with no radius
 /// reaches everywhere, which the renderer spells as an enormous range.
 fn to_scene_light(light: &WorldLight) -> engine::scene::light::SceneLight {
+    let scale = BRIGHTNESS_SCALE * dev_params::get(dev_params::OBJECT_LIGHT_BRIGHTNESS);
     let color_intensity = Vector4::new(
-        light.brightness.x,
-        light.brightness.y,
-        light.brightness.z,
+        light.brightness.x * scale,
+        light.brightness.y * scale,
+        light.brightness.z * scale,
         1.0,
     );
     let range = if light.radius > 0.0 {

--- a/shock2vr/src/object_lighting.rs
+++ b/shock2vr/src/object_lighting.rs
@@ -1,0 +1,265 @@
+//! Per-object lighting: which of a mission's lights shade a given object.
+//!
+//! World geometry is lit by baked lightmaps, but objects - props, creatures,
+//! held items - are not in those lightmaps. The original engine lights them
+//! from a second database shipped alongside: a table of lights, and per cell
+//! the list of lights that reach it. Lighting an object is therefore "find its
+//! cell, evaluate that cell's lights", which is what this module does.
+//!
+//! The renderer has fewer light slots than a room can have lights, so the set
+//! is ranked by how much each light contributes at the object's position and
+//! the strongest are kept.
+
+use cgmath::{InnerSpace, Vector3, Vector4, vec3};
+use dark::mission::{LightTable, WorldLight};
+use engine::scene::light::{LightArray, PointLight, SpotLight};
+
+use crate::mission::spatial_query::SpatialQueryEngine;
+
+/// How many lights the renderer can apply to one object.
+const MAX_OBJECT_LIGHTS: usize = 6;
+
+/// Stop once the kept lights account for this much of the total contribution -
+/// the remainder cannot meaningfully change the shading.
+const ENERGY_CUTOFF: f32 = 0.95;
+
+/// Distances below this are treated as this, so a light sitting exactly on an
+/// object doesn't divide by zero.
+const MIN_DISTANCE: f32 = 0.01;
+
+/// Perceptual weighting used to rank lights against each other - green carries
+/// most of the apparent brightness.
+fn perceived_brightness(brightness: Vector3<f32>) -> f32 {
+    0.25 * brightness.x + 0.5 * brightness.y + 0.25 * brightness.z
+}
+
+/// How much of a spotlight's cone covers `position`: 1 inside the inner cone,
+/// falling linearly to 0 at the outer one. Omni lights are always 1.
+///
+/// This ranks lights; it does NOT scale the light we hand the renderer. The
+/// shader evaluates the cone per fragment, which is finer than the whole-object
+/// answer here - pre-scaling as well would apply the cone twice.
+fn cone_coverage(light: &WorldLight, position: Vector3<f32>) -> f32 {
+    if !light.is_spotlight() {
+        return 1.0;
+    }
+
+    let to_position = position - light.position;
+    if to_position.magnitude2() < MIN_DISTANCE * MIN_DISTANCE {
+        return 1.0;
+    }
+
+    let alignment = to_position.normalize().dot(light.direction.normalize());
+    if alignment <= light.outer {
+        return 0.0;
+    }
+    if alignment >= light.inner {
+        return 1.0;
+    }
+
+    (alignment - light.outer) / (light.inner - light.outer)
+}
+
+/// The lights that shade an object at `position`, strongest first.
+pub fn lights_for_position(
+    spatial: &dyn SpatialQueryEngine,
+    table: &LightTable,
+    position: Vector3<f32>,
+) -> LightArray {
+    let mut lights = LightArray::new();
+
+    let Some(cell) = spatial.get_cell_from_position(position) else {
+        // Outside the world rep (or in a scene with none) - no cell, no lights.
+        return lights;
+    };
+
+    let mut candidates: Vec<(f32, &WorldLight)> = Vec::new();
+    let mut total_contribution = 0.0;
+
+    for index in &cell.light_indices {
+        let Some(light) = table.get(*index) else {
+            continue;
+        };
+
+        let to_light = light.position - position;
+        let distance2 = to_light.magnitude2();
+        if light.radius > 0.0 && distance2 > light.radius * light.radius {
+            continue;
+        }
+
+        let coverage = cone_coverage(light, position);
+        if coverage <= 0.0 {
+            continue;
+        }
+
+        let distance = distance2.sqrt().max(MIN_DISTANCE);
+        let contribution = perceived_brightness(light.brightness) * coverage / distance;
+        if contribution <= 0.0 {
+            continue;
+        }
+
+        total_contribution += contribution;
+        candidates.push((contribution, light));
+    }
+
+    candidates.sort_by(|a, b| b.0.total_cmp(&a.0));
+
+    let enough = total_contribution * ENERGY_CUTOFF;
+    let mut kept = 0.0;
+    for (contribution, light) in candidates.into_iter().take(MAX_OBJECT_LIGHTS) {
+        lights.add_light(to_scene_light(light));
+        kept += contribution;
+        if kept >= enough {
+            break;
+        }
+    }
+
+    lights
+}
+
+/// Convert a parsed light into the renderer's representation. Cone angles are
+/// stored as cosines and the renderer wants radians; a light with no radius
+/// reaches everywhere, which the renderer spells as an enormous range.
+fn to_scene_light(light: &WorldLight) -> engine::scene::light::SceneLight {
+    let color_intensity = Vector4::new(
+        light.brightness.x,
+        light.brightness.y,
+        light.brightness.z,
+        1.0,
+    );
+    let range = if light.radius > 0.0 {
+        light.radius
+    } else {
+        f32::MAX
+    };
+
+    if light.is_spotlight() {
+        SpotLight {
+            position: light.position,
+            direction: normalize_or_down(light.direction),
+            color_intensity,
+            inner_cone_angle: light.inner.clamp(-1.0, 1.0).acos(),
+            outer_cone_angle: light.outer.clamp(-1.0, 1.0).acos(),
+            range,
+        }
+        .into()
+    } else {
+        PointLight {
+            position: light.position,
+            color_intensity,
+            range,
+        }
+        .into()
+    }
+}
+
+fn normalize_or_down(direction: Vector3<f32>) -> Vector3<f32> {
+    if direction.magnitude2() > 0.0 {
+        direction.normalize()
+    } else {
+        vec3(0.0, -1.0, 0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn omni(position: Vector3<f32>, brightness: f32, radius: f32) -> WorldLight {
+        WorldLight {
+            position,
+            direction: vec3(0.0, 0.0, 0.0),
+            brightness: vec3(brightness, brightness, brightness),
+            inner: -1.0,
+            outer: 0.0,
+            radius,
+        }
+    }
+
+    fn spot(position: Vector3<f32>, direction: Vector3<f32>) -> WorldLight {
+        WorldLight {
+            position,
+            direction,
+            brightness: vec3(1.0, 1.0, 1.0),
+            // 60 degrees to full-off at 90.
+            inner: 0.5,
+            outer: 0.0,
+            radius: 0.0,
+        }
+    }
+
+    #[test]
+    fn a_light_outside_its_radius_does_not_reach() {
+        let light = omni(vec3(0.0, 0.0, 0.0), 1.0, 5.0);
+        assert!(light.radius > 0.0);
+
+        // The radius test lives in lights_for_position; assert the geometry it
+        // relies on rather than duplicating the loop.
+        let inside = vec3(4.0, 0.0, 0.0);
+        let outside = vec3(6.0, 0.0, 0.0);
+        assert!((inside - light.position).magnitude2() <= light.radius * light.radius);
+        assert!((outside - light.position).magnitude2() > light.radius * light.radius);
+    }
+
+    #[test]
+    fn a_cone_covers_what_it_points_at_and_nothing_behind_it() {
+        let light = spot(vec3(0.0, 0.0, 0.0), vec3(0.0, -1.0, 0.0));
+
+        assert_eq!(cone_coverage(&light, vec3(0.0, -10.0, 0.0)), 1.0, "on axis");
+        assert_eq!(cone_coverage(&light, vec3(0.0, 10.0, 0.0)), 0.0, "behind");
+
+        // Inside the inner cone (cosine 0.5 = 60 degrees) is still full.
+        assert_eq!(cone_coverage(&light, vec3(7.0, -7.0, 0.0)), 1.0, "45 deg");
+
+        // Between the cones - alignment 0.25, i.e. ~75 degrees off axis.
+        let edge = cone_coverage(&light, vec3(9.68, -2.5, 0.0));
+        assert!(
+            edge > 0.0 && edge < 1.0,
+            "between the cones it should fall off, got {edge}"
+        );
+    }
+
+    #[test]
+    fn an_omni_covers_every_direction() {
+        let light = omni(vec3(0.0, 0.0, 0.0), 1.0, 0.0);
+        for position in [
+            vec3(5.0, 0.0, 0.0),
+            vec3(-5.0, 0.0, 0.0),
+            vec3(0.0, 5.0, 0.0),
+        ] {
+            assert_eq!(cone_coverage(&light, position), 1.0);
+        }
+    }
+
+    #[test]
+    fn brightness_ranking_weights_green_most() {
+        assert!(
+            perceived_brightness(vec3(0.0, 1.0, 0.0)) > perceived_brightness(vec3(1.0, 0.0, 0.0))
+        );
+        assert_eq!(perceived_brightness(vec3(1.0, 1.0, 1.0)), 1.0);
+    }
+
+    #[test]
+    fn an_omni_becomes_a_point_light_and_a_cone_becomes_a_spotlight() {
+        let point = to_scene_light(&omni(vec3(1.0, 2.0, 3.0), 0.5, 0.0));
+        assert!(point.inner_cone_angle() < 0.0, "a point light has no cone");
+        assert_eq!(point.range(), f32::MAX, "radius 0 reaches everywhere");
+
+        let cone = to_scene_light(&spot(vec3(0.0, 0.0, 0.0), vec3(0.0, -1.0, 0.0)));
+        assert!(cone.inner_cone_angle() >= 0.0);
+        // inner cosine 0.5 is 60 degrees.
+        assert!((cone.inner_cone_angle().to_degrees() - 60.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_zero_direction_cone_does_not_produce_a_nan_direction() {
+        let mut light = spot(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
+        light.inner = 0.5;
+        let converted = to_scene_light(&light);
+        let direction = match converted {
+            engine::scene::light::SceneLight::Spot(spot) => spot.direction,
+            engine::scene::light::SceneLight::Point(_) => panic!("expected a spotlight"),
+        };
+        assert!(direction.magnitude2().is_finite() && direction.magnitude2() > 0.0);
+    }
+}

--- a/shock2vr/src/object_lighting.rs
+++ b/shock2vr/src/object_lighting.rs
@@ -11,8 +11,8 @@
 //! the strongest are kept.
 
 use cgmath::{InnerSpace, Vector3, Vector4, vec3};
-use dark::mission::{LightTable, WorldLight};
-use engine::scene::light::{LightArray, PointLight, SpotLight};
+use dark::mission::WorldLight;
+use engine::scene::light::{LightArray, PointLight, SceneLight, SpotLight};
 
 use crate::dev_params;
 use crate::mission::spatial_query::SpatialQueryEngine;
@@ -28,6 +28,12 @@ const ENERGY_CUTOFF: f32 = 0.95;
 /// light inside its own lamp model would otherwise score in the hundreds and
 /// take the entire energy budget, ejecting every light that actually matters.
 const MIN_DISTANCE: f32 = engine::scene::light::LIGHT_SOURCE_RADIUS;
+
+/// Range handed to the renderer for a light with no authored cutoff. The
+/// uniform is `mediump` on GLES, whose guaranteed range stops around 2^14, so
+/// `f32::MAX` would be outside what the shader can be relied on to compare -
+/// this is simply larger than any level.
+const UNBOUNDED_RANGE: f32 = 1.0e4;
 
 /// Brightness is authored against the mission's own units, but our world is
 /// `SCALE_FACTOR` smaller - so every distance is smaller by that factor and the
@@ -69,9 +75,12 @@ fn cone_coverage(light: &WorldLight, position: Vector3<f32>) -> f32 {
 }
 
 /// How much light an object at `position` receives from `lights`, ignoring
-/// which way its surfaces face. This is the scalar the original engine used to
-/// answer "how lit is this object" - including, notably, for whether AI can see
-/// the player - so it is the right summary number for tooling to report.
+/// which way its surfaces face and ignoring any spotlight cone. Reported by the
+/// debug runtime so tooling can compare objects without screenshots.
+///
+/// This is in renderer scale, i.e. after the unit conversion and the brightness
+/// dev param, so it moves when that knob does - compare objects within one run,
+/// not across settings.
 pub fn received_light(lights: &LightArray, position: Vector3<f32>) -> f32 {
     lights
         .iter_active()
@@ -85,11 +94,9 @@ pub fn received_light(lights: &LightArray, position: Vector3<f32>) -> f32 {
 }
 
 /// The lights that shade an object at `position`, strongest first.
-pub fn lights_for_position(
-    spatial: &dyn SpatialQueryEngine,
-    table: &LightTable,
-    position: Vector3<f32>,
-) -> LightArray {
+pub fn lights_for_position(spatial: &dyn SpatialQueryEngine, position: Vector3<f32>) -> LightArray {
+    let table = spatial.get_light_table();
+    let brightness = BRIGHTNESS_SCALE * dev_params::get(dev_params::OBJECT_LIGHT_BRIGHTNESS);
     let ambient_boost = dev_params::get(dev_params::OBJECT_LIGHT_AMBIENT_BOOST);
     let ambient = spatial.get_ambient_light() + vec3(ambient_boost, ambient_boost, ambient_boost);
     let mut lights = LightArray::new()
@@ -100,7 +107,7 @@ pub fn lights_for_position(
         return lights;
     };
 
-    let mut candidates: Vec<(f32, &WorldLight)> = Vec::new();
+    let mut candidates: Vec<(f32, SceneLight)> = Vec::new();
     let mut total_contribution = 0.0;
 
     for index in &cell.light_indices {
@@ -108,9 +115,10 @@ pub fn lights_for_position(
             continue;
         };
 
-        let to_light = light.position - position;
-        let distance2 = to_light.magnitude2();
-        if light.radius > 0.0 && distance2 > light.radius * light.radius {
+        // Convert first, then ask the renderer's own reach test - so the lights
+        // we rank are judged by exactly the rule that will shade them.
+        let scene_light = to_scene_light(light, brightness);
+        if !scene_light.affects_position(position) {
             continue;
         }
 
@@ -119,14 +127,14 @@ pub fn lights_for_position(
             continue;
         }
 
-        let distance = distance2.sqrt().max(MIN_DISTANCE);
+        let distance = (light.position - position).magnitude().max(MIN_DISTANCE);
         let contribution = perceived_brightness(light.brightness) * coverage / distance;
         if contribution <= 0.0 {
             continue;
         }
 
         total_contribution += contribution;
-        candidates.push((contribution, light));
+        candidates.push((contribution, scene_light));
     }
 
     candidates.sort_by(|a, b| b.0.total_cmp(&a.0));
@@ -134,7 +142,7 @@ pub fn lights_for_position(
     let enough = total_contribution * ENERGY_CUTOFF;
     let mut kept = 0.0;
     for (contribution, light) in candidates.into_iter().take(MAX_OBJECT_LIGHTS) {
-        lights.add_light(to_scene_light(light));
+        lights.add_light(light);
         kept += contribution;
         if kept >= enough {
             break;
@@ -147,8 +155,7 @@ pub fn lights_for_position(
 /// Convert a parsed light into the renderer's representation. Cone angles are
 /// stored as cosines and the renderer wants radians; a light with no radius
 /// reaches everywhere, which the renderer spells as an enormous range.
-fn to_scene_light(light: &WorldLight) -> engine::scene::light::SceneLight {
-    let scale = BRIGHTNESS_SCALE * dev_params::get(dev_params::OBJECT_LIGHT_BRIGHTNESS);
+fn to_scene_light(light: &WorldLight, scale: f32) -> SceneLight {
     let color_intensity = Vector4::new(
         light.brightness.x * scale,
         light.brightness.y * scale,
@@ -158,7 +165,7 @@ fn to_scene_light(light: &WorldLight) -> engine::scene::light::SceneLight {
     let range = if light.radius > 0.0 {
         light.radius
     } else {
-        f32::MAX
+        UNBOUNDED_RANGE
     };
 
     if light.is_spotlight() {
@@ -269,11 +276,15 @@ mod tests {
 
     #[test]
     fn an_omni_becomes_a_point_light_and_a_cone_becomes_a_spotlight() {
-        let point = to_scene_light(&omni(vec3(1.0, 2.0, 3.0), 0.5, 0.0));
+        let point = to_scene_light(&omni(vec3(1.0, 2.0, 3.0), 0.5, 0.0), 1.0);
         assert!(point.inner_cone_angle() < 0.0, "a point light has no cone");
-        assert_eq!(point.range(), f32::MAX, "radius 0 reaches everywhere");
+        assert_eq!(
+            point.range(),
+            UNBOUNDED_RANGE,
+            "radius 0 reaches everywhere"
+        );
 
-        let cone = to_scene_light(&spot(vec3(0.0, 0.0, 0.0), vec3(0.0, -1.0, 0.0)));
+        let cone = to_scene_light(&spot(vec3(0.0, 0.0, 0.0), vec3(0.0, -1.0, 0.0)), 1.0);
         assert!(cone.inner_cone_angle() >= 0.0);
         // inner cosine 0.5 is 60 degrees.
         assert!((cone.inner_cone_angle().to_degrees() - 60.0).abs() < 0.01);
@@ -283,10 +294,10 @@ mod tests {
     fn a_zero_direction_cone_does_not_produce_a_nan_direction() {
         let mut light = spot(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
         light.inner = 0.5;
-        let converted = to_scene_light(&light);
+        let converted = to_scene_light(&light, 1.0);
         let direction = match converted {
-            engine::scene::light::SceneLight::Spot(spot) => spot.direction,
-            engine::scene::light::SceneLight::Point(_) => panic!("expected a spotlight"),
+            SceneLight::Spot(spot) => spot.direction,
+            SceneLight::Point(_) => panic!("expected a spotlight"),
         };
         assert!(direction.magnitude2().is_finite() && direction.magnitude2() > 0.0);
     }


### PR DESCRIPTION
Props and creatures now receive the authored lights that reach their world cell when launched with `--experimental object_lighting`. The default path stays unchanged. Stacked on #1226.

Selection uses the BSP cell's light list, radius/cone rejection, brightness-over-distance ranking, six slots, and a 95% energy cutoff. Basic and skinned materials use inverse-distance lighting over the mission ambient floor. A 0.8-world-unit source-radius floor prevents a lamp at its own origin from monopolizing selection; this is a deliberate approximation, not exact retail parity.

Rebased onto current main, preserving its ambient controls, psi visuals, and held-weapon transforms. Review found that the old merge applied object-light falloff to flashlights. Falloff is now per slot: scene lights keep their smooth attenuation and unwrapped diffuse response when merged with authored lights. A regression covers this separation.

The `object_light_brightness`, `object_light_ambient`, and `object_light_wrap` controls live under Camera & view. `/v1/scene` reports the selected authored lights' count, received energy, and ambient before hand lights are merged.

Validation at the stack tip: warning-free core/desktop/debug check; 73 engine tests; all 23 mission loads; flat/VR rendered comparisons. The follow-up layer synchronizes switched-light intensities with wall lightmaps.

Limitations: six light slots; origin-based selection; possible rank transitions; no object shadows; first-person flat viewmodels retain their existing lighting path. Quest performance is unmeasured; feature remains opt-in and the user's headset was left untouched.

## Visual verification

![Object lighting flag off and on in MedSci1](https://gist.githubusercontent.com/tommy-xr/107af9dbf971496450f9a2731997e5a6/raw/medsci-static-toggle.gif)

<sub>Alternating stills from separate matched headless `medsci1.mis` launches with `object_lighting` disabled and enabled, captured after 30 fixed-timestep frames at the default spawn. This is a flag comparison, not a recording of simulation motion. The foreground gurney picks up the room's authored lighting.</sub>

![Object lighting flag comparison side by side](https://gist.githubusercontent.com/tommy-xr/107af9dbf971496450f9a2731997e5a6/raw/medsci-static.png)
