### PR TITLE
feat(scripts): TrapMessage shows its P$UseMsg text on the HUD message line

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -435,6 +435,12 @@ impl PropObjectNameType {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropObjShortName(pub String);
 
+/// `P$UseMsg`: the status-line message an object shows the player - either a
+/// key into USEMSG.STR or, when the value carries its own quoted text, that
+/// text (see `resolve_localized_property_string`).
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropUseMsg(pub String);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropPhysState {
     pub position: Vector3<f32>,
@@ -1744,6 +1750,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$UseMsg",
+            read_variable_length_string,
+            PropUseMsg,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$PsiPower",
             PropPsiPower::read,
             identity,
@@ -2574,6 +2586,19 @@ mod tests {
         let options = PhysAttachOptions::read(&mut cursor, 12);
 
         assert_eq!(options.offset, vec3(4.0, -0.2, -0.075));
+    }
+
+    /// The eng2 "Message Trap" P$UseMsg chunk: a leading u32 the readers
+    /// ignore, then the NUL-terminated key ("OutOfOrder", 15 bytes total).
+    #[test]
+    fn use_message_reads_its_key_from_a_variable_length_string_chunk() {
+        let mut bytes = 11u32.to_le_bytes().to_vec();
+        bytes.extend_from_slice(b"OutOfOrder\0");
+        let mut cursor = Cursor::new(bytes);
+
+        let property = PropUseMsg(read_variable_length_string(&mut cursor, 15));
+
+        assert_eq!(property.0, "OutOfOrder");
     }
 
     #[test]

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -616,6 +616,8 @@ pub struct UiStateResult {
     /// while the interface is up in VR. Aim a controller at a canvas rect by
     /// mapping it through this.
     pub panel_pose: Option<shock2vr::game_scene::DebugUiPanelPose>,
+    /// The HUD status-message lines showing right now, oldest first.
+    pub messages: Vec<String>,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1332,6 +1332,7 @@ fn process_command(
                         readout: ui.readout,
                         pointer: ui.pointer,
                         panel_pose: ui.panel_pose,
+                        messages: ui.messages,
                     }
                 })
                 .unwrap_or(commands::UiStateResult {
@@ -1343,6 +1344,7 @@ fn process_command(
                     readout: Vec::new(),
                     pointer: None,
                     panel_pose: None,
+                    messages: Vec::new(),
                 });
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send ui state - receiver dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -578,6 +578,9 @@ pub struct DebugUiState {
     /// while the interface is up in VR. Lets a client aim a controller at a
     /// canvas rect without re-deriving the panel's placement.
     pub panel_pose: Option<DebugUiPanelPose>,
+    /// The HUD status-message lines showing right now, oldest first (the
+    /// channel `TrapMessage` and friends write to). Empty when none are up.
+    pub messages: Vec<String>,
 }
 
 /// One frame of pointing at the shared UI canvas.
@@ -903,6 +906,7 @@ pub trait DebuggableScene {
             readout: Vec::new(),
             pointer: None,
             panel_pose: None,
+            messages: Vec::new(),
         }
     }
 

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -11,6 +11,7 @@ use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use shipyard::World;
 
 use super::ammo_panel::{self, AmmoReadout, ReadoutButtonSpec};
+use super::message_line;
 use super::{get_health_percentage, get_psi_percentage, get_wielded_psi_charge};
 use crate::runtime_props::{PsiChargePhase, RuntimePropPsiCharge};
 use crate::ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign};
@@ -105,6 +106,7 @@ pub(crate) fn build_flat_hud_canvas(
     psi_fraction: f32,
     psi_charge: Option<RuntimePropPsiCharge>,
     ammo_readout: &AmmoReadout,
+    messages: &[String],
 ) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(VIRTUAL_W, VIRTUAL_H));
 
@@ -181,6 +183,10 @@ pub(crate) fn build_flat_hud_canvas(
         ammo_panel::emit(&mut canvas, AMMO_PANEL_ORIGIN, ammo_readout);
     }
 
+    // Status messages, placed by the shared `message_line` layout the VR head
+    // panel draws with.
+    message_line::emit(&mut canvas, message_line::flat_origin(), messages);
+
     canvas
 }
 
@@ -192,6 +198,7 @@ pub(crate) fn create_flat_hud(
     screen_size: cgmath::Vector2<f32>,
     crosshair: bool,
     use_mode: bool,
+    messages: &[String],
 ) -> Vec<SceneObject> {
     let canvas = build_flat_hud_canvas(
         crosshair,
@@ -202,6 +209,7 @@ pub(crate) fn create_flat_hud(
         // The buttons are drawn exactly when the pointer can reach them - use
         // mode - and the hit-test below reads the same readout.
         &AmmoReadout::from_world(world, use_mode),
+        messages,
     );
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
@@ -255,6 +263,7 @@ mod tests {
             0.75,
             None,
             &readout(None, None, None, false),
+            &[],
         );
         assert_eq!(canvas.element_count(), 6);
     }
@@ -269,6 +278,7 @@ mod tests {
             0.75,
             None,
             &readout(Some(12), None, None, false),
+            &[],
         );
         assert_eq!(canvas.element_count(), 8);
     }
@@ -283,6 +293,7 @@ mod tests {
             0.75,
             None,
             &readout(Some(12), Some("STD_I.PCX"), Some("std"), false),
+            &[],
         );
         assert_eq!(canvas.element_count(), 10);
     }
@@ -302,6 +313,7 @@ mod tests {
                 ammo: Some(0),
                 ..Default::default()
             },
+            &[],
         );
         assert_eq!(canvas.element_count(), 9);
     }
@@ -318,6 +330,7 @@ mod tests {
             0.75,
             None,
             &readout(Some(12), None, None, false),
+            &[],
         );
         assert_eq!(shooter.element_count(), 8);
         // Use mode (crosshair off) with an empty multi-ammo weapon: the same
@@ -330,6 +343,7 @@ mod tests {
             0.75,
             None,
             &readout(Some(0), None, None, true),
+            &[],
         );
         assert_eq!(use_mode.element_count(), 8);
         // The cycle button only appears when the weapon can actually cycle.
@@ -340,6 +354,7 @@ mod tests {
             0.75,
             None,
             &readout(Some(0), None, None, false),
+            &[],
         );
         assert_eq!(single_ammo.element_count(), 7);
     }
@@ -399,9 +414,30 @@ mod tests {
         // The original turns the crosshair overlay off while the cursor is
         // up (ShockOverlayMouseMode) - one fewer element than shooter mode.
         let empty = readout(None, None, None, false);
-        let shooter = build_flat_hud_canvas(true, false, 1.0, 0.75, None, &empty);
-        let use_mode = build_flat_hud_canvas(false, false, 1.0, 0.75, None, &empty);
+        let shooter = build_flat_hud_canvas(true, false, 1.0, 0.75, None, &empty, &[]);
+        let use_mode = build_flat_hud_canvas(false, false, 1.0, 0.75, None, &empty, &[]);
         assert_eq!(use_mode.element_count(), shooter.element_count() - 1);
+    }
+
+    /// A status message adds one text element per line, at the shared
+    /// `message_line` block's origin on the HUD canvas.
+    #[test]
+    fn a_status_message_adds_a_line_to_the_hud() {
+        let empty = readout(None, None, None, false);
+        let base = build_flat_hud_canvas(true, false, 1.0, 0.75, None, &empty, &[]);
+        let with_message = build_flat_hud_canvas(
+            true,
+            false,
+            1.0,
+            0.75,
+            None,
+            &empty,
+            &["This lift has been taken offline for repairs.".to_string()],
+        );
+
+        assert_eq!(with_message.element_count(), base.element_count() + 1);
+        let line = with_message.elements().last().unwrap().rect();
+        assert_eq!(vec2(line.x, line.y), message_line::flat_origin());
     }
 
     #[test]
@@ -414,6 +450,7 @@ mod tests {
             -1.0,
             None,
             &readout(None, None, None, false),
+            &[],
         );
     }
 }

--- a/shock2vr/src/hud/message_line.rs
+++ b/shock2vr/src/hud/message_line.rs
@@ -1,0 +1,139 @@
+//! The HUD status-message line: short lines of text the game tells the player
+//! ("This lift has been taken offline for repairs.").
+//!
+//! The original draws these as a stack of up to six lines under the top-left
+//! of the HUD, each expiring five seconds after it was added; a seventh line
+//! scrolls the oldest one off. Placement lives here once, in 640x480 canvas
+//! pixels: flat emits it into the HUD canvas, VR draws the same canvas on a
+//! head-anchored panel.
+
+use std::time::Duration;
+
+use cgmath::{Vector2, vec2};
+use shipyard::Unique;
+
+use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
+
+/// How long a line stays up. The original's default message time (5 s).
+pub const MESSAGE_DURATION: Duration = Duration::from_secs(5);
+
+/// How many lines are shown at once; a further line scrolls the oldest off.
+pub const MAX_LINES: usize = 6;
+
+/// The block's upper-left corner on the 640x480 HUD canvas, and the width the
+/// original wraps its message text within.
+const ORIGIN: Vector2<f32> = vec2(192.0, 18.0);
+const LINE_WIDTH: f32 = 446.0;
+/// One line's box: the bitmap font's native height plus the original's 5px
+/// inter-line spacing.
+const LINE_HEIGHT: f32 = 20.0;
+
+const FONT: &str = "mainfont.fon";
+
+/// The message block's own canvas size, used by the VR panel.
+pub const PANEL_SIZE: Vector2<f32> = vec2(LINE_WIDTH, LINE_HEIGHT * MAX_LINES as f32);
+
+/// The status messages currently on screen, oldest first, each with the
+/// mission time it stops being shown.
+#[derive(Unique, Default)]
+pub struct HudMessages {
+    lines: Vec<(Duration, String)>,
+}
+
+impl HudMessages {
+    /// Show `text` for [`MESSAGE_DURATION`]. Past [`MAX_LINES`] the oldest line
+    /// scrolls off, as the original's overlay does.
+    pub fn push(&mut self, text: String, now: Duration) {
+        self.lines.retain(|(expiry, _)| *expiry > now);
+        if self.lines.len() == MAX_LINES {
+            self.lines.remove(0);
+        }
+        self.lines.push((now + MESSAGE_DURATION, text));
+    }
+
+    /// The lines still showing at `now`, oldest first. Expired lines are
+    /// dropped here rather than on a timer (the `DamageFlash` pattern).
+    pub fn active(&mut self, now: Duration) -> Vec<String> {
+        self.lines.retain(|(expiry, _)| *expiry > now);
+        self.lines.iter().map(|(_, text)| text.clone()).collect()
+    }
+}
+
+/// Emit the message lines into `canvas` with the block's upper-left corner at
+/// `origin` in that canvas's pixel space.
+pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, lines: &[String]) {
+    for (index, line) in lines.iter().take(MAX_LINES).enumerate() {
+        canvas.text_native(
+            Rect::new(
+                origin.x,
+                origin.y + LINE_HEIGHT * index as f32,
+                LINE_WIDTH,
+                LINE_HEIGHT,
+            ),
+            line,
+            FONT,
+            HAlign::Left,
+            VAlign::Top,
+        );
+    }
+}
+
+/// Where the block sits on the flat HUD canvas.
+pub(crate) fn flat_origin() -> Vector2<f32> {
+    ORIGIN
+}
+
+/// The block as the VR head panel draws it: the same lines on a canvas that is
+/// exactly the block, so the panel *is* the block (the `ammo_panel` pattern).
+pub(crate) fn build_message_canvas(lines: &[String]) -> UiCanvas {
+    let mut canvas = UiCanvas::new(PANEL_SIZE);
+    emit(&mut canvas, vec2(0.0, 0.0), lines);
+    canvas
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    #[test]
+    fn a_message_shows_for_five_seconds() {
+        let mut messages = HudMessages::default();
+        messages.push("Access Denied.".to_string(), secs(10));
+
+        assert_eq!(messages.active(secs(14)), vec!["Access Denied."]);
+        assert!(messages.active(secs(15)).is_empty());
+    }
+
+    #[test]
+    fn a_seventh_line_scrolls_the_oldest_off() {
+        let mut messages = HudMessages::default();
+        for index in 0..7 {
+            messages.push(format!("line {index}"), secs(10));
+        }
+
+        let active = messages.active(secs(11));
+        assert_eq!(active.len(), MAX_LINES);
+        assert_eq!(active.first().unwrap(), "line 1");
+        assert_eq!(active.last().unwrap(), "line 6");
+    }
+
+    /// Flat and VR emit the same lines at the same offsets; only the block's
+    /// origin differs, so a line cannot land differently between them.
+    #[test]
+    fn the_panel_canvas_holds_one_element_per_line_stacked_by_line_height() {
+        let canvas = build_message_canvas(&["one".to_string(), "two".to_string()]);
+
+        let rects: Vec<Rect> = canvas
+            .elements()
+            .iter()
+            .map(|element| element.rect())
+            .collect();
+        assert_eq!(rects.len(), 2);
+        assert_eq!(rects[0].y, 0.0);
+        assert_eq!(rects[1].y, LINE_HEIGHT);
+    }
+}

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -12,6 +12,9 @@ pub use virtual_arms::*;
 
 pub(crate) mod ammo_panel;
 
+pub(crate) mod message_line;
+pub use message_line::HudMessages;
+
 mod flat_hud;
 pub(crate) use flat_hud::*;
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1930,6 +1930,7 @@ impl MissionCore {
         world.add_unique(crate::scripts::healing_item::ActiveHealing::default());
         world.add_unique(crate::scripts::radiation::ActiveRadiation::default());
         world.add_unique(DamageFlash::default());
+        world.add_unique(crate::hud::HudMessages::default());
 
         // ** Entity creation
 
@@ -2227,6 +2228,10 @@ impl MissionCore {
         // Preload the elevator floor labels (MISC.STR) + current mission so the
         // AssetCache-less ElevatorGui can label/gate floors at draw time.
         world.add_unique(crate::hud::HudStrings::load(asset_cache));
+        // USEMSG.STR, which TrapMessage resolves its P$UseMsg key against.
+        world.add_unique(crate::scripts::trap_message::UseMessageStrings::load(
+            asset_cache,
+        ));
         world.add_unique(crate::scripts::ElevatorContext::load(asset_cache, &mission));
         world.add_unique(crate::scripts::gui::TraitsContext::load(asset_cache));
         world.add_unique(crate::scripts::gui::ComputerContext::load(asset_cache));
@@ -7286,6 +7291,14 @@ impl MissionCore {
                         door.base_location = base_location;
                     }
                 }
+                Effect::ShowMessage { text } => {
+                    let now = self.world.borrow::<UniqueView<Time>>().unwrap().total;
+                    self.world
+                        .borrow::<UniqueViewMut<crate::hud::HudMessages>>()
+                        .unwrap()
+                        .push(text, now);
+                }
+
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,
@@ -8490,6 +8503,7 @@ impl MissionCore {
 
             // Flat 2D HUD (screen size is available here; the VR forearm HUD is
             // built in `render`). Drawn after the viewmodel so it stays on top.
+            let messages = self.hud_messages();
             ret.extend(crate::hud::create_flat_hud(
                 asset_cache,
                 &self.world,
@@ -8500,6 +8514,7 @@ impl MissionCore {
                 !self.use_mode,
                 // Use mode expands the compact readouts to BIOFULL/AMMOFULL.
                 self.use_mode,
+                &messages,
             ));
 
             // Flat MFD panel (keypad, container, ...) + cursor, drawn over
@@ -8548,6 +8563,55 @@ impl MissionCore {
     /// screen this is a mode of play, so the player's own hands are still being
     /// rendered by the interaction controller, and a second static glove would
     /// stack on top of them (the defect issue #1018 fixed for the pause menu).
+    /// The status-message lines showing this frame, oldest first. Expired
+    /// lines are dropped here (the `DamageFlash` pattern), so they clear
+    /// whether or not the message block is being drawn.
+    fn hud_messages(&self) -> Vec<String> {
+        let now = self
+            .world
+            .borrow::<UniqueView<Time>>()
+            .map(|time| time.total)
+            .unwrap_or_default();
+        self.world
+            .borrow::<UniqueViewMut<crate::hud::HudMessages>>()
+            .map(|mut messages| messages.active(now))
+            .unwrap_or_default()
+    }
+
+    /// The status-message block in VR: the same canvas flat draws into its HUD,
+    /// on a small panel hung off the head. The original's placement is a line
+    /// near the top of a 640x480 screen, which has no world position - so the
+    /// one thing this presentation decides for itself is where to hang the
+    /// block; everything on it is placed by the shared `message_line` layout.
+    /// Head-locked rather than world-locked (a `FrontendPanelAnchor` placement)
+    /// because a message is read at a glance and then gone, not inspected.
+    fn render_vr_messages(
+        &self,
+        asset_cache: &mut AssetCache,
+        messages: &[String],
+    ) -> Vec<SceneObject> {
+        let placement =
+            crate::ui::PanelPlacement::from_head(self.last_head_position, self.last_head_rotation);
+        let panel = placement.panel();
+        let size = crate::hud::message_line::PANEL_SIZE;
+        // Sized off the frontend panel (which is FRONTEND_PANEL_SIZE wide for a
+        // 640-pixel canvas), so a message glyph subtends the same angle it
+        // would on a frontend screen, and lifted above the gaze so it does not
+        // sit over what the player is aiming at.
+        let scale = panel.size.x / crate::mission::flat_ui_host::CANVAS_SIZE.x;
+        let root = Matrix4::from_translation(
+            panel.center + panel.rotation * vec3(0.0, size.y * scale * 0.5 + 0.2, 0.0),
+        ) * Matrix4::from(panel.rotation)
+            * Matrix4::from_nonuniform_scale(size.x * scale, size.y * scale, 1.0);
+        crate::hud::message_line::build_message_canvas(messages).render_world_space(
+            asset_cache,
+            root,
+            None,
+            None,
+            0.001,
+        )
+    }
+
     fn render_vr_use_mode(&self, asset_cache: &mut AssetCache) -> Vec<SceneObject> {
         use crate::ui::world_dim;
         let panel = self.vr_use_mode_anchor.panel();
@@ -8978,6 +9042,22 @@ impl MissionCore {
                 object.set_transform(pawn_to_world * object.get_transform());
             }
             scene.extend(use_mode_objects);
+        }
+
+        // Status messages in VR: flat draws them into its 2D HUD above, so this
+        // is the VR half of the same shared canvas.
+        if options.presentation_mode == crate::PresentationMode::Vr {
+            let messages = self.hud_messages();
+            if !messages.is_empty() {
+                let pawn_to_world =
+                    Matrix4::from_translation(player.pos) * Matrix4::from(player.rotation);
+                let mut objects = self.render_vr_messages(asset_cache, &messages);
+                for object in &mut objects {
+                    object.set_render_layer(RenderLayer::SystemOverlay);
+                    object.set_transform(pawn_to_world * object.get_transform());
+                }
+                scene.extend(objects);
+            }
         }
 
         // Floating damage readouts, in the shared world pass so flat and VR
@@ -10782,6 +10862,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     ],
                 }
             }),
+            messages: self.hud_messages(),
         }
     }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -843,6 +843,12 @@ pub enum Effect {
         components: Vec<GuiComponentRenderInfo>,
     },
 
+    /// Put a line on the HUD's status-message channel, where it stays for the
+    /// original's five-second message time.
+    ShowMessage {
+        text: String,
+    },
+
     Multiple(Vec<Effect>),
     // Deprecated:
     // Use Multiple instead

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -63,6 +63,7 @@ mod trap_destroyer;
 mod trap_email;
 mod trap_exp_once;
 mod trap_inverter;
+pub mod trap_message;
 mod trap_new_tripwire;
 mod trap_off_filter;
 mod trap_on_filter;
@@ -133,6 +134,7 @@ use self::radiation::RadPatchScript;
 use self::reduce_psi::ReducePsi;
 use self::reroute_elevator_button::RerouteElevatorButton;
 use self::researchable::ResearchableScript;
+use self::trap_message::TrapMessage;
 use self::trap_signal::TrapSignal;
 use self::{
     auto_install_soft::AutoInstallSoft,
@@ -946,7 +948,7 @@ impl ScriptWorld {
             // TODO: Should these actually be implemented?
             "earthtext" => Box::new(NoopScript::new()),
             "trapgravity" => Box::new(NoopScript {}), // medsci1 - vent that falls
-            "trapmessage" => Box::new(NoopScript {}), // eng2 - installing override. What prop for message? Where to load string?
+            "trapmessage" => Box::new(TrapMessage::new()),
             "charmable" => Box::new(NoopScript::new()),
             "transientcorpse" => Box::new(NoopScript::new()),
             "whiteout" => Box::new(WhiteOut::new()),

--- a/shock2vr/src/scripts/trap_message.rs
+++ b/shock2vr/src/scripts/trap_message.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+
+use dark::{importers::resolve_localized_property_string, properties::PropUseMsg};
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{EntityId, Get, Unique, UniqueView, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// USEMSG.STR, the table a `P$UseMsg` key resolves against. Held as a world
+/// `Unique` because scripts have no `AssetCache` when a message arrives (the
+/// `HudStrings` pattern).
+#[derive(Unique, Clone, Debug, Default)]
+pub struct UseMessageStrings(pub HashMap<String, String>);
+
+impl UseMessageStrings {
+    pub fn load(asset_cache: &mut AssetCache) -> UseMessageStrings {
+        UseMessageStrings(
+            asset_cache
+                .get_opt(&dark::importers::STRINGS_IMPORTER, "usemsg.str")
+                .map(|strings| (*strings).clone())
+                .unwrap_or_default(),
+        )
+    }
+}
+
+/// Resolve an entity's `P$UseMsg` to the text the player is shown: a key into
+/// USEMSG.STR, or the quoted text the property carries when the key misses.
+fn message_text(world: &World, entity_id: EntityId) -> Option<String> {
+    let v_use_msg = world.borrow::<View<PropUseMsg>>().ok()?;
+    let raw = v_use_msg.get(entity_id).ok()?;
+    let strings = world
+        .borrow::<UniqueView<UseMessageStrings>>()
+        .map(|strings| strings.0.clone())
+        .unwrap_or_default();
+    let text = resolve_localized_property_string(&raw.0, &strings);
+    (!text.is_empty()).then_some(text)
+}
+
+/// `TrapMessage`: on a switch-on, puts its own `P$UseMsg` text on the HUD
+/// status-message line (eng2's broken lift buttons). Switch-off shows nothing,
+/// and the trap has no output of its own to forward to.
+pub struct TrapMessage;
+
+impl TrapMessage {
+    pub fn new() -> TrapMessage {
+        TrapMessage
+    }
+}
+
+impl Script for TrapMessage {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { from: _ } => match message_text(world, entity_id) {
+                Some(text) => Effect::ShowMessage { text },
+                None => Effect::NoEffect,
+            },
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::PhysicsWorld;
+
+    fn world_with(raw: &str, strings: &[(&str, &str)]) -> (World, EntityId) {
+        let mut world = World::new();
+        let entity_id = world.add_entity((PropUseMsg(raw.to_string()),));
+        world.add_unique(UseMessageStrings(
+            strings
+                .iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect(),
+        ));
+        (world, entity_id)
+    }
+
+    fn turn_on(world: &World, entity_id: EntityId) -> Effect {
+        TrapMessage::new().handle_message(
+            entity_id,
+            world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn {
+                from: EntityId::dead(),
+            },
+        )
+    }
+
+    /// eng2's "Message Trap": `P$UseMsg` is the bare key `OutOfOrder`.
+    #[test]
+    fn turn_on_shows_the_text_its_key_resolves_to() {
+        let (world, entity_id) = world_with(
+            "OutOfOrder",
+            &[(
+                "outoforder",
+                "This lift has been taken offline for repairs.",
+            )],
+        );
+
+        match turn_on(&world, entity_id) {
+            Effect::ShowMessage { text } => {
+                assert_eq!(text, "This lift has been taken offline for repairs.")
+            }
+            effect => panic!("expected a message, got {effect:?}"),
+        }
+    }
+
+    /// eng2 entity 393 pastes the whole STR line in as the value; with no
+    /// table entry the quoted text it carries is what the player sees.
+    #[test]
+    fn a_pasted_str_line_falls_back_to_its_own_quoted_text() {
+        let (world, entity_id) = world_with(
+            r#"Broken: "This lift is malfunctioning.""#,
+            &[("outoforder", "unrelated")],
+        );
+
+        match turn_on(&world, entity_id) {
+            Effect::ShowMessage { text } => assert_eq!(text, "This lift is malfunctioning."),
+            effect => panic!("expected a message, got {effect:?}"),
+        }
+    }
+
+    #[test]
+    fn a_key_that_resolves_to_nothing_shows_nothing() {
+        let (world, entity_id) = world_with("exp1", &[]);
+
+        assert!(matches!(
+            turn_on(&world, entity_id),
+            Effect::NoEffect | Effect::Multiple(_)
+        ));
+    }
+
+    #[test]
+    fn turn_off_shows_nothing() {
+        let (world, entity_id) = world_with("OutOfOrder", &[("outoforder", "Offline.")]);
+
+        let effect = TrapMessage::new().handle_message(
+            entity_id,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOff {
+                from: EntityId::dead(),
+            },
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -813,6 +813,12 @@ export interface UiState {
    * mapping it through this pose - see `test/helpers/vr-hand.ts`.
    */
   panel_pose: UiPanelPose | null;
+  /**
+   * The HUD status-message lines showing right now, oldest first - the channel
+   * a `TrapMessage` writes its `P$UseMsg` text to. Each line clears five
+   * seconds after it was added.
+   */
+  messages: string[];
 }
 
 /** One frame of pointing at the shared UI canvas. */

--- a/tools/shock2-sdk/test/trap-message.e2e.test.ts
+++ b/tools/shock2-sdk/test/trap-message.e2e.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for TrapMessage (GitHub #1029).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: `trapmessage` was a no-op script and `P$UseMsg` was not even
+// parsed, so pressing eng2's broken lift buttons told the player nothing.
+//
+// eng2 wiring (stable mission object ids, reported as `template_id`):
+//   Elevator buttons 445/446/447 -> SwitchLink -> Message Trap 689
+//   Message Trap 689: P$UseMsg "OutOfOrder" -> USEMSG.STR
+// Runtime entity ids are not stable across runs, so the trap is discovered by
+// mission object id each launch.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const MESSAGE_TRAP = 689;
+const EXPECTED = "This lift has been taken offline for repairs.";
+
+test(
+  "eng2: the broken lift's message trap puts its UseMsg text on the HUD",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "eng2.mis" });
+    await game.step({ frames: 10 });
+
+    // Nothing has fired yet, so the message channel is empty.
+    assert.deepEqual((await game.ui.state()).messages, []);
+
+    const found = await game.entities.byTemplate(MESSAGE_TRAP);
+    assert.equal(
+      found.length,
+      1,
+      `expected exactly one eng2 Message Trap ${MESSAGE_TRAP}, got ${found.length}`,
+    );
+
+    // The buttons switch-link into the trap; TurnOn is what they send.
+    await game.entities.sendMessage(found[0].id, { type: "TurnOn" });
+    await game.step({ frames: 10 });
+
+    assert.deepEqual(
+      (await game.ui.state()).messages,
+      [EXPECTED],
+      "the trap's P$UseMsg key should resolve against USEMSG.STR",
+    );
+
+    // The line expires five seconds after it was shown.
+    await game.step({ frames: 4 * 60 });
+    assert.deepEqual(
+      (await game.ui.state()).messages,
+      [EXPECTED],
+      "the message should still be up four seconds in",
+    );
+    await game.step({ frames: 2 * 60 });
+    assert.deepEqual(
+      (await game.ui.state()).messages,
+      [],
+      "the message should clear after its five-second window",
+    );
+  },
+);


### PR DESCRIPTION
`trapmessage` was a `NoopScript` ("What prop for message? Where to load string?"), so eng2's broken lift buttons told the player nothing. This parses `P$UseMsg`, implements the script, and gives the port the HUD status-message line the original writes those strings to.

Fixes #1029

## What the original does

**The trap.** A message trap carries no output of its own - in eng2 the three cargo-lift buttons switch-link into it and it has no outgoing links. Firing it puts one line of text on the HUD's status-message channel; a switch-off shows nothing and there is nothing to forward. So: `TurnOn` -> message, everything else -> no effect.

**The text.** The source is the per-entity string property `P$UseMsg`, laid out like the other string properties (an ignored u32, then the NUL-terminated string). It is resolved the way every other object string is: split at the colon into a lookup key and the quoted text the value carries, look the key up in the matching string table (`res/strings/USEMSG.STR`), and fall back to the inline quoted text when the key misses. Both forms occur in eng2 - three entities carry a bare key (`OutOfOrder`, `Comp_Online`, `Botcoming`), while entity 393 has the whole STR line pasted in as the value. The port already has exactly this resolver (`resolve_localized_property_string`), so both cases fall out for free; a value that resolves to nothing (USEMSG.STR has several empty entries) shows nothing.

**Where it is shown.** A status-message channel drawn as a stack of up to **six** lines starting near the top-left of the 640x480 HUD (the block sits right of the inventory column, wrapped to 446 px, mono HUD font, green), each line expiring **five seconds** after it was added; a seventh line scrolls the oldest one off. Messages therefore **queue, they do not replace**. The channel is general: the same line carries pickup ("picked up X") and locked-door messages, XP awards, "inventory full", nanite/research/hacking feedback, the elevator's "blocked" notice, and the frob-time `P$UseMsg` text of an object the player uses directly. This PR ports only what `TrapMessage` needs - one shared timed line stack - and leaves rewiring those other systems onto it as follow-ups.

**Naming.** The chunk is `P$UseMsg` (confirmed against eng2: `cargo dq entities eng2.mis 689` now prints `PropUseMsg("OutOfOrder")` and lists no unparsed properties). `P$UsgMsg` does not exist.

## What this adds

- `dark`: `PropUseMsg`, parsed as a variable-length string like `P$ObjName`/`P$ObjShort`.
- `shock2vr/src/scripts/trap_message.rs`: pure script - reads `P$UseMsg` plus a preloaded `UseMessageStrings` (USEMSG.STR, held as a world `Unique` because scripts have no `AssetCache`), returns `Effect::ShowMessage`.
- `shock2vr/src/hud/message_line.rs`: the shared message line - `HudMessages` (six lines, five seconds each, oldest scrolls off, expiry pruned on read like `DamageFlash`) plus one layout in canvas pixels. Flat emits it into the HUD canvas at the original's block origin; VR draws **the same canvas** on a small head-locked panel above the gaze (the one thing the VR presenter decides is where to hang the block - a screen-top line has no world position). Runtime-only state: a message mid-display does not survive save/load.
- `GET /v1/ui` gains `messages` (+ SDK type) so tests can assert on the line.

## Verification

- `cargo test -p shock2vr --lib -p dark --lib` - new unit tests: the `P$UseMsg` chunk round-trip, key-vs-pasted-literal resolution, TurnOn/TurnOff script effects, the six-line scroll-off, and that flat's canvas gains one text element per line at the shared origin.
- `tools/shock2-sdk/test/trap-message.e2e.test.ts`: eng2, discovers the Message Trap by mission object id, injects `TurnOn`, asserts the HUD shows *"This lift has been taken offline for repairs."* and that it clears after five seconds.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query`, `cargo fmt`.

## Leftovers

- The other retail users of this channel (pickups, locked messages, XP, inventory-full, nanites, research, the direct-frob `P$UseMsg` text) still print nothing - each is its own small change onto `Effect::ShowMessage`.
- No line wrapping yet (the original wraps at 446 px) and no per-line colour (the canvas text API has no tint); the eng2 messages fit on one line.
- Where narration subtitles (#1026) and the debrief screen (#1030) land, their head-anchored text and this message line should converge on one presenter rather than two.
- `earthtext` remains a no-op: its entity carries no text property, so its string is not recoverable from the mission data.


## Visuals

![Message Trap HUD text demo (flat)](https://gist.githubusercontent.com/tommy-xr/14d701e7d7d088b50eb7a7b159a2c544/raw/demo.gif)

<sub>Flat presentation: triggering the Message Trap (eng2, entity 689) pushes its `P$UseMsg` text onto the HUD status line for 5 seconds. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| Flat | VR |
| --- | --- |
| ![Flat still](https://gist.githubusercontent.com/tommy-xr/14d701e7d7d088b50eb7a7b159a2c544/raw/flat_still.png) | ![VR still](https://gist.githubusercontent.com/tommy-xr/14d701e7d7d088b50eb7a7b159a2c544/raw/vr_still.png) |
| Screen-space HUD canvas, block origin (192,18) | Same canvas on the head-locked panel above the gaze |
