### PR TITLE
feat(vr): letting go of a climb hold throws the body with the pull

### DIFF
--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -954,8 +954,10 @@ fn main() {
         let tracked_head_position = head_location.location_flags.contains(
             xr::SpaceLocationFlags::POSITION_VALID | xr::SpaceLocationFlags::POSITION_TRACKED,
         );
-        let physically_crouched =
-            vr_crouch.update(tracked_head_position.then_some(head_location.pose.position.y));
+        let physically_crouched = vr_crouch.update(
+            tracked_head_position.then_some(head_location.pose.position.y),
+            game.player_is_gripping(),
+        );
         let center_above_floor = game.player_center_above_floor();
         let right_hand_position = stage_to_pawn(
             vec3(

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -158,6 +158,12 @@ pub trait GameScene {
         false
     }
 
+    /// Whether a VR hand is holding a climb hold (see `crate::vr_climb`).
+    /// VR runtimes freeze their physical-crouch detector while it is true.
+    fn player_is_gripping(&self) -> bool {
+        false
+    }
+
     /// Degrees to pull the flat FOV in by this frame (subtracted from the
     /// base FOV), eased over a personal-UI mode's entry/exit ramp - see the
     /// cyber interface's `ui::entry_ramp`. Implementations must return 0 in

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -53,6 +53,8 @@ pub struct ClimbContext<'a> {
     pub pawn_rotation: Quaternion<f32>,
     /// World height of the player's feet, for the ledge grip test.
     pub feet_y: f32,
+    /// This frame's simulation step, for the release velocity.
+    pub dt: f32,
 }
 
 /// How the player interacts with the world. The effects returned by `update`
@@ -62,10 +64,10 @@ pub trait PlayerInteraction {
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect>;
 
     /// Resolve this frame's hand-climb intent: the body translation a gripping
-    /// hand demands, or `None` when no hand holds a climb hold. Flat climbs by
-    /// pushing into a ladder instead and never grips.
-    fn update_hand_climb(&mut self, _ctx: &ClimbContext) -> Option<Vector3<f32>> {
-        None
+    /// hand demands, and the velocity a release throws the body with. Flat
+    /// climbs by pushing into a ladder instead and never grips.
+    fn update_hand_climb(&mut self, _ctx: &ClimbContext) -> crate::vr_climb::ClimbFrame {
+        crate::vr_climb::ClimbFrame::default()
     }
 
     /// Hand-climb state, for debug introspection (`/v1/info`).
@@ -172,7 +174,7 @@ impl Default for VrInteraction {
 }
 
 impl PlayerInteraction for VrInteraction {
-    fn update_hand_climb(&mut self, ctx: &ClimbContext) -> Option<Vector3<f32>> {
+    fn update_hand_climb(&mut self, ctx: &ClimbContext) -> crate::vr_climb::ClimbFrame {
         use shipyard::EntitiesView;
 
         let hand_input = |hand: &VirtualHand, input: &crate::input_context::Hand| {
@@ -186,6 +188,7 @@ impl PlayerInteraction for VrInteraction {
         self.hand_climb.update(
             ctx.pawn_pos,
             ctx.pawn_rotation,
+            ctx.dt,
             [
                 hand_input(&self.left_hand, &ctx.input.left_hand),
                 hand_input(&self.right_hand, &ctx.input.right_hand),

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -53,8 +53,9 @@ pub struct ClimbContext<'a> {
     pub pawn_rotation: Quaternion<f32>,
     /// World height of the player's feet, for the ledge grip test.
     pub feet_y: f32,
-    /// This frame's simulation step, for the release velocity.
-    pub dt: f32,
+    /// The fixed timestep the coming movement frame integrates with, for the
+    /// release velocity (NOT the wall clock - see `vr_climb`).
+    pub step_dt: f32,
 }
 
 /// How the player interacts with the world. The effects returned by `update`
@@ -188,7 +189,7 @@ impl PlayerInteraction for VrInteraction {
         self.hand_climb.update(
             ctx.pawn_pos,
             ctx.pawn_rotation,
-            ctx.dt,
+            ctx.step_dt,
             [
                 hand_input(&self.left_hand, &ctx.input.left_hand),
                 hand_input(&self.right_hand, &ctx.input.right_hand),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -2036,6 +2036,13 @@ impl Game {
         physics::player_center_above_floor(self.active_game_scene.player_is_crouched())
     }
 
+    /// Whether a VR hand is holding a climb hold. VR runtimes freeze their
+    /// physical-crouch detector while it is true - see
+    /// [`vr_crouch::VrCrouchDetector::update`].
+    pub fn player_is_gripping(&self) -> bool {
+        self.active_game_scene.player_is_gripping()
+    }
+
     /// Highest the eye may sit (world units) above the player collider's
     /// center for the current stance. VR runtimes clamp the tracked eye to
     /// this so the camera cannot leave the collider crown; see
@@ -2553,6 +2560,14 @@ impl App {
         match self {
             App::Ready(game) => game.player_center_above_floor(),
             App::MissingAssets(_) => physics::player_center_above_floor(false),
+        }
+    }
+
+    /// See [`Game::player_is_gripping`].
+    pub fn player_is_gripping(&self) -> bool {
+        match self {
+            App::Ready(game) => game.player_is_gripping(),
+            App::MissingAssets(_) => false,
         }
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2913,9 +2913,10 @@ impl MissionCore {
                             - crate::physics::player_center_above_floor(
                                 self.player_handle.is_crouched(),
                             ),
+                        dt: time.elapsed.as_secs_f32(),
                     })
             })
-            .flatten();
+            .unwrap_or_default();
 
         // Skip physics while time is frozen (the debug runtime's paused state
         // calls update with zero dt): the Rapier pipeline advances by a fixed
@@ -2938,11 +2939,16 @@ impl MissionCore {
             // hand grips: the swap shifts the capsule centre further than the
             // grip's stretch tolerance, so a VR player who ducks (or whose
             // tracked head dips) on a ladder would be dropped by it.
-            if hand_climb.is_none() {
+            if hand_climb.translation.is_none() {
                 self.physics
                     .set_player_crouch(input_context.crouch, &mut self.player_handle);
             }
-            let request = match hand_climb {
+            // Letting go of the last hold throws the body with the momentum of
+            // the pull, so a hard haul-and-release sails on past the hold.
+            if let Some(launch) = hand_climb.launch {
+                self.physics.launch_player(launch, &mut self.player_handle);
+            }
+            let request = match hand_climb.translation {
                 Some(translation) => crate::physics::PlayerMoveRequest::HandClimb { translation },
                 None => crate::physics::PlayerMoveRequest::Walk {
                     movement: forward + cgmath::vec3(0.0, up_value, 0.0),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2937,8 +2937,10 @@ impl MissionCore {
             // feet-planted; standing up is refused without headroom (the
             // actual state is read back via `player_is_crouched`). Not while a
             // hand grips: the swap shifts the capsule centre further than the
-            // grip's stretch tolerance, so a VR player who ducks (or whose
-            // tracked head dips) on a ladder would be dropped by it.
+            // grip's stretch tolerance, so a VR player who ducks on a ladder
+            // would be dropped by it. The VR runtime also freezes its physical
+            // crouch detector while gripping (`vr_crouch`); this covers the
+            // crouch *button*, which no detector sees.
             if hand_climb.translation.is_none() {
                 self.physics
                     .set_player_crouch(input_context.crouch, &mut self.player_handle);
@@ -8820,6 +8822,13 @@ impl MissionCore {
     /// for lack of headroom, so this can lag the crouch input).
     pub fn player_is_crouched(&self) -> bool {
         self.player_handle.is_crouched()
+    }
+
+    /// Whether either VR hand currently holds a climb hold.
+    pub fn player_is_gripping(&self) -> bool {
+        self.interaction
+            .hand_climb()
+            .is_some_and(|climb| climb.grips().next().is_some())
     }
 
     pub fn player_save_position(&self) -> Result<Vector3<f32>, PlayerSavePoseError> {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2913,7 +2913,7 @@ impl MissionCore {
                             - crate::physics::player_center_above_floor(
                                 self.player_handle.is_crouched(),
                             ),
-                        dt: time.elapsed.as_secs_f32(),
+                        step_dt: self.physics.player_step_dt(),
                     })
             })
             .unwrap_or_default();

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -266,6 +266,10 @@ impl crate::game_scene::GameScene for Mission {
         self.mission_core.player_is_crouched()
     }
 
+    fn player_is_gripping(&self) -> bool {
+        self.mission_core.player_is_gripping()
+    }
+
     fn fov_pull_deg(&self, game_options: &GameOptions) -> f32 {
         self.mission_core.fov_pull_deg(game_options)
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -232,6 +232,10 @@ const PLAYER_STEP_HEIGHT: f32 = 2.0;
 const PLAYER_JUMP_SPEED: f32 = 28.0;
 const PLAYER_JUMP_GRAVITY: f32 = 40.0;
 const PLAYER_MAX_FALL_SPEED: f32 = 30.0;
+/// The jump's launch speed in world units/second. Doubles as the ceiling on
+/// any other way of throwing the player into the air (see
+/// [`crate::vr_climb::CLIMB_RELEASE_MAX_SPEED`]).
+pub const PLAYER_JUMP_LAUNCH_SPEED: f32 = PLAYER_JUMP_SPEED / SCALE_FACTOR;
 /// Maximum forward search for a jump-through landing. This is deliberately a
 /// short body-scale transition, not a general wall bypass.
 const PLAYER_JUMP_MANTLE_FORWARD: f32 = 8.0;
@@ -2416,6 +2420,10 @@ pub struct PlayerHandle {
     jump_velocity: Option<Real>,
     // Held-button edge state: one press launches at most one jump.
     jump_was_pressed: bool,
+    // Horizontal velocity (world units/second) carried through the current
+    // ballistic arc: what a VR climb release throws the player sideways with.
+    // Ordinary jumps steer with the stick instead and leave this zero.
+    air_velocity: Vector<Real>,
     // The player's OWN translation from the last movement frame - this
     // frame's total travel minus the moving-support carry - so a rider
     // standing still on an elevator reports zero. Purely derived per-frame
@@ -3123,6 +3131,7 @@ impl PhysicsWorld {
         player_handle.slope_displacement = Vector::zeros();
         player_handle.is_grounded = false;
         player_handle.jump_velocity = None;
+        player_handle.air_velocity = Vector::zeros();
         let collider_handle = self.rigid_body_set[player_handle.character_handle].colliders()[0];
         let shape = if player_handle.is_crouched {
             crouched_player_shared_shape()
@@ -4397,6 +4406,7 @@ impl PhysicsWorld {
             is_grounded: false,
             jump_velocity: None,
             jump_was_pressed: false,
+            air_velocity: Vector::zeros(),
             self_translation: Vector3::new(0.0, 0.0, 0.0),
             is_climbing: false,
         }
@@ -4809,6 +4819,22 @@ impl PhysicsWorld {
         )
     }
 
+    /// Throw the player into the air at `velocity` (world units/second).
+    ///
+    /// The same ballistic state an ordinary jump launches, seeded from
+    /// somewhere else: a VR climb release hands over the momentum of the pull
+    /// it let go of (see [`crate::vr_climb::release_velocity`]). Everything
+    /// after - the arc, the ceiling rejection, the landing - is the existing
+    /// jump path. Must be called before this frame's movement request.
+    pub fn launch_player(&mut self, velocity: Vector3<f32>, player_handle: &mut PlayerHandle) {
+        player_handle.jump_velocity = Some(velocity.y);
+        player_handle.air_velocity = vector![velocity.x, 0.0, velocity.z];
+        player_handle.is_grounded = false;
+        // Launched off whatever was carrying them, as a jump is.
+        player_handle.support = None;
+        player_handle.slope_displacement = Vector::zeros();
+    }
+
     /// Step the simulation and resolve one frame of player movement.
     ///
     /// How far the player actually got is
@@ -5065,12 +5091,20 @@ impl PhysicsWorld {
             // Hanging: the hand owns the body, so any ballistic arc ends here
             // and no gravity pass runs below.
             player_handle.jump_velocity = None;
+            player_handle.air_velocity = Vector::zeros();
         }
+        // Carried launch momentum rides along with whatever the player steers
+        // this frame; it lives only as long as the arc that started it.
+        let desired_movement = if player_handle.jump_velocity.is_some() {
+            desired_movement + player_handle.air_velocity * self.integration_parameters.dt
+        } else {
+            desired_movement
+        };
         let jump_edge = jump_pressed && !player_handle.jump_was_pressed;
         player_handle.jump_was_pressed = jump_pressed;
         let launch_jump = jump_edge && player_handle.is_grounded && player_handle.top_out.is_none();
         if launch_jump {
-            player_handle.jump_velocity = Some(PLAYER_JUMP_SPEED / SCALE_FACTOR);
+            player_handle.jump_velocity = Some(PLAYER_JUMP_LAUNCH_SPEED);
             player_handle.is_grounded = false;
             // A jumping player has left their moving support. Its carry is
             // already represented by the first frame's body pose; do not keep
@@ -5420,12 +5454,14 @@ impl PhysicsWorld {
 
         if is_top_out {
             player_handle.jump_velocity = None;
+            player_handle.air_velocity = Vector::zeros();
             player_handle.is_grounded = false;
         } else if let Some(mut velocity) = player_handle.jump_velocity {
             let requested_vertical = velocity * self.integration_parameters.dt;
             let applied_vertical = self_translation.y;
             if mvt.grounded && requested_vertical <= 0.0 {
                 player_handle.jump_velocity = None;
+                player_handle.air_velocity = Vector::zeros();
                 player_handle.is_grounded = true;
             } else {
                 // A ceiling (or other overhead collision) consumes the upward

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -235,7 +235,7 @@ const PLAYER_MAX_FALL_SPEED: f32 = 30.0;
 /// The jump's launch speed in world units/second. Doubles as the ceiling on
 /// any other way of throwing the player into the air (see
 /// [`crate::vr_climb::CLIMB_RELEASE_MAX_SPEED`]).
-pub const PLAYER_JUMP_LAUNCH_SPEED: f32 = PLAYER_JUMP_SPEED / SCALE_FACTOR;
+pub(crate) const PLAYER_JUMP_LAUNCH_SPEED: f32 = PLAYER_JUMP_SPEED / SCALE_FACTOR;
 /// Maximum forward search for a jump-through landing. This is deliberately a
 /// short body-scale transition, not a general wall bypass.
 const PLAYER_JUMP_MANTLE_FORWARD: f32 = 8.0;
@@ -4827,12 +4827,23 @@ impl PhysicsWorld {
     /// after - the arc, the ceiling rejection, the landing - is the existing
     /// jump path. Must be called before this frame's movement request.
     pub fn launch_player(&mut self, velocity: Vector3<f32>, player_handle: &mut PlayerHandle) {
+        // A scripted mantle owns the body until it finishes and would drop the
+        // arc on its next frame anyway; same rule as `set_player_crouch`.
+        if player_handle.top_out.is_some() {
+            return;
+        }
         player_handle.jump_velocity = Some(velocity.y);
         player_handle.air_velocity = vector![velocity.x, 0.0, velocity.z];
         player_handle.is_grounded = false;
         // Launched off whatever was carrying them, as a jump is.
         player_handle.support = None;
-        player_handle.slope_displacement = Vector::zeros();
+    }
+
+    /// The fixed timestep one movement frame integrates with. A velocity
+    /// handed to [`launch_player`](Self::launch_player) has to be expressed in
+    /// it - see [`crate::vr_climb::release_velocity`].
+    pub fn player_step_dt(&self) -> f32 {
+        self.integration_parameters.dt
     }
 
     /// Step the simulation and resolve one frame of player movement.
@@ -5105,6 +5116,7 @@ impl PhysicsWorld {
         let launch_jump = jump_edge && player_handle.is_grounded && player_handle.top_out.is_none();
         if launch_jump {
             player_handle.jump_velocity = Some(PLAYER_JUMP_LAUNCH_SPEED);
+            player_handle.air_velocity = Vector::zeros();
             player_handle.is_grounded = false;
             // A jumping player has left their moving support. Its carry is
             // already represented by the first frame's body pose; do not keep

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -272,6 +272,10 @@ impl GameScene for DebugScene {
         self.core.player_is_crouched()
     }
 
+    fn player_is_gripping(&self) -> bool {
+        self.core.player_is_gripping()
+    }
+
     fn fov_pull_deg(&self, game_options: &GameOptions) -> f32 {
         self.core.fov_pull_deg(game_options)
     }
@@ -502,6 +506,10 @@ impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
 
     fn player_is_crouched(&self) -> bool {
         self.core.player_is_crouched()
+    }
+
+    fn player_is_gripping(&self) -> bool {
+        self.core.player_is_gripping()
     }
 
     fn fov_pull_deg(&self, game_options: &GameOptions) -> f32 {

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -4,7 +4,9 @@
 //! State only - the grip probe and the resulting body motion belong to
 //! `physics`. Owned by `VrInteraction`, which already drives both hands.
 
-use cgmath::{InnerSpace, Quaternion, Vector3};
+use std::collections::VecDeque;
+
+use cgmath::{InnerSpace, Quaternion, Vector3, Zero};
 
 use crate::{physics::ClimbGrip, virtual_hand::hand_world_position, vr_config::Handedness};
 
@@ -13,6 +15,58 @@ use crate::{physics::ClimbGrip, virtual_hand::hand_world_position, vr_config::Ha
 /// frame at exactly the offset the hand opened up, so a persistent gap means
 /// something blocked it. Roughly Dark's 2 ft climb-detach distance.
 pub const CLIMB_STRETCH_BREAK: f32 = 0.6;
+
+/// How many frames of hand travel a release averages over. Long enough to ride
+/// out one noisy tracked frame, short enough to still read as the flick the
+/// player just made.
+const RELEASE_SAMPLE_FRAMES: usize = 4;
+
+/// Ceiling on the speed a release throws the body with (world units/s), at the
+/// ordinary jump's own launch speed: letting go can never fling the player
+/// harder than they could jump.
+pub const CLIMB_RELEASE_MAX_SPEED: f32 = crate::physics::PLAYER_JUMP_LAUNCH_SPEED;
+
+/// Separate ceiling on the UPWARD component, at the same jump speed, so a
+/// two-handed haul cannot loft the player above jump apex - the drop back down
+/// is what a fall would eventually be scored on (issue #802).
+pub const CLIMB_RELEASE_MAX_UP_SPEED: f32 = crate::physics::PLAYER_JUMP_LAUNCH_SPEED;
+
+/// Below this a release is just letting go: not worth putting the body into a
+/// ballistic arc (world units/s).
+pub const CLIMB_RELEASE_MIN_SPEED: f32 = 0.5;
+
+/// The body velocity a release throws the player with, from the anchor hand's
+/// recent per-frame travel relative to the pawn (newest last).
+///
+/// Negated: a hand hauled DOWN past the body throws the body up, the VR
+/// climbing convention (Climbey, Boneworks, Stride). `None` when there is
+/// nothing to throw with.
+pub fn release_velocity(travel: &[Vector3<f32>], dt: f32) -> Option<Vector3<f32>> {
+    if travel.is_empty() || dt <= 0.0 {
+        return None;
+    }
+    let mean = travel
+        .iter()
+        .fold(Vector3::zero(), |sum, delta| sum + delta)
+        / travel.len() as f32;
+    let mut velocity = -mean / dt;
+    let speed = velocity.magnitude();
+    if speed > CLIMB_RELEASE_MAX_SPEED {
+        velocity *= CLIMB_RELEASE_MAX_SPEED / speed;
+    }
+    velocity.y = velocity.y.min(CLIMB_RELEASE_MAX_UP_SPEED);
+    (velocity.magnitude() > CLIMB_RELEASE_MIN_SPEED).then_some(velocity)
+}
+
+/// What one frame of hand climbing asks of the body.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ClimbFrame {
+    /// Body translation the anchor hand demands, or `None` when no hand holds.
+    pub translation: Option<Vector3<f32>>,
+    /// Velocity to launch the body with, set on the frame the LAST hold is
+    /// voluntarily released (see [`release_velocity`]).
+    pub launch: Option<Vector3<f32>>,
+}
 
 /// One hand's hold: what it grabbed, and where the hand was in the world when
 /// it did. The body is moved to keep the hand back at that point.
@@ -63,6 +117,12 @@ pub struct HandClimb {
     /// lost its hold (over-stretched, or the object went away) must not
     /// silently re-grab while the same squeeze is still held.
     was_squeezing: [bool; 2],
+    /// The anchor hand's recent travel relative to the pawn, in world axes,
+    /// newest last - the pull, which a release throws the body with. Cleared
+    /// when the anchor changes: the history belongs to the hand that made it.
+    recent_anchor_travel: VecDeque<Vector3<f32>>,
+    /// That hand's pawn-space position last frame, to difference against.
+    last_anchor_local: Option<Vector3<f32>>,
 }
 
 impl HandClimb {
@@ -76,10 +136,17 @@ impl HandClimb {
         &mut self,
         pawn_pos: Vector3<f32>,
         pawn_rotation: Quaternion<f32>,
+        dt: f32,
         hands: [ClimbHandInput; 2],
         probe: impl Fn(Vector3<f32>) -> Option<ClimbGrip>,
         is_alive: impl Fn(shipyard::EntityId) -> bool,
-    ) -> Option<Vector3<f32>> {
+    ) -> ClimbFrame {
+        let previous_anchor = self.anchor;
+        let had_a_hold = self.grips.iter().any(Option::is_some);
+        // Only an opened hand throws the body. A hold torn off by an
+        // over-stretched (blocked) body, or by the entity going away, recorded
+        // travel that was the body failing to follow, not a pull.
+        let mut let_go_cleanly = true;
         let hand_world = hands
             .each_ref()
             .map(|hand| hand_world_position(pawn_pos, pawn_rotation, hand.local_position));
@@ -98,6 +165,7 @@ impl HandClimb {
                     // go of the ladder rather than holding both.
                     if !squeezing || !hand.is_empty || over_stretched || gone {
                         self.grips[index] = None;
+                        let_go_cleanly &= !squeezing && !over_stretched && !gone;
                     }
                 }
                 None if squeezing && !was_squeezing && hand.is_empty => {
@@ -130,14 +198,53 @@ impl HandClimb {
             }
         }
 
-        let index = slot(self.anchor?);
-        let anchor = self.grips[index]?;
-        Some(anchored_body_translation(
-            anchor.hand_world_at_grab,
-            pawn_pos,
-            pawn_rotation,
-            hands[index].local_position,
-        ))
+        let launch = if had_a_hold && self.anchor.is_none() && let_go_cleanly {
+            release_velocity(self.recent_anchor_travel.make_contiguous(), dt)
+        } else {
+            None
+        };
+
+        // Record this frame's pull for whatever release comes next.
+        match self.anchor {
+            Some(hand) => {
+                let local = hands[slot(hand)].local_position;
+                let previous = (self.anchor == previous_anchor)
+                    .then(|| self.last_anchor_local)
+                    .flatten();
+                match previous {
+                    Some(previous) => {
+                        if self.recent_anchor_travel.len() == RELEASE_SAMPLE_FRAMES {
+                            self.recent_anchor_travel.pop_front();
+                        }
+                        self.recent_anchor_travel.push_back(
+                            hand_world_position(pawn_pos, pawn_rotation, local)
+                                - hand_world_position(pawn_pos, pawn_rotation, previous),
+                        );
+                    }
+                    None => self.recent_anchor_travel.clear(),
+                }
+                self.last_anchor_local = Some(local);
+            }
+            None => {
+                self.recent_anchor_travel.clear();
+                self.last_anchor_local = None;
+            }
+        }
+
+        let translation = self.anchor.and_then(|hand| {
+            let index = slot(hand);
+            let anchor = self.grips[index]?;
+            Some(anchored_body_translation(
+                anchor.hand_world_at_grab,
+                pawn_pos,
+                pawn_rotation,
+                hands[index].local_position,
+            ))
+        });
+        ClimbFrame {
+            translation,
+            launch,
+        }
     }
 
     /// The hand currently moving the body, if any.
@@ -159,6 +266,9 @@ mod tests {
     use super::*;
     use crate::physics::{ClimbGrip, ClimbGripKind};
     use cgmath::{Rotation3, Zero, vec3};
+
+    /// One 60 Hz frame.
+    const DT: f32 = 1.0 / 60.0;
 
     fn ladder_grip(point: Vector3<f32>) -> ClimbGrip {
         ClimbGrip {
@@ -182,8 +292,10 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_translation(actual: Option<Vector3<f32>>, expected: Vector3<f32>) {
-        let actual = actual.expect("expected a gripping hand to move the body");
+    fn assert_translation(actual: ClimbFrame, expected: Vector3<f32>) {
+        let actual = actual
+            .translation
+            .expect("expected a gripping hand to move the body");
         assert!(
             (actual - expected).magnitude() < 1.0e-5,
             "expected {expected:?}, got {actual:?}"
@@ -231,6 +343,7 @@ mod tests {
         let first = climb.update(
             pawn,
             identity,
+            DT,
             [no_hand(), hand(reach, 1.0)],
             |point| Some(ladder_grip(point)),
             |_| true,
@@ -242,6 +355,7 @@ mod tests {
         let pull = climb.update(
             pawn,
             identity,
+            DT,
             [no_hand(), hand(reach - vec3(0.0, 0.4, 0.0), 1.0)],
             |_| None,
             |_| true,
@@ -252,11 +366,12 @@ mod tests {
         let released = climb.update(
             pawn,
             identity,
+            DT,
             [no_hand(), hand(reach, 0.0)],
             |_| None,
             |_| true,
         );
-        assert_eq!(released, None);
+        assert_eq!(released.translation, None);
         assert_eq!(climb.anchor(), None);
         assert_eq!(climb.grips().count(), 0);
     }
@@ -271,26 +386,32 @@ mod tests {
         let mut full = hand(reach, 1.0);
         full.is_empty = false;
         assert_eq!(
-            climb.update(
-                pawn,
-                identity,
-                [no_hand(), full],
-                |p| Some(ladder_grip(p)),
-                |_| true
-            ),
+            climb
+                .update(
+                    pawn,
+                    identity,
+                    DT,
+                    [no_hand(), full],
+                    |p| Some(ladder_grip(p)),
+                    |_| true
+                )
+                .translation,
             None,
         );
 
         // The squeeze was already down last frame, so an empty hand arriving
         // now still needs a fresh press.
         assert_eq!(
-            climb.update(
-                pawn,
-                identity,
-                [no_hand(), hand(reach, 1.0)],
-                |p| Some(ladder_grip(p)),
-                |_| true
-            ),
+            climb
+                .update(
+                    pawn,
+                    identity,
+                    DT,
+                    [no_hand(), hand(reach, 1.0)],
+                    |p| Some(ladder_grip(p)),
+                    |_| true
+                )
+                .translation,
             None,
         );
     }
@@ -304,6 +425,7 @@ mod tests {
         climb.update(
             pawn,
             identity,
+            DT,
             [no_hand(), hand(reach, 1.0)],
             |p| Some(ladder_grip(p)),
             |_| true,
@@ -314,6 +436,7 @@ mod tests {
         let held = climb.update(
             pawn,
             identity,
+            DT,
             [
                 no_hand(),
                 hand(reach - vec3(0.0, CLIMB_STRETCH_BREAK - 0.05, 0.0), 1.0),
@@ -321,20 +444,23 @@ mod tests {
             |_| None,
             |_| true,
         );
-        assert!(held.is_some());
+        assert!(held.translation.is_some());
 
         // ... and past it the hand comes off.
         assert_eq!(
-            climb.update(
-                pawn,
-                identity,
-                [
-                    no_hand(),
-                    hand(reach - vec3(0.0, CLIMB_STRETCH_BREAK + 0.05, 0.0), 1.0)
-                ],
-                |_| None,
-                |_| true
-            ),
+            climb
+                .update(
+                    pawn,
+                    identity,
+                    DT,
+                    [
+                        no_hand(),
+                        hand(reach - vec3(0.0, CLIMB_STRETCH_BREAK + 0.05, 0.0), 1.0)
+                    ],
+                    |_| None,
+                    |_| true
+                )
+                .translation,
             None,
         );
     }
@@ -350,6 +476,7 @@ mod tests {
         climb.update(
             pawn,
             identity,
+            DT,
             [no_hand(), hand(right, 1.0)],
             |p| Some(ladder_grip(p)),
             |_| true,
@@ -357,6 +484,7 @@ mod tests {
         climb.update(
             pawn,
             identity,
+            DT,
             [hand(left, 1.0), hand(right, 1.0)],
             |p| Some(ladder_grip(p)),
             |_| true,
@@ -369,6 +497,7 @@ mod tests {
         climb.update(
             pawn,
             identity,
+            DT,
             [hand(left + travel, 1.0), hand(right + travel, 1.0)],
             |_| None,
             |_| true,
@@ -379,6 +508,7 @@ mod tests {
         let handoff = climb.update(
             pawn,
             identity,
+            DT,
             [hand(left + travel, 0.0), hand(right + travel, 1.0)],
             |_| None,
             |_| true,
@@ -390,6 +520,7 @@ mod tests {
         let after = climb.update(
             pawn,
             identity,
+            DT,
             [
                 hand(left + travel, 0.0),
                 hand(right + travel - vec3(0.0, 0.2, 0.0), 1.0),
@@ -398,6 +529,166 @@ mod tests {
             |_| true,
         );
         assert_translation(after, vec3(0.0, 0.2, 0.0));
+    }
+
+    #[test]
+    fn a_release_throws_the_body_against_the_pull() {
+        // A hand hauled down 0.1 wu per frame throws the body up at 6 wu/s.
+        let velocity = release_velocity(&[vec3(0.0, -0.1, 0.0); 4], DT)
+            .expect("a real pull should throw the body");
+        assert!(
+            (velocity - vec3(0.0, 6.0, 0.0)).magnitude() < 1.0e-4,
+            "{velocity:?}"
+        );
+
+        // The mean is what counts: one frame of tracking noise cannot double it.
+        let averaged = release_velocity(
+            &[
+                vec3(0.0, -0.1, 0.0),
+                vec3(0.0, -0.3, 0.0),
+                vec3(0.0, -0.1, 0.0),
+                vec3(0.0, 0.1, 0.0),
+            ],
+            DT,
+        )
+        .expect("a real pull should throw the body");
+        assert!((averaged.y - 6.0).abs() < 1.0e-4, "{averaged:?}");
+    }
+
+    #[test]
+    fn a_release_is_clamped_to_jump_speed_and_never_lofts_higher() {
+        // A yank far faster than anything a jump does.
+        let sideways = release_velocity(&[vec3(-1.0, 0.0, 0.0)], DT).unwrap();
+        assert!(
+            (sideways.magnitude() - CLIMB_RELEASE_MAX_SPEED).abs() < 1.0e-4,
+            "{sideways:?}"
+        );
+        assert!(sideways.x > 0.0, "the throw opposes the pull: {sideways:?}");
+
+        // The up cap applies after the magnitude clamp, so a diagonal yank
+        // keeps its horizontal reach and only loses the excess rise.
+        let diagonal = release_velocity(&[vec3(0.0, -1.0, -1.0)], DT).unwrap();
+        assert!(
+            diagonal.y <= CLIMB_RELEASE_MAX_UP_SPEED + 1.0e-4,
+            "{diagonal:?}"
+        );
+        assert!(diagonal.z > 1.0, "{diagonal:?}");
+    }
+
+    #[test]
+    fn barely_moving_hands_and_a_frozen_frame_throw_nothing() {
+        assert_eq!(release_velocity(&[vec3(0.0, -0.001, 0.0); 4], DT), None);
+        assert_eq!(release_velocity(&[], DT), None);
+        assert_eq!(release_velocity(&[vec3(0.0, -0.1, 0.0)], 0.0), None);
+    }
+
+    /// Grab, pull `travel` per frame for `frames`, then end the grip the way
+    /// `finish` says. Returns the frame the last hold came off on.
+    fn pull_and_finish(
+        frames: usize,
+        travel: Vector3<f32>,
+        mut finish: impl FnMut(&mut HandClimb, Vector3<f32>) -> ClimbFrame,
+    ) -> ClimbFrame {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(reach, 1.0)],
+            |p| Some(ladder_grip(p)),
+            |_| true,
+        );
+        let mut at = reach;
+        for _ in 0..frames {
+            at += travel;
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(at, 1.0)],
+                |_| None,
+                |_| true,
+            );
+        }
+        finish(&mut climb, at)
+    }
+
+    fn open_the_hand(climb: &mut HandClimb, at: Vector3<f32>) -> ClimbFrame {
+        climb.update(
+            Vector3::zero(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            DT,
+            [no_hand(), hand(at, 0.0)],
+            |_| None,
+            |_| true,
+        )
+    }
+
+    #[test]
+    fn letting_go_of_the_last_hold_launches_the_body() {
+        // A quick haul: 0.1 wu of hand travel per frame, released open-handed.
+        let released = pull_and_finish(4, vec3(0.0, -0.1, 0.0), open_the_hand);
+        let launch = released.launch.expect("a quick pull should launch");
+        assert!((launch.y - 6.0).abs() < 0.1, "{launch:?}");
+        assert_eq!(released.translation, None);
+    }
+
+    #[test]
+    fn a_grip_torn_off_by_a_blocked_body_launches_nothing() {
+        // Same hand travel, but the body never followed: the hand ran past the
+        // stretch break instead of being opened, so the "pull" was the body
+        // failing to move and there is nothing to throw it with.
+        let mut broke = ClimbFrame::default();
+        pull_and_finish(
+            (CLIMB_STRETCH_BREAK / 0.1) as usize + 2,
+            vec3(0.0, -0.1, 0.0),
+            |climb, at| {
+                broke = climb.update(
+                    Vector3::zero(),
+                    Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                    DT,
+                    [no_hand(), hand(at, 1.0)],
+                    |_| None,
+                    |_| true,
+                );
+                broke
+            },
+        );
+        assert_eq!(broke.translation, None, "the grip should have broken");
+        assert_eq!(broke.launch, None);
+    }
+
+    #[test]
+    fn handing_over_to_the_other_hand_is_not_a_release() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let right = vec3(0.3, 1.0, -1.0);
+        let left = vec3(-0.3, 1.6, -1.0);
+        let step = |climb: &mut HandClimb, hands: [ClimbHandInput; 2], probe: bool| {
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                hands,
+                |p| probe.then(|| ladder_grip(p)),
+                |_| true,
+            )
+        };
+        step(&mut climb, [hand(left, 1.0), hand(right, 1.0)], true);
+        let mut at = left;
+        for _ in 0..4 {
+            at += vec3(0.0, -0.1, 0.0);
+            step(&mut climb, [hand(at, 1.0), hand(right, 1.0)], false);
+        }
+        // The left opens while the right is still on: the body keeps climbing,
+        // it does not get thrown.
+        let handoff = step(&mut climb, [hand(at, 0.0), hand(right, 1.0)], false);
+        assert_eq!(handoff.launch, None);
+        assert_eq!(climb.anchor(), Some(Handedness::Right));
     }
 
     #[test]
@@ -411,6 +702,7 @@ mod tests {
         climb.update(
             pawn,
             identity,
+            DT,
             [no_hand(), hand(reach, 1.0)],
             |point| {
                 ClimbGrip {
@@ -424,13 +716,16 @@ mod tests {
         assert_eq!(climb.grips().count(), 1);
 
         assert_eq!(
-            climb.update(
-                pawn,
-                identity,
-                [no_hand(), hand(reach, 1.0)],
-                |_| None,
-                |_| false
-            ),
+            climb
+                .update(
+                    pawn,
+                    identity,
+                    DT,
+                    [no_hand(), hand(reach, 1.0)],
+                    |_| None,
+                    |_| false
+                )
+                .translation,
             None,
         );
     }

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -6,7 +6,7 @@
 
 use std::collections::VecDeque;
 
-use cgmath::{InnerSpace, Quaternion, Vector3, Zero};
+use cgmath::{InnerSpace, Quaternion, Rotation, Vector3, Zero};
 
 use crate::{physics::ClimbGrip, virtual_hand::hand_world_position, vr_config::Handedness};
 
@@ -21,19 +21,17 @@ pub const CLIMB_STRETCH_BREAK: f32 = 0.6;
 /// player just made.
 const RELEASE_SAMPLE_FRAMES: usize = 4;
 
-/// Ceiling on the speed a release throws the body with (world units/s), at the
-/// ordinary jump's own launch speed: letting go can never fling the player
-/// harder than they could jump.
-pub const CLIMB_RELEASE_MAX_SPEED: f32 = crate::physics::PLAYER_JUMP_LAUNCH_SPEED;
+/// Ceiling on the speed a release throws the body with (world units/s).
+pub(crate) const CLIMB_RELEASE_MAX_SPEED: f32 = 12.0;
 
-/// Separate ceiling on the UPWARD component, at the same jump speed, so a
-/// two-handed haul cannot loft the player above jump apex - the drop back down
-/// is what a fall would eventually be scored on (issue #802).
-pub const CLIMB_RELEASE_MAX_UP_SPEED: f32 = crate::physics::PLAYER_JUMP_LAUNCH_SPEED;
+/// Tighter ceiling on the UPWARD component, at the ordinary jump's own launch
+/// speed: a haul-and-let-go can never rise higher than a jump, so it can never
+/// drop the player further than a jump either (SS2 scores falls - issue #802).
+pub(crate) const CLIMB_RELEASE_MAX_UP_SPEED: f32 = crate::physics::PLAYER_JUMP_LAUNCH_SPEED;
 
 /// Below this a release is just letting go: not worth putting the body into a
 /// ballistic arc (world units/s).
-pub const CLIMB_RELEASE_MIN_SPEED: f32 = 0.5;
+pub(crate) const CLIMB_RELEASE_MIN_SPEED: f32 = 0.5;
 
 /// The body velocity a release throws the player with, from the anchor hand's
 /// recent per-frame travel relative to the pawn (newest last).
@@ -41,15 +39,20 @@ pub const CLIMB_RELEASE_MIN_SPEED: f32 = 0.5;
 /// Negated: a hand hauled DOWN past the body throws the body up, the VR
 /// climbing convention (Climbey, Boneworks, Stride). `None` when there is
 /// nothing to throw with.
-pub fn release_velocity(travel: &[Vector3<f32>], dt: f32) -> Option<Vector3<f32>> {
-    if travel.is_empty() || dt <= 0.0 {
+///
+/// `step_dt` is the timestep the resulting arc will be INTEGRATED with, not
+/// the wall clock: one sample of travel per game update becomes one physics
+/// step of flight, so dividing by anything else makes the throw faster or
+/// slower than the pull that produced it at any frame rate but 60 Hz.
+pub(crate) fn release_velocity(travel: &[Vector3<f32>], step_dt: f32) -> Option<Vector3<f32>> {
+    if travel.is_empty() || step_dt <= 0.0 {
         return None;
     }
     let mean = travel
         .iter()
         .fold(Vector3::zero(), |sum, delta| sum + delta)
         / travel.len() as f32;
-    let mut velocity = -mean / dt;
+    let mut velocity = -mean / step_dt;
     let speed = velocity.magnitude();
     if speed > CLIMB_RELEASE_MAX_SPEED {
         velocity *= CLIMB_RELEASE_MAX_SPEED / speed;
@@ -136,20 +139,37 @@ impl HandClimb {
         &mut self,
         pawn_pos: Vector3<f32>,
         pawn_rotation: Quaternion<f32>,
-        dt: f32,
+        step_dt: f32,
         hands: [ClimbHandInput; 2],
         probe: impl Fn(Vector3<f32>) -> Option<ClimbGrip>,
         is_alive: impl Fn(shipyard::EntityId) -> bool,
     ) -> ClimbFrame {
         let previous_anchor = self.anchor;
         let had_a_hold = self.grips.iter().any(Option::is_some);
-        // Only an opened hand throws the body. A hold torn off by an
-        // over-stretched (blocked) body, or by the entity going away, recorded
-        // travel that was the body failing to follow, not a pull.
-        let mut let_go_cleanly = true;
+        // Per hand: was this the player opening their hand? A hold torn off by
+        // an over-stretched (blocked) body, or by the entity going away,
+        // recorded travel that was the body failing to follow, not a pull -
+        // and one hand's break must not swallow the other hand's throw.
+        let mut let_go_cleanly = [true; 2];
         let hand_world = hands
             .each_ref()
             .map(|hand| hand_world_position(pawn_pos, pawn_rotation, hand.local_position));
+
+        // Sample the anchor's travel BEFORE the releases below, so the flick
+        // on the very frame the hand opens is part of what throws the body.
+        if let Some(hand) = previous_anchor {
+            let local = hands[slot(hand)].local_position;
+            match self.last_anchor_local.replace(local) {
+                Some(previous) => {
+                    if self.recent_anchor_travel.len() == RELEASE_SAMPLE_FRAMES {
+                        self.recent_anchor_travel.pop_front();
+                    }
+                    self.recent_anchor_travel
+                        .push_back(pawn_rotation.rotate_vector(local - previous));
+                }
+                None => self.recent_anchor_travel.clear(),
+            }
+        }
 
         for (index, hand) in hands.iter().enumerate() {
             let squeezing = hand.squeeze > crate::ui::VR_TRIGGER_THRESHOLD;
@@ -165,7 +185,7 @@ impl HandClimb {
                     // go of the ladder rather than holding both.
                     if !squeezing || !hand.is_empty || over_stretched || gone {
                         self.grips[index] = None;
-                        let_go_cleanly &= !squeezing && !over_stretched && !gone;
+                        let_go_cleanly[index] = !squeezing && !over_stretched && !gone;
                     }
                 }
                 None if squeezing && !was_squeezing && hand.is_empty => {
@@ -198,37 +218,20 @@ impl HandClimb {
             }
         }
 
-        let launch = if had_a_hold && self.anchor.is_none() && let_go_cleanly {
-            release_velocity(self.recent_anchor_travel.make_contiguous(), dt)
+        let launch = if had_a_hold
+            && self.anchor.is_none()
+            && previous_anchor.is_some_and(|hand| let_go_cleanly[slot(hand)])
+        {
+            release_velocity(self.recent_anchor_travel.make_contiguous(), step_dt)
         } else {
             None
         };
 
-        // Record this frame's pull for whatever release comes next.
-        match self.anchor {
-            Some(hand) => {
-                let local = hands[slot(hand)].local_position;
-                let previous = (self.anchor == previous_anchor)
-                    .then(|| self.last_anchor_local)
-                    .flatten();
-                match previous {
-                    Some(previous) => {
-                        if self.recent_anchor_travel.len() == RELEASE_SAMPLE_FRAMES {
-                            self.recent_anchor_travel.pop_front();
-                        }
-                        self.recent_anchor_travel.push_back(
-                            hand_world_position(pawn_pos, pawn_rotation, local)
-                                - hand_world_position(pawn_pos, pawn_rotation, previous),
-                        );
-                    }
-                    None => self.recent_anchor_travel.clear(),
-                }
-                self.last_anchor_local = Some(local);
-            }
-            None => {
-                self.recent_anchor_travel.clear();
-                self.last_anchor_local = None;
-            }
+        // A new anchor starts a fresh history: the travel so far is the other
+        // hand's, and a re-based hold is a new pull.
+        if self.anchor != previous_anchor {
+            self.recent_anchor_travel.clear();
+            self.last_anchor_local = self.anchor.map(|hand| hands[slot(hand)].local_position);
         }
 
         let translation = self.anchor.and_then(|hand| {
@@ -565,14 +568,14 @@ mod tests {
         );
         assert!(sideways.x > 0.0, "the throw opposes the pull: {sideways:?}");
 
-        // The up cap applies after the magnitude clamp, so a diagonal yank
-        // keeps its horizontal reach and only loses the excess rise.
-        let diagonal = release_velocity(&[vec3(0.0, -1.0, -1.0)], DT).unwrap();
+        // The up cap is tighter than the magnitude clamp, so a near-vertical
+        // yank loses the excess rise and keeps its horizontal reach.
+        let steep = release_velocity(&[vec3(0.0, -1.0, -0.15)], DT).unwrap();
         assert!(
-            diagonal.y <= CLIMB_RELEASE_MAX_UP_SPEED + 1.0e-4,
-            "{diagonal:?}"
+            (steep.y - CLIMB_RELEASE_MAX_UP_SPEED).abs() < 1.0e-4,
+            "{steep:?}"
         );
-        assert!(diagonal.z > 1.0, "{diagonal:?}");
+        assert!(steep.z > 1.0, "{steep:?}");
     }
 
     #[test]
@@ -629,11 +632,19 @@ mod tests {
 
     #[test]
     fn letting_go_of_the_last_hold_launches_the_body() {
-        // A quick haul: 0.1 wu of hand travel per frame, released open-handed.
-        let released = pull_and_finish(4, vec3(0.0, -0.1, 0.0), open_the_hand);
+        // A quick haul: 0.1 wu of hand travel per frame, let go mid-pull.
+        let released = pull_and_finish(4, vec3(0.0, -0.1, 0.0), |climb, at| {
+            open_the_hand(climb, at + vec3(0.0, -0.1, 0.0))
+        });
         let launch = released.launch.expect("a quick pull should launch");
         assert!((launch.y - 6.0).abs() < 0.1, "{launch:?}");
         assert_eq!(released.translation, None);
+
+        // Stopping the hand before opening it is part of the pull: the same
+        // haul, released from rest, throws proportionally less.
+        let stopped = pull_and_finish(4, vec3(0.0, -0.1, 0.0), open_the_hand);
+        let stopped = stopped.launch.expect("a quick pull should launch");
+        assert!(stopped.y > 0.0 && stopped.y < launch.y, "{stopped:?}");
     }
 
     #[test]

--- a/shock2vr/src/vr_crouch.rs
+++ b/shock2vr/src/vr_crouch.rs
@@ -25,7 +25,15 @@ impl VrCrouchDetector {
     ///
     /// `None` means tracking is currently unavailable; the last request is
     /// retained until a valid sample returns.
-    pub fn update(&mut self, tracked_eye_height: Option<f32>) -> bool {
+    ///
+    /// `frozen` holds the current request and the calibration untouched - a
+    /// player hanging off a climb hold reaches, ducks and leans in ways that
+    /// are not a crouch, and the collider must not swap under a grip anyway
+    /// (the capsule centre moves further than the grip's stretch tolerance).
+    pub fn update(&mut self, tracked_eye_height: Option<f32>, frozen: bool) -> bool {
+        if frozen {
+            return self.crouching;
+        }
         let Some(eye_height) = tracked_eye_height.filter(|height| {
             height.is_finite() && (0.0..=MAX_PLAUSIBLE_EYE_HEIGHT_METERS).contains(height)
         }) else {
@@ -73,49 +81,63 @@ mod tests {
     fn crouches_and_stands_with_hysteresis() {
         let mut detector = VrCrouchDetector::default();
 
-        assert!(!detector.update(Some(1.70)));
-        assert!(!detector.update(Some(1.20)));
-        assert!(detector.update(Some(1.18)));
+        assert!(!detector.update(Some(1.70), false));
+        assert!(!detector.update(Some(1.20), false));
+        assert!(detector.update(Some(1.18), false));
 
         // Remain crouched throughout the dead band between 70% and 85%.
-        assert!(detector.update(Some(1.30)));
-        assert!(detector.update(Some(1.44)));
-        assert!(!detector.update(Some(1.45)));
+        assert!(detector.update(Some(1.30), false));
+        assert!(detector.update(Some(1.44), false));
+        assert!(!detector.update(Some(1.45), false));
 
         // Remain standing throughout that same dead band.
-        assert!(!detector.update(Some(1.30)));
+        assert!(!detector.update(Some(1.30), false));
     }
 
     #[test]
     fn calibration_adapts_when_the_first_sample_was_crouched() {
         let mut detector = VrCrouchDetector::default();
 
-        assert!(!detector.update(Some(1.05)));
-        assert!(!detector.update(Some(1.70)));
-        assert!(detector.update(Some(1.10)));
+        assert!(!detector.update(Some(1.05), false));
+        assert!(!detector.update(Some(1.70), false));
+        assert!(detector.update(Some(1.10), false));
     }
 
     #[test]
     fn unavailable_or_invalid_tracking_preserves_the_current_request() {
         let mut detector = VrCrouchDetector::default();
-        detector.update(Some(1.70));
-        assert!(detector.update(Some(1.00)));
+        detector.update(Some(1.70), false);
+        assert!(detector.update(Some(1.00), false));
 
-        assert!(detector.update(None));
-        assert!(detector.update(Some(f32::NAN)));
-        assert!(detector.update(Some(f32::INFINITY)));
-        assert!(detector.update(Some(-0.1)));
-        assert!(detector.update(Some(3.1)));
+        assert!(detector.update(None, false));
+        assert!(detector.update(Some(f32::NAN), false));
+        assert!(detector.update(Some(f32::INFINITY), false));
+        assert!(detector.update(Some(-0.1), false));
+        assert!(detector.update(Some(3.1), false));
+    }
+
+    #[test]
+    fn a_frozen_detector_neither_crouches_nor_recalibrates() {
+        let mut detector = VrCrouchDetector::default();
+        detector.update(Some(1.70), false);
+
+        // Hanging off a hold: however low the head goes, the stance holds.
+        assert!(!detector.update(Some(1.00), true));
+        assert!(!detector.update(Some(0.60), true));
+
+        // And the hanging pose never became the new standing height, so the
+        // same low head still crouches once the hold is let go.
+        assert!(detector.update(Some(1.00), false));
     }
 
     #[test]
     fn reset_discards_state_and_calibration() {
         let mut detector = VrCrouchDetector::default();
-        detector.update(Some(1.70));
-        assert!(detector.update(Some(1.00)));
+        detector.update(Some(1.70), false);
+        assert!(detector.update(Some(1.00), false));
 
         detector.reset();
 
-        assert!(!detector.update(Some(1.00)));
+        assert!(!detector.update(Some(1.00), false));
     }
 }

--- a/tools/shock2-sdk/test/vr-climb.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-climb.e2e.test.ts
@@ -250,3 +250,186 @@ test(
     await game.input.set("right_hand.thumbstick", [0, 0]);
   },
 );
+
+/** Every pawn height while stepping `frames` frames, one at a time. */
+async function stepTrackingHeight(
+  game: GameServer,
+  frames: number,
+): Promise<number[]> {
+  const heights: number[] = [];
+  for (let frame = 0; frame < frames; frame += 1) {
+    await game.step({ frames: 1 });
+    heights.push((await game.info()).player.position[1]);
+  }
+  return heights;
+}
+
+test(
+  "debug_ladder (VR): letting go of a hard pull throws the body upward",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    // A wrench of a pull: 1 wu of hand travel in 6 frames.
+    const { after } = await vrClimbPull(game, {
+      hand: "right",
+      grabAt: LADDER_HOLD,
+      pull: [0, -1.0, 0],
+      frames: 6,
+      release: true,
+    });
+
+    const heights = await stepTrackingHeight(game, 120);
+    const peak = Math.max(...heights);
+    assert.ok(
+      peak > after[1] + 0.3,
+      `the release should have thrown the body up from ${after[1]}, peaked at ${peak}`,
+    );
+    assert.equal((await game.info()).player.climb.grips.length, 0);
+    // ... and the arc ends: whatever it landed on, it is no longer rising.
+    const settled = heights.slice(-10);
+    assert.ok(
+      Math.max(...settled) - Math.min(...settled) < 0.1,
+      `expected a landing, still moving: ${settled.join(",")}`,
+    );
+  },
+);
+
+test(
+  "debug_ladder (VR): letting go of a slow pull does not throw the body",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    // The same 1 wu of hand travel, at a leisurely 1 wu per second.
+    const { after } = await vrClimbPull(game, {
+      hand: "right",
+      grabAt: LADDER_HOLD,
+      pull: [0, -1.0, 0],
+      frames: 60,
+      release: true,
+    });
+
+    const peak = Math.max(...(await stepTrackingHeight(game, 120)));
+    assert.ok(
+      peak < after[1] + 0.1,
+      `a gentle release should just drop the player, ${after[1]} -> peak ${peak}`,
+    );
+  },
+);
+
+test(
+  "debug_ladder (VR): a grip torn off by a blocked body throws nothing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    // Haul the body into the wall the ladder hangs on until the grip breaks
+    // (the same blocked-body break the stretch test drives), then check that
+    // the recorded "pull" - which was the body failing to follow - did not
+    // become a launch.
+    const atGrab = await vrHandLocal(game, LADDER_HOLD);
+    const into = await vrHandLocalDelta(game, [0.12, 0, 0]);
+    await game.input.set("right_hand.position", atGrab);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 1 });
+
+    let brokeAt: number | null = null;
+    for (let frame = 1; frame <= 24 && brokeAt === null; frame += 1) {
+      await game.input.set("right_hand.position", [
+        atGrab[0] + into[0] * frame,
+        atGrab[1] + into[1] * frame,
+        atGrab[2] + into[2] * frame,
+      ]);
+      await game.step({ frames: 1 });
+      if ((await game.info()).player.climb.grips.length === 0) {
+        brokeAt = frame;
+      }
+    }
+    assert.ok(brokeAt !== null, "the blocked body should have broken the grip");
+
+    const broken = (await game.info()).player.position[1];
+    const peak = Math.max(...(await stepTrackingHeight(game, 90)));
+    assert.ok(
+      peak < broken + 0.1,
+      `a broken grip must not launch, ${broken} -> peak ${peak}`,
+    );
+  },
+);
+
+test(
+  "debug_ladder (VR): hand over hand climbs the ladder",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAtTheLadder(game);
+
+    // Hands are tracked in PAWN space, so one reach height serves every
+    // cycle: as the body rises, the same reach lands on a higher rung.
+    const reach = await vrHandLocal(game, LADDER_HOLD);
+    const PULL = 0.5;
+    const FRAMES = 12;
+    const down = await vrHandLocalDelta(game, [0, -PULL, 0]);
+    const lowered: Vec3 = [
+      reach[0] + down[0],
+      reach[1] + down[1],
+      reach[2] + down[2],
+    ];
+
+    const heights = [(await game.info()).player.position[1]];
+    let pulling: "left" | "right" = "right";
+    await game.input.set("right_hand.position", reach);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 1);
+    heights.push(...(await stepTrackingHeight(game, 1)));
+
+    for (let half = 0; half < 6; half += 1) {
+      // Haul the gripping hand down: the body comes up to meet it.
+      for (let frame = 1; frame <= FRAMES; frame += 1) {
+        await game.input.set(`${pulling}_hand.position`, [
+          reach[0] + (down[0] * frame) / FRAMES,
+          reach[1] + (down[1] * frame) / FRAMES,
+          reach[2] + (down[2] * frame) / FRAMES,
+        ]);
+        heights.push(...(await stepTrackingHeight(game, 1)));
+      }
+      assert.equal(
+        (await game.info()).player.climb.anchor_hand,
+        pulling,
+        `the ${pulling} hand should be driving on half-cycle ${half}`,
+      );
+
+      // The other hand reaches past it and takes over, then this one lets go
+      // while still holding on - a handoff, not a release.
+      const other = pulling === "right" ? "left" : "right";
+      await game.input.set(`${other}_hand.position`, reach);
+      await game.input.set(`${other}_hand.squeeze`, 0);
+      heights.push(...(await stepTrackingHeight(game, 1)));
+      await game.input.set(`${other}_hand.squeeze`, 1);
+      heights.push(...(await stepTrackingHeight(game, 1)));
+      await game.input.set(`${pulling}_hand.squeeze`, 0);
+      await game.input.set(`${pulling}_hand.position`, lowered);
+      heights.push(...(await stepTrackingHeight(game, 1)));
+
+      const climb = (await game.info()).player.climb;
+      assert.equal(climb.anchor_hand, other, `handoff failed on half ${half}`);
+      assert.equal(climb.grips.length, 1);
+      pulling = other;
+    }
+
+    const climbed = heights[heights.length - 1] - heights[0];
+    assert.ok(climbed > 2.5, `hand over hand climbed only ${climbed} wu`);
+    for (let i = 1; i < heights.length; i += 1) {
+      assert.ok(
+        Math.abs(heights[i] - heights[i - 1]) < 0.1,
+        `the body jumped ${heights[i - 1]} -> ${heights[i]} in one frame`,
+      );
+    }
+  },
+);

--- a/tools/shock2-sdk/test/vr-climb.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-climb.e2e.test.ts
@@ -297,18 +297,19 @@ test(
 );
 
 test(
-  "debug_ladder (VR): letting go of a slow pull does not throw the body",
+  "debug_ladder (VR): letting go of a pull below the deadzone throws nothing",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await launchVr();
     await standAtTheLadder(game);
 
-    // The same 1 wu of hand travel, at a leisurely 1 wu per second.
+    // The same 1 wu of hand travel at 0.33 wu/s - under the release
+    // deadzone (CLIMB_RELEASE_MIN_SPEED), so letting go is just letting go.
     const { after } = await vrClimbPull(game, {
       hand: "right",
       grabAt: LADDER_HOLD,
       pull: [0, -1.0, 0],
-      frames: 60,
+      frames: 180,
       release: true,
     });
 
@@ -407,7 +408,7 @@ test(
 
       // The other hand reaches past it and takes over, then this one lets go
       // while still holding on - a handoff, not a release.
-      const other = pulling === "right" ? "left" : "right";
+      const other: "left" | "right" = pulling === "right" ? "left" : "right";
       await game.input.set(`${other}_hand.position`, reach);
       await game.input.set(`${other}_hand.squeeze`, 0);
       heights.push(...(await stepTrackingHeight(game, 1)));


### PR DESCRIPTION
PR 4 of the VR hand-climbing campaign. Stacked on #1235 (`feat/climb-hand-anchor`).

## Letting go carries you

A gripping hand's travel relative to the pawn *is* the pull. `HandClimb` keeps the
last 4 frames of it for whichever hand is the anchor; opening that hand when no
other hand is on throws the body with `-mean(travel) / step_dt` — the VR climbing
convention (Climbey, Boneworks, Stride), which is what makes pull-up-and-let-go
land you on the ledge instead of feeling sticky.

- **12 wu/s** magnitude ceiling; upward component capped tighter at the ordinary
  jump's own launch speed (**11.2 wu/s**), so a haul can never rise higher — nor
  fall further — than a jump (SS2 scores falls, #802).
- **0.5 wu/s deadzone**: letting go slowly is just letting go.
- The velocity is expressed in the **physics step**, not the wall clock: one
  sample of travel per update becomes one physics step of flight, so the throw
  matches the pull at 72/90/120 Hz, not only at 60.
- A stretch break or a vanished hold launches nothing (that "pull" was the body
  failing to follow, per hand — one hand's break can't swallow the other's throw).
  A handoff to the other hand is not a release.
- `PhysicsWorld::launch_player` seeds the existing jump arc plus a new
  `PlayerHandle.air_velocity` horizontal carry; the ballistic/landing path is
  unchanged.

## Crouch while gripped

PR 3 skipped `set_player_crouch` while gripping because the capsule swap moves the
centre 0.64 wu, past the 0.6 stretch break. Now `VrCrouchDetector::update` takes a
`frozen` flag, driven from `Game::player_is_gripping()` in `oculus_runtime`: a
hanging player neither enters nor exits crouch, and a hanging pose never becomes
the new standing calibration. PR 3's skip stays — it covers the crouch *button*,
which no detector sees.

## Tests

- 6 new unit tests in `vr_climb` (velocity average, both clamps, deadzone, launch
  on release, no launch on a blocked break, handoff is not a release) and 1 in
  `vr_crouch` (frozen: no stance change, no recalibration).
- 4 new e2e on `debug_ladder --vr`: a hard pull sails past the release point and
  lands; a pull under the deadzone does not; a blocked-body break throws nothing;
  hand-over-hand climbs 3 wu over 3 cycles with no per-frame jump > 0.1.
- `cargo test -p shock2vr` 1220 pass; the climb/ladder/grip/missions e2e set 37/37;
  the full `npm run test:e2e` shows only the known pre-existing failures.
- `cargo apk check` clean for the Quest runtime.

## Demo

![VR ladder release momentum](https://gist.githubusercontent.com/tommy-xr/6788dc371f95f7d9d38d7682ee94adf8/raw/demo.gif)

<sub>Right hand pulls down on a ladder rung, releases, and the body sails on past the release point before falling and landing — captured headlessly on `debug_ladder --vr` (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). Net-new behavior, no prior state to compare against.</sub>

Release (y=2.24) → apex (y=4.06), a 1.82 wu overshoot past the point the hand let go:

![release moment](https://gist.githubusercontent.com/tommy-xr/6788dc371f95f7d9d38d7682ee94adf8/raw/still_release.png)
![apex of the throw](https://gist.githubusercontent.com/tommy-xr/6788dc371f95f7d9d38d7682ee94adf8/raw/still_apex.png)
