### PR TITLE
feat(debug): debug_psi pen and full stats

### DIFF
--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -15,12 +15,12 @@ use engine::{
         light::SpotLight,
     },
 };
-use rapier3d::prelude::{Collider, ColliderBuilder};
+use rapier3d::prelude::{Collider, ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
 use crate::{
     GameOptions,
-    game_scene::GameScene,
+    game_scene::{DebugPlayerStatsRequest, DebugSkillLevelsRequest, DebuggableScene, GameScene},
     input_context::InputContext,
     mission::{
         AbstractMission, AlwaysVisible, GlobalContext, SpawnLocation,
@@ -29,9 +29,68 @@ use crate::{
     },
     quest_info::QuestInfo,
     save_load::HeldItemSaveData,
-    scripts::{Effect, GlobalEffect},
+    scripts::{
+        Effect, GlobalEffect,
+        gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP},
+    },
     time::Time,
 };
+
+/// A box of debug geometry: (color, center, size) in world units.
+pub type DebugBox = (Vector3<f32>, Vector3<f32>, Vector3<f32>);
+
+/// Visuals plus one compound collider for a list of boxes. Every piece is a
+/// (visual, collider) pair built from the same box so the two cannot drift:
+/// the unit cube spans [-0.5, 0.5], so a size is twice the collider
+/// half-extent.
+pub fn boxes_to_geometry(boxes: &[DebugBox]) -> (Vec<SceneObject>, Collider) {
+    let scene_objects = boxes
+        .iter()
+        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
+        .collect();
+    let collider = ColliderBuilder::compound(
+        boxes
+            .iter()
+            .map(|(_, translation, scale)| {
+                (
+                    Isometry::translation(translation.x, translation.y, translation.z),
+                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
+                )
+            })
+            .collect(),
+    )
+    .build();
+    (scene_objects, collider)
+}
+
+/// Max the character sheet (every stat, skill and psi tier at cap) through
+/// the same provisioning path as `POST /v1/player/stats`, so no skill gate
+/// stands between a tester and the scene's content. `scene` tags the warning.
+pub fn max_player_stats(core: &mut MissionCore, scene: &str) {
+    let request = DebugPlayerStatsRequest {
+        strength: Some(STAT_CAP),
+        endurance: Some(STAT_CAP),
+        agility: Some(STAT_CAP),
+        psionic_ability: Some(STAT_CAP),
+        cyber_affinity: Some(STAT_CAP),
+        skills: DebugSkillLevelsRequest {
+            standard_weapons: Some(SKILL_CAP),
+            energy_weapons: Some(SKILL_CAP),
+            heavy_weapons: Some(SKILL_CAP),
+            exotic_weapons: Some(SKILL_CAP),
+            hack: Some(SKILL_CAP),
+            repair: Some(SKILL_CAP),
+            modify: Some(SKILL_CAP),
+            maintenance: Some(SKILL_CAP),
+            research: Some(SKILL_CAP),
+        },
+        psi_tier: Some(PSI_TIER_CAP),
+        cyber_modules: None,
+    };
+    if let Err(err) = core.set_player_stats(&request) {
+        tracing::warn!("[{scene}] failed to max player stats: {err}");
+    }
+}
 
 /// Convenience builder for MissionCore-backed debug scenes that only need a floor and spawn point.
 pub struct DebugSceneBuilder {

--- a/shock2vr/src/scenes/debug_melee.rs
+++ b/shock2vr/src/scenes/debug_melee.rs
@@ -20,9 +20,8 @@
 //! between them is the calibration error, and it is only visible with both on
 //! screen at once.
 
-use cgmath::{Deg, Point3, Quaternion, Rotation3, Vector3, vec3};
+use cgmath::{Deg, Point3, Quaternion, Rotation3, vec3};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
-use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
 use crate::{
@@ -30,8 +29,8 @@ use crate::{
     game_scene::GameScene,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene, cube_object,
-        spawn_at,
+        DebugBox, DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+        boxes_to_geometry, spawn_at,
     },
     scripts::Effect,
 };
@@ -92,10 +91,7 @@ pub fn create_debug_melee_scene(
     dev_params::set(dev_params::MELEE_GLOVE_OVERLAY, 1.0);
     dev_params::set(dev_params::MELEE_VOLUMES, 1.0);
 
-    // The unit cube spans [-0.5, 0.5], so a nonuniform scale is twice the
-    // matching collider half-extent. Every piece is a (visual, collider) pair
-    // built from one box so the two cannot drift.
-    let mut boxes: Vec<(Vector3<f32>, Vector3<f32>, Vector3<f32>)> = vec![
+    let boxes: &[DebugBox] = &[
         // floor
         (
             vec3(0.18, 0.18, 0.22),
@@ -134,22 +130,7 @@ pub fn create_debug_melee_scene(
         ),
     ];
 
-    let scene_objects = boxes
-        .iter()
-        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
-        .collect::<Vec<_>>();
-    let collider = ColliderBuilder::compound(
-        boxes
-            .drain(..)
-            .map(|(_, translation, scale)| {
-                (
-                    Isometry::translation(translation.x, translation.y, translation.z),
-                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
-                )
-            })
-            .collect(),
-    )
-    .build();
+    let (scene_objects, collider) = boxes_to_geometry(boxes);
 
     // Laid out along -X, the default view forward with an identity spawn yaw
     // in both presentations (same convention as `debug_weapons`). Verified by

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -1,33 +1,61 @@
 //! Debug scene for psi amp / psi power work.
 //!
-//! The player spawns holding the psi amp on a floor facing a flat wall (same
-//! layout as `debug_weapons`), so each power's cast can be observed in
-//! isolation. Select a power with `CyclePsiPower` (`Y` on desktop /
+//! The player spawns holding the psi amp with a full psi pool and a maxed
+//! character sheet, facing a walled pen of creatures straight ahead with a
+//! flat wall behind it. Select a power with `CyclePsiPower` (`Y` on desktop /
 //! `POST /v1/input/action {"action":"CyclePsiPower"}`) and fire; projectile
-//! powers (Cryokinesis, Pyrokinesis, ...) land on the wall, and the psi bar
-//! on the HUD drains by the power's tier per cast.
+//! powers (Cryokinesis, Pyrokinesis, ...) hit the creatures or the wall, the
+//! pen keeps the targets at range so offensive powers can be measured against
+//! a live creature, and the psi bar on the HUD drains by the power's tier per
+//! cast.
 
-use cgmath::{Deg, Quaternion, Rotation3, vec3};
+use cgmath::{Deg, Point3, Quaternion, Rotation3, vec3};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
-use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
-use shipyard::EntityId;
+use shipyard::{EntityId, Get, UniqueView, ViewMut};
 
 use crate::{
     GameOptions,
     game_scene::GameScene,
-    mission::{GlobalContext, SpawnLocation},
+    mission::{
+        GlobalContext, SpawnLocation,
+        mission_core::{MissionCore, PlayerInfo},
+    },
+    scripts::Effect,
 };
 
 use super::debug_common::{
-    AutoEquipHooks, DebugSceneBuildOptions, DebugSceneBuilder, HookedDebugScene, cube_object,
+    AutoEquipHooks, DebugBox, DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks,
+    boxes_to_geometry, max_player_stats, spawn_at,
 };
 
 /// The Psi Amp player weapon.
 const PSI_AMP_TEMPLATE_ID: i32 = -247;
 
-/// Distance (world units) from the player to the test wall, straight ahead
-/// (-X, the default-view forward).
-const WALL_DISTANCE: f32 = 12.0;
+/// The penned creature: -397 = grunt og-pipe (pipe hybrid), the same actor
+/// `debug_melee` and `debug_hitbox` use, so damage/AI observations line up
+/// across scenes.
+const TARGET_CREATURE: i32 = -397;
+
+/// Where the creatures stand inside the pen, as (x, z): world units ahead of
+/// the player along -X, and across the firing line. The near one sits on the
+/// line so a straight cast lands without aiming; the far one is offset so the
+/// near one does not screen it.
+const TARGET_POSITIONS: &[(f32, f32)] = &[(9.0, 0.0), (11.0, 1.8)];
+
+/// The pen: a box closed on all four sides. Debug scenes have no nav mesh, so
+/// a loose creature would walk straight at the player and turn every
+/// measurement into a melee. The wall height is a measurement, not a rule:
+/// 1.2 was verified to hold an alerted pipe hybrid (~3.4 tall, no step over)
+/// while a level cast from the player's eye (~2.3) clears it onto the
+/// creature's torso. Re-check it if `TARGET_CREATURE` changes.
+const PEN_NEAR: f32 = 7.0;
+const PEN_FAR: f32 = 13.0;
+const PEN_HALF_WIDTH: f32 = 3.0;
+const PEN_WALL_HEIGHT: f32 = 1.2;
+
+/// Distance (world units) from the player to the backstop wall, straight
+/// ahead (-X, the default-view forward), behind the pen.
+const WALL_DISTANCE: f32 = 15.0;
 
 pub fn create_debug_psi_scene(
     global_context: &GlobalContext,
@@ -35,53 +63,129 @@ pub fn create_debug_psi_scene(
     asset_cache: &mut AssetCache,
     audio_context: &mut AudioContext<EntityId, String>,
 ) -> Box<dyn GameScene> {
-    // Same controlled environment as debug_weapons: a floor under the player
-    // and a vertical wall straight ahead to catch projectiles.
-    let floor = cube_object(
-        vec3(0.18, 0.18, 0.22),
-        vec3(0.0, -0.5, 0.0),
-        vec3(40.0, 1.0, 40.0),
-    );
-    let wall = cube_object(
-        vec3(0.45, 0.45, 0.5),
-        vec3(-WALL_DISTANCE, 5.0, 0.0),
-        vec3(1.0, 30.0, 30.0),
-    );
-
-    let collider = ColliderBuilder::compound(vec![
+    let pen_wall = vec3(0.55, 0.32, 0.28);
+    let pen_mid_x = -(PEN_NEAR + PEN_FAR) / 2.0;
+    let pen_len = PEN_FAR - PEN_NEAR;
+    let boxes: &[DebugBox] = &[
+        // floor
         (
-            Isometry::translation(0.0, -0.5, 0.0),
-            SharedShape::cuboid(20.0, 0.5, 20.0),
+            vec3(0.18, 0.18, 0.22),
+            vec3(0.0, -0.5, 0.0),
+            vec3(40.0, 1.0, 40.0),
+        ),
+        // backstop wall
+        (
+            vec3(0.45, 0.45, 0.5),
+            vec3(-WALL_DISTANCE, 5.0, 0.0),
+            vec3(1.0, 30.0, 30.0),
+        ),
+        // pen: front and back
+        (
+            pen_wall,
+            vec3(-PEN_NEAR, PEN_WALL_HEIGHT / 2.0, 0.0),
+            vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
         ),
         (
-            Isometry::translation(-WALL_DISTANCE, 5.0, 0.0),
-            SharedShape::cuboid(0.5, 15.0, 15.0),
+            pen_wall,
+            vec3(-PEN_FAR, PEN_WALL_HEIGHT / 2.0, 0.0),
+            vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
         ),
-    ])
-    .build();
+        // pen: sides
+        (
+            pen_wall,
+            vec3(pen_mid_x, PEN_WALL_HEIGHT / 2.0, -PEN_HALF_WIDTH),
+            vec3(pen_len, PEN_WALL_HEIGHT, 1.0),
+        ),
+        (
+            pen_wall,
+            vec3(pen_mid_x, PEN_WALL_HEIGHT / 2.0, PEN_HALF_WIDTH),
+            vec3(pen_len, PEN_WALL_HEIGHT, 1.0),
+        ),
+    ];
+    let (scene_objects, collider) = boxes_to_geometry(boxes);
 
-    let builder = DebugSceneBuilder::new("debug_psi")
+    let mut builder = DebugSceneBuilder::new("debug_psi")
         .with_spawn_location(SpawnLocation::PositionRotation(
             vec3(0.0, 2.0, 0.0),
             Quaternion::from_angle_y(Deg(0.0)),
         ))
-        .with_physics_geometry(collider)
-        .add_scene_object(floor)
-        .add_scene_object(wall);
+        .with_physics_geometry(collider);
+    for scene_object in scene_objects {
+        builder = builder.add_scene_object(scene_object);
+    }
 
-    let core = builder.build_core(DebugSceneBuildOptions {
-        global_context,
-        game_options,
-        asset_cache,
-        audio_context,
-    });
     println!(
-        "[debug_psi] Player is equipped with the Psi Amp.\n\
+        "[debug_psi] Player is equipped with the Psi Amp, psi pool full, every stat at cap.\n\
          Select a power with the `CyclePsiPower` input action (`Y` on desktop),\n\
-         then fire to cast it. Projectile powers land on the wall ahead."
+         then fire to cast it. Two pipe hybrids stand in the pen ahead."
     );
-    Box::new(HookedDebugScene::new(
-        core,
-        AutoEquipHooks::new(PSI_AMP_TEMPLATE_ID),
-    ))
+    builder.build_with_hooks(
+        DebugSceneBuildOptions {
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        },
+        PsiHooks {
+            populated: false,
+            equip: AutoEquipHooks::new(PSI_AMP_TEMPLATE_ID),
+        },
+    )
+}
+
+struct PsiHooks {
+    populated: bool,
+    equip: AutoEquipHooks,
+}
+
+impl DebugSceneHooks for PsiHooks {
+    fn before_handle_effects(
+        &mut self,
+        core: &mut MissionCore,
+        effects: &mut Vec<Effect>,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if !self.populated {
+            self.populated = true;
+
+            // Nothing on the psi cast path reads the character sheet yet
+            // (every power is already known in a debug scene, and the amp's
+            // effective PSI stat is a constant), so this is parity with
+            // `debug_weapons` and future-proofing, not a gate being lifted.
+            max_player_stats(core, "debug_psi");
+            // The psi pool is what actually limits a test session: the player
+            // template seeds it short of its maximum. Start full.
+            core.world.run(
+                |player: UniqueView<PlayerInfo>,
+                 mut psi: ViewMut<dark::properties::PropPsiState>| {
+                    if let Ok(psi) = (&mut psi).get(player.entity_id) {
+                        psi.psi_points = psi.max_psi_points;
+                    }
+                },
+            );
+
+            let spawns = TARGET_POSITIONS
+                .iter()
+                .map(|(x, z)| spawn_at(TARGET_CREATURE, Point3::new(-x, 1.0, *z)))
+                .collect();
+            core.handle_effects(
+                spawns,
+                global_context,
+                game_options,
+                asset_cache,
+                audio_context,
+            );
+        }
+        self.equip.before_handle_effects(
+            core,
+            effects,
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        );
+    }
 }

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -15,18 +15,17 @@
 
 use cgmath::{Deg, Point3, Quaternion, Rotation3, vec3};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
-use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
 use crate::{
     GameOptions,
-    game_scene::{DebugPlayerStatsRequest, DebugSkillLevelsRequest, DebuggableScene, GameScene},
+    game_scene::GameScene,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, cube_object, spawn_at,
+        DebugBox, DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, boxes_to_geometry,
+        max_player_stats, spawn_at,
     },
     scripts::Effect,
-    scripts::gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP},
 };
 
 /// Distance (world units) from the player to the test wall, straight ahead (-X,
@@ -107,11 +106,7 @@ pub fn create_debug_weapons_scene(
     // and a flat table sheds them onto the floor within seconds.
     let lip_color = vec3(0.36, 0.31, 0.24);
     let lip_top = BENCH_HEIGHT + BENCH_LIP_HEIGHT / 2.0;
-    let boxes: &[(
-        cgmath::Vector3<f32>,
-        cgmath::Vector3<f32>,
-        cgmath::Vector3<f32>,
-    )] = &[
+    let boxes: &[DebugBox] = &[
         // floor
         (
             vec3(0.18, 0.18, 0.22),
@@ -174,22 +169,7 @@ pub fn create_debug_weapons_scene(
         ),
     ];
 
-    let scene_objects = boxes
-        .iter()
-        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
-        .collect::<Vec<_>>();
-    let collider = ColliderBuilder::compound(
-        boxes
-            .iter()
-            .map(|(_, translation, scale)| {
-                (
-                    Isometry::translation(translation.x, translation.y, translation.z),
-                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
-                )
-            })
-            .collect(),
-    )
-    .build();
+    let (scene_objects, collider) = boxes_to_geometry(boxes);
 
     // Spawn at the floor with identity yaw: the default view forward is -X, so
     // the wall sits dead ahead and the bench is a quarter-turn to the left.
@@ -241,32 +221,7 @@ impl DebugSceneHooks for ArsenalHooks {
         }
         self.populated = true;
 
-        // "Full stats": max the character sheet through the same provisioning
-        // path as `POST /v1/player/stats`, so nothing (skill gates, psi tiers)
-        // stands between the tester and any weapon on the bench.
-        let request = DebugPlayerStatsRequest {
-            strength: Some(STAT_CAP),
-            endurance: Some(STAT_CAP),
-            agility: Some(STAT_CAP),
-            psionic_ability: Some(STAT_CAP),
-            cyber_affinity: Some(STAT_CAP),
-            skills: DebugSkillLevelsRequest {
-                standard_weapons: Some(SKILL_CAP),
-                energy_weapons: Some(SKILL_CAP),
-                heavy_weapons: Some(SKILL_CAP),
-                exotic_weapons: Some(SKILL_CAP),
-                hack: Some(SKILL_CAP),
-                repair: Some(SKILL_CAP),
-                modify: Some(SKILL_CAP),
-                maintenance: Some(SKILL_CAP),
-                research: Some(SKILL_CAP),
-            },
-            psi_tier: Some(PSI_TIER_CAP),
-            cyber_modules: None,
-        };
-        if let Err(err) = core.set_player_stats(&request) {
-            tracing::warn!("[debug_weapons] failed to max player stats: {err}");
-        }
+        max_player_stats(core, "debug_weapons");
 
         // Guns on the outer row, ammo on the inner row. Drop heights are
         // load-bearing: a big gun's collider extends below its origin, and a


### PR DESCRIPTION
## What

`debug_psi` gets an enemy pen and a full character sheet so psi powers can be measured against a live creature:

- Two pipe hybrids (-397, the actor `debug_melee`/`debug_hitbox` use) stand in a closed, knee-high pen 9 and 11 units ahead. The 1.2 wall was measured, not guessed: an alerted hybrid piles up at x≈-8.2 and never crosses it, while a level cast from eye height (~2.3) clears it onto the near creature's torso. The far one is offset so the near one doesn't screen it.
- The psi pool starts full (50/50 instead of the template's 40) and every stat, skill and psi tier is at cap via the same path as `POST /v1/player/stats`. Nothing on the cast path reads the sheet yet (debug scenes already know every power; the amp's effective PSI is a constant), so that half is parity with `debug_weapons`, stated as such in the code.

The box geometry idiom, `cube_object`, and the max-stats block were each on their third copy across debug scenes; they move to `debug_common` (`boxes_to_geometry`, `cube_object`, `max_player_stats`) and `debug_melee`/`debug_weapons` use them. Net −60 lines.

Groundwork for a per-power psi audit (next PRs: registry dump over HTTP, an SDK audit script, e2e lock-in of the implemented powers).

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean.
- Runtime: two straight cryo casts take the near hybrid 12→10 HP and psi 50→48; damage-alerted hybrids stay penned after 15 s.
- e2e: every suite that launches `debug_psi`, `debug_melee` or `debug_weapons` (29 files) — see the results comment below.
- `/xreview` (Claude reviewers; Codex was out of quota): the duplication and target-placement findings are addressed in this commit.

## Media

![debug_psi pen demo](https://gist.githubusercontent.com/tommy-xr/f969ce22c16826d78f37d1cc6330148a/raw/debug_psi_pen.gif)

<sub>Two Projected Cryokinesis casts into the pen from the player's eye. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![impact still](https://gist.githubusercontent.com/tommy-xr/f969ce22c16826d78f37d1cc6330148a/raw/debug_psi_impact.png)
