### PR TITLE
feat(weapons): parse every gun fire-mode setting and its display strings

### DIFF
--- a/dark/src/importers/strings_importer.rs
+++ b/dark/src/importers/strings_importer.rs
@@ -79,12 +79,137 @@ pub fn parse_strings(content: &[String]) -> HashMap<String, String> {
     map
 }
 
+/// Split a Dark object string (`key: "fallback text"`) into its lookup key and
+/// its inline fallback text.
+fn split_object_string(raw: &str) -> (&str, &str) {
+    match raw.split_once(':') {
+        Some((key, remainder)) => {
+            let remainder = remainder.trim();
+            let fallback = match remainder.strip_prefix('"') {
+                Some(quoted) => quoted.split_once('"').map_or("", |(value, _)| value),
+                None => remainder,
+            };
+            (key.trim(), fallback)
+        }
+        None => (raw.trim(), ""),
+    }
+}
+
+fn lookup(strings: &HashMap<String, String>, key: &str) -> Option<String> {
+    if key.is_empty() {
+        return None;
+    }
+    strings.get(&key.to_ascii_lowercase()).cloned()
+}
+
+/// Resolve an object string against a string table, falling back to the inline
+/// text the property carries.
+pub fn resolve_localized_property_string(raw: &str, strings: &HashMap<String, String>) -> String {
+    let (key, fallback) = split_object_string(raw);
+    lookup(strings, key).unwrap_or_else(|| fallback.to_owned())
+}
+
+/// Resolve a gun fire-setting string (`P$Sett1`/`P$SHead2`/...) against its
+/// `SETT*`/`SHEAD*` table.
+///
+/// Some guns author no setting property at all - the Stasis Field Generator,
+/// Worm Launcher and Viral Proliferator - yet the tables carry entries for
+/// them, keyed by their symbolic name with spaces underscored
+/// (`Stasis_Field_Generator`). So the symbolic name is tried whenever the
+/// property is missing or its own key misses.
+pub fn resolve_gun_setting_string(
+    raw: Option<&str>,
+    sym_name: Option<&str>,
+    strings: &HashMap<String, String>,
+) -> Option<String> {
+    let (key, fallback) = raw.map_or(("", ""), split_object_string);
+    lookup(strings, key)
+        .or_else(|| lookup(strings, &sym_name.unwrap_or_default().replace(' ', "_")))
+        .or_else(|| (!fallback.is_empty()).then(|| fallback.to_owned()))
+}
+
 pub static STRINGS_IMPORTER: Lazy<AssetImporter<Vec<String>, HashMap<String, String>, ()>> =
     Lazy::new(|| AssetImporter::define(import_strings, process_strings));
 
 #[cfg(test)]
 mod tests {
-    use super::parse_strings;
+    use std::collections::HashMap;
+
+    use super::{parse_strings, resolve_gun_setting_string, resolve_localized_property_string};
+
+    fn table(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| (key.to_ascii_lowercase(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn object_string_resolves_its_key_against_the_table() {
+        let strings = table(&[("elevator_button", "Localized elevator button")]);
+
+        assert_eq!(
+            resolve_localized_property_string(
+                r#"Elevator_Button: "A two-state button.""#,
+                &strings
+            ),
+            "Localized elevator button"
+        );
+    }
+
+    #[test]
+    fn object_string_falls_back_to_its_embedded_text() {
+        assert_eq!(
+            resolve_localized_property_string(r#"HumanCorpses: "A corpse.""#, &table(&[])),
+            "A corpse."
+        );
+    }
+
+    #[test]
+    fn a_bare_key_with_no_embedded_text_still_resolves() {
+        let strings = table(&[("basketball", "A basketball.")]);
+
+        assert_eq!(
+            resolve_localized_property_string("Basketball", &strings),
+            "A basketball."
+        );
+    }
+
+    #[test]
+    fn setting_string_prefers_the_table_over_the_inline_fallback() {
+        let strings = table(&[("pistol", "BURST")]);
+
+        assert_eq!(
+            resolve_gun_setting_string(Some(r#"Pistol: "stale""#), Some("Pistol"), &strings),
+            Some("BURST".to_string())
+        );
+    }
+
+    #[test]
+    fn setting_string_falls_back_to_the_inline_text() {
+        assert_eq!(
+            resolve_gun_setting_string(Some(r#"Pistol: "BURST""#), Some("Pistol"), &table(&[])),
+            Some("BURST".to_string())
+        );
+    }
+
+    #[test]
+    fn setting_string_falls_back_to_the_underscored_symbolic_name() {
+        let strings = table(&[("stasis_field_generator", "AREA")]);
+
+        assert_eq!(
+            resolve_gun_setting_string(None, Some("Stasis Field Generator"), &strings),
+            Some("AREA".to_string())
+        );
+    }
+
+    #[test]
+    fn setting_string_is_absent_when_nothing_resolves() {
+        assert_eq!(
+            resolve_gun_setting_string(None, Some("Rick Turret Gun"), &table(&[])),
+            None
+        );
+    }
 
     #[test]
     fn accepts_whitespace_between_colon_and_opening_quote() {

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -366,6 +366,23 @@ impl PropInventoryDimensions {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropObjIcon(pub String);
 
+/// `P$Sett1` / `P$Sett2` - the description text for a gun's first / second fire
+/// setting, and `P$SHead1` / `P$SHead2` - the short header shown beside it
+/// (e.g. "NORM" / "BURST"). Each holds an object string (`key: "fallback"`)
+/// resolved against the matching `SETT1`/`SETT2`/`SHEAD1`/`SHEAD2` string
+/// table; see `dark::importers::resolve_gun_setting_string`.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropGunSettingText1(pub String);
+
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropGunSettingText2(pub String);
+
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropGunSettingHeader1(pub String);
+
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropGunSettingHeader2(pub String);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropObjName(pub String);
 
@@ -1486,6 +1503,30 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$BaseGunDe",
             PropBaseGunDesc::read,
             identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$Sett1",
+            read_variable_length_string,
+            PropGunSettingText1,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$Sett2",
+            read_variable_length_string,
+            PropGunSettingText2,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$SHead1",
+            read_variable_length_string,
+            PropGunSettingHeader1,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$SHead2",
+            read_variable_length_string,
+            PropGunSettingHeader2,
             accumulator::latest,
         ),
         define_prop(

--- a/dark/src/properties/prop_base_gun_desc.rs
+++ b/dark/src/properties/prop_base_gun_desc.rs
@@ -6,41 +6,57 @@ use crate::ss2_common::{read_i32, read_single, read_u32};
 
 use serde::{Deserialize, Serialize};
 
-/// `P$BaseGunDe` - the per-archetype gun description. Mirrors the leading fields
-/// of the Dark engine's `sBaseGunDesc` (engfeat/gunbase.h), in field order. The
-/// SS2 chunk is larger than this 40-byte Thief layout (it carries per-setting
-/// data too), so [`PropBaseGunDesc::read`] reads only the leading fields and
-/// then seeks to the end of the chunk (`len`), leaving the rest available later.
-///
-/// For now only `clip` (magazine size) is used at runtime, to refill ammo on
-/// reload; the rest are parsed so the values are available later (per-shot
-/// ammo usage, reload time, fire timing).
-#[derive(Debug, Component, Clone, Serialize, Deserialize)]
-pub struct PropBaseGunDesc {
-    /// `m_burst` - projectiles per trigger pull (over time).
+/// Fire settings a gun description carries. A gun's UI exposes the first two
+/// (the two selectable fire modes); the third is an unselected leftover.
+pub const GUN_SETTING_COUNT: usize = 3;
+
+/// On-disk size of one [`GunSettingDesc`]: the nine fields below plus a
+/// trailing i32 that the shipped data never initializes.
+const SETTING_SIZE: u64 = 40;
+
+/// One fire setting of a gun. Retail guns author different values per setting -
+/// e.g. the pistol's second setting is a 3-round burst with a longer gap
+/// between pulls.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GunSettingDesc {
+    /// Projectiles per trigger pull, over time. `-1` is unlimited (full auto).
     pub burst: i32,
-    /// `m_clip` - magazine size (rounds per full clip).
+    /// Magazine size (rounds per full clip).
     pub clip: i32,
-    /// `m_spray` - projectiles per trigger pull (instantaneous).
+    /// Projectiles per trigger pull, instantaneous.
     pub spray: i32,
-    /// `m_stimModifier` - multiplier on projectile stimulus intensity.
+    /// Multiplier on projectile stimulus intensity.
     pub stim_modifier: f32,
-    /// `m_burstInterval` - interval between bursts (`tSimTime`, milliseconds).
+    /// Interval between bursts, in milliseconds.
     pub burst_interval_ms: u32,
-    /// `m_shotInterval` - interval between shots (`tSimTime`, milliseconds).
+    /// Interval between shots, in milliseconds.
     pub shot_interval_ms: u32,
-    /// `m_ammoUsage` - ammo units consumed per shot.
+    /// Ammo units consumed per shot.
     pub ammo_usage: i32,
-    /// `m_speedModifier` - multiplier on projectile speed.
+    /// Multiplier on projectile speed.
     pub speed_modifier: f32,
-    /// `m_reloadTime` - time to reload (`tSimTime`, milliseconds).
+    /// Time to reload, in milliseconds.
     pub reload_time_ms: u32,
 }
 
-impl PropBaseGunDesc {
-    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropBaseGunDesc {
-        let start = reader.stream_position().unwrap();
+impl Default for GunSettingDesc {
+    fn default() -> Self {
+        GunSettingDesc {
+            burst: 1,
+            clip: 0,
+            spray: 1,
+            stim_modifier: 1.0,
+            burst_interval_ms: 0,
+            shot_interval_ms: 0,
+            ammo_usage: 1,
+            speed_modifier: 1.0,
+            reload_time_ms: 0,
+        }
+    }
+}
 
+impl GunSettingDesc {
+    fn read<T: io::Read + io::Seek>(reader: &mut T) -> GunSettingDesc {
         let burst = read_i32(reader);
         let clip = read_i32(reader);
         let spray = read_i32(reader);
@@ -50,12 +66,10 @@ impl PropBaseGunDesc {
         let ammo_usage = read_i32(reader);
         let speed_modifier = read_single(reader);
         let reload_time_ms = read_u32(reader);
+        // Trailing i32 of the on-disk record; never initialized in shipped data.
+        let _pad = read_i32(reader);
 
-        // The SS2 chunk carries more than the leading fields above; snap to the
-        // end of the property so the chunk round-trips regardless of its size.
-        reader.seek(SeekFrom::Start(start + len as u64)).unwrap();
-
-        PropBaseGunDesc {
+        GunSettingDesc {
             burst,
             clip,
             spray,
@@ -66,5 +80,139 @@ impl PropBaseGunDesc {
             speed_modifier,
             reload_time_ms,
         }
+    }
+}
+
+/// `P$BaseGunDe` - a gun archetype's per-setting firing description: an array
+/// of [`GUN_SETTING_COUNT`] fixed-size records, selected at runtime by
+/// `PropGunState::setting`.
+///
+/// The shipped chunk is 136 bytes - the three 40-byte records plus a 16-byte
+/// tail of uninitialized memory, which is never parsed.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropBaseGunDesc {
+    pub settings: [GunSettingDesc; GUN_SETTING_COUNT],
+}
+
+impl PropBaseGunDesc {
+    /// The description for fire setting `index`, falling back to setting 0 for
+    /// an index the gun does not have.
+    pub fn setting(&self, index: i32) -> &GunSettingDesc {
+        usize::try_from(index)
+            .ok()
+            .and_then(|index| self.settings.get(index))
+            .unwrap_or(&self.settings[0])
+    }
+
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropBaseGunDesc {
+        let start = reader.stream_position().unwrap();
+
+        // Only records the chunk actually covers are read; a short chunk (never
+        // seen in shipped data) defaults the rest rather than reading past it.
+        let settings = std::array::from_fn(|index| {
+            if (index as u64 + 1) * SETTING_SIZE <= len as u64 {
+                GunSettingDesc::read(reader)
+            } else {
+                GunSettingDesc::default()
+            }
+        });
+
+        // Snap past the uninitialized tail so the chunk round-trips.
+        reader.seek(SeekFrom::Start(start + len as u64)).unwrap();
+
+        PropBaseGunDesc { settings }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{GunSettingDesc, PropBaseGunDesc};
+
+    fn setting_bytes(desc: &GunSettingDesc, pad: i32) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend(desc.burst.to_le_bytes());
+        out.extend(desc.clip.to_le_bytes());
+        out.extend(desc.spray.to_le_bytes());
+        out.extend(desc.stim_modifier.to_le_bytes());
+        out.extend(desc.burst_interval_ms.to_le_bytes());
+        out.extend(desc.shot_interval_ms.to_le_bytes());
+        out.extend(desc.ammo_usage.to_le_bytes());
+        out.extend(desc.speed_modifier.to_le_bytes());
+        out.extend(desc.reload_time_ms.to_le_bytes());
+        out.extend(pad.to_le_bytes());
+        out
+    }
+
+    /// The pistol as shipped: single shot, then a 3-round burst.
+    fn pistol_settings() -> [GunSettingDesc; 3] {
+        let normal = GunSettingDesc {
+            burst: 1,
+            clip: 12,
+            spray: 1,
+            stim_modifier: 1.0,
+            burst_interval_ms: 0,
+            shot_interval_ms: 500,
+            ammo_usage: 1,
+            speed_modifier: 1.0,
+            reload_time_ms: 500,
+        };
+        let burst = GunSettingDesc {
+            burst: 3,
+            burst_interval_ms: 10,
+            shot_interval_ms: 700,
+            ..normal.clone()
+        };
+        [normal.clone(), burst, normal]
+    }
+
+    /// A retail-shaped chunk: three records plus a garbage tail.
+    fn pistol_chunk() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for (index, setting) in pistol_settings().iter().enumerate() {
+            bytes.extend(setting_bytes(setting, index as i32 * -7));
+        }
+        bytes.extend([0xAB; 16]);
+        bytes
+    }
+
+    #[test]
+    fn parses_every_setting_and_ignores_the_tail() {
+        let chunk = pistol_chunk();
+        let len = chunk.len() as u32;
+        assert_eq!(len, 136);
+        let mut cursor = Cursor::new(chunk);
+
+        let desc = PropBaseGunDesc::read(&mut cursor, len);
+
+        assert_eq!(desc.settings, pistol_settings());
+        assert_eq!(cursor.position(), len as u64);
+    }
+
+    #[test]
+    fn setting_selects_by_index_and_falls_back_to_the_first() {
+        let desc = PropBaseGunDesc::read(&mut Cursor::new(pistol_chunk()), 136);
+
+        assert_eq!(desc.setting(0).burst, 1);
+        assert_eq!(desc.setting(1).burst, 3);
+        assert_eq!(desc.setting(1).shot_interval_ms, 700);
+        assert_eq!(desc.setting(3), desc.setting(0), "out of range");
+        assert_eq!(desc.setting(-1), desc.setting(0), "negative");
+    }
+
+    #[test]
+    fn a_short_chunk_defaults_the_records_it_does_not_cover() {
+        let settings = pistol_settings();
+        let chunk = setting_bytes(&settings[0], 0);
+        let len = chunk.len() as u32;
+        let mut cursor = Cursor::new(chunk);
+
+        let desc = PropBaseGunDesc::read(&mut cursor, len);
+
+        assert_eq!(desc.settings[0], settings[0]);
+        assert_eq!(desc.settings[1], GunSettingDesc::default());
+        assert_eq!(desc.settings[2], GunSettingDesc::default());
+        assert_eq!(cursor.position(), len as u64, "never reads past the chunk");
     }
 }

--- a/dark/src/properties/prop_gun_state.rs
+++ b/dark/src/properties/prop_gun_state.rs
@@ -6,28 +6,28 @@ use crate::ss2_common::{read_i32, read_single};
 
 use serde::{Deserialize, Serialize};
 
-/// `P$GunState` - the mutable per-weapon firing state. Mirrors the Dark engine's
-/// `sGunState` (engfeat/gunbase.h), in field order. For now only `ammo` is used
+/// `P$GunState` - the mutable per-weapon firing state, in on-disk field order.
+/// For now only `ammo` is used
 /// at runtime (current rounds in the clip); the rest are parsed so the chunk
 /// round-trips and is available later (condition, fire setting, modification
 /// level, silencing).
 ///
-/// SS2's on-disk chunk is 16 bytes (it omits the trailing `m_silenceValue`),
-/// while Thief's `sGunState` is 20 bytes. [`PropGunState::read`] therefore reads
+/// The shipped chunk is 16 bytes (it omits the trailing silencing value), while
+/// the 20-byte variant carries it. [`PropGunState::read`] therefore reads
 /// each field only if `len` covers it, then snaps to the end of the chunk - so
 /// both variants parse without over-reading. (A fixed 20-byte read panicked the
 /// chunk-length assertion on every mission.)
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropGunState {
-    /// `m_ammoCount` - current rounds in the clip.
+    /// Current rounds in the clip.
     pub ammo: i32,
-    /// `m_condition` - 0..1 weapon condition (1 = perfect).
+    /// Weapon condition as a percentage (shipped guns author 100.0 = perfect).
     pub condition: f32,
-    /// `m_setting` - current fire setting.
+    /// Current fire setting; indexes `PropBaseGunDesc::settings`.
     pub setting: i32,
-    /// `m_modification` - current modification level.
+    /// Current modification level.
     pub modification: i32,
-    /// `m_silenceValue` - 0..1 amount of silencing (1 = perfect).
+    /// Amount of silencing, 0..1 (1 = perfect).
     pub silence_value: f32,
 }
 

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
-
 use cgmath::{Matrix4, Vector2, point2, vec2, vec3};
 use collision::{Aabb2, Aabb3};
 use dark::{
-    importers::{FONT_IMPORTER, STRINGS_IMPORTER, TEXTURE_IMPORTER},
+    importers::{
+        FONT_IMPORTER, STRINGS_IMPORTER, TEXTURE_IMPORTER, resolve_localized_property_string,
+    },
     properties::{
         ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
         PropObjName, PropObjectNameType, PropShowHP, PropStackCount, PropTemplateId,
@@ -44,26 +44,6 @@ const LABEL_HEIGHT: f32 = 10.0;
 /// Screen inset for the hover label: the bracket it sits beside plus the line
 /// of text drawn above it.
 const LABEL_MARGIN: f32 = BRACKET_SIZE + LABEL_HEIGHT;
-
-fn resolve_localized_property_string(raw: &str, strings: &HashMap<String, String>) -> String {
-    let (key, fallback) = match raw.split_once(':') {
-        Some((key, remainder)) => {
-            let remainder = remainder.trim();
-            let fallback = match remainder.strip_prefix('"') {
-                Some(quoted) => quoted.split_once('"').map_or("", |(value, _)| value),
-                None => remainder,
-            };
-            (key.trim(), fallback)
-        }
-        None => (raw.trim(), ""),
-    };
-
-    strings
-        .get(&key.to_ascii_lowercase())
-        .map(String::as_str)
-        .unwrap_or(fallback)
-        .to_owned()
-}
 
 fn format_stack_aware_item_name(item_name: &str, stack_count: Option<i32>) -> String {
     match stack_count {
@@ -263,6 +243,8 @@ pub fn draw_item_name(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
 
     const SCREEN: Vector2<f32> = Vector2::new(800.0, 600.0);
@@ -367,40 +349,6 @@ mod tests {
 
         assert!(!is_frobbable(&world, id));
         assert!(!is_hud_selectable(&world, id));
-    }
-
-    #[test]
-    fn object_name_resource_reference_uses_localized_value() {
-        let strings = HashMap::from([(
-            "elevator_button".to_string(),
-            "Localized elevator button".to_string(),
-        )]);
-
-        assert_eq!(
-            resolve_localized_property_string(
-                r#"Elevator_Button: "A two-state button.""#,
-                &strings,
-            ),
-            "Localized elevator button",
-        );
-    }
-
-    #[test]
-    fn object_name_resource_reference_uses_embedded_fallback() {
-        assert_eq!(
-            resolve_localized_property_string(r#"HumanCorpses: "A corpse.""#, &HashMap::new(),),
-            "A corpse.",
-        );
-    }
-
-    #[test]
-    fn object_name_resource_key_without_fallback_uses_localized_value() {
-        let strings = HashMap::from([("basketball".to_string(), "A basketball.".to_string())]);
-
-        assert_eq!(
-            resolve_localized_property_string("Basketball", &strings),
-            "A basketball.",
-        );
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7704,7 +7704,7 @@ impl MissionCore {
     /// clip is swapped, then raises it back up; the peak angle and pitch speed
     /// come from the weapon's own data (`PropPlayerGun`'s reload pitch/rate, as
     /// 16-bit angle units where 65536 = 360 deg) and the hold from its reload
-    /// time (`PropBaseGunDesc.reload_time_ms`). No-op for non-guns (no
+    /// time (the selected fire setting's reload time). No-op for non-guns (no
     /// `PropBaseGunDesc`), while a reload is already in progress, or when no
     /// compatible reserve rounds are available.
     ///
@@ -7729,15 +7729,11 @@ impl MissionCore {
         }
 
         // Only guns reload; bail (and don't restart an in-progress reload).
-        let (clip, hold) = {
-            let v_desc = self
-                .world
-                .borrow::<View<dark::properties::PropBaseGunDesc>>();
-            match v_desc.as_ref().ok().and_then(|v| v.get(weapon).ok()) {
+        let (clip, hold) =
+            match crate::scripts::script_util::active_gun_setting(&self.world, weapon) {
                 Some(d) => (d.clip, d.reload_time_ms as f32 / 1000.0),
                 None => return Effect::NoEffect,
-            }
-        };
+            };
         if let Ok(v) = self.world.borrow::<View<RuntimePropReloading>>() {
             if v.get(weapon).is_ok_and(|r| !r.is_done()) {
                 return Effect::NoEffect;

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -399,7 +399,7 @@ pub enum Effect {
     },
 
     /// Reload the player's wielded weapon from compatible backpack reserve,
-    /// up to its magazine capacity (`PropBaseGunDesc.clip`). No-op when no
+    /// up to the magazine capacity of its selected fire setting. No-op when no
     /// weapon is wielded, it has no gun state / clip, or no matching reserve is
     /// carried.
     ReloadWeapon,

--- a/shock2vr/src/scripts/energy_weapon.rs
+++ b/shock2vr/src/scripts/energy_weapon.rs
@@ -1,7 +1,7 @@
-use dark::properties::{PropBaseGunDesc, PropGunState};
+use dark::properties::PropGunState;
 use shipyard::{EntityId, Get, View, World};
 
-use crate::physics::PhysicsWorld;
+use crate::{physics::PhysicsWorld, scripts::script_util::active_gun_setting};
 
 use super::{Effect, MessagePayload, Script};
 
@@ -32,10 +32,11 @@ impl Script for EnergyWeapon {
             return Effect::NoEffect;
         }
 
-        let v_gun_desc = world.borrow::<View<PropBaseGunDesc>>().unwrap();
         let v_gun_state = world.borrow::<View<PropGunState>>().unwrap();
-        let (Ok(gun_desc), Ok(gun_state)) = (v_gun_desc.get(entity_id), v_gun_state.get(entity_id))
-        else {
+        let (Some(gun_desc), Ok(gun_state)) = (
+            active_gun_setting(world, entity_id),
+            v_gun_state.get(entity_id),
+        ) else {
             return Effect::NoEffect;
         };
         let capacity = gun_desc.clip.max(0);
@@ -53,24 +54,23 @@ impl Script for EnergyWeapon {
 
 #[cfg(test)]
 mod tests {
-    use dark::properties::{PropBaseGunDesc, PropGunState};
+    use dark::properties::{GunSettingDesc, PropBaseGunDesc, PropGunState};
     use shipyard::{Get, View, ViewMut, World};
 
     use crate::{physics::PhysicsWorld, scripts::effect::recharge_ammo_to_capacity};
 
     use super::{Effect, EnergyWeapon, MessagePayload, Script};
 
+    fn setting(clip: i32) -> GunSettingDesc {
+        GunSettingDesc {
+            clip,
+            ..GunSettingDesc::default()
+        }
+    }
+
     fn gun_desc(clip: i32) -> PropBaseGunDesc {
         PropBaseGunDesc {
-            burst: 1,
-            clip,
-            spray: 1,
-            stim_modifier: 1.0,
-            burst_interval_ms: 0,
-            shot_interval_ms: 0,
-            ammo_usage: 1,
-            speed_modifier: 1.0,
-            reload_time_ms: 0,
+            settings: [setting(clip), setting(clip), setting(clip)],
         }
     }
 
@@ -116,6 +116,21 @@ mod tests {
         assert_eq!(state.setting, 1);
         assert_eq!(state.modification, 2);
         assert_eq!(state.silence_value, 0.25);
+    }
+
+    #[test]
+    fn recharge_uses_the_capacity_of_the_selected_fire_setting() {
+        let mut world = World::new();
+        // gun_state selects setting 1, whose capacity differs from setting 0's.
+        let desc = PropBaseGunDesc {
+            settings: [setting(50), setting(100), setting(0)],
+        };
+        let weapon = world.add_entity((desc, gun_state(0)));
+
+        match recharge(&world, weapon) {
+            Effect::RechargeAmmo { capacity, .. } => assert_eq!(capacity, 100),
+            other => panic!("expected recharge ammo adjustment, got {other:?}"),
+        }
     }
 
     #[test]

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -8,8 +8,8 @@ use cgmath::{Transform, Vector3, point3};
 use dark::{
     EnvSoundQuery,
     properties::{
-        Link, Links, ProjectileOptions, PropClassTag, PropGunState, PropMaterial, PropSymName,
-        PropTemplateId, PropTweqModelConfig, ToLink,
+        GunSettingDesc, Link, Links, ProjectileOptions, PropBaseGunDesc, PropClassTag,
+        PropGunState, PropMaterial, PropSymName, PropTemplateId, PropTweqModelConfig, ToLink,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -262,6 +262,33 @@ pub fn has_death_links(world: &World, entity_id: EntityId) -> bool {
     .is_empty()
 }
 
+/// `weapon`'s selected fire setting, 0 when it has no gun state. Ammo-type
+/// selection and the firing description both key off this, so they agree.
+fn current_gun_setting(world: &World, weapon: EntityId) -> i32 {
+    world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|states| states.get(weapon).ok().map(|state| state.setting))
+        .unwrap_or(0)
+}
+
+/// The firing description for `weapon`'s currently selected fire setting, or
+/// `None` when it is not a gun. The setting comes from the weapon's live
+/// `PropGunState` (0 when it has none), and an index the archetype does not
+/// author falls back to setting 0.
+pub fn active_gun_setting(world: &World, weapon: EntityId) -> Option<GunSettingDesc> {
+    let setting = current_gun_setting(world, weapon);
+    world
+        .borrow::<View<PropBaseGunDesc>>()
+        .ok()
+        .and_then(|descs| {
+            descs
+                .get(weapon)
+                .ok()
+                .map(|desc| desc.setting(setting).clone())
+        })
+}
+
 /// A weapon's selectable `Projectile` links (its ammo types), filtered to the
 /// current gun setting and ordered by `ProjectileOptions.order`. This is the
 /// canonical ammo-type list - firing, ammo-type cycling, and the HUD all derive
@@ -269,11 +296,7 @@ pub fn has_death_links(world: &World, entity_id: EntityId) -> bool {
 /// otherwise it must match the weapon's current `PropGunState.setting`
 /// (defaulting to 0 when the weapon has no gun state).
 pub fn ordered_projectile_links(world: &World, weapon: EntityId) -> Vec<(i32, ProjectileOptions)> {
-    let setting = world
-        .borrow::<View<PropGunState>>()
-        .ok()
-        .and_then(|v| v.get(weapon).ok().map(|g| g.setting))
-        .unwrap_or(0);
+    let setting = current_gun_setting(world, weapon);
     let mut links = get_all_links_with_template(world, weapon, |link| match link {
         Link::Projectile(data) => Some(*data),
         _ => None,
@@ -998,18 +1021,63 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 #[cfg(test)]
 mod tests {
     use super::{
-        debit_player_nanites, door_blocks_pathfinding, door_is_closed, is_always_collected,
-        is_nanite_pickup, plan_stack_payment, player_nanite_total, spend_player_nanites,
-        stat_nanite_balance,
+        active_gun_setting, debit_player_nanites, door_blocks_pathfinding, door_is_closed,
+        is_always_collected, is_nanite_pickup, plan_stack_payment, player_nanite_total,
+        spend_player_nanites, stat_nanite_balance,
     };
     use crate::mission::PlayerInfo;
     use crate::quest_info::QuestInfo;
     use crate::runtime_props::RuntimePropTransform;
     use cgmath::{Matrix4, Quaternion, Vector3, vec3};
     use dark::properties::{
-        Link, Links, PropObjIcon, PropStackCount, PropTranslatingDoor, ToLink, WrappedEntityId,
+        GunSettingDesc, Link, Links, PropBaseGunDesc, PropGunState, PropObjIcon, PropStackCount,
+        PropTranslatingDoor, ToLink, WrappedEntityId,
     };
     use shipyard::{EntityId, Get, View, World};
+
+    fn gun_desc() -> PropBaseGunDesc {
+        let setting = |clip| GunSettingDesc {
+            clip,
+            ..GunSettingDesc::default()
+        };
+        PropBaseGunDesc {
+            settings: [setting(10), setting(20), setting(30)],
+        }
+    }
+
+    fn gun_state(setting: i32) -> PropGunState {
+        PropGunState {
+            ammo: 0,
+            condition: 100.0,
+            setting,
+            modification: 0,
+            silence_value: 0.0,
+        }
+    }
+
+    #[test]
+    fn active_gun_setting_follows_the_live_gun_state() {
+        let mut world = World::new();
+        let weapon = world.add_entity((gun_desc(), gun_state(1)));
+
+        assert_eq!(active_gun_setting(&world, weapon).unwrap().clip, 20);
+    }
+
+    #[test]
+    fn active_gun_setting_defaults_to_the_first_setting_without_a_gun_state() {
+        let mut world = World::new();
+        let weapon = world.add_entity(gun_desc());
+
+        assert_eq!(active_gun_setting(&world, weapon).unwrap().clip, 10);
+    }
+
+    #[test]
+    fn active_gun_setting_is_absent_for_a_non_gun() {
+        let mut world = World::new();
+        let not_a_gun = world.add_entity(gun_state(0));
+
+        assert!(active_gun_setting(&world, not_a_gun).is_none());
+    }
 
     fn door_world(
         closed: Vector3<f32>,


### PR DESCRIPTION
## What

`P$BaseGunDe` is an array of **three** fixed 40-byte fire-setting records, but the parser
only ever read the first one and seeked to the end of the chunk. This reads all three into
`PropBaseGunDesc { settings: [GunSettingDesc; 3] }`, adds a `setting(i)` accessor that falls
back to slot 0 for an index a gun doesn't author, and parses the four display-string
properties that go with the settings (`P$Sett1`/`P$Sett2` setting text, `P$SHead1`/`P$SHead2`
setting header).

The shipped chunk is 136 bytes = 3 x 40 + a 16-byte tail of uninitialized memory; the tail is
never parsed. Each record ends in a junk pad `i32`, also never used.

The two existing consumers - reload capacity/hold time (`mission/mission_core.rs`) and energy
recharge capacity (`scripts/energy_weapon.rs`) - now read through a new pure helper,
`script_util::active_gun_setting`, which resolves the description for the weapon's live
`PropGunState.setting` (0 when it has no gun state). **No gameplay change today**: every
shipped `P$GunState` authors setting 0, verified across the gamesys and all 23 missions.

## Why

Fire modes are entirely data-driven, and the second mode is where the interesting values
live. Nothing downstream can implement burst/auto/overcharge fire until the data is parsed.
This is the data-only first step.

## Retail deltas, setting 0 -> setting 1

Read back with `cargo dq templates <n>`:

| Weapon (template) | Setting 0 -> 1 |
| --- | --- |
| Pistol (-17) | `burst` 1 -> 3, `burst_interval_ms` 0 -> 10, `shot_interval_ms` 500 -> 700 |
| Assault Rifle (-18) | `burst` 1 -> -1 (unlimited), `burst_interval_ms` 0 -> 100 |
| Shotgun (-19) | `ammo_usage` 1 -> 3, `reload_time_ms` 1000 -> 1500 |
| Laser Pistol (-22) | `shot_interval_ms` 350 -> 3000, `ammo_usage` 3 -> 20, `reload_time_ms` 0 -> 2000 |
| EMP Rifle (-23) | `stim_modifier` 1.0 -> 3.0, `ammo_usage` 2 -> 20 |

Slot 2 is an unselected leftover (the pistol's is all zeros), consistent with the UI only
exposing two modes.

## Display strings and their fallback

The string props hold an object string (`key: "fallback"`) resolved against
`SETT1`/`SETT2`/`SHEAD1`/`SHEAD2`. `resolve_localized_property_string` moved from
`shock2vr/src/hud/item_outline.rs` into `dark::importers` (identical behavior) so the new
`resolve_gun_setting_string` shares its object-string splitting instead of re-implementing it;
its tests moved with it.

**Data finding:** of the 17 gun archetypes in the gamesys, 8 author these properties (Pistol,
Assault Rifle, Shotgun, Gren Launcher, Laser Pistol, EMP Rifle, Fusion Cannon, Hybrid_Shotgun). Three that do **not** - Stasis Field Generator (-25), Worm Launcher (-27),
Viral Prolif (-29) - still have entries in the string tables, keyed by their symbolic name
with spaces underscored (`Stasis_Field_Generator`, `Worm_Launcher`, `Viral_Prolif`). So the
resolver falls back to the underscored `P$SymName` before giving up. Turret/psi-amp guns
author neither the props nor table entries and correctly resolve to nothing.

## Tests

Negative-first: with the parser restricted to one record (simulating the old behavior) the two
new parse tests fail on exactly the second setting's `burst`/`burst_interval_ms`/
`shot_interval_ms`; they pass with the full parse.

- `cargo test -p dark --lib` - **138 passed, 0 failed** (3 new gun-desc parse tests: all three
  records, garbage tail ignored + cursor lands at the chunk end, index clamping; 7 string
  resolution tests)
- `cargo test -p shock2vr --lib` - **1204 passed, 0 failed, 2 ignored** (3 new
  `active_gun_setting` tests, 1 new energy-recharge per-setting-capacity test)
- `cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query` clean

## e2e (`SHOCK2_E2E=1`)

Targeted run (a parser change has to keep every mission loading), all green:

```
# tests 29
# pass 29
# fail 0
```

covering `missions.e2e.test.ts` (all 23 missions load), `weapon-reload`, `weapon-ammo-type`,
`weapon-ammo`, `vr-weapon-reload`, `energy-weapon-recharge`.

The full suite is running; results will be added here when it completes.
