### PR TITLE
feat(vr): the gun hand's upper button toggles its fire mode

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,7 +121,7 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 | `B` | `DebugCycleWeapon` | spawns and wields the next weapon (unlike the number row) |
 | `Alt+X` | `EjectClip` | magazine back to the backpack reserve; Quest: the gun hand's *lower* face button |
 | `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | no Quest binding - in VR ammo is swapped by inserting a clip of the other type |
-| `F` | `CycleGunSetting` | switch the wielded gun's fire mode (e.g. NORM / BURST); flat only |
+| `F` | `CycleGunSetting` | switch the wielded gun's fire mode (e.g. NORM / BURST); Quest: the gun hand's *upper* face button |
 | `U` | `ReadLastUnreadLog` | on Quest an *upper* face button resolves to this - see below |
 | `M` | `ToggleMap` | flat only |
 | `Tab` / `I` | `ToggleUseMode` | the cyber interface; on Quest a *lower* face button resolves to this |
@@ -145,7 +145,7 @@ that hand holds (`shock2vr/src/hand_buttons.rs`):
 | that hand holds | lower | upper |
 | --- | --- | --- |
 | nothing, a melee weapon, or any other item | `ToggleUseMode` (cyber interface) | `ReadLastUnreadLog` |
-| a gun | `EjectClip` - that hand's gun, so dual wielding ejects the one pressed | reserved for the fire-mode toggle - inert for now |
+| a gun | `EjectClip` - that hand's gun, so dual wielding ejects the one pressed | `CycleGunSetting` - likewise that hand's gun; a gun with one mode is a no-op |
 | the psi amp | reserved for power selection - inert for now | reserved for power selection - inert for now |
 
 Mode first: while the cyber interface is up both buttons keep their interface

--- a/shock2vr/src/hand_buttons.rs
+++ b/shock2vr/src/hand_buttons.rs
@@ -65,7 +65,7 @@ pub enum HandButtonMode {
 /// | hand holds | lower | upper |
 /// |---|---|---|
 /// | nothing, melee, or any other item | `ToggleUseMode` | `ReadLastUnreadLog` |
-/// | a gun | `EjectClip` (that hand's gun) | fire-mode toggle (not yet bound) |
+/// | a gun | `EjectClip` (that hand's gun) | `CycleGunSetting` (that hand's gun) |
 /// | the psi amp | power selection (not yet bound) | power selection (not yet bound) |
 ///
 /// **Mode first.** While the interface is up both buttons keep their interface
@@ -78,8 +78,8 @@ pub enum HandButtonMode {
 ///
 /// `hand` does not change which action is returned (the mapping is symmetric);
 /// it is taken because a gun/psi row resolves to an action *about that hand's
-/// weapon* - `EjectClip` ejects the gun in the hand that pressed it, so the
-/// caller must carry the hand through.
+/// weapon* - `EjectClip` and `CycleGunSetting` act on the gun in the hand that
+/// pressed, so the caller must carry the hand through.
 pub fn resolve_hand_button(
     mode: HandButtonMode,
     hand: Handedness,
@@ -99,15 +99,13 @@ pub fn resolve_hand_button(
 
     match held {
         HeldKind::Empty | HeldKind::Melee | HeldKind::Other => Some(interface_action),
-        // The gun hand's lower button ejects that gun's magazine. Its upper
-        // button is reserved for the fire-mode toggle and is not bound yet -
-        // inert rather than falling through to the panels and having to be
-        // taken away again.
+        // The gun hand's own handling controls: lower ejects that gun's
+        // magazine, upper toggles its fire mode.
         HeldKind::Gun => match button {
             HandButton::Lower => Some(InputAction::EjectClip),
-            HandButton::Upper => None,
+            HandButton::Upper => Some(InputAction::CycleGunSetting),
         },
-        // Reserved for power selection, likewise not yet bound.
+        // Reserved for power selection, not yet bound.
         HeldKind::PsiAmp => None,
     }
 }
@@ -201,12 +199,16 @@ mod tests {
         }
     }
 
-    /// Row 2, upper: the fire-mode toggle is not wired to this button yet, so
-    /// it is inert rather than borrowing another meaning.
+    /// Row 2, upper: the gun hand's upper button toggles that gun's fire mode
+    /// - on either hand, resolved against the hand that pressed it.
     #[test]
-    fn a_gun_hands_upper_button_is_not_bound_yet() {
+    fn a_gun_hands_upper_button_toggles_its_fire_mode() {
         for hand in HANDS {
-            assert_eq!(resolve(HeldKind::Gun, hand, HandButton::Upper), None);
+            assert_eq!(
+                resolve(HeldKind::Gun, hand, HandButton::Upper),
+                Some(InputAction::CycleGunSetting),
+                "{hand:?}"
+            );
         }
     }
 

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -232,13 +232,13 @@ impl InputAction {
             // The right controller's menu button is reserved by the Quest
             // system UI; the left one is the app's.
             InputAction::TogglePauseMenu => Some("/user/hand/left/input/menu/click"),
-            // `Reload`, `CycleAmmo` and `EjectClip` deliberately have NO Quest
-            // binding of their own: in VR reloading is the physical
-            // clip-insert gesture and an eject is the gun hand's lower face
-            // button, both of which name a hand and so work while dual
-            // wielding, where a hand-agnostic action cannot say which gun it
-            // meant. All three remain reachable everywhere else (flat keys,
-            // HTTP, the SDK).
+            // `Reload`, `CycleAmmo`, `EjectClip` and `CycleGunSetting`
+            // deliberately have NO Quest binding of their own: in VR reloading
+            // is the physical clip-insert gesture, an eject is the gun hand's
+            // lower face button and a fire-mode switch its upper one - each
+            // names a hand and so works while dual wielding, where a
+            // hand-agnostic action cannot say which gun it meant. All four
+            // remain reachable everywhere else (flat keys, HTTP, the SDK).
             _ => None,
         }
     }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -126,7 +126,9 @@ impl ActionDispatcher {
             effects.push(Effect::CycleAmmo);
         }
         if state.just_triggered(InputAction::CycleGunSetting) {
-            effects.push(Effect::CycleGunSetting);
+            // Hand-agnostic: the flat key and HTTP mean "the wielded weapon".
+            // A per-hand press arrives as `Effect::HandButton` instead.
+            effects.push(Effect::CycleGunSetting { hand: None });
         }
         if state.just_triggered(InputAction::Reload) {
             effects.push(Effect::ReloadWeapon);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5591,9 +5591,12 @@ impl MissionCore {
                     }
                 }
 
-                Effect::CycleGunSetting => {
-                    // Whichever hand holds the gun, like ReloadWeapon above.
-                    if let Some(weapon) = crate::wielded_weapon::wielded_weapon(&self.world) {
+                Effect::CycleGunSetting { hand } => {
+                    // The gun goes with the hand that pressed; the hand-agnostic
+                    // action means whichever hand holds one.
+                    if let Some(weapon) =
+                        crate::wielded_weapon::hand_weapon_target(&self.world, hand)
+                    {
                         // An SS2 gun has exactly two modes, so the switch is a
                         // toggle - and any other stored value lands on mode 0.
                         let current =
@@ -5651,7 +5654,9 @@ impl MissionCore {
                 }
 
                 Effect::EjectClip { hand } => {
-                    if let Some(weapon) = crate::wielded_weapon::eject_target(&self.world, hand) {
+                    if let Some(weapon) =
+                        crate::wielded_weapon::hand_weapon_target(&self.world, hand)
+                    {
                         if let Some(cue) = self.eject_magazine(asset_cache, weapon) {
                             effects.push_back(cue);
                         }
@@ -5683,9 +5688,11 @@ impl MissionCore {
                         Some(crate::input::InputAction::EjectClip) => {
                             effects.push_front(Effect::EjectClip { hand: Some(hand) })
                         }
-                        // The psi amp's buttons, and a gun hand's upper one
-                        // (the fire-mode toggle), resolve to nothing yet -
-                        // their arms land with the actions themselves.
+                        Some(crate::input::InputAction::CycleGunSetting) => {
+                            effects.push_front(Effect::CycleGunSetting { hand: Some(hand) })
+                        }
+                        // The psi amp's buttons resolve to nothing yet - their
+                        // arms land with the power-selection action itself.
                         None => {}
                         Some(action) => warn!("unroutable hand button action: {action}"),
                     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -240,9 +240,18 @@ pub enum Effect {
         setting: i32,
     },
 
-    /// Switch the player's wielded gun to its other fire setting. No-op when
-    /// nothing is wielded or the gun has no second mode (turrets, the psi amp).
-    CycleGunSetting,
+    /// Switch a gun to its other fire setting.
+    ///
+    /// `hand` names the gun, as [`Effect::EjectClip`] does: `Some(hand)` is the
+    /// gun in that hand - what a per-hand face button means, so a dual-wielding
+    /// player switches the one they pressed - and `None` is the hand-agnostic
+    /// `InputAction::CycleGunSetting`, meaning whichever weapon is wielded.
+    ///
+    /// No-op when that hand holds no weapon, or the gun has no second mode
+    /// (turrets, the psi amp).
+    CycleGunSetting {
+        hand: Option<Handedness>,
+    },
 
     /// Open the weapon settings MFD for the wielded gun in the presentation's
     /// panel slot. No-op when nothing is wielded.

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -59,12 +59,12 @@ pub fn wielded_weapon(world: &World) -> Option<EntityId> {
     weapon_in_hand(world, Handedness::Right).or_else(|| weapon_in_hand(world, Handedness::Left))
 }
 
-/// The weapon an eject applies to. `Some(hand)` - a per-hand face button -
-/// means the weapon in THAT hand, so a dual-wielding player ejects the
-/// magazine of the gun they pressed; `None` - the hand-agnostic input action -
-/// means whichever weapon is wielded. Both arms filter to weapons, so a hand
-/// carrying a medkit is not an eject target.
-pub fn eject_target(world: &World, hand: Option<Handedness>) -> Option<EntityId> {
+/// The weapon a per-hand gun action (eject, fire-mode toggle) applies to.
+/// `Some(hand)` - a face button - means the weapon in THAT hand, so a
+/// dual-wielding player acts on the gun they pressed; `None` - the
+/// hand-agnostic input action - means whichever weapon is wielded. Both arms
+/// filter to weapons, so a hand carrying a medkit is not a target.
+pub fn hand_weapon_target(world: &World, hand: Option<Handedness>) -> Option<EntityId> {
     match hand {
         Some(hand) => weapon_in_hand(world, hand),
         None => wielded_weapon(world),
@@ -139,15 +139,18 @@ mod tests {
         (world, left_hand_entity_id, right_hand_entity_id)
     }
 
-    /// A per-hand eject means the gun in that hand and no other - the whole
-    /// point of carrying the hand through, since dual wielding otherwise
-    /// ejects whichever gun `wielded_weapon` happens to prefer.
+    /// A per-hand action means the gun in that hand and no other - the whole
+    /// point of carrying the hand through, since dual wielding otherwise hits
+    /// whichever gun `wielded_weapon` happens to prefer.
     #[test]
-    fn a_per_hand_eject_targets_only_that_hand() {
+    fn a_per_hand_action_targets_only_that_hand() {
         let (world, left_gun, right_gun) = player_holding(true, true);
 
-        assert_eq!(eject_target(&world, Some(Handedness::Right)), right_gun);
-        assert_eq!(eject_target(&world, Some(Handedness::Left)), left_gun);
+        assert_eq!(
+            hand_weapon_target(&world, Some(Handedness::Right)),
+            right_gun
+        );
+        assert_eq!(hand_weapon_target(&world, Some(Handedness::Left)), left_gun);
         assert_ne!(left_gun, right_gun);
     }
 
@@ -156,7 +159,7 @@ mod tests {
     fn an_empty_hand_has_nothing_to_eject() {
         let (world, _, _) = player_holding(false, true);
 
-        assert_eq!(eject_target(&world, Some(Handedness::Left)), None);
+        assert_eq!(hand_weapon_target(&world, Some(Handedness::Left)), None);
     }
 
     /// A hand carrying something that is not a weapon is not an eject target
@@ -176,6 +179,6 @@ mod tests {
             inventory_entity_id: inventory,
         });
 
-        assert_eq!(eject_target(&world, Some(Handedness::Right)), None);
+        assert_eq!(hand_weapon_target(&world, Some(Handedness::Right)), None);
     }
 }

--- a/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
@@ -92,8 +92,8 @@ test(
     await game.step({ frames: 30 });
     await grabPistol(game);
 
-    // The gun hand's buttons are the gun's now - and nothing is bound to them
-    // yet, so they do nothing at all rather than reaching the panels.
+    // The gun hand's buttons are the gun's now - they handle the weapon
+    // (eject, fire mode) rather than reaching the panels.
     await press(game, "RightHandLowerButton");
     assert.equal(
       await uiMode(game),
@@ -152,7 +152,7 @@ test(
     assert.equal(
       await uiMode(game),
       "shooter",
-      "with the interface down the gun hand's button is inert again",
+      "with the interface down the gun hand's button is the gun's again",
     );
   },
 );

--- a/tools/shock2-sdk/test/vr-fire-mode-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-fire-mode-button.e2e.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { describeSounds } from "./helpers/audio.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// The gun hand's UPPER face button (right B / left Y) toggles that gun's fire
+// mode - the same switch the flat `F` key makes, resolved against the hand that
+// pressed it so a dual-wielding player switches the gun they meant.
+//
+// Negative-first: on the parent a gun hand's upper button resolves to nothing
+// (`vr-contextual-buttons` asserts it reaches no panel), so the mode never
+// leaves NORM and no `bset` sting plays.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8686);
+
+/** The debug pistol (NORM / BURST). */
+const PISTOL = -17;
+/** An energy weapon with a second mode of its own (NORM / OVER). */
+const LASER_PISTOL = -22;
+
+/** The wielded gun's fire setting and its header, from /v1/info. */
+async function fireMode(
+  game: GameServer,
+): Promise<[number | null, string | null]> {
+  const player = (await game.info()).player;
+  return [player.wielded_gun_setting, player.wielded_gun_setting_header];
+}
+
+async function press(game: GameServer, action: string): Promise<void> {
+  await game.input.trigger(action);
+  await game.step({ frames: 5 });
+}
+
+/** Spawn `template` and take it in the VR RIGHT hand. */
+async function grabWeapon(game: GameServer, template: number): Promise<number> {
+  // Diffed against the entity list: `debug_weapons` already stocks one of every
+  // gun, so a plain template search could hand back the scenery one.
+  const weapon = await cycleToWeapon(game, (e) => e.template_id === template);
+  await aimVrHandAt(game, weapon.position as Vec3, 0.3);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    weapon.id,
+    "the VR right hand must hold the weapon",
+  );
+  return weapon.id;
+}
+
+test(
+  "the gun hand's upper button toggles that gun's fire mode",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    const pistol = await grabWeapon(game, PISTOL);
+
+    assert.deepEqual(
+      await fireMode(game),
+      [0, "NORM"],
+      "the pistol starts on its first mode",
+    );
+
+    const before = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await press(game, "RightHandUpperButton");
+    assert.deepEqual(
+      await fireMode(game),
+      [1, "BURST"],
+      "right B switches the gun in that hand to its second mode",
+    );
+
+    // The same `bset` sting the flat switch plays.
+    const played = (await game.audio.recent()).sounds.filter(
+      (s) => s.sequence > before,
+    );
+    assert.ok(
+      played.some((s) => s.sample.toLowerCase().startsWith("bset")),
+      `the switch should play the bset sting, got ${describeSounds(played)}`,
+    );
+
+    await press(game, "RightHandUpperButton");
+    assert.deepEqual(
+      await fireMode(game),
+      [0, "NORM"],
+      "and back - there are only two modes",
+    );
+
+    // The button belongs to the hand that PRESSED it: the free left hand's
+    // upper button is the log reader's, and leaves the right gun's mode alone.
+    await press(game, "RightHandUpperButton");
+    assert.deepEqual(await fireMode(game), [1, "BURST"]);
+    await press(game, "LeftHandUpperButton");
+    assert.deepEqual(
+      await fireMode(game),
+      [1, "BURST"],
+      "the free hand's button must not switch the other hand's gun",
+    );
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol,
+      "the gun stays in the hand throughout",
+    );
+  },
+);
+
+test(
+  "an energy weapon's own second mode switches the same way",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    await grabWeapon(game, LASER_PISTOL);
+
+    assert.deepEqual(await fireMode(game), [0, "NORM"]);
+    await press(game, "RightHandUpperButton");
+    assert.deepEqual(
+      await fireMode(game),
+      [1, "OVER"],
+      "the laser pistol switches to its overcharge",
+    );
+    await press(game, "RightHandUpperButton");
+    assert.deepEqual(await fireMode(game), [0, "NORM"]);
+  },
+);


### PR DESCRIPTION
The Quest gun-hand row's **upper** face button (right `B` / left `Y`) was reserved and inert. It now toggles that gun's **fire mode** - so a gun's two handling controls sit on the controller holding it: lower ejects the magazine (#1258), upper switches NORM/BURST.

**Per-hand, like the eject.** `Effect::CycleGunSetting` gained `hand: Option<Handedness>`, mirroring `Effect::EjectClip`:

- `Some(hand)` - a face button - is the gun in **that** hand, so a dual-wielding player switches the one they pressed, and a free hand's upper button still reaches the log reader.
- `None` - the hand-agnostic `InputAction::CycleGunSetting` (flat `F`, HTTP, the SDK) - still means whichever weapon is wielded. Behavior there is unchanged.

Both resolve through one lookup, `wielded_weapon::eject_target` renamed `hand_weapon_target` now that it serves both actions. A gun with no second mode stays a no-op through the unchanged `set_gun_setting` gate, and the switch plays the same `bset` sting as on flat.

| that hand holds | lower | upper |
| --- | --- | --- |
| nothing, melee, any other item | `ToggleUseMode` | `ReadLastUnreadLog` |
| a gun | `EjectClip` (that hand's gun) | **`CycleGunSetting` (that hand's gun)** |
| the psi amp | reserved - inert | reserved - inert |

### Tests

Negative-first, both levels: with the Gun/Upper row left at `None` the new unit test fails (`left: None, right: Some(CycleGunSetting)`) and 2 of the 2 new e2e assertions fail (mode never leaves `NORM`).

- Unit (`cargo test -p shock2vr --lib`): **1276 passed, 0 failed**. New/updated: `hand_buttons::a_gun_hands_upper_button_toggles_its_fire_mode`, `wielded_weapon::a_per_hand_action_targets_only_that_hand`.
- New e2e `tools/shock2-sdk/test/vr-fire-mode-button.e2e.test.ts` (`--vr`, `debug_weapons`): pistol in the right hand, right `B` flips `0/NORM -> 1/BURST -> 0/NORM` with the `bset` sting; the free left hand's `Y` leaves the right gun's mode alone; the laser pistol toggles `NORM -> OVER`. **2 pass.**
- `vr-contextual-buttons`, `vr-eject-clip`, `weapon-fire-mode`: **9 pass, 0 fail.**
- `missions.e2e.test.ts`: **23 pass, 0 fail.**

No single-mode-gun e2e: every gun on the `debug_weapons` bench has a second mode (BURST/AUTO/TRIPLE/OVER/BOUNCE/AREA/DEATH/ANNELID); the psi amp is a different row entirely. That gate is unchanged and stays covered by the flat `weapon-fire-mode` test.

Stacked on #1258.
