### PR TITLE
feat(ai): push apart from the neighbour crowding the doorway

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -690,6 +690,9 @@ pub struct CrowdRepel {
     pub full: f32,
     /// At or beyond this distance there is no push at all
     pub none: f32,
+    /// Overall multiplier, so a caller can fade the whole term in and out
+    /// smoothly (see the melee suppression in the path-follow strategy)
+    pub strength: f32,
 }
 
 /// Repel strength for one neighbour: 0 at (or beyond) `none`, 1 at (or
@@ -717,8 +720,10 @@ pub fn repel_ramp(distance: f32, full: f32, none: f32) -> f32 {
 ///   `separation_radius`, which keeps a group's lines from converging; and
 /// - `repel` (optional), the near-field push modelled on the original
 ///   engine's object regulator, which is what actually stops bodies from
-///   stacking up in a doorway. The chase target (the player) is never
-///   repelled from - closing on the target is the point.
+///   stacking up in a doorway.
+///
+/// The player is not a creature body (no `PropCreature`), so nothing here
+/// ever pushes an AI off its chase target.
 pub fn crowd_bias(
     world: &World,
     entity_id: EntityId,
@@ -729,10 +734,6 @@ pub fn crowd_bias(
     let v_creature = world.borrow::<View<PropCreature>>().unwrap();
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
-    let player = world
-        .borrow::<UniqueView<PlayerInfo>>()
-        .ok()
-        .map(|player| player.entity_id);
     let reach = repel
         .as_ref()
         .map(|repel| separation_radius.max(repel.none))
@@ -760,15 +761,11 @@ pub fn crowd_bias(
         if distance >= reach || distance < 1e-3 {
             continue;
         }
-        let mut weight = if distance < separation_radius {
-            (separation_radius - distance) / separation_radius
-        } else {
-            0.0
-        };
+        // Two ramps with different knees: separation fades in gently from
+        // the whole radius, repel bites hard up close.
+        let mut weight = repel_ramp(distance, 0.0, separation_radius);
         if let Some(repel) = &repel {
-            if Some(other_id) != player {
-                weight += repel_ramp(distance, repel.full, repel.none);
-            }
+            weight += repel.strength * repel_ramp(distance, repel.full, repel.none);
         }
         if weight <= 0.0 {
             continue;
@@ -1261,10 +1258,10 @@ mod separation_tests {
     }
 
     #[test]
-    fn repel_outpushes_separation_up_close_and_spares_the_player() {
+    fn repel_outpushes_separation_up_close() {
         let mut world = World::new();
         let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
-        let neighbor = spawn_creature(&mut world, vec3(1.5, 0.0, 0.0), 10);
+        spawn_creature(&mut world, vec3(1.5, 0.0, 0.0), 10);
 
         let separation_only = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 6.0, None);
         let with_repel = crowd_bias(
@@ -1275,6 +1272,7 @@ mod separation_tests {
             Some(CrowdRepel {
                 full: 1.5,
                 none: 4.5,
+                strength: 1.0,
             }),
         );
         assert!(
@@ -1283,16 +1281,8 @@ mod separation_tests {
              than separation alone: {with_repel:?} vs {separation_only:?}"
         );
 
-        // ...but not when that neighbor is the chase target
-        world.add_unique(PlayerInfo {
-            pos: vec3(1.5, 0.0, 0.0),
-            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            entity_id: neighbor,
-            left_hand_entity_id: None,
-            right_hand_entity_id: None,
-            inventory_entity_id: neighbor,
-        });
-        let spared = crowd_bias(
+        // ...and a faded-out repel is exactly the separation bias again
+        let faded = crowd_bias(
             &world,
             me,
             vec3(0.0, 0.0, 0.0),
@@ -1300,11 +1290,12 @@ mod separation_tests {
             Some(CrowdRepel {
                 full: 1.5,
                 none: 4.5,
+                strength: 0.0,
             }),
         );
         assert!(
-            (spared.x - separation_only.x).abs() < 1e-6,
-            "the player is never repelled from: {spared:?} vs {separation_only:?}"
+            (faded.x - separation_only.x).abs() < 1e-6,
+            "{faded:?} vs {separation_only:?}"
         );
     }
 

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -682,22 +682,61 @@ pub fn hit_points(entity_id: EntityId, world: &World) -> Option<i32> {
     v_prop_hit_points.get(entity_id).ok().map(|p| p.hit_points)
 }
 
-/// Horizontal crowd-separation bias: the sum of repulsions from other
-/// LIVING creatures within `radius` of `position` (same floor), each
-/// weighted by proximity. Returns a direction-and-magnitude vector in the
-/// XZ plane; empty crowd = zero. Callers blend a capped amount of this
-/// into their steering target so converging AIs bend around each other
-/// instead of pushing capsule-to-capsule into a gridlock (issue #487) -
-/// it must BIAS the route, never veto it (see collision avoidance history).
-pub fn separation_bias(
+/// AI-to-AI repel, the near-field half of `crowd_bias`: how hard one
+/// neighbour pushes, ramping from nothing at `none` to a full push at
+/// `full`.
+pub struct CrowdRepel {
+    /// At or inside this distance the push is at full strength
+    pub full: f32,
+    /// At or beyond this distance there is no push at all
+    pub none: f32,
+}
+
+/// Repel strength for one neighbour: 0 at (or beyond) `none`, 1 at (or
+/// inside) `full`, linear in between.
+pub fn repel_ramp(distance: f32, full: f32, none: f32) -> f32 {
+    if distance >= none {
+        0.0
+    } else if distance <= full {
+        1.0
+    } else {
+        (none - distance) / (none - full)
+    }
+}
+
+/// Horizontal crowd bias: the sum of repulsions from other LIVING
+/// creatures near `position` (same floor). Returns a direction-and-
+/// magnitude vector in the XZ plane; empty crowd = zero. Callers blend a
+/// capped amount of this into their steering target so converging AIs bend
+/// around each other instead of pushing capsule-to-capsule into a gridlock
+/// (issue #487) - it must BIAS the route, never veto it (see collision
+/// avoidance history).
+///
+/// Two terms over one neighbour walk:
+/// - crowd separation, a mild proximity-weighted push over the whole
+///   `separation_radius`, which keeps a group's lines from converging; and
+/// - `repel` (optional), the near-field push modelled on the original
+///   engine's object regulator, which is what actually stops bodies from
+///   stacking up in a doorway. The chase target (the player) is never
+///   repelled from - closing on the target is the point.
+pub fn crowd_bias(
     world: &World,
     entity_id: EntityId,
     position: Vector3<f32>,
-    radius: f32,
+    separation_radius: f32,
+    repel: Option<CrowdRepel>,
 ) -> Vector3<f32> {
     let v_creature = world.borrow::<View<PropCreature>>().unwrap();
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
+    let player = world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .ok()
+        .map(|player| player.entity_id);
+    let reach = repel
+        .as_ref()
+        .map(|repel| separation_radius.max(repel.none))
+        .unwrap_or(separation_radius);
     let mut bias = vec3(0.0, 0.0, 0.0);
     for (other_id, (_, xform)) in (&v_creature, &v_transform).iter().with_id() {
         if other_id == entity_id {
@@ -718,10 +757,22 @@ pub fn separation_bias(
         let dx = position.x - other.x;
         let dz = position.z - other.z;
         let distance = (dx * dx + dz * dz).sqrt();
-        if distance >= radius || distance < 1e-3 {
+        if distance >= reach || distance < 1e-3 {
             continue;
         }
-        let weight = (radius - distance) / radius;
+        let mut weight = if distance < separation_radius {
+            (separation_radius - distance) / separation_radius
+        } else {
+            0.0
+        };
+        if let Some(repel) = &repel {
+            if Some(other_id) != player {
+                weight += repel_ramp(distance, repel.full, repel.none);
+            }
+        }
+        if weight <= 0.0 {
+            continue;
+        }
         bias += vec3(dx / distance, 0.0, dz / distance) * weight;
     }
     bias
@@ -1173,7 +1224,7 @@ mod separation_tests {
         let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
 
-        let bias = separation_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
         assert!(
             bias.x < -0.1,
             "neighbor at +x must push toward -x: {bias:?}"
@@ -1190,10 +1241,70 @@ mod separation_tests {
         spawn_creature(&mut world, vec3(10.0, 0.0, 0.0), 10); // out of radius
         spawn_creature(&mut world, vec3(1.0, 5.0, 0.0), 10); // floor above
 
-        let bias = separation_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
         assert!(
             bias.magnitude() < 1e-6,
             "corpses, far and stacked-floor creatures must not repel: {bias:?}"
+        );
+    }
+
+    #[test]
+    fn repel_ramps_from_nothing_at_reach_to_full_up_close() {
+        assert_eq!(repel_ramp(4.5, 1.5, 4.5), 0.0, "no push at the reach");
+        assert_eq!(repel_ramp(9.0, 1.5, 4.5), 0.0, "none beyond it either");
+        assert_eq!(repel_ramp(1.5, 1.5, 4.5), 1.0, "full push at the near end");
+        assert_eq!(repel_ramp(0.1, 1.5, 4.5), 1.0, "and no more than full");
+        assert!(
+            (repel_ramp(3.0, 1.5, 4.5) - 0.5).abs() < 1e-6,
+            "linear in between"
+        );
+    }
+
+    #[test]
+    fn repel_outpushes_separation_up_close_and_spares_the_player() {
+        let mut world = World::new();
+        let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
+        let neighbor = spawn_creature(&mut world, vec3(1.5, 0.0, 0.0), 10);
+
+        let separation_only = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 6.0, None);
+        let with_repel = crowd_bias(
+            &world,
+            me,
+            vec3(0.0, 0.0, 0.0),
+            6.0,
+            Some(CrowdRepel {
+                full: 1.5,
+                none: 4.5,
+            }),
+        );
+        assert!(
+            with_repel.x < separation_only.x - 0.5,
+            "a neighbor inside the full-push distance must push much harder \
+             than separation alone: {with_repel:?} vs {separation_only:?}"
+        );
+
+        // ...but not when that neighbor is the chase target
+        world.add_unique(PlayerInfo {
+            pos: vec3(1.5, 0.0, 0.0),
+            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: neighbor,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: neighbor,
+        });
+        let spared = crowd_bias(
+            &world,
+            me,
+            vec3(0.0, 0.0, 0.0),
+            6.0,
+            Some(CrowdRepel {
+                full: 1.5,
+                none: 4.5,
+            }),
+        );
+        assert!(
+            (spared.x - separation_only.x).abs() < 1e-6,
+            "the player is never repelled from: {spared:?} vs {separation_only:?}"
         );
     }
 
@@ -1204,7 +1315,7 @@ mod separation_tests {
         spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(-1.0, 0.0, 0.0), 10);
 
-        let bias = separation_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
         assert!(
             bias.x.abs() < 1e-6,
             "symmetric neighbors cancel on x: {bias:?}"

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -100,6 +100,13 @@ const SEPARATION_RADIUS: f32 = 6.0 / SCALE_FACTOR;
 /// steer an AI backwards, it just bows its line around the neighbors
 /// (issue #487).
 const SEPARATION_MAX_OFFSET: f32 = 3.0 / SCALE_FACTOR;
+/// AI-to-AI repel (the original engine's object regulator): a neighbour
+/// this close pushes back, ramping from nothing here...
+const REPEL_RADIUS: f32 = 4.5 / SCALE_FACTOR;
+/// ...to a full push at this distance. Far stronger near-field than crowd
+/// separation, which fades linearly over six feet and so barely registers
+/// at the range where bodies actually stack up (a doorway).
+const REPEL_FULL_DISTANCE: f32 = 1.5 / SCALE_FACTOR;
 
 /// A partial route counts as reaching its goal anyway when its last waypoint
 /// lands within this distance (6 Dark feet). A* answers an unreachable goal
@@ -427,12 +434,23 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // No route (or none yet) - let the next strategy in the chain steer
         let waypoint = *self.path.get(self.next_waypoint)?;
 
-        // Crowd separation: bend the aim point away from nearby living
-        // creatures so converging AIs pass around each other instead of
-        // pushing capsule-to-capsule into a gridlock. The waypoint (and the
-        // path) stay authoritative - the bias is capped well below the
-        // waypoint spacing.
-        let separation = ai_util::separation_bias(world, entity_id, position, SEPARATION_RADIUS);
+        // Crowd bias: bend the aim point away from nearby living creatures
+        // so converging AIs pass around each other instead of pushing
+        // capsule-to-capsule into a gridlock. The waypoint (and the path)
+        // stay authoritative - the bias is capped well below the waypoint
+        // spacing.
+        //
+        // The near-field repel is suppressed once we are inside melee reach
+        // of the chase target: an attacker closing on the player is not
+        // crowding, and pushing it off the target would cost it the blow.
+        let repel = ai_util::chase_target_distance(world, entity_id)
+            .map(|distance| distance >= ai_util::MELEE_ATTACK_RANGE)
+            .unwrap_or(true)
+            .then_some(ai_util::CrowdRepel {
+                full: REPEL_FULL_DISTANCE,
+                none: REPEL_RADIUS,
+            });
+        let crowd = ai_util::crowd_bias(world, entity_id, position, SEPARATION_RADIUS, repel);
         // ...and the same treatment for static geometry the navigation mesh
         // doesn't model (a railing, a crate left on the route): whiskers bend
         // the line around it before the body wedges, without ever taking the
@@ -443,7 +461,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         let aim = aim_with_bias(
             position,
             waypoint,
-            capped(separation + whiskers, SEPARATION_MAX_OFFSET),
+            capped(crowd + whiskers, SEPARATION_MAX_OFFSET),
         );
 
         // Stall escape: if we stop making progress toward the current
@@ -1025,6 +1043,16 @@ mod tests {
 
     #[test]
     fn biases_are_capped_together() {
+        // Crowd separation, near-field repel and whiskers all sum into one
+        // offset that is shortened once - three pushes the same way still
+        // bend the line no further than one may.
+        let shortened = capped(
+            vec3(1.0, 0.0, 0.0) + vec3(2.0, 0.0, 0.0) + vec3(0.0, 0.0, 4.0),
+            2.5,
+        );
+        assert!(
+            ((shortened.x * shortened.x + shortened.z * shortened.z).sqrt() - 2.5).abs() < 1e-5
+        );
         let shortened = capped(vec3(3.0, 0.0, 4.0), 2.5);
         assert!(
             ((shortened.x * shortened.x + shortened.z * shortened.z).sqrt() - 2.5).abs() < 1e-5

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -2,7 +2,7 @@ use cgmath::{Deg, EuclideanSpace, Vector3, vec4};
 use dark::SCALE_FACTOR;
 use dark::mission::path_database::MovementBits;
 use rand::Rng;
-use shipyard::{EntityId, UniqueView, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
     mission::{GlobalAsyncPathfinding, GlobalPathfinding},
@@ -103,10 +103,16 @@ const SEPARATION_MAX_OFFSET: f32 = 3.0 / SCALE_FACTOR;
 /// AI-to-AI repel (the original engine's object regulator): a neighbour
 /// this close pushes back, ramping from nothing here...
 const REPEL_RADIUS: f32 = 4.5 / SCALE_FACTOR;
-/// ...to a full push at this distance. Far stronger near-field than crowd
-/// separation, which fades linearly over six feet and so barely registers
-/// at the range where bodies actually stack up (a doorway).
+/// ...to a full push at this distance. Crowd separation is not steep
+/// enough near contact to unstack bodies - it fades linearly over its
+/// whole six feet, so between two AIs already shoulder to shoulder it
+/// barely changes as they close the last foot. This term does.
 const REPEL_FULL_DISTANCE: f32 = 1.5 / SCALE_FACTOR;
+/// The repel fades out as an AI closes on its target - off at
+/// `MELEE_ATTACK_RANGE`, full again by this distance. A hard switch would
+/// step the aim point sideways by the whole offset budget in the frame the
+/// target drifted across the boundary.
+const REPEL_MELEE_FADE_DISTANCE: f32 = 12.0 / SCALE_FACTOR;
 
 /// A partial route counts as reaching its goal anyway when its last waypoint
 /// lands within this distance (6 Dark feet). A* answers an unreachable goal
@@ -440,16 +446,28 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // stay authoritative - the bias is capped well below the waypoint
         // spacing.
         //
-        // The near-field repel is suppressed once we are inside melee reach
-        // of the chase target: an attacker closing on the player is not
-        // crowding, and pushing it off the target would cost it the blow.
-        let repel = ai_util::chase_target_distance(world, entity_id)
-            .map(|distance| distance >= ai_util::MELEE_ATTACK_RANGE)
-            .unwrap_or(true)
-            .then_some(ai_util::CrowdRepel {
-                full: REPEL_FULL_DISTANCE,
-                none: REPEL_RADIUS,
-            });
+        // The near-field repel fades out as we close on the chase target:
+        // an attacker in reach of the player is not crowding, and pushing
+        // it off the target would cost it the blow.
+        // Only an AI that actually HAS a target fades: `chase_target`
+        // answers with the player's true position for one that has never
+        // seen them, and a patrol passing a wall away from the player must
+        // still repel.
+        let strength = match target_awareness_distance(world, entity_id, position) {
+            Some(distance) => {
+                1.0 - ai_util::repel_ramp(
+                    distance,
+                    ai_util::MELEE_ATTACK_RANGE,
+                    REPEL_MELEE_FADE_DISTANCE,
+                )
+            }
+            None => 1.0,
+        };
+        let repel = (strength > 0.0).then_some(ai_util::CrowdRepel {
+            full: REPEL_FULL_DISTANCE,
+            none: REPEL_RADIUS,
+            strength,
+        });
         let crowd = ai_util::crowd_bias(world, entity_id, position, SEPARATION_RADIUS, repel);
         // ...and the same treatment for static geometry the navigation mesh
         // doesn't model (a railing, a crate left on the route): whiskers bend
@@ -461,7 +479,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         let aim = aim_with_bias(
             position,
             waypoint,
-            capped(crowd + whiskers, SEPARATION_MAX_OFFSET),
+            blend_biases(crowd, whiskers, SEPARATION_MAX_OFFSET),
         );
 
         // Stall escape: if we stop making progress toward the current
@@ -721,6 +739,33 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
             Effect::DrawDebugLines { lines },
         ))
     }
+}
+
+/// How far the AI's believed target is, or None when it has no target at
+/// all (nothing has ever published awareness for it).
+fn target_awareness_distance(
+    world: &World,
+    entity_id: EntityId,
+    position: Vector3<f32>,
+) -> Option<f32> {
+    let v_awareness = world
+        .borrow::<View<crate::runtime_props::RuntimePropAITargetAwareness>>()
+        .ok()?;
+    let awareness = v_awareness.get(entity_id).ok()?;
+    Some(xz_distance(position, awareness.last_known_pos))
+}
+
+/// Combine the crowd bias with the whisker bias into one aim offset.
+///
+/// The crowd term is a sum of per-neighbour weights with no bound of its
+/// own, so it is shortened to the offset budget BEFORE the sum: otherwise
+/// a dense crowd - or simply a stronger repel term - buys magnitude out of
+/// the whiskers' share and bends the line into the very geometry the
+/// whiskers are there to avoid. The blend is then shortened once, so two
+/// biases pointing the same way still cannot bend the line further than
+/// one of them may.
+fn blend_biases(crowd: Vector3<f32>, whiskers: Vector3<f32>, max: f32) -> Vector3<f32> {
+    capped(capped(crowd, max) + whiskers, max)
 }
 
 /// Shorten a horizontal bias to at most `max`.
@@ -1042,17 +1087,26 @@ mod tests {
     }
 
     #[test]
-    fn biases_are_capped_together() {
-        // Crowd separation, near-field repel and whiskers all sum into one
-        // offset that is shortened once - three pushes the same way still
-        // bend the line no further than one may.
-        let shortened = capped(
-            vec3(1.0, 0.0, 0.0) + vec3(2.0, 0.0, 0.0) + vec3(0.0, 0.0, 4.0),
-            2.5,
-        );
+    fn a_crowd_cannot_outbid_the_whiskers() {
+        // A huge crowd push (many neighbors, or a saturated repel) plus a
+        // whisker push at right angles: the crowd is shortened to the
+        // budget first, so the geometry it is steering around keeps half
+        // the blend instead of being rounded away.
+        let blended = blend_biases(vec3(100.0, 0.0, 0.0), vec3(0.0, 0.0, 2.5), 2.5);
         assert!(
-            ((shortened.x * shortened.x + shortened.z * shortened.z).sqrt() - 2.5).abs() < 1e-5
+            (blended.z - blended.x).abs() < 1e-4,
+            "an unbounded crowd must not outweigh the whiskers: {blended:?}"
         );
+        // ...and the blend is still shortened once, to the budget
+        let magnitude = (blended.x * blended.x + blended.z * blended.z).sqrt();
+        assert!((magnitude - 2.5).abs() < 1e-4, "got {magnitude}");
+        // A crowd on its own is capped like any other bias
+        let alone = blend_biases(vec3(100.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), 2.5);
+        assert!((alone.x - 2.5).abs() < 1e-4, "got {alone:?}");
+    }
+
+    #[test]
+    fn biases_are_capped_together() {
         let shortened = capped(vec3(3.0, 0.0, 4.0), 2.5);
         assert!(
             ((shortened.x * shortened.x + shortened.z * shortened.z).sqrt() - 2.5).abs() < 1e-5


### PR DESCRIPTION
Crowd separation is not steep enough near contact to unstack bodies — it fades linearly over its whole six feet, so between two AIs already shoulder to shoulder it barely changes as they close the last foot. The medsci1 chase pass wedges hybrids halting just outside melee reach *behind each other*, and in medsci2 three of them piled into one Science-wing doorway.

This adds the near-field repel the original engine's object regulator applies — nothing at 4.5 feet, ramping to a full push at 1.5 — as an aim-point bias beside the existing separation bias. It shares separation's neighbour walk, and the route stays authoritative: the crowd term is shortened to the offset budget and the blend with the whisker bias is capped once (#1248's treatment), so a crowd can bow an AI's line but never veto it, and never at the whiskers' expense.

Closing on the target is the point, so the repel fades out as the AI closes: off inside `MELEE_ATTACK_RANGE` of its believed target, full again by 12 feet — and only for an AI that actually has a target, so a patrol standing near the player through a wall keeps its repel. (The player itself carries no `PropCreature`, so it is never in the neighbour walk to begin with.)

Ledger step 8 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

## Before / after

Reachability harness (PR #1242, `--pass chase`), three runs per branch, base = `fix/ai-stall-reroute`:

| mission | metric | before (3 runs) | after (3 runs) |
|---|---|---|---|
| medsci1.mis | **wedged** | 7 / 7 / 7 | **6 / 4 / 6** |
| medsci1.mis | **arrived** | 4 / 2 / 2 | **4 / 4 / 4** |
| medsci2.mis | wedged | 0 / 0 / 0 | 0 / 0 / 0 |
| medsci2.mis | arrived | 2 / 2 / 2 | 3 / 2 / 2 |
| medsci2.mis | progressing | 8 / 8 / 8 | 7 / 8 / 8 |

medsci1 chase wedges drop (mean 7.0 -> 5.3) while arrivals rise (2.7 -> 4.0); medsci2 is unchanged-or-better. Nothing regresses.


## Media

![doorway before/after](https://gist.githubusercontent.com/tommy-xr/5a5f114ecf526bf6445a86a99a4a86bf/raw/repel-doorway.gif)

<sub>medsci2 Science-wing security door, `DebugForceChase` from spawn, free camera on the jamb — same deterministic request sequence on both branches (`/v1/step` + `/v1/screenshot`, fixed timestep). Only one hybrid reaches this jamb in the deterministic run, so the visible delta here is small by construction: the repel term does nothing without a neighbour. The measurable effect is the medsci1 chase table above, where AIs do converge on each other.</sub>

![still](https://gist.githubusercontent.com/tommy-xr/5a5f114ecf526bf6445a86a99a4a86bf/raw/repel-doorway-t2.png)

## Tests

- Unit: `repel_ramps_from_nothing_at_reach_to_full_up_close` (the ramp), `repel_outpushes_separation_up_close` (near-field dominance, and a faded-out repel is exactly the old separation bias), `a_crowd_cannot_outbid_the_whiskers` (the blend).
- `cargo test -p shock2vr`: 1232 passed.
- e2e: `force-chase` 1/1, `patrol` 4/4, `ally-line-of-fire` 1/1, `medsci2-doorjamb-chase` 1/1, `medsci2-patrol-railing` **4/4**, `missions` 23/23.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Review

`/xreview` (Claude adversarial reviewer + a dedicated de-dup reviewer; the Codex engine is unavailable this week, so this ran single-engine plus de-dup). Fixed:

- **High** - the crowd bias is an unbounded sum of per-neighbour weights while the whisker bias arrives already capped in world units; summed and capped once, a strong crowd rounded the static-geometry avoidance away. The crowd is now shortened to the offset budget first (`blend_biases`), then the blend is capped once as before.
- **Medium** - the melee suppression was a hard on/off whose radius (8 ft) exceeds the whole repel radius (4.5 ft), stepping the aim point by the full budget as the target crossed it. It is now a fade (off at melee reach, full by 12 ft).
- **Medium** - the fade keyed on `chase_target`, which falls back to the player's *true* position for an AI that has never seen them, so a patrol standing near the player through a wall lost its repel. It now keys on published target awareness.
- **Medium** - the "never repel the player" guard was dead code (the player entity carries no `PropCreature`, so it is never in the neighbour walk) and its test fabricated an impossible world. Both removed; the doc says why no exclusion is needed.
- **Low** - reworded a factually wrong comment about separation's near-field strength, and replaced a cap assertion that duplicated the line below it.

Not taken: a deterministic tie-break for exactly co-located creatures (pre-existing blind spot of the neighbour walk, unrelated to this term), and hoisting the whisker module's own proximity falloff into a shared helper (a different file, out of scope here).
