### PR TITLE
feat(vr): face buttons resolve per hand by what the hand holds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,11 @@ Oculus:   OpenXR action states            → InputActionState → ActionDispatc
 Quest button/chord paths live beside their actions in
 `InputAction::quest_touch_click_path` / `quest_touch_chord_paths`, so the
 mapping is host-testable even though `oculus_runtime` only builds for Android.
-The current key and controller bindings are listed in
+The four Touch **face buttons** are bound there RAW, by hand and position
+(`LeftHandLowerButton` .. `RightHandUpperButton`); what a press means is
+resolved per hand against what that hand holds, by the pure table in
+`shock2vr/src/hand_buttons.rs` (`resolve_hand_button`), which the mission
+applies. The current key and controller bindings are listed in
 [DEVELOPMENT.md](DEVELOPMENT.md#debug--developer-keys).
 
 - **`InputAction`** (`input/actions.rs`) - serde-enabled enum of all discrete actions

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,9 +121,9 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 | `B` | `DebugCycleWeapon` | spawns and wields the next weapon (unlike the number row) |
 | `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | no Quest binding - in VR ammo is swapped by inserting a clip of the other type |
 | `F` | `CycleGunSetting` | switch the wielded gun's fire mode (e.g. NORM / BURST); flat only |
-| `U` | `ReadLastUnreadLog` | Quest: left `Y` |
+| `U` | `ReadLastUnreadLog` | on Quest an *upper* face button resolves to this - see below |
 | `M` | `ToggleMap` | flat only |
-| `Tab` / `I` | `ToggleUseMode` | the cyber interface; Quest: left `X` |
+| `Tab` / `I` | `ToggleUseMode` | the cyber interface; on Quest a *lower* face button resolves to this |
 | `Esc` | `TogglePauseMenu` | Quest: left `Menu` |
 | `Alt+S` / `Alt+L` | `QuickSave` / `QuickLoad` | |
 | `Alt+G` | `DebugForceChase` | every monster hunts the player, pinned |
@@ -133,6 +133,25 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 Every action is also triggerable without a keyboard - over HTTP on the debug
 runtime (`POST /v1/input/action`) or through the SDK (`game.input.trigger(...)`).
 `GET /v1/input/actions` lists them.
+
+#### Quest face buttons are per-hand and contextual
+
+The four face buttons are bound raw, by hand and position - lower is left `X` /
+right `A`, upper is left `Y` / right `B` (`LeftHandLowerButton` ..
+`RightHandUpperButton`). What a press does is resolved per hand against what
+that hand holds (`shock2vr/src/hand_buttons.rs`):
+
+| that hand holds | lower | upper |
+| --- | --- | --- |
+| nothing, a melee weapon, or any other item | `ToggleUseMode` (cyber interface) | `ReadLastUnreadLog` |
+| a gun | reserved for gun handling - inert for now | reserved for gun handling - inert for now |
+| the psi amp | reserved for power selection - inert for now | reserved for power selection - inert for now |
+
+Mode first: while the cyber interface is up both buttons keep their interface
+meaning on both hands whatever is held, so it can always be closed. With a gun
+in each hand neither panel is reachable until a hand is free. While the **Free
+camera** developer option is on, the right hand's two buttons are the chord and
+nothing else - they resolve to nothing at all.
 
 ### Developer options
 

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -349,12 +349,24 @@ fn main() {
         .create_action::<bool>("crouch", "Crouch Toggle", &[])
         .unwrap();
 
-    let use_mode_action = action_set
-        .create_action::<bool>("use_mode", "Cyber Interface (Use Mode)", &[])
+    // The four face buttons, bound RAW by hand and position (lower = left X /
+    // right A, upper = left Y / right B). What a press means depends on what
+    // that hand is holding, and is resolved in the mission - see
+    // `shock2vr::hand_buttons`.
+    let left_lower_action = action_set
+        .create_action::<bool>("left_lower_face", "Left Hand Lower Button (X)", &[])
         .unwrap();
 
-    let audio_log_action = action_set
-        .create_action::<bool>("audio_log_reader", "Audio Log Reader", &[])
+    let left_upper_action = action_set
+        .create_action::<bool>("left_upper_face", "Left Hand Upper Button (Y)", &[])
+        .unwrap();
+
+    let right_lower_action = action_set
+        .create_action::<bool>("right_lower_face", "Right Hand Lower Button (A)", &[])
+        .unwrap();
+
+    let right_upper_action = action_set
+        .create_action::<bool>("right_upper_face", "Right Hand Upper Button (B)", &[])
         .unwrap();
 
     // The left controller's Menu button. (The right controller's is reserved
@@ -362,21 +374,6 @@ fn main() {
     let menu_action = action_set
         .create_action::<bool>("menu", "Pause Menu", &[])
         .unwrap();
-
-    // The right controller's two face buttons. Nothing binds them singly - VR
-    // reloading is the physical clip-insert gesture - so they exist only as the
-    // two halves of the free-camera chord.
-    let free_camera_a_action = action_set
-        .create_action::<bool>("free_camera_a", "Free Camera Chord (A)", &[])
-        .unwrap();
-
-    let free_camera_b_action = action_set
-        .create_action::<bool>("free_camera_b", "Free Camera Chord (B)", &[])
-        .unwrap();
-
-    let free_camera_chord = shock2vr::input::InputAction::ToggleFreeCamera
-        .quest_touch_chord_paths()
-        .expect("Quest free-camera chord binding");
 
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
@@ -460,22 +457,42 @@ fn main() {
                         .unwrap(),
                 ),
                 xr::Binding::new(
-                    &use_mode_action,
+                    &left_lower_action,
                     xr_instance
                         .string_to_path(
-                            shock2vr::input::InputAction::ToggleUseMode
+                            shock2vr::input::InputAction::LeftHandLowerButton
                                 .quest_touch_click_path()
-                                .expect("Quest use-mode binding"),
+                                .expect("Quest left lower face-button binding"),
                         )
                         .unwrap(),
                 ),
                 xr::Binding::new(
-                    &audio_log_action,
+                    &left_upper_action,
                     xr_instance
                         .string_to_path(
-                            shock2vr::input::InputAction::ReadLastUnreadLog
+                            shock2vr::input::InputAction::LeftHandUpperButton
                                 .quest_touch_click_path()
-                                .expect("Quest audio-log binding"),
+                                .expect("Quest left upper face-button binding"),
+                        )
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &right_lower_action,
+                    xr_instance
+                        .string_to_path(
+                            shock2vr::input::InputAction::RightHandLowerButton
+                                .quest_touch_click_path()
+                                .expect("Quest right lower face-button binding"),
+                        )
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &right_upper_action,
+                    xr_instance
+                        .string_to_path(
+                            shock2vr::input::InputAction::RightHandUpperButton
+                                .quest_touch_click_path()
+                                .expect("Quest right upper face-button binding"),
                         )
                         .unwrap(),
                 ),
@@ -488,14 +505,6 @@ fn main() {
                                 .expect("Quest pause-menu binding"),
                         )
                         .unwrap(),
-                ),
-                xr::Binding::new(
-                    &free_camera_a_action,
-                    xr_instance.string_to_path(free_camera_chord.0).unwrap(),
-                ),
-                xr::Binding::new(
-                    &free_camera_b_action,
-                    xr_instance.string_to_path(free_camera_chord.1).unwrap(),
                 ),
             ],
         )
@@ -682,8 +691,12 @@ fn main() {
                             // otherwise resume invisibly crouched).
                             crouch_toggled = false;
                             crouch_button_was_pressed = false;
-                            action_state.release(shock2vr::input::InputAction::ToggleUseMode);
-                            action_state.release(shock2vr::input::InputAction::ReadLastUnreadLog);
+                            action_state.release(shock2vr::input::InputAction::LeftHandLowerButton);
+                            action_state.release(shock2vr::input::InputAction::LeftHandUpperButton);
+                            action_state
+                                .release(shock2vr::input::InputAction::RightHandLowerButton);
+                            action_state
+                                .release(shock2vr::input::InputAction::RightHandUpperButton);
                         }
                         xr::SessionState::STOPPING => {
                             session.end().unwrap();
@@ -800,15 +813,11 @@ fn main() {
             .unwrap()
             .current_state;
         let crouch_state = crouch_action.state(&session, xr::Path::NULL).unwrap();
-        let use_mode_state = use_mode_action.state(&session, xr::Path::NULL).unwrap();
-        let audio_log_state = audio_log_action.state(&session, xr::Path::NULL).unwrap();
+        let left_lower_state = left_lower_action.state(&session, xr::Path::NULL).unwrap();
+        let left_upper_state = left_upper_action.state(&session, xr::Path::NULL).unwrap();
+        let right_lower_state = right_lower_action.state(&session, xr::Path::NULL).unwrap();
+        let right_upper_state = right_upper_action.state(&session, xr::Path::NULL).unwrap();
         let menu_state = menu_action.state(&session, xr::Path::NULL).unwrap();
-        let free_camera_a_state = free_camera_a_action
-            .state(&session, xr::Path::NULL)
-            .unwrap();
-        let free_camera_b_state = free_camera_b_action
-            .state(&session, xr::Path::NULL)
-            .unwrap();
         // Only edge-detect while the action is live: with the session merely
         // VISIBLE (system overlay up), current_state reads false even though
         // the button may still be physically held, and treating that as a
@@ -819,29 +828,41 @@ fn main() {
             }
             crouch_button_was_pressed = crouch_state.current_state;
         }
-        action_state.sync_discrete_button(
-            shock2vr::input::InputAction::ToggleUseMode,
-            use_mode_state.is_active,
-            use_mode_state.changed_since_last_sync,
-            use_mode_state.current_state,
-        );
-        action_state.sync_discrete_button(
-            shock2vr::input::InputAction::ReadLastUnreadLog,
-            audio_log_state.is_active,
-            audio_log_state.changed_since_last_sync,
-            audio_log_state.current_state,
-        );
+        for (action, state) in [
+            (
+                shock2vr::input::InputAction::LeftHandLowerButton,
+                &left_lower_state,
+            ),
+            (
+                shock2vr::input::InputAction::LeftHandUpperButton,
+                &left_upper_state,
+            ),
+            (
+                shock2vr::input::InputAction::RightHandLowerButton,
+                &right_lower_state,
+            ),
+            (
+                shock2vr::input::InputAction::RightHandUpperButton,
+                &right_upper_state,
+            ),
+        ] {
+            action_state.sync_discrete_button(
+                action,
+                state.is_active,
+                state.changed_since_last_sync,
+                state.current_state,
+            );
+        }
         action_state.sync_discrete_button(
             shock2vr::input::InputAction::TogglePauseMenu,
             menu_state.is_active,
             menu_state.changed_since_last_sync,
             menu_state.current_state,
         );
-        // Right A and B are the free camera's chord and nothing else: gun
-        // handling in VR is the physical clip-insert gesture, so neither button
-        // carries an action of its own and pressing one alone does nothing.
-        // (That is what retires #1144's second-press suppression - there is no
-        // longer an ammo swap for completing the chord to trigger.)
+        // The free camera is right A+B together - the same two buttons the
+        // right hand carries singly, so while its dev option is on `Game`
+        // suppresses that hand's contextual buttons and the pair is the chord
+        // and nothing else.
         //
         // A chord is edge-detected from the pair's raw states, so it takes
         // them directly rather than through `sync_discrete_button`. Activity
@@ -851,9 +872,9 @@ fn main() {
         // the same hazard the latched crouch above guards against.
         action_state.sync_chord(
             shock2vr::input::InputAction::ToggleFreeCamera,
-            free_camera_a_state.is_active && free_camera_b_state.is_active,
-            free_camera_a_state.current_state,
-            free_camera_b_state.current_state,
+            right_lower_state.is_active && right_upper_state.is_active,
+            right_lower_state.current_state,
+            right_upper_state.current_state,
         );
 
         let left_trigger_value = left_trigger

--- a/shock2vr/src/hand_buttons.rs
+++ b/shock2vr/src/hand_buttons.rs
@@ -1,0 +1,216 @@
+//! What a face button means on the hand that pressed it.
+//!
+//! The Touch controllers offer two face buttons per hand (left X/Y, right
+//! A/B), which this module treats as one symmetric pair per hand: a **lower**
+//! button (left X, right A) and an **upper** one (left Y, right B). What the
+//! pair does depends on what that hand is holding, so a gun can carry its own
+//! handling controls on the controller wielding it while the other hand keeps
+//! the player-owned panels.
+//!
+//! Only the Quest binds these (`InputAction::quest_touch_click_path`); flat
+//! has no face buttons and binds no key to them. That matters because in flat
+//! the LEFT hand slot is where the controller wields, so a flat press would
+//! read the wielded weapon as "the left hand's load".
+//!
+//! One exception lives outside the table: while the free-camera developer
+//! option is on, `Game::update` suppresses the RIGHT hand's two buttons -
+//! they are that toggle's chord, and a chord is pressed one button at a time.
+//!
+//! Resolution is pure ([`resolve_hand_button`]) and the world lookup that
+//! feeds it is one function ([`held_kind_in_hand`]), so the whole table is
+//! host-testable. This is contextual input - it reads game state - so it lives
+//! beside `VirtualHand` rather than in `ActionDispatcher`, which only handles
+//! actions whose meaning never changes.
+
+use dark::properties::PropBaseGunDesc;
+use shipyard::{Get, View, World};
+
+use crate::{input::InputAction, vr_config::Handedness};
+
+/// Which of a hand's two face buttons was pressed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandButton {
+    /// Left X / right A.
+    Lower,
+    /// Left Y / right B.
+    Upper,
+}
+
+/// What a hand is holding, as the resolution table sees it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HeldKind {
+    Empty,
+    /// A weapon swung by contact (wrench, shard, psi sword).
+    Melee,
+    /// A ranged weapon, which owns its hand's buttons for gun handling.
+    Gun,
+    /// The psi amp, which owns its hand's buttons for power selection.
+    PsiAmp,
+    /// Anything else carried: a clip, a log disc, a medkit.
+    Other,
+}
+
+/// Whether the player-owned interface (the cyber interface / use mode) is up.
+///
+/// It takes the buttons back from whatever is held, so the press that opened
+/// the interface can always close it again.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandButtonMode {
+    World,
+    Interface,
+}
+
+/// The action a face button means for the hand that pressed it.
+///
+/// | hand holds | lower | upper |
+/// |---|---|---|
+/// | nothing, melee, or any other item | `ToggleUseMode` | `ReadLastUnreadLog` |
+/// | a gun | gun handling (not yet bound) | gun handling (not yet bound) |
+/// | the psi amp | power selection (not yet bound) | power selection (not yet bound) |
+///
+/// **Mode first.** While the interface is up both buttons keep their interface
+/// meaning on both hands whatever is held, so grabbing a gun off the inventory
+/// strip cannot strand the player inside the interface.
+///
+/// Consequence: with a gun in each hand neither the interface nor the log
+/// reader is reachable until a hand is free. That is the point of a per-hand
+/// mapping - free a hand, or use the one that is already free.
+///
+/// `hand` does not change the outcome today (the mapping is symmetric); it is
+/// taken because a gun/psi row resolves to an action *about that hand's
+/// weapon*, which the later PRs bind.
+pub fn resolve_hand_button(
+    mode: HandButtonMode,
+    hand: Handedness,
+    held: HeldKind,
+    button: HandButton,
+) -> Option<InputAction> {
+    let _ = hand;
+
+    let interface_action = match button {
+        HandButton::Lower => InputAction::ToggleUseMode,
+        HandButton::Upper => InputAction::ReadLastUnreadLog,
+    };
+
+    if mode == HandButtonMode::Interface {
+        return Some(interface_action);
+    }
+
+    match held {
+        HeldKind::Empty | HeldKind::Melee | HeldKind::Other => Some(interface_action),
+        // Reserved for the gun and psi-amp handling actions; deliberately
+        // inert until those land, rather than falling through to the panels
+        // and having to be taken away again.
+        HeldKind::Gun | HeldKind::PsiAmp => None,
+    }
+}
+
+/// What `hand` is holding, in the terms [`resolve_hand_button`] resolves.
+pub fn held_kind_in_hand(world: &World, hand: Handedness) -> HeldKind {
+    let Some(held) = crate::wielded_weapon::held_by_hand(world, hand) else {
+        return HeldKind::Empty;
+    };
+
+    // Psi amp first: it is a gun by property (it fires) and answers to power
+    // selection, not gun handling. Melee before guns for the same reason -
+    // the electro-shock and the shard are swung, whatever they carry.
+    if crate::wielded_weapon::is_psi_amp(world, held) {
+        HeldKind::PsiAmp
+    } else if crate::mission::mission_core::is_melee_weapon(world, held) {
+        HeldKind::Melee
+    // `PropBaseGunDesc` rather than the runtime clip (`PropGunState`): it is
+    // the authored description every player gun carries, so a gun with no
+    // magazine component yet still reads as one.
+    } else if world
+        .borrow::<View<PropBaseGunDesc>>()
+        .is_ok_and(|guns| guns.get(held).is_ok())
+    {
+        HeldKind::Gun
+    } else {
+        HeldKind::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HANDS: [Handedness; 2] = [Handedness::Left, Handedness::Right];
+    const BUTTONS: [HandButton; 2] = [HandButton::Lower, HandButton::Upper];
+
+    fn resolve(held: HeldKind, hand: Handedness, button: HandButton) -> Option<InputAction> {
+        resolve_hand_button(HandButtonMode::World, hand, held, button)
+    }
+
+    /// Row 1, on both hands: an empty hand (or one holding anything that is
+    /// not a weapon of its own) reaches the player-owned panels.
+    #[test]
+    fn a_hand_without_a_weapon_owns_the_panels() {
+        for hand in HANDS {
+            for held in [HeldKind::Empty, HeldKind::Melee, HeldKind::Other] {
+                assert_eq!(
+                    resolve(held, hand, HandButton::Lower),
+                    Some(InputAction::ToggleUseMode),
+                    "{held:?} in {hand:?}"
+                );
+                assert_eq!(
+                    resolve(held, hand, HandButton::Upper),
+                    Some(InputAction::ReadLastUnreadLog),
+                    "{held:?} in {hand:?}"
+                );
+            }
+        }
+    }
+
+    /// Rows 2 and 3: a weapon hand's buttons are its weapon's, and no action
+    /// is bound to them yet - so they do nothing rather than quietly keeping
+    /// the panels they are about to lose.
+    #[test]
+    fn a_weapon_hand_reaches_neither_panel() {
+        for hand in HANDS {
+            for held in [HeldKind::Gun, HeldKind::PsiAmp] {
+                for button in BUTTONS {
+                    assert_eq!(resolve(held, hand, button), None, "{held:?} in {hand:?}");
+                }
+            }
+        }
+    }
+
+    /// Mode first: the interface takes both buttons back on both hands, so the
+    /// press that opened it always closes it - even if a gun was grabbed off
+    /// the inventory strip in between.
+    #[test]
+    fn the_open_interface_outranks_whatever_is_held() {
+        for hand in HANDS {
+            for held in [
+                HeldKind::Empty,
+                HeldKind::Melee,
+                HeldKind::Gun,
+                HeldKind::PsiAmp,
+                HeldKind::Other,
+            ] {
+                assert_eq!(
+                    resolve_hand_button(HandButtonMode::Interface, hand, held, HandButton::Lower),
+                    Some(InputAction::ToggleUseMode),
+                    "{held:?} in {hand:?}"
+                );
+                assert_eq!(
+                    resolve_hand_button(HandButtonMode::Interface, hand, held, HandButton::Upper),
+                    Some(InputAction::ReadLastUnreadLog),
+                    "{held:?} in {hand:?}"
+                );
+            }
+        }
+    }
+
+    /// Dual wielding costs the player both panels until a hand is free -
+    /// intended, and asserted so it is a decision rather than a surprise.
+    #[test]
+    fn dual_wielding_reaches_no_panel_on_either_hand() {
+        for hand in HANDS {
+            for button in BUTTONS {
+                assert_eq!(resolve(HeldKind::Gun, hand, button), None);
+            }
+        }
+    }
+}

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -104,6 +104,18 @@ pub enum InputAction {
     /// `play_unread_log`), or replay the newest collected log once all are read.
     /// Collecting a disc only files it in the PDA, so this is how it is read.
     ReadLastUnreadLog,
+
+    /// A Touch face button, named by the hand that pressed it rather than by
+    /// what it does: the pair is contextual, so what a press means depends on
+    /// what that hand holds and whether the cyber interface is up. The
+    /// mapping - and the whole table - lives in [`crate::hand_buttons`];
+    /// the mission resolves it, because only the mission knows the hands.
+    ///
+    /// Lower is left X / right A, upper is left Y / right B.
+    LeftHandLowerButton,
+    LeftHandUpperButton,
+    RightHandLowerButton,
+    RightHandUpperButton,
 }
 
 impl InputAction {
@@ -145,6 +157,10 @@ impl InputAction {
             InputAction::ToggleMap,
             InputAction::TogglePauseMenu,
             InputAction::ToggleFreeCamera,
+            InputAction::LeftHandLowerButton,
+            InputAction::LeftHandUpperButton,
+            InputAction::RightHandLowerButton,
+            InputAction::RightHandUpperButton,
         ]
     }
 
@@ -184,6 +200,10 @@ impl InputAction {
             InputAction::ToggleMap => "ToggleMap",
             InputAction::TogglePauseMenu => "TogglePauseMenu",
             InputAction::ToggleFreeCamera => "ToggleFreeCamera",
+            InputAction::LeftHandLowerButton => "LeftHandLowerButton",
+            InputAction::LeftHandUpperButton => "LeftHandUpperButton",
+            InputAction::RightHandLowerButton => "RightHandLowerButton",
+            InputAction::RightHandUpperButton => "RightHandUpperButton",
         }
     }
 
@@ -193,10 +213,15 @@ impl InputAction {
     /// mapping host-testable even though that runtime only compiles for Android.
     pub fn quest_touch_click_path(&self) -> Option<&'static str> {
         match self {
-            InputAction::ReadLastUnreadLog => Some("/user/hand/left/input/y/click"),
-            // Left X toggles the cyber interface (use mode) - the binding the
-            // removed world-quad backpack (MoveInventory) used to own.
-            InputAction::ToggleUseMode => Some("/user/hand/left/input/x/click"),
+            // The four face buttons are bound RAW, by hand and position: what
+            // a press means is decided later, against what that hand holds
+            // (`crate::hand_buttons`). `ToggleUseMode` and `ReadLastUnreadLog`
+            // are what a free hand's buttons usually resolve TO, so neither
+            // owns a Quest binding of its own any more.
+            InputAction::LeftHandLowerButton => Some("/user/hand/left/input/x/click"),
+            InputAction::LeftHandUpperButton => Some("/user/hand/left/input/y/click"),
+            InputAction::RightHandLowerButton => Some("/user/hand/right/input/a/click"),
+            InputAction::RightHandUpperButton => Some("/user/hand/right/input/b/click"),
             // The right controller's menu button is reserved by the Quest
             // system UI; the left one is the app's.
             InputAction::TogglePauseMenu => Some("/user/hand/left/input/menu/click"),
@@ -213,12 +238,18 @@ impl InputAction {
     /// Production Meta Quest Touch binding for actions reached by a two-button
     /// **chord** rather than a button of their own.
     ///
-    /// The Touch has few buttons to give: `X`, `Y` and the left `Menu` are
-    /// taken, both thumbstick clicks are jump and crouch, and the right `Menu`
-    /// belongs to the Quest system UI. A debug toggle takes a *pair* rather
-    /// than a scarce single button - here right `A`+`B`, which the physical
-    /// clip-insert reload freed of the gun-handling actions they used to
-    /// carry. The pair's edge is resolved by [`InputActionState::sync_chord`].
+    /// The Touch has few buttons to give: every face button is a per-hand
+    /// contextual button, the left `Menu` is the pause menu, both thumbstick
+    /// clicks are jump and crouch, and the right `Menu` belongs to the Quest
+    /// system UI. A debug toggle takes a *pair* rather than a scarce single
+    /// button - here right `A`+`B`. The pair's edge is resolved by
+    /// [`InputActionState::sync_chord`].
+    ///
+    /// The halves are the right hand's own two buttons, and a chord is pressed
+    /// one button at a time - so while the free camera's dev option is on,
+    /// `Game::update` suppresses that hand's two contextual buttons entirely.
+    /// Arming the developer toggle costs the right hand its face buttons; the
+    /// left hand keeps its own.
     ///
     /// [`InputActionState::sync_chord`]: crate::input::InputActionState::sync_chord
     pub fn quest_touch_chord_paths(&self) -> Option<(&'static str, &'static str)> {
@@ -285,15 +316,25 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// The face buttons are bound raw and symmetrically: lower is left X /
+    /// right A, upper is left Y / right B.
     #[test]
-    fn quest_touch_assigns_x_to_use_mode_and_y_to_the_log_reader() {
+    fn quest_touch_binds_the_face_buttons_per_hand() {
         assert_eq!(
-            InputAction::ToggleUseMode.quest_touch_click_path(),
+            InputAction::LeftHandLowerButton.quest_touch_click_path(),
             Some("/user/hand/left/input/x/click")
         );
         assert_eq!(
-            InputAction::ReadLastUnreadLog.quest_touch_click_path(),
+            InputAction::LeftHandUpperButton.quest_touch_click_path(),
             Some("/user/hand/left/input/y/click")
+        );
+        assert_eq!(
+            InputAction::RightHandLowerButton.quest_touch_click_path(),
+            Some("/user/hand/right/input/a/click")
+        );
+        assert_eq!(
+            InputAction::RightHandUpperButton.quest_touch_click_path(),
+            Some("/user/hand/right/input/b/click")
         );
         assert_eq!(
             InputAction::TogglePauseMenu.quest_touch_click_path(),
@@ -301,17 +342,47 @@ mod tests {
         );
     }
 
-    /// The free camera is a chord, not a button, and must never quietly
-    /// become one: a single-path binding here would consume a face button the
-    /// Touch does not have to spare.
+    /// The panels are what a free hand's buttons RESOLVE to
+    /// (`crate::hand_buttons`), so neither may hold a Quest binding itself -
+    /// a direct one would fire whatever the hand was holding.
     #[test]
-    fn the_free_camera_chord_owns_the_right_face_buttons() {
+    fn the_panel_actions_have_no_quest_binding_of_their_own() {
+        assert_eq!(InputAction::ToggleUseMode.quest_touch_click_path(), None);
+        assert_eq!(
+            InputAction::ReadLastUnreadLog.quest_touch_click_path(),
+            None
+        );
+    }
+
+    /// The free camera is a chord, not a button, and must never quietly
+    /// become one: a single-path binding here would take a face button away
+    /// from the hand it belongs to.
+    #[test]
+    fn the_free_camera_is_a_chord_of_the_right_face_buttons() {
         assert_eq!(InputAction::ToggleFreeCamera.quest_touch_click_path(), None);
         let (first, second) = InputAction::ToggleFreeCamera
             .quest_touch_chord_paths()
             .expect("free camera chord binding");
         assert_eq!(first, "/user/hand/right/input/a/click");
         assert_eq!(second, "/user/hand/right/input/b/click");
+    }
+
+    /// The chord IS the right hand's own two buttons - the oculus runtime
+    /// drives it from their states rather than binding a second pair of
+    /// OpenXR actions to the same paths, so the two spellings must agree.
+    #[test]
+    fn the_free_camera_chord_is_the_right_hands_two_buttons() {
+        assert_eq!(
+            InputAction::ToggleFreeCamera.quest_touch_chord_paths(),
+            Some((
+                InputAction::RightHandLowerButton
+                    .quest_touch_click_path()
+                    .unwrap(),
+                InputAction::RightHandUpperButton
+                    .quest_touch_click_path()
+                    .unwrap(),
+            ))
+        );
     }
 
     /// Every action is reachable by exactly one kind of binding, or none.

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -1,5 +1,7 @@
+use crate::hand_buttons::HandButton;
 use crate::input_context::InputContext;
 use crate::scripts::{Effect, GlobalEffect};
+use crate::vr_config::Handedness;
 use dark::properties::AIAlertLevel;
 
 use super::{InputAction, InputActionState};
@@ -42,6 +44,30 @@ const CARRIED_WEAPON_ACTIONS: &[(InputAction, i32)] = &[
     (InputAction::EquipViralProliferator, -29),
     (InputAction::EquipWormLauncher, -27),
     (InputAction::EquipPsiAmp, -247),
+];
+
+/// The raw per-hand face buttons, in the terms `crate::hand_buttons` resolves.
+const HAND_BUTTON_ACTIONS: &[(InputAction, Handedness, HandButton)] = &[
+    (
+        InputAction::LeftHandLowerButton,
+        Handedness::Left,
+        HandButton::Lower,
+    ),
+    (
+        InputAction::LeftHandUpperButton,
+        Handedness::Left,
+        HandButton::Upper,
+    ),
+    (
+        InputAction::RightHandLowerButton,
+        Handedness::Right,
+        HandButton::Lower,
+    ),
+    (
+        InputAction::RightHandUpperButton,
+        Handedness::Right,
+        HandButton::Upper,
+    ),
 ];
 
 pub struct ActionDispatcher;
@@ -144,6 +170,15 @@ impl ActionDispatcher {
         }
         if state.just_triggered(InputAction::ReadLastUnreadLog) {
             effects.push(Effect::ReadLastUnreadLog);
+        }
+        // The face buttons are forwarded RAW, hand and position intact: what a
+        // press means depends on what that hand is holding, which only the
+        // mission can see. This dispatcher stays non-contextual; the table
+        // lives in `crate::hand_buttons`.
+        for &(action, hand, button) in HAND_BUTTON_ACTIONS {
+            if state.just_triggered(action) {
+                effects.push(Effect::HandButton { hand, button });
+            }
         }
         // `InputAction::TogglePauseMenu` deliberately produces no effect: the
         // pause overlay is owned by `Game`, which reads the action directly

--- a/shock2vr/src/input/state.rs
+++ b/shock2vr/src/input/state.rs
@@ -47,6 +47,16 @@ impl InputActionState {
         self.held.remove(&action);
     }
 
+    /// Drop an action entirely for this frame: neither triggered nor held.
+    ///
+    /// For a button that is bound to two things at once and must not fire
+    /// both - the free-camera chord's halves, which are also the right hand's
+    /// contextual face buttons.
+    pub fn suppress(&mut self, action: InputAction) {
+        self.triggered.remove(&action);
+        self.held.remove(&action);
+    }
+
     /// Feed one platform boolean action into semantic input state. OpenXR uses
     /// `is_active`/`changed_since_last_sync`; keeping that edge policy here
     /// makes Quest button mappings host-testable without compiling Android-only
@@ -213,6 +223,21 @@ mod tests {
         // A genuine release still re-arms it.
         state.sync_chord(InputAction::ToggleFreeCamera, true, false, false);
         state.sync_chord(InputAction::ToggleFreeCamera, true, true, true);
+        assert!(state.just_triggered(InputAction::ToggleFreeCamera));
+    }
+
+    #[test]
+    fn suppress_drops_both_the_edge_and_the_latch() {
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::RightHandLowerButton);
+
+        state.suppress(InputAction::RightHandLowerButton);
+
+        assert!(!state.just_triggered(InputAction::RightHandLowerButton));
+        assert!(!state.is_held(InputAction::RightHandLowerButton));
+        // Only the named action - the chord it belongs to must survive.
+        state.trigger(InputAction::ToggleFreeCamera);
+        state.suppress(InputAction::RightHandUpperButton);
         assert!(state.just_triggered(InputAction::ToggleFreeCamera));
     }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audio_log;
 pub mod game_scene;
+pub mod hand_buttons;
 pub mod hand_pose;
 pub mod hand_pose_library;
 pub mod hit_feedback;
@@ -1386,10 +1387,17 @@ impl Game {
         // for HTTP injection alike, so no input path can drift from the rule
         // that the toggle is inert until the Developer screen enables it.
         self.free_camera.sync_gate();
-        if actions.just_triggered(input::InputAction::ToggleFreeCamera)
-            && free_camera::FreeCamera::is_enabled()
-        {
-            self.free_camera.toggle();
+        if free_camera::FreeCamera::is_enabled() {
+            // The chord IS the right hand's own two face buttons, and a chord
+            // is pressed one button at a time - so without this the press on
+            // the way to A+B would first open the cyber interface. Arming the
+            // developer toggle costs that hand its contextual buttons; nothing
+            // else can reach them anyway while the camera is being flown.
+            actions.suppress(input::InputAction::RightHandLowerButton);
+            actions.suppress(input::InputAction::RightHandUpperButton);
+            if actions.just_triggered(input::InputAction::ToggleFreeCamera) {
+                self.free_camera.toggle();
+            }
         }
 
         // Drive a background transition: the loading screen animates while the parse

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1545,7 +1545,8 @@ pub struct MissionCore {
     flat_melee_anim: Option<(EntityId, AnimationPlayer)>,
 
     /// "Use" (metagame) mode, toggled by `Effect::ToggleUseMode` (Tab on
-    /// flat; left-controller X in VR). One mode, two presentations: flat
+    /// flat; a free hand's lower face button in VR). One mode, two
+    /// presentations: flat
     /// shows the cursor + top-docked inventory strip on screen
     /// (`projects/flat-ui.md`); VR presents the same strip canvas on a
     /// head-anchored world panel - the "cyber interface" - with the world
@@ -1557,17 +1558,17 @@ pub struct MissionCore {
     weapon_settings_gun: Option<EntityId>,
 
     /// Whether this use-mode session was opened by the VR log-reader shortcut
-    /// (Quest Y / `Effect::ReadLastUnreadLog`) rather than a deliberate
+    /// (an upper face button / `Effect::ReadLastUnreadLog`) rather than a deliberate
     /// `ToggleUseMode`. It makes Y a true inverse of itself: the press that
-    /// dismisses the reader closes the whole interface when Y is what opened
-    /// it, and only puts the reader away - back to the inventory strip - when
+    /// dismisses the reader closes the whole interface when that button is
+    /// what opened it, and only puts the reader away - back to the strip - when
     /// the player was already in the interface. Transient like `use_mode`
     /// itself (not serialized: a load leaves the mode closed).
     ///
-    /// Only Y consults it. Dismissing the reader with the canvas's own close
-    /// button is the host's generic "put this panel away" and leaves the
-    /// interface up on the inventory strip however it was opened; X or Y
-    /// still exits from there.
+    /// Only the reader shortcut consults it. Dismissing the reader with the
+    /// canvas's own close button is the host's generic "put this panel away"
+    /// and leaves the interface up on the inventory strip however it was
+    /// opened; either face button still exits from there.
     use_mode_from_log_reader: bool,
 
     /// Entry/exit feel for `use_mode`: one eased 0..1 ramp driving the rim
@@ -5646,6 +5647,34 @@ impl MissionCore {
                     }
                 }
 
+                Effect::HandButton { hand, button } => {
+                    // A face button means whatever the hand that pressed it is
+                    // holding says it means - except while the cyber interface
+                    // is up, which takes both buttons back on both hands so
+                    // the press that opened it can always close it.
+                    let mode = if self.use_mode {
+                        crate::hand_buttons::HandButtonMode::Interface
+                    } else {
+                        crate::hand_buttons::HandButtonMode::World
+                    };
+                    let held = crate::hand_buttons::held_kind_in_hand(&self.world, hand);
+                    let resolved =
+                        crate::hand_buttons::resolve_hand_button(mode, hand, held, button);
+                    match resolved {
+                        Some(crate::input::InputAction::ToggleUseMode) => {
+                            effects.push_front(Effect::ToggleUseMode)
+                        }
+                        Some(crate::input::InputAction::ReadLastUnreadLog) => {
+                            effects.push_front(Effect::ReadLastUnreadLog)
+                        }
+                        // A weapon hand resolves to nothing yet - the gun and
+                        // psi-amp handling actions add their arms here when
+                        // they land.
+                        None => {}
+                        Some(action) => warn!("unroutable hand button action: {action}"),
+                    }
+                }
+
                 Effect::ToggleUseMode => {
                     match game_options.presentation_mode {
                         crate::PresentationMode::Flat => {
@@ -5844,13 +5873,14 @@ impl MissionCore {
 
                     let is_vr = game_options.presentation_mode == crate::PresentationMode::Vr;
 
-                    // Y is also the production dismiss affordance in VR. The
-                    // next press re-enters this path, re-resolves and replays
-                    // the latest collected log even when it is already read.
-                    // Y is a true inverse of itself: it puts back exactly what
-                    // it brought up - the whole interface when Y opened it,
-                    // just the reader (leaving the inventory strip) when the
-                    // player was already inside.
+                    // A free hand's UPPER face button is also the production
+                    // dismiss affordance in VR. The next press re-enters this
+                    // path, re-resolves and replays the latest collected log
+                    // even when it is already read. It is a true inverse of
+                    // itself: it puts back exactly what it brought up - the
+                    // whole interface when it opened it, just the reader
+                    // (leaving the inventory strip) when the player was
+                    // already inside.
                     if is_vr && self.flat_ui.active_panel() == Some(panel_entity) {
                         if self.use_mode_from_log_reader {
                             effects.push_front(self.leave_use_mode());
@@ -9865,9 +9895,15 @@ pub fn is_vr_melee_weapon(world: &World, entity_id: EntityId) -> bool {
     world
         .borrow::<UniqueView<GlobalPresentationMode>>()
         .is_ok_and(|mode| mode.0 == crate::PresentationMode::Vr)
-        && world
-            .borrow::<View<PropLimbModel>>()
-            .is_ok_and(|limb_models| limb_models.get(entity_id).is_ok())
+        && is_melee_weapon(world, entity_id)
+}
+
+/// The marker itself, without the VR gate: what the player swings rather than
+/// fires. Callers that care about the presentation use `is_vr_melee_weapon`.
+pub fn is_melee_weapon(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropLimbModel>>()
+        .is_ok_and(|limb_models| limb_models.get(entity_id).is_ok())
 }
 
 /// Physics for an item restored into a hand by save/load or a level change.

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -316,6 +316,15 @@ pub enum Effect {
     /// rotation sampled at the input edge.
     ReadLastUnreadLog,
 
+    /// A face button was pressed on one hand, before anything decided what it
+    /// means. The mission resolves it against what that hand holds and
+    /// whether the cyber interface is up - see [`crate::hand_buttons`] - and
+    /// emits the resolved effect, if any.
+    HandButton {
+        hand: Handedness,
+        button: crate::hand_buttons::HandButton,
+    },
+
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key, `kOverlayMap 26`). Opens the wide map MFD bound to the
     /// synthetic map-panel entity, or closes it if it is already open. No-op in

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -25,12 +25,18 @@ use crate::{mission::PlayerInfo, vr_config::Handedness};
 /// The weapon held in `hand`, or `None` when that hand is empty or holds
 /// something with no ammo/charge of its own (a medkit, a melee weapon).
 pub fn weapon_in_hand(world: &World, hand: Handedness) -> Option<EntityId> {
+    let held = held_by_hand(world, hand)?;
+    is_weapon(world, held).then_some(held)
+}
+
+/// Whatever `hand` holds, weapon or not. The one place `PlayerInfo`'s two
+/// slots are read by handedness.
+pub fn held_by_hand(world: &World, hand: Handedness) -> Option<EntityId> {
     let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
-    let held = match hand {
+    match hand {
         Handedness::Left => player_info.left_hand_entity_id,
         Handedness::Right => player_info.right_hand_entity_id,
-    }?;
-    is_weapon(world, held).then_some(held)
+    }
 }
 
 /// Whether the player holds `entity` in either hand. Unlike

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -25,6 +25,13 @@ export type InputAction =
   | "CyclePsiPower"
   | "ToggleUseMode"
   | "TogglePauseMenu"
+  // Raw Touch face buttons: lower is left X / right A, upper is left Y /
+  // right B. What a press does is resolved per hand against what that hand
+  // holds (shock2vr/src/hand_buttons.rs).
+  | "LeftHandLowerButton"
+  | "LeftHandUpperButton"
+  | "RightHandLowerButton"
+  | "RightHandUpperButton"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 

--- a/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// The Touch face buttons are per-hand and contextual: lower (left X / right A)
+// and upper (left Y / right B) mean the player-owned panels while that hand is
+// free, and belong to the weapon while it holds one. The interface outranks
+// both, so the press that opened it always closes it.
+//
+// Negative-first: on the parent these actions do not exist at all
+// (`/v1/input/action` rejects the name), and right A/B carried nothing.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8656);
+
+/** The debug pistol `DebugCycleWeapon` spawns first. */
+const PISTOL = -17;
+
+async function uiMode(game: GameServer): Promise<string> {
+  return (await game.ui.state()).mode;
+}
+
+async function press(game: GameServer, action: string): Promise<void> {
+  await game.input.trigger(action);
+  await game.step({ frames: 5 });
+}
+
+/** Spawn the debug pistol and take it in the VR RIGHT hand. */
+async function grabPistol(game: GameServer): Promise<number> {
+  // Diffed against the entity list: `debug_weapons` already stocks a pistol,
+  // so a plain template search could hand back the scenery one.
+  const pistol = await cycleToWeapon(game, (e) => e.template_id === PISTOL);
+
+  await aimVrHandAt(game, pistol.position as Vec3, 0.3);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    pistol.id,
+    "the VR right hand must hold the pistol",
+  );
+  return pistol.id;
+}
+
+test(
+  "a free right hand's lower button opens and closes the cyber interface",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    assert.equal(await uiMode(game), "shooter");
+
+    // Right A, mirroring left X - the new half of the symmetry.
+    await press(game, "RightHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "use",
+      "right A with an empty hand must open the cyber interface",
+    );
+
+    await press(game, "RightHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "right A must close what it opened",
+    );
+
+    // The left hand's own buttons are unchanged.
+    await press(game, "LeftHandLowerButton");
+    assert.equal(await uiMode(game), "use", "left X must still open it");
+    await press(game, "LeftHandLowerButton");
+    assert.equal(await uiMode(game), "shooter");
+  },
+);
+
+test(
+  "a gun takes its own hand's buttons, and only its own",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    await grabPistol(game);
+
+    // The gun hand's buttons are the gun's now - and nothing is bound to them
+    // yet, so they do nothing at all rather than reaching the panels.
+    await press(game, "RightHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "right A must not open the interface while that hand holds a gun",
+    );
+    await press(game, "RightHandUpperButton");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "right B must not open the reader while that hand holds a gun",
+    );
+
+    // The free hand still owns the panels: per-hand, not per-player.
+    await press(game, "LeftHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "use",
+      "the free left hand must still reach the interface",
+    );
+  },
+);
+
+test(
+  "the open interface takes both buttons back from the hand holding a gun",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 2,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    const pistol = await grabPistol(game);
+
+    await press(game, "LeftHandLowerButton");
+    assert.equal(await uiMode(game), "use", "the free hand opens it");
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol,
+      "the gun stays held while the interface is up (it is safed, not taken)",
+    );
+
+    // Mode first: the gun hand's own button closes the interface rather than
+    // being swallowed by the weapon it holds - otherwise picking a gun up
+    // inside the interface could strand the player in it.
+    await press(game, "RightHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "right A must close the interface even with a gun in that hand",
+    );
+
+    // ...and once it is closed, that button belongs to the gun again.
+    await press(game, "RightHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "with the interface down the gun hand's button is inert again",
+    );
+  },
+);
+
+test(
+  "arming the free-camera chord takes the right hand's buttons out of play",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 3,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // The chord IS right A+B, and a chord is pressed one button at a time -
+    // so while its developer option is on, A must not open the interface on
+    // the way to A+B.
+    await game.devParams.set("free_camera", 1);
+    await game.step({ frames: 2 });
+    await press(game, "RightHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "right A must be inert while the free-camera chord is armed",
+    );
+    await press(game, "RightHandUpperButton");
+    assert.equal(await uiMode(game), "shooter", "and so must right B");
+
+    // The left hand keeps its buttons - the chord is right-handed.
+    await press(game, "LeftHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "use",
+      "the left hand is unaffected by the chord",
+    );
+    await press(game, "LeftHandLowerButton");
+
+    // Disarmed again, the right hand gets them back.
+    await game.devParams.set("free_camera", 0);
+    await game.step({ frames: 2 });
+    await press(game, "RightHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "use",
+      "right A works again once the chord is disarmed",
+    );
+  },
+);


### PR DESCRIPTION
Rebased onto main b443ff86: this PR's new by-hand `wielded_weapon::held_in_hand` is renamed `held_by_hand` to avoid colliding with main's same-named "is this entity held?" predicate; the `Effect::HandButton` arm sits beside main's new gun-setting / unload / weapon-settings arms.

Stacked on #1166 (`feat/vr-log-reader-surface`) — review that first.

## What

The Touch's four face buttons stop being two global shortcuts and become **per-hand, contextual controls**, symmetric across hands: **lower** is left `X` / right `A`, **upper** is left `Y` / right `B`. They are bound **raw**, by hand and position (`LeftHandLowerButton` .. `RightHandUpperButton`); what a press *means* is resolved per hand against what that hand holds.

| that hand holds | lower | upper |
| --- | --- | --- |
| nothing / melee weapon / clip / log / any other item | `ToggleUseMode` (cyber interface) | `ReadLastUnreadLog` |
| a gun (`PropBaseGunDesc`) | *EjectClip* — **no-op now** | *CycleGunSetting* — **no-op now** |
| the psi amp | *OpenPsiSelector* — **no-op now** | *CyclePsiPower* — **no-op now** |

This PR ships **only the resolver and the empty mapping**. The gun and psi-amp rows have their slots in the table and resolve to `None`: a weapon hand's buttons do nothing at all rather than keeping panels they are about to lose. Their actions arrive in later PRs, which add one arm each.

**Mode first.** While the cyber interface is up, lower/upper keep their interface meaning on **both** hands whatever is held — so grabbing a gun off the inventory strip cannot strand the player inside the interface, and #1166's close semantics survive intact (the reader's dismiss is now "either hand's upper button", and `use_mode_from_log_reader` still decides whether that closes the whole interface or just the reader). The pause menu is unchanged: it clears triggered actions, so a face button never reaches the mission while paused.

**Dual wield is a real cost.** With a gun in each hand neither the interface nor the log reader is reachable until a hand is free. That is the point of a per-hand mapping — free a hand, or use the one that already is. Documented on `resolve_hand_button` and asserted by a test so it reads as a decision, not a surprise.

Flat is untouched: no key is bound to these, and `ToggleUseMode` / `ReadLastUnreadLog` remain first-class actions everywhere else (flat keys, HTTP, SDK) — they simply no longer own a Quest binding of their own, because they are now what a free hand's buttons *resolve to*.

## Shape

- **`shock2vr/src/hand_buttons.rs`** (new): `HandButton::{Lower, Upper}`, `HeldKind::{Empty, Melee, Gun, PsiAmp, Other}`, `HandButtonMode::{World, Interface}`, and the pure `resolve_hand_button(mode, hand, held, button) -> Option<InputAction>`. The world lookup is one function, `held_kind_in_hand`, reusing `wielded_weapon::held_in_hand` / `is_psi_amp` and `mission_core::is_melee_weapon` so no marker is spelled twice.
- **Contextual input stays out of `ActionDispatcher`**: it forwards the raw buttons as `Effect::HandButton { hand, button }` and makes no decision. The mission resolves them, because only the mission can see the hands.
- **`runtimes/oculus_runtime`**: the four buttons are four OpenXR actions bound to their own click paths; the right pair also drives the free-camera chord rather than binding a second pair of actions to the same paths (a unit test keeps the two spellings in agreement).

### The chord

The free-camera chord is still right `A`+`B`, unchanged — but a chord is pressed one button at a time, so `A` on the way to `A`+`B` would otherwise open the cyber interface first. `Game::update` now suppresses the **right hand's** two contextual buttons while the *Free camera* developer option is on, in the one place that gate already lives (so every runtime and HTTP injection get the same rule). Arming the developer toggle costs that hand its face buttons; the left hand keeps its own.

## Tests

- **Unit** (`hand_buttons.rs`): every table row on both hands — a hand without a weapon reaches the panels; a gun/psi-amp hand reaches neither; the open interface outranks every held kind on both hands; dual wielding yields `None` for both buttons on both hands. Plus (`actions.rs`) the raw per-hand Quest paths, that `ToggleUseMode`/`ReadLastUnreadLog` no longer hold a binding of their own, and that the chord is exactly the right hand's two buttons; and (`state.rs`) that `suppress` drops both the edge and the latch for one action only.
- **e2e** (`vr-contextual-buttons.e2e.test.ts`, `--vr`, `debug_weapons`), 4/4 green:
  1. right `A` with an empty hand opens `/v1/ui` mode `"use"` and closes it again; left `X` still does too;
  2. with a pistol in the right hand, right `A` and right `B` do nothing while the free **left** hand still opens the interface;
  3. interface open with a gun held: right `A` still closes it (mode first), and is inert again once it is closed;
  4. with the *Free camera* option armed, right `A`/`B` are inert and the left hand is unaffected — inert again in reverse once it is disarmed.
- Negative-first: on the parent all four fail immediately — `/v1/input/action` rejects the action names outright. Scenario 4 was written against the reviewed regression and fails without the suppression.
- **Regression, all green**: `vr-cyber-interface{,-deposit,-frob,-pointer}` , `vr-audio-log-reader`, `vr-clip-insert-reload`, `free-camera`, `dev-menu`, and `missions` **23/23**. Known baseline failures, unrelated and present on the parent: `dev-menu`'s two debug-scene-launch subtests.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo apk check` (oculus) clean; `cargo test -p shock2vr --lib` 1226 passed; `cargo fmt` clean.

No visuals: nothing rendered changes — the buttons reach existing surfaces (the cyber interface and the log reader, both captured in #1166).

