### PR TITLE
feat(vr): the gun hand's lower button ejects the clip

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,6 +119,7 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 | --- | ------ | ----- |
 | `P` | `PathfindingTestCycle` | set start → set goal → show path |
 | `B` | `DebugCycleWeapon` | spawns and wields the next weapon (unlike the number row) |
+| `Alt+X` | `EjectClip` | magazine back to the backpack reserve; Quest: the gun hand's *lower* face button |
 | `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | no Quest binding - in VR ammo is swapped by inserting a clip of the other type |
 | `F` | `CycleGunSetting` | switch the wielded gun's fire mode (e.g. NORM / BURST); flat only |
 | `U` | `ReadLastUnreadLog` | on Quest an *upper* face button resolves to this - see below |
@@ -144,7 +145,7 @@ that hand holds (`shock2vr/src/hand_buttons.rs`):
 | that hand holds | lower | upper |
 | --- | --- | --- |
 | nothing, a melee weapon, or any other item | `ToggleUseMode` (cyber interface) | `ReadLastUnreadLog` |
-| a gun | reserved for gun handling - inert for now | reserved for gun handling - inert for now |
+| a gun | `EjectClip` - that hand's gun, so dual wielding ejects the one pressed | reserved for the fire-mode toggle - inert for now |
 | the psi amp | reserved for power selection - inert for now | reserved for power selection - inert for now |
 
 Mode first: while the cyber interface is up both buttons keep their interface

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -130,6 +130,15 @@ impl DesktopInputMapper {
                 modifier: Modifier::None,
                 action: InputAction::CycleAmmo,
             },
+            // Alt-modified so a stray press cannot dump a magazine mid-fight;
+            // in VR this is the gun hand's lower face button instead. NOT
+            // `Alt+R`: `poll` keys its edges on the action, so with `R` held
+            // down a mere Alt tap would flip `Reload` off and fire the eject.
+            Binding {
+                key: Key::X,
+                modifier: Modifier::Alt,
+                action: InputAction::EjectClip,
+            },
             Binding {
                 key: Key::F,
                 modifier: Modifier::None,

--- a/shock2vr/src/hand_buttons.rs
+++ b/shock2vr/src/hand_buttons.rs
@@ -65,7 +65,7 @@ pub enum HandButtonMode {
 /// | hand holds | lower | upper |
 /// |---|---|---|
 /// | nothing, melee, or any other item | `ToggleUseMode` | `ReadLastUnreadLog` |
-/// | a gun | gun handling (not yet bound) | gun handling (not yet bound) |
+/// | a gun | `EjectClip` (that hand's gun) | fire-mode toggle (not yet bound) |
 /// | the psi amp | power selection (not yet bound) | power selection (not yet bound) |
 ///
 /// **Mode first.** While the interface is up both buttons keep their interface
@@ -76,9 +76,10 @@ pub enum HandButtonMode {
 /// reader is reachable until a hand is free. That is the point of a per-hand
 /// mapping - free a hand, or use the one that is already free.
 ///
-/// `hand` does not change the outcome today (the mapping is symmetric); it is
-/// taken because a gun/psi row resolves to an action *about that hand's
-/// weapon*, which the later PRs bind.
+/// `hand` does not change which action is returned (the mapping is symmetric);
+/// it is taken because a gun/psi row resolves to an action *about that hand's
+/// weapon* - `EjectClip` ejects the gun in the hand that pressed it, so the
+/// caller must carry the hand through.
 pub fn resolve_hand_button(
     mode: HandButtonMode,
     hand: Handedness,
@@ -98,10 +99,16 @@ pub fn resolve_hand_button(
 
     match held {
         HeldKind::Empty | HeldKind::Melee | HeldKind::Other => Some(interface_action),
-        // Reserved for the gun and psi-amp handling actions; deliberately
-        // inert until those land, rather than falling through to the panels
-        // and having to be taken away again.
-        HeldKind::Gun | HeldKind::PsiAmp => None,
+        // The gun hand's lower button ejects that gun's magazine. Its upper
+        // button is reserved for the fire-mode toggle and is not bound yet -
+        // inert rather than falling through to the panels and having to be
+        // taken away again.
+        HeldKind::Gun => match button {
+            HandButton::Lower => Some(InputAction::EjectClip),
+            HandButton::Upper => None,
+        },
+        // Reserved for power selection, likewise not yet bound.
+        HeldKind::PsiAmp => None,
     }
 }
 
@@ -162,17 +169,44 @@ mod tests {
         }
     }
 
-    /// Rows 2 and 3: a weapon hand's buttons are its weapon's, and no action
-    /// is bound to them yet - so they do nothing rather than quietly keeping
-    /// the panels they are about to lose.
+    /// Rows 2 and 3: a weapon hand's buttons are its weapon's, so neither
+    /// reaches a panel - whether or not the weapon's own action is bound yet.
     #[test]
     fn a_weapon_hand_reaches_neither_panel() {
         for hand in HANDS {
             for held in [HeldKind::Gun, HeldKind::PsiAmp] {
                 for button in BUTTONS {
-                    assert_eq!(resolve(held, hand, button), None, "{held:?} in {hand:?}");
+                    let resolved = resolve(held, hand, button);
+                    assert!(
+                        resolved != Some(InputAction::ToggleUseMode)
+                            && resolved != Some(InputAction::ReadLastUnreadLog),
+                        "{held:?} in {hand:?} reached a panel: {resolved:?}"
+                    );
                 }
             }
+        }
+    }
+
+    /// Row 2, lower: the gun hand's lower button ejects the magazine - on
+    /// either hand, since the action is resolved against the hand that pressed
+    /// it.
+    #[test]
+    fn a_gun_hands_lower_button_ejects_its_clip() {
+        for hand in HANDS {
+            assert_eq!(
+                resolve(HeldKind::Gun, hand, HandButton::Lower),
+                Some(InputAction::EjectClip),
+                "{hand:?}"
+            );
+        }
+    }
+
+    /// Row 2, upper: the fire-mode toggle is not wired to this button yet, so
+    /// it is inert rather than borrowing another meaning.
+    #[test]
+    fn a_gun_hands_upper_button_is_not_bound_yet() {
+        for hand in HANDS {
+            assert_eq!(resolve(HeldKind::Gun, hand, HandButton::Upper), None);
         }
     }
 
@@ -199,17 +233,6 @@ mod tests {
                     Some(InputAction::ReadLastUnreadLog),
                     "{held:?} in {hand:?}"
                 );
-            }
-        }
-    }
-
-    /// Dual wielding costs the player both panels until a hand is free -
-    /// intended, and asserted so it is a decision rather than a surprise.
-    #[test]
-    fn dual_wielding_reaches_no_panel_on_either_hand() {
-        for hand in HANDS {
-            for button in BUTTONS {
-                assert_eq!(resolve(HeldKind::Gun, hand, button), None);
             }
         }
     }

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -56,6 +56,11 @@ pub enum InputAction {
     CycleGunSetting,
     /// Reload the wielded weapon from compatible backpack reserve.
     Reload,
+    /// Eject the loaded magazine back to the backpack reserve, as clips of the
+    /// ammo type the rounds already are. Hand-agnostic here (it means the
+    /// wielded weapon); on Quest a gun hand's LOWER face button resolves to it
+    /// for the gun in THAT hand - see [`crate::hand_buttons`].
+    EjectClip,
     /// Select the next psi power (used when firing the psi amp).
     CyclePsiPower,
     /// Reload the current level in place (debug). Exercises the level-transition path,
@@ -147,6 +152,7 @@ impl InputAction {
             InputAction::CycleAmmo,
             InputAction::CycleGunSetting,
             InputAction::Reload,
+            InputAction::EjectClip,
             InputAction::CyclePsiPower,
             InputAction::DebugReloadLevel,
             InputAction::DebugAlertAll,
@@ -190,6 +196,7 @@ impl InputAction {
             InputAction::CycleAmmo => "CycleAmmo",
             InputAction::CycleGunSetting => "CycleGunSetting",
             InputAction::Reload => "Reload",
+            InputAction::EjectClip => "EjectClip",
             InputAction::CyclePsiPower => "CyclePsiPower",
             InputAction::DebugReloadLevel => "DebugReloadLevel",
             InputAction::DebugAlertAll => "DebugAlertAll",
@@ -225,11 +232,12 @@ impl InputAction {
             // The right controller's menu button is reserved by the Quest
             // system UI; the left one is the app's.
             InputAction::TogglePauseMenu => Some("/user/hand/left/input/menu/click"),
-            // `Reload` and `CycleAmmo` deliberately have NO Quest binding: in
-            // VR reloading is the physical clip-insert gesture, which is
-            // unambiguous per weapon and therefore works while dual wielding,
-            // where a face button on one controller cannot say which gun it
-            // meant. Both actions remain reachable everywhere else (flat keys,
+            // `Reload`, `CycleAmmo` and `EjectClip` deliberately have NO Quest
+            // binding of their own: in VR reloading is the physical
+            // clip-insert gesture and an eject is the gun hand's lower face
+            // button, both of which name a hand and so work while dual
+            // wielding, where a hand-agnostic action cannot say which gun it
+            // meant. All three remain reachable everywhere else (flat keys,
             // HTTP, the SDK).
             _ => None,
         }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -165,6 +165,11 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::ToggleUseMode) {
             effects.push(Effect::ToggleUseMode);
         }
+        if state.just_triggered(InputAction::EjectClip) {
+            // Hand-agnostic: the flat key and HTTP mean "the wielded weapon".
+            // A per-hand press arrives as `Effect::HandButton` instead.
+            effects.push(Effect::EjectClip { hand: None });
+        }
         if state.just_triggered(InputAction::ToggleMap) {
             effects.push(Effect::ToggleMap);
         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5612,7 +5612,10 @@ impl MissionCore {
                 }
 
                 Effect::UnloadWeapon { entity_id } => {
-                    self.eject_magazine(asset_cache, entity_id);
+                    // Same ejection the VR eject button performs, cue included.
+                    if let Some(cue) = self.eject_magazine(asset_cache, entity_id) {
+                        effects.push_back(cue);
+                    }
                 }
 
                 Effect::OpenWeaponSettings => {
@@ -5647,6 +5650,14 @@ impl MissionCore {
                     }
                 }
 
+                Effect::EjectClip { hand } => {
+                    if let Some(weapon) = crate::wielded_weapon::eject_target(&self.world, hand) {
+                        if let Some(cue) = self.eject_magazine(asset_cache, weapon) {
+                            effects.push_back(cue);
+                        }
+                    }
+                }
+
                 Effect::HandButton { hand, button } => {
                     // A face button means whatever the hand that pressed it is
                     // holding says it means - except while the cyber interface
@@ -5667,9 +5678,14 @@ impl MissionCore {
                         Some(crate::input::InputAction::ReadLastUnreadLog) => {
                             effects.push_front(Effect::ReadLastUnreadLog)
                         }
-                        // A weapon hand resolves to nothing yet - the gun and
-                        // psi-amp handling actions add their arms here when
-                        // they land.
+                        // The gun goes with the hand that pressed, so a
+                        // dual-wielding player ejects the magazine they meant.
+                        Some(crate::input::InputAction::EjectClip) => {
+                            effects.push_front(Effect::EjectClip { hand: Some(hand) })
+                        }
+                        // The psi amp's buttons, and a gun hand's upper one
+                        // (the fire-mode toggle), resolve to nothing yet -
+                        // their arms land with the actions themselves.
                         None => {}
                         Some(action) => warn!("unroutable hand button action: {action}"),
                     }
@@ -8119,6 +8135,16 @@ impl MissionCore {
         crate::scripts::script_util::active_gun_setting(&self.world, weapon).map(|d| d.clip)
     }
 
+    /// How many rounds `weapon`'s magazine currently holds (0 for anything
+    /// with no magazine at all).
+    fn magazine_rounds(&self, weapon: EntityId) -> i32 {
+        self.world
+            .borrow::<View<dark::properties::PropGunState>>()
+            .ok()
+            .and_then(|states| states.get(weapon).ok().map(|state| state.ammo))
+            .unwrap_or(0)
+    }
+
     /// The world position of `entity`'s live transform.
     fn entity_world_position(&self, entity: EntityId) -> Option<Vector3<f32>> {
         use cgmath::Transform as _;
@@ -8148,7 +8174,7 @@ impl MissionCore {
         }
         let Some(index) = crate::mission::reload::clip_projectile_index(&self.world, weapon, clip)
         else {
-            return vec![self.refuse_clip_insert(weapon)];
+            return vec![self.refuse_clip_handling(weapon)];
         };
         // Nothing below may run unless rounds could actually MOVE. Both halves
         // of the swap - the eject and the selection change - are committed
@@ -8156,28 +8182,17 @@ impl MissionCore {
         // empty clip entity would otherwise dump the magazine and switch the
         // ammo type having loaded nothing at all.
         if capacity <= 0 || crate::mission::reload::clip_rounds(&self.world, clip) <= 0 {
-            return vec![self.refuse_clip_insert(weapon)];
+            return vec![self.refuse_clip_handling(weapon)];
         }
 
         if index != crate::mission::reload::selected_ammo_index(&self.world, weapon) {
             // A different ammo type: the loaded rounds go back to the backpack
             // as what they already are, exactly as an ammo-cycle ejects them.
-            if let Some((clip_template, rounds)) =
-                crate::mission::reload::unload_to_reserve(&self.world, weapon).spawn_clip
-            {
-                self.give_ejected_clip(asset_cache, weapon, clip_template, rounds);
-            }
             // The swap is earned by an empty magazine, never assumed - see
             // `cycle_ammo`. Rounds that could not be returned stay loaded, and
             // switching over them would convert them for free.
-            let still_loaded = self
-                .world
-                .borrow::<View<dark::properties::PropGunState>>()
-                .ok()
-                .and_then(|states| states.get(weapon).ok().map(|state| state.ammo > 0))
-                .unwrap_or(false);
-            if still_loaded {
-                return vec![self.refuse_clip_insert(weapon)];
+            if !self.unload_magazine(asset_cache, weapon) {
+                return vec![self.refuse_clip_handling(weapon)];
             }
             self.world
                 .add_component(weapon, RuntimePropSelectedAmmo(index));
@@ -8209,12 +8224,13 @@ impl MissionCore {
         )]
     }
 
-    /// The insert-refused cue: `repfail`, the game's own "that request is not
-    /// going to happen" chime (the replicator plays it for an unaffordable
-    /// purchase). Deliberately NOT the weapon's dry-fire schema - most guns,
-    /// the pistol included, author no `dryfire` event at all, so the refusal
-    /// would be silent on exactly the weapons a player reloads most.
-    fn refuse_clip_insert(&self, weapon: EntityId) -> Effect {
+    /// The clip-handling refusal cue: `repfail`, the game's own "that request
+    /// is not going to happen" chime (the replicator plays it for an
+    /// unaffordable purchase). Deliberately NOT the weapon's dry-fire schema -
+    /// most guns, the pistol included, author no `dryfire` event at all, so
+    /// the refusal would be silent on exactly the weapons a player reloads
+    /// most.
+    fn refuse_clip_handling(&self, weapon: EntityId) -> Effect {
         Effect::PlaySound {
             handle: AudioHandle::new(),
             source: Some(weapon),
@@ -8236,19 +8252,12 @@ impl MissionCore {
         if !crate::scripts::script_util::can_cycle_ammo(&self.world, weapon) {
             return;
         }
-        self.eject_magazine(asset_cache, weapon);
         // The switch is earned by an empty magazine, never assumed. Every way an
         // eject can fall short - the fresh clip refused by the backpack, a
         // borrow that did not come through - leaves rounds loaded, and switching
         // then would convert them to the next type for free, which is the exact
         // thing this ejection exists to prevent.
-        let still_loaded = self
-            .world
-            .borrow::<View<dark::properties::PropGunState>>()
-            .ok()
-            .and_then(|states| states.get(weapon).ok().map(|state| state.ammo > 0))
-            .unwrap_or(false);
-        if still_loaded {
+        if !self.unload_magazine(asset_cache, weapon) {
             return;
         }
         let count =
@@ -8314,17 +8323,56 @@ impl MissionCore {
         })
     }
 
-    /// Eject `weapon`'s magazine back to the backpack, as clips of the ammo
-    /// type the rounds already are. Shared by the ammo-type switch (which has
-    /// to empty the gun before it may change type) and the settings MFD's
-    /// UNLOAD button (where emptying it *is* the point). A magazine that cannot
-    /// be returned - no clip archetype, or a backpack that refuses it - is left
-    /// loaded.
-    fn eject_magazine(&mut self, asset_cache: &mut AssetCache, weapon: EntityId) {
-        if let Some((clip_template, rounds)) =
-            crate::mission::reload::unload_to_reserve(&self.world, weapon).spawn_clip
+    /// Return `weapon`'s loaded rounds to the backpack as clips of the ammo
+    /// type they already are - the ammo cycle's ejection on its own, without
+    /// the type switch. Nothing is dropped into the world: a clip on the floor
+    /// is a chore to pick up in VR, and the rounds are as usable in the
+    /// backpack.
+    ///
+    /// Returns the cue to play. Silent when there was nothing to eject - an
+    /// empty magazine, or ammo with no clip archetype to return to (an energy
+    /// weapon's charge) - because a cue for an eject that did not happen would
+    /// be a lie. A refusal the player *earned* (the backpack could not take
+    /// the clip) is audible instead: silence there is indistinguishable from a
+    /// dead button.
+    fn eject_magazine(&mut self, asset_cache: &mut AssetCache, weapon: EntityId) -> Option<Effect> {
+        if self.magazine_rounds(weapon) <= 0
+            || !crate::mission::reload::can_unload(&self.world, weapon)
         {
-            self.give_ejected_clip(asset_cache, weapon, clip_template, rounds);
+            return None;
+        }
+        if !self.unload_magazine(asset_cache, weapon) {
+            return Some(self.refuse_clip_handling(weapon));
+        }
+        // The gun's own clip-handling schema, as the physical clip insert
+        // plays on the way in.
+        Some(crate::scripts::script_util::play_environmental_sound(
+            &self.world,
+            weapon,
+            "reload",
+            vec![],
+            AudioHandle::new(),
+        ))
+    }
+
+    /// Move `weapon`'s loaded rounds to the backpack reserve, minting the clip
+    /// [`reload::unload_to_reserve`] asks for when no carried stack absorbs
+    /// them. The one implementation behind every ejection: the eject button,
+    /// the ammo cycle, and the clip insert that swaps ammo type.
+    ///
+    /// Returns whether the magazine is now EMPTY. `false` means the rounds are
+    /// still loaded - the backpack refused the fresh clip, or this ammo has no
+    /// clip archetype at all - so whatever the caller meant to do next is
+    /// unearned. Rounds exist in exactly one place at every instant.
+    fn unload_magazine(&mut self, asset_cache: &mut AssetCache, weapon: EntityId) -> bool {
+        let outcome = crate::mission::reload::unload_to_reserve(&self.world, weapon);
+        match outcome.spawn_clip {
+            Some((clip_template, rounds)) => {
+                self.give_ejected_clip(asset_cache, weapon, clip_template, rounds)
+            }
+            // No clip to place: the rounds either merged into a carried stack
+            // or never moved, and only the magazine can say which.
+            None => outcome.rounds_unloaded > 0 || self.magazine_rounds(weapon) == 0,
         }
     }
 
@@ -8335,18 +8383,20 @@ impl MissionCore {
     /// The magazine is emptied only AFTER the fresh clip is genuinely carried,
     /// so the rounds exist in exactly one place at every instant: a refused
     /// clip simply leaves the weapon loaded and the swap unearned.
+    /// Returns whether the clip was carried - and so whether the magazine was
+    /// emptied.
     fn give_ejected_clip(
         &mut self,
         asset_cache: &mut AssetCache,
         weapon: EntityId,
         clip_template: i32,
         rounds: i32,
-    ) {
+    ) -> bool {
         let entity_id = match self.spawn_into_backpack(asset_cache, clip_template) {
             Ok(entity_id) => entity_id,
             Err(e) => {
                 game_log!(WARN, "Ejected clip could not be carried: {e}");
-                return;
+                return false;
             }
         };
         // The archetype carries its authored stack size; this clip holds
@@ -8354,6 +8404,7 @@ impl MissionCore {
         self.world
             .add_component(entity_id, dark::properties::PropStackCount(rounds));
         crate::mission::reload::empty_magazine(&self.world, weapon);
+        true
     }
 
     /// Instantiate `template_id` and route it through the ordinary pickup path

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -316,6 +316,21 @@ pub enum Effect {
     /// rotation sampled at the input edge.
     ReadLastUnreadLog,
 
+    /// Return a gun's loaded magazine to the backpack reserve, as clips of the
+    /// ammo type the rounds already are (`reload::unload_to_reserve`). No
+    /// physical clip is dropped into the world.
+    ///
+    /// `hand` names the gun: `Some(hand)` is the gun in that hand, which is
+    /// what a per-hand face button means and what makes the eject dual-wield
+    /// safe; `None` is the hand-agnostic `InputAction::EjectClip` and means
+    /// whichever weapon is wielded.
+    ///
+    /// No-op with nothing loaded, and on a weapon whose ammo has no clip
+    /// archetype to return to (an energy weapon).
+    EjectClip {
+        hand: Option<Handedness>,
+    },
+
     /// A face button was pressed on one hand, before anything decided what it
     /// means. The mission resolves it against what that hand holds and
     /// whether the cyber interface is up - see [`crate::hand_buttons`] - and

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -59,6 +59,18 @@ pub fn wielded_weapon(world: &World) -> Option<EntityId> {
     weapon_in_hand(world, Handedness::Right).or_else(|| weapon_in_hand(world, Handedness::Left))
 }
 
+/// The weapon an eject applies to. `Some(hand)` - a per-hand face button -
+/// means the weapon in THAT hand, so a dual-wielding player ejects the
+/// magazine of the gun they pressed; `None` - the hand-agnostic input action -
+/// means whichever weapon is wielded. Both arms filter to weapons, so a hand
+/// carrying a medkit is not an eject target.
+pub fn eject_target(world: &World, hand: Option<Handedness>) -> Option<EntityId> {
+    match hand {
+        Some(hand) => weapon_in_hand(world, hand),
+        None => wielded_weapon(world),
+    }
+}
+
 /// Whether the held `entity` is a weapon the ammo readout and the reload /
 /// ammo-cycle actions apply to: a gun (it has a `PropGunState` clip) or the
 /// psi amp (whose readout is its selected power, not a clip).
@@ -92,4 +104,78 @@ pub(crate) fn is_psi_amp(world: &World, entity: EntityId) -> bool {
         .ok()
         .and_then(|tags| tags.0.get(&template_id)?.get("weapontype").cloned())
         .is_some_and(|weapon_type| weapon_type == "psiamp")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Quaternion, Vector3};
+
+    /// A world whose player holds a GUN in each named hand, returned with the
+    /// two held ids.
+    fn player_holding(left: bool, right: bool) -> (World, Option<EntityId>, Option<EntityId>) {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        let mut gun = |world: &mut World| {
+            world.add_entity((PropGunState {
+                ammo: 12,
+                condition: 1.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },))
+        };
+        let left_hand_entity_id = left.then(|| gun(&mut world));
+        let right_hand_entity_id = right.then(|| gun(&mut world));
+        world.add_unique(PlayerInfo {
+            pos: Vector3::new(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id,
+            right_hand_entity_id,
+            inventory_entity_id: inventory,
+        });
+        (world, left_hand_entity_id, right_hand_entity_id)
+    }
+
+    /// A per-hand eject means the gun in that hand and no other - the whole
+    /// point of carrying the hand through, since dual wielding otherwise
+    /// ejects whichever gun `wielded_weapon` happens to prefer.
+    #[test]
+    fn a_per_hand_eject_targets_only_that_hand() {
+        let (world, left_gun, right_gun) = player_holding(true, true);
+
+        assert_eq!(eject_target(&world, Some(Handedness::Right)), right_gun);
+        assert_eq!(eject_target(&world, Some(Handedness::Left)), left_gun);
+        assert_ne!(left_gun, right_gun);
+    }
+
+    /// An empty hand ejects nothing, even with a gun in the other one.
+    #[test]
+    fn an_empty_hand_has_nothing_to_eject() {
+        let (world, _, _) = player_holding(false, true);
+
+        assert_eq!(eject_target(&world, Some(Handedness::Left)), None);
+    }
+
+    /// A hand carrying something that is not a weapon is not an eject target
+    /// either - both arms filter the same way.
+    #[test]
+    fn a_hand_holding_something_that_is_not_a_weapon_has_nothing_to_eject() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        let medkit = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: Vector3::new(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: Some(medkit),
+            inventory_entity_id: inventory,
+        });
+
+        assert_eq!(eject_target(&world, Some(Handedness::Right)), None);
+    }
 }

--- a/tools/shock2-sdk/test/vr-eject-clip.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-eject-clip.e2e.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// The gun hand's LOWER face button (right A / left X) ejects that gun's
+// magazine: the rounds go back to the backpack reserve as clips of the ammo
+// type they already are, and nothing is dropped on the floor.
+//
+// Negative-first: on the parent a gun hand's buttons resolve to nothing at all
+// (`vr-contextual-buttons` asserts exactly that), so every assertion below
+// fails - the magazine stays full and no clip reaches the backpack.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8676);
+
+/** The debug pistol, and the standard clip its rounds come back as. */
+const PISTOL = -17;
+const STD_CLIP = -31;
+/** An energy weapon: its charge has no clip archetype to return to. */
+const LASER_PISTOL = -22;
+
+function propOf(
+  detail: { properties: { name: string; value: string }[] },
+  name: string,
+): number | undefined {
+  const p = detail.properties.find((x) => x.name === name);
+  return p === undefined ? undefined : Number(p.value);
+}
+
+async function ammoOf(game: GameServer, weapon: number): Promise<number> {
+  const value = propOf(await game.entities.detail(weapon), "Ammo");
+  assert.ok(value !== undefined, "a weapon should expose an Ammo property");
+  return value;
+}
+
+/** Every standard clip the player is carrying. */
+async function carriedClips(game: GameServer): Promise<EntitySummary[]> {
+  const carried = new Set(
+    (await game.player.inventory()).items.map((item) => item.entity_id),
+  );
+  return (await game.entities.list({ limit: 300 })).entities.filter(
+    (entity) => entity.template_id === STD_CLIP && carried.has(entity.id),
+  );
+}
+
+/** Standard clips lying in the world (the scene stocks some of its own). */
+async function looseClips(game: GameServer): Promise<number> {
+  const carried = new Set((await carriedClips(game)).map((clip) => clip.id));
+  return (await game.entities.list({ limit: 300 })).entities.filter(
+    (entity) => entity.template_id === STD_CLIP && !carried.has(entity.id),
+  ).length;
+}
+
+/** Total standard rounds the player carries in reserve, across all stacks. */
+async function reserveRounds(game: GameServer): Promise<number> {
+  let total = 0;
+  for (const clip of await carriedClips(game)) {
+    total += propOf(await game.entities.detail(clip.id), "StackCount") ?? 0;
+  }
+  return total;
+}
+
+/** Spawn `template` and take it in the VR RIGHT hand. */
+async function grabWeapon(
+  game: GameServer,
+  template: number,
+): Promise<EntitySummary> {
+  // Diffed against the entity list: `debug_weapons` already stocks one of every
+  // gun, so a plain template search could hand back the scenery one.
+  const weapon = await cycleToWeapon(game, (e) => e.template_id === template);
+  await aimVrHandAt(game, weapon.position as Vec3, 0.3);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    weapon.id,
+    "the VR right hand must hold the weapon",
+  );
+  return weapon;
+}
+
+async function pressRightLower(game: GameServer): Promise<void> {
+  await game.input.trigger("RightHandLowerButton");
+  await game.step({ frames: 5 });
+}
+
+test(
+  "the gun hand's lower button ejects that gun's magazine into the backpack",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    const pistol = (await grabWeapon(game, PISTOL)).id;
+
+    const loaded = await ammoOf(game, pistol);
+    const looseBefore = await looseClips(game);
+    assert.ok(loaded > 0, "the debug pistol starts loaded");
+    assert.equal(
+      await reserveRounds(game),
+      0,
+      "and carries no reserve of its own",
+    );
+
+    await pressRightLower(game);
+    assert.equal(await ammoOf(game, pistol), 0, "the magazine is emptied");
+    assert.equal(
+      await reserveRounds(game),
+      loaded,
+      "the reserve gained exactly the ejected rounds",
+    );
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol,
+      "the gun stays in the hand",
+    );
+    assert.equal(
+      await looseClips(game),
+      looseBefore,
+      "the eject leaves no clip lying in the world",
+    );
+
+    // Pressing an empty gun's button again is a no-op, not a second free clip.
+    await pressRightLower(game);
+    assert.equal(await ammoOf(game, pistol), 0);
+    assert.equal(
+      await reserveRounds(game),
+      loaded,
+      "an empty magazine mints nothing",
+    );
+
+    // Reload from the rounds just ejected: they are genuinely usable again.
+    // The spare clip is what leaves a stack behind for the merge case below -
+    // a reload that drains the ejected clip destroys it.
+    await game.player.spawnItem(STD_CLIP);
+    await game.input.trigger("Reload");
+    await game.step({ frames: 2 });
+    const refilled = await ammoOf(game, pistol);
+    assert.ok(refilled > 0, "the pistol refills from its own ejected rounds");
+
+    // The button belongs to the hand that PRESSED it: the empty left hand's
+    // lower button reaches the interface, and leaves the right gun loaded.
+    await game.input.trigger("LeftHandLowerButton");
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).mode, "use");
+    assert.equal(
+      await ammoOf(game, pistol),
+      refilled,
+      "the free hand's button must not eject the other hand's gun",
+    );
+    await game.input.trigger("LeftHandLowerButton");
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).mode, "shooter");
+
+    // The merge path: with a stack already carried the rounds join it instead
+    // of minting a second clip.
+    const stacksBefore = (await carriedClips(game)).length;
+    const reserveBefore = await reserveRounds(game);
+    await pressRightLower(game);
+    assert.equal(await ammoOf(game, pistol), 0);
+    assert.equal(
+      await reserveRounds(game),
+      reserveBefore + refilled,
+      "the whole magazine came back to reserve",
+    );
+    assert.equal(
+      (await carriedClips(game)).length,
+      stacksBefore,
+      "merging into the carried stack rather than minting another",
+    );
+  },
+);
+
+test(
+  "an energy weapon's charge cannot be ejected",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    const laser = (await grabWeapon(game, LASER_PISTOL)).id;
+
+    const before = await ammoOf(game, laser);
+    const carriedBefore = (await game.player.inventory()).items.length;
+
+    await pressRightLower(game);
+    assert.equal(
+      await ammoOf(game, laser),
+      before,
+      "an energy weapon's charge stays where it is",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.length,
+      carriedBefore,
+      "and nothing is minted into the backpack",
+    );
+  },
+);


### PR DESCRIPTION
Rebased onto main b443ff86: this PR's `eject_magazine`/`unload_magazine` pair and main's `eject_magazine` were the same ejection written twice - deduped to this PR's cue-returning `eject_magazine` on top of `unload_magazine`, so the settings MFD's UNLOAD button (`Effect::UnloadWeapon`) now plays the same clip-handling cue the VR eject button does.

Fills the first cell of the per-hand face-button table from #1256: a **gun hand's LOWER button** (right `A` / left `X`) ejects that gun's magazine.

## What

The rounds go back to the **backpack reserve** as clips of the ammo type they already are, through the existing `reload::unload_to_reserve` machinery the ammo cycle and the physical clip insert already use. **No clip object is spawned in the world** - a magazine on the floor is a chore to pick up in VR, and the rounds are just as usable in the backpack.

**Per-hand.** The eject applies to the weapon in the hand that pressed (`wielded_weapon::eject_target`), not the hand-agnostic wielded lookup - so a dual-wielding player ejects the gun they meant.

Cue policy, matching `insert_held_clip`:

- nothing to eject - an empty magazine, or an energy weapon whose charge has no clip archetype to return to - is a **silent** no-op;
- a refusal the player earned (the backpack could not take the minted clip) plays `repfail`, because silence there is indistinguishable from a dead button;
- a successful eject plays the weapon's own `reload` schema, the sound the physical clip insert plays on the way in.

The three ejection sites (this button, `cycle_ammo`, the ammo-swapping `insert_held_clip`) now share one `unload_magazine`, so the "rounds still loaded means this is unearned" invariant lives in one place instead of three.

Flat keeps parity through the hand-agnostic `InputAction::EjectClip` on **`Alt+X`**. Deliberately not `Alt+R`: `DesktopInputMapper::poll` keys its rising edges on the *action*, so with `R` held a mere Alt tap would flip `Reload` off and fire an eject with no new key press.

**Deferred:** the gun hand's UPPER button is the fire-mode toggle. It needs `Effect::CycleGunSetting` from #1247, on a different stack, so it stays inert here and the table, the docs and a test all say so.

## Tests

Unit (`cargo test -p shock2vr --lib`: 1230 passed, 0 failed):

- `hand_buttons::a_gun_hands_lower_button_ejects_its_clip` - the Gun/Lower row resolves to `EjectClip` on either hand.
- `hand_buttons::a_gun_hands_upper_button_is_not_bound_yet` - the deferred toggle stays `None`.
- `hand_buttons::a_weapon_hand_reaches_neither_panel` - a gun hand still reaches neither panel.
- `wielded_weapon::a_per_hand_eject_targets_only_that_hand`, `an_empty_hand_has_nothing_to_eject`, `a_hand_holding_something_that_is_not_a_weapon_has_nothing_to_eject`.
- The empty-magazine and clipless-ammo (energy) no-ops are already asserted at the unload layer: `reload::ejecting_an_empty_magazine_does_nothing`, `reload::a_magazine_with_no_clip_archetype_is_not_ejected`.

e2e `tools/shock2-sdk/test/vr-eject-clip.e2e.test.ts` (`--vr`, `debug_weapons`): a loaded pistol in the VR right hand, right `A` -> magazine 0, the reserve gains exactly the ejected rounds, the gun stays held and no clip is left lying in the world; press again -> nothing changes; reload, then the free LEFT hand's lower button opens the interface and leaves the right gun loaded (the button follows the hand); eject again with a stack carried -> the rounds merge into it rather than minting a second clip. A laser pistol -> charge and backpack untouched.

**Negative-first:** with the Gun/Lower row returning `None` (parent behavior) the first case fails at `expected: 0, actual: 12` - the magazine simply stays full.

Full runs, `SHOCK2_E2E=1`:

```
vr-eject-clip            2/2
vr-contextual-buttons    4/4
vr-clip-insert-reload    3/3
weapon-ammo-eject        2/2
weapon-reload            1/1
vr-weapon-reload         2/2
missions                23/23
```

`cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean. No `oculus_runtime` change: the raw face buttons and their Quest click paths already exist, and `EjectClip` binds no path of its own.

## Review

`/xreview` (Claude + Codex + a de-dup pass). Fixed: the `Alt+R`/`R` edge collision (now `Alt+X`), the silent refusal (now `repfail`), `eject_target` not filtering to weapons, the third copy of the unload-then-verify transaction (now one `unload_magazine`), a test that had become a duplicate, and the e2e's missing merge/hand-routing/no-world-clip coverage. Consciously kept: the flat `Alt+X` binding and the `hand: None` path, which Codex offered to cut as out of scope - flat parity for the action is intended.

