### PR TITLE
feat(weapons): fire-mode ammo cost, cooldown and projectile modifiers

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -829,6 +829,9 @@ pub struct PlayerInfo {
     /// `CycleGunSetting` input action. See `shock2vr::PlayerStateSnapshot`.
     pub wielded_gun_setting: Option<i32>,
     pub wielded_gun_setting_header: Option<String>,
+    /// Milliseconds left of the wielded gun's between-shots wait (0 = ready to
+    /// fire, `null` = nothing wielded). Pulls during the wait are ignored.
+    pub wielded_gun_cooldown_ms: Option<i32>,
     /// The player's current / maximum hit points, or `null` when the player
     /// has no health pool. See `shock2vr::PlayerStateSnapshot`.
     pub hit_points: Option<i32>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2357,6 +2357,7 @@ fn capture_frame_snapshot(
                 wielded_gun_setting_header: state
                     .as_ref()
                     .and_then(|s| s.wielded_gun_setting_header.clone()),
+                wielded_gun_cooldown_ms: state.as_ref().and_then(|s| s.wielded_gun_cooldown_ms),
                 hit_points: state
                     .as_ref()
                     .and_then(|s| s.hit_points.map(|(cur, _)| cur)),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -683,6 +683,10 @@ pub struct PlayerStateSnapshot {
     /// with the `CycleGunSetting` input action.
     pub wielded_gun_setting: Option<i32>,
     pub wielded_gun_setting_header: Option<String>,
+    /// Milliseconds left of the between-shots wait the wielded gun's fire
+    /// setting imposes - 0 when it is ready to fire, `None` when nothing is
+    /// wielded. A trigger pull while this is above zero does nothing.
+    pub wielded_gun_cooldown_ms: Option<i32>,
     /// The player's hit points (current, max), or `None` when the player has
     /// no health pool. Seeded from `The Player` template and consumed by every
     /// damage path, with zero entering the player death lifecycle.
@@ -798,6 +802,18 @@ impl Game {
             wielded_ammo_type: crate::hud::get_wielded_ammo_type(world),
             wielded_gun_setting: gun_setting.as_ref().map(|(setting, _)| *setting),
             wielded_gun_setting_header: gun_setting.and_then(|(_, header)| header),
+            wielded_gun_cooldown_ms: wielded.map(|weapon| {
+                world
+                    .borrow::<shipyard::View<crate::runtime_props::RuntimePropShotCooldown>>()
+                    .ok()
+                    .and_then(|v| {
+                        use shipyard::Get;
+                        v.get(weapon)
+                            .ok()
+                            .map(|c| (c.remaining * 1000.0).ceil() as i32)
+                    })
+                    .unwrap_or(0)
+            }),
             hit_points: (|| {
                 use dark::properties::{PropHitPoints, PropMaxHitPoints};
                 let v_hp = world.borrow::<shipyard::View<PropHitPoints>>().ok()?;

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -189,6 +189,10 @@ pub fn create_entity_with_position(
         world.add_component(entity_id, RuntimePropLaunchedProjectile);
     }
 
+    if let Some(modifiers) = additional_options.shot_modifiers {
+        world.add_component(entity_id, modifiers);
+    }
+
     create_entity_core(
         entity_id,
         template_id,
@@ -1616,6 +1620,10 @@ pub struct CreateEntityOptions {
     /// Tweq emitter calls `launchProjectile`; this keeps frobbable emitted
     /// archetypes from being reduced to kinematic selection colliders.
     pub launch_projectile: bool,
+    /// The firing gun's per-shot multipliers, stamped on a launched projectile
+    /// as `RuntimePropShotModifiers` so its damage and speed follow the fire
+    /// mode that launched it. `None` for anything that is not a gun shot.
+    pub shot_modifiers: Option<crate::runtime_props::RuntimePropShotModifiers>,
     /// This entity was created as a Flinderize target. Keeping this separate
     /// from the general model-bounds fallback lets only launched debris turn a
     /// dimension-less moving sphere into a simulated body.
@@ -1630,6 +1638,7 @@ impl Default for CreateEntityOptions {
             transient_fx: false,
             projectile_raycast_origin: None,
             launch_projectile: false,
+            shot_modifiers: None,
             flinderize_debris: false,
         }
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -92,7 +92,8 @@ use crate::{
         RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
         RuntimePropLaunchedProjectile, RuntimePropReloading, RuntimePropSelectedAmmo,
-        RuntimePropTransform, RuntimePropVhots, RuntimePropVrGripOffset,
+        RuntimePropShotCooldown, RuntimePropShotModifiers, RuntimePropTransform, RuntimePropVhots,
+        RuntimePropVrGripOffset,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -3361,6 +3362,9 @@ impl MissionCore {
         // Advance any in-progress reload (clears itself when complete).
         self.update_flat_reload_anim(time.elapsed);
 
+        // Advance the between-shots wait a fire setting imposes on a gun.
+        self.update_shot_cooldowns(time.elapsed);
+
         // Sync up the position of all the physics objects
         // The timing of this is important - things like the GUI rendering depend on an up-to-date position
         // from physics
@@ -4922,6 +4926,11 @@ impl MissionCore {
         info
     }
 
+    /// Launch speed (Dark units/s) above which a projectile is resolved by
+    /// raycast instead of simulated: a bullet crosses a room inside one frame,
+    /// so stepping it as a physics body tunnels it through walls.
+    const FAST_PROJECTILE_SPEED: f32 = 80.0;
+
     fn finish_instantiating_entity(
         id_to_model: &mut HashMap<EntityId, Model>,
         id_to_bitmap: &mut HashMap<EntityId, Rc<BitmapAnimation>>,
@@ -4956,9 +4965,16 @@ impl MissionCore {
                 //.map(|v| vec3(v.0.z.abs(), v.0.y.abs(), v.0.x.abs()))
                 .unwrap_or(vec3(0.0, 0.0, 0.0));
 
+            // The launch speed is the projectile's authored one scaled by the
+            // fire mode that fired it (the fusion cannon's DEATH lob leaves at
+            // 0.4x). The raycast/simulated split below stays on the AUTHORED
+            // speed: it says which kind of projectile this is, and the two
+            // paths do not deal the same damage, so letting a modifier move a
+            // shot across it would change far more than its speed.
+            let modifiers = RuntimePropShotModifiers::of(world, created_entity.entity_id);
             let mag = initial_velocity.magnitude();
-            let x_velocity = root_transform.transform_vector(vec3(0.0, 0.0, mag));
-            if initial_velocity.magnitude() > 80.0 {
+            let x_velocity = root_transform.transform_vector(vec3(0.0, 0.0, mag * modifiers.speed));
+            if mag > Self::FAST_PROJECTILE_SPEED {
                 // Use raycast strategy for fast moving objects
                 script_world.add_entity2(
                     created_entity.entity_id,
@@ -5386,6 +5402,11 @@ impl MissionCore {
                     if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
                         gun_state.ammo = (gun_state.ammo + delta).max(0);
                     }
+                }
+
+                Effect::BeginShotCooldown { entity_id, seconds } => {
+                    self.world
+                        .add_component(entity_id, RuntimePropShotCooldown { remaining: seconds });
                 }
 
                 Effect::RechargeAmmo {
@@ -7988,27 +8009,45 @@ impl MissionCore {
         Ok(info.entity_id)
     }
 
+    /// Advance any running between-shots cooldown by `dt` and clear it when the
+    /// gun is ready again.
+    fn update_shot_cooldowns(&self, dt: std::time::Duration) {
+        self.advance_timer_prop(dt, |cooldown: &mut RuntimePropShotCooldown, dt_s| {
+            cooldown.remaining -= dt_s;
+            cooldown.remaining <= 0.0
+        });
+    }
+
     /// Advance any in-progress reload by `dt` and clear it when complete.
     fn update_flat_reload_anim(&self, dt: std::time::Duration) {
+        self.advance_timer_prop(dt, |reload: &mut RuntimePropReloading, dt_s| {
+            reload.elapsed += dt_s;
+            reload.is_done()
+        });
+    }
+
+    /// Advance every instance of a runtime timer component by `dt` and remove
+    /// the ones `advance` reports finished. Removal is a second pass: the
+    /// storage is still borrowed while the first one iterates it.
+    fn advance_timer_prop<
+        T: shipyard::Component<Tracking = shipyard::track::Untracked> + Send + Sync,
+    >(
+        &self,
+        dt: std::time::Duration,
+        mut advance: impl FnMut(&mut T, f32) -> bool,
+    ) {
         let dt_s = dt.as_secs_f32();
         let mut done = Vec::new();
         {
-            let mut v = self
-                .world
-                .borrow::<ViewMut<RuntimePropReloading>>()
-                .unwrap();
-            for (id, r) in (&mut v).iter().with_id() {
-                r.elapsed += dt_s;
-                if r.is_done() {
+            let mut v = self.world.borrow::<ViewMut<T>>().unwrap();
+            for (id, timer) in (&mut v).iter().with_id() {
+                if advance(timer, dt_s) {
                     done.push(id);
                 }
             }
         }
         if !done.is_empty() {
-            let mut v = self
-                .world
-                .borrow::<ViewMut<RuntimePropReloading>>()
-                .unwrap();
+            let mut v = self.world.borrow::<ViewMut<T>>().unwrap();
             for id in done {
                 v.remove(id);
             }

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -200,6 +200,57 @@ impl RuntimePropReloading {
     }
 }
 
+/// RuntimePropShotCooldown - the wait a gun's active fire setting imposes
+/// between shots (`shot_interval_ms`), counted down on the weapon while it is
+/// running. A trigger pull during the countdown is silently ignored, so the
+/// laser's overcharge really does take three seconds to come round again.
+///
+/// Set by the firing script through `Effect::BeginShotCooldown` and ticked by
+/// the mission loop, the same split as `RuntimePropReloading` above - and, like
+/// it, not serialized: a save taken mid-cooldown loads ready to fire.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropShotCooldown {
+    pub remaining: f32,
+}
+
+/// RuntimePropShotModifiers - the multipliers the firing gun's active fire
+/// setting applies to the projectile it just launched: `stim` scales the damage
+/// it deals (the EMP rifle's overcharge hits 3x), `speed` its launch velocity
+/// (the fusion cannon's DEATH lob travels at 0.4x). Stamped on the projectile
+/// at creation, since the shot outlives the pull that fired it.
+///
+/// Not serialized, like every runtime prop: a shot still in the air when the
+/// game is saved lands, after a load, at its own authored damage and speed.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropShotModifiers {
+    pub stim: f32,
+    pub speed: f32,
+}
+
+impl Default for RuntimePropShotModifiers {
+    fn default() -> Self {
+        RuntimePropShotModifiers {
+            stim: 1.0,
+            speed: 1.0,
+        }
+    }
+}
+
+impl RuntimePropShotModifiers {
+    /// The modifiers `entity_id` was launched with - the neutral ones for
+    /// anything not launched by a gun.
+    pub fn of(world: &shipyard::World, entity_id: shipyard::EntityId) -> Self {
+        world
+            .borrow::<shipyard::View<RuntimePropShotModifiers>>()
+            .ok()
+            .and_then(|v| {
+                use shipyard::Get;
+                v.get(entity_id).ok().copied()
+            })
+            .unwrap_or_default()
+    }
+}
+
 // RuntimePropSelectedAmmo - which of the wielded weapon's Projectile links is
 // selected (index into `ordered_projectile_links`). Many SS2 guns carry several
 // ammo types (e.g. the pistol: standard / HE / AP); firing uses the selected

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -212,6 +212,13 @@ pub enum Effect {
         delta: i32,
     },
 
+    /// Start the wait a gun's fire setting imposes between shots
+    /// (`RuntimePropShotCooldown`), in seconds. Pulls during it do nothing.
+    BeginShotCooldown {
+        entity_id: EntityId,
+        seconds: f32,
+    },
+
     /// Raise an energy weapon's charge to at least its authored capacity.
     /// Applied against the live gun state so duplicate recharge messages in one
     /// tick remain idempotent. No-op for entities without a gun state.

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -74,7 +74,10 @@ impl Script for InternalCollisionType {
                         // projectile path's hardcoded 6.0 in
                         // internal_fast_projectile.rs.
                         payload: MessagePayload::Damage {
-                            amount: 1.0,
+                            amount: crate::runtime_props::RuntimePropShotModifiers::of(
+                                world, entity_id,
+                            )
+                            .stim,
                             impact: None,
                         },
                     },

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -11,7 +11,9 @@ use crate::{
     creature::RuntimePropHitBox,
     mission::entity_creator::CreateEntityOptions,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
-    runtime_props::{RuntimePropProjectileRayOrigin, RuntimePropTransform},
+    runtime_props::{
+        RuntimePropProjectileRayOrigin, RuntimePropShotModifiers, RuntimePropTransform,
+    },
     scripts::{
         Message,
         script_util::{choose_impact_spang, play_impact_sound},
@@ -104,7 +106,7 @@ impl Script for InternalFastProjectileScript {
                         to: hit_entity_id,
                         // TODO: Properly calculate damage
                         payload: MessagePayload::Damage {
-                            amount: 6.0,
+                            amount: 6.0 * RuntimePropShotModifiers::of(world, entity_id).stim,
                             // The shot's travel direction + hit point seed the
                             // victim's death-ragdoll reaction. Bone is filled
                             // in by the hitbox script when a hitbox was struck.

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -356,6 +356,10 @@ fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) 
                 order: 0,
                 setting: 0,
             },
+            // A psi bolt is not a gun shot: the amp's fire-setting record is
+            // the editor's uninitialized one (every multiplier 0), so cast at
+            // the projectile's own authored damage and speed.
+            crate::runtime_props::RuntimePropShotModifiers::default(),
         ),
     ];
     effects.extend(amp_cast_flashes(world, amp_entity));

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -3,7 +3,7 @@ use cgmath::{
 };
 use dark::{
     SCALE_FACTOR,
-    properties::{GunFlashOptions, Link, ProjectileOptions},
+    properties::{GunFlashOptions, GunSettingDesc, Link, ProjectileOptions},
 };
 use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, UniqueView, View, World};
@@ -12,8 +12,8 @@ use crate::{
     mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateClassTags},
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::{
-        RuntimePropFlatAim, RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropTransform,
-        RuntimePropVhots,
+        RuntimePropFlatAim, RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropShotCooldown,
+        RuntimePropShotModifiers, RuntimePropTransform, RuntimePropVhots,
     },
     util::{get_rotation_from_forward_vector, resolve_proxy_entity},
     vr_config,
@@ -60,7 +60,8 @@ fn weapon_world_position(world: &World, entity_id: EntityId) -> Option<cgmath::V
 use super::{
     Effect, Message, MessagePayload, Script,
     script_util::{
-        get_all_links_with_template, ordered_projectile_links, play_environmental_sound,
+        active_gun_setting, get_all_links_with_template, ordered_projectile_links,
+        play_environmental_sound,
     },
 };
 
@@ -71,6 +72,56 @@ fn get_ammotype_from_projectile_template(
 ) -> Option<String> {
     let template_tags = class_tag_map.get(&template_id)?;
     template_tags.get("ammotype").cloned()
+}
+
+/// Rounds one shot consumes in this fire setting: the laser pistol spends 3 per
+/// normal shot and 20 per overcharge. A shot always costs at least one round,
+/// so a setting a gun never authored cannot make it free to fire.
+fn rounds_per_shot(setting: &GunSettingDesc) -> i32 {
+    setting.ammo_usage.max(1)
+}
+
+/// Whether a magazine of `ammo` rounds can pay for a shot costing `rounds`.
+/// `None` is a weapon that tracks no ammo at all (unlimited debug weapons).
+fn can_pay_for_shot(ammo: Option<i32>, rounds: i32) -> bool {
+    ammo.is_none_or(|ammo| ammo >= rounds)
+}
+
+/// The wait this fire setting imposes before the next pull may fire, in
+/// seconds. Zero is a gun that fires as fast as the trigger is pulled.
+fn shot_cooldown_seconds(setting: &GunSettingDesc) -> f32 {
+    setting.shot_interval_ms as f32 / 1000.0
+}
+
+/// One per-shot multiplier of a fire setting, sanitized. The shipped data
+/// leaves the modifiers of a setting the gun never authored at 0, which taken
+/// literally would make its shots damageless and motionless - so only a
+/// positive multiplier counts as one.
+fn shot_multiplier(raw: f32) -> f32 {
+    if raw.is_finite() && raw > 0.0 {
+        raw
+    } else {
+        1.0
+    }
+}
+
+/// The damage and speed multipliers this fire setting puts on the projectile it
+/// launches (the EMP rifle's overcharge hits 3x; the fusion cannon's DEATH lob
+/// travels at 0.4x).
+fn shot_modifiers(setting: &GunSettingDesc) -> RuntimePropShotModifiers {
+    RuntimePropShotModifiers {
+        stim: shot_multiplier(setting.stim_modifier),
+        speed: shot_multiplier(setting.speed_modifier),
+    }
+}
+
+/// Whether `entity_id` is still inside the wait its last shot imposed.
+fn is_cooling_down(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<RuntimePropShotCooldown>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|c| c.remaining > 0.0))
+        .unwrap_or(false)
 }
 
 pub struct WeaponScript;
@@ -136,16 +187,29 @@ impl Script for WeaponScript {
                     }
                 }
 
+                // Everything below is governed by the gun's ACTIVE fire setting -
+                // the mode the player has it switched to - so a laser pistol's
+                // overcharge costs 20 rounds and waits 3 seconds where its
+                // normal shot costs 3 and waits 350 ms. A weapon with no gun
+                // description fires on the neutral default.
+                let setting = active_gun_setting(world, entity_id).unwrap_or_default();
+
+                // The wait the last shot imposed: a pull inside it does nothing
+                // at all, not even the empty-clip click.
+                if is_cooling_down(world, entity_id) {
+                    return Effect::NoEffect;
+                }
+
                 // Ammo gating: weapons that carry a `PropGunState` are limited by
-                // their clip. An empty clip dry-fires (no shot/flash); a live shot
-                // consumes one round (the per-shot `m_ammoUsage` from BaseGunDesc
-                // is a TODO - one round per pull for now). Weapons without a gun
-                // state (e.g. unlimited debug weapons) are unaffected.
+                // their clip. A magazine that cannot pay the setting's per-shot
+                // cost dry-fires (no shot/flash). Weapons without a gun state
+                // (e.g. unlimited debug weapons) are unaffected.
                 let maybe_ammo = world
                     .borrow::<View<dark::properties::PropGunState>>()
                     .ok()
                     .and_then(|v| v.get(entity_id).ok().map(|g| g.ammo));
-                if maybe_ammo == Some(0) {
+                let rounds = rounds_per_shot(&setting);
+                if !can_pay_for_shot(maybe_ammo, rounds) {
                     return dry_fire(world, entity_id);
                 }
 
@@ -189,7 +253,13 @@ impl Script for WeaponScript {
                     maybe_projectile
                         .into_iter()
                         .map(|(template_id, options)| {
-                            create_projectile(world, entity_id, template_id, &options)
+                            create_projectile(
+                                world,
+                                entity_id,
+                                template_id,
+                                &options,
+                                shot_modifiers(&setting),
+                            )
                         })
                         .collect(),
                 );
@@ -211,12 +281,29 @@ impl Script for WeaponScript {
                 //         * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Rad(PI / 2.0)),
                 // };
 
-                // Consume a round when the weapon tracks ammo.
+                // Consume the setting's per-shot cost when the weapon tracks ammo.
                 let mut effects = vec![sound_effect, muzzle_flash_effect, projectile_effect];
                 if maybe_ammo.is_some() {
                     effects.push(Effect::AdjustAmmo {
                         entity_id,
-                        delta: -1,
+                        delta: -rounds,
+                    });
+                }
+                // Start the setting's between-shots wait. Only a real shot
+                // starts one - a melee weapon that reached here has nothing to
+                // pace.
+                //
+                // This is the interval between trigger PULLS, which is the
+                // whole of a single-shot mode. A burst mode also authors how
+                // many rounds one pull sends and how fast (`burst` /
+                // `burst_interval_ms`, both still unimplemented), so until
+                // those land the pistol's BURST spends its longer interval on
+                // a single round.
+                let cooldown = shot_cooldown_seconds(&setting);
+                if is_gunshot && cooldown > 0.0 {
+                    effects.push(Effect::BeginShotCooldown {
+                        entity_id,
+                        seconds: cooldown,
                     });
                 }
                 // A gunshot is loud: nearby AIs hear it and investigate the
@@ -349,6 +436,7 @@ pub(super) fn create_projectile(
     entity_id: EntityId,
     projectile_template_id: i32,
     _options: &ProjectileOptions,
+    modifiers: RuntimePropShotModifiers,
 ) -> Effect {
     // Flatscreen camera-origin aim: if the weapon carries a flat fire ray, spawn
     // the projectile just ahead of the camera travelling straight along the
@@ -372,6 +460,7 @@ pub(super) fn create_projectile(
                 options: CreateEntityOptions {
                     force_visible: true,
                     projectile_raycast_origin: Some(aim.origin),
+                    shot_modifiers: Some(modifiers),
                     ..CreateEntityOptions::default()
                 },
             };
@@ -421,6 +510,7 @@ pub(super) fn create_projectile(
             * Matrix4::from(barrel_axis_from_forward()),
         options: CreateEntityOptions {
             force_visible: true,
+            shot_modifiers: Some(modifiers),
             ..CreateEntityOptions::default()
         },
     }
@@ -512,6 +602,7 @@ mod tests {
                 order: 0,
                 setting: 0,
             },
+            RuntimePropShotModifiers::default(),
         );
         let Effect::CreateEntity {
             position,
@@ -570,6 +661,64 @@ mod tests {
 
         assert!((origin - vec3(1.0, 2.0, 3.0)).magnitude() < 1e-5);
         assert!((forward - rotation * vec3(-1.0, 0.0, 0.0)).magnitude() < 1e-5);
+    }
+
+    /// The laser pistol: 3 rounds a normal shot, 20 an overcharge.
+    fn laser_setting(ammo_usage: i32, shot_interval_ms: u32) -> GunSettingDesc {
+        GunSettingDesc {
+            ammo_usage,
+            shot_interval_ms,
+            ..GunSettingDesc::default()
+        }
+    }
+
+    #[test]
+    fn a_shot_costs_the_settings_ammo_usage() {
+        assert_eq!(rounds_per_shot(&laser_setting(3, 350)), 3, "laser NORM");
+        assert_eq!(rounds_per_shot(&laser_setting(20, 3000)), 20, "laser OVER");
+        // A setting the gun never authored must not make it free to fire.
+        assert_eq!(rounds_per_shot(&laser_setting(0, 0)), 1);
+    }
+
+    #[test]
+    fn a_magazine_must_cover_the_whole_shot() {
+        assert!(can_pay_for_shot(Some(3), 3), "exactly enough still fires");
+        assert!(!can_pay_for_shot(Some(2), 3), "a partial charge dry-fires");
+        assert!(!can_pay_for_shot(Some(0), 1));
+        assert!(
+            can_pay_for_shot(None, 20),
+            "a weapon with no clip is unlimited"
+        );
+    }
+
+    #[test]
+    fn the_cooldown_is_the_settings_shot_interval() {
+        assert_eq!(shot_cooldown_seconds(&laser_setting(3, 350)), 0.35);
+        assert_eq!(shot_cooldown_seconds(&laser_setting(20, 3000)), 3.0);
+        assert_eq!(shot_cooldown_seconds(&laser_setting(1, 0)), 0.0);
+    }
+
+    #[test]
+    fn only_a_positive_multiplier_modifies_a_shot() {
+        let emp_over = GunSettingDesc {
+            stim_modifier: 3.0,
+            speed_modifier: 0.8,
+            ..GunSettingDesc::default()
+        };
+        let modifiers = shot_modifiers(&emp_over);
+        assert_eq!(modifiers.stim, 3.0);
+        assert_eq!(modifiers.speed, 0.8);
+
+        // The uninitialized record every gun carries for a mode it does not
+        // have: zeroes must not silently disarm the shot.
+        let unauthored = GunSettingDesc {
+            stim_modifier: 0.0,
+            speed_modifier: 0.0,
+            ..GunSettingDesc::default()
+        };
+        let modifiers = shot_modifiers(&unauthored);
+        assert_eq!(modifiers.stim, 1.0);
+        assert_eq!(modifiers.speed, 1.0);
     }
 
     #[test]

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -508,6 +508,9 @@ export interface PlayerSnapshot {
    * `CycleGunSetting` input action. */
   wielded_gun_setting: number | null;
   wielded_gun_setting_header: string | null;
+  /** Milliseconds left of the wielded gun's between-shots wait (0 = ready to
+   * fire, null = nothing wielded). A pull during the wait is ignored. */
+  wielded_gun_cooldown_ms: number | null;
   /** The player's current / maximum hit points, or null when the player has
    * no health pool. Drained by psi burnout. */
   hit_points: number | null;

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { waitForShotReady } from "./helpers/weapon.js";
 
 // End-to-end test for data-driven impact spangs: a projectile spawns the spang
 // its authored links say, not a hardcoded effect.
@@ -106,10 +107,12 @@ test(
 
     // Shot 2 - terrain, from back at spawn (the shot hybrid is alerted and
     // closing in, but a wall can't walk out of the aim): the default facing
-    // (yaw 0) looks at a wall.
+    // (yaw 0) looks at a wall. The pistol waits 500 ms between shots, so shot 1
+    // is still being paid for here.
     await game.player.teleport({ x: spawn[0], y: spawn[1], z: spawn[2] });
     await game.input.set("head.look", [0, 0]);
     await game.step({ frames: 5 });
+    await waitForShotReady(game);
     await game.input.set("right_hand.trigger", 1.0);
     await game.step({ frames: 2 });
     await game.input.set("right_hand.trigger", 0.0);

--- a/tools/shock2-sdk/test/helpers/weapon.ts
+++ b/tools/shock2-sdk/test/helpers/weapon.ts
@@ -11,13 +11,35 @@ export function ammoOf(detail: {
   return Number(ammo.value);
 }
 
-/** Fire one round: edge-triggered pull (fires on the rising edge), then release,
- * stepping a frame for each so the next pull is a fresh edge. */
-export async function fireOnce(game: GameServer): Promise<void> {
+/** Step until the wielded gun is out of the between-shots wait its fire setting
+ * imposes (`shot_interval_ms`), so the next pull actually fires. A pull inside
+ * the wait is silently ignored, and the waits are long: 1 s on the shotgun,
+ * 3 s on the laser's overcharge. */
+export async function waitForShotReady(game: GameServer): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const remaining = (await game.info()).player.wielded_gun_cooldown_ms;
+    // Absent for a runtime predating the field, null when nothing is wielded.
+    if (typeof remaining !== "number" || remaining <= 0) return;
+    await game.step({ frames: Math.ceil((remaining / 1000) * 60) + 1 });
+  }
+  throw new Error("the wielded gun never came out of its between-shots wait");
+}
+
+/** One edge-triggered pull (weapons fire on the rising edge) and release,
+ * stepping a frame for each so the next pull is a fresh edge. Does NOT wait out
+ * the gun's between-shots interval - use `fireOnce` unless the point is a pull
+ * that lands too early. */
+export async function pullTrigger(game: GameServer): Promise<void> {
   await game.input.set("right_hand.trigger", 1.0);
   await game.step({ frames: 1 });
   await game.input.set("right_hand.trigger", 0.0);
   await game.step({ frames: 1 });
+}
+
+/** Fire one round: wait out the previous shot's interval, then pull. */
+export async function fireOnce(game: GameServer): Promise<void> {
+  await waitForShotReady(game);
+  await pullTrigger(game);
 }
 
 /** Trigger `DebugCycleWeapon` until it spawns an entity matching `match`, and

--- a/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   describeSounds as describe,
   tagValue,
 } from "./helpers/audio.js";
+import { waitForShotReady } from "./helpers/weapon.js";
 
 // End-to-end test for weapon impact sounds: a bullet hit plays the
 // material-tagged collision schema (event=collision + the projectile's
@@ -119,6 +120,10 @@ test(
     await game.player.teleport({ x: spawn[0], y: spawn[1], z: spawn[2] });
     await game.input.set("head.look", [0, 0]);
     await game.step({ frames: 5 });
+
+    // The pistol waits 500 ms between shots; the creature shot above is still
+    // being paid for.
+    await waitForShotReady(game);
 
     const beforeTerrain =
       (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;

--- a/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-handedness.e2e.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import { cycleToWeapon } from "./helpers/weapon.js";
+import { cycleToWeapon, fireOnce } from "./helpers/weapon.js";
 import type { SceneObjectSummary, Vec3 } from "../src/types.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
 
@@ -121,10 +121,10 @@ test(
     //    context by `hud::ammo_panel`'s unit tests).
     const loaded = ammoOf(await game.entities.detail(pistol.id));
     assert.ok(loaded > 3, "debug pistol starts loaded");
+    // fireOnce waits out the pistol's 500 ms between-shots interval - a pull
+    // inside it is ignored.
     for (let i = 0; i < 3; i++) {
-      await game.input.set("right_hand.trigger", 1.0);
-      await game.step({ frames: 1 });
-      await game.input.set("right_hand.trigger", 0.0);
+      await fireOnce(game);
       await game.step({ frames: 10 });
     }
     assert.equal(
@@ -156,9 +156,7 @@ test(
     // 5. CycleAmmo likewise. Cycling needs an empty magazine (a loaded one has
     //    an established projectile identity), so empty it first.
     for (let i = 0; i < loaded; i++) {
-      await game.input.set("right_hand.trigger", 1.0);
-      await game.step({ frames: 1 });
-      await game.input.set("right_hand.trigger", 0.0);
+      await fireOnce(game);
       await game.step({ frames: 10 });
     }
     assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0, "magazine emptied");

--- a/tools/shock2-sdk/test/weapon-fire-mode-stats.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-fire-mode-stats.e2e.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import {
+  ammoOf,
+  cycleToWeapon,
+  pullTrigger,
+  waitForShotReady,
+} from "./helpers/weapon.js";
+
+// End-to-end coverage for the NUMBERS behind a fire mode (BaseGunDesc): how many
+// rounds a shot costs (ammo_usage), how long the gun waits before the next one
+// (shot_interval_ms), and how the mode scales the projectile it launches
+// (speed_modifier). Mode SWITCHING itself is covered by weapon-fire-mode.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "the laser pistol spends its setting's rounds and waits its setting's interval",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const laser = await cycleToWeapon(game, (e) => e.name === "Laser Pistol");
+    const charge = async () => ammoOf(await game.entities.detail(laser.id));
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting_header,
+      "NORM",
+      "the laser starts on its normal setting",
+    );
+
+    // NORM: 3 charge a shot, 350 ms between shots.
+    const start = await charge();
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    assert.equal(await charge(), start - 3, "a normal laser shot costs 3 charge");
+
+    // A second pull two frames into the 350 ms wait is ignored outright.
+    await pullTrigger(game);
+    assert.equal(await charge(), start - 3, "a pull inside the shot interval does not fire");
+
+    // Past the interval it fires again.
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    assert.equal(await charge(), start - 6, "the next pull after the interval fires");
+
+    // OVER: 20 charge a shot, 3 s between shots.
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting_header,
+      "OVER",
+      "switched to the overcharge",
+    );
+
+    await waitForShotReady(game);
+    const beforeOvercharge = await charge();
+    await pullTrigger(game);
+    assert.equal(await charge(), beforeOvercharge - 20, "an overcharge costs 20 charge");
+
+    // One second in - well past NORM's 350 ms, well short of OVER's 3 s.
+    await game.step({ frames: 60 });
+    await pullTrigger(game);
+    assert.equal(
+      await charge(),
+      beforeOvercharge - 20,
+      "the overcharge is still recovering a second later",
+    );
+
+    // ... and once the full 3 s is up it fires again.
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    assert.equal(
+      await charge(),
+      beforeOvercharge - 40,
+      "past the 3 s interval the overcharge fires again",
+    );
+  },
+);
+
+test(
+  "the shotgun's triple load costs three shells and refuses to fire on two",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const shotgun = await cycleToWeapon(game, (e) => e.name === "Shotgun");
+    const shells = async () => ammoOf(await game.entities.detail(shotgun.id));
+    const loaded = await shells();
+    assert.equal(loaded, 6, "the debug shotgun starts on a full 6-shell tube");
+
+    const switchMode = async (header: "NORM" | "TRIPLE") => {
+      await game.input.trigger("CycleGunSetting");
+      await game.step({ frames: 2 });
+      assert.equal((await game.info()).player.wielded_gun_setting_header, header);
+    };
+
+    await switchMode("TRIPLE");
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    assert.equal(await shells(), loaded - 3, "a triple shot burns three shells");
+
+    // Down to two shells on the single load - fewer than a triple shot costs.
+    await switchMode("NORM");
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    assert.equal(await shells(), 2, "a single shot costs one shell");
+
+    await switchMode("TRIPLE");
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    assert.equal(
+      await shells(),
+      2,
+      "a magazine that cannot pay for the whole shot dry-fires instead",
+    );
+  },
+);
+
+test(
+  "the fusion cannon's DEATH mode launches its shot at the mode's 0.4x speed",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const fusion = await cycleToWeapon(game, (e) => e.name === "Fusion Cannon");
+    assert.ok(ammoOf(await game.entities.detail(fusion.id)) > 4, "the fusion starts charged");
+
+    /** Speed of the fusion shot in flight, one frame after the trigger. */
+    const shotSpeed = async (): Promise<number> => {
+      await waitForShotReady(game);
+      await pullTrigger(game);
+      const inFlight = (await game.physics.bodies({ limit: 300 })).bodies.filter((b) =>
+        (b.entity_name ?? "").includes("Fusion Shot"),
+      );
+      assert.equal(
+        inFlight.length,
+        1,
+        "exactly the shot just fired should be in flight (an earlier one still " +
+          "airborne would be measured instead)",
+      );
+      const shot = inFlight[0];
+      return Math.hypot(shot.velocity[0], shot.velocity[1], shot.velocity[2]);
+    };
+
+    const norm = await shotSpeed();
+    assert.ok(norm > 0, `the NORM shot should be moving, got ${norm}`);
+
+    // Both of the fusion's shots are authored with the same launch speed, so
+    // the whole difference below is the DEATH setting's 0.4x speed modifier.
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting_header,
+      "DEATH",
+      "switched to the slow, heavy mode",
+    );
+
+    const death = await shotSpeed();
+    assert.ok(
+      Math.abs(death / norm - 0.4) < 0.05,
+      `DEATH should launch at 0.4x NORM (${death} vs ${norm})`,
+    );
+  },
+);


### PR DESCRIPTION
Third slice of fire modes. #1244 parsed all three settings of `P$BaseGunDe`; #1247 let the player switch between the two selectable ones. Until now the numbers in those records were inert: every pull spent exactly one round, fired instantly, and launched the projectile at its authored damage and speed — so switching a gun's mode changed its label and its ammo list but nothing about how it shot.

This makes the active setting govern the shot.

## What changed

- **`ammo_usage` — rounds per shot.** A pull fires only if the magazine covers the whole cost; otherwise it dry-fires, exactly as an empty clip does today. This also corrects the *first* setting's economy, which the hardcoded `-1` had wrong for half the arsenal (see the table).
- **`shot_interval_ms` — between-shots wait.** A gun that has fired carries a `RuntimePropShotCooldown`, counted down by the mission loop beside the reload animation; a pull inside the wait is ignored outright — no shot, no dry-fire click. Same split as `RuntimePropReloading`: the script reads it, `Effect::BeginShotCooldown` writes it, the loop ticks it — both now through one `advance_timer_prop`. Not serialized (a save taken mid-wait loads ready).
- **`stim_modifier` / `speed_modifier` — the projectile.** Both ride the launched projectile as `RuntimePropShotModifiers`: the damage scale is applied at the two projectile impact paths, the speed scale at instantiation.
- Only a *positive* multiplier counts: the shipped data leaves the modifiers of a setting a gun never authored at `0`, and taken literally those would make its shots damageless and motionless.
- The raycast-vs-simulated split stays on the **authored** speed. It says which kind of projectile this is, and the two paths do not deal the same damage today, so a speed modifier must not move a shot across it. Nothing in the shipped data straddles the threshold anyway: every gun with a `speed_modifier != 1.0` fires an already-slow projectile.
- `burst` / `burst_interval_ms` stay out of scope (next slice), so a burst mode currently spends its longer interval on a single round — called out in a comment at the cooldown site. Energy weapons are unchanged apart from their ammo cost.

Both firing presentations go through `WeaponScript::TriggerPull`, so flat and VR get this from one place. Melee is untouched: a projectile-less weapon returns its swing before any of the above, and never starts a cooldown. The psi amp is untouched too — its leaf `P$Scripts` is `psiampscript` with `inherits: false`, so it never reaches this path (and its own setting record is the editor's all-zero one).

## The values that now apply

Setting 0 / setting 1, straight from the shipped gun descriptions:

| Gun | Mode 0 | rounds | interval | modifiers | Mode 1 | rounds | interval | modifiers |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Pistol | NORM | 1 | 500 ms | — | BURST | 1 | 700 ms | — |
| Assault Rifle | NORM | 1 | 250 ms | — | AUTO | 1 | 250 ms | — |
| Shotgun | NORM | 1 | 1000 ms | — | TRIPLE | **3** | 1000 ms | — |
| Gren Launcher | CONTACT | 1 | 1000 ms | — | BOUNCE | 1 | 1000 ms | — |
| Laser Pistol | NORM | **3** | 350 ms | — | OVER | **20** | 3000 ms | — |
| EMP Rifle | NORM | **2** | 400 ms | speed 0.8 | OVER | **20** | 400 ms | **stim 3.0**, speed 0.8 |
| Stasis Field Gen | NORM | **4** | 200 ms | speed 0.6 | AREA | **8** | 200 ms | speed 0.6 |
| Fusion Cannon | NORM | **2** | 1000 ms | — | DEATH | **2** | 2000 ms | **speed 0.4** |
| Worm Launcher | — | **4** | 200 ms | — | — | **4** | 200 ms | — |
| Viral Prolif | — | **2** | 200 ms | — | — | **2** | 200 ms | — |

Bold = a value the port previously ignored. The setting-0 corrections are deliberate: the laser really does spend 3 charge a shot and the stasis generator 4, which is what makes their magazines the resource they are meant to be.

## Tests

Unit (the pure helpers):

```
test scripts::weapon_script::tests::a_shot_costs_the_settings_ammo_usage ... ok
test scripts::weapon_script::tests::a_magazine_must_cover_the_whole_shot ... ok
test scripts::weapon_script::tests::the_cooldown_is_the_settings_shot_interval ... ok
test scripts::weapon_script::tests::only_a_positive_multiplier_modifies_a_shot ... ok

test result: ok. 1214 passed; 0 failed; 2 ignored
```

New e2e `tools/shock2-sdk/test/weapon-fire-mode-stats.e2e.test.ts`, verified failing on the parent branch first:

```
not ok 1 - the laser pistol spends its setting's rounds and waits its setting's interval
  expected: 47   actual: 49
not ok 2 - the shotgun's triple load costs three shells and refuses to fire on two
  expected: 3    actual: 5
not ok 3 - the fusion cannon's DEATH mode launches its shot at the mode's 0.4x speed
  error: 'DEATH should launch at 0.4x NORM (14.400000000000231 vs 14.400000000000231)'
```

and passing here, with every weapon/projectile suite:

```
ok 1 - projectile impacts spawn the authored spangs (terrain + blood)
ok 2 - flat projectiles damage targets at melee-close and ordinary ranges
ok 3 - a wall inside flat muzzle clearance still blocks a fast projectile
ok 4 - flat slow physical projectiles retain forward spawn clearance
ok 5 - earth.mis: the authored station recharges the normally acquired Laser Pistol
ok 6 - bullet impacts play material-tagged collision schemas (flesh vs terrain)
ok 7 - slow projectile impacts spawn the authored spang (laser bolt -> Laser Spang)
ok 8 - VR: a weapon in the right hand reloads, cycles ammo and drives the forearm readout
ok 9 - a VR-held pistol reloads from reserve and announces it audibly
ok 10 - a VR-held pistol cycles through its ammo types
ok 11 - weapon ammo decrements per shot and dry-fires at empty
ok 12 - the laser pistol spends its setting's rounds and waits its setting's interval
ok 13 - the shotgun's triple load costs three shells and refuses to fire on two
ok 14 - the fusion cannon's DEATH mode launches its shot at the mode's 0.4x speed
ok 15 - the pistol switches between its NORM and BURST modes and back
ok 16 - a shotgun mode switch keeps the selected ammo type
ok 17 - a gun with only one fire mode ignores the switch
ok 18 - reload tilts the viewmodel and blocks firing
ok 19 - earth reload consumes matching reserve entities and partial stacks
# tests 19  # pass 19  # fail 0
```

```
# save-load + missions
# tests 27  # pass 27  # fail 0   (all 23 missions load)
```

Also green: `weapon-ammo-eject`, `weapon-ammo-type`, `bullet-hole`, `muzzle-flash`, `projectile-trail`, `ranged-hitbox`, `sound-awareness`, `per-limb-damage`, `melee-swing-stop`, `flat-melee-animation-event`, `hostile-ranged-damage`, `monster-death`, `ragdoll-death`, `vr-muzzle-origin`, `weapon-selection`, `weapon-swap-holster`, `world-aim`, `psi*`, `provisioning`, `command-shuttle-destroy`. SDK unit suite: 32 pass, 0 fail. `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

Unchanged known failures: `bio-ammo-full` (fails on the parent branch too) and `baby-arachnid`, which is flaky on the parent branch independently of this change — 2 pass / 2 fail across four runs *there*, always on the wrench swing.

## Existing expectations that moved

Three e2e tests fired a second shot inside the gun's newly-honored interval:

- `helpers/weapon.ts` — `fireOnce` now waits out the interval first (`waitForShotReady`, polling the new `wielded_gun_cooldown_ms` readout) and then calls the extracted `pullTrigger`, so every test that fires through it is unaffected.
- `blood-spang` / `impact-sounds` — the wall shot follows the creature shot ~8 frames later, inside the pistol's 500 ms wait; both now wait first.
- `vr-weapon-handedness` — its two hand-rolled pull loops (11-frame spacing) now go through `fireOnce`.

No expectation about *ammo counts* needed changing: the tests that count rounds use the pistol and the shotgun's single load, both of which cost 1 round in retail as they did in the port.

## Review

`/xreview` (Claude + Codex + a de-dup pass): no Critical or High findings. Applied — the raycast/simulated split moved back onto the authored speed (both engines' strongest point, plus the 6x damage difference between the two paths); the modifier lookup became one `RuntimePropShotModifiers::of` instead of two hand-rolled reads in different modules; the duplicated cooldown/reload tick collapsed into `advance_timer_prop` (preserving the original borrow-failure behavior); `pullTrigger` extracted into the shared helper; the fusion probe now asserts exactly one shot is in flight before measuring it; the missing `burst` half documented at the cooldown site. Declined: persisting the cooldown and modifier components through save/load — runtime props are deliberately not serialized (the same stance `RuntimePropReloading` documents), and a mid-flight shot losing its modifiers across a load is the benign end of that.
