### PR TITLE
fix(physics): stand arachnids on their legs

### DIFF
--- a/shock2vr/src/creature/creature_definitions.rs
+++ b/shock2vr/src/creature/creature_definitions.rs
@@ -71,11 +71,19 @@ pub const HUMAN_PHYS_OFFSET: f32 = 1.0 / SCALE_FACTOR;
 pub const DROID_HEIGHT: f32 = 7.0 / SCALE_FACTOR;
 pub const DROID_WIDTH: f32 = 5.0 / SCALE_FACTOR;
 
-pub const BABY_SPIDER_WIDTH: f32 = 3.0 / SCALE_FACTOR;
+// An arachnid's origin sits low - the legs reach only ~0.2 (baby) / ~0.4
+// (adult) below it while the body rises well above - so the capsule is raised
+// (a negative offset) until its bottom meets the leg tips. Sized so the
+// capsule is as tall as the mesh whether it comes from these bounds or from
+// an authored sphere model; a capsule centred on the origin left the spider
+// standing on air. Widths follow the authored collision (~2 ft).
+pub const BABY_SPIDER_WIDTH: f32 = 2.0 / SCALE_FACTOR;
 pub const BABY_SPIDER_HEIGHT: f32 = 3.0 / SCALE_FACTOR;
+pub const BABY_SPIDER_PHYS_OFFSET: f32 = -1.0 / SCALE_FACTOR;
 
-pub const SPIDER_WIDTH: f32 = 4.0 / SCALE_FACTOR;
-pub const SPIDER_HEIGHT: f32 = 4.0 / SCALE_FACTOR;
+pub const SPIDER_WIDTH: f32 = 3.0 / SCALE_FACTOR;
+pub const SPIDER_HEIGHT: f32 = 4.5 / SCALE_FACTOR;
+pub const SPIDER_PHYS_OFFSET: f32 = -1.3 / SCALE_FACTOR;
 
 pub const MONKEY_HEIGHT: f32 = 3.0 / SCALE_FACTOR;
 pub const MONKEY_WIDTH: f32 = 3.0 / SCALE_FACTOR;
@@ -245,7 +253,7 @@ pub const OVERLORD: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
 
 pub const ARACHNID: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
     Arc::new(CreatureDefinition {
-        physics_offset_height: 0.0,
+        physics_offset_height: SPIDER_PHYS_OFFSET,
         bounding_size: vec3(SPIDER_WIDTH, SPIDER_HEIGHT, SPIDER_WIDTH),
         actor_type: ActorType::Arachnid,
         joint_map: vec![
@@ -272,7 +280,7 @@ pub const MONKEY: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
 
 pub const BABY_ARACHNID: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
     Arc::new(CreatureDefinition {
-        physics_offset_height: 0.0,
+        physics_offset_height: BABY_SPIDER_PHYS_OFFSET,
         bounding_size: vec3(BABY_SPIDER_WIDTH, BABY_SPIDER_HEIGHT, BABY_SPIDER_WIDTH),
         actor_type: ActorType::Arachnid,
         joint_map: vec![
@@ -321,6 +329,31 @@ pub fn get_entity_creature(world: &World, entity_id: EntityId) -> Option<Arc<Cre
     let v_creature = world.borrow::<View<PropCreature>>().ok()?;
     let creature_type = v_creature.get(entity_id).ok()?;
     get_creature_definition(creature_type.0)
+}
+
+/// Where a creature senses from, relative to its origin. A creature whose
+/// collider is raised above the origin (the arachnids: a negative
+/// `physics_offset_height`) looks, feels for door sensors and whiskers from
+/// the collider's centre, not from ankle height where a ray meets the floor
+/// within a stride. A collider hung below the origin (humanoids) leaves the
+/// origin alone: there it is already the higher point, roughly the chest.
+pub fn sense_offset(world: &World, entity_id: EntityId) -> Vector3<f32> {
+    let lift = get_entity_creature(world, entity_id)
+        .map(|creature| (-creature.physics_offset_height).max(0.0))
+        .unwrap_or(0.0);
+    vec3(0.0, lift, 0.0)
+}
+
+/// How far the sense point sits above the bottom of the creature's collider -
+/// its height above the floor when standing. Both creature shapes total
+/// `bounding_size.y` tall, centred `physics_offset_height` below the origin.
+pub fn sense_height(world: &World, entity_id: EntityId) -> Option<f32> {
+    let creature = get_entity_creature(world, entity_id)?;
+    Some(
+        creature.physics_offset_height
+            + creature.bounding_size.y / 2.0
+            + sense_offset(world, entity_id).y,
+    )
 }
 
 #[cfg(test)]
@@ -381,5 +414,23 @@ mod tests {
             assert_eq!(worth(shoulder + 2), Some(0.5), "leg {leg} wrist");
         }
         assert_eq!(worth(29), None, "claw");
+    }
+
+    /// An arachnid senses from its raised collider's centre; a humanoid from
+    /// its origin, which already sits above the collider's centre.
+    #[test]
+    fn a_raised_collider_lifts_the_sense_point() {
+        let mut world = World::new();
+        let human = world.add_entity(PropCreature(0));
+        let arachnid = world.add_entity(PropCreature(6));
+        let baby = world.add_entity(PropCreature(8));
+
+        assert_eq!(sense_offset(&world, human).y, 0.0);
+        assert!((sense_offset(&world, arachnid).y - 1.3 / SCALE_FACTOR).abs() < 1e-5);
+        assert!((sense_offset(&world, baby).y - 1.0 / SCALE_FACTOR).abs() < 1e-5);
+
+        // Standing heights of the sense point: human origin, spider collider centre.
+        assert!((sense_height(&world, human).unwrap() - 4.25 / SCALE_FACTOR).abs() < 1e-5);
+        assert!((sense_height(&world, baby).unwrap() - 1.5 / SCALE_FACTOR).abs() < 1e-5);
     }
 }

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -2001,6 +2001,30 @@ mod tests {
         }
     }
 
+    /// An arachnid's capsule bottom meets its leg tips - 0.2 (baby) / 0.38
+    /// (adult) below the origin - whether the capsule comes from the creature
+    /// bounds or from the shipped sphere model. Both must agree, since the
+    /// same offset serves debug spawns and missions.
+    #[test]
+    fn arachnid_capsules_stand_on_the_leg_tips() {
+        for (creature_type, imported, leg_tips) in [(6, [0.16, 0.2], -0.38), (8, [0.08, 0.1], -0.2)]
+        {
+            let creature = get_creature_definition(creature_type).unwrap();
+            let dimensions = sphere_dimensions(imported[0], imported[1]);
+            for shape in [
+                live_creature_shape(&creature, None, None),
+                live_creature_shape(&creature, Some(&sphere_type(2)), Some(&dimensions)),
+            ] {
+                let (radius, segment_height) = capsule(shape);
+                let bottom = -creature.physics_offset_height - (segment_height / 2.0 + radius);
+                assert!(
+                    (bottom - leg_tips).abs() < 0.01,
+                    "creature {creature_type}: capsule bottom {bottom} vs leg tips {leg_tips}"
+                );
+            }
+        }
+    }
+
     /// A wall fixture the player can frob but never pick up or move - a
     /// console, a card slot, the Resurrection Station casing. `phys_type` is
     /// `None` for the shipped case that has no `P$PhysType` in its chain.

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -607,7 +607,10 @@ pub fn melee_contact_attack(world: &World, entity_id: EntityId, physics: &Physic
         v_current_pos
             .get(entity_id)
             .ok()
-            .map(|pos| (pos.position - player_pos).magnitude() < MELEE_ATTACK_RANGE)
+            .map(|pos| {
+                (pos.position + creature::sense_offset(world, entity_id) - player_pos).magnitude()
+                    < MELEE_ATTACK_RANGE
+            })
             .unwrap_or(false)
     };
     if !in_range {
@@ -936,7 +939,8 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
     let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
 
     if let Ok(ent_pos) = v_current_pos.get(from_entity) {
-        let start_point = point3(0.0, 0.0, 0.0) + ent_pos.position;
+        let start_point =
+            point3(0.0, 0.0, 0.0) + ent_pos.position + creature::sense_offset(world, from_entity);
         let end_point = point3(0.0, 0.0, 0.0) + u_player.pos;
         return has_clear_sight_between(
             from_entity,
@@ -976,7 +980,8 @@ pub fn has_line_of_fire(
     let Ok(ent_pos) = v_current_pos.get(from_entity) else {
         return false;
     };
-    let start_point = point3(0.0, 0.0, 0.0) + ent_pos.position;
+    let start_point =
+        point3(0.0, 0.0, 0.0) + ent_pos.position + creature::sense_offset(world, from_entity);
     let Some(target_entity) = world
         .borrow::<UniqueView<PlayerInfo>>()
         .ok()
@@ -1138,7 +1143,8 @@ pub fn is_player_visible_in_fov(
         }
 
         // Player is in FOV, now check line-of-sight
-        let start_point = point3(0.0, 0.0, 0.0) + entity_pos;
+        let start_point =
+            point3(0.0, 0.0, 0.0) + entity_pos + creature::sense_offset(world, from_entity);
         let end_point = point3(0.0, 0.0, 0.0) + player_pos;
         return has_clear_sight_between(
             from_entity,

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -350,11 +350,16 @@ impl AnimatedMonsterAI {
         entity_id: EntityId,
     ) -> Effect {
         let (position, forward) = get_position_and_forward(world, entity_id);
-
-        let down_amount = 2.0 / SCALE_FACTOR;
-        let down_vector = vec3(0.0, -down_amount, 0.0);
+        let position = position + crate::creature::sense_offset(world, entity_id);
 
         let distance = 8.0 / SCALE_FACTOR;
+        // Dip so the probe meets flat floor two thirds of the way out, whatever
+        // the creature's height: a fixed dip that suits a human's chest puts a
+        // spider's probe into the floor within a stride.
+        let down_amount = crate::creature::sense_height(world, entity_id)
+            .map(|height| height * 1.5 / distance)
+            .unwrap_or(2.0 / SCALE_FACTOR);
+        let down_vector = vec3(0.0, -down_amount, 0.0);
 
         let _direction = forward + down_vector;
 

--- a/shock2vr/src/scripts/ai/steering/collision_avoidance_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/collision_avoidance_steering_strategy.rs
@@ -56,7 +56,11 @@ impl SteeringStrategy for CollisionAvoidanceSteeringStrategy {
         // (vertical faces, so the mostly-vertical-normal filter doesn't
         // reject them) and treats the descent the route chose as a wall.
         // Real walls extend above body center and are still seen.
-        let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+        let position = get_position_from_transform(
+            world,
+            entity_id,
+            crate::creature::sense_offset(world, entity_id),
+        );
 
         let mut debug_lines = vec![];
 


### PR DESCRIPTION
Stacked on #1238. Fixes #1239.

An arachnid's capsule was centred on its origin and sized from bounds copied for a tall creature, so the Baby Arachnid stood with its leg tips ~0.7 units above the floor (~0.4 in missions, where the authored sphere model shrinks the radius but not the height). The origin sits low in the spider mesh - the legs reach only ~0.2 (baby) / ~0.4 (adult) below it - so this sizes the capsule to the mesh and raises it with a negative `physics_offset_height` until its bottom meets the leg tips. Both the spawn-bounds and authored-sphere paths now give a mesh-tall capsule, so the same offset works in `debug_melee` and in `hydro3`.

The AI's sight, line-of-fire, door-sensor and whisker rays, and its melee range check, all start at the creature origin, which for a spider is now ankle height - the door probe (forward and down) met the floor within a stride. They now start at `creature::sense_offset` (the raised collider's centre; zero for every creature whose collider hangs below the origin), and the door probe's dip scales with `creature::sense_height` so it reaches as far along the floor for a spider as it does for a human (a human's dip is unchanged to 3 decimals). Checked in `debug_melee`: a spider spots a player at the pen mouth and chases.

Measured in `debug_melee` after settling (hitbox-union bounds, min y): baby 0.69 → -0.01, adult 0.82 → 0.00. Origins now 0.20 / 0.38 above the floor.

Verification: `cargo test -p shock2vr creature entity_creator`, `RUSTFLAGS=-D warnings cargo check`, and the e2e set baby-arachnid (hydro3), selection-bounds, hitbox-coverage, melee-swing-stop, ai-alertness, ai-reacquire, door-frob pass; `cargo test -p shock2vr creature ai entity_creator` passes, including new tests for the sense point and for the capsule bottom meeting the leg tips on both shape paths.

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/b01925971dd4973e9d0078e25ee70149/raw/grounding-beforeafter.png)

<sub>Spider pen in `debug_melee`, same free-camera placement. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`).</sub>
