### PR TITLE
feat(weapons): burst and full-auto fire modes

### DIFF
--- a/shock2vr/src/scripts/burst_fire.rs
+++ b/shock2vr/src/scripts/burst_fire.rs
@@ -1,0 +1,227 @@
+//! The shots a single trigger pull still owes.
+//!
+//! A gun's fire setting authors `burst` - shots per pull, `-1` meaning
+//! unlimited while the trigger is down - and `burst_interval_ms`, the gap
+//! between them: the pistol's BURST sends 3 rounds 10 ms apart, the assault
+//! rifle's AUTO keeps firing every 100 ms until the trigger comes up. This is
+//! the pure counting/timing half of that; `WeaponScript` fires the shots.
+
+use dark::properties::GunSettingDesc;
+
+/// What the burst wants done this frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BurstStep {
+    /// The next shot is not due yet.
+    Wait,
+    /// Fire one more shot now.
+    Fire,
+    /// The pull owes nothing more - drop the burst.
+    Done,
+}
+
+/// The remainder of a burst: what is still owed, and when the next of it is
+/// due. Created after the pull's own first shot.
+#[derive(Debug)]
+pub struct BurstState {
+    /// Shots still owed, or `None` for an unlimited burst, which owes shots
+    /// for as long as the trigger is held.
+    remaining: Option<i32>,
+    /// Seconds between shots inside the burst.
+    interval: f32,
+    /// Seconds until the next shot is due.
+    time_to_next: f32,
+    /// Whether the trigger is still down.
+    held: bool,
+    /// The burst was created this frame, by the pull's own shot. That shot's
+    /// ammo is not spent until the frame's effects are applied, so the burst
+    /// idles one frame rather than firing a second round against a magazine
+    /// that still reads full.
+    starting: bool,
+}
+
+impl BurstState {
+    /// What a pull in this setting owes AFTER its first shot, or `None` when
+    /// the setting sends a single shot per pull - which is every gun in the
+    /// game bar the pistol's BURST and the assault rifle's AUTO.
+    pub fn begin(setting: &GunSettingDesc) -> Option<BurstState> {
+        // A negative count is the unlimited burst; one or fewer shots are
+        // already paid out by the pull's own.
+        let remaining = if setting.burst < 0 {
+            None
+        } else if setting.burst > 1 {
+            Some(setting.burst - 1)
+        } else {
+            return None;
+        };
+        let interval = setting.burst_interval_ms as f32 / 1000.0;
+        Some(BurstState {
+            remaining,
+            interval,
+            time_to_next: interval,
+            held: true,
+            starting: true,
+        })
+    }
+
+    /// The trigger came up. A finite burst plays out regardless - letting go of
+    /// the pistol's BURST one frame in still sends all three rounds - so only
+    /// an unlimited burst ends here.
+    pub fn release(&mut self) {
+        self.held = false;
+    }
+
+    /// Advance by `dt` seconds. `can_fire` is whether the gun could pay for
+    /// another shot right now: a burst that runs the magazine dry simply
+    /// stops, without a click. At most one shot comes out per call, so a burst
+    /// interval shorter than a frame paces to the frame rate.
+    pub fn advance(&mut self, dt: f32, can_fire: bool) -> BurstStep {
+        // Ahead of the gates below, so the creation frame never judges the
+        // burst on the stale ammo `starting` exists to sit out.
+        if self.starting {
+            self.starting = false;
+            return BurstStep::Wait;
+        }
+        if !can_fire || self.remaining == Some(0) || (self.remaining.is_none() && !self.held) {
+            return BurstStep::Done;
+        }
+
+        self.time_to_next -= dt;
+        if self.time_to_next > 0.0 {
+            return BurstStep::Wait;
+        }
+        // Carry the overshoot into the next gap so a long frame does not
+        // stretch the burst, but never bank more than one shot's worth.
+        self.time_to_next = (self.time_to_next + self.interval).max(0.0);
+        if let Some(remaining) = self.remaining.as_mut() {
+            *remaining -= 1;
+        }
+        BurstStep::Fire
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One 60 Hz simulation frame - the rate `advance` is called at.
+    const FRAME: f32 = 1.0 / 60.0;
+
+    /// The pistol as shipped: NORM sends one round a pull, BURST three 10 ms
+    /// apart.
+    fn pistol_burst() -> GunSettingDesc {
+        GunSettingDesc {
+            burst: 3,
+            burst_interval_ms: 10,
+            ..GunSettingDesc::default()
+        }
+    }
+
+    /// The assault rifle's AUTO: unlimited while held, 100 ms apart.
+    fn assault_rifle_auto() -> GunSettingDesc {
+        GunSettingDesc {
+            burst: -1,
+            burst_interval_ms: 100,
+            ..GunSettingDesc::default()
+        }
+    }
+
+    /// Run `frames` frames, returning how many shots the burst asked for and
+    /// whether it finished.
+    fn run(state: &mut BurstState, frames: u32, can_fire: bool) -> (u32, bool) {
+        let mut shots = 0;
+        for _ in 0..frames {
+            match state.advance(FRAME, can_fire) {
+                BurstStep::Fire => shots += 1,
+                BurstStep::Wait => {}
+                BurstStep::Done => return (shots, true),
+            }
+        }
+        (shots, false)
+    }
+
+    #[test]
+    fn a_single_shot_setting_owes_nothing_after_its_pull() {
+        assert!(BurstState::begin(&GunSettingDesc::default()).is_none());
+        // Zero and one are the same thing: the pull's own shot is the whole of it.
+        assert!(
+            BurstState::begin(&GunSettingDesc {
+                burst: 0,
+                ..GunSettingDesc::default()
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn the_pistols_burst_owes_two_more_shots_then_stops() {
+        let mut state = BurstState::begin(&pistol_burst()).expect("BURST is a burst");
+        let (shots, done) = run(&mut state, 60, true);
+        assert_eq!(shots, 2, "three rounds a pull, one of them already fired");
+        assert!(done, "and then the burst is over");
+    }
+
+    #[test]
+    fn a_burst_fires_at_most_one_shot_a_frame() {
+        // 10 ms is shorter than a frame, so the three-round burst still takes
+        // one frame per round rather than emptying into a single update - and
+        // its first round waits out the frame the pull fired in.
+        let mut state = BurstState::begin(&pistol_burst()).unwrap();
+        assert_eq!(state.advance(FRAME, true), BurstStep::Wait);
+        assert_eq!(state.advance(FRAME, true), BurstStep::Fire);
+        assert_eq!(state.advance(FRAME, true), BurstStep::Fire);
+        assert_eq!(state.advance(FRAME, true), BurstStep::Done);
+    }
+
+    #[test]
+    fn a_burst_never_fires_in_the_frame_the_pull_did() {
+        // A zero-interval burst is the pushiest case: its next round is due
+        // immediately, and it still has to wait out the pull's own frame.
+        let mut state = BurstState::begin(&GunSettingDesc {
+            burst: 3,
+            burst_interval_ms: 0,
+            ..GunSettingDesc::default()
+        })
+        .unwrap();
+        assert_eq!(state.advance(FRAME, true), BurstStep::Wait);
+        assert_eq!(state.advance(FRAME, true), BurstStep::Fire);
+    }
+
+    #[test]
+    fn a_finite_burst_finishes_after_the_trigger_is_released() {
+        let mut state = BurstState::begin(&pistol_burst()).unwrap();
+        state.release();
+        let (shots, done) = run(&mut state, 60, true);
+        assert_eq!(shots, 2, "the remaining rounds go out anyway");
+        assert!(done);
+    }
+
+    #[test]
+    fn full_auto_keeps_firing_while_the_trigger_is_down() {
+        let mut state = BurstState::begin(&assault_rifle_auto()).unwrap();
+        // A second of holding, at 100 ms a shot: the pull's own shot plus these.
+        let (shots, done) = run(&mut state, 60, true);
+        assert!(
+            (8..=10).contains(&shots),
+            "a second of AUTO is about nine more rounds, got {shots}"
+        );
+        assert!(!done, "and it is still going");
+    }
+
+    #[test]
+    fn full_auto_stops_when_the_trigger_comes_up() {
+        let mut state = BurstState::begin(&assault_rifle_auto()).unwrap();
+        run(&mut state, 30, true);
+        state.release();
+        let (shots, done) = run(&mut state, 60, true);
+        assert_eq!(shots, 0, "nothing more goes out after the release");
+        assert!(done);
+    }
+
+    #[test]
+    fn a_burst_stops_when_the_magazine_cannot_pay_for_the_next_shot() {
+        let mut state = BurstState::begin(&pistol_burst()).unwrap();
+        assert_eq!(state.advance(FRAME, true), BurstStep::Wait);
+        assert_eq!(state.advance(FRAME, true), BurstStep::Fire);
+        assert_eq!(state.advance(FRAME, false), BurstStep::Done);
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -10,6 +10,7 @@ mod base_elevator;
 mod base_light;
 mod base_monster;
 mod base_room;
+mod burst_fire;
 mod camera_alert;
 mod chemical;
 mod choose_mission;

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -59,6 +59,7 @@ fn weapon_world_position(world: &World, entity_id: EntityId) -> Option<cgmath::V
 
 use super::{
     Effect, Message, MessagePayload, Script,
+    burst_fire::{BurstState, BurstStep},
     script_util::{
         active_gun_setting, get_all_links_with_template, ordered_projectile_links,
         play_environmental_sound,
@@ -124,14 +125,98 @@ fn is_cooling_down(world: &World, entity_id: EntityId) -> bool {
         .unwrap_or(false)
 }
 
-pub struct WeaponScript;
+/// Whether a reload is running on this weapon - firing is blocked throughout.
+fn is_reloading(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<RuntimePropReloading>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|r| !r.is_done()))
+        == Some(true)
+}
+
+/// The rounds loaded in this weapon, or `None` for one that tracks no ammo at
+/// all (the unlimited debug weapons).
+fn loaded_ammo(world: &World, entity_id: EntityId) -> Option<i32> {
+    world
+        .borrow::<View<dark::properties::PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|g| g.ammo))
+}
+
+/// What one shot came to.
+enum ShotOutcome {
+    /// The gun fired: these effects are the shot.
+    Fired(Effect),
+    /// The magazine cannot pay for the shot.
+    Empty,
+    /// Not a gun at all - a flat-aimed melee weapon, whose trigger starts a
+    /// swing instead of firing.
+    FlatMeleeSwing,
+}
+
+pub struct WeaponScript {
+    /// Shots the current trigger pull still owes, paid out one per frame by
+    /// `update` (the pistol's BURST, the assault rifle's AUTO). Script-private
+    /// and deliberately not saved: a save taken mid-burst loads with the
+    /// trigger at rest, the same call `RuntimePropShotCooldown` makes.
+    burst: Option<ActiveBurst>,
+}
+
+/// A burst in flight, with the setting the pull started in - so switching fire
+/// mode part-way through cannot re-price the rounds it still owes.
+struct ActiveBurst {
+    setting: GunSettingDesc,
+    state: BurstState,
+}
+
 impl WeaponScript {
     pub fn new() -> WeaponScript {
-        WeaponScript
+        WeaponScript { burst: None }
     }
 }
 
 impl Script for WeaponScript {
+    /// Pay out the shots the current pull still owes. Nothing else about a
+    /// weapon ticks per frame.
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &crate::time::Time,
+    ) -> Effect {
+        let Some(burst) = self.burst.as_mut() else {
+            return Effect::NoEffect;
+        };
+        // A burst belongs to the pull that started it: a reload, or the gun
+        // leaving the player's hands, ends it.
+        if is_reloading(world, entity_id) || !crate::wielded_weapon::held_in_hand(world, entity_id)
+        {
+            self.burst = None;
+            return Effect::NoEffect;
+        }
+
+        let setting = burst.setting.clone();
+        let can_fire = can_pay_for_shot(loaded_ammo(world, entity_id), rounds_per_shot(&setting));
+        match burst.state.advance(time.elapsed.as_secs_f32(), can_fire) {
+            BurstStep::Wait => Effect::NoEffect,
+            BurstStep::Done => {
+                self.burst = None;
+                Effect::NoEffect
+            }
+            BurstStep::Fire => match fire_one_shot(world, entity_id, &setting) {
+                ShotOutcome::Fired(effect) => effect,
+                // Unreachable in practice - `can_fire` covers the magazine and
+                // a melee weapon authors no burst - but a burst that cannot
+                // fire is over either way.
+                ShotOutcome::Empty | ShotOutcome::FlatMeleeSwing => {
+                    self.burst = None;
+                    Effect::NoEffect
+                }
+            },
+        }
+    }
+
     fn handle_message(
         &mut self,
         entity_id: EntityId,
@@ -142,49 +227,8 @@ impl Script for WeaponScript {
         match msg {
             MessagePayload::TriggerPull => {
                 // Firing is blocked while a reload is in progress.
-                if world
-                    .borrow::<View<RuntimePropReloading>>()
-                    .ok()
-                    .and_then(|v| v.get(entity_id).ok().map(|r| !r.is_done()))
-                    == Some(true)
-                {
+                if is_reloading(world, entity_id) {
                     return Effect::NoEffect;
-                }
-
-                //Create muzzle flash
-                let muzzle_flashes =
-                    get_all_links_with_template(world, entity_id, |link| match link {
-                        Link::GunFlash(data) => Some(*data),
-                        _ => None,
-                    });
-
-                // Pick the selected ammo type: guns carry several Projectile
-                // links (standard / HE / AP, ...); RuntimePropSelectedAmmo indexes
-                // into the ordered, setting-filtered list (absent = the first).
-                let projectiles = ordered_projectile_links(world, entity_id);
-                let selected_ammo = world
-                    .borrow::<View<RuntimePropSelectedAmmo>>()
-                    .ok()
-                    .and_then(|v| v.get(entity_id).ok().map(|s| s.0))
-                    .unwrap_or(0);
-                let maybe_projectile = projectiles
-                    .get(selected_ammo % projectiles.len().max(1))
-                    .cloned();
-
-                // A weapon with no Projectile link is melee. In flat mode the
-                // trigger starts the authored player-arm swing; its MF_TRIGGER1
-                // animation event resolves the short aimed raycast later, at
-                // visible impact. (VR has no flat aim and damages through its
-                // trigger-gated physical contact handler.)
-                if maybe_projectile.is_none() {
-                    if world
-                        .borrow::<View<RuntimePropFlatAim>>()
-                        .unwrap()
-                        .get(entity_id)
-                        .is_ok()
-                    {
-                        return Effect::FlatMeleeSwing { entity_id };
-                    }
                 }
 
                 // Everything below is governed by the gun's ACTIVE fire setting -
@@ -195,130 +239,24 @@ impl Script for WeaponScript {
                 let setting = active_gun_setting(world, entity_id).unwrap_or_default();
 
                 // The wait the last shot imposed: a pull inside it does nothing
-                // at all, not even the empty-clip click.
+                // at all, not even the empty-clip click. Ahead of the melee
+                // gate inside `fire_one_shot`, which is safe because only a
+                // gunshot ever starts a cooldown.
                 if is_cooling_down(world, entity_id) {
                     return Effect::NoEffect;
                 }
 
-                // Ammo gating: weapons that carry a `PropGunState` are limited by
-                // their clip. A magazine that cannot pay the setting's per-shot
-                // cost dry-fires (no shot/flash). Weapons without a gun state
-                // (e.g. unlimited debug weapons) are unaffected.
-                let maybe_ammo = world
-                    .borrow::<View<dark::properties::PropGunState>>()
-                    .ok()
-                    .and_then(|v| v.get(entity_id).ok().map(|g| g.ammo));
-                let rounds = rounds_per_shot(&setting);
-                if !can_pay_for_shot(maybe_ammo, rounds) {
-                    return dry_fire(world, entity_id);
-                }
-
-                // Include projectile class tags (ie, ammotype) and weaponmode for sound lookup
-                let mut projectile_class_tags: Vec<(String, String)> =
-                    if let Some((projectile_template_id, _)) = &maybe_projectile {
-                        let class_tags = world
-                            .borrow::<UniqueView<GlobalTemplateClassTags>>()
-                            .unwrap();
-                        get_ammotype_from_projectile_template(
-                            *projectile_template_id,
-                            &class_tags.0,
-                        )
-                        .map(|ammotype| vec![("ammotype".to_string(), ammotype)])
-                        .unwrap_or_default()
-                    } else {
-                        Vec::new()
-                    };
-
-                // Add weaponmode=0 for shoot mode
-                projectile_class_tags.push(("weaponmode".to_string(), "0".to_string()));
-
-                let additional_sound_tags = projectile_class_tags
-                    .iter()
-                    .map(|(tag, value)| (tag.as_str(), value.as_str()))
-                    .collect::<Vec<_>>();
-
-                let sound_effect = play_environmental_sound(
-                    world,
-                    entity_id,
-                    "shoot",
-                    additional_sound_tags,
-                    AudioHandle::new(),
-                );
-
-                // Only a real gunshot (a fired projectile) raises noise - a
-                // projectile-less weapon that falls through the melee gate
-                // must not emit a phantom gunshot.
-                let is_gunshot = maybe_projectile.is_some();
-                let projectile_effect = Effect::Multiple(
-                    maybe_projectile
-                        .into_iter()
-                        .map(|(template_id, options)| {
-                            create_projectile(
-                                world,
-                                entity_id,
-                                template_id,
-                                &options,
-                                shot_modifiers(&setting),
-                            )
-                        })
-                        .collect(),
-                );
-
-                let muzzle_flash_effect = Effect::Multiple(
-                    muzzle_flashes
-                        .into_iter()
-                        .map(|(template_id, options)| {
-                            create_muzzle_flash(world, entity_id, template_id, &options)
-                        })
-                        .collect(),
-                );
-                // let offset = obj_rotation * vec3(0.0128545, 0.5026805, -3.0933015) / SCALE_FACTOR;
-
-                // let muzzle_flash_effect = Effect::CreateEntity {
-                //     template_id: -2653,
-                //     position: position + offset,
-                //     orientation: *obj_rotation
-                //         * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Rad(PI / 2.0)),
-                // };
-
-                // Consume the setting's per-shot cost when the weapon tracks ammo.
-                let mut effects = vec![sound_effect, muzzle_flash_effect, projectile_effect];
-                if maybe_ammo.is_some() {
-                    effects.push(Effect::AdjustAmmo {
-                        entity_id,
-                        delta: -rounds,
-                    });
-                }
-                // Start the setting's between-shots wait. Only a real shot
-                // starts one - a melee weapon that reached here has nothing to
-                // pace.
-                //
-                // This is the interval between trigger PULLS, which is the
-                // whole of a single-shot mode. A burst mode also authors how
-                // many rounds one pull sends and how fast (`burst` /
-                // `burst_interval_ms`, both still unimplemented), so until
-                // those land the pistol's BURST spends its longer interval on
-                // a single round.
-                let cooldown = shot_cooldown_seconds(&setting);
-                if is_gunshot && cooldown > 0.0 {
-                    effects.push(Effect::BeginShotCooldown {
-                        entity_id,
-                        seconds: cooldown,
-                    });
-                }
-                // A gunshot is loud: nearby AIs hear it and investigate the
-                // shooter, even without line of sight. The noise comes from
-                // the weapon (in the player's hands), so its position stands
-                // in for the shooter's.
-                if is_gunshot {
-                    if let Some(origin) = weapon_world_position(world, entity_id) {
-                        effects.push(Effect::RaiseNoise {
-                            origin,
-                            radius: GUNSHOT_NOISE_RADIUS,
-                        });
+                match fire_one_shot(world, entity_id, &setting) {
+                    ShotOutcome::FlatMeleeSwing => Effect::FlatMeleeSwing { entity_id },
+                    ShotOutcome::Empty => dry_fire(world, entity_id),
+                    ShotOutcome::Fired(effect) => {
+                        // A burst setting owes more rounds than the one just
+                        // fired; `update` pays them out.
+                        self.burst =
+                            BurstState::begin(&setting).map(|state| ActiveBurst { setting, state });
+                        effect
                     }
                 }
-                Effect::Multiple(effects)
             }
             MessagePayload::AnimationFlagTriggered { motion_flags }
                 if motion_flags.contains(dark::motion::MotionFlags::TRIGGER1)
@@ -334,10 +272,174 @@ impl Script for WeaponScript {
                 };
                 flat_melee_hit(physics, aim, world)
             }
-            MessagePayload::TriggerRelease => Effect::NoEffect,
+            MessagePayload::TriggerRelease => {
+                // An unlimited burst ends with the trigger. A finite one plays
+                // out regardless - letting go of the pistol's BURST one frame
+                // in still sends all three rounds.
+                if let Some(burst) = self.burst.as_mut() {
+                    burst.state.release();
+                }
+                Effect::NoEffect
+            }
             _ => Effect::NoEffect,
         }
     }
+}
+
+/// Fire one shot in `setting`: its sound, muzzle flash, projectile, ammo cost,
+/// between-shots wait and the noise it makes. Shared by the trigger pull and by
+/// the burst that pull leaves behind, so a burst round is in every way the shot
+/// a pull would have fired. The caller has already cleared the reload and
+/// cooldown gates, and decides what an `Empty` magazine means (a pull clicks; a
+/// burst just stops).
+fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -> ShotOutcome {
+    //Create muzzle flash
+    let muzzle_flashes = get_all_links_with_template(world, entity_id, |link| match link {
+        Link::GunFlash(data) => Some(*data),
+        _ => None,
+    });
+
+    // Pick the selected ammo type: guns carry several Projectile
+    // links (standard / HE / AP, ...); RuntimePropSelectedAmmo indexes
+    // into the ordered, setting-filtered list (absent = the first).
+    let projectiles = ordered_projectile_links(world, entity_id);
+    let selected_ammo = world
+        .borrow::<View<RuntimePropSelectedAmmo>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|s| s.0))
+        .unwrap_or(0);
+    let maybe_projectile = projectiles
+        .get(selected_ammo % projectiles.len().max(1))
+        .cloned();
+
+    // A weapon with no Projectile link is melee. In flat mode the
+    // trigger starts the authored player-arm swing; its MF_TRIGGER1
+    // animation event resolves the short aimed raycast later, at
+    // visible impact. (VR has no flat aim and damages through its
+    // trigger-gated physical contact handler.)
+    if maybe_projectile.is_none() {
+        if world
+            .borrow::<View<RuntimePropFlatAim>>()
+            .unwrap()
+            .get(entity_id)
+            .is_ok()
+        {
+            return ShotOutcome::FlatMeleeSwing;
+        }
+    }
+
+    // Ammo gating: weapons that carry a `PropGunState` are limited by
+    // their clip. A magazine that cannot pay the setting's per-shot
+    // cost dry-fires (no shot/flash). Weapons without a gun state
+    // (e.g. unlimited debug weapons) are unaffected.
+    let maybe_ammo = loaded_ammo(world, entity_id);
+    let rounds = rounds_per_shot(setting);
+    if !can_pay_for_shot(maybe_ammo, rounds) {
+        return ShotOutcome::Empty;
+    }
+
+    // Include projectile class tags (ie, ammotype) and weaponmode for sound lookup
+    let mut projectile_class_tags: Vec<(String, String)> =
+        if let Some((projectile_template_id, _)) = &maybe_projectile {
+            let class_tags = world
+                .borrow::<UniqueView<GlobalTemplateClassTags>>()
+                .unwrap();
+            get_ammotype_from_projectile_template(*projectile_template_id, &class_tags.0)
+                .map(|ammotype| vec![("ammotype".to_string(), ammotype)])
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+    // Add weaponmode=0 for shoot mode
+    projectile_class_tags.push(("weaponmode".to_string(), "0".to_string()));
+
+    let additional_sound_tags = projectile_class_tags
+        .iter()
+        .map(|(tag, value)| (tag.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+
+    let sound_effect = play_environmental_sound(
+        world,
+        entity_id,
+        "shoot",
+        additional_sound_tags,
+        AudioHandle::new(),
+    );
+
+    // Only a real gunshot (a fired projectile) raises noise - a
+    // projectile-less weapon that falls through the melee gate
+    // must not emit a phantom gunshot.
+    let is_gunshot = maybe_projectile.is_some();
+    let projectile_effect = Effect::Multiple(
+        maybe_projectile
+            .into_iter()
+            .map(|(template_id, options)| {
+                create_projectile(
+                    world,
+                    entity_id,
+                    template_id,
+                    &options,
+                    shot_modifiers(setting),
+                )
+            })
+            .collect(),
+    );
+
+    let muzzle_flash_effect = Effect::Multiple(
+        muzzle_flashes
+            .into_iter()
+            .map(|(template_id, options)| {
+                create_muzzle_flash(world, entity_id, template_id, &options)
+            })
+            .collect(),
+    );
+    // let offset = obj_rotation * vec3(0.0128545, 0.5026805, -3.0933015) / SCALE_FACTOR;
+
+    // let muzzle_flash_effect = Effect::CreateEntity {
+    //     template_id: -2653,
+    //     position: position + offset,
+    //     orientation: *obj_rotation
+    //         * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Rad(PI / 2.0)),
+    // };
+
+    // Consume the setting's per-shot cost when the weapon tracks ammo.
+    let mut effects = vec![sound_effect, muzzle_flash_effect, projectile_effect];
+    if maybe_ammo.is_some() {
+        effects.push(Effect::AdjustAmmo {
+            entity_id,
+            delta: -rounds,
+        });
+    }
+    // Start the setting's between-shots wait. Only a real shot
+    // starts one - a melee weapon that reached here has nothing to
+    // pace.
+    //
+    // Every shot restarts it, burst rounds included: a burst pays
+    // its rounds out on the shorter `burst_interval_ms` without
+    // consulting the cooldown, so what is left when the burst ends
+    // is the last round's full wait - the gap the setting asks for
+    // between pulls.
+    let cooldown = shot_cooldown_seconds(setting);
+    if is_gunshot && cooldown > 0.0 {
+        effects.push(Effect::BeginShotCooldown {
+            entity_id,
+            seconds: cooldown,
+        });
+    }
+    // A gunshot is loud: nearby AIs hear it and investigate the
+    // shooter, even without line of sight. The noise comes from
+    // the weapon (in the player's hands), so its position stands
+    // in for the shooter's.
+    if is_gunshot {
+        if let Some(origin) = weapon_world_position(world, entity_id) {
+            effects.push(Effect::RaiseNoise {
+                origin,
+                radius: GUNSHOT_NOISE_RADIUS,
+            });
+        }
+    }
+    ShotOutcome::Fired(Effect::Multiple(effects))
 }
 
 /// Resolve the authored hit event of a flat melee swing: raycast a short

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -33,6 +33,19 @@ pub fn weapon_in_hand(world: &World, hand: Handedness) -> Option<EntityId> {
     is_weapon(world, held).then_some(held)
 }
 
+/// Whether the player holds `entity` in either hand. Unlike
+/// [`weapon_in_hand`] this asks nothing about what the object is, so it also
+/// covers a gun with no clip of its own. `PlayerInfo` is written before scripts
+/// run each frame, so a pickup is visible to the same frame's scripts.
+pub fn held_in_hand(world: &World, entity: EntityId) -> bool {
+    world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .map(|info| {
+            info.left_hand_entity_id == Some(entity) || info.right_hand_entity_id == Some(entity)
+        })
+        .unwrap_or(false)
+}
+
 /// The weapon the player is wielding, for actions and readouts that are not
 /// tied to one hand (the Reload/CycleAmmo input actions, the ammo readout).
 /// Right hand first - see the module docs for the precedence rule.

--- a/tools/shock2-sdk/test/weapon-burst-fire.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-burst-fire.e2e.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import {
+  ammoOf,
+  cycleToWeapon,
+  pullTrigger,
+  waitForShotReady,
+} from "./helpers/weapon.js";
+
+// End-to-end coverage for the two fire settings that send more than one round
+// per trigger pull: the pistol's BURST (3 rounds, 10 ms apart) and the assault
+// rifle's AUTO (unlimited while the trigger is down, 100 ms apart). The other
+// numbers behind a fire mode are covered by weapon-fire-mode-stats, and mode
+// switching itself by weapon-fire-mode.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** Hold the trigger down (no edge on its own - `step` is what makes frames). */
+async function holdTrigger(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.trigger", 1.0);
+}
+
+async function releaseTrigger(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.trigger", 0.0);
+}
+
+test(
+  "the pistol's BURST sends three rounds off one pull, then waits out its interval",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const pistol = await cycleToWeapon(game, (e) => e.name === "Pistol");
+    const rounds = async () => ammoOf(await game.entities.detail(pistol.id));
+    assert.equal(await rounds(), 12, "the debug pistol starts on a full clip");
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting_header,
+      "NORM",
+      "the pistol starts on its single-shot setting",
+    );
+
+    // NORM: one round a pull, whatever the trigger does afterwards.
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+    assert.equal(
+      await rounds(),
+      11,
+      "a NORM pull is one round and stays one round",
+    );
+
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting_header,
+      "BURST",
+      "switched to the 3-round burst",
+    );
+
+    // One pull, released immediately: the burst plays out anyway, and it takes
+    // frames to do it rather than emptying into the one the pull landed in.
+    await waitForShotReady(game);
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0.0);
+    // 11 rounds are loaded here, so 8 left would be the whole burst emptying
+    // into the pull's own frame - the regression the burst's frame pacing is
+    // there to prevent.
+    const partway = await rounds();
+    assert.ok(
+      partway > 8,
+      `the burst should still owe rounds a frame in, got ${partway} left`,
+    );
+
+    await game.step({ frames: 30 });
+    assert.equal(await rounds(), 8, "three rounds off the one pull");
+
+    // The setting's 700 ms shot interval then holds off the next burst - half a
+    // second later the gun is still recovering.
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+    assert.equal(
+      await rounds(),
+      8,
+      "a pull inside the interval starts nothing",
+    );
+
+    // Past the interval, another pull is another three rounds.
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+    assert.equal(await rounds(), 5, "the next burst after the interval fires");
+  },
+);
+
+test(
+  "the assault rifle's AUTO fires for as long as the trigger is held",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const rifle = await cycleToWeapon(game, (e) => e.name === "Assault Rifle");
+    const rounds = async () => ammoOf(await game.entities.detail(rifle.id));
+    const loaded = await rounds();
+    assert.ok(loaded >= 8, `the debug rifle starts loaded, got ${loaded}`);
+
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting_header,
+      "AUTO",
+      "switched to continual fire",
+    );
+
+    // Half a second on the trigger at the setting's 100 ms interval: about
+    // five rounds. Coarse, because the pull's own round and the frame the
+    // burst starts on land either side of the window - and short of the
+    // magazine, so it is the interval being measured and not the clip.
+    await waitForShotReady(game);
+    await holdTrigger(game);
+    await game.step({ frames: 30 });
+    await releaseTrigger(game);
+    await game.step({ frames: 1 });
+    const fired = loaded - (await rounds());
+    assert.ok(
+      fired >= 4 && fired <= 7,
+      `half a second of AUTO is about five rounds, got ${fired}`,
+    );
+
+    // And the release really is what stops it.
+    const afterRelease = await rounds();
+    await game.step({ frames: 60 });
+    assert.equal(
+      await rounds(),
+      afterRelease,
+      "nothing more goes out once the trigger is up",
+    );
+  },
+);
+
+test(
+  "an AUTO burst stops on the last round instead of overdrawing the magazine",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const rifle = await cycleToWeapon(game, (e) => e.name === "Assault Rifle");
+    const rounds = async () => ammoOf(await game.entities.detail(rifle.id));
+
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.wielded_gun_setting_header, "AUTO");
+
+    // Hold the magazine down to its last round. Three frames at a time: a round
+    // leaves every six, so the poll cannot step past 1.
+    await waitForShotReady(game);
+    await holdTrigger(game);
+    for (let i = 0; i < 400 && (await rounds()) > 1; i += 1) {
+      await game.step({ frames: 3 });
+    }
+    await releaseTrigger(game);
+    await game.step({ frames: 1 });
+    assert.equal(await rounds(), 1, "held down to a single round");
+
+    // One more pull spends it and the burst ends there - the magazine never
+    // goes below empty, and the empty gun keeps clicking rather than firing.
+    await waitForShotReady(game);
+    await pullTrigger(game);
+    await game.step({ frames: 60 });
+    assert.equal(
+      await rounds(),
+      0,
+      "the last round fires, and only the last round",
+    );
+  },
+);


### PR DESCRIPTION
A trigger pull sent exactly one round whatever the fire setting said, so the
pistol's BURST and the assault rifle's AUTO were single shots with an oddly long
recovery. `burst` (rounds per pull, `-1` = unlimited while held) and
`burst_interval_ms` (the gap between them) now govern the pull.

## The state machine

Script-private, in `WeaponScript`; the counting and timing are pure in
`scripts/burst_fire.rs`.

- A pull fires its round as before, then `BurstState::begin` records what the
  setting still owes - nothing at all for the 1-round settings every other gun
  has, so nothing about them changes.
- Each frame, `update` counts down `burst_interval_ms` and pays out one more
  round. Never more than one per frame, so an interval shorter than a frame
  paces to the frame rate.
- It stops on the last owed round, on a magazine that cannot pay for the next
  one, on a reload, on the gun leaving the player's hands, and - for an
  unlimited burst only - on the trigger release. A finite burst plays out after
  the release: letting go of the pistol's BURST one frame in still sends all
  three rounds.

Every round of a burst is the shot a pull would have fired - same sound, muzzle
flash, projectile, ammo cost and gunshot noise - because the pull and the burst
share one `fire_one_shot` (extracted from the old `TriggerPull` body). Each also
restarts the setting's `shot_interval_ms`, which the burst itself ignores, so
what is left when the burst ends is the last round's full wait: the gap the
setting asks for between pulls.

## Retail values

| Gun | Setting | `burst` | `burst_interval_ms` | `shot_interval_ms` |
| --- | --- | --- | --- | --- |
| Pistol | NORM | 1 | 0 | 500 |
| Pistol | BURST | 3 | 10 | 700 |
| Assault Rifle | NORM | 1 | 0 | 250 |
| Assault Rifle | AUTO | -1 | 100 | 250 |

Every other gun and setting is `burst` 1.

## Save/load

The burst is not serialized, the same call `RuntimePropShotCooldown` makes: a
save taken mid-burst loads with the trigger at rest and the owed rounds
forgotten. Saving inside the ~50 ms of a pistol burst is not worth a state hook.

## Tests

`cargo test -p shock2vr --lib` - 1222 passed. New unit tests in `burst_fire`
cover the counting and timing: one shot a frame, no round in the pull's own
frame, release semantics both ways, and a dry magazine.

New e2e `tools/shock2-sdk/test/weapon-burst-fire.e2e.test.ts` (all three fail on
the parent commit):

```
ok 1 - the pistol's BURST sends three rounds off one pull, then waits out its interval
ok 2 - the assault rifle's AUTO fires for as long as the trigger is held
ok 3 - an AUTO burst stops on the last round instead of overdrawing the magazine
```

Also re-run green: `weapon-fire-mode*`, `weapon-ammo*`, `weapon-reload*`,
`vr-weapon-*`, `blood-spang`, `impact-sounds`, `save-load*` (18 + 6 passed) and
`missions.e2e.test.ts` (23/23 load).

## Review notes

Two behaviours `/xreview` raised that are deliberate, both pre-existing classes
rather than anything this change introduces:

- A pull that lands inside the between-shots wait is dropped, so releasing AUTO
  and re-pressing within the wait needs one more press. That is the parent PR's
  cooldown gate, and it applies to every gun; latching a held trigger across the
  wait is its own change.
- Hitting Reload in the exact frame a burst round is due can leave the reloaded
  magazine one round short, because effects apply after scripts run. The same
  race already exists for a pull in a reload's frame.
