### PR TITLE
feat(combat): give arachnids a hitbox per leg, and a spider pen in debug_melee

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,7 +490,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_joint_constraint` | Test physics joint constraints               |
    | `debug_hud`              | Test HUD rendering                           |
    | `debug_map`              | Test map/automap rendering                   |
-   | `debug_melee`            | VR melee: weapon rack, damageable creatures, trigger-free contact damage |
+   | `debug_melee`            | VR melee: weapon rack, hybrids and arachnids to hit, trigger-free contact damage |
    | `debug_ladder`           | Climbing stations: ledge top-out, two-sided arch, stacked rungs, short ladder, mantle block, plain wall (flat + VR) |
    | `debug_minimal`          | Bare minimum scene for basic testing         |
    | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `DebugCycleWeapon`) |

--- a/shock2vr/src/creature/creature_definitions.rs
+++ b/shock2vr/src/creature/creature_definitions.rs
@@ -143,8 +143,25 @@ pub const HUMANOID_JOINT_LIMITS: Lazy<Arc<HashMap<u32, JointLimit>>> = Lazy::new
 pub const EMPTY_JOINT_LIMITS: Lazy<Arc<HashMap<u32, JointLimit>>> =
     Lazy::new(|| Arc::new(HashMap::new()));
 
-pub const SPIDER_HIT_BOXES: Lazy<Arc<HashMap<u32, HitBoxType>>> =
-    Lazy::new(|| Arc::new(HashMap::from_iter(vec![(0, HitBoxType::Body)])));
+/// The arachnid skeleton: joint 0 is the body, 1-4 the two mandibles (root,
+/// elbow), then eight legs of three joints each - shoulder, elbow, wrist -
+/// four per side. The mapping is written whole so it does not depend on
+/// which joints the mesh happens to skin: in practice the mandible roots and
+/// six of the eight shoulders carry no vertices (nor do the claws and
+/// mandible tips, 29-38), so 21 of these 29 joints get a proxy.
+pub const SPIDER_HIT_BOXES: Lazy<Arc<HashMap<u32, HitBoxType>>> = Lazy::new(|| {
+    let mut hit_boxes = HashMap::from([(0, HitBoxType::Body)]);
+    // The mandibles are the bite: the spider's face.
+    for joint in 1..=4 {
+        hit_boxes.insert(joint, HitBoxType::Head);
+    }
+    for shoulder in (5..=26).step_by(3) {
+        hit_boxes.insert(shoulder, HitBoxType::Limb);
+        hit_boxes.insert(shoulder + 1, HitBoxType::Limb);
+        hit_boxes.insert(shoulder + 2, HitBoxType::Extremity);
+    }
+    Arc::new(hit_boxes)
+});
 
 pub const OVERLORD_HIT_BOXES: Lazy<Arc<HashMap<u32, HitBoxType>>> =
     Lazy::new(|| Arc::new(HashMap::from_iter(vec![(0, HitBoxType::Body)])));
@@ -342,5 +359,27 @@ mod tests {
         for (joint, part) in [(14, "left hand"), (15, "right hand")] {
             assert_eq!(worth(joint), Some(0.5), "{part}");
         }
+    }
+
+    /// The spider map covers the whole skeleton: body, both mandibles, and
+    /// every joint of all eight legs - the shoulder and elbow as near limb,
+    /// the wrist as far. The claws are not mapped.
+    #[test]
+    fn spider_joints_are_mapped_leg_by_leg() {
+        let map = SPIDER_HIT_BOXES.clone();
+        let worth = |joint: u32| map.get(&joint).copied().map(HitBoxType::damage_multiplier);
+
+        assert_eq!(map.len(), 29);
+        assert_eq!(worth(0), Some(1.0), "body");
+        for joint in 1..=4 {
+            assert_eq!(worth(joint), Some(1.25), "mandible {joint}");
+        }
+        for leg in 0..8 {
+            let shoulder = 5 + leg * 3;
+            assert_eq!(worth(shoulder), Some(0.75), "leg {leg} shoulder");
+            assert_eq!(worth(shoulder + 1), Some(0.75), "leg {leg} elbow");
+            assert_eq!(worth(shoulder + 2), Some(0.5), "leg {leg} wrist");
+        }
+        assert_eq!(worth(29), None, "claw");
     }
 }

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -40,11 +40,10 @@ pub(crate) fn is_hit_box(world: &World, entity_id: EntityId) -> bool {
 /// Whether a creature's hitboxes stand in for its *body*, i.e. whether missing
 /// all of them means the shot missed the creature.
 ///
-/// A definition that maps one `Body` joint (`SPIDER_HIT_BOXES`,
-/// `OVERLORD_HIT_BOXES`) leaves the legs and limbs with no proxy at all, so
-/// treating a miss on that one blob as a miss on the animal would make whole
-/// bands of it unshootable. Those creatures keep their capsule; widening their
-/// definitions is what would let them join the rule.
+/// A definition that maps one `Body` joint (`OVERLORD_HIT_BOXES`) leaves the
+/// limbs with no proxy at all, so treating a miss on that one blob as a miss
+/// on the animal would make whole bands of it unshootable. That creature keeps
+/// its capsule; widening its definition is what would let it join the rule.
 pub(crate) fn hit_boxes_cover_body(world: &World, entity_id: EntityId) -> bool {
     crate::creature::get_entity_creature(world, entity_id)
         .is_some_and(|creature| creature.hit_boxes.len() > 1)
@@ -189,12 +188,11 @@ impl HitBoxManager {
     /// nominal cylinder rather than the creature - and frames the same
     /// cylinder whatever the creature is doing.
     ///
-    /// A definition that maps a single `Body` joint (the arachnids and the
-    /// Overlord) gets a body-only frame, legs excluded - measured on hydro3's
-    /// Baby Arachnids at 0.33-0.58 across, against a 0.40 collider. Neither is
-    /// the animal: the shipped creature colliders are their own known problem
-    /// (#904). The hitbox is at least measured from the mesh, so it is what is
-    /// used, and widening those definitions is the fix worth making.
+    /// A definition that maps a single `Body` joint (the Overlord) gets a
+    /// body-only frame, limbs excluded. That is not the animal either - the
+    /// shipped creature colliders are their own known problem (#904) - but the
+    /// hitbox is at least measured from the mesh, so it is what is used, and
+    /// widening that definition is the fix worth making.
     ///
     /// The boxes are world AABBs of the *rotated* proxy shapes, so a diagonal
     /// limb contributes a little more than its thickness. The extremes come
@@ -516,9 +514,9 @@ mod tests {
         );
     }
 
-    /// A creature that maps a single `Body` hitbox (the arachnids, the
-    /// Overlord) still gets that hitbox's bounds - it is measured from the
-    /// mesh, unlike the capsule beside it.
+    /// A creature that maps a single `Body` hitbox (the Overlord) still gets
+    /// that hitbox's bounds - it is measured from the mesh, unlike the capsule
+    /// beside it.
     #[test]
     fn a_single_hit_box_still_gives_bounds() {
         let mut world = World::new();

--- a/shock2vr/src/scenes/debug_melee.rs
+++ b/shock2vr/src/scenes/debug_melee.rs
@@ -47,9 +47,20 @@ const MELEE_WEAPONS: &[(i32, &str)] = &[
 /// resolves through the authored stim/receptron path rather than a stand-in.
 const TARGET_CREATURE: i32 = -397;
 
-/// Distances (world units) ahead of the player for the target row, inside the
-/// pen. Spaced so a swing can only ever reach one of them.
-const TARGET_DISTANCES: &[f32] = &[8.0, 10.0, 12.0];
+/// The targets: (template, distance ahead of the player, pen centre line z).
+/// The hybrids stand in the pen ahead, spaced so a swing can only ever reach
+/// one of them; the arachnids in the pen beside it. A spider is the other
+/// skeleton the hitbox tables have to fit - low, wide, eight legs - so the
+/// bench keeps one of each size. The plain Arachnid template (-2013) is
+/// abstract - no model - so the adult is the boss-mesh variant the missions
+/// actually place, -1439.
+const TARGETS: &[(i32, f32, f32)] = &[
+    (TARGET_CREATURE, 8.0, 0.0),
+    (TARGET_CREATURE, 10.0, 0.0),
+    (TARGET_CREATURE, 12.0, 0.0),
+    (-1439, 9.0, SPIDER_PEN_Z),
+    (-2014, 11.0, SPIDER_PEN_Z),
+];
 
 /// The creatures stand in a walled corridor that opens toward the player. They
 /// are live AI and will charge, which is the point - but the walls keep them
@@ -67,6 +78,11 @@ const PEN_NEAR: f32 = 5.0;
 const PEN_FAR: f32 = 12.5;
 const PEN_HALF_WIDTH: f32 = 2.5;
 const PEN_WALL_HEIGHT: f32 = 4.0;
+const PEN_WALL_THICKNESS: f32 = 1.0;
+
+/// Centre line (z) of the spider pen: the same corridor again, laid alongside
+/// the hybrids' one on +Z, wall to wall.
+const SPIDER_PEN_Z: f32 = 2.0 * PEN_HALF_WIDTH + PEN_WALL_THICKNESS;
 
 /// Distance to the wall the player can swing into, straight ahead. Also the
 /// pen's back wall.
@@ -104,31 +120,31 @@ pub fn create_debug_melee_scene(
             vec3(-RACK_DISTANCE, RACK_HEIGHT / 2.0, 0.0),
             vec3(0.6, RACK_HEIGHT, 3.0),
         ),
-        // corridor: back wall (also the surface to swing into) and two sides
+        // back wall (also the surface to swing into), spanning both pens
         (
             vec3(0.45, 0.45, 0.5),
-            vec3(-WALL_DISTANCE, PEN_WALL_HEIGHT / 2.0, 0.0),
-            vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
-        ),
-        (
-            vec3(0.40, 0.40, 0.45),
+            vec3(-WALL_DISTANCE, PEN_WALL_HEIGHT / 2.0, SPIDER_PEN_Z / 2.0),
             vec3(
-                -(PEN_NEAR + PEN_FAR) / 2.0,
-                PEN_WALL_HEIGHT / 2.0,
-                -PEN_HALF_WIDTH,
+                PEN_WALL_THICKNESS,
+                PEN_WALL_HEIGHT,
+                2.0 * PEN_HALF_WIDTH + SPIDER_PEN_Z,
             ),
-            vec3(PEN_FAR - PEN_NEAR, PEN_WALL_HEIGHT, 1.0),
-        ),
-        (
-            vec3(0.40, 0.40, 0.45),
-            vec3(
-                -(PEN_NEAR + PEN_FAR) / 2.0,
-                PEN_WALL_HEIGHT / 2.0,
-                PEN_HALF_WIDTH,
-            ),
-            vec3(PEN_FAR - PEN_NEAR, PEN_WALL_HEIGHT, 1.0),
         ),
     ];
+    // corridor sides: the hybrids' pen on the centre line, the spiders' beside it
+    for pen_z in [0.0, SPIDER_PEN_Z] {
+        for side in [-PEN_HALF_WIDTH, PEN_HALF_WIDTH] {
+            boxes.push((
+                vec3(0.40, 0.40, 0.45),
+                vec3(
+                    -(PEN_NEAR + PEN_FAR) / 2.0,
+                    PEN_WALL_HEIGHT / 2.0,
+                    pen_z + side,
+                ),
+                vec3(PEN_FAR - PEN_NEAR, PEN_WALL_HEIGHT, PEN_WALL_THICKNESS),
+            ));
+        }
+    }
 
     let (scene_objects, collider) = boxes_to_geometry(boxes);
 
@@ -207,8 +223,8 @@ impl DebugSceneHooks for MeleeHooks {
                 Point3::new(-RACK_DISTANCE, RACK_HEIGHT + 0.05, z),
             ));
         }
-        for distance in TARGET_DISTANCES {
-            effects.push(spawn_at(TARGET_CREATURE, Point3::new(-distance, 1.0, 0.0)));
+        for (template_id, distance, pen_z) in TARGETS {
+            effects.push(spawn_at(*template_id, Point3::new(-distance, 1.0, *pen_z)));
         }
 
         core.handle_effects(

--- a/shock2vr/src/scenes/debug_melee.rs
+++ b/shock2vr/src/scenes/debug_melee.rs
@@ -107,7 +107,7 @@ pub fn create_debug_melee_scene(
     dev_params::set(dev_params::MELEE_GLOVE_OVERLAY, 1.0);
     dev_params::set(dev_params::MELEE_VOLUMES, 1.0);
 
-    let boxes: &[DebugBox] = &[
+    let mut boxes: Vec<DebugBox> = vec![
         // floor
         (
             vec3(0.18, 0.18, 0.22),
@@ -146,7 +146,7 @@ pub fn create_debug_melee_scene(
         }
     }
 
-    let (scene_objects, collider) = boxes_to_geometry(boxes);
+    let (scene_objects, collider) = boxes_to_geometry(&boxes);
 
     // Laid out along -X, the default view forward with an identity spawn yaw
     // in both presentations (same convention as `debug_weapons`). Verified by

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -296,11 +296,11 @@ fn projectile_ray_cast(
         }
         if !crate::creature::hit_boxes_cover_body(world, hit_entity_id) {
             // The creature's hitboxes do not stand in for its body: the
-            // arachnids and the Overlord map a single `Body` joint, so their
-            // legs and limbs have no proxy at all. Passing through would make
-            // whole bands of them unshootable, so the capsule keeps the shot
-            // (with no joint to report). Widening those definitions is the fix
-            // that would let them join the rule above.
+            // Overlord maps a single `Body` joint, so its limbs have no proxy
+            // at all. Passing through would make whole bands of it
+            // unshootable, so the capsule keeps the shot (with no joint to
+            // report). Widening that definition is the fix that would let
+            // it join the rule above.
             return maybe_hit_spot;
         }
         if fired_from_inside(physics, start_point, hit_entity_id) {
@@ -528,10 +528,10 @@ mod tests {
         );
     }
 
-    /// The arachnids and the Overlord map a single `Body` joint, so their legs
-    /// and limbs have no proxy at all. A shot that misses that one blob has
-    /// not missed the animal - passing through would leave whole bands of it
-    /// unshootable - so those creatures keep their capsule.
+    /// The Overlord maps a single `Body` joint, so its limbs have no proxy at
+    /// all. A shot that misses that one blob has not missed the creature -
+    /// passing through would leave whole bands of it unshootable - so it keeps
+    /// its capsule.
     ///
     /// Negative-first: without the coverage gate this shot reaches the wall.
     #[test]
@@ -539,8 +539,8 @@ mod tests {
         let mut physics = PhysicsWorld::new();
         let mut world = World::new();
 
-        // Creature type 6 is ARACHNID: one mapped joint.
-        let creature = world.add_entity((crate::creature::RuntimePropHasHitBoxes, PropCreature(6)));
+        // Creature type 5 is OVERLORD: one mapped joint.
+        let creature = world.add_entity((crate::creature::RuntimePropHasHitBoxes, PropCreature(5)));
         physics.add_kinematic(
             creature,
             vec3(0.0, 0.0, 5.0),
@@ -555,7 +555,7 @@ mod tests {
             hit_box_type: HitBoxType::Body,
             joint_id: 0,
         });
-        // Off to the side, as an arachnid's body blob is from its legs.
+        // Off to the side, as a body blob is from the limbs.
         physics.add_kinematic(
             hit_box,
             vec3(1.2, 0.0, 5.0),

--- a/tools/shock2-sdk/test/per-limb-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/per-limb-damage.e2e.test.ts
@@ -27,12 +27,14 @@ test(
     await using game = await GameServer.launch({ mission: "debug_melee" });
     await game.step({ frames: 30 });
 
+    // The joint table below is the humanoid one, so pick the hybrids by name:
+    // the scene's arachnids have per-joint hitboxes of their own now.
     const creatures = [];
-    for (const entity of (await game.entities.list()).entities) {
+    for (const entity of (await game.entities.list({ filter: "OG-Pipe" })).entities) {
       const detail = await game.entities.detail(entity.id);
       if ((detail.aim_points ?? []).length > 1) creatures.push(detail);
     }
-    assert.ok(creatures.length >= 3, "expected three creatures in debug_melee");
+    assert.ok(creatures.length >= 3, "expected three hybrids in debug_melee");
 
     // joint -> the factor the hitbox table gives it.
     const cases: Array<[number, string, number]> = [
@@ -80,7 +82,7 @@ test(
     // carries is a separate object with no hitbox at all - so a blow there is
     // a blow on a hand, worth what the far half of a limb is worth.
     let creature;
-    for (const entity of (await game.entities.list()).entities) {
+    for (const entity of (await game.entities.list({ filter: "OG-Pipe" })).entities) {
       const detail = await game.entities.detail(entity.id);
       if ((detail.aim_points ?? []).some((point) => point.joint_id === 14 || point.joint_id === 15)) {
         creature = detail;

--- a/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
@@ -87,7 +87,7 @@ test(
 );
 
 test(
-  "an arachnid is framed by its single Body hitbox, at collider scale",
+  "an arachnid is framed by its legs, not just its body",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({ mission: "hydro3.mis" });
@@ -98,23 +98,26 @@ test(
     );
     assert.ok(arachnid, "expected a Baby Arachnid in hydro3");
     const detail = await game.entities.detail(arachnid.id);
+    const points = detail.aim_points ?? [];
     assert.equal(
-      (detail.aim_points ?? []).length,
-      1,
-      "the arachnid definition maps exactly one Body hitbox",
+      points.length,
+      21,
+      "the arachnid definition maps every skinned joint: body, mandibles, eight legs",
     );
+    const parts = new Set(points.map((point) => point.classification));
+    for (const part of ["torso", "head", "limb", "extremity"]) {
+      assert.ok(parts.has(part), `expected a ${part} hitbox on the arachnid`);
+    }
 
-    // A single Body hitbox frames the body without the legs. Coarser than a
-    // humanoid's frame, but still the scale of the creature (its collider
-    // measures 0.40 across) rather than collapsing to a point - which is the
-    // regression a future change here would introduce.
+    // With only the Body joint mapped the frame measured 0.33-0.58 across -
+    // the body blob, legs excluded. The legs roughly double that.
     const bounds = detail.selection_bounds;
-    assert.ok(bounds, "the arachnid should still report bounds");
+    assert.ok(bounds, "the arachnid should report bounds");
     const width = Math.max(bounds[1][0] - bounds[0][0], bounds[1][2] - bounds[0][2]);
     const height = bounds[1][1] - bounds[0][1];
     assert.ok(
-      width > 0.25 && width < 1.0,
-      `expected a body-scale frame, got ${width.toFixed(2)} across`,
+      width > 0.8 && width < 2.0,
+      `expected a leg-span frame, got ${width.toFixed(2)} across`,
     );
     assert.ok(height > 0.25, `expected a body-scale frame, got ${height.toFixed(2)} tall`);
   },


### PR DESCRIPTION
`SPIDER_HIT_BOXES` mapped only joint 0, so an arachnid had one body-blob proxy: a swing or shot through a leg or mandible missed, the HUD framed a 0.3-unit box, and ranged hits fell back to the capsule. The fitted per-joint shapes were already fine (`hitbox_analyzer`: 94-95% bone coverage on `aracyoun`/`aracboss`); only the joint → type table was missing.

- Map every skinned spider joint: body, mandibles as Head (1.25), each leg's shoulder + elbow as Limb (0.75), wrist as Extremity (0.5). Both sizes now expose 21 proxies (the mandible roots and six shoulders carry no vertices).
- `debug_melee`: a second pen beside the hybrids with an adult and a Baby Arachnid. The plain Arachnid template (-2013) has no model, so the adult is -1439 (`aracboss`), the only adult the missions place.
- Comments and the projectile unit test that assumed "arachnids map one joint" now refer to the Overlord; Rust unit test for the table; e2e tests updated (`selection-bounds` asserts the leg-span frame, `per-limb-damage` picks hybrids by name).

Behaviour note: with >1 hitbox, arachnids now join the projectile pass-through rule (a shot that crosses the capsule but no limb passes through). Measured on the resting adult, the uncovered band is the air under the body between the legs.

Not in scope: the Baby Arachnid hovers with its legs ~0.7 units above the floor. The proxies track the mesh; that gap is the creature capsule (#904).

Verification: `cargo test -p shock2vr` (creature + projectile), `RUSTFLAGS=-D warnings cargo check`, and the debug_melee e2e set (hitbox-coverage, melee-hitbox, melee-swing-stop, ranged-hitbox, per-limb-damage, selection-bounds, damage-overlay) pass.


## Visuals

![arachnid per-limb hitboxes](https://gist.githubusercontent.com/tommy-xr/b01925971dd4973e9d0078e25ee70149/raw/arachnid-hitboxes.gif)

<sub>`debug_melee` spider pen: damage dealt to a leg wrist hitbox reads `-5 HP extremity`, to a mandible `-12.5 HP head` — 21 per-joint hitboxes on each arachnid where there used to be one body proxy. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| New spider pen | Per-limb damage readouts |
| --- | --- |
| ![spider pen](https://gist.githubusercontent.com/tommy-xr/b01925971dd4973e9d0078e25ee70149/raw/spider-pen.png) | ![hitbox readouts](https://gist.githubusercontent.com/tommy-xr/b01925971dd4973e9d0078e25ee70149/raw/hitbox-readout.png) |

<sub>Left: the second `debug_melee` pen — an adult Invisible Arachnid (translucent `aracboss`) and a Baby Arachnid. Right: the same pair with `damage_numbers` on, showing the limb the hit resolved to. No before/after: the pen is net-new and the hitbox split is only observable through the readout.</sub>
