### PR TITLE
feat(hud): weapon settings MFD

### DIFF
--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -19,6 +19,10 @@ pub(crate) use flat_hud::*;
 /// MISC.STR, for a data install that lacks the table.
 const FALLBACK_RELOAD_LABEL: &str = "RELOAD";
 
+/// The English fallback for the weapon-settings modification line, verbatim
+/// from the shipped MISC.STR (`%d` is the gun's `PropGunState.modification`).
+const FALLBACK_MOD_LEVEL_LABEL: &str = "Modification Level %d";
+
 /// HUD label strings preloaded from MISC.STR, stored as a world `Unique`
 /// because the readout layout has no `AssetCache` at draw time (the
 /// `ElevatorContext` pattern).
@@ -26,12 +30,16 @@ const FALLBACK_RELOAD_LABEL: &str = "RELOAD";
 pub struct HudStrings {
     /// MISC.STR `Reload` ("RELOAD"), the AMMOFULL reload button's label.
     pub reload_label: String,
+    /// MISC.STR `ModLevel` ("Modification Level %d"), the settings MFD's
+    /// modification line. The `%d` is substituted at draw time.
+    pub mod_level_label: String,
 }
 
 impl Default for HudStrings {
     fn default() -> Self {
         Self {
             reload_label: FALLBACK_RELOAD_LABEL.to_owned(),
+            mod_level_label: FALLBACK_MOD_LEVEL_LABEL.to_owned(),
         }
     }
 }
@@ -44,6 +52,11 @@ impl HudStrings {
                 strings.as_deref(),
                 "reload",
                 FALLBACK_RELOAD_LABEL,
+            ),
+            mod_level_label: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "modlevel",
+                FALLBACK_MOD_LEVEL_LABEL,
             ),
         }
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1373,6 +1373,13 @@ pub struct GlobalTemplateObjIcons(pub HashMap<i32, String>);
 #[derive(Unique, Clone, Default)]
 pub struct GlobalGunSettingHeaders(pub [HashMap<String, String>; 2]);
 
+/// The `SETT1`/`SETT2` string tables - the description of a gun's first /
+/// second fire setting ("This is the normal single-shot firing mode."), shown
+/// on the weapon settings MFD. Loaded here beside the headers for the same
+/// reason: the panel has no asset cache at draw time.
+#[derive(Unique, Clone, Default)]
+pub struct GlobalGunSettingTexts(pub [HashMap<String, String>; 2]);
+
 /// The synthetic player-owned entity hosting the automap panel (`MapGui`).
 /// Created at mission init; `Effect::ToggleMap` opens/closes its panel in the
 /// flat host. See `projects/flat-ui-panels.md` §5.
@@ -1384,6 +1391,12 @@ pub struct MapPanelEntity(pub EntityId);
 /// so a persisted `(deck, log)` can be localized and replayed anywhere.
 #[derive(Unique, Clone, Copy)]
 pub struct MediaPanelEntity(pub EntityId);
+
+/// Nonserialized player-owned host for the weapon settings MFD. The panel
+/// presents the *wielded* gun rather than a world object, so one host serves
+/// every weapon and `Effect::OpenWeaponSettings` binds it to the panel slot.
+#[derive(Unique, Clone, Copy)]
+pub struct WeaponSettingsPanelEntity(pub EntityId);
 
 /// The automap location (`PropMapLoc`) of the mapped room the player most
 /// recently entered - the player's *current* map location. The automap uses it
@@ -1551,6 +1564,9 @@ pub struct MissionCore {
     /// dimmed behind it and the wielded weapon safed. Unlike the pause menu,
     /// the world keeps simulating while it is up.
     pub use_mode: bool,
+    /// The gun an open weapon settings panel was opened for; the panel is
+    /// dismissed as soon as that gun stops being wielded.
+    weapon_settings_gun: Option<EntityId>,
 
     /// Entry/exit feel for `use_mode`: one eased 0..1 ramp driving the rim
     /// vignette (both presentations), the VR comfort dim's strength, and the
@@ -1829,15 +1845,19 @@ impl MissionCore {
         {
             crate::psi::apply_display_names(&mut psi_powers, &psi_strings);
         }
-        let mut gun_setting_header_table = |file| {
+        let mut gun_setting_string_table = |file| {
             asset_cache
                 .get_opt(&dark::importers::STRINGS_IMPORTER, file)
                 .map(|strings| (*strings).clone())
                 .unwrap_or_default()
         };
         world.add_unique(GlobalGunSettingHeaders([
-            gun_setting_header_table("shead1.str"),
-            gun_setting_header_table("shead2.str"),
+            gun_setting_string_table("shead1.str"),
+            gun_setting_string_table("shead2.str"),
+        ]));
+        world.add_unique(GlobalGunSettingTexts([
+            gun_setting_string_table("sett1.str"),
+            gun_setting_string_table("sett2.str"),
         ]));
         // Debug scenes unlock every power (debug_psi exercises the whole
         // registry); real missions start with the player template's learned
@@ -2022,6 +2042,27 @@ impl MissionCore {
             RuntimePropDoNotSerialize,
         ));
         world.add_unique(MediaPanelEntity(media_panel));
+
+        // The weapon settings MFD's host. Like the reader above it has no world
+        // object of its own: it presents whichever gun is wielded, so it is
+        // rebuilt per mission and never serialized.
+        let weapon_settings_panel = world.add_entity((
+            Links::empty(),
+            PropScripts {
+                scripts: vec!["internal_weapon_settings".to_owned()],
+                inherits: false,
+            },
+            dark::properties::PropTemplateId { template_id: -1 },
+            PropSymName("Weapon Settings".to_owned()),
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+            RuntimePropTransform(Matrix4::identity()),
+            RuntimePropDoNotSerialize,
+        ));
+        world.add_unique(WeaponSettingsPanelEntity(weapon_settings_panel));
 
         world.add_unique(GlobalTemplateIdMap(template_to_entity_id.clone()));
 
@@ -2429,6 +2470,7 @@ impl MissionCore {
             player_footsteps: crate::mission::player_footsteps::PlayerFootsteps::new(),
             flat_melee_anim: None,
             use_mode: false,
+            weapon_settings_gun: None,
             use_mode_ramp: crate::ui::entry_ramp::EntryExitRamp::new(),
             vr_use_mode_anchor: crate::ui::FrontendPanelAnchor::new(),
             vr_use_mode_head: crate::ui::world_dim::UNTRACKED_HEAD,
@@ -3375,6 +3417,32 @@ impl MissionCore {
         // now-current transform, so they track a moving parent rather than their
         // spawn pose. Runs after physics sync so parents' transforms are current.
         self.update_attached_entities();
+
+        // The weapon settings MFD belongs to one gun: putting that gun away -
+        // dropping it, holstering it, cycling weapons - dismisses the panel.
+        // The flag means "our panel is docked", so it is also dropped when the
+        // slot went elsewhere (close button, Tab, another panel opening); that
+        // keeps it from outliving the panel it describes.
+        if let Some(opened_for) = self.weapon_settings_gun {
+            let panel = self
+                .world
+                .borrow::<UniqueView<WeaponSettingsPanelEntity>>()
+                .map(|panel| panel.0)
+                .ok();
+            let ours_is_docked = panel.is_some() && self.flat_ui.active_panel() == panel;
+            let put_away = crate::scripts::gui::should_close_settings_panel(
+                opened_for,
+                crate::wielded_weapon::wielded_weapon(&self.world),
+            );
+            if put_away {
+                if ours_is_docked {
+                    self.flat_ui.close();
+                }
+                self.weapon_settings_gun = None;
+            } else if !ours_is_docked {
+                self.weapon_settings_gun = None;
+            }
+        }
 
         // Flat-mode MFD panel input: map the 2D pointer onto the active panel
         // and drive it through the same GUIHover contract the VR hand ray
@@ -4640,7 +4708,11 @@ impl MissionCore {
                 let step = |axis, forward| vec![Effect::StepPsiSelection { axis, forward }];
                 match button {
                     ReadoutButton::CycleAmmo => vec![Effect::CycleAmmo],
-                    ReadoutButton::GunSetting => vec![Effect::CycleGunSetting],
+                    // The exception: SETTING opens the weapon settings MFD
+                    // (the original's own behavior for this button), where the
+                    // mode is *chosen* from a described list. The
+                    // `CycleGunSetting` action (F) still toggles directly.
+                    ReadoutButton::GunSetting => vec![Effect::OpenWeaponSettings],
                     ReadoutButton::Reload => vec![Effect::ReloadWeapon],
                     ReadoutButton::PsiTierPrev => step(PsiSelectionAxis::Tier, false),
                     ReadoutButton::PsiTierNext => step(PsiSelectionAxis::Tier, true),
@@ -5486,6 +5558,42 @@ impl MissionCore {
                 Effect::SetGunSetting { entity_id, setting } => {
                     if let Some(cue) = self.set_gun_setting(entity_id, setting) {
                         effects.push_back(cue);
+                    }
+                }
+
+                Effect::UnloadWeapon { entity_id } => {
+                    self.eject_magazine(asset_cache, entity_id);
+                }
+
+                Effect::OpenWeaponSettings => {
+                    // The MFD presents the *wielded* gun, so it opens only with
+                    // one in hand and is remembered so it can be dismissed when
+                    // that gun is put away. Unbound: the host is synthetic, so
+                    // there is no world object to walk away from.
+                    //
+                    // The panel slot has to actually be presented, or this would
+                    // dock a panel nothing draws and nothing can dismiss. Flat
+                    // always presents it; VR presents it only inside the cyber
+                    // interface, which is also the only place a VR pointer could
+                    // ever press the button that emits this.
+                    let slot_is_presented = game_options.presentation_mode
+                        == crate::PresentationMode::Flat
+                        || self.use_mode;
+                    if let Some(weapon) = crate::wielded_weapon::wielded_weapon(&self.world)
+                        .filter(|_| slot_is_presented)
+                    {
+                        let panel = self
+                            .world
+                            .borrow::<UniqueView<WeaponSettingsPanelEntity>>()
+                            .map(|panel| panel.0);
+                        if let Ok(panel) = panel {
+                            self.script_world.dispatch(Message {
+                                to: panel,
+                                payload: MessagePayload::PanelOpened,
+                            });
+                            self.flat_ui.open_unbound(panel);
+                            self.weapon_settings_gun = Some(weapon);
+                        }
                     }
                 }
 
@@ -7872,11 +7980,7 @@ impl MissionCore {
         if !crate::scripts::script_util::can_cycle_ammo(&self.world, weapon) {
             return;
         }
-        if let Some((clip_template, rounds)) =
-            crate::mission::reload::unload_to_reserve(&self.world, weapon).spawn_clip
-        {
-            self.give_ejected_clip(asset_cache, weapon, clip_template, rounds);
-        }
+        self.eject_magazine(asset_cache, weapon);
         // The switch is earned by an empty magazine, never assumed. Every way an
         // eject can fall short - the fresh clip refused by the backpack, a
         // borrow that did not come through - leaves rounds loaded, and switching
@@ -7952,6 +8056,20 @@ impl MissionCore {
             name: "bset".to_owned(),
             spatial: false,
         })
+    }
+
+    /// Eject `weapon`'s magazine back to the backpack, as clips of the ammo
+    /// type the rounds already are. Shared by the ammo-type switch (which has
+    /// to empty the gun before it may change type) and the settings MFD's
+    /// UNLOAD button (where emptying it *is* the point). A magazine that cannot
+    /// be returned - no clip archetype, or a backpack that refuses it - is left
+    /// loaded.
+    fn eject_magazine(&mut self, asset_cache: &mut AssetCache, weapon: EntityId) {
+        if let Some((clip_template, rounds)) =
+            crate::mission::reload::unload_to_reserve(&self.world, weapon).spawn_clip
+        {
+            self.give_ejected_clip(asset_cache, weapon, clip_template, rounds);
+        }
     }
 
     /// Mint `rounds` rounds of `clip_template` into the backpack - the half of

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -244,6 +244,17 @@ pub enum Effect {
     /// nothing is wielded or the gun has no second mode (turrets, the psi amp).
     CycleGunSetting,
 
+    /// Open the weapon settings MFD for the wielded gun in the presentation's
+    /// panel slot. No-op when nothing is wielded.
+    OpenWeaponSettings,
+
+    /// Eject `entity_id`'s magazine back to the backpack, as clips of the ammo
+    /// type the rounds already are. No-op for an empty gun, or one whose
+    /// projectile has no clip archetype to return to.
+    UnloadWeapon {
+        entity_id: EntityId,
+    },
+
     /// Equip a weapon of this gamesys class from the player's carried items.
     /// The handler resolves the live entity through the template hierarchy and
     /// then reuses `GrabEntity`, so no item is spawned and a displaced flat

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -10,6 +10,7 @@ mod replicator;
 mod research;
 mod trainer;
 mod traits;
+mod weapon_settings;
 
 pub use computer::*;
 pub use container::*;
@@ -23,3 +24,4 @@ pub use replicator::*;
 pub use research::*;
 pub use trainer::*;
 pub use traits::*;
+pub use weapon_settings::*;

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -241,7 +241,9 @@ fn property_fallback(world: &World, entity_id: EntityId, report: bool) -> String
     }
 }
 
-fn localized_fallback(value: &str) -> String {
+/// The English text out of an object string (`key: "text"`), for a data
+/// install whose string table does not resolve the key.
+pub(super) fn localized_fallback(value: &str) -> String {
     value
         .split_once('"')
         .and_then(|(_, tail)| tail.rsplit_once('"').map(|(text, _)| text))

--- a/shock2vr/src/scripts/gui/weapon_settings.rs
+++ b/shock2vr/src/scripts/gui/weapon_settings.rs
@@ -1,0 +1,686 @@
+//! Weapon settings MFD - the panel the AMMOFULL readout's SETTING button opens.
+//!
+//! The original's weapon-settings overlay: a `SETTINGS.PCX` backdrop naming the
+//! wielded gun and its modification level, over two selectable rows - one per
+//! fire setting - each reading "{header}: {description}" from the gun's
+//! `P$SHead1`/`P$Sett1` and `P$SHead2`/`P$Sett2` object strings. `SETSEL.PCX`
+//! highlights the row the gun is currently set to; clicking the other row
+//! switches to it. A gun that takes clips also carries an UNLOAD button that
+//! ejects the magazine back to the backpack.
+//!
+//! The canvas is presentation-agnostic - placement is decided once here, in
+//! panel pixels (AGENTS.md section 3), and `FlatUiHost` presents that one
+//! component list in flat's MFD slot and in VR's cyber-interface panel slot
+//! alike. What VR does not have yet is a *way in*: the forearm readout draws no
+//! buttons, because the VR pointer only ever reaches the cyber-interface panel
+//! and never the forearm quad. When that readout gains its buttons, its SETTING
+//! button emits the same `Effect::OpenWeaponSettings` and this panel works with
+//! no further wiring.
+
+use cgmath::{Vector2, Vector3, vec2};
+use dark::properties::{PropGunState, PropObjShortName, PropSymName};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::gui::{self, ButtonHoverBehavior, Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::scripts::Effect;
+use crate::scripts::script_util;
+use crate::ui::Rect;
+
+use super::research::localized_fallback;
+
+/// A panel-local rect's upper-left corner / extent, as the component builders
+/// want them.
+fn origin_of(rect: Rect) -> Vector2<f32> {
+    vec2(rect.x, rect.y)
+}
+fn extent_of(rect: Rect) -> Vector2<f32> {
+    vec2(rect.w, rect.h)
+}
+
+/// `SETTINGS.PCX` is 188x300 - the MFD slot's 188 width, four pixels taller
+/// than the 188x296 reader/keypad art. The panel is drawn at the art's own size.
+const PANEL_W: f32 = 188.0;
+const PANEL_H: f32 = 300.0;
+
+/// The gun's short name, on the art's name bar (y 127..147).
+const NAME_POS: (f32, f32) = (24.0, 133.0);
+/// The two fire-setting rows: the selection highlight covers the whole row and
+/// the row is the click target.
+///
+/// Both are 164x68 - `SETSEL.PCX`'s native size - because that is what the
+/// backdrop authors. Scanning a column of `SETTINGS.PCX` gives the boxes as
+/// y 150..217 and y 220..287, 68 px each, separated by a 2 px rule; drawing the
+/// highlight at any other height squashes the art non-uniformly.
+const ROWS: [Rect; 2] = [
+    Rect::new(11.0, 150.0, 164.0, HIGHLIGHT_SIZE.1),
+    Rect::new(11.0, 220.0, 164.0, HIGHLIGHT_SIZE.1),
+];
+/// `SETSEL.PCX`'s authored size. A row that is not exactly this is a bug.
+const HIGHLIGHT_SIZE: (f32, f32) = (164.0, 68.0);
+/// Where each row's text starts, inset from the row box.
+const ROW_TEXT_POS: [(f32, f32); 2] = [(22.0, 153.0), (22.0, 223.0)];
+/// Row text runs to the row's right edge.
+const ROW_TEXT_RIGHT: f32 = 175.0;
+/// The modification line sits 50 px above the first row, which puts it at the
+/// foot of the art's large top box. That box is the weapon-icon area; the panel
+/// draws no icon into it today, so the line has it to itself.
+const MOD_LEVEL_Y: f32 = ROWS[0].y - 50.0;
+const LINE_H: f32 = 11.0;
+/// `UNLOAD0.PCX` is 142x22, centred exactly ((188 - 142) / 2 = 23) and flush to
+/// the panel's bottom edge. The backdrop authors no strip of its own for it, so
+/// it necessarily overlays something; sitting it below the last line row 1 can
+/// hold (223 + 5 * 11 = 278) costs only the thin bottom bezel, where any
+/// higher placement would cover the row's own text. It is pushed last, and the
+/// hit test takes the last match, so the overlap resolves to UNLOAD - the
+/// control actually drawn there.
+const UNLOAD_RECT: Rect = Rect::new(23.0, 278.0, 142.0, 22.0);
+
+/// Approximate characters per line at the row text width. `mainfont` is
+/// variable-width; this is the same conservative greedy-wrap budget the log
+/// reader uses (26 chars at 136 px), scaled to this rect.
+const ROW_WRAP: usize = 29;
+
+const BACKDROP: &str = "iface/settings.pcx";
+const HIGHLIGHT: &str = "iface/setsel.pcx";
+/// The UNLOAD button's rest and lit art, the pair every shipped button ships as.
+const UNLOAD_ART: &str = "iface/unload0.pcx";
+const UNLOAD_ART_HOVER: &str = "iface/unload1.pcx";
+
+/// `/v1/ui` labels, so a client clicks a row by meaning rather than by pixel.
+const ROW_LABELS: [&str; 2] = ["setting_0", "setting_1"];
+const UNLOAD_LABEL: &str = "unload";
+
+pub struct WeaponSettingsGui;
+
+#[derive(Clone, Debug, Default)]
+pub struct WeaponSettingsGuiState;
+
+#[derive(Clone, Debug)]
+pub enum WeaponSettingsGuiMsg {
+    /// Switch the gun to fire setting 0 or 1.
+    SelectSetting(i32),
+    /// Eject the magazine back to the backpack.
+    Unload,
+}
+
+/// Whether an open settings panel must now close. The panel is opened for the
+/// gun that was wielded at the time and shows only that gun, so unwielding it -
+/// dropping it, holstering it, or cycling to another weapon - dismisses it.
+pub fn should_close_settings_panel(opened_for: EntityId, wielded: Option<EntityId>) -> bool {
+    wielded != Some(opened_for)
+}
+
+/// The gun's display name: its authored short name (an object string), falling
+/// back to the symbolic name every entity has.
+fn display_name(world: &World, weapon: EntityId) -> Option<String> {
+    let short = world
+        .borrow::<View<PropObjShortName>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|n| localized_fallback(&n.0)))
+        .filter(|name| !name.is_empty());
+    short.or_else(|| {
+        world
+            .borrow::<View<PropSymName>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|n| n.0.clone()))
+    })
+}
+
+/// The line each row shows: "{header}: {description}". A gun that names no
+/// header for a setting has no such setting and draws no row.
+fn row_text(header: Option<&str>, description: Option<&str>) -> Option<String> {
+    let header = header?;
+    Some(match description {
+        Some(description) => format!("{header}: {description}"),
+        None => header.to_owned(),
+    })
+}
+
+/// Substitute the modification level into the MISC.STR `ModLevel` format
+/// ("Modification Level %d") - the same `replace` the HUD's own `%d` item
+/// labels use, so a data install whose string lacks the placeholder still draws
+/// its own text.
+fn mod_level_text(format: &str, modification: i32) -> String {
+    format.replace("%d", &modification.to_string())
+}
+
+/// Whether the settings panel offers an UNLOAD button for `weapon`. The button
+/// appears only when pressing it would do something, the way the readout's own
+/// controls do: an energy weapon has no magazine at all - it recharges - and
+/// neither an empty magazine nor one whose projectile has no clip archetype to
+/// return to has rounds this could hand back.
+fn shows_unload(world: &World, weapon: EntityId) -> bool {
+    if crate::wielded_weapon::is_energy_weapon(world, weapon) {
+        return false;
+    }
+    let loaded = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|state| state.ammo > 0))
+        .unwrap_or(false);
+    loaded && crate::mission::reload::can_unload(world, weapon)
+}
+
+/// How many wrapped lines fit inside `row` starting at `text_y`.
+fn row_line_budget(row: Rect, text_y: f32) -> usize {
+    ((row.y + row.h - text_y) / LINE_H).floor().max(0.0) as usize
+}
+
+impl Gui<WeaponSettingsGuiState, WeaponSettingsGuiMsg> for WeaponSettingsGui {
+    fn get_components(
+        &self,
+        _cursor: &Option<GuiCursor>,
+        _entity_id: EntityId,
+        world: &World,
+        _state: &WeaponSettingsGuiState,
+    ) -> Vec<GuiComponent<WeaponSettingsGuiMsg>> {
+        // Archive-qualified for the same reason the log reader qualifies its
+        // backdrop: obj.crf and iface.crf collide on plain basenames.
+        let mut components: Vec<GuiComponent<WeaponSettingsGuiMsg>> = vec![
+            gui::image(BACKDROP)
+                .with_position(vec2(0.0, 0.0))
+                .with_size(vec2(PANEL_W, PANEL_H)),
+        ];
+
+        // The panel always shows the wielded gun; the host closes it when that
+        // changes (`should_close_settings_panel`), so this cannot draw a stale weapon.
+        let Some(weapon) = crate::wielded_weapon::wielded_weapon(world) else {
+            return components;
+        };
+
+        let modification = world
+            .borrow::<View<PropGunState>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|state| state.modification))
+            .unwrap_or(0);
+        components.push(
+            gui::text(&mod_level_text(
+                &crate::hud::hud_strings(world).mod_level_label,
+                modification,
+            ))
+            .with_position(vec2(NAME_POS.0, MOD_LEVEL_Y))
+            .with_size(vec2(ROW_TEXT_RIGHT - NAME_POS.0, LINE_H)),
+        );
+
+        if let Some(name) = display_name(world, weapon) {
+            components.push(
+                gui::text(&name)
+                    .with_position(vec2(NAME_POS.0, NAME_POS.1))
+                    .with_size(vec2(ROW_TEXT_RIGHT - NAME_POS.0, LINE_H)),
+            );
+        }
+
+        let current = script_util::current_gun_setting(world, weapon);
+        for setting in 0..2i32 {
+            let row = ROWS[setting as usize];
+            let header = script_util::gun_setting_header(world, weapon, setting);
+            let Some(line) = row_text(
+                header.as_deref(),
+                script_util::gun_setting_description(world, weapon, setting).as_deref(),
+            ) else {
+                continue;
+            };
+            // The highlight and the click target are one rect: both are `row`.
+            if setting == current {
+                components.push(
+                    gui::image(HIGHLIGHT)
+                        .with_position(origin_of(row))
+                        .with_size(extent_of(row)),
+                );
+            }
+            // A zero-alpha button is the established "hit target over backdrop
+            // art" convention (`flat_ui_host::draw_components`): the row boxes
+            // are painted into SETTINGS.PCX, so the row must be clickable
+            // without painting anything of its own over them.
+            components.push(
+                gui::button(WeaponSettingsGuiMsg::SelectSetting(setting))
+                    .with_image(HIGHLIGHT)
+                    .with_alpha(0.0)
+                    .with_label(ROW_LABELS[setting as usize])
+                    .with_position(origin_of(row))
+                    .with_size(extent_of(row)),
+            );
+            let (text_x, text_y) = ROW_TEXT_POS[setting as usize];
+            for (idx, wrapped) in super::media::wrap_text(&line, ROW_WRAP)
+                .iter()
+                .take(row_line_budget(row, text_y))
+                .enumerate()
+            {
+                if wrapped.is_empty() {
+                    continue;
+                }
+                components.push(
+                    gui::text(wrapped)
+                        .with_position(vec2(text_x, text_y + idx as f32 * LINE_H))
+                        .with_size(vec2(ROW_TEXT_RIGHT - text_x, LINE_H)),
+                );
+            }
+        }
+
+        if shows_unload(world, weapon) {
+            components.push(
+                gui::button(WeaponSettingsGuiMsg::Unload)
+                    .with_image(UNLOAD_ART)
+                    .with_hover(ButtonHoverBehavior::Texture(UNLOAD_ART_HOVER.to_owned()))
+                    .with_label(UNLOAD_LABEL)
+                    .with_position(origin_of(UNLOAD_RECT))
+                    .with_size(extent_of(UNLOAD_RECT)),
+            );
+        }
+
+        components
+    }
+
+    fn get_config(&self) -> GuiConfig {
+        GuiConfig {
+            world_offset: Vector3::new(0.0, 0.0, -0.1),
+            screen_size_in_pixels: Vector2::new(PANEL_W, PANEL_H),
+        }
+    }
+
+    fn handle_msg(
+        &self,
+        _entity_id: EntityId,
+        world: &World,
+        state: &WeaponSettingsGuiState,
+        msg: &WeaponSettingsGuiMsg,
+    ) -> (WeaponSettingsGuiState, Effect) {
+        let Some(weapon) = crate::wielded_weapon::wielded_weapon(world) else {
+            return (state.clone(), Effect::NoEffect);
+        };
+        let effect = match msg {
+            // `SetGunSetting` is a no-op for a gun with no second mode and
+            // plays the mode-switch cue itself.
+            WeaponSettingsGuiMsg::SelectSetting(setting) => Effect::SetGunSetting {
+                entity_id: weapon,
+                setting: *setting,
+            },
+            WeaponSettingsGuiMsg::Unload => Effect::UnloadWeapon { entity_id: weapon },
+        };
+        (state.clone(), effect)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mission::PlayerInfo;
+    use crate::mission::mission_core::{GlobalGunSettingHeaders, GlobalGunSettingTexts};
+    use crate::mission::reload::GlobalProjectileClips;
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{
+        Link, Links, ProjectileOptions, PropGunSettingHeader1, PropGunSettingHeader2,
+        PropGunSettingText1, PropGunSettingText2, PropScripts, ToLink,
+    };
+    use std::collections::HashMap;
+
+    /// A world with `weapon` wielded in the right hand, and empty gun-setting
+    /// string tables (every setting resolves from the entity's own properties).
+    fn wield(world: &mut World, weapon: EntityId) {
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: Some(weapon),
+            inventory_entity_id: inventory,
+        });
+        world.add_unique(GlobalGunSettingHeaders([HashMap::new(), HashMap::new()]));
+        world.add_unique(GlobalGunSettingTexts([HashMap::new(), HashMap::new()]));
+    }
+
+    fn gun_state(setting: i32, modification: i32) -> PropGunState {
+        PropGunState {
+            ammo: 6,
+            condition: 100.0,
+            setting,
+            modification,
+            silence_value: 0.0,
+        }
+    }
+
+    /// The pistol's standard projectile and the clip archetype its rounds go
+    /// back to - all `can_unload` needs to say the magazine is returnable.
+    const STD_PROJECTILE: i32 = -37;
+    const STD_CLIP: i32 = -31;
+
+    /// A two-mode pistol, wielded, at fire setting `setting`, holding `ammo`
+    /// returnable rounds.
+    fn pistol_world_with_ammo(setting: i32, ammo: i32) -> (World, EntityId) {
+        let mut world = World::new();
+        let weapon = world.add_entity((
+            PropGunState {
+                ammo,
+                ..gun_state(setting, 2)
+            },
+            PropSymName("Pistol".to_owned()),
+            PropObjShortName("name_pistol: \"Pistol\"".to_owned()),
+            PropGunSettingHeader1("pistol: \"NORM\"".to_owned()),
+            PropGunSettingHeader2("pistol: \"BURST\"".to_owned()),
+        ));
+        world.add_component(
+            weapon,
+            Links {
+                to_links: vec![ToLink {
+                    link: Link::Projectile(ProjectileOptions {
+                        order: 0,
+                        setting: -1,
+                    }),
+                    to_entity_id: None,
+                    to_template_id: STD_PROJECTILE,
+                }],
+            },
+        );
+        world.add_unique(GlobalProjectileClips {
+            clips: HashMap::from([(STD_PROJECTILE, vec![STD_CLIP])]),
+            clip_sizes: HashMap::from([(STD_CLIP, 12)]),
+        });
+        world.add_component(
+            weapon,
+            PropGunSettingText1(
+                "Pistol: \"This is the normal single-shot firing mode.\"".to_owned(),
+            ),
+        );
+        world.add_component(
+            weapon,
+            PropGunSettingText2("Pistol: \"This is the 3-shot rapid burst mode.\"".to_owned()),
+        );
+        wield(&mut world, weapon);
+        (world, weapon)
+    }
+
+    /// The pistol as the bench hands it out: loaded.
+    fn pistol_world(setting: i32) -> (World, EntityId) {
+        pistol_world_with_ammo(setting, 6)
+    }
+
+    fn components(world: &World) -> Vec<GuiComponent<WeaponSettingsGuiMsg>> {
+        let host = EntityId::dead();
+        WeaponSettingsGui.get_components(&None, host, world, &WeaponSettingsGuiState)
+    }
+
+    /// Every placed (texture, position, size, interactive) - images and buttons.
+    fn placed(
+        components: &[GuiComponent<WeaponSettingsGuiMsg>],
+    ) -> Vec<(String, Vector2<f32>, Vector2<f32>, bool)> {
+        components
+            .iter()
+            .filter_map(|c| match c {
+                GuiComponent::Image {
+                    texture,
+                    position,
+                    size,
+                    ..
+                } => Some((texture.clone(), *position, *size, false)),
+                GuiComponent::Button {
+                    texture,
+                    position,
+                    size,
+                    ..
+                } => Some((texture.clone(), *position, *size, true)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn texts(components: &[GuiComponent<WeaponSettingsGuiMsg>]) -> Vec<String> {
+        components
+            .iter()
+            .filter_map(|c| match c {
+                GuiComponent::Text { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn labels(components: &[GuiComponent<WeaponSettingsGuiMsg>]) -> Vec<String> {
+        components
+            .iter()
+            .filter_map(|c| match c {
+                GuiComponent::Button { label, .. } => label.clone(),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The rect of the (single) drawn `SETSEL` highlight, if any.
+    fn highlight(
+        components: &[GuiComponent<WeaponSettingsGuiMsg>],
+    ) -> Option<(Vector2<f32>, Vector2<f32>)> {
+        let mut found = placed(components)
+            .into_iter()
+            .filter(|(texture, _, _, interactive)| texture == HIGHLIGHT && !interactive)
+            .map(|(_, position, size, _)| (position, size));
+        let first = found.next();
+        assert!(found.next().is_none(), "at most one row is highlighted");
+        first
+    }
+
+    #[test]
+    fn the_rows_do_not_overlap_and_sit_inside_the_panel() {
+        assert!(ROWS[0].y + ROWS[0].h <= ROWS[1].y, "rows must not overlap");
+        for row in ROWS {
+            assert!(row.x >= 0.0 && row.x + row.w <= PANEL_W);
+            assert!(row.y >= 0.0 && row.y + row.h <= PANEL_H);
+        }
+        // The UNLOAD strip is centred and flush to the panel's bottom edge, and
+        // starts below the last line of text row 1 can hold - so it covers only
+        // the bezel, never a row's own words.
+        assert_eq!(UNLOAD_RECT.y + UNLOAD_RECT.h, PANEL_H);
+        assert_eq!(UNLOAD_RECT.x, (PANEL_W - UNLOAD_RECT.w) / 2.0);
+        let (row1_text_x, row1_text_y) = ROW_TEXT_POS[1];
+        let _ = row1_text_x;
+        let last_line_bottom = row1_text_y + row_line_budget(ROWS[1], row1_text_y) as f32 * LINE_H;
+        assert!(
+            UNLOAD_RECT.y >= last_line_bottom,
+            "UNLOAD ({}) must start below row 1's last line ({last_line_bottom})",
+            UNLOAD_RECT.y
+        );
+    }
+
+    /// The selection highlight is blitted at its authored size, so a row that is
+    /// not exactly `SETSEL.PCX`'s 164x68 squashes the art. Both of the
+    /// backdrop's setting boxes measure 68 px tall (y 150..217 and y 220..287).
+    #[test]
+    fn every_row_is_exactly_the_highlight_arts_native_size() {
+        for row in ROWS {
+            assert_eq!(
+                (row.w, row.h),
+                HIGHLIGHT_SIZE,
+                "row {row:?} does not match SETSEL.PCX"
+            );
+        }
+    }
+
+    #[test]
+    fn the_highlight_covers_exactly_the_current_setting_row() {
+        for setting in 0..2usize {
+            let (world, _) = pistol_world(setting as i32);
+            let components = components(&world);
+            assert_eq!(
+                highlight(&components),
+                Some((origin_of(ROWS[setting]), extent_of(ROWS[setting]))),
+                "setting {setting}'s row must carry the highlight"
+            );
+        }
+    }
+
+    #[test]
+    fn each_row_is_clickable_over_exactly_its_highlight_rect() {
+        let (world, _) = pistol_world(0);
+        let components = components(&world);
+        let rows: Vec<_> = placed(&components)
+            .into_iter()
+            .filter(|(texture, _, _, interactive)| texture == HIGHLIGHT && *interactive)
+            .map(|(_, position, size, _)| (position, size))
+            .collect();
+        assert_eq!(
+            rows,
+            vec![
+                (origin_of(ROWS[0]), extent_of(ROWS[0])),
+                (origin_of(ROWS[1]), extent_of(ROWS[1])),
+            ],
+            "the hit target and the highlight are the same rect, so they cannot diverge"
+        );
+        assert_eq!(labels(&components)[0..2], ROW_LABELS.map(str::to_owned));
+    }
+
+    #[test]
+    fn a_row_reads_its_header_and_description() {
+        let (world, _) = pistol_world(0);
+        let drawn = texts(&components(&world)).join(" ");
+        assert!(
+            drawn.contains("NORM: This is the normal"),
+            "row 0 must read \"{{header}}: {{description}}\", got {drawn:?}"
+        );
+        assert!(drawn.contains("BURST: This is the 3-shot"));
+        assert!(drawn.contains("Pistol"), "the panel names the gun");
+        assert!(
+            drawn.contains("Modification Level 2"),
+            "the panel reports the gun's modification level, got {drawn:?}"
+        );
+    }
+
+    #[test]
+    fn a_gun_with_one_fire_mode_draws_one_row() {
+        let mut world = World::new();
+        let weapon = world.add_entity((
+            gun_state(0, 0),
+            PropSymName("Rick Turret Gun".to_owned()),
+            PropGunSettingHeader1("turret: \"NORM\"".to_owned()),
+        ));
+        wield(&mut world, weapon);
+        let components = components(&world);
+        assert_eq!(
+            labels(&components)
+                .into_iter()
+                .filter(|label| label.starts_with("setting_"))
+                .collect::<Vec<_>>(),
+            vec![ROW_LABELS[0]],
+            "a gun that names no second header offers no second row"
+        );
+    }
+
+    #[test]
+    fn an_energy_weapon_has_no_unload_button() {
+        let (world, _) = pistol_world(0);
+        assert!(
+            labels(&components(&world)).contains(&UNLOAD_LABEL.to_owned()),
+            "a loaded gun whose rounds have a clip to go back to can eject them"
+        );
+
+        // An empty magazine has nothing to hand back, so the button that would
+        // hand it back is not drawn dead.
+        let (empty, _) = pistol_world_with_ammo(0, 0);
+        assert!(
+            !labels(&components(&empty)).contains(&UNLOAD_LABEL.to_owned()),
+            "an empty magazine offers no UNLOAD"
+        );
+
+        let mut world = World::new();
+        let weapon = world.add_entity((
+            gun_state(0, 0),
+            PropSymName("laser".to_owned()),
+            PropGunSettingHeader1("laser: \"NORM\"".to_owned()),
+            PropGunSettingHeader2("laser: \"OVER\"".to_owned()),
+            PropScripts {
+                scripts: vec!["EnergyWeapon".to_owned()],
+                inherits: true,
+            },
+        ));
+        wield(&mut world, weapon);
+        assert!(
+            !labels(&components(&world)).contains(&UNLOAD_LABEL.to_owned()),
+            "a rechargeable weapon has no magazine to eject"
+        );
+    }
+
+    #[test]
+    fn nothing_wielded_draws_only_the_backdrop() {
+        let mut world = World::new();
+        let empty = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: empty,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: empty,
+        });
+        let components = components(&world);
+        assert_eq!(placed(&components).len(), 1);
+        assert!(texts(&components).is_empty());
+    }
+
+    #[test]
+    fn clicking_a_row_sets_that_fire_mode_on_the_wielded_gun() {
+        let (world, weapon) = pistol_world(0);
+        let (_, effect) = WeaponSettingsGui.handle_msg(
+            EntityId::dead(),
+            &world,
+            &WeaponSettingsGuiState,
+            &WeaponSettingsGuiMsg::SelectSetting(1),
+        );
+        assert!(matches!(
+            effect,
+            Effect::SetGunSetting {
+                entity_id,
+                setting: 1
+            } if entity_id == weapon
+        ));
+
+        let (_, effect) = WeaponSettingsGui.handle_msg(
+            EntityId::dead(),
+            &world,
+            &WeaponSettingsGuiState,
+            &WeaponSettingsGuiMsg::Unload,
+        );
+        assert!(matches!(
+            effect,
+            Effect::UnloadWeapon { entity_id } if entity_id == weapon
+        ));
+    }
+
+    #[test]
+    fn the_panel_closes_when_its_gun_stops_being_wielded() {
+        let mut world = World::new();
+        let gun = world.add_entity(());
+        let other = world.add_entity(());
+        assert!(!should_close_settings_panel(gun, Some(gun)));
+        assert!(should_close_settings_panel(gun, Some(other)));
+        assert!(should_close_settings_panel(gun, None));
+    }
+
+    #[test]
+    fn the_row_line_budget_keeps_text_inside_its_row() {
+        for (row, (_, text_y)) in ROWS.iter().zip(ROW_TEXT_POS) {
+            let lines = row_line_budget(*row, text_y);
+            assert!(lines > 0);
+            assert!(
+                text_y + lines as f32 * LINE_H <= row.y + row.h,
+                "a full page of row text must not spill past the row"
+            );
+        }
+    }
+
+    #[test]
+    fn mod_level_substitutes_the_level_and_survives_a_string_without_it() {
+        assert_eq!(
+            mod_level_text("Modification Level %d", 3),
+            "Modification Level 3"
+        );
+        assert_eq!(mod_level_text("Modification", 3), "Modification");
+    }
+
+    #[test]
+    fn a_row_without_a_header_has_no_line_at_all() {
+        assert_eq!(row_text(None, Some("described")), None);
+        assert_eq!(row_text(Some("NORM"), None), Some("NORM".to_owned()));
+        assert_eq!(
+            row_text(Some("NORM"), Some("single shot")),
+            Some("NORM: single shot".to_owned())
+        );
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -120,7 +120,7 @@ use self::comestible::Comestible;
 pub use self::gui::ElevatorContext;
 use self::gui::{
     ComputerGui, ContainerGui, ElevatorGui, GamePigGui, HackableCrateGui, KeyPadGui, MapGui,
-    MediaGui, ReplicatorGui, ResearchGui, TrainerGui, TrainerMode, TraitGui,
+    MediaGui, ReplicatorGui, ResearchGui, TrainerGui, TrainerMode, TraitGui, WeaponSettingsGui,
 };
 use self::healing_item::{HealingItemKind, HealingItemScript};
 use self::internal_frob_move::InternalFrobMove;
@@ -957,6 +957,7 @@ impl ScriptWorld {
             "internal_inventory" => gui_script(Box::new(ContainerGui::inv_container())),
             "internal_map" => gui_script(Box::new(MapGui)),
             "internal_media" => gui_script(Box::new(MediaGui)),
+            "internal_weapon_settings" => gui_script(Box::new(WeaponSettingsGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
             "internal_radiation_source" => Box::new(InternalRadiationSource),

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -9,8 +9,8 @@ use dark::{
     EnvSoundQuery,
     properties::{
         GunSettingDesc, Link, Links, ProjectileOptions, PropBaseGunDesc, PropClassTag,
-        PropGunSettingHeader1, PropGunSettingHeader2, PropGunState, PropMaterial, PropSymName,
-        PropTemplateId, PropTweqModelConfig, ToLink,
+        PropGunSettingHeader1, PropGunSettingHeader2, PropGunSettingText1, PropGunSettingText2,
+        PropGunState, PropMaterial, PropSymName, PropTemplateId, PropTweqModelConfig, ToLink,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -358,15 +358,49 @@ pub fn gun_setting_header(world: &World, weapon: EntityId, setting: i32) -> Opti
             .and_then(|v| v.get(weapon).ok().map(|header| header.0.clone())),
         _ => return None,
     };
+    let tables = world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalGunSettingHeaders>>()
+        .ok()?;
+    resolve_setting_string(world, weapon, raw, tables.0.get(setting as usize)?)
+}
+
+/// Resolve one of a gun's fire-setting object strings against its string table.
+/// The gun's own property is only half the answer: a gun that authors no
+/// property of its own is still named by the table, keyed on its symbolic name.
+fn resolve_setting_string(
+    world: &World,
+    weapon: EntityId,
+    raw: Option<String>,
+    table: &std::collections::HashMap<String, String>,
+) -> Option<String> {
     let sym_name = world
         .borrow::<View<PropSymName>>()
         .ok()
         .and_then(|v| v.get(weapon).ok().map(|name| name.0.clone()));
-    let tables = world
-        .borrow::<UniqueView<crate::mission::mission_core::GlobalGunSettingHeaders>>()
-        .ok()?;
-    let table = tables.0.get(setting as usize)?;
     dark::importers::resolve_gun_setting_string(raw.as_deref(), sym_name.as_deref(), table)
+}
+
+/// The description text for `weapon`'s fire setting `setting` - "This is the
+/// normal single-shot firing mode." - or `None` when the gun names no such
+/// setting. Resolved from the gun's own `P$Sett1`/`P$Sett2` against the
+/// matching string table, exactly as [`gun_setting_header`] resolves the short
+/// header beside it.
+pub fn gun_setting_description(world: &World, weapon: EntityId, setting: i32) -> Option<String> {
+    let raw = match setting {
+        0 => world
+            .borrow::<View<PropGunSettingText1>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|text| text.0.clone())),
+        1 => world
+            .borrow::<View<PropGunSettingText2>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|text| text.0.clone())),
+        _ => return None,
+    };
+    let tables = world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalGunSettingTexts>>()
+        .ok()?;
+    resolve_setting_string(world, weapon, raw, tables.0.get(setting as usize)?)
 }
 
 /// The ammo index to select after a fire-mode switch. `order` is the ammo

--- a/tools/shock2-sdk/test/ammo-readout.e2e.test.ts
+++ b/tools/shock2-sdk/test/ammo-readout.e2e.test.ts
@@ -38,7 +38,7 @@ async function labels(game: GameServer): Promise<string[]> {
 }
 
 test(
-  "the setting button is labeled with the fire mode and clicking it switches modes",
+  "the setting button is labeled with the fire mode and opens the settings MFD",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({ mission: "debug_weapons" });
@@ -65,16 +65,27 @@ test(
     );
     assert.equal(setting.text, "NORM");
 
+    // The button OPENS the settings MFD (as the original does) rather than
+    // toggling in place - the mode is chosen there, from a described list.
+    // `weapon-settings-mfd.e2e.test.ts` covers the panel itself.
     await clickUiElement(game, setting);
-    const after = (await game.info()).player;
-    assert.equal(after.wielded_gun_setting, 1, "the click switched the fire mode");
-    assert.equal(after.wielded_gun_setting_header, "BURST");
-    // ...and the button now says so.
-    assert.equal((await button(game, "gun_setting")).text, "BURST");
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.ui.state()).active_panel?.name,
+      "Weapon Settings",
+      "SETTING docks the weapon settings MFD",
+    );
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting,
+      0,
+      "opening the panel does not itself switch modes",
+    );
 
-    // There are only two modes: clicking again comes back.
-    await clickUiElement(game, await button(game, "gun_setting"));
-    assert.equal((await game.info()).player.wielded_gun_setting_header, "NORM");
+    // The direct action (F) still toggles, and the button relabels with it.
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 3 });
+    assert.equal((await game.info()).player.wielded_gun_setting_header, "BURST");
+    assert.equal((await button(game, "gun_setting")).text, "BURST");
   },
 );
 
@@ -127,10 +138,11 @@ test(
     const setting = await button(game, "gun_setting");
     assert.ok(setting.text, "the laser names its fire mode");
     await clickUiElement(game, setting);
+    await game.step({ frames: 3 });
     assert.equal(
-      (await game.info()).player.wielded_gun_setting,
-      1,
-      "the laser switches to its overcharge mode",
+      (await game.ui.state()).active_panel?.name,
+      "Weapon Settings",
+      "the laser's SETTING button opens the same MFD",
     );
   },
 );

--- a/tools/shock2-sdk/test/weapon-settings-mfd.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-settings-mfd.e2e.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, type UiElement } from "../src/index.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { ammoOf, cycleToWeapon } from "./helpers/weapon.js";
+
+// End-to-end coverage for the weapon settings MFD.
+//
+// The original's SETTING button does not toggle the fire mode: it opens a panel
+// in the left MFD slot listing the gun's settings with the description of each,
+// highlights the one the gun is in, and switches when the other row is clicked.
+// A gun that takes clips also carries an UNLOAD button that returns the
+// magazine to the backpack.
+//
+// Negative-first: on the base branch clicking SETTING cycles the mode directly
+// and no panel ever opens, so every assertion below fails.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The synthetic host entity's name, as `/v1/ui` reports it. */
+const PANEL_NAME = "Weapon Settings";
+
+async function panelElements(game: GameServer): Promise<UiElement[]> {
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "the weapon settings panel should be open");
+  assert.equal(panel.name, PANEL_NAME);
+  return panel.elements;
+}
+
+async function rowButton(game: GameServer, row: 0 | 1): Promise<UiElement> {
+  const label = `setting_${row}`;
+  const found = (await panelElements(game)).find((e) => e.label === label);
+  assert.ok(found, `expected a "${label}" row on the settings panel`);
+  return found;
+}
+
+/** The drawn `SETSEL` highlight (an image, not the row's own hit target). */
+async function highlight(game: GameServer): Promise<UiElement> {
+  const found = (await panelElements(game)).filter(
+    (e) => e.kind === "image" && (e.texture ?? "").includes("setsel"),
+  );
+  assert.equal(found.length, 1, "exactly one row is highlighted");
+  return found[0];
+}
+
+/** Open the settings MFD the way a player does: use mode, then SETTING. */
+async function openSettings(game: GameServer): Promise<void> {
+  const setting = ((await game.ui.state()).readout ?? []).find(
+    (e) => e.label === "gun_setting",
+  );
+  assert.ok(setting, "the readout should carry a SETTING button");
+  await clickUiElement(game, setting);
+  await game.step({ frames: 3 });
+}
+
+test(
+  "SETTING opens a two-row settings panel and a row click switches the fire mode",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    // The pistol is the first weapon DebugCycleWeapon hands out.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.ui.state()).active_panel,
+      null,
+      "nothing is docked in the MFD slot before SETTING is pressed",
+    );
+    await openSettings(game);
+
+    // Both of the pistol's fire settings are listed, each reading
+    // "{header}: {description}".
+    const elements = await panelElements(game);
+    const text = elements
+      .filter((e) => e.kind === "text")
+      .map((e) => e.text ?? "")
+      .join(" ");
+    assert.match(text, /NORM:/, `row 0 names the normal mode: ${text}`);
+    assert.match(text, /BURST:/, `row 1 names the burst mode: ${text}`);
+    assert.match(text, /Pistol/, "the panel names the gun");
+    assert.match(text, /Modification level/i, "the panel reports the mod level");
+
+    // The gun starts in mode 0, so the highlight sits on row 0 - exactly over
+    // it, since the highlight and the click target are the same rect.
+    assert.deepEqual(
+      (await highlight(game)).rect,
+      (await rowButton(game, 0)).rect,
+      "the highlight covers the current setting's row",
+    );
+
+    await clickUiElement(game, await rowButton(game, 1));
+    await game.step({ frames: 3 });
+    const player = (await game.info()).player;
+    assert.equal(player.wielded_gun_setting, 1, "clicking row 1 selects setting 1");
+    assert.equal(player.wielded_gun_setting_header, "BURST");
+    assert.deepEqual(
+      (await highlight(game)).rect,
+      (await rowButton(game, 1)).rect,
+      "and the highlight follows it",
+    );
+
+    // Clicking the row the gun is already in is idempotent.
+    await clickUiElement(game, await rowButton(game, 1));
+    await game.step({ frames: 3 });
+    assert.equal((await game.info()).player.wielded_gun_setting, 1);
+  },
+);
+
+test(
+  "UNLOAD returns the magazine to the backpack, and an energy weapon has none",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    const pistol = await cycleToWeapon(game, (e) => (e.name ?? "") === "Pistol");
+    const loaded = ammoOf(await game.entities.detail(pistol.id));
+    assert.ok(loaded > 0, "the bench hands out a loaded pistol");
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    await openSettings(game);
+
+    const unload = (await panelElements(game)).find((e) => e.label === "unload");
+    assert.ok(unload, "a gun that takes clips can eject its magazine");
+    await clickUiElement(game, unload);
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      0,
+      "UNLOAD empties the magazine",
+    );
+    const clips = (await game.player.inventory()).items.filter((item) =>
+      (item.name ?? "").includes("Clip"),
+    );
+    assert.ok(clips.length > 0, `the rounds came back as a clip: ${JSON.stringify(clips)}`);
+
+    // ...and with the magazine now empty the button that empties it is gone,
+    // rather than sitting there doing nothing.
+    assert.ok(
+      !(await panelElements(game)).some((e) => e.label === "unload"),
+      "an empty magazine offers no UNLOAD",
+    );
+
+    // The laser recharges - it has no magazine to eject - so it shows no
+    // UNLOAD, but it still lists both of its fire settings.
+    await cycleToWeapon(game, (e) => (e.name ?? "") === "Laser Pistol");
+    await game.step({ frames: 5 });
+    await openSettings(game);
+    const laserLabels = (await panelElements(game))
+      .map((e) => e.label)
+      .filter((label): label is string => typeof label === "string");
+    assert.ok(!laserLabels.includes("unload"), `no UNLOAD on the laser: ${laserLabels}`);
+    assert.ok(laserLabels.includes("setting_0") && laserLabels.includes("setting_1"));
+  },
+);
+
+test(
+  "putting the gun away closes the settings panel",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 5 });
+
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 5 });
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    await openSettings(game);
+    await panelElements(game);
+
+    // The panel belongs to one gun: cycling to another dismisses it rather
+    // than silently re-pointing at the new weapon.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.ui.state()).active_panel,
+      null,
+      "cycling weapons closes the settings panel",
+    );
+  },
+);


### PR DESCRIPTION
Stacked on #1253 (`feat/ammo-readout-fidelity`).

#1253 gave the AMMOFULL readout a SETTING button that toggled the fire mode in place. That is not what the button does: it opens a panel listing the gun's fire settings with the *description* of each, highlights the one the gun is in, and switches when the other row is clicked. This adds that panel — the weapon settings MFD — as a shared `Gui` canvas in the left MFD slot, and points SETTING at it.

## Layout

Panel-local pixels, docked at the canvas `(2, 124)` MFD slot the log reader and keypad use. `SETTINGS.PCX` is **188x300** — four pixels taller than the 188x296 reader art — so the panel is drawn at the art's own size.

There is no `SETTINGSR.BIN` for this screen, so the rects are **measured from the backdrop** rather than eyeballed. Decoding `SETTINGS.PCX` and scanning a column gives the interior runs:

```
127..147  name bar        (h 21)
150..217  setting box 0   (h 68)
220..287  setting box 1   (h 68)
288..291  bottom bezel
```

Both setting boxes are 68 px tall, which is exactly `SETSEL.PCX`'s authored height — so both rows are 164x68 and the highlight is blitted at its native size.

| Element | Rect (panel-local) | Source |
| --- | --- | --- |
| Backdrop | `(0, 0, 188, 300)` | `iface/settings.pcx` |
| Modification line | `(24, 100)` — 50 px above row 0 | MISC.STR `ModLevel` ("Modification Level %d") + `PropGunState.modification` |
| Gun name | `(24, 133)` | `P$ObjShortName`, falling back to `P$SymName` |
| Row 0 | `(11, 150, 164, 68)` | click target + highlight rect |
| Row 0 text | `(22, 153)`, wrapped to x=175 | `{P$SHead1}: {P$Sett1}` via SHEAD1.STR / SETT1.STR |
| Row 1 | `(11, 220, 164, 68)` | click target + highlight rect |
| Row 1 text | `(22, 223)`, wrapped to x=175 | `{P$SHead2}: {P$Sett2}` via SHEAD2.STR / SETT2.STR |
| Selection highlight | the current setting's row rect | `iface/setsel.pcx` (164x68 native — it matches **both** rows exactly) |
| UNLOAD | `(23, 278, 142, 22)` | `iface/unload0.pcx` / `unload1.pcx` (142x22 native, centred exactly, flush to the panel's bottom) |
| Close | host-drawn | `FlatUiHost`'s own close button |

The archive-qualified `iface/` prefixes matter: obj.crf and iface.crf collide on plain basenames.

**The highlight and the click target are the same rect** — both are `ROWS[i]` — so a drawn selection and a clickable row cannot diverge (AGENTS.md section 3's "make divergence impossible" over testing for it). The row's hit target is a zero-alpha button, the established convention for a control whose art is baked into the backdrop (`flat_ui_host::draw_components`, the HRM board's unlit nodes).

The backdrop authors no strip of its own for UNLOAD, so it necessarily overlays something. It sits just below the last line row 1 can hold (`223 + 5 * 11 = 278`), which costs only the thin bottom bezel — any higher placement would cover the row's own text. It is pushed last and the hit test takes the last match, so the 10 px overlap resolves to UNLOAD, the control actually drawn there.

## What changed

- **`shock2vr/src/scripts/gui/weapon_settings.rs`** — `WeaponSettingsGui`, hosted on a synthetic player-owned entity (`internal_weapon_settings`, `RuntimePropDoNotSerialize`) exactly like the audio-log reader's host. It presents whichever gun is *wielded* rather than a world object, so one host serves every weapon and the click always acts on the gun the panel is drawing.
- **`Effect::OpenWeaponSettings`** docks that host with `flat_ui.open_unbound` (no world object, so no walk-away close), and records the gun. **`Effect::UnloadWeapon`** ejects the magazine through the same `reload::unload_to_reserve` path the ammo-type switch already used — extracted as `MissionCore::eject_magazine` so both callers share it rather than duplicating the mint-then-empty sequence.
- **`GlobalGunSettingTexts`** loads SETT1.STR/SETT2.STR beside the existing `GlobalGunSettingHeaders`; `script_util::gun_setting_description` resolves a setting's description the way `gun_setting_header` resolves its header (both through `dark::importers::resolve_gun_setting_string`).
- **`HudStrings`** gains MISC.STR `ModLevel`.
- `research::localized_fallback` is now `pub(super)` and reused for the gun's short name rather than copied.

**Visibility.** A gun that names no second header has no second mode and draws one row (`can_cycle_gun_setting`'s rule, spelled per-row). UNLOAD appears only when pressing it would do something, the way #1253's readout controls do: an energy weapon has no magazine at all (the laser keeps both its settings but loses the button), and neither an empty magazine nor one whose projectile has no clip archetype has rounds to hand back.

**Closing.** The panel belongs to the one gun it was opened for: dropping it, holstering it, or cycling weapons dismisses the panel rather than silently re-pointing at the new weapon.

## Entry points

| Entry | Before | After |
| --- | --- | --- |
| AMMOFULL **SETTING** button (flat use mode) | `Effect::CycleGunSetting` — toggled in place | `Effect::OpenWeaponSettings` — opens this panel; the mode is *chosen* from the described list |
| `CycleGunSetting` action (F / Quest chord) | toggles | **unchanged** — still toggles directly |

#1253's `ammo-readout.e2e.test.ts` asserted the old click-toggles behavior; its expectation is updated here (the click now docks the MFD, and the F action is what the test drives to prove the label still tracks the live mode). That is this PR's behavior change, not a stale test.

## VR

**The canvas is presentation-agnostic and the panel slot is already shared** — `FlatUiHost::update_canvas` is what VR's cyber interface drives, and `Effect::OpenWeaponSettings` takes the one unbranched `open_unbound` path — so the MFD renders and clicks identically in the cyber interface with no VR-specific code.

What is **not** shipped in VR is an *entry point*: #1253 deliberately draws the forearm readout without buttons, because the VR pointer only ever reaches the cyber-interface panel and never the forearm quad. So in VR nothing opens this panel yet. Follow-up: when the VR readout gains its buttons (the cyber-interface readout PR #1253 names), its SETTING button emits this same effect and the panel works — no further wiring.

## Tests

`cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p shock2vr --lib` **1249 passed, 0 failed, 2 ignored**.

New unit tests (`weapon_settings`), 13, all negative-first — verified failing by breaking the code they lock (forcing the highlight onto every row fails `the_highlight_covers_exactly_the_current_setting_row`; dropping the energy-weapon guard fails `an_energy_weapon_has_no_unload_button`; restoring the 58 px row-1 height fails `every_row_is_exactly_the_highlight_arts_native_size`):

- `every_row_is_exactly_the_highlight_arts_native_size`
- `the_rows_do_not_overlap_and_sit_inside_the_panel`
- `the_highlight_covers_exactly_the_current_setting_row`
- `each_row_is_clickable_over_exactly_its_highlight_rect`
- `a_row_reads_its_header_and_description`
- `a_gun_with_one_fire_mode_draws_one_row`
- `an_energy_weapon_has_no_unload_button`
- `nothing_wielded_draws_only_the_backdrop`
- `clicking_a_row_sets_that_fire_mode_on_the_wielded_gun`
- `the_panel_closes_when_its_gun_stops_being_wielded`
- `the_row_line_budget_keeps_text_inside_its_row`
- `mod_level_substitutes_the_level_and_survives_a_string_without_it`
- `a_row_without_a_header_has_no_line_at_all`

New e2e `tools/shock2-sdk/test/weapon-settings-mfd.e2e.test.ts` on `debug_weapons`. Negative-first: with the SETTING button reverted to `CycleGunSetting` and the runtime rebuilt, all three fail (`# pass 0 / # fail 3`); with the change, all three pass:

```
ok 1 - SETTING opens a two-row settings panel and a row click switches the fire mode
ok 2 - UNLOAD returns the magazine to the backpack, and an energy weapon has none
ok 3 - putting the gun away closes the settings panel
# pass 3
# fail 0
```

Neighbouring suites, one file at a time:

```
ok 1 - the setting button is labeled with the fire mode and opens the settings MFD
ok 2 - the reload button reloads the wielded gun
ok 3 - an energy weapon keeps its setting button but shows no reload or ammo cycle
ok 4 - the psi amp swaps the gun controls for its four selector arrows
ok 5 - flat presentation: renders a frame with the screen-space HUD
ok 6 - flat UI plumbing: /v1/ui mode toggle + pointer channels
# pass 6
# fail 0

ok 1 - cycling a loaded weapon returns its rounds to the backpack
ok 2 - the ejected clip is the archetype whose authored size fits the rounds
ok 3 - cycling advances the selected ammo type and wraps
ok 4 - weapon ammo decrements per shot and dry-fires at empty
ok 5 - the laser pistol spends its setting's rounds and waits its setting's interval
ok 6 - the shotgun's triple load costs three shells and refuses to fire on two
ok 7 - the fusion cannon's DEATH mode launches its shot at the mode's 0.4x speed
ok 8 - the pistol switches between its NORM and BURST modes and back
ok 9 - a shotgun mode switch keeps the selected ammo type
ok 10 - a gun with only one fire mode ignores the switch
# pass 10
# fail 0

ok 1 - log reader MFD: collecting files the log, reading it opens the 45100 transcript, persists
ok 2 - log reader MFD: a log collected before a save still reads back after loading
not ok 3 - hydro3: collected Korenchkin log opens its double-spaced transcript
# pass 2
# fail 1

ok 1 - 25AE Earth log 1/24 collects, reads and renders in flat and VR
ok 1 - flat keypad MFD: frob opens panel, clicking 45100 opens the door
ok 1 - flat elevator MFD: power states, labeled floors, current-floor inert, click transitions

missions.e2e.test.ts: # pass 23  # fail 0
```

The single failure, `hydro3: collected Korenchkin log`, is a known pre-existing failure on `main` and is untouched by this diff.


## Review

`/xreview` ran with the media attached. Codex was unavailable this session (`ERROR: You've hit your usage limit`), so this was the Claude correctness/visual reviewer plus the dedicated de-duplication reviewer rather than the usual two engines — noting that, since cross-engine agreement is the skill's main signal and it wasn't available here.

Fixed:

- **High — `ROWS[1]` was 58 px tall against the art's 68.** The highlight is blitted at the row's size, so selecting row 1 squashed `SETSEL.PCX` by 15% and shrank the hit target by 10 px; it is visible in the pre-fix GIF. Confirmed by decoding the backdrop (runs above). Both rows are now 164x68, and `every_row_is_exactly_the_highlight_arts_native_size` fails if either drifts from the art again.
- **Diverged — UNLOAD drew dead on an empty gun.** `shows_unload` was `!is_energy_weapon`, but `reload::can_unload` says nothing about the magazine and `unload_to_reserve` no-ops at zero rounds — so an empty pistol showed a button that did nothing, which the doc comment claimed it would not. It now also requires loaded, returnable rounds, covered by a unit test and an e2e assertion that the button disappears after an unload.
- **Extract — `gun_setting_description` was a line-for-line clone of `gun_setting_header`** (both reviewers, and the clone report). Their shared tail is now `resolve_setting_string`.
- **Medium — everything in the module was `pub`** and glob-re-exported into `crate::scripts::gui`, where `research.rs` already has a private `PANEL_W`/`PANEL_H` at the same values. Only `should_close_settings_panel` and the three `Gui` types are public now.
- **`weapon_settings_gun` could outlive its panel** (close button / Tab / another panel taking the slot left the flag set). The flag now means "our panel is docked" and is dropped when the slot goes elsewhere.
- **`Effect::OpenWeaponSettings` docked the slot unconditionally.** In VR that slot is only pumped inside the cyber interface, so a future VR caller could have bound a panel nothing draws and nothing can dismiss. It now requires the slot to actually be presented.
- Smaller: `UNLOAD1.PCX` (the shipped lit art) is now the button's hover state; `mod_level_text` is the `.replace("%d", …)` the HUD's own `%d` labels use rather than a hand-rolled `split_once`; the new close-check no longer sits between an existing comment and the code it documents.

Considered and deliberately not done, with reasons:

- **Localizing the gun's name through `objshort.str`** (both reviewers). Real, but it needs a new string-table `Unique` and the same gap exists for every other panel that names an item — `research.rs`'s `chemical_display_name` takes the identical English-fallback path. Cross-cutting; belongs in its own PR rather than riding along here.
- **Extracting a `spawn_panel_host` helper** for the third copy of the synthetic-host archetype. The three hosts genuinely differ (the map host carries map data and no symbolic name), and rewriting the two existing ones is outside this change's goal.
- **Moving `origin_of`/`extent_of` onto `ui::Rect`.** Fair placement point, but it touches a type used across the UI for no behavior change.
- **Making SETTING toggle the panel closed.** The second click is idempotent, and the close button and Tab both dismiss; matching `ToggleMap` here is a UX guess without reference evidence.
- **A confirmation sound for UNLOAD.** The round count visibly drops and a clip appears; inventing a cue the original may not play is speculation.

A `review-for-duplicates` pass before the review also caught a local `PanelRect` duplicating `crate::ui::Rect`; that is gone.

## Visuals

![weapon settings MFD demo](https://gist.githubusercontent.com/tommy-xr/508e172f22dbf6675278952cae0261f6/raw/weapon-settings-mfd-v2.gif)

<sub>Clicking the SETTING readout docks the Weapon Settings panel in the left MFD slot; clicking the second row moves the highlight and the readout label flips NORM to BURST. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep, `debug_weapons`).</sub>

![pistol settings panel](https://gist.githubusercontent.com/tommy-xr/508e172f22dbf6675278952cae0261f6/raw/weapon-settings-pistol-v2.png)

<sub>Pistol: modification level, NORM/BURST rows with the SETSEL highlight on row 0, and an UNLOAD button.</sub>

![laser pistol settings panel](https://gist.githubusercontent.com/tommy-xr/508e172f22dbf6675278952cae0261f6/raw/weapon-settings-laser-v2.png)

<sub>Laser Pistol: NORM/OVER rows and no UNLOAD button - an energy weapon has no magazine to unload.</sub>


