### PR TITLE
fix(ai): agent-radius clearance for nav portals and waypoints

### DIFF
--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -29,6 +29,19 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 /// subdivision edges, not just walls.
 const EDGE_CLEARANCE: f32 = 3.0 / SCALE_FACTOR;
 
+/// Width of the body a walking AI has to fit through (2.4 Dark feet - the
+/// widest humanoid capsule, hybrids/grunts at 0.48 world-unit radius). The
+/// original engine baked clearance offline and deleted portals a creature
+/// could not pass; shipped okBits carry no such marking for the sliver
+/// portals we synthesize walkability for, so we gate them geometrically.
+const AGENT_WIDTH: f32 = 2.4 / SCALE_FACTOR;
+
+/// Extra cost (Dark feet of detour) for crossing a portal narrower than the
+/// walker's body. Large enough to outweigh any local detour around the
+/// pinch, small enough that a sliver still beats no route at all - the
+/// shipped mesh sometimes has no other way into a spot.
+const NARROW_PORTAL_PENALTY: u32 = 250;
+
 /// A zero-bit link counts as a flat walkable seam when the two cell floors
 /// differ by no more than this (3 Dark feet - covers small steps; genuine
 /// cliffs in the data differ by up to 15)
@@ -168,6 +181,16 @@ pub struct PathfindingService {
     /// cross-zone links inherit bits from the zone-pair table, and flat
     /// zero-bit seams (pervasive in shipped data) are granted WALK.
     effective_bits: Vec<MovementBits>,
+    /// Free width at each link's portal (distance from the portal to the
+    /// nearest wall in the mesh), parallel to `effective_bits`. A portal
+    /// with less than the walker's radius is impassable for anything but a
+    /// small creature. Synthesized bridge links carry `f32::INFINITY` -
+    /// their clearance is validated by raycast when they are built.
+    portal_clearances: Vec<f32>,
+    /// Free half-width at each cell's center, parallel to
+    /// `path_database.cells`: a cell whose center is tighter than the
+    /// walker's radius is no place to send a body.
+    cell_clearances: Vec<f32>,
     /// Synthesized island-crossing links (experimental `nav_bridges`),
     /// indexed after `path_database.links`
     bridge_links: Vec<PathCellLink>,
@@ -238,6 +261,9 @@ impl PathfindingService {
             .map(|cd| (cd.cell, cd.door))
             .collect();
         let mut effective_bits = compute_effective_bits(&path_database);
+        let boundary = NavBoundary::build(&path_database);
+        let mut portal_clearances = boundary.portal_clearances(&path_database);
+        let cell_clearances = boundary.cell_clearances(&path_database);
         let bridge_links = if bridge_islands {
             compute_bridge_links(&path_database, &effective_bits, nav_validator)
         } else {
@@ -249,6 +275,7 @@ impl PathfindingService {
                 links.push(idx);
             }
             effective_bits.push(link.ok_bits);
+            portal_clearances.push(f32::INFINITY);
         }
         if !bridge_links.is_empty() {
             tracing::info!(
@@ -261,6 +288,8 @@ impl PathfindingService {
             links_by_cell,
             cell_to_door,
             effective_bits,
+            portal_clearances,
+            cell_clearances,
             bridge_links,
             relaxed: bridge_islands,
             ai_paths: std::sync::Mutex::new(HashMap::new()),
@@ -528,13 +557,33 @@ impl PathfindingService {
         let distance_to_goal = |cell: u32| -> f32 {
             (goal - self.path_database.cells[cell as usize].center).magnitude()
         };
+        // Stop somewhere the body fits. A partial route is aimed at a cell
+        // center, and the cells nearest an unreachable goal are often the
+        // pinch it is unreachable through - the wedge at the bottom of a
+        // converging corner, where an AI parks itself against the geometry
+        // and grinds. Cells too tight to stand in are only considered when
+        // nothing roomier is reachable.
+        let roomy = |cell: u32| -> bool {
+            self.cell_clearances
+                .get(cell as usize)
+                .is_none_or(|&clearance| clearance >= AGENT_WIDTH * 0.5)
+        };
         let mut best = start_cell;
         let mut best_distance = distance_to_goal(start_cell);
         for &cell in reachable.keys() {
             let d = distance_to_goal(cell);
-            if d < best_distance {
+            if d < best_distance && roomy(cell) {
                 best_distance = d;
                 best = cell;
+            }
+        }
+        if best == start_cell {
+            for &cell in reachable.keys() {
+                let d = distance_to_goal(cell);
+                if d < best_distance {
+                    best_distance = d;
+                    best = cell;
+                }
             }
         }
         if best == start_cell {
@@ -627,6 +676,18 @@ impl PathfindingService {
         waypoints.extend(points);
         waypoints.push(goal);
         waypoints
+    }
+
+    /// Free width the mesh leaves at the portal between two cells (nearest
+    /// wall distance at the roomiest point of the shared edge). Inspection
+    /// aid for nav tooling; `None` when the cells share no link.
+    pub fn portal_clearance(&self, from_cell: u32, to_cell: u32) -> Option<f32> {
+        let idx = *self
+            .links_by_cell
+            .get(from_cell as usize)?
+            .iter()
+            .find(|&&idx| self.link_at(idx).to_cell == to_cell)?;
+        self.portal_clearances.get(idx as usize).copied()
     }
 
     /// Find a traversable link from one cell to an adjacent cell
@@ -764,6 +825,15 @@ impl PathfindingService {
             .map(|&idx| {
                 let link = self.link_at(idx);
                 let mut cost = (link.cost as u32).max(1);
+                // A portal the body does not fit through costs a detour's
+                // worth extra, so A* threads a sliver only when nothing else
+                // reaches the goal at all (the mesh's own boundary is the
+                // measure - see `portal_clearances`).
+                if !movement_bits.contains(MovementBits::SMALL_CREATURE)
+                    && self.portal_clearances[idx as usize] < AGENT_WIDTH * 0.5
+                {
+                    cost += NARROW_PORTAL_PENALTY;
+                }
                 if self.relaxed {
                     let dest = &self.path_database.cells[link.to_cell as usize];
                     if dest.flags.contains(PathCellFlags::BLOCKING_OBB) {
@@ -1076,6 +1146,235 @@ fn compute_bridge_links(
         );
     }
     bridges
+}
+
+/// The navigable region's boundary: every stretch of cell edge with no
+/// linked, pathable cell on the other side.
+///
+/// This is what makes a spot too tight for a body. Portal edge lengths do
+/// not: the mesh subdivides open floor into many short portals, while the
+/// 0.6-wide strip beside a door jamb has portals as long as the strip is
+/// wide. Distance to this boundary is the free width, wherever it is
+/// measured.
+struct NavBoundary {
+    /// Wall segments (XZ; `y` from the cell floor they bound)
+    walls: Vec<(Vector3<f32>, Vector3<f32>)>,
+    /// Wall indices per spatial bucket, for nearest-wall queries
+    buckets: HashMap<(i32, i32), Vec<u32>>,
+}
+
+/// Vertical window in which a wall counts against a point (5 Dark feet -
+/// under a deck height, over any step or railing), so a wall on the deck
+/// above doesn't shrink a spot below it
+const WALL_FLOOR_SPAN: f32 = 5.0 / SCALE_FACTOR;
+/// Spatial-hash bucket for boundary lookup (Dark feet)
+const WALL_BUCKET: f32 = 10.0 / SCALE_FACTOR;
+/// Collinearity / overlap tolerance when matching one cell's boundary
+/// against its neighbours' (world units - shipped cells leave slivers of gap
+/// between neighbours, and links name the neighbour's vertices for the same
+/// seam, so the shared stretches are matched geometrically rather than by
+/// vertex id)
+const BOUNDARY_TOLERANCE: f32 = 0.15;
+
+fn bucket_of(x: f32, z: f32) -> (i32, i32) {
+    (
+        (x / WALL_BUCKET).floor() as i32,
+        (z / WALL_BUCKET).floor() as i32,
+    )
+}
+
+impl NavBoundary {
+    fn build(db: &PathDatabase) -> Self {
+        let linked: std::collections::HashSet<(u32, u32)> = db
+            .links
+            .iter()
+            .map(|link| (link.from_cell, link.to_cell))
+            .collect();
+
+        let mut edges: Vec<(u32, Vector3<f32>, Vector3<f32>)> = Vec::new();
+        for cell in &db.cells {
+            let n = cell.vertex_indices.len();
+            if n < 3 {
+                continue;
+            }
+            for i in 0..n {
+                if let (Some(&a), Some(&b)) = (
+                    db.vertices.get(cell.vertex_indices[i] as usize),
+                    db.vertices.get(cell.vertex_indices[(i + 1) % n] as usize),
+                ) {
+                    edges.push((cell.id, a, b));
+                }
+            }
+        }
+        let mut edge_buckets: HashMap<(i32, i32), Vec<u32>> = HashMap::new();
+        for (idx, (_, a, b)) in edges.iter().enumerate() {
+            let (bx0, bz0) = bucket_of(a.x.min(b.x), a.z.min(b.z));
+            let (bx1, bz1) = bucket_of(a.x.max(b.x), a.z.max(b.z));
+            for bx in bx0..=bx1 {
+                for bz in bz0..=bz1 {
+                    edge_buckets.entry((bx, bz)).or_default().push(idx as u32);
+                }
+            }
+        }
+
+        let blocked = PathCellFlags::UNPATHABLE | PathCellFlags::BLOCKING_OBB;
+        let mut walls: Vec<(Vector3<f32>, Vector3<f32>)> = Vec::new();
+        for (edge_idx, &(cell_id, a, b)) in edges.iter().enumerate() {
+            let (dx, dz) = (b.x - a.x, b.z - a.z);
+            let len = (dx * dx + dz * dz).sqrt();
+            if len < BOUNDARY_TOLERANCE {
+                continue;
+            }
+            let (ux, uz) = (dx / len, dz / len);
+            // Stretches of this edge shared with a linked, pathable
+            // neighbour, as intervals [t0, t1] along it
+            let mut open: Vec<(f32, f32)> = Vec::new();
+            let (bx0, bz0) = bucket_of(a.x.min(b.x), a.z.min(b.z));
+            let (bx1, bz1) = bucket_of(a.x.max(b.x), a.z.max(b.z));
+            for bx in (bx0 - 1)..=(bx1 + 1) {
+                for bz in (bz0 - 1)..=(bz1 + 1) {
+                    let Some(candidates) = edge_buckets.get(&(bx, bz)) else {
+                        continue;
+                    };
+                    for &other in candidates {
+                        if other as usize == edge_idx {
+                            continue;
+                        }
+                        let (other_cell, oa, ob) = edges[other as usize];
+                        if other_cell == cell_id || !linked.contains(&(cell_id, other_cell)) {
+                            continue;
+                        }
+                        match db.cells.get(other_cell as usize) {
+                            Some(cell) if !cell.flags.intersects(blocked) => {}
+                            _ => continue,
+                        }
+                        if (oa.y - a.y).abs() > WALL_FLOOR_SPAN
+                            || (ob.y - a.y).abs() > WALL_FLOOR_SPAN
+                        {
+                            continue;
+                        }
+                        let on_line = |p: Vector3<f32>| {
+                            ((p.x - a.x) * uz - (p.z - a.z) * ux).abs() <= BOUNDARY_TOLERANCE
+                        };
+                        if !on_line(oa) || !on_line(ob) {
+                            continue;
+                        }
+                        let ta = (oa.x - a.x) * ux + (oa.z - a.z) * uz;
+                        let tb = (ob.x - a.x) * ux + (ob.z - a.z) * uz;
+                        let (lo, hi) = if ta <= tb { (ta, tb) } else { (tb, ta) };
+                        let (lo, hi) = (lo.max(0.0), hi.min(len));
+                        if hi - lo > BOUNDARY_TOLERANCE {
+                            open.push((lo, hi));
+                        }
+                    }
+                }
+            }
+            open.sort_by(|x, y| x.0.partial_cmp(&y.0).unwrap_or(std::cmp::Ordering::Equal));
+            // What is left of the edge once the shared stretches are removed
+            // is wall
+            let mut cursor = 0.0f32;
+            let point_at = |t: f32| Vector3::new(a.x + ux * t, a.y, a.z + uz * t);
+            for (lo, hi) in open {
+                if lo - cursor > BOUNDARY_TOLERANCE {
+                    walls.push((point_at(cursor), point_at(lo)));
+                }
+                cursor = cursor.max(hi);
+            }
+            if len - cursor > BOUNDARY_TOLERANCE {
+                walls.push((point_at(cursor), point_at(len)));
+            }
+        }
+
+        let mut buckets: HashMap<(i32, i32), Vec<u32>> = HashMap::new();
+        for (idx, (a, b)) in walls.iter().enumerate() {
+            // A wall spans buckets; register it in every one its XZ extent
+            // touches so a nearby query can't miss it
+            let (bx0, bz0) = bucket_of(a.x.min(b.x), a.z.min(b.z));
+            let (bx1, bz1) = bucket_of(a.x.max(b.x), a.z.max(b.z));
+            for bx in bx0..=bx1 {
+                for bz in bz0..=bz1 {
+                    buckets.entry((bx, bz)).or_default().push(idx as u32);
+                }
+            }
+        }
+
+        Self { walls, buckets }
+    }
+
+    /// Distance from a point to the nearest wall (XZ) - half the free width
+    /// there. Unbounded when no wall is near.
+    fn clearance_at(&self, at: Vector3<f32>) -> f32 {
+        let (bx, bz) = bucket_of(at.x, at.z);
+        let mut nearest = f32::INFINITY;
+        for dx in -1..=1 {
+            for dz in -1..=1 {
+                let Some(candidates) = self.buckets.get(&(bx + dx, bz + dz)) else {
+                    continue;
+                };
+                for &idx in candidates {
+                    let (wa, wb) = self.walls[idx as usize];
+                    if (wa.y - at.y).abs() > WALL_FLOOR_SPAN
+                        && (wb.y - at.y).abs() > WALL_FLOOR_SPAN
+                    {
+                        continue;
+                    }
+                    let closest = closest_point_on_segment_xz(wa, wb, at);
+                    let (dx, dz) = (closest.x - at.x, closest.z - at.z);
+                    nearest = nearest.min((dx * dx + dz * dz).sqrt());
+                }
+            }
+        }
+        nearest
+    }
+
+    /// Free half-width at each link's portal, parallel to `db.links`: the
+    /// body crosses wherever the portal is roomiest (a portal at a cell
+    /// corner is open on the corner side), so the best point along the
+    /// shared edge wins.
+    fn portal_clearances(&self, db: &PathDatabase) -> Vec<f32> {
+        const SAMPLES: usize = 9;
+        db.links
+            .iter()
+            .map(|link| {
+                let (Some(a), Some(b)) = (
+                    db.vertices.get(link.edge_vertex_a as usize),
+                    db.vertices.get(link.edge_vertex_b as usize),
+                ) else {
+                    return f32::INFINITY;
+                };
+                (0..SAMPLES)
+                    .map(|i| {
+                        let t = i as f32 / (SAMPLES - 1) as f32;
+                        self.clearance_at(a + (b - a) * t)
+                    })
+                    .fold(0.0f32, f32::max)
+            })
+            .collect()
+    }
+
+    /// Free half-width at each cell's center, parallel to `db.cells` - can a
+    /// body stand there at all?
+    fn cell_clearances(&self, db: &PathDatabase) -> Vec<f32> {
+        db.cells
+            .iter()
+            .map(|cell| self.clearance_at(cell.center))
+            .collect()
+    }
+}
+
+/// Closest point to `target` on segment `a`-`b`, in the XZ plane
+fn closest_point_on_segment_xz(
+    a: Vector3<f32>,
+    b: Vector3<f32>,
+    target: Vector3<f32>,
+) -> Vector3<f32> {
+    let (dx, dz) = (b.x - a.x, b.z - a.z);
+    let len_sq = dx * dx + dz * dz;
+    if len_sq < 1e-8 {
+        return a;
+    }
+    let t = (((target.x - a.x) * dx + (target.z - a.z) * dz) / len_sq).clamp(0.0, 1.0);
+    a + (b - a) * t
 }
 
 /// Shrink an edge toward its center by EDGE_CLEARANCE on each end, so taut

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -571,9 +571,11 @@ impl PathfindingService {
         // and grinds. Cells too tight to stand in are only considered when
         // nothing roomier is reachable.
         let roomy = |cell: u32| -> bool {
-            self.cell_clearances
-                .get(cell as usize)
-                .is_none_or(|&clearance| clearance >= AGENT_STANDING_WIDTH * 0.5)
+            movement_bits.contains(MovementBits::SMALL_CREATURE)
+                || self
+                    .cell_clearances
+                    .get(cell as usize)
+                    .is_none_or(|&clearance| clearance >= AGENT_STANDING_WIDTH * 0.5)
         };
         let mut best = start_cell;
         let mut best_distance = distance_to_goal(start_cell);
@@ -1193,6 +1195,24 @@ fn bucket_of(x: f32, z: f32) -> (i32, i32) {
     (bucket(x), bucket(z))
 }
 
+/// Index segments (by position in `segments`) into every XZ bucket their
+/// extent touches, so a nearby query can't miss one.
+fn bucket_segments(
+    segments: impl Iterator<Item = (Vector3<f32>, Vector3<f32>)>,
+) -> HashMap<(i32, i32), Vec<u32>> {
+    let mut buckets: HashMap<(i32, i32), Vec<u32>> = HashMap::new();
+    for (idx, (a, b)) in segments.enumerate() {
+        let (bx0, bz0) = bucket_of(a.x.min(b.x), a.z.min(b.z));
+        let (bx1, bz1) = bucket_of(a.x.max(b.x), a.z.max(b.z));
+        for bx in bx0..=bx1 {
+            for bz in bz0..=bz1 {
+                buckets.entry((bx, bz)).or_default().push(idx as u32);
+            }
+        }
+    }
+    buckets
+}
+
 impl NavBoundary {
     fn build(db: &PathDatabase) -> Self {
         // Adjacency is undirected here: a seam is open floor whichever way
@@ -1208,8 +1228,10 @@ impl NavBoundary {
         // millions of buckets.
         let sane = |a: Vector3<f32>, b: Vector3<f32>| {
             a.x.is_finite()
+                && a.y.is_finite()
                 && a.z.is_finite()
                 && b.x.is_finite()
+                && b.y.is_finite()
                 && b.z.is_finite()
                 && (a.x - b.x).abs() < 1.0e4
                 && (a.z - b.z).abs() < 1.0e4
@@ -1231,16 +1253,7 @@ impl NavBoundary {
                 }
             }
         }
-        let mut edge_buckets: HashMap<(i32, i32), Vec<u32>> = HashMap::new();
-        for (idx, (_, a, b)) in edges.iter().enumerate() {
-            let (bx0, bz0) = bucket_of(a.x.min(b.x), a.z.min(b.z));
-            let (bx1, bz1) = bucket_of(a.x.max(b.x), a.z.max(b.z));
-            for bx in bx0..=bx1 {
-                for bz in bz0..=bz1 {
-                    edge_buckets.entry((bx, bz)).or_default().push(idx as u32);
-                }
-            }
-        }
+        let edge_buckets = bucket_segments(edges.iter().map(|&(_, a, b)| (a, b)));
 
         let blocked = PathCellFlags::UNPATHABLE | PathCellFlags::BLOCKING_OBB;
         let mut walls: Vec<(Vector3<f32>, Vector3<f32>)> = Vec::new();
@@ -1310,18 +1323,9 @@ impl NavBoundary {
             }
         }
 
-        let mut buckets: HashMap<(i32, i32), Vec<u32>> = HashMap::new();
-        for (idx, (a, b)) in walls.iter().enumerate() {
-            // A wall spans buckets; register it in every one its XZ extent
-            // touches so a nearby query can't miss it
-            let (bx0, bz0) = bucket_of(a.x.min(b.x), a.z.min(b.z));
-            let (bx1, bz1) = bucket_of(a.x.max(b.x), a.z.max(b.z));
-            for bx in bx0..=bx1 {
-                for bz in bz0..=bz1 {
-                    buckets.entry((bx, bz)).or_default().push(idx as u32);
-                }
-            }
-        }
+        // A wall spans buckets; register it in every one its XZ extent
+        // touches so a nearby query can't miss it
+        let buckets = bucket_segments(walls.iter().copied());
 
         Self { walls, buckets }
     }
@@ -1390,19 +1394,15 @@ impl NavBoundary {
     }
 }
 
-/// Closest point to `target` on segment `a`-`b`, in the XZ plane
+/// Closest point to `target` on segment `a`-`b`, in the XZ plane (only x/z
+/// are meaningful in the result - callers that need y should not use this).
 fn closest_point_on_segment_xz(
     a: Vector3<f32>,
     b: Vector3<f32>,
     target: Vector3<f32>,
 ) -> Vector3<f32> {
-    let (dx, dz) = (b.x - a.x, b.z - a.z);
-    let len_sq = dx * dx + dz * dz;
-    if len_sq < 1e-8 {
-        return a;
-    }
-    let t = (((target.x - a.x) * dx + (target.z - a.z) * dz) / len_sq).clamp(0.0, 1.0);
-    a + (b - a) * t
+    let flatten = |v: Vector3<f32>| Vector3::new(v.x, 0.0, v.z);
+    closest_point_on_segment(flatten(a), flatten(b), flatten(target))
 }
 
 /// Shrink an edge toward its center by EDGE_CLEARANCE on each end, so taut

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -1185,11 +1185,13 @@ fn bucket_of(x: f32, z: f32) -> (i32, i32) {
 
 impl NavBoundary {
     fn build(db: &PathDatabase) -> Self {
-        let linked: std::collections::HashSet<(u32, u32)> = db
-            .links
-            .iter()
-            .map(|link| (link.from_cell, link.to_cell))
-            .collect();
+        // Adjacency is undirected here: a seam is open floor whichever way
+        // the shipped link happens to point.
+        let mut linked: std::collections::HashSet<(u32, u32)> = std::collections::HashSet::new();
+        for link in &db.links {
+            linked.insert((link.from_cell, link.to_cell));
+            linked.insert((link.to_cell, link.from_cell));
+        }
 
         let mut edges: Vec<(u32, Vector3<f32>, Vector3<f32>)> = Vec::new();
         for cell in &db.cells {
@@ -1465,6 +1467,89 @@ pub(crate) mod tests {
                 cost: 5,
             },
         ];
+        PathDatabase {
+            cells,
+            vertices,
+            links,
+            cell_doors: Vec::new(),
+            cell_zones: Vec::new(),
+            zone_pairs: Vec::new(),
+        }
+    }
+
+    /// A wide room (0) connected to a goal room (3) two ways: a 0.2-wide
+    /// pinch corridor (1) that is the cheap route, and a roomy corridor (2)
+    /// that is twice the cost. Cell 2 also serves as the roomy alternative
+    /// to parking in the pinch.
+    fn pinch_and_detour_db() -> PathDatabase {
+        let vertices = vec![
+            // room 0
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 0.0, 0.0),
+            vec3(4.0, 0.0, 5.0),
+            vec3(0.0, 0.0, 5.0),
+            // pinch corridor 1
+            vec3(4.0, 0.0, 0.9),
+            vec3(6.0, 0.0, 0.9),
+            vec3(6.0, 0.0, 1.1),
+            vec3(4.0, 0.0, 1.1),
+            // roomy corridor 2
+            vec3(4.0, 0.0, 3.0),
+            vec3(6.0, 0.0, 3.0),
+            vec3(6.0, 0.0, 5.0),
+            vec3(4.0, 0.0, 5.0),
+            // goal room 3
+            vec3(6.0, 0.0, 0.0),
+            vec3(10.0, 0.0, 0.0),
+            vec3(10.0, 0.0, 5.0),
+            vec3(6.0, 0.0, 5.0),
+        ];
+        let cells = vec![
+            PathCell {
+                id: 0,
+                center: vec3(2.0, 0.0, 2.5),
+                vertex_indices: vec![0, 1, 2, 3],
+                flags: PathCellFlags::empty(),
+            },
+            PathCell {
+                id: 1,
+                center: vec3(5.0, 0.0, 1.0),
+                vertex_indices: vec![4, 5, 6, 7],
+                flags: PathCellFlags::empty(),
+            },
+            PathCell {
+                id: 2,
+                center: vec3(5.0, 0.0, 4.0),
+                vertex_indices: vec![8, 9, 10, 11],
+                flags: PathCellFlags::empty(),
+            },
+            PathCell {
+                id: 3,
+                center: vec3(8.0, 0.0, 2.5),
+                vertex_indices: vec![12, 13, 14, 15],
+                flags: PathCellFlags::empty(),
+            },
+        ];
+        // (from, to, edge, cost) - both directions, pinch cheaper than detour
+        let seams = [
+            (0u32, 1u32, (4u32, 7u32), 2u8),
+            (1, 3, (5, 6), 2),
+            (0, 2, (8, 11), 5),
+            (2, 3, (9, 10), 5),
+        ];
+        let mut links = Vec::new();
+        for (a, b, (va, vb), cost) in seams {
+            for (from, to) in [(a, b), (b, a)] {
+                links.push(PathCellLink {
+                    from_cell: from,
+                    to_cell: to,
+                    edge_vertex_a: va,
+                    edge_vertex_b: vb,
+                    ok_bits: MovementBits::WALK,
+                    cost,
+                });
+            }
+        }
         PathDatabase {
             cells,
             vertices,
@@ -1984,5 +2069,66 @@ pub(crate) mod tests {
         let service = service(db);
         assert_eq!(service.cell_from_position(vec3(1.0, 0.5, 1.0)), Some(0));
         assert_eq!(service.cell_from_position(vec3(1.0, 9.5, 1.0)), Some(3));
+    }
+
+    #[test]
+    fn a_route_detours_around_a_gap_narrower_than_the_body() {
+        let service = service(pinch_and_detour_db());
+        let path = service
+            .find_path(vec3(2.0, 0.0, 2.5), vec3(8.0, 0.0, 2.5), MovementBits::WALK)
+            .expect("both corridors reach the goal");
+        // The pinch corridor is the cheaper route but only 0.2 wide; the
+        // walker takes the roomy one (z >= 3) instead.
+        assert!(
+            path.iter().any(|w| w.z >= 3.0),
+            "expected the roomy corridor, got {path:?}"
+        );
+        assert!(
+            !path.iter().any(|w| w.x > 4.0 && w.z < 2.0),
+            "route threaded the pinch: {path:?}"
+        );
+    }
+
+    #[test]
+    fn a_small_creature_still_uses_the_narrow_gap() {
+        let mut db = pinch_and_detour_db();
+        for link in &mut db.links {
+            link.ok_bits |= MovementBits::SMALL_CREATURE;
+        }
+        let service = service(db);
+        let path = service
+            .find_path(
+                vec3(2.0, 0.0, 2.5),
+                vec3(8.0, 0.0, 2.5),
+                MovementBits::SMALL_CREATURE,
+            )
+            .expect("route exists");
+        assert!(
+            path.iter().any(|w| w.x > 4.0 && w.z < 2.0),
+            "a small creature should take the cheap pinch: {path:?}"
+        );
+    }
+
+    #[test]
+    fn a_partial_route_stops_where_the_body_fits() {
+        let mut db = pinch_and_detour_db();
+        // Cut the goal room off: the pinch (cell 1) is then the reachable
+        // cell closest to a goal beyond it, but nothing can stand in it.
+        db.links
+            .retain(|link| link.from_cell != 3 && link.to_cell != 3);
+        let service = service(db);
+        let path = service
+            .find_path_toward(
+                vec3(2.0, 0.0, 2.5),
+                vec3(12.0, 0.0, 1.0),
+                MovementBits::WALK,
+            )
+            .expect("a partial route exists");
+        let end = *path.last().expect("waypoints");
+        assert_eq!(
+            end,
+            vec3(5.0, 0.0, 4.0),
+            "partial route should end in the roomy corridor, got {end:?}"
+        );
     }
 }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -30,11 +30,18 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 const EDGE_CLEARANCE: f32 = 3.0 / SCALE_FACTOR;
 
 /// Width of the body a walking AI has to fit through (2.4 Dark feet - the
-/// widest humanoid capsule, hybrids/grunts at 0.48 world-unit radius). The
-/// original engine baked clearance offline and deleted portals a creature
-/// could not pass; shipped okBits carry no such marking for the sliver
-/// portals we synthesize walkability for, so we gate them geometrically.
+/// widest humanoid capsule, hybrids and grunts). The original engine baked
+/// clearance offline and deleted portals a creature could not pass; shipped
+/// okBits carry no such marking for the sliver portals we synthesize
+/// walkability for, so we measure clearance against the mesh's own boundary
+/// instead.
 const AGENT_WIDTH: f32 = 2.4 / SCALE_FACTOR;
+
+/// Room an AI needs where it comes to a *stop*: its width plus slack to
+/// manoeuvre. Squeezing through a gap on the way past is one thing; being
+/// sent to stand in one is how an AI ends up pressed into the geometry,
+/// grinding, since steering reaches a spot by pushing toward it.
+const AGENT_STANDING_WIDTH: f32 = 3.5 / SCALE_FACTOR;
 
 /// Extra cost (Dark feet of detour) for crossing a portal narrower than the
 /// walker's body. Large enough to outweigh any local detour around the
@@ -566,7 +573,7 @@ impl PathfindingService {
         let roomy = |cell: u32| -> bool {
             self.cell_clearances
                 .get(cell as usize)
-                .is_none_or(|&clearance| clearance >= AGENT_WIDTH * 0.5)
+                .is_none_or(|&clearance| clearance >= AGENT_STANDING_WIDTH * 0.5)
         };
         let mut best = start_cell;
         let mut best_distance = distance_to_goal(start_cell);

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -1183,11 +1183,14 @@ const WALL_BUCKET: f32 = 10.0 / SCALE_FACTOR;
 /// vertex id)
 const BOUNDARY_TOLERANCE: f32 = 0.15;
 
+/// Shipped data carries the odd garbage vertex (coordinates far outside the
+/// level, observed in ops4); clamping the hash keeps bucket arithmetic and
+/// the extent loops finite.
+const MAX_BUCKET: i32 = 1 << 20;
+
 fn bucket_of(x: f32, z: f32) -> (i32, i32) {
-    (
-        (x / WALL_BUCKET).floor() as i32,
-        (z / WALL_BUCKET).floor() as i32,
-    )
+    let bucket = |v: f32| ((v / WALL_BUCKET).floor() as i32).clamp(-MAX_BUCKET, MAX_BUCKET);
+    (bucket(x), bucket(z))
 }
 
 impl NavBoundary {
@@ -1200,6 +1203,17 @@ impl NavBoundary {
             linked.insert((link.to_cell, link.from_cell));
         }
 
+        // A segment is only usable geometry if both ends are finite and it
+        // is short enough to hash: garbage vertices would otherwise fill
+        // millions of buckets.
+        let sane = |a: Vector3<f32>, b: Vector3<f32>| {
+            a.x.is_finite()
+                && a.z.is_finite()
+                && b.x.is_finite()
+                && b.z.is_finite()
+                && (a.x - b.x).abs() < 1.0e4
+                && (a.z - b.z).abs() < 1.0e4
+        };
         let mut edges: Vec<(u32, Vector3<f32>, Vector3<f32>)> = Vec::new();
         for cell in &db.cells {
             let n = cell.vertex_indices.len();
@@ -1211,7 +1225,9 @@ impl NavBoundary {
                     db.vertices.get(cell.vertex_indices[i] as usize),
                     db.vertices.get(cell.vertex_indices[(i + 1) % n] as usize),
                 ) {
-                    edges.push((cell.id, a, b));
+                    if sane(a, b) {
+                        edges.push((cell.id, a, b));
+                    }
                 }
             }
         }
@@ -1240,8 +1256,8 @@ impl NavBoundary {
             let mut open: Vec<(f32, f32)> = Vec::new();
             let (bx0, bz0) = bucket_of(a.x.min(b.x), a.z.min(b.z));
             let (bx1, bz1) = bucket_of(a.x.max(b.x), a.z.max(b.z));
-            for bx in (bx0 - 1)..=(bx1 + 1) {
-                for bz in (bz0 - 1)..=(bz1 + 1) {
+            for bx in bx0.saturating_sub(1)..=bx1.saturating_add(1) {
+                for bz in bz0.saturating_sub(1)..=bz1.saturating_add(1) {
                     let Some(candidates) = edge_buckets.get(&(bx, bz)) else {
                         continue;
                     };
@@ -1317,7 +1333,10 @@ impl NavBoundary {
         let mut nearest = f32::INFINITY;
         for dx in -1..=1 {
             for dz in -1..=1 {
-                let Some(candidates) = self.buckets.get(&(bx + dx, bz + dz)) else {
+                let Some(candidates) = self
+                    .buckets
+                    .get(&(bx.saturating_add(dx), bz.saturating_add(dz)))
+                else {
                     continue;
                 };
                 for &idx in candidates {

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -875,11 +875,32 @@ fn dump_cells_at(db: PathDatabase, at: Vector3<f32>) {
             "  cell {} center=({:.2}, {:.2}, {:.2}) flags={:?} {component}",
             cell.id, cell.center.x, cell.center.y, cell.center.z, cell.flags
         );
+        let verts: Vec<String> = cell
+            .vertex_indices
+            .iter()
+            .filter_map(|&i| db.vertices.get(i as usize))
+            .map(|v| format!("({:.2},{:.2},{:.2})", v.x, v.y, v.z))
+            .collect();
+        println!("    poly: {}", verts.join(" "));
         for link in db.links.iter().filter(|l| l.from_cell == cell.id) {
+            // Portal width is what an agent body has to fit through.
+            let width = match (
+                db.vertices.get(link.edge_vertex_a as usize),
+                db.vertices.get(link.edge_vertex_b as usize),
+            ) {
+                (Some(a), Some(b)) => format!("{:.2}", (b - a).magnitude()),
+                _ => "?".to_string(),
+            };
+            let clearance = service
+                .portal_clearance(cell.id, link.to_cell)
+                .map(|c| format!("{c:.2}"))
+                .unwrap_or_else(|| "-".to_string());
             println!(
-                "    -> cell {:<5} cost {:<3} [{}]",
+                "    -> cell {:<5} cost {:<3} portal {:>5} clearance {:>5} [{}]",
                 link.to_cell,
                 link.cost,
+                width,
+                clearance,
                 describe_bits(link.ok_bits)
             );
         }

--- a/tools/shock2-sdk/test/medsci2-doorjamb-chase.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-doorjamb-chase.e2e.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The hybrid that chases the player up the Science-wing corridor */
+const HYBRID_TEMPLATE = 705;
+/** Where it used to wedge: the door jamb beside the open security door */
+const JAMB: [number, number, number] = [37.33, 0.1, -36.62];
+
+function distXZ(a: [number, number, number], b: [number, number, number]): number {
+  return Math.hypot(a[0] - b[0], a[2] - b[2]);
+}
+
+test(
+  "a chasing hybrid takes the open door, not the sliver beside its jamb",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci2.mis" });
+    await game.step({ frames: 60 });
+
+    const [hybrid] = await game.entities.byTemplate(HYBRID_TEMPLATE);
+    assert.ok(hybrid, `expected a hybrid of template ${HYBRID_TEMPLATE} in medsci2`);
+
+    await game.input.trigger("DebugForceChase");
+
+    // Sample its position each second of simulation. The nav mesh threads a
+    // 0.6-wide strip beside the jamb, which a 0.96-wide hybrid cannot walk:
+    // it used to press into the corner there and grind for the rest of the
+    // run.
+    const track: [number, number, number][] = [];
+    for (let i = 0; i < 20; i++) {
+      await game.step({ frames: 60 });
+      const detail = await game.entities.detail(hybrid.id).catch(() => null);
+      if (!detail) break;
+      track.push(detail.position);
+    }
+    assert.ok(track.length >= 10, `hybrid vanished after ${track.length} samples`);
+
+    let pinnedAtJamb = 0;
+    let worstPinnedAtJamb = 0;
+    for (const at of track) {
+      pinnedAtJamb = distXZ(at, JAMB) < 1.0 ? pinnedAtJamb + 1 : 0;
+      worstPinnedAtJamb = Math.max(worstPinnedAtJamb, pinnedAtJamb);
+    }
+    assert.ok(
+      worstPinnedAtJamb < 4,
+      `hybrid sat at the door jamb for ${worstPinnedAtJamb}s: ${JSON.stringify(track)}`,
+    );
+
+    // ...and it got somewhere: the chase runs the length of the corridor,
+    // well past the door it was stuck outside of.
+    const travelled = distXZ(track[0], track[track.length - 1]);
+    assert.ok(travelled > 8, `hybrid barely moved (${travelled.toFixed(1)}): ${JSON.stringify(track)}`);
+  },
+);


### PR DESCRIPTION
Agent-radius clearance for nav portals and stopping places (pathfinding-eval ledger steps 3 + 4).

## Visual: door-jamb chase (before -> after)

![door-jamb chase demo](https://gist.githubusercontent.com/tommy-xr/771ed404ed6946798912ed0dd7812360/raw/demo.gif)

<sub>Chasing hybrid clears the open Science-wing security door instead of wedging beside the jamb. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep, `DebugForceChase`).</sub>

![before/after](https://gist.githubusercontent.com/tommy-xr/771ed404ed6946798912ed0dd7812360/raw/beforeafter.png)

## Root cause

Not mis-read okBits. The links through both wedge spots carry **no okBits at
all** (0x00 - 59% of medsci2's links do), and it is our own flat-seam repair
that makes them walkable. Nothing in the shipped data marks them as too
tight; the original bakes clearance offline and deletes such portals, so the
information simply is not in the file. We have to measure it.

The measure that works is the **mesh's own boundary**: a stretch of cell edge
with no linked, pathable cell across it is a wall, and distance to that
boundary is the free width anywhere on the mesh. Portal edge *length* does
not work - the mesh subdivides open floor into many short portals (a gate on
edge length loses 15-30% of routable pairs), while the 0.6-wide strip beside
a door jamb has portals as long as the strip is wide.

Two uses of it, both non-fatal by design (connectivity is never removed):

- **Narrow crossings cost a detour** (`NARROW_PORTAL_PENALTY`), so A* threads
  a sliver only when nothing else reaches the goal at all. Small creatures
  are exempt.
- **A partial route stops where the body fits**: the reachable cell nearest
  an unreachable goal is often the pinch that makes it unreachable. A
  stopping place is held to a wider bar than a crossing (`AGENT_STANDING_WIDTH`
  vs `AGENT_WIDTH`) - reaching a spot means pressing toward it.

Also fixes an overflow: ops4 carries cell vertices far outside the level, and
bucket arithmetic panicked on them at load (caught by `missions.e2e`).

## Case 1: door-jamb sliver (chase) - fixed

medsci2's Science-wing chase threaded two 0.1-ft sliver cells in a 0.6-wide
strip beside an OPEN security door instead of the door itself.

`cargo bn path show medsci2.mis --from "50.7,0.1,-23.3" --to "36.8,-1.6,-38.0"`

| | before | after |
|---|---|---|
| route | through cells 1258 -> **1259** -> (off-mesh waypoints) -> 3244 | through the door: 1266 -> 1261 -> 1265 -> 1272 -> 3219 -> 3229 -> 3217 -> 3244 |
| waypoints | 13 (two of them in no cell at all) | 16 |
| length / inflation | 26.24 / 1.29 | 27.50 / 1.35 |

Live (`DebugForceChase` from player spawn, hybrid template 705, sampled once
per second):

| | before | after |
|---|---|---|
| position after 5 s | (37.28, 0.10, -36.62) | (38.70, 0.10, -34.81) |
| after 9 s | (37.28, 0.10, -36.62) - wedged | (39.56, 0.10, -43.06) - through the door |
| after 13 s | (37.28, 0.10, -36.62) - wedged | (39.67, 0.10, -59.95) |
| longest pinned run | 7 s (to end of run) | 1 s |
| mean `live_stall_seconds`, all AIs | 0.29 s | 0.05 s |

Covered by `tools/shock2-sdk/test/medsci2-doorjamb-chase.e2e.test.ts`, which
fails on main ("hybrid sat at the door jamb for 13s").

## Case 2: railing V-corner (idle patrol) - NOT this bug

Worth recording: the patrol wedge at (49.0, 0.1, -97.7) is **not** a route
problem, before or after. Both builds route the hybrid *out* of the corner
(next waypoint (48.34, -1.6, -97.5), then north). What happens is:

1. patrol marker 649 sits on the lower floor and is unreachable;
2. once the AI reaches the closest cell to it, `find_path_toward` returns
   None - it is already as close as the mesh allows - and the record goes
   `Failed`;
3. with no path the AI steers straight at the unreachable marker, walks into
   the converging corner, and presses into the railing;
4. steering has no whiskers while a path exists, so it never gets out.

That is ledger steps 5/6 (whisker avoidance during path-follow; patrol skips
an unreachable marker instead of grinding), not clearance. This PR does
narrow the corner's route options (the 0.04-wide portals at the bottom of the
V now cost a detour) and drops the idle-run mean stall from 0.64 s to 0.48 s,
but the hybrid still ends up pinned. No e2e is added for it - a test for
behaviour this PR does not fix would be a lie.

## Bench regression (all missions, `--seed 424242`)

Success rate is identical everywhere, including the pre-existing misses
(eng2 19, medsci1 5, ops3 3, rick1 9). Quality moves a little in both
directions - detouring around a pinch is longer, but avoiding the sliver
knots takes turns out.

<details><summary>before (main)</summary>

```
mission         cells   links  found/miss   badcell  lookup p50    path p95 noroute p95  toward p95  inflate  turn deg  waypts bridges   build
command1.mis     4305   22251    200/0            0        124u        269u        574u        165u     1.11       262    16.2       0      0m
command2.mis     4884   22513    200/0            0        140u        316u        650u        187u     1.67       463    22.9       0      0m
earth.mis        5010   20581    200/0            0        132u        315u        752u        256u     1.10       456    24.3       0      0m
eng1.mis         6819   38670    200/0            0        199u        528u       1442u        388u     2.20      1026    52.4       0      0m
eng2.mis         5680   33787    181/19           0        171u       1775u       1892u        760u     1.68      1746    57.4       0      0m
hydro1.mis       2074   11950    200/0            0         61u        178u        418u        144u     1.53       506    15.9       0      0m
hydro2.mis       5244   30424    200/0            0        159u        754u       1694u        705u     2.46      1636    65.2       0      0m
hydro3.mis       1010    4781    200/0            0         31u         82u        209u         71u     1.26       333    14.7       0      0m
many.mis         6879   32084    200/0            0        213u        878u        918u        227u     1.30       306    10.3       0     14m
medsci1.mis      4695   27035    195/5            0        140u        613u       1356u        540u     1.83       980    42.0       0      0m
medsci2.mis      4038   21361    200/0            0        121u        431u       1131u        420u     1.65      1044    45.0       0      0m
ops1.mis          187    1268    200/0            0          5u         18u         78u         43u     1.07       149     8.3       0      0m
ops2.mis         3026   19472    200/0            0         90u        324u        862u        371u     1.48       871    31.1       0      0m
ops3.mis         2702   14345    197/3            0         80u        317u        774u        305u     1.68       910    38.4       0      0m
ops4.mis         2204   14038    200/0            0         64u        289u        714u        252u     1.45       838    30.3       0      0m
rec1.mis         4422   30288    200/0            0        137u        606u       1723u        742u     1.52      1005    38.1       0      0m
rec2.mis         3499   21309    200/0            0        105u        447u       1358u        591u     1.64       965    41.4       0      0m
rec3.mis         2829   15428    200/0            0         87u        334u        908u        345u     1.60       903    36.3       0      0m
rick1.mis        4880   19241    191/9            0        139u        297u        601u        164u     1.31       341    13.2       0      0m
rick2.mis         445    1491    200/0            0         13u         36u         76u         25u     1.28       152     8.7       0      0m
rick3.mis        1889    8543    200/0            0         59u        153u        354u        115u     1.33       322    17.7       0      0m
shodan.mis       1553    5265    200/0            0         47u        175u        379u        150u     1.81       809    41.0       0      0m
station.mis      2337   10371    200/0            0         69u        169u        435u        119u     1.47       298    13.8       0      0m
```
</details>

<details><summary>after</summary>

```
mission         cells   links  found/miss   badcell  lookup p50    path p95 noroute p95  toward p95  inflate  turn deg  waypts bridges   build
command1.mis     4305   22251    200/0            0        192u        577u       1310u        458u     1.11       265    16.2       0    220m
command2.mis     4884   22513    200/0            0        218u        739u       1403u        407u     1.75       476    23.6       0    380m
earth.mis        5010   20581    200/0            0        201u        582u       1603u        575u     1.10       461    24.4       0    159m
eng1.mis         6819   38670    200/0            0        386u       1438u       3792u       1390u     2.24       914    50.9       0    527m
eng2.mis         5680   33787    181/19           0        265u       3410u       4097u       1965u     1.71      1890    59.2       0    353m
hydro1.mis       2074   11950    200/0            0         87u        292u        832u        313u     1.56       455    15.6       0    140m
hydro2.mis       5244   30424    200/0            0        327u       1946u       4745u       2273u     2.46      1544    65.4       0    330m
hydro3.mis       1010    4781    200/0            0         66u        275u        617u        204u     1.33       374    13.4       0     74m
many.mis         6879   32084    200/0            0        441u       1876u       2347u        537u     1.35       339    10.4       0    482m
medsci1.mis      4695   27035    195/5            0        294u       1462u       3769u       1640u     1.99       993    47.9       0    446m
medsci2.mis      4038   21361    200/0            0        254u       1163u       3073u       1282u     1.67       944    45.8       0    365m
ops1.mis          187    1268    200/0            0         11u         62u        192u        116u     1.08       158     8.4       0     10m
ops2.mis         3026   19472    200/0            0        189u        908u       2482u       1076u     1.50       878    32.1       0    261m
ops3.mis         2702   14345    197/3            0        166u        742u       4317u       1098u     1.71       957    39.8       0    170m
ops4.mis         2204   14038    200/0            0         98u        503u       1676u        640u     1.46       901    31.0       0    151m
rec1.mis         4422   30288    200/0            0        209u       1282u       3588u       1518u     1.53       976    38.9       0    281m
rec2.mis         3499   21309    200/0            0        192u       1155u       3552u       1575u     2.11      1138    51.6       0    192m
rec3.mis         2829   15428    200/0            0        133u        644u       1653u        615u     1.61       866    36.6       0    170m
rick1.mis        4880   19241    191/9            0        234u        747u       1519u        421u     1.37       324    13.0       0    397m
rick2.mis         445    1491    200/0            0         23u         86u        173u         63u     1.29       156     8.9       0     15m
rick3.mis        1889    8543    200/0            0        122u        359u        786u        300u     1.33       316    17.7       0    195m
shodan.mis       1553    5265    200/0            0         97u        422u       1108u        461u     1.85       774    36.7       0     71m
station.mis      2337   10371    200/0            0        143u        525u       1176u        421u     1.49       295    13.8       0    182m
```
</details>

Success counts are identical to before. Inflation/turn move less than 5% almost everywhere; the one outlier is `rec2.mis`, where inflate rises 1.64 -> 2.11 (+29%) and turn 965 -> 1138 (+18%) - a detour route now threads a narrow crossing (or is routed around one) that used to go straight.

Load cost: building the boundary adds ~70-280 ms per mission at level load
(the `build` column), once.

## Tests

- `cargo test -p shock2vr` - three new pathfinding unit tests on a synthetic
  pinch-and-detour graph (route detours around the pinch; a small creature
  still takes it; a partial route stops in the roomy cell). All three fail
  with the change backed out.
- `cargo test -p shock2vr -p dark`, `npm test` (SDK), and the e2e suites
  `pathfinding*`, `force-chase`, `patrol`, `missions`, plus the new one.

