### PR TITLE
feat(ui): draw loot panels as a hologram grid

### DIFF
--- a/dark/src/importers/texture_importer.rs
+++ b/dark/src/importers/texture_importer.rs
@@ -16,13 +16,18 @@ pub(crate) fn load_texture(
     let extension = Path::new(&name).extension().unwrap();
     let mut buf = Vec::new();
     reader.read_to_end(&mut buf).unwrap();
-    if config.transparent_index_0 && extension.eq_ignore_ascii_case("pcx") {
-        return engine::texture_format::PCX.load_indexed(&buf, true);
+    let raw = if config.transparent_index_0 && extension.eq_ignore_ascii_case("pcx") {
+        engine::texture_format::PCX.load_indexed(&buf, true)
+    } else {
+        let format =
+            engine::texture_format::extension_to_format(extension.to_str().unwrap().to_string())
+                .unwrap();
+        format.load(&buf)
+    };
+    match config.luminance_alpha_tint {
+        Some(tint) => engine::texture_format::tint_alpha_from_luminance(raw, tint),
+        None => raw,
     }
-    let format =
-        engine::texture_format::extension_to_format(extension.to_str().unwrap().to_string())
-            .unwrap();
-    format.load(&buf)
 }
 
 pub(crate) fn process_texture(

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -39,7 +39,7 @@ pub mod cube;
 pub use cube::Cube;
 
 pub mod quad;
-pub use quad::{Quad, QuadUv, create as create_quad, create_with_uv as create_quad_with_uv};
+pub use quad::{Quad, create as create_quad};
 
 pub mod quad_unit;
 pub use quad_unit::{QuadUnit, create as create_quad_unit};

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -39,7 +39,7 @@ pub mod cube;
 pub use cube::Cube;
 
 pub mod quad;
-pub use quad::{Quad, create as create_quad};
+pub use quad::{Quad, QuadUv, create as create_quad, create_with_uv as create_quad_with_uv};
 
 pub mod quad_unit;
 pub use quad_unit::{QuadUnit, create as create_quad_unit};

--- a/engine/src/scene/quad.rs
+++ b/engine/src/scene/quad.rs
@@ -6,6 +6,9 @@ pub use crate::scene::Geometry;
 
 use super::{Mesh, VertexPositionTextureNormal, mesh};
 use cgmath::Vector2;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
 
 pub struct Quad;
 
@@ -68,39 +71,66 @@ impl Geometry for Quad {
 /// 0..1 tiles the texture (with `TextureOptions::wrap`) - which is how a grid
 /// panel repeats one cell bitmap across its cells.
 ///
-/// Unlike [`Quad`] the geometry is per-instance (the UVs vary), so this owns
-/// its mesh rather than sharing the cached one.
+/// Like [`Quad`] the mesh is built on first draw and cached (keyed by the UV
+/// rectangle): a panel rebuilds its scene objects every frame, and allocating a
+/// VAO and two VBOs per frame per element is exactly what that cache exists to
+/// avoid.
 pub struct QuadUv {
-    mesh: Mesh,
+    uv_min: Vector2<f32>,
+    uv_max: Vector2<f32>,
+}
+
+thread_local! {
+    static UV_QUAD_GEOMETRY: RefCell<HashMap<[u32; 4], Rc<Mesh>>> =
+        RefCell::new(HashMap::new());
 }
 
 pub fn create_with_uv(uv_min: Vector2<f32>, uv_max: Vector2<f32>) -> QuadUv {
-    let normal = vec3(0.0, 0.0, 1.0);
-    // Same corners as `Quad`, so an element's placement is unaffected by
-    // whether it samples a sub-rectangle.
-    let corner = |x: f32, y: f32| VertexPositionTextureNormal {
-        position: vec3(x - 0.5, y - 0.5, 0.0),
-        uv: vec2(
-            uv_min.x + (uv_max.x - uv_min.x) * x,
-            uv_min.y + (uv_max.y - uv_min.y) * y,
-        ),
-        normal,
-    };
-    let vertices = vec![
-        corner(0.0, 0.0),
-        corner(0.0, 1.0),
-        corner(1.0, 1.0),
-        corner(1.0, 0.0),
-        corner(1.0, 1.0),
-        corner(0.0, 0.0),
-    ];
-    QuadUv {
-        mesh: mesh::create(vertices),
+    QuadUv { uv_min, uv_max }
+}
+
+impl QuadUv {
+    fn mesh(&self) -> Rc<Mesh> {
+        let key = [
+            self.uv_min.x.to_bits(),
+            self.uv_min.y.to_bits(),
+            self.uv_max.x.to_bits(),
+            self.uv_max.y.to_bits(),
+        ];
+        UV_QUAD_GEOMETRY.with(|cache| {
+            cache
+                .borrow_mut()
+                .entry(key)
+                .or_insert_with(|| Rc::new(self.build()))
+                .clone()
+        })
+    }
+
+    fn build(&self) -> Mesh {
+        let normal = vec3(0.0, 0.0, 1.0);
+        // Same corners as `Quad`, so an element's placement is unaffected by
+        // whether it samples a sub-rectangle.
+        let corner = |x: f32, y: f32| VertexPositionTextureNormal {
+            position: vec3(x - 0.5, y - 0.5, 0.0),
+            uv: vec2(
+                self.uv_min.x + (self.uv_max.x - self.uv_min.x) * x,
+                self.uv_min.y + (self.uv_max.y - self.uv_min.y) * y,
+            ),
+            normal,
+        };
+        mesh::create(vec![
+            corner(0.0, 0.0),
+            corner(0.0, 1.0),
+            corner(1.0, 1.0),
+            corner(1.0, 0.0),
+            corner(1.0, 1.0),
+            corner(0.0, 0.0),
+        ])
     }
 }
 
 impl Geometry for QuadUv {
     fn draw(&self) {
-        self.mesh.draw();
+        self.mesh().draw();
     }
 }

--- a/engine/src/scene/quad.rs
+++ b/engine/src/scene/quad.rs
@@ -5,6 +5,7 @@ use once_cell::sync::OnceCell;
 pub use crate::scene::Geometry;
 
 use super::{Mesh, VertexPositionTextureNormal, mesh};
+use cgmath::Vector2;
 
 pub struct Quad;
 
@@ -59,5 +60,47 @@ impl Geometry for Quad {
         });
 
         mesh.draw();
+    }
+}
+
+/// A [`Quad`] that samples an arbitrary rectangle of its texture instead of the
+/// whole of it. `uv_min`/`uv_max` are in texture units, so a range wider than
+/// 0..1 tiles the texture (with `TextureOptions::wrap`) - which is how a grid
+/// panel repeats one cell bitmap across its cells.
+///
+/// Unlike [`Quad`] the geometry is per-instance (the UVs vary), so this owns
+/// its mesh rather than sharing the cached one.
+pub struct QuadUv {
+    mesh: Mesh,
+}
+
+pub fn create_with_uv(uv_min: Vector2<f32>, uv_max: Vector2<f32>) -> QuadUv {
+    let normal = vec3(0.0, 0.0, 1.0);
+    // Same corners as `Quad`, so an element's placement is unaffected by
+    // whether it samples a sub-rectangle.
+    let corner = |x: f32, y: f32| VertexPositionTextureNormal {
+        position: vec3(x - 0.5, y - 0.5, 0.0),
+        uv: vec2(
+            uv_min.x + (uv_max.x - uv_min.x) * x,
+            uv_min.y + (uv_max.y - uv_min.y) * y,
+        ),
+        normal,
+    };
+    let vertices = vec![
+        corner(0.0, 0.0),
+        corner(0.0, 1.0),
+        corner(1.0, 1.0),
+        corner(1.0, 0.0),
+        corner(1.0, 1.0),
+        corner(0.0, 0.0),
+    ];
+    QuadUv {
+        mesh: mesh::create(vertices),
+    }
+}
+
+impl Geometry for QuadUv {
+    fn draw(&self) {
+        self.mesh.draw();
     }
 }

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -125,12 +125,44 @@ impl SceneObject {
         position: Vector2<f32>,
         size: Vector2<f32>,
     ) -> SceneObject {
+        Self::screen_space_geometry_object(material, position, size, Box::new(quad::create()))
+    }
+
+    /// As [`Self::screen_space_quad_object`], for geometry that is not the
+    /// shared unit quad (a quad sampling a texture sub-rectangle).
+    fn screen_space_geometry_object(
+        material: Box<dyn Material>,
+        position: Vector2<f32>,
+        size: Vector2<f32>,
+        geometry: Box<dyn Geometry>,
+    ) -> SceneObject {
         let xform = Matrix4::from_translation(vec3(position.x, position.y, 0.0))
             * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
             * Matrix4::from_translation(vec3(0.5, 0.5, 0.0));
-        let mut ret = Self::new(material, Box::new(quad::create()));
+        let mut ret = Self::new(material, geometry);
         ret.set_local_transform(xform);
         ret
+    }
+
+    /// A screen-space quad sampling `uv_min`..`uv_max` of its texture instead
+    /// of the whole of it. A range outside 0..1 tiles the texture, so a grid
+    /// bitmap can repeat across the quad.
+    pub fn screen_space_quad_uv(
+        texture: Rc<dyn TextureTrait>,
+        position: Vector2<f32>,
+        size: Vector2<f32>,
+        opacity: f32,
+        uv_min: Vector2<f32>,
+        uv_max: Vector2<f32>,
+    ) -> SceneObject {
+        let material =
+            materials::ScreenSpaceMaterial::create(texture, vec4(1.0, 1.0, 1.0, opacity));
+        Self::screen_space_geometry_object(
+            material,
+            position,
+            size,
+            Box::new(quad::create_with_uv(uv_min, uv_max)),
+        )
     }
 
     pub fn screen_space_quad2(

--- a/engine/src/texture.rs
+++ b/engine/src/texture.rs
@@ -132,6 +132,11 @@ pub enum TextureFilter {
     /// minified: blending across the key boundary turns it into a visible
     /// fringe that no colour-key test can then recognize.
     Nearest,
+    /// Linear, with mipmaps for minification. Right for fine line art drawn
+    /// smaller than its texels and at a viewpoint-dependent scale (a hologram
+    /// grid on a VR panel): plain `Linear` point-samples the lines, so their
+    /// brightness swims with sub-pixel phase as the panel moves.
+    LinearMipmap,
 }
 
 #[derive(Hash)]
@@ -182,12 +187,13 @@ pub fn init_from_memory2(raw_texture_data: RawTextureData, options: &TextureOpti
         // gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as i32);
 
         // set texture filtering parameters
-        let filter = match options.filter {
-            TextureFilter::Linear => gl::LINEAR,
-            TextureFilter::Nearest => gl::NEAREST,
+        let (min_filter, mag_filter) = match options.filter {
+            TextureFilter::Linear => (gl::LINEAR, gl::LINEAR),
+            TextureFilter::Nearest => (gl::NEAREST, gl::NEAREST),
+            TextureFilter::LinearMipmap => (gl::LINEAR_MIPMAP_LINEAR, gl::LINEAR),
         };
-        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, filter as i32);
-        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, filter as i32);
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, min_filter as i32);
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, mag_filter as i32);
     }
 
     let pixel_format = match raw_texture_data.format {
@@ -222,7 +228,9 @@ pub fn init_from_memory2(raw_texture_data: RawTextureData, options: &TextureOpti
             gl::UNSIGNED_BYTE,
             &raw_texture_data.bytes[0] as *const u8 as *const c_void,
         );
-        //gl::GenerateMipmap(gl::TEXTURE_2D);
+        if matches!(options.filter, TextureFilter::LinearMipmap) {
+            gl::GenerateMipmap(gl::TEXTURE_2D);
+        }
     }
 
     Texture {

--- a/engine/src/texture.rs
+++ b/engine/src/texture.rs
@@ -141,6 +141,11 @@ pub struct TextureOptions {
     /// (PCX). Dark bitmap sprites (particles) are keyed this way; wall/UI
     /// textures are not, so this is opt-in.
     pub transparent_index_0: bool,
+    /// Turn opaque line art into a translucent tinted overlay: each texel's
+    /// alpha becomes its luminance and its colour becomes this tint. Black
+    /// therefore drops out entirely, which is what makes a grid bitmap read as
+    /// a hologram over the world instead of a black panel.
+    pub luminance_alpha_tint: Option<[u8; 3]>,
     pub filter: TextureFilter,
 }
 
@@ -149,6 +154,7 @@ impl Default for TextureOptions {
         TextureOptions {
             wrap: true,
             transparent_index_0: false,
+            luminance_alpha_tint: None,
             filter: TextureFilter::Linear,
         }
     }

--- a/engine/src/texture_format.rs
+++ b/engine/src/texture_format.rs
@@ -75,7 +75,7 @@ pub fn tint_alpha_from_luminance(data: RawTextureData, tint: [u8; 3]) -> RawText
         let g = data.bytes[src + 1] as u32;
         let b = data.bytes[src + 2] as u32;
         // Rec. 601 luma, the usual perceptual weighting.
-        let luma = ((r * 299 + g * 587 + b * 114) / 1000).min(255) as u8;
+        let luma = ((r * 299 + g * 587 + b * 114) / 1000) as u8;
         // A source alpha (a colour key, say) still wins: a keyed-out texel
         // must not come back as a lit line.
         let alpha = if has_alpha {

--- a/engine/src/texture_format.rs
+++ b/engine/src/texture_format.rs
@@ -58,6 +58,45 @@ fn apply_color_key(pixels: &mut [u8], width: u32, height: u32) {
     }
 }
 
+/// Re-key opaque line art as a translucent tinted overlay: every texel's alpha
+/// becomes its luminance and its colour becomes `tint`. Black drops out
+/// completely and a bright line stays solid, so a grid bitmap drawn over the
+/// world reads as a hologram rather than as a black panel.
+pub fn tint_alpha_from_luminance(data: RawTextureData, tint: [u8; 3]) -> RawTextureData {
+    let (stride, has_alpha) = match data.format {
+        PixelFormat::RGB => (3usize, false),
+        PixelFormat::RGBA => (4usize, true),
+    };
+    let count = (data.width * data.height) as usize;
+    let mut out = vec![0u8; count * 4];
+    for i in 0..count {
+        let src = i * stride;
+        let r = data.bytes[src] as u32;
+        let g = data.bytes[src + 1] as u32;
+        let b = data.bytes[src + 2] as u32;
+        // Rec. 601 luma, the usual perceptual weighting.
+        let luma = ((r * 299 + g * 587 + b * 114) / 1000).min(255) as u8;
+        // A source alpha (a colour key, say) still wins: a keyed-out texel
+        // must not come back as a lit line.
+        let alpha = if has_alpha {
+            ((luma as u32 * data.bytes[src + 3] as u32) / 255) as u8
+        } else {
+            luma
+        };
+        let dst = i * 4;
+        out[dst] = tint[0];
+        out[dst + 1] = tint[1];
+        out[dst + 2] = tint[2];
+        out[dst + 3] = alpha;
+    }
+    RawTextureData {
+        bytes: out,
+        width: data.width,
+        height: data.height,
+        format: PixelFormat::RGBA,
+    }
+}
+
 /// GL-free PCX dimension read. Reuses the same `pcx::Reader` header parse as the full
 /// decode in `PcxFormat::load`, so `(width, height)` are guaranteed to match
 /// `Texture::width()/height()` — but WITHOUT decoding pixels or touching the GPU. This
@@ -216,6 +255,33 @@ mod tests {
             writer.finish().unwrap();
         }
         assert_eq!(read_pcx_dimensions(&buf), Some((w as u32, h as u32)));
+    }
+
+    #[test]
+    fn luminance_alpha_tint_drops_black_and_keeps_bright_lines() {
+        // One black texel, one near-white line texel.
+        let data = RawTextureData {
+            bytes: vec![0, 0, 0, 255, 246, 247, 255, 255],
+            width: 2,
+            height: 1,
+            format: PixelFormat::RGBA,
+        };
+        let out = tint_alpha_from_luminance(data, [80, 220, 255]);
+        assert_eq!(out.bytes[3], 0, "black must drop out entirely");
+        assert!(out.bytes[7] > 240, "a bright line stays solid");
+        assert_eq!(&out.bytes[4..7], &[80, 220, 255], "lines take the tint");
+    }
+
+    #[test]
+    fn luminance_alpha_tint_respects_a_keyed_out_texel() {
+        let data = RawTextureData {
+            bytes: vec![255, 255, 255, 0],
+            width: 1,
+            height: 1,
+            format: PixelFormat::RGBA,
+        };
+        let out = tint_alpha_from_luminance(data, [80, 220, 255]);
+        assert_eq!(out.bytes[3], 0);
     }
 
     #[test]

--- a/projects/flat-ui.md
+++ b/projects/flat-ui.md
@@ -458,7 +458,7 @@ attaches them** to the right entities:
 | Script name(s) | Gui | Notes |
 | --- | --- | --- |
 | `keypad`, `keypadunhackable` (`scripts/mod.rs:574-575`) | `KeyPadGui` (`scripts/gui/keypad.rs`) | full digit grid (`key<d>0/1.pcx`), value display, **code check against `PropKeypadCode` + `TurnOn` to all SwitchLinks** (`:216-238`), `bkeypad`/`hacksucc` sounds. This is the logic #435 needs — it only lacks a flat way in. |
-| `containerscript` (`:437`) | `ContainerGui::loot_container()` (`scripts/gui/container.rs:27`) | `contain.pcx` 188×296, 4×4 grid; enumerates the entity's `Contains` links (`:76-93`), renders `PropObjIcon` icons sized by `PropInventoryDimensions`, grab-to-hand + frob msgs (`:170-205`) |
+| `containerscript` (`:437`) | `ContainerGui::loot_container()` (`scripts/gui/container.rs:27`) | hologram grid (`fam/SHODAN/s45.pcx`) 188×152, 4×4 grid; enumerates the entity's `Contains` links (`:76-93`), renders `PropObjIcon` icons sized by `PropInventoryDimensions`, grab-to-hand + frob msgs (`:170-205`) |
 | `internal_inventory` (`:491`) | `ContainerGui::inv_container()` (`container.rs:39`) | `invback.pcx` 635×120, **15×3 grid — the player backpack UI already exists**; attached to the synthetic player-inventory entity (`inventory/player_inventory_entity.rs:20`) |
 | `elevatorbutton` (`:681`) | `ElevatorGui` | floor select |
 | `replicatorscript` (`:718`) | `ReplicatorGui` | purchase panel |

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -358,6 +358,19 @@ where
     /// the element's rect (see [`ImageKind`]). The rect still defines layout
     /// and hit-testing.
     pub fn with_object_icon(self) -> GuiComponent<TEvent> {
+        self.with_kind(ImageKind::ObjectIcon)
+    }
+
+    /// Declare this element's art to be a holographic grid tile, repeated
+    /// `tiles_x` x `tiles_y` across the element's rect (see
+    /// [`ImageKind::Hologram`]).
+    pub fn with_hologram(self, tiles_x: u8, tiles_y: u8) -> GuiComponent<TEvent> {
+        self.with_kind(ImageKind::Hologram { tiles_x, tiles_y })
+    }
+
+    /// How this element's art is keyed and sized. No-op for components that
+    /// draw no art.
+    fn with_kind(self, kind: ImageKind) -> GuiComponent<TEvent> {
         match self {
             Self::Image {
                 position,
@@ -370,7 +383,7 @@ where
                 size,
                 texture,
                 alpha,
-                kind: ImageKind::ObjectIcon,
+                kind,
             },
             Self::Button {
                 position,
@@ -393,29 +406,7 @@ where
                 alpha,
                 entity,
                 label,
-                kind: ImageKind::ObjectIcon,
-            },
-            other => other,
-        }
-    }
-
-    /// Declare this element's art to be a holographic grid tile, repeated
-    /// `tiles_x` x `tiles_y` across the element's rect (see
-    /// [`ImageKind::Hologram`]).
-    pub fn with_hologram(self, tiles_x: u8, tiles_y: u8) -> GuiComponent<TEvent> {
-        match self {
-            Self::Image {
-                position,
-                size,
-                texture,
-                alpha,
-                ..
-            } => Self::Image {
-                position,
-                size,
-                texture,
-                alpha,
-                kind: ImageKind::Hologram { tiles_x, tiles_y },
+                kind,
             },
             other => other,
         }

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -399,6 +399,28 @@ where
         }
     }
 
+    /// Declare this element's art to be a holographic grid tile, repeated
+    /// `tiles_x` x `tiles_y` across the element's rect (see
+    /// [`ImageKind::Hologram`]).
+    pub fn with_hologram(self, tiles_x: u8, tiles_y: u8) -> GuiComponent<TEvent> {
+        match self {
+            Self::Image {
+                position,
+                size,
+                texture,
+                alpha,
+                ..
+            } => Self::Image {
+                position,
+                size,
+                texture,
+                alpha,
+                kind: ImageKind::Hologram { tiles_x, tiles_y },
+            },
+            other => other,
+        }
+    }
+
     /// Tag a `Button` with the world entity it stands for (no-op for other
     /// component kinds) - see `GuiComponent::Button::entity`.
     pub fn with_entity(self, new_entity: EntityId) -> GuiComponent<TEvent> {

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -92,7 +92,7 @@ const SLOT_PITCH: Vector2<f32> = Vector2::new(35.0, 34.0);
 /// width the flat MFD slot reserves, with the same margin at the top.
 const LOOT_GRID_ORIGIN: Vector2<f32> = Vector2::new(
     (LOOT_PANEL_WIDTH - SLOT_PITCH.x * LOOT_SLOTS.0 as f32) / 2.0,
-    LOOT_GRID_MARGIN,
+    LOOT_GRID_TOP_MARGIN,
 );
 
 /// The loot panel keeps the 188px width of the flat MFD slot it docks into.
@@ -101,10 +101,14 @@ const LOOT_PANEL_WIDTH: f32 = 188.0;
 /// Cells in the loot grid.
 const LOOT_SLOTS: (usize, usize) = (4, 4);
 
-/// Breathing room around the loot grid, so the hologram's outer separators are
-/// not flush with the panel edge (and the flat host's close button, which hugs
-/// the panel's top-right corner, does not sit on the grid).
+/// Breathing room below and beside the loot grid, so the hologram's outer
+/// separators are not flush with the panel edge.
 const LOOT_GRID_MARGIN: f32 = 8.0;
+
+/// Clearance above the grid: the flat host draws its close button hugging the
+/// panel's top-right corner (21px tall at y=8), and a grid tucked under it
+/// would hand that corner cell's clicks to the close button.
+const LOOT_GRID_TOP_MARGIN: f32 = 34.0;
 
 /// Top-left of the backpack strip's 15x3 item grid, in `invback.pcx` pixels:
 /// separators at x = 2 + 35n and y = 15 + 34n, so this sits 2px inside the
@@ -203,6 +207,10 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // between the lines.
             PanelBackdrop::HologramGrid => gui::image(self.backdrop.texture())
                 .with_hologram(self.num_slots_x as u8, self.num_slots_y as u8)
+                // Fully opaque: the grid's own translucency is in its alpha,
+                // and `gui::image`'s 0.5 default would otherwise halve the
+                // lines in VR while the flat host draws them at full strength.
+                .with_alpha(1.0)
                 .with_position(vec2(self.inv_offset_x, self.inv_offset_y))
                 .with_size(vec2(
                     SLOT_PITCH.x * self.num_slots_x as f32,
@@ -776,7 +784,7 @@ mod tests {
         let (world, container, item, _inventory) = loot_world();
 
         for (gui, expected_origin) in [
-            (ContainerGui::loot_container(), vec2(24.0, 8.0)),
+            (ContainerGui::loot_container(), vec2(24.0, 34.0)),
             (ContainerGui::inv_container(), vec2(4.0, 17.0)),
         ] {
             let components = gui.get_components(&None, container, &world, &ContainerGuiState {});

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -15,8 +15,27 @@ use crate::gui;
 
 use crate::scripts::{Effect, MessagePayload};
 
+/// What a panel draws behind its item cells.
+enum PanelBackdrop {
+    /// The original panel bitmap, filling the whole panel.
+    Art(String),
+    /// A bare holographic grid over the item cells and nothing else - no
+    /// backdrop, no chrome (see [`ImageKind::Hologram`]).
+    HologramGrid,
+}
+
+impl PanelBackdrop {
+    /// The bitmap this backdrop draws from.
+    fn texture(&self) -> &str {
+        match self {
+            Self::Art(texture) => texture.as_str(),
+            Self::HologramGrid => crate::ui::HOLOGRAM_TILE_TEXTURE,
+        }
+    }
+}
+
 pub struct ContainerGui {
-    background_image: String,
+    backdrop: PanelBackdrop,
     width: f32,
     height: f32,
     inv_offset_x: f32,
@@ -68,12 +87,24 @@ fn creature_is_lootable(world: &World, entity_id: EntityId) -> bool {
 /// 35px apart horizontally and 34px apart vertically.
 const SLOT_PITCH: Vector2<f32> = Vector2::new(35.0, 34.0);
 
-/// Top-left of the loot panel's 4x4 item grid, in `contain.pcx` pixels. Its
-/// cell separators run at x = 13 + 35n and y = 150 + 34n; both are 2px wide,
-/// so this is flush with the first cell's interior horizontally and one row
-/// below it vertically. The two panels' insets differ - that asymmetry is the
-/// original's, not a rounding of ours.
-const LOOT_GRID_ORIGIN: Vector2<f32> = Vector2::new(15.0, 153.0);
+/// Top-left of the loot panel's 4x4 item grid. The panel is nothing but the
+/// grid now, so this is a plain margin: horizontally centered in the 188px
+/// width the flat MFD slot reserves, with the same margin at the top.
+const LOOT_GRID_ORIGIN: Vector2<f32> = Vector2::new(
+    (LOOT_PANEL_WIDTH - SLOT_PITCH.x * LOOT_SLOTS.0 as f32) / 2.0,
+    LOOT_GRID_MARGIN,
+);
+
+/// The loot panel keeps the 188px width of the flat MFD slot it docks into.
+const LOOT_PANEL_WIDTH: f32 = 188.0;
+
+/// Cells in the loot grid.
+const LOOT_SLOTS: (usize, usize) = (4, 4);
+
+/// Breathing room around the loot grid, so the hologram's outer separators are
+/// not flush with the panel edge (and the flat host's close button, which hugs
+/// the panel's top-right corner, does not sit on the grid).
+const LOOT_GRID_MARGIN: f32 = 8.0;
 
 /// Top-left of the backpack strip's 15x3 item grid, in `invback.pcx` pixels:
 /// separators at x = 2 + 35n and y = 15 + 34n, so this sits 2px inside the
@@ -105,13 +136,13 @@ pub fn backpack_cell_at(panel_pos: Vector2<f32>, grid: (usize, usize)) -> Option
 impl ContainerGui {
     pub fn loot_container() -> ContainerGui {
         ContainerGui {
-            background_image: "contain.pcx".to_owned(),
-            width: 188.0,
-            height: 296.0,
+            backdrop: PanelBackdrop::HologramGrid,
+            width: LOOT_PANEL_WIDTH,
+            height: LOOT_GRID_ORIGIN.y + SLOT_PITCH.y * LOOT_SLOTS.1 as f32 + LOOT_GRID_MARGIN,
             inv_offset_x: LOOT_GRID_ORIGIN.x,
             inv_offset_y: LOOT_GRID_ORIGIN.y,
-            num_slots_x: 4,
-            num_slots_y: 4,
+            num_slots_x: LOOT_SLOTS.0,
+            num_slots_y: LOOT_SLOTS.1,
             take_on_click: true,
             require_lootable_creature: false,
         }
@@ -130,7 +161,7 @@ impl ContainerGui {
 
     pub fn inv_container() -> ContainerGui {
         ContainerGui {
-            background_image: "invback.pcx".to_owned(),
+            backdrop: PanelBackdrop::Art("invback.pcx".to_owned()),
             width: 635.0,
             height: 120.0,
             inv_offset_x: BACKPACK_GRID_ORIGIN.x,
@@ -163,11 +194,21 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
         world: &World,
         _state: &ContainerGuiState,
     ) -> Vec<GuiComponent<ContainerGuiMsg>> {
-        let mut components: Vec<GuiComponent<ContainerGuiMsg>> = vec![
-            gui::image(self.background_image.as_str())
+        let mut components: Vec<GuiComponent<ContainerGuiMsg>> = vec![match &self.backdrop {
+            PanelBackdrop::Art(_) => gui::image(self.backdrop.texture())
                 .with_position(vec2(0.0, 0.0))
                 .with_size(vec2(self.width, self.height)),
-        ];
+            // One hologram cell per item cell, drawn over the item grid only:
+            // the panel has no backdrop of its own, so the world shows through
+            // between the lines.
+            PanelBackdrop::HologramGrid => gui::image(self.backdrop.texture())
+                .with_hologram(self.num_slots_x as u8, self.num_slots_y as u8)
+                .with_position(vec2(self.inv_offset_x, self.inv_offset_y))
+                .with_size(vec2(
+                    SLOT_PITCH.x * self.num_slots_x as f32,
+                    SLOT_PITCH.y * self.num_slots_y as f32,
+                )),
+        }];
 
         // Resolve the usable grid once in panel pixels. Both flat and VR
         // presentations consume this same component list, so blocked-cell and
@@ -726,16 +767,16 @@ mod tests {
         }
     }
 
-    /// Both panels' item grids must land on the cell separators authored into
-    /// their backdrops - `contain.pcx` (loot) and `invback.pcx` (backpack) -
-    /// stepping by the shared 35x34 cell pitch. A 1x1 item therefore occupies
-    /// exactly one cell at the grid origin.
+    /// Both panels' item grids must land on their cell separators - the loot
+    /// panel's hologram lines, the backpack's `invback.pcx` art - stepping by
+    /// the shared 35x34 cell pitch. A 1x1 item therefore occupies exactly one
+    /// cell at the grid origin.
     #[test]
     fn item_grids_sit_on_the_authored_backdrop_cells() {
         let (world, container, item, _inventory) = loot_world();
 
         for (gui, expected_origin) in [
-            (ContainerGui::loot_container(), vec2(15.0, 153.0)),
+            (ContainerGui::loot_container(), vec2(24.0, 8.0)),
             (ContainerGui::inv_container(), vec2(4.0, 17.0)),
         ] {
             let components = gui.get_components(&None, container, &world, &ContainerGuiState {});
@@ -823,14 +864,14 @@ mod tests {
             ContainerGui::loot_container(),
             ContainerGui::inv_container(),
         ] {
-            let backdrop = gui.background_image.clone();
+            let backdrop = gui.backdrop.texture().to_owned();
             let components = gui.get_components(&cursor, container, &world, &ContainerGuiState {});
             let kinds: Vec<ImageKind> = components
                 .iter()
                 .filter_map(|c| match c {
                     GuiComponent::Button { kind, .. } => Some(*kind),
-                    // The panel's own backdrop is the only art that is not
-                    // an item icon.
+                    // The panel's own backdrop (art or hologram grid) is the
+                    // only image that is not an item icon.
                     GuiComponent::Image { kind, texture, .. } if *texture != backdrop => {
                         Some(*kind)
                     }

--- a/shock2vr/src/scripts/gui/hackable_crate.rs
+++ b/shock2vr/src/scripts/gui/hackable_crate.rs
@@ -371,8 +371,8 @@ mod tests {
         );
 
         assert!(
-            has_texture(&components, "contain.pcx"),
-            "a hacked crate should draw the loot panel backdrop"
+            has_texture(&components, crate::ui::HOLOGRAM_TILE_TEXTURE),
+            "a hacked crate should draw the loot panel's hologram grid"
         );
         assert!(
             button_for(&components, clip),

--- a/shock2vr/src/scripts/gui/hackable_crate.rs
+++ b/shock2vr/src/scripts/gui/hackable_crate.rs
@@ -26,6 +26,7 @@
 //! held item is released onto a target - via [`Gui::on_provide_for_consumption`],
 //! so the pick opens the crate instead of being deposited into it.
 
+use cgmath::Vector2;
 use dark::properties::ObjectState;
 use engine::audio::AudioHandle;
 use shipyard::{EntityId, World};
@@ -52,6 +53,18 @@ impl HackableCrateGui {
     pub fn new() -> HackableCrateGui {
         HackableCrateGui {
             loot: ContainerGui::loot_container(),
+        }
+    }
+}
+
+impl HackableCrateGui {
+    /// The HRM board's own canvas: the retail 188x296 MFD art `draw_hack_board`
+    /// lays out, at the loot panel's world placement so the crate's two faces
+    /// appear in the same spot.
+    fn board_config(loot: &ContainerGui) -> GuiConfig {
+        GuiConfig {
+            screen_size_in_pixels: Vector2::new(188.0, 296.0),
+            ..loot.get_config()
         }
     }
 }
@@ -161,10 +174,25 @@ impl Gui<HackableCrateState, HackableCrateMsg> for HackableCrateGui {
     }
 
     fn get_config(&self) -> GuiConfig {
-        // The HRM board and the loot panel share the retail 188x296 MFD
-        // canvas, so the loot panel's own config covers both faces of the
-        // crate - and stays in step with it if that panel ever changes.
-        self.loot.get_config()
+        // A crate starts sealed, so the board is the default face.
+        Self::board_config(&self.loot)
+    }
+
+    /// The crate's two faces have two canvases: the HRM board is the retail
+    /// 188x296 MFD art, while the hacked face is the loot panel, which is only
+    /// as tall as its grid. Sizing the board with the loot panel's config
+    /// would squash the board art and move every one of its buttons.
+    fn get_config_for(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        _state: &HackableCrateState,
+    ) -> GuiConfig {
+        if is_open(world, entity_id) {
+            self.loot.get_config()
+        } else {
+            Self::board_config(&self.loot)
+        }
     }
 
     /// A crate ruined by a critical failure is finished: frobbing it does
@@ -357,6 +385,38 @@ mod tests {
 
     /// Once hacked, the crate is an ordinary loot container: the contained
     /// clip gets its own clickable slot.
+    /// The crate's two faces have two canvases: sealed, it is the retail
+    /// 188x296 HRM board; hacked, it is the loot panel, which is only as tall
+    /// as its grid. Sizing the board from the loot panel squashes the board
+    /// art and moves every one of its buttons (START included).
+    #[test]
+    fn the_board_keeps_its_own_canvas_when_the_loot_panel_shrinks() {
+        let (mut world, security_crate, _clip) = crate_world();
+        let gui = HackableCrateGui::new();
+        let state = HackableCrateState::default();
+
+        let sealed = gui.get_config_for(security_crate, &world, &state);
+        assert_eq!(sealed.screen_size_in_pixels, Vector2::new(188.0, 296.0));
+        assert_eq!(
+            gui.get_config().screen_size_in_pixels,
+            Vector2::new(188.0, 296.0)
+        );
+
+        world.add_component(security_crate, PropObjState(ObjectState::Hacked));
+        let hacked = gui.get_config_for(security_crate, &world, &state);
+        assert_eq!(
+            hacked.screen_size_in_pixels,
+            ContainerGui::loot_container()
+                .get_config()
+                .screen_size_in_pixels,
+            "a hacked crate is an ordinary loot panel"
+        );
+        assert_eq!(
+            sealed.world_offset, hacked.world_offset,
+            "both faces appear in the same place"
+        );
+    }
+
     #[test]
     fn hacked_crate_shows_its_contents_as_a_loot_panel() {
         let (mut world, security_crate, clip) = crate_world();

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -931,6 +931,14 @@ fn texture_options(kind: ImageKind) -> TextureOptions {
         wrap: hologram,
         transparent_index_0: kind.transparent_index_0(),
         luminance_alpha_tint: hologram.then_some(HOLOGRAM_TINT),
+        // The grid's lines are a texel wide and are drawn well under their
+        // authored size, at a distance the VR viewer changes at will; without
+        // mipmaps they alias into a swimming, unevenly-bright grid.
+        filter: if hologram {
+            engine::texture::TextureFilter::LinearMipmap
+        } else {
+            engine::texture::TextureFilter::Linear
+        },
         ..Default::default()
     }
 }
@@ -1383,6 +1391,10 @@ mod tests {
         });
         assert!(options.wrap);
         assert_eq!(options.luminance_alpha_tint, Some(HOLOGRAM_TINT));
+        assert!(matches!(
+            options.filter,
+            engine::texture::TextureFilter::LinearMipmap
+        ));
         assert!(!options.transparent_index_0);
 
         let ui = texture_options(ImageKind::Ui);

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -373,11 +373,49 @@ pub enum ImageKind {
     /// without stretching or overlapping adjacent rows. Smaller art remains
     /// at its authored size.
     ObjectIconFit,
+    /// A holographic grid: the SHODAN family grid tile repeated `tiles_x` x
+    /// `tiles_y` times across the element's rect, with its black dropped and
+    /// its lines tinted (see [`HOLOGRAM_TINT`]). Sized like [`Self::Ui`].
+    Hologram { tiles_x: u8, tiles_y: u8 },
 }
+
+/// The grid tile every hologram panel is drawn from (`fam/SHODAN/S45.PCX`):
+/// 128x128, a black cell bounded by a bright 1px cross at row/column 64, with
+/// a faint dotted sub-grid and a DIM line along the wrap edge at row/column 0.
+const HOLOGRAM_TILE_PX: f32 = 128.0;
+
+/// The hologram's line colour. The tile's own art is near-white; a cyan tint
+/// is what makes it read as SHODAN's projection rather than as white chrome.
+const HOLOGRAM_TINT: [u8; 3] = [90, 226, 255];
+
+/// The tile bitmap for [`ImageKind::Hologram`].
+pub const HOLOGRAM_TILE_TEXTURE: &str = "s45.pcx";
 
 impl ImageKind {
     pub(crate) fn transparent_index_0(self) -> bool {
         matches!(self, Self::ObjectIcon | Self::ObjectIconFit)
+    }
+
+    /// The texture rectangle this art samples, in texture units, or `None` for
+    /// the whole texture. Both presentations ask this one question, so a
+    /// hologram cannot tile differently on a flat panel than on a VR quad.
+    ///
+    /// A hologram starts half a tile in and ends half a tile past the last
+    /// tile, so the tile's bright cross lands on every cell border - the outer
+    /// edges included, where the tile's own dim wrap-edge line would otherwise
+    /// fall. The half-texel margin keeps the border line whole rather than
+    /// clipped in half.
+    pub(crate) fn uv_rect(self) -> Option<(Vector2<f32>, Vector2<f32>)> {
+        match self {
+            Self::Hologram { tiles_x, tiles_y } => {
+                let margin = 0.5 + 1.0 / HOLOGRAM_TILE_PX;
+                Some((
+                    vec2(0.5 - 1.0 / HOLOGRAM_TILE_PX, 0.5 - 1.0 / HOLOGRAM_TILE_PX),
+                    vec2(tiles_x as f32 + margin, tiles_y as f32 + margin),
+                ))
+            }
+            _ => None,
+        }
     }
 }
 
@@ -882,9 +920,13 @@ impl UiCanvas<()> {
 /// How a `kind`'s art is sampled. Shared so layout and the presenters key the
 /// asset cache the same way.
 fn texture_options(kind: ImageKind) -> TextureOptions {
+    let hologram = matches!(kind, ImageKind::Hologram { .. });
     TextureOptions {
-        wrap: false,
+        // A hologram repeats one tile across its cells, so it - and only it -
+        // needs the sampler to wrap.
+        wrap: hologram,
         transparent_index_0: kind.transparent_index_0(),
+        luminance_alpha_tint: hologram.then_some(HOLOGRAM_TINT),
         ..Default::default()
     }
 }
@@ -990,12 +1032,22 @@ fn present_screen(
     match &element.content {
         PlacedContent::Image { texture, kind } => {
             let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options(*kind));
-            SceneObject::screen_space_quad2(
-                texture.clone() as Rc<dyn TextureTrait>,
-                vec2(rect.x, rect.y),
-                vec2(rect.w, rect.h),
-                element.alpha,
-            )
+            match kind.uv_rect() {
+                Some((uv_min, uv_max)) => SceneObject::screen_space_quad_uv(
+                    texture.clone() as Rc<dyn TextureTrait>,
+                    vec2(rect.x, rect.y),
+                    vec2(rect.w, rect.h),
+                    element.alpha,
+                    uv_min,
+                    uv_max,
+                ),
+                None => SceneObject::screen_space_quad2(
+                    texture.clone() as Rc<dyn TextureTrait>,
+                    vec2(rect.x, rect.y),
+                    vec2(rect.w, rect.h),
+                    element.alpha,
+                ),
+            }
         }
         PlacedContent::Bar { texture, fill } => {
             let texture =
@@ -1045,7 +1097,13 @@ fn present_world(
                 1.0,
                 1.0 - alpha,
             );
-            SceneObject::new(material, Box::new(engine::scene::quad::create()))
+            match kind.uv_rect() {
+                Some((uv_min, uv_max)) => SceneObject::new(
+                    material,
+                    Box::new(engine::scene::quad::create_with_uv(uv_min, uv_max)),
+                ),
+                None => SceneObject::new(material, Box::new(engine::scene::quad::create())),
+            }
         }
         PlacedContent::Bar { texture, fill } => {
             let texture =
@@ -1080,7 +1138,7 @@ pub(crate) fn drawn_rect(
     kind: ImageKind,
 ) -> (Vector2<f32>, Vector2<f32>) {
     match kind {
-        ImageKind::Ui => (position, size),
+        ImageKind::Ui | ImageKind::Hologram { .. } => (position, size),
         ImageKind::ObjectIcon => (position + centered_offset(size, texture_px), texture_px),
         ImageKind::ObjectIconFit => {
             let scale = (size.x / texture_px.x).min(size.y / texture_px.y).min(1.0);
@@ -1277,6 +1335,64 @@ mod tests {
         assert_eq!(
             centered_offset(vec2(35.0, 34.0), vec2(66.0, 68.0)),
             vec2(0.0, 0.0)
+        );
+    }
+
+    /// One cell = one whole tile, bounded by the tile's bright cross. Half a
+    /// tile in on each side is what puts a bright line on all four outer
+    /// edges too, instead of the tile's dim wrap-edge line.
+    #[test]
+    fn a_hologram_puts_a_bright_separator_on_every_cell_border() {
+        let (uv_min, uv_max) = ImageKind::Hologram {
+            tiles_x: 4,
+            tiles_y: 4,
+        }
+        .uv_rect()
+        .expect("a hologram samples a sub-rectangle");
+        let texel = 1.0 / 128.0;
+        assert_eq!(uv_min, vec2(0.5 - texel, 0.5 - texel));
+        assert_eq!(uv_max, vec2(4.5 + texel, 4.5 + texel));
+        // Bright lines land at every half-tile boundary: 5 of them across 4 cells.
+        assert!(((uv_max.x - uv_min.x) - (4.0 + 2.0 * texel)).abs() < 1e-6);
+
+        assert_eq!(ImageKind::Ui.uv_rect(), None);
+        assert_eq!(ImageKind::ObjectIcon.uv_rect(), None);
+    }
+
+    /// A hologram tiles (so its sampler must wrap) and drops its black (so the
+    /// world shows through between the lines).
+    #[test]
+    fn hologram_art_tiles_and_drops_its_black() {
+        let options = texture_options(ImageKind::Hologram {
+            tiles_x: 4,
+            tiles_y: 4,
+        });
+        assert!(options.wrap);
+        assert_eq!(options.luminance_alpha_tint, Some(HOLOGRAM_TINT));
+        assert!(!options.transparent_index_0);
+
+        let ui = texture_options(ImageKind::Ui);
+        assert!(!ui.wrap);
+        assert_eq!(ui.luminance_alpha_tint, None);
+    }
+
+    /// A hologram fills its slot like ordinary UI art - the tile scales to the
+    /// cells, it is not blitted at its authored 128px.
+    #[test]
+    fn a_hologram_stretches_to_its_rect() {
+        let at = vec2(15.0, 8.0);
+        let size = vec2(140.0, 136.0);
+        assert_eq!(
+            drawn_rect(
+                at,
+                size,
+                vec2(128.0, 128.0),
+                ImageKind::Hologram {
+                    tiles_x: 4,
+                    tiles_y: 4
+                }
+            ),
+            (at, size)
         );
     }
 

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -379,9 +379,11 @@ pub enum ImageKind {
     Hologram { tiles_x: u8, tiles_y: u8 },
 }
 
-/// The grid tile every hologram panel is drawn from (`fam/SHODAN/S45.PCX`):
-/// 128x128, a black cell bounded by a bright 1px cross at row/column 64, with
-/// a faint dotted sub-grid and a DIM line along the wrap edge at row/column 0.
+/// The grid tile every hologram panel is drawn from (`shodan/s45.pcx`): a black
+/// cell bounded by a bright cross at row/column 64 (a 1px peak with a few
+/// texels of glow), with a faint dotted sub-grid and a DIM line along the wrap
+/// edge at row/column 0. Its size is fixed at the shipped asset's 128x128 - a
+/// mod that replaced it with a different resolution would need this updated.
 const HOLOGRAM_TILE_PX: f32 = 128.0;
 
 /// The hologram's line colour. The tile's own art is near-white; a cyan tint
@@ -389,7 +391,7 @@ const HOLOGRAM_TILE_PX: f32 = 128.0;
 const HOLOGRAM_TINT: [u8; 3] = [90, 226, 255];
 
 /// The tile bitmap for [`ImageKind::Hologram`].
-pub const HOLOGRAM_TILE_TEXTURE: &str = "s45.pcx";
+pub const HOLOGRAM_TILE_TEXTURE: &str = "shodan/s45.pcx";
 
 impl ImageKind {
     pub(crate) fn transparent_index_0(self) -> bool {
@@ -400,18 +402,20 @@ impl ImageKind {
     /// the whole texture. Both presentations ask this one question, so a
     /// hologram cannot tile differently on a flat panel than on a VR quad.
     ///
-    /// A hologram starts half a tile in and ends half a tile past the last
-    /// tile, so the tile's bright cross lands on every cell border - the outer
-    /// edges included, where the tile's own dim wrap-edge line would otherwise
-    /// fall. The half-texel margin keeps the border line whole rather than
-    /// clipped in half.
+    /// A hologram spans exactly `tiles` whole tiles, starting at the CENTER of
+    /// the tile's bright cross. Every cell border therefore lands on that
+    /// bright line - the outer edges included - at the same sub-texel phase, so
+    /// the separators are evenly bright and the cells line up exactly with the
+    /// item grid's pitch. (A span that is not a whole number of tiles drifts:
+    /// the borders creep off the item grid and each one samples the line at a
+    /// different point, which renders them at visibly different brightness.)
     pub(crate) fn uv_rect(self) -> Option<(Vector2<f32>, Vector2<f32>)> {
         match self {
             Self::Hologram { tiles_x, tiles_y } => {
-                let margin = 0.5 + 1.0 / HOLOGRAM_TILE_PX;
+                let first = (HOLOGRAM_TILE_PX / 2.0 + 0.5) / HOLOGRAM_TILE_PX;
                 Some((
-                    vec2(0.5 - 1.0 / HOLOGRAM_TILE_PX, 0.5 - 1.0 / HOLOGRAM_TILE_PX),
-                    vec2(tiles_x as f32 + margin, tiles_y as f32 + margin),
+                    vec2(first, first),
+                    vec2(first + tiles_x as f32, first + tiles_y as f32),
                 ))
             }
             _ => None,
@@ -1338,22 +1342,32 @@ mod tests {
         );
     }
 
-    /// One cell = one whole tile, bounded by the tile's bright cross. Half a
-    /// tile in on each side is what puts a bright line on all four outer
-    /// edges too, instead of the tile's dim wrap-edge line.
+    /// One cell = one whole tile, bounded by the tile's bright cross - and
+    /// every border, outer edges included, samples that line at the SAME
+    /// sub-texel phase. A span that is not a whole number of tiles (an outward
+    /// margin, say) fails this: the phase drifts across the panel and the
+    /// separators render at visibly different brightness.
     #[test]
-    fn a_hologram_puts_a_bright_separator_on_every_cell_border() {
+    fn a_hologram_puts_every_cell_border_on_the_bright_line() {
+        const TILES: u8 = 4;
         let (uv_min, uv_max) = ImageKind::Hologram {
-            tiles_x: 4,
-            tiles_y: 4,
+            tiles_x: TILES,
+            tiles_y: TILES,
         }
         .uv_rect()
         .expect("a hologram samples a sub-rectangle");
-        let texel = 1.0 / 128.0;
-        assert_eq!(uv_min, vec2(0.5 - texel, 0.5 - texel));
-        assert_eq!(uv_max, vec2(4.5 + texel, 4.5 + texel));
-        // Bright lines land at every half-tile boundary: 5 of them across 4 cells.
-        assert!(((uv_max.x - uv_min.x) - (4.0 + 2.0 * texel)).abs() < 1e-6);
+
+        let bright_texel_center = 64.5 / 128.0;
+        for border in 0..=TILES {
+            let u = uv_min.x + (uv_max.x - uv_min.x) * (border as f32 / TILES as f32);
+            assert!(
+                (u.fract() - bright_texel_center).abs() < 1e-6,
+                "border {border} samples texel {} of its tile, not the bright cross",
+                u.fract() * 128.0
+            );
+        }
+        assert_eq!(uv_max.x - uv_min.x, TILES as f32, "a whole number of tiles");
+        assert_eq!(uv_min.x, uv_min.y, "square cells sample squarely");
 
         assert_eq!(ImageKind::Ui.uv_rect(), None);
         assert_eq!(ImageKind::ObjectIcon.uv_rect(), None);

--- a/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
+++ b/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
@@ -26,6 +26,11 @@ import { clickUiElement } from "./helpers/ui.js";
 // assertion fails and the clip can never be reached.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
+/// The loot panel's hologram grid tile - the art a container panel draws
+/// (`ContainerGui::loot_container`), and how a loot panel is told apart from
+/// the hack board.
+const LOOT_GRID_TEXTURE = "s45.pcx";
+
 const CLIP_CRATE = 325; // Contains -> Small HE Clip
 const BIG_NANITE_PILE = -1591;
 
@@ -85,7 +90,7 @@ async function playHackBoardToWin(game: GameServer): Promise<UiPanel> {
   ];
   for (let attempt = 0; attempt < 15; attempt += 1) {
     let panel = await activePanel(game);
-    if (hasTexture(panel, "contain.pcx")) return panel;
+    if (hasTexture(panel, LOOT_GRID_TEXTURE)) return panel;
     // A ruined crate is terminal - fail loudly rather than spin.
     assert.ok(
       !hasTexture(panel, "loseh.pcx"),
@@ -115,7 +120,7 @@ async function playHackBoardToWin(game: GameServer): Promise<UiPanel> {
 
     for (const label of routes[attempt % routes.length]) {
       panel = await activePanel(game);
-      if (hasTexture(panel, "contain.pcx")) return panel;
+      if (hasTexture(panel, LOOT_GRID_TEXTURE)) return panel;
       if (hasTexture(panel, "failh.pcx") || hasTexture(panel, "loseh.pcx")) break;
       await clickUiElement(game, button(panel, label));
     }
@@ -204,7 +209,7 @@ test(
     // into the ordinary loot MFD showing the authored contents. ---
     const loot = await playHackBoardToWin(game);
     assert.ok(
-      hasTexture(loot, "contain.pcx"),
+      hasTexture(loot, LOOT_GRID_TEXTURE),
       "a won hack should turn the crate into the normal loot MFD",
     );
     assert.ok(
@@ -253,7 +258,7 @@ test(
     await frobCrate(game, reloadedCrate.id);
     const reloadedPanel = await activePanel(game);
     assert.ok(
-      hasTexture(reloadedPanel, "contain.pcx") &&
+      hasTexture(reloadedPanel, LOOT_GRID_TEXTURE) &&
         !hasTexture(reloadedPanel, "hack.pcx"),
       "a hacked crate must stay hacked across save/load, not relock",
     );

--- a/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
+++ b/tools/shock2-sdk/test/hackable-crate.e2e.test.ts
@@ -29,7 +29,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 /// The loot panel's hologram grid tile - the art a container panel draws
 /// (`ContainerGui::loot_container`), and how a loot panel is told apart from
 /// the hack board.
-const LOOT_GRID_TEXTURE = "s45.pcx";
+const LOOT_GRID_TEXTURE = "shodan/s45.pcx";
 
 const CLIP_CRATE = 325; // Contains -> Small HE Clip
 const BIG_NANITE_PILE = -1591;

--- a/tools/shock2-sdk/test/healing-items.e2e.test.ts
+++ b/tools/shock2-sdk/test/healing-items.e2e.test.ts
@@ -5,7 +5,7 @@ import { GameServer } from "../src/index.js";
 import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
 import { clickUiElement } from "./helpers/ui.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import { LOOT_PANEL_SIZE_PX, add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 
 // End-to-end regression for #668, reproducing the campaign's exact production
 // path before covering the sibling item and flat presentation:
@@ -28,7 +28,6 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const MEDSCI2_DESK_WITH_PATCH = 471;
 const MEDSCI2_PATCH = 1054;
 const PANEL_PIXEL_TO_WORLD = 1 / 250;
-const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const BACKPACK_PANEL_SIZE_PX: Vec3 = [635, 120, 0];
 const VR_BACKPACK_SCALE = 0.55;
 

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -154,7 +154,10 @@ export const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
  * the 188px width of the MFD slot it docks into, and just enough height for
  * its 4x4 hologram grid plus margins.
  */
-export const LOOT_PANEL_SIZE_PX: Vec3 = [188, 152, 0];
+export const LOOT_PANEL_SIZE_PX: Vec3 = [188, 178, 0];
+
+/** Center of the loot panel's first 35x34 cell, in panel pixels. */
+export const LOOT_SLOT_CENTER_PX: Vec3 = [24 + 35 / 2, 34 + 34 / 2, 0];
 
 /**
  * Squeeze one element of an open world panel with the production VR hand.

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -149,8 +149,12 @@ export async function aimVrHandAt(
 /** One canvas pixel of a world panel in world units (`gui::GUI_PIXEL_TO_WORLD_SIZE`). */
 export const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 
-/** The retail MFD canvas the loot panel is drawn on. */
-export const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+/**
+ * The loot panel's canvas in panel pixels (`ContainerGui::loot_container`):
+ * the 188px width of the MFD slot it docks into, and just enough height for
+ * its 4x4 hologram grid plus margins.
+ */
+export const LOOT_PANEL_SIZE_PX: Vec3 = [188, 152, 0];
 
 /**
  * Squeeze one element of an open world panel with the production VR hand.

--- a/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro3-vr-desk-loot.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import { LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX, add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 
 // Production-VR regression for #1100. Hydro3 mission Desk #2 (2116) has an
 // authored desk_sd OBB and Contains the deck-3/log-16 Audio Log (200) in its
@@ -25,7 +25,6 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const HYDRO3_DESK_2 = 2116;
 const HYDRO3_AUDIO_LOG = 200;
-const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 
 test(

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -10,7 +10,7 @@ import type {
   Vec3,
 } from "../src/index.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX, aimVrHandAt } from "./helpers/vr-hand.js";
 
 // Production regression for #978. The MedSci1 Wrench is a concrete mission
 // object (990), but its authored melee class is the gamesys Wrench (-928).
@@ -26,7 +26,6 @@ const MONKEY = 543;
 const PIPE_HYBRID = 1293;
 const SHOTGUN_HYBRID = 1392;
 const BREAKABLE_PANE = 237;
-const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 const WRENCH_WINDUP_DISTANCE = 1.5;
 const WRENCH_SWEEP_END_DISTANCE = -0.75;

--- a/tools/shock2-sdk/test/medsci2-vr-released-item.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-vr-released-item.e2e.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import { GameServer, findRepoRoot } from "../src/index.js";
 import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import { LOOT_PANEL_SIZE_PX, add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 
 // MedSci2 production-VR guard for #974: the whole carry cycle for an ordinary
 // contained prop, player-observable and using no direct Frob/Grab/Give message:
@@ -187,7 +187,7 @@ test(
     assert.ok(lootPanel, "loot panel must have a production VR collider");
     const itemButtonWorld = panelElementWorldPoint(
       lootPanel,
-      [188, 296, 0],
+      LOOT_PANEL_SIZE_PX,
       1,
       itemButton,
     );

--- a/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
@@ -4,7 +4,13 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { PhysicsBodySummary, UiPanel, Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX, add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import {
+  LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX,
+  LOOT_SLOT_CENTER_PX as LOG_SLOT_CENTER_PX,
+  add,
+  aimVrHandAt,
+  quatRotate,
+} from "./helpers/vr-hand.js";
 
 // Exact MedSci campaign regression for #921. This uses the authentic production
 // VR chain rather than a debug Frob shortcut:
@@ -22,7 +28,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const AMANPOUR_CORPSE = 1680;
 const AMANPOUR_LOG = 1608;
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
-const LOG_SLOT_CENTER_PX: Vec3 = [24 + 35 / 2, 8 + 34 / 2, 0];
+
 
 const uiBodies = async (game: GameServer): Promise<PhysicsBodySummary[]> =>
   (await game.physics.bodies()).bodies.filter((body) =>

--- a/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { PhysicsBodySummary, UiPanel, Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import { LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX, add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 
 // Exact MedSci campaign regression for #921. This uses the authentic production
 // VR chain rather than a debug Frob shortcut:
@@ -21,9 +21,8 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const AMANPOUR_CORPSE = 1680;
 const AMANPOUR_LOG = 1608;
-const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
-const LOG_SLOT_CENTER_PX: Vec3 = [15 + 35 / 2, 153 + 34 / 2, 0];
+const LOG_SLOT_CENTER_PX: Vec3 = [24 + 35 / 2, 8 + 34 / 2, 0];
 
 const uiBodies = async (game: GameServer): Promise<PhysicsBodySummary[]> =>
   (await game.physics.bodies()).bodies.filter((body) =>

--- a/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import { LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX, add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 
 // Default-VR regression for #940. The mission data and gameplay path are the
 // real ones:
@@ -19,9 +19,8 @@ import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const CORPSE_PSI_AMP = 219;
-const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
-const LOOT_SLOT_CENTER_PX: Vec3 = [15 + 35 / 2, 153 + 34 / 2, 0];
+const LOOT_SLOT_CENTER_PX: Vec3 = [24 + 35 / 2, 8 + 34 / 2, 0];
 
 test(
   "default VR opens a container world panel and grabs contained loot through the hand ray",

--- a/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
@@ -4,7 +4,13 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX, add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import {
+  LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX,
+  LOOT_SLOT_CENTER_PX,
+  add,
+  aimVrHandAt,
+  quatRotate,
+} from "./helpers/vr-hand.js";
 
 // Default-VR regression for #940. The mission data and gameplay path are the
 // real ones:
@@ -20,7 +26,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const CORPSE_PSI_AMP = 219;
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
-const LOOT_SLOT_CENTER_PX: Vec3 = [24 + 35 / 2, 8 + 34 / 2, 0];
+
 
 test(
   "default VR opens a container world panel and grabs contained loot through the hand ray",


### PR DESCRIPTION
Loot containers and corpses drop the `contain.pcx` skin (logo, SEARCH tab, backdrop) and draw a bare 4x4 grid as a hologram instead - one canvas, both presentations - so the world shows through between the lines and item icons draw normally on top.

![VR hologram grid](https://gist.githubusercontent.com/tommy-xr/5e52d180b7efbc3da4379c38d54ddbf9/raw/vr-hologram.gif)

**Flat MFD - before / after**

![flat before and after](https://gist.githubusercontent.com/tommy-xr/5e52d180b7efbc3da4379c38d54ddbf9/raw/flat-before-after.png)

**VR world panel - before / after**

![vr before and after](https://gist.githubusercontent.com/tommy-xr/5e52d180b7efbc3da4379c38d54ddbf9/raw/vr-before-after.png)

## How the grid is drawn

The art is the SHODAN family tile `shodan/s45.pcx` (128x128: a black cell bounded by a bright cross at row/col 64, plus a faint dotted sub-grid). **One cell = one whole tile.** The quad samples `[64.5/128, 64.5/128 + tiles]` on both axes - starting at the *center* of the bright line and spanning a whole number of tiles - so every cell border, outer edges included, lands on that line at the same sub-texel phase and the borders coincide exactly with the item grid's 35x34 pitch. (A span that is not a whole number of tiles drifts: borders creep off the item grid and each renders at a different brightness.)

The black is dropped at texture decode: a new `TextureOptions::luminance_alpha_tint` derives alpha from each texel's luminance and recolors the lines cyan. No new blend mode - ordinary alpha over the world is what a hologram wants, and doing it at decode is what keeps the two presentations showing the same pixels (a material-level tint exists only on the flat path). The tile is mipmapped (`TextureFilter::LinearMipmap`): its lines are a texel wide, drawn well under their authored size, at a distance the VR viewer changes at will.

The UV rectangle is asked for once, by `ImageKind::uv_rect`, and consumed by both presenters, so flat and VR cannot tile differently. `ImageKind::Hologram { tiles_x, tiles_y }` rides the existing `kind` field all the way from the GUI component to the placed element - no new field on any of the three layout structs.

Panel geometry: still 188 wide (the flat MFD slot at (2,124) reserves that), height shrunk to the grid (178), with the grid inset below the host-drawn close button so that corner cell stays clickable. `world_offset` unchanged. The backpack strip (`invback.pcx`) is untouched.

## Verification

- Unit: `uv_rect` asserts every cell border samples the bright texel at the same phase (fails on any non-integer tile span); hologram texture options (wrap + tint + mipmap); `drawn_rect` stretches a hologram like ordinary UI art; the luminance/tint decode; the HRM board keeps its own 188x296 canvas when the loot panel shrinks; `backpack_cell_at` round-trip and the item-grid origin test still hold.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr --lib` (1208), `cargo test -p engine --lib`, `cargo fmt`.
- Render-verified both presentations headlessly on medsci1 corpse 219 (screenshots above; before/after captured from `origin/main` with the same request sequence).
- e2e: container-loot, vr-container-world-panel, hackable-crate, hydro3-vr-desk-loot, vr-audio-log-reader, healing-items, medsci2-vr-released-item, always-collected-categories, hydro2-vr-keycard and missions (all 23) - 36/36 after the hack-board fix below.
- `/xreview`: its High findings are fixed here - a per-frame GL mesh churn (the UV quad's mesh is now cached), the UV phase drift, and the VR grid inheriting `gui::image`'s 0.5 alpha while flat forced 1.0.

The e2e suite caught a real regression: `HackableCrateGui` sized its HRM board from the loot panel's config, so shrinking the loot panel squashed the board and moved START. The two faces now carry their own canvases (`get_config_for`), pinned by a test.

## Leftovers

- No billboarding / projection cone - deliberately the next slice.
- The panel keeps 188px of width for a 140px grid, so ~24px of transparent canvas each side still carries the VR panel's collider. That width is the flat MFD slot's; narrowing it is a separate change.
- `basic_material` discards texels under alpha 0.1, so the very faintest sub-grid texels (3-9% alpha) drop out in VR but not in flat. Pre-existing material behavior, imperceptible here.