### PR TITLE
fix(ai): never steer at a goal with no route, and whisker past geometry the mesh misses

### DIFF
--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -111,8 +111,10 @@ impl PatrolBehavior {
 
     fn steering_to(goal: Vector3<f32>) -> Box<dyn SteeringStrategy> {
         steering::chained(vec![
-            // Path steering leads; whisker avoidance only covers the no-route
-            // case (see chase_behavior for the deadlock this prevents)
+            // Path steering leads - it carries its own whiskers as a bias on
+            // its aim point; this one is the no-route fallback, where a
+            // heading override is safe (see chase_behavior for the deadlock
+            // that overriding an ACTIVE route causes)
             Box::new(PathFollowSteeringStrategy::to_point(goal)),
             Box::new(CollisionAvoidanceSteeringStrategy::conservative()),
         ])
@@ -163,6 +165,22 @@ impl PatrolBehavior {
                 Effect::combine(effects)
             }
         }
+    }
+
+    /// Give up on the current point and try the next one. Enough of those in
+    /// a row - without reaching one in between - and the whole route is out
+    /// of reach, so stop patrolling and hand back to idle rather than
+    /// shuffling (and re-querying A*) between points forever.
+    fn skip_point(&mut self, world: &World, entity_id: EntityId) -> Effect {
+        self.skipped_points += 1;
+        if self.skipped_points >= PATROL_MAX_SKIPPED_POINTS {
+            self.finished = true;
+            return Effect::SetAICurrentPatrol {
+                entity_id,
+                target: None,
+            };
+        }
+        self.advance(world, entity_id, false)
     }
 
     /// Whether the AI has failed to cover ground for PATROL_STALL_SECONDS.
@@ -217,26 +235,19 @@ impl Behavior for PatrolBehavior {
                 // the floor below). Move on at once rather than steering at it
                 // on a heading nothing checked, grinding into the geometry in
                 // between until the stall watchdog retires the whole route.
+                // Counted like a stalled skip, so a route with no reachable
+                // point left ends instead of cycling (and re-querying) forever.
                 tracing::debug!(
                     "patrol {entity_id:?}: no route to point {:?}, skipping to the next one",
                     self.target_point
                 );
-                patrol_effects.push(self.advance(world, entity_id, false));
+                patrol_effects.push(self.skip_point(world, entity_id));
             } else if self.stalled(position, time) {
                 // Going nowhere: give up on this point and try the next one.
                 // Enough of those in a row and the whole route is out of
                 // reach, so stop patrolling and hand back to idle via
                 // next_behavior rather than walking in place forever.
-                self.skipped_points += 1;
-                if self.skipped_points >= PATROL_MAX_SKIPPED_POINTS {
-                    self.finished = true;
-                    patrol_effects.push(Effect::SetAICurrentPatrol {
-                        entity_id,
-                        target: None,
-                    });
-                } else {
-                    patrol_effects.push(self.advance(world, entity_id, false));
-                }
+                patrol_effects.push(self.skip_point(world, entity_id));
             }
         }
 
@@ -415,6 +426,9 @@ mod tests {
 
     /// Steering that reports no route to whatever goal it was given.
     struct UnreachableSteering;
+    /// ...and its counterpart, which has a route.
+    struct ReachableSteering;
+    impl SteeringStrategy for ReachableSteering {}
     impl SteeringStrategy for UnreachableSteering {
         fn goal_unreachable(&self) -> bool {
             true
@@ -439,18 +453,9 @@ mod tests {
             }
         }
 
-        assert!(
-            !patrol.finished,
-            "skipping unreachable points must keep the route running"
-        );
-        assert!(
-            !emitted
-                .iter()
-                .any(|effect| matches!(effect, Effect::SetAICurrentPatrol { target: None, .. })),
-            "the patrol must not retire itself over unreachable points"
-        );
-        // The three-point loop keeps advancing: every tick targets a
-        // different point than the one before it.
+        // The route moves on at once - one tick per point, no waiting out the
+        // stall watchdog - and, since NO point on this loop is reachable, it
+        // ends at the skip cap rather than cycling (and re-querying) forever.
         let targets: Vec<EntityId> = emitted
             .iter()
             .filter_map(|effect| match effect {
@@ -458,10 +463,53 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert!(
-            targets.len() > 3 && targets.windows(2).all(|pair| pair[0] != pair[1]),
-            "expected the route to keep advancing, got {targets:?}"
+        assert_eq!(
+            targets.len(),
+            PATROL_MAX_SKIPPED_POINTS as usize,
+            "expected one skip per tick up to the cap, got {targets:?}"
         );
+        assert!(patrol.finished, "a route with no reachable point ends");
+    }
+
+    thread_local! {
+        /// How many steering strategies the test below has handed out
+        static STEERINGS_BUILT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    }
+
+    /// One unreachable point does not end a route: the AI skips it and
+    /// carries on toward the next, which it can route to.
+    #[test]
+    fn one_unreachable_point_does_not_end_the_route() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        STEERINGS_BUILT.with(|built| built.set(0));
+        // Only the first point reports no route.
+        let mut patrol = PatrolBehavior::with_steering(first, goal, |_| {
+            let nth = STEERINGS_BUILT.with(|built| {
+                let nth = built.get();
+                built.set(nth + 1);
+                nth
+            });
+            if nth == 0 {
+                Box::new(UnreachableSteering)
+            } else {
+                Box::new(ReachableSteering) as Box<dyn SteeringStrategy>
+            }
+        });
+
+        let mut emitted = Vec::new();
+        for _ in 0..20 {
+            if let Some((_, effect)) = patrol.steer(Deg(0.0), &world, &physics, creature, &tick()) {
+                emitted.extend(Effect::flatten(vec![effect]));
+            }
+        }
+
+        assert!(!patrol.finished, "the route carries on past one bad point");
+        let skips = emitted
+            .iter()
+            .filter(|effect| matches!(effect, Effect::SetAICurrentPatrol { .. }))
+            .count();
+        assert_eq!(skips, 2, "the initial target, then one skip");
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -68,6 +68,9 @@ pub struct PatrolBehavior {
     /// The runtime AICurrentPatrol link must be published once for a fresh
     /// behavior and whenever the target changes.
     target_dirty: bool,
+    /// Builds the steering for a goal - a hook so tests can drive the
+    /// behavior with a stubbed route outcome.
+    make_steering: fn(Vector3<f32>) -> Box<dyn SteeringStrategy>,
     /// Whether the route has actually advanced at least one edge. Dark clears
     /// the authored AI_Patrol flag at a real end of chain, but the start rule
     /// targets the *destination* of the nearest link, which in shipped data
@@ -83,12 +86,26 @@ impl PatrolBehavior {
             target_point,
             goal,
             steering_strategy: Self::steering_to(goal),
+            make_steering: Self::steering_to,
             finished: false,
             stall_anchor: None,
             stall_seconds: 0.0,
             skipped_points: 0,
             target_dirty: true,
             walked_an_edge: false,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_steering(
+        target_point: EntityId,
+        goal: Vector3<f32>,
+        make_steering: fn(Vector3<f32>) -> Box<dyn SteeringStrategy>,
+    ) -> PatrolBehavior {
+        PatrolBehavior {
+            steering_strategy: make_steering(goal),
+            make_steering,
+            ..PatrolBehavior::new(target_point, goal)
         }
     }
 
@@ -116,7 +133,7 @@ impl PatrolBehavior {
             Some((next, goal)) => {
                 self.target_point = next;
                 self.goal = goal;
-                self.steering_strategy = Self::steering_to(goal);
+                self.steering_strategy = (self.make_steering)(goal);
                 self.stall_anchor = None;
                 self.stall_seconds = 0.0;
                 self.walked_an_edge = true;
@@ -194,6 +211,17 @@ impl Behavior for PatrolBehavior {
             if self.arrived(position) {
                 self.skipped_points = 0;
                 patrol_effects.push(self.advance(world, entity_id, true));
+            } else if self.steering_strategy.goal_unreachable() {
+                // No route to this point (shipped routes include points on a
+                // disconnected part of the navigation graph, e.g. a marker on
+                // the floor below). Move on at once rather than steering at it
+                // on a heading nothing checked, grinding into the geometry in
+                // between until the stall watchdog retires the whole route.
+                tracing::debug!(
+                    "patrol {entity_id:?}: no route to point {:?}, skipping to the next one",
+                    self.target_point
+                );
+                patrol_effects.push(self.advance(world, entity_id, false));
             } else if self.stalled(position, time) {
                 // Going nowhere: give up on this point and try the next one.
                 // Enough of those in a row and the whole route is out of
@@ -383,6 +411,57 @@ mod tests {
             "a moving patroller must stay on its route"
         );
         assert_eq!(patrol.target_point, first, "and keep the same point");
+    }
+
+    /// Steering that reports no route to whatever goal it was given.
+    struct UnreachableSteering;
+    impl SteeringStrategy for UnreachableSteering {
+        fn goal_unreachable(&self) -> bool {
+            true
+        }
+    }
+
+    /// A patrol point with no route to it (shipped routes include points on
+    /// a disconnected part of the navigation graph) is skipped at once - and
+    /// the route keeps going, rather than the AI grinding into the geometry
+    /// between it and the point until the watchdog retires the patrol.
+    #[test]
+    fn a_patroller_skips_a_point_it_has_no_route_to() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        let mut patrol =
+            PatrolBehavior::with_steering(first, goal, |_| Box::new(UnreachableSteering));
+
+        let mut emitted = Vec::new();
+        for _ in 0..100 {
+            if let Some((_, effect)) = patrol.steer(Deg(0.0), &world, &physics, creature, &tick()) {
+                emitted.extend(Effect::flatten(vec![effect]));
+            }
+        }
+
+        assert!(
+            !patrol.finished,
+            "skipping unreachable points must keep the route running"
+        );
+        assert!(
+            !emitted
+                .iter()
+                .any(|effect| matches!(effect, Effect::SetAICurrentPatrol { target: None, .. })),
+            "the patrol must not retire itself over unreachable points"
+        );
+        // The three-point loop keeps advancing: every tick targets a
+        // different point than the one before it.
+        let targets: Vec<EntityId> = emitted
+            .iter()
+            .filter_map(|effect| match effect {
+                Effect::SetAICurrentPatrol { target, .. } => *target,
+                _ => None,
+            })
+            .collect();
+        assert!(
+            targets.len() > 3 && targets.windows(2).all(|pair| pair[0] != pair[1]),
+            "expected the route to keep advancing, got {targets:?}"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -38,9 +38,10 @@ const PATROL_STALL_SECONDS: f32 = 5.0;
 /// the stall watchdog. A patrolling AI clears this in a fraction of a second,
 /// so only a body that is genuinely going nowhere trips the timer.
 const PATROL_STALL_PROGRESS: f32 = 2.0 / SCALE_FACTOR;
-/// Points skipped in a row, without reaching one in between, after which the
-/// AI stops patrolling altogether and hands back to idle - rather than
-/// shuffling forever between points it has no route to.
+/// Points STALLED on in a row, without reaching one in between, after which
+/// the AI stops patrolling altogether and hands back to idle - rather than
+/// grinding into geometry forever. (Points with no route at all are cheap to
+/// skip and are bounded separately, by `unreachable_points`.)
 const PATROL_MAX_SKIPPED_POINTS: u32 = 3;
 
 /// Walk an authored patrol route: head to the current patrol point, and on
@@ -65,6 +66,12 @@ pub struct PatrolBehavior {
     stall_seconds: f32,
     /// Points given up on since the last one actually reached.
     skipped_points: u32,
+    /// Points with no route to them, given up on since the last one actually
+    /// reached. Kept apart from `skipped_points`: an unreachable point costs
+    /// nothing to skip (there is no route to grind on), so it must not eat
+    /// the stall budget - but coming back around to one already skipped means
+    /// the whole loop is out of reach, and the route ends there.
+    unreachable_points: Vec<EntityId>,
     /// The runtime AICurrentPatrol link must be published once for a fresh
     /// behavior and whenever the target changes.
     target_dirty: bool,
@@ -91,6 +98,7 @@ impl PatrolBehavior {
             stall_anchor: None,
             stall_seconds: 0.0,
             skipped_points: 0,
+            unreachable_points: Vec::new(),
             target_dirty: true,
             walked_an_edge: false,
         }
@@ -228,6 +236,7 @@ impl Behavior for PatrolBehavior {
             let position = position.to_vec();
             if self.arrived(position) {
                 self.skipped_points = 0;
+                self.unreachable_points.clear();
                 patrol_effects.push(self.advance(world, entity_id, true));
             } else if self.steering_strategy.goal_unreachable() {
                 // No route to this point (shipped routes include points on a
@@ -241,7 +250,18 @@ impl Behavior for PatrolBehavior {
                     "patrol {entity_id:?}: no route to point {:?}, skipping to the next one",
                     self.target_point
                 );
-                patrol_effects.push(self.skip_point(world, entity_id));
+                if self.unreachable_points.contains(&self.target_point) {
+                    // Been here before without reaching anything in between:
+                    // the whole loop is out of reach.
+                    self.finished = true;
+                    patrol_effects.push(Effect::SetAICurrentPatrol {
+                        entity_id,
+                        target: None,
+                    });
+                } else {
+                    self.unreachable_points.push(self.target_point);
+                    patrol_effects.push(self.advance(world, entity_id, false));
+                }
             } else if self.stalled(position, time) {
                 // Going nowhere: give up on this point and try the next one.
                 // Enough of those in a row and the whole route is out of
@@ -455,18 +475,25 @@ mod tests {
 
         // The route moves on at once - one tick per point, no waiting out the
         // stall watchdog - and, since NO point on this loop is reachable, it
-        // ends at the skip cap rather than cycling (and re-querying) forever.
-        let targets: Vec<EntityId> = emitted
+        // ends when it comes back around to one it already gave up on, rather
+        // than cycling (and re-querying) forever.
+        let targets: Vec<Option<EntityId>> = emitted
             .iter()
             .filter_map(|effect| match effect {
-                Effect::SetAICurrentPatrol { target, .. } => *target,
+                Effect::SetAICurrentPatrol { target, .. } => Some(*target),
                 _ => None,
             })
             .collect();
+        let tried: Vec<EntityId> = targets.iter().flatten().copied().collect();
         assert_eq!(
-            targets.len(),
-            PATROL_MAX_SKIPPED_POINTS as usize,
-            "expected one skip per tick up to the cap, got {targets:?}"
+            tried.iter().collect::<std::collections::HashSet<_>>().len(),
+            3,
+            "every point on the loop gets one try, got {tried:?}"
+        );
+        assert_eq!(
+            targets.last(),
+            Some(&None),
+            "and the route then retires, got {targets:?}"
         );
         assert!(patrol.finished, "a route with no reachable point ends");
     }

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -38,11 +38,6 @@ const PATROL_STALL_SECONDS: f32 = 5.0;
 /// the stall watchdog. A patrolling AI clears this in a fraction of a second,
 /// so only a body that is genuinely going nowhere trips the timer.
 const PATROL_STALL_PROGRESS: f32 = 2.0 / SCALE_FACTOR;
-/// Points STALLED on in a row, without reaching one in between, after which
-/// the AI stops patrolling altogether and hands back to idle - rather than
-/// grinding into geometry forever. (Points with no route at all are cheap to
-/// skip and are bounded separately, by `unreachable_points`.)
-const PATROL_MAX_SKIPPED_POINTS: u32 = 3;
 
 /// Walk an authored patrol route: head to the current patrol point, and on
 /// arrival advance to the next one along the `AIPatrol` link chain. Routes are
@@ -57,21 +52,19 @@ pub struct PatrolBehavior {
     steering_strategy: Box<dyn SteeringStrategy>,
     /// Set when the route dead-ends (a chain that isn't a loop): the AI has
     /// reached the final point and there is nowhere further to go, so it stops
-    /// patrolling and hands back to idle. Also set once the AI has skipped
-    /// PATROL_MAX_SKIPPED_POINTS unreachable points in a row.
+    /// patrolling and hands back to idle. Also set once every point on the
+    /// route has been given up on with no arrival in between.
     finished: bool,
     /// Stall watchdog: where the AI was when the timer was last re-anchored,
     /// and how long it has been stuck within PATROL_STALL_PROGRESS of it.
     stall_anchor: Option<Vector3<f32>>,
     stall_seconds: f32,
-    /// Points given up on since the last one actually reached.
-    skipped_points: u32,
-    /// Points with no route to them, given up on since the last one actually
-    /// reached. Kept apart from `skipped_points`: an unreachable point costs
-    /// nothing to skip (there is no route to grind on), so it must not eat
-    /// the stall budget - but coming back around to one already skipped means
-    /// the whole loop is out of reach, and the route ends there.
-    unreachable_points: Vec<EntityId>,
+    /// Points given up on - no route to them, or stalled against geometry -
+    /// since the last one actually reached. Coming back around to a point
+    /// already on this list means the AI has tried the whole loop without
+    /// reaching anything, and the route ends there. A single wedge must not
+    /// retire a route the AI walks fine the rest of the way round.
+    given_up_points: Vec<EntityId>,
     /// The runtime AICurrentPatrol link must be published once for a fresh
     /// behavior and whenever the target changes.
     target_dirty: bool,
@@ -97,8 +90,7 @@ impl PatrolBehavior {
             finished: false,
             stall_anchor: None,
             stall_seconds: 0.0,
-            skipped_points: 0,
-            unreachable_points: Vec::new(),
+            given_up_points: Vec::new(),
             target_dirty: true,
             walked_an_edge: false,
         }
@@ -175,19 +167,24 @@ impl PatrolBehavior {
         }
     }
 
-    /// Give up on the current point and try the next one. Enough of those in
-    /// a row - without reaching one in between - and the whole route is out
-    /// of reach, so stop patrolling and hand back to idle rather than
-    /// shuffling (and re-querying A*) between points forever.
-    fn skip_point(&mut self, world: &World, entity_id: EntityId) -> Effect {
-        self.skipped_points += 1;
-        if self.skipped_points >= PATROL_MAX_SKIPPED_POINTS {
+    /// Give up on the current point and try the next one. Only a whole lap
+    /// of these - every point given up on, with no arrival in between - ends
+    /// the route, so one bad point (or one wedge the AI walks out of on the
+    /// next leg) never retires a patrol, while a route with nothing reachable
+    /// left stops instead of cycling (and re-querying A*) forever.
+    fn give_up_on_point(&mut self, world: &World, entity_id: EntityId) -> Effect {
+        if self.given_up_points.contains(&self.target_point) {
+            tracing::debug!(
+                "patrol {entity_id:?}: gave up on the whole loop, retiring at {:?}",
+                self.target_point
+            );
             self.finished = true;
             return Effect::SetAICurrentPatrol {
                 entity_id,
                 target: None,
             };
         }
+        self.given_up_points.push(self.target_point);
         self.advance(world, entity_id, false)
     }
 
@@ -235,8 +232,7 @@ impl Behavior for PatrolBehavior {
             let (position, _) = ai_util::get_position_and_forward(world, entity_id);
             let position = position.to_vec();
             if self.arrived(position) {
-                self.skipped_points = 0;
-                self.unreachable_points.clear();
+                self.given_up_points.clear();
                 patrol_effects.push(self.advance(world, entity_id, true));
             } else if self.steering_strategy.goal_unreachable() {
                 // No route to this point (shipped routes include points on a
@@ -250,24 +246,16 @@ impl Behavior for PatrolBehavior {
                     "patrol {entity_id:?}: no route to point {:?}, skipping to the next one",
                     self.target_point
                 );
-                if self.unreachable_points.contains(&self.target_point) {
-                    // Been here before without reaching anything in between:
-                    // the whole loop is out of reach.
-                    self.finished = true;
-                    patrol_effects.push(Effect::SetAICurrentPatrol {
-                        entity_id,
-                        target: None,
-                    });
-                } else {
-                    self.unreachable_points.push(self.target_point);
-                    patrol_effects.push(self.advance(world, entity_id, false));
-                }
+                patrol_effects.push(self.give_up_on_point(world, entity_id));
             } else if self.stalled(position, time) {
                 // Going nowhere: give up on this point and try the next one.
-                // Enough of those in a row and the whole route is out of
-                // reach, so stop patrolling and hand back to idle via
-                // next_behavior rather than walking in place forever.
-                patrol_effects.push(self.skip_point(world, entity_id));
+                // A wedge is a fact about the body's current spot, not about
+                // the route, so the next leg usually walks straight out of it.
+                tracing::debug!(
+                    "patrol {entity_id:?}: stalled on point {:?}",
+                    self.target_point
+                );
+                patrol_effects.push(self.give_up_on_point(world, entity_id));
             }
         }
 
@@ -357,6 +345,35 @@ mod tests {
         (world, creature, points[0], vec3(100.0, 0.0, 100.0))
     }
 
+    /// A wedged patroller must get the whole loop's worth of tries. A stall
+    /// is a fact about the spot the body is standing in, not about the route:
+    /// the AI usually walks out of it on the next leg, so giving up on a
+    /// handful of points in a row must not retire a patrol permanently (an
+    /// Idle creature stands in that corner for the rest of the mission).
+    #[test]
+    fn a_wedged_patroller_tries_every_point_before_retiring() {
+        let (world, creature, first, goal) = world_with_six_point_route();
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(first, goal);
+
+        // The body never moves, so every point stalls. Four stall windows in.
+        let mut tried = Vec::new();
+        for _ in 0..300 {
+            patrol.steer(Deg(0.0), &world, &physics, creature, &tick());
+            if !tried.contains(&patrol.target_point) {
+                tried.push(patrol.target_point);
+            }
+            if patrol.finished {
+                break;
+            }
+        }
+
+        assert!(
+            tried.len() >= 6,
+            "every point on the loop gets a try before the route retires, got {tried:?}"
+        );
+    }
+
     /// A patroller that cannot reach its route must not walk into the
     /// geometry forever. The nearest point is chosen geometrically, so it can
     /// sit in a disconnected part of the navigation graph - A* then returns
@@ -368,11 +385,12 @@ mod tests {
         let physics = PhysicsWorld::new();
         let mut patrol = PatrolBehavior::new(first, goal);
 
-        // 20 simulated seconds without the body ever moving - four times the
-        // stall window, so every point on the loop gets its turn.
+        // 30 simulated seconds without the body ever moving - six times the
+        // stall window, so every point on the loop gets its turn and the
+        // route comes back around to the first one it gave up on.
         let mut elapsed = 0.0;
         let mut emitted = Vec::new();
-        for _ in 0..200 {
+        for _ in 0..300 {
             let time = Time {
                 elapsed: std::time::Duration::from_millis(100),
                 total: std::time::Duration::from_millis(0),
@@ -453,6 +471,36 @@ mod tests {
         fn goal_unreachable(&self) -> bool {
             true
         }
+    }
+
+    /// The medsci2 shape: a six-point loop, none of it reachable from where
+    /// the creature stands.
+    fn world_with_six_point_route() -> (World, EntityId, EntityId, Vector3<f32>) {
+        let mut world = World::new();
+        let creature = world.add_entity(RuntimePropTransform(Matrix4::from_scale(1.0)));
+        let points: Vec<EntityId> = (0..6)
+            .map(|i| {
+                world.add_entity((
+                    RuntimePropTransform(Matrix4::from_translation(vec3(
+                        100.0 + i as f32,
+                        0.0,
+                        100.0,
+                    ))),
+                    Links::empty(),
+                ))
+            })
+            .collect();
+        {
+            let mut v_links = world.borrow::<ViewMut<Links>>().unwrap();
+            for (index, point) in points.iter().enumerate() {
+                (&mut v_links).get(*point).unwrap().to_links.push(ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(points[(index + 1) % points.len()])),
+                    link: Link::AIPatrol,
+                });
+            }
+        }
+        (world, creature, points[0], vec3(100.0, 0.0, 100.0))
     }
 
     /// A patrol point with no route to it (shipped routes include points on

--- a/shock2vr/src/scripts/ai/steering/chained_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/chained_steering_strategy.rs
@@ -11,6 +11,10 @@ pub struct ChainedSteeringStrategy {
 }
 
 impl SteeringStrategy for ChainedSteeringStrategy {
+    fn goal_unreachable(&self) -> bool {
+        self.strategies.iter().any(|s| s.goal_unreachable())
+    }
+
     fn steer(
         &mut self,
         _current_heading: Deg<f32>,

--- a/shock2vr/src/scripts/ai/steering/mod.rs
+++ b/shock2vr/src/scripts/ai/steering/mod.rs
@@ -50,6 +50,15 @@ impl Steering {
 }
 
 pub trait SteeringStrategy {
+    /// Whether the destination this strategy was given has no route to it -
+    /// A* reported no route at all, or only a partial one that stops well
+    /// short. The owning behavior decides what to do about it (a patrol
+    /// skips the point); steering itself must never answer an unreachable
+    /// goal by aiming straight at it.
+    fn goal_unreachable(&self) -> bool {
+        false
+    }
+
     fn steer(
         &mut self,
         _current_heading: Deg<f32>,

--- a/shock2vr/src/scripts/ai/steering/mod.rs
+++ b/shock2vr/src/scripts/ai/steering/mod.rs
@@ -4,12 +4,14 @@ mod chase_player_steering_strategy;
 mod collision_avoidance_steering_strategy;
 mod path_follow_steering_strategy;
 mod wander_steering_strategy;
+mod whisker_avoidance;
 
 pub use chained_steering_strategy::*;
 pub use chase_entity_steering_strategy::*;
 pub use chase_player_steering_strategy::*;
 pub use collision_avoidance_steering_strategy::*;
 pub use path_follow_steering_strategy::*;
+pub use whisker_avoidance::*;
 
 use cgmath::{Deg, EuclideanSpace, Point3};
 use shipyard::{EntityId, World};

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -94,10 +94,11 @@ const SEPARATION_RADIUS: f32 = 6.0 / SCALE_FACTOR;
 /// (issue #487).
 const SEPARATION_MAX_OFFSET: f32 = 3.0 / SCALE_FACTOR;
 
-/// A route counts as reaching its goal when its last waypoint lands within
-/// this distance (6 Dark feet) in XZ. A* answers an unreachable goal with a
-/// partial route to the closest reachable point, which for a goal on another
-/// walk component can stop a whole room short - following it to the end just
+/// A partial route counts as reaching its goal anyway when its last waypoint
+/// lands within this distance (6 Dark feet). A* answers an unreachable goal
+/// with a partial route to the closest reachable CELL CENTER, which lands
+/// near a goal it merely could not resolve to a cell, but a whole room short
+/// of one on another walk component - and following that to its end just
 /// presses the body into whatever geometry sits in between.
 const GOAL_REACHED_DISTANCE: f32 = 6.0 / SCALE_FACTOR;
 
@@ -267,8 +268,10 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                             REPATH_FAILURE_BACKOFF_SECONDS * rand::thread_rng().gen_range(0.8..1.2);
                     }
                     _ if goal_current => {
-                        self.goal_unreachable =
-                            !route_reaches_goal(&response.waypoints, response.goal);
+                        // Only a PARTIAL route says anything about
+                        // reachability: it is A*'s "closest I could get".
+                        self.goal_unreachable = response.outcome == AiPathOutcome::Partial
+                            && !route_reaches_goal(&response.waypoints, response.goal);
                         self.path = response.waypoints;
                         self.path_goal = Some(response.goal);
                         // waypoint 0 is the position the query started from
@@ -322,6 +325,10 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     // same frames forever
                     self.repath_cooldown =
                         REPATH_COOLDOWN_SECONDS * rand::thread_rng().gen_range(0.8..1.2);
+                    // A fresh question: the previous answer's verdict on
+                    // reachability no longer stands (goals move, and blocked
+                    // crossings expire)
+                    self.goal_unreachable = false;
                     // The worker computes a full route, or - when the goal
                     // is unreachable (another island, off-mesh) - a partial
                     // route to the closest reachable point, so the AI
@@ -369,20 +376,18 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // path) stay authoritative - the bias is capped well below the
         // waypoint spacing.
         let separation = ai_util::separation_bias(world, entity_id, position, SEPARATION_RADIUS);
-        let separation = {
-            let magnitude = (separation.x * separation.x + separation.z * separation.z).sqrt();
-            if magnitude > 1e-3 {
-                separation * (magnitude.min(SEPARATION_MAX_OFFSET) / magnitude)
-            } else {
-                Vector3::new(0.0, 0.0, 0.0)
-            }
-        };
         // ...and the same treatment for static geometry the navigation mesh
         // doesn't model (a railing, a crate left on the route): whiskers bend
         // the line around it before the body wedges, without ever taking the
-        // heading away from the route.
+        // heading away from the route. Both together are capped ONCE, so two
+        // biases pointing the same way still cannot bend the line further
+        // than one of them may.
         let whiskers = self.whiskers.update(world, physics, entity_id, time);
-        let aim = aim_with_bias(position, waypoint, separation + whiskers);
+        let aim = aim_with_bias(
+            position,
+            waypoint,
+            capped(separation + whiskers, SEPARATION_MAX_OFFSET),
+        );
 
         // Stall escape: if we stop making progress toward the current
         // waypoint (blocked by a prop, another AI, or bad geometry), drop
@@ -537,6 +542,16 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
     }
 }
 
+/// Shorten a horizontal bias to at most `max`.
+fn capped(bias: Vector3<f32>, max: f32) -> Vector3<f32> {
+    let magnitude = (bias.x * bias.x + bias.z * bias.z).sqrt();
+    if magnitude > max {
+        bias * (max / magnitude)
+    } else {
+        bias
+    }
+}
+
 /// Bend the aim point by a steering bias, keeping the route authoritative:
 /// a bias that would drag the aim point onto (or behind) the body is
 /// dropped, since turning to a point you are standing on is not steering.
@@ -575,7 +590,13 @@ fn aim_with_bias(
 fn route_reaches_goal(waypoints: &[Vector3<f32>], goal: Vector3<f32>) -> bool {
     waypoints
         .last()
-        .map(|last| xz_distance(*last, goal) <= GOAL_REACHED_DISTANCE)
+        .map(|last| {
+            // Height matters as much as ground distance here: the case this
+            // exists for is a goal on the floor below, whose XZ distance is
+            // nearly zero.
+            xz_distance(*last, goal) <= GOAL_REACHED_DISTANCE
+                && (last.y - goal.y).abs() <= GOAL_REACHED_DISTANCE
+        })
         .unwrap_or(false)
 }
 
@@ -722,6 +743,25 @@ mod tests {
             goal
         ));
         assert!(!route_reaches_goal(&[], goal));
+    }
+
+    /// ...and a route that ends directly above (or below) the goal has not
+    /// reached it either - the balcony case.
+    #[test]
+    fn a_route_ending_on_another_floor_does_not_reach_its_goal() {
+        assert!(!route_reaches_goal(
+            &[vec3(10.0, 0.0, 10.0)],
+            vec3(10.0, -4.8, 10.0)
+        ));
+    }
+
+    #[test]
+    fn biases_are_capped_together() {
+        let shortened = capped(vec3(3.0, 0.0, 4.0), 2.5);
+        assert!(
+            ((shortened.x * shortened.x + shortened.z * shortened.z).sqrt() - 2.5).abs() < 1e-5
+        );
+        assert_eq!(capped(vec3(0.3, 0.0, 0.4), 2.5), vec3(0.3, 0.0, 0.4));
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -94,6 +94,13 @@ const SEPARATION_RADIUS: f32 = 6.0 / SCALE_FACTOR;
 /// (issue #487).
 const SEPARATION_MAX_OFFSET: f32 = 3.0 / SCALE_FACTOR;
 
+/// A route counts as reaching its goal when its last waypoint lands within
+/// this distance (6 Dark feet) in XZ. A* answers an unreachable goal with a
+/// partial route to the closest reachable point, which for a goal on another
+/// walk component can stop a whole room short - following it to the end just
+/// presses the body into whatever geometry sits in between.
+const GOAL_REACHED_DISTANCE: f32 = 6.0 / SCALE_FACTOR;
+
 /// Steers along a route computed by the PathfindingService, the counterpart
 /// of the original engine's cAIPath following (Advance / UpdateTargetEdge in
 /// aipath.cpp). Returns None when no pathfinding data or no route exists so
@@ -119,6 +126,8 @@ pub struct PathFollowSteeringStrategy {
     /// spot means retreat + re-path freed nothing and the body is pinned
     /// (see UNSTICK_NUDGE_DISTANCE)
     last_stall_position: Option<Vector3<f32>>,
+    /// Last query said the goal has no route (see `goal_unreachable`)
+    goal_unreachable: bool,
 }
 
 impl PathFollowSteeringStrategy {
@@ -147,6 +156,7 @@ impl PathFollowSteeringStrategy {
             recovery: None,
             displacement_anchor: None,
             last_stall_position: None,
+            goal_unreachable: false,
         }
     }
 
@@ -166,6 +176,10 @@ impl PathFollowSteeringStrategy {
 }
 
 impl SteeringStrategy for PathFollowSteeringStrategy {
+    fn goal_unreachable(&self) -> bool {
+        self.goal_unreachable
+    }
+
     fn steer(
         &mut self,
         _current_heading: Deg<f32>,
@@ -241,6 +255,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 };
                 match response.outcome {
                     AiPathOutcome::Failed => {
+                        self.goal_unreachable = true;
                         self.clear_path();
                         // No route (even partially) - back off before asking
                         // again; the fallback chain is the worker's most
@@ -249,6 +264,8 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                             REPATH_FAILURE_BACKOFF_SECONDS * rand::thread_rng().gen_range(0.8..1.2);
                     }
                     _ if goal_current => {
+                        self.goal_unreachable =
+                            !route_reaches_goal(&response.waypoints, response.goal);
                         self.path = response.waypoints;
                         self.path_goal = Some(response.goal);
                         // waypoint 0 is the position the query started from
@@ -512,6 +529,15 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
     }
 }
 
+/// Whether a route actually arrives at the goal it was computed for. An
+/// empty route arrives nowhere.
+fn route_reaches_goal(waypoints: &[Vector3<f32>], goal: Vector3<f32>) -> bool {
+    waypoints
+        .last()
+        .map(|last| xz_distance(*last, goal) <= GOAL_REACHED_DISTANCE)
+        .unwrap_or(false)
+}
+
 /// Skip every waypoint already within reach, returning the new index
 fn advance_waypoint(position: Vector3<f32>, path: &[Vector3<f32>], mut index: usize) -> usize {
     while index < path.len() && waypoint_reached(position, path[index]) {
@@ -599,6 +625,28 @@ mod tests {
         // ran in place through an endless stall/re-path loop).
         let path = vec![vec3(0.0, -1.7, 0.0), vec3(10.0, -1.7, 0.0)];
         assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 1);
+    }
+
+    #[test]
+    fn a_route_ending_at_its_goal_reaches_it() {
+        let goal = vec3(10.0, 0.0, 10.0);
+        assert!(route_reaches_goal(
+            &[vec3(0.0, 0.0, 0.0), vec3(10.5, 0.0, 10.0)],
+            goal
+        ));
+    }
+
+    /// A partial route stopping a room short of an unreachable goal is not
+    /// arrival - the patrol layer skips such a point instead of walking the
+    /// route's end and then pressing on toward the goal.
+    #[test]
+    fn a_partial_route_stopping_short_does_not_reach_its_goal() {
+        let goal = vec3(10.0, 0.0, 10.0);
+        assert!(!route_reaches_goal(
+            &[vec3(0.0, 0.0, 0.0), vec3(4.0, 0.0, 10.0)],
+            goal
+        ));
+        assert!(!route_reaches_goal(&[], goal));
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -15,7 +15,7 @@ use crate::{
     util::vec3_to_point3,
 };
 
-use super::{Steering, SteeringOutput, SteeringStrategy};
+use super::{Steering, SteeringOutput, SteeringStrategy, WhiskerAvoidance};
 
 /// How the strategy picks its destination
 pub enum PathTarget {
@@ -128,6 +128,8 @@ pub struct PathFollowSteeringStrategy {
     last_stall_position: Option<Vector3<f32>>,
     /// Last query said the goal has no route (see `goal_unreachable`)
     goal_unreachable: bool,
+    /// Static-geometry whiskers, biasing the aim point (see `aim_with_bias`)
+    whiskers: WhiskerAvoidance,
 }
 
 impl PathFollowSteeringStrategy {
@@ -157,6 +159,7 @@ impl PathFollowSteeringStrategy {
             displacement_anchor: None,
             last_stall_position: None,
             goal_unreachable: false,
+            whiskers: WhiskerAvoidance::new(),
         }
     }
 
@@ -184,7 +187,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         &mut self,
         _current_heading: Deg<f32>,
         world: &World,
-        _physics: &PhysicsWorld,
+        physics: &PhysicsWorld,
         entity_id: EntityId,
         time: &Time,
     ) -> Option<(SteeringOutput, Effect)> {
@@ -366,15 +369,20 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // path) stay authoritative - the bias is capped well below the
         // waypoint spacing.
         let separation = ai_util::separation_bias(world, entity_id, position, SEPARATION_RADIUS);
-        let aim = {
+        let separation = {
             let magnitude = (separation.x * separation.x + separation.z * separation.z).sqrt();
             if magnitude > 1e-3 {
-                let capped = magnitude.min(SEPARATION_MAX_OFFSET);
-                waypoint + separation * (capped / magnitude)
+                separation * (magnitude.min(SEPARATION_MAX_OFFSET) / magnitude)
             } else {
-                waypoint
+                Vector3::new(0.0, 0.0, 0.0)
             }
         };
+        // ...and the same treatment for static geometry the navigation mesh
+        // doesn't model (a railing, a crate left on the route): whiskers bend
+        // the line around it before the body wedges, without ever taking the
+        // heading away from the route.
+        let whiskers = self.whiskers.update(world, physics, entity_id, time);
+        let aim = aim_with_bias(position, waypoint, separation + whiskers);
 
         // Stall escape: if we stop making progress toward the current
         // waypoint (blocked by a prop, another AI, or bad geometry), drop
@@ -529,6 +537,22 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
     }
 }
 
+/// Bend the aim point by a steering bias, keeping the route authoritative:
+/// a bias that would drag the aim point onto (or behind) the body is
+/// dropped, since turning to a point you are standing on is not steering.
+fn aim_with_bias(
+    position: Vector3<f32>,
+    waypoint: Vector3<f32>,
+    bias: Vector3<f32>,
+) -> Vector3<f32> {
+    let aim = waypoint + bias;
+    if xz_distance(position, aim) < WAYPOINT_ADVANCE_DISTANCE {
+        waypoint
+    } else {
+        aim
+    }
+}
+
 /// Whether a route actually arrives at the goal it was computed for. An
 /// empty route arrives nowhere.
 fn route_reaches_goal(waypoints: &[Vector3<f32>], goal: Vector3<f32>) -> bool {
@@ -625,6 +649,28 @@ mod tests {
         // ran in place through an endless stall/re-path loop).
         let path = vec![vec3(0.0, -1.7, 0.0), vec3(10.0, -1.7, 0.0)];
         assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 1);
+    }
+
+    #[test]
+    fn a_bias_bends_the_aim_point() {
+        let aim = aim_with_bias(
+            vec3(0.0, 0.0, 0.0),
+            vec3(10.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 1.0),
+        );
+        assert_eq!(aim, vec3(10.0, 0.0, 1.0));
+    }
+
+    /// ...but never onto the body itself: a bias pointing back at an AI
+    /// nearly on top of its waypoint would spin it around.
+    #[test]
+    fn a_bias_never_aims_at_the_body() {
+        let position = vec3(0.0, 0.0, 0.0);
+        let waypoint = vec3(0.3, 0.0, 0.0);
+        assert_eq!(
+            aim_with_bias(position, waypoint, vec3(-0.3, 0.0, 0.0)),
+            waypoint
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -545,6 +545,23 @@ fn aim_with_bias(
     waypoint: Vector3<f32>,
     bias: Vector3<f32>,
 ) -> Vector3<f32> {
+    // Drop whatever part of the bias points back down the route: an
+    // obstacle square across the path answers with its own normal, and
+    // pulling the aim point backwards would only stop the AI in front of it
+    // instead of taking it around (what is left is the sideways part).
+    let toward = waypoint - position;
+    let length = (toward.x * toward.x + toward.z * toward.z).sqrt();
+    let bias = if length > 1e-3 {
+        let toward = Vector3::new(toward.x / length, 0.0, toward.z / length);
+        let along = bias.x * toward.x + bias.z * toward.z;
+        if along < 0.0 {
+            bias - toward * along
+        } else {
+            bias
+        }
+    } else {
+        bias
+    };
     let aim = waypoint + bias;
     if xz_distance(position, aim) < WAYPOINT_ADVANCE_DISTANCE {
         waypoint
@@ -671,6 +688,18 @@ mod tests {
             aim_with_bias(position, waypoint, vec3(-0.3, 0.0, 0.0)),
             waypoint
         );
+    }
+
+    /// A bias pointing back down the route keeps only its sideways part -
+    /// the AI passes the obstacle instead of stopping in front of it.
+    #[test]
+    fn a_backward_bias_becomes_a_sideways_one() {
+        let aim = aim_with_bias(
+            vec3(0.0, 0.0, 0.0),
+            vec3(10.0, 0.0, 0.0),
+            vec3(-2.0, 0.0, 1.0),
+        );
+        assert_eq!(aim, vec3(10.0, 0.0, 1.0));
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -252,13 +252,9 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // desire is discarded (the submit below re-queries).
         if advancing {
             if let Some(response) = async_pathfinding.take_result(entity_id.inner()) {
-                let goal_current = match desired_goal {
-                    Some(now) => xz_distance(response.goal, now) <= REPATH_TARGET_DRIFT,
-                    // Wander/Point requested this exact goal
-                    None => true,
-                };
+                let goal_current = answers_goal(&self.target, response.goal, desired_goal);
                 match response.outcome {
-                    AiPathOutcome::Failed => {
+                    AiPathOutcome::Failed if goal_current => {
                         self.goal_unreachable = true;
                         self.clear_path();
                         // No route (even partially) - back off before asking
@@ -585,6 +581,29 @@ fn aim_with_bias(
     }
 }
 
+/// Whether a completed query answers the goal this strategy wants *now*.
+/// Queries are keyed by entity, so a result can outlive the strategy that
+/// asked for it - a patrol that gives up on a point builds a fresh follower
+/// while the old query is still in flight. Adopting that answer would steer
+/// the body along the abandoned point's route and, worse, carry its
+/// reachability verdict over to a point nothing ever asked about.
+fn answers_goal(
+    target: &PathTarget,
+    response_goal: Vector3<f32>,
+    desired_goal: Option<Vector3<f32>>,
+) -> bool {
+    match (target, desired_goal) {
+        // A moving target (the player): the answer is current if it was
+        // computed near where the target is now
+        (_, Some(now)) => xz_distance(response_goal, now) <= REPATH_TARGET_DRIFT,
+        // A fixed point is requested verbatim and echoed back verbatim, so
+        // any other goal belongs to a request this strategy did not make
+        (PathTarget::Point(point), None) => response_goal == *point,
+        // Wander picks its goal inside this strategy, so any answer is its own
+        (_, None) => true,
+    }
+}
+
 /// Whether a route actually arrives at the goal it was computed for. An
 /// empty route arrives nowhere.
 fn route_reaches_goal(waypoints: &[Vector3<f32>], goal: Vector3<f32>) -> bool {
@@ -721,6 +740,28 @@ mod tests {
             vec3(-2.0, 0.0, 1.0),
         );
         assert_eq!(aim, vec3(10.0, 0.0, 1.0));
+    }
+
+    /// Queries are keyed by entity, so an answer can outlive the strategy
+    /// that asked for it - a patrol that gives up on a point builds a fresh
+    /// follower while the old query is still in flight. That answer says
+    /// nothing about the new point and must not be adopted (its route would
+    /// steer the body back at the abandoned point, and its verdict would
+    /// declare the new point unreachable without anyone asking).
+    #[test]
+    fn an_answer_for_an_abandoned_point_is_not_adopted() {
+        let point = vec3(10.0, 0.0, 10.0);
+        let target = PathTarget::Point(point);
+        assert!(answers_goal(&target, point, None), "its own answer");
+        assert!(
+            !answers_goal(&target, vec3(30.0, 0.0, 30.0), None),
+            "an answer for the point the patrol just gave up on"
+        );
+        // A goal on the floor below is a different point, however close in XZ
+        assert!(
+            !answers_goal(&target, vec3(10.0, -6.0, 10.0), None),
+            "an answer for a goal below this one"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
+++ b/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
@@ -1,0 +1,197 @@
+use cgmath::{Deg, InnerSpace, Quaternion, Rotation, Rotation3, Vector3, vec3};
+use dark::SCALE_FACTOR;
+use shipyard::{EntityId, World};
+
+use crate::{
+    physics::{InternalCollisionGroups, PhysicsWorld},
+    scripts::ai::ai_util,
+    time::Time,
+    util::{get_position_from_transform, get_rotation_from_transform},
+};
+
+/// How far ahead the whiskers look (3 Dark feet - a body width plus a
+/// little, so the bias builds while there is still room to turn)
+const WHISKER_DISTANCE: f32 = 3.0 / SCALE_FACTOR;
+/// Whiskers to either side of the facing direction
+const WHISKER_SPREAD: Deg<f32> = Deg(30.0);
+/// Probe heights, relative to the body origin (roughly body center). A
+/// railing is a thin slab whose top sits just BELOW an upright creature's
+/// center, so a single center-height ray sails over it - the wedge this
+/// exists to prevent. Two heights also discriminate: a low obstacle (a
+/// stair riser, a kerb) blocks only the knee ray, and a bias is only taken
+/// when BOTH heights are blocked, so climbable steps don't push AIs
+/// sideways off staircases the route chose.
+const WHISKER_KNEE_HEIGHT: f32 = -3.0 / SCALE_FACTOR;
+const WHISKER_CHEST_HEIGHT: f32 = -1.0 / SCALE_FACTOR;
+/// Seconds between probes. Static geometry doesn't move and every
+/// path-following AI runs this, so the rays are cast a few times a second
+/// and the bias is held in between (the original engine's wall regulator
+/// runs on a comparable interval).
+const WHISKER_INTERVAL_SECONDS: f32 = 0.2;
+/// The bias bends the aim point at most this far (3 Dark feet), the same
+/// cap crowd separation uses: whiskers nudge the route around geometry the
+/// navigation mesh doesn't model, they never veto it.
+pub const WHISKER_MAX_OFFSET: f32 = 3.0 / SCALE_FACTOR;
+
+/// One blocked whisker: the surface normal at the hit and how far away it is
+pub struct WhiskerHit {
+    pub normal: Vector3<f32>,
+    pub distance: f32,
+}
+
+/// Static-geometry whiskers, sampled on an interval and blended into path
+/// following as a bias on the aim point. Unlike `CollisionAvoidanceSteering`
+/// this never takes the heading over - it runs *while* a route is being
+/// followed, where overriding the route deadlocks AIs against walls the path
+/// was about to turn away from (issue #481).
+pub struct WhiskerAvoidance {
+    bias: Vector3<f32>,
+    seconds_since_probe: f32,
+}
+
+impl WhiskerAvoidance {
+    pub fn new() -> WhiskerAvoidance {
+        WhiskerAvoidance {
+            // Probe on the first update
+            bias: vec3(0.0, 0.0, 0.0),
+            seconds_since_probe: f32::MAX,
+        }
+    }
+
+    /// The current avoidance bias (world units, horizontal), re-probing at
+    /// most every WHISKER_INTERVAL_SECONDS.
+    pub fn update(
+        &mut self,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+        time: &Time,
+    ) -> Vector3<f32> {
+        self.seconds_since_probe += time.elapsed.as_secs_f32();
+        if self.seconds_since_probe < WHISKER_INTERVAL_SECONDS {
+            return self.bias;
+        }
+        self.seconds_since_probe = 0.0;
+        self.bias = whisker_bias(&self.probe(world, physics, entity_id), WHISKER_DISTANCE);
+        self.bias
+    }
+
+    fn probe(&self, world: &World, physics: &PhysicsWorld, entity_id: EntityId) -> Vec<WhiskerHit> {
+        let rotation = get_rotation_from_transform(world, entity_id);
+        let knee =
+            get_position_from_transform(world, entity_id, vec3(0.0, WHISKER_KNEE_HEIGHT, 0.0));
+        let chest =
+            get_position_from_transform(world, entity_id, vec3(0.0, WHISKER_CHEST_HEIGHT, 0.0));
+
+        let mut hits = Vec::new();
+        for spread in [Deg(0.0), WHISKER_SPREAD, -WHISKER_SPREAD] {
+            let forward = (rotation * Quaternion::from_angle_y(spread))
+                .rotate_vector(vec3(0.0, 0.0, 1.0))
+                .normalize();
+            let cast = |from| {
+                physics
+                    .ray_cast2_as_actor(
+                        from,
+                        forward,
+                        WHISKER_DISTANCE,
+                        InternalCollisionGroups::ALL_COLLIDABLE,
+                        Some(entity_id),
+                        true,
+                    )
+                    // A door the AI can open is not an obstacle to bend around
+                    .filter(|hit| {
+                        !hit.maybe_entity_id
+                            .map(|id| ai_util::is_entity_door(world, id))
+                            .unwrap_or(false)
+                    })
+            };
+            // Both heights must be blocked - see WHISKER_KNEE_HEIGHT
+            let (Some(low), Some(high)) = (cast(knee), cast(chest)) else {
+                continue;
+            };
+            let nearest =
+                if (low.hit_point - knee).magnitude() < (high.hit_point - chest).magnitude() {
+                    (low, knee)
+                } else {
+                    (high, chest)
+                };
+            hits.push(WhiskerHit {
+                normal: nearest.0.hit_normal,
+                distance: (nearest.0.hit_point - nearest.1).magnitude(),
+            });
+        }
+        hits
+    }
+}
+
+/// Sum the blocked whiskers into a horizontal push away from the geometry:
+/// each hit contributes its surface normal, weighted by how close it is, and
+/// the total is capped at WHISKER_MAX_OFFSET. Floors and ceilings (normals
+/// without a horizontal component) contribute nothing - the route walks on
+/// them.
+pub fn whisker_bias(hits: &[WhiskerHit], max_distance: f32) -> Vector3<f32> {
+    let mut bias = vec3(0.0, 0.0, 0.0);
+    for hit in hits {
+        let horizontal = vec3(hit.normal.x, 0.0, hit.normal.z);
+        let length = horizontal.magnitude();
+        if length < 0.5 {
+            continue;
+        }
+        let weight = ((max_distance - hit.distance) / max_distance).clamp(0.0, 1.0);
+        bias += horizontal / length * weight * WHISKER_MAX_OFFSET;
+    }
+    let magnitude = bias.magnitude();
+    if magnitude > WHISKER_MAX_OFFSET {
+        bias *= WHISKER_MAX_OFFSET / magnitude;
+    }
+    bias
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(normal: Vector3<f32>, distance: f32) -> WhiskerHit {
+        WhiskerHit { normal, distance }
+    }
+
+    #[test]
+    fn clear_whiskers_do_not_bend_the_route() {
+        assert_eq!(whisker_bias(&[], 1.0), vec3(0.0, 0.0, 0.0));
+    }
+
+    /// A wall dead ahead pushes back along its normal, proportionally to how
+    /// close it is.
+    #[test]
+    fn a_near_wall_pushes_away_harder_than_a_far_one() {
+        let near = whisker_bias(&[hit(vec3(-1.0, 0.0, 0.0), 0.25)], 1.0);
+        let far = whisker_bias(&[hit(vec3(-1.0, 0.0, 0.0), 0.75)], 1.0);
+        assert!(near.x < far.x && far.x < 0.0, "near {near:?} far {far:?}");
+        assert_eq!(near.z, 0.0);
+    }
+
+    /// Floors and ceilings are not obstacles.
+    #[test]
+    fn horizontal_surfaces_are_ignored() {
+        assert_eq!(
+            whisker_bias(&[hit(vec3(0.0, 1.0, 0.0), 0.1)], 1.0),
+            vec3(0.0, 0.0, 0.0)
+        );
+    }
+
+    /// However many whiskers are blocked, the bias stays a bias: it can
+    /// never bend the aim point further than the cap.
+    #[test]
+    fn the_bias_is_capped() {
+        let boxed_in = whisker_bias(
+            &[
+                hit(vec3(-1.0, 0.0, 0.0), 0.0),
+                hit(vec3(-0.7, 0.0, -0.7), 0.0),
+                hit(vec3(0.0, 0.0, -1.0), 0.0),
+            ],
+            1.0,
+        );
+        assert!(boxed_in.magnitude() <= WHISKER_MAX_OFFSET + 1e-5);
+        assert!(boxed_in.magnitude() > 0.0);
+    }
+}

--- a/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
+++ b/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
@@ -126,7 +126,9 @@ impl WhiskerAvoidance {
                     from,
                     forward,
                     WHISKER_DISTANCE,
-                    InternalCollisionGroups::WORLD | InternalCollisionGroups::ENTITY,
+                    InternalCollisionGroups::ALL_COLLIDABLE
+                        - InternalCollisionGroups::PLAYER
+                        - InternalCollisionGroups::ACTOR,
                     Some(entity_id),
                     true,
                     &not_a_door,

--- a/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
+++ b/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
@@ -1,6 +1,7 @@
 use cgmath::{Deg, InnerSpace, Quaternion, Rotation, Rotation3, Vector3, vec3};
 use dark::SCALE_FACTOR;
-use shipyard::{EntityId, World};
+use dark::properties::PropCreature;
+use shipyard::{EntityId, Get, View, World};
 
 use crate::{
     physics::{InternalCollisionGroups, PhysicsWorld},
@@ -14,15 +15,19 @@ use crate::{
 const WHISKER_DISTANCE: f32 = 3.0 / SCALE_FACTOR;
 /// Whiskers to either side of the facing direction
 const WHISKER_SPREAD: Deg<f32> = Deg(30.0);
-/// Probe heights, relative to the body origin (roughly body center). A
-/// railing is a thin slab whose top sits just BELOW an upright creature's
-/// center, so a single center-height ray sails over it - the wedge this
-/// exists to prevent. Two heights also discriminate: a low obstacle (a
-/// stair riser, a kerb) blocks only the knee ray, and a bias is only taken
-/// when BOTH heights are blocked, so climbable steps don't push AIs
-/// sideways off staircases the route chose.
-const WHISKER_KNEE_HEIGHT: f32 = -3.0 / SCALE_FACTOR;
-const WHISKER_CHEST_HEIGHT: f32 = -1.0 / SCALE_FACTOR;
+/// Probe heights, as a fraction of the creature's own height below its body
+/// origin (colliders are centered on that origin). A railing is a thin slab
+/// whose top sits just BELOW an upright creature's center, so a single
+/// center-height ray sails over it - the wedge this exists to prevent. Two
+/// heights also discriminate: a low obstacle (a stair riser, a kerb) blocks
+/// only the knee ray, and a bias is only taken when BOTH heights are
+/// blocked, so climbable steps don't push AIs sideways off staircases the
+/// route chose. Fractions rather than fixed feet, because a monkey is half
+/// a hybrid's height and fixed offsets would put both its probes underground.
+const WHISKER_KNEE_FRACTION: f32 = 0.35;
+const WHISKER_CHEST_FRACTION: f32 = 0.15;
+/// Height to fall back on when the creature has no definition (world units)
+const WHISKER_DEFAULT_HEIGHT: f32 = 6.5 / SCALE_FACTOR;
 /// Seconds between probes. Static geometry doesn't move and every
 /// path-following AI runs this, so the rays are cast a few times a second
 /// and the bias is held in between (the original engine's wall regulator
@@ -47,8 +52,10 @@ pub struct WhiskerReading {
 }
 
 /// Static-geometry whiskers, sampled on an interval and blended into path
-/// following as a bias on the aim point. Unlike `CollisionAvoidanceSteering`
-/// this never takes the heading over - it runs *while* a route is being
+/// following as a bias on the aim point. Unlike
+/// `CollisionAvoidanceSteeringStrategy` - which probes at body center only
+/// and answers with a heading of its own, and stays the no-route fallback -
+/// this never takes the heading over: it runs *while* a route is being
 /// followed, where overriding the route deadlocks AIs against walls the path
 /// was about to turn away from (issue #481).
 pub struct WhiskerAvoidance {
@@ -90,10 +97,17 @@ impl WhiskerAvoidance {
         entity_id: EntityId,
     ) -> Vec<WhiskerReading> {
         let rotation = get_rotation_from_transform(world, entity_id);
-        let knee =
-            get_position_from_transform(world, entity_id, vec3(0.0, WHISKER_KNEE_HEIGHT, 0.0));
-        let chest =
-            get_position_from_transform(world, entity_id, vec3(0.0, WHISKER_CHEST_HEIGHT, 0.0));
+        let height = creature_height(world, entity_id);
+        let knee = get_position_from_transform(
+            world,
+            entity_id,
+            vec3(0.0, -height * WHISKER_KNEE_FRACTION, 0.0),
+        );
+        let chest = get_position_from_transform(
+            world,
+            entity_id,
+            vec3(0.0, -height * WHISKER_CHEST_FRACTION, 0.0),
+        );
 
         // Center first, then the sides - whisker_bias reads them that way
         let mut readings = Vec::new();
@@ -101,22 +115,22 @@ impl WhiskerAvoidance {
             let forward = (rotation * Quaternion::from_angle_y(spread))
                 .rotate_vector(vec3(0.0, 0.0, 1.0))
                 .normalize();
+            // Only static geometry and props: living bodies (and the player)
+            // are what crowd separation is for, and biasing away from them
+            // here would repel a chasing AI from its own target. A door the
+            // AI can open is not an obstacle to bend around either - filtered
+            // inside the query, so whatever stands behind it is still seen.
+            let not_a_door = |id: EntityId| !ai_util::is_entity_door(world, id);
             let cast = |from| {
-                physics
-                    .ray_cast2_as_actor(
-                        from,
-                        forward,
-                        WHISKER_DISTANCE,
-                        InternalCollisionGroups::ALL_COLLIDABLE,
-                        Some(entity_id),
-                        true,
-                    )
-                    // A door the AI can open is not an obstacle to bend around
-                    .filter(|hit| {
-                        !hit.maybe_entity_id
-                            .map(|id| ai_util::is_entity_door(world, id))
-                            .unwrap_or(false)
-                    })
+                physics.ray_cast2_as_actor_with_entity_filter(
+                    from,
+                    forward,
+                    WHISKER_DISTANCE,
+                    InternalCollisionGroups::WORLD | InternalCollisionGroups::ENTITY,
+                    Some(entity_id),
+                    true,
+                    &not_a_door,
+                )
             };
             // Both heights must be blocked - see WHISKER_KNEE_HEIGHT
             let hit = match (cast(knee), cast(chest)) {
@@ -142,6 +156,18 @@ impl WhiskerAvoidance {
         }
         readings
     }
+}
+
+/// The creature's height in world units, for placing the probes on a body
+/// that is not a 6.5-foot hybrid.
+fn creature_height(world: &World, entity_id: EntityId) -> f32 {
+    world
+        .borrow::<View<PropCreature>>()
+        .ok()
+        .and_then(|v_creature| v_creature.get(entity_id).ok().map(|creature| creature.0))
+        .and_then(crate::creature::get_creature_definition)
+        .map(|definition| definition.bounding_size.y / SCALE_FACTOR)
+        .unwrap_or(WHISKER_DEFAULT_HEIGHT)
 }
 
 /// Sum the whiskers into a horizontal push away from the geometry ahead:

--- a/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
+++ b/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
@@ -39,6 +39,13 @@ pub struct WhiskerHit {
     pub distance: f32,
 }
 
+/// One whisker: the (horizontal, unit) direction it was cast along, and what
+/// it found. Readings are ordered CENTER FIRST, then the side whiskers.
+pub struct WhiskerReading {
+    pub direction: Vector3<f32>,
+    pub hit: Option<WhiskerHit>,
+}
+
 /// Static-geometry whiskers, sampled on an interval and blended into path
 /// following as a bias on the aim point. Unlike `CollisionAvoidanceSteering`
 /// this never takes the heading over - it runs *while* a route is being
@@ -76,14 +83,20 @@ impl WhiskerAvoidance {
         self.bias
     }
 
-    fn probe(&self, world: &World, physics: &PhysicsWorld, entity_id: EntityId) -> Vec<WhiskerHit> {
+    fn probe(
+        &self,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+    ) -> Vec<WhiskerReading> {
         let rotation = get_rotation_from_transform(world, entity_id);
         let knee =
             get_position_from_transform(world, entity_id, vec3(0.0, WHISKER_KNEE_HEIGHT, 0.0));
         let chest =
             get_position_from_transform(world, entity_id, vec3(0.0, WHISKER_CHEST_HEIGHT, 0.0));
 
-        let mut hits = Vec::new();
+        // Center first, then the sides - whisker_bias reads them that way
+        let mut readings = Vec::new();
         for spread in [Deg(0.0), WHISKER_SPREAD, -WHISKER_SPREAD] {
             let forward = (rotation * Quaternion::from_angle_y(spread))
                 .rotate_vector(vec3(0.0, 0.0, 1.0))
@@ -106,40 +119,68 @@ impl WhiskerAvoidance {
                     })
             };
             // Both heights must be blocked - see WHISKER_KNEE_HEIGHT
-            let (Some(low), Some(high)) = (cast(knee), cast(chest)) else {
-                continue;
+            let hit = match (cast(knee), cast(chest)) {
+                (Some(low), Some(high)) => {
+                    let nearest = if (low.hit_point - knee).magnitude()
+                        < (high.hit_point - chest).magnitude()
+                    {
+                        (low, knee)
+                    } else {
+                        (high, chest)
+                    };
+                    Some(WhiskerHit {
+                        normal: nearest.0.hit_normal,
+                        distance: (nearest.0.hit_point - nearest.1).magnitude(),
+                    })
+                }
+                _ => None,
             };
-            let nearest =
-                if (low.hit_point - knee).magnitude() < (high.hit_point - chest).magnitude() {
-                    (low, knee)
-                } else {
-                    (high, chest)
-                };
-            hits.push(WhiskerHit {
-                normal: nearest.0.hit_normal,
-                distance: (nearest.0.hit_point - nearest.1).magnitude(),
+            readings.push(WhiskerReading {
+                direction: vec3(forward.x, 0.0, forward.z).normalize(),
+                hit,
             });
         }
-        hits
+        readings
     }
 }
 
-/// Sum the blocked whiskers into a horizontal push away from the geometry:
-/// each hit contributes its surface normal, weighted by how close it is, and
-/// the total is capped at WHISKER_MAX_OFFSET. Floors and ceilings (normals
-/// without a horizontal component) contribute nothing - the route walks on
-/// them.
-pub fn whisker_bias(hits: &[WhiskerHit], max_distance: f32) -> Vector3<f32> {
+/// Sum the whiskers into a horizontal push away from the geometry ahead:
+/// each blocked whisker contributes its surface normal, weighted by how
+/// close it is, and the total is capped at WHISKER_MAX_OFFSET. Floors and
+/// ceilings (normals without a horizontal component) contribute nothing -
+/// the route walks on them.
+///
+/// A surface square across the path pushes straight BACK, which is no help
+/// to a body that has to get past it, so a blocked center whisker also
+/// contributes a sideways push toward whichever side has more room. That is
+/// what carries an AI along a wall (or a railing) instead of into it.
+pub fn whisker_bias(readings: &[WhiskerReading], max_distance: f32) -> Vector3<f32> {
+    let weight = |hit: &WhiskerHit| ((max_distance - hit.distance) / max_distance).clamp(0.0, 1.0);
     let mut bias = vec3(0.0, 0.0, 0.0);
-    for hit in hits {
+    for reading in readings {
+        let Some(hit) = &reading.hit else { continue };
         let horizontal = vec3(hit.normal.x, 0.0, hit.normal.z);
         let length = horizontal.magnitude();
         if length < 0.5 {
             continue;
         }
-        let weight = ((max_distance - hit.distance) / max_distance).clamp(0.0, 1.0);
-        bias += horizontal / length * weight * WHISKER_MAX_OFFSET;
+        bias += horizontal / length * weight(hit) * WHISKER_MAX_OFFSET;
     }
+
+    // Sideways escape, when the way ahead itself is blocked: aim past the
+    // obstacle on its roomier side (an unblocked whisker has the full
+    // whisker length of room).
+    if let Some(center) = readings.first().and_then(|r| r.hit.as_ref()) {
+        let clearance =
+            |r: &WhiskerReading| r.hit.as_ref().map(|h| h.distance).unwrap_or(max_distance);
+        let roomiest = readings[1..]
+            .iter()
+            .max_by(|a, b| clearance(a).total_cmp(&clearance(b)));
+        if let Some(side) = roomiest {
+            bias += side.direction * weight(center) * WHISKER_MAX_OFFSET;
+        }
+    }
+
     let magnitude = bias.magnitude();
     if magnitude > WHISKER_MAX_OFFSET {
         bias *= WHISKER_MAX_OFFSET / magnitude;
@@ -151,30 +192,63 @@ pub fn whisker_bias(hits: &[WhiskerHit], max_distance: f32) -> Vector3<f32> {
 mod tests {
     use super::*;
 
-    fn hit(normal: Vector3<f32>, distance: f32) -> WhiskerHit {
-        WhiskerHit { normal, distance }
+    fn clear(direction: Vector3<f32>) -> WhiskerReading {
+        WhiskerReading {
+            direction,
+            hit: None,
+        }
     }
+
+    fn blocked(direction: Vector3<f32>, normal: Vector3<f32>, distance: f32) -> WhiskerReading {
+        WhiskerReading {
+            direction,
+            hit: Some(WhiskerHit { normal, distance }),
+        }
+    }
+
+    const AHEAD: Vector3<f32> = Vector3::new(0.0, 0.0, 1.0);
+    const RIGHT: Vector3<f32> = Vector3::new(1.0, 0.0, 0.0);
+    const LEFT: Vector3<f32> = Vector3::new(-1.0, 0.0, 0.0);
 
     #[test]
     fn clear_whiskers_do_not_bend_the_route() {
-        assert_eq!(whisker_bias(&[], 1.0), vec3(0.0, 0.0, 0.0));
+        let readings = [clear(AHEAD), clear(RIGHT), clear(LEFT)];
+        assert_eq!(whisker_bias(&readings, 1.0), vec3(0.0, 0.0, 0.0));
     }
 
-    /// A wall dead ahead pushes back along its normal, proportionally to how
-    /// close it is.
+    /// A wall to one side pushes away from it, harder the closer it is.
     #[test]
     fn a_near_wall_pushes_away_harder_than_a_far_one() {
-        let near = whisker_bias(&[hit(vec3(-1.0, 0.0, 0.0), 0.25)], 1.0);
-        let far = whisker_bias(&[hit(vec3(-1.0, 0.0, 0.0), 0.75)], 1.0);
+        let near = whisker_bias(&[clear(AHEAD), blocked(RIGHT, LEFT, 0.25)], 1.0);
+        let far = whisker_bias(&[clear(AHEAD), blocked(RIGHT, LEFT, 0.75)], 1.0);
         assert!(near.x < far.x && far.x < 0.0, "near {near:?} far {far:?}");
         assert_eq!(near.z, 0.0);
+    }
+
+    /// A wall square across the path: its normal points straight back, so
+    /// without a sideways term the AI would just be pushed into itself. The
+    /// bias must carry it toward the side with room (here, the right).
+    #[test]
+    fn a_wall_across_the_path_steers_to_the_roomier_side() {
+        let bias = whisker_bias(
+            &[
+                blocked(AHEAD, -AHEAD, 0.2),
+                clear(RIGHT),
+                blocked(LEFT, RIGHT, 0.2),
+            ],
+            1.0,
+        );
+        assert!(bias.x > 0.0, "expected a push to the right, got {bias:?}");
     }
 
     /// Floors and ceilings are not obstacles.
     #[test]
     fn horizontal_surfaces_are_ignored() {
         assert_eq!(
-            whisker_bias(&[hit(vec3(0.0, 1.0, 0.0), 0.1)], 1.0),
+            whisker_bias(
+                &[clear(AHEAD), blocked(RIGHT, vec3(0.0, 1.0, 0.0), 0.1)],
+                1.0
+            ),
             vec3(0.0, 0.0, 0.0)
         );
     }
@@ -185,9 +259,9 @@ mod tests {
     fn the_bias_is_capped() {
         let boxed_in = whisker_bias(
             &[
-                hit(vec3(-1.0, 0.0, 0.0), 0.0),
-                hit(vec3(-0.7, 0.0, -0.7), 0.0),
-                hit(vec3(0.0, 0.0, -1.0), 0.0),
+                blocked(AHEAD, -AHEAD, 0.0),
+                blocked(RIGHT, LEFT, 0.0),
+                blocked(LEFT, RIGHT, 0.0),
             ],
             1.0,
         );

--- a/tools/shock2-sdk/test/medsci2-patrol-railing.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-patrol-railing.e2e.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end: medsci2's balcony patroller must not wedge on the railing.
+//
+// Its authored route includes a point on the floor BELOW the balcony, in a
+// disconnected part of the navigation graph. With no route to it, the AI used
+// to steer straight at the point, press into the converging corner behind a
+// thin railing, and finally have its whole patrol retired by the stall
+// watchdog - standing idle there for the rest of the mission. Zero player
+// input reproduces it within a minute.
+//
+// Opt-in (needs Data/ assets + compiles the runtime): npm run test:e2e
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable across runs (runtime entity ids are not): the balcony patroller's
+// template.
+const PATROLLER_TEMPLATE = 668;
+
+const SAMPLE_FRAMES = 60; // 1 s of simulation per sample
+const SAMPLES = 60; // ...for a minute in total
+// Holding within this distance (1 world unit = 2.5 Dark feet) counts as not
+// moving.
+const STUCK_RADIUS = 1.0;
+// ...for this many consecutive samples (6 s) is a wedge.
+const STUCK_SAMPLES = 6;
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+function distXZ(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  return Math.hypot(a[0] - b[0], a[2] - b[2]);
+}
+
+test(
+  "the medsci2 balcony patroller never wedges on the railing",
+  { skip: !e2eEnabled, timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci2.mis" });
+    await game.step({ frames: 60 });
+
+    const pipes = await game.entities.list({ filter: "OG-Pipe", limit: 200 });
+    const patroller = pipes.entities.find(
+      (entity) => entity.template_id === PATROLLER_TEMPLATE,
+    );
+    assert.ok(
+      patroller,
+      `medsci2 should contain the balcony patroller (template ${PATROLLER_TEMPLATE})`,
+    );
+
+    let anchor = (await game.entities.detail(patroller.id)).position;
+    let heldSamples = 0;
+    let worstHold = 0;
+    let behavior: string | undefined;
+    const wedges: string[] = [];
+
+    for (let sample = 0; sample < SAMPLES; sample++) {
+      await game.step({ frames: SAMPLE_FRAMES });
+      const detail = await game.entities.detail(patroller.id);
+      behavior = aiProp(detail, "AIBehavior");
+      if (distXZ(detail.position, anchor) < STUCK_RADIUS) {
+        heldSamples += 1;
+        worstHold = Math.max(worstHold, heldSamples);
+        if (heldSamples >= STUCK_SAMPLES) {
+          wedges.push(
+            `held ${heldSamples}s at ${detail.position
+              .map((v) => v.toFixed(2))
+              .join(",")} (behavior ${behavior ?? "?"})`,
+          );
+        }
+      } else {
+        heldSamples = 0;
+        anchor = detail.position;
+      }
+    }
+
+    assert.equal(
+      wedges.length,
+      0,
+      `the patroller should never hold one spot for ${STUCK_SAMPLES}s: ${wedges.join("; ")}`,
+    );
+    assert.equal(
+      behavior,
+      "Patrol",
+      `the patroller should still be patrolling after ${SAMPLES}s (worst hold ${worstHold}s)`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/medsci2-patrol-railing.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-patrol-railing.e2e.test.ts
@@ -47,24 +47,33 @@ test(
     await game.step({ frames: 60 });
 
     const pipes = await game.entities.list({ filter: "OG-Pipe", limit: 200 });
-    const patroller = pipes.entities.find(
+    const matches = pipes.entities.filter(
       (entity) => entity.template_id === PATROLLER_TEMPLATE,
     );
-    assert.ok(
-      patroller,
-      `medsci2 should contain the balcony patroller (template ${PATROLLER_TEMPLATE})`,
+    // Exactly one, or the run would be watching some other hybrid.
+    assert.equal(
+      matches.length,
+      1,
+      `expected one medsci2 balcony patroller (template ${PATROLLER_TEMPLATE}), got ${matches.length}`,
     );
+    const patroller = matches[0];
 
     let anchor = (await game.entities.detail(patroller.id)).position;
+    let previous = anchor;
+    let travelled = 0;
     let heldSamples = 0;
     let worstHold = 0;
     let behavior: string | undefined;
+    const leftPatrol: string[] = [];
     const wedges: string[] = [];
 
     for (let sample = 0; sample < SAMPLES; sample++) {
       await game.step({ frames: SAMPLE_FRAMES });
       const detail = await game.entities.detail(patroller.id);
       behavior = aiProp(detail, "AIBehavior");
+      if (behavior !== "Patrol") leftPatrol.push(`${sample}s ${behavior ?? "?"}`);
+      travelled += distXZ(detail.position, previous);
+      previous = detail.position;
       if (distXZ(detail.position, anchor) < STUCK_RADIUS) {
         heldSamples += 1;
         worstHold = Math.max(worstHold, heldSamples);
@@ -86,10 +95,16 @@ test(
       0,
       `the patroller should never hold one spot for ${STUCK_SAMPLES}s: ${wedges.join("; ")}`,
     );
-    assert.equal(
-      behavior,
-      "Patrol",
-      `the patroller should still be patrolling after ${SAMPLES}s (worst hold ${worstHold}s)`,
+    assert.deepEqual(
+      leftPatrol,
+      [],
+      `the patroller should stay in Patrol for the whole minute (worst hold ${worstHold}s)`,
+    );
+    // A patrol route on this balcony is tens of units long; an AI shuffling
+    // on the spot (or cycling markers in a corner) covers almost nothing.
+    assert.ok(
+      travelled > 40,
+      `the patroller should walk its route, covered only ${travelled.toFixed(1)} units`,
     );
   },
 );


### PR DESCRIPTION
Fixes the user-reported medsci2 railing wedge: a patrolling hybrid pins itself in the balcony's south corner, sweeps its yaw for a few seconds, then stands there for the rest of the mission.

**Root cause.** OG-Pipe template 668 patrols six markers; marker 649 sits on the floor *below* the balcony, in a disconnected walk component (no link chain even under a stressed search - a genuine data dead end). A* therefore answers with no route at all. With no route, the AI kept the heading it had - straight at the marker - and pressed into the converging corner (45 degree wall plus a thin `Railing End` collider). Static-geometry whisker avoidance could not help: it only ran when *no* path existed at all, and its single body-centre ray sails just over a railing whose top sits a few inches below an upright creature's centre. After 3 stall skips the patrol watchdog retired the route and the AI went Idle permanently.

## What changed

1. **A patrol skips a point it has no route to** (`patrol_behavior.rs`, `path_follow_steering_strategy.rs`). Steering now reports an unreachable goal - A* answered with a *partial* route whose last waypoint stops more than 6 Dark feet short, in ground distance or in height - and the patrol advances to the next point at once instead of steering at it on an unchecked heading. One bad marker never retires a patrol; the route ends only if it comes back around to a point it already gave up on (so a wholly unreachable loop still stops, rather than cycling and re-querying forever).
2. **Whiskers while path-following** (new `steering/whisker_avoidance.rs`). Static-geometry whiskers now bias the path follower's aim point - capped at 3 Dark feet, exactly like the existing crowd-separation bias, so the route stays authoritative - and are sampled every 200 ms per AI rather than every frame. Probes go out at **two heights** (knee and chest, relative to the body origin): a railing is a thin slab that a single centre ray misses, and requiring *both* heights to be blocked also keeps stair risers and kerbs from bending routes sideways.
3. **Whiskers steer *around*, not just away.** A surface square across the route answers with a normal pointing straight back, which only stops the body in front of it; the blocked centre whisker now also pushes toward whichever side has room, and the aim point keeps only the sideways part of a backward-pointing bias.

The chase chain order is unchanged, and the stall/nudge logic and `pathfinding/mod.rs` are untouched (separate PRs).

## Before / after at the corner

Free camera on the balcony (medsci2, no player input, deterministic stepping). Before: the hybrid is pinned in the corner and only its idle animation moves - same spot at every timestamp. After: the corridor is clear while it is away on its route, and it walks back through.

![contact sheet](https://gist.githubusercontent.com/tommy-xr/0e58460effa57cce14b6a70b3698ab1f/raw/railing-contact-sheet.png)

| before (origin/main) | after |
|---|---|
| ![before](https://gist.githubusercontent.com/tommy-xr/0e58460effa57cce14b6a70b3698ab1f/raw/railing-before.gif) | ![after](https://gist.githubusercontent.com/tommy-xr/0e58460effa57cce14b6a70b3698ab1f/raw/railing-after.gif) |

## Measurements

**Repeated medsci2 idle observation of template 668** (60 s, no player input; longest window the body stayed within 1 world unit, and whether it was still patrolling at the end). This is the direct measure of the reported bug. AI path queries run on a worker thread, so runs vary - hence the repetition.

| build | runs | still Patrol at 60 s | longest hold (s) | ground covered (world units) |
|---|---|---|---|---|
| origin/main | 8 | **0/8** | 38-57 | 8.6, 9.0, 9.1, 9.1, 9.3, 37.2, 37.5, 72.8 |
| this PR | 8 | **4/8** | 4-48 | 21.1, 21.2, 57.1, 92.9, 127.5, 127.5, 128.0, 162.2 |

Every baseline run ends with the patrol retired (Idle) and the body parked in the corner; half the runs here walk the route for the full minute, and the median ground covered goes from 9 to ~110 units.

**AI reachability harness** (#1242's `ai-reachability`, idle 3600 frames + force-chase 1800 frames per mission, one run each):

before (origin/main)

| mission | pass | AIs | arrived | progressing | wedged | no_route | expected_unreachable | idle_by_design |
|---|---|---|---|---|---|---|---|---|
| medsci2.mis | idle | 18 | 0 | 6 | 5 | 0 | 0 | 7 |
| medsci2.mis | chase | 18 | 1 | 9 | 0 | 0 | 8 | 0 |
| medsci1.mis | idle | 26 | 0 | 13 | 1 | 0 | 0 | 12 |
| medsci1.mis | chase | 26 | 3 | 0 | 6 | 0 | 17 | 0 |

after

| mission | pass | AIs | arrived | progressing | wedged | no_route | expected_unreachable | idle_by_design |
|---|---|---|---|---|---|---|---|---|
| medsci2.mis | idle | 18 | 0 | **9** | **2** | 0 | 0 | 7 |
| medsci2.mis | chase | 18 | 2 | 8 | 0 | 0 | 8 | 0 |
| medsci1.mis | idle | 26 | 0 | 13 | 1 | 0 | 0 | 12 |
| medsci1.mis | chase | 26 | 3 | 0 | 7 | 0 | 16 | 0 |

medsci2's idle pass goes from 5 wedged / 6 progressing to 2 wedged / 9 progressing; medsci1 is unchanged, which is what a change that only bends aim points should do. (Template 668 itself happened to draw a bad run here - 47 s wedged - which is why the repeated table above, not a single harness pass, is the measure for that one creature.)

medsci2 idle trail maps (AI trails over the nav cells):

| before | after |
|---|---|
| ![trail before](https://gist.githubusercontent.com/tommy-xr/0e58460effa57cce14b6a70b3698ab1f/raw/trail-medsci2-idle-before.png) | ![trail after](https://gist.githubusercontent.com/tommy-xr/0e58460effa57cce14b6a70b3698ab1f/raw/trail-medsci2-idle-after.png) |

## Tests

- New unit tests: the patrol skip and its two termination cases (stubbed steering outcomes), route-reaches-goal including the stacked-floor case, the whisker bias math (sideways escape, cap, ignored floors), and the aim-bias projection (sideways-only, never onto the body).
- New e2e `tools/shock2-sdk/test/medsci2-patrol-railing.e2e.test.ts`: loads medsci2, no input, samples template 668 for 60 s and asserts it never holds one spot for 6 s and is still patrolling at the end. **Fails on origin/main** (`held 6s ... 48s at 49.00,0.10,-98.45`, behavior flips to Idle), passes here.
- `cargo test -p shock2vr` 1220 pass; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo fmt`.
- e2e: `patrol` (4/4), `force-chase`, `chase-last-seen`, `missions` (23/23); the new railing test passes 1 run in 4 (see the follow-up section above).

## Follow-up in this branch: a wedge must not retire the patrol

Tracing the e2e failures (`shock2vr::scripts::ai=debug`, medsci2, 3600 stepped frames) showed the residual failure was **not** an unreachable-point sweep. In every failing run the body wedged in the corner and the *stall* watchdog then retired the whole route:

```
05:51:07 patrol: stalled on point EId(376.0), skip #1
05:51:12 patrol: stalled on point EId(702.0), skip #2
05:51:12 patrol: no route to point EId(152.0), skipping
05:51:18 patrol: stalled on point EId(612.0), skip #3   -> route retired, AI Idle for the rest of the mission
```

Two defects behind that:

- **Three stall skips retired the patrol permanently.** A stall is a fact about the spot the body is standing in, not about the route - the AI usually walks out of it on the next leg. Both give-up paths (no route, and stalled) now share one ledger, cleared on arrival: the route ends only when *every* point on it has been given up on with no arrival in between.
- **A patrol adopted another goal's route.** Path queries are keyed by entity, so an answer outlives the strategy that asked for it: a patrol that gave up on a point built a fresh follower while the old query was in flight, then adopted that answer as its own. Because a fixed-point target never re-paths while it holds a route, it then steered along the abandoned point's route forever, carrying that goal's unreachable verdict onto a point nothing had asked about. A response is now only adopted if it answers the goal the follower actually wants.

New unit tests: a wedged patroller gets the whole loop's worth of tries before retiring (fails before the change - the old code retired after three), and an answer for an abandoned point is not adopted.

**Railing e2e after this commit: 1/4** (was 1-2/4). The retire-to-Idle failure mode is gone - the failing runs now stay in Patrol - but the run still fails on the 6-second hold rule, because the body is *physically* wedged and skipping to another point does not free it. That wedge is the stall/blacklist work in the stacked #1264, where it is also 1/4 today.

## Known remaining

About half the runs still end in a *different* wedge on the same balcony: the AI has a **full** route and simply presses against geometry the navigation mesh doesn't model, which the whisker bias (capped, never a veto) does not always clear. That is the stall/blacklist half of the ledger step - deliberately not touched here.

## Review

Ran the two-engine adversarial review plus a dedicated duplication pass. Fixed: unreachable skips are now bounded (a route that comes back around to a point it already gave up on retires, so nothing cycles or re-queries forever) but no longer spend the stall budget; only a *partial* route can declare a goal unreachable, and the check looks at height too (the balcony case is a goal almost directly below); the verdict is cleared whenever a fresh query goes out; whiskers no longer see living bodies or the player (that is crowd separation's job, and it repelled a chasing AI from its target); probe heights follow the creature's own height (fixed feet put both probes underground for a monkey); separation and whiskers are capped once, together; the e2e asserts a single matching patroller, Patrol throughout, and real ground covered; the stills were replaced with the timestamped contact sheet above.

Deliberately **not** done: merging the whisker probe with `collision_avoidance_steering_strategy.rs`'s. The two responses differ (a capped aim-point bias vs a heading override), the chain short-circuits so they never both run, and refactoring the existing no-route fallback is outside this fix - flagged as a follow-up rather than folded in.

