### PR TITLE
fix(ai): a stall changes the route

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -1103,6 +1103,11 @@ pub struct DebugPathfindingStats {
     pub queries: u64,
     pub stressed_retries: u64,
     pub no_route: u64,
+    /// Cell crossings currently excluded because an AI's steering stalled
+    /// on them (see `PathfindingService::report_blocked_link`)
+    pub blocked_links: usize,
+    /// Cells currently penalized because an AI stalled inside them
+    pub blocked_cells: usize,
 }
 
 /// A script message a debug client can inject into a specific entity.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -12188,6 +12188,8 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 queries: stats.queries,
                 stressed_retries: stats.stressed_retries,
                 no_route: stats.no_route,
+                blocked_links: stats.blocked_links,
+                blocked_cells: stats.blocked_cells,
             }
         })
     }

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -298,7 +298,7 @@ mod tests {
         let response = wait_for_result(&async_pf, 21).expect("worker must respond");
         assert_eq!(response.outcome, AiPathOutcome::Full);
         assert!(
-            response.waypoints.iter().any(|w| w.z > 1.9),
+            crate::pathfinding::tests::took_the_detour(&response.waypoints),
             "the second AI must take the detour: {:?}",
             response.waypoints
         );

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -75,9 +75,11 @@ impl AsyncPathfinding {
                 while let Ok(request) = rx.recv() {
                     let mut outcome = AiPathOutcome::Full;
                     // Crossings ANY AI's steering reported as physically
-                    // blocked (stall mid-route) are excluded, so re-paths -
+                    // blocked (stall mid-route) are excluded, and cells an
+                    // AI is stalled in are made expensive, so re-paths -
                     // including fresh arrivals' - route around the obstacle
-                    let avoid = service.blocked_links(request.now_seconds);
+                    // instead of piling into it
+                    let avoid = service.avoidance(request.now_seconds);
                     let path = service
                         .find_path_avoiding(
                             request.start,
@@ -274,5 +276,31 @@ mod tests {
         }));
         let response = wait_for_result(&async_pf, 12).expect("worker must respond");
         assert_eq!(response.outcome, AiPathOutcome::Partial);
+    }
+
+    #[test]
+    fn worker_routes_a_second_ai_around_a_cell_somebody_is_stalled_in() {
+        // One AI is wedged in the middle cell. The next AI to ask for the
+        // same trip must be sent the long way round instead of inheriting
+        // the route into the pile-up.
+        let service = Arc::new(PathfindingService::new(Arc::new(
+            crate::pathfinding::tests::detour_db(),
+        )));
+        service.report_blocked_cell(1, 0.0);
+        let async_pf = AsyncPathfinding::spawn(service.clone());
+        assert!(async_pf.submit(PathQueryRequest {
+            entity: 21,
+            start: cgmath::vec3(1.0, 0.0, 1.0),
+            goal: cgmath::vec3(5.0, 0.0, 1.0),
+            movement_bits: MovementBits::WALK,
+            now_seconds: 1.0,
+        }));
+        let response = wait_for_result(&async_pf, 21).expect("worker must respond");
+        assert_eq!(response.outcome, AiPathOutcome::Full);
+        assert!(
+            response.waypoints.iter().any(|w| w.z > 1.9),
+            "the second AI must take the detour: {:?}",
+            response.waypoints
+        );
     }
 }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -14,6 +14,7 @@ use dark::{
         path_database::{MovementBits, NO_ZONE, PathCell, PathCellFlags, PathCellLink},
     },
 };
+use rand::Rng;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -77,6 +78,23 @@ const BLOCKED_LINK_TTL_SECONDS: f32 = 30.0;
 /// live entries) - bounds memory; entries expire on their TTL.
 const MAX_BLOCKED_LINKS: usize = 64;
 
+/// How long a cell an AI stalled in stays expensive to enter. Shorter than
+/// the crossing TTL: a whole cell is a much blunter instrument, and the
+/// common cause (an AI wedged in it right now) clears as soon as that AI
+/// frees itself.
+const STALLED_CELL_TTL_SECONDS: f32 = 10.0;
+/// Jitter applied to each cell TTL so a pile-up of AIs reporting the same
+/// cell in the same second doesn't reopen it for all of them at once.
+const STALLED_CELL_TTL_JITTER: std::ops::Range<f32> = 0.8..1.2;
+/// Cap on remembered stalled cells (see `MAX_BLOCKED_LINKS`)
+const MAX_BLOCKED_CELLS: usize = 64;
+/// Extra cost (Dark feet, the unit link costs and the heuristic use) for
+/// ENTERING a cell an AI recently stalled in. Deliberately a penalty and
+/// not a cut: an AI wedged in a dead end must still be able to path out
+/// through the only cell it has, and a corridor everyone must cross stays
+/// usable. Worth about a 200-foot detour, so any real alternative wins.
+const STALLED_CELL_COST_PENALTY: u32 = 200;
+
 /// Per-frame cap on AI-initiated pathfind queries. A slot now covers the
 /// full fallback chain (A* + stressed retry + partial-route Dijkstra when
 /// the goal is unreachable), benched at ~0.5ms p95 / ~3ms worst per slot on
@@ -122,6 +140,17 @@ impl Default for PathfindingFrameBudget {
     }
 }
 
+/// Steering-reported obstacles the navigation mesh doesn't model, applied to
+/// one path query. Links are impassable; cells are merely expensive (see
+/// `STALLED_CELL_COST_PENALTY`).
+#[derive(Debug, Clone, Default)]
+pub struct NavAvoidance {
+    /// Directed cell crossings some AI failed to traverse
+    pub links: std::collections::HashSet<(u32, u32)>,
+    /// Cells some AI is (or recently was) stalled in
+    pub cells: std::collections::HashSet<u32>,
+}
+
 /// Monotonic query counters, for load measurement and budget verification.
 /// Callers diff snapshots across frames to get rates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -132,6 +161,13 @@ pub struct PathfindingStats {
     pub stressed_retries: u64,
     /// Queries that found no route at all (the most expensive outcome)
     pub no_route: u64,
+    /// Crossings currently excluded by steering reports (see
+    /// `report_blocked_link`). Pruned as queries run, so this is the count
+    /// as of the last query rather than as of this instant.
+    pub blocked_links: usize,
+    /// Cells currently penalized by steering reports (see
+    /// `report_blocked_cell`), pruned the same way.
+    pub blocked_cells: usize,
 }
 
 /// Outcome of an AI's most recent path query
@@ -223,6 +259,16 @@ pub struct PathfindingService {
     /// cells) so one blocked doorway can't seal every other entrance into
     /// a large cell.
     blocked_links: std::sync::Mutex<HashMap<(u32, u32), f32>>,
+    /// Cells an AI's steering stalled in, mapped to their expiry in mission
+    /// seconds. Two jobs, one input: a stall that happens INSIDE a single
+    /// cell has no crossing to blacklist (the AI never reached the edge),
+    /// and a cell somebody is currently wedged in is a bad place to send
+    /// the next AI - three hybrids piled into one medsci2 door jamb by
+    /// each inheriting the route the first one was stuck on. Applied as a
+    /// COST penalty, never a cut (see `STALLED_CELL_COST_PENALTY`), and
+    /// only on ENTERING - an AI already standing in the cell can still
+    /// path out of it.
+    blocked_cells: std::sync::Mutex<HashMap<u32, f32>>,
     /// Mission object ids of doors that are impassable: locked-and-closed,
     /// permanently closed, or otherwise inoperable. A* refuses links into
     /// their below-door cells; closed-but-openable doors stay pathable and
@@ -302,6 +348,7 @@ impl PathfindingService {
             ai_paths: std::sync::Mutex::new(HashMap::new()),
             ai_steering: std::sync::Mutex::new(HashMap::new()),
             blocked_links: std::sync::Mutex::new(HashMap::new()),
+            blocked_cells: std::sync::Mutex::new(HashMap::new()),
             blocked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
@@ -361,6 +408,46 @@ impl PathfindingService {
         };
         blocked.retain(|_, &mut expiry| expiry > now_seconds);
         blocked.keys().copied().collect()
+    }
+
+    /// Remember that an AI stalled inside `cell`. The cell stays expensive
+    /// to ENTER for a jittered ~10 seconds, so other AIs' routes prefer
+    /// another way round and the stalled AI's own re-path does not turn
+    /// back into it. Unlike a blocked crossing this is a cost penalty, not
+    /// an exclusion - a wholly blocked-in AI must still be able to leave.
+    pub fn report_blocked_cell(&self, cell: u32, now_seconds: f32) {
+        let Ok(mut blocked) = self.blocked_cells.lock() else {
+            return;
+        };
+        blocked.retain(|_, &mut expiry| expiry > now_seconds);
+        if blocked.len() >= MAX_BLOCKED_CELLS && !blocked.contains_key(&cell) {
+            return; // full of live entries - drop rather than grow unbounded
+        }
+        let ttl = STALLED_CELL_TTL_SECONDS * rand::thread_rng().gen_range(STALLED_CELL_TTL_JITTER);
+        let expiry = now_seconds + ttl;
+        // Re-reporting a cell (an escalating stall) extends its TTL, never
+        // shortens it
+        let entry = blocked.entry(cell).or_insert(expiry);
+        *entry = entry.max(expiry);
+    }
+
+    /// The cells currently penalized by steering stall reports. Expired
+    /// entries are dropped.
+    pub fn blocked_cells(&self, now_seconds: f32) -> std::collections::HashSet<u32> {
+        let Ok(mut blocked) = self.blocked_cells.lock() else {
+            return std::collections::HashSet::new();
+        };
+        blocked.retain(|_, &mut expiry| expiry > now_seconds);
+        blocked.keys().copied().collect()
+    }
+
+    /// Everything steering has reported as physically impassable or
+    /// expensive right now, for one path query.
+    pub fn avoidance(&self, now_seconds: f32) -> NavAvoidance {
+        NavAvoidance {
+            links: self.blocked_links(now_seconds),
+            cells: self.blocked_cells(now_seconds),
+        }
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -451,6 +538,8 @@ impl PathfindingService {
             queries: self.queries.load(Ordering::Relaxed),
             stressed_retries: self.stressed_retries.load(Ordering::Relaxed),
             no_route: self.no_route.load(Ordering::Relaxed),
+            blocked_links: self.blocked_links.lock().map(|b| b.len()).unwrap_or(0),
+            blocked_cells: self.blocked_cells.lock().map(|b| b.len()).unwrap_or(0),
         }
     }
 
@@ -486,12 +575,7 @@ impl PathfindingService {
         goal: Vector3<f32>,
         movement_bits: MovementBits,
     ) -> Option<Vec<Vector3<f32>>> {
-        self.find_path_avoiding(
-            start,
-            goal,
-            movement_bits,
-            &std::collections::HashSet::new(),
-        )
+        self.find_path_avoiding(start, goal, movement_bits, &NavAvoidance::default())
     }
 
     /// `find_path` with a set of directed cell crossings to treat as
@@ -503,7 +587,7 @@ impl PathfindingService {
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<(u32, u32)>,
+        avoid: &NavAvoidance,
     ) -> Option<Vec<Vector3<f32>>> {
         self.queries.fetch_add(1, Ordering::Relaxed);
         if let Some(path) = self.find_path_with_bits(start, goal, movement_bits, avoid) {
@@ -538,12 +622,7 @@ impl PathfindingService {
         goal: Vector3<f32>,
         movement_bits: MovementBits,
     ) -> Option<Vec<Vector3<f32>>> {
-        self.find_path_toward_avoiding(
-            start,
-            goal,
-            movement_bits,
-            &std::collections::HashSet::new(),
-        )
+        self.find_path_toward_avoiding(start, goal, movement_bits, &NavAvoidance::default())
     }
 
     /// `find_path_toward` with steering-reported blocked crossings excluded
@@ -554,7 +633,7 @@ impl PathfindingService {
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<(u32, u32)>,
+        avoid: &NavAvoidance,
     ) -> Option<Vec<Vector3<f32>>> {
         let start_cell = self.cell_from_position(start)?;
         let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell, |&cell| {
@@ -617,7 +696,7 @@ impl PathfindingService {
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<(u32, u32)>,
+        avoid: &NavAvoidance,
     ) -> Option<Vec<Vector3<f32>>> {
         // Find start and goal cells
         let start_cell_id = self.cell_from_position(start)?;
@@ -730,7 +809,7 @@ impl PathfindingService {
 
         // Find all reachable cells using Dijkstra's algorithm
         let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell_id, |&cell_id| {
-            self.get_successors(cell_id, movement_bits, &std::collections::HashSet::new())
+            self.get_successors(cell_id, movement_bits, &NavAvoidance::default())
         });
 
         // Find the reachable cell closest to the goal
@@ -820,7 +899,7 @@ impl PathfindingService {
         &self,
         cell_id: u32,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<(u32, u32)>,
+        avoid: &NavAvoidance,
     ) -> Vec<(u32, u32)> {
         let Some(link_indices) = self.links_by_cell.get(cell_id as usize) else {
             return Vec::new();
@@ -828,7 +907,7 @@ impl PathfindingService {
         link_indices
             .iter()
             .filter(|&&idx| {
-                !avoid.contains(&(cell_id, self.link_at(idx).to_cell))
+                !avoid.links.contains(&(cell_id, self.link_at(idx).to_cell))
                     && self.can_use_link(idx, movement_bits)
             })
             .map(|&idx| {
@@ -848,6 +927,11 @@ impl PathfindingService {
                     if dest.flags.contains(PathCellFlags::BLOCKING_OBB) {
                         cost *= BLOCKING_CELL_COST_PENALTY;
                     }
+                }
+                // Somebody is stalled in there: worth a long detour, but
+                // still passable if it is the only way
+                if avoid.cells.contains(&link.to_cell) {
+                    cost = cost.saturating_add(STALLED_CELL_COST_PENALTY);
                 }
                 (link.to_cell, cost)
             })
@@ -1586,6 +1670,63 @@ pub(crate) mod tests {
         }
     }
 
+    /// Start (0) -> goal (2) two ways: straight through the middle cell 1
+    /// (cost 10) or the long way round through cell 3 (cost 40). Lets a
+    /// test see whether a penalty on cell 1 is enough to buy the detour.
+    pub(crate) fn detour_db() -> PathDatabase {
+        let vertices = vec![
+            vec3(0.0, 0.0, 0.0),
+            vec3(2.0, 0.0, 0.0),
+            vec3(2.0, 0.0, 2.0),
+            vec3(0.0, 0.0, 2.0),
+            vec3(4.0, 0.0, 0.0),
+            vec3(4.0, 0.0, 2.0),
+            vec3(6.0, 0.0, 0.0),
+            vec3(6.0, 0.0, 2.0),
+            vec3(0.0, 0.0, 4.0),
+            vec3(6.0, 0.0, 4.0),
+        ];
+        let cell = |id: u32, center: Vector3<f32>, vertex_indices: Vec<u32>| PathCell {
+            id,
+            center,
+            vertex_indices,
+            flags: PathCellFlags::empty(),
+        };
+        let cells = vec![
+            cell(0, vec3(1.0, 0.0, 1.0), vec![0, 1, 2, 3]),
+            cell(1, vec3(3.0, 0.0, 1.0), vec![1, 4, 5, 2]),
+            cell(2, vec3(5.0, 0.0, 1.0), vec![4, 6, 7, 5]),
+            // The detour lane, north of all three
+            cell(3, vec3(3.0, 0.0, 3.0), vec![3, 7, 9, 8]),
+        ];
+        let link = |from_cell: u32, to_cell: u32, a: u32, b: u32, cost: u8| PathCellLink {
+            from_cell,
+            to_cell,
+            edge_vertex_a: a,
+            edge_vertex_b: b,
+            ok_bits: MovementBits::WALK,
+            cost,
+        };
+        let links = vec![
+            link(0, 1, 1, 2, 5),
+            link(1, 0, 1, 2, 5),
+            link(1, 2, 4, 5, 5),
+            link(2, 1, 4, 5, 5),
+            link(0, 3, 3, 2, 20),
+            link(3, 0, 3, 2, 20),
+            link(3, 2, 5, 7, 20),
+            link(2, 3, 5, 7, 20),
+        ];
+        PathDatabase {
+            cells,
+            vertices,
+            links,
+            cell_doors: Vec::new(),
+            cell_zones: Vec::new(),
+            zone_pairs: Vec::new(),
+        }
+    }
+
     fn service(db: PathDatabase) -> PathfindingService {
         PathfindingService::new(Arc::new(db))
     }
@@ -1940,7 +2081,9 @@ pub(crate) mod tests {
             PathfindingStats {
                 queries: 1,
                 stressed_retries: 0,
-                no_route: 0
+                no_route: 0,
+                blocked_links: 0,
+                blocked_cells: 0,
             }
         );
 
@@ -1953,7 +2096,9 @@ pub(crate) mod tests {
             PathfindingStats {
                 queries: 2,
                 stressed_retries: 1,
-                no_route: 0
+                no_route: 0,
+                blocked_links: 0,
+                blocked_cells: 0,
             }
         );
 
@@ -1969,7 +2114,9 @@ pub(crate) mod tests {
             PathfindingStats {
                 queries: 3,
                 stressed_retries: 2,
-                no_route: 1
+                no_route: 1,
+                blocked_links: 0,
+                blocked_cells: 0,
             }
         );
     }
@@ -1999,8 +2146,8 @@ pub(crate) mod tests {
         // obstacle - issue #481). The exclusion is SHARED - the blockage is
         // a physical fact, and it must protect fresh arrivals too.
         service.report_blocked_link(0, 1, 0.0);
-        let avoid = service.blocked_links(1.0);
-        assert!(avoid.contains(&(0, 1)));
+        let avoid = service.avoidance(1.0);
+        assert!(avoid.links.contains(&(0, 1)));
         assert!(
             service
                 .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
@@ -2030,8 +2177,8 @@ pub(crate) mod tests {
                 .blocked_links(100.0 + BLOCKED_LINK_TTL_SECONDS - 1.0)
                 .contains(&(0, 1))
         );
-        let expired = service.blocked_links(100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
-        assert!(expired.is_empty(), "entries must expire: {expired:?}");
+        let expired = service.avoidance(100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
+        assert!(expired.links.is_empty(), "entries must expire: {expired:?}");
         // The route is usable again once the entry expired
         assert!(
             service
@@ -2115,6 +2262,37 @@ pub(crate) mod tests {
         );
     }
 
+    /// How far north a route ran: only the detour through cell 3 crosses
+    /// the z = 2 line.
+    fn took_the_detour(waypoints: &[Vector3<f32>]) -> bool {
+        waypoints.iter().any(|w| w.z > 1.9)
+    }
+
+    #[test]
+    fn a_stall_inside_one_cell_routes_the_next_query_around_it() {
+        let service = service(detour_db());
+        let start = vec3(1.0, 0.0, 1.0);
+        let goal = vec3(5.0, 0.0, 1.0);
+        let direct = service.find_path(start, goal, MovementBits::WALK).unwrap();
+        assert!(
+            !took_the_detour(&direct),
+            "baseline route must go straight through: {direct:?}"
+        );
+
+        // An AI wedged INSIDE cell 1 has no crossing to blacklist - the
+        // cell itself is the report.
+        service.report_blocked_cell(1, 0.0);
+        let avoid = service.avoidance(1.0);
+        assert!(avoid.cells.contains(&1));
+        let rerouted = service
+            .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
+            .unwrap();
+        assert!(
+            took_the_detour(&rerouted),
+            "a stalled cell must be worth a detour: {rerouted:?}"
+        );
+    }
+
     #[test]
     fn a_small_creature_still_uses_the_narrow_gap() {
         let mut db = pinch_and_detour_db();
@@ -2156,5 +2334,66 @@ pub(crate) mod tests {
             vec3(5.0, 0.0, 4.0),
             "partial route should end in the roomy corridor, got {end:?}"
         );
+    }
+
+    #[test]
+    fn a_stalled_cell_stays_passable_when_it_is_the_only_way() {
+        // The penalty must never sever connectivity: with the detour gone,
+        // the route still goes through the stalled cell rather than failing
+        // (an AI blocked into a dead end has to be able to leave).
+        let mut db = detour_db();
+        db.links
+            .retain(|link| link.from_cell != 3 && link.to_cell != 3);
+        let service = service(db);
+        service.report_blocked_cell(1, 0.0);
+        let avoid = service.avoidance(1.0);
+        assert!(
+            service
+                .find_path_avoiding(
+                    vec3(1.0, 0.0, 1.0),
+                    vec3(5.0, 0.0, 1.0),
+                    MovementBits::WALK,
+                    &avoid
+                )
+                .is_some(),
+            "the penalty is a cost, not a cut"
+        );
+    }
+
+    #[test]
+    fn blocked_cells_expire_after_their_ttl() {
+        let service = service(detour_db());
+        service.report_blocked_cell(1, 100.0);
+        assert!(
+            service
+                .blocked_cells(100.0 + STALLED_CELL_TTL_SECONDS * 0.5)
+                .contains(&1),
+            "the entry must outlive its jitter floor"
+        );
+        let expired = service.avoidance(100.0 + STALLED_CELL_TTL_SECONDS * 1.3);
+        assert!(expired.cells.is_empty(), "entries must expire: {expired:?}");
+        let restored = service
+            .find_path_avoiding(
+                vec3(1.0, 0.0, 1.0),
+                vec3(5.0, 0.0, 1.0),
+                MovementBits::WALK,
+                &expired,
+            )
+            .unwrap();
+        assert!(
+            !took_the_detour(&restored),
+            "the straight route must come back once the entry expired: {restored:?}"
+        );
+    }
+
+    #[test]
+    fn stats_report_the_live_blacklists() {
+        let service = service(detour_db());
+        assert_eq!(service.stats().blocked_cells, 0);
+        assert_eq!(service.stats().blocked_links, 0);
+        service.report_blocked_cell(1, 0.0);
+        service.report_blocked_link(0, 1, 0.0);
+        assert_eq!(service.stats().blocked_cells, 1);
+        assert_eq!(service.stats().blocked_links, 1);
     }
 }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -14,7 +14,6 @@ use dark::{
         path_database::{MovementBits, NO_ZONE, PathCell, PathCellFlags, PathCellLink},
     },
 };
-use rand::Rng;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -83,9 +82,6 @@ const MAX_BLOCKED_LINKS: usize = 64;
 /// common cause (an AI wedged in it right now) clears as soon as that AI
 /// frees itself.
 const STALLED_CELL_TTL_SECONDS: f32 = 10.0;
-/// Jitter applied to each cell TTL so a pile-up of AIs reporting the same
-/// cell in the same second doesn't reopen it for all of them at once.
-const STALLED_CELL_TTL_JITTER: std::ops::Range<f32> = 0.8..1.2;
 /// Cap on remembered stalled cells (see `MAX_BLOCKED_LINKS`)
 const MAX_BLOCKED_CELLS: usize = 64;
 /// Extra cost (Dark feet, the unit link costs and the heuristic use) for
@@ -411,7 +407,7 @@ impl PathfindingService {
     }
 
     /// Remember that an AI stalled inside `cell`. The cell stays expensive
-    /// to ENTER for a jittered ~10 seconds, so other AIs' routes prefer
+    /// to ENTER for ~10 seconds, so other AIs' routes prefer
     /// another way round and the stalled AI's own re-path does not turn
     /// back into it. Unlike a blocked crossing this is a cost penalty, not
     /// an exclusion - a wholly blocked-in AI must still be able to leave.
@@ -423,10 +419,9 @@ impl PathfindingService {
         if blocked.len() >= MAX_BLOCKED_CELLS && !blocked.contains_key(&cell) {
             return; // full of live entries - drop rather than grow unbounded
         }
-        let ttl = STALLED_CELL_TTL_SECONDS * rand::thread_rng().gen_range(STALLED_CELL_TTL_JITTER);
-        let expiry = now_seconds + ttl;
         // Re-reporting a cell (an escalating stall) extends its TTL, never
         // shortens it
+        let expiry = now_seconds + STALLED_CELL_TTL_SECONDS;
         let entry = blocked.entry(cell).or_insert(expiry);
         *entry = entry.max(expiry);
     }
@@ -793,6 +788,20 @@ impl PathfindingService {
                 self.link_at(idx).to_cell == to_cell && self.can_use_link(idx, movement_bits)
             })
             .map(|idx| self.link_at(idx))
+    }
+
+    /// Whether the mesh actually has a crossing from one cell to another.
+    /// Steering names candidate pairs from waypoints, which sit on cell
+    /// edges and can be denser than the mesh - a pair that is not a link
+    /// would occupy a blacklist slot while excluding nothing.
+    pub fn has_link(&self, from_cell: u32, to_cell: u32) -> bool {
+        self.links_by_cell
+            .get(from_cell as usize)
+            .is_some_and(|links| {
+                links
+                    .iter()
+                    .any(|&idx| self.link_at(idx).to_cell == to_cell)
+            })
     }
 
     /// Find the closest reachable cell to a goal position
@@ -1670,35 +1679,26 @@ pub(crate) mod tests {
         }
     }
 
-    /// Start (0) -> goal (2) two ways: straight through the middle cell 1
-    /// (cost 10) or the long way round through cell 3 (cost 40). Lets a
-    /// test see whether a penalty on cell 1 is enough to buy the detour.
+    /// `three_cell_db` plus a long way round: start (0) reaches goal (2)
+    /// either straight through the middle cell 1 (cost 10) or through the
+    /// detour lane, cell 3, to its north (cost 40). Lets a test see whether
+    /// a penalty on cell 1 is enough to buy the detour.
     pub(crate) fn detour_db() -> PathDatabase {
-        let vertices = vec![
-            vec3(0.0, 0.0, 0.0),
-            vec3(2.0, 0.0, 0.0),
-            vec3(2.0, 0.0, 2.0),
-            vec3(0.0, 0.0, 2.0),
-            vec3(4.0, 0.0, 0.0),
-            vec3(4.0, 0.0, 2.0),
-            vec3(6.0, 0.0, 0.0),
-            vec3(6.0, 0.0, 2.0),
-            vec3(0.0, 0.0, 4.0),
-            vec3(6.0, 0.0, 4.0),
-        ];
-        let cell = |id: u32, center: Vector3<f32>, vertex_indices: Vec<u32>| PathCell {
-            id,
-            center,
-            vertex_indices,
+        let mut db = three_cell_db(PathCellFlags::empty());
+        // Plain walking, both ways: three_cell_db gates 1 -> 2 on STRESSED,
+        // which would leave the detour as the only route rather than a choice
+        for link in &mut db.links {
+            link.ok_bits = MovementBits::WALK;
+        }
+        // The detour lane's two far corners; its near ones are cells 0/2's
+        db.vertices.push(vec3(0.0, 0.0, 4.0)); // 8
+        db.vertices.push(vec3(6.0, 0.0, 4.0)); // 9
+        db.cells.push(PathCell {
+            id: 3,
+            center: vec3(3.0, 0.0, 3.0),
+            vertex_indices: vec![3, 7, 9, 8],
             flags: PathCellFlags::empty(),
-        };
-        let cells = vec![
-            cell(0, vec3(1.0, 0.0, 1.0), vec![0, 1, 2, 3]),
-            cell(1, vec3(3.0, 0.0, 1.0), vec![1, 4, 5, 2]),
-            cell(2, vec3(5.0, 0.0, 1.0), vec![4, 6, 7, 5]),
-            // The detour lane, north of all three
-            cell(3, vec3(3.0, 0.0, 3.0), vec![3, 7, 9, 8]),
-        ];
+        });
         let link = |from_cell: u32, to_cell: u32, a: u32, b: u32, cost: u8| PathCellLink {
             from_cell,
             to_cell,
@@ -1707,24 +1707,21 @@ pub(crate) mod tests {
             ok_bits: MovementBits::WALK,
             cost,
         };
-        let links = vec![
-            link(0, 1, 1, 2, 5),
-            link(1, 0, 1, 2, 5),
-            link(1, 2, 4, 5, 5),
-            link(2, 1, 4, 5, 5),
-            link(0, 3, 3, 2, 20),
-            link(3, 0, 3, 2, 20),
-            link(3, 2, 5, 7, 20),
-            link(2, 3, 5, 7, 20),
-        ];
-        PathDatabase {
-            cells,
-            vertices,
-            links,
-            cell_doors: Vec::new(),
-            cell_zones: Vec::new(),
-            zone_pairs: Vec::new(),
-        }
+        // three_cell_db is one-way; the detour is only a choice if the
+        // straight route can be walked in both directions too
+        db.links.push(link(1, 0, 1, 2, 5));
+        db.links.push(link(2, 1, 4, 5, 5));
+        db.links.push(link(0, 3, 3, 2, 20));
+        db.links.push(link(3, 0, 3, 2, 20));
+        db.links.push(link(3, 2, 5, 7, 20));
+        db.links.push(link(2, 3, 5, 7, 20));
+        db
+    }
+
+    /// How far north a route ran: only the detour through cell 3 crosses
+    /// the z = 2 line.
+    pub(crate) fn took_the_detour(waypoints: &[Vector3<f32>]) -> bool {
+        waypoints.iter().any(|w| w.z > 1.9)
     }
 
     fn service(db: PathDatabase) -> PathfindingService {
@@ -2260,12 +2257,6 @@ pub(crate) mod tests {
             !path.iter().any(|w| w.x > 4.0 && w.z < 2.0),
             "route threaded the pinch: {path:?}"
         );
-    }
-
-    /// How far north a route ran: only the detour through cell 3 crosses
-    /// the z = 2 line.
-    fn took_the_detour(waypoints: &[Vector3<f32>]) -> bool {
-        waypoints.iter().any(|w| w.z > 1.9)
     }
 
     #[test]

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -31,6 +31,14 @@ use self::debug_render_pipeline::DebugRenderer;
 /// Original standing player collision profile (SS2 ft): six feet tall and
 /// 2.4 feet wide. Dark represents it as a vertical stack of spheres; a capsule
 /// is the continuous equivalent and preserves the rounded traversal behavior.
+/// Horizontal speed (world units/s) a kinematic body must carry before it
+/// counts as moving terrain sweeping a creature. A kinematic body's velocity
+/// is derived from its pose deltas, so a prop that never moves still reports
+/// ~1e-3 of float jitter - and the old 1e-3 gate let a STATIONARY railing
+/// pin a hybrid touching it at its current translation, every frame, forever
+/// (the medsci2 balcony patroller, frozen to the last decimal for a minute).
+/// A door leaf in motion runs an order of magnitude above this.
+const MOVING_TERRAIN_SPEED: f32 = 0.1;
 const PLAYER_STANDING_HEIGHT: f32 = 6.0;
 const PLAYER_STANDING_RADIUS: f32 = 1.2;
 
@@ -6155,7 +6163,7 @@ impl PhysicsWorld {
                             + other_body.linvel().z * other_body.linvel().z;
                         let is_horizontal_kinematic_side_contact = other_body.body_type()
                             == RigidBodyType::KinematicPositionBased
-                            && horizontal_motion > 1.0e-6
+                            && horizontal_motion > MOVING_TERRAIN_SPEED * MOVING_TERRAIN_SPEED
                             && pair.manifolds.iter().any(|manifold| {
                                 !manifold.data.solver_contacts.is_empty()
                                     && manifold.data.normal.y.abs() < 0.5
@@ -8439,6 +8447,39 @@ mod tests {
         assert!(
             end.y > 0.5 && end.x < 2.5,
             "moving terrain swept the live creature off its supported deck: {end:?}"
+        );
+    }
+
+    /// A kinematic prop that never actually goes anywhere still reports a
+    /// whisper of velocity, because a kinematic body's velocity is derived
+    /// from its pose deltas. Reading that as moving terrain pinned a creature
+    /// brushing against it at its exact translation, every frame, for as long
+    /// as it stood there - the medsci2 balcony railing, which froze the
+    /// patroller to the last decimal.
+    #[test]
+    fn a_stationary_kinematic_with_jitter_does_not_pin_a_creature() {
+        let (mut world, mut player, creature_id, creature) = live_creature_test_world(2130, 40.0);
+        let wall = add_sweeping_wall(&mut world, 2133);
+        // Up against the creature's side, and staying there
+        world.set_translation(wall, vec3(-1.15, 1.0, 0.0));
+        step_creature_test(&mut world, &mut player, &[creature_id], 30);
+
+        let start = world.get_position(creature).unwrap();
+        for frame in 0..120 {
+            // ~3e-3 units/s of jitter: nothing, but ten times the old gate
+            let jitter = if frame % 2 == 0 { 5.0e-5 } else { -5.0e-5 };
+            world.set_translation(wall, vec3(-1.15 + jitter, 1.0, 0.0));
+            let y_velocity = world.get_velocity(creature_id).unwrap().y;
+            // Leaning on the wall while walking along it, so the side
+            // contact holds - the pose an AI takes rounding a railing
+            world.set_velocity(creature_id, vec3(-0.5, y_velocity, 1.0));
+            step_creature_test(&mut world, &mut player, &[creature_id], 1);
+        }
+
+        let end = world.get_position(creature).unwrap();
+        assert!(
+            end.z - start.z > 1.0,
+            "a stationary railing must not hold a walking creature in place: {start:?} -> {end:?}"
         );
     }
 

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -62,8 +62,15 @@ const STALL_RECOVERY_SECONDS: f32 = 0.8;
 /// Progress smaller than this doesn't count toward un-stalling (jitter)
 const STALL_PROGRESS_EPSILON: f32 = 0.25 / SCALE_FACTOR;
 /// Displacement watchdog: with an active waypoint, failing to move this far
-/// (XZ, 1 Dark foot) ...
-const DISPLACEMENT_STALL_DISTANCE: f32 = 1.0 / SCALE_FACTOR;
+/// (XZ, 3 Dark feet) ...
+///
+/// One foot was under the amplitude of a wedged body's own sliding: a
+/// hybrid pressed into medsci2's stair rail rocked ~1 foot about a fixed
+/// spot and reset the anchor forever, so no stall ever fired and the route
+/// never changed (measured). A walking creature covers many times this in
+/// the window below, so the wider bar only catches bodies that are going
+/// nowhere.
+const DISPLACEMENT_STALL_DISTANCE: f32 = 3.0 / SCALE_FACTOR;
 /// ...within this long also counts as a stall. Micro-sliding around a
 /// blocking capsule (another creature, a prop corner) can keep improving
 /// the waypoint distance by more than the epsilon, resetting the progress
@@ -505,7 +512,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 };
                 if let Some(from) = service.cell_from_position(position) {
                     // The cell we are stuck in is reported EVERY stall, not
-                    // only when the waypoint shares it. Two things need it:
+                    // only when the crossing is unknown. Two things need it:
                     // a stall entirely inside one cell has no crossing to
                     // blacklist at all (the body never reached an edge), and
                     // a cell somebody is wedged in is a bad place to route
@@ -513,7 +520,25 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     // doomed route and pile in behind (three hybrids in one
                     // medsci2 door jamb).
                     service.report_blocked_cell(from, now_seconds);
-                    if let Some(to) = crossing_into.filter(|to| *to != from) {
+                    // Nothing across the waypoint means the body never
+                    // reached the edge; the crossing that is actually
+                    // blocked is then the next one along the route (the
+                    // medsci2 Science-door jamb is exactly this - the body
+                    // presses into the jamb feet short of the boundary).
+                    let crossing = crossing_into
+                        .filter(|to| *to != from)
+                        .map(|to| (from, to))
+                        .or_else(|| {
+                            first_crossing_along(&service, from, &self.path[self.next_waypoint..])
+                        });
+                    if let Some((from, to)) = crossing {
+                        // The cell we could not get into is blacklisted as
+                        // well as the crossing. Waypoints sit on cell edges
+                        // and a route can be denser than the mesh, so the
+                        // pair we can name is not always an actual graph
+                        // link - the cell penalty bites whichever way A*
+                        // would have come in.
+                        service.report_blocked_cell(to, now_seconds);
                         service.report_blocked_link(from, to, now_seconds);
                     }
                 }
@@ -699,17 +724,32 @@ fn escalate_blocked_route(
         return;
     };
     service.report_blocked_cell(from, now_seconds);
+    if let Some((from, to)) = first_crossing_along(service, from, prefix) {
+        service.report_blocked_link(from, to, now_seconds);
+    }
+}
+
+/// The first cell crossing a route makes after `from`, as an adjacent
+/// `(from, to)` pair - what `report_blocked_link` needs, and what a stall
+/// that happened short of any cell edge has no other way to name. Only the
+/// leading waypoints are considered; a blockage further away than that is
+/// not what stopped the body.
+fn first_crossing_along(
+    service: &crate::pathfinding::PathfindingService,
+    from: u32,
+    waypoints: &[Vector3<f32>],
+) -> Option<(u32, u32)> {
     let mut previous = from;
-    for waypoint in prefix {
+    for waypoint in waypoints.iter().take(STALL_ROUTE_PREFIX) {
         let Some(cell) = service.cell_from_position(*waypoint) else {
             continue;
         };
         if cell != previous {
-            service.report_blocked_link(previous, cell, now_seconds);
-            return;
+            return Some((previous, cell));
         }
         previous = cell;
     }
+    None
 }
 
 fn route_reaches_goal(waypoints: &[Vector3<f32>], goal: Vector3<f32>) -> bool {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -85,6 +85,16 @@ const UNSTICK_NUDGE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
 /// off the shared edge without skipping a narrow destination cell (0.5
 /// Dark feet)
 const BLOCKED_PROBE_DISTANCE: f32 = 0.5 / SCALE_FACTOR;
+/// How many leading waypoints of the pre-stall route are remembered to
+/// check whether the re-path actually produced a different route
+const STALL_ROUTE_PREFIX: usize = 3;
+/// Two waypoints this close (Dark feet) count as the same waypoint when
+/// comparing a fresh route against the one that stalled
+const SAME_WAYPOINT_DISTANCE: f32 = 0.5 / SCALE_FACTOR;
+/// How many times one stall incident may escalate (blacklist more of the
+/// reproduced route) before falling through to the physical nudge. Bounded
+/// so a genuinely one-way corridor can't be sealed link by link.
+const MAX_STALL_ESCALATIONS: u32 = 3;
 /// Crowd separation: repel from living creatures within this radius (6 Dark
 /// feet - about two body widths)
 const SEPARATION_RADIUS: f32 = 6.0 / SCALE_FACTOR;
@@ -131,6 +141,15 @@ pub struct PathFollowSteeringStrategy {
     goal_unreachable: bool,
     /// Static-geometry whiskers, biasing the aim point (see `aim_with_bias`)
     whiskers: WhiskerAvoidance,
+    /// The leading waypoints of the route that was in force when the last
+    /// stall fired, kept until the next route is adopted. If the fresh
+    /// route starts the same way, the re-path reproduced the doomed route
+    /// and walking it again just grinds - escalate instead (see
+    /// `MAX_STALL_ESCALATIONS`).
+    stall_route_prefix: Option<Vec<Vector3<f32>>>,
+    /// Escalations spent on the current stall incident; reset once the body
+    /// actually moves
+    stall_escalations: u32,
 }
 
 impl PathFollowSteeringStrategy {
@@ -161,6 +180,8 @@ impl PathFollowSteeringStrategy {
             last_stall_position: None,
             goal_unreachable: false,
             whiskers: WhiskerAvoidance::new(),
+            stall_route_prefix: None,
+            stall_escalations: 0,
         }
     }
 
@@ -257,6 +278,8 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     AiPathOutcome::Failed if goal_current => {
                         self.goal_unreachable = true;
                         self.clear_path();
+                        // Nothing to compare a stalled route against
+                        self.stall_route_prefix = None;
                         // No route (even partially) - back off before asking
                         // again; the fallback chain is the worker's most
                         // expensive outcome
@@ -273,6 +296,29 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         // waypoint 0 is the position the query started from
                         self.next_waypoint = 1;
                         self.reset_stall();
+                        // A stall's re-path has to actually change the
+                        // route. When it comes back starting exactly the
+                        // way the stalled one did, walking it again just
+                        // grinds on the same obstacle - blacklist more of
+                        // it and ask once more (bounded, so a genuinely
+                        // one-way corridor still gets walked and the
+                        // existing nudge remains the last resort).
+                        if let Some(prefix) = self.stall_route_prefix.take() {
+                            if self.stall_escalations < MAX_STALL_ESCALATIONS
+                                && route_starts_the_same(&prefix, &self.path[self.next_waypoint..])
+                            {
+                                self.stall_escalations += 1;
+                                escalate_blocked_route(
+                                    &service,
+                                    position,
+                                    &prefix,
+                                    time.total.as_secs_f32(),
+                                );
+                                self.clear_path();
+                                self.repath_cooldown = REPATH_COOLDOWN_SECONDS
+                                    * rand::thread_rng().gen_range(0.8..1.2);
+                            }
+                        }
                     }
                     _ => {}
                 }
@@ -408,6 +454,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 // Real movement: the next stall (if any) is a fresh incident,
                 // not a continuation of a pinned body
                 self.last_stall_position = None;
+                self.stall_escalations = 0;
                 false
             }
             Some((anchor, age)) => {
@@ -440,25 +487,45 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 // the WAYPOINT's height (an edge-inset waypoint then
                 // resolves to the cell beyond the crossing; keeping Y fixed
                 // avoids blacklisting a stacked floor's cell).
+                let now_seconds = time.total.as_secs_f32();
                 let toward = waypoint - position;
                 let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
-                if toward_len > 1e-3 {
+                let crossing_into = if toward_len > 1e-3 {
                     let step = BLOCKED_PROBE_DISTANCE / toward_len;
                     let probe = Vector3::new(
                         waypoint.x + toward.x * step,
                         waypoint.y,
                         waypoint.z + toward.z * step,
                     );
-                    let from = service.cell_from_position(position);
-                    let to = service
+                    service
                         .cell_from_position(probe)
-                        .or_else(|| service.cell_from_position(waypoint));
-                    if let (Some(from), Some(to)) = (from, to) {
-                        if from != to {
-                            service.report_blocked_link(from, to, time.total.as_secs_f32());
-                        }
+                        .or_else(|| service.cell_from_position(waypoint))
+                } else {
+                    None
+                };
+                if let Some(from) = service.cell_from_position(position) {
+                    // The cell we are stuck in is reported EVERY stall, not
+                    // only when the waypoint shares it. Two things need it:
+                    // a stall entirely inside one cell has no crossing to
+                    // blacklist at all (the body never reached an edge), and
+                    // a cell somebody is wedged in is a bad place to route
+                    // the next AI through - otherwise followers inherit the
+                    // doomed route and pile in behind (three hybrids in one
+                    // medsci2 door jamb).
+                    service.report_blocked_cell(from, now_seconds);
+                    if let Some(to) = crossing_into.filter(|to| *to != from) {
+                        service.report_blocked_link(from, to, now_seconds);
                     }
                 }
+                // Remember how the route that failed began, so the re-path
+                // can be checked against it when it lands
+                self.stall_route_prefix = Some(
+                    self.path[self.next_waypoint..]
+                        .iter()
+                        .take(STALL_ROUTE_PREFIX)
+                        .copied()
+                        .collect(),
+                );
                 // ALWAYS back out toward the previous waypoint before
                 // re-pathing, reported or not: the retreat both disengages
                 // the body from whatever it wedged on (an AI boxed among
@@ -606,6 +673,45 @@ fn answers_goal(
 
 /// Whether a route actually arrives at the goal it was computed for. An
 /// empty route arrives nowhere.
+/// Whether a fresh route begins the same way the route that stalled did.
+/// A shorter fresh route is by definition a different one.
+fn route_starts_the_same(previous: &[Vector3<f32>], fresh: &[Vector3<f32>]) -> bool {
+    if previous.is_empty() || fresh.len() < previous.len() {
+        return false;
+    }
+    previous.iter().zip(fresh).all(|(a, b)| {
+        xz_distance(*a, *b) < SAME_WAYPOINT_DISTANCE && (a.y - b.y).abs() < SAME_WAYPOINT_DISTANCE
+    })
+}
+
+/// Blacklist more of a route the AI could not walk: the cell it is standing
+/// in (refreshing that entry's TTL) plus the first cell crossing along the
+/// reproduced route, so the next query cannot answer with the same route
+/// again. One crossing per escalation - sealing the whole prefix at once
+/// would shut a corridor for every AI on a single creature's bad minute.
+fn escalate_blocked_route(
+    service: &crate::pathfinding::PathfindingService,
+    position: Vector3<f32>,
+    prefix: &[Vector3<f32>],
+    now_seconds: f32,
+) {
+    let Some(from) = service.cell_from_position(position) else {
+        return;
+    };
+    service.report_blocked_cell(from, now_seconds);
+    let mut previous = from;
+    for waypoint in prefix {
+        let Some(cell) = service.cell_from_position(*waypoint) else {
+            continue;
+        };
+        if cell != previous {
+            service.report_blocked_link(previous, cell, now_seconds);
+            return;
+        }
+        previous = cell;
+    }
+}
+
 fn route_reaches_goal(waypoints: &[Vector3<f32>], goal: Vector3<f32>) -> bool {
     waypoints
         .last()
@@ -811,5 +917,29 @@ mod tests {
         // reached by standing beneath it
         let path = vec![vec3(0.0, 5.0, 0.0), vec3(10.0, 5.0, 0.0)];
         assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 0);
+    }
+
+    #[test]
+    fn a_repath_that_repeats_the_stalled_route_is_recognized() {
+        let stalled = vec![vec3(1.0, 0.0, 0.0), vec3(2.0, 0.0, 0.0)];
+        // Same route back, plus more of it: still the same doomed opening
+        let same = vec![
+            vec3(1.0, 0.0, 0.0),
+            vec3(2.0, 0.0, 0.0),
+            vec3(3.0, 0.0, 0.0),
+        ];
+        assert!(route_starts_the_same(&stalled, &same));
+    }
+
+    #[test]
+    fn a_repath_that_turns_away_is_a_different_route() {
+        let stalled = vec![vec3(1.0, 0.0, 0.0), vec3(2.0, 0.0, 0.0)];
+        let different = vec![vec3(1.0, 0.0, 0.0), vec3(2.0, 0.0, 5.0)];
+        assert!(!route_starts_the_same(&stalled, &different));
+        // A route on another floor is different even directly overhead
+        let stacked = vec![vec3(1.0, 5.0, 0.0), vec3(2.0, 5.0, 0.0)];
+        assert!(!route_starts_the_same(&stalled, &stacked));
+        // ...and so is one that stops short
+        assert!(!route_starts_the_same(&stalled, &stalled[..1]));
     }
 }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -305,9 +305,20 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         if let Some(stalled) = self.stall_route_cells.take() {
                             let fresh =
                                 route_cells(&service, position, &self.path[self.next_waypoint..]);
-                            if self.stall_escalations < MAX_STALL_ESCALATIONS
-                                && repeats_route(&stalled, &fresh)
-                            {
+                            let repeats = repeats_route(&stalled, &fresh);
+                            tracing::debug!(
+                                "ai {:?}: repath adopted, cells {:?} -> {:?}, repeats={}",
+                                entity_id,
+                                stalled,
+                                fresh,
+                                repeats
+                            );
+                            if self.stall_escalations < MAX_STALL_ESCALATIONS && repeats {
+                                tracing::debug!(
+                                    "ai {:?}: escalate #{} on the reproduced route",
+                                    entity_id,
+                                    self.stall_escalations + 1
+                                );
                                 // The cell penalty alone was outbid. Cut the
                                 // crossing this route opens with, so the next
                                 // query cannot answer with it again - one per
@@ -492,6 +503,24 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 // resolves to the cell beyond the crossing; keeping Y fixed
                 // avoids blacklisting a stacked floor's cell).
                 let now_seconds = time.total.as_secs_f32();
+                tracing::debug!(
+                    "ai {:?}: stall ({}) at {:.2},{:.2},{:.2} cell={:?} wp[{}]={:.2},{:.2},{:.2} d={:.2}",
+                    entity_id,
+                    if displaced_stall {
+                        "displacement"
+                    } else {
+                        "no-progress"
+                    },
+                    position.x,
+                    position.y,
+                    position.z,
+                    service.cell_from_position(position),
+                    self.next_waypoint,
+                    waypoint.x,
+                    waypoint.y,
+                    waypoint.z,
+                    distance
+                );
                 let toward = waypoint - position;
                 let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
                 let crossing_into = if toward_len > 1e-3 {
@@ -524,6 +553,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     }
                     _ => route,
                 };
+                tracing::debug!("ai {:?}: blocked report cells={:?}", entity_id, route);
                 report_stall(&service, &route, now_seconds);
                 // Remember how the route that failed began, so the re-path
                 // can be checked against it when it lands
@@ -555,6 +585,16 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     .map(|prev| xz_distance(position, prev) < DISPLACEMENT_STALL_DISTANCE)
                     .unwrap_or(false);
                 self.last_stall_position = Some(position);
+                tracing::debug!(
+                    "ai {:?}: backout to {:.2},{:.2},{:.2} (heading {:.2},{:.2}) pinned={}",
+                    entity_id,
+                    retreat.x,
+                    retreat.y,
+                    retreat.z,
+                    retreat.x - position.x,
+                    retreat.z - position.z,
+                    pinned
+                );
                 let unstick_effect = if pinned {
                     let dir = retreat - position;
                     let len = xz_distance(retreat, position);
@@ -602,16 +642,33 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                                     .then_some(nudged)
                             });
                         match landing {
-                            Some(landing) => Effect::SetPositionRotation {
-                                entity_id,
-                                position: landing,
-                                rotation: crate::util::get_rotation_from_transform(
-                                    world, entity_id,
-                                ),
-                            },
-                            None => Effect::NoEffect,
+                            Some(landing) => {
+                                tracing::debug!(
+                                    "ai {:?}: nudge {:.2},{:.2} -> {:.2},{:.2}",
+                                    entity_id,
+                                    position.x,
+                                    position.z,
+                                    landing.x,
+                                    landing.z
+                                );
+                                Effect::SetPositionRotation {
+                                    entity_id,
+                                    position: landing,
+                                    rotation: crate::util::get_rotation_from_transform(
+                                        world, entity_id,
+                                    ),
+                                }
+                            }
+                            None => {
+                                tracing::debug!(
+                                    "ai {:?}: nudge refused, no navigable landing",
+                                    entity_id
+                                );
+                                Effect::NoEffect
+                            }
                         }
                     } else {
+                        tracing::debug!("ai {:?}: nudge refused, retreat is here", entity_id);
                         Effect::NoEffect
                     }
                 } else {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -62,15 +62,8 @@ const STALL_RECOVERY_SECONDS: f32 = 0.8;
 /// Progress smaller than this doesn't count toward un-stalling (jitter)
 const STALL_PROGRESS_EPSILON: f32 = 0.25 / SCALE_FACTOR;
 /// Displacement watchdog: with an active waypoint, failing to move this far
-/// (XZ, 3 Dark feet) ...
-///
-/// One foot was under the amplitude of a wedged body's own sliding: a
-/// hybrid pressed into medsci2's stair rail rocked ~1 foot about a fixed
-/// spot and reset the anchor forever, so no stall ever fired and the route
-/// never changed (measured). A walking creature covers many times this in
-/// the window below, so the wider bar only catches bodies that are going
-/// nowhere.
-const DISPLACEMENT_STALL_DISTANCE: f32 = 3.0 / SCALE_FACTOR;
+/// (XZ, 1 Dark foot) ...
+const DISPLACEMENT_STALL_DISTANCE: f32 = 1.0 / SCALE_FACTOR;
 /// ...within this long also counts as a stall. Micro-sliding around a
 /// blocking capsule (another creature, a prop corner) can keep improving
 /// the waypoint distance by more than the epsilon, resetting the progress
@@ -588,10 +581,41 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                             position.y,
                             position.z + dir.z / len * step,
                         );
-                        Effect::SetPositionRotation {
-                            entity_id,
-                            position: nudged,
-                            rotation: crate::util::get_rotation_from_transform(world, entity_id),
+                        // Only onto navigable floor. A nudge is a teleport,
+                        // and one aimed through a wall drops the body out of
+                        // the level entirely (a creature a thousand units
+                        // from everything, once stalls became easier to
+                        // detect). When the retreat direction leaves the
+                        // mesh, step toward the current cell's middle
+                        // instead - still away from whatever the body is
+                        // pressed against, and known-navigable.
+                        let landing = on_mesh(&service, nudged).or_else(|| {
+                            let cell = service.cell_from_position(position)?;
+                            let center = service.path_database.cells.get(cell as usize)?.center;
+                            let away = center - position;
+                            let len = (away.x * away.x + away.z * away.z).sqrt();
+                            if len <= 1e-3 {
+                                return None;
+                            }
+                            let step = UNSTICK_NUDGE_DISTANCE.min(len);
+                            on_mesh(
+                                &service,
+                                Vector3::new(
+                                    position.x + away.x / len * step,
+                                    position.y,
+                                    position.z + away.z / len * step,
+                                ),
+                            )
+                        });
+                        match landing {
+                            Some(landing) => Effect::SetPositionRotation {
+                                entity_id,
+                                position: landing,
+                                rotation: crate::util::get_rotation_from_transform(
+                                    world, entity_id,
+                                ),
+                            },
+                            None => Effect::NoEffect,
                         }
                     } else {
                         Effect::NoEffect
@@ -698,6 +722,15 @@ fn answers_goal(
 
 /// Whether a route actually arrives at the goal it was computed for. An
 /// empty route arrives nowhere.
+/// `point` if it sits on a navigable cell, else None - a teleport target
+/// off the mesh is a body dropped out of the level.
+fn on_mesh(
+    service: &crate::pathfinding::PathfindingService,
+    point: Vector3<f32>,
+) -> Option<Vector3<f32>> {
+    service.cell_from_position(point).map(|_| point)
+}
+
 /// Whether a fresh route begins the same way the route that stalled did.
 /// A shorter fresh route is by definition a different one.
 fn route_starts_the_same(previous: &[Vector3<f32>], fresh: &[Vector3<f32>]) -> bool {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -85,12 +85,9 @@ const UNSTICK_NUDGE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
 /// off the shared edge without skipping a narrow destination cell (0.5
 /// Dark feet)
 const BLOCKED_PROBE_DISTANCE: f32 = 0.5 / SCALE_FACTOR;
-/// How many leading waypoints of the pre-stall route are remembered to
-/// check whether the re-path actually produced a different route
+/// How many leading cells of the pre-stall route are remembered to check
+/// whether the re-path actually produced a different route
 const STALL_ROUTE_PREFIX: usize = 3;
-/// Two waypoints this close (Dark feet) count as the same waypoint when
-/// comparing a fresh route against the one that stalled
-const SAME_WAYPOINT_DISTANCE: f32 = 0.5 / SCALE_FACTOR;
 /// How many times one stall incident may escalate (blacklist more of the
 /// reproduced route) before falling through to the physical nudge. Bounded
 /// so a genuinely one-way corridor can't be sealed link by link.
@@ -141,12 +138,14 @@ pub struct PathFollowSteeringStrategy {
     goal_unreachable: bool,
     /// Static-geometry whiskers, biasing the aim point (see `aim_with_bias`)
     whiskers: WhiskerAvoidance,
-    /// The leading waypoints of the route that was in force when the last
-    /// stall fired, kept until the next route is adopted. If the fresh
-    /// route starts the same way, the re-path reproduced the doomed route
-    /// and walking it again just grinds - escalate instead (see
-    /// `MAX_STALL_ESCALATIONS`).
-    stall_route_prefix: Option<Vec<Vector3<f32>>>,
+    /// The leading CELLS of the route that was in force when the last stall
+    /// fired, kept until the next route is adopted. Cells, not waypoints:
+    /// waypoints are pulled taut backwards from the goal, so a chase whose
+    /// goal moved a foot renames every one of them while the route is the
+    /// same route. If the fresh route walks the same cells, the re-path
+    /// reproduced the doomed route and walking it again just grinds -
+    /// escalate instead (see `MAX_STALL_ESCALATIONS`).
+    stall_route_cells: Option<Vec<u32>>,
     /// Escalations spent on the current stall incident; reset once the body
     /// actually moves
     stall_escalations: u32,
@@ -180,7 +179,7 @@ impl PathFollowSteeringStrategy {
             last_stall_position: None,
             goal_unreachable: false,
             whiskers: WhiskerAvoidance::new(),
-            stall_route_prefix: None,
+            stall_route_cells: None,
             stall_escalations: 0,
         }
     }
@@ -279,7 +278,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         self.goal_unreachable = true;
                         self.clear_path();
                         // Nothing to compare a stalled route against
-                        self.stall_route_prefix = None;
+                        self.stall_route_cells = None;
                         // No route (even partially) - back off before asking
                         // again; the fallback chain is the worker's most
                         // expensive outcome
@@ -303,24 +302,29 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         // it and ask once more (bounded, so a genuinely
                         // one-way corridor still gets walked and the
                         // existing nudge remains the last resort).
-                        if let Some(prefix) = self.stall_route_prefix.take() {
+                        if let Some(stalled) = self.stall_route_cells.take() {
+                            let fresh =
+                                route_cells(&service, position, &self.path[self.next_waypoint..]);
                             if self.stall_escalations < MAX_STALL_ESCALATIONS
-                                && route_starts_the_same(&prefix, &self.path[self.next_waypoint..])
+                                && repeats_route(&stalled, &fresh)
                             {
+                                // The cell penalty alone was outbid. Cut the
+                                // crossing this route opens with, so the next
+                                // query cannot answer with it again - one per
+                                // escalation, or a single creature's bad
+                                // minute would seal a corridor for everyone.
                                 self.stall_escalations += 1;
-                                escalate_blocked_route(
-                                    &service,
-                                    position,
-                                    &prefix,
-                                    time.total.as_secs_f32(),
-                                );
+                                report_stall(&service, &fresh, time.total.as_secs_f32());
                                 self.clear_path();
                                 self.repath_cooldown = REPATH_COOLDOWN_SECONDS
                                     * rand::thread_rng().gen_range(0.8..1.2);
                             }
                         }
                     }
-                    _ => {}
+                    _ => {
+                        // A discarded result is no comparison either
+                        self.stall_route_cells = None;
+                    }
                 }
             }
         }
@@ -503,47 +507,27 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 } else {
                     None
                 };
-                if let Some(from) = service.cell_from_position(position) {
-                    // The cell we are stuck in is reported EVERY stall, not
-                    // only when the crossing is unknown. Two things need it:
-                    // a stall entirely inside one cell has no crossing to
-                    // blacklist at all (the body never reached an edge), and
-                    // a cell somebody is wedged in is a bad place to route
-                    // the next AI through - otherwise followers inherit the
-                    // doomed route and pile in behind (three hybrids in one
-                    // medsci2 door jamb).
-                    service.report_blocked_cell(from, now_seconds);
-                    // Nothing across the waypoint means the body never
-                    // reached the edge; the crossing that is actually
-                    // blocked is then the next one along the route (the
-                    // medsci2 Science-door jamb is exactly this - the body
-                    // presses into the jamb feet short of the boundary).
-                    let crossing = crossing_into
-                        .filter(|to| *to != from)
-                        .map(|to| (from, to))
-                        .or_else(|| {
-                            first_crossing_along(&service, from, &self.path[self.next_waypoint..])
-                        });
-                    if let Some((from, to)) = crossing {
-                        // The cell we could not get into is blacklisted as
-                        // well as the crossing. Waypoints sit on cell edges
-                        // and a route can be denser than the mesh, so the
-                        // pair we can name is not always an actual graph
-                        // link - the cell penalty bites whichever way A*
-                        // would have come in.
-                        service.report_blocked_cell(to, now_seconds);
-                        service.report_blocked_link(from, to, now_seconds);
+                // The route ahead, as cells: what a stall can name, and
+                // what the re-path is later checked against.
+                let route = route_cells(&service, position, &self.path[self.next_waypoint..]);
+                // The probe cell is the better blame when the body reached
+                // the edge; a stall short of any edge (the medsci2 Science
+                // door jamb - the body presses into the jamb feet before the
+                // boundary) has only the route to go on.
+                let route = match crossing_into.filter(|to| Some(*to) != route.first().copied()) {
+                    Some(to)
+                        if route
+                            .first()
+                            .is_some_and(|from| service.has_link(*from, to)) =>
+                    {
+                        vec![route[0], to]
                     }
-                }
+                    _ => route,
+                };
+                report_stall(&service, &route, now_seconds);
                 // Remember how the route that failed began, so the re-path
                 // can be checked against it when it lands
-                self.stall_route_prefix = Some(
-                    self.path[self.next_waypoint..]
-                        .iter()
-                        .take(STALL_ROUTE_PREFIX)
-                        .copied()
-                        .collect(),
-                );
+                self.stall_route_cells = Some(route);
                 // ALWAYS back out toward the previous waypoint before
                 // re-pathing, reported or not: the retreat both disengages
                 // the body from whatever it wedged on (an AI boxed among
@@ -573,7 +557,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 self.last_stall_position = Some(position);
                 let unstick_effect = if pinned {
                     let dir = retreat - position;
-                    let len = (dir.x * dir.x + dir.z * dir.z).sqrt();
+                    let len = xz_distance(retreat, position);
                     if len > 1e-3 {
                         let step = UNSTICK_NUDGE_DISTANCE.min(len);
                         let nudged = Vector3::new(
@@ -589,24 +573,34 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         // mesh, step toward the current cell's middle
                         // instead - still away from whatever the body is
                         // pressed against, and known-navigable.
-                        let landing = on_mesh(&service, nudged).or_else(|| {
-                            let cell = service.cell_from_position(position)?;
-                            let center = service.path_database.cells.get(cell as usize)?.center;
-                            let away = center - position;
-                            let len = (away.x * away.x + away.z * away.z).sqrt();
-                            if len <= 1e-3 {
-                                return None;
-                            }
-                            let step = UNSTICK_NUDGE_DISTANCE.min(len);
-                            on_mesh(
-                                &service,
-                                Vector3::new(
-                                    position.x + away.x / len * step,
-                                    position.y,
-                                    position.z + away.z / len * step,
-                                ),
-                            )
-                        });
+                        let landing = on_mesh(&service, nudged)
+                            .or_else(|| {
+                                let cell = service.cell_from_position(position)?;
+                                let center = service.path_database.cells.get(cell as usize)?.center;
+                                let len = xz_distance(center, position);
+                                if len <= 1e-3 {
+                                    return None;
+                                }
+                                let step = UNSTICK_NUDGE_DISTANCE.min(len);
+                                on_mesh(
+                                    &service,
+                                    Vector3::new(
+                                        position.x + (center.x - position.x) / len * step,
+                                        position.y,
+                                        position.z + (center.z - position.z) / len * step,
+                                    ),
+                                )
+                            })
+                            // A body ALREADY off the mesh is the case the
+                            // unstick exists for; refusing to move it is the
+                            // permanent freeze, not a safeguard. It cannot be
+                            // made worse by a step toward route ground.
+                            .or_else(|| {
+                                service
+                                    .cell_from_position(position)
+                                    .is_none()
+                                    .then_some(nudged)
+                            });
                         match landing {
                             Some(landing) => Effect::SetPositionRotation {
                                 entity_id,
@@ -720,8 +714,6 @@ fn answers_goal(
     }
 }
 
-/// Whether a route actually arrives at the goal it was computed for. An
-/// empty route arrives nowhere.
 /// `point` if it sits on a navigable cell, else None - a teleport target
 /// off the mesh is a body dropped out of the level.
 fn on_mesh(
@@ -731,60 +723,59 @@ fn on_mesh(
     service.cell_from_position(point).map(|_| point)
 }
 
-/// Whether a fresh route begins the same way the route that stalled did.
-/// A shorter fresh route is by definition a different one.
-fn route_starts_the_same(previous: &[Vector3<f32>], fresh: &[Vector3<f32>]) -> bool {
-    if previous.is_empty() || fresh.len() < previous.len() {
-        return false;
-    }
-    previous.iter().zip(fresh).all(|(a, b)| {
-        xz_distance(*a, *b) < SAME_WAYPOINT_DISTANCE && (a.y - b.y).abs() < SAME_WAYPOINT_DISTANCE
-    })
-}
-
-/// Blacklist more of a route the AI could not walk: the cell it is standing
-/// in (refreshing that entry's TTL) plus the first cell crossing along the
-/// reproduced route, so the next query cannot answer with the same route
-/// again. One crossing per escalation - sealing the whole prefix at once
-/// would shut a corridor for every AI on a single creature's bad minute.
-fn escalate_blocked_route(
+/// The leading cells a route walks, starting with the one `position` is in.
+/// Consecutive waypoints inside one cell collapse to a single entry, so this
+/// is the route's shape on the mesh rather than its geometry - two queries a
+/// second apart at a moving goal name different waypoints for the same cells.
+fn route_cells(
     service: &crate::pathfinding::PathfindingService,
     position: Vector3<f32>,
-    prefix: &[Vector3<f32>],
-    now_seconds: f32,
-) {
-    let Some(from) = service.cell_from_position(position) else {
+    waypoints: &[Vector3<f32>],
+) -> Vec<u32> {
+    let mut cells = Vec::new();
+    for point in std::iter::once(&position).chain(waypoints) {
+        let Some(cell) = service.cell_from_position(*point) else {
+            continue;
+        };
+        if cells.last() != Some(&cell) {
+            cells.push(cell);
+        }
+        if cells.len() > STALL_ROUTE_PREFIX {
+            break;
+        }
+    }
+    cells
+}
+
+/// Whether a fresh route walks the cells the stalled one did. A contiguous
+/// match anywhere, not just at the head: backing out of the wedge can leave
+/// the body a cell short of where it stalled, which shifts the sequence
+/// without changing the route.
+fn repeats_route(stalled: &[u32], fresh: &[u32]) -> bool {
+    !stalled.is_empty() && fresh.windows(stalled.len()).any(|window| window == stalled)
+}
+
+/// Blacklist what a route the AI could not walk can be blamed on: the cell
+/// it is standing in (a stall inside one cell has nothing else to name), and
+/// the first crossing along the route that is a real mesh link. Only real
+/// links: a pair named from waypoints need not be one, and an inert entry
+/// would hold one of the bounded blacklist slots while excluding nothing.
+fn report_stall(service: &crate::pathfinding::PathfindingService, route: &[u32], now_seconds: f32) {
+    let Some(&from) = route.first() else {
         return;
     };
     service.report_blocked_cell(from, now_seconds);
-    if let Some((from, to)) = first_crossing_along(service, from, prefix) {
+    if let Some((from, to)) = route
+        .windows(2)
+        .map(|pair| (pair[0], pair[1]))
+        .find(|&(from, to)| service.has_link(from, to))
+    {
         service.report_blocked_link(from, to, now_seconds);
     }
 }
 
-/// The first cell crossing a route makes after `from`, as an adjacent
-/// `(from, to)` pair - what `report_blocked_link` needs, and what a stall
-/// that happened short of any cell edge has no other way to name. Only the
-/// leading waypoints are considered; a blockage further away than that is
-/// not what stopped the body.
-fn first_crossing_along(
-    service: &crate::pathfinding::PathfindingService,
-    from: u32,
-    waypoints: &[Vector3<f32>],
-) -> Option<(u32, u32)> {
-    let mut previous = from;
-    for waypoint in waypoints.iter().take(STALL_ROUTE_PREFIX) {
-        let Some(cell) = service.cell_from_position(*waypoint) else {
-            continue;
-        };
-        if cell != previous {
-            return Some((previous, cell));
-        }
-        previous = cell;
-    }
-    None
-}
-
+/// Whether a route actually arrives at the goal it was computed for. An
+/// empty route arrives nowhere.
 fn route_reaches_goal(waypoints: &[Vector3<f32>], goal: Vector3<f32>) -> bool {
     waypoints
         .last()
@@ -994,25 +985,44 @@ mod tests {
 
     #[test]
     fn a_repath_that_repeats_the_stalled_route_is_recognized() {
-        let stalled = vec![vec3(1.0, 0.0, 0.0), vec3(2.0, 0.0, 0.0)];
-        // Same route back, plus more of it: still the same doomed opening
-        let same = vec![
-            vec3(1.0, 0.0, 0.0),
-            vec3(2.0, 0.0, 0.0),
-            vec3(3.0, 0.0, 0.0),
-        ];
-        assert!(route_starts_the_same(&stalled, &same));
+        let stalled = vec![7, 8];
+        // The same cells, plus more of the route: still the same opening
+        assert!(repeats_route(&stalled, &[7, 8, 9]));
+        // ...and still the same route when the retreat left the body one
+        // cell further back than it stalled in
+        assert!(repeats_route(&stalled, &[6, 7, 8]));
     }
 
     #[test]
     fn a_repath_that_turns_away_is_a_different_route() {
-        let stalled = vec![vec3(1.0, 0.0, 0.0), vec3(2.0, 0.0, 0.0)];
-        let different = vec![vec3(1.0, 0.0, 0.0), vec3(2.0, 0.0, 5.0)];
-        assert!(!route_starts_the_same(&stalled, &different));
-        // A route on another floor is different even directly overhead
-        let stacked = vec![vec3(1.0, 5.0, 0.0), vec3(2.0, 5.0, 0.0)];
-        assert!(!route_starts_the_same(&stalled, &stacked));
-        // ...and so is one that stops short
-        assert!(!route_starts_the_same(&stalled, &stalled[..1]));
+        let stalled = vec![7, 8];
+        assert!(!repeats_route(&stalled, &[7, 12]));
+        // A route that stops short is different too
+        assert!(!repeats_route(&stalled, &[7]));
+        // Nothing to compare against is not a repeat
+        assert!(!repeats_route(&[], &[7, 8]));
+    }
+
+    #[test]
+    fn a_stall_reports_only_crossings_the_mesh_actually_has() {
+        use crate::pathfinding::PathfindingService;
+        use std::sync::Arc;
+
+        // 0 -> 1 -> 2 is a real chain; the route below also names 0 -> 2,
+        // which is not a link and must not eat a blacklist slot.
+        let service = PathfindingService::new(Arc::new(crate::pathfinding::tests::three_cell_db(
+            dark::mission::path_database::PathCellFlags::empty(),
+        )));
+        report_stall(&service, &[0, 2, 1], 0.0);
+        let avoidance = service.avoidance(1.0);
+        assert!(avoidance.cells.contains(&0), "the stalled cell is reported");
+        assert_eq!(
+            avoidance.links.into_iter().collect::<Vec<_>>(),
+            Vec::new(),
+            "0 -> 2 is not a link, and 2 -> 1 is not a crossing this route makes first"
+        );
+
+        report_stall(&service, &[0, 1], 0.0);
+        assert!(service.avoidance(1.0).links.contains(&(0, 1)));
     }
 }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -80,6 +80,10 @@ export interface PathfindingStats {
   queries: number;
   stressed_retries: number;
   no_route: number;
+  /** Cell crossings currently excluded because an AI stalled on them. */
+  blocked_links: number;
+  /** Cells currently penalized because an AI stalled inside them. */
+  blocked_cells: number;
 }
 
 export interface PathfindingTestStatus {

--- a/tools/shock2-sdk/test/medsci2-doorjamb-chase.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-doorjamb-chase.e2e.test.ts
@@ -67,7 +67,7 @@ test(
       // The hybrids chase a player who does not fight back, so the mission
       // ends when they reach him. Everything before that is the window
       // under test.
-      if (!(await game.pathfinding.stats())) break;
+      if (!(await game.pathfinding.stats().catch(() => null))) break;
       sampled++;
       for (const pipe of pipes.entities) {
         const detail = await game.entities.detail(pipe.id).catch(() => null);

--- a/tools/shock2-sdk/test/medsci2-doorjamb-chase.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-doorjamb-chase.e2e.test.ts
@@ -3,21 +3,129 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 
-// End-to-end test against a real debug runtime. Requires game assets in
-// Data/ and compiles the runtime on first run, so it is opt-in:
+// End-to-end: no medsci2 hybrid may grind in place while chasing.
 //
-//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+// Chasing hybrids used to pile into the Science-wing door jamb: the first one
+// wedged, and every follower inherited the identical route into the same spot
+// because a stall inside a single cell reported nothing a re-path could route
+// around. Every AI in the level chases at once here, so the pile-up is the
+// thing under test, not one creature's luck.
+//
+// Opt-in (needs Data/ assets + compiles the runtime): npm run test:e2e
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const SAMPLE_FRAMES = 60; // 1 s of simulation per sample
+const SAMPLES = 30; // 1800 frames in total
+// Holding within this distance (1 world unit = 2.5 Dark feet) counts as not
+// moving...
+const STUCK_RADIUS = 1.0;
+// Holds are judged in the Science wing, north of this line - the corridor
+// the chase runs up and where the pile-up happens. South of it is the
+// balcony, whose separate wedge (a mesh route down a ledge the character
+// controller cannot take) is the known-remaining defect and not what this
+// test is about.
+const SCIENCE_WING_Z = -60;
+// ...and doing so for longer than this many seconds is a wedge.
+const MAX_HOLD_SECONDS = 6;
+
+function distXZ(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  return Math.hypot(a[0] - b[0], a[2] - b[2]);
+}
+
+test(
+  "chasing medsci2 hybrids never grind in one spot",
+  { skip: !e2eEnabled, timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci2.mis" });
+    await game.step({ frames: 60 });
+
+    const pipes = await game.entities.list({ filter: "OG-Pipe", limit: 200 });
+    assert.ok(
+      pipes.entities.length > 0,
+      "expected OG-Pipe hybrids in medsci2",
+    );
+
+    await game.input.trigger("DebugForceChase");
+
+    // Longest run of consecutive samples each hybrid spent inside
+    // STUCK_RADIUS of where that run started.
+    const held = new Map<number, number>();
+    const worst = new Map<number, number>();
+    const anchor = new Map<number, [number, number, number]>();
+    const lastAt = new Map<number, [number, number, number]>();
+    // Hybrids that walked at least once. One that never moves at all has no
+    // route to the player (medsci2's chase pass has several: locked areas,
+    // other floors) - a grind is only meaningful for one that was walking.
+    const mobile = new Set<number>();
+
+    let sampled = 0;
+    for (let i = 0; i < SAMPLES; i++) {
+      await game.step({ frames: SAMPLE_FRAMES });
+      // The hybrids chase a player who does not fight back, so the mission
+      // ends when they reach him. Everything before that is the window
+      // under test.
+      if (!(await game.pathfinding.stats())) break;
+      sampled++;
+      for (const pipe of pipes.entities) {
+        const detail = await game.entities.detail(pipe.id).catch(() => null);
+        // Dead or despawned: stop tracking it rather than freezing its run
+        if (!detail) {
+          held.set(pipe.id, 0);
+          anchor.delete(pipe.id);
+          continue;
+        }
+        const at = detail.position;
+        lastAt.set(pipe.id, at);
+        if (at[2] < SCIENCE_WING_Z) {
+          // Out of the region under test: end any run it had going
+          held.set(pipe.id, 0);
+          anchor.delete(pipe.id);
+          continue;
+        }
+        const from = anchor.get(pipe.id);
+        if (from && distXZ(at, from) < STUCK_RADIUS) {
+          const run = (held.get(pipe.id) ?? 0) + 1;
+          held.set(pipe.id, run);
+          worst.set(pipe.id, Math.max(worst.get(pipe.id) ?? 0, run));
+        } else {
+          if (from) mobile.add(pipe.id);
+          held.set(pipe.id, 0);
+          anchor.set(pipe.id, at);
+        }
+      }
+    }
+
+    assert.ok(
+      sampled > MAX_HOLD_SECONDS + 4,
+      `only ${sampled}s of chase to judge`,
+    );
+
+    const wedged = [...worst.entries()]
+      .filter(([id, seconds]) => mobile.has(id) && seconds > MAX_HOLD_SECONDS)
+      .map(
+        ([id, seconds]) =>
+          `${id} held ${seconds}s at ${JSON.stringify(lastAt.get(id))}`,
+      );
+    assert.deepEqual(
+      wedged,
+      [],
+      `hybrids ground in place while chasing: ${wedged.join("; ")}`,
+    );
+  },
+);
 
 /** The hybrid that chases the player up the Science-wing corridor */
 const HYBRID_TEMPLATE = 705;
 /** Where it used to wedge: the door jamb beside the open security door */
 const JAMB: [number, number, number] = [37.33, 0.1, -36.62];
 
-function distXZ(a: [number, number, number], b: [number, number, number]): number {
-  return Math.hypot(a[0] - b[0], a[2] - b[2]);
-}
-
+// The pile-up test above judges every hybrid loosely; this one pins the
+// specific route defect that agent-radius clearance fixes - the nav mesh
+// threads a 0.6-wide strip beside the jamb that a 0.96-wide hybrid cannot
+// walk, and the chaser used to press into that corner and grind.
 test(
   "a chasing hybrid takes the open door, not the sliver beside its jamb",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -26,14 +134,13 @@ test(
     await game.step({ frames: 60 });
 
     const [hybrid] = await game.entities.byTemplate(HYBRID_TEMPLATE);
-    assert.ok(hybrid, `expected a hybrid of template ${HYBRID_TEMPLATE} in medsci2`);
+    assert.ok(
+      hybrid,
+      `expected a hybrid of template ${HYBRID_TEMPLATE} in medsci2`,
+    );
 
     await game.input.trigger("DebugForceChase");
 
-    // Sample its position each second of simulation. The nav mesh threads a
-    // 0.6-wide strip beside the jamb, which a 0.96-wide hybrid cannot walk:
-    // it used to press into the corner there and grind for the rest of the
-    // run.
     const track: [number, number, number][] = [];
     for (let i = 0; i < 20; i++) {
       await game.step({ frames: 60 });
@@ -41,7 +148,10 @@ test(
       if (!detail) break;
       track.push(detail.position);
     }
-    assert.ok(track.length >= 10, `hybrid vanished after ${track.length} samples`);
+    assert.ok(
+      track.length >= 10,
+      `hybrid vanished after ${track.length} samples`,
+    );
 
     let pinnedAtJamb = 0;
     let worstPinnedAtJamb = 0;
@@ -57,6 +167,9 @@ test(
     // ...and it got somewhere: the chase runs the length of the corridor,
     // well past the door it was stuck outside of.
     const travelled = distXZ(track[0], track[track.length - 1]);
-    assert.ok(travelled > 8, `hybrid barely moved (${travelled.toFixed(1)}): ${JSON.stringify(track)}`);
+    assert.ok(
+      travelled > 8,
+      `hybrid barely moved (${travelled.toFixed(1)}): ${JSON.stringify(track)}`,
+    );
   },
 );


### PR DESCRIPTION
Stacked on #1248 (base `fix/ai-unreachable-goal-steering`).

A stall used to report a *crossing*, and `report_blocked_link` is a no-op when
the AI never reached one. A body wedged inside a single cell therefore reported
nothing, its re-path returned the identical route, and it ground on the same
obstacle until its behavior was retired. Followers inherited the same route and
piled in behind it — three hybrids in one medsci2 door jamb.

## What changed

- **A stall blacklists the cell it happened in**, TTL'd (~10 s) as an A\* cost
  penalty on *entering* — never a cut, so an AI blocked into a dead end can
  still path out and a corridor everyone needs stays usable.
- **The same report is the occupancy signal**: the next AI to ask routes around
  a cell somebody is currently wedged in instead of inheriting the doomed route.
- **A stall-triggered re-path is checked against the route that stalled**,
  compared as the sequence of *cells* it walks rather than its waypoints —
  waypoints are pulled taut backwards from the goal, so a chase whose goal moved
  a foot renames every one of them while the route is the same route. An
  identical opening escalates (one more crossing cut, the cell's TTL refreshed),
  bounded at three, before falling through to the existing physical nudge.
- **Only crossings the mesh actually has are reported.** A pair named from
  waypoints need not be a link; an inert entry held one of the 64 blacklist
  slots for 30 s while excluding nothing.
- **The unstick nudge never lands off the mesh** — one aimed through a wall
  dropped a creature out of the level entirely — but it no longer refuses to
  move a body that is *already* off the mesh, which is the case it exists for.
- `/v1/pathfinding/stats` reports both blacklist sizes (SDK types too).

## Measurements

`tools/shock2-sdk/scripts/ai-reachability.ts` (from `feat/ai-reachability-eval`,
merged locally, not committed), `--mission medsci2.mis`, 3 runs per side. Base =
`fix/ai-unreachable-goal-steering` @ 9af65e28.

| pass | wedged (base, 3 runs) | wedged (this branch, 3 runs) |
|---|---|---|
| idle | 2, 3, 2 | 3, 2, 1 |
| chase | 1, 1, 1 | **0, 0, 0** |

The named wedges are the story rather than the totals:

| wedge | base | this branch |
|---|---|---|
| door jamb, chase (t705, ~37, −36) | 6.5 s / 7.5 s / 7.0 s — **3/3 runs** | **absent, 3/3 runs** |
| balcony patroller, idle (t668, ~49, −95.8) | 25 s / 36 s / 47 s — **3/3 runs** | **absent, 3/3 runs** |
| t1661 (~45, −9) | 7.0 / 6.0 / 6.5 s | 6.5 / 6.0 / 6.0 s — unchanged, out of scope |
| Blue Monkey 519 | 1/3 runs | 2/3 runs — sporadic both sides |

**Trail maps** (medsci2, nav cells + every AI's trail):
[before idle](https://gist.githubusercontent.com/tommy-xr/8ba6fb5888b9f323b74449c31845edbf/raw/before-idle.png) ·
[after idle](https://gist.githubusercontent.com/tommy-xr/8ba6fb5888b9f323b74449c31845edbf/raw/after-idle.png) ·
[before chase](https://gist.githubusercontent.com/tommy-xr/8ba6fb5888b9f323b74449c31845edbf/raw/before-chase.png) ·
[after chase](https://gist.githubusercontent.com/tommy-xr/8ba6fb5888b9f323b74449c31845edbf/raw/after-chase.png)

![before idle](https://gist.githubusercontent.com/tommy-xr/8ba6fb5888b9f323b74449c31845edbf/raw/before-idle.png)
![after idle](https://gist.githubusercontent.com/tommy-xr/8ba6fb5888b9f323b74449c31845edbf/raw/after-idle.png)

### Pathfinding bench — unchanged

`cargo bn path bench medsci2.mis --seed 424242`, base vs branch: `200/0` found,
inflation `1.65`, turn `1044`, `45.0` waypoints, 4038 cells / 21361 links on
both. Only the microsecond timings move (125u/459u vs 128u/476u), which is noise
— the penalty costs nothing when no cell is blacklisted.

### e2e

`SHOCK2_E2E=1`, from a clean `dist/`:

- `medsci2-doorjamb-chase` (added here) **4/4** — but it also passes 4/4 on the
  *current* base, which has moved since the commit that added it was measured.
  The harness above is what still separates the two.
- `medsci2-patrol-railing` — was **1/4** at the time of this measurement; now
  **4/4**, see "The balcony wedge was not a wedge" below.
- Green: `force-chase`, `patrol`, `search-behavior`, `pathfinding`,
  `pathfinding-budget`, `ai-alertness`, `chase-last-seen`, `missions` (all 23
  missions load).
- `cargo test -p shock2vr`: 1226 pass. New unit tests cover the cell blacklist
  routing a query around a stall, the penalty staying passable when it is the
  only way, TTL expiry, the worker sending a *second* AI around a stalled cell,
  the cell-sequence route comparison, and the mesh-adjacency filter on reports.

### Review

`/xreview` against the base. Codex was unavailable (usage limit), so this is the
Claude reviewer plus the duplication pass. Fixed: the waypoint-based route
comparison that could not fire for a moving goal (Medium-High); the nudge that
refused to move an off-mesh body (Medium); the over-broad far-side cell penalty
(Medium); non-adjacent pairs eating blacklist slots (Medium); a TTL jitter that
desynchronized nothing while ratcheting the TTL up (Low); a stale route prefix
left behind on a discarded query result (Low); an e2e guard that would reject
rather than break (Low). Duplication: the two stall-report paths merged into one
`report_stall`, `detour_db` rebuilt on `three_cell_db`, `took_the_detour` and
`xz_distance` shared. Not taken: extracting a generic `TtlSet<K>` for the two
blacklists (two call sites, and the link map is a hard exclusion while the cell
map is a cost — a shared type would have to carry both), and pruning the debug
stats by time (they prune on every query, and the doc says what they are).


---

## The balcony wedge was not a wedge — a railing was holding the body

The one case this PR could not fix (`medsci2-patrol-railing`, 1/4) turned out
not to be a navigation problem at all, and no amount of re-routing was ever
going to move it.

**Symptom.** With zero player input the balcony patroller (template 668) stops
dead — position identical *to three decimals* for 25–37 s — while its patrol
keeps re-pathing, giving up on points and cycling the loop, until the watchdog
retires it to `Idle`.

**What was holding it.** Nothing it was walking into. At the frozen pose the
body is dynamic, awake, and carries a commanded velocity (e.g.
`(-1.28, 0, 0.31)`), yet its translation never changes; the 8-direction probe
around it finds 3.2 units of open floor in most directions. The freeze happens
in two different spots — the dead-end corner at `(49.0, 0.1, −95.8)` *and* open
corridor at `(49.1, 0.1, −82.8)` — which is the tell: the corner geometry is
incidental.

`PhysicsWorld::recover_live_creatures_swept_off_support` was pinning it. That
recovery exists so moving terrain (a door leaf, SHODAN's sweeping spike) cannot
carry a creature off a ledge: while a creature has a *side* contact with a
kinematic body that is moving horizontally, it is held at its last supported
translation — `body.set_translation(support_translation, true)` — every frame.
A kinematic body's velocity is derived from its pose deltas, so a prop that
never moves still reports a whisper of float jitter, and the gate was
`horizontal_motion > 1.0e-6`: **speed > 1e-3 units/s**. A stationary railing
clears that. The patroller brushes `Railing End 4x4`, and from that frame on it
is re-pinned to its own current translation forever.

Confirmed with a temporary log in that function: **525 consecutive frames**
pinned, always by one body — rapid-body handle 434, entity `Railing End 4x4`,
horizontal speed `0.0017` units/s. The creature's own limb hitbox proxies (also
kinematic, also nearby, moving at up to 19 units/s) were ruled out: they never
appear as the pinning body, so their colliders produce no solver contact with
the capsule.

**Fix.** Require a real sweep speed: `MOVING_TERRAIN_SPEED = 0.1` world units/s
(0.25 Dark ft/s). Measured across medsci2 (peak horizontal speed per kinematic
body over 20 s of play), the two populations are a decade and a half apart, so
the threshold sits in empty space:

| body | peak horizontal speed |
|---|---|
| `Sci Med Door` (a door actually opening) | **4.80** units/s |
| `Curved Pipe 2' diameter` (never moves) | 0.0031 |
| `Railing End 4x4` (the culprit) | 0.0018 |
| 98 of 100 kinematic bodies | **below 0.1** |

A door leaf runs 48× the new gate; the noisiest stationary prop runs 32× below
it. Doors have no acceleration model (`std_door` steps `dt * speed` from rest),
so nothing ramps through the band either.

### Instrumentation

`steering/` and `pathfinding/` carried two `tracing` calls between them, so a
wedged AI was a black box — which is why this took a physics log to find. The
stall path now logs one terse line per event at `debug`, entity first: the stall
(kind, position, cell, waypoint, distance), the cells it blames, the backout
point and heading, whether the re-path reproduced the route, each escalation,
and the nudge (or why it was refused).

```
ai EId(582.0): stall (no-progress) at 49.00,0.10,-95.82 cell=Some(3591) wp[1]=48.44,-0.80,-92.98 d=2.90
ai EId(582.0): blocked report cells=[3591]
ai EId(582.0): backout to 49.40,0.10,-97.78 (heading 0.39,-1.96) pinned=false
ai EId(582.0): repath adopted, cells [3591] -> [3591], repeats=true
ai EId(582.0): escalate #1 on the reproduced route
```

### `medsci2-patrol-railing`: 2/4 → 4/4

Measured this session, `SHOCK2_E2E=1` from a clean `dist/`, four runs a side:

| | runs |
|---|---|
| base (`927558cd`) | **2/4** — held 36 s and 43 s at `(49.0, 0.1, −95.8)`, `Patrol` then `Idle` |
| this branch | **4/4** (and 4/4 again on a second build of the same tree — 8/8) |

Idle-pass sampling of the patroller over 60 s, same seed conditions: worst hold
**37.5 s → 3.5 s**, ground covered **72.5 → 168.6** units, and it never leaves
`Patrol`.

Also green: `patrol`, `force-chase`, `search-behavior`, `pathfinding`,
`pathfinding-budget`, `medsci2-doorjamb-chase`, `chase-last-seen`,
`ai-alertness`, `missions` (all 23 load). `cargo test -p shock2vr` 1229 pass,
including a new physics test that is red before this change and green after: a
stationary kinematic wall jittering at ~3e-3 units/s must not hold a creature
that is leaning on it while walking along it.

### Harness reconciliation

The measurement above claimed 0/3 balcony wedges while the e2e still saw the
body frozen. The classifier is not at fault. Replaying this session's recorded
tracks through `classifyTrack` (`tools/shock2-sdk/src/ai-reachability.ts` on
`feat/ai-reachability-eval`, `pass: "idle"`) reproduces the e2e verdict exactly:

```
pre-fix run 1: wedged - stationary 37.5s at (48.40, 0.10, -83.52)
pre-fix run 2: wedged - stationary 25.5s at (48.81, 0.10, -95.83)
pre-fix run 3: wedged - stationary 37.0s at (49.14, 0.10, -82.82)
post-fix run:  progressing - moved 168.6, ended 50.0 from the player
```

So the 0/3 was run-to-run variance — the wedge needs the patroller to brush the
railing, which it did in 2 of 4 e2e runs on the same build — not a missing rule.
No harness change; **#1242 needs no fix on this account**.

### Not taken

A first attempt made the stall backout probe eight directions and retreat
toward the freest one, rather than toward the route's previous waypoint (which,
on the first leg, is A\*'s snapped *start* cell centre and in the corner case
pointed into a wall 0.6 units away). It measured 4/4 — but so did the physics
fix alone, so the steering change was carrying no weight and was dropped. The
mis-aimed backout is real and still there; it is worth its own change with its
own evidence.


### Re-verification (2026-09-03, current tip)

Re-ran validation on the current branch tip (`108b753c`):

- `medsci2-patrol-railing`: **4/4** (individual runs, clean `dist/`).
- Full AI e2e suite: `patrol`, `force-chase`, `search-behavior`,
  `chase-last-seen`, `medsci2-doorjamb-chase`, `pathfinding`,
  `pathfinding-budget` — **11/11 pass**.
- `missions.e2e.test.ts` — **23/23** mission loads.
- `cargo test -p shock2vr` — **1229 passed**, 0 failed.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo fmt --check` — clean.

Two full-suite failures from a prior run were **not** on the pre-existing
main-failure list (issue #1262) and needed triage: `baby-arachnid.e2e.test.ts`
("Hydro3 Baby Arachnids can be pushed aside and hit by normal weapons") and
`ragdoll-death.e2e.test.ts` ("a lethal VR Wrench contact seeds the death
ragdoll along the physical swing"). Both pass cleanly when run alone on this
branch (arachnid: 1/1 ok in 14s; ragdoll: 2/2 ok in 33s) — consistent with the
documented port-collision flake pattern from concurrent sessions during a full
suite run, not a regression from this stack. No fix needed.

### Re-review (2026-09-03, physics fix + instrumentation commits)

Ran `/xreview` against the base again to cover the two commits added since the
original review (`4c9f3f83` instrumentation, `108b753c` physics fix). Codex was
unavailable (usage limit) both times attempted; proceeded with the Claude
correctness/simplicity reviewer plus the dedicated duplication reviewer.

- **Correctness/simplicity**: no Critical or High findings. The widened
  `MOVING_TERRAIN_SPEED` threshold, the cell-blacklist TTL/cap logic, the
  escalation state machine, the mesh-adjacency filter on stall reports, and the
  nudge's on/off-mesh fallback chain were all read through and check out; every
  changed hunk traces to the stated goal (the two new debug-stats fields are
  proportional, the `xz_distance` reuse in the nudge path is a minor justified
  simplification, not a refactor).
- **Duplication**: no actionable duplication. The new items (`report_blocked_cell`
  /`blocked_cells`, `NavAvoidance`, `has_link`, `route_cells`/`repeats_route`,
  `on_mesh`, `MOVING_TERRAIN_SPEED`, the escalation counter) pair only with
  sibling functions in the same family the diff itself extends (e.g.
  `report_blocked_link`/`blocked_links`) — intentional API twins.

No fixes required from this pass.
