### PR TITLE
fix(hud): fall back to the symbolic name in objname.str

### DIFF
--- a/dark/src/importers/strings_importer.rs
+++ b/dark/src/importers/strings_importer.rs
@@ -109,14 +109,20 @@ pub fn resolve_localized_property_string(raw: &str, strings: &HashMap<String, St
     lookup(strings, key).unwrap_or_else(|| fallback.to_owned())
 }
 
+/// Resolve a symbolic name (`P$SymName`) directly against a string table,
+/// underscoring spaces first - multi-word entries are keyed that way in the
+/// shipped tables (`Stasis_Field_Generator`, `laser_pistol`).
+pub fn resolve_symbolic_name(sym_name: &str, strings: &HashMap<String, String>) -> Option<String> {
+    lookup(strings, &sym_name.replace(' ', "_"))
+}
+
 /// Resolve a gun fire-setting string (`P$Sett1`/`P$SHead2`/...) against its
 /// `SETT*`/`SHEAD*` table.
 ///
 /// Some guns author no setting property at all - the Stasis Field Generator,
 /// Worm Launcher and Viral Proliferator - yet the tables carry entries for
-/// them, keyed by their symbolic name with spaces underscored
-/// (`Stasis_Field_Generator`). So the symbolic name is tried whenever the
-/// property is missing or its own key misses.
+/// them, keyed by their symbolic name. So the symbolic name is tried
+/// whenever the property is missing or its own key misses.
 pub fn resolve_gun_setting_string(
     raw: Option<&str>,
     sym_name: Option<&str>,
@@ -124,7 +130,7 @@ pub fn resolve_gun_setting_string(
 ) -> Option<String> {
     let (key, fallback) = raw.map_or(("", ""), split_object_string);
     lookup(strings, key)
-        .or_else(|| lookup(strings, &sym_name.unwrap_or_default().replace(' ', "_")))
+        .or_else(|| sym_name.and_then(|name| resolve_symbolic_name(name, strings)))
         .or_else(|| (!fallback.is_empty()).then(|| fallback.to_owned()))
 }
 

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -3,6 +3,7 @@ use collision::{Aabb2, Aabb3};
 use dark::{
     importers::{
         FONT_IMPORTER, STRINGS_IMPORTER, TEXTURE_IMPORTER, resolve_localized_property_string,
+        resolve_symbolic_name,
     },
     properties::{
         ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
@@ -140,27 +141,14 @@ fn localized_weapon_condition(
 /// An object with no `P$ObjName` of its own (e.g. the Wrench, which inherits
 /// only a symbolic name) falls back to looking its `P$SymName` up in
 /// `objname.str` directly - no embedded fallback text, since there is no
-/// property to carry one. A multi-word symbolic name ("Laser Pistol") is
-/// tried with spaces replaced by underscores too, the same convention
-/// `resolve_gun_setting_string` uses for its own symbolic-name fallback,
-/// since the table keys multi-word entries that way ("laser_pistol").
+/// property to carry one.
 fn resolve_symname_fallback(
     world: &World,
     entity_id: EntityId,
     object_name_strings: &std::collections::HashMap<String, String>,
 ) -> Option<String> {
-    let sym_name = world
-        .borrow::<View<PropSymName>>()
-        .ok()?
-        .get(entity_id)
-        .ok()?
-        .0
-        .clone();
-    let key = sym_name.to_ascii_lowercase();
-    object_name_strings
-        .get(&key)
-        .or_else(|| object_name_strings.get(&key.replace(' ', "_")))
-        .cloned()
+    let sym_name = world.borrow::<View<PropSymName>>().ok()?;
+    resolve_symbolic_name(&sym_name.get(entity_id).ok()?.0, object_name_strings)
 }
 
 /// The player-facing display name of `entity_id`: its `P$ObjName` resolved
@@ -177,12 +165,14 @@ pub fn resolve_item_name(
     world: &World,
     entity_id: EntityId,
 ) -> Option<String> {
+    // Own property present (even empty) vs. absent entirely - only the
+    // latter falls back to SymName, matching the original: an empty
+    // P$ObjName resolves to "" (caught by the emptiness check below) rather
+    // than borrowing a name from elsewhere.
     let obj_name = world
         .borrow::<View<PropObjName>>()
         .ok()
-        .and_then(|v_prop_obj_name| v_prop_obj_name.get(entity_id).ok().cloned())
-        .filter(|prop| !prop.0.is_empty())
-        .map(|prop| prop.0);
+        .and_then(|v_prop_obj_name| v_prop_obj_name.get(entity_id).ok().map(|p| p.0.clone()));
 
     let object_name_strings = asset_cache.get(&STRINGS_IMPORTER, "objname.str");
     let localized_name = match &obj_name {

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -6,7 +6,7 @@ use dark::{
     },
     properties::{
         ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
-        PropObjName, PropObjectNameType, PropShowHP, PropStackCount, PropTemplateId,
+        PropObjName, PropObjectNameType, PropShowHP, PropStackCount, PropSymName, PropTemplateId,
     },
 };
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
@@ -137,8 +137,35 @@ fn localized_weapon_condition(
         .cloned()
 }
 
+/// An object with no `P$ObjName` of its own (e.g. the Wrench, which inherits
+/// only a symbolic name) falls back to looking its `P$SymName` up in
+/// `objname.str` directly - no embedded fallback text, since there is no
+/// property to carry one. A multi-word symbolic name ("Laser Pistol") is
+/// tried with spaces replaced by underscores too, the same convention
+/// `resolve_gun_setting_string` uses for its own symbolic-name fallback,
+/// since the table keys multi-word entries that way ("laser_pistol").
+fn resolve_symname_fallback(
+    world: &World,
+    entity_id: EntityId,
+    object_name_strings: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    let sym_name = world
+        .borrow::<View<PropSymName>>()
+        .ok()?
+        .get(entity_id)
+        .ok()?
+        .0
+        .clone();
+    let key = sym_name.to_ascii_lowercase();
+    object_name_strings
+        .get(&key)
+        .or_else(|| object_name_strings.get(&key.replace(' ', "_")))
+        .cloned()
+}
+
 /// The player-facing display name of `entity_id`: its `P$ObjName` resolved
-/// through `objname.str` and then through whatever substitution its
+/// through `objname.str`, falling back to its `P$SymName` when it has no
+/// `P$ObjName` of its own, and then through whatever substitution its
 /// `P$ObjectNameType` asks for (a stack count, a log's title, a gun's
 /// condition word). `None` when the object has no name to show.
 ///
@@ -150,17 +177,18 @@ pub fn resolve_item_name(
     world: &World,
     entity_id: EntityId,
 ) -> Option<String> {
-    let obj_name = {
-        let v_prop_obj_name = world.borrow::<View<PropObjName>>().ok()?;
-        let prop_obj_name = v_prop_obj_name.get(entity_id).ok()?;
-        if prop_obj_name.0.is_empty() {
-            return None;
-        }
-        prop_obj_name.0.clone()
-    };
+    let obj_name = world
+        .borrow::<View<PropObjName>>()
+        .ok()
+        .and_then(|v_prop_obj_name| v_prop_obj_name.get(entity_id).ok().cloned())
+        .filter(|prop| !prop.0.is_empty())
+        .map(|prop| prop.0);
 
     let object_name_strings = asset_cache.get(&STRINGS_IMPORTER, "objname.str");
-    let localized_name = resolve_localized_property_string(&obj_name, &object_name_strings);
+    let localized_name = match &obj_name {
+        Some(obj_name) => resolve_localized_property_string(obj_name, &object_name_strings),
+        None => resolve_symname_fallback(world, entity_id, &object_name_strings)?,
+    };
     if localized_name.is_empty() {
         return None;
     }
@@ -534,6 +562,49 @@ mod tests {
             format_stack_aware_item_name(r#"Nanites: "%d nanites.""#, None),
             r#"Nanites: "%d nanites.""#,
         );
+    }
+
+    /// The Wrench inherits only `P$SymName`, never `P$ObjName`; without the
+    /// fallback, `resolve_symname_fallback` (and so `resolve_item_name`) has
+    /// nothing to key `objname.str` with.
+    #[test]
+    fn symname_only_entity_resolves_via_the_objname_table() {
+        let strings = HashMap::from([("wrench".to_string(), "A very solid wrench.".to_string())]);
+        let mut world = World::new();
+        let id = world.add_entity(PropSymName("Wrench".to_owned()));
+
+        assert_eq!(
+            resolve_symname_fallback(&world, id, &strings),
+            Some("A very solid wrench.".to_string()),
+        );
+    }
+
+    /// Multi-word symbolic names are keyed with underscores in the shipped
+    /// table ("Laser Pistol" -> "laser_pistol"), the same convention
+    /// `resolve_gun_setting_string` already uses for its own symbolic-name
+    /// fallback.
+    #[test]
+    fn multi_word_symname_falls_back_to_its_underscored_key() {
+        let strings = HashMap::from([("laser_pistol".to_string(), "A laser pistol.".to_string())]);
+        let mut world = World::new();
+        let id = world.add_entity(PropSymName("Laser Pistol".to_owned()));
+
+        assert_eq!(
+            resolve_symname_fallback(&world, id, &strings),
+            Some("A laser pistol.".to_string()),
+        );
+    }
+
+    /// A symbolic name absent from the table (an internal/abstract
+    /// archetype, not a player-facing object) still yields no name - the
+    /// fallback must not invent text the original wouldn't show either.
+    #[test]
+    fn unknown_symname_has_no_fallback() {
+        let strings = HashMap::new();
+        let mut world = World::new();
+        let id = world.add_entity(PropSymName("Ammo".to_owned()));
+
+        assert_eq!(resolve_symname_fallback(&world, id, &strings), None);
     }
 }
 

--- a/tools/shock2-sdk/test/use-mode-name-strip.e2e.test.ts
+++ b/tools/shock2-sdk/test/use-mode-name-strip.e2e.test.ts
@@ -21,6 +21,15 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const NAMED_ITEM = "Basketball";
 const NAMED_ITEM_READOUT = "A basketball";
 
+/**
+ * The Wrench carries no `P$ObjName` at all - only `P$SymName` ("Wrench"),
+ * inherited unmodified. The readout must still fall back to `objname.str`
+ * keyed by that symbolic name ("wrench" -> "A very solid wrench."), not go
+ * blank.
+ */
+const SYMNAME_ONLY_ITEM = "Wrench";
+const SYMNAME_ONLY_ITEM_READOUT = "A very solid wrench";
+
 /** SpawnDebugMonster's template (grunt og-pipe), named "A hybrid". */
 const DEBUG_MONSTER_TEMPLATE = -397;
 
@@ -85,6 +94,28 @@ test(
     const shooter = await game.ui.state();
     assert.equal(shooter.mode, "shooter");
     assert.equal(shooter.name_strip, null, "no inventory bar, no readout");
+  },
+);
+
+test(
+  "flat use mode names a SymName-only item via its objname.str fallback",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 30 });
+
+    const item = await game.player.spawnItem(SYMNAME_ONLY_ITEM);
+    const ui = await openUseMode(game);
+    assert.equal(ui.mode, "use");
+
+    const [sx, sy, sw, sh] = slotFor(ui, item.entity_id).screen_rect;
+    await game.input.set("pointer.position", [sx + sw / 2, sy + sh / 2]);
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.ui.state()).name_strip,
+      SYMNAME_ONLY_ITEM_READOUT,
+      "a SymName-only item still gets a readout, not a blank strip",
+    );
   },
 );
 


### PR DESCRIPTION
## Problem

`resolve_item_name` (the single player-facing name resolver behind the HUD
rollover label and the use-mode name strip, #1261) only reads `P$ObjName`.
Most weapons and several other pickups carry no `P$ObjName` at all - only an
inherited `P$SymName` - so they showed no name whatsoever. The Wrench is one
example; the base Pistol, Laser Pistol, Assault Rifle, Fusion Cannon, and
several armor/turret/key templates are others.

## Findings (from data, not source)

- Retail's name lookup falls back to the object's symbolic name only when the
  name property is genuinely **absent** (not merely empty), keying the string
  table with that name directly - confirmed by decoding the shipped
  `objname.str` and cross-checking gamesys templates with `dark_query`: the
  Wrench template has no `P$ObjName` anywhere in its ancestor chain but does
  carry `P$SymName("Wrench")`, and `objname.str` has an entry keyed `Wrench`.
- Multi-word symbolic names are keyed with underscores in the shipped table
  (`"Laser Pistol"` -> `laser_pistol`), the same convention already used by
  `resolve_gun_setting_string` for a different table.
- Blast radius: of the 205 gamesys templates marked `P$HUDSelect` (the
  brackets-and-rollover population) that have a `P$SymName` but no
  `P$ObjName`, 89 now resolve a name via this fallback (up from 33 without the
  underscore convention) - the rest are internal/abstract archetypes
  ("Ammo", "Crew") that genuinely have no display name in retail either.

## Change

- `dark/src/importers/strings_importer.rs`: extracted `resolve_symbolic_name`
  (underscore-then-lookup) out of `resolve_gun_setting_string` so both call
  sites share it.
- `shock2vr/src/hud/item_outline.rs`: `resolve_item_name` falls back to
  `P$SymName` only when `P$ObjName` is absent (an empty-but-present
  `P$ObjName` still resolves to no name, unchanged from before).
- Negative-first unit tests for the fallback (SymName-only, underscored
  multi-word, unknown-name), plus an e2e Wrench case in
  `use-mode-name-strip.e2e.test.ts`.

## Testing

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` (1211 passed), `cargo test -p dark --lib` (138 passed)
- `cargo fmt --check`
- `use-mode-name-strip.e2e.test.ts` (3/3), `missions.e2e.test.ts` (23/23 missions load)
- `/xreview` (Claude reviewer + de-dup reviewer; Codex was rate-limited) -
  both independently flagged the SymName-lookup duplication, fixed by sharing
  `resolve_symbolic_name`; also fixed an untested empty-ObjName edge case the
  Claude reviewer caught


## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/8c0ddb10de71612bf2357004fa65532e/raw/beforeafter.png)

<sub>Wrench hover in use-mode inventory (medsci1). Before: name strip blank. After: "A very solid wrench". Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>
