### PR TITLE
feat(physics): hand grip query for climbable faces and ledges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,12 @@ For debugging visual/rendering changes without a full interactive session:
    curl "http://127.0.0.1:8080/v1/physics/bodies?entity_id=4"
    curl http://127.0.0.1:8080/v1/physics/bodies/12   # detail by body_id
 
+   # Ask what a hand at a world point could grab: "ladder" (an authored
+   # climbable face whose per-face `PropPhysAttr.climbable` bit is set),
+   # "ledge" (a walkable top more than a step above the feet - the mantle
+   # hold), or null. Optional `radius` and `feet_y` (defaults to the player's).
+   curl "http://127.0.0.1:8080/v1/physics/grip?x=-6.8&y=3&z=0"
+
    # Inspect what the renderer actually drew on the last frame: per-object
    # entity/model, effective transparency, depth-write and backface-culling
    # winding. Answers "why does this prop look transparent/inside-out?" with

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -199,6 +199,14 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<PhysicsJointsResult>,
     },
 
+    /// Ask what a hand at a world point could grab (ladder face / ledge).
+    ClimbGrip {
+        point: [f32; 3],
+        radius: Option<f32>,
+        feet_y: Option<f32>,
+        reply: oneshot::Sender<ClimbGripResult>,
+    },
+
     /// Apply a world-space impulse to a dynamic physics body (waking it) -
     /// e.g. poke a settled ragdoll to verify it wakes and reacts.
     ApplyBodyImpulse {
@@ -367,6 +375,26 @@ pub struct RagdollMetricsEntry {
     pub min_y: f32,
     pub max_nonadjacent_overlap: f32,
     pub max_drift: f32,
+}
+
+/// What a hand at the queried point can hold onto - `grip` is null when
+/// nothing there is grabbable.
+#[derive(Debug, Serialize)]
+pub struct ClimbGripResult {
+    pub grip: Option<ClimbGripEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClimbGripEntry {
+    /// `"ladder"` (an authored climbable face) or `"ledge"` (a walkable top
+    /// above the player's feet).
+    pub kind: String,
+    pub entity_id: Option<i32>,
+    pub entity_name: Option<String>,
+    /// World-space point on the gripped surface.
+    pub point: [f32; 3],
+    /// World-space surface normal, pointing out toward the hand.
+    pub normal: [f32; 3],
 }
 
 /// Joint diagnostics (ragdoll constraint health), impulse + multibody.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -3602,7 +3602,6 @@ async fn get_ragdoll_metrics(
     }
 }
 
-/// HTTP handler for impulse-joint diagnostics (ragdoll constraint health).
 #[derive(Deserialize)]
 struct ClimbGripQueryParams {
     x: f32,
@@ -3644,6 +3643,7 @@ async fn climb_grip(
     }
 }
 
+/// HTTP handler for impulse-joint diagnostics (ragdoll constraint health).
 async fn list_physics_joints(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
 ) -> Json<commands::PhysicsJointsResult> {

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -405,6 +405,7 @@ async fn start_http_server(
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
         .route("/v1/physics/joints", get(list_physics_joints))
+        .route("/v1/physics/grip", get(climb_grip))
         .route(
             "/v1/physics/bodies/:id/impulse",
             axum::routing::post(apply_body_impulse),
@@ -1917,6 +1918,32 @@ fn process_command(
                 .unwrap_or_default();
             if let Err(_) = reply.send(commands::PhysicsJointsResult { joints }) {
                 tracing::warn!("Failed to send physics joints - receiver dropped");
+            }
+        }
+        RuntimeCommand::ClimbGrip {
+            point,
+            radius,
+            feet_y,
+            reply,
+        } => {
+            let grip = game
+                .debug_scene()
+                .and_then(|scene| {
+                    scene.climb_grip(
+                        cgmath::Vector3::new(point[0], point[1], point[2]),
+                        radius,
+                        feet_y,
+                    )
+                })
+                .map(|grip| commands::ClimbGripEntry {
+                    kind: grip.kind.to_string(),
+                    entity_id: grip.entity_id,
+                    entity_name: grip.entity_name,
+                    point: grip.point,
+                    normal: grip.normal,
+                });
+            if reply.send(commands::ClimbGripResult { grip }).is_err() {
+                tracing::warn!("Failed to send climb grip - receiver dropped");
             }
         }
         RuntimeCommand::ApplyBodyImpulse {
@@ -3576,6 +3603,47 @@ async fn get_ragdoll_metrics(
 }
 
 /// HTTP handler for impulse-joint diagnostics (ragdoll constraint health).
+#[derive(Deserialize)]
+struct ClimbGripQueryParams {
+    x: f32,
+    y: f32,
+    z: f32,
+    /// Probe ball radius, world units (default: the hand-sized grip radius).
+    radius: Option<f32>,
+    /// Reference feet height for the ledge test (default: the player's own).
+    feet_y: Option<f32>,
+}
+
+/// HTTP handler for `GET /v1/physics/grip`: what a hand at (x, y, z) could
+/// grab. `grip` is null when nothing there is grabbable.
+async fn climb_grip(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    Query(params): Query<ClimbGripQueryParams>,
+) -> Json<commands::ClimbGripResult> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if command_tx
+        .send(RuntimeCommand::ClimbGrip {
+            point: [params.x, params.y, params.z],
+            radius: params.radius,
+            feet_y: params.feet_y,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send ClimbGrip command - game loop receiver dropped");
+        return Json(commands::ClimbGripResult { grip: None });
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive climb grip - sender dropped");
+            Json(commands::ClimbGripResult { grip: None })
+        }
+    }
+}
+
 async fn list_physics_joints(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
 ) -> Json<commands::PhysicsJointsResult> {

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -336,6 +336,17 @@ pub struct DebugRayHit {
     pub is_sensor: bool,
 }
 
+/// A climbing hold reported by `GET /v1/physics/grip`. `kind` is "ladder"
+/// (an authored climbable face) or "ledge" (a walkable top above the feet).
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugClimbGrip {
+    pub kind: &'static str,
+    pub entity_id: Option<i32>,
+    pub entity_name: Option<String>,
+    pub point: [f32; 3],
+    pub normal: [f32; 3],
+}
+
 /// Raycast mask for collision group filtering
 #[derive(Debug, Clone)]
 pub struct RaycastMask {
@@ -770,6 +781,19 @@ pub trait DebuggableScene {
     /// # Returns
     /// Raycast hit result with entity and collision information
     fn raycast(&self, start: Point3<f32>, end: Point3<f32>, mask: RaycastMask) -> DebugRayHit;
+
+    /// What a hand at `point` could grab (see
+    /// [`crate::physics::PhysicsWorld::climbable_grip_at`]). `feet_y` defaults
+    /// to the player's own feet when None. Scenes without a player or physics
+    /// report nothing.
+    fn climb_grip(
+        &self,
+        _point: Vector3<f32>,
+        _radius: Option<f32>,
+        _feet_y: Option<f32>,
+    ) -> Option<DebugClimbGrip> {
+        None
+    }
 
     /// Teleport the player to a specific position
     ///

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1325,15 +1325,14 @@ fn create_physics_representation_with_options(
         let immobile = v_immobile.get(entity_id).is_ok();
 
         // Climbable surfaces (ladders: PropPhysAttr.climbable != 0) carry an
-        // extra marker membership so player movement can detect contact.
-        // Simplifications: `climbable` is plausibly a per-face bitmask in
-        // the original engine (27 = the four vertical sides on ladders) -
-        // any non-zero value marks the whole collider solid-climbable here;
-        // the per-face bits are handed to physics for the hand grip query
-        // (`PhysicsWorld::climbable_grip_at`). And
-        // only this (non-frobbable) creation branch checks it: all known
-        // ladders are plain terrain objects; a frobbable climbable would
-        // need the same treatment in the branch above.
+        // extra marker membership so player movement can detect contact. The
+        // value is a per-face bitmask; contact detection ignores the faces
+        // (any non-zero value marks the whole collider climbable), while the
+        // bits go to physics for the hand grip query
+        // (`PhysicsWorld::climbable_grip_at`). Only this (non-frobbable)
+        // creation branch checks it: all known ladders are plain terrain
+        // objects; a frobbable climbable would need the same treatment in the
+        // branch above.
         let climbable_sides = v_phys_attr
             .get(entity_id)
             .map(|pa| pa.climbable)

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1328,14 +1328,17 @@ fn create_physics_representation_with_options(
         // extra marker membership so player movement can detect contact.
         // Simplifications: `climbable` is plausibly a per-face bitmask in
         // the original engine (27 = the four vertical sides on ladders) -
-        // any non-zero value marks the whole collider climbable here. And
+        // any non-zero value marks the whole collider solid-climbable here;
+        // the per-face bits are handed to physics for the hand grip query
+        // (`PhysicsWorld::climbable_grip_at`). And
         // only this (non-frobbable) creation branch checks it: all known
         // ladders are plain terrain objects; a frobbable climbable would
         // need the same treatment in the branch above.
-        let is_climbable = v_phys_attr
+        let climbable_sides = v_phys_attr
             .get(entity_id)
-            .map(|pa| pa.climbable != 0)
-            .unwrap_or(false);
+            .map(|pa| pa.climbable)
+            .unwrap_or(0);
+        let is_climbable = climbable_sides != 0;
 
         // `P$PhysDims` is an instantiated, non-inherited property in Dark. A
         // concrete object can therefore inherit a physics type without storing
@@ -1537,6 +1540,11 @@ fn create_physics_representation_with_options(
                     is_sensor,
                 )
             };
+            if is_climbable {
+                // Contact detection only needs the CLIMBABLE membership above;
+                // the hand grip query needs the authored per-face bits.
+                physics.set_climbable_sides(entity_id, climbable_sides);
+            }
             Some(rigid_body_handle)
         } else {
             None

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -10161,6 +10161,40 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         )
     }
 
+    fn climb_grip(
+        &self,
+        point: Vector3<f32>,
+        radius: Option<f32>,
+        feet_y: Option<f32>,
+    ) -> Option<crate::game_scene::DebugClimbGrip> {
+        let feet_y = feet_y.unwrap_or_else(|| {
+            let center = self.physics.get_player_translation(&self.player_handle);
+            center.y - crate::physics::player_center_above_floor(self.player_handle.is_crouched())
+        });
+        let grip = self.physics.climbable_grip_at(
+            point,
+            radius.unwrap_or(crate::physics::CLIMB_GRIP_RADIUS),
+            feet_y,
+        )?;
+        let entity_name = grip.entity_id.and_then(|id| {
+            self.world.run(
+                |v_sym_name: shipyard::View<dark::properties::PropSymName>| {
+                    v_sym_name.get(id).ok().map(|s| s.0.clone())
+                },
+            )
+        });
+        Some(crate::game_scene::DebugClimbGrip {
+            kind: match grip.kind {
+                crate::physics::ClimbGripKind::Ladder => "ladder",
+                crate::physics::ClimbGripKind::Ledge => "ledge",
+            },
+            entity_id: grip.entity_id.map(|id| id.inner() as i32),
+            entity_name,
+            point: [grip.point.x, grip.point.y, grip.point.z],
+            normal: [grip.normal.x, grip.normal.y, grip.normal.z],
+        })
+    }
+
     fn raycast(
         &self,
         start: cgmath::Point3<f32>,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -353,6 +353,15 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.raycast(start, end, mask)
     }
 
+    fn climb_grip(
+        &self,
+        point: Vector3<f32>,
+        radius: Option<f32>,
+        feet_y: Option<f32>,
+    ) -> Option<crate::game_scene::DebugClimbGrip> {
+        self.mission_core.climb_grip(point, radius, feet_y)
+    }
+
     fn teleport_player(&mut self, position: Vector3<f32>) -> Result<(), String> {
         self.mission_core.teleport_player(position)
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2178,6 +2178,61 @@ impl CollisionGroup {
     }
 }
 
+/// Radius (world units) of the ball a hand probes with in
+/// [`PhysicsWorld::climbable_grip_at`]. Roughly a fist: big enough to find the
+/// surface a tracked hand is resting on, small enough that it only finds the
+/// one face the hand is actually against.
+pub const CLIMB_GRIP_RADIUS: f32 = 0.15;
+
+/// What a hand found to hold onto.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClimbGripKind {
+    /// An authored climbable surface (`PropPhysAttr.climbable`), on a face
+    /// whose per-face bit is set - a ladder rail or rung.
+    Ladder,
+    /// A walkable top surface above the player's feet: the mantle-emulation
+    /// hold. Any solid, non-climbable geometry can offer one.
+    Ledge,
+}
+
+/// A hold found by [`PhysicsWorld::climbable_grip_at`].
+#[derive(Clone, Copy, Debug)]
+pub struct ClimbGrip {
+    pub kind: ClimbGripKind,
+    /// Owning entity, when the surface belongs to one (level terrain has none).
+    pub entity_id: Option<EntityId>,
+    /// World-space point on the surface.
+    pub point: Vector3<f32>,
+    /// World-space surface normal, pointing out of the surface toward the hand.
+    pub normal: Vector3<f32>,
+}
+
+/// Dark's `PropPhysAttr.climbable` is a per-face bitmask over the six OBB
+/// faces in Dark's Z-up local frame: 1=+X, 2=+Y, 4=+Z (top), 8=-X, 16=-Y,
+/// 32=-Z (bottom). The importer maps a Dark vector (x, y, z) to engine
+/// (-x, z, y) (`read_vec3`, dark/src/ss2_common.rs:54), so in the engine's
+/// Y-up frame those bits are: 1=-X, 2=+Z, 4=+Y (top), 8=+X, 16=-Z, 32=-Y.
+///
+/// `local_normal` is the outward face normal in the collider's local frame;
+/// its dominant axis picks the face. Every shipped ladder authors 27
+/// (= 1|2|8|16), the four vertical sides.
+fn climbable_face_bit(local_normal: Vector<Real>) -> u32 {
+    let (ax, ay, az) = (
+        local_normal.x.abs(),
+        local_normal.y.abs(),
+        local_normal.z.abs(),
+    );
+    if ax >= ay && ax >= az {
+        if local_normal.x >= 0.0 { 8 } else { 1 }
+    } else if ay >= az {
+        if local_normal.y >= 0.0 { 4 } else { 32 }
+    } else if local_normal.z >= 0.0 {
+        2
+    } else {
+        16
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct RayCastResult {
     pub hit_point: Point3<f32>,
@@ -2440,6 +2495,11 @@ pub struct PhysicsWorld {
     rigid_bodies_with_forces: Vec<RigidBodyHandle>,
 
     entity_id_to_body: HashMap<EntityId, RigidBodyHandle>,
+
+    // Per-face grip bits (Dark `PropPhysAttr.climbable`) for climbable
+    // entities, keyed by owner. Contact detection only needs the CLIMBABLE
+    // group membership; the hand grip query needs to know WHICH face.
+    climbable_sides: HashMap<EntityId, u32>,
 
     // Short-lived recovery state created only while a living, gravity-driven
     // creature is touching the side of horizontally-moving kinematic terrain.
@@ -4239,6 +4299,7 @@ impl PhysicsWorld {
             );
         }
         self.entity_id_to_body.remove(&entity_id);
+        self.climbable_sides.remove(&entity_id);
         self.live_creature_sweep_recovery.remove(&entity_id);
         self.pending_player_push_velocity.remove(&entity_id);
     }
@@ -4458,6 +4519,7 @@ impl PhysicsWorld {
             // physics_hooks: Box::new(physics_hooks),
             // event_handler: Box::new(event_handler),
             entity_id_to_body: HashMap::new(),
+            climbable_sides: HashMap::new(),
             live_creature_sweep_recovery: HashMap::new(),
             pending_player_push_velocity: HashMap::new(),
             kinematic_attachments: HashMap::new(),
@@ -4787,6 +4849,104 @@ impl PhysicsWorld {
         );
         queries.bodies = &self.no_bodies;
         queries
+    }
+
+    /// Record an entity's authored per-face climbable bits (see
+    /// [`climbable_face_bit`]). Called at creation for every climbable entity.
+    pub fn set_climbable_sides(&mut self, entity_id: EntityId, sides: u32) {
+        self.climbable_sides.insert(entity_id, sides);
+    }
+
+    /// What, if anything, a hand at `point` can hold onto.
+    ///
+    /// Probes a ball of `radius` and returns the nearest qualifying contact.
+    /// Two classes (see [`ClimbGripKind`]): a **Ladder** face is an authored
+    /// climbable whose touched face has its bit set, so a ladder authored 27
+    /// rejects grabs on its top and bottom caps; a **Ledge** is any other
+    /// solid, player-blocking surface whose face is walkable and sits more
+    /// than a step above `feet_y` - the mantle-emulation hold. A wall face,
+    /// and the floor the player is standing on, offer neither.
+    pub fn climbable_grip_at(
+        &self,
+        point: Vector3<f32>,
+        radius: f32,
+        feet_y: f32,
+    ) -> Option<ClimbGrip> {
+        let ball = Ball::new(radius.max(1.0e-3));
+        let ball_pos = Isometry::translation(point.x, point.y, point.z);
+        // Probe AS the player, so only geometry that blocks the player can be
+        // held. Climbables are matched explicitly: a ladder is solid to the
+        // player anyway, but the bit keeps the intent visible.
+        let filter = QueryFilter::new()
+            .groups(InteractionGroups::new(
+                InternalCollisionGroups::PLAYER.bits.into(),
+                (InternalCollisionGroups::WORLD.bits
+                    | InternalCollisionGroups::ENTITY.bits
+                    | InternalCollisionGroups::SELECTABLE.bits
+                    | InternalCollisionGroups::CLIMBABLE.bits)
+                    .into(),
+                Default::default(),
+            ))
+            .exclude_sensors();
+        let dispatcher = self.narrow_phase.query_dispatcher();
+        let queries = self.broad_phase.as_query_pipeline(
+            dispatcher,
+            &self.rigid_body_set,
+            &self.collider_set,
+            filter,
+        );
+
+        let min_ledge_height = feet_y + PLAYER_STEP_HEIGHT / SCALE_FACTOR;
+        let mut nearest: Option<(f32, ClimbGrip)> = None;
+        for (_handle, collider) in queries.intersect_shape(ball_pos, &ball) {
+            let Ok(Some(contact)) = rapier3d::parry::query::contact(
+                &ball_pos,
+                &ball,
+                collider.position(),
+                collider.shape(),
+                0.0,
+            ) else {
+                continue;
+            };
+            // normal1 points from the hand toward the surface; the outward
+            // surface normal is its opposite.
+            let outward = -contact.normal1.into_inner();
+            let is_climbable = collider
+                .collision_groups()
+                .memberships
+                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into());
+            let entity_id = EntityId::from_inner(collider.user_data as u64);
+            let kind = if is_climbable {
+                // No recorded mask means the whole collider is grippable -
+                // the behavior climbables had before per-face bits existed.
+                let sides = entity_id
+                    .and_then(|id| self.climbable_sides.get(&id).copied())
+                    .unwrap_or(u32::MAX);
+                let local = collider.rotation().inverse_transform_vector(&outward);
+                if sides & climbable_face_bit(local) == 0 {
+                    continue;
+                }
+                ClimbGripKind::Ladder
+            } else {
+                let world_point = contact.point2;
+                if outward.y < PLAYER_MIN_WALKABLE_NORMAL || world_point.y <= min_ledge_height {
+                    continue;
+                }
+                ClimbGripKind::Ledge
+            };
+            if nearest.is_none_or(|(dist, _)| contact.dist < dist) {
+                nearest = Some((
+                    contact.dist,
+                    ClimbGrip {
+                        kind,
+                        entity_id,
+                        point: vec3(contact.point2.x, contact.point2.y, contact.point2.z),
+                        normal: vec3(outward.x, outward.y, outward.z),
+                    },
+                ));
+            }
+        }
+        nearest.map(|(_, grip)| grip)
     }
 
     fn move_player(
@@ -8433,6 +8593,183 @@ mod tests {
 
     /// A player standing at the base of a climbable wall who pushes into it
     /// climbs it; against an identical NON-climbable wall the same input leaves
+    /// Grip-query fixture: a parentless trimesh floor with its top at y=0 and
+    /// the player parked far away, stepped once so the broad-phase BVH exists.
+    fn grip_world() -> (PhysicsWorld, PlayerHandle) {
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, floor_tris)
+                .expect("floor trimesh")
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(50.0, 1.0, 50.0), EntityId::from_inner(1001).unwrap());
+        step(&mut world, &mut player, 1);
+        (world, player)
+    }
+
+    /// A `ladder.bin`-shaped box (0.9 x 6.4 x 0.1, faces on +-Z at identity)
+    /// stood on the floor at x=-5 and yawed 90 degrees, exactly as the
+    /// `debug_ladder` scene spawns them. After the yaw its broad face points
+    /// along world +X and its narrow edges along world +-Z.
+    fn add_yawed_ladder(
+        world: &mut PhysicsWorld,
+        player: &mut PlayerHandle,
+        climbable: Option<u32>,
+    ) -> EntityId {
+        let entity = EntityId::from_inner(2001).unwrap();
+        let yaw_90 = <Quaternion<f32> as cgmath::Rotation3>::from_angle_y(cgmath::Deg(90.0));
+        world.add_kinematic(
+            entity,
+            vec3(-5.0, 3.2, 0.0),
+            yaw_90,
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.9, 6.4, 0.1),
+            if climbable.is_some() {
+                CollisionGroup::climbable_entity()
+            } else {
+                CollisionGroup::entity()
+            },
+            false,
+        );
+        if let Some(sides) = climbable {
+            world.set_climbable_sides(entity, sides);
+        }
+        step(world, player, 1);
+        entity
+    }
+
+    /// Dark's per-face bits live in its Z-up frame; the importer flips X and
+    /// swaps Y/Z. Verified through the query on a YAWED collider, so a wrong
+    /// local/world frame or a wrong axis swap shows up as a grip on the wrong
+    /// face. 27 is what every shipped ladder authors.
+    #[test]
+    fn ladder_face_bits_grip_only_the_authored_faces() {
+        // The broad face (world +X after the yaw) is one of the four vertical
+        // sides in mask 27.
+        let (mut world, mut player) = grip_world();
+        add_yawed_ladder(&mut world, &mut player, Some(27));
+        let side = world
+            .climbable_grip_at(vec3(-4.85, 3.0, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+            .expect("the broad face of a 27 ladder is grippable");
+        assert_eq!(side.kind, ClimbGripKind::Ladder);
+        assert!(
+            side.normal.x > 0.9,
+            "expected a +X face, got {:?}",
+            side.normal
+        );
+        // ... and its top cap is not.
+        assert!(
+            world
+                .climbable_grip_at(vec3(-5.0, 6.45, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .is_none(),
+            "mask 27 excludes the top cap"
+        );
+
+        // Top-only (4) is the exact inverse.
+        let (mut world, mut player) = grip_world();
+        add_yawed_ladder(&mut world, &mut player, Some(4));
+        assert_eq!(
+            world
+                .climbable_grip_at(vec3(-5.0, 6.45, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .map(|grip| grip.kind),
+            Some(ClimbGripKind::Ladder),
+            "mask 4 is the top cap"
+        );
+        assert!(
+            world
+                .climbable_grip_at(vec3(-4.85, 3.0, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .is_none(),
+            "mask 4 excludes the sides"
+        );
+
+        // Asymmetric single side: Dark +X (bit 1) is engine -X, which the
+        // 90-degree yaw turns into world +Z. The opposite edge stays bare.
+        let (mut world, mut player) = grip_world();
+        add_yawed_ladder(&mut world, &mut player, Some(1));
+        assert_eq!(
+            world
+                .climbable_grip_at(vec3(-5.0, 3.0, 0.5), CLIMB_GRIP_RADIUS, 0.0)
+                .map(|grip| grip.kind),
+            Some(ClimbGripKind::Ladder),
+            "bit 1 lands on world +Z once the ladder is yawed"
+        );
+        assert!(
+            world
+                .climbable_grip_at(vec3(-5.0, 3.0, -0.5), CLIMB_GRIP_RADIUS, 0.0)
+                .is_none(),
+            "the opposite edge has no bit"
+        );
+    }
+
+    /// The same box without the climbable marker offers nothing to a hand on
+    /// its vertical face - a wall is not a hold.
+    #[test]
+    fn plain_wall_face_offers_no_grip() {
+        let (mut world, mut player) = grip_world();
+        add_yawed_ladder(&mut world, &mut player, None);
+        assert!(
+            world
+                .climbable_grip_at(vec3(-4.85, 3.0, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .is_none()
+        );
+    }
+
+    /// Mantle emulation: the walkable top of a solid block above the player's
+    /// feet is a Ledge; the floor they are standing on is not (it is not more
+    /// than a step above their feet).
+    #[test]
+    fn walkable_top_above_the_feet_is_a_ledge_but_the_floor_is_not() {
+        let (mut world, mut player) = grip_world();
+        world.add_kinematic(
+            EntityId::from_inner(2002).unwrap(),
+            vec3(0.0, 1.5, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(4.0, 3.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+
+        let lip = world
+            .climbable_grip_at(vec3(0.0, 3.05, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+            .expect("a block top above the feet is grippable");
+        assert_eq!(lip.kind, ClimbGripKind::Ledge);
+        assert!(
+            lip.normal.y > 0.9,
+            "expected an up-facing hold, got {:?}",
+            lip.normal
+        );
+
+        assert!(
+            world
+                .climbable_grip_at(vec3(0.0, 3.05, 0.0), CLIMB_GRIP_RADIUS, 3.0)
+                .is_none(),
+            "the surface the player stands ON is not a hold"
+        );
+        assert!(
+            world
+                .climbable_grip_at(vec3(8.0, 0.05, 8.0), CLIMB_GRIP_RADIUS, 0.0)
+                .is_none(),
+            "the floor at the player's feet is not a hold"
+        );
+        assert!(
+            world
+                .climbable_grip_at(vec3(2.15, 1.5, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .is_none(),
+            "the block's vertical side is not a hold"
+        );
+    }
+
     /// the player on the floor. (Negative-first: without the CLIMBABLE
     /// detection + redirect in `move_player`, both cases stay at floor height
     /// and the ascent assertion fails.)

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2213,24 +2213,41 @@ pub struct ClimbGrip {
 /// (-x, z, y) (`read_vec3`, dark/src/ss2_common.rs:54), so in the engine's
 /// Y-up frame those bits are: 1=-X, 2=+Z, 4=+Y (top), 8=+X, 16=-Z, 32=-Y.
 ///
-/// `local_normal` is the outward face normal in the collider's local frame;
-/// its dominant axis picks the face. Every shipped ladder authors 27
-/// (= 1|2|8|16), the four vertical sides.
-fn climbable_face_bit(local_normal: Vector<Real>) -> u32 {
-    let (ax, ay, az) = (
-        local_normal.x.abs(),
-        local_normal.y.abs(),
-        local_normal.z.abs(),
-    );
-    if ax >= ay && ax >= az {
-        if local_normal.x >= 0.0 { 8 } else { 1 }
-    } else if ay >= az {
-        if local_normal.y >= 0.0 { 4 } else { 32 }
-    } else if local_normal.z >= 0.0 {
-        2
-    } else {
-        16
-    }
+/// `local_normal` is the outward face normal in the collider's local frame.
+/// The shipped ladders author 27 (= 1|2|8|16, the four vertical sides) on the
+/// `Ladders` template, and some instances override it - medsci1's `Rick
+/// Ladder 16`s author 54 (= 2|4|16|32), the two broad faces plus both caps.
+/// Both include the faces a ladder is actually climbed on.
+///
+/// Returns every face the normal plausibly touches, OR-ed together, not just
+/// the dominant one: a contact on an edge has a diagonal normal, and
+/// collapsing it to whichever axis wins by a hair leaves a dead wedge at the
+/// top of a ladder - exactly where a hand reaches when topping out.
+fn climbable_face_bits(local_normal: Vector<Real>) -> u32 {
+    /// How far off the dominant axis a component still counts as touching its
+    /// face. 0.3 admits an edge contact from either side while a square-on
+    /// face normal still names one face.
+    const EDGE_FRACTION: f32 = 0.3;
+
+    let axes = [
+        (local_normal.x, 8, 1),
+        (local_normal.y, 4, 32),
+        (local_normal.z, 2, 16),
+    ];
+    let threshold = axes
+        .iter()
+        .fold(0.0f32, |acc, (component, _, _)| acc.max(component.abs()))
+        * EDGE_FRACTION;
+    axes.iter()
+        .filter(|(component, _, _)| component.abs() > threshold)
+        .map(|(component, positive, negative)| {
+            if *component >= 0.0 {
+                *positive
+            } else {
+                *negative
+            }
+        })
+        .fold(0, |acc, bit| acc | bit)
 }
 
 #[derive(Clone, Debug)]
@@ -4866,6 +4883,15 @@ impl PhysicsWorld {
     /// solid, player-blocking surface whose face is walkable and sits more
     /// than a step above `feet_y` - the mantle-emulation hold. A wall face,
     /// and the floor the player is standing on, offer neither.
+    ///
+    /// The nearest *qualifying* contact wins: a nearer ungrippable face does
+    /// not occlude a grippable one behind it. A hand reaching past a ladder's
+    /// bare top edge onto the block beside it should still find the block,
+    /// and both surfaces have to be inside one fist-sized ball to compete.
+    ///
+    /// Only this query consults the per-face bits. Flat push-into-ladder
+    /// climbing (`move_player`) grips any sufficiently vertical face of a
+    /// climbable - identical behavior for the 27 every shipped ladder authors.
     pub fn climbable_grip_at(
         &self,
         point: Vector3<f32>,
@@ -4875,8 +4901,8 @@ impl PhysicsWorld {
         let ball = Ball::new(radius.max(1.0e-3));
         let ball_pos = Isometry::translation(point.x, point.y, point.z);
         // Probe AS the player, so only geometry that blocks the player can be
-        // held. Climbables are matched explicitly: a ladder is solid to the
-        // player anyway, but the bit keeps the intent visible.
+        // held. Ladders match through `ENTITY`; `CLIMBABLE` is listed so one
+        // authored with only the marker membership is still found.
         let filter = QueryFilter::new()
             .groups(InteractionGroups::new(
                 InternalCollisionGroups::PLAYER.bits.into(),
@@ -4917,13 +4943,16 @@ impl PhysicsWorld {
                 .intersects(InternalCollisionGroups::CLIMBABLE.bits.into());
             let entity_id = EntityId::from_inner(collider.user_data as u64);
             let kind = if is_climbable {
-                // No recorded mask means the whole collider is grippable -
-                // the behavior climbables had before per-face bits existed.
+                // A climbable with no recorded mask is grippable all over;
+                // refusing it would make it silently unclimbable by hand.
                 let sides = entity_id
                     .and_then(|id| self.climbable_sides.get(&id).copied())
                     .unwrap_or(u32::MAX);
                 let local = collider.rotation().inverse_transform_vector(&outward);
-                if sides & climbable_face_bit(local) == 0 {
+                if sides & climbable_face_bits(local) == 0 {
+                    // A climbable object's authored mask is the whole answer
+                    // for it - a refused face does not fall through to the
+                    // ledge rule and come back as a hold anyway.
                     continue;
                 }
                 ClimbGripKind::Ladder
@@ -8591,27 +8620,10 @@ mod tests {
         );
     }
 
-    /// A player standing at the base of a climbable wall who pushes into it
-    /// climbs it; against an identical NON-climbable wall the same input leaves
-    /// Grip-query fixture: a parentless trimesh floor with its top at y=0 and
-    /// the player parked far away, stepped once so the broad-phase BVH exists.
+    /// Grip-query fixture: the shared floor world (top at y=0, player parked
+    /// far away), stepped once so the broad-phase BVH the query reads exists.
     fn grip_world() -> (PhysicsWorld, PlayerHandle) {
-        let mut world = PhysicsWorld::new();
-        let floor_verts = vec![
-            point![-100.0, 0.0, -100.0],
-            point![100.0, 0.0, -100.0],
-            point![100.0, 0.0, 100.0],
-            point![-100.0, 0.0, 100.0],
-        ];
-        let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
-        world.add_collider(
-            EntityId::from_inner(1000).unwrap(),
-            ColliderBuilder::trimesh(floor_verts, floor_tris)
-                .expect("floor trimesh")
-                .build(),
-        );
-        let mut player =
-            world.create_player(vec3(50.0, 1.0, 50.0), EntityId::from_inner(1001).unwrap());
+        let (mut world, mut player) = world_with_floor();
         step(&mut world, &mut player, 1);
         (world, player)
     }
@@ -8650,7 +8662,8 @@ mod tests {
     /// Dark's per-face bits live in its Z-up frame; the importer flips X and
     /// swaps Y/Z. Verified through the query on a YAWED collider, so a wrong
     /// local/world frame or a wrong axis swap shows up as a grip on the wrong
-    /// face. 27 is what every shipped ladder authors.
+    /// face. 27 is the shipped `Ladders` template's mask; 54 is what medsci1's
+    /// ladder instances override it with.
     #[test]
     fn ladder_face_bits_grip_only_the_authored_faces() {
         // The broad face (world +X after the yaw) is one of the four vertical
@@ -8674,6 +8687,18 @@ mod tests {
             "mask 27 excludes the top cap"
         );
 
+        // The top EDGE, where a hand lands when topping out: its contact
+        // normal is diagonal, so a single-dominant-axis pick would call it
+        // the (unauthored) top cap and refuse the whole wedge above 45
+        // degrees. Both plausible faces are tested, so the +X side carries it.
+        assert_eq!(
+            world
+                .climbable_grip_at(vec3(-4.899, 6.451, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .map(|grip| grip.kind),
+            Some(ClimbGripKind::Ladder),
+            "the top edge is still the authored side face"
+        );
+
         // Top-only (4) is the exact inverse.
         let (mut world, mut player) = grip_world();
         add_yawed_ladder(&mut world, &mut player, Some(4));
@@ -8689,6 +8714,26 @@ mod tests {
                 .climbable_grip_at(vec3(-4.85, 3.0, 0.0), CLIMB_GRIP_RADIUS, 0.0)
                 .is_none(),
             "mask 4 excludes the sides"
+        );
+
+        // 54 (medsci1's instance override) keeps the broad faces and ADDS
+        // the caps - the mapping has to distinguish it from 27, not just
+        // accept both.
+        let (mut world, mut player) = grip_world();
+        add_yawed_ladder(&mut world, &mut player, Some(54));
+        assert_eq!(
+            world
+                .climbable_grip_at(vec3(-4.85, 3.0, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .map(|grip| grip.kind),
+            Some(ClimbGripKind::Ladder),
+            "54 keeps the broad face"
+        );
+        assert_eq!(
+            world
+                .climbable_grip_at(vec3(-5.0, 6.45, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+                .map(|grip| grip.kind),
+            Some(ClimbGripKind::Ladder),
+            "54 adds the top cap that 27 refuses"
         );
 
         // Asymmetric single side: Dark +X (bit 1) is engine -X, which the
@@ -8770,6 +8815,8 @@ mod tests {
         );
     }
 
+    /// A player standing at the base of a climbable wall who pushes into it
+    /// climbs it; against an identical NON-climbable wall the same input leaves
     /// the player on the floor. (Negative-first: without the CLIMBABLE
     /// detection + redirect in `move_player`, both cases stay at floor height
     /// and the ascent assertion fails.)

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -19,6 +19,7 @@ import type {
   SceneObjectSummary,
   Position,
   RagdollMetricsResult,
+  ClimbGripResult,
   RayCastRequest,
   RayCastResult,
   ScreenshotResult,
@@ -543,6 +544,26 @@ export class PhysicsApi {
   /** Per-ragdoll settle/quality metrics (empty list when no ragdolls exist). */
   async ragdolls(): Promise<RagdollMetricsResult> {
     return this.client.get<RagdollMetricsResult>("/v1/ragdoll/metrics");
+  }
+
+  /**
+   * What a hand at `point` could grab: an authored ladder face, a walkable
+   * ledge above the player's feet, or nothing. `feetY` defaults to the
+   * player's own feet height.
+   */
+  async grip(
+    point: Vec3,
+    options?: { radius?: number; feetY?: number },
+  ): Promise<ClimbGripResult> {
+    const params = new URLSearchParams({
+      x: String(point[0]),
+      y: String(point[1]),
+      z: String(point[2]),
+    });
+    if (options?.radius !== undefined)
+      params.set("radius", String(options.radius));
+    if (options?.feetY !== undefined) params.set("feet_y", String(options.feetY));
+    return this.client.get<ClimbGripResult>(`/v1/physics/grip?${params}`);
   }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -474,6 +474,24 @@ export interface RagdollMetricsResult {
   ragdolls: RagdollMetrics[];
 }
 
+/** A climbing hold a hand could take (GET /v1/physics/grip). */
+export interface ClimbGrip {
+  /** `"ladder"` = an authored climbable face whose per-face bit is set;
+   * `"ledge"` = a walkable top surface more than a step above the feet. */
+  kind: "ladder" | "ledge";
+  entity_id: number | null;
+  entity_name: string | null;
+  /** World-space point on the gripped surface. */
+  point: Vec3;
+  /** World-space surface normal, pointing out toward the hand. */
+  normal: Vec3;
+}
+
+export interface ClimbGripResult {
+  /** Null when nothing at the queried point is grabbable. */
+  grip: ClimbGrip | null;
+}
+
 export interface PlayerSnapshot {
   entity_id: number | null;
   /** Runtime id of the backpack container; rediscover it after save/load. */

--- a/tools/shock2-sdk/test/climb-grip.e2e.test.ts
+++ b/tools/shock2-sdk/test/climb-grip.e2e.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+
+// `GET /v1/physics/grip` answers "could a hand hold on here?" against the
+// debug_ladder stations (see shock2vr/src/scenes/debug_ladder.rs). The two
+// classes must be told apart on the SHIPPED geometry: an authored ladder face
+// is a Ladder, a block top above the feet is a Ledge, and a ladder's top cap,
+// a plain wall and the floor are nothing at all.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+type Probe = {
+  name: string;
+  point: Vec3;
+  expected: "ladder" | "ledge" | null;
+};
+
+const PROBES: Probe[] = [
+  // The ledge station's 16' ladder: model bounds put its near face at
+  // x ≈ -6.83, its top cap at y = 6.4.
+  { name: "ledge ladder face", point: [-6.8, 3.0, 0], expected: "ladder" },
+  {
+    name: "ledge ladder top cap (mask 27 excludes it)",
+    point: [-6.9, 6.45, 0],
+    expected: null,
+  },
+  // The block the ladder leans on: near face x = -7, top y = 6.
+  { name: "ledge block lip", point: [-7.2, 6.05, 0], expected: "ledge" },
+  // The ladderless mantle block: top y = 3.
+  { name: "mantle block lip", point: [-7.2, 3.05, 24], expected: "ledge" },
+  { name: "plain wall face", point: [-6.9, 3.0, -16], expected: null },
+  { name: "floor at the player's feet", point: [0, 0.05, 0], expected: null },
+];
+
+test(
+  "debug_ladder: a hand finds ladder faces and ledges, and nothing else",
+  { skip: !e2eEnabled, timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_ladder" });
+    // Let the player settle onto the floor - the ledge test is relative to
+    // their feet.
+    await game.step({ frames: 60 });
+    // The reported position is the capsule CENTER; on this floor that is
+    // ~1.24, i.e. feet at y ~= 0 - which is what the ledge test is relative to.
+    const player = await game.player.position();
+    assert.ok(
+      Math.abs(player.y - 1.24) < 0.2,
+      `expected the player standing on the floor, got y=${player.y}`,
+    );
+
+    for (const probe of PROBES) {
+      const { grip } = await game.physics.grip(probe.point);
+      assert.equal(
+        grip?.kind ?? null,
+        probe.expected,
+        `${probe.name} at ${probe.point.join(",")}: got ${JSON.stringify(grip)}`,
+      );
+    }
+
+    // A ladder grip identifies its entity and faces the player (+X here);
+    // a ledge grip faces up.
+    const ladder = (await game.physics.grip([-6.8, 3.0, 0])).grip!;
+    assert.ok(ladder.entity_id !== null, "a ladder grip names its entity");
+    assert.ok(
+      ladder.normal[0] > 0.9,
+      `expected a +X ladder face, got ${ladder.normal.join(",")}`,
+    );
+    const ledge = (await game.physics.grip([-7.2, 6.05, 0])).grip!;
+    assert.ok(
+      ledge.normal[1] > 0.9,
+      `expected an up-facing ledge, got ${ledge.normal.join(",")}`,
+    );
+
+    // The ledge class is feet-relative: the same block top is not a hold for
+    // a player already standing on it.
+    const standingOnIt = await game.physics.grip([-7.2, 6.05, 0], {
+      feetY: 6.0,
+    });
+    assert.equal(standingOnIt.grip, null);
+  },
+);

--- a/tools/shock2-sdk/test/climb-grip.e2e.test.ts
+++ b/tools/shock2-sdk/test/climb-grip.e2e.test.ts
@@ -22,6 +22,8 @@ const PROBES: Probe[] = [
   // x ≈ -6.83, its top cap at y = 6.4.
   { name: "ledge ladder face", point: [-6.8, 3.0, 0], expected: "ladder" },
   {
+    // The scene's ladders inherit the Ladders template's mask 27 - the four
+    // vertical sides, no caps.
     name: "ledge ladder top cap (mask 27 excludes it)",
     point: [-6.9, 6.45, 0],
     expected: null,
@@ -79,5 +81,43 @@ test(
       feetY: 6.0,
     });
     assert.equal(standingOnIt.grip, null);
+  },
+);
+
+test(
+  "medsci1: a shipped ladder's broad face is a Ladder grip",
+  { skip: !e2eEnabled, timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 30 });
+
+    // Discover by name - runtime entity ids are not stable across launches.
+    const { entities } = await game.entities.list({ filter: "Rick Ladder 16" });
+    assert.ok(entities.length > 0, "medsci1 should place Rick Ladder 16s");
+
+    // These instances override the template's 27 with 54 (the broad faces
+    // plus both caps). Either mask must grip the broad face, so probe a ring
+    // around each ladder's own origin and require a Ladder somewhere on it.
+    const RING = 0.12;
+    const kinds = new Set<string>();
+    for (const ladder of entities) {
+      for (const [dx, dz] of [
+        [RING, 0],
+        [-RING, 0],
+        [0, RING],
+        [0, -RING],
+      ]) {
+        const { grip } = await game.physics.grip([
+          ladder.position[0] + dx,
+          ladder.position[1],
+          ladder.position[2] + dz,
+        ]);
+        if (grip?.kind) kinds.add(grip.kind);
+      }
+    }
+    assert.ok(
+      kinds.has("ladder"),
+      `expected a Ladder grip on a shipped ladder, saw ${[...kinds]}`,
+    );
   },
 );


### PR DESCRIPTION
PR 2 of the VR hand-climbing campaign. A hand can now ask the world **"is there something climbable here?"** — query only. No controller wiring and no body motion; those are PR 3.

## Summary

`PhysicsWorld::climbable_grip_at(point, radius, feet_y) -> Option<ClimbGrip>` probes a fist-sized ball (0.15 wu) and returns the nearest *qualifying* contact, in one of two classes:

- **`Ladder`** — the collider is in the `CLIMBABLE` group **and** the touched face's bit is set in the entity's authored `PropPhysAttr.climbable` mask. So a ladder is no longer grippable over its whole bounding box.
- **`Ledge`** — any other solid, player-blocking surface whose contact normal is walkable (`PLAYER_MIN_WALKABLE_NORMAL`) and whose contact point is more than a step height above `feet_y`. This is the mantle-emulation hold. A wall face, and the floor you're standing on, return `None`.

Supporting pieces: the authored mask is recorded per entity at creation (`entity_creator`), `GET /v1/physics/grip?x=&y=&z=` exposes the query headlessly, and the SDK gains `game.physics.grip(point, { radius, feetY })`.

## The face-bit mapping

Dark stores `climbable` as a per-face bitmask over the six OBB faces **in its own Z-up local frame**:

| bit | 1 | 2 | 4 | 8 | 16 | 32 |
|---|---|---|---|---|---|---|
| Dark (Z-up) | +X | +Y | +Z (top) | −X | −Y | −Z (bottom) |
| engine (Y-up) | **−X** | **+Z** | **+Y (top)** | **+X** | **−Z** | **−Y (bottom)** |

The engine row is the Dark row put through the importer's axis convention — `read_vec3` maps a Dark vector `(x, y, z)` to engine `(-x, z, y)` (`dark/src/ss2_common.rs:54`). The contact normal is rotated into the collider's local frame and matched against those bits.

Two shipped masks, both of which include the faces a ladder is actually climbed on:

- **27** (`1|2|8|16`) on the `Ladders` template — the four vertical sides, no caps.
- **54** (`2|4|16|32`) on medsci1's `Rick Ladder 16` *instances*, which override the template — the two broad faces plus both caps.

Only 27 discriminates between the correct mapping and a naive "Dark bit n = engine axis n" one; under the naive mapping 27 would exclude a ladder's broad climbing faces entirely.

An edge contact's normal is diagonal, so the query returns **every** face the normal plausibly touches (any axis within 30% of the dominant one), OR-ed together — collapsing to a single dominant axis left a dead wedge at the top of a ladder, exactly where a hand reaches when topping out.

## Test plan

Unit (`shock2vr/src/physics/mod.rs`), all on a **yaw-90° collider** so a wrong local/world frame or a wrong axis swap shows up as a grip on the wrong face:

- mask 27 → broad face `Ladder`, top cap `None`
- mask 54 → broad face `Ladder`, top cap `Ladder` (distinguishes 54 from 27)
- top **edge** → `Ladder` (regression for the diagonal-normal wedge)
- mask 4 → the exact inverse of 27
- mask 1 → single asymmetric side, opposite edge bare
- plain wall face → `None`
- block top above the feet → `Ledge`; same point with feet on it → `None`; floor → `None`; block side → `None`

Negative-first on each: flipping the axis mapping to the naive one fails the 27 case, and restoring the single-dominant-axis pick fails the top-edge case.

E2E (`tools/shock2-sdk/test/climb-grip.e2e.test.ts`, `SHOCK2_E2E=1`):

- `debug_ladder` — ladder face → `ladder`, its top cap → `null`, ledge block lip → `ledge`, mantle block lip → `ledge`, plain wall → `null`, floor → `null`, plus normal directions and the feet-relative ledge rule.
- `medsci1.mis` — a shipped ladder (discovered by name, never by runtime id) yields a `ladder` grip on real data with its real overridden mask.

`debug-ladder.e2e.test.js` and `climbing.e2e.test.js` re-run green: the flat push-into-ladder path is untouched.

## Deliberate scoping

- **The flat climb path does not consult the mask.** It grips any sufficiently vertical face of a climbable, which is identical behavior for both shipped masks. Keeping flat climbing byte-for-byte unchanged was in scope; unifying the two policies is not.
- **A refused climbable face does not fall through to the ledge rule.** A climbable object's authored mask is the whole answer for it.
- **No `exclude_collider` parameter yet.** A prop held in the other hand could currently read as a `Ledge`; that belongs with PR 3, which is the first consumer.

No visuals — nothing rendered changes.
