### PR TITLE
feat(weapons): switch a gun between its fire modes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -120,6 +120,7 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 | `P` | `PathfindingTestCycle` | set start → set goal → show path |
 | `B` | `DebugCycleWeapon` | spawns and wields the next weapon (unlike the number row) |
 | `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | |
+| `F` | `CycleGunSetting` | switch the wielded gun's fire mode (e.g. NORM / BURST); flat only |
 | `U` | `ReadLastUnreadLog` | Quest: left `Y` |
 | `M` | `ToggleMap` | flat only |
 | `Tab` / `I` | `ToggleUseMode` | the cyber interface; Quest: left `X` |

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -824,6 +824,11 @@ pub struct PlayerInfo {
     /// The wielded weapon's selected ammo type (e.g. "std" / "he" / "ap"), or
     /// `null` when unarmed / melee. See `shock2vr::PlayerStateSnapshot`.
     pub wielded_ammo_type: Option<String>,
+    /// The wielded gun's fire setting (0 or 1) and its short header ("NORM" /
+    /// "BURST"), or `null` when nothing gun-like is wielded. Cycle with the
+    /// `CycleGunSetting` input action. See `shock2vr::PlayerStateSnapshot`.
+    pub wielded_gun_setting: Option<i32>,
+    pub wielded_gun_setting_header: Option<String>,
     /// The player's current / maximum hit points, or `null` when the player
     /// has no health pool. See `shock2vr::PlayerStateSnapshot`.
     pub hit_points: Option<i32>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2353,6 +2353,10 @@ fn capture_frame_snapshot(
                 reload_pitch_deg: state.as_ref().map(|s| s.reload_pitch_deg).unwrap_or(0.0),
                 reload_progress: state.as_ref().map(|s| s.reload_progress).unwrap_or(0.0),
                 wielded_ammo_type: state.as_ref().and_then(|s| s.wielded_ammo_type.clone()),
+                wielded_gun_setting: state.as_ref().and_then(|s| s.wielded_gun_setting),
+                wielded_gun_setting_header: state
+                    .as_ref()
+                    .and_then(|s| s.wielded_gun_setting_header.clone()),
                 hit_points: state
                     .as_ref()
                     .and_then(|s| s.hit_points.map(|(cur, _)| cur)),

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -131,6 +131,11 @@ impl DesktopInputMapper {
                 action: InputAction::CycleAmmo,
             },
             Binding {
+                key: Key::F,
+                modifier: Modifier::None,
+                action: InputAction::CycleGunSetting,
+            },
+            Binding {
                 key: Key::Y,
                 modifier: Modifier::None,
                 action: InputAction::CyclePsiPower,

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -231,6 +231,19 @@ pub(crate) fn get_wielded_ammo_type(world: &World) -> Option<String> {
     class_tags.0.get(&template_id)?.get("ammotype").cloned()
 }
 
+/// The wielded gun's fire setting: its index (0 or 1) and the short header for
+/// that setting ("NORM" / "BURST"), or `None` when nothing gun-like is wielded.
+/// The header is absent for a gun whose data names no header for the setting.
+pub(crate) fn get_wielded_gun_setting(world: &World) -> Option<(i32, Option<String>)> {
+    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
+    let setting = world
+        .borrow::<View<dark::properties::PropGunState>>()
+        .ok()
+        .and_then(|states| states.get(weapon).ok().map(|state| state.setting))?;
+    let header = crate::scripts::script_util::gun_setting_header(world, weapon, setting);
+    Some((setting, header))
+}
+
 /// The object-icon bitmap filename (e.g. "STD_I.pcx") of the wielded weapon's
 /// selected ammo type, or `None`. Resolved from the selected projectile
 /// template's `P$ObjIcon` (projectiles are templates, not instantiated entities,

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -51,6 +51,9 @@ pub enum InputAction {
     EquipPsiAmp,
     /// Cycle an empty wielded weapon's ammo type (its next Projectile link).
     CycleAmmo,
+    /// Switch the wielded gun between its two fire modes (e.g. the pistol's
+    /// single shot and its 3-round burst).
+    CycleGunSetting,
     /// Reload the wielded weapon from compatible backpack reserve.
     Reload,
     /// Select the next psi power (used when firing the psi amp).
@@ -130,6 +133,7 @@ impl InputAction {
             InputAction::EquipWormLauncher,
             InputAction::EquipPsiAmp,
             InputAction::CycleAmmo,
+            InputAction::CycleGunSetting,
             InputAction::Reload,
             InputAction::CyclePsiPower,
             InputAction::DebugReloadLevel,
@@ -168,6 +172,7 @@ impl InputAction {
             InputAction::EquipWormLauncher => "EquipWormLauncher",
             InputAction::EquipPsiAmp => "EquipPsiAmp",
             InputAction::CycleAmmo => "CycleAmmo",
+            InputAction::CycleGunSetting => "CycleGunSetting",
             InputAction::Reload => "Reload",
             InputAction::CyclePsiPower => "CyclePsiPower",
             InputAction::DebugReloadLevel => "DebugReloadLevel",

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -99,6 +99,9 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::CycleAmmo) {
             effects.push(Effect::CycleAmmo);
         }
+        if state.just_triggered(InputAction::CycleGunSetting) {
+            effects.push(Effect::CycleGunSetting);
+        }
         if state.just_triggered(InputAction::Reload) {
             effects.push(Effect::ReloadWeapon);
         }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -678,6 +678,11 @@ pub struct PlayerStateSnapshot {
     /// links (melee). Reported whenever there is a projectile link, even if there
     /// is only one (it just cannot be cycled).
     pub wielded_ammo_type: Option<String>,
+    /// The wielded gun's fire setting (0 or 1) and the short header for it
+    /// ("NORM" / "BURST"), or `None` when nothing gun-like is wielded. Cycle
+    /// with the `CycleGunSetting` input action.
+    pub wielded_gun_setting: Option<i32>,
+    pub wielded_gun_setting_header: Option<String>,
     /// The player's hit points (current, max), or `None` when the player has
     /// no health pool. Seeded from `The Player` template and consumed by every
     /// damage path, with zero entering the player death lifecycle.
@@ -770,6 +775,7 @@ impl Game {
                     v.get(weapon).ok().map(|r| (r.pitch_deg(), r.progress()))
                 })
         });
+        let gun_setting = crate::hud::get_wielded_gun_setting(world);
         Some(PlayerStateSnapshot {
             entity_id: info.entity_id.inner() as i32,
             inventory_entity_id: info.inventory_entity_id.inner() as i32,
@@ -790,6 +796,8 @@ impl Game {
             reload_pitch_deg: reload.map(|(p, _)| p).unwrap_or(0.0),
             reload_progress: reload.map(|(_, p)| p).unwrap_or(0.0),
             wielded_ammo_type: crate::hud::get_wielded_ammo_type(world),
+            wielded_gun_setting: gun_setting.as_ref().map(|(setting, _)| *setting),
+            wielded_gun_setting_header: gun_setting.and_then(|(_, header)| header),
             hit_points: (|| {
                 use dark::properties::{PropHitPoints, PropMaxHitPoints};
                 let v_hp = world.borrow::<shipyard::View<PropHitPoints>>().ok()?;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1366,6 +1366,12 @@ pub struct GlobalTemplateClassTags(pub HashMap<i32, HashMap<String, String>>);
 #[derive(Unique, Clone)]
 pub struct GlobalTemplateObjIcons(pub HashMap<i32, String>);
 
+/// The `SHEAD1`/`SHEAD2` string tables - the short header for a gun's first /
+/// second fire setting ("NORM" / "BURST"). Loaded once here because the
+/// readouts that want them (the player state snapshot) have no asset cache.
+#[derive(Unique, Clone, Default)]
+pub struct GlobalGunSettingHeaders(pub [HashMap<String, String>; 2]);
+
 /// The synthetic player-owned entity hosting the automap panel (`MapGui`).
 /// Created at mission init; `Effect::ToggleMap` opens/closes its panel in the
 /// flat host. See `projects/flat-ui-panels.md` §5.
@@ -1822,6 +1828,16 @@ impl MissionCore {
         {
             crate::psi::apply_display_names(&mut psi_powers, &psi_strings);
         }
+        let mut gun_setting_header_table = |file| {
+            asset_cache
+                .get_opt(&dark::importers::STRINGS_IMPORTER, file)
+                .map(|strings| (*strings).clone())
+                .unwrap_or_default()
+        };
+        world.add_unique(GlobalGunSettingHeaders([
+            gun_setting_header_table("shead1.str"),
+            gun_setting_header_table("shead2.str"),
+        ]));
         // Debug scenes unlock every power (debug_psi exercises the whole
         // registry); real missions start with the player template's learned
         // bits plus the default OSA loadout (Cryokinesis).
@@ -5423,6 +5439,26 @@ impl MissionCore {
                     }
                 }
 
+                Effect::CycleGunSetting => {
+                    // Whichever hand holds the gun, like ReloadWeapon above.
+                    if let Some(weapon) = crate::wielded_weapon::wielded_weapon(&self.world) {
+                        // An SS2 gun has exactly two modes, so the switch is a
+                        // toggle - and any other stored value lands on mode 0.
+                        let current =
+                            crate::scripts::script_util::current_gun_setting(&self.world, weapon);
+                        effects.push_back(Effect::SetGunSetting {
+                            entity_id: weapon,
+                            setting: i32::from(current == 0),
+                        });
+                    }
+                }
+
+                Effect::SetGunSetting { entity_id, setting } => {
+                    if let Some(cue) = self.set_gun_setting(entity_id, setting) {
+                        effects.push_back(cue);
+                    }
+                }
+
                 Effect::ToggleUseMode => {
                     match game_options.presentation_mode {
                         crate::PresentationMode::Flat => {
@@ -7840,6 +7876,57 @@ impl MissionCore {
             .unwrap_or(0);
         self.world
             .add_component(weapon, RuntimePropSelectedAmmo((current + 1) % count));
+    }
+
+    /// Switch `weapon` to fire setting `setting`, keeping the selected ammo
+    /// type across the switch by its `ProjectileOptions.order` (the shotgun's
+    /// pellets stay pellets when it goes to its double load). Returns the
+    /// mode-change sting, or `None` when the setting is not a real mode or the
+    /// gun has no second one.
+    ///
+    /// Unlike `cycle_ammo` just above, this does NOT require an empty magazine.
+    /// That rule exists so loaded rounds cannot be converted to a different
+    /// ammo TYPE for free - and a fire setting is not an ammo type: the pair of
+    /// projectiles sharing an `order` across the two modes also share one clip
+    /// archetype (Rifled Slug and Double Slug are both `-43`), so the loaded
+    /// rounds and the reserve they unload to are unchanged by the switch.
+    fn set_gun_setting(&mut self, weapon: EntityId, setting: i32) -> Option<Effect> {
+        use crate::scripts::script_util;
+        // An SS2 gun has two modes; the effect's raw index must name one.
+        if !(0..2).contains(&setting) {
+            return None;
+        }
+        if !script_util::can_cycle_gun_setting(&self.world, weapon) {
+            return None;
+        }
+        let current = script_util::ordered_projectile_links(&self.world, weapon);
+        let next = script_util::ordered_projectile_links_for_setting(&self.world, weapon, setting);
+        let selected = self
+            .world
+            .borrow::<View<RuntimePropSelectedAmmo>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|s| s.0))
+            .unwrap_or(0);
+        let remapped = script_util::remap_selected_ammo(&current, selected, &next);
+
+        let mut gun_state = {
+            let v_gun_state = self.world.borrow::<View<dark::properties::PropGunState>>();
+            v_gun_state
+                .as_ref()
+                .ok()
+                .and_then(|states| states.get(weapon).ok().cloned())?
+        };
+        gun_state.setting = setting;
+        self.world.add_component(weapon, gun_state);
+        self.world
+            .add_component(weapon, RuntimePropSelectedAmmo(remapped));
+
+        Some(Effect::PlaySound {
+            handle: AudioHandle::new(),
+            source: None,
+            name: "bset".to_owned(),
+            spatial: false,
+        })
     }
 
     /// Mint `rounds` rounds of `clip_template` into the backpack - the half of

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -225,6 +225,18 @@ pub enum Effect {
     /// two projectile links, or while its magazine still has loaded rounds.
     CycleAmmo,
 
+    /// Switch `entity_id`'s gun to fire setting `setting`, remapping its
+    /// selected ammo type by `ProjectileOptions.order` so the same ammo stays
+    /// chosen across the switch. No-op for a gun with no second fire mode.
+    SetGunSetting {
+        entity_id: EntityId,
+        setting: i32,
+    },
+
+    /// Switch the player's wielded gun to its other fire setting. No-op when
+    /// nothing is wielded or the gun has no second mode (turrets, the psi amp).
+    CycleGunSetting,
+
     /// Equip a weapon of this gamesys class from the player's carried items.
     /// The handler resolves the live entity through the template hierarchy and
     /// then reuses `GrabEntity`, so no item is spawned and a displaced flat

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -9,7 +9,8 @@ use dark::{
     EnvSoundQuery,
     properties::{
         GunSettingDesc, Link, Links, ProjectileOptions, PropBaseGunDesc, PropClassTag,
-        PropGunState, PropMaterial, PropSymName, PropTemplateId, PropTweqModelConfig, ToLink,
+        PropGunSettingHeader1, PropGunSettingHeader2, PropGunState, PropMaterial, PropSymName,
+        PropTemplateId, PropTweqModelConfig, ToLink,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -264,7 +265,7 @@ pub fn has_death_links(world: &World, entity_id: EntityId) -> bool {
 
 /// `weapon`'s selected fire setting, 0 when it has no gun state. Ammo-type
 /// selection and the firing description both key off this, so they agree.
-fn current_gun_setting(world: &World, weapon: EntityId) -> i32 {
+pub fn current_gun_setting(world: &World, weapon: EntityId) -> i32 {
     world
         .borrow::<View<PropGunState>>()
         .ok()
@@ -296,14 +297,100 @@ pub fn active_gun_setting(world: &World, weapon: EntityId) -> Option<GunSettingD
 /// otherwise it must match the weapon's current `PropGunState.setting`
 /// (defaulting to 0 when the weapon has no gun state).
 pub fn ordered_projectile_links(world: &World, weapon: EntityId) -> Vec<(i32, ProjectileOptions)> {
-    let setting = current_gun_setting(world, weapon);
-    let mut links = get_all_links_with_template(world, weapon, |link| match link {
-        Link::Projectile(data) => Some(*data),
-        _ => None,
-    });
+    ordered_projectile_links_for_setting(world, weapon, current_gun_setting(world, weapon))
+}
+
+/// [`ordered_projectile_links`] against an arbitrary fire setting - what the
+/// ammo list *would* be in that mode, which a mode switch needs before it
+/// commits to the new setting.
+pub fn ordered_projectile_links_for_setting(
+    world: &World,
+    weapon: EntityId,
+    setting: i32,
+) -> Vec<(i32, ProjectileOptions)> {
+    let mut links = all_projectile_links(world, weapon);
     links.retain(|(_, opts)| opts.setting < 0 || opts.setting == setting);
     links.sort_by_key(|(_, opts)| opts.order);
     links
+}
+
+fn all_projectile_links(world: &World, weapon: EntityId) -> Vec<(i32, ProjectileOptions)> {
+    get_all_links_with_template(world, weapon, |link| match link {
+        Link::Projectile(data) => Some(*data),
+        _ => None,
+    })
+}
+
+/// Whether a gun offers a second fire mode at all. Two independent signals in
+/// the shipped data, either of which is enough: the gun links ammo that belongs
+/// to setting 1 (the shotgun's double load, the laser's overcharge), or it
+/// NAMES the mode in its display strings (the pistol's BURST and the assault
+/// rifle's AUTO fire the same ammo, so links alone miss them). Guns with
+/// neither - the psi amp, turrets - have one mode.
+///
+/// The second setting's magazine is deliberately not a signal: a gun that never
+/// authored setting 1 still carries the editor's default record there, clip
+/// included, so `clip != 0` would give the psi amp a mode it does not have.
+fn has_second_fire_mode(second_header: Option<&str>, links: &[(i32, ProjectileOptions)]) -> bool {
+    second_header.is_some() || links.iter().any(|(_, opts)| opts.setting == 1)
+}
+
+/// Whether `weapon` can switch fire modes. See [`has_second_fire_mode`].
+pub fn can_cycle_gun_setting(world: &World, weapon: EntityId) -> bool {
+    let links = all_projectile_links(world, weapon);
+    let second_header = gun_setting_header(world, weapon, 1);
+    has_second_fire_mode(second_header.as_deref(), &links)
+}
+
+/// The short header for `weapon`'s fire setting `setting` - "NORM" / "BURST" -
+/// or `None` when the gun names no such setting. Resolved from the gun's own
+/// `P$SHead1`/`P$SHead2` against the matching string table, which also covers
+/// the guns that author no header property of their own.
+pub fn gun_setting_header(world: &World, weapon: EntityId, setting: i32) -> Option<String> {
+    let raw = match setting {
+        0 => world
+            .borrow::<View<PropGunSettingHeader1>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|header| header.0.clone())),
+        1 => world
+            .borrow::<View<PropGunSettingHeader2>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|header| header.0.clone())),
+        _ => return None,
+    };
+    let sym_name = world
+        .borrow::<View<PropSymName>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|name| name.0.clone()));
+    let tables = world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalGunSettingHeaders>>()
+        .ok()?;
+    let table = tables.0.get(setting as usize)?;
+    dark::importers::resolve_gun_setting_string(raw.as_deref(), sym_name.as_deref(), table)
+}
+
+/// The ammo index to select after a fire-mode switch. `order` is the ammo
+/// type's identity (the shotgun's pellets carry the same `order` in both
+/// modes), so the selection follows its order across the switch and falls back
+/// to the first entry when the new mode has no counterpart.
+///
+/// Every shipped gun happens to author the same order set in both modes, which
+/// makes this the identity mapping today - it is what keeps the switch honest
+/// if a mode ever offers a different set.
+pub fn remap_selected_ammo(
+    current: &[(i32, ProjectileOptions)],
+    selected: usize,
+    next: &[(i32, ProjectileOptions)],
+) -> usize {
+    if current.is_empty() {
+        return 0;
+    }
+    // Wrap the index the way every other reader of `RuntimePropSelectedAmmo`
+    // does, so the switch remaps the ammo the HUD and the shot agree is chosen.
+    let (_, opts) = &current[selected % current.len()];
+    next.iter()
+        .position(|(_, candidate)| candidate.order == opts.order)
+        .unwrap_or(0)
 }
 
 /// Whether `weapon` may select a different projectile type: it needs two or
@@ -1022,16 +1109,16 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 mod tests {
     use super::{
         active_gun_setting, debit_player_nanites, door_blocks_pathfinding, door_is_closed,
-        is_always_collected, is_nanite_pickup, plan_stack_payment, player_nanite_total,
-        spend_player_nanites, stat_nanite_balance,
+        has_second_fire_mode, is_always_collected, is_nanite_pickup, plan_stack_payment,
+        player_nanite_total, remap_selected_ammo, spend_player_nanites, stat_nanite_balance,
     };
     use crate::mission::PlayerInfo;
     use crate::quest_info::QuestInfo;
     use crate::runtime_props::RuntimePropTransform;
     use cgmath::{Matrix4, Quaternion, Vector3, vec3};
     use dark::properties::{
-        GunSettingDesc, Link, Links, PropBaseGunDesc, PropGunState, PropObjIcon, PropStackCount,
-        PropTranslatingDoor, ToLink, WrappedEntityId,
+        GunSettingDesc, Link, Links, ProjectileOptions, PropBaseGunDesc, PropGunState, PropObjIcon,
+        PropStackCount, PropTranslatingDoor, ToLink, WrappedEntityId,
     };
     use shipyard::{EntityId, Get, View, World};
 
@@ -1077,6 +1164,73 @@ mod tests {
         let not_a_gun = world.add_entity(gun_state(0));
 
         assert!(active_gun_setting(&world, not_a_gun).is_none());
+    }
+
+    fn projectile(order: i32, setting: i32) -> ProjectileOptions {
+        ProjectileOptions { order, setting }
+    }
+
+    /// The shotgun: pellets and slugs in each mode, the same `order` in both.
+    fn shotgun_ammo() -> (Vec<(i32, ProjectileOptions)>, Vec<(i32, ProjectileOptions)>) {
+        (
+            vec![(-524, projectile(0, 0)), (-516, projectile(1, 0))],
+            vec![(-3423, projectile(0, 1)), (-3422, projectile(1, 1))],
+        )
+    }
+
+    /// The pistol: one ammo set shared by both modes, so only its BURST header
+    /// says the second mode exists.
+    #[test]
+    fn a_gun_that_names_its_second_mode_has_one() {
+        let shared_ammo = [
+            (-362, projectile(1, -1)),
+            (-492, projectile(2, -1)),
+            (-33, projectile(3, -1)),
+        ];
+
+        assert!(has_second_fire_mode(Some("BURST"), &shared_ammo));
+    }
+
+    /// The shotgun: setting-1 ammo, so the links alone settle it.
+    #[test]
+    fn a_gun_with_setting_specific_ammo_has_a_second_fire_mode() {
+        let (normal, double) = shotgun_ammo();
+        let links = [normal, double].concat();
+
+        assert!(has_second_fire_mode(None, &links));
+    }
+
+    /// The psi amp: no setting-1 ammo and no name for a second mode.
+    #[test]
+    fn a_gun_with_neither_has_no_second_fire_mode() {
+        assert!(!has_second_fire_mode(None, &[(-362, projectile(1, -1))]));
+        assert!(!has_second_fire_mode(None, &[]));
+    }
+
+    #[test]
+    fn a_switch_keeps_the_selected_ammo_order() {
+        let (normal, double) = shotgun_ammo();
+
+        // Slugs (order 1) stay slugs; pellets (order 0) stay pellets.
+        assert_eq!(remap_selected_ammo(&normal, 1, &double), 1);
+        assert_eq!(remap_selected_ammo(&normal, 0, &double), 0);
+        assert_eq!(remap_selected_ammo(&double, 1, &normal), 1);
+    }
+
+    #[test]
+    fn a_switch_falls_back_to_the_first_ammo_when_the_order_is_gone() {
+        let (normal, _) = shotgun_ammo();
+        let only_pellets = vec![(-3423, projectile(0, 1))];
+
+        assert_eq!(remap_selected_ammo(&normal, 1, &only_pellets), 0);
+    }
+
+    #[test]
+    fn a_switch_wraps_an_out_of_range_selection_like_every_other_reader() {
+        let (normal, double) = shotgun_ammo();
+
+        assert_eq!(remap_selected_ammo(&normal, 7, &double), 1, "7 % 2 = slugs");
+        assert_eq!(remap_selected_ammo(&[], 0, &double), 0, "no ammo at all");
     }
 
     fn door_world(

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -20,6 +20,7 @@ export type InputAction =
   | "EquipWormLauncher"
   | "EquipPsiAmp"
   | "CycleAmmo"
+  | "CycleGunSetting"
   | "Reload"
   | "CyclePsiPower"
   | "ToggleUseMode"
@@ -502,6 +503,11 @@ export interface PlayerSnapshot {
   /** The wielded weapon's selected ammo type (e.g. "std"/"he"/"ap"), or null
    * when unarmed / melee (no projectile links). */
   wielded_ammo_type: string | null;
+  /** The wielded gun's fire setting (0 or 1) and its short header ("NORM" /
+   * "BURST"), or null when nothing gun-like is wielded. Switch modes with the
+   * `CycleGunSetting` input action. */
+  wielded_gun_setting: number | null;
+  wielded_gun_setting_header: string | null;
   /** The player's current / maximum hit points, or null when the player has
    * no health pool. Drained by psi burnout. */
   hit_points: number | null;

--- a/tools/shock2-sdk/test/helpers/weapon.ts
+++ b/tools/shock2-sdk/test/helpers/weapon.ts
@@ -1,4 +1,15 @@
+import assert from "node:assert/strict";
+
 import type { EntitySummary, GameServer } from "../../src/index.js";
+
+/** The `Ammo` property of a weapon's entity detail - its loaded rounds. */
+export function ammoOf(detail: {
+  properties: { name: string; value: string }[];
+}): number {
+  const ammo = detail.properties.find((p) => p.name === "Ammo");
+  assert.ok(ammo, "weapon should expose an Ammo property");
+  return Number(ammo.value);
+}
 
 /** Fire one round: edge-triggered pull (fires on the rising edge), then release,
  * stepping a frame for each so the next pull is a fresh edge. */

--- a/tools/shock2-sdk/test/weapon-fire-mode.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-fire-mode.e2e.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { describeSounds } from "./helpers/audio.js";
+import { ammoOf, cycleToWeapon, fireOnce } from "./helpers/weapon.js";
+
+// End-to-end coverage for fire-mode switching (InputAction::CycleGunSetting).
+// SS2 guns have exactly two modes; switching swaps the firing description and
+// the ammo set, keeping the chosen ammo TYPE across the switch by its
+// ProjectileOptions.order. Observable headlessly via /v1/info's
+// wielded_gun_setting / wielded_gun_setting_header / wielded_ammo_type.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+async function fireMode(game: GameServer): Promise<[number | null, string | null]> {
+  const player = (await game.info()).player;
+  return [player.wielded_gun_setting, player.wielded_gun_setting_header];
+}
+
+test(
+  "the pistol switches between its NORM and BURST modes and back",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+
+    await game.step({ frames: 5 });
+    assert.deepEqual(await fireMode(game), [null, null], "unarmed has no fire mode");
+
+    // The pistol is the first weapon DebugCycleWeapon hands out.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    assert.deepEqual(await fireMode(game), [0, "NORM"], "pistol starts on its first mode");
+
+    const before = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    assert.deepEqual(await fireMode(game), [1, "BURST"], "switches to the 3-round burst");
+
+    // Retail plays the `bset` sting on a mode change.
+    const played = (await game.audio.recent()).sounds.filter((s) => s.sequence > before);
+    assert.ok(
+      played.some((s) => s.sample.toLowerCase().startsWith("bset")),
+      `the switch should play the bset sting, got ${describeSounds(played)}`,
+    );
+
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    assert.deepEqual(await fireMode(game), [0, "NORM"], "and back - there are only two modes");
+  },
+);
+
+test(
+  "a shotgun mode switch keeps the selected ammo type",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const shotgun = await cycleToWeapon(game, (e) => e.name.includes("Shotgun"));
+    assert.deepEqual(await fireMode(game), [0, "NORM"], "shotgun starts on its first mode");
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "rslug",
+      "the shotgun's first ammo type in order is the rifled slug",
+    );
+
+    // Cycling ammo needs an empty magazine (a loaded one is ejected instead),
+    // so fire it dry first. Pellets are the SECOND ammo type in order, which is
+    // what makes the remap below observable: a switch that reset the selection
+    // would land back on slugs.
+    const loaded = ammoOf(await game.entities.detail(shotgun.id));
+    assert.ok(loaded > 0, "debug shotgun starts loaded");
+    for (let i = 0; i < loaded; i++) await fireOnce(game);
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.wielded_ammo_type, "pellet", "pellets selected");
+
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+
+    assert.deepEqual(await fireMode(game), [1, "TRIPLE"], "switches to the double load");
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "pellet",
+      "the double load keeps pellets (Double Pellet shares Pellet's order)",
+    );
+  },
+);
+
+test(
+  "a gun with only one fire mode ignores the switch",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    // The psi amp links no setting-specific ammo and names no second mode.
+    await cycleToWeapon(game, (e) => e.name.includes("Psi Amp"));
+    const before = await fireMode(game);
+    assert.equal(before[0], 0, "psi amp is on setting 0");
+
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+
+    assert.deepEqual(await fireMode(game), before, "a one-mode gun does not switch");
+  },
+);


### PR DESCRIPTION
PR 2a of the fire-modes stack. Rebased onto `main` because its parent
(#1244) merged while this was in flight.

## What

`CycleGunSetting` (desktop `F`, flat only — no Quest button is free) flips the
wielded gun's `PropGunState.setting` between its two modes and plays the retail
`bset` sting. `Effect::SetGunSetting { entity_id, setting }` does the work;
`Effect::CycleGunSetting` resolves the wielded gun the way `CycleAmmo` /
`ReloadWeapon` do (inheriting their known left-hand assumption — not fixed here)
and toggles.

Telemetry: `/v1/info`'s player block gains `wielded_gun_setting` and
`wielded_gun_setting_header` ("NORM" / "BURST"), beside `wielded_ammo_type`.

## The order-preserving remap

`RuntimePropSelectedAmmo` is an *index* into the setting-filtered, order-sorted
projectile list, so a mode switch would otherwise silently repoint it. The rule
(what the original does): read the current selection's `ProjectileOptions.order`,
recompute the list for the new setting, select the entry with the same `order`,
else index 0. `order` is the ammo type's identity — the shotgun's Pellet and
Double Pellet share one — so pellets stay pellets across the switch.

Every shipped gun authors the same order set in both modes, which makes the
remap the identity mapping on real data; it is what keeps the switch honest if a
mode ever offers a different set. Not requiring an empty magazine (unlike
`cycle_ammo`) is safe and documented in the code: the two projectiles sharing an
`order` also share one clip archetype, so loaded rounds and the reserve they
unload to are unchanged.

## Mode gating

A gun has a second mode when it either links ammo belonging to setting 1 (the
shotgun's double load, the laser's overcharge) **or** names the mode in its
display strings (the pistol's BURST and the assault rifle's AUTO share one ammo
set, so links alone miss them). The second setting's magazine is deliberately
**not** a signal: a gun that never authored setting 1 still carries the editor's
default record there, clip included — `settings[1].clip != 0` would hand the psi
amp a mode it does not have. Turrets and the psi amp switch to nothing.

## Known intermediate state (deliberate)

Firing already reads the *setting-filtered* link list (`weapon_script.rs`), so
this PR does change what a gun fires: setting 1 shoots the "Big"/"Double"
projectile. The second mode's **costs** — `ammo_usage`, `shot_interval_ms`,
`burst` — are not read anywhere in the port yet, so until the follow-up lands,
mode 1 is a damage upgrade at the same ammo cost. Landing `ammo_usage` here
would also change six weapons' *existing* setting-0 economy (laser 3/shot, EMP
2, stasis 4, …), which belongs in its own PR with its own tests.

## Tests

Pure, unit-tested helpers: `has_second_fire_mode` (gating) and
`remap_selected_ammo` (the order remap). Both verified negative-first — a naive
`remap` that always returns 0 fails `a_switch_keeps_the_selected_ammo_order`,
and the same stub fails the shotgun e2e below.

New e2e `tools/shock2-sdk/test/weapon-fire-mode.e2e.test.ts` on `debug_weapons`:
pistol NORM -> BURST -> NORM (plus an assertion that `bset` actually played);
shotgun with pellets selected keeps pellets through the switch to TRIPLE; the
psi amp ignores the switch.

```
cargo test -p shock2vr --lib
test result: ok. 1210 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out

RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime
Finished `dev` profile

npm test (SDK unit)
# pass 32  # fail 0

e2e (SHOCK2_E2E=1)
ok 1 - save then load in a fresh runtime restores mission and player position
ok 2 - loading a corrupt save returns 500 without bricking the runtime
ok 3 - saving an unsupported player returns a structured pose refusal
ok 4 - current and maximum player vitals survive mission transition and cross-process save/load
ok 5 - cycling advances the selected ammo type and wraps
ok 6 - the pistol switches between its NORM and BURST modes and back
ok 7 - a shotgun mode switch keeps the selected ammo type
ok 8 - a gun with only one fire mode ignores the switch
ok 9 - earth reload consumes matching reserve entities and partial stacks
# tests 9  # pass 9  # fail 0

missions.e2e.test.ts
# tests 23  # pass 23  # fail 0
```

Save/load: `PropGunState` already round-trips through the generic property loop,
verified with `setting = 1` — no new test, since one could not fail.
