### PR TITLE
feat(vr): a gripping hand climbs the body up a ladder

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -885,6 +885,9 @@ pub struct PlayerInfo {
     /// The automap locations explored in the current mission (ascending).
     /// Persisted per mission in `QuestInfo`; survives save/load.
     pub explored_map_locations: Vec<i32>,
+    /// Climb state: whether the player is on a ladder/hand hold at all, and
+    /// (VR) which hands hold what. See `shock2vr::vr_climb`.
+    pub climb: shock2vr::game_scene::DebugClimbState,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2411,6 +2411,10 @@ fn capture_frame_snapshot(
                     .as_ref()
                     .map(|s| s.explored_map_locations.clone())
                     .unwrap_or_default(),
+                climb: game
+                    .debug_scene()
+                    .and_then(|scene| scene.player_climb())
+                    .unwrap_or_default(),
             }
         },
         entity_count,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -347,6 +347,26 @@ pub struct DebugClimbGrip {
     pub normal: [f32; 3],
 }
 
+/// One hand's hold, in the `/v1/info` climb readout.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugClimbHold {
+    pub hand: &'static str,
+    pub kind: &'static str,
+    pub entity_id: Option<i32>,
+    pub point: [f32; 3],
+}
+
+/// The player's hand-climb state (see `crate::vr_climb`), reported by
+/// `/v1/info`. Flatscreen holds nothing, but still climbs ladders by pushing
+/// into them, so `is_climbing` is not implied by `grips`.
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct DebugClimbState {
+    pub is_climbing: bool,
+    /// The hand currently moving the body ("left"/"right"), if any.
+    pub anchor_hand: Option<&'static str>,
+    pub grips: Vec<DebugClimbHold>,
+}
+
 /// Raycast mask for collision group filtering
 #[derive(Debug, Clone)]
 pub struct RaycastMask {
@@ -792,6 +812,12 @@ pub trait DebuggableScene {
         _radius: Option<f32>,
         _feet_y: Option<f32>,
     ) -> Option<DebugClimbGrip> {
+        None
+    }
+
+    /// The player's climb state (see [`DebugClimbState`]). Scenes without a
+    /// player report nothing.
+    fn player_climb(&self) -> Option<DebugClimbState> {
         None
     }
 

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -194,10 +194,11 @@ impl PlayerInteraction for VrInteraction {
                 ctx.physics
                     .climbable_grip_at(point, crate::physics::CLIMB_GRIP_RADIUS, ctx.feet_y)
             },
+            // "Cannot check" is not "gone" - a failed borrow keeps the hold.
             |entity_id| {
                 ctx.world
                     .borrow::<EntitiesView>()
-                    .is_ok_and(|entities| entities.is_alive(entity_id))
+                    .map_or(true, |entities| entities.is_alive(entity_id))
             },
         )
     }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -42,11 +42,36 @@ pub struct InteractionContext<'a> {
     pub eye_height: f32,
 }
 
+/// Read-only per-frame inputs for the VR hand-climb resolve. Separate from
+/// [`InteractionContext`] because it runs BEFORE the movement pass - its
+/// result IS the movement - while the hands update after it.
+pub struct ClimbContext<'a> {
+    pub physics: &'a PhysicsWorld,
+    pub world: &'a World,
+    pub input: &'a InputContext,
+    pub pawn_pos: Vector3<f32>,
+    pub pawn_rotation: Quaternion<f32>,
+    /// World height of the player's feet, for the ledge grip test.
+    pub feet_y: f32,
+}
+
 /// How the player interacts with the world. The effects returned by `update`
 /// (and `grab`/`wield`) are applied by `mission_core::process_virtual_hand_effects`.
 pub trait PlayerInteraction {
     /// Per-frame update; returns effects to apply.
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect>;
+
+    /// Resolve this frame's hand-climb intent: the body translation a gripping
+    /// hand demands, or `None` when no hand holds a climb hold. Flat climbs by
+    /// pushing into a ladder instead and never grips.
+    fn update_hand_climb(&mut self, _ctx: &ClimbContext) -> Option<Vector3<f32>> {
+        None
+    }
+
+    /// Hand-climb state, for debug introspection (`/v1/info`).
+    fn hand_climb(&self) -> Option<&crate::vr_climb::HandClimb> {
+        None
+    }
 
     /// Entities held in (left, right) - for `PlayerInfo`. Flat reports its
     /// wielded weapon as the "left".
@@ -125,6 +150,8 @@ pub struct VrInteraction {
     /// `Option` is "have we tried yet" - a glove that failed to load stays
     /// `Some(None)` so we don't hit the asset cache's miss path every frame.
     glove_renderer: RefCell<Option<Option<GloveRenderer>>>,
+    /// Which hands hold a climbing hold, and which one moves the body.
+    hand_climb: crate::vr_climb::HandClimb,
 }
 
 impl VrInteraction {
@@ -133,6 +160,7 @@ impl VrInteraction {
             left_hand: VirtualHand::new(Handedness::Left),
             right_hand: VirtualHand::new(Handedness::Right),
             glove_renderer: RefCell::new(None),
+            hand_climb: crate::vr_climb::HandClimb::default(),
         }
     }
 }
@@ -144,6 +172,40 @@ impl Default for VrInteraction {
 }
 
 impl PlayerInteraction for VrInteraction {
+    fn update_hand_climb(&mut self, ctx: &ClimbContext) -> Option<Vector3<f32>> {
+        use shipyard::EntitiesView;
+
+        let hand_input = |hand: &VirtualHand, input: &crate::input_context::Hand| {
+            crate::vr_climb::ClimbHandInput {
+                local_position: input.position,
+                squeeze: input.squeeze_value,
+                // A hand that is carrying something cannot also hold a ladder.
+                is_empty: hand.get_held_entity().is_none(),
+            }
+        };
+        self.hand_climb.update(
+            ctx.pawn_pos,
+            ctx.pawn_rotation,
+            [
+                hand_input(&self.left_hand, &ctx.input.left_hand),
+                hand_input(&self.right_hand, &ctx.input.right_hand),
+            ],
+            |point| {
+                ctx.physics
+                    .climbable_grip_at(point, crate::physics::CLIMB_GRIP_RADIUS, ctx.feet_y)
+            },
+            |entity_id| {
+                ctx.world
+                    .borrow::<EntitiesView>()
+                    .is_ok_and(|entities| entities.is_alive(entity_id))
+            },
+        )
+    }
+
+    fn hand_climb(&self) -> Option<&crate::vr_climb::HandClimb> {
+        Some(&self.hand_climb)
+    }
+
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
         let left_held_entity = self.left_hand.get_held_entity();
         let (right_hand, mut right_msgs) = VirtualHand::update(

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -53,6 +53,7 @@ mod vr_config;
 /// can re-measure the melee `_h` contact offsets off the shipped rigs with the
 /// same maths the wield uses.
 pub use vr_config::{MeleePosedArm, melee_contact_offset};
+pub mod vr_climb;
 pub mod vr_crouch;
 mod wielded_weapon;
 pub mod zip_asset_path;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2888,6 +2888,27 @@ impl MissionCore {
 
         let up_value = input_context.left_hand.thumbstick.y / dark::SCALE_FACTOR;
 
+        // VR climbs by hand: a gripping hand resolves to a body translation
+        // that replaces locomotion entirely for the frame (right-stick
+        // movement is ignored; left-stick turn above still applies). Flat has
+        // no hands and keeps its push-into-ladder climb.
+        let hand_climb = (!time.elapsed.is_zero())
+            .then(|| {
+                self.interaction
+                    .update_hand_climb(&crate::interaction::ClimbContext {
+                        physics: &self.physics,
+                        world: &self.world,
+                        input: input_context,
+                        pawn_pos: player.pos,
+                        pawn_rotation: new_rotation,
+                        feet_y: player.pos.y
+                            - crate::physics::player_center_above_floor(
+                                self.player_handle.is_crouched(),
+                            ),
+                    })
+            })
+            .flatten();
+
         // Skip physics while time is frozen (the debug runtime's paused state
         // calls update with zero dt): the Rapier pipeline advances by a fixed
         // internal dt per call regardless of elapsed time, so stepping it here
@@ -2908,14 +2929,21 @@ impl MissionCore {
             // actual state is read back via `player_is_crouched`).
             self.physics
                 .set_player_crouch(input_context.crouch, &mut self.player_handle);
+            let request = match hand_climb {
+                Some(translation) => crate::physics::PlayerMoveRequest::HandClimb { translation },
+                None => crate::physics::PlayerMoveRequest::Walk {
+                    movement: forward + cgmath::vec3(0.0, up_value, 0.0),
+                    facing,
+                    jump_pressed: input_context.jump,
+                    // Push-to-climb is the FLAT climb input; VR's hands are
+                    // its own (see `vr_climb`).
+                    push_to_climb: game_options.presentation_mode == crate::PresentationMode::Flat,
+                },
+            };
             profile!(
                 "shock2.update.physics",
-                self.physics.update_with_facing_and_jump(
-                    forward + cgmath::vec3(0.0, up_value, 0.0),
-                    facing,
-                    input_context.jump,
-                    &mut self.player_handle,
-                )
+                self.physics
+                    .update_player_movement(request, &mut self.player_handle)
             )
         };
 
@@ -10192,6 +10220,35 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             entity_name,
             point: [grip.point.x, grip.point.y, grip.point.z],
             normal: [grip.normal.x, grip.normal.y, grip.normal.z],
+        })
+    }
+
+    fn player_climb(&self) -> Option<crate::game_scene::DebugClimbState> {
+        let hand_name = |hand: crate::vr_config::Handedness| match hand {
+            crate::vr_config::Handedness::Left => "left",
+            crate::vr_config::Handedness::Right => "right",
+        };
+        let climb = self.interaction.hand_climb();
+        Some(crate::game_scene::DebugClimbState {
+            is_climbing: self.player_handle.is_climbing(),
+            anchor_hand: climb.and_then(|climb| climb.anchor()).map(hand_name),
+            grips: climb
+                .into_iter()
+                .flat_map(|climb| climb.grips())
+                .map(|(hand, anchor)| crate::game_scene::DebugClimbHold {
+                    hand: hand_name(hand),
+                    kind: match anchor.grip.kind {
+                        crate::physics::ClimbGripKind::Ladder => "ladder",
+                        crate::physics::ClimbGripKind::Ledge => "ledge",
+                    },
+                    entity_id: anchor.grip.entity_id.map(|id| id.inner() as i32),
+                    point: [
+                        anchor.grip.point.x,
+                        anchor.grip.point.y,
+                        anchor.grip.point.z,
+                    ],
+                })
+                .collect(),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2892,16 +2892,24 @@ impl MissionCore {
         // that replaces locomotion entirely for the frame (right-stick
         // movement is ignored; left-stick turn above still applies). Flat has
         // no hands and keeps its push-into-ladder climb.
+        //
+        // Composed against the pose the coming step will land on, not the one
+        // `PlayerInfo` carries: the movement is cast from the queued kinematic
+        // target, and composing against the superseded pose would apply each
+        // correction on top of a body that has already absorbed the last one.
         let hand_climb = (!time.elapsed.is_zero())
             .then(|| {
+                let pawn_pos = self
+                    .physics
+                    .get_player_next_translation(&self.player_handle);
                 self.interaction
                     .update_hand_climb(&crate::interaction::ClimbContext {
                         physics: &self.physics,
                         world: &self.world,
                         input: input_context,
-                        pawn_pos: player.pos,
+                        pawn_pos,
                         pawn_rotation: new_rotation,
-                        feet_y: player.pos.y
+                        feet_y: pawn_pos.y
                             - crate::physics::player_center_above_floor(
                                 self.player_handle.is_crouched(),
                             ),
@@ -2926,9 +2934,14 @@ impl MissionCore {
         } else {
             // Apply the crouch request before moving: swaps the capsule size
             // feet-planted; standing up is refused without headroom (the
-            // actual state is read back via `player_is_crouched`).
-            self.physics
-                .set_player_crouch(input_context.crouch, &mut self.player_handle);
+            // actual state is read back via `player_is_crouched`). Not while a
+            // hand grips: the swap shifts the capsule centre further than the
+            // grip's stretch tolerance, so a VR player who ducks (or whose
+            // tracked head dips) on a ladder would be dropped by it.
+            if hand_climb.is_none() {
+                self.physics
+                    .set_player_crouch(input_context.crouch, &mut self.player_handle);
+            }
             let request = match hand_climb {
                 Some(translation) => crate::physics::PlayerMoveRequest::HandClimb { translation },
                 None => crate::physics::PlayerMoveRequest::Walk {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -362,6 +362,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.climb_grip(point, radius, feet_y)
     }
 
+    fn player_climb(&self) -> Option<crate::game_scene::DebugClimbState> {
+        self.mission_core.player_climb()
+    }
+
     fn teleport_player(&mut self, position: Vector3<f32>) -> Result<(), String> {
         self.mission_core.teleport_player(position)
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3338,6 +3338,20 @@ impl PhysicsWorld {
         nvec_to_cgmath(*character_body.translation())
     }
 
+    /// The pose the next step will move the character body to - the queued
+    /// kinematic target, which is where this frame's movement will be cast
+    /// FROM. The pawn-space hand composition has to use this: composing
+    /// against the already-superseded `get_player_translation` applies each
+    /// correction on top of a body that has already absorbed the last one,
+    /// which rings instead of settling.
+    pub fn get_player_next_translation(&self, player_handle: &PlayerHandle) -> Vector3<f32> {
+        let character_body = self
+            .rigid_body_set
+            .get(player_handle.character_handle)
+            .unwrap();
+        nvec_to_cgmath(character_body.next_position().translation.vector)
+    }
+
     fn top_out_save_pose_is_clear(
         &self,
         player_handle: &PlayerHandle,
@@ -4798,8 +4812,8 @@ impl PhysicsWorld {
     /// Step the simulation and resolve one frame of player movement.
     ///
     /// How far the player actually got is
-    /// [`PlayerHandle::self_translation`] - what a hand climb needs to know
-    /// whether the body kept up with the hand.
+    /// [`PlayerHandle::self_translation`]; a hand climb's leftover separation
+    /// (the hand's drift from its hold) is what breaks its grip.
     pub fn update_player_movement(
         &mut self,
         request: PlayerMoveRequest,
@@ -5216,27 +5230,7 @@ impl PhysicsWorld {
 
         let player_movement = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             let queries = self.player_movement_queries(dispatcher, movement_filter);
-            if let Some(translation) = hand_climb {
-                // The gripping hand IS the movement: no walk, no gravity, and
-                // the same climbable-excluding cast the ladder pass uses, so a
-                // body pulled up a ladder passes through the slab it holds.
-                let mvt = player_handle.controller.move_shape(
-                    self.integration_parameters.dt,
-                    &queries.with_filter(climb_pass_filter),
-                    character_shape.as_ref(),
-                    &character_pos,
-                    translation,
-                    |_c| (),
-                );
-                PlayerMovement {
-                    self_translation: mvt.translation,
-                    movement: mvt,
-                    is_climbing: true,
-                    top_out: None,
-                    slope_displacement: Vector::zeros(),
-                    actor_collisions: Vec::new(),
-                }
-            } else if let Some(top_out) = player_handle.top_out {
+            if let Some(top_out) = player_handle.top_out {
                 let (movement, top_out) = advance_climb_top_out(
                     &player_handle.controller,
                     &queries,
@@ -5250,6 +5244,31 @@ impl PhysicsWorld {
                     movement,
                     is_climbing: true,
                     top_out,
+                    slope_displacement: Vector::zeros(),
+                    actor_collisions: Vec::new(),
+                }
+            } else if let Some(translation) = hand_climb {
+                // The gripping hand IS the movement: no walk, no gravity, and
+                // the same climbable-excluding cast the ladder pass uses, so a
+                // body pulled up a ladder passes through the slab it holds.
+                //
+                // A scripted mantle outranks it (above): that state runs on a
+                // temporary compressed collider, and abandoning it mid-lip
+                // would restore the full capsule inside the geometry it is
+                // crossing.
+                let mvt = player_handle.controller.move_shape(
+                    self.integration_parameters.dt,
+                    &queries.with_filter(climb_pass_filter),
+                    character_shape.as_ref(),
+                    &character_pos,
+                    translation,
+                    |_c| (),
+                );
+                PlayerMovement {
+                    self_translation: mvt.translation,
+                    movement: mvt,
+                    is_climbing: true,
+                    top_out: None,
                     slope_displacement: Vector::zeros(),
                     actor_collisions: Vec::new(),
                 }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2207,6 +2207,25 @@ pub struct ClimbGrip {
     pub normal: Vector3<f32>,
 }
 
+/// What the player's movement pass is being asked to do this frame.
+///
+/// Physics stays presentation-agnostic: flat resolves "push into a ladder"
+/// and VR resolves "a hand is gripping here", and both arrive as a request.
+#[derive(Clone, Copy, Debug)]
+pub enum PlayerMoveRequest {
+    /// Ordinary locomotion. `push_to_climb` enables the flat push-into-ladder
+    /// climb; VR turns it off and climbs with its hands instead.
+    Walk {
+        movement: Vector3<f32>,
+        facing: Vector3<f32>,
+        jump_pressed: bool,
+        push_to_climb: bool,
+    },
+    /// A gripping VR hand demands this body translation (see
+    /// [`crate::vr_climb`]). Gravity and the walk pass are both suspended.
+    HandClimb { translation: Vector3<f32> },
+}
+
 /// Dark's `PropPhysAttr.climbable` is a per-face bitmask over the six OBB
 /// faces in Dark's Z-up local frame: 1=+X, 2=+Y, 4=+Z (top), 8=-X, 16=-Y,
 /// 32=-Z (bottom). The importer maps a Dark vector (x, y, z) to engine
@@ -4765,6 +4784,27 @@ impl PhysicsWorld {
         jump_pressed: bool,
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
+        self.update_player_movement(
+            PlayerMoveRequest::Walk {
+                movement: desired_movement,
+                facing,
+                jump_pressed,
+                push_to_climb: true,
+            },
+            player_handle,
+        )
+    }
+
+    /// Step the simulation and resolve one frame of player movement.
+    ///
+    /// How far the player actually got is
+    /// [`PlayerHandle::self_translation`] - what a hand climb needs to know
+    /// whether the body kept up with the hand.
+    pub fn update_player_movement(
+        &mut self,
+        request: PlayerMoveRequest,
+        player_handle: &mut PlayerHandle,
+    ) -> (Vector3<f32>, Vec<CollisionEvent>) {
         // Queue every PhysAttach child at its parent's same next-frame target
         // before Rapier derives kinematic velocities. Moving-terrain assemblies
         // (tram floor + walls/buttons) therefore advance as one physical body,
@@ -4797,10 +4837,7 @@ impl PhysicsWorld {
         self.has_stepped = true;
 
         // Update character controller
-        let desired_movement = vec_to_nvec(desired_movement);
-        let facing = vec_to_nvec(facing);
-        let (mut collision_events, character_body) =
-            { self.move_player(desired_movement, facing, jump_pressed, player_handle) };
+        let (mut collision_events, character_body) = { self.move_player(request, player_handle) };
         let translation = nvec_to_cgmath(*character_body.translation());
 
         let mut additional_collision_events = { self.events.get_and_clear_events() };
@@ -4980,11 +5017,41 @@ impl PhysicsWorld {
 
     fn move_player(
         &mut self,
-        desired_movement: Vector<Real>,
-        facing: Vector<Real>,
-        jump_pressed: bool,
+        request: PlayerMoveRequest,
         player_handle: &mut PlayerHandle,
     ) -> (Vec<CollisionEvent>, &RigidBody) {
+        let hand_climb = match request {
+            PlayerMoveRequest::HandClimb { translation } => Some(vec_to_nvec(translation)),
+            PlayerMoveRequest::Walk { .. } => None,
+        };
+        let (desired_movement, facing, jump_pressed, push_to_climb) = match request {
+            PlayerMoveRequest::Walk {
+                movement,
+                facing,
+                jump_pressed,
+                push_to_climb,
+            } => (
+                vec_to_nvec(movement),
+                vec_to_nvec(facing),
+                jump_pressed,
+                push_to_climb,
+            ),
+            // A hand climb has no locomotion input at all. Reporting the jump
+            // button as unchanged leaves its edge state exactly where the last
+            // walking frame left it, so a button held across a climb neither
+            // fires nor re-arms.
+            PlayerMoveRequest::HandClimb { .. } => (
+                Vector::zeros(),
+                Vector::zeros(),
+                player_handle.jump_was_pressed,
+                false,
+            ),
+        };
+        if hand_climb.is_some() {
+            // Hanging: the hand owns the body, so any ballistic arc ends here
+            // and no gravity pass runs below.
+            player_handle.jump_velocity = None;
+        }
         let jump_edge = jump_pressed && !player_handle.jump_was_pressed;
         player_handle.jump_was_pressed = jump_pressed;
         let launch_jump = jump_edge && player_handle.is_grounded && player_handle.top_out.is_none();
@@ -5017,7 +5084,7 @@ impl PhysicsWorld {
         // Flat climbing: when the player overlaps a climbable surface (ladder)
         // and pushes toward it, redirect that input to vertical movement and
         // suppress the gravity pass for this frame (see `climb_redirect`).
-        let climb_movement = if player_handle.jump_velocity.is_some() {
+        let climb_movement = if !push_to_climb || player_handle.jump_velocity.is_some() {
             None
         } else {
             let climb_filter = QueryFilter::new()
@@ -5149,7 +5216,27 @@ impl PhysicsWorld {
 
         let player_movement = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             let queries = self.player_movement_queries(dispatcher, movement_filter);
-            if let Some(top_out) = player_handle.top_out {
+            if let Some(translation) = hand_climb {
+                // The gripping hand IS the movement: no walk, no gravity, and
+                // the same climbable-excluding cast the ladder pass uses, so a
+                // body pulled up a ladder passes through the slab it holds.
+                let mvt = player_handle.controller.move_shape(
+                    self.integration_parameters.dt,
+                    &queries.with_filter(climb_pass_filter),
+                    character_shape.as_ref(),
+                    &character_pos,
+                    translation,
+                    |_c| (),
+                );
+                PlayerMovement {
+                    self_translation: mvt.translation,
+                    movement: mvt,
+                    is_climbing: true,
+                    top_out: None,
+                    slope_displacement: Vector::zeros(),
+                    actor_collisions: Vec::new(),
+                }
+            } else if let Some(top_out) = player_handle.top_out {
                 let (movement, top_out) = advance_climb_top_out(
                     &player_handle.controller,
                     &queries,

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -23,6 +23,17 @@ use crate::{
 
 const HAND_OFFSET: Vector3<f32> = vec3(0.0, 0.0, 0.0);
 
+/// Where a tracked controller is in the world. Inputs are in pawn space, so
+/// this is the one place that composition lives - `vr_climb` resolves grips
+/// against exactly the pose the hand is drawn and raycast from.
+pub fn hand_world_position(
+    pawn_pos: Vector3<f32>,
+    pawn_rotation: Quaternion<f32>,
+    hand_local: Vector3<f32>,
+) -> Vector3<f32> {
+    pawn_pos + HAND_OFFSET + pawn_rotation.rotate_vector(hand_local)
+}
+
 /// Maximum world-space distance from the hand/eye to a frob target's visible
 /// surface. Retail `shock2.gam` authors `GAMEPARAM.Frob Dist = 50`; the
 /// original `PickSetFocus` treats that as squared SS2 units, while this engine
@@ -224,7 +235,7 @@ impl VirtualHand {
         held_by_other_hand: Option<EntityId>,
     ) -> (VirtualHand, Vec<VirtualHandEffect>) {
         let handedness = prev.handedness;
-        let hand_position = pawn_pos + HAND_OFFSET + pawn_rot.rotate_vector(input_hand.position);
+        let hand_position = hand_world_position(pawn_pos, pawn_rot, input_hand.position);
         let hand_rotation = pawn_rot * input_hand.rotation;
 
         // Also do a raycast to provide the 'Hover' effect

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -24,8 +24,8 @@ use crate::{
 const HAND_OFFSET: Vector3<f32> = vec3(0.0, 0.0, 0.0);
 
 /// Where a tracked controller is in the world. Inputs are in pawn space, so
-/// this is the one place that composition lives - `vr_climb` resolves grips
-/// against exactly the pose the hand is drawn and raycast from.
+/// `vr_climb` resolves grips against exactly the pose the hand is drawn and
+/// raycast from.
 pub fn hand_world_position(
     pawn_pos: Vector3<f32>,
     pawn_rotation: Quaternion<f32>,

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -8,9 +8,6 @@ use cgmath::{InnerSpace, Quaternion, Vector3};
 
 use crate::{physics::ClimbGrip, virtual_hand::hand_world_position, vr_config::Handedness};
 
-/// Squeeze value a hand must cross to grab, matching `VirtualHand`'s grab edge.
-const GRIP_SQUEEZE_THRESHOLD: f32 = 0.5;
-
 /// How far a gripping hand may drift from the point it grabbed before the grip
 /// breaks. The drift IS the body's failure to follow: the body is cast every
 /// frame at exactly the offset the hand opened up, so a persistent gap means
@@ -88,7 +85,7 @@ impl HandClimb {
             .map(|hand| hand_world_position(pawn_pos, pawn_rotation, hand.local_position));
 
         for (index, hand) in hands.iter().enumerate() {
-            let squeezing = hand.squeeze > GRIP_SQUEEZE_THRESHOLD;
+            let squeezing = hand.squeeze > crate::ui::VR_TRIGGER_THRESHOLD;
             let was_squeezing = std::mem::replace(&mut self.was_squeezing[index], squeezing);
             match self.grips[index] {
                 Some(anchor) => {
@@ -96,7 +93,10 @@ impl HandClimb {
                         .magnitude()
                         > CLIMB_STRETCH_BREAK;
                     let gone = anchor.grip.entity_id.is_some_and(|id| !is_alive(id));
-                    if !squeezing || over_stretched || gone {
+                    // The hands update after this, so the same squeeze that
+                    // took a hold can also close on an item; a full hand lets
+                    // go of the ladder rather than holding both.
+                    if !squeezing || !hand.is_empty || over_stretched || gone {
                         self.grips[index] = None;
                     }
                 }
@@ -132,7 +132,12 @@ impl HandClimb {
 
         let index = slot(self.anchor?);
         let anchor = self.grips[index]?;
-        Some(anchor.hand_world_at_grab - hand_world[index])
+        Some(anchored_body_translation(
+            anchor.hand_world_at_grab,
+            pawn_pos,
+            pawn_rotation,
+            hands[index].local_position,
+        ))
     }
 
     /// The hand currently moving the body, if any.

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -1,0 +1,432 @@
+//! Hand-anchored climbing: a gripping VR hand pins itself to the hold it
+//! grabbed and the body moves inversely underneath it.
+//!
+//! State only - the grip probe and the resulting body motion belong to
+//! `physics`. Owned by `VrInteraction`, which already drives both hands.
+
+use cgmath::{InnerSpace, Quaternion, Vector3};
+
+use crate::{physics::ClimbGrip, virtual_hand::hand_world_position, vr_config::Handedness};
+
+/// Squeeze value a hand must cross to grab, matching `VirtualHand`'s grab edge.
+const GRIP_SQUEEZE_THRESHOLD: f32 = 0.5;
+
+/// How far a gripping hand may drift from the point it grabbed before the grip
+/// breaks. The drift IS the body's failure to follow: the body is cast every
+/// frame at exactly the offset the hand opened up, so a persistent gap means
+/// something blocked it. Roughly Dark's 2 ft climb-detach distance.
+pub const CLIMB_STRETCH_BREAK: f32 = 0.6;
+
+/// One hand's hold: what it grabbed, and where the hand was in the world when
+/// it did. The body is moved to keep the hand back at that point.
+#[derive(Clone, Copy, Debug)]
+pub struct GripAnchor {
+    pub grip: ClimbGrip,
+    pub hand_world_at_grab: Vector3<f32>,
+}
+
+/// One hand's per-frame climb input.
+pub struct ClimbHandInput {
+    /// Controller position in pawn space, as `InputContext` reports it.
+    pub local_position: Vector3<f32>,
+    pub squeeze: f32,
+    /// False while the hand holds an item - a full hand cannot take a hold.
+    pub is_empty: bool,
+}
+
+/// Which hand each slot of [`HandClimb::grips`] belongs to.
+const HANDS: [Handedness; 2] = [Handedness::Left, Handedness::Right];
+
+fn slot(hand: Handedness) -> usize {
+    match hand {
+        Handedness::Left => 0,
+        Handedness::Right => 1,
+    }
+}
+
+/// The body translation that puts a gripping hand back on the hold it grabbed.
+///
+/// Hands are tracked in pawn space, so moving the pawn moves the hand with it:
+/// the translation that cancels a hand's drift is exactly that drift, negated.
+pub fn anchored_body_translation(
+    hand_world_at_grab: Vector3<f32>,
+    pawn_pos: Vector3<f32>,
+    pawn_rotation: Quaternion<f32>,
+    hand_local_now: Vector3<f32>,
+) -> Vector3<f32> {
+    hand_world_at_grab - hand_world_position(pawn_pos, pawn_rotation, hand_local_now)
+}
+
+/// Which hands hold a climb hold, and which one currently moves the body.
+#[derive(Default)]
+pub struct HandClimb {
+    grips: [Option<GripAnchor>; 2],
+    anchor: Option<Handedness>,
+    /// Last frame's squeeze state, so a grab needs a fresh press: a hand that
+    /// lost its hold (over-stretched, or the object went away) must not
+    /// silently re-grab while the same squeeze is still held.
+    was_squeezing: [bool; 2],
+}
+
+impl HandClimb {
+    /// Advance one frame and return the body translation the anchor hand
+    /// demands, or `None` when no hand holds anything.
+    ///
+    /// `probe` answers "what could a hand at this world point grab?" (see
+    /// [`crate::physics::PhysicsWorld::climbable_grip_at`]) and `is_alive`
+    /// whether a gripped entity still exists.
+    pub fn update(
+        &mut self,
+        pawn_pos: Vector3<f32>,
+        pawn_rotation: Quaternion<f32>,
+        hands: [ClimbHandInput; 2],
+        probe: impl Fn(Vector3<f32>) -> Option<ClimbGrip>,
+        is_alive: impl Fn(shipyard::EntityId) -> bool,
+    ) -> Option<Vector3<f32>> {
+        let hand_world = hands
+            .each_ref()
+            .map(|hand| hand_world_position(pawn_pos, pawn_rotation, hand.local_position));
+
+        for (index, hand) in hands.iter().enumerate() {
+            let squeezing = hand.squeeze > GRIP_SQUEEZE_THRESHOLD;
+            let was_squeezing = std::mem::replace(&mut self.was_squeezing[index], squeezing);
+            match self.grips[index] {
+                Some(anchor) => {
+                    let over_stretched = (hand_world[index] - anchor.hand_world_at_grab)
+                        .magnitude()
+                        > CLIMB_STRETCH_BREAK;
+                    let gone = anchor.grip.entity_id.is_some_and(|id| !is_alive(id));
+                    if !squeezing || over_stretched || gone {
+                        self.grips[index] = None;
+                    }
+                }
+                None if squeezing && !was_squeezing && hand.is_empty => {
+                    if let Some(grip) = probe(hand_world[index]) {
+                        self.grips[index] = Some(GripAnchor {
+                            grip,
+                            hand_world_at_grab: hand_world[index],
+                        });
+                        // Last hand to grab drives the body.
+                        self.anchor = Some(HANDS[index]);
+                    }
+                }
+                None => {}
+            }
+        }
+
+        // The anchor let go. Hand over to the other hand if it is still on -
+        // re-based to where that hand is NOW, so the body continues from here
+        // instead of snapping back to a grab point it has since travelled from.
+        if self
+            .anchor
+            .is_some_and(|hand| self.grips[slot(hand)].is_none())
+        {
+            self.anchor = None;
+            for index in 0..HANDS.len() {
+                if let Some(anchor) = self.grips[index].as_mut() {
+                    anchor.hand_world_at_grab = hand_world[index];
+                    self.anchor = Some(HANDS[index]);
+                }
+            }
+        }
+
+        let index = slot(self.anchor?);
+        let anchor = self.grips[index]?;
+        Some(anchor.hand_world_at_grab - hand_world[index])
+    }
+
+    /// The hand currently moving the body, if any.
+    pub fn anchor(&self) -> Option<Handedness> {
+        self.anchor
+    }
+
+    /// Every hand that holds a hold, with the hold it holds.
+    pub fn grips(&self) -> impl Iterator<Item = (Handedness, &GripAnchor)> {
+        HANDS
+            .iter()
+            .enumerate()
+            .filter_map(|(index, hand)| Some((*hand, self.grips[index].as_ref()?)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::{ClimbGrip, ClimbGripKind};
+    use cgmath::{Rotation3, Zero, vec3};
+
+    fn ladder_grip(point: Vector3<f32>) -> ClimbGrip {
+        ClimbGrip {
+            kind: ClimbGripKind::Ladder,
+            entity_id: None,
+            point,
+            normal: vec3(1.0, 0.0, 0.0),
+        }
+    }
+
+    fn hand(local: Vector3<f32>, squeeze: f32) -> ClimbHandInput {
+        ClimbHandInput {
+            local_position: local,
+            squeeze,
+            is_empty: true,
+        }
+    }
+
+    fn no_hand() -> ClimbHandInput {
+        hand(Vector3::zero(), 0.0)
+    }
+
+    #[track_caller]
+    fn assert_translation(actual: Option<Vector3<f32>>, expected: Vector3<f32>) {
+        let actual = actual.expect("expected a gripping hand to move the body");
+        assert!(
+            (actual - expected).magnitude() < 1.0e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn pulling_a_gripped_hand_down_lifts_the_body_by_the_same_amount() {
+        let grab = vec3(-6.8, 2.6, 0.0);
+        let pawn = vec3(-5.5, 1.5, 0.0);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        // The hand that grabbed `grab` from `pawn`, then pulled down 0.5.
+        let pulled = grab - pawn - vec3(0.0, 0.5, 0.0);
+
+        let translation = anchored_body_translation(grab, pawn, identity, pulled);
+        assert!((translation - vec3(0.0, 0.5, 0.0)).magnitude() < 1.0e-5);
+    }
+
+    #[test]
+    fn the_inverse_motion_follows_the_pawns_yaw() {
+        // A pawn yawed 90 degrees turns a hand pulled along its local -Z into
+        // a body translation along world +X: the hand's LOCAL offset is what
+        // the pawn rotates, so the body has to answer in world space.
+        let pawn = vec3(2.0, 0.0, 3.0);
+        let yaw = Quaternion::from_angle_y(cgmath::Deg(90.0));
+        let grabbed_local = vec3(0.0, 1.0, -1.0);
+        let grab = hand_world_position(pawn, yaw, grabbed_local);
+
+        let translation =
+            anchored_body_translation(grab, pawn, yaw, grabbed_local + vec3(0.0, 0.0, -0.5));
+        assert!(
+            (translation - vec3(0.5, 0.0, 0.0)).magnitude() < 1.0e-5,
+            "got {translation:?}"
+        );
+    }
+
+    #[test]
+    fn a_grab_anchors_the_hand_and_a_release_ends_the_climb() {
+        let mut climb = HandClimb::default();
+        let pawn = vec3(0.0, 0.0, 0.0);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+
+        // The grab frame itself moves nothing - the hand is already there.
+        let first = climb.update(
+            pawn,
+            identity,
+            [no_hand(), hand(reach, 1.0)],
+            |point| Some(ladder_grip(point)),
+            |_| true,
+        );
+        assert_translation(first, Vector3::zero());
+        assert_eq!(climb.anchor(), Some(Handedness::Right));
+
+        // Pulling down lifts the body; nothing new is probed.
+        let pull = climb.update(
+            pawn,
+            identity,
+            [no_hand(), hand(reach - vec3(0.0, 0.4, 0.0), 1.0)],
+            |_| None,
+            |_| true,
+        );
+        assert_translation(pull, vec3(0.0, 0.4, 0.0));
+
+        // Opening the hand drops the hold.
+        let released = climb.update(
+            pawn,
+            identity,
+            [no_hand(), hand(reach, 0.0)],
+            |_| None,
+            |_| true,
+        );
+        assert_eq!(released, None);
+        assert_eq!(climb.anchor(), None);
+        assert_eq!(climb.grips().count(), 0);
+    }
+
+    #[test]
+    fn a_full_hand_and_a_held_squeeze_never_take_a_hold() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+
+        let mut full = hand(reach, 1.0);
+        full.is_empty = false;
+        assert_eq!(
+            climb.update(
+                pawn,
+                identity,
+                [no_hand(), full],
+                |p| Some(ladder_grip(p)),
+                |_| true
+            ),
+            None,
+        );
+
+        // The squeeze was already down last frame, so an empty hand arriving
+        // now still needs a fresh press.
+        assert_eq!(
+            climb.update(
+                pawn,
+                identity,
+                [no_hand(), hand(reach, 1.0)],
+                |p| Some(ladder_grip(p)),
+                |_| true
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn a_body_that_cannot_follow_stretches_the_grip_until_it_breaks() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+        climb.update(
+            pawn,
+            identity,
+            [no_hand(), hand(reach, 1.0)],
+            |p| Some(ladder_grip(p)),
+            |_| true,
+        );
+
+        // The pawn never moves (blocked), so the hand's own travel is the
+        // whole stretch. Just under the break is still a hold...
+        let held = climb.update(
+            pawn,
+            identity,
+            [
+                no_hand(),
+                hand(reach - vec3(0.0, CLIMB_STRETCH_BREAK - 0.05, 0.0), 1.0),
+            ],
+            |_| None,
+            |_| true,
+        );
+        assert!(held.is_some());
+
+        // ... and past it the hand comes off.
+        assert_eq!(
+            climb.update(
+                pawn,
+                identity,
+                [
+                    no_hand(),
+                    hand(reach - vec3(0.0, CLIMB_STRETCH_BREAK + 0.05, 0.0), 1.0)
+                ],
+                |_| None,
+                |_| true
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn releasing_the_anchor_hands_off_to_the_other_hand_without_a_snap() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let right = vec3(0.3, 1.0, -1.0);
+        let left = vec3(-0.3, 1.6, -1.0);
+
+        climb.update(
+            pawn,
+            identity,
+            [no_hand(), hand(right, 1.0)],
+            |p| Some(ladder_grip(p)),
+            |_| true,
+        );
+        climb.update(
+            pawn,
+            identity,
+            [hand(left, 1.0), hand(right, 1.0)],
+            |p| Some(ladder_grip(p)),
+            |_| true,
+        );
+        assert_eq!(climb.anchor(), Some(Handedness::Left), "last grab wins");
+
+        // Both hands travel while the left is the anchor, so the right's
+        // original grab point is now stale by that travel.
+        let travel = vec3(0.0, -0.4, 0.0);
+        climb.update(
+            pawn,
+            identity,
+            [hand(left + travel, 1.0), hand(right + travel, 1.0)],
+            |_| None,
+            |_| true,
+        );
+
+        // Letting the left go must not yank the body back to the right hand's
+        // stale grab point: the handoff frame asks for no motion at all.
+        let handoff = climb.update(
+            pawn,
+            identity,
+            [hand(left + travel, 0.0), hand(right + travel, 1.0)],
+            |_| None,
+            |_| true,
+        );
+        assert_eq!(climb.anchor(), Some(Handedness::Right));
+        assert_translation(handoff, Vector3::zero());
+
+        // ... and the right hand then drives from where it actually is.
+        let after = climb.update(
+            pawn,
+            identity,
+            [
+                hand(left + travel, 0.0),
+                hand(right + travel - vec3(0.0, 0.2, 0.0), 1.0),
+            ],
+            |_| None,
+            |_| true,
+        );
+        assert_translation(after, vec3(0.0, 0.2, 0.0));
+    }
+
+    #[test]
+    fn a_grip_on_an_entity_that_went_away_is_dropped() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+        let entity = shipyard::EntityId::from_inner(42).unwrap();
+
+        climb.update(
+            pawn,
+            identity,
+            [no_hand(), hand(reach, 1.0)],
+            |point| {
+                ClimbGrip {
+                    entity_id: Some(entity),
+                    ..ladder_grip(point)
+                }
+                .into()
+            },
+            |_| true,
+        );
+        assert_eq!(climb.grips().count(), 1);
+
+        assert_eq!(
+            climb.update(
+                pawn,
+                identity,
+                [no_hand(), hand(reach, 1.0)],
+                |_| None,
+                |_| false
+            ),
+            None,
+        );
+    }
+}

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -550,6 +550,25 @@ export interface PlayerSnapshot {
   /** The automap locations explored in the current mission (ascending).
    * Persisted per mission in QuestInfo; survives save/load. */
   explored_map_locations: number[];
+  /** Climb state: ladder/hand climbing, and (VR) the hands holding on. */
+  climb: ClimbState;
+}
+
+/** One hand's hold in the /v1/info climb readout. */
+export interface ClimbHold {
+  hand: "left" | "right";
+  kind: "ladder" | "ledge";
+  entity_id: number | null;
+  point: Vec3;
+}
+
+/** The player's climb state (GET /v1/info). Flat climbs ladders by pushing
+ * into them and holds nothing, so `is_climbing` is not implied by `grips`. */
+export interface ClimbState {
+  is_climbing: boolean;
+  /** The hand currently moving the body, or null. */
+  anchor_hand: "left" | "right" | null;
+  grips: ClimbHold[];
 }
 
 /** One audio log the player has collected, keyed by its per-deck identity. */

--- a/tools/shock2-sdk/test/helpers/vr-climb.ts
+++ b/tools/shock2-sdk/test/helpers/vr-climb.ts
@@ -1,0 +1,92 @@
+import type { GameServer } from "../../src/index.js";
+import type { Vec3 } from "../../src/types.js";
+
+import { add, quatConjugate, quatRotate, scale, sub } from "./vr-hand.js";
+
+/**
+ * A world point as a hand channel value.
+ *
+ * Hand channels are in PAWN space, and a climbing pawn is exactly what moves,
+ * so the conversion has to be re-derived from the pawn's pose at the moment the
+ * hand reaches for the point. Once the hand is on a hold, though, it is held
+ * still in pawn space (a real player's hand stays where their arm put it, in
+ * the room) and the body travels underneath it - so a pull is a pawn-space
+ * offset from the grab pose, NOT a fresh world target each frame.
+ */
+export async function vrHandLocal(
+  game: GameServer,
+  world: Vec3,
+): Promise<Vec3> {
+  const { player } = await game.info();
+  return quatRotate(quatConjugate(player.rotation), sub(world, player.position));
+}
+
+/** A world-space displacement in pawn space (rotation only). */
+export async function vrHandLocalDelta(
+  game: GameServer,
+  worldDelta: Vec3,
+): Promise<Vec3> {
+  const { player } = await game.info();
+  return quatRotate(quatConjugate(player.rotation), worldDelta);
+}
+
+export interface VrClimbPullResult {
+  before: Vec3;
+  after: Vec3;
+  /** The pawn position after every pull frame, in order - for continuity
+   * checks, since a handoff or a break must not teleport the body. */
+  path: Vec3[];
+}
+
+/**
+ * Grab a hold with one VR hand and pull, one frame at a time.
+ *
+ * `grabAt` is the world point the hand closes on; `pull` is how far the player
+ * then moves that hand, spread over `frames`. Pulling a gripped hand DOWN is
+ * what lifts the body up.
+ */
+export async function vrClimbPull(
+  game: GameServer,
+  {
+    hand = "right",
+    grabAt,
+    pull,
+    frames,
+    release = false,
+  }: {
+    hand?: "left" | "right";
+    grabAt: Vec3;
+    pull: Vec3;
+    frames: number;
+    release?: boolean;
+  },
+): Promise<VrClimbPullResult> {
+  const before = (await game.info()).player.position;
+  const atGrab = await vrHandLocal(game, grabAt);
+  const pullLocal = await vrHandLocalDelta(game, pull);
+
+  // Reach out with an OPEN hand first: the grab is a squeeze edge, so the
+  // squeeze has to be down on a frame where it was up on the one before.
+  await game.input.set(`${hand}_hand.position`, atGrab);
+  await game.input.set(`${hand}_hand.squeeze`, 0);
+  await game.step({ frames: 1 });
+  await game.input.set(`${hand}_hand.squeeze`, 1);
+  await game.step({ frames: 1 });
+
+  const path: Vec3[] = [];
+  for (let frame = 1; frame <= frames; frame += 1) {
+    await game.input.set(
+      `${hand}_hand.position`,
+      add(atGrab, scale(pullLocal, frame / frames)),
+    );
+    await game.step({ frames: 1 });
+    path.push((await game.info()).player.position);
+  }
+
+  if (release) {
+    await game.input.set(`${hand}_hand.squeeze`, 0);
+    await game.step({ frames: 1 });
+  }
+
+  return { before, after: (await game.info()).player.position, path };
+}

--- a/tools/shock2-sdk/test/vr-climb.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-climb.e2e.test.ts
@@ -155,21 +155,40 @@ test(
     await game.step({ frames: 1 });
     assert.equal((await game.info()).player.climb.grips.length, 1);
 
-    // Straight into the wall the ladder hangs on: the body is blocked, so the
-    // hand runs away from its hold and the grip breaks.
-    await game.input.set(
-      "right_hand.position",
-      await vrHandLocal(game, [
-        LADDER_HOLD[0] - 1.5,
-        LADDER_HOLD[1],
-        LADDER_HOLD[2],
-      ]),
-    );
-    await game.step({ frames: 2 });
+    // Pull the hand back toward the body, a step at a time: pinned to the
+    // hold, that hauls the BODY into the wall the ladder hangs on. Each step
+    // is far short of the break distance, so nothing breaks on the reach
+    // alone - the grip only comes off once the wall stops the body and the
+    // separation accumulates.
+    const STEP = 0.12;
+    const atGrab = await vrHandLocal(game, LADDER_HOLD);
+    const into = await vrHandLocalDelta(game, [STEP, 0, 0]);
+    let broke = 0;
+    for (let frame = 1; frame <= 24; frame += 1) {
+      await game.input.set("right_hand.position", [
+        atGrab[0] + into[0] * frame,
+        atGrab[1] + into[1] * frame,
+        atGrab[2] + into[2] * frame,
+      ]);
+      await game.step({ frames: 1 });
+      if ((await game.info()).player.climb.grips.length === 0) {
+        broke = frame;
+        break;
+      }
+    }
 
-    const climb = (await game.info()).player.climb;
-    assert.equal(climb.grips.length, 0);
-    assert.equal(climb.anchor_hand, null);
+    // The player has ~0.8 wu of floor before the block stops them, so the
+    // first several steps are free travel the body follows exactly - proof the
+    // break comes from the blocked body and not from the reach itself.
+    assert.ok(
+      broke > 5,
+      `an unobstructed reach must not break the grip, broke at step ${broke}`,
+    );
+    assert.ok(
+      broke <= 20,
+      `a blocked body must break the grip, still held after ${STEP * 24} wu`,
+    );
+    assert.equal((await game.info()).player.climb.anchor_hand, null);
   },
 );
 

--- a/tools/shock2-sdk/test/vr-climb.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-climb.e2e.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import {
+  vrClimbPull,
+  vrHandLocal,
+  vrHandLocalDelta,
+} from "./helpers/vr-climb.js";
+
+// VR climbs with its hands: a squeeze on a hold pins the hand to the point it
+// grabbed and the body moves inversely underneath it. Driven on the
+// debug_ladder scene's ledge station (see shock2vr/src/scenes/debug_ladder.rs):
+// a 6 wu block at x = -7 with a 16' ladder on its near face (x ~= -6.83).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** In front of the ledge station's ladder, on the floor. */
+const STAND: Vec3 = [-5.5, 1.5, 0];
+/** A rung of the ledge ladder, within a standing player's reach. */
+const LADDER_HOLD: Vec3 = [-6.8, 2.6, 0];
+/** The plain, non-climbable wall station. */
+const WALL_HOLD: Vec3 = [-6.9, 2.6, -16];
+/** Capsule-center height of a player standing on this scene's floor. */
+const FLOOR_Y = 1.24;
+
+const launchVr = () =>
+  GameServer.launch({ mission: "debug_ladder", debugFlags: ["--vr"] });
+
+async function standAtTheLadder(game: GameServer, at: Vec3 = STAND) {
+  await game.step({ frames: 5 });
+  await teleportVerified(game, { x: at[0], y: at[1], z: at[2] });
+  await game.step({ frames: 30 });
+}
+
+test(
+  "debug_ladder (VR): pulling a gripped hand down lifts the body",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    const { before, after } = await vrClimbPull(game, {
+      hand: "right",
+      grabAt: LADDER_HOLD,
+      pull: [0, -1.0, 0],
+      frames: 30,
+    });
+
+    assert.ok(
+      Math.abs(after[1] - before[1] - 1.0) < 0.15,
+      `expected the body to rise by the pull, ${before[1]} -> ${after[1]}`,
+    );
+    const climb = (await game.info()).player.climb;
+    assert.equal(climb.anchor_hand, "right");
+    assert.equal(climb.is_climbing, true);
+    assert.equal(climb.grips.length, 1);
+    assert.equal(climb.grips[0].kind, "ladder");
+
+    // The hand stayed on the hold it grabbed - that is the whole mechanic.
+    const held = climb.grips[0].point;
+    assert.ok(
+      Math.abs(held[1] - LADDER_HOLD[1]) < 0.1,
+      `the grip should stay at the grabbed height, got ${held.join(",")}`,
+    );
+
+    // Letting go drops the player back to the floor.
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 60 });
+    const landed = await game.info();
+    assert.equal(landed.player.climb.grips.length, 0);
+    assert.equal(landed.player.climb.anchor_hand, null);
+    assert.ok(
+      Math.abs(landed.player.position[1] - FLOOR_Y) < 0.2,
+      `expected a fall back to the floor, got ${landed.player.position[1]}`,
+    );
+  },
+);
+
+test(
+  "debug_ladder (VR): the second hand takes over without snapping the body",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    const rightHold: Vec3 = [-6.8, 2.4, 0];
+    const leftHold: Vec3 = [-6.8, 3.0, 0];
+
+    // Right hand on, then the left higher up: the last hand to grab drives.
+    await game.input.set("right_hand.position", await vrHandLocal(game, rightHold));
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 1 });
+    const leftAtGrab = await vrHandLocal(game, leftHold);
+    await game.input.set("left_hand.position", leftAtGrab);
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 1 });
+    assert.equal((await game.info()).player.climb.anchor_hand, "left");
+
+    // Pull with the left. The right hand is left where it is: a hand that is
+    // holding on does not move relative to the player, the player moves.
+    const heights: number[] = [(await game.info()).player.position[1]];
+    const PULL = 0.4;
+    const FRAMES = 20;
+    const down = await vrHandLocalDelta(game, [0, -PULL, 0]);
+    for (let frame = 1; frame <= FRAMES; frame += 1) {
+      await game.input.set("left_hand.position", [
+        leftAtGrab[0] + (down[0] * frame) / FRAMES,
+        leftAtGrab[1] + (down[1] * frame) / FRAMES,
+        leftAtGrab[2] + (down[2] * frame) / FRAMES,
+      ]);
+      await game.step({ frames: 1 });
+      heights.push((await game.info()).player.position[1]);
+    }
+    assert.ok(
+      heights[heights.length - 1] - heights[0] > PULL - 0.1,
+      `expected the left pull to lift the body, ${heights[0]} -> ${heights[heights.length - 1]}`,
+    );
+
+    // Release the anchor. The right hand is still on, so it takes over - and
+    // must not yank the body back to where the right hand first grabbed.
+    await game.input.set("left_hand.squeeze", 0);
+    for (let frame = 0; frame < 10; frame += 1) {
+      await game.step({ frames: 1 });
+      heights.push((await game.info()).player.position[1]);
+    }
+    const handoff = (await game.info()).player.climb;
+    assert.equal(handoff.anchor_hand, "right");
+    assert.equal(handoff.grips.length, 1);
+
+    for (let i = 1; i < heights.length; i += 1) {
+      assert.ok(
+        Math.abs(heights[i] - heights[i - 1]) < 0.1,
+        `the body jumped ${heights[i - 1]} -> ${heights[i]} in one frame`,
+      );
+    }
+  },
+);
+
+test(
+  "debug_ladder (VR): a hand the body cannot follow stretches off the hold",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    await game.input.set(
+      "right_hand.position",
+      await vrHandLocal(game, LADDER_HOLD),
+    );
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 1 });
+    assert.equal((await game.info()).player.climb.grips.length, 1);
+
+    // Straight into the wall the ladder hangs on: the body is blocked, so the
+    // hand runs away from its hold and the grip breaks.
+    await game.input.set(
+      "right_hand.position",
+      await vrHandLocal(game, [
+        LADDER_HOLD[0] - 1.5,
+        LADDER_HOLD[1],
+        LADDER_HOLD[2],
+      ]),
+    );
+    await game.step({ frames: 2 });
+
+    const climb = (await game.info()).player.climb;
+    assert.equal(climb.grips.length, 0);
+    assert.equal(climb.anchor_hand, null);
+  },
+);
+
+test(
+  "debug_ladder (VR): squeezing on the plain wall grabs nothing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game, [-5.5, 1.5, -16]);
+
+    const { before, after } = await vrClimbPull(game, {
+      hand: "right",
+      grabAt: WALL_HOLD,
+      pull: [0, -1.0, 0],
+      frames: 30,
+    });
+
+    assert.equal((await game.info()).player.climb.grips.length, 0);
+    assert.ok(
+      Math.abs(after[1] - before[1]) < 0.1,
+      `a wall is not a hold, but the body moved ${before[1]} -> ${after[1]}`,
+    );
+  },
+);
+
+test(
+  "debug_ladder (VR): pushing the stick into a ladder does not climb",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    const floorY = (await game.info()).player.position[1];
+    await game.input.lookAtWorldPoint([
+      -7,
+      floorY + (await game.info()).player.camera_offset[1],
+      0,
+    ]);
+    await game.step({ frames: 5 });
+
+    // Every stick direction, so whichever one is "into the ladder" for this
+    // pawn is covered. Hands are the climb input in VR (see vr_climb).
+    for (const stick of [
+      [0, 1],
+      [0, -1],
+      [1, 0],
+      [-1, 0],
+    ]) {
+      await teleportVerified(game, { x: STAND[0], y: STAND[1], z: STAND[2] });
+      await game.step({ frames: 20 });
+      await game.input.set("right_hand.thumbstick", stick);
+      await game.step({ frames: 120 });
+      const y = (await game.info()).player.position[1];
+      assert.ok(
+        y < floorY + 0.3,
+        `stick ${stick.join(",")} climbed to y=${y} in VR`,
+      );
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+  },
+);


### PR DESCRIPTION
PR 3 of the VR hand-climbing campaign (stacked on #1233). **A gripping hand moves the body.**

A VR hand that squeezes on a climb hold — the grip query #1233 added — pins itself to the world point it grabbed, and the body is translated every frame to put the hand back there. Pull a gripped hand down and you go up.

![VR hand-anchored climbing](https://gist.githubusercontent.com/tommy-xr/ff5ce6d96c6820317675acde6c3d4bb0/raw/climb.gif)

<sub>Third-person view of the `debug_ladder` ledge station: the right hand squeezes a rung and stays pinned to it while the body (and the free hand) rise 1.2 wu; releasing drops back to the floor. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![gripped hand pinned, body risen](https://gist.githubusercontent.com/tommy-xr/ff5ce6d96c6820317675acde6c3d4bb0/raw/still-top.png)

<sub>Top of the pull: the gripping hand has not moved off its rung, the free hand is a full rung-and-a-half higher.</sub>

## What's here

- **`shock2vr/src/vr_climb.rs`** — the state: which hands hold a hold, which one is the anchor (last to grab wins), and the inverse-motion solve. A hold comes off when the squeeze opens, the hand fills up with an item, the gripped entity goes away, or the hand drifts more than `CLIMB_STRETCH_BREAK` (0.6 wu) from its hold — the leftover separation *is* the body's failure to follow, since the body is cast at exactly the offset the hand opened up. On an anchor release the other gripping hand takes over, re-based to where it is now, so the body never snaps.
- **`PhysicsWorld::update_player_movement(PlayerMoveRequest, ..)`** — physics stays presentation-agnostic and takes resolved intent: `Walk { .., push_to_climb }` or `HandClimb { translation }`. The hand climb reuses the ladder pass's climbable-excluding cast, with gravity and the walk pass suspended, and a scripted mantle outranks it. `update_with_facing_and_jump` is now a thin wrapper, so nothing else changed.
- **Push-to-climb is flat-only.** Hands are the climb input in VR (design §0).
- **`/v1/info` `player.climb`** — `is_climbing`, `anchor_hand`, and the held grips; SDK types and a `vrClimbPull` test helper alongside.

## Verification

- 7 unit tests in `vr_climb` (inverse motion under pawn yaw, grab/release edges, stretch break, anchor handoff, entity gone); `cargo test -p shock2vr` 1213 pass.
- New `tools/shock2-sdk/test/vr-climb.e2e.test.ts` on `debug_ladder --vr`: pull → rise, release → fall, two-hand handoff with no per-frame jump > 0.1, stretch break proved on a body the wall stops (an unobstructed reach of the same size does not break it), a plain wall grabs nothing, and the right stick does **not** climb in VR (that last one fails if the flat gate is removed).
- Flat unchanged: `climbing.e2e` and `debug-ladder.e2e` green; all 23 missions load.

## Not here (PRs 4-5)

Release velocity, crouch-freeze polish, ledge landing / eye-over-lip vault.

