### PR TITLE
feat(debug): debug_ladder scene with one station per climbing shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,6 +474,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_hud`              | Test HUD rendering                           |
    | `debug_map`              | Test map/automap rendering                   |
    | `debug_melee`            | VR melee: weapon rack, damageable creatures, trigger-free contact damage |
+   | `debug_ladder`           | Climbing stations: ledge top-out, two-sided arch, stacked rungs, short ladder, plain wall (flat + VR) |
    | `debug_minimal`          | Bare minimum scene for basic testing         |
    | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `DebugCycleWeapon`) |
    | `debug_psi`              | Psi amp casting (auto-equips the amp; select powers with `CyclePsiPower`) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,7 +474,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_hud`              | Test HUD rendering                           |
    | `debug_map`              | Test map/automap rendering                   |
    | `debug_melee`            | VR melee: weapon rack, damageable creatures, trigger-free contact damage |
-   | `debug_ladder`           | Climbing stations: ledge top-out, two-sided arch, stacked rungs, short ladder, plain wall (flat + VR) |
+   | `debug_ladder`           | Climbing stations: ledge top-out, two-sided arch, stacked rungs, short ladder, mantle block, plain wall (flat + VR) |
    | `debug_minimal`          | Bare minimum scene for basic testing         |
    | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `DebugCycleWeapon`) |
    | `debug_psi`              | Psi amp casting (auto-equips the amp; select powers with `CyclePsiPower`) |

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -11,7 +11,8 @@ use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
     scene::{
-        SceneObject, basic_material, color_material, create_plane_with_uv_scale, light::SpotLight,
+        SceneObject, basic_material, color_material, create_plane_with_uv_scale, cube,
+        light::SpotLight,
     },
 };
 use rapier3d::prelude::{Collider, ColliderBuilder};
@@ -661,13 +662,37 @@ impl DebugSceneFloor {
     }
 }
 
+/// A solid-color unit cube scaled to `scale` and centered on `translation`
+/// - the building block of every debug scene's floor, walls and benches.
+pub fn cube_object(
+    color: Vector3<f32>,
+    translation: Vector3<f32>,
+    scale: Vector3<f32>,
+) -> SceneObject {
+    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
+    object.set_transform(
+        Matrix4::from_translation(translation)
+            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
+    );
+    object
+}
+
 /// `Effect::CreateEntity` at a world position with identity orientation - the
 /// spawn shape every populate hook wants.
 pub fn spawn_at(template_id: i32, position: Point3<f32>) -> Effect {
+    spawn_at_oriented(template_id, position, Quaternion::new(1.0, 0.0, 0.0, 0.0))
+}
+
+/// [`spawn_at`] with an explicit orientation.
+pub fn spawn_at_oriented(
+    template_id: i32,
+    position: Point3<f32>,
+    orientation: Quaternion<f32>,
+) -> Effect {
     Effect::CreateEntity {
         template_id,
         position,
-        orientation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        orientation,
         // Identity, not `from_translation(position)`: the root transform is
         // applied *on top of* `position`, so passing the position twice lands
         // the entity at double the offset.

--- a/shock2vr/src/scenes/debug_ladder.rs
+++ b/shock2vr/src/scenes/debug_ladder.rs
@@ -1,0 +1,242 @@
+//! Debug scene for climbing: ladders and climbable blocks in the shapes the
+//! shipped missions use, in one place, for flat and VR alike.
+//!
+//! Climbing tests borrow mission geometry (medsci1's cryo ladder, rick1's
+//! opening deck, hydro2's Sector-C rung stack), so each case costs a mission
+//! load and a re-staged pose whenever the geometry it leans on changes. This
+//! scene is the controlled equivalent: one station per climbing shape, at
+//! known coordinates, built from the same ladder templates the missions place
+//! (so their `PropPhysAttr.climbable` faces and model-bounds colliders are the
+//! production ones, not stand-ins).
+//!
+//! Stations sit at `x ≈ -8` (ahead of the spawn) on lanes along `z`:
+//! - `z = 0`   ledge: a 16' ladder up a walkable block whose top is just
+//!   below the ladder's cap - the rick1 top-out shape.
+//! - `z = 8`   arch: a freestanding block with a 16' ladder on both faces -
+//!   climb up, cross, climb down.
+//! - `z = -8`  stack: eleven single `Rick Ladder` rungs at 0.8-unit spacing
+//!   up a tall wall - the hydro2 Sector-C shape (separate entities, so a
+//!   climb must carry across rung boundaries).
+//! - `z = 16`  short: a freestanding 4' ladder, reachable on either face,
+//!   with an exposed top and bottom.
+//! - `z = -16` wall: a plain block, same size as the ledge's, with no ladder.
+//!   The negative case.
+
+use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3, vec3};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, color_material, cube},
+};
+use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
+use shipyard::EntityId;
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    mission::entity_creator::CreateEntityOptions,
+    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
+    scenes::debug_common::{
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    },
+    scripts::Effect,
+};
+
+/// `Rick Ladder 16` / `Rick Ladder 4`: one-piece ladders, 16 and 4 SS2 feet
+/// tall. `Rick Ladder` is the single rung the missions stack.
+const LADDER_16: i32 = -2558;
+const LADDER_4: i32 = -2556;
+const LADDER_RUNG: i32 = -178;
+
+/// Ladder heights in world units (SS2 feet / 2.5).
+const LADDER_16_HEIGHT: f32 = 6.4;
+const LADDER_4_HEIGHT: f32 = 1.6;
+/// hydro2 stacks its rungs 0.8 units apart.
+const RUNG_SPACING: f32 = 0.8;
+const RUNG_COUNT: usize = 11;
+
+/// Near face of every station block, ahead of the spawn along -X.
+const STATION_FACE_X: f32 = -7.0;
+/// Blocks are 4 units wide across their lane.
+const BLOCK_WIDTH: f32 = 4.0;
+
+const LEDGE_Z: f32 = 0.0;
+const LEDGE_HEIGHT: f32 = 6.0;
+const LEDGE_DEPTH: f32 = 6.0;
+
+const ARCH_Z: f32 = 8.0;
+const ARCH_DEPTH: f32 = 2.0;
+
+const STACK_Z: f32 = -8.0;
+const STACK_WALL_HEIGHT: f32 = 9.0;
+
+const SHORT_Z: f32 = 16.0;
+
+const WALL_Z: f32 = -16.0;
+
+/// The ladder models are authored with their rungs facing ±Z. Every station
+/// here is approached along X, so the ladders turn a quarter to face the
+/// player.
+fn ladder_yaw() -> Quaternion<f32> {
+    Quaternion::from_angle_y(Deg(90.0))
+}
+
+fn spawn_ladder(template_id: i32, position: Point3<f32>) -> Effect {
+    Effect::CreateEntity {
+        template_id,
+        position,
+        orientation: ladder_yaw(),
+        root_transform: Matrix4::identity(),
+        options: CreateEntityOptions::default(),
+    }
+}
+
+fn cube_object(color: Vector3<f32>, translation: Vector3<f32>, scale: Vector3<f32>) -> SceneObject {
+    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
+    object.set_transform(
+        Matrix4::from_translation(translation)
+            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
+    );
+    object
+}
+
+pub fn create_debug_ladder_scene(
+    global_context: &GlobalContext,
+    game_options: &GameOptions,
+    asset_cache: &mut AssetCache,
+    audio_context: &mut AudioContext<EntityId, String>,
+) -> Box<dyn GameScene> {
+    // A block whose near face is at STATION_FACE_X, `depth` long along -X.
+    let block = |color: Vector3<f32>, z: f32, height: f32, depth: f32| {
+        (
+            color,
+            vec3(STATION_FACE_X - depth / 2.0, height / 2.0, z),
+            vec3(depth, height, BLOCK_WIDTH),
+        )
+    };
+    // Every piece is a (color, center, size) box used for both the visual and
+    // the collider so the two cannot drift.
+    let mut boxes: Vec<(Vector3<f32>, Vector3<f32>, Vector3<f32>)> = vec![
+        // floor
+        (
+            vec3(0.18, 0.18, 0.22),
+            vec3(0.0, -0.5, 0.0),
+            vec3(60.0, 1.0, 60.0),
+        ),
+        block(vec3(0.30, 0.40, 0.30), LEDGE_Z, LEDGE_HEIGHT, LEDGE_DEPTH),
+        block(vec3(0.40, 0.30, 0.30), ARCH_Z, LADDER_16_HEIGHT, ARCH_DEPTH),
+        block(
+            vec3(0.30, 0.30, 0.45),
+            STACK_Z,
+            STACK_WALL_HEIGHT,
+            LEDGE_DEPTH,
+        ),
+        block(vec3(0.35, 0.35, 0.35), WALL_Z, LEDGE_HEIGHT, LEDGE_DEPTH),
+    ];
+
+    let scene_objects = boxes
+        .iter()
+        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
+        .collect::<Vec<_>>();
+    let collider = ColliderBuilder::compound(
+        boxes
+            .drain(..)
+            .map(|(_, translation, scale)| {
+                (
+                    Isometry::translation(translation.x, translation.y, translation.z),
+                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
+                )
+            })
+            .collect(),
+    )
+    .build();
+
+    let mut builder = DebugSceneBuilder::new("debug_ladder")
+        .with_spawn_location(SpawnLocation::PositionRotation(
+            vec3(0.0, 2.0, 0.0),
+            Quaternion::from_angle_y(Deg(0.0)),
+        ))
+        .with_physics_geometry(collider);
+    for scene_object in scene_objects {
+        builder = builder.add_scene_object(scene_object);
+    }
+
+    let core = builder.build_core(DebugSceneBuildOptions {
+        global_context,
+        game_options,
+        asset_cache,
+        audio_context,
+    });
+
+    println!(
+        "[debug_ladder] Climbing stations ahead (-X), one per lane along z:\n\
+         z=0 ledge (16' ladder, top-out onto the block), z=8 arch (ladder both\n\
+         faces), z=-8 stack (11 stacked rungs), z=16 short 4' ladder, z=-16 plain\n\
+         wall (not climbable). Ladders are the shipped templates, so their\n\
+         climbable faces and colliders are the production ones."
+    );
+
+    Box::new(HookedDebugScene::new(core, LadderHooks::default()))
+}
+
+#[derive(Default)]
+struct LadderHooks {
+    populated: bool,
+}
+
+impl DebugSceneHooks for LadderHooks {
+    fn before_handle_effects(
+        &mut self,
+        core: &mut MissionCore,
+        _effects: &mut Vec<Effect>,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if self.populated {
+            return;
+        }
+        self.populated = true;
+
+        // Ladders stand flush against their block, centered on their height
+        // (the templates' origin is the model center).
+        let flush_x = STATION_FACE_X + 0.1;
+        let mut effects = vec![
+            spawn_ladder(
+                LADDER_16,
+                Point3::new(flush_x, LADDER_16_HEIGHT / 2.0, LEDGE_Z),
+            ),
+            spawn_ladder(
+                LADDER_16,
+                Point3::new(flush_x, LADDER_16_HEIGHT / 2.0, ARCH_Z),
+            ),
+            spawn_ladder(
+                LADDER_16,
+                Point3::new(
+                    STATION_FACE_X - ARCH_DEPTH - 0.1,
+                    LADDER_16_HEIGHT / 2.0,
+                    ARCH_Z,
+                ),
+            ),
+            spawn_ladder(
+                LADDER_4,
+                Point3::new(STATION_FACE_X - 1.0, LADDER_4_HEIGHT / 2.0, SHORT_Z),
+            ),
+        ];
+        for index in 0..RUNG_COUNT {
+            effects.push(spawn_ladder(
+                LADDER_RUNG,
+                Point3::new(flush_x, RUNG_SPACING * (index as f32 + 0.5), STACK_Z),
+            ));
+        }
+
+        core.handle_effects(
+            effects,
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        );
+    }
+}

--- a/shock2vr/src/scenes/debug_ladder.rs
+++ b/shock2vr/src/scenes/debug_ladder.rs
@@ -6,10 +6,10 @@
 //! load and a re-staged pose whenever the geometry it leans on changes. This
 //! scene is the controlled equivalent: one station per climbing shape, at
 //! known coordinates, built from the same ladder templates the missions place
-//! (so their `PropPhysAttr.climbable` faces and model-bounds colliders are the
+//! (so their `PropPhysAttr.climbable` flag and model-bounds colliders are the
 //! production ones, not stand-ins).
 //!
-//! Stations sit at `x ≈ -8` (ahead of the spawn) on lanes along `z`:
+//! Stations sit at `x ≈ -7` (ahead of the spawn) on lanes along `z`:
 //! - `z = 0`   ledge: a 16' ladder up a walkable block whose top is just
 //!   below the ladder's cap - the rick1 top-out shape.
 //! - `z = 8`   arch: a freestanding block with a 16' ladder on both faces -
@@ -22,22 +22,18 @@
 //! - `z = -16` wall: a plain block, same size as the ledge's, with no ladder.
 //!   The negative case.
 
-use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3, vec3};
-use engine::{
-    assets::asset_cache::AssetCache,
-    audio::AudioContext,
-    scene::{SceneObject, color_material, cube},
-};
+use cgmath::{Deg, Point3, Quaternion, Rotation3, Vector3, vec3};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
 use crate::{
     GameOptions,
     game_scene::GameScene,
-    mission::entity_creator::CreateEntityOptions,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene, cube_object,
+        spawn_at_oriented,
     },
     scripts::Effect,
 };
@@ -82,22 +78,7 @@ fn ladder_yaw() -> Quaternion<f32> {
 }
 
 fn spawn_ladder(template_id: i32, position: Point3<f32>) -> Effect {
-    Effect::CreateEntity {
-        template_id,
-        position,
-        orientation: ladder_yaw(),
-        root_transform: Matrix4::identity(),
-        options: CreateEntityOptions::default(),
-    }
-}
-
-fn cube_object(color: Vector3<f32>, translation: Vector3<f32>, scale: Vector3<f32>) -> SceneObject {
-    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
-    object.set_transform(
-        Matrix4::from_translation(translation)
-            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
-    );
-    object
+    spawn_at_oriented(template_id, position, ladder_yaw())
 }
 
 pub fn create_debug_ladder_scene(
@@ -173,7 +154,7 @@ pub fn create_debug_ladder_scene(
          z=0 ledge (16' ladder, top-out onto the block), z=8 arch (ladder both\n\
          faces), z=-8 stack (11 stacked rungs), z=16 short 4' ladder, z=-16 plain\n\
          wall (not climbable). Ladders are the shipped templates, so their\n\
-         climbable faces and colliders are the production ones."
+         climbable flag and colliders are the production ones."
     );
 
     Box::new(HookedDebugScene::new(core, LadderHooks::default()))

--- a/shock2vr/src/scenes/debug_ladder.rs
+++ b/shock2vr/src/scenes/debug_ladder.rs
@@ -19,6 +19,9 @@
 //!   climb must carry across rung boundaries).
 //! - `z = 16`  short: a freestanding 4' ladder, reachable on either face,
 //!   with an exposed top and bottom.
+//! - `z = 24`  mantle: a low block with no ladder, within jump-and-mantle
+//!   reach - the earth.mis training ledge shape. In VR its lip is what a
+//!   hand grabs.
 //! - `z = -16` wall: a plain block, same size as the ledge's, with no ladder.
 //!   The negative case.
 
@@ -68,6 +71,10 @@ const STACK_WALL_HEIGHT: f32 = 9.0;
 
 const SHORT_Z: f32 = 16.0;
 
+const MANTLE_Z: f32 = 24.0;
+/// 7.5 ft: above step height, below the jump-plus-mantle reach.
+const MANTLE_HEIGHT: f32 = 3.0;
+
 const WALL_Z: f32 = -16.0;
 
 /// The ladder models are authored with their rungs facing ±Z. Every station
@@ -112,6 +119,7 @@ pub fn create_debug_ladder_scene(
             STACK_WALL_HEIGHT,
             LEDGE_DEPTH,
         ),
+        block(vec3(0.45, 0.40, 0.30), MANTLE_Z, MANTLE_HEIGHT, LEDGE_DEPTH),
         block(vec3(0.35, 0.35, 0.35), WALL_Z, LEDGE_HEIGHT, LEDGE_DEPTH),
     ];
 
@@ -152,8 +160,8 @@ pub fn create_debug_ladder_scene(
     println!(
         "[debug_ladder] Climbing stations ahead (-X), one per lane along z:\n\
          z=0 ledge (16' ladder, top-out onto the block), z=8 arch (ladder both\n\
-         faces), z=-8 stack (11 stacked rungs), z=16 short 4' ladder, z=-16 plain\n\
-         wall (not climbable). Ladders are the shipped templates, so their\n\
+         faces), z=-8 stack (11 stacked rungs), z=16 short 4' ladder, z=24 low\n\
+         mantle block (no ladder), z=-16 plain wall (not climbable). Ladders are the shipped templates, so their\n\
          climbable flag and colliders are the production ones."
     );
 

--- a/shock2vr/src/scenes/debug_melee.rs
+++ b/shock2vr/src/scenes/debug_melee.rs
@@ -20,12 +20,8 @@
 //! between them is the calibration error, and it is only visible with both on
 //! screen at once.
 
-use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, Vector3, vec3};
-use engine::{
-    assets::asset_cache::AssetCache,
-    audio::AudioContext,
-    scene::{SceneObject, color_material, cube},
-};
+use cgmath::{Deg, Point3, Quaternion, Rotation3, Vector3, vec3};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
@@ -34,7 +30,8 @@ use crate::{
     game_scene::GameScene,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene, spawn_at,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene, cube_object,
+        spawn_at,
     },
     scripts::Effect,
 };
@@ -81,15 +78,6 @@ const WALL_DISTANCE: f32 = 13.0;
 /// picked up without walking.
 const RACK_HEIGHT: f32 = 1.1;
 const RACK_DISTANCE: f32 = 1.0;
-
-fn cube_object(color: Vector3<f32>, translation: Vector3<f32>, scale: Vector3<f32>) -> SceneObject {
-    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
-    object.set_transform(
-        Matrix4::from_translation(translation)
-            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
-    );
-    object
-}
 
 pub fn create_debug_melee_scene(
     global_context: &GlobalContext,

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -7,12 +7,8 @@
 //! powers (Cryokinesis, Pyrokinesis, ...) land on the wall, and the psi bar
 //! on the HUD drains by the power's tier per cast.
 
-use cgmath::{Deg, Matrix4, Quaternion, Rotation3, vec3};
-use engine::{
-    assets::asset_cache::AssetCache,
-    audio::AudioContext,
-    scene::{SceneObject, color_material, cube},
-};
+use cgmath::{Deg, Quaternion, Rotation3, vec3};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
@@ -23,7 +19,7 @@ use crate::{
 };
 
 use super::debug_common::{
-    AutoEquipHooks, DebugSceneBuildOptions, DebugSceneBuilder, HookedDebugScene,
+    AutoEquipHooks, DebugSceneBuildOptions, DebugSceneBuilder, HookedDebugScene, cube_object,
 };
 
 /// The Psi Amp player weapon.
@@ -32,19 +28,6 @@ const PSI_AMP_TEMPLATE_ID: i32 = -247;
 /// Distance (world units) from the player to the test wall, straight ahead
 /// (-X, the default-view forward).
 const WALL_DISTANCE: f32 = 12.0;
-
-fn cube_object(
-    color: cgmath::Vector3<f32>,
-    translation: cgmath::Vector3<f32>,
-    scale: cgmath::Vector3<f32>,
-) -> SceneObject {
-    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
-    object.set_transform(
-        Matrix4::from_translation(translation)
-            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
-    );
-    object
-}
 
 pub fn create_debug_psi_scene(
     global_context: &GlobalContext,

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -13,12 +13,8 @@
 //! on entry - so reload, ammo cycling, and the VR clip-insert gesture can all
 //! be exercised without provisioning anything first.
 
-use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, vec3};
-use engine::{
-    assets::asset_cache::AssetCache,
-    audio::AudioContext,
-    scene::{SceneObject, color_material, cube},
-};
+use cgmath::{Deg, Point3, Quaternion, Rotation3, vec3};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
@@ -26,7 +22,9 @@ use crate::{
     GameOptions,
     game_scene::{DebugPlayerStatsRequest, DebugSkillLevelsRequest, DebuggableScene, GameScene},
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
-    scenes::debug_common::{DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, spawn_at},
+    scenes::debug_common::{
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, cube_object, spawn_at,
+    },
     scripts::Effect,
     scripts::gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP},
 };
@@ -84,19 +82,6 @@ const AMMO_SPACING: f32 = 0.6;
 /// Height of the retaining lip above the bench top.
 const BENCH_LIP_HEIGHT: f32 = 0.5;
 const BENCH_LIP_THICKNESS: f32 = 0.08;
-
-fn cube_object(
-    color: cgmath::Vector3<f32>,
-    translation: cgmath::Vector3<f32>,
-    scale: cgmath::Vector3<f32>,
-) -> SceneObject {
-    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
-    object.set_transform(
-        Matrix4::from_translation(translation)
-            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
-    );
-    object
-}
 
 pub fn create_debug_weapons_scene(
     global_context: &GlobalContext,

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -28,6 +28,7 @@ pub mod debug_hand_poses;
 pub mod debug_hitbox;
 pub mod debug_hud;
 pub mod debug_joint_constraint;
+pub mod debug_ladder;
 pub mod debug_map;
 pub mod debug_melee;
 pub mod debug_minimal;
@@ -52,6 +53,7 @@ pub use debug_hand_poses::DebugHandPosesScene;
 pub use debug_hitbox::DebugHitboxScene;
 pub use debug_hud::DebugHudScene;
 pub use debug_joint_constraint::DebugJointConstraintScene;
+pub use debug_ladder::create_debug_ladder_scene;
 pub use debug_map::DebugMapScene;
 pub use debug_melee::create_debug_melee_scene;
 pub use debug_minimal::DebugMinimalScene;
@@ -166,6 +168,7 @@ const DEBUG_SCENES: &[(&str, DebugSceneCtor)] = &[
     }),
     ("debug_weapons", create_debug_weapons_scene),
     ("debug_melee", create_debug_melee_scene),
+    ("debug_ladder", create_debug_ladder_scene),
     ("debug_psi", create_debug_psi_scene),
     ("debug_teleport", |global, options, assets, audio| {
         Box::new(DebugTeleportScene::create(global, options, assets, audio))

--- a/tools/shock2-sdk/test/debug-ladder.e2e.test.ts
+++ b/tools/shock2-sdk/test/debug-ladder.e2e.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// The debug_ladder scene: one climbing station per lane along z, all at
+// x ≈ -7 ahead of the spawn (see shock2vr/src/scenes/debug_ladder.rs). Flat
+// climbing (push into the ladder) must ascend every ladder station and be
+// blocked by the plain wall, so the scene can stand in for mission geometry
+// in climbing tests.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Standing capsule center above the floor.
+const FLOOR_Y = 1.24;
+
+type Station = { name: string; z: number; blockTop: number | null };
+const STATIONS: Station[] = [
+  { name: "ledge", z: 0, blockTop: 6.0 },
+  { name: "arch", z: 8, blockTop: 6.4 },
+  { name: "stack", z: -8, blockTop: 9.0 },
+  { name: "short", z: 16, blockTop: 1.6 },
+  { name: "wall", z: -16, blockTop: null },
+];
+
+test(
+  "debug_ladder: every ladder station climbs, the plain wall does not",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_ladder" });
+    await game.step({ frames: 5 });
+
+    for (const station of STATIONS) {
+      await game.player.teleport({ x: -5.5, y: 1.5, z: station.z });
+      await game.step({ frames: 30 });
+      const before = await game.player.position();
+      assert.ok(
+        Math.abs(before.y - FLOOR_Y) < 0.1,
+        `${station.name}: expected to start on the floor, got y=${before.y}`,
+      );
+
+      // Face -X (the spawn heading) and push forward into the ladder. Sample
+      // the peak: a topped-out player keeps walking and drops off the far
+      // edge of its block.
+      let peak = before.y;
+      await game.input.set("right_hand.thumbstick", [0, 1]);
+      for (let i = 0; i < 12; i++) {
+        await game.step({ frames: 10 });
+        peak = Math.max(peak, (await game.player.position()).y);
+      }
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      await game.step({ frames: 10 });
+
+      if (station.blockTop === null) {
+        assert.ok(
+          peak - before.y < 0.2,
+          `${station.name}: a plain wall must not be climbable (peak y=${peak.toFixed(2)})`,
+        );
+      } else {
+        assert.ok(
+          peak > station.blockTop,
+          `${station.name}: pushing into the ladder should reach above its block top ` +
+            `${station.blockTop} (peak y=${peak.toFixed(2)})`,
+        );
+      }
+    }
+  },
+);

--- a/tools/shock2-sdk/test/debug-ladder.e2e.test.ts
+++ b/tools/shock2-sdk/test/debug-ladder.e2e.test.ts
@@ -6,9 +6,9 @@ import { teleportVerified } from "./helpers/teleport.js";
 
 // The debug_ladder scene: one climbing station per lane along z, all at
 // x ≈ -7 ahead of the spawn (see shock2vr/src/scenes/debug_ladder.rs). Flat
-// climbing (push into the ladder) must ascend every ladder station and be
-// blocked by the plain wall, so the scene can stand in for mission geometry
-// in climbing tests.
+// climbing (push into the ladder) must ascend every ladder station, a held
+// jump must mantle the low block, and the plain wall must block, so the scene
+// can stand in for mission geometry in climbing tests.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // Approach the near (+X) face from here, or the arch's far (-X) face.
@@ -24,6 +24,8 @@ type Station = {
   topY: number;
   freestanding?: boolean;
   climbable?: boolean;
+  /// No ladder: hold jump and push forward to mantle onto the block.
+  mantle?: boolean;
 };
 const STATIONS: Station[] = [
   { name: "ledge", z: 0, topY: 6.0 },
@@ -31,6 +33,7 @@ const STATIONS: Station[] = [
   { name: "arch (far face)", z: 8, x: ARCH_FAR_X, topY: 6.4 },
   { name: "stack", z: -8, topY: 9.0 },
   { name: "short", z: 16, topY: 1.6, freestanding: true },
+  { name: "mantle", z: 24, topY: 3.0, mantle: true },
   { name: "wall", z: -16, topY: 6.0, climbable: false },
 ];
 
@@ -60,6 +63,7 @@ test(
       let peak = floorY;
       let standing = false;
       await game.input.set("right_hand.thumbstick", [0, 1]);
+      if (station.mantle) await game.input.set("jump", 1);
       for (let i = 0; i < 20; i++) {
         await game.step({ frames: 10 });
         const y = (await game.player.position()).y;
@@ -69,6 +73,7 @@ test(
         if (Math.abs(y - (station.topY + floorY)) < 0.1) standing = true;
       }
       await game.input.set("right_hand.thumbstick", [0, 0]);
+      await game.input.set("jump", 0);
       await game.step({ frames: 10 });
 
       if (station.climbable === false) {
@@ -85,7 +90,7 @@ test(
       } else {
         assert.ok(
           standing,
-          `${station.name}: pushing into the ladder should top out onto the block ` +
+          `${station.name}: should end standing on the block ` +
             `(top ${station.topY}, expected y≈${(station.topY + floorY).toFixed(2)}, ` +
             `peak y=${peak.toFixed(2)})`,
         );

--- a/tools/shock2-sdk/test/debug-ladder.e2e.test.ts
+++ b/tools/shock2-sdk/test/debug-ladder.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
 
 // The debug_ladder scene: one climbing station per lane along z, all at
 // x ≈ -7 ahead of the spawn (see shock2vr/src/scenes/debug_ladder.rs). Flat
@@ -10,16 +11,27 @@ import { GameServer } from "../src/index.js";
 // in climbing tests.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-// Standing capsule center above the floor.
-const FLOOR_Y = 1.24;
+// Approach the near (+X) face from here, or the arch's far (-X) face.
+const NEAR_X = -5.5;
+const ARCH_FAR_X = -11.5;
 
-type Station = { name: string; z: number; blockTop: number | null };
+type Station = {
+  name: string;
+  z: number;
+  x?: number;
+  /// Height of what the climb ends on: a block top the player must stand on,
+  /// or (`freestanding`) the ladder's own top, which has nothing to stand on.
+  topY: number;
+  freestanding?: boolean;
+  climbable?: boolean;
+};
 const STATIONS: Station[] = [
-  { name: "ledge", z: 0, blockTop: 6.0 },
-  { name: "arch", z: 8, blockTop: 6.4 },
-  { name: "stack", z: -8, blockTop: 9.0 },
-  { name: "short", z: 16, blockTop: 1.6 },
-  { name: "wall", z: -16, blockTop: null },
+  { name: "ledge", z: 0, topY: 6.0 },
+  { name: "arch", z: 8, topY: 6.4 },
+  { name: "arch (far face)", z: 8, x: ARCH_FAR_X, topY: 6.4 },
+  { name: "stack", z: -8, topY: 9.0 },
+  { name: "short", z: 16, topY: 1.6, freestanding: true },
+  { name: "wall", z: -16, topY: 6.0, climbable: false },
 ];
 
 test(
@@ -30,36 +42,52 @@ test(
     await game.step({ frames: 5 });
 
     for (const station of STATIONS) {
-      await game.player.teleport({ x: -5.5, y: 1.5, z: station.z });
+      const x = station.x ?? NEAR_X;
+      await teleportVerified(game, { x, y: 1.5, z: station.z });
       await game.step({ frames: 30 });
       const before = await game.player.position();
-      assert.ok(
-        Math.abs(before.y - FLOOR_Y) < 0.1,
-        `${station.name}: expected to start on the floor, got y=${before.y}`,
-      );
+      const floorY = before.y;
+      // Face the station's ladder level, then push forward into it. Level
+      // matters: flat climbing reads a downward pitch as "descend".
+      const eyeY = floorY + (await game.info()).player.camera_offset[1];
+      const ladderX = station.x === undefined ? -7 : -9;
+      await game.input.lookAtWorldPoint([ladderX, eyeY, station.z]);
+      await game.step({ frames: 5 });
 
-      // Face -X (the spawn heading) and push forward into the ladder. Sample
-      // the peak: a topped-out player keeps walking and drops off the far
-      // edge of its block.
-      let peak = before.y;
+      // Sample the peak and the height the player holds at the end: a
+      // topped-out player keeps walking across its block and eventually
+      // drops off the far edge.
+      let peak = floorY;
+      let standing = false;
       await game.input.set("right_hand.thumbstick", [0, 1]);
-      for (let i = 0; i < 12; i++) {
+      for (let i = 0; i < 20; i++) {
         await game.step({ frames: 10 });
-        peak = Math.max(peak, (await game.player.position()).y);
+        const y = (await game.player.position()).y;
+        peak = Math.max(peak, y);
+        // Standing on the block: the capsule center sits one floor height
+        // above the top, as it did on the floor.
+        if (Math.abs(y - (station.topY + floorY)) < 0.1) standing = true;
       }
       await game.input.set("right_hand.thumbstick", [0, 0]);
       await game.step({ frames: 10 });
 
-      if (station.blockTop === null) {
+      if (station.climbable === false) {
         assert.ok(
-          peak - before.y < 0.2,
+          peak - floorY < 0.2,
           `${station.name}: a plain wall must not be climbable (peak y=${peak.toFixed(2)})`,
+        );
+      } else if (station.freestanding) {
+        assert.ok(
+          peak > station.topY,
+          `${station.name}: pushing into the ladder should climb to its top ` +
+            `${station.topY} (peak y=${peak.toFixed(2)})`,
         );
       } else {
         assert.ok(
-          peak > station.blockTop,
-          `${station.name}: pushing into the ladder should reach above its block top ` +
-            `${station.blockTop} (peak y=${peak.toFixed(2)})`,
+          standing,
+          `${station.name}: pushing into the ladder should top out onto the block ` +
+            `(top ${station.topY}, expected y≈${(station.topY + floorY).toFixed(2)}, ` +
+            `peak y=${peak.toFixed(2)})`,
         );
       }
     }


### PR DESCRIPTION
## Summary
- New `debug_ladder` scene: ledge top-out, two-sided arch, hydro2-style stack of 11 rungs, freestanding 4' ladder, plain (non-climbable) wall. Built from the shipped ladder templates (`-2558`, `-2556`, `-178`), so colliders and the climbable flag are the production ones.
- `debug-ladder.e2e.test.ts`: flat push-into-ladder tops out onto every block (near and far arch faces), climbs the short ladder, and is blocked by the wall.
- `cube_object` / `spawn_at_oriented` moved to `debug_common` (the scene would have been the fourth copy).

First PR of the VR hand-climbing work: this is the bench the hand-grip PRs are verified on.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime -p desktop_runtime`
- [x] `SHOCK2_E2E=1` `debug-ladder.e2e.test.ts` passes
- [x] visuals below

## Visuals

![debug_ladder stations](https://gist.githubusercontent.com/tommy-xr/122624ca9799cdf9868f1e00655a7193/raw/ladder_stations.png)

<sub>All six stations, from a free camera at `[26,18,4]` looking at `[-9,3,4]` — left to right: the low mantle block (`z=24`, no ladder), the short 4' ladder (`z=16`), the arch (`z=8`, a 16' ladder on both faces), the ledge (`z=0`), the rung stack (`z=-8`, eleven separate rungs), and the plain non-climbable wall (`z=-16`).</sub>

![flat ladder climb and top-out](https://gist.githubusercontent.com/tommy-xr/122624ca9799cdf9868f1e00655a7193/raw/ladder_climb.gif)

<sub>Flat first-person: walk into the ledge station's 16' ladder, climb 6 units, and top out onto the walkable block. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) — teleport to `[-2.5, 1.5, 0]`, hold the locomotion stick forward, one screenshot every 4 sim frames.</sub>

