### PR TITLE
feat(tools): AI reachability evaluation harness

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -141,6 +141,13 @@ pub enum RuntimeCommand {
     /// Get the latest path each AI computed (goal, waypoints, outcome)
     GetAiPaths(oneshot::Sender<Vec<shock2vr::game_scene::DebugAiPathEntry>>),
 
+    /// One-off walk-graph reachability query between two world positions
+    GetPathfindingRoute {
+        from: [f32; 3],
+        to: [f32; 3],
+        reply: oneshot::Sender<Option<shock2vr::game_scene::DebugPathRoute>>,
+    },
+
     /// List entities near the player
     ListEntities {
         limit: Option<usize>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -420,6 +420,7 @@ async fn start_http_server(
         )
         .route("/v1/pathfinding/stats", get(pathfinding_stats))
         .route("/v1/ai/paths", get(ai_paths))
+        .route("/v1/pathfinding/route", get(pathfinding_route))
         .route(
             "/v1/input/action",
             axum::routing::post(trigger_input_action),
@@ -1575,6 +1576,14 @@ fn process_command(
                 .unwrap_or_default();
             if reply.send(paths).is_err() {
                 tracing::warn!("Failed to send AI paths - receiver dropped");
+            }
+        }
+        RuntimeCommand::GetPathfindingRoute { from, to, reply } => {
+            let route = game
+                .debug_scene()
+                .and_then(|debug_scene| debug_scene.pathfinding_route(from, to));
+            if reply.send(route).is_err() {
+                tracing::warn!("Failed to send pathfinding route - receiver dropped");
             }
         }
         RuntimeCommand::ListEntities {
@@ -4072,6 +4081,58 @@ async fn pathfinding_stats(
         Ok(result) => Ok(Json(result)),
         Err(_) => {
             tracing::error!("Failed to receive pathfinding stats - sender dropped");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RouteQueryParams {
+    /// Start position as "x,y,z"
+    from: String,
+    /// Goal position as "x,y,z"
+    to: String,
+}
+
+fn parse_vec3_param(s: &str) -> Option<[f32; 3]> {
+    let parts: Vec<f32> = s.split(',').filter_map(|p| p.trim().parse().ok()).collect();
+    match parts.len() {
+        3 => Some([parts[0], parts[1], parts[2]]),
+        _ => None,
+    }
+}
+
+/// HTTP endpoint handler: does a walk route exist between two world
+/// positions? Answers "unreachable by design" vs "the AI failed to route".
+async fn pathfinding_route(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    Query(params): Query<RouteQueryParams>,
+) -> Result<Json<shock2vr::game_scene::DebugPathRoute>, StatusCode> {
+    let (Some(from), Some(to)) = (parse_vec3_param(&params.from), parse_vec3_param(&params.to))
+    else {
+        return Err(StatusCode::BAD_REQUEST);
+    };
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::GetPathfindingRoute {
+            from,
+            to,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send GetPathfindingRoute - game loop receiver dropped");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    match reply_rx.await {
+        // No pathfinding data in this scene (e.g. a debug scene): not found,
+        // rather than a route answer the caller would read as "unreachable".
+        Ok(Some(route)) => Ok(Json(route)),
+        Ok(None) => Err(StatusCode::NOT_FOUND),
+        Err(_) => {
+            tracing::error!("Failed to receive pathfinding route - sender dropped");
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -4095,7 +4095,12 @@ struct RouteQueryParams {
 }
 
 fn parse_vec3_param(s: &str) -> Option<[f32; 3]> {
-    let parts: Vec<f32> = s.split(',').filter_map(|p| p.trim().parse().ok()).collect();
+    // Every component must parse and be finite: dropping a bad one would
+    // answer a reachability question about a point nobody asked for.
+    let parts: Vec<f32> = s
+        .split(',')
+        .map(|p| p.trim().parse::<f32>().ok().filter(|v| v.is_finite()))
+        .collect::<Option<Vec<f32>>>()?;
     match parts.len() {
         3 => Some([parts[0], parts[1], parts[2]]),
         _ => None,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -1084,6 +1084,28 @@ pub trait DebuggableScene {
     fn ai_paths(&self) -> Vec<DebugAiPathEntry> {
         Vec::new()
     }
+
+    /// Static walk-graph reachability between two world positions (None when
+    /// the scene has no pathfinding data). Lets remote clients tell "this AI
+    /// is failing to route" apart from "nothing walkable connects it to the
+    /// player at all".
+    fn pathfinding_route(&self, _from: [f32; 3], _to: [f32; 3]) -> Option<DebugPathRoute> {
+        None
+    }
+}
+
+/// A one-off walk-graph query between two positions, for debug introspection
+/// (GET /v1/pathfinding/route in the debug runtime)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DebugPathRoute {
+    /// AIPATH cell containing `from` (None when the position is off-mesh)
+    pub from_cell: Option<u32>,
+    /// AIPATH cell containing `to` (None when the position is off-mesh)
+    pub to_cell: Option<u32>,
+    /// Whether a walk route exists between the two cells
+    pub reachable: bool,
+    /// Waypoint count of that route (0 when unreachable)
+    pub waypoints: usize,
 }
 
 /// One AI's most recent path query, for debug introspection

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -12500,6 +12500,24 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             .collect()
     }
 
+    fn pathfinding_route(
+        &self,
+        from: [f32; 3],
+        to: [f32; 3],
+    ) -> Option<crate::game_scene::DebugPathRoute> {
+        use dark::mission::path_database::MovementBits;
+        let service = self.pathfinding_service.as_ref()?;
+        let from = cgmath::Vector3::new(from[0], from[1], from[2]);
+        let to = cgmath::Vector3::new(to[0], to[1], to[2]);
+        let route = service.find_path(from, to, MovementBits::WALK);
+        Some(crate::game_scene::DebugPathRoute {
+            from_cell: service.cell_from_position(from),
+            to_cell: service.cell_from_position(to),
+            reachable: route.is_some(),
+            waypoints: route.map(|w| w.len()).unwrap_or(0),
+        })
+    }
+
     fn send_entity_message(
         &mut self,
         id: EntityId,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -477,6 +477,14 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.ai_paths()
     }
 
+    fn pathfinding_route(
+        &self,
+        from: [f32; 3],
+        to: [f32; 3],
+    ) -> Option<crate::game_scene::DebugPathRoute> {
+        self.mission_core.pathfinding_route(from, to)
+    }
+
     fn send_entity_message(
         &mut self,
         id: EntityId,

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -91,13 +91,10 @@ enum PathCommand {
     },
     /// Dump every nav cell as JSON (polygon, center, flags, walk component)
     /// - the geometry a map visualization draws over
-    Dump {
-        mission: String,
-        /// Emit JSON (the only supported format; accepted for symmetry with
-        /// `bench --json`)
-        #[arg(long, default_value_t = true)]
-        json: bool,
-    },
+    Dump { mission: String },
+    /// List the missions in the game data, one per line (they can live inside
+    /// an archive, so a directory listing is not enough)
+    Missions,
     /// Show the walk component containing a position and its frontier links
     /// (how the component connects - or fails to connect - to neighbors)
     Component {
@@ -173,7 +170,12 @@ fn run_path_command(command: PathCommand) -> Result<()> {
             let db = load_path_database(&mission)?;
             dump_cells_at(db, parse_vec3(&at)?);
         }
-        PathCommand::Dump { mission, json: _ } => {
+        PathCommand::Missions => {
+            for mission in data_files::mission_names(paths::data_root()) {
+                println!("{mission}");
+            }
+        }
+        PathCommand::Dump { mission } => {
             let db = load_path_database(&mission)?;
             println!("{}", serde_json::to_string(&dump_cells(&mission, &db))?);
         }

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -89,6 +89,15 @@ enum PathCommand {
         #[arg(long)]
         at: String,
     },
+    /// Dump every nav cell as JSON (polygon, center, flags, walk component)
+    /// - the geometry a map visualization draws over
+    Dump {
+        mission: String,
+        /// Emit JSON (the only supported format; accepted for symmetry with
+        /// `bench --json`)
+        #[arg(long, default_value_t = true)]
+        json: bool,
+    },
     /// Show the walk component containing a position and its frontier links
     /// (how the component connects - or fails to connect - to neighbors)
     Component {
@@ -163,6 +172,10 @@ fn run_path_command(command: PathCommand) -> Result<()> {
         PathCommand::Cell { mission, at } => {
             let db = load_path_database(&mission)?;
             dump_cells_at(db, parse_vec3(&at)?);
+        }
+        PathCommand::Dump { mission, json: _ } => {
+            let db = load_path_database(&mission)?;
+            println!("{}", serde_json::to_string(&dump_cells(&mission, &db))?);
         }
         PathCommand::Component { mission, at } => {
             let db = load_path_database(&mission)?;
@@ -430,6 +443,54 @@ fn print_stats(mission: &str, db: PathDatabase) {
 
 /// Connected components of pathable cells over walk links (undirected),
 /// sorted largest-first.
+#[derive(Serialize)]
+struct CellDump {
+    mission: String,
+    cells: Vec<CellDumpEntry>,
+}
+
+#[derive(Serialize)]
+struct CellDumpEntry {
+    id: u32,
+    center: [f32; 3],
+    /// Cell polygon, in vertex order (XZ is the map plane)
+    polygon: Vec<[f32; 3]>,
+    flags: String,
+    /// Index into the walk components (largest first); None for cells no
+    /// plain WALK query can stand in
+    component: Option<usize>,
+}
+
+/// Every cell as JSON, for a map renderer to draw.
+fn dump_cells(mission: &str, db: &PathDatabase) -> CellDump {
+    let components = walk_components(db);
+    let mut component_of: std::collections::HashMap<u32, usize> = std::collections::HashMap::new();
+    for (index, cells) in components.iter().enumerate() {
+        for &cell in cells {
+            component_of.insert(cell, index);
+        }
+    }
+    CellDump {
+        mission: mission.to_string(),
+        cells: db
+            .cells
+            .iter()
+            .map(|cell| CellDumpEntry {
+                id: cell.id,
+                center: cell.center.into(),
+                polygon: cell
+                    .vertex_indices
+                    .iter()
+                    .filter_map(|&i| db.vertices.get(i as usize))
+                    .map(|v| (*v).into())
+                    .collect(),
+                flags: format!("{:?}", cell.flags),
+                component: component_of.get(&cell.id).copied(),
+            })
+            .collect(),
+    }
+}
+
 fn walk_components(db: &PathDatabase) -> Vec<Vec<u32>> {
     fn find(parent: &mut [u32], mut x: u32) -> u32 {
         while parent[x as usize] != x {

--- a/tools/shock2-sdk/package.json
+++ b/tools/shock2-sdk/package.json
@@ -23,6 +23,8 @@
     "test:e2e:reliability": "tsc && node scripts/reliability.mjs",
     "preanim-smoothness": "node scripts/check-deps.mjs",
     "anim-smoothness": "tsc && node dist/scripts/anim-smoothness.js",
+    "preai-reachability": "node scripts/check-deps.mjs",
+    "ai-reachability": "tsc && node dist/scripts/ai-reachability.js",
     "clean:saves": "tsc && node scripts/clean-test-saves.mjs",
     "posttest:e2e": "node scripts/clean-test-saves.mjs"
   },

--- a/tools/shock2-sdk/scripts/ai-reachability.ts
+++ b/tools/shock2-sdk/scripts/ai-reachability.ts
@@ -128,7 +128,8 @@ async function discoverAis(game: Game): Promise<EntityDetailResult[]> {
   const { entities } = await game.entities.list({ limit: 5000 });
   const ais: EntityDetailResult[] = [];
   for (const entity of entities) {
-    const detail = await game.entities.detail(entity.id);
+    const detail = await game.entities.detail(entity.id).catch(() => null);
+    if (!detail) continue;
     const props = new Set(detail.properties.map((p) => p.name));
     if (props.has("AIAlertness") || props.has("AIBehavior")) ais.push(detail);
   }
@@ -181,12 +182,10 @@ async function runPass(
     const t = (step * sampleEvery) / 60;
     const paths = new Map((await game.pathfinding.aiPaths()).map((p) => [p.entity_id, p]));
     for (const [id, track] of tracks) {
-      let detail: EntityDetailResult;
-      try {
-        detail = await game.entities.detail(id);
-      } catch {
-        continue; // dead or despawned - the samples so far still classify
-      }
+      // A dead or despawned AI stops reporting; the samples so far still
+      // classify, so drop the sample rather than the whole pass.
+      const detail = await game.entities.detail(id).catch(() => null);
+      if (!detail) continue;
       const route = paths.get(track.entity_id);
       const sample: AiSample = {
         t,

--- a/tools/shock2-sdk/scripts/ai-reachability.ts
+++ b/tools/shock2-sdk/scripts/ai-reachability.ts
@@ -1,0 +1,343 @@
+/**
+ * AI reachability harness: does every AI in a mission actually get where it
+ * is going?
+ *
+ * Two passes per mission, each on a freshly launched runtime:
+ *   idle  - no player input, the AIs run their authored patrols
+ *   chase - the player stands at a fixed spot, DebugForceChase pins every AI
+ *           onto them, and we watch who arrives
+ *
+ * Every AI is sampled every N frames (position, behavior, alertness, its
+ * live path + stall) and classified at the end of the pass (see
+ * src/ai-reachability.ts). Writes <out>/<mission>.json with every sample, a
+ * <out>/summary.md table, and per-pass trail maps drawn over the mission's
+ * nav cells.
+ *
+ *   npm run ai-reachability -- --mission medsci2.mis --out /tmp/aire
+ *   npm run ai-reachability -- --all --experimental nav_bridges
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { readdirSync } from "node:fs";
+import path from "node:path";
+
+import { findRepoRoot, GameServer } from "../src/index.js";
+import type { Game } from "../src/index.js";
+import {
+  classifyTrack,
+  distance3,
+  tally,
+  VERDICTS,
+  type AiSample,
+  type AiTrack,
+  type Classification,
+} from "../src/ai-reachability.js";
+import type { EntityDetailResult, Vec3 } from "../src/types.js";
+
+/**
+ * Where the player stands for the chase pass, per mission. An empty list
+ * means "wherever the mission spawns the player"; add positions here to
+ * probe more of a deck.
+ */
+const CHASE_POSITIONS: Record<string, Vec3[]> = {
+  // The medsci1 spawn is the sealed cryo recovery room (AI-unreachable by
+  // design), so chase from the open deck instead.
+  "medsci1.mis": [[-14.0, 0.5, -30.0]],
+};
+
+interface Args {
+  missions: string[];
+  out: string;
+  idleFrames: number;
+  chaseFrames: number;
+  sampleEvery: number;
+  experimental: string[];
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    missions: [],
+    out: path.join("/tmp", "ai-reachability"),
+    idleFrames: 3600,
+    chaseFrames: 1800,
+    sampleEvery: 30,
+    experimental: [],
+  };
+  let all = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const value = () => {
+      const v = argv[++i];
+      if (v === undefined) throw new Error(`${a} needs a value`);
+      return v;
+    };
+    switch (a) {
+      case "--mission":
+        args.missions.push(value());
+        break;
+      case "--all":
+        all = true;
+        break;
+      case "--out":
+        args.out = value();
+        break;
+      case "--idle-frames":
+        args.idleFrames = Number(value());
+        break;
+      case "--chase-frames":
+        args.chaseFrames = Number(value());
+        break;
+      case "--sample-every":
+        args.sampleEvery = Number(value());
+        break;
+      case "--experimental":
+        args.experimental.push(...value().split(","));
+        break;
+      default:
+        throw new Error(`unknown argument ${a}`);
+    }
+  }
+  if (all) args.missions = missionsInData();
+  if (args.missions.length === 0) throw new Error("pass --mission <name> or --all");
+  return args;
+}
+
+function repoRoot(): string {
+  const root = findRepoRoot(process.cwd());
+  if (!root) throw new Error("could not find the cargo workspace root");
+  return root;
+}
+
+function dataRoot(): string {
+  return process.env.DARK_ASSET_PATH ?? path.join(repoRoot(), "Data");
+}
+
+function missionsInData(): string[] {
+  return readdirSync(dataRoot())
+    .filter((f) => f.endsWith(".mis"))
+    .sort();
+}
+
+/**
+ * Every AI in the scene, found by the AI runtime properties rather than by
+ * name - runtime entity ids are not stable across runs, and creature names
+ * vary per mission.
+ */
+async function discoverAis(game: Game): Promise<EntityDetailResult[]> {
+  const { entities } = await game.entities.list({ limit: 5000 });
+  const ais: EntityDetailResult[] = [];
+  for (const entity of entities) {
+    const detail = await game.entities.detail(entity.id);
+    const props = new Set(detail.properties.map((p) => p.name));
+    if (props.has("AIAlertness") || props.has("AIBehavior")) ais.push(detail);
+  }
+  return ais;
+}
+
+function prop(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+/** Yaw (radians) from the entity's [w,x,y,z] rotation quaternion. */
+function yawOf(rotation: [number, number, number, number]): number {
+  const [w, x, y, z] = rotation;
+  return Math.atan2(2 * (w * y + x * z), 1 - 2 * (y * y + z * z));
+}
+
+interface PassResult {
+  pass: string;
+  player: Vec3;
+  frames: number;
+  tracks: (AiTrack & { classification: Classification })[];
+}
+
+async function runPass(
+  game: Game,
+  passName: "idle" | "chase",
+  label: string,
+  frames: number,
+  sampleEvery: number,
+): Promise<PassResult> {
+  const playerPos = await game.player.position();
+  const player: Vec3 = [playerPos.x, playerPos.y, playerPos.z];
+
+  const ais = await discoverAis(game);
+  const tracks = new Map<number, AiTrack>();
+  for (const ai of ais) {
+    const route = await game.pathfinding.route(ai.position, player);
+    tracks.set(ai.entity_id, {
+      entity_id: ai.entity_id,
+      name: ai.name,
+      template_id: ai.template_id,
+      reachable: route ? route.reachable : null,
+      samples: [],
+    });
+  }
+
+  const steps = Math.floor(frames / sampleEvery);
+  for (let step = 1; step <= steps; step++) {
+    await game.step({ frames: sampleEvery });
+    const t = (step * sampleEvery) / 60;
+    const paths = new Map((await game.pathfinding.aiPaths()).map((p) => [p.entity_id, p]));
+    for (const [id, track] of tracks) {
+      let detail: EntityDetailResult;
+      try {
+        detail = await game.entities.detail(id);
+      } catch {
+        continue; // dead or despawned - the samples so far still classify
+      }
+      const route = paths.get(track.entity_id);
+      const sample: AiSample = {
+        t,
+        position: detail.position,
+        yaw: yawOf(detail.rotation),
+        behavior: prop(detail, "AIBehavior"),
+        alertness: prop(detail, "AIAlertness"),
+        outcome: route?.outcome,
+        live_next_waypoint: route?.live_next_waypoint ?? null,
+        live_path_len: route?.live_path_len ?? null,
+        live_target: route?.live_target ?? null,
+        live_stall_seconds: route?.live_stall_seconds ?? null,
+        distance: distance3(detail.position, player),
+      };
+      track.samples.push(sample);
+    }
+  }
+
+  return {
+    pass: label,
+    player,
+    frames,
+    tracks: [...tracks.values()].map((track) => ({
+      ...track,
+      classification: classifyTrack(track, { pass: passName }),
+    })),
+  };
+}
+
+/** `cargo bn path dump` - the mission's nav cells, for the trail map. */
+async function dumpCells(mission: string, outFile: string): Promise<boolean> {
+  const result = spawnSync(
+    "cargo",
+    ["run", "--release", "-q", "-p", "bench", "--", "path", "dump", mission],
+    { cwd: repoRoot(), encoding: "utf8", maxBuffer: 512 * 1024 * 1024 },
+  );
+  if (result.status !== 0 || !result.stdout) {
+    console.warn(`  nav-cell dump failed for ${mission}: ${result.stderr?.slice(-400) ?? ""}`);
+    return false;
+  }
+  await writeFile(outFile, result.stdout);
+  return true;
+}
+
+function renderMap(cellsFile: string, passFile: string, pngFile: string): void {
+  const script = path.join(repoRoot(), "tools/shock2-sdk/scripts/render-trail-map.py");
+  const result = spawnSync("python3", [script, cellsFile, passFile, pngFile], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    console.warn(`  trail map failed: ${result.stderr?.slice(-400) ?? ""}`);
+  }
+}
+
+function passTable(mission: string, pass: PassResult): string {
+  const counts = tally(pass.tracks.map((t) => t.classification));
+  const cells = VERDICTS.map((v) => `${counts[v]}`).join(" | ");
+  return `| ${mission} | ${pass.pass} | ${pass.tracks.length} | ${cells} |`;
+}
+
+function wedgeLines(pass: PassResult): string[] {
+  return pass.tracks
+    .filter((t) => t.classification.verdict === "wedged")
+    .map(
+      (t) =>
+        `  - ${t.name} (template ${t.template_id}) wedged ${t.classification.wedge_seconds?.toFixed(1)}s at (${t.classification
+          .wedge_at!.map((c) => c.toFixed(2))
+          .join(", ")}) [${pass.pass}]`,
+    );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  await mkdir(args.out, { recursive: true });
+
+  const header = `| mission | pass | AIs | ${VERDICTS.join(" | ")} |`;
+  const divider = `|${"---|".repeat(VERDICTS.length + 3)}`;
+  const rows: string[] = [];
+  const wedges: string[] = [];
+
+  for (const mission of args.missions) {
+    console.log(`\n=== ${mission} ===`);
+    const passes: PassResult[] = [];
+
+    // Idle pass: nobody touches the controls; the AIs run their patrols.
+    {
+      await using game = await GameServer.launch({
+        mission,
+        experimental: args.experimental,
+      });
+      await game.step({ frames: 10 });
+      const pass = await runPass(game, "idle", "idle", args.idleFrames, args.sampleEvery);
+      passes.push(pass);
+      console.log(passTable(mission, pass));
+    }
+
+    // Chase passes: one per authored player position (or the spawn).
+    const positions = CHASE_POSITIONS[mission] ?? [];
+    const chaseSpots: (Vec3 | null)[] = positions.length > 0 ? positions : [null];
+    for (const [index, spot] of chaseSpots.entries()) {
+      await using game = await GameServer.launch({
+        mission,
+        experimental: args.experimental,
+      });
+      await game.step({ frames: 10 });
+      if (spot) {
+        await game.player.teleport({ x: spot[0], y: spot[1], z: spot[2] });
+        await game.step({ frames: 10 });
+      }
+      await game.input.trigger("DebugForceChase");
+      await game.step({ frames: 30 });
+      const label = chaseSpots.length > 1 ? `chase#${index}` : "chase";
+      const pass = await runPass(game, "chase", label, args.chaseFrames, args.sampleEvery);
+      passes.push(pass);
+      console.log(passTable(mission, pass));
+    }
+
+    const report = { mission, experimental: args.experimental, passes };
+    const jsonFile = path.join(args.out, `${mission}.json`);
+    await writeFile(jsonFile, JSON.stringify(report, null, 1));
+
+    const cellsFile = path.join(args.out, `${mission}-cells.json`);
+    const haveCells = await dumpCells(mission, cellsFile);
+    for (const pass of passes) {
+      rows.push(passTable(mission, pass));
+      wedges.push(...wedgeLines(pass));
+      if (haveCells) {
+        const passFile = path.join(args.out, `${mission}-${pass.pass}-pass.json`);
+        await writeFile(passFile, JSON.stringify(pass));
+        renderMap(cellsFile, passFile, path.join(args.out, `${mission}-${pass.pass}.png`));
+      }
+    }
+  }
+
+  const summary = [
+    "# AI reachability",
+    "",
+    header,
+    divider,
+    ...rows,
+    "",
+    "## Wedges",
+    "",
+    ...(wedges.length > 0 ? wedges : ["  (none)"]),
+    "",
+  ].join("\n");
+  await writeFile(path.join(args.out, "summary.md"), summary);
+  console.log(`\n${summary}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tools/shock2-sdk/scripts/ai-reachability.ts
+++ b/tools/shock2-sdk/scripts/ai-reachability.ts
@@ -15,6 +15,7 @@
  *
  *   npm run ai-reachability -- --mission medsci2.mis --out /tmp/aire
  *   npm run ai-reachability -- --all --experimental nav_bridges
+ *   npm run ai-reachability -- --all --pass chase --experimental nav_bridges
  */
 
 import { spawnSync } from "node:child_process";
@@ -45,6 +46,8 @@ const CHASE_POSITIONS: Record<string, Vec3[]> = {
   "medsci1.mis": [[-14.0, 0.5, -30.0]],
 };
 
+type PassSelector = "idle" | "chase" | "both";
+
 interface Args {
   missions: string[];
   out: string;
@@ -52,6 +55,7 @@ interface Args {
   chaseFrames: number;
   sampleEvery: number;
   experimental: string[];
+  pass: PassSelector;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -62,6 +66,7 @@ function parseArgs(argv: string[]): Args {
     chaseFrames: 1800,
     sampleEvery: 30,
     experimental: [],
+    pass: "both",
   };
   let all = false;
   for (let i = 0; i < argv.length; i++) {
@@ -93,6 +98,14 @@ function parseArgs(argv: string[]): Args {
       case "--experimental":
         args.experimental.push(...value().split(","));
         break;
+      case "--pass": {
+        const v = value();
+        if (v !== "idle" && v !== "chase" && v !== "both") {
+          throw new Error(`--pass must be idle, chase, or both, got ${v}`);
+        }
+        args.pass = v;
+        break;
+      }
       default:
         throw new Error(`unknown argument ${a}`);
     }
@@ -310,7 +323,7 @@ async function main(): Promise<void> {
     const passes: PassResult[] = [];
 
     // Idle pass: nobody touches the controls; the AIs run their patrols.
-    {
+    if (args.pass === "idle" || args.pass === "both") {
       await using game = await GameServer.launch({
         mission,
         experimental: args.experimental,
@@ -322,24 +335,26 @@ async function main(): Promise<void> {
     }
 
     // Chase passes: one per authored player position (or the spawn).
-    const positions = CHASE_POSITIONS[mission] ?? [];
-    const chaseSpots: (Vec3 | null)[] = positions.length > 0 ? positions : [null];
-    for (const [index, spot] of chaseSpots.entries()) {
-      await using game = await GameServer.launch({
-        mission,
-        experimental: args.experimental,
-      });
-      await game.step({ frames: 10 });
-      if (spot) {
-        await game.player.teleport({ x: spot[0], y: spot[1], z: spot[2] });
+    if (args.pass === "chase" || args.pass === "both") {
+      const positions = CHASE_POSITIONS[mission] ?? [];
+      const chaseSpots: (Vec3 | null)[] = positions.length > 0 ? positions : [null];
+      for (const [index, spot] of chaseSpots.entries()) {
+        await using game = await GameServer.launch({
+          mission,
+          experimental: args.experimental,
+        });
         await game.step({ frames: 10 });
+        if (spot) {
+          await game.player.teleport({ x: spot[0], y: spot[1], z: spot[2] });
+          await game.step({ frames: 10 });
+        }
+        await game.input.trigger("DebugForceChase");
+        await game.step({ frames: 30 });
+        const label = chaseSpots.length > 1 ? `chase-${index}` : "chase";
+        const pass = await runPass(game, "chase", label, args.chaseFrames, args.sampleEvery);
+        passes.push(pass);
+        console.log(passTable(mission, pass));
       }
-      await game.input.trigger("DebugForceChase");
-      await game.step({ frames: 30 });
-      const label = chaseSpots.length > 1 ? `chase-${index}` : "chase";
-      const pass = await runPass(game, "chase", label, args.chaseFrames, args.sampleEvery);
-      passes.push(pass);
-      console.log(passTable(mission, pass));
     }
 
     const report = { mission, experimental: args.experimental, passes };

--- a/tools/shock2-sdk/scripts/ai-reachability.ts
+++ b/tools/shock2-sdk/scripts/ai-reachability.ts
@@ -19,10 +19,9 @@
 
 import { spawnSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
-import { readdirSync } from "node:fs";
 import path from "node:path";
 
-import { findRepoRoot, GameServer } from "../src/index.js";
+import { findRepoRoot, GameServer, HttpError } from "../src/index.js";
 import type { Game } from "../src/index.js";
 import {
   classifyTrack,
@@ -83,13 +82,13 @@ function parseArgs(argv: string[]): Args {
         args.out = value();
         break;
       case "--idle-frames":
-        args.idleFrames = Number(value());
+        args.idleFrames = positiveInt(a, value());
         break;
       case "--chase-frames":
-        args.chaseFrames = Number(value());
+        args.chaseFrames = positiveInt(a, value());
         break;
       case "--sample-every":
-        args.sampleEvery = Number(value());
+        args.sampleEvery = positiveInt(a, value());
         break;
       case "--experimental":
         args.experimental.push(...value().split(","));
@@ -100,7 +99,24 @@ function parseArgs(argv: string[]): Args {
   }
   if (all) args.missions = missionsInData();
   if (args.missions.length === 0) throw new Error("pass --mission <name> or --all");
+  // A pass shorter than one sample would report every AI as "no samples".
+  for (const [name, frames] of [
+    ["--idle-frames", args.idleFrames],
+    ["--chase-frames", args.chaseFrames],
+  ] as const) {
+    if (frames < args.sampleEvery) {
+      throw new Error(`${name} (${frames}) must be at least --sample-every (${args.sampleEvery})`);
+    }
+  }
   return args;
+}
+
+function positiveInt(flag: string, raw: string): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${flag} needs a positive whole number, got ${raw}`);
+  }
+  return value;
 }
 
 function repoRoot(): string {
@@ -109,14 +125,24 @@ function repoRoot(): string {
   return root;
 }
 
-function dataRoot(): string {
-  return process.env.DARK_ASSET_PATH ?? path.join(repoRoot(), "Data");
-}
-
+/**
+ * Missions in the game data, from the engine's own discovery - a 25th
+ * Anniversary install keeps every .mis inside an archive, so listing the data
+ * directory finds nothing there.
+ */
 function missionsInData(): string[] {
-  return readdirSync(dataRoot())
-    .filter((f) => f.endsWith(".mis"))
-    .sort();
+  const result = spawnSync("cargo", ["run", "--release", "-q", "-p", "bench", "--", "path", "missions"], {
+    cwd: repoRoot(),
+    encoding: "utf8",
+  });
+  const missions = (result.stdout ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith(".mis"));
+  if (result.status !== 0 || missions.length === 0) {
+    throw new Error(`could not list missions: ${result.stderr?.slice(-400) ?? "no output"}`);
+  }
+  return missions.sort();
 }
 
 /**
@@ -128,7 +154,10 @@ async function discoverAis(game: Game): Promise<EntityDetailResult[]> {
   const { entities } = await game.entities.list({ limit: 5000 });
   const ais: EntityDetailResult[] = [];
   for (const entity of entities) {
-    const detail = await game.entities.detail(entity.id).catch(() => null);
+    const detail = await game.entities.detail(entity.id).catch((error: unknown) => {
+      if (error instanceof HttpError && error.status === 404) return null;
+      throw error;
+    });
     if (!detail) continue;
     const props = new Set(detail.properties.map((p) => p.name));
     if (props.has("AIAlertness") || props.has("AIBehavior")) ais.push(detail);
@@ -167,11 +196,14 @@ async function runPass(
   const tracks = new Map<number, AiTrack>();
   for (const ai of ais) {
     const route = await game.pathfinding.route(ai.position, player);
+    // An off-mesh endpoint fails the query exactly like a disconnected one,
+    // so only a route between two resolved cells answers "unreachable".
+    const resolved = route !== null && route.from_cell !== null && route.to_cell !== null;
     tracks.set(ai.entity_id, {
       entity_id: ai.entity_id,
       name: ai.name,
       template_id: ai.template_id,
-      reachable: route ? route.reachable : null,
+      reachable: resolved ? route.reachable : null,
       samples: [],
     });
   }
@@ -180,11 +212,18 @@ async function runPass(
   for (let step = 1; step <= steps; step++) {
     await game.step({ frames: sampleEvery });
     const t = (step * sampleEvery) / 60;
+    // Re-read the player: a chase pass sends every creature into melee, and
+    // distances to a stale position would be fiction if the player is moved.
+    const live = await game.player.position();
+    const playerNow: Vec3 = [live.x, live.y, live.z];
     const paths = new Map((await game.pathfinding.aiPaths()).map((p) => [p.entity_id, p]));
     for (const [id, track] of tracks) {
-      // A dead or despawned AI stops reporting; the samples so far still
-      // classify, so drop the sample rather than the whole pass.
-      const detail = await game.entities.detail(id).catch(() => null);
+      // A dead or despawned AI stops reporting (404); the samples so far
+      // still classify. Any other failure is a broken run, not a datum.
+      const detail = await game.entities.detail(id).catch((error: unknown) => {
+        if (error instanceof HttpError && error.status === 404) return null;
+        throw error;
+      });
       if (!detail) continue;
       const route = paths.get(track.entity_id);
       const sample: AiSample = {
@@ -198,7 +237,7 @@ async function runPass(
         live_path_len: route?.live_path_len ?? null,
         live_target: route?.live_target ?? null,
         live_stall_seconds: route?.live_stall_seconds ?? null,
-        distance: distance3(detail.position, player),
+        distance: distance3(detail.position, playerNow),
       };
       track.samples.push(sample);
     }
@@ -297,7 +336,7 @@ async function main(): Promise<void> {
       }
       await game.input.trigger("DebugForceChase");
       await game.step({ frames: 30 });
-      const label = chaseSpots.length > 1 ? `chase#${index}` : "chase";
+      const label = chaseSpots.length > 1 ? `chase-${index}` : "chase";
       const pass = await runPass(game, "chase", label, args.chaseFrames, args.sampleEvery);
       passes.push(pass);
       console.log(passTable(mission, pass));

--- a/tools/shock2-sdk/scripts/anim-smoothness.ts
+++ b/tools/shock2-sdk/scripts/anim-smoothness.ts
@@ -16,16 +16,13 @@ import path from "node:path";
 import { findRepoRoot, GameServer } from "../src/index.js";
 import type { Game } from "../src/index.js";
 import { analyzePhase, type PhaseReport } from "../src/anim-metrics.js";
+import { distance3 as distance } from "../src/ai-reachability.js";
 import type { AnimationState, EntitySummary, Vec3 } from "../src/types.js";
 
 const PORT = 8095;
 const MISSION = "medsci1.mis";
 const CAPTURE_FRAMES = 600; // 10 s at the fixed 60 Hz step rate
 const FPS = 60;
-
-function distance(a: Vec3, b: Vec3): number {
-  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
-}
 
 /**
  * Find the pipe hybrids by NAME - runtime entity ids are NOT stable across

--- a/tools/shock2-sdk/scripts/render-trail-map.py
+++ b/tools/shock2-sdk/scripts/render-trail-map.py
@@ -94,8 +94,11 @@ def main():
             draw.ellipse([wx - 12, wy - 12, wx + 12, wy + 12], outline=(255, 40, 40), width=3)
         legend.append(f"{track['name']} t{track['template_id']}: {verdict}")
 
-    text_x = width - LEGEND_WIDTH + 12
-    for row, line in enumerate(legend):
+    # Legend runs in columns so a crowded mission cannot push rows off the page.
+    rows_per_column = max(1, (height - 2 * MARGIN) // 16)
+    for index, line in enumerate(legend):
+        column, row = divmod(index, rows_per_column)
+        text_x = width - LEGEND_WIDTH + 12 + column * 170
         color = (255, 90, 90) if "wedged" in line else (220, 220, 225)
         draw.text((text_x, MARGIN + row * 16), line, fill=color)
 

--- a/tools/shock2-sdk/scripts/render-trail-map.py
+++ b/tools/shock2-sdk/scripts/render-trail-map.py
@@ -1,0 +1,107 @@
+"""Draw one AI-reachability pass as a top-down (XZ) trail map.
+
+    python3 render-trail-map.py <cells.json> <pass.json> <out.png>
+
+Nav cells (from `cargo bn path dump`) are the faint background; each AI's
+sampled trail is a colored polyline with a start dot and an end square, a red
+ring wherever it wedged, and the player marked with a magenta cross.
+"""
+
+import json
+import sys
+
+from PIL import Image, ImageDraw
+
+MAX_PIXELS = 2400
+MARGIN = 40
+LEGEND_WIDTH = 360
+
+TRAIL_COLORS = [
+    (255, 96, 96),
+    (96, 200, 255),
+    (140, 230, 140),
+    (255, 200, 80),
+    (210, 140, 255),
+    (255, 140, 200),
+    (120, 255, 220),
+    (200, 200, 120),
+]
+
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def main():
+    cells_file, pass_file, out_file = sys.argv[1:4]
+    cells = load(cells_file)["cells"]
+    data = load(pass_file)
+
+    polygons = [c["polygon"] for c in cells if len(c["polygon"]) >= 3]
+    points = [(p[0], p[2]) for poly in polygons for p in poly]
+    for track in data["tracks"]:
+        points += [(s["position"][0], s["position"][2]) for s in track["samples"]]
+    points.append((data["player"][0], data["player"][2]))
+    if not points:
+        raise SystemExit("nothing to draw")
+
+    min_x = min(p[0] for p in points)
+    max_x = max(p[0] for p in points)
+    min_z = min(p[1] for p in points)
+    max_z = max(p[1] for p in points)
+    span = max(max_x - min_x, max_z - min_z, 1.0)
+    scale = (MAX_PIXELS - 2 * MARGIN) / span
+
+    width = int((max_x - min_x) * scale) + 2 * MARGIN + LEGEND_WIDTH
+    height = int((max_z - min_z) * scale) + 2 * MARGIN
+
+    def xy(pos_x, pos_z):
+        # Flip Z so the map reads like the in-game overhead view.
+        return (
+            MARGIN + (pos_x - min_x) * scale,
+            MARGIN + (max_z - pos_z) * scale,
+        )
+
+    image = Image.new("RGB", (width, height), (16, 16, 20))
+    draw = ImageDraw.Draw(image)
+
+    for polygon in polygons:
+        draw.polygon([xy(p[0], p[2]) for p in polygon], outline=(56, 60, 70))
+
+    px, pz = xy(data["player"][0], data["player"][2])
+    for dx, dy in ((-9, -9, ), (-9, 9)):
+        draw.line([px + dx, pz + dy, px - dx, pz - dy], fill=(255, 64, 220), width=3)
+
+    legend = [f"{data['pass']} pass - {len(data['tracks'])} AIs"]
+    for index, track in enumerate(data["tracks"]):
+        samples = track["samples"]
+        if not samples:
+            continue
+        color = TRAIL_COLORS[index % len(TRAIL_COLORS)]
+        trail = [xy(s["position"][0], s["position"][2]) for s in samples]
+        if len(trail) >= 2:
+            draw.line([c for point in trail for c in point], fill=color, width=2)
+        sx, sy = trail[0]
+        draw.ellipse([sx - 4, sy - 4, sx + 4, sy + 4], fill=color)
+        ex, ey = trail[-1]
+        draw.rectangle([ex - 4, ey - 4, ex + 4, ey + 4], outline=color, width=2)
+
+        verdict = track["classification"]["verdict"]
+        wedge = track["classification"].get("wedge_at")
+        if wedge:
+            wx, wy = xy(wedge[0], wedge[2])
+            draw.ellipse([wx - 12, wy - 12, wx + 12, wy + 12], outline=(255, 40, 40), width=3)
+        legend.append(f"{track['name']} t{track['template_id']}: {verdict}")
+
+    text_x = width - LEGEND_WIDTH + 12
+    for row, line in enumerate(legend):
+        color = (255, 90, 90) if "wedged" in line else (220, 220, 225)
+        draw.text((text_x, MARGIN + row * 16), line, fill=color)
+
+    image.save(out_file)
+    print(f"wrote {out_file} ({width}x{height})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -36,7 +36,9 @@ export interface AiTrack {
   template_id: number;
   /**
    * Does the static walk graph connect this AI's start cell to the player's?
-   * Null when the scene has no pathfinding data.
+   * Null when the answer is unknown - no pathfinding data, or either end was
+   * off the nav mesh at pass start (a query from an off-mesh point fails the
+   * same way a disconnected one does, and must not be read as "by design").
    */
   reachable: boolean | null;
   samples: AiSample[];
@@ -94,9 +96,15 @@ function lastOutcome(samples: AiSample[]): string | undefined {
 }
 
 /**
- * The longest span in which the AI stayed put while it had somewhere to be:
- * a stationary window carrying stall time or an active route. Returns the
- * first such window that clears the duration threshold.
+ * The first span in which the AI stayed put while it was actively trying to
+ * move: stationary for long enough, with stall time that CHANGES across the
+ * window.
+ *
+ * The change requirement matters - the steering's live record is only
+ * refreshed while path-following runs, so an AI that stopped following a path
+ * (reached its patrol end, switched to attacking) keeps its last snapshot
+ * forever. A frozen snapshot is not evidence of a wedge; a stall clock that
+ * ticks (or resets on a backout) is.
  */
 function findWedge(
   samples: AiSample[],
@@ -116,16 +124,11 @@ function findWedge(
     // No behavior data at all is not evidence of standing by design - the
     // runtime sometimes omits AIBehavior - so fall back to the path evidence.
     const traveling = behaviors.length === 0 || behaviors.some((b) => LOCOMOTING.has(b));
-    const blocked = window.some(
-      (s) =>
-        (s.live_stall_seconds ?? 0) > 0 ||
-        (s.outcome === "Full" && (s.live_path_len ?? 0) > 0),
-    );
+    const stalls = new Set(window.map((s) => s.live_stall_seconds ?? 0));
+    const blocked = stalls.size > 1 && Math.max(...stalls) > 0;
     if (traveling && blocked) {
       return { at: samples[i].position, seconds };
     }
-    // Windows are maximal, so the next one can only start after this one.
-    i = j;
   }
   return undefined;
 }
@@ -157,10 +160,13 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
   const final = samples[samples.length - 1].distance;
   const base = { closest_distance: closest, final_distance: final };
 
-  if (options.pass === "chase" && closest <= arriveRadius) {
+  // Arrival means the AI CLOSED on the player: one that started inside melee
+  // reach and never moved must still be able to come out as wedged.
+  const start = samples[0].distance;
+  if (options.pass === "chase" && closest <= arriveRadius && start > arriveRadius) {
     return {
       verdict: "arrived",
-      reason: `closed to ${closest.toFixed(1)} (<= ${arriveRadius})`,
+      reason: `closed from ${start.toFixed(1)} to ${closest.toFixed(1)} (<= ${arriveRadius})`,
       ...base,
     };
   }
@@ -192,7 +198,10 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     if (alertness.length > 0 && alertness.every((a) => a === "Lowest")) {
       return {
         verdict: "expected_unreachable",
-        reason: "alertness stayed Lowest through a forced chase (alert-capped)",
+        // Either the mission caps its alertness (P$AI_AlertC) or the pin never
+        // reaches it at all (it only goes to creatures, so turrets and cameras
+        // land here too) - in both cases it was never coming.
+        reason: "alertness never rose above Lowest under a forced chase",
         ...base,
       };
     }
@@ -214,7 +223,11 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     return { verdict: "no_route", reason: `last path outcome ${outcome}`, ...base };
   }
 
-  const traveled = distance3(samples[0].position, samples[samples.length - 1].position);
+  // Path length, not start-to-end displacement: a loop patrol returns to where
+  // it started and would otherwise read as "never moved".
+  const traveled = samples
+    .slice(1)
+    .reduce((sum, s, i) => sum + distance3(samples[i].position, s.position), 0);
   const everPathed = samples.some(
     (s) => Boolean(s.outcome) || (s.live_path_len ?? 0) > 0 || (s.live_stall_seconds ?? 0) > 0,
   );

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -64,7 +64,10 @@ export interface Classification {
 
 export interface ClassifyOptions {
   pass: "idle" | "chase";
-  /** Distance at which a chasing AI counts as having reached the player. */
+  /**
+   * Distance at which a chasing AI counts as having reached the player.
+   * Defaults to the engine's own melee reach (MELEE_ATTACK_RANGE).
+   */
   arriveRadius?: number;
   /** Minimum stationary span that counts as a wedge, seconds. */
   wedgeWindowSeconds?: number;
@@ -136,7 +139,7 @@ function findWedge(
  * or alert-capped AI is not counted as a pathfinding failure.
  */
 export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classification {
-  const arriveRadius = options.arriveRadius ?? 3.0;
+  const arriveRadius = options.arriveRadius ?? 3.2;
   const windowSeconds = options.wedgeWindowSeconds ?? 6.0;
   const wedgeDisplacement = options.wedgeDisplacement ?? 1.0;
   const samples = track.samples;
@@ -195,7 +198,10 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     }
   }
 
-  if (track.reachable === false) {
+  // Only the chase pass holds an AI to the player's position: in the idle
+  // pass it is walking its own patrol, so its connectivity to the player says
+  // nothing about whether it is doing its job.
+  if (options.pass === "chase" && track.reachable === false) {
     return {
       verdict: "expected_unreachable",
       reason: "no walk route from its start cell to the player",

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -1,0 +1,240 @@
+/**
+ * Classification of AI reachability samples: given one AI's trail over a
+ * pass, decide whether it reached the player, is still making progress, is
+ * physically wedged, failed to route, or was never going anywhere.
+ *
+ * Pure over the samples so it is unit-testable without a running game (the
+ * harness that collects the samples lives in scripts/ai-reachability.ts).
+ */
+
+import type { Vec3 } from "./types.js";
+
+/** One observation of an AI, taken every N stepped frames. */
+export interface AiSample {
+  /** Seconds of simulation since the pass started. */
+  t: number;
+  position: Vec3;
+  /** Facing, radians. */
+  yaw: number;
+  /** AIBehavior ("Patrol", "Chase", ...); absent when the runtime omits it. */
+  behavior?: string;
+  /** AIAlertness ("Lowest".."High"); absent when the runtime omits it. */
+  alertness?: string;
+  /** Latest path outcome: "Full" | "Partial" | "Failed". */
+  outcome?: string;
+  live_next_waypoint?: number | null;
+  live_path_len?: number | null;
+  live_target?: Vec3 | null;
+  live_stall_seconds?: number | null;
+  /** Distance to the player at this sample. */
+  distance: number;
+}
+
+export interface AiTrack {
+  entity_id: number;
+  name: string;
+  template_id: number;
+  /**
+   * Does the static walk graph connect this AI's start cell to the player's?
+   * Null when the scene has no pathfinding data.
+   */
+  reachable: boolean | null;
+  samples: AiSample[];
+}
+
+export type Verdict =
+  | "arrived"
+  | "progressing"
+  | "wedged"
+  | "no_route"
+  | "expected_unreachable"
+  | "idle_by_design";
+
+export interface Classification {
+  verdict: Verdict;
+  /** One line saying which rule fired, with the numbers behind it. */
+  reason: string;
+  /** Where the AI was stuck (wedged only) - a reproducible seed position. */
+  wedge_at?: Vec3;
+  /** How long it was stuck there, seconds (wedged only). */
+  wedge_seconds?: number;
+  closest_distance: number;
+  final_distance: number;
+}
+
+export interface ClassifyOptions {
+  pass: "idle" | "chase";
+  /** Distance at which a chasing AI counts as having reached the player. */
+  arriveRadius?: number;
+  /** Minimum stationary span that counts as a wedge, seconds. */
+  wedgeWindowSeconds?: number;
+  /** Displacement below which the AI counts as not moving, world units. */
+  wedgeDisplacement?: number;
+}
+
+/** Behaviors that mean the AI is trying to travel somewhere. */
+const LOCOMOTING = new Set(["Patrol", "Wander", "Chase", "Search"]);
+
+/** Behaviors that never travel, so failing to arrive is not a defect. */
+const NON_TRAVELING = new Set(["ScriptedSequence", "Noop", "Dead", "SelfDestruct"]);
+
+export function distance3(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+/** Latest non-null path outcome in the pass, if the AI ever pathed. */
+function lastOutcome(samples: AiSample[]): string | undefined {
+  for (let i = samples.length - 1; i >= 0; i--) {
+    if (samples[i].outcome) return samples[i].outcome;
+  }
+  return undefined;
+}
+
+/**
+ * The longest span in which the AI stayed put while it had somewhere to be:
+ * a stationary window carrying stall time or an active route. Returns the
+ * first such window that clears the duration threshold.
+ */
+function findWedge(
+  samples: AiSample[],
+  windowSeconds: number,
+  displacement: number,
+): { at: Vec3; seconds: number } | undefined {
+  for (let i = 0; i < samples.length; i++) {
+    let j = i;
+    while (j + 1 < samples.length && distance3(samples[i].position, samples[j + 1].position) < displacement) {
+      j++;
+    }
+    const seconds = samples[j].t - samples[i].t;
+    if (seconds < windowSeconds) continue;
+
+    const window = samples.slice(i, j + 1);
+    const behaviors = window.map((s) => s.behavior).filter((b): b is string => Boolean(b));
+    // No behavior data at all is not evidence of standing by design - the
+    // runtime sometimes omits AIBehavior - so fall back to the path evidence.
+    const traveling = behaviors.length === 0 || behaviors.some((b) => LOCOMOTING.has(b));
+    const blocked = window.some(
+      (s) =>
+        (s.live_stall_seconds ?? 0) > 0 ||
+        (s.outcome === "Full" && (s.live_path_len ?? 0) > 0),
+    );
+    if (traveling && blocked) {
+      return { at: samples[i].position, seconds };
+    }
+    // Windows are maximal, so the next one can only start after this one.
+    i = j;
+  }
+  return undefined;
+}
+
+/**
+ * Classify one AI's pass.
+ *
+ * Order matters: a wedge is reported even for an AI that could never have
+ * reached the player anyway (being physically stuck is a defect on its own),
+ * and "expected unreachable" outranks the routing verdicts so a sealed-off
+ * or alert-capped AI is not counted as a pathfinding failure.
+ */
+export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classification {
+  const arriveRadius = options.arriveRadius ?? 3.0;
+  const windowSeconds = options.wedgeWindowSeconds ?? 6.0;
+  const wedgeDisplacement = options.wedgeDisplacement ?? 1.0;
+  const samples = track.samples;
+
+  if (samples.length === 0) {
+    return {
+      verdict: "idle_by_design",
+      reason: "no samples",
+      closest_distance: Infinity,
+      final_distance: Infinity,
+    };
+  }
+
+  const closest = Math.min(...samples.map((s) => s.distance));
+  const final = samples[samples.length - 1].distance;
+  const base = { closest_distance: closest, final_distance: final };
+
+  if (options.pass === "chase" && closest <= arriveRadius) {
+    return {
+      verdict: "arrived",
+      reason: `closed to ${closest.toFixed(1)} (<= ${arriveRadius})`,
+      ...base,
+    };
+  }
+
+  const wedge = findWedge(samples, windowSeconds, wedgeDisplacement);
+  if (wedge) {
+    return {
+      verdict: "wedged",
+      reason: `stationary ${wedge.seconds.toFixed(1)}s at (${wedge.at.map((c) => c.toFixed(2)).join(", ")}) with a route or stall active`,
+      wedge_at: wedge.at,
+      wedge_seconds: wedge.seconds,
+      ...base,
+    };
+  }
+
+  const behaviors = new Set(samples.map((s) => s.behavior).filter((b): b is string => Boolean(b)));
+  if (behaviors.size > 0 && [...behaviors].every((b) => NON_TRAVELING.has(b))) {
+    return {
+      verdict: "expected_unreachable",
+      reason: `never travels (${[...behaviors].join("/")})`,
+      ...base,
+    };
+  }
+
+  // An AI that cannot be roused above Lowest by a forced chase is alert-capped
+  // in the mission data (P$AI_AlertC) - it is not supposed to come.
+  if (options.pass === "chase") {
+    const alertness = samples.map((s) => s.alertness).filter((a): a is string => Boolean(a));
+    if (alertness.length > 0 && alertness.every((a) => a === "Lowest")) {
+      return {
+        verdict: "expected_unreachable",
+        reason: "alertness stayed Lowest through a forced chase (alert-capped)",
+        ...base,
+      };
+    }
+  }
+
+  if (track.reachable === false) {
+    return {
+      verdict: "expected_unreachable",
+      reason: "no walk route from its start cell to the player",
+      ...base,
+    };
+  }
+
+  const outcome = lastOutcome(samples);
+  if (outcome === "Partial" || outcome === "Failed") {
+    return { verdict: "no_route", reason: `last path outcome ${outcome}`, ...base };
+  }
+
+  const traveled = distance3(samples[0].position, samples[samples.length - 1].position);
+  const everPathed = samples.some(
+    (s) => Boolean(s.outcome) || (s.live_path_len ?? 0) > 0 || (s.live_stall_seconds ?? 0) > 0,
+  );
+  if (traveled < wedgeDisplacement && !everPathed) {
+    return { verdict: "idle_by_design", reason: "never moved and never pathed", ...base };
+  }
+
+  return {
+    verdict: "progressing",
+    reason: `moved ${traveled.toFixed(1)}, ended ${final.toFixed(1)} from the player`,
+    ...base,
+  };
+}
+
+/** Counts by verdict, in table order. */
+export const VERDICTS: Verdict[] = [
+  "arrived",
+  "progressing",
+  "wedged",
+  "no_route",
+  "expected_unreachable",
+  "idle_by_design",
+];
+
+export function tally(classifications: Classification[]): Record<Verdict, number> {
+  const counts = Object.fromEntries(VERDICTS.map((v) => [v, 0])) as Record<Verdict, number>;
+  for (const c of classifications) counts[c.verdict] += 1;
+  return counts;
+}

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -42,6 +42,7 @@ import type {
   TransitionsResult,
   WaitForOptions,
   AiPathEntry,
+  PathRouteResult,
   AimOptions,
   AimPoint,
   AimResult,
@@ -832,6 +833,22 @@ export class PathfindingApi {
    */
   async aiPaths(): Promise<AiPathEntry[]> {
     return this.client.get<AiPathEntry[]>("/v1/ai/paths");
+  }
+
+  /**
+   * Does a walk route exist between two world positions? Answers "the AI is
+   * failing to route" vs "nothing walkable connects these at all". Null when
+   * the scene has no pathfinding data.
+   */
+  async route(from: Vec3, to: Vec3): Promise<PathRouteResult | null> {
+    const q = (v: Vec3) => v.join(",");
+    try {
+      return await this.client.get<PathRouteResult>(
+        `/v1/pathfinding/route?from=${q(from)}&to=${q(to)}`,
+      );
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from "./client.js";
+import { HttpClient, HttpError } from "./client.js";
 import type {
   AnimationState,
   CommandResult,
@@ -846,8 +846,11 @@ export class PathfindingApi {
       return await this.client.get<PathRouteResult>(
         `/v1/pathfinding/route?from=${q(from)}&to=${q(to)}`,
       );
-    } catch {
-      return null;
+    } catch (error) {
+      // Only "this scene has no pathfinding data" is an answer; a transport
+      // error or a 500 must not masquerade as one.
+      if (error instanceof HttpError && error.status === 404) return null;
+      throw error;
     }
   }
 }

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -17,4 +17,5 @@ export {
 } from "./game.js";
 export { findRepoRoot, GameServer, type LaunchOptions } from "./server.js";
 export * from "./anim-metrics.js";
+export * from "./ai-reachability.js";
 export type * from "./types.js";

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -78,6 +78,26 @@ export interface AiPathEntry {
   outcome: string;
   /** Route waypoints (empty for Failed). */
   waypoints: [number, number, number][];
+  /** Index of the waypoint the steering is CURRENTLY following. */
+  live_next_waypoint?: number | null;
+  /** Length of the live path being followed. */
+  live_path_len?: number | null;
+  /** World position currently steered toward. */
+  live_target?: [number, number, number] | null;
+  /** Seconds without progress toward the current waypoint. */
+  live_stall_seconds?: number | null;
+}
+
+/** One-off walk-graph query between two positions (GET /v1/pathfinding/route). */
+export interface PathRouteResult {
+  /** Cell containing the start (null when off-mesh). */
+  from_cell: number | null;
+  /** Cell containing the goal (null when off-mesh). */
+  to_cell: number | null;
+  /** Whether a walk route exists between them. */
+  reachable: boolean;
+  /** Waypoint count of that route (0 when unreachable). */
+  waypoints: number;
 }
 
 export interface PathfindingStats {

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -46,7 +46,12 @@ test("a patrolling AI stuck against geometry is 'wedged', with its position", ()
   const result = classifyTrack(
     track([
       { position: [48, 0.1, -85], outcome: "Full", live_path_len: 4, live_stall_seconds: 0 },
-      ...stationary(20, { outcome: "Full", live_path_len: 11, live_stall_seconds: 2.5, behavior: "Patrol" }),
+      // The stall clock ticks up and resets on each backout - what a live
+      // wedge looks like, as opposed to a frozen snapshot.
+      ...stationary(20, { outcome: "Full", live_path_len: 11, behavior: "Patrol" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: (i % 6) * 0.5,
+      })),
     ]),
     { pass: "idle" },
   );
@@ -109,7 +114,7 @@ test("an AI that never leaves Lowest under a forced chase is alert-capped", () =
     { pass: "chase" },
   );
   assert.equal(result.verdict, "expected_unreachable");
-  assert.match(result.reason, /alert-capped/);
+  assert.match(result.reason, /never rose above Lowest/);
 });
 
 test("a scripted-sequence AI is expected-unreachable", () => {
@@ -131,6 +136,57 @@ test("an AI still closing on the player is 'progressing'", () => {
       { position: [20, 0, 0], distance: 30, outcome: "Full", behavior: "Chase", alertness: "High" },
     ]),
     { pass: "chase" },
+  );
+  assert.equal(result.verdict, "progressing");
+});
+
+test("a frozen steering snapshot is not evidence of a wedge", () => {
+  // The live path/stall record is only refreshed while path-following runs,
+  // so an AI that stopped following keeps its last snapshot forever.
+  const result = classifyTrack(
+    track(stationary(30, { outcome: "Full", live_path_len: 5, live_stall_seconds: 0.78, behavior: "Idle" })),
+    { pass: "idle" },
+  );
+  assert.notEqual(result.verdict, "wedged");
+});
+
+test("an AI that starts inside melee reach and never moves is wedged, not 'arrived'", () => {
+  const result = classifyTrack(
+    track(
+      stationary(20, { behavior: "Chase", alertness: "High", live_stall_seconds: 1 }).map((s, i) => ({
+        ...s,
+        distance: 2.5,
+        live_stall_seconds: i % 4, // the stall clock ticks and resets
+      })),
+    ),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "wedged");
+});
+
+test("a wedge that starts after an unblocked stationary spell is still found", () => {
+  const result = classifyTrack(
+    track([
+      // 8s parked with no stall evidence, then 8s parked while stalling.
+      ...stationary(16, { behavior: "Patrol" }),
+      ...stationary(16, { behavior: "Patrol" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+      })),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+});
+
+test("a loop patrol that returns to its start is not 'never moved'", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], behavior: "Patrol" },
+      { position: [0, 0, 20], behavior: "Patrol" },
+      { position: [0, 0, 0], behavior: "Patrol" },
+    ]),
+    { pass: "idle" },
   );
   assert.equal(result.verdict, "progressing");
 });

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -86,6 +86,20 @@ test("an AI with no walk route to the player is expected-unreachable, not a fail
   assert.equal(result.verdict, "expected_unreachable");
 });
 
+test("player connectivity does not judge the idle pass - the AI is on its own patrol", () => {
+  const result = classifyTrack(
+    track(
+      [
+        { position: [0, 0, 0], outcome: "Full", behavior: "Patrol" },
+        { position: [8, 0, 0], outcome: "Full", behavior: "Patrol" },
+      ],
+      { reachable: false },
+    ),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "progressing");
+});
+
 test("an AI that never leaves Lowest under a forced chase is alert-capped", () => {
   const result = classifyTrack(
     track([

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { classifyTrack, tally, type AiSample, type AiTrack } from "../src/ai-reachability.js";
+
+type SampleOverrides = Partial<AiSample>;
+
+/** A track sampled every 0.5s, like the harness does (30 frames at 60Hz). */
+function track(samples: SampleOverrides[], overrides: Partial<AiTrack> = {}): AiTrack {
+  return {
+    entity_id: 1,
+    name: "OG-Pipe",
+    template_id: 668,
+    reachable: true,
+    samples: samples.map((s, i) => ({
+      t: i * 0.5,
+      position: [0, 0, 0],
+      yaw: 0,
+      distance: 50,
+      ...s,
+    })),
+    ...overrides,
+  };
+}
+
+/** N samples standing at one spot. */
+function stationary(count: number, overrides: SampleOverrides = {}): SampleOverrides[] {
+  return Array.from({ length: count }, () => ({ position: [49, 0.1, -98.5] as const, ...overrides }));
+}
+
+test("a chasing AI that reaches the player is 'arrived'", () => {
+  const result = classifyTrack(
+    track([
+      { position: [20, 0, 0], distance: 20 },
+      { position: [10, 0, 0], distance: 10 },
+      { position: [2, 0, 0], distance: 2 },
+    ]),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "arrived");
+});
+
+test("a patrolling AI stuck against geometry is 'wedged', with its position", () => {
+  // The medsci2 railing bug: patrol route is Full, the AI never moves, and
+  // the steering reports stall time.
+  const result = classifyTrack(
+    track([
+      { position: [48, 0.1, -85], outcome: "Full", live_path_len: 4, live_stall_seconds: 0 },
+      ...stationary(20, { outcome: "Full", live_path_len: 11, live_stall_seconds: 2.5, behavior: "Patrol" }),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+  assert.deepEqual(result.wedge_at, [49, 0.1, -98.5]);
+  assert.ok((result.wedge_seconds ?? 0) >= 6);
+});
+
+test("standing still with no route is not a wedge", () => {
+  const result = classifyTrack(track(stationary(30, { behavior: "Idle" })), { pass: "idle" });
+  assert.equal(result.verdict, "idle_by_design");
+});
+
+test("a failed route is 'no_route'", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], outcome: "Failed", behavior: "Chase" },
+      { position: [1, 0, 0], outcome: "Failed", behavior: "Chase" },
+      { position: [3, 0, 0], outcome: "Partial", behavior: "Chase" },
+    ]),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "no_route");
+});
+
+test("an AI with no walk route to the player is expected-unreachable, not a failure", () => {
+  const result = classifyTrack(
+    track(
+      [
+        { position: [0, 0, 0], outcome: "Failed", behavior: "Chase", alertness: "High" },
+        { position: [1, 0, 0], outcome: "Failed", behavior: "Chase", alertness: "High" },
+      ],
+      { reachable: false },
+    ),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "expected_unreachable");
+});
+
+test("an AI that never leaves Lowest under a forced chase is alert-capped", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], alertness: "Lowest", behavior: "Idle" },
+      { position: [4, 0, 0], alertness: "Lowest", behavior: "Idle" },
+    ]),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "expected_unreachable");
+  assert.match(result.reason, /alert-capped/);
+});
+
+test("a scripted-sequence AI is expected-unreachable", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], behavior: "ScriptedSequence", alertness: "High" },
+      { position: [5, 0, 0], behavior: "ScriptedSequence", alertness: "High" },
+    ]),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "expected_unreachable");
+});
+
+test("an AI still closing on the player is 'progressing'", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], distance: 60, outcome: "Full", behavior: "Chase", alertness: "High" },
+      { position: [10, 0, 0], distance: 45, outcome: "Full", behavior: "Chase", alertness: "High" },
+      { position: [20, 0, 0], distance: 30, outcome: "Full", behavior: "Chase", alertness: "High" },
+    ]),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "progressing");
+});
+
+test("tally counts every verdict bucket", () => {
+  const counts = tally([
+    { verdict: "arrived", reason: "", closest_distance: 1, final_distance: 1 },
+    { verdict: "wedged", reason: "", closest_distance: 1, final_distance: 1 },
+    { verdict: "wedged", reason: "", closest_distance: 1, final_distance: 1 },
+  ]);
+  assert.equal(counts.arrived, 1);
+  assert.equal(counts.wedged, 2);
+  assert.equal(counts.no_route, 0);
+});


### PR DESCRIPTION
Step 1 of the pathfinding evaluation plan: measure whether AIs actually get where they are going, so every later steering/graph fix has before/after numbers.

## What it does

`npm run ai-reachability -- --mission medsci2.mis --out /tmp/aire` runs two passes per mission, each on a freshly launched runtime:

- **idle** — no player input; the AIs run their authored patrols (3600 frames).
- **chase** — the player stands at a fixed spot, `DebugForceChase` pins everyone onto them (1800 frames).

Every AI is discovered by its AI runtime properties (never by a hardcoded runtime id) and sampled every 30 frames: position, yaw, `AIBehavior`/`AIAlertness`, its `/v1/ai/paths` entry (outcome, live waypoint, live path length, stall seconds, live target) and its distance to the player. At the end of a pass each AI is classified `arrived` / `progressing` / `wedged` / `no_route` / `expected_unreachable` / `idle_by_design`.

Outputs per mission: `<out>/<mission>.json` (every sample + classifications), `<out>/summary.md` plus the same table on stdout, and a top-down trail map per pass.

The expected-unreachable filter is data-driven, no hand lists: an AI that never travels (ScriptedSequence/Noop/Dead/SelfDestruct), one whose alertness cannot be lifted off `Lowest` by a forced chase (the mission's alert cap), and one with no walk route from its start cell to the player (only counted when both endpoints resolved to a nav cell, so an off-mesh sample is never mistaken for "by design"). A wedge outranks all of them, so an AI that is physically stuck is still reported even where it could never have reached the player.

## Supporting changes

- `GET /v1/pathfinding/route?from=x,y,z&to=x,y,z` — does a walk route exist between two positions? This is what separates "the AI failed to route" from "nothing walkable connects it to the player".
- `cargo bn path dump <mission>` — every nav cell as JSON (polygon, center, flags, walk component), the geometry the trail map draws over; `cargo bn path missions` lists the missions the engine can actually open (they live inside an archive on a 25AE install).
- `scripts/render-trail-map.py` — nav cells faint, one colored polyline per AI, dot at the start, square at the end, red ring at each wedge, magenta cross at the player.

## Results (this branch, no experimental flags)

| mission | pass | AIs | arrived | progressing | wedged | no_route | expected_unreachable | idle_by_design |
|---|---|---|---|---|---|---|---|---|
| medsci1.mis | idle | 26 | 0 | 13 | 1 | 0 | 0 | 12 |
| medsci1.mis | chase | 26 | 3 | 0 | 5 | 0 | 18 | 0 |
| medsci2.mis | idle | 18 | 0 | 8 | 3 | 0 | 0 | 7 |
| medsci2.mis | chase | 18 | 3 | 6 | 1 | 0 | 8 | 0 |

Wedges, each a reproducible seed (name + stable template id + coordinates):

```
medsci2  idle   OG-Pipe t668       56.0s at (48.54, 0.10, -97.90)   <- the known railing wedge
medsci2  idle   OG-Pipe t705        6.0s at (37.71, 0.10, -36.25)
medsci2  idle   OG-Pipe t1661       6.0s at (45.24, -0.18,  -9.01)
medsci2  chase  OG-Pipe t705        6.5s at (37.88, 0.10, -36.25)   <- the known door-jamb wedge
medsci1  idle   OG-Pipe t596       51.0s at ( 7.68, 0.10, -36.32)
medsci1  chase  Chucky t964        19.5s at (-14.10, 0.10, -27.29)
medsci1  chase  Maintenance t87     8.0s at ( 11.63, -2.60, -51.50)
medsci1  chase  OG-Pipe t163        6.0s at (-10.85, -4.70,  36.35)
medsci1  chase  OG-Shotgun t1624   11.0s at (-18.44, 0.50,  65.94)
medsci1  chase  OG-Shotgun t1632    8.5s at (-19.12, 0.50,  65.88)
```

The two documented wedges are the harness's negative test and it flags both: template 668 at the medsci2 railing dead-end, and template 705 at the Science-wing door jamb under a forced chase.

The expected-unreachable filter drops medsci1's scripted vent grunt (OG-Shotgun t613, "alertness never rose above Lowest under a forced chase") and the caged hybrid t1007 ("no walk route from its start cell to the player") rather than counting them as failures.

## Trail maps

medsci1 idle / chase:

![medsci1 idle](https://gist.githubusercontent.com/tommy-xr/08341968e88b54dcc473f44731a302b2/raw/medsci1-idle.png)
![medsci1 chase](https://gist.githubusercontent.com/tommy-xr/08341968e88b54dcc473f44731a302b2/raw/medsci1-chase.png)

medsci2 idle / chase:

![medsci2 idle](https://gist.githubusercontent.com/tommy-xr/08341968e88b54dcc473f44731a302b2/raw/medsci2-idle.png)
![medsci2 chase](https://gist.githubusercontent.com/tommy-xr/08341968e88b54dcc473f44731a302b2/raw/medsci2-chase.png)

## Known limitations

- A few medsci1 chase wedges are AIs standing just outside melee reach of the player (Chucky at 3.4 units) rather than jammed in geometry: they got there but never closed, which is the AI-to-AI crowding gap in the plan. The wedge test does require a stall clock that is actively ticking, so a stopped AI with a stale route no longer counts.
- The chase pass teleports the player to one spot per mission (a small per-mission table in the script; medsci1 uses the open deck because its spawn is the sealed cryo room). More spots per mission is a table edit.
- Discovering AIs walks every entity's detail once per pass (~17 s on medsci2), so a full `--all` sweep is minutes per mission.
- `cargo bn path dump` reads the shipped graph, so the trail map's cells do not show `nav_bridges` synthesized links.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p bench`, `cargo fmt`
- `npm test` in tools/shock2-sdk, including 14 new classifier unit tests
- e2e: `missions.e2e.test.ts` (all 23 missions load), `pathfinding.e2e.test.ts`, `force-chase.e2e.test.ts` - all green
- `/xreview` run; every Critical/High finding addressed (stale steering snapshots reading as wedges, arrival masking a wedge, off-mesh endpoints reading as "unreachable by design", swallowed HTTP errors, unvalidated arguments, `--all` missing archive-packed missions)
