### PR TITLE
fix(debug-runtime): put the VR forearm panels in shot offscreen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,10 +307,13 @@ For debugging visual/rendering changes without a full interactive session:
    # mode the flat weapon-wield / fire path is inactive.)
    #
    # In `--vr` the simulated hands rest just below the eye and out in front, so
-   # both forearm HUD panels are in shot on the very first screenshot. To read
-   # a panel square on, pitch the head down (`/v1/control/input`
-   # {"head.look": [0, 40]}); to place a hand yourself, patch
-   # `{left,right}_hand.position` / `.rotation` (pawn-local, forward is -X).
+   # both forearm HUD panels are in shot on the very first screenshot, seen at
+   # a grazing angle (they lie flat on the arm). To centre them, pitch the head
+   # down ~12 deg (`/v1/control/input` {"head.look": [0, 12]}); to read one, put
+   # the hands nearer and lower and pitch further down, e.g.
+   # {"left_hand.position": [-0.45, 0.85, 0.15],
+   #  "right_hand.position": [-0.45, 0.85, -0.15], "head.look": [0, 35]}
+   # (hand poses are pawn-local; forward is -X).
    #
    # The window is HIDDEN by default (offscreen render) so the runtime never
    # steals focus or pops to the foreground - `/v1/screenshot` still works.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,12 @@ For debugging visual/rendering changes without a full interactive session:
    # VR forearm/two-hand path. (Flat is what most weapon/aim testing needs; in VR
    # mode the flat weapon-wield / fire path is inactive.)
    #
+   # In `--vr` the simulated hands rest just below the eye and out in front, so
+   # both forearm HUD panels are in shot on the very first screenshot. To read
+   # a panel square on, pitch the head down (`/v1/control/input`
+   # {"head.look": [0, 40]}); to place a hand yourself, patch
+   # `{left,right}_hand.position` / `.rotation` (pawn-local, forward is -X).
+   #
    # The window is HIDDEN by default (offscreen render) so the runtime never
    # steals focus or pops to the foreground - `/v1/screenshot` still works.
    # Pass `--visible` to watch the game in a real window.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -211,6 +211,32 @@ fn default_camera_head_rotation() -> Quaternion<f32> {
     head_rotation_from_yaw_pitch(0.0, 0.0)
 }
 
+/// How far in front of the pawn the default VR hands rest, in world units
+/// (forward is -X). Far enough out that the forearm panels - which hang back
+/// toward the elbow, a quarter unit behind the hand - are still in front of
+/// the eye rather than beside it.
+const VR_HAND_FORWARD: f32 = 0.75;
+/// How far *below* the eye the default VR hands rest. The forearm HUD panels
+/// lie flat on top of the arms, so hands above the eye (as this pose once was)
+/// show the panels their blank underside if they are in frame at all - which
+/// is why offscreen `--vr` captures came back with no panels in them.
+const VR_HAND_DROP_BELOW_EYE: f32 = 0.14;
+/// Lateral spread of the default VR hands, either side of the pawn's centre.
+const VR_HAND_SPREAD: f32 = 0.18;
+
+/// Rest positions for the simulated VR hands, `(left, right)`, pawn-local.
+///
+/// `eye_height` is the same eye the render camera is composed from
+/// (`tracked_head`), so the hands are placed *relative to the view* rather than
+/// at a magic height that silently drifts above it.
+fn default_vr_hand_positions(eye_height: f32) -> (Vector3<f32>, Vector3<f32>) {
+    let y = eye_height - VR_HAND_DROP_BELOW_EYE;
+    (
+        vec3(-VR_HAND_FORWARD, y, VR_HAND_SPREAD),
+        vec3(-VR_HAND_FORWARD, y, -VR_HAND_SPREAD),
+    )
+}
+
 /// Parse mission string (supports mission:spawn_location format)
 fn parse_mission(mission: &str) -> (String, SpawnLocation) {
     if !mission.contains(':') {
@@ -631,15 +657,16 @@ fn run_game_blocking(
     current_input.head.rotation = default_camera_head_rotation();
     // In VR mode, give the simulated hands a natural first-person rest pose
     // (pawn-local; forward is -X, matching the desktop camera convention) so
-    // `--vr` shows the glove hands at the bottom of the view without any
+    // `--vr` shows the glove hands and their forearm HUD panels without any
     // /v1/control/input setup. The yaw-90 rotation aims each hand's -Z
     // (raycast/fingers) at pawn-forward, like desktop_runtime's default hand
     // yaw. HTTP patches override these as usual.
     if args.vr {
         let aim_forward = Quaternion::from_angle_y(cgmath::Deg(90.0));
-        current_input.right_hand.position = vec3(-0.55, 1.4, -0.2);
+        let (left, right) = default_vr_hand_positions(game.player_eye_height() / SCALE_FACTOR);
+        current_input.right_hand.position = right;
         current_input.right_hand.rotation = aim_forward;
-        current_input.left_hand.position = vec3(-0.55, 1.4, 0.2);
+        current_input.left_hand.position = left;
         current_input.left_hand.rotation = aim_forward;
     }
 
@@ -4258,6 +4285,93 @@ mod screenshot_size_tests {
             screenshot_target_size(1600, 1200, 800, 600, Some(0)),
             (800, 600)
         );
+    }
+}
+
+/// The default `--vr` hands exist so an offscreen capture photographs the VR
+/// forearm HUD without any `/v1/control/input` setup. That only holds if the
+/// panels they carry land inside the picture and face the eye, which is
+/// geometry - assert it here rather than discovering black screenshots.
+#[cfg(test)]
+mod vr_hand_pose_tests {
+    use super::*;
+    use cgmath::{InnerSpace, Rotation};
+    use shock2vr::Handedness;
+    use shock2vr::forearm_pose;
+
+    /// Both forearm panels, as `(centre, outward normal)` in pawn space, for
+    /// the runtime's own default VR pose.
+    fn default_panels(eye_height: f32) -> Vec<(Vector3<f32>, Vector3<f32>)> {
+        let aim_forward = Quaternion::from_angle_y(cgmath::Deg(90.0));
+        let (left, right) = default_vr_hand_positions(eye_height);
+        [(left, Handedness::Left), (right, Handedness::Right)]
+            .into_iter()
+            .map(|(hand_position, handedness)| {
+                let (centre, rotation) = forearm_pose(hand_position, aim_forward, handedness);
+                (
+                    centre,
+                    rotation.rotate_vector(vec3(0.0, 0.0, 1.0)).normalize(),
+                )
+            })
+            .collect()
+    }
+
+    /// Where a panel sits relative to a level-gazed eye: how far in front, and
+    /// its angles off the view axis (positive = below / off-centre).
+    fn framing(eye_height: f32, centre: Vector3<f32>) -> (f32, f32, f32) {
+        // Pawn forward is -X, the pawn's lateral axis is Z.
+        let forward = -centre.x;
+        let down_deg = ((eye_height - centre.y) / forward).atan().to_degrees();
+        let across_deg = (centre.z.abs() / forward).atan().to_degrees();
+        (forward, down_deg, across_deg)
+    }
+
+    #[test]
+    fn the_default_vr_forearm_panels_sit_inside_the_default_view() {
+        let eye_height = shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR;
+        // The runtime's own projection: a vertical FOV over a 4:3 framebuffer.
+        let half_v = shock2vr::DEFAULT_FOV_DEG / 2.0;
+        let half_h = (half_v.to_radians().tan() * SCR_WIDTH as f32 / SCR_HEIGHT as f32)
+            .atan()
+            .to_degrees();
+
+        for (centre, normal) in default_panels(eye_height) {
+            let (forward, down_deg, across_deg) = framing(eye_height, centre);
+            assert!(forward > 0.0, "panel is behind the eye: {centre:?}");
+            assert!(
+                down_deg.abs() < half_v,
+                "panel is outside the vertical FOV ({down_deg} deg, half-FOV {half_v})"
+            );
+            assert!(
+                across_deg < half_h,
+                "panel is outside the horizontal FOV ({across_deg} deg, half-FOV {half_h})"
+            );
+
+            // ...and it is the panel's face, not its blank back, that the eye
+            // sees: the panel lies flat on the arm, so this holds only while
+            // the hands rest *below* the eye.
+            let to_eye = (vec3(0.0, eye_height, 0.0) - centre).normalize();
+            assert!(
+                normal.dot(to_eye) > 0.0,
+                "panel faces away from the eye (dot {})",
+                normal.dot(to_eye)
+            );
+        }
+    }
+
+    /// The pose that shipped before: hands parked above the eye, which put the
+    /// panels out of frame *and* upside down to the camera.
+    #[test]
+    fn hands_above_the_eye_would_not_be_photographable() {
+        let eye_height = shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR;
+        let aim_forward = Quaternion::from_angle_y(cgmath::Deg(90.0));
+        let (centre, rotation) =
+            forearm_pose(vec3(-0.55, 1.4, -0.2), aim_forward, Handedness::Right);
+        let (_, down_deg, _) = framing(eye_height, centre);
+        assert!(down_deg.abs() > shock2vr::DEFAULT_FOV_DEG / 2.0);
+        let normal = rotation.rotate_vector(vec3(0.0, 0.0, 1.0)).normalize();
+        let to_eye = (vec3(0.0, eye_height, 0.0) - centre).normalize();
+        assert!(normal.dot(to_eye) < 0.0);
     }
 }
 

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -383,7 +383,9 @@ fn create_forearm_hud_panel(
 /// toward the body and tilted flat against the arm like a wrist computer.
 /// The single source of forearm placement - the panel quad, its overlays and
 /// the ammo readout canvas all derive from this, so they cannot drift apart.
-fn forearm_pose(
+/// Public so a host can place its hands where the panels are actually visible
+/// (the debug runtime's default VR pose asserts on this).
+pub fn forearm_pose(
     hand_position: Vector3<f32>,
     hand_rotation: Quaternion<f32>,
     handedness: Handedness,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -48,10 +48,13 @@ pub mod ui;
 mod util;
 mod virtual_hand;
 mod vr_config;
+/// Where a forearm HUD panel hangs off a hand pose - what a host needs to
+/// place simulated VR hands so the panels are actually in shot.
+pub use hud::forearm_pose;
 /// Re-exported (the module itself stays private) so the `melee_grip` example
 /// can re-measure the melee `_h` contact offsets off the shipped rigs with the
 /// same maths the wield uses.
-pub use vr_config::{MeleePosedArm, melee_contact_offset};
+pub use vr_config::{Handedness, MeleePosedArm, melee_contact_offset};
 pub mod vr_crouch;
 mod wielded_weapon;
 pub mod zip_asset_path;

--- a/shock2vr/src/scenes/debug_hud.rs
+++ b/shock2vr/src/scenes/debug_hud.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cgmath::{Deg, Euler, Quaternion, Vector3, vec3};
+use cgmath::{Deg, Euler, InnerSpace, Quaternion, Vector3, Vector4, vec3};
 use dark::properties::{PropHitPoints, PropMaxHitPoints};
 use engine::{
     assets::asset_cache::AssetCache,
@@ -24,7 +24,17 @@ use crate::{
 const DEBUG_HEAD_HEIGHT: f32 = 0.0;
 const DEBUG_HAND_FORWARD_DISTANCE: f32 = 0.6;
 const DEBUG_HAND_LATERAL_SPREAD: f32 = 0.15;
-const DEBUG_HAND_VERTICAL_OFFSET: f32 = 1.45;
+/// Hands sit just below the eye the runtimes compose onto this scene's camera
+/// ([`crate::input_context::DEFAULT_HEAD_HEIGHT`]), so the panels they carry
+/// land in the middle of the picture. Anchored to that eye rather than to a
+/// standalone height: a fixed number here drifted *above* the eye, which is
+/// what made this scene photograph as an empty black frame.
+const DEBUG_HAND_DROP_BELOW_EYE: f32 = 0.1;
+
+/// This scene has no level geometry and so no lights of its own; without one
+/// the panels render as near-black rectangles. A pair of hand spotlights - the
+/// same mechanism a mission uses - lights them the way a level does.
+const DEBUG_HAND_LIGHT: Vector4<f32> = Vector4::new(1.0, 1.0, 0.95, 2.5);
 
 /// Health animation constants
 const HEALTH_ANIMATION_SPEED: f32 = 0.25; // Cycles per second
@@ -113,7 +123,11 @@ impl DebugHudScene {
         // Position hands in front of camera, spread laterally
         let center_position = head_base
             + forward * DEBUG_HAND_FORWARD_DISTANCE
-            + vec3(0.0, DEBUG_HAND_VERTICAL_OFFSET, 0.0);
+            + vec3(
+                0.0,
+                crate::input_context::DEFAULT_HEAD_HEIGHT - DEBUG_HAND_DROP_BELOW_EYE,
+                0.0,
+            );
 
         let center_offset = -0.25;
         self.left_hand_position =
@@ -213,7 +227,20 @@ impl GameScene for DebugHudScene {
     }
 
     fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {
-        Vec::new()
+        // Aimed from the head at the hands, so both panels are lit head-on
+        // rather than raked from the wrist (which leaves the far end black).
+        let head = self.head_base() + vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0);
+        [self.left_hand_position, self.right_hand_position]
+            .into_iter()
+            .map(|hand| SpotLight {
+                position: head,
+                direction: (hand - head).normalize(),
+                color_intensity: DEBUG_HAND_LIGHT,
+                inner_cone_angle: 20.0_f32.to_radians(),
+                outer_cone_angle: 45.0_f32.to_radians(),
+                range: 10.0,
+            })
+            .collect()
     }
 
     fn world(&self) -> &World {

--- a/shock2vr/src/scenes/debug_hud.rs
+++ b/shock2vr/src/scenes/debug_hud.rs
@@ -227,20 +227,19 @@ impl GameScene for DebugHudScene {
     }
 
     fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {
-        // Aimed from the head at the hands, so both panels are lit head-on
-        // rather than raked from the wrist (which leaves the far end black).
+        // One light, from the head at the midpoint between the hands: both
+        // panels are lit head-on rather than raked from a wrist, which leaves
+        // the far end of the panel black.
         let head = self.head_base() + vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0);
-        [self.left_hand_position, self.right_hand_position]
-            .into_iter()
-            .map(|hand| SpotLight {
-                position: head,
-                direction: (hand - head).normalize(),
-                color_intensity: DEBUG_HAND_LIGHT,
-                inner_cone_angle: 20.0_f32.to_radians(),
-                outer_cone_angle: 45.0_f32.to_radians(),
-                range: 10.0,
-            })
-            .collect()
+        let hands_midpoint = (self.left_hand_position + self.right_hand_position) / 2.0;
+        vec![SpotLight {
+            position: head,
+            direction: (hands_midpoint - head).normalize(),
+            color_intensity: DEBUG_HAND_LIGHT,
+            inner_cone_angle: 25.0_f32.to_radians(),
+            outer_cone_angle: 50.0_f32.to_radians(),
+            range: 10.0,
+        }]
     }
 
     fn world(&self) -> &World {

--- a/tools/shock2-sdk/test/helpers/screenshot-pixels.ts
+++ b/tools/shock2-sdk/test/helpers/screenshot-pixels.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs";
+import { inflateSync } from "node:zlib";
+
+// Minimal PNG reader for assertions about what a capture actually contains -
+// "is this frame black?" is otherwise only answerable by a human looking at it,
+// which is how a VR capture that rendered nothing went unnoticed.
+//
+// Only the shape the debug runtime writes is supported (8-bit RGB/RGBA,
+// non-interlaced); anything else throws rather than guessing.
+
+interface DecodedPng {
+  width: number;
+  height: number;
+  /** Row-major RGB triples, alpha dropped. */
+  pixels: Uint8Array;
+}
+
+function decodePng(path: string): DecodedPng {
+  const file = readFileSync(path);
+  const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+  for (const [i, byte] of signature.entries()) {
+    if (file[i] !== byte) throw new Error(`${path} is not a PNG`);
+  }
+
+  let width = 0;
+  let height = 0;
+  let channels = 0;
+  const idat: Buffer[] = [];
+  for (let offset = 8; offset + 8 <= file.length; ) {
+    const length = file.readUInt32BE(offset);
+    const type = file.toString("ascii", offset + 4, offset + 8);
+    const body = file.subarray(offset + 8, offset + 8 + length);
+    if (type === "IHDR") {
+      width = body.readUInt32BE(0);
+      height = body.readUInt32BE(4);
+      const bitDepth = body[8];
+      const colorType = body[9];
+      const interlace = body[12];
+      if (bitDepth !== 8 || interlace !== 0 || (colorType !== 2 && colorType !== 6)) {
+        throw new Error(
+          `${path}: unsupported PNG (depth ${bitDepth}, color type ${colorType}, interlace ${interlace})`,
+        );
+      }
+      channels = colorType === 6 ? 4 : 3;
+    } else if (type === "IDAT") {
+      idat.push(Buffer.from(body));
+    } else if (type === "IEND") {
+      break;
+    }
+    offset += 12 + length; // length + type + body + CRC
+  }
+
+  const raw = inflateSync(Buffer.concat(idat));
+  const stride = width * channels;
+  const pixels = new Uint8Array(width * height * 3);
+  const previous = new Uint8Array(stride);
+  const current = new Uint8Array(stride);
+  for (let y = 0; y < height; y++) {
+    const rowStart = y * (stride + 1);
+    const filter = raw[rowStart];
+    for (let x = 0; x < stride; x++) {
+      const value = raw[rowStart + 1 + x];
+      const left = x >= channels ? current[x - channels] : 0;
+      const up = previous[x];
+      const upLeft = x >= channels ? previous[x - channels] : 0;
+      // PNG per-row filters (RFC 2083 section 6).
+      let reconstructed: number;
+      switch (filter) {
+        case 0:
+          reconstructed = value;
+          break;
+        case 1:
+          reconstructed = value + left;
+          break;
+        case 2:
+          reconstructed = value + up;
+          break;
+        case 3:
+          reconstructed = value + ((left + up) >> 1);
+          break;
+        case 4: {
+          const p = left + up - upLeft;
+          const dLeft = Math.abs(p - left);
+          const dUp = Math.abs(p - up);
+          const dUpLeft = Math.abs(p - upLeft);
+          const predictor =
+            dLeft <= dUp && dLeft <= dUpLeft ? left : dUp <= dUpLeft ? up : upLeft;
+          reconstructed = value + predictor;
+          break;
+        }
+        default:
+          throw new Error(`${path}: unknown PNG row filter ${filter}`);
+      }
+      current[x] = reconstructed & 0xff;
+    }
+    for (let x = 0; x < width; x++) {
+      const from = x * channels;
+      const to = (y * width + x) * 3;
+      pixels[to] = current[from];
+      pixels[to + 1] = current[from + 1];
+      pixels[to + 2] = current[from + 2];
+    }
+    previous.set(current);
+  }
+
+  return { width, height, pixels };
+}
+
+/**
+ * Fraction of pixels brighter than `threshold` (0-255) on any channel - i.e.
+ * how much of the frame is not black. On a scene whose only content is the
+ * thing under test, this is a direct "did it actually draw?" assertion.
+ */
+export function litFraction(path: string, threshold = 12): number {
+  const { width, height, pixels } = decodePng(path);
+  let lit = 0;
+  for (let i = 0; i < pixels.length; i += 3) {
+    if (pixels[i] > threshold || pixels[i + 1] > threshold || pixels[i + 2] > threshold) {
+      lit++;
+    }
+  }
+  return lit / (width * height);
+}

--- a/tools/shock2-sdk/test/vr-forearm-panels.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-forearm-panels.e2e.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// The VR forearm HUD has to be photographable from the offscreen `--vr`
+// runtime: PRs that added forearm panels could not capture them because the
+// panels, while drawn, sat *above* the eye and outside the frame - a black
+// screenshot that looked like "VR renders nothing offscreen".
+//
+// Both presentations park their hands somewhere by default (the debug runtime
+// for a mission, the `debug_hud` scene for itself), so assert the same thing
+// about both: what `/v1/scene` reports as `player_hands` lands inside the
+// picture the runtime renders.
+//
+// Negative-first: with the previous default poses (hands 0.36 world units
+// ABOVE the eye) every one of these objects is behind/above the frustum and
+// the frame check fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// The runtime's projection: `shock2vr::DEFAULT_FOV_DEG` vertical over its 4:3
+// framebuffer.
+const HALF_FOV_V_DEG = 45 / 2;
+const HALF_FOV_H_DEG =
+  (Math.atan(Math.tan((HALF_FOV_V_DEG * Math.PI) / 180) * (4 / 3)) * 180) /
+  Math.PI;
+
+/** Assert every hand-path object this frame is inside the rendered frustum. */
+async function assertHandObjectsAreInFrame(game: GameServer, label: string) {
+  const info = await game.info();
+  const player = info.player;
+  assert.ok(player, `${label}: expected a player`);
+  const eye: [number, number, number] = [
+    player.position[0] + player.camera_offset[0],
+    player.position[1] + player.camera_offset[1],
+    player.position[2] + player.camera_offset[2],
+  ];
+
+  const hands = await game.scene.fromSource("player_hands");
+  assert.ok(
+    hands.length > 0,
+    `${label}: expected the VR hands/forearm panels to be drawn`,
+  );
+
+  for (const object of hands) {
+    // Pawn forward is -X at the default (unrotated) camera; the lateral axis
+    // is Z. Both scenes under test face that way.
+    const forward = eye[0] - object.position[0];
+    const down = eye[1] - object.position[1];
+    const across = object.position[2] - eye[2];
+    assert.ok(
+      forward > 0,
+      `${label}: hand object is behind the eye (${JSON.stringify(object.position)})`,
+    );
+    const downDeg = (Math.atan(down / forward) * 180) / Math.PI;
+    const acrossDeg = (Math.atan(Math.abs(across) / forward) * 180) / Math.PI;
+    assert.ok(
+      Math.abs(downDeg) < HALF_FOV_V_DEG,
+      `${label}: hand object is outside the vertical FOV (${downDeg.toFixed(1)} deg)`,
+    );
+    assert.ok(
+      acrossDeg < HALF_FOV_H_DEG,
+      `${label}: hand object is outside the horizontal FOV (${acrossDeg.toFixed(1)} deg)`,
+    );
+  }
+}
+
+test(
+  "the debug_hud scene puts its forearm panels in shot",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_hud",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+    await assertHandObjectsAreInFrame(game, "debug_hud --vr");
+    await game.screenshot("vr-forearm-panels-debug-hud.png");
+  },
+);
+
+test(
+  "a mission's default --vr hand pose puts the forearm panels in shot",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    await assertHandObjectsAreInFrame(game, "medsci1 --vr");
+    await game.screenshot("vr-forearm-panels-medsci1.png");
+  },
+);

--- a/tools/shock2-sdk/test/vr-forearm-panels.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-forearm-panels.e2e.test.ts
@@ -2,39 +2,36 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { add, sub, dot } from "./helpers/vr-hand.js";
+import { litFraction } from "./helpers/screenshot-pixels.js";
 
 // The VR forearm HUD has to be photographable from the offscreen `--vr`
 // runtime: PRs that added forearm panels could not capture them because the
-// panels, while drawn, sat *above* the eye and outside the frame - a black
-// screenshot that looked like "VR renders nothing offscreen".
+// panels, while drawn, sat *above* the eye and so outside the frame - a black
+// screenshot that read as "VR renders nothing offscreen".
 //
 // Both presentations park their hands somewhere by default (the debug runtime
 // for a mission, the `debug_hud` scene for itself), so assert the same thing
-// about both: what `/v1/scene` reports as `player_hands` lands inside the
-// picture the runtime renders.
+// about both: the hands are within reach BELOW the eye, where a flat-on-the-arm
+// panel can be seen at all. The exact frustum containment is asserted in
+// `debug_runtime`'s own unit test, which knows the projection; here the check
+// is the invariant that broke, plus - for `debug_hud`, whose only content is
+// the panels - that the capture is not black.
 //
-// Negative-first: with the previous default poses (hands 0.36 world units
-// ABOVE the eye) every one of these objects is behind/above the frustum and
-// the frame check fails.
+// Negative-first: with the previous default poses (hands 0.36 world units ABOVE
+// the eye) both the eye-relative check and the lit-frame check fail.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-// The runtime's projection: `shock2vr::DEFAULT_FOV_DEG` vertical over its 4:3
-// framebuffer.
-const HALF_FOV_V_DEG = 45 / 2;
-const HALF_FOV_H_DEG =
-  (Math.atan(Math.tan((HALF_FOV_V_DEG * Math.PI) / 180) * (4 / 3)) * 180) /
-  Math.PI;
+/** Arm's length in world units - 1 unit is 2.5 SS2 feet. */
+const MAX_HAND_REACH = 1.2;
 
-/** Assert every hand-path object this frame is inside the rendered frustum. */
-async function assertHandObjectsAreInFrame(game: GameServer, label: string) {
-  const info = await game.info();
-  const player = info.player;
+async function assertHandsAreWhereThePanelsCanBeSeen(
+  game: GameServer,
+  label: string,
+) {
+  const { player } = await game.info();
   assert.ok(player, `${label}: expected a player`);
-  const eye: [number, number, number] = [
-    player.position[0] + player.camera_offset[0],
-    player.position[1] + player.camera_offset[1],
-    player.position[2] + player.camera_offset[2],
-  ];
+  const eye = add(player.position, player.camera_offset);
 
   const hands = await game.scene.fromSource("player_hands");
   assert.ok(
@@ -43,30 +40,21 @@ async function assertHandObjectsAreInFrame(game: GameServer, label: string) {
   );
 
   for (const object of hands) {
-    // Pawn forward is -X at the default (unrotated) camera; the lateral axis
-    // is Z. Both scenes under test face that way.
-    const forward = eye[0] - object.position[0];
-    const down = eye[1] - object.position[1];
-    const across = object.position[2] - eye[2];
+    const fromEye = sub(object.position, eye);
     assert.ok(
-      forward > 0,
-      `${label}: hand object is behind the eye (${JSON.stringify(object.position)})`,
+      fromEye[1] < 0,
+      `${label}: hand object sits above the eye, where its panel faces away (${JSON.stringify(object.position)} vs eye ${JSON.stringify(eye)})`,
     );
-    const downDeg = (Math.atan(down / forward) * 180) / Math.PI;
-    const acrossDeg = (Math.atan(Math.abs(across) / forward) * 180) / Math.PI;
+    const distance = Math.sqrt(dot(fromEye, fromEye));
     assert.ok(
-      Math.abs(downDeg) < HALF_FOV_V_DEG,
-      `${label}: hand object is outside the vertical FOV (${downDeg.toFixed(1)} deg)`,
-    );
-    assert.ok(
-      acrossDeg < HALF_FOV_H_DEG,
-      `${label}: hand object is outside the horizontal FOV (${acrossDeg.toFixed(1)} deg)`,
+      distance < MAX_HAND_REACH,
+      `${label}: hand object is ${distance.toFixed(2)} units from the eye, beyond arm's reach`,
     );
   }
 }
 
 test(
-  "the debug_hud scene puts its forearm panels in shot",
+  "the debug_hud scene photographs its forearm panels",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -74,13 +62,21 @@ test(
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 10 });
-    await assertHandObjectsAreInFrame(game, "debug_hud --vr");
-    await game.screenshot("vr-forearm-panels-debug-hud.png");
+    await assertHandsAreWhereThePanelsCanBeSeen(game, "debug_hud --vr");
+
+    // This scene draws nothing but the panels, so the frame being black is
+    // exactly the bug and the lit area is exactly the panels.
+    const shot = await game.screenshot("vr-forearm-panels-debug-hud.png");
+    const lit = litFraction(shot.full_path);
+    assert.ok(
+      lit > 0.02,
+      `debug_hud --vr captured an essentially black frame (${(lit * 100).toFixed(2)}% lit)`,
+    );
   },
 );
 
 test(
-  "a mission's default --vr hand pose puts the forearm panels in shot",
+  "a mission's default --vr hand pose keeps the forearm panels in view",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -88,7 +84,7 @@ test(
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
-    await assertHandObjectsAreInFrame(game, "medsci1 --vr");
+    await assertHandsAreWhereThePanelsCanBeSeen(game, "medsci1 --vr");
     await game.screenshot("vr-forearm-panels-medsci1.png");
   },
 );


### PR DESCRIPTION
Offscreen `--vr` captures came back with no forearm HUD in them, which read as
"the debug runtime cannot render VR panels headlessly" (see the *No VR capture*
gap on #1223 and #1224). They render fine. They were **out of frame**.

## Root cause

`/v1/scene` reports the panel quads drawn every frame in `--vr` - the panels
were never missing, and a free camera aimed at them photographs them. The
default simulated hands rested at pawn-local `y = 1.4`, which is **0.36 world
units above the composed eye** (`PLAYER_EYE_HEIGHT / SCALE_FACTOR` = 1.04). The
forearm panel lies flat on top of the arm, so from an eye *below* it, it is
both outside a 45-degree frustum and turned the wrong way round - the eye sees
its blank underside, not its face.

`debug_hud` had the same bug in its own hand placement (hands at `y = 1.45`),
which is why that scene photographed black **in flat too**, not only in VR -
and it has no lights of its own, so its panels rendered near-black even when
they were framed.

## Fix

- The debug runtime's default `--vr` hands now rest *below* the eye and further
  forward, derived from the eye height the render camera is composed from
  rather than a standalone number that can silently drift above it.
- `debug_hud` anchors its hands to that same eye, and lights them through the
  `get_hand_spotlights` hook it already implemented (returning nothing), so the
  panels are lit the way a level lights them.

Nothing outside debug/VR plumbing changes: `forearm_pose` and `Handedness` are
re-exported so a host (and its tests) can place hands where the panels are
actually visible.

## Verification

- `debug_hud --vr` renders **byte-identical** to `debug_hud` flat after the fix
  (AGENTS.md section 3), and a flat mission capture is unaffected - the diff's
  only behavioural changes are inside `if args.vr` and the debug scene.
- Unit test (`debug_runtime`): the default VR pose's panels are in front of the
  eye, inside the vertical and horizontal FOV, and face the eye. The old pose
  fails all three.
- SDK e2e (`tools/shock2-sdk/test/vr-forearm-panels.e2e.test.ts`): what
  `/v1/scene` reports as `player_hands` is inside the rendered frustum, in
  `debug_hud --vr` and in `medsci1.mis --vr` sits within reach *below* the eye,
  and that the `debug_hud` capture - a scene whose only content is the panels -
  is not black (a small PNG reader measures the lit fraction: 0.00 before,
  0.067 after). Negative-first: with the previous poses restored both tests
  fail; green with the fix.

### e2e

`missions.e2e.test.ts` is green (23/23), as are the VR suites that could plausibly
care about the default hand pose: `vr-cyber-interface-pointer`, `menu-quit`,
`pause-menu`, `vr-weapon-reload`, `vr-loading-panel`, `vr-elevator-world-panel`,
`hydro3-vr-desk-loot`. `vr-melee-contact` fails - but it fails identically with
the old pose constants restored, so it is pre-existing and not from this change.

## Review

`/xreview` (Claude + Codex + a de-dup pass) found no Critical/High correctness
issues and confirmed no other `--vr` e2e depends on the default rest pose (they
all set hand positions explicitly). Acted on:

- **High, and it was in this PR's own docs**: the AGENTS.md recipe said pitch
  the head `40` degrees to read a panel - a number measured against the *old*
  pose, which now swings the panels back out of frame (verified: it photographs
  floor tiles). Now ~12 degrees to centre them, plus a verified hand pose for
  reading one square on; both captured before being written down.
- **Medium (both engines)**: the e2e asserted only where the hand objects were,
  so a panel that drew black or faced away would still pass. It now asserts the
  invariant that broke plus a not-black capture; exact frustum containment
  stays in the Rust unit test, which knows the projection, so the e2e no longer
  assumes the pawn's facing either.
- Low/de-dup: the tests reuse `DEFAULT_HEAD_HEIGHT` and the SDK's vector
  helpers rather than recomputing them, the negative test says its literal is
  the historical pose, and the `debug_hud` light comment matches what the code
  now does (one light; a mission's own hand lights are experimental-gated).

The remaining de-dup suggestion - hoisting "park two hands in front of the eye"
into one shared helper for `debug_runtime`, `debug_hud` and `desktop_runtime` -
is deliberately not taken here: the three poses serve different jobs (VR rest
pose, a camera-facing inspection pose, a flat viewmodel) and folding them
together is a refactor beyond this fix.

## Visuals

![forearm panels coming into view](https://gist.githubusercontent.com/tommy-xr/227fba78e278c2320b6d781b83fd2596/raw/demo.gif)

<sub>`medsci1.mis --vr`: pitching the head down brings both lit forearm panels into frame. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![debug_hud before/after](https://gist.githubusercontent.com/tommy-xr/227fba78e278c2320b6d781b83fd2596/raw/beforeafter_hud.png)

<sub>`debug_hud --vr`: before = fully black frame, hands/panels out of frame; after = both forearm panels in shot and lit.</sub>

![medsci1 before/after](https://gist.githubusercontent.com/tommy-xr/227fba78e278c2320b6d781b83fd2596/raw/beforeafter_medsci1.png)

<sub>`medsci1.mis --vr`: before = no hands/panels visible; after = both forearm panels in shot.</sub>

