### PR TITLE
feat(hud): faithful use-mode ammo readout with fire-mode, reload and psi buttons

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -600,9 +600,10 @@ pub struct UiStateResult {
     /// The item held on the cursor mid-drag (cursor-is-the-item); `Some`
     /// between a lift and the place/throw that clears it.
     pub cursor: Option<shock2vr::game_scene::DebugUiCursor>,
-    /// The AMMOFULL ammo-cycle button (use mode + multi-ammo weapon); `Some`
-    /// when shown. Click it to cycle the wielded weapon's ammo type.
-    pub ammo_cycle: Option<shock2vr::game_scene::DebugUiElement>,
+    /// Every AMMOFULL readout control shown this frame (fire-mode SETTING,
+    /// RELOAD, the ammo-cycle arrow, the psi selector arrows), labeled by
+    /// meaning. Empty outside use mode.
+    pub readout: Vec<shock2vr::game_scene::DebugUiElement>,
     /// Where the pointer last landed on the shared canvas (flat: the mouse;
     /// VR: the controller ray on the cyber-interface panel).
     pub pointer: Option<shock2vr::game_scene::DebugUiPointer>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1328,7 +1328,7 @@ fn process_command(
                         active_panel: ui.active_panel,
                         strip: ui.strip,
                         cursor: ui.cursor,
-                        ammo_cycle: ui.ammo_cycle,
+                        readout: ui.readout,
                         pointer: ui.pointer,
                         panel_pose: ui.panel_pose,
                     }
@@ -1338,7 +1338,7 @@ fn process_command(
                     active_panel: None,
                     strip: None,
                     cursor: None,
-                    ammo_cycle: None,
+                    readout: Vec::new(),
                     pointer: None,
                     panel_pose: None,
                 });

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -562,7 +562,10 @@ pub struct DebugUiState {
     /// The AMMOFULL ammo-cycle button (use mode + empty multi-ammo weapon
     /// wielded); clicking it cycles the wielded weapon's ammo type. `None`
     /// otherwise.
-    pub ammo_cycle: Option<DebugUiElement>,
+    /// Every AMMOFULL readout control shown this frame (fire-mode SETTING,
+    /// RELOAD, the ammo-cycle arrow, the psi selector arrows), labeled by
+    /// meaning. Empty outside use mode.
+    pub readout: Vec<DebugUiElement>,
     /// Where the pointer last landed on the shared canvas (flat: the mouse;
     /// VR: the controller ray on the cyber-interface panel).
     pub pointer: Option<DebugUiPointer>,
@@ -891,7 +894,7 @@ pub trait DebuggableScene {
             active_panel: None,
             strip: None,
             cursor: None,
-            ammo_cycle: None,
+            readout: Vec::new(),
             pointer: None,
             panel_pose: None,
         }

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -8,7 +8,15 @@
 //! sit in the same place relative to the panel art in the headset as they do
 //! on screen (AGENTS.md section 3).
 //!
-//! Rects are panel-local: (0,0) is the panel's upper-left corner.
+//! Rects are panel-local: (0,0) is the panel's upper-left corner. Two regions
+//! matter, both measured off the shipped art: the **gauge well** - the lit
+//! recess at panel x 176..249, y 13..55, which is exactly what the compact
+//! AMMOBACK.PCX (94x64) crop shows - holds the readout itself, and the
+//! **use-mode button column** left of it (from x 117, present only on the
+//! expanded AMMOFULL art, whose recess runs 117..249 unbroken) holds the
+//! controls the cursor clicks. Everything drawn therefore stays inside the
+//! gauge well, so the compact panel is not missing half its readout and the
+//! buttons do not land on top of it.
 
 use cgmath::{Vector2, vec2};
 use shipyard::World;
@@ -20,20 +28,79 @@ pub(crate) const PANEL_W: f32 = 260.0;
 pub(crate) const PANEL_H: f32 = 64.0;
 pub(crate) const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
 
-/// Round count, centered over the gauge (the AMMOBACK footprint at the panel's
-/// right end).
-pub(crate) const COUNT: Rect = Rect::new(166.0, 22.0, 94.0, 20.0);
-/// Selected ammo type's object icon (P$ObjIcon), just left of the gauge.
-pub(crate) const ICON: Rect = Rect::new(126.0, 16.0, 32.0, 32.0);
-/// Ammo-type label (std/he/ap), below the count.
-pub(crate) const TYPE_LABEL: Rect = Rect::new(166.0, 44.0, 94.0, 16.0);
-/// The ammo-type cycle button (the original's `ammoarw` hotspot).
+/// Selected ammo type's object icon (P$ObjIcon), at the gauge well's left -
+/// right of the cycle arrow, which claims the well's leading 12 px.
+pub(crate) const ICON: Rect = Rect::new(200.0, 18.0, 24.0, 24.0);
+/// Round count, right of the ammo icon inside the gauge well.
+pub(crate) const COUNT: Rect = Rect::new(224.0, 20.0, 25.0, 20.0);
+/// Ammo-type label (std/he/ap), across the bottom of the gauge well.
+pub(crate) const TYPE_LABEL: Rect = Rect::new(198.0, 42.0, 51.0, 13.0);
+
+/// The ammo-type cycle button (the original's `ammoarw` hotspot, 12x41 art).
 pub(crate) const CYCLE_BUTTON: Rect = Rect::new(186.0, 15.0, 12.0, 41.0);
-/// Psi tier badge, in place of the ammo icon while the amp is wielded.
-pub(crate) const PSI_TIER_BADGE: Rect = Rect::new(122.0, 22.0, 32.0, 19.0);
-/// Psi discipline name. Longer than the ammo-type label, so it starts further
-/// left.
-pub(crate) const PSI_POWER_NAME: Rect = Rect::new(106.0, 44.0, 154.0, 16.0);
+/// The fire-mode SETTING button. Its label is the gun's current mode header
+/// (`P$SHead1`/`P$SHead2` -> "NORM"/"BURST"/"AUTO"); a click cycles the mode.
+pub(crate) const SETTING_BUTTON: Rect = Rect::new(118.0, 15.0, 66.0, 20.0);
+/// The RELOAD button - the same thing the Reload key does.
+pub(crate) const RELOAD_BUTTON: Rect = Rect::new(118.0, 37.0, 66.0, 20.0);
+
+/// Psi tier badge (AmPsi&lt;tier&gt;1.PCX, 32x19), in the gauge well while the
+/// amp is wielded - the amp has no clip, so this replaces the ammo readout.
+pub(crate) const PSI_TIER_BADGE: Rect = Rect::new(177.0, 16.0, 32.0, 19.0);
+/// Psi discipline name, under the badge and between the power arrows.
+pub(crate) const PSI_POWER_NAME: Rect = Rect::new(177.0, 37.0, 60.0, 18.0);
+/// Tier step buttons (`left`/`right` art, 18x18), in the button column.
+pub(crate) const PSI_TIER_PREV: Rect = Rect::new(118.0, 15.0, 18.0, 18.0);
+pub(crate) const PSI_TIER_NEXT: Rect = Rect::new(136.0, 15.0, 18.0, 18.0);
+/// Power step buttons (`pleft`/`pright` art, 12x41), flanking the power name.
+pub(crate) const PSI_POWER_PREV: Rect = Rect::new(157.0, 15.0, 12.0, 41.0);
+pub(crate) const PSI_POWER_NEXT: Rect = Rect::new(237.0, 15.0, 12.0, 41.0);
+
+/// The font every readout label uses (the original's HUD font).
+const FONT: &str = "mainfont.fon";
+
+/// A clickable control on the ammo readout. The layout owns the set, so the
+/// drawn button and the hit-tested rect can never disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadoutButton {
+    /// Cycle the wielded weapon's ammo type.
+    CycleAmmo,
+    /// Cycle the wielded gun's fire mode.
+    GunSetting,
+    /// Reload the wielded gun with its current ammo type.
+    Reload,
+    PsiTierPrev,
+    PsiTierNext,
+    PsiPowerPrev,
+    PsiPowerNext,
+}
+
+impl ReadoutButton {
+    /// Stable semantic id, so `/v1/ui` clients click by meaning.
+    pub fn label(self) -> &'static str {
+        match self {
+            ReadoutButton::CycleAmmo => "cycle_ammo",
+            ReadoutButton::GunSetting => "gun_setting",
+            ReadoutButton::Reload => "reload",
+            ReadoutButton::PsiTierPrev => "psi_tier_prev",
+            ReadoutButton::PsiTierNext => "psi_tier_next",
+            ReadoutButton::PsiPowerPrev => "psi_power_prev",
+            ReadoutButton::PsiPowerNext => "psi_power_next",
+        }
+    }
+}
+
+/// One placed readout button: what it does, where it is, and what it shows.
+/// `rect` is panel-local as produced by [`buttons`]; [`crate::hud::flat_hud`]
+/// maps it into canvas space with [`at`] before handing it to the pointer host,
+/// so the drawn and clickable rects are the same rect.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReadoutButtonSpec {
+    pub button: ReadoutButton,
+    pub rect: Rect,
+    pub texture: Option<&'static str>,
+    pub text: Option<String>,
+}
 
 /// Place a panel-local rect into a canvas whose panel origin is `origin`.
 pub(crate) const fn at(origin: Vector2<f32>, rect: Rect) -> Rect {
@@ -53,23 +120,41 @@ pub(crate) struct AmmoReadout {
     pub ammo_icon: Option<String>,
     /// The selected ammo type's class tag ("std", "he", "ap").
     pub ammo_type: Option<String>,
-    /// Whether to draw the ammo-type cycle arrow. Flat sets this only in use
-    /// mode, where the pointer can actually click it; VR leaves it off (no
-    /// forearm pointer affordance exists - that is an interaction-design
-    /// decision, not a layout one).
-    pub show_cycle_button: bool,
+    /// The wielded gun's current fire-mode header ("NORM"/"BURST"/"AUTO") -
+    /// the SETTING button's label. Absent when the gun names no header.
+    pub gun_setting_header: Option<String>,
+    /// The weapon offers a different projectile type to switch to.
+    pub can_cycle_ammo: bool,
+    /// The weapon takes clips (an energy weapon recharges instead).
+    pub can_reload: bool,
+    /// MISC.STR `Reload` - the reload button's label.
+    pub reload_label: String,
+    /// Whether the interactive controls are drawn and hit-tested. Flat sets
+    /// this only in use mode, where the pointer can actually click them; VR
+    /// leaves it off (the forearm panel has no pointer affordance - that is an
+    /// interaction-design decision, not a layout one).
+    pub show_buttons: bool,
 }
 
 impl AmmoReadout {
-    /// Read the wielded weapon's readout from the world. `show_cycle_button`
-    /// is the caller's (presentation's) call.
-    pub(crate) fn from_world(world: &World, show_cycle_button: bool) -> Self {
+    /// Read the wielded weapon's readout from the world. `show_buttons` is the
+    /// caller's (presentation's) call.
+    pub(crate) fn from_world(world: &World, show_buttons: bool) -> Self {
+        let weapon = crate::wielded_weapon::wielded_weapon(world);
         Self {
             psi_power: super::get_wielded_psi_power(world),
             ammo: super::get_wielded_ammo(world),
             ammo_icon: super::get_wielded_ammo_icon(world),
             ammo_type: super::get_wielded_ammo_type(world),
-            show_cycle_button,
+            gun_setting_header: super::get_wielded_gun_setting(world)
+                .and_then(|(_, header)| header),
+            can_cycle_ammo: weapon
+                .is_some_and(|w| crate::scripts::script_util::can_cycle_ammo(world, w)),
+            // An energy weapon has no magazine to swap - it recharges - so it
+            // shows no reload control, exactly as the original.
+            can_reload: weapon.is_some_and(|w| !crate::wielded_weapon::is_energy_weapon(world, w)),
+            reload_label: super::hud_strings(world).reload_label,
+            show_buttons,
         }
     }
 
@@ -80,6 +165,85 @@ impl AmmoReadout {
     }
 }
 
+/// The readout's clickable controls this frame, in panel-local pixels.
+///
+/// The single source of truth for the button set: [`emit`] draws exactly these
+/// and the pointer host hit-tests exactly these, so a drawn button is always
+/// clickable and vice versa.
+pub(crate) fn buttons(readout: &AmmoReadout) -> Vec<ReadoutButtonSpec> {
+    let spec = |button, rect, texture, text: Option<&str>| ReadoutButtonSpec {
+        button,
+        rect,
+        texture,
+        text: text.map(str::to_owned),
+    };
+    if !readout.show_buttons {
+        return Vec::new();
+    }
+    // The amp replaces the gun controls with its power selector: tier stepping
+    // on the left, power stepping flanking the discipline name.
+    if readout.psi_power.is_some() {
+        return vec![
+            spec(
+                ReadoutButton::PsiTierPrev,
+                PSI_TIER_PREV,
+                Some("LEFT0.PCX"),
+                None,
+            ),
+            spec(
+                ReadoutButton::PsiTierNext,
+                PSI_TIER_NEXT,
+                Some("RIGHT0.PCX"),
+                None,
+            ),
+            spec(
+                ReadoutButton::PsiPowerPrev,
+                PSI_POWER_PREV,
+                Some("PLEFT0.PCX"),
+                None,
+            ),
+            spec(
+                ReadoutButton::PsiPowerNext,
+                PSI_POWER_NEXT,
+                Some("PRIGHT0.PCX"),
+                None,
+            ),
+        ];
+    }
+    if readout.ammo.is_none() {
+        // Nothing with a magazine wielded: no gun controls at all.
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    // The fire-mode button is shown for every gun with a magazine, energy
+    // weapons included - only a gun whose data names no mode has none.
+    if let Some(header) = &readout.gun_setting_header {
+        out.push(spec(
+            ReadoutButton::GunSetting,
+            SETTING_BUTTON,
+            None,
+            Some(header),
+        ));
+    }
+    if readout.can_reload {
+        out.push(spec(
+            ReadoutButton::Reload,
+            RELOAD_BUTTON,
+            None,
+            Some(&readout.reload_label),
+        ));
+    }
+    if readout.can_cycle_ammo {
+        out.push(spec(
+            ReadoutButton::CycleAmmo,
+            CYCLE_BUTTON,
+            Some("ammoarw0.pcx"),
+            None,
+        ));
+    }
+    out
+}
+
 /// Emit the readout's elements into `canvas`, with the AMMOFULL panel's
 /// upper-left corner at `origin` in that canvas's pixel space. The backdrop
 /// art is the caller's (flat swaps AMMOBACK/AMMOFULL with use mode); every
@@ -87,53 +251,55 @@ impl AmmoReadout {
 pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoReadout) {
     // The psi amp shows its selected discipline where a gun shows its clip.
     if let Some((power_name, tier)) = &readout.psi_power {
-        let tier = *tier;
         canvas
             .image(
                 at(origin, PSI_TIER_BADGE),
-                &format!("AmPsi{}1.PCX", tier.clamp(1, 5)),
+                &format!("AmPsi{}1.PCX", (*tier).clamp(1, 5)),
             )
-            .text_native(
-                at(origin, COUNT),
-                &format!("{tier}"),
-                "mainfont.fon",
-                HAlign::Center,
-                VAlign::Middle,
-            )
-            .text_native(
+            .text_native_fit(
                 at(origin, PSI_POWER_NAME),
                 &power_name.to_ascii_uppercase(),
-                "mainfont.fon",
+                FONT,
                 HAlign::Center,
                 VAlign::Middle,
             );
-        return;
-    }
-
-    let Some(rounds) = readout.ammo else {
-        return;
-    };
-    canvas.text_native(
-        at(origin, COUNT),
-        &format!("{rounds}"),
-        "mainfont.fon",
-        HAlign::Center,
-        VAlign::Middle,
-    );
-    if let Some(icon) = &readout.ammo_icon {
-        canvas.image(at(origin, ICON), icon);
-    }
-    if let Some(ammo_type) = &readout.ammo_type {
+    } else if let Some(rounds) = readout.ammo {
         canvas.text_native(
-            at(origin, TYPE_LABEL),
-            &ammo_type.to_ascii_uppercase(),
-            "mainfont.fon",
+            at(origin, COUNT),
+            &format!("{rounds}"),
+            FONT,
             HAlign::Center,
             VAlign::Middle,
         );
+        if let Some(icon) = &readout.ammo_icon {
+            canvas.image(at(origin, ICON), icon);
+        }
+        if let Some(ammo_type) = &readout.ammo_type {
+            // Ellipsized: the class tag is data ("std", but also "lasershot"),
+            // and an over-wide label would spill out of the gauge well.
+            canvas.text_native_fit(
+                at(origin, TYPE_LABEL),
+                &ammo_type.to_ascii_uppercase(),
+                FONT,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+        }
+    } else {
+        return;
     }
-    if readout.show_cycle_button {
-        canvas.image(at(origin, CYCLE_BUTTON), "ammoarw0.pcx");
+
+    for button in buttons(readout) {
+        let rect = at(origin, button.rect);
+        if let Some(texture) = button.texture {
+            canvas.image(rect, texture);
+        }
+        if let Some(text) = &button.text {
+            // Ellipsized like the ammo-type label: both labels are data (a
+            // localized MISC.STR string, an authored `P$SHead` header), and an
+            // over-wide one would spill onto the gauge.
+            canvas.text_native_fit(rect, text, FONT, HAlign::Center, VAlign::Middle);
+        }
     }
 }
 
@@ -152,13 +318,32 @@ pub(crate) fn build_readout_canvas(readout: &AmmoReadout) -> UiCanvas {
 mod tests {
     use super::*;
 
+    /// The gauge well the compact AMMOBACK crop shows, read off the art.
+    const WELL: Rect = Rect::new(176.0, 13.0, 73.0, 42.0);
+
     fn gun(ammo: i32, icon: Option<&str>, ammo_type: Option<&str>) -> AmmoReadout {
         AmmoReadout {
             ammo: Some(ammo),
             ammo_icon: icon.map(str::to_string),
             ammo_type: ammo_type.map(str::to_string),
+            reload_label: "RELOAD".to_string(),
             ..Default::default()
         }
+    }
+
+    /// A gun with everything a gun can offer, in use mode.
+    fn full_gun() -> AmmoReadout {
+        AmmoReadout {
+            gun_setting_header: Some("NORM".to_string()),
+            can_cycle_ammo: true,
+            can_reload: true,
+            show_buttons: true,
+            ..gun(12, Some("STD_I.PCX"), Some("std"))
+        }
+    }
+
+    fn kinds(readout: &AmmoReadout) -> Vec<ReadoutButton> {
+        buttons(readout).into_iter().map(|b| b.button).collect()
     }
 
     #[test]
@@ -205,14 +390,14 @@ mod tests {
 
     #[test]
     fn the_psi_amp_shows_its_discipline_on_the_forearm_too() {
-        // Tier badge + tier count + discipline name = 3, and the amp's
-        // meaningless clip is suppressed exactly as in flat.
+        // Tier badge + discipline name = 2, and the amp's meaningless clip is
+        // suppressed exactly as in flat.
         let canvas = build_readout_canvas(&AmmoReadout {
             psi_power: Some(("Projected Cryokinesis".to_string(), 1)),
             ammo: Some(0),
             ..Default::default()
         });
-        assert_eq!(canvas.element_count(), 3);
+        assert_eq!(canvas.element_count(), 2);
     }
 
     /// Every readout element is authored inside the panel, so the VR forearm
@@ -224,8 +409,14 @@ mod tests {
             ICON,
             TYPE_LABEL,
             CYCLE_BUTTON,
+            SETTING_BUTTON,
+            RELOAD_BUTTON,
             PSI_TIER_BADGE,
             PSI_POWER_NAME,
+            PSI_TIER_PREV,
+            PSI_TIER_NEXT,
+            PSI_POWER_PREV,
+            PSI_POWER_NEXT,
         ] {
             assert!(
                 rect.x >= 0.0 && rect.y >= 0.0,
@@ -240,6 +431,170 @@ mod tests {
                 "{rect:?} overflows the panel height"
             );
         }
+    }
+
+    /// The readout proper lives in the gauge well - the part of the panel the
+    /// COMPACT AMMOBACK art also shows. Before this layout the ammo icon sat
+    /// 40 px to the left of the compact backdrop entirely, so shooter mode drew
+    /// it on bare 3D view.
+    #[test]
+    fn the_readout_sits_inside_the_compact_gauge_well() {
+        for rect in [COUNT, ICON, TYPE_LABEL, PSI_TIER_BADGE, PSI_POWER_NAME] {
+            assert!(
+                rect.x >= WELL.x && rect.x + rect.w <= WELL.x + WELL.w,
+                "{rect:?} leaves the gauge well horizontally"
+            );
+            assert!(
+                rect.y >= WELL.y && rect.y + rect.h <= WELL.y + WELL.h,
+                "{rect:?} leaves the gauge well vertically"
+            );
+        }
+    }
+
+    /// No control may be drawn on top of the readout it annotates - the bug
+    /// this layout fixes is exactly that (the ammo icon sat inside the SETTING
+    /// button's rect).
+    #[test]
+    fn no_button_overlaps_the_readout() {
+        let overlaps = |a: Rect, b: Rect| {
+            a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+        };
+        let psi = AmmoReadout {
+            psi_power: Some(("Cryokinesis".to_string(), 1)),
+            show_buttons: true,
+            ..Default::default()
+        };
+        for (readout, drawn) in [
+            (full_gun(), vec![COUNT, ICON, TYPE_LABEL]),
+            (psi, vec![PSI_TIER_BADGE, PSI_POWER_NAME]),
+        ] {
+            for spec in buttons(&readout) {
+                for rect in &drawn {
+                    assert!(
+                        !overlaps(spec.rect, *rect),
+                        "{:?} at {:?} covers {rect:?}",
+                        spec.button,
+                        spec.rect
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn buttons_only_appear_where_the_pointer_can_reach_them() {
+        // Shooter mode / the VR forearm: the readout draws, the controls do not.
+        assert!(
+            kinds(&AmmoReadout {
+                show_buttons: false,
+                ..full_gun()
+            })
+            .is_empty()
+        );
+        assert_eq!(
+            kinds(&full_gun()),
+            vec![
+                ReadoutButton::GunSetting,
+                ReadoutButton::Reload,
+                ReadoutButton::CycleAmmo
+            ]
+        );
+    }
+
+    #[test]
+    fn an_energy_weapon_keeps_its_setting_button_but_loses_cycle_and_reload() {
+        // The laser recharges and offers one projectile, but it still switches
+        // between its normal and overcharged modes.
+        let laser = AmmoReadout {
+            can_cycle_ammo: false,
+            can_reload: false,
+            ..full_gun()
+        };
+        assert_eq!(kinds(&laser), vec![ReadoutButton::GunSetting]);
+    }
+
+    #[test]
+    fn a_gun_with_no_named_mode_has_no_setting_button() {
+        let plain = AmmoReadout {
+            gun_setting_header: None,
+            ..full_gun()
+        };
+        assert_eq!(
+            kinds(&plain),
+            vec![ReadoutButton::Reload, ReadoutButton::CycleAmmo]
+        );
+    }
+
+    #[test]
+    fn the_setting_button_is_labeled_with_the_current_mode() {
+        let spec = buttons(&AmmoReadout {
+            gun_setting_header: Some("BURST".to_string()),
+            ..full_gun()
+        })
+        .into_iter()
+        .find(|b| b.button == ReadoutButton::GunSetting)
+        .expect("the setting button is shown");
+        assert_eq!(spec.text.as_deref(), Some("BURST"));
+        assert_eq!(spec.rect, SETTING_BUTTON);
+    }
+
+    #[test]
+    fn the_psi_amp_shows_four_selector_arrows_and_no_gun_controls() {
+        let amp = AmmoReadout {
+            psi_power: Some(("Projected Cryokinesis".to_string(), 1)),
+            // The amp carries a meaningless clip; it must not produce gun
+            // controls.
+            ammo: Some(0),
+            gun_setting_header: Some("NORM".to_string()),
+            can_reload: true,
+            show_buttons: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            kinds(&amp),
+            vec![
+                ReadoutButton::PsiTierPrev,
+                ReadoutButton::PsiTierNext,
+                ReadoutButton::PsiPowerPrev,
+                ReadoutButton::PsiPowerNext
+            ]
+        );
+    }
+
+    #[test]
+    fn nothing_wielded_has_no_buttons() {
+        assert!(
+            kinds(&AmmoReadout {
+                show_buttons: true,
+                gun_setting_header: Some("NORM".to_string()),
+                can_reload: true,
+                ..Default::default()
+            })
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn drawn_buttons_match_the_hit_tested_set() {
+        // Every button `buttons()` reports adds exactly one canvas element at
+        // the same rect, so `mission_core` can hit-test that list verbatim.
+        let readout = full_gun();
+        let specs = buttons(&readout);
+        let canvas = build_readout_canvas(&readout);
+        for spec in &specs {
+            assert!(
+                canvas.elements().iter().any(|element| match element {
+                    crate::ui::UiElement::Text { position, .. }
+                    | crate::ui::UiElement::Image { position, .. } =>
+                        *position == vec2(spec.rect.x, spec.rect.y),
+                    _ => false,
+                }),
+                "{:?} is hit-tested but not drawn",
+                spec.button
+            );
+        }
+        // count + icon + type + 3 buttons
+        assert_eq!(canvas.element_count(), 3 + specs.len());
     }
 
     #[test]

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -10,11 +10,8 @@ use cgmath::{Vector2, vec2};
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use shipyard::World;
 
-use super::ammo_panel::{self, AmmoReadout};
-use super::{
-    get_health_percentage, get_psi_percentage, get_wielded_ammo, get_wielded_psi_charge,
-    get_wielded_psi_power,
-};
+use super::ammo_panel::{self, AmmoReadout, ReadoutButtonSpec};
+use super::{get_health_percentage, get_psi_percentage, get_wielded_psi_charge};
 use crate::runtime_props::{PsiChargePhase, RuntimePropPsiCharge};
 use crate::ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign};
 
@@ -68,11 +65,9 @@ const AMMO_GAUGE: Rect = Rect::new(AMMO_X, AMMO_Y, AMMO_W, AMMO_H);
 //    the left crop of BIOFULL.PCX, so the bars/numbers land identically). The
 //    right half is baked research/query/map + nanite/cyber chrome (art stub).
 //  - AMMOFULL: use ("mouse") mode expands the ammo panel LEFT by
-//    166 (AMMOBACK 94 -> AMMOFULL 260), UL = (378,414); the
-//    ammo-type CYCLE button is {{186,15},{198,56}} panel-local
-//    (art ammoarw0/1), i.e. canvas (564,429,12,41). The round count/icon stay
-//    in the panel's right gauge (the AMMOBACK footprint), so their compact
-//    offsets are reused.
+//    166 (AMMOBACK 94 -> AMMOFULL 260), UL = (378,414). Everything inside the
+//    panel - the readout and its SETTING / RELOAD / ammo-cycle / psi-selector
+//    buttons - is laid out once in `ammo_panel` in panel pixels.
 const METERS_FULL_W: f32 = 260.0;
 const AMMO_FULL_MODE_DX: f32 = 166.0;
 const AMMO_FULL_X: f32 = AMMO_X - AMMO_FULL_MODE_DX; // 378
@@ -83,11 +78,6 @@ const AMMO_FULL_GAUGE: Rect = Rect::new(AMMO_FULL_X, AMMO_Y, METERS_FULL_W, AMMO
 /// panel pixels and placed relative to this - the VR forearm draws the same
 /// panel with its own origin.
 const AMMO_PANEL_ORIGIN: Vector2<f32> = vec2(AMMO_FULL_X, AMMO_Y);
-/// The AMMOFULL ammo-type cycle button (the original's cycle hotspot, ammoarw
-/// art). Clicking it cycles the wielded weapon's ammo type. Exposed so the
-/// flat pointer host can hit-test the same rect it is drawn at.
-pub(crate) const AMMO_CYCLE_BUTTON: Rect =
-    ammo_panel::at(AMMO_PANEL_ORIGIN, ammo_panel::CYCLE_BUTTON);
 
 // Psi overload meter - drawn center-screen below the crosshair while the psi
 // amp's trigger is held on an overloadable power (and briefly after release,
@@ -209,54 +199,49 @@ pub(crate) fn create_flat_hud(
         get_health_percentage(world),
         get_psi_percentage(world),
         get_wielded_psi_charge(world),
-        // The same predicate the pointer hit-test uses, so drawn == clickable.
-        &AmmoReadout::from_world(world, ammo_cycle_button_visible(world, use_mode)),
+        // The buttons are drawn exactly when the pointer can reach them - use
+        // mode - and the hit-test below reads the same readout.
+        &AmmoReadout::from_world(world, use_mode),
     );
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
 }
 
-/// Whether the wielded weapon may cycle ammo (2+ selectable projectile types,
-/// and a magazine that can be ejected if it is loaded). Uses the same predicate
-/// as `cycle_ammo`.
-pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
-    let Some(weapon) = crate::wielded_weapon::wielded_weapon(world) else {
-        return false;
-    };
-    crate::scripts::script_util::can_cycle_ammo(world, weapon)
-}
-
-/// The single source of truth for whether the AMMOFULL ammo-cycle button is
-/// shown/active this frame - used for BOTH rendering (via `create_flat_hud`'s
-/// `can_cycle_ammo`) and pointer hit-testing (`mission_core`), so the drawn and
-/// clickable regions never diverge. Requires use mode, a wielded gun that may
-/// cycle (2+ ammo types, and an ejectable magazine when loaded), and no psi-amp
-/// display (which replaces the ammo section - `build_flat_hud_canvas`'s
-/// psi-power early return).
-pub(crate) fn ammo_cycle_button_visible(world: &World, use_mode: bool) -> bool {
-    use_mode
-        && get_wielded_psi_power(world).is_none()
-        && get_wielded_ammo(world).is_some()
-        && can_cycle_wielded_ammo(world)
+/// The readout's clickable buttons this frame, on the 640x480 HUD canvas.
+///
+/// The single source of truth for BOTH rendering and pointer hit-testing: the
+/// rects come from the shared `ammo_panel` layout that drew them, mapped
+/// through the same panel origin, so the drawn and clickable regions cannot
+/// diverge.
+pub(crate) fn readout_buttons(world: &World, use_mode: bool) -> Vec<ReadoutButtonSpec> {
+    ammo_panel::buttons(&AmmoReadout::from_world(world, use_mode))
+        .into_iter()
+        .map(|spec| ReadoutButtonSpec {
+            rect: ammo_panel::at(AMMO_PANEL_ORIGIN, spec.rect),
+            ..spec
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// `AmmoReadout` for the common test shapes.
+    /// `AmmoReadout` for the common test shapes. `cycle` stands in for a
+    /// multi-ammo weapon; nothing else offers a button.
     fn readout(
         ammo: Option<i32>,
         ammo_icon: Option<&str>,
         ammo_type: Option<&str>,
-        show_cycle_button: bool,
+        cycle: bool,
     ) -> AmmoReadout {
         AmmoReadout {
-            psi_power: None,
             ammo,
             ammo_icon: ammo_icon.map(str::to_string),
             ammo_type: ammo_type.map(str::to_string),
-            show_cycle_button,
+            can_cycle_ammo: cycle,
+            show_buttons: cycle,
+            ..Default::default()
         }
     }
 
@@ -304,8 +289,8 @@ mod tests {
 
     #[test]
     fn psi_amp_shows_discipline_instead_of_clip() {
-        // Base 6 + gauge backdrop + tier badge + tier count + name = 10;
-        // the clip readout is suppressed even though the amp has ammo=0.
+        // Base 6 + gauge backdrop + tier badge + discipline name = 9; the clip
+        // readout is suppressed even though the amp has ammo=0.
         let canvas = build_flat_hud_canvas(
             true,
             false,
@@ -318,14 +303,14 @@ mod tests {
                 ..Default::default()
             },
         );
-        assert_eq!(canvas.element_count(), 10);
+        assert_eq!(canvas.element_count(), 9);
     }
 
     #[test]
     fn use_mode_expands_readouts_and_adds_the_ammo_cycle_button() {
         // Shooter with a multi-ammo weapon: crosshair + bio + 2 bars + 2
-        // numbers + ammo backdrop + count = 8; NO cycle button (the caller
-        // gates it on use mode, see `ammo_cycle_button_visible`).
+        // numbers + ammo backdrop + count = 8; NO cycle button (the pointer
+        // cannot reach it outside use mode).
         let shooter = build_flat_hud_canvas(
             true,
             false,
@@ -359,44 +344,43 @@ mod tests {
         assert_eq!(single_ammo.element_count(), 7);
     }
 
+    /// Every control the layout offers is inside the expanded AMMOFULL gauge,
+    /// which is the only backdrop that is up while they are clickable.
     #[test]
-    fn ammo_cycle_button_sits_in_the_ammofull_panel() {
-        // The cycle button (the original's cycle hotspot) is inside the expanded
-        // AMMOFULL gauge and left of the compact AMMOBACK footprint.
-        assert!(AMMO_FULL_GAUGE.x <= AMMO_CYCLE_BUTTON.x);
-        assert!(AMMO_CYCLE_BUTTON.x + AMMO_CYCLE_BUTTON.w <= AMMO_FULL_GAUGE.x + AMMO_FULL_GAUGE.w);
+    fn every_readout_button_sits_in_the_ammofull_panel() {
+        for rect in [
+            ammo_panel::CYCLE_BUTTON,
+            ammo_panel::SETTING_BUTTON,
+            ammo_panel::RELOAD_BUTTON,
+            ammo_panel::PSI_TIER_PREV,
+            ammo_panel::PSI_TIER_NEXT,
+            ammo_panel::PSI_POWER_PREV,
+            ammo_panel::PSI_POWER_NEXT,
+        ] {
+            let placed = ammo_panel::at(AMMO_PANEL_ORIGIN, rect);
+            assert!(AMMO_FULL_GAUGE.x <= placed.x, "{placed:?}");
+            assert!(placed.x + placed.w <= AMMO_FULL_GAUGE.x + AMMO_FULL_GAUGE.w);
+        }
     }
 
-    /// The shared panel layout must keep landing where the flat HUD authored
-    /// it: the ammo readout moved into `ammo_panel` in panel-local pixels, and
-    /// these are the absolute canvas rects it replaced.
+    /// The readout proper stays inside the COMPACT gauge too, so shooter mode
+    /// is not drawing half the readout onto bare 3D view.
     #[test]
-    fn shared_panel_layout_reproduces_the_authored_flat_rects() {
-        let placed = |rect| ammo_panel::at(AMMO_PANEL_ORIGIN, rect);
-        assert_eq!(
-            placed(ammo_panel::CYCLE_BUTTON),
-            Rect::new(564.0, 429.0, 12.0, 41.0)
-        );
-        assert_eq!(
-            placed(ammo_panel::COUNT),
-            Rect::new(544.0, 436.0, 94.0, 20.0)
-        );
-        assert_eq!(
-            placed(ammo_panel::ICON),
-            Rect::new(504.0, 430.0, 32.0, 32.0)
-        );
-        assert_eq!(
-            placed(ammo_panel::TYPE_LABEL),
-            Rect::new(544.0, 458.0, 94.0, 16.0)
-        );
-        assert_eq!(
-            placed(ammo_panel::PSI_TIER_BADGE),
-            Rect::new(500.0, 436.0, 32.0, 19.0)
-        );
-        assert_eq!(
-            placed(ammo_panel::PSI_POWER_NAME),
-            Rect::new(484.0, 458.0, 154.0, 16.0)
-        );
+    fn the_readout_sits_inside_the_compact_gauge() {
+        for rect in [
+            ammo_panel::COUNT,
+            ammo_panel::ICON,
+            ammo_panel::TYPE_LABEL,
+            ammo_panel::PSI_TIER_BADGE,
+            ammo_panel::PSI_POWER_NAME,
+        ] {
+            let placed = ammo_panel::at(AMMO_PANEL_ORIGIN, rect);
+            assert!(AMMO_GAUGE.x <= placed.x, "{placed:?} left of AMMOBACK");
+            assert!(
+                placed.x + placed.w <= AMMO_GAUGE.x + AMMO_GAUGE.w,
+                "{placed:?} right of AMMOBACK"
+            );
+        }
     }
 
     #[test]

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -1,3 +1,6 @@
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{Unique, UniqueView, World};
+
 mod damage_flash;
 pub use damage_flash::*;
 
@@ -11,3 +14,46 @@ pub(crate) mod ammo_panel;
 
 mod flat_hud;
 pub(crate) use flat_hud::*;
+
+/// The English fallback for the reload button, verbatim from the shipped
+/// MISC.STR, for a data install that lacks the table.
+const FALLBACK_RELOAD_LABEL: &str = "RELOAD";
+
+/// HUD label strings preloaded from MISC.STR, stored as a world `Unique`
+/// because the readout layout has no `AssetCache` at draw time (the
+/// `ElevatorContext` pattern).
+#[derive(Unique, Clone, Debug)]
+pub struct HudStrings {
+    /// MISC.STR `Reload` ("RELOAD"), the AMMOFULL reload button's label.
+    pub reload_label: String,
+}
+
+impl Default for HudStrings {
+    fn default() -> Self {
+        Self {
+            reload_label: FALLBACK_RELOAD_LABEL.to_owned(),
+        }
+    }
+}
+
+impl HudStrings {
+    pub fn load(asset_cache: &mut AssetCache) -> HudStrings {
+        let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "misc.str");
+        HudStrings {
+            reload_label: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "reload",
+                FALLBACK_RELOAD_LABEL,
+            ),
+        }
+    }
+}
+
+/// The preloaded HUD strings, or the English defaults in a world that has none
+/// (the unit-test worlds, and any scene loaded without a strings table).
+pub(crate) fn hud_strings(world: &World) -> HudStrings {
+    world
+        .borrow::<UniqueView<HudStrings>>()
+        .map(|s| s.clone())
+        .unwrap_or_default()
+}

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -452,8 +452,11 @@ fn create_ammo_forearm_panel(
         Handedness::Right,
     )];
 
-    // No cycle affordance on the forearm: nothing points at this panel yet, and
-    // drawing a button nobody can press would be a lie.
+    // No controls on the forearm: the VR pointer only hits the cyber-interface
+    // panel, never this quad, so drawing a SETTING/RELOAD/cycle button nobody
+    // can press would be a lie. The readout itself is placed identically to
+    // flat's (AGENTS.md section 3) - only the interactive layer differs, and
+    // it differs by whether a pointer can reach it, not by presentation.
     let readout = ammo_panel::AmmoReadout::from_world(world, false);
     objects.append(
         &mut ammo_panel::build_readout_canvas(&readout).render_world_space(

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -106,7 +106,10 @@ impl ActionDispatcher {
             effects.push(Effect::ReloadWeapon);
         }
         if state.just_triggered(InputAction::CyclePsiPower) {
-            effects.push(Effect::CyclePsiPower);
+            effects.push(Effect::StepPsiSelection {
+                axis: crate::psi::PsiSelectionAxis::Any,
+                forward: true,
+            });
         }
         if state.just_triggered(InputAction::DebugReloadLevel) {
             effects.push(Effect::GlobalEffect(GlobalEffect::TestReload));

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -27,6 +27,7 @@ use shipyard::{EntitiesView, EntityId, Get, UniqueView, View, World};
 
 use crate::{
     gui::GuiComponentRenderInfo,
+    hud::ammo_panel::{ReadoutButton, ReadoutButtonSpec},
     input_context::Pointer2D,
     mission::PlayerInfo,
     scripts::{Message, MessagePayload},
@@ -77,10 +78,10 @@ const CURSOR_SIZE: Vector2<f32> = Vector2::new(12.0, 16.0);
 pub enum FlatUiDragAction {
     Throw(EntityId),
     Wield(EntityId),
-    /// Cycle the wielded weapon's ammo type (the AMMOFULL cycle button
-    /// was clicked). Not tied to a cursor item - the caller maps it to
-    /// `Effect::CycleAmmo`, which acts on the wielded weapon.
-    CycleAmmo,
+    /// One of the AMMOFULL readout's controls was clicked (fire-mode setting,
+    /// reload, ammo cycle, psi selector). Not tied to a cursor item - the
+    /// caller maps it to the effect that acts on the wielded weapon.
+    Readout(ReadoutButton),
 }
 
 /// Double-click window (frames at 60Hz) and radius (canvas px) for the
@@ -213,10 +214,10 @@ pub struct FlatUiHost {
     /// The most recent lift, for double-click (wield) detection. Counts down
     /// each frame and clears when the window elapses.
     last_lift: Option<LiftMark>,
-    /// The AMMOFULL ammo-cycle button rect on the 640x480 canvas, set each
-    /// frame by the mission when use mode has a multi-ammo weapon wielded
-    /// (flat UI 5); `None` otherwise. Clicking it emits `CycleAmmo`.
-    ammo_cycle_rect: Option<Rect>,
+    /// The AMMOFULL readout's clickable controls on the 640x480 canvas, set
+    /// each frame by the mission from the same shared layout that drew them
+    /// (empty outside use mode). Clicking one emits `FlatUiDragAction::Readout`.
+    readout_buttons: Vec<ReadoutButtonSpec>,
     /// The active panel was opened unbound (the automap): it has no world
     /// object, so the walk-away distance auto-close is skipped. Cleared on
     /// open/close.
@@ -259,7 +260,7 @@ impl FlatUiHost {
             strip: None,
             cursor_item: None,
             last_lift: None,
-            ammo_cycle_rect: None,
+            readout_buttons: Vec::new(),
             sticky_panel: false,
             cursor_canvas: None,
             hover_close: false,
@@ -351,26 +352,36 @@ impl FlatUiHost {
         self.last_pointer_pressed = true;
     }
 
-    /// Set (or clear) the AMMOFULL ammo-cycle button's canvas rect for this
-    /// frame. The mission passes `Some(rect)` only in use mode with a
-    /// multi-ammo weapon wielded, matching what the flat HUD draws.
-    pub fn set_ammo_cycle_button(&mut self, rect: Option<Rect>) {
-        self.ammo_cycle_rect = rect;
+    /// Set the AMMOFULL readout's clickable controls for this frame. The
+    /// mission passes exactly what the flat HUD drew, so a control is
+    /// clickable if and only if it is on screen.
+    pub fn set_readout_buttons(&mut self, buttons: Vec<ReadoutButtonSpec>) {
+        self.readout_buttons = buttons;
     }
 
-    /// The ammo-cycle button as a `/v1/ui` element (so tests click it by
-    /// meaning), or `None` when it is not shown.
-    pub fn ammo_cycle_debug(&self) -> Option<crate::game_scene::DebugUiElement> {
-        self.ammo_cycle_rect
-            .map(|r| crate::game_scene::DebugUiElement {
+    /// The readout's controls as `/v1/ui` elements (so tests click them by
+    /// meaning), empty when none are shown.
+    pub fn readout_buttons_debug(&self) -> Vec<crate::game_scene::DebugUiElement> {
+        self.readout_buttons
+            .iter()
+            .map(|spec| crate::game_scene::DebugUiElement {
                 kind: "button".to_string(),
-                texture: Some("ammoarw0.pcx".to_string()),
-                text: None,
-                label: Some("cycle_ammo".to_string()),
+                texture: spec.texture.map(str::to_string),
+                text: spec.text.clone(),
+                label: Some(spec.button.label().to_string()),
                 entity_id: None,
-                rect: [r.x, r.y, r.w, r.h],
-                screen_rect: self.to_screen_rect(r),
+                rect: [spec.rect.x, spec.rect.y, spec.rect.w, spec.rect.h],
+                screen_rect: self.to_screen_rect(spec.rect),
             })
+            .collect()
+    }
+
+    /// The ammo-cycle control specifically, kept as its own `/v1/ui` field
+    /// because clients grew up on it before the readout gained the rest.
+    pub fn ammo_cycle_debug(&self) -> Option<crate::game_scene::DebugUiElement> {
+        self.readout_buttons_debug()
+            .into_iter()
+            .find(|element| element.label.as_deref() == Some(ReadoutButton::CycleAmmo.label()))
     }
 
     /// Take the item off the cursor (clearing it), returning its entity id.
@@ -669,10 +680,12 @@ impl FlatUiHost {
         let over_panel = panel_rect
             .map(|r| r.contains(canvas_pos) || close_button_canvas_rect(r).contains(canvas_pos))
             .unwrap_or(false);
-        let over_ammo = self
-            .ammo_cycle_rect
-            .map(|r| r.contains(canvas_pos))
-            .unwrap_or(false);
+        let readout_hit = self
+            .readout_buttons
+            .iter()
+            .find(|spec| spec.rect.contains(canvas_pos))
+            .map(|spec| spec.button);
+        let over_ammo = readout_hit.is_some();
 
         // --- Cursor-is-the-item drag: while an item rides the cursor, LMB
         // places/swaps/throws it and never routes to a GuiScript (protecting
@@ -726,8 +739,8 @@ impl FlatUiHost {
                 return (Vec::new(), Vec::new());
             }
             if over_panel || over_ammo || pointer.bare_view == BareViewPress::Ignore {
-                // Escape hatch: a click on an open MFD or the AMMOFULL cycle
-                // button keeps the held item (a visible button must not throw
+                // Escape hatch: a click on an open MFD or an AMMOFULL readout
+                // control keeps the held item (a visible button must not throw
                 // the item you're carrying) - and so does empty panel space in
                 // VR, where there is no 3D view behind the canvas to throw at.
                 return (Vec::new(), Vec::new());
@@ -738,15 +751,13 @@ impl FlatUiHost {
             return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
         }
 
-        // --- AMMOFULL ammo-cycle button (use mode, multi-ammo weapon): a
-        // click cycles the wielded ammo type. Checked with an empty cursor
-        // only (mid-drag, a bottom-right click is a throw), before strip/panel
-        // routing since the button is disjoint from both. ---
+        // --- AMMOFULL readout controls (use mode): a click acts on the
+        // wielded weapon. Checked with an empty cursor only (mid-drag, a
+        // bottom-right click is a throw), before strip/panel routing since the
+        // controls are disjoint from both. ---
         if pressed_edge {
-            if let Some(rect) = self.ammo_cycle_rect {
-                if rect.contains(canvas_pos) {
-                    return (Vec::new(), vec![FlatUiDragAction::CycleAmmo]);
-                }
+            if let Some(button) = readout_hit {
+                return (Vec::new(), vec![FlatUiDragAction::Readout(button)]);
             }
         }
 
@@ -2005,24 +2016,61 @@ mod tests {
         assert_eq!(host.strip_item_at(vec2(58.5, 34.0)), None);
     }
 
+    /// The AMMOFULL readout controls as the flat HUD places them on the canvas.
+    fn readout_fixture() -> Vec<ReadoutButtonSpec> {
+        vec![
+            ReadoutButtonSpec {
+                button: ReadoutButton::CycleAmmo,
+                rect: Rect::new(564.0, 429.0, 12.0, 41.0),
+                texture: Some("ammoarw0.pcx"),
+                text: None,
+            },
+            ReadoutButtonSpec {
+                button: ReadoutButton::GunSetting,
+                rect: Rect::new(496.0, 429.0, 66.0, 20.0),
+                texture: None,
+                text: Some("NORM".to_string()),
+            },
+        ]
+    }
+
     #[test]
-    fn clicking_the_ammo_cycle_button_emits_cycle_ammo() {
+    fn clicking_a_readout_button_emits_its_action() {
         let (world, mut host, _wrench, _inv) = drag_world();
-        // The AMMOFULL cycle button lives at canvas (564,429,12,41).
-        host.set_ammo_cycle_button(Some(Rect::new(564.0, 429.0, 12.0, 41.0)));
-        // A click on its center (570, 449) cycles the ammo.
+        host.set_readout_buttons(readout_fixture());
+        // A click on the cycle arrow's center (570, 449) cycles the ammo.
         let actions = press_edge(&mut host, &world, (570.0, 449.0));
-        assert_eq!(actions, vec![FlatUiDragAction::CycleAmmo]);
-        // The /v1/ui element is exposed with a clickable label.
-        let el = host.ammo_cycle_debug().expect("the button is exposed");
+        assert_eq!(
+            actions,
+            vec![FlatUiDragAction::Readout(ReadoutButton::CycleAmmo)]
+        );
+        // ...and one on the SETTING button switches the fire mode.
+        let actions = press_edge(&mut host, &world, (529.0, 439.0));
+        assert_eq!(
+            actions,
+            vec![FlatUiDragAction::Readout(ReadoutButton::GunSetting)]
+        );
+        // The /v1/ui elements are exposed with clickable labels, and the
+        // setting button carries the mode header it is drawn with.
+        let elements = host.readout_buttons_debug();
+        assert_eq!(
+            elements
+                .iter()
+                .map(|e| e.label.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["cycle_ammo", "gun_setting"]
+        );
+        assert_eq!(elements[1].text.as_deref(), Some("NORM"));
+        assert!(elements.iter().all(|e| e.kind == "button"));
+        let el = host.ammo_cycle_debug().expect("the arrow is exposed");
         assert_eq!(el.label.as_deref(), Some("cycle_ammo"));
-        assert_eq!(el.kind, "button");
         // A click elsewhere in the bare view does not cycle.
         let actions = press_edge(&mut host, &world, (300.0, 300.0));
         assert!(actions.is_empty());
         // Cleared when not shown.
-        host.set_ammo_cycle_button(None);
+        host.set_readout_buttons(Vec::new());
         assert!(host.ammo_cycle_debug().is_none());
+        assert!(host.readout_buttons_debug().is_empty());
     }
 
     #[test]
@@ -2031,7 +2079,7 @@ mod tests {
         // the ammo-cycle button mid-drag protects the held item (no throw, no
         // cycle) rather than treating it as a bare-view throw.
         let (world, mut host, _wrench, _inv) = drag_world();
-        host.set_ammo_cycle_button(Some(Rect::new(564.0, 429.0, 12.0, 41.0)));
+        host.set_readout_buttons(readout_fixture());
         press_edge(&mut host, &world, (23.5, 34.0)); // lift the Wrench
         assert!(host.cursor_debug().is_some());
         let actions = press_edge(&mut host, &world, (570.0, 449.0)); // click the ammo button

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2185,6 +2185,7 @@ impl MissionCore {
 
         // Preload the elevator floor labels (MISC.STR) + current mission so the
         // AssetCache-less ElevatorGui can label/gate floors at draw time.
+        world.add_unique(crate::hud::HudStrings::load(asset_cache));
         world.add_unique(crate::scripts::ElevatorContext::load(asset_cache, &mission));
         world.add_unique(crate::scripts::gui::TraitsContext::load(asset_cache));
         world.add_unique(crate::scripts::gui::ComputerContext::load(asset_cache));
@@ -3381,17 +3382,11 @@ impl MissionCore {
         // processed this frame.
         let (ui_messages, ui_drag_actions) = match game_options.presentation_mode {
             crate::PresentationMode::Flat => {
-                // Expose the AMMOFULL ammo-cycle button for hit-testing exactly
-                // when the flat HUD draws it (the shared visibility predicate,
-                // so the clickable rect never diverges from the rendered
-                // button).
-                let ammo_button =
-                    if crate::hud::ammo_cycle_button_visible(&self.world, self.use_mode) {
-                        Some(crate::hud::AMMO_CYCLE_BUTTON)
-                    } else {
-                        None
-                    };
-                self.flat_ui.set_ammo_cycle_button(ammo_button);
+                // Expose the AMMOFULL readout's controls for hit-testing from
+                // the same shared layout that drew them, so a clickable rect
+                // can never diverge from a rendered button.
+                self.flat_ui
+                    .set_readout_buttons(crate::hud::readout_buttons(&self.world, self.use_mode));
                 self.flat_ui.update(&self.world, input_context.pointer)
             }
             // The cyber interface's pointer bridge: the controller ray's canvas
@@ -4636,9 +4631,23 @@ impl MissionCore {
                 self.throw_entity_into_world(entity_id);
                 Vec::new()
             }
-            // The AMMOFULL cycle button: advance the wielded weapon's ammo type
-            // via the same effect as the CycleAmmo key/action.
-            FlatUiDragAction::CycleAmmo => vec![Effect::CycleAmmo],
+            // The AMMOFULL readout's controls emit the same effects as their
+            // keyboard/action counterparts, so the button and the key are one
+            // behavior.
+            FlatUiDragAction::Readout(button) => {
+                use crate::hud::ammo_panel::ReadoutButton;
+                use crate::psi::PsiSelectionAxis;
+                let step = |axis, forward| vec![Effect::StepPsiSelection { axis, forward }];
+                match button {
+                    ReadoutButton::CycleAmmo => vec![Effect::CycleAmmo],
+                    ReadoutButton::GunSetting => vec![Effect::CycleGunSetting],
+                    ReadoutButton::Reload => vec![Effect::ReloadWeapon],
+                    ReadoutButton::PsiTierPrev => step(PsiSelectionAxis::Tier, false),
+                    ReadoutButton::PsiTierNext => step(PsiSelectionAxis::Tier, true),
+                    ReadoutButton::PsiPowerPrev => step(PsiSelectionAxis::Power, false),
+                    ReadoutButton::PsiPowerNext => step(PsiSelectionAxis::Power, true),
+                }
+            }
             // Double-click = equip/use, acting on the still-contained item -
             // identical to the ContainerGui backpack click (shared weapon test,
             // shared effects): a weapon (gun or melee) wields via `GrabEntity`
@@ -5815,7 +5824,7 @@ impl MissionCore {
                     }
                 }
 
-                Effect::CyclePsiPower => {
+                Effect::StepPsiSelection { axis, forward } => {
                     let powers = self.world.borrow::<UniqueView<GlobalPsiPowers>>().unwrap();
                     let known = self
                         .world
@@ -5825,19 +5834,14 @@ impl MissionCore {
                         .world
                         .borrow::<UniqueViewMut<PsiPowerSelection>>()
                         .unwrap();
-                    if !powers.0.is_empty() {
-                        // Advance to the next *trained* power, wrapping (at
-                        // most one lap - with a single trained power the lap
-                        // lands back on it, so the selection never moves onto
-                        // an untrained power).
-                        for step in 1..=powers.0.len() {
-                            let index = (selection.index + step) % powers.0.len();
-                            if known.0.contains(&powers.0[index].template_id) {
-                                selection.index = index;
-                                break;
-                            }
-                        }
-                        let power = &powers.0[selection.index];
+                    selection.index = crate::psi::step_selection(
+                        &powers.0,
+                        &known.0,
+                        selection.index,
+                        axis,
+                        forward,
+                    );
+                    if let Some(power) = powers.0.get(selection.index) {
                         game_log!(
                             INFO,
                             "Selected psi power: {} (tier {})",
@@ -10598,7 +10602,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             active_panel,
             strip,
             cursor: self.flat_ui.cursor_debug(),
-            ammo_cycle: self.flat_ui.ammo_cycle_debug(),
+            readout: self.flat_ui.readout_buttons_debug(),
             pointer: self.flat_ui.pointer_debug(),
             // The panel a client aims a controller at, reported straight off
             // the anchor that placed it - so a test cannot aim at a placement

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -138,6 +138,97 @@ pub struct PsiPowerSelection {
     pub index: usize,
 }
 
+/// Which axis of the psi selection a step moves along: the AMMOFULL readout's
+/// tier arrows move between tiers, its power arrows move within one, and the
+/// `CyclePsiPower` key walks every trained power in order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PsiSelectionAxis {
+    Tier,
+    Power,
+    /// Every trained power, tiers included - the single-key cycle.
+    Any,
+}
+
+/// The selection a psi selection step lands on.
+///
+/// `Tier` steps to the next tier that owns a trained power (empty tiers are
+/// skipped) and lands on its first one; `Power` wraps within the current tier;
+/// `Any` walks the whole trained list. All wrap, and all leave the selection
+/// alone when nothing else is trained, so a step can never select a power the
+/// player has not learned.
+pub fn step_selection(
+    powers: &[PsiPowerInfo],
+    known: &HashSet<i32>,
+    index: usize,
+    axis: PsiSelectionAxis,
+    forward: bool,
+) -> usize {
+    let Some(current) = powers.get(index) else {
+        return index;
+    };
+    // `powers` is sorted by (tier, power id), so a tier's trained powers are a
+    // contiguous run and tier order is just the order of the distinct tiers.
+    let trained: Vec<(usize, i32)> = powers
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| known.contains(&p.template_id))
+        .map(|(i, p)| (i, p.power.psi_cost))
+        .collect();
+    if trained.is_empty() {
+        return index;
+    }
+    // The registry holds untrained powers too, and nothing normalizes the
+    // selection when a power is granted - so the selection can be sitting on an
+    // untrained power with no neighbour to step from. Recover onto the first
+    // trained power rather than leaving every step a no-op.
+    if !known.contains(&current.template_id) {
+        return trained[0].0;
+    }
+    let tier = current.power.psi_cost;
+    match axis {
+        PsiSelectionAxis::Any => {
+            let every: Vec<usize> = trained.iter().map(|(i, _)| *i).collect();
+            neighbor(&every, index, forward).unwrap_or(index)
+        }
+        PsiSelectionAxis::Power => {
+            let in_tier: Vec<usize> = trained
+                .iter()
+                .filter(|(_, t)| *t == tier)
+                .map(|(i, _)| *i)
+                .collect();
+            neighbor(&in_tier, index, forward).unwrap_or(index)
+        }
+        PsiSelectionAxis::Tier => {
+            let mut tiers: Vec<i32> = trained.iter().map(|(_, t)| *t).collect();
+            tiers.dedup();
+            let Some(next_tier) = neighbor(&tiers, tier, forward).filter(|next| *next != tier)
+            else {
+                // Only one tier is trained: a tier step has nowhere to go, and
+                // must not quietly behave like a power step.
+                return index;
+            };
+            trained
+                .iter()
+                .find(|(_, t)| *t == next_tier)
+                .map(|(i, _)| *i)
+                .unwrap_or(index)
+        }
+    }
+}
+
+/// The entry after (`forward`) or before `current` in `items`, wrapping.
+/// `None` when `current` is not in `items`.
+fn neighbor<T: Copy + PartialEq>(items: &[T], current: T, forward: bool) -> Option<T> {
+    let at = items.iter().position(|item| *item == current)?;
+    let len = items.len();
+    let next = if forward {
+        (at + 1) % len
+    } else {
+        (at + len - 1) % len
+    };
+    Some(items[next])
+}
+
 /// The psi powers the player has been trained in, by power template id -
 /// the only powers selectable (`Effect::CyclePsiPower`) and castable
 /// (`PsiAmpScript`). Grown at runtime via `Effect::GrantPsiPower`.
@@ -314,6 +405,135 @@ mod tests {
         assert!(learned_bit_set(0, 0b10, 33));
         assert!(learned_bit_set(0, 1 << 7, 39));
         assert!(!learned_bit_set(0, 0, 39));
+    }
+
+    /// A registry in the shape `build_psi_power_registry` produces: sorted by
+    /// (tier, power id). `(template_id, tier)` pairs.
+    fn registry(powers: &[(i32, i32)]) -> Vec<PsiPowerInfo> {
+        powers
+            .iter()
+            .map(|(template_id, tier)| PsiPowerInfo {
+                template_id: *template_id,
+                name: format!("Power {template_id}"),
+                display_name: None,
+                power: PropPsiPower {
+                    power_id: -template_id,
+                    activation_type: 0,
+                    psi_cost: *tier,
+                    data: [0.0; 4],
+                },
+                projectiles: Vec::new(),
+                overloadable: false,
+                duration: None,
+            })
+            .collect()
+    }
+
+    /// Tiers 1, 1, 3 - tier 2 is authored but untrained, so it must be skipped.
+    fn tiered() -> (Vec<PsiPowerInfo>, HashSet<i32>) {
+        let powers = registry(&[(-1, 1), (-2, 1), (-3, 2), (-4, 3), (-5, 3)]);
+        (powers, HashSet::from([-1, -2, -4, -5]))
+    }
+
+    #[test]
+    fn power_arrows_wrap_within_the_current_tier() {
+        let (powers, known) = tiered();
+        let step = |index, forward| {
+            step_selection(&powers, &known, index, PsiSelectionAxis::Power, forward)
+        };
+        assert_eq!(step(0, true), 1);
+        // ...and wraps rather than spilling into the next tier.
+        assert_eq!(step(1, true), 0);
+        assert_eq!(step(0, false), 1);
+        // Tier 3's pair is independent of tier 1's.
+        assert_eq!(step(3, true), 4);
+        assert_eq!(step(4, true), 3);
+    }
+
+    #[test]
+    fn tier_arrows_skip_tiers_with_no_trained_power() {
+        let (powers, known) = tiered();
+        let step = |index, forward| {
+            step_selection(&powers, &known, index, PsiSelectionAxis::Tier, forward)
+        };
+        // Tier 1 -> tier 3: tier 2 is untrained, so it is not a stop.
+        assert_eq!(step(0, true), 3);
+        // ...and back again, wrapping.
+        assert_eq!(step(3, true), 0);
+        assert_eq!(step(0, false), 3);
+        // A tier step lands on that tier's FIRST trained power, not the one at
+        // the same offset.
+        assert_eq!(step(4, true), 0);
+    }
+
+    #[test]
+    fn a_selection_sitting_on_an_untrained_power_recovers() {
+        // The registry holds every power, trained or not, and the default
+        // selection is index 0 - so a player whose training starts at tier 3
+        // begins on an untrained power. Both axes must escape it, not stall.
+        let (powers, _) = tiered();
+        let known = HashSet::from([-4, -5]);
+        for axis in [
+            PsiSelectionAxis::Tier,
+            PsiSelectionAxis::Power,
+            PsiSelectionAxis::Any,
+        ] {
+            assert_eq!(
+                step_selection(&powers, &known, 0, axis, true),
+                3,
+                "{axis:?} should recover onto the first trained power"
+            );
+        }
+    }
+
+    #[test]
+    fn an_arrow_never_selects_an_untrained_power() {
+        let (powers, _) = tiered();
+        // Only the tier-1 pair is trained: both axes stay inside it.
+        let known = HashSet::from([-1, -2]);
+        for axis in [PsiSelectionAxis::Tier, PsiSelectionAxis::Power] {
+            for forward in [true, false] {
+                let next = step_selection(&powers, &known, 0, axis, forward);
+                assert!(
+                    known.contains(&powers[next].template_id),
+                    "{axis:?}/{forward} selected an untrained power"
+                );
+            }
+        }
+        // A lone trained power has nowhere to go, on any axis.
+        let single = HashSet::from([-1]);
+        for axis in [
+            PsiSelectionAxis::Tier,
+            PsiSelectionAxis::Power,
+            PsiSelectionAxis::Any,
+        ] {
+            assert_eq!(
+                step_selection(&powers, &single, 0, axis, true),
+                0,
+                "{axis:?}"
+            );
+        }
+        // Nor does a tier step become a power step when the trained powers all
+        // share one tier.
+        let one_tier = HashSet::from([-1, -2]);
+        assert_eq!(
+            step_selection(&powers, &one_tier, 1, PsiSelectionAxis::Tier, true),
+            1,
+            "one trained tier means the tier arrow is inert"
+        );
+    }
+
+    #[test]
+    fn an_empty_or_out_of_range_selection_is_left_alone() {
+        let (powers, known) = tiered();
+        assert_eq!(
+            step_selection(&powers, &known, 99, PsiSelectionAxis::Tier, true),
+            99
+        );
+        assert_eq!(
+            step_selection(&[], &known, 0, PsiSelectionAxis::Power, true),
+            0
+        );
     }
 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -320,10 +320,14 @@ pub enum Effect {
         location: i32,
     },
 
-    /// Select the player's next *trained* psi power (advances
-    /// `PsiPowerSelection` through the `GlobalPsiPowers` registry, wrapping,
-    /// skipping powers not in `PlayerPsiKnownPowers`).
-    CyclePsiPower,
+    /// Step the psi selection one place along an axis, skipping powers not in
+    /// `PlayerPsiKnownPowers` and wrapping. `Any` is the single-key cycle
+    /// (`InputAction::CyclePsiPower`); `Tier`/`Power` are the AMMOFULL
+    /// readout's four arrows. See [`crate::psi::step_selection`].
+    StepPsiSelection {
+        axis: crate::psi::PsiSelectionAxis,
+        forward: bool,
+    },
 
     /// Train the player in a psi power (insert its template id into
     /// `PlayerPsiKnownPowers`), making it selectable and castable - for

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -135,7 +135,7 @@ impl Script for PsiAmpScript {
                 // The selection changed mid-hold: the bar wasn't timed for
                 // the now-selected power, so the charge fizzles. (A cycle
                 // and a release landing on the SAME frame still cast the
-                // held power - CyclePsiPower is an effect applied after
+                // held power - the selection step is an effect applied after
                 // message dispatch - which matches the player's intent: they
                 // charged that power the whole hold.)
                 if selected_power(world).map(|p| p.template_id) != Some(power_template_id) {
@@ -289,7 +289,7 @@ fn burnout(world: &World, amp_entity: EntityId) -> Effect {
 }
 
 /// Whether the player has been trained in the power. Selection gating
-/// (`Effect::CyclePsiPower`) means an untrained power should never be
+/// (`Effect::StepPsiSelection`) means an untrained power should never be
 /// selected; this is the belt-and-braces check on the cast paths. Fails
 /// closed: the unique is seeded unconditionally at mission load, so a
 /// missing one is a setup bug - don't let it disable the gate.

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -67,6 +67,14 @@ fn is_weapon(world: &World, entity: EntityId) -> bool {
     is_psi_amp(world, entity)
 }
 
+/// Whether `entity` is an energy weapon - one that recharges instead of taking
+/// clips, so it offers no reload control. Identified by the `EnergyWeapon`
+/// script the `Energy` archetype hands down, which is the thing that makes it
+/// rechargeable.
+pub(crate) fn is_energy_weapon(world: &World, entity: EntityId) -> bool {
+    crate::scripts::script_util::entity_has_script(world, entity, "energyweapon")
+}
+
 /// Whether `entity`'s template carries the `weapontype psiamp` class tag.
 pub(crate) fn is_psi_amp(world: &World, entity: EntityId) -> bool {
     let Some(template_id) = crate::scripts::script_util::entity_class_template_id(world, entity)

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -786,12 +786,13 @@ export interface UiState {
   /** The item held on the cursor mid-drag, or null when the cursor is empty. */
   cursor: UiCursor | null;
   /**
-   * The AMMOFULL ammo-type cycle button, exposed only in use mode when a gun
-   * with 2+ ammo types is wielded (the expanded weapon panel, flat UI 5).
-   * Click its `screen_rect` center to cycle the wielded weapon's ammo type
-   * (Effect::CycleAmmo). null in shooter mode / unarmed / single-ammo weapons.
+   * Every AMMOFULL readout control shown this frame, labeled by meaning:
+   * `gun_setting` (its `text` is the current fire-mode header), `reload`,
+   * `cycle_ammo`, and the psi selector's `psi_tier_prev`/`psi_tier_next`/
+   * `psi_power_prev`/`psi_power_next`. Empty outside use mode. Click a
+   * control's `screen_rect` center to invoke it.
    */
-  ammo_cycle: UiElement | null;
+  readout: UiElement[];
   /**
    * Where the pointer last landed on the shared canvas: the mouse on flat, the
    * controller ray on the VR cyber-interface panel. null when nothing is

--- a/tools/shock2-sdk/test/ammo-readout.e2e.test.ts
+++ b/tools/shock2-sdk/test/ammo-readout.e2e.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, type UiElement } from "../src/index.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { ammoOf, cycleToWeapon, fireOnce } from "./helpers/weapon.js";
+
+// End-to-end coverage for the use-mode AMMOFULL readout's controls.
+//
+// The original's expanded weapon panel carries three gun controls - a SETTING
+// button labeled with the current fire mode, a RELOAD button, and the ammo-type
+// cycle arrow - and swaps all three for the psi amp's four selector arrows.
+// They are exposed over `/v1/ui` as the `readout` list, labeled by meaning, and
+// clicking one does exactly what its keyboard action does.
+//
+// Negative-first: on the base branch `/v1/ui` has no `readout` field and only
+// the ammo-cycle arrow exists, so every assertion below fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The readout's controls this frame, by label. */
+async function readout(game: GameServer): Promise<UiElement[]> {
+  return (await game.ui.state()).readout ?? [];
+}
+
+async function button(game: GameServer, label: string): Promise<UiElement> {
+  const found = (await readout(game)).find((e) => e.label === label);
+  assert.ok(
+    found,
+    `expected a "${label}" readout control (got ${JSON.stringify(
+      (await readout(game)).map((e) => e.label),
+    )})`,
+  );
+  return found;
+}
+
+async function labels(game: GameServer): Promise<string[]> {
+  return (await readout(game)).map((e) => e.label ?? "");
+}
+
+test(
+  "the setting button is labeled with the fire mode and clicking it switches modes",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    // Shooter mode has no readout controls at all - the pointer is not up.
+    assert.deepEqual(await labels(game), [], "shooter mode exposes no controls");
+
+    // The pistol is the first weapon DebugCycleWeapon hands out.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    // Every gun control the pistol offers, in panel order.
+    assert.deepEqual(await labels(game), ["gun_setting", "reload", "cycle_ammo"]);
+
+    const before = (await game.info()).player;
+    const setting = await button(game, "gun_setting");
+    assert.equal(
+      setting.text,
+      before.wielded_gun_setting_header,
+      "the button is labeled with the mode the gun is actually in",
+    );
+    assert.equal(setting.text, "NORM");
+
+    await clickUiElement(game, setting);
+    const after = (await game.info()).player;
+    assert.equal(after.wielded_gun_setting, 1, "the click switched the fire mode");
+    assert.equal(after.wielded_gun_setting_header, "BURST");
+    // ...and the button now says so.
+    assert.equal((await button(game, "gun_setting")).text, "BURST");
+
+    // There are only two modes: clicking again comes back.
+    await clickUiElement(game, await button(game, "gun_setting"));
+    assert.equal((await game.info()).player.wielded_gun_setting_header, "NORM");
+  },
+);
+
+test(
+  "the reload button reloads the wielded gun",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const pistol = await cycleToWeapon(game, (e) => (e.name ?? "") === "Pistol");
+    // Stock the backpack so a reload has something to draw on.
+    const clip = (await game.entities.list({ filter: "Standard Clip", limit: 20 })).entities.find(
+      (e) => (e.name ?? "") === "Standard Clip",
+    );
+    assert.ok(clip, "debug_weapons stocks a Standard Clip");
+    await game.player.give(clip.id);
+
+    // Spend a couple of rounds so a reload is observable.
+    await fireOnce(game);
+    await fireOnce(game);
+    const spent = ammoOf(await game.entities.detail(pistol.id));
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    await clickUiElement(game, await button(game, "reload"));
+    await game.step({ frames: 10 });
+
+    assert.ok(
+      ammoOf(await game.entities.detail(pistol.id)) > spent,
+      "clicking RELOAD should top the magazine back up",
+    );
+  },
+);
+
+test(
+  "an energy weapon keeps its setting button but shows no reload or ammo cycle",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    await cycleToWeapon(game, (e) => (e.name ?? "") === "Laser Pistol");
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    // The laser recharges and fires one projectile type, but it still has an
+    // overcharge mode to switch into.
+    assert.deepEqual(await labels(game), ["gun_setting"]);
+    const setting = await button(game, "gun_setting");
+    assert.ok(setting.text, "the laser names its fire mode");
+    await clickUiElement(game, setting);
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting,
+      1,
+      "the laser switches to its overcharge mode",
+    );
+  },
+);
+
+test(
+  "the psi amp swaps the gun controls for its four selector arrows",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // debug_psi auto-equips the amp and unlocks every power.
+    await using game = await GameServer.launch({ mission: "debug_psi" });
+    await game.step({ frames: 5 });
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    assert.deepEqual(await labels(game), [
+      "psi_tier_prev",
+      "psi_tier_next",
+      "psi_power_prev",
+      "psi_power_next",
+    ]);
+
+    const selected = async () => (await game.info()).player.selected_psi_power;
+    const start = await selected();
+    assert.ok(start, "a power is selected to begin with");
+
+    // A tier step lands somewhere else...
+    await clickUiElement(game, await button(game, "psi_tier_next"));
+    const tierStep = await selected();
+    assert.notEqual(tierStep, start, "the tier arrow changes the selection");
+
+    // ...and a tier step lands on that tier's FIRST power, so from there five
+    // more steps walk all five tiers and come back around. (A power step wraps
+    // inside one tier instead, so it cannot produce this cycle.)
+    const tierBase = tierStep;
+    const visited = [];
+    for (let i = 0; i < 5; i += 1) {
+      await clickUiElement(game, await button(game, "psi_tier_next"));
+      visited.push(await selected());
+    }
+    assert.equal(visited.at(-1), tierBase, "five tier steps wrap through all five tiers");
+    assert.equal(new Set(visited).size, 5, `each tier is a distinct stop: ${visited}`);
+
+    // The power arrow moves within the tier: a different power, and stepping
+    // back returns to where it started.
+    await clickUiElement(game, await button(game, "psi_power_next"));
+    const powerStep = await selected();
+    assert.notEqual(powerStep, tierBase, "the power arrow changes the selection");
+    assert.notEqual(
+      powerStep,
+      visited[0],
+      "stepping the power is not the same as stepping the tier",
+    );
+    await clickUiElement(game, await button(game, "psi_power_prev"));
+    assert.equal(await selected(), tierBase, "and back again");
+  },
+);

--- a/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
+++ b/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, type UiElement, type UiState } from "../src/index.js";
 import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end test for the BIOFULL/AMMOFULL expanded readouts in use mode
@@ -10,17 +10,22 @@ import { fireOnce } from "./helpers/weapon.js";
 //   - Entering use mode (Tab) expands the compact bottom readouts: BIO.PCX ->
 //     BIOFULL.PCX (bottom-left) and AMMOBACK -> AMMOFULL.PCX (bottom-right).
 //   - With a gun that has 2+ ammo types wielded, AMMOFULL shows an ammo-type
-//     CYCLE button while the magazine is empty, exposed via /v1/ui
-//     `ammo_cycle`. Clicking it cycles the wielded weapon's ammo type
+//     CYCLE button while the magazine is empty, exposed in /v1/ui's `readout`
+//     list. Clicking it cycles the wielded weapon's ammo type
 //     (Effect::CycleAmmo).
-//   - Shooter mode keeps the compact readouts (no ammo_cycle element).
+//   - Shooter mode keeps the compact readouts (no readout controls).
 //
 // Negative-first: on the base branch (flat UI 4.5) there is no AMMOFULL cycle
-// button and /v1/ui has no `ammo_cycle` field, so the KEY assertion ("use mode
-// exposes the ammo-cycle button with a gun wielded") fails.
+// button, so the KEY assertion ("use mode exposes the ammo-cycle button with a
+// gun wielded") fails.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // The Pistol (gamesys template -17) has 3 ammo types (Standard / HE / AP).
+
+/** The AMMOFULL ammo-type cycle control, when the readout is showing one. */
+function cycleControl(ui: UiState): UiElement | undefined {
+  return ui.readout?.find((element) => element.label === "cycle_ammo");
+}
 
 function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
   const p = detail.properties.find((x) => x.name === "Ammo");
@@ -53,10 +58,10 @@ test(
     assert.ok(pistol, `expected a Pistol in medsci1 (got ${JSON.stringify(pistols.map((e) => e.name))})`);
     await game.player.give(pistol.id);
 
-    // Shooter baseline: no ammo_cycle element (compact readouts).
+    // Shooter baseline: no readout controls (compact readouts).
     const shooter = await game.ui.state();
     assert.equal(shooter.mode, "shooter");
-    assert.ok(!shooter.ammo_cycle, "shooter mode must not expose the ammo-cycle button");
+    assert.ok(!cycleControl(shooter), "shooter mode must not expose the ammo-cycle button");
     await game.screenshot("ammo-shooter-compact.png");
 
     // Tab into use mode and wield the Pistol from the strip (double-click).
@@ -76,13 +81,15 @@ test(
       `the Pistol should be wielded with an ammo type (got ${JSON.stringify(wielded.player)})`,
     );
 
-    // Loaded rounds have an established projectile identity, so drain the
-    // magazine before asking the UI to expose its ammo-type cycle control.
+    // A loaded magazine is cyclable too - cycling ejects the rounds back to the
+    // backpack as the type they are, never converting them (the eject itself is
+    // weapon-ammo-eject.e2e.test.ts's). Drain it anyway, so the assertion below
+    // is about the empty-magazine case this test is named for.
     const loaded = ammoOf(await game.entities.detail(pistol.id));
     if (loaded > 0) {
       assert.ok(
-        !(await game.ui.state()).ammo_cycle,
-        "loaded magazine must not expose a conversion control",
+        cycleControl(await game.ui.state()),
+        "a loaded magazine that can be ejected still exposes the cycle control",
       );
       await game.input.trigger("ToggleUseMode");
       await game.step({ frames: 5 });
@@ -95,15 +102,16 @@ test(
     // --- KEY: use mode exposes the AMMOFULL ammo-cycle button when empty ---
     const use = await game.ui.state();
     assert.equal(use.mode, "use");
+    const cycle = cycleControl(use);
     assert.ok(
-      use.ammo_cycle,
+      cycle,
       `use mode with a multi-ammo gun must expose the ammo-cycle button (got ${JSON.stringify(use)})`,
     );
     await game.screenshot("ammo-use-expanded.png");
 
     // --- Clicking the ammo-cycle button cycles the wielded ammo type ---
     const before = (await game.info()).player.wielded_ammo_type;
-    await clickScreen(use.ammo_cycle.screen_rect);
+    await clickScreen(cycle.screen_rect);
     await game.step({ frames: 3 });
     const after = (await game.info()).player.wielded_ammo_type;
     assert.notEqual(
@@ -113,12 +121,12 @@ test(
     );
     await game.screenshot("ammo-use-cycled.png");
 
-    // --- Tab back to shooter: compact readouts, no ammo_cycle ---
+    // --- Tab back to shooter: compact readouts, no readout controls ---
     await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 5 });
     const restored = await game.ui.state();
     assert.equal(restored.mode, "shooter");
-    assert.ok(!restored.ammo_cycle, "leaving use mode drops the ammo-cycle button");
+    assert.ok(!cycleControl(restored), "leaving use mode drops the ammo-cycle button");
     await game.screenshot("ammo-shooter-after.png");
   },
 );


### PR DESCRIPTION
Stacked on #1252 (`feat/gun-burst-fire`).

The use-mode ammo readout was neither correct nor complete. This makes it faithful to the original's AMMOFULL panel and adds the controls that panel carries.

## Audit

Reference rects are in AMMOFULL panel pixels (the panel is 260x64, upper-left = 0,0). They are corroborated by the shipped art: the panel's lit recess measures x 117..249, y 14..56, the compact `AMMOBACK.PCX` crop is exactly the panel's right 94 px (well x 176..249), `AMMOARW0` is 12x41, `LEFT0`/`RIGHT0` are 18x18, `PLEFT0`/`PRIGHT0` are 12x41 - each matching its rect.

| Element | Before | After | Discrepancy fixed |
| --- | --- | --- | --- |
| Fire-mode SETTING button | absent | `(118, 15, 66, 20)`, label = current `P$SHead` header | The panel's largest control did not exist. Clicking it emits `Effect::CycleGunSetting` - the same thing the mode-switch action does. |
| RELOAD button | absent | `(118, 37, 66, 20)`, label = MISC.STR `Reload` ("RELOAD") | Ditto; emits `Effect::ReloadWeapon`, the same thing the `R` key does. |
| Ammo-type cycle arrow | `(186, 15, 12, 41)` | unchanged | Correct already. |
| Ammo icon | `(126, 16, 32, 32)` | `(200, 18, 24, 24)` | **Two bugs.** It sat 40 px LEFT of the compact `AMMOBACK` backdrop, so shooter mode drew it on bare 3D view; and it sat inside the new SETTING button's rect. Now in the gauge well. |
| Round count | `(166, 22, 94, 20)` | `(224, 20, 25, 20)` | Moved into the gauge well beside the icon, clear of the cycle arrow. |
| Ammo-type label | `(166, 44, 94, 16)` | `(198, 42, 51, 13)`, ellipsized | Was 94 px wide starting outside the well; now inside it. Ellipsized because the label is a data-driven class tag (`std`, but also `lasershot`). |
| Psi tier badge | `(122, 22, 32, 19)` | `(177, 16, 32, 19)` | Also outside the compact backdrop before. |
| Psi discipline name | `(106, 44, 154, 16)` | `(177, 37, 60, 18)`, ellipsized | Was 154 px starting outside the well; the reference power arrows bound it to 60 px. See "Known limitation". |
| Psi tier arrows | absent | `(118, 15, 18, 18)` / `(136, 15, 18, 18)`, art `LEFT0`/`RIGHT0` | Tier stepping did not exist. |
| Psi power arrows | absent | `(157, 15, 12, 41)` / `(237, 15, 12, 41)`, art `PLEFT0`/`PRIGHT0` | Power stepping did not exist. |
| Redundant psi tier number | drawn in `COUNT` | removed | The `AmPsi<n>1` badge already shows the tier. |
| Font | `mainfont.fon` at native size | unchanged | Correct already. |
| Visibility, gun | cycle arrow only, use mode only | SETTING (any gun with a magazine that names a mode) + RELOAD (any non-energy gun) + cycle arrow (multi-ammo) | |
| Visibility, energy weapon | n/a | SETTING only | The laser recharges and offers one projectile type, so RELOAD and the cycle arrow are hidden - but it still has an overcharge mode. |
| Visibility, psi amp | tier badge + name | + the four arrows | The amp's gun controls are meaningless; the arrows replace them. |
| Visibility, nothing wielded | nothing | nothing | Unchanged. |
| Mouse-help lines (`MouseHelpSettings`, ...) | n/a | not added | The port has no mouse-help line to hang them on. |

No reference screenshot exists in `research/` or `projects/`; the rects above were checked against the decoded panel art instead, and `projects/flat-ui.md` §1.2 already described the missing SETTING/RELOAD buttons as part of this panel.

## What changed

**Placement is still decided once**, in `shock2vr/src/hud/ammo_panel.rs`, in panel pixels. That module now also owns the *button set*: `ammo_panel::buttons(&readout)` is the single producer, `emit` draws exactly that list, and `flat_hud::readout_buttons` maps the same list through the same panel origin for hit-testing - so a drawn control and a clickable rect cannot diverge (locked by `drawn_buttons_match_the_hit_tested_set`).

- `FlatUiHost` takes `set_readout_buttons(Vec<ReadoutButtonSpec>)` instead of one hardcoded `Option<Rect>` ammo-cycle rect, and `FlatUiDragAction::CycleAmmo` becomes `FlatUiDragAction::Readout(ReadoutButton)`.
- `/v1/ui` gains `readout`: every visible control, labeled by meaning (`gun_setting` - whose `text` is the live mode header - `reload`, `cycle_ammo`, `psi_tier_prev/next`, `psi_power_prev/next`). The old `ammo_cycle` field is gone; it was a pure projection of one entry of this list.
- `hud::HudStrings` preloads MISC.STR `Reload` as a world unique (the layout has no `AssetCache` at draw time - the `ElevatorContext` pattern).
- `wielded_weapon::is_energy_weapon` identifies a rechargeable weapon by the `EnergyWeapon` script the `Energy` archetype hands down.
- `psi::step_selection` is a new pure function: `Tier` steps to the next tier that owns a trained power (skipping empty tiers) and lands on its first one, `Power` wraps within the tier, `Any` walks the whole trained list. `Effect::CyclePsiPower` is gone - the single-key cycle now routes through the same function as `Effect::StepPsiSelection { axis: Any, forward: true }`, so there is one selection algorithm rather than two.

**VR: display-only, deliberately.** The VR pointer only ever hits the cyber-interface panel, never the forearm quad, so the forearm shows the readout and no buttons. Drawing a control nobody can press would be a lie. The readout *placement* is identical in both presentations - only the interactive layer differs, and it differs by whether a pointer can reach it, not by presentation (AGENTS.md §3). The VR buttons arrive with the cyber-interface readouts in a later PR.

## `bio-ammo-full.e2e.test.ts` baseline failure: a stale test, not a bug

It failed on the base branch at `loaded magazine must not expose a conversion control`. Cause: `script_util::can_cycle_ammo` gained `|| can_unload(world, weapon)` in an already-merged PR, so a loaded magazine that can be ejected *is* cyclable now (cycling ejects the rounds back as the type they are - `weapon-ammo-eject.e2e.test.ts` covers that). Nothing in this diff touches that predicate. The assertion is flipped to match the shipped contract, in this PR because it would otherwise stay red; it is a stale-test fix, not a behavior change from this work.

## Known limitation

The psi discipline name ellipsizes to `PROJECT...` for "Projected Cryokinesis": the reference power arrows sit at panel x 157 and 237, leaving 60 px between them. The original presumably wraps the name over the taller area the reference implies, which needs multi-line text the canvas does not have yet. The full psi MFD is the follow-up PR; this one keeps the arrows at their authored rects rather than moving them to buy width.

## Tests

`cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p shock2vr --lib` **1236 passed, 0 failed**.

New/changed unit tests (negative-first - each fails on the base branch):
- `ammo_panel`: `the_readout_sits_inside_the_compact_gauge_well`, `no_button_overlaps_the_readout`, `buttons_only_appear_where_the_pointer_can_reach_them`, `an_energy_weapon_keeps_its_setting_button_but_loses_cycle_and_reload`, `a_gun_with_no_named_mode_has_no_setting_button`, `the_setting_button_is_labeled_with_the_current_mode`, `the_psi_amp_shows_four_selector_arrows_and_no_gun_controls`, `nothing_wielded_has_no_buttons`, `drawn_buttons_match_the_hit_tested_set`, `every_element_sits_inside_the_panel`
- `flat_hud`: `every_readout_button_sits_in_the_ammofull_panel`, `the_readout_sits_inside_the_compact_gauge`
- `flat_ui_host`: `clicking_a_readout_button_emits_its_action`
- `psi`: `power_arrows_wrap_within_the_current_tier`, `tier_arrows_skip_tiers_with_no_trained_power`, `a_selection_sitting_on_an_untrained_power_recovers`, `an_arrow_never_selects_an_untrained_power`, `an_empty_or_out_of_range_selection_is_left_alone`

e2e (`SHOCK2_E2E=1`), all pass:

```
ok 1 - the setting button is labeled with the fire mode and clicking it switches modes
ok 2 - the reload button reloads the wielded gun
ok 3 - an energy weapon keeps its setting button but shows no reload or ammo cycle
ok 4 - the psi amp swaps the gun controls for its four selector arrows
ok 5 - use mode exposes AMMOFULL ammo-cycle for an empty multi-ammo weapon
ok 6 - flat presentation: renders a frame with the screen-space HUD
ok 7 - flat UI plumbing: /v1/ui mode toggle + pointer channels
# tests 7 / # pass 7 / # fail 0
```

```
ok 1 - cycling a loaded weapon returns its rounds to the backpack
ok 2 - the ejected clip is the archetype whose authored size fits the rounds
ok 3 - cycling advances the selected ammo type and wraps
ok 4 - the pistol's BURST sends three rounds off one pull, then waits out its interval
ok 5 - the assault rifle's AUTO fires for as long as the trigger is held
ok 6 - an AUTO burst stops on the last round instead of overdrawing the magazine
ok 7 - the laser pistol spends its setting's rounds and waits its setting's interval
ok 8 - the shotgun's triple load costs three shells and refuses to fire on two
ok 9 - the fusion cannon's DEATH mode launches its shot at the mode's 0.4x speed
ok 10 - the pistol switches between its NORM and BURST modes and back
ok 11 - a shotgun mode switch keeps the selected ammo type
ok 12 - a gun with only one fire mode ignores the switch
ok 13 - earth reload consumes matching reserve entities and partial stacks
# tests 13 / # pass 13 / # fail 0
```

```
ok 1 - VR uses the actual held Earth Psi Booster through its authored inventory action
ok 2 - VR world-frob consumes one Psi Booster without racing its automatic pickup
ok 3 - Earth Psionic Training reduces, refills, casts, and cleans up through real objectives
ok 4 - psi amp hold-to-overload: normal cast, overload, and burnout
ok 5 - sustained psi power (Inviso): cast spends psi, refresh, and timed expiry
ok 6 - Photonic Redirection hides the player from the security camera
ok 7 - debug scenes unlock every psi power (cycling reaches many powers)
ok 8 - real missions gate CyclePsiPower to trained powers only
ok 9 - psi amp casts the selected power and drains psi points
ok 10 - releasing a held item over the VR inventory strip deposits it in the backpack
ok 11 - releasing a held item away from the VR inventory strip still drops it into the world
ok 12 - releasing a held item on the cyber-interface canvas below the strip still drops it into the world
ok 13 - an item squeezed out of a strip slot and released in place returns to the backpack
ok 14 - releasing a held item over a specific empty strip cell deposits it there, not at the first free slot
ok 15 - an off-panel hand still frobs the world while the VR cyber interface is open
ok 16 - a trigger pull begun on the cyber-interface panel cannot slide off into a world frob
ok 17 - a VR controller ray hovers, clicks and drags on the cyber-interface canvas
ok 18 - a squeeze on an inventory slot pulls the item into that VR hand
ok 19 - VR ToggleUseMode presents the use-mode strip while the world keeps simulating
ok 20 - the cyber interface safes the wielded weapon and swallows a held trigger across exit
ok 21 - VR: a weapon in the right hand reloads, cycles ammo and drives the forearm readout
ok 22 - a VR-held pistol reloads from reserve and announces it audibly
ok 23 - a VR-held pistol cycles through its ammo types
# tests 23 / # pass 23 / # fail 0
```

`missions.e2e.test.ts`: all 23 missions load (`# pass 23 / # fail 0`). SDK unit tests: `# pass 32 / # fail 0`.

## Review

`/xreview` ran with the flat/energy/psi captures attached. Codex was unavailable (usage limit), so this was one adversarial engine plus the dedicated de-duplication pass. Resolved:

- **High** - the psi arrows were dead whenever the selection sat on an *untrained* power (the registry holds every power, the default selection is index 0, and granting a power never normalizes the selection): neither axis could find the current index among the trained ones, so both returned it unchanged. `step_selection` now recovers onto the first trained power; covered by `a_selection_sitting_on_an_untrained_power_recovers`.
- **Medium** - button labels were drawn non-ellipsized while the adjacent data-driven label was not; both are external data (`P$SHead`, MISC.STR) with ~11 px of headroom. Both now use `text_native_fit`.
- **Low** - a tier arrow with only one trained tier quietly behaved like a power step; it is now inert, matching its documented contract.
- **Low** - a module-doc range and a stale `flat_ui_host` comment corrected.
- **De-dup, `merge`** - `Effect::StepPsiSelection`'s handler duplicated `Effect::CyclePsiPower`'s borrow/log block, and `CyclePsiPower`'s hand-rolled wrapping scan *was* `step_selection`. `Effect::CyclePsiPower` is removed and the key routes through `PsiSelectionAxis::Any`.
- **De-dup, `reuse`** - `HudStrings::load` open-coded a table-or-fallback lookup; it now calls `ui::resolve_menu_label`, which additionally rejects an empty localized value.
- **De-dup, `reuse`** - the new e2e file had its own `clickElement`; it uses the shared `test/helpers/ui.ts` `clickUiElement`.
- **De-dup, `merge`** - `/v1/ui`'s `ammo_cycle` was a pure projection of the new `readout` list; removed.

Reviewer-suggested and **not** taken: widening `TYPE_LABEL` to the full gauge well (the cycle arrow occupies x 186..198 across that row, so it would render under the arrow) and moving the psi power arrows out of the well to widen the name (that would abandon their verified authored rects - see "Known limitation").

De-dup coverage: all four strategies ran - S1 names (157 lines, 29 queries over 8053 candidates), S2 clones (629 pairs whole-repo, 4 touching changed files), S3 index (4126 lines), S4 read (full diff). None unavailable.


## Visuals

Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). Panel crops are the canvas rect x 378..640, y 410..480, upscaled 2x.

![fire-mode button toggling NORM to BURST](https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/firemode-toggle.gif)

<sub>Flat use mode, pistol (`debug_weapons`). Clicking the SETTING button through the flat pointer flips the header NORM → BURST (`player.wielded_gun_setting_header` confirms the change).</sub>

### Flat use mode — pistol

![use-mode ammo panel, pistol](https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/panel-pistol.png)

<sub>SETTING (NORM), RELOAD, the ammo-type cycle arrow, and the ammo readout (icon / 12 / STD) sitting in the gauge well. <a href="https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/full-pistol-usemode.png">Full uncropped frame</a>.</sub>

### Flat use mode — laser pistol (energy weapon)

![use-mode ammo panel, laser pistol](https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/panel-laser.png)

<sub>Reload and ammo-type cycle are hidden for an energy weapon — `GET /v1/ui` reports exactly one readout button, `gun_setting`.</sub>

### Flat use mode — psi amp

![use-mode ammo panel, psi amp](https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/panel-psiamp.png)

<sub>`debug_psi`: four selector arrows (`psi_tier_prev/next`, `psi_power_prev/next`), the tier badge and the power name instead of the gun buttons.</sub>

### Before → after

![before/after, use mode](https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/beforeafter-usemode.png)

<sub>Use mode, pistol. Before: only the ammo icon / count / type. After: the readout moves into the gauge well and the SETTING + RELOAD buttons and cycle arrow appear.</sub>

![before/after, shooter mode](https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/beforeafter-shooter.png)

<sub>Shooter mode (no use mode), pistol. Before: the ammo icon floats ~40 px left of the compact AMMOBACK backdrop, on bare 3D view. After: it sits inside the backdrop with the count and type.</sub>

### VR

![VR forearm panel readout](https://gist.githubusercontent.com/tommy-xr/ba2f3436224c656b3b75430e77e51019/raw/vr-forearm-readout.png)

<sub>`--vr --mission debug_weapons`, pistol grabbed with the right hand, free camera placed at the forearm panel. The readout (ammo icon / 12 / STD) renders on the worn AMMOFULL panel. There are no buttons here by design — the VR pointer never reaches this quad, so the forearm is display-only. This is a partial frame: the panel is large and close-range and the sleeve/hand mesh occludes it at every distance where the whole panel fits, so the gauge well is legible and the (empty) button column is not.</sub>

## Full e2e suite (run on 5babffef, concurrently with other runtimes)

`# tests 387 / # pass 367 / # fail 12`. Port collisions (`Address already in use`): free-camera x2, Command Floor Pod. Known baseline: baby-arachnid, creature-loot, earth-hacking, hydro3 Korenchkin log. Verified failing on main 43ced887 too (pre-existing): dev-menu x2 (launches cs1.avi instead of debug_minimal), trap-unlock grav-lift, vr-melee-contact idle-wrench. medsci-saved-vr-melee fails at a different assertion each run (flaky); none of these files are touched by this stack.

