### PR TITLE
feat(combat): a swing stops on the limb it strikes, and limbs are worth different amounts

### DIFF
--- a/shock2vr/src/creature/creature_definitions.rs
+++ b/shock2vr/src/creature/creature_definitions.rs
@@ -104,8 +104,13 @@ pub const HUMANOID_HIT_BOXES: Lazy<Arc<HashMap<u32, HitBoxType>>> = Lazy::new(||
         (11, HitBoxType::Limb),      // RShoulder
         (12, HitBoxType::Extremity), // LElbow - forearm
         (13, HitBoxType::Extremity), // RElbow - forearm
-        (14, HitBoxType::NoDamage),  // LWeap - the weapon in its hand
-        (15, HitBoxType::NoDamage),  // RWeap
+        // The `LWeap`/`RWeap` joints are where a weapon is *attached*; the
+        // vertices skinned to them are the creature's own hands, and the pipe
+        // it carries is a separate object with no hitbox at all. So these are
+        // hands - far limb - and a blow on the weapon itself is not something
+        // this engine can currently tell apart.
+        (14, HitBoxType::Extremity), // LWeap - the hand
+        (15, HitBoxType::Extremity), // RWeap
         (18, HitBoxType::Body),      // Abdomen
     ]))
 });
@@ -334,8 +339,8 @@ mod tests {
         ] {
             assert_eq!(worth(joint), Some(0.5), "{part}");
         }
-        for (joint, part) in [(14, "left weapon"), (15, "right weapon")] {
-            assert_eq!(worth(joint), Some(0.0), "{part}");
+        for (joint, part) in [(14, "left hand"), (15, "right hand")] {
+            assert_eq!(worth(joint), Some(0.5), "{part}");
         }
     }
 }

--- a/shock2vr/src/creature/creature_definitions.rs
+++ b/shock2vr/src/creature/creature_definitions.rs
@@ -83,22 +83,29 @@ pub const MONKEY_WIDTH: f32 = 3.0 / SCALE_FACTOR;
 pub const RUMBLER_HEIGHT: f32 = 6.25 / SCALE_FACTOR;
 pub const RUMBLER_WIDTH: f32 = 5.0 / SCALE_FACTOR;
 
+/// Which part of a humanoid each skeleton joint is, and so what a blow there
+/// is worth (see [`HitBoxType::damage_multiplier`]).
+///
+/// `Limb` is the near half of a limb - the segment hanging off the torso - and
+/// `Extremity` the far half, which a blow reaches more easily and which carries
+/// less of the creature. The two used to be split by "leg or arm" instead, so
+/// an elbow counted for as much as a shoulder and a foot for less than a knee.
 pub const HUMANOID_HIT_BOXES: Lazy<Arc<HashMap<u32, HitBoxType>>> = Lazy::new(|| {
     Arc::new(HashMap::from_iter(vec![
         (2, HitBoxType::Extremity),  // LToe
         (3, HitBoxType::Extremity),  //Rtoe
-        (4, HitBoxType::Limb),       // LKnee
-        (5, HitBoxType::Limb),       // RKnee
+        (4, HitBoxType::Extremity),  // LKnee - lower leg
+        (5, HitBoxType::Extremity),  // RKnee - lower leg
         (6, HitBoxType::Limb),       // LThigh
         (7, HitBoxType::Limb),       // RThigh
         (8, HitBoxType::Body),       // Neck
         (9, HitBoxType::Head),       // Head
         (10, HitBoxType::Limb),      // LShoulder
         (11, HitBoxType::Limb),      // RShoulder
-        (12, HitBoxType::Limb),      // LElbow
-        (13, HitBoxType::Limb),      // RElbow
-        (14, HitBoxType::Extremity), // LWeap
-        (15, HitBoxType::Extremity), // RWeap
+        (12, HitBoxType::Extremity), // LElbow - forearm
+        (13, HitBoxType::Extremity), // RElbow - forearm
+        (14, HitBoxType::NoDamage),  // LWeap - the weapon in its hand
+        (15, HitBoxType::NoDamage),  // RWeap
         (18, HitBoxType::Body),      // Abdomen
     ]))
 });
@@ -292,4 +299,43 @@ pub fn get_entity_creature(world: &World, entity_id: EntityId) -> Option<Arc<Cre
     let v_creature = world.borrow::<View<PropCreature>>().ok()?;
     let creature_type = v_creature.get(entity_id).ok()?;
     get_creature_definition(creature_type.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The humanoid map is what turns "which joint" into "what it is worth",
+    /// so its buckets are load-bearing: near limb segments are worth more than
+    /// far ones, and the weapon in a creature's hand is worth nothing.
+    #[test]
+    fn humanoid_joints_are_bucketed_by_what_a_blow_there_is_worth() {
+        let map = HUMANOID_HIT_BOXES.clone();
+        let worth = |joint: u32| map.get(&joint).copied().map(HitBoxType::damage_multiplier);
+
+        assert_eq!(worth(9), Some(1.25), "head");
+        assert_eq!(worth(8), Some(1.0), "neck");
+        assert_eq!(worth(18), Some(1.0), "abdomen");
+        for (joint, part) in [
+            (6, "left thigh"),
+            (7, "right thigh"),
+            (10, "left shoulder"),
+            (11, "right shoulder"),
+        ] {
+            assert_eq!(worth(joint), Some(0.75), "{part}");
+        }
+        for (joint, part) in [
+            (4, "left knee"),
+            (5, "right knee"),
+            (12, "left elbow"),
+            (13, "right elbow"),
+            (2, "left toe"),
+            (3, "right toe"),
+        ] {
+            assert_eq!(worth(joint), Some(0.5), "{part}");
+        }
+        for (joint, part) in [(14, "left weapon"), (15, "right weapon")] {
+            assert_eq!(worth(joint), Some(0.0), "{part}");
+        }
+    }
 }

--- a/shock2vr/src/creature/hit_box_script.rs
+++ b/shock2vr/src/creature/hit_box_script.rs
@@ -40,13 +40,8 @@ impl Script for HitBoxScript {
     ) -> Effect {
         match msg {
             MessagePayload::Damage { amount, impact } => {
-                // What this part is worth. A blow on the creature's own weapon
-                // is worth nothing, and is absorbed here rather than reaching
-                // the creature as a zero that still reads as being hit.
+                // What this part is worth.
                 let multiplier = self.hit_box_type.damage_multiplier();
-                if multiplier <= 0.0 {
-                    return Effect::NoEffect;
-                }
                 Effect::Send {
                     msg: Message {
                         to: self.parent_entity_id,
@@ -121,11 +116,17 @@ mod tests {
         assert_eq!(blow(&mut script(HitBoxType::Extremity), 10.0), Some(5.0));
     }
 
-    /// A creature's own weapon is not the creature: a blow that lands on the
-    /// pipe it is holding is absorbed there, rather than reaching it as a zero
-    /// that still reads as a hit.
+    /// Every blow reaches the creature, whatever it is worth: its AI wakes on
+    /// being hit, so a part must never swallow the message.
     #[test]
-    fn a_blow_on_the_weapon_it_holds_reaches_nothing() {
-        assert_eq!(blow(&mut script(HitBoxType::NoDamage), 10.0), None);
+    fn every_blow_reaches_the_creature() {
+        for part in [
+            HitBoxType::Head,
+            HitBoxType::Body,
+            HitBoxType::Limb,
+            HitBoxType::Extremity,
+        ] {
+            assert!(blow(&mut script(part), 10.0).is_some(), "{part:?}");
+        }
     }
 }

--- a/shock2vr/src/creature/hit_box_script.rs
+++ b/shock2vr/src/creature/hit_box_script.rs
@@ -7,9 +7,9 @@ use crate::{
 
 use super::HitBoxType;
 
-// Script to handle simple health behavior
+/// A creature's per-joint damage proxy: it forwards what struck it to the
+/// creature it belongs to, scaled by what that part is worth.
 pub struct HitBoxScript {
-    #[allow(dead_code)]
     hit_box_type: HitBoxType,
     parent_entity_id: EntityId,
     #[allow(dead_code)]
@@ -39,22 +39,93 @@ impl Script for HitBoxScript {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Damage { amount, impact } => Effect::Send {
-                msg: Message {
-                    to: self.parent_entity_id,
-                    // Forward to the owning creature, stamping which skeleton
-                    // joint was struck so a death ragdoll can react at the
-                    // right limb.
-                    payload: MessagePayload::Damage {
-                        amount: *amount,
-                        impact: impact.map(|i| crate::scripts::DamageImpact {
-                            bone: Some(self.hit_box_joint_idx),
-                            ..i
-                        }),
+            MessagePayload::Damage { amount, impact } => {
+                // What this part is worth. A blow on the creature's own weapon
+                // is worth nothing, and is absorbed here rather than reaching
+                // the creature as a zero that still reads as being hit.
+                let multiplier = self.hit_box_type.damage_multiplier();
+                if multiplier <= 0.0 {
+                    return Effect::NoEffect;
+                }
+                Effect::Send {
+                    msg: Message {
+                        to: self.parent_entity_id,
+                        // Forward to the owning creature, stamping which
+                        // skeleton joint was struck so a death ragdoll can
+                        // react at the right limb.
+                        payload: MessagePayload::Damage {
+                            amount: *amount * multiplier,
+                            impact: impact.map(|i| crate::scripts::DamageImpact {
+                                bone: Some(self.hit_box_joint_idx),
+                                ..i
+                            }),
+                        },
                     },
-                },
-            },
+                }
+            }
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::PhysicsWorld;
+    use crate::scripts::DamageImpact;
+    use cgmath::vec3;
+
+    fn blow(script: &mut HitBoxScript, amount: f32) -> Option<f32> {
+        let world = World::new();
+        let physics = PhysicsWorld::new();
+        let effect = script.handle_message(
+            EntityId::from_inner(1).unwrap(),
+            &world,
+            &physics,
+            &MessagePayload::Damage {
+                amount,
+                impact: Some(DamageImpact {
+                    direction: vec3(0.0, 0.0, 1.0),
+                    point: vec3(0.0, 0.0, 0.0),
+                    bone: None,
+                }),
+            },
+        );
+        match effect {
+            Effect::Send { msg } => match msg.payload {
+                MessagePayload::Damage { amount, impact } => {
+                    // The forwarded blow always names the joint it struck.
+                    assert_eq!(impact.and_then(|impact| impact.bone), Some(7));
+                    Some(amount)
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn script(hit_box_type: HitBoxType) -> HitBoxScript {
+        HitBoxScript::new(hit_box_type, EntityId::from_inner(2).unwrap(), 7)
+    }
+
+    /// Where a blow lands is worth something: this is the whole point of
+    /// aiming at limbs.
+    ///
+    /// Negative-first: forwarding the authored amount unchanged makes every
+    /// part of a creature worth the same.
+    #[test]
+    fn a_blow_is_worth_what_the_part_it_struck_is_worth() {
+        assert_eq!(blow(&mut script(HitBoxType::Head), 10.0), Some(12.5));
+        assert_eq!(blow(&mut script(HitBoxType::Body), 10.0), Some(10.0));
+        assert_eq!(blow(&mut script(HitBoxType::Limb), 10.0), Some(7.5));
+        assert_eq!(blow(&mut script(HitBoxType::Extremity), 10.0), Some(5.0));
+    }
+
+    /// A creature's own weapon is not the creature: a blow that lands on the
+    /// pipe it is holding is absorbed there, rather than reaching it as a zero
+    /// that still reads as a hit.
+    #[test]
+    fn a_blow_on_the_weapon_it_holds_reaches_nothing() {
+        assert_eq!(blow(&mut script(HitBoxType::NoDamage), 10.0), None);
     }
 }

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -65,14 +65,35 @@ pub struct RuntimePropHitBox {
     pub joint_id: JointId,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HitBoxType {
     Head,
     Body,
     Limb,
     Extremity,
-    #[allow(dead_code)]
     NoDamage,
+}
+
+impl HitBoxType {
+    /// What a blow on this part is worth, as a factor on the authored damage.
+    ///
+    /// A deliberate divergence: the original scales damage by the *stim* and
+    /// the victim's receptrons, never by where the blow landed. Aiming is what
+    /// the per-joint hitboxes make possible, so this is what makes aiming
+    /// matter - a head is worth more than a shin, and a creature's own weapon
+    /// is worth nothing at all.
+    pub fn damage_multiplier(self) -> f32 {
+        match self {
+            HitBoxType::Head => 1.25,
+            HitBoxType::Body => 1.0,
+            // The near half of a limb: thigh, shoulder.
+            HitBoxType::Limb => 0.75,
+            // The far half: forearm, shin, foot.
+            HitBoxType::Extremity => 0.5,
+            // The pipe it is holding. Hitting that is hitting the pipe.
+            HitBoxType::NoDamage => 0.0,
+        }
+    }
 }
 
 /// Floor for the AABB fallback's half-extents: a degenerate joint AABB (a joint

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -71,7 +71,6 @@ pub enum HitBoxType {
     Body,
     Limb,
     Extremity,
-    NoDamage,
 }
 
 impl HitBoxType {
@@ -80,18 +79,15 @@ impl HitBoxType {
     /// A deliberate divergence: the original scales damage by the *stim* and
     /// the victim's receptrons, never by where the blow landed. Aiming is what
     /// the per-joint hitboxes make possible, so this is what makes aiming
-    /// matter - a head is worth more than a shin, and a creature's own weapon
-    /// is worth nothing at all.
+    /// matter - a head is worth more than a shin.
     pub fn damage_multiplier(self) -> f32 {
         match self {
             HitBoxType::Head => 1.25,
             HitBoxType::Body => 1.0,
             // The near half of a limb: thigh, shoulder.
             HitBoxType::Limb => 0.75,
-            // The far half: forearm, shin, foot.
+            // The far half: forearm, shin, hand, foot.
             HitBoxType::Extremity => 0.5,
-            // The pipe it is holding. Hitting that is hitting the pipe.
-            HitBoxType::NoDamage => 0.0,
         }
     }
 }

--- a/shock2vr/src/damage_overlay.rs
+++ b/shock2vr/src/damage_overlay.rs
@@ -65,7 +65,6 @@ fn hit_box_label(hit_box: HitBoxType) -> &'static str {
         HitBoxType::Body => "body",
         HitBoxType::Limb => "limb",
         HitBoxType::Extremity => "extremity",
-        HitBoxType::NoDamage => "no-damage",
     }
 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3027,6 +3027,7 @@ impl MissionCore {
                             contact: contact.map(|contact| physics::CollisionContact {
                                 point: contact.point,
                                 normal: -contact.normal,
+                                closing_speed: contact.closing_speed,
                             }),
                         },
                     });

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9904,7 +9904,6 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                                 crate::creature::HitBoxType::Body => "torso",
                                 crate::creature::HitBoxType::Limb => "limb",
                                 crate::creature::HitBoxType::Extremity => "extremity",
-                                crate::creature::HitBoxType::NoDamage => "no_damage",
                             }
                             .to_string(),
                             position: body.position,

--- a/shock2vr/src/physics/held_melee_drive.rs
+++ b/shock2vr/src/physics/held_melee_drive.rs
@@ -444,3 +444,63 @@ fn melee_drive_trace() {
         }
     }
 }
+
+/// A swing stopped by a limb reports the blow, and reports it pointing the way
+/// the weapon was going. The contact's normal drives the killing blow's ragdoll
+/// impulse (`rag_doll::apply_killing_blow`), so an inverted one throws the
+/// corpse back at the player.
+///
+/// Negative-first: `cast_shape` reports the normal *on the limb*, i.e. limb ->
+/// weapon, which is the opposite of what a `CollisionContact` means.
+#[test]
+fn a_swing_stopped_by_a_limb_reports_it_pointing_at_the_limb() {
+    let (mut world, mut player) = world_with_floor();
+    let (weapon, _) = spawn_held_wrench(&mut world, vec3(0.0, 1.2, 0.0));
+
+    // A limb straight ahead of the weapon, in the hitbox group.
+    let limb = EntityId::from_inner(7).unwrap();
+    world.add_kinematic(
+        limb,
+        vec3(0.0, 1.2, 1.5),
+        identity_quat(),
+        Vector3::new(0.0, 0.0, 0.0),
+        vec3(0.6, 0.6, 0.6),
+        CollisionGroup::hitbox(),
+        false,
+    );
+
+    // Drive the hand through it, and collect what the sweep reported.
+    let mut reported = None;
+    for frame in 0..30 {
+        let z = 0.1 * frame as f32;
+        world.set_position_rotation2(weapon, vec3(0.0, 1.2, z), identity_quat());
+        let (_, events) = world.update(vec3(0.0, 0.0, 0.0), &mut player);
+        for event in events {
+            if let super::CollisionEvent::CollisionStarted {
+                entity1_id,
+                entity2_id,
+                contact: Some(contact),
+            } = event
+            {
+                if entity1_id == weapon && entity2_id == limb {
+                    reported = Some(contact);
+                }
+            }
+        }
+        if reported.is_some() {
+            break;
+        }
+    }
+
+    let contact = reported.expect("the swing should have reported the limb it stopped on");
+    assert!(
+        contact.normal.z > 0.5,
+        "the normal should point from the weapon toward the limb (+z), got {:?}",
+        contact.normal
+    );
+    assert!(
+        contact.closing_speed.unwrap_or(0.0) > 0.0,
+        "a swept blow carries the speed the sweep measured, got {:?}",
+        contact.closing_speed
+    );
+}

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2234,6 +2234,13 @@ pub struct CollisionContact {
     pub point: Vector3<f32>,
     /// Unit normal pointing from `entity1_id` toward `entity2_id`.
     pub normal: Vector3<f32>,
+    /// How fast the bodies were closing when the contact was found, when the
+    /// finder knows. Set for a swing stopped by a creature's hitbox: the sweep
+    /// measured the speed *before* it clamped the weapon, and by the time the
+    /// contact is read the weapon is standing still against the limb. `None`
+    /// for an ordinary narrow-phase contact, where the reader computes it from
+    /// the live bodies.
+    pub closing_speed: Option<f32>,
 }
 
 /// Predicate selecting *only* sensor colliders - the volumes the player's
@@ -2339,6 +2346,18 @@ struct HeldMeleeDrive {
     /// The loose/restored world body is seated at the first tracked pose once;
     /// later hand poses move only `target` so world contact stays physical.
     seated: bool,
+    /// The creature hitbox this swing is currently resting against, so the
+    /// blow is reported when the weapon arrives rather than every frame it
+    /// leans there.
+    stopped_on: Option<EntityId>,
+}
+
+/// What stopped a swing: the limb, and where the cast met it.
+#[derive(Clone, Copy, Debug)]
+struct SweepStop {
+    limb: EntityId,
+    point: Vector3<f32>,
+    normal: Vector3<f32>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2462,6 +2481,10 @@ pub struct PhysicsWorld {
     // edges are only delivered by a stepped frame, so moving while the sim is
     // paused accumulates them until it resumes.
     pending_player_sensor_events: Vec<CollisionEvent>,
+    /// Blows reported by the held-melee sweep: a swing stopped by a limb is a
+    /// hit on that limb, and the stop is what prevents the narrow phase from
+    /// ever seeing it.
+    pending_melee_sweep_events: Vec<CollisionEvent>,
 
     // Entities already reported by report_nonfinite_rigid_body_state, so a
     // body fed bad state every frame (e.g. NaN animation joints driving a
@@ -2799,6 +2822,7 @@ impl PhysicsWorld {
                 HeldMeleeDrive {
                     target,
                     seated: false,
+                    stopped_on: None,
                 },
             );
         }
@@ -3995,6 +4019,7 @@ impl PhysicsWorld {
             let current = *body.position();
             let delta = desired.translation.vector - current.translation.vector;
             let distance = delta.norm();
+            let mut sweep_stop: Option<SweepStop> = None;
 
             // Cap how far one step may carry the weapon, and sweep the capped
             // distance - never skip the sweep for a long jump. Skipping it is
@@ -4008,7 +4033,10 @@ impl PhysicsWorld {
                 0.0
             } else {
                 let direction = delta / distance;
-                step * self.held_melee_sweep_fraction(weapon, &current, direction, step)
+                let (fraction, stop) =
+                    self.held_melee_sweep_fraction(weapon, &current, direction, step);
+                sweep_stop = stop;
+                step * fraction
             };
 
             let mut next = desired;
@@ -4019,6 +4047,42 @@ impl PhysicsWorld {
             };
             if let Some(body) = self.rigid_body_set.get_mut(weapon) {
                 body.set_next_kinematic_position(next);
+            }
+
+            // One blow per arrival: the sweep re-reports the same limb every
+            // frame the weapon leans on it, and a swing is a swing, not a
+            // per-frame billing.
+            let weapon_entity = self
+                .rigid_body_set
+                .get(weapon)
+                .and_then(|body| EntityId::from_inner(body.user_data as u64));
+            let previous = self
+                .held_melee_drives
+                .get(&weapon)
+                .and_then(|drive| drive.stopped_on);
+            let arrived = sweep_stop
+                .as_ref()
+                .filter(|stop| previous != Some(stop.limb))
+                .zip(weapon_entity);
+            if let Some((stop, weapon_entity)) = arrived {
+                let speed = if self.integration_parameters.dt > 0.0 {
+                    step / self.integration_parameters.dt
+                } else {
+                    0.0
+                };
+                self.pending_melee_sweep_events
+                    .push(CollisionEvent::CollisionStarted {
+                        entity1_id: weapon_entity,
+                        entity2_id: stop.limb,
+                        contact: Some(CollisionContact {
+                            point: stop.point,
+                            normal: stop.normal,
+                            closing_speed: Some(speed),
+                        }),
+                    });
+            }
+            if let Some(drive) = self.held_melee_drives.get_mut(&weapon) {
+                drive.stopped_on = sweep_stop.map(|stop| stop.limb);
             }
         }
     }
@@ -4031,14 +4095,23 @@ impl PhysicsWorld {
         current: &Isometry<Real>,
         direction: Vector<Real>,
         distance: Real,
-    ) -> Real {
+    ) -> (Real, Option<SweepStop>) {
         let Some(body) = self.rigid_body_set.get(weapon) else {
-            return 1.0;
+            return (1.0, None);
         };
         let filter = QueryFilter::new()
             .groups(InteractionGroups::new(
-                InternalCollisionGroups::ENTITY.bits.into(),
-                InternalCollisionGroups::WORLD.bits.into(),
+                // The weapon carries its melee membership here, not just
+                // `ENTITY`: a creature's hitboxes answer to `HELD_MELEE`
+                // alone, so without it the pair test fails and the swing
+                // sweeps straight through the limb.
+                (InternalCollisionGroups::ENTITY.bits | InternalCollisionGroups::HELD_MELEE.bits)
+                    .into(),
+                // Stopped by the world, and by the limbs of a creature - not
+                // by its actor capsule, which is a movement volume wider than
+                // the creature: stopping on that would halt the weapon in the
+                // air beside it.
+                (InternalCollisionGroups::WORLD.bits | InternalCollisionGroups::HITBOX.bits).into(),
                 Default::default(),
             ))
             .exclude_rigid_body(weapon)
@@ -4052,6 +4125,7 @@ impl PhysicsWorld {
         );
 
         let mut nearest = distance;
+        let mut stopped_by: Option<SweepStop> = None;
         for collider_handle in body.colliders() {
             let Some(collider) = self.collider_set.get(*collider_handle) else {
                 continue;
@@ -4060,7 +4134,7 @@ impl PhysicsWorld {
             // is offset from the body origin, so sweeping the body's origin
             // would probe empty space beside the weapon.
             let shape_pose = current * collider.position_wrt_parent().copied().unwrap_or_default();
-            if let Some((_, hit)) = queries.cast_shape(
+            if let Some((hit_collider, hit)) = queries.cast_shape(
                 &shape_pose,
                 &direction,
                 collider.shape(),
@@ -4075,14 +4149,36 @@ impl PhysicsWorld {
                     compute_impact_geometry_on_penetration: true,
                 },
             ) {
-                nearest = nearest.min(hit.time_of_impact);
+                if hit.time_of_impact >= nearest {
+                    continue;
+                }
+                nearest = hit.time_of_impact;
+                // A swing stopped by a creature's hitbox *is* a blow landing
+                // on that limb: the cast knows which one, where, and how fast
+                // the weapon was travelling. Reported so the damage can come
+                // from here rather than from a contact the stop prevents.
+                stopped_by = self
+                    .collider_set
+                    .get(hit_collider)
+                    .filter(|collider| {
+                        collider.collision_groups().memberships.bits()
+                            & InternalCollisionGroups::HITBOX.bits
+                            != 0
+                    })
+                    .and_then(|collider| EntityId::from_inner(collider.user_data as u64))
+                    .map(|limb| SweepStop {
+                        limb,
+                        point: npoint_to_cgvec(hit.witness1),
+                        normal: nvec_to_cgmath(hit.normal1.into_inner()),
+                    });
             }
         }
-        if distance <= 0.0 {
+        let fraction = if distance <= 0.0 {
             1.0
         } else {
             (nearest / distance).clamp(0.0, 1.0)
-        }
+        };
+        (fraction, stopped_by)
     }
 
     pub fn remove(&mut self, entity_id: EntityId) {
@@ -4349,6 +4445,7 @@ impl PhysicsWorld {
 
             player_sensor_intersections: HashSet::new(),
             pending_player_sensor_events: Vec::new(),
+            pending_melee_sweep_events: Vec::new(),
 
             reported_nonfinite_entities: HashSet::new(),
 
@@ -5034,6 +5131,7 @@ impl PhysicsWorld {
         // `player_sensor_intersections` at the hop's final occupancy, so the
         // diff below sees no change for anything they already reported.
         let mut collision_events = std::mem::take(&mut self.pending_player_sensor_events);
+        collision_events.append(&mut std::mem::take(&mut self.pending_melee_sweep_events));
         let current_sensor_intersections = profile!(scope: "physics", level: TRACE, "physics.intersections_with_shape", {
             // Only consider sensor colliders for player/sensor intersections.
             let sensor_filter = QueryFilter::new().predicate(&is_sensor_collider);
@@ -6558,6 +6656,7 @@ mod tests {
             } if *entity1_id == actor && *entity2_id == weapon => Some(CollisionContact {
                 point: contact.point,
                 normal: -contact.normal,
+                closing_speed: None,
             }),
             _ => None,
         });

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2343,6 +2343,9 @@ pub struct PlayerHandle {
 #[derive(Clone, Copy)]
 struct HeldMeleeDrive {
     target: RigidBodyHandle,
+    /// The weapon's own entity, so a swept blow can be reported without
+    /// digging it back out of the body's user data every frame.
+    weapon_entity: Option<EntityId>,
     /// The loose/restored world body is seated at the first tracked pose once;
     /// later hand poses move only `target` so world contact stays physical.
     seated: bool,
@@ -2821,6 +2824,12 @@ impl PhysicsWorld {
                 handle,
                 HeldMeleeDrive {
                     target,
+                    weapon_entity: EntityId::from_inner(
+                        self.rigid_body_set
+                            .get(handle)
+                            .map(|body| body.user_data as u64)
+                            .unwrap_or(0),
+                    ),
                     seated: false,
                     stopped_on: None,
                 },
@@ -3990,9 +3999,11 @@ impl PhysicsWorld {
     /// far milder than the one taking the hand's rotation prevents (a weapon
     /// whose angle is not the angle of the hand holding it).
     ///
-    /// Only WORLD geometry blocks. Actors deliberately do not: a swing has to
-    /// travel *into* a creature to damage it, and loose props are better
-    /// swept through than treated as walls.
+    /// World geometry blocks, and so do a creature's hitboxes - the limbs a
+    /// swing can see. Its actor capsule deliberately does not: that is a
+    /// movement volume wider than the creature, and stopping on it would halt
+    /// the weapon in the air beside its target. Loose props are likewise
+    /// better swept through than treated as walls.
     fn drive_held_melee(&mut self) {
         let max_step = crate::dev_params::get(crate::dev_params::MELEE_MAX_SPEED)
             * self.integration_parameters.dt;
@@ -4052,24 +4063,29 @@ impl PhysicsWorld {
             // One blow per arrival: the sweep re-reports the same limb every
             // frame the weapon leans on it, and a swing is a swing, not a
             // per-frame billing.
-            let weapon_entity = self
-                .rigid_body_set
-                .get(weapon)
-                .and_then(|body| EntityId::from_inner(body.user_data as u64));
-            let previous = self
+            let (weapon_entity, previous) = self
                 .held_melee_drives
                 .get(&weapon)
-                .and_then(|drive| drive.stopped_on);
+                .map(|drive| (drive.weapon_entity, drive.stopped_on))
+                .unwrap_or((None, None));
             let arrived = sweep_stop
                 .as_ref()
                 .filter(|stop| previous != Some(stop.limb))
                 .zip(weapon_entity);
             if let Some((stop, weapon_entity)) = arrived {
-                let speed = if self.integration_parameters.dt > 0.0 {
+                // How fast the weapon was closing on the limb, not how fast the
+                // hand was travelling: a weapon dragged along a creature, or
+                // simply carried into one at walking pace, covers ground
+                // without closing on anything. This is the swept equivalent of
+                // `melee_weapon::closing_speed`'s projection, which cannot be
+                // computed later because the stop leaves the weapon still.
+                let travel = if self.integration_parameters.dt > 0.0 {
                     step / self.integration_parameters.dt
                 } else {
                     0.0
                 };
+                let heading = delta / distance;
+                let speed = travel * heading.dot(&vec_to_nvec(stop.normal)).abs();
                 self.pending_melee_sweep_events
                     .push(CollisionEvent::CollisionStarted {
                         entity1_id: weapon_entity,
@@ -4168,8 +4184,14 @@ impl PhysicsWorld {
                     .and_then(|collider| EntityId::from_inner(collider.user_data as u64))
                     .map(|limb| SweepStop {
                         limb,
+                        // World-space, on the limb: the pipeline is shape 1 of
+                        // the cast, so witness1/normal1 belong to what was hit.
                         point: npoint_to_cgvec(hit.witness1),
-                        normal: nvec_to_cgmath(hit.normal1.into_inner()),
+                        // ...which means `normal1` points limb -> weapon, and a
+                        // `CollisionContact` normal points entity1 -> entity2,
+                        // i.e. weapon -> limb. Un-negated it drives the killing
+                        // blow's ragdoll impulse back toward the player.
+                        normal: -nvec_to_cgmath(hit.normal1.into_inner()),
                     });
             }
         }

--- a/shock2vr/src/physics/physics_events.rs
+++ b/shock2vr/src/physics/physics_events.rs
@@ -65,6 +65,8 @@ impl EventHandler for PhysicsEvents {
                         .map(|(manifold, contact)| super::CollisionContact {
                             point: npoint_to_cgvec(contact.point),
                             normal: nvec_to_cgmath(manifold.data.normal),
+                            // The reader computes it from the live bodies.
+                            closing_speed: None,
                         });
                     self.queued_events.lock().unwrap().push(
                         super::CollisionEvent::CollisionStarted {

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -286,6 +286,9 @@ fn is_vr(world: &World) -> bool {
 /// - **Not a raw magnitude.** Sliding a weapon *along* a surface is fast but
 ///   closes on nothing.
 ///
+/// The exception is a contact that already knows: see `closing_speed` on
+/// [`crate::physics::CollisionContact`].
+///
 /// `abs` because the normal's orientation depends on which collider Rapier
 /// listed first. With no contact geometry there is no surface to project onto,
 /// so the relative speed is taken whole.
@@ -295,6 +298,12 @@ fn closing_speed(
     physics: &PhysicsWorld,
     contact: Option<crate::physics::CollisionContact>,
 ) -> f32 {
+    // A blow the swing sweep found carries the speed it measured. It has to:
+    // the sweep stops the weapon on the limb, so by the time this runs the
+    // weapon is standing still and every live-velocity reading is zero.
+    if let Some(speed) = contact.and_then(|contact| contact.closing_speed) {
+        return speed;
+    }
     let Some(contact) = contact else {
         let weapon_velocity = physics
             .get_velocity(weapon)
@@ -449,7 +458,40 @@ mod tests {
         Some(crate::physics::CollisionContact {
             point,
             normal: vec3(1.0, 0.0, 0.0),
+            closing_speed: None,
         })
+    }
+
+    /// A blow found by the swing sweep carries the speed the sweep measured.
+    /// It has to: the sweep stops the weapon on the limb, so by the time the
+    /// blow is read every live velocity is zero and the swing gate would
+    /// reject its own hit.
+    ///
+    /// Negative-first: without the carried speed this reads 0.
+    #[test]
+    fn a_swept_blow_uses_the_speed_the_sweep_measured() {
+        let mut physics = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(1).unwrap();
+        let victim = EntityId::from_inner(2).unwrap();
+        let swept = Some(crate::physics::CollisionContact {
+            point: vec3(0.0, 0.0, 0.0),
+            normal: vec3(1.0, 0.0, 0.0),
+            closing_speed: Some(7.5),
+        });
+
+        assert_eq!(closing_speed(weapon, victim, &physics, swept), 7.5);
+        // Neither body exists in this world, so an ordinary contact - which
+        // reads the live bodies - has nothing to report.
+        let _ = &mut physics;
+        assert_eq!(
+            closing_speed(
+                weapon,
+                victim,
+                &physics,
+                head_on_contact(vec3(0.0, 0.0, 0.0))
+            ),
+            0.0
+        );
     }
 
     /// The bug this rule exists to fix: a held weapon rides the player, so
@@ -750,6 +792,7 @@ mod tests {
                 contact: Some(crate::physics::CollisionContact {
                     point: vec3(2.0, 3.0, 4.0),
                     normal: vec3(1.0, 0.0, 0.0),
+                    closing_speed: None,
                 }),
             },
         )
@@ -991,6 +1034,7 @@ mod tests {
                 contact: Some(crate::physics::CollisionContact {
                     point: vec3(2.0, 3.0, 4.0),
                     normal: vec3(1.0, 0.0, 0.0),
+                    closing_speed: None,
                 }),
             },
         );

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -237,6 +237,11 @@ impl HeldMeleeWeapon {
     /// separate functions because they answer different questions at different
     /// thresholds - audible is a much lower bar than damaging, and a contact
     /// that is too gentle to bill should still clink.
+    /// Whether this contact thuds. Same speed question as [`Self::may_damage`],
+    /// a lower bar - and the same reason for reading the sweep's own
+    /// measurement: a swing stopped on a limb has no live velocity left to
+    /// read, so without it exactly the blows that now land are the ones that
+    /// would fall silent.
     fn may_play_impact_sound(
         &mut self,
         entity_id: EntityId,

--- a/tools/shock2-sdk/test/melee-swing-stop.e2e.test.ts
+++ b/tools/shock2-sdk/test/melee-swing-stop.e2e.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// A swing is stopped by the limb it strikes - not by the actor capsule around
+// the creature, which is a movement volume wider than the creature.
+//
+// The stop is also what *reports* the blow. Clamped at the limb's surface, the
+// weapon never generates a narrow-phase contact while still moving, so the old
+// contact-driven rule scored nothing: the shape-cast that stopped the swing is
+// the thing that knows which limb, where, and how fast.
+const SWING_FRAMES = 30;
+const SWING_FROM_X = 0.9;
+const SWING_TO_X = -1.7;
+
+async function weaponX(game: GameServer, weaponId: number): Promise<number> {
+  const { bodies } = await game.physics.bodies({ entityId: weaponId });
+  assert.ok(bodies[0], "the held weapon should have a body");
+  return bodies[0].position[0];
+}
+
+test(
+  "a swing stops on the limb it strikes, and that stop is the blow",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_melee",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // Grab the authored Wrench off the rack.
+    const { player } = await game.info();
+    const wrench = (await game.entities.list()).entities.find(
+      (entity) => entity.name === "Wrench",
+    );
+    assert.ok(wrench, "expected a Wrench in debug_melee");
+    await game.input.set("right_hand.position", [
+      wrench.position[0] - player.position[0],
+      wrench.position[1] - player.position[1],
+      wrench.position[2] - player.position[2],
+    ]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.step({ frames: 10 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 15 });
+
+    let target;
+    for (const entity of (await game.entities.list()).entities) {
+      const detail = await game.entities.detail(entity.id);
+      if ((detail.aim_points ?? []).length > 1) {
+        target = detail;
+        break;
+      }
+    }
+    assert.ok(target, "expected a creature with hitboxes in debug_melee");
+    const [tx, ty, tz] = target.position;
+    await game.player.teleport({ x: tx + 2.0, y: ty - 1.0, z: tz });
+    await game.step({ frames: 20 });
+    const { player: stance } = await game.info();
+
+    // Swing through the creature. The hand goes all the way; the weapon
+    // should not.
+    let handX = 0;
+    for (let frame = 1; frame <= SWING_FRAMES; frame += 1) {
+      const t = frame / SWING_FRAMES;
+      handX = SWING_FROM_X + (SWING_TO_X - SWING_FROM_X) * t;
+      await game.input.set("right_hand.position", [
+        handX,
+        ty + 0.35 - stance.position[1],
+        0,
+      ]);
+      await game.step({ frames: 1 });
+    }
+
+    // Negative-first: with the sweep passing through limbs the weapon tracks
+    // the hand exactly (measured lag 0.00 for the whole swing).
+    const stoppedAt = await weaponX(game, wrench.id);
+    const separation = Math.abs(stance.position[0] + handX - stoppedAt);
+    assert.ok(
+      separation > 0.5,
+      `the swing should have been stopped by the creature; weapon is ${separation.toFixed(2)} behind the hand`,
+    );
+
+    // ...and the stop is the blow: it names the limb it struck.
+    const damage = (await game.messages.recent()).messages.filter(
+      (message) => message.payload === "Damage" && message.to.entity_id === target.entity_id,
+    );
+    assert.ok(
+      damage.length > 0,
+      "stopping on the limb should have damaged the creature",
+    );
+    assert.ok(
+      damage.every(
+        (message) => message.impact?.bone !== undefined && message.impact?.bone !== null,
+      ),
+      `each blow should name its joint; got ${JSON.stringify(damage.map((d) => d.impact))}`,
+    );
+
+    // Pulling the hand back frees the weapon: a stop must not be a trap.
+    for (let frame = 1; frame <= 24; frame += 1) {
+      const t = frame / 24;
+      await game.input.set("right_hand.position", [
+        SWING_TO_X + (1.0 - SWING_TO_X) * t,
+        ty + 0.35 - stance.position[1],
+        0,
+      ]);
+      await game.step({ frames: 1 });
+    }
+    const recovered = Math.abs(stance.position[0] + 1.0 - (await weaponX(game, wrench.id)));
+    assert.ok(
+      recovered < 0.2,
+      `the weapon should follow the hand back out, got ${recovered.toFixed(2)} behind`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/per-limb-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/per-limb-damage.e2e.test.ts
@@ -69,12 +69,16 @@ test(
 );
 
 test(
-  "a blow on the weapon a creature is holding reaches nothing",
+  "a blow on the hand is worth a far-limb blow, and still reaches the creature",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({ mission: "debug_melee" });
     await game.step({ frames: 30 });
 
+    // Joints 14/15 are `LWeap`/`RWeap`: where a weapon is *attached*. The
+    // vertices skinned to them are the creature's own hand - the pipe it
+    // carries is a separate object with no hitbox at all - so a blow there is
+    // a blow on a hand, worth what the far half of a limb is worth.
     let creature;
     for (const entity of (await game.entities.list()).entities) {
       const detail = await game.entities.detail(entity.id);
@@ -84,23 +88,26 @@ test(
       }
     }
     assert.ok(creature, "expected a creature with weapon-hand hitboxes");
-    const weapon = (creature.aim_points ?? []).find(
+    const hand = (creature.aim_points ?? []).find(
       (point) => point.joint_id === 14 || point.joint_id === 15,
     )!;
 
     const before = await hitPoints(game, creature.entity_id);
-    await game.entities.sendMessage(weapon.proxy_entity_id, {
+    assert.ok(before !== null, "the creature should report hit points");
+    await game.entities.sendMessage(hand.proxy_entity_id, {
       type: "Damage",
       amount: AUTHORED,
-      point: weapon.position,
+      point: hand.position,
       direction: [0, 0, 1],
     });
     await game.step({ frames: 3 });
+    const after = await hitPoints(game, creature.entity_id);
+    assert.ok(after !== null, "the creature should still report hit points");
 
-    assert.equal(
-      await hitPoints(game, creature.entity_id),
-      before,
-      "hitting the pipe in its hand should cost the creature nothing",
+    const dealt = before - after;
+    assert.ok(
+      Math.abs(dealt - AUTHORED * 0.5) <= 0.5,
+      `a blow on the hand should cost about ${AUTHORED * 0.5}, got ${dealt}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/per-limb-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/per-limb-damage.e2e.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// What a blow is worth depends on where it landed: a head is worth more than a
+// shin, and a creature's own weapon is worth nothing. This is what the per-joint
+// hitboxes are *for* - aiming only matters if aim changes the outcome.
+//
+// Each blow lands on a different creature: 10 points is enough to kill, and a
+// dead creature ignores damage, so reusing one target would read every blow
+// after the first as zero.
+const AUTHORED = 10;
+
+async function hitPoints(game: GameServer, entityId: number): Promise<number | null> {
+  const detail = await game.entities.detail(entityId);
+  const property = detail.properties.find((p) => p.name === "HitPoints");
+  return property ? Number(property.value) : null;
+}
+
+test(
+  "a blow is worth what the part it struck is worth",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_melee" });
+    await game.step({ frames: 30 });
+
+    const creatures = [];
+    for (const entity of (await game.entities.list()).entities) {
+      const detail = await game.entities.detail(entity.id);
+      if ((detail.aim_points ?? []).length > 1) creatures.push(detail);
+    }
+    assert.ok(creatures.length >= 3, "expected three creatures in debug_melee");
+
+    // joint -> the factor the hitbox table gives it.
+    const cases: Array<[number, string, number]> = [
+      [9, "head", 1.25],
+      [18, "abdomen", 1.0],
+      [12, "elbow", 0.5],
+    ];
+
+    for (const [index, [joint, part, factor]] of cases.entries()) {
+      const creature = creatures[index]!;
+      const aim = (creature.aim_points ?? []).find((point) => point.joint_id === joint);
+      assert.ok(aim, `expected a ${part} hitbox on the creature`);
+
+      const before = await hitPoints(game, creature.entity_id);
+      assert.ok(before !== null, "the creature should report hit points");
+      await game.entities.sendMessage(aim.proxy_entity_id, {
+        type: "Damage",
+        amount: AUTHORED,
+        point: aim.position,
+        direction: [0, 0, 1],
+      });
+      await game.step({ frames: 3 });
+      const after = await hitPoints(game, creature.entity_id);
+      assert.ok(after !== null, "the creature should still report hit points");
+
+      // Negative-first: unscaled, every part costs the authored 10.
+      const dealt = before - after;
+      assert.ok(
+        Math.abs(dealt - AUTHORED * factor) <= 0.5,
+        `a blow on the ${part} should cost about ${AUTHORED * factor}, got ${dealt}`,
+      );
+    }
+  },
+);
+
+test(
+  "a blow on the weapon a creature is holding reaches nothing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_melee" });
+    await game.step({ frames: 30 });
+
+    let creature;
+    for (const entity of (await game.entities.list()).entities) {
+      const detail = await game.entities.detail(entity.id);
+      if ((detail.aim_points ?? []).some((point) => point.joint_id === 14 || point.joint_id === 15)) {
+        creature = detail;
+        break;
+      }
+    }
+    assert.ok(creature, "expected a creature with weapon-hand hitboxes");
+    const weapon = (creature.aim_points ?? []).find(
+      (point) => point.joint_id === 14 || point.joint_id === 15,
+    )!;
+
+    const before = await hitPoints(game, creature.entity_id);
+    await game.entities.sendMessage(weapon.proxy_entity_id, {
+      type: "Damage",
+      amount: AUTHORED,
+      point: weapon.position,
+      direction: [0, 0, 1],
+    });
+    await game.step({ frames: 3 });
+
+    assert.equal(
+      await hitPoints(game, creature.entity_id),
+      before,
+      "hitting the pipe in its hand should cost the creature nothing",
+    );
+  },
+);


### PR DESCRIPTION
Stacked on #1220. Two features, together because the review that hardened them spans both.

## 1. A swing stops on the limb it strikes — and that stop is the blow

The swing sweep stopped only on world geometry, so a weapon passed through a creature entirely. It now stops on the creature's hitboxes, while still passing through the actor capsule — a movement volume wider than the creature, which would halt the weapon in the air beside its target.

The catch, measured rather than guessed: **stopping the swing destroys the evidence that it landed.** Clamped at the limb's surface, the weapon never generates a narrow-phase contact *while moving*, and the swing gate then reads a stationary weapon. The same swing that scored two hits scored none. Softening it with a penetration allowance doesn't fix that either — per frame the weapon walks through the body, once-only it sticks inside the limb.

So the stop reports the blow itself. The shape-cast already knows which limb it met, where, and how fast the weapon was travelling; the contact carries that speed, because by the time a script reads it the weapon is standing still. No penetration allowance at all.

Measured: the weapon halts 1.3 units behind the hand, damages the limb it stopped on, and follows the hand back out when pulled — a stop, not a trap.

## 2. What a blow is worth depends on where it landed

![per-limb damage](https://gist.githubusercontent.com/tommy-xr/b196ece76e5afd98777d4f428bbf11dd/raw/per-limb-damage.png)

<sub>One authored value, three outcomes. The readouts are #1216's.</sub>

| part | factor |
| --- | --- |
| head | 1.25 |
| neck, abdomen | 1.0 |
| thigh, shoulder | 0.75 |
| forearm, shin, hand, foot | 0.5 |

`HitBoxType` has carried these categories since the hitboxes were built and had never been read. This is a deliberate divergence: the original scales damage by the stim and the victim's receptrons, never by where the blow landed — but per-joint hitboxes are what make aiming possible, so this is what makes aiming matter.

The humanoid map is re-bucketed to suit: `Limb` is now the near half of a limb and `Extremity` the far half, where the split used to be "leg or arm" — an elbow counted for as much as a shoulder, and a foot for less than a knee.

## What review changed

Both of these were wrong in ways nothing would have shouted about:

- **The swept blow's normal was inverted.** `cast_shape` reports the normal on the shape it *hit*, so it ran limb→weapon, while a `CollisionContact` normal runs entity1→entity2. It feeds `DamageImpact.direction`, which the killing blow turns into a ragdoll impulse — corpses would have been thrown back toward the player. Pinned by a test that reads −1.0 on the axis it should read +1.0.
- **The carried speed was the hand's whole travel**, not the part closing on the limb — the very measure `closing_speed` exists to avoid, so dragging a weapon along a creature, or walking into one, would have billed a hit. Now projected onto the contact normal.
- **Joints 14/15 are hands, not weapons.** `LWeap`/`RWeap` are where a weapon is *attached*; the vertices skinned to them are the creature's own hand, and the pipe it carries is a separate object with no hitbox at all. They are far-limb, not weightless — "0 for the weapon it holds" has nothing to attach to until a held weapon gets a damage proxy of its own. `HitBoxType::NoDamage` then had no producer and is gone rather than left as a ghost.
- The impact sound reads the same measured speed, or exactly the blows that now land would have fallen silent.

## Verification

- Unit: the multiplier table and the humanoid buckets joint by joint; every blow reaches the creature whatever it is worth (its AI wakes on being hit); and the swept blow's normal and carried speed, in the headless held-melee harness.
- e2e `melee-swing-stop.e2e.test.ts`: a real VR swing is stopped by the creature, damages the limb it stopped on, and frees when the hand withdraws.
- e2e `per-limb-damage.e2e.test.ts`: one authored blow per joint on a fresh creature, checked against hit points — head 12.5, abdomen 10, elbow 5, hand 5.
- Full SDK e2e suite: 353/369, all 8 failures also fail on `main`.
