### PR TITLE
feat(vr): pull your head over a ledge and vault onto it

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -368,6 +368,9 @@ pub struct DebugClimbHold {
 #[derive(Debug, Serialize, Clone, Default)]
 pub struct DebugClimbState {
     pub is_climbing: bool,
+    /// A scripted top-out is carrying the body over a lip - the hand vault's
+    /// second half, and flat's ladder mantle.
+    pub vaulting: bool,
     /// The hand currently moving the body ("left"/"right"), if any.
     pub anchor_hand: Option<&'static str>,
     pub grips: Vec<DebugClimbHold>,

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -76,6 +76,10 @@ pub trait PlayerInteraction {
         None
     }
 
+    /// Drop every climb hold without throwing the body - the vault took over
+    /// (see [`crate::vr_climb::HandClimb::release_all`]).
+    fn release_climb_grips(&mut self) {}
+
     /// Entities held in (left, right) - for `PlayerInfo`. Flat reports its
     /// wielded weapon as the "left".
     fn held_entities(&self) -> (Option<EntityId>, Option<EntityId>);
@@ -209,6 +213,10 @@ impl PlayerInteraction for VrInteraction {
 
     fn hand_climb(&self) -> Option<&crate::vr_climb::HandClimb> {
         Some(&self.hand_climb)
+    }
+
+    fn release_climb_grips(&mut self) {
+        self.hand_climb.release_all();
     }
 
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2897,7 +2897,9 @@ impl MissionCore {
         // `PlayerInfo` carries: the movement is cast from the queued kinematic
         // target, and composing against the superseded pose would apply each
         // correction on top of a body that has already absorbed the last one.
-        let hand_climb = (!time.elapsed.is_zero())
+        // A scripted top-out owns the body outright, so the hands do nothing
+        // while one runs and cannot take a fresh hold part-way over the lip.
+        let hand_climb = (!time.elapsed.is_zero() && !self.player_handle.is_topping_out())
             .then(|| {
                 let pawn_pos = self
                     .physics
@@ -2935,15 +2937,38 @@ impl MissionCore {
         } else {
             // Apply the crouch request before moving: swaps the capsule size
             // feet-planted; standing up is refused without headroom (the
-            // actual state is read back via `player_is_crouched`). Not while a
-            // hand grips: the swap shifts the capsule centre further than the
-            // grip's stretch tolerance, so a VR player who ducks on a ladder
-            // would be dropped by it. The VR runtime also freezes its physical
-            // crouch detector while gripping (`vr_crouch`); this covers the
-            // crouch *button*, which no detector sees.
-            if hand_climb.translation.is_none() {
+            // actual state is read back via `player_is_crouched`).
+            //
+            // A hand on a ledge balls the body up regardless of the crouch
+            // input, so the knees clear the lip being pulled over - and it
+            // swaps the capsule around the body CENTER, since a hanging body's
+            // feet rest on nothing and the gripping hand rides that center.
+            let hangs_from_a_ledge = self
+                .interaction
+                .hand_climb()
+                .is_some_and(|climb| climb.holds_a_ledge());
+            if hangs_from_a_ledge || self.player_handle.is_hanging_crouched() {
+                // Undone the same way it was made, so the body ends up back
+                // where it started rather than 0.64 wu above it.
+                self.physics
+                    .set_player_crouch_hanging(hangs_from_a_ledge, &mut self.player_handle);
+            } else if hand_climb.translation.is_none() {
                 self.physics
                     .set_player_crouch(input_context.crouch, &mut self.player_handle);
+            }
+            // Head over the lip: the hands have done all they can, so hand the
+            // body to the scripted top-out and let go of everything. A route
+            // the planner cannot find is simply not taken - the holds stay and
+            // the player keeps pulling.
+            let mut hand_climb = hand_climb;
+            if let Some(direction) = self.hand_vault_direction() {
+                if self
+                    .physics
+                    .plan_hand_top_out(direction, &mut self.player_handle)
+                {
+                    self.interaction.release_climb_grips();
+                    hand_climb.translation = None;
+                }
             }
             // Letting go of the last hold throws the body with the momentum of
             // the pull, so a hard haul-and-release sails on past the hold.
@@ -8824,6 +8849,32 @@ impl MissionCore {
         self.player_handle.is_crouched()
     }
 
+    /// Where to throw the body if the player has pulled their head over the
+    /// ledge their anchor hand is lying on, or `None` if they have not (see
+    /// [`crate::vr_climb::vault_ready`]).
+    ///
+    /// The eye is taken at the STANDING line above the body center, whatever
+    /// stance the collider is in: a VR player's real head does not shrink when
+    /// their capsule balls up, and it is the center the tracked head rides.
+    fn hand_vault_direction(&self) -> Option<Vector3<f32>> {
+        let anchor = self.interaction.hand_climb()?.anchor_grip()?;
+        let center = self.physics.get_player_translation(&self.player_handle);
+        let eye_y = center.y + crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
+        if !crate::vr_climb::vault_ready(
+            eye_y,
+            anchor.grip.point.y,
+            anchor.grip.kind,
+            crate::physics::is_walkable_normal(anchor.grip.normal.y),
+        ) {
+            return None;
+        }
+        // Over the lip, toward the hand: the landing is whatever the planner
+        // finds that way.
+        let toward = anchor.grip.point - center;
+        let direction = cgmath::vec3(toward.x, 0.0, toward.z);
+        (direction.magnitude() > 1.0e-4).then_some(direction)
+    }
+
     /// Whether either VR hand currently holds a climb hold.
     pub fn player_is_gripping(&self) -> bool {
         self.interaction
@@ -10259,6 +10310,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         let climb = self.interaction.hand_climb();
         Some(crate::game_scene::DebugClimbState {
             is_climbing: self.player_handle.is_climbing(),
+            vaulting: self.player_handle.is_topping_out(),
             anchor_hand: climb.and_then(|climb| climb.anchor()).map(hand_name),
             grips: climb
                 .into_iter()

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2911,9 +2911,15 @@ impl MissionCore {
                         input: input_context,
                         pawn_pos,
                         pawn_rotation: new_rotation,
+                        // Measured from the STANDING capsule while balling up
+                        // on a hold: that swap raises the collider's feet
+                        // without the body moving, and a ledge must not stop
+                        // being a ledge just because the player tucked their
+                        // knees under it.
                         feet_y: pawn_pos.y
                             - crate::physics::player_center_above_floor(
-                                self.player_handle.is_crouched(),
+                                self.player_handle.is_crouched()
+                                    && !self.player_handle.is_hanging_crouched(),
                             ),
                         step_dt: self.physics.player_step_dt(),
                     })
@@ -2943,10 +2949,17 @@ impl MissionCore {
             // input, so the knees clear the lip being pulled over - and it
             // swaps the capsule around the body CENTER, since a hanging body's
             // feet rest on nothing and the gripping hand rides that center.
-            let hangs_from_a_ledge = self
-                .interaction
-                .hand_climb()
-                .is_some_and(|climb| climb.holds_a_ledge());
+            //
+            // Only while they are actually hanging, though. A player still
+            // standing on the deck holding a waist-high ledge has their weight
+            // on their feet, and a center-anchored swap there would lift them
+            // off the floor going down and drive the standing capsule through
+            // it coming back up.
+            let hangs_from_a_ledge = !self.player_handle.is_grounded()
+                && self
+                    .interaction
+                    .hand_climb()
+                    .is_some_and(|climb| climb.holds_a_ledge());
             let still_hanging =
                 self.player_handle.is_hanging_crouched() && !self.player_handle.is_grounded();
             if hangs_from_a_ledge || still_hanging {
@@ -2956,8 +2969,10 @@ impl MissionCore {
                 // feet-planted path below is the correct one - and the only one
                 // that can stand them up at all, since a center-anchored
                 // expansion would put their feet through that floor.
-                self.physics
-                    .set_player_crouch_hanging(hangs_from_a_ledge, &mut self.player_handle);
+                self.physics.set_player_crouch_hanging(
+                    hangs_from_a_ledge || input_context.crouch,
+                    &mut self.player_handle,
+                );
             } else if hand_climb.translation.is_none() {
                 self.physics
                     .set_player_crouch(input_context.crouch, &mut self.player_handle);
@@ -8864,10 +8879,15 @@ impl MissionCore {
     /// their capsule balls up, and it is the center the tracked head rides.
     fn hand_vault_direction(&self) -> Option<Vector3<f32>> {
         let anchor = self.interaction.hand_climb()?.anchor_grip()?;
-        let center = self.physics.get_player_translation(&self.player_handle);
-        let eye_y = center.y + crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
+        // The pose the coming step will land on, as the grip itself is resolved
+        // against - judging the eye against the superseded one lags the pull.
+        let center = self
+            .physics
+            .get_player_next_translation(&self.player_handle);
+        let eye_above_center = crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
         if !crate::vr_climb::vault_ready(
-            eye_y,
+            center.y + eye_above_center,
+            anchor.pawn_at_grab.y + eye_above_center,
             anchor.grip.point.y,
             anchor.grip.kind,
             crate::physics::is_walkable_normal(anchor.grip.normal.y),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2947,9 +2947,15 @@ impl MissionCore {
                 .interaction
                 .hand_climb()
                 .is_some_and(|climb| climb.holds_a_ledge());
-            if hangs_from_a_ledge || self.player_handle.is_hanging_crouched() {
-                // Undone the same way it was made, so the body ends up back
-                // where it started rather than 0.64 wu above it.
+            let still_hanging =
+                self.player_handle.is_hanging_crouched() && !self.player_handle.is_grounded();
+            if hangs_from_a_ledge || still_hanging {
+                // Undone the same way it was made, so a body that is still in
+                // the air ends up back where it hung rather than 0.64 wu above
+                // it. Once their feet are on something the ordinary
+                // feet-planted path below is the correct one - and the only one
+                // that can stand them up at all, since a center-anchored
+                // expansion would put their feet through that floor.
                 self.physics
                     .set_player_crouch_hanging(hangs_from_a_ledge, &mut self.player_handle);
             } else if hand_climb.translation.is_none() {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -96,6 +96,27 @@ pub fn player_crouch_center_shift() -> f32 {
     (PLAYER_STANDING_HEIGHT - PLAYER_CROUCH_HEIGHT) / 2.0 / SCALE_FACTOR
 }
 
+/// What holds a crouching player up, and therefore what stays put as the
+/// capsule changes size (see [`PhysicsWorld::set_player_crouch`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CrouchAnchor {
+    /// Standing on something: the feet stay planted and the center moves.
+    Feet,
+    /// Hanging from their hands: nothing is under the feet, and the tracked
+    /// hands and eye ride the body center, so the center stays put and the
+    /// capsule shrinks toward the hands instead.
+    Center,
+}
+
+impl CrouchAnchor {
+    fn center_shift(self) -> f32 {
+        match self {
+            CrouchAnchor::Feet => player_crouch_center_shift(),
+            CrouchAnchor::Center => 0.0,
+        }
+    }
+}
+
 /// Clearance (SS2 ft) kept between a capped eye and the capsule crown, so the
 /// camera stays strictly inside the collider rather than sitting exactly on
 /// its surface where a coplanar ceiling could still catch it.
@@ -1566,6 +1587,16 @@ fn sync_top_out_collider(
         collider_set[collider_handle].set_shape(restored);
     }
     rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
+}
+
+/// Whether a collider is NOT an authored climbable surface. Membership is
+/// checked rather than filtered by group because a ladder is also an `ENTITY`,
+/// so masking the CLIMBABLE bit out of a group filter would not exclude it.
+fn collider_is_not_climbable(collider: &Collider) -> bool {
+    !collider
+        .collision_groups()
+        .memberships
+        .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
 }
 
 fn advance_climb_top_out(
@@ -4484,7 +4515,7 @@ impl PhysicsWorld {
         want_crouch: bool,
         player_handle: &mut PlayerHandle,
     ) -> bool {
-        self.set_player_crouch_anchored(want_crouch, player_crouch_center_shift(), player_handle)
+        self.set_player_crouch_anchored(want_crouch, CrouchAnchor::Feet, player_handle)
     }
 
     /// Set the crouch state of a player whose weight hangs from their hands
@@ -4503,13 +4534,13 @@ impl PhysicsWorld {
         want_crouch: bool,
         player_handle: &mut PlayerHandle,
     ) -> bool {
-        self.set_player_crouch_anchored(want_crouch, 0.0, player_handle)
+        self.set_player_crouch_anchored(want_crouch, CrouchAnchor::Center, player_handle)
     }
 
     fn set_player_crouch_anchored(
         &mut self,
         want_crouch: bool,
-        center_shift: f32,
+        anchor: CrouchAnchor,
         player_handle: &mut PlayerHandle,
     ) -> bool {
         // Dark disables ordinary player motion while its mantle sequence is
@@ -4519,11 +4550,20 @@ impl PhysicsWorld {
             return player_handle.is_crouched;
         }
         if want_crouch == player_handle.is_crouched {
+            // Already in the wanted stance, so nothing moves - but the request
+            // still says how the body is being held up NOW, and the undo has to
+            // match that, not how the crouch happened to be made. A player who
+            // crouch-walked a duct and then took a ledge hold is hanging from
+            // it, however they got low.
+            if want_crouch {
+                player_handle.is_hanging_crouched = anchor == CrouchAnchor::Center;
+            }
             return player_handle.is_crouched;
         }
 
         let character_handle = player_handle.character_handle;
         let collider_handle = self.rigid_body_set[character_handle].colliders()[0];
+        let center_shift = anchor.center_shift();
 
         if want_crouch {
             self.collider_set[collider_handle].set_shape(crouched_player_shared_shape());
@@ -4532,7 +4572,7 @@ impl PhysicsWorld {
             translation.y -= center_shift;
             body.set_translation(translation, true);
             player_handle.is_crouched = true;
-            player_handle.is_hanging_crouched = center_shift == 0.0;
+            player_handle.is_hanging_crouched = anchor == CrouchAnchor::Center;
         } else {
             // Headroom check: intersect a test capsule at the feet-planted
             // standing pose against the same groups the movement casts use.
@@ -4952,15 +4992,27 @@ impl PhysicsWorld {
         // The same three pipelines the flat ladder top-out plans against: the
         // probes ignore the climbable the player is hanging off, and the
         // scripted route may cross parentless terrain (see `ClimbPass`).
-        let not_climbable = |_handle: ColliderHandle, collider: &Collider| {
-            !collider
-                .collision_groups()
-                .memberships
-                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
+        let not_climbable =
+            |_handle: ColliderHandle, collider: &Collider| collider_is_not_climbable(collider);
+        let parented_non_climbable = |_handle: ColliderHandle, collider: &Collider| {
+            collider.parent().is_some() && collider_is_not_climbable(collider)
         };
-        let parented_non_climbable = |handle: ColliderHandle, collider: &Collider| {
-            collider.parent().is_some() && not_climbable(handle, collider)
+        // The route is planned for, and ends by expanding, the STANDING
+        // capsule, so a balled-up body has to fit one where it hangs. Test that
+        // first - it is one query, against the planner's hundreds - and refuse
+        // the vault if it does not; the player keeps pulling instead.
+        let stand_anchor = if player_handle.is_hanging_crouched {
+            CrouchAnchor::Center
+        } else {
+            CrouchAnchor::Feet
         };
+        let standing_center = nvec_to_cgmath(character_pos.translation.vector)
+            + vec3(0.0, stand_anchor.center_shift(), 0.0);
+        if player_handle.is_crouched
+            && !self.standing_player_pose_is_clear(standing_center, player_handle)
+        {
+            return false;
+        }
         // Plan before committing to anything: a refused route must leave the
         // player exactly as they were, still holding on.
         let planned = {
@@ -4980,11 +5032,11 @@ impl PhysicsWorld {
         let Some(planned) = planned else {
             return false;
         };
-        // The route is planned for, and ends by expanding, the STANDING
-        // capsule, so a body balled up on the hold un-balls here. Refuse the
-        // vault if it does not fit where the player hangs - they can keep
-        // pulling instead.
-        if player_handle.is_crouched && self.set_player_crouch_hanging(false, player_handle) {
+        // Un-ball on the anchor the crouch was made with, so the body ends up
+        // where the pre-check said the standing capsule fits.
+        if player_handle.is_crouched
+            && self.set_player_crouch_anchored(false, stand_anchor, player_handle)
+        {
             return false;
         }
         player_handle.top_out = planned.top_out;
@@ -5204,7 +5256,7 @@ impl PhysicsWorld {
                 ClimbGripKind::Ladder
             } else {
                 let world_point = contact.point2;
-                if outward.y < PLAYER_MIN_WALKABLE_NORMAL || world_point.y <= min_ledge_height {
+                if !is_walkable_normal(outward.y) || world_point.y <= min_ledge_height {
                     continue;
                 }
                 ClimbGripKind::Ledge
@@ -5403,14 +5455,10 @@ impl PhysicsWorld {
         // by predicate rather than by group filter because a ladder is also an
         // `ENTITY`, so masking the CLIMBABLE bit out of the group filter would
         // not exclude it.
-        let not_climbable = |_handle: ColliderHandle, collider: &Collider| {
-            !collider
-                .collision_groups()
-                .memberships
-                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
-        };
-        let parented_non_climbable = |handle: ColliderHandle, collider: &Collider| {
-            collider.parent().is_some() && not_climbable(handle, collider)
+        let not_climbable =
+            |_handle: ColliderHandle, collider: &Collider| collider_is_not_climbable(collider);
+        let parented_non_climbable = |_handle: ColliderHandle, collider: &Collider| {
+            collider.parent().is_some() && collider_is_not_climbable(collider)
         };
         let climb_pass_filter = movement_filter.predicate(&not_climbable);
         // Dark's scripted jump-through may cross immutable world terrain.

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -251,6 +251,13 @@ const PLAYER_JUMP_MANTLE_MAX_DROP: f32 = 40.0;
 /// climb/slide boundary.
 const PLAYER_MIN_WALKABLE_NORMAL: f32 = 0.7;
 
+/// Whether a surface with this upward normal component can be stood on - and
+/// so whether a hand touching it is lying ON the surface rather than hooked on
+/// a face of it (see [`crate::vr_climb::vault_ready`]).
+pub fn is_walkable_normal(normal_y: f32) -> bool {
+    normal_y >= PLAYER_MIN_WALKABLE_NORMAL
+}
+
 /// How far below the player's feet (world units) a surface still counts as the
 /// thing they are *standing on* for support-motion transfer (see
 /// [`PlayerSupport`]). Comfortably clears the controller's contact offset plus
@@ -1527,6 +1534,40 @@ fn plan_jump_mantle(
 /// exception. A newly-blocked route returns to its last valid standing pose
 /// before the capsule is expanded, and final standing fit is checked against
 /// every collider.
+/// Give the player the collider their top-out state calls for: the scripted
+/// mantle's compressed ball while it runs, their own capsule again once it
+/// ends. One place, because a top-out is entered both from the movement pass
+/// (flat, pushing into a ladder top) and outright (a VR hand vault - see
+/// [`PhysicsWorld::plan_hand_top_out`]).
+fn sync_top_out_collider(
+    collider_set: &mut ColliderSet,
+    rigid_body_set: &mut RigidBodySet,
+    was_top_out: bool,
+    player_handle: &PlayerHandle,
+) {
+    let is_top_out = player_handle.top_out.is_some();
+    let collider_handle = rigid_body_set[player_handle.character_handle].colliders()[0];
+    if !was_top_out && is_top_out {
+        let compressed_radius = if player_handle
+            .top_out
+            .is_some_and(|top_out| top_out.is_crouched)
+        {
+            PLAYER_CROUCH_RADIUS / SCALE_FACTOR
+        } else {
+            CLIMB_TOP_OUT_RADIUS
+        };
+        collider_set[collider_handle].set_shape(SharedShape::ball(compressed_radius));
+    } else if was_top_out && !is_top_out {
+        let restored = if player_handle.is_crouched {
+            crouched_player_shared_shape()
+        } else {
+            standing_player_shared_shape()
+        };
+        collider_set[collider_handle].set_shape(restored);
+    }
+    rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
+}
+
 fn advance_climb_top_out(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
@@ -2400,6 +2441,10 @@ pub struct PlayerHandle {
     // `PhysicsWorld::set_player_crouch`, which keeps the shape and this flag
     // in sync.
     is_crouched: bool,
+    // Whether that crouch was made by `set_player_crouch_hanging` (anchored on
+    // the body center rather than the feet). It has to be undone the same way,
+    // or the body ends up a crouch shift above where it hung.
+    is_hanging_crouched: bool,
     // Live-validated waypoints for an in-progress ladder top-out. This is
     // transient locomotion state: direct relocation and crouching cancel it,
     // while save/load uses the last valid standing pose stored with it.
@@ -2484,6 +2529,19 @@ impl PlayerHandle {
     /// the requested input.
     pub fn is_crouched(&self) -> bool {
         self.is_crouched
+    }
+
+    /// Whether the current crouch is a hanging ball-up (see
+    /// [`PhysicsWorld::set_player_crouch_hanging`]), which must be undone the
+    /// same way it was made.
+    pub fn is_hanging_crouched(&self) -> bool {
+        self.is_hanging_crouched
+    }
+
+    /// Whether a scripted mantle/top-out currently owns the body. Nothing else
+    /// may move it, resize it, or take a climb hold while it does.
+    pub fn is_topping_out(&self) -> bool {
+        self.top_out.is_some()
     }
 
     /// Ground contact reported by the last movement frame. Unlike a support
@@ -4400,6 +4458,7 @@ impl PhysicsWorld {
             controller,
             character_handle,
             is_crouched: false,
+            is_hanging_crouched: false,
             top_out: None,
             support: None,
             slope_displacement: Vector::zeros(),
@@ -4422,6 +4481,34 @@ impl PhysicsWorld {
         want_crouch: bool,
         player_handle: &mut PlayerHandle,
     ) -> bool {
+        self.set_player_crouch_anchored(want_crouch, player_crouch_center_shift(), player_handle)
+    }
+
+    /// Set the crouch state of a player whose weight hangs from their hands
+    /// (a VR climb hold - see [`crate::vr_climb`]), balling them up so their
+    /// knees clear the lip they are pulling over.
+    ///
+    /// Same capsules, anchored on the BODY CENTER instead of the feet: a
+    /// hanging body has no feet on anything, and the tracked hands and eye
+    /// ride that center, so planting the feet instead would drag the gripping
+    /// hand off its hold (the shift is larger than the grip's whole stretch
+    /// tolerance). Holding the center still makes the swap invisible to the
+    /// grip: the capsule shrinks toward the hands, which is what balling up
+    /// physically is.
+    pub fn set_player_crouch_hanging(
+        &mut self,
+        want_crouch: bool,
+        player_handle: &mut PlayerHandle,
+    ) -> bool {
+        self.set_player_crouch_anchored(want_crouch, 0.0, player_handle)
+    }
+
+    fn set_player_crouch_anchored(
+        &mut self,
+        want_crouch: bool,
+        center_shift: f32,
+        player_handle: &mut PlayerHandle,
+    ) -> bool {
         // Dark disables ordinary player motion while its mantle sequence is
         // active. In particular, do not resize the temporary head sphere in
         // response to a crouch edge part-way across a lip.
@@ -4434,8 +4521,6 @@ impl PhysicsWorld {
 
         let character_handle = player_handle.character_handle;
         let collider_handle = self.rigid_body_set[character_handle].colliders()[0];
-        // Feet-planted center shift between the two capsule sizes.
-        let center_shift = (PLAYER_STANDING_HEIGHT - PLAYER_CROUCH_HEIGHT) / 2.0 / SCALE_FACTOR;
 
         if want_crouch {
             self.collider_set[collider_handle].set_shape(crouched_player_shared_shape());
@@ -4444,6 +4529,7 @@ impl PhysicsWorld {
             translation.y -= center_shift;
             body.set_translation(translation, true);
             player_handle.is_crouched = true;
+            player_handle.is_hanging_crouched = center_shift == 0.0;
         } else {
             // Headroom check: intersect a test capsule at the feet-planted
             // standing pose against the same groups the movement casts use.
@@ -4528,6 +4614,7 @@ impl PhysicsWorld {
                 translation.y += center_shift;
                 body.set_translation(translation, true);
                 player_handle.is_crouched = false;
+                player_handle.is_hanging_crouched = false;
             }
         }
 
@@ -4837,6 +4924,74 @@ impl PhysicsWorld {
         player_handle.is_grounded = false;
         // Launched off whatever was carrying them, as a jump is.
         player_handle.support = None;
+    }
+
+    /// Start the scripted top-out (Dark's crouched up-and-forward mantle
+    /// waypoints, the same sequence flat runs at a ladder top) from wherever
+    /// the player currently hangs, heading `direction`.
+    ///
+    /// This is how a VR hand vault finishes: once the eye clears the lip
+    /// ([`crate::vr_climb::vault_ready`]) the hands have done all they can,
+    /// and the body is thrown over by the planner rather than hauled. Returns
+    /// whether a route was found - if not, nothing changes and the player
+    /// keeps climbing.
+    pub fn plan_hand_top_out(
+        &mut self,
+        direction: Vector3<f32>,
+        player_handle: &mut PlayerHandle,
+    ) -> bool {
+        if player_handle.top_out.is_some() {
+            return false;
+        }
+        let character_handle = player_handle.character_handle;
+        let character_pos = *self.rigid_body_set[character_handle].position();
+        let movement_filter = player_movement_filter(character_handle);
+        // The same three pipelines the flat ladder top-out plans against: the
+        // probes ignore the climbable the player is hanging off, and the
+        // scripted route may cross parentless terrain (see `ClimbPass`).
+        let not_climbable = |_handle: ColliderHandle, collider: &Collider| {
+            !collider
+                .collision_groups()
+                .memberships
+                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
+        };
+        let parented_non_climbable = |handle: ColliderHandle, collider: &Collider| {
+            collider.parent().is_some() && not_climbable(handle, collider)
+        };
+        // Plan before committing to anything: a refused route must leave the
+        // player exactly as they were, still holding on.
+        let planned = {
+            let dispatcher = self.narrow_phase.query_dispatcher();
+            let queries = self.player_movement_queries(dispatcher, movement_filter);
+            plan_climb_top_out(
+                &player_handle.controller,
+                &queries,
+                &queries.with_filter(movement_filter.predicate(&not_climbable)),
+                &queries.with_filter(movement_filter.predicate(&parented_non_climbable)),
+                &character_pos,
+                vec_to_nvec(direction),
+                0.0,
+                self.integration_parameters.dt,
+            )
+        };
+        let Some(planned) = planned else {
+            return false;
+        };
+        // The route is planned for, and ends by expanding, the STANDING
+        // capsule, so a body balled up on the hold un-balls here. Refuse the
+        // vault if it does not fit where the player hangs - they can keep
+        // pulling instead.
+        if player_handle.is_crouched && self.set_player_crouch_hanging(false, player_handle) {
+            return false;
+        }
+        player_handle.top_out = planned.top_out;
+        sync_top_out_collider(
+            &mut self.collider_set,
+            &mut self.rigid_body_set,
+            false,
+            player_handle,
+        );
+        true
     }
 
     /// The fixed timestep one movement frame integrates with. A velocity
@@ -5373,26 +5528,12 @@ impl PhysicsWorld {
         player_handle.top_out = player_movement.top_out;
         player_handle.slope_displacement = player_movement.slope_displacement;
         let is_top_out = player_handle.top_out.is_some();
-        let collider_handle = self.rigid_body_set[player_handle.character_handle].colliders()[0];
-        if !was_top_out && is_top_out {
-            let compressed_radius = if player_handle
-                .top_out
-                .is_some_and(|top_out| top_out.is_crouched)
-            {
-                PLAYER_CROUCH_RADIUS / SCALE_FACTOR
-            } else {
-                CLIMB_TOP_OUT_RADIUS
-            };
-            self.collider_set[collider_handle].set_shape(SharedShape::ball(compressed_radius));
-        } else if was_top_out && !is_top_out {
-            let restored = if player_handle.is_crouched {
-                crouched_player_shared_shape()
-            } else {
-                standing_player_shared_shape()
-            };
-            self.collider_set[collider_handle].set_shape(restored);
-        }
-        self.rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
+        sync_top_out_collider(
+            &mut self.collider_set,
+            &mut self.rigid_body_set,
+            was_top_out,
+            player_handle,
+        );
         let scripted_top_out_frame = was_top_out || is_top_out;
         let mvt = player_movement.movement;
         let actor_collisions = player_movement.actor_collisions;
@@ -7613,6 +7754,34 @@ mod tests {
             world.get_player_save_translation(&player),
             Err(PlayerSavePoseError::UnsupportedPose),
             "a falling player with no walkable support must not brick a save slot"
+        );
+    }
+
+    /// A hanging ball-up must be invisible to the hand holding the player up:
+    /// the tracked hands ride the body center, and moving it by the ordinary
+    /// feet-planted crouch shift (0.64 wu) would exceed the grip's whole
+    /// stretch tolerance (0.6 wu) and drop them off the hold.
+    #[test]
+    fn a_hanging_crouch_shrinks_the_capsule_without_moving_the_body() {
+        let mut world = PhysicsWorld::new();
+        let mut player =
+            world.create_player(vec3(0.0, 3.0, 0.0), EntityId::from_inner(2104).unwrap());
+        // Standing up consults the broad phase, which only exists after a step.
+        step(&mut world, &mut player, 1);
+        let hanging = world.get_player_translation(&player);
+
+        assert!(world.set_player_crouch_hanging(true, &mut player));
+        assert_eq!(world.get_player_translation(&player), hanging);
+        assert!(!world.set_player_crouch_hanging(false, &mut player));
+        assert_eq!(world.get_player_translation(&player), hanging);
+
+        // The feet-planted crouch the flat runtime uses moves it, which is
+        // exactly what the hanging variant exists to avoid.
+        assert!(world.set_player_crouch(true, &mut player));
+        assert!(
+            (world.get_player_translation(&player).y - hanging.y + player_crouch_center_shift())
+                .abs()
+                < 1.0e-5,
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3186,6 +3186,9 @@ impl PhysicsWorld {
             nvec_to_cgmath(*self.rigid_body_set[player_handle.character_handle].translation());
         self.translate_held_melee_for_player_relocation(position - previous);
         player_handle.top_out = None;
+        // Relocated, so they are no longer hanging off anything: the stance
+        // they are in is now an ordinary crouch, undone feet-planted.
+        player_handle.is_hanging_crouched = false;
         player_handle.slope_displacement = Vector::zeros();
         player_handle.is_grounded = false;
         player_handle.jump_velocity = None;

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -8,7 +8,11 @@ use std::collections::VecDeque;
 
 use cgmath::{InnerSpace, Quaternion, Rotation, Vector3, Zero};
 
-use crate::{physics::ClimbGrip, virtual_hand::hand_world_position, vr_config::Handedness};
+use crate::{
+    physics::{ClimbGrip, ClimbGripKind},
+    virtual_hand::hand_world_position,
+    vr_config::Handedness,
+};
 
 /// How far a gripping hand may drift from the point it grabbed before the grip
 /// breaks. The drift IS the body's failure to follow: the body is cast every
@@ -32,6 +36,30 @@ pub(crate) const CLIMB_RELEASE_MAX_UP_SPEED: f32 = crate::physics::PLAYER_JUMP_L
 /// Below this a release is just letting go: not worth putting the body into a
 /// ballistic arc (world units/s).
 pub(crate) const CLIMB_RELEASE_MIN_SPEED: f32 = 0.5;
+
+/// How far the eye must clear a ledge's lip before the body vaults onto it
+/// (world units). Small: the moment the head is over the top is the moment a
+/// climber commits, and waiting longer just makes the pull feel sticky.
+pub const VAULT_EYE_MARGIN: f32 = 0.1;
+
+/// Whether the player has pulled far enough up a ledge to be thrown onto it.
+///
+/// The head-over-the-lip convention (Boneworks, Blade & Sorcery): once the eye
+/// clears the surface the anchor hand is lying ON, the climb is over and the
+/// scripted top-out takes the body the rest of the way. A ladder rail offers no
+/// vault - a hand reaching over a ladder's top onto the deck behind it takes a
+/// `Ledge` grip on that deck, and vaults from there.
+///
+/// `anchor_on_top_surface` is the hand's contact normal being walkable: a hand
+/// hooked on a lip's vertical face is not yet on top of anything.
+pub fn vault_ready(
+    eye_y: f32,
+    lip_y: f32,
+    anchor_kind: ClimbGripKind,
+    anchor_on_top_surface: bool,
+) -> bool {
+    anchor_kind == ClimbGripKind::Ledge && anchor_on_top_surface && eye_y > lip_y + VAULT_EYE_MARGIN
+}
 
 /// The body velocity a release throws the player with, from the anchor hand's
 /// recent per-frame travel relative to the pawn (newest last).
@@ -253,6 +281,28 @@ impl HandClimb {
     /// The hand currently moving the body, if any.
     pub fn anchor(&self) -> Option<Handedness> {
         self.anchor
+    }
+
+    /// The hold the anchor hand is on, if any.
+    pub fn anchor_grip(&self) -> Option<&GripAnchor> {
+        self.grips[slot(self.anchor?)].as_ref()
+    }
+
+    /// Whether any hand is on a ledge - the body balls up while it is.
+    pub fn holds_a_ledge(&self) -> bool {
+        self.grips()
+            .any(|(_, anchor)| anchor.grip.kind == ClimbGripKind::Ledge)
+    }
+
+    /// Drop every hold without throwing the body: the vault took over, and it
+    /// is not the player letting go. The still-closed squeeze cannot re-grab
+    /// (a grab needs a fresh press), so the hands stay out of the way until
+    /// the scripted top-out has finished.
+    pub fn release_all(&mut self) {
+        self.grips = [None, None];
+        self.anchor = None;
+        self.recent_anchor_travel.clear();
+        self.last_anchor_local = None;
     }
 
     /// Every hand that holds a hold, with the hold it holds.
@@ -700,6 +750,95 @@ mod tests {
         let handoff = step(&mut climb, [hand(at, 0.0), hand(right, 1.0)], false);
         assert_eq!(handoff.launch, None);
         assert_eq!(climb.anchor(), Some(Handedness::Right));
+    }
+
+    #[test]
+    fn the_eye_must_clear_the_lip_of_a_ledge_the_hand_is_lying_on() {
+        // On the top surface, eye over the lip: vault.
+        assert!(vault_ready(6.2, 6.0, ClimbGripKind::Ledge, true));
+        // Still below it, or only just level with it: keep pulling.
+        assert!(!vault_ready(5.9, 6.0, ClimbGripKind::Ledge, true));
+        assert!(!vault_ready(
+            6.0 + VAULT_EYE_MARGIN,
+            6.0,
+            ClimbGripKind::Ledge,
+            true
+        ));
+        // Hooked on the lip's vertical face, not lying on the top.
+        assert!(!vault_ready(6.2, 6.0, ClimbGripKind::Ledge, false));
+        // A ladder rail is never a vault, however high the eye gets.
+        assert!(!vault_ready(9.0, 6.0, ClimbGripKind::Ladder, true));
+    }
+
+    #[test]
+    fn a_stance_swap_that_leaves_the_pawn_where_it_is_neither_moves_nor_breaks_the_grip() {
+        // The hands hang off the pawn origin, so the ONLY thing a capsule swap
+        // could do to a grip is move that origin - see
+        // `PhysicsWorld::set_player_crouch_hanging`, which holds it still. A
+        // full crouch's worth of shape change is therefore this: nothing.
+        let mut climb = HandClimb::default();
+        let pawn = vec3(0.0, 1.24, 0.0);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+        let ledge = |point: Vector3<f32>| ClimbGrip {
+            kind: ClimbGripKind::Ledge,
+            normal: vec3(0.0, 1.0, 0.0),
+            ..ladder_grip(point)
+        };
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(reach, 1.0)],
+            |p| Some(ledge(p)),
+            |_| true,
+        );
+        assert!(climb.holds_a_ledge());
+
+        let swapped = climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(reach, 1.0)],
+            |_| None,
+            |_| true,
+        );
+        assert_translation(swapped, Vector3::zero());
+        assert_eq!(climb.grips().count(), 1);
+    }
+
+    #[test]
+    fn a_vault_drops_every_hold_without_throwing_the_body() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+        let step = |climb: &mut HandClimb, at: Vector3<f32>, probe: bool| {
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(at, 1.0)],
+                |p| probe.then(|| ladder_grip(p)),
+                |_| true,
+            )
+        };
+        step(&mut climb, reach, true);
+        let mut at = reach;
+        for _ in 0..4 {
+            at += vec3(0.0, -0.1, 0.0);
+            step(&mut climb, at, false);
+        }
+
+        climb.release_all();
+        assert_eq!(climb.grips().count(), 0);
+        assert_eq!(climb.anchor(), None);
+
+        // The squeeze is still down, so the hand cannot take a new hold while
+        // the scripted top-out is running, and nothing is thrown.
+        let after = step(&mut climb, at, true);
+        assert_eq!(after.translation, None);
+        assert_eq!(after.launch, None);
     }
 
     #[test]

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -52,13 +52,22 @@ pub const VAULT_EYE_MARGIN: f32 = 0.1;
 ///
 /// `anchor_on_top_surface` is the hand's contact normal being walkable: a hand
 /// hooked on a lip's vertical face is not yet on top of anything.
+///
+/// The vault has to be EARNED, hence `eye_y_at_grab`: the eye must have risen
+/// past the lip while the hand held it. Without that, every crate, console and
+/// railing a standing player can already see over would throw them on top of
+/// it the instant they squeezed - leaning on a chest-high box is not a mantle.
 pub fn vault_ready(
     eye_y: f32,
+    eye_y_at_grab: f32,
     lip_y: f32,
     anchor_kind: ClimbGripKind,
     anchor_on_top_surface: bool,
 ) -> bool {
-    anchor_kind == ClimbGripKind::Ledge && anchor_on_top_surface && eye_y > lip_y + VAULT_EYE_MARGIN
+    anchor_kind == ClimbGripKind::Ledge
+        && anchor_on_top_surface
+        && eye_y_at_grab <= lip_y
+        && eye_y > lip_y + VAULT_EYE_MARGIN
 }
 
 /// The body velocity a release throws the player with, from the anchor hand's
@@ -105,6 +114,9 @@ pub struct ClimbFrame {
 pub struct GripAnchor {
     pub grip: ClimbGrip,
     pub hand_world_at_grab: Vector3<f32>,
+    /// Where the body was when this hold was taken, so a vault can tell a pull
+    /// from a grab (see [`vault_ready`]).
+    pub pawn_at_grab: Vector3<f32>,
 }
 
 /// One hand's per-frame climb input.
@@ -221,6 +233,7 @@ impl HandClimb {
                         self.grips[index] = Some(GripAnchor {
                             grip,
                             hand_world_at_grab: hand_world[index],
+                            pawn_at_grab: pawn_pos,
                         });
                         // Last hand to grab drives the body.
                         self.anchor = Some(HANDS[index]);
@@ -754,28 +767,28 @@ mod tests {
 
     #[test]
     fn the_eye_must_clear_the_lip_of_a_ledge_the_hand_is_lying_on() {
-        // On the top surface, eye over the lip: vault.
-        assert!(vault_ready(6.2, 6.0, ClimbGripKind::Ledge, true));
+        // Grabbed from below the lip, pulled until the eye cleared it: vault.
+        assert!(vault_ready(6.2, 5.0, 6.0, ClimbGripKind::Ledge, true));
         // Still below it, or only just level with it: keep pulling.
-        assert!(!vault_ready(5.9, 6.0, ClimbGripKind::Ledge, true));
+        assert!(!vault_ready(5.9, 5.0, 6.0, ClimbGripKind::Ledge, true));
         assert!(!vault_ready(
             6.0 + VAULT_EYE_MARGIN,
+            5.0,
             6.0,
             ClimbGripKind::Ledge,
             true
         ));
+        // Never pulled at all: a standing player who grabs a chest-high crate
+        // was already looking over it, and leaning on it is not a mantle.
+        assert!(!vault_ready(6.2, 6.2, 6.0, ClimbGripKind::Ledge, true));
         // Hooked on the lip's vertical face, not lying on the top.
-        assert!(!vault_ready(6.2, 6.0, ClimbGripKind::Ledge, false));
+        assert!(!vault_ready(6.2, 5.0, 6.0, ClimbGripKind::Ledge, false));
         // A ladder rail is never a vault, however high the eye gets.
-        assert!(!vault_ready(9.0, 6.0, ClimbGripKind::Ladder, true));
+        assert!(!vault_ready(9.0, 5.0, 6.0, ClimbGripKind::Ladder, true));
     }
 
     #[test]
-    fn a_stance_swap_that_leaves_the_pawn_where_it_is_neither_moves_nor_breaks_the_grip() {
-        // The hands hang off the pawn origin, so the ONLY thing a capsule swap
-        // could do to a grip is move that origin - see
-        // `PhysicsWorld::set_player_crouch_hanging`, which holds it still. A
-        // full crouch's worth of shape change is therefore this: nothing.
+    fn only_a_ledge_hold_balls_the_body_up_and_it_remembers_where_it_was_taken() {
         let mut climb = HandClimb::default();
         let pawn = vec3(0.0, 1.24, 0.0);
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
@@ -785,26 +798,44 @@ mod tests {
             normal: vec3(0.0, 1.0, 0.0),
             ..ladder_grip(point)
         };
+
+        // A ladder rung is not something to ball up on.
         climb.update(
             pawn,
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
+            |p| Some(ladder_grip(p)),
+            |_| true,
+        );
+        assert!(!climb.holds_a_ledge());
+
+        // The other hand takes a ledge: now it is, and the anchor records the
+        // body pose that grab was made from - what tells a pull from a grab.
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [hand(reach, 1.0), hand(reach, 1.0)],
             |p| Some(ledge(p)),
             |_| true,
         );
         assert!(climb.holds_a_ledge());
+        assert_eq!(climb.anchor(), Some(Handedness::Left));
+        assert_eq!(climb.anchor_grip().unwrap().pawn_at_grab, pawn);
 
-        let swapped = climb.update(
-            pawn,
+        // Hauling the body up does not rewrite it: the pull is measured from
+        // where the hold was taken, however far the body has since travelled.
+        let lifted = pawn + vec3(0.0, 0.4, 0.0);
+        climb.update(
+            lifted,
             identity,
             DT,
-            [no_hand(), hand(reach, 1.0)],
+            [hand(reach, 1.0), hand(reach, 1.0)],
             |_| None,
             |_| true,
         );
-        assert_translation(swapped, Vector3::zero());
-        assert_eq!(climb.grips().count(), 1);
+        assert_eq!(climb.anchor_grip().unwrap().pawn_at_grab, pawn);
     }
 
     #[test]

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -566,6 +566,9 @@ export interface ClimbHold {
  * into them and holds nothing, so `is_climbing` is not implied by `grips`. */
 export interface ClimbState {
   is_climbing: boolean;
+  /** A scripted top-out is carrying the body over a lip: the second half of a
+   * VR hand vault, and flat's ladder mantle. */
+  vaulting: boolean;
   /** The hand currently moving the body, or null. */
   anchor_hand: "left" | "right" | null;
   grips: ClimbHold[];

--- a/tools/shock2-sdk/test/vr-vault.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-vault.e2e.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { vrHandLocal, vrHandLocalDelta } from "./helpers/vr-climb.js";
+
+// Finishing the mantle: a hand on a ledge gets the body onto it. Once the eye
+// clears the lip the hand is lying on, the grips let go and the scripted
+// top-out throws the body over. Driven on the debug_ladder scene (see
+// shock2vr/src/scenes/debug_ladder.rs).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** Capsule-center height of a player standing on a surface at height `top`. */
+const standingOn = (top: number) => top + 1.24;
+
+/** Mantle station (z = 24): a 3 wu block with no ladder. */
+const MANTLE_Z = 24;
+const MANTLE_TOP = 3.0;
+/** Ledge station (z = 0): a 6 wu block with a 16' ladder on its near face. */
+const LEDGE_Z = 0;
+const LEDGE_TOP = 6.0;
+/** Plain, non-climbable block (z = -16). */
+const WALL_Z = -16;
+
+/** Scripted top-out substeps are capped at 0.067 wu/frame. */
+const MAX_SCRIPTED_STEP = 0.1;
+
+const launchVr = () =>
+  GameServer.launch({ mission: "debug_ladder", debugFlags: ["--vr"] });
+
+async function standAt(game: GameServer, at: Vec3) {
+  await game.step({ frames: 5 });
+  await teleportVerified(game, { x: at[0], y: at[1], z: at[2] });
+  await game.step({ frames: 30 });
+}
+
+/** Close an open hand on a world point, and report what it took hold of. */
+async function grab(
+  game: GameServer,
+  hand: "left" | "right",
+  world: Vec3,
+): Promise<Vec3> {
+  const local = await vrHandLocal(game, world);
+  await game.input.set(`${hand}_hand.position`, local);
+  await game.input.set(`${hand}_hand.squeeze`, 0);
+  await game.step({ frames: 1 });
+  await game.input.set(`${hand}_hand.squeeze`, 1);
+  await game.step({ frames: 1 });
+  return local;
+}
+
+/** Step one frame at a time, collecting the body height each frame. */
+async function stepTrackingHeight(
+  game: GameServer,
+  frames: number,
+): Promise<number[]> {
+  const heights: number[] = [];
+  for (let i = 0; i < frames; i += 1) {
+    await game.step({ frames: 1 });
+    heights.push((await game.info()).player.position[1]);
+  }
+  return heights;
+}
+
+function assertNoJumps(heights: number[], label: string) {
+  for (let i = 1; i < heights.length; i += 1) {
+    assert.ok(
+      Math.abs(heights[i] - heights[i - 1]) < MAX_SCRIPTED_STEP,
+      `${label}: the body jumped ${heights[i - 1]} -> ${heights[i]} in one frame`,
+    );
+  }
+}
+
+test(
+  "debug_ladder (VR): pulling the eye over a mantle lip vaults onto the block",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAt(game, [-5.5, 1.5, MANTLE_Z]);
+
+    const atGrab = await grab(game, "right", [-7.2, 3.05, MANTLE_Z]);
+    const grabbed = (await game.info()).player.climb;
+    assert.equal(grabbed.grips.length, 1);
+    assert.equal(grabbed.grips[0].kind, "ledge");
+    assert.equal(grabbed.vaulting, false);
+
+    // Haul down until the head clears the lip. The eye sits 1.04 wu above the
+    // body center, so ~0.9 wu of pull puts it over a 3.0 lip.
+    const PULL = 1.2;
+    const FRAMES = 40;
+    const down = await vrHandLocalDelta(game, [0, -PULL, 0]);
+    const heights: number[] = [];
+    let vaulted = false;
+    for (let frame = 1; frame <= FRAMES && !vaulted; frame += 1) {
+      await game.input.set("right_hand.position", [
+        atGrab[0] + (down[0] * frame) / FRAMES,
+        atGrab[1] + (down[1] * frame) / FRAMES,
+        atGrab[2] + (down[2] * frame) / FRAMES,
+      ]);
+      heights.push(...(await stepTrackingHeight(game, 1)));
+      vaulted = (await game.info()).player.climb.vaulting;
+    }
+    assert.ok(vaulted, "the pull should have started a vault");
+    assert.equal(
+      (await game.info()).player.climb.grips.length,
+      0,
+      "a vault lets go of everything",
+    );
+
+    // Let the scripted top-out run to its landing, then settle.
+    for (let elapsed = 0; elapsed < 240; elapsed += 1) {
+      heights.push(...(await stepTrackingHeight(game, 1)));
+      if (!(await game.info()).player.climb.vaulting) break;
+    }
+    heights.push(...(await stepTrackingHeight(game, 60)));
+
+    const landed = (await game.info()).player;
+    assert.equal(landed.climb.vaulting, false);
+    assert.equal(landed.climb.grips.length, 0);
+    assert.ok(
+      Math.abs(landed.position[1] - standingOn(MANTLE_TOP)) < 0.15,
+      `expected to stand on the block (y ~= ${standingOn(MANTLE_TOP)}), got ${landed.position[1]}`,
+    );
+    assert.ok(
+      landed.position[0] < -7.0,
+      `expected to end past the block's near face, got x ${landed.position[0]}`,
+    );
+    assertNoJumps(heights, "mantle vault");
+  },
+);
+
+test(
+  "debug_ladder (VR): a hand on the ledge top vaults off the ladder",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAt(game, [-5.5, 1.5, LEDGE_Z]);
+
+    // Hand over hand up the near-face ladder. Hands are tracked in PAWN space,
+    // so one reach height serves every cycle - the same reach lands on a
+    // higher rung as the body rises.
+    const reach = await vrHandLocal(game, [-6.8, 2.6, LEDGE_Z]);
+    const PULL = 0.5;
+    const FRAMES = 10;
+    const down = await vrHandLocalDelta(game, [0, -PULL, 0]);
+    const lowered: Vec3 = [
+      reach[0] + down[0],
+      reach[1] + down[1],
+      reach[2] + down[2],
+    ];
+
+    let pulling: "left" | "right" = "right";
+    await grab(game, pulling, [-6.8, 2.6, LEDGE_Z]);
+    for (let half = 0; half < 8; half += 1) {
+      if ((await game.info()).player.position[1] > 4.5) break;
+      for (let frame = 1; frame <= FRAMES; frame += 1) {
+        await game.input.set(`${pulling}_hand.position`, [
+          reach[0] + (down[0] * frame) / FRAMES,
+          reach[1] + (down[1] * frame) / FRAMES,
+          reach[2] + (down[2] * frame) / FRAMES,
+        ]);
+        await game.step({ frames: 1 });
+      }
+      const other: "left" | "right" = pulling === "right" ? "left" : "right";
+      await game.input.set(`${other}_hand.position`, reach);
+      await game.input.set(`${other}_hand.squeeze`, 0);
+      await game.step({ frames: 1 });
+      await game.input.set(`${other}_hand.squeeze`, 1);
+      await game.step({ frames: 1 });
+      await game.input.set(`${pulling}_hand.squeeze`, 0);
+      await game.input.set(`${pulling}_hand.position`, lowered);
+      await game.step({ frames: 1 });
+      pulling = other;
+    }
+    const climbed = (await game.info()).player;
+    assert.ok(
+      climbed.position[1] > 4.7,
+      `hand over hand only reached ${climbed.position[1]}`,
+    );
+    assert.equal(climbed.climb.grips[0].kind, "ladder");
+    assert.equal(climbed.climb.vaulting, false, "a ladder rail never vaults");
+
+    // Reach over the ladder's top onto the block's top surface: that is a
+    // ledge, and the eye is still under it, so the vault waits for the pull.
+    const other: "left" | "right" = pulling === "right" ? "left" : "right";
+    const onTop = await grab(game, other, [-7.6, 6.05, LEDGE_Z]);
+    const held = (await game.info()).player.climb;
+    assert.equal(held.anchor_hand, other);
+    assert.equal(
+      held.grips.find((grip) => grip.hand === other)?.kind,
+      "ledge",
+      "the block's top surface is a ledge hold",
+    );
+
+    const topOut = await vrHandLocalDelta(game, [0, -0.8, 0]);
+    const heights: number[] = [];
+    let vaulted = false;
+    for (let frame = 1; frame <= 40 && !vaulted; frame += 1) {
+      await game.input.set(`${other}_hand.position`, [
+        onTop[0] + (topOut[0] * frame) / 40,
+        onTop[1] + (topOut[1] * frame) / 40,
+        onTop[2] + (topOut[2] * frame) / 40,
+      ]);
+      heights.push(...(await stepTrackingHeight(game, 1)));
+      vaulted = (await game.info()).player.climb.vaulting;
+    }
+    assert.ok(vaulted, "the eye clearing 6.0 should have started a vault");
+
+    for (let elapsed = 0; elapsed < 240; elapsed += 1) {
+      heights.push(...(await stepTrackingHeight(game, 1)));
+      if (!(await game.info()).player.climb.vaulting) break;
+    }
+    heights.push(...(await stepTrackingHeight(game, 60)));
+
+    const landed = (await game.info()).player;
+    assert.equal(landed.climb.grips.length, 0);
+    assert.ok(
+      Math.abs(landed.position[1] - standingOn(LEDGE_TOP)) < 0.15,
+      `expected to stand on the block (y ~= ${standingOn(LEDGE_TOP)}), got ${landed.position[1]}`,
+    );
+    assertNoJumps(heights, "ledge vault");
+  },
+);
+
+test(
+  "debug_ladder (VR): a plain wall and a low eye never vault",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+
+    // The plain wall offers no hold at all, so there is nothing to vault from.
+    await standAt(game, [-5.5, 1.5, WALL_Z]);
+    await grab(game, "right", [-6.9, 2.6, WALL_Z]);
+    let climb = (await game.info()).player.climb;
+    assert.equal(climb.grips.length, 0);
+    assert.equal(climb.vaulting, false);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 1 });
+
+    // On the ledge ladder with the eye far below the block top, pulling climbs
+    // and nothing else.
+    await standAt(game, [-5.5, 1.5, LEDGE_Z]);
+    const atGrab = await grab(game, "right", [-6.8, 2.6, LEDGE_Z]);
+    const down = await vrHandLocalDelta(game, [0, -1.0, 0]);
+    for (let frame = 1; frame <= 30; frame += 1) {
+      await game.input.set("right_hand.position", [
+        atGrab[0] + (down[0] * frame) / 30,
+        atGrab[1] + (down[1] * frame) / 30,
+        atGrab[2] + (down[2] * frame) / 30,
+      ]);
+      await game.step({ frames: 1 });
+      assert.equal(
+        (await game.info()).player.climb.vaulting,
+        false,
+        `vaulted at frame ${frame} with the eye far below the lip`,
+      );
+    }
+    climb = (await game.info()).player.climb;
+    assert.equal(climb.grips.length, 1);
+    assert.equal(climb.grips[0].kind, "ladder");
+  },
+);
+
+test(
+  "debug_ladder (VR): letting go of a ledge before the vault just drops you",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await launchVr();
+    await standAt(game, [-5.5, 1.5, MANTLE_Z]);
+    const floorY = (await game.info()).player.position[1];
+
+    const atGrab = await grab(game, "right", [-7.2, 3.05, MANTLE_Z]);
+    // A short, slow pull: the eye stays under the lip the whole way.
+    const down = await vrHandLocalDelta(game, [0, -0.3, 0]);
+    for (let frame = 1; frame <= 40; frame += 1) {
+      await game.input.set("right_hand.position", [
+        atGrab[0] + (down[0] * frame) / 40,
+        atGrab[1] + (down[1] * frame) / 40,
+        atGrab[2] + (down[2] * frame) / 40,
+      ]);
+      await game.step({ frames: 1 });
+      assert.equal((await game.info()).player.climb.vaulting, false);
+    }
+
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 90 });
+    const dropped = (await game.info()).player;
+    assert.equal(dropped.climb.vaulting, false, "a release is not a vault");
+    assert.equal(dropped.climb.grips.length, 0);
+    assert.ok(
+      Math.abs(dropped.position[1] - floorY) < 0.2,
+      `expected a fall back to the floor (${floorY}), got ${dropped.position[1]}`,
+    );
+  },
+);


### PR DESCRIPTION
Finishes the mantle: a hand on a ledge can now get the body onto it. PR 5 of the VR hand-climbing stack, on top of #1236.

**Ball up while hanging.** While a hand holds a `Ledge` and the body is off the ground, the collider swaps to the crouched capsule so the knees clear the lip being pulled over. The swap is anchored on the body CENTER, not the feet (`set_player_crouch_hanging`): the tracked hands ride that center, and the ordinary feet-planted shift (0.64 wu) is larger than the grip's whole stretch tolerance (0.6 wu), so planting the feet would drag the hand off its hold. A `CrouchAnchor` records which way the crouch was made so it is undone the same way — except once the feet are back on something, where the ordinary feet-planted path takes over (a center-anchored expansion there would drive the standing capsule through the floor).

**Eye over the lip = vault.** `vr_climb::vault_ready` is a pure predicate: the anchor grip is a `Ledge` whose contact normal is walkable, the eye was BELOW the lip when the hold was taken, and it is now above it by 0.1 wu. The middle clause is what keeps leaning on a chest-high crate from being a mantle — the vault has to be pulled for. On that edge every grip is dropped (no launch: this is not the player letting go) and `PhysicsWorld::plan_hand_top_out` starts the existing scripted `plan_climb_top_out` route, aimed from the body toward the grip point, horizontalized. If the planner finds no landing nothing changes and the player keeps pulling hand over hand. A scripted top-out owns the body outright while it runs — no grip can be taken, and no capsule resized.

Ladder tops arrive through the same door: a hand reaching over a ladder's cap onto the deck behind it takes a `Ledge` grip on that deck, so the eye test uses the landing surface the planner will find rather than the ladder cap.

`/v1/info` `player.climb` gained `vaulting`.

### Tests

- 3 new `vr_climb` unit tests (vault predicate incl. the un-earned grab, ledge classification + grab-pose memory, vault releases without throwing) and 1 new physics test (a hanging swap resizes the capsule without moving the body, unlike the feet-planted one).
- 4 new e2e on `debug_ladder --vr` (`test/vr-vault.e2e.test.ts`): pull the eye over the 3 wu mantle lip and land standing on the block; climb the ledge ladder hand over hand, take the block's top surface, pull and vault onto it; the plain wall and a low eye never vault; releasing before the vault just drops you. All assert no per-frame jump beyond the scripted substep bound.
- Existing `vr-climb`, `climbing`, `debug-ladder`, `climb-grip` e2e and `cargo test -p shock2vr` green.


## Visuals

![VR ledge vault demo](https://gist.githubusercontent.com/tommy-xr/6a3017651f8aca6bd326dd3561cc1a76/raw/vault.gif)

<sub>`debug_ladder --vr`, mantle station: the right hand closes on the 3 wu block's lip, the pull hauls the body up the face, and once the eye clears the lip the grips let go and the scripted top-out throws the body onto the block (final capsule centre y = 4.24). Left = the player's own eye, right = a free camera to the side; same deterministic request sequence as `test/vr-vault.e2e.test.ts`. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, fixed-timestep).</sub>

Mid-vault still, the eye crossing the lip:

![mid-vault](https://gist.githubusercontent.com/tommy-xr/6a3017651f8aca6bd326dd3561cc1a76/raw/vault-still.png)
