### PR TITLE
fix(psi): cast with the player's PSI stat

### DIFF
--- a/projects/psi-powers.md
+++ b/projects/psi-powers.md
@@ -18,8 +18,9 @@ Landed (phase 1 - all powers selectable, projectile powers castable):
 - **Casting**: `psiampscript` → `PsiAmpScript` casts the selected power on
   trigger pull: checks/deducts psi points (`Effect::SpendPsiPoints`), spawns
   the PSI-scaled projectile plus the amp's `GunFlash` (Spinning Psi Ring).
-  Non-projectile activation types log and spend nothing (yet). Effective PSI
-  stat is a fixed placeholder (5) until player stats land.
+  Non-projectile activation types log and spend nothing (yet). The effective
+  PSI stat is the character sheet's `PlayerStats::psionic_ability` (from
+  `QuestInfo`), plus the overload bonus.
 - **HUD/introspection**: the psi bar shows the real pool; `/v1/info` (and the
   SDK `FrameSnapshot`) expose `psi_points`, `max_psi_points`,
   `selected_psi_power`.
@@ -42,7 +43,7 @@ Landed (phase 1 - all powers selectable, projectile powers castable):
   unique (`shock2vr/src/psi.rs`), ticked down/expired per frame by
   `MissionCore::update`, and are exposed via `/v1/info`
   (`active_psi_powers`) and the SDK. **Photonic Redirection** (`Inviso`,
-  tier 4, 30 s at PSI 5) is the first wired behavior: while active the
+  tier 4, `5 + 5 × PSI` seconds) is the first wired behavior: while active the
   player fails every AI/camera/turret visibility check
   (`scripts/ai/ai_util.rs`). The `debug_camera` scene auto-equips the amp
   so this is testable end-to-end (`psi-sustained.e2e.test.ts`: cost,

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -48,6 +48,16 @@ pub const STABILITY_TEMPLATE_ID: i32 = -3148;
 /// (`duration_base + duration_per_psi × PSI` seconds).
 pub const ACTIVATION_TYPE_SUSTAINED: i32 = 1;
 
+/// `PropPsiPower::activation_type` for instant/special powers - they resolve
+/// immediately on cast, with no duration and no projectile. Self-targeted
+/// (the heals, SomaDrain) and remote (CyberHack, ForceWall) powers both land
+/// here.
+pub const ACTIVATION_TYPE_INSTANT: i32 = 2;
+
+/// `PsiHeal` - Cerebro-stimulated Regeneration (tier 2 instant power): heals
+/// the caster.
+pub const PSI_HEAL_TEMPLATE_ID: i32 = -1017;
+
 /// The powers that support hold-to-overload (per the published gameplay
 /// tables), by template id. Comments give the gamesys name and the
 /// discipline name players know it by.

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -91,6 +91,16 @@ pub const OVERLOAD_ZONE_START: f32 = 0.85;
 pub const OVERLOAD_PSI_BONUS: i32 = 2;
 pub const OVERLOAD_MAX_EFFECTIVE_PSI: i32 = 10;
 
+/// The effective PSI a cast resolves at: the caster's PSI stat, plus the
+/// overload bonus when the charge released in the end zone, capped.
+pub fn effective_psi_for_cast(psi_stat: i32, overload: bool) -> i32 {
+    if overload {
+        (psi_stat + OVERLOAD_PSI_BONUS).min(OVERLOAD_MAX_EFFECTIVE_PSI)
+    } else {
+        psi_stat
+    }
+}
+
 /// Burnout damage: 3 per tier of the burned power.
 pub const BURNOUT_DAMAGE_PER_TIER: i32 = 3;
 
@@ -453,6 +463,16 @@ mod tests {
         let entry = &normalized["psi6"];
         assert!(!entry.contains('\\'), "{entry:?} still carries an escape");
         assert_eq!(entry.lines().next(), Some("Projected Cryokinesis"));
+    }
+
+    #[test]
+    fn overload_adds_the_bonus_and_caps() {
+        assert_eq!(effective_psi_for_cast(2, false), 2);
+        assert_eq!(effective_psi_for_cast(2, true), 2 + OVERLOAD_PSI_BONUS);
+        assert_eq!(
+            effective_psi_for_cast(OVERLOAD_MAX_EFFECTIVE_PSI - 1, true),
+            OVERLOAD_MAX_EFFECTIVE_PSI
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/gui/trainer.rs
+++ b/shock2vr/src/scripts/gui/trainer.rs
@@ -71,7 +71,10 @@ pub const ENDURANCE_HP_PER_LEVEL: u32 = 5;
 /// Keep this gate shared by display, immediate feedback, and authoritative
 /// effect handling so a future caller cannot bypass the module-loss guard.
 pub fn stat_upgrade_available(stat: Stat) -> bool {
-    matches!(stat, Stat::Strength | Stat::Endurance | Stat::CyberAffinity)
+    matches!(
+        stat,
+        Stat::Strength | Stat::Endurance | Stat::CyberAffinity | Stat::PsionicAbility
+    )
 }
 
 /// The cost of buying `target`'s next level given the player's current sheet,
@@ -553,12 +556,15 @@ mod tests {
             Some(3),
             "Strength is purchasable once backpack capacity consumes it"
         );
-        for unsupported in [Stat::PsionicAbility, Stat::Agility] {
-            assert_eq!(
-                upgrade_quote(&costs, &stats, TrainerTarget::Stat(unsupported)),
-                None,
-                "{unsupported:?} must not be sold until it has a gameplay effect"
-            );
-        }
+        assert_eq!(
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::PsionicAbility)),
+            Some(3),
+            "PSI is purchasable now that psi casts scale with it"
+        );
+        assert_eq!(
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Agility)),
+            None,
+            "Agility must not be sold until it has a gameplay effect"
+        );
     }
 }

--- a/shock2vr/src/scripts/healing_item.rs
+++ b/shock2vr/src/scripts/healing_item.rs
@@ -1,8 +1,7 @@
-use dark::properties::{PropHitPoints, PropMaxHitPoints};
 use serde::{Deserialize, Serialize};
-use shipyard::{Get, Unique, UniqueView, View, World};
+use shipyard::{Unique, UniqueView, World};
 
-use crate::{mission::PlayerInfo, physics::PhysicsWorld, quest_info::QuestInfo};
+use crate::{physics::PhysicsWorld, quest_info::QuestInfo};
 
 use super::{Effect, MessagePayload, Script};
 use crate::scripts::gui::TRAIT_PHARMO_FRIENDLY;
@@ -173,20 +172,7 @@ impl ActiveHealing {
 /// effect. `MissionCore` remains the only place that mutates HP, preserving its
 /// player-death guard and the shared HP trace.
 pub fn tick_player_healing(world: &World, elapsed_secs: f32) -> Option<Effect> {
-    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
-    let current = world
-        .borrow::<View<PropHitPoints>>()
-        .ok()
-        .and_then(|hit_points| hit_points.get(player).ok().map(|hp| hp.hit_points))?;
-    let maximum = world
-        .borrow::<View<PropMaxHitPoints>>()
-        .ok()
-        .and_then(|max_hit_points| {
-            max_hit_points
-                .get(player)
-                .ok()
-                .map(|hp| hp.hit_points.min(i32::MAX as u32) as i32)
-        })?;
+    let (player, current, maximum) = crate::scripts::script_util::player_hit_points(world)?;
     let delta = world
         .borrow::<shipyard::UniqueViewMut<ActiveHealing>>()
         .ok()

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -35,21 +35,24 @@ use super::{
 /// The caster's PSI stat from the character sheet, used to pick the power's
 /// projectile (links are ordered by PSI level 1..8) and to scale sustained
 /// durations. Falls back to the sheet's baseline when the scene has no
-/// `QuestInfo` (a bare debug scene).
+/// `QuestInfo` (a bare debug scene) - logged, because the same borrow also
+/// fails if something else holds `QuestInfo` mutably, and a silent fallback
+/// would cast at the wrong tier.
 fn player_psi_stat(world: &World) -> i32 {
-    world
-        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
-        .map(|quests| quests.player_stats().psionic_ability)
-        .unwrap_or_else(|_| crate::player_stats::PlayerStats::default().psionic_ability)
-}
-
-/// The effective PSI a cast resolves at: the character sheet's PSI, plus the
-/// overload bonus when the charge released in the end zone, capped.
-fn effective_psi_for_cast(psi_stat: i32, overload: bool) -> i32 {
-    if overload {
-        (psi_stat + psi::OVERLOAD_PSI_BONUS).min(psi::OVERLOAD_MAX_EFFECTIVE_PSI)
-    } else {
-        psi_stat
+    match world.borrow::<UniqueView<crate::quest_info::QuestInfo>>() {
+        Ok(quests) => quests
+            .player_stats()
+            .stat_level(crate::player_stats::Stat::PsionicAbility),
+        Err(err) => {
+            let baseline = crate::player_stats::PlayerStats::default().psionic_ability;
+            game_log!(
+                WARN,
+                "No character sheet for the psi cast ({}); casting at PSI {}",
+                err,
+                baseline
+            );
+            baseline
+        }
     }
 }
 
@@ -159,7 +162,7 @@ impl Script for PsiAmpScript {
                 }
                 let fraction = elapsed / duration;
                 let overload = fraction >= psi::OVERLOAD_ZONE_START;
-                let effective_psi = effective_psi_for_cast(player_psi_stat(world), overload);
+                let effective_psi = psi::effective_psi_for_cast(player_psi_stat(world), overload);
                 let cast = cast_selected_power(world, entity_id, effective_psi);
                 // A successful overload flashes the success art briefly; a
                 // normal cast - or a fizzle (no psi / power not implemented)
@@ -461,16 +464,6 @@ mod tests {
         assert_eq!(
             player_psi_stat(&world),
             crate::player_stats::PlayerStats::default().psionic_ability
-        );
-    }
-
-    #[test]
-    fn overload_adds_the_bonus_and_caps() {
-        assert_eq!(effective_psi_for_cast(2, false), 2);
-        assert_eq!(effective_psi_for_cast(2, true), 2 + psi::OVERLOAD_PSI_BONUS);
-        assert_eq!(
-            effective_psi_for_cast(psi::OVERLOAD_MAX_EFFECTIVE_PSI, true),
-            psi::OVERLOAD_MAX_EFFECTIVE_PSI
         );
     }
 }

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -12,8 +12,8 @@
 //! full bar is a psi burnout - the cast fails, the points are spent, and the
 //! player takes damage. Non-overloadable powers cast immediately on pull.
 //!
-//! Only projectile ("shot") powers actually fire so far - sustained, shield,
-//! and cursor-targeted powers are logged and skipped without spending points.
+//! Projectile ("shot"), sustained, and instant self-targeted powers cast so
+//! far - the remaining kinds are logged and skipped without spending points.
 
 use engine::{audio::AudioHandle, game_log};
 use shipyard::{EntityId, Get, UniqueView, View, World};
@@ -123,6 +123,13 @@ impl Script for PsiAmpScript {
                             player_psi_points(world),
                             power.power.psi_cost
                         );
+                        return Effect::NoEffect;
+                    }
+                    // Nor charge a cast that would resolve to nothing (a heal
+                    // at full health): over-holding it would burn out for a
+                    // cast the release refuses anyway.
+                    if instant_cast_is_futile(world, &power, player_psi_stat(world)) {
+                        game_log!(INFO, "{} would do nothing right now", power.name);
                         return Effect::NoEffect;
                     }
                     // Cast happens on release; start the meter.
@@ -344,6 +351,12 @@ fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) 
         return cast_sustained_power(world, amp_entity, &power, effective_psi);
     }
 
+    // Instant (self-targeted) powers resolve immediately - no duration, no
+    // projectile.
+    if power.power.activation_type == psi::ACTIVATION_TYPE_INSTANT {
+        return cast_instant_power(world, amp_entity, &power, effective_psi);
+    }
+
     let Some(projectile_template) = power.projectile_for_psi_stat(effective_psi) else {
         game_log!(
             INFO,
@@ -431,6 +444,120 @@ fn cast_sustained_power(
     Effect::Multiple(effects)
 }
 
+/// Cast an instant (activation type 2) power: it resolves on the spot, with
+/// no duration and no projectile. Dispatch is by template id so the remaining
+/// instant powers (Major Heal, SomaDrain, ForceWall, CyberHack) slot in
+/// beside this one.
+fn cast_instant_power(
+    world: &World,
+    amp_entity: EntityId,
+    power: &PsiPowerInfo,
+    effective_psi: i32,
+) -> Effect {
+    match power.template_id {
+        // Cerebro-stimulated Regeneration: restores the caster's health.
+        psi::PSI_HEAL_TEMPLATE_ID => cast_self_heal(world, amp_entity, power, effective_psi),
+        _ => {
+            game_log!(
+                INFO,
+                "Instant psi power {} is not implemented yet",
+                power.name
+            );
+            Effect::NoEffect
+        }
+    }
+}
+
+/// Heal the caster by [`self_heal_amount`], spending the power's tier. A cast
+/// at full health is refused and spends nothing, matching the empty-pool
+/// guard - the player keeps their points rather than burning them on a cast
+/// that could do nothing.
+fn cast_self_heal(
+    world: &World,
+    amp_entity: EntityId,
+    power: &PsiPowerInfo,
+    effective_psi: i32,
+) -> Effect {
+    let Some((player_entity, current_hp, max_hp)) = super::script_util::player_hit_points(world)
+    else {
+        game_log!(WARN, "No player hit points for {}", power.name);
+        return Effect::NoEffect;
+    };
+    let amount = self_heal_amount(&power.power.data, effective_psi);
+    if amount <= 0 {
+        game_log!(INFO, "{} has no heal data (P$PsiPower)", power.name);
+        return Effect::NoEffect;
+    }
+    let heal = clamped_self_heal(&power.power.data, effective_psi, current_hp, max_hp);
+    if heal <= 0 {
+        game_log!(
+            INFO,
+            "{} would heal nothing (already at full health)",
+            power.name
+        );
+        return Effect::NoEffect;
+    }
+
+    let mut effects = vec![
+        play_environmental_sound(world, amp_entity, "shoot", vec![], AudioHandle::new()),
+        Effect::SpendPsiPoints {
+            amount: power.power.psi_cost,
+        },
+        // PlayerScript handles only Damage - there is no heal message - so
+        // adjust HP directly. The applier does not clamp to the maximum,
+        // hence the clamp above.
+        Effect::AdjustHitPoints {
+            entity_id: player_entity,
+            delta: heal,
+        },
+    ];
+    effects.extend(amp_cast_flashes(world, amp_entity));
+
+    game_log!(
+        INFO,
+        "Cast psi power: {} (tier {}, healed {} HP at effective PSI {})",
+        power.name,
+        power.power.psi_cost,
+        heal,
+        effective_psi
+    );
+    Effect::Multiple(effects)
+}
+
+/// The HP an instant self-heal restores at full strength (the caller clamps
+/// it to the caster's missing health): `data[0] + data[1] x effective PSI`.
+/// 0 for a power with no (or unusable) heal data.
+///
+/// Assumption: the two floats split base / per-PSI the way the sustained
+/// powers' `P$PsiShield` duration data does. PsiHeal's `[0, 2]` therefore
+/// reads as 2 HP per point of PSI (Major Heal's `[5, 5]` as 5 + 5 x PSI).
+fn self_heal_amount(data: &[f32; 4], effective_psi: i32) -> i32 {
+    let amount = data[0] + data[1] * effective_psi as f32;
+    if !amount.is_finite() || amount <= 0.0 {
+        return 0;
+    }
+    amount.floor().min(i32::MAX as f32) as i32
+}
+
+/// Whether an instant cast would resolve to nothing right now (a heal with
+/// no health missing). Checked before a charge starts so a pointless cast
+/// cannot be over-held into a burnout, which spends points and deals damage.
+fn instant_cast_is_futile(world: &World, power: &PsiPowerInfo, effective_psi: i32) -> bool {
+    if power.template_id != psi::PSI_HEAL_TEMPLATE_ID {
+        return false;
+    }
+    let Some((_, current_hp, max_hp)) = super::script_util::player_hit_points(world) else {
+        return false;
+    };
+    clamped_self_heal(&power.power.data, effective_psi, current_hp, max_hp) <= 0
+}
+
+/// The HP a cast actually restores: [`self_heal_amount`] clamped to the
+/// caster's missing health.
+fn clamped_self_heal(data: &[f32; 4], effective_psi: i32, current_hp: i32, max_hp: i32) -> i32 {
+    self_heal_amount(data, effective_psi).min((max_hp - current_hp).max(0))
+}
+
 /// The amp's `GunFlash` links supply the cast visual (Spinning Psi Ring).
 fn amp_cast_flashes(world: &World, amp_entity: EntityId) -> Vec<Effect> {
     super::script_util::get_all_links_with_template(world, amp_entity, |link| match link {
@@ -446,6 +573,34 @@ fn amp_cast_flashes(world: &World, amp_entity: EntityId) -> Vec<Effect> {
 mod tests {
     use super::*;
     use crate::quest_info::QuestInfo;
+
+    #[test]
+    fn self_heal_scales_with_psi() {
+        // PsiHeal's authored data: 0 base + 2 HP per PSI point.
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5), 10);
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 7), 14);
+        // A base term adds on top of the per-PSI term (Major Heal's shape).
+        assert_eq!(self_heal_amount(&[5.0, 5.0, 0.0, 0.0], 5), 30);
+    }
+
+    #[test]
+    fn self_heal_ignores_powers_with_no_heal_data() {
+        assert_eq!(self_heal_amount(&[0.0, 0.0, 0.0, 0.0], 5), 0);
+        assert_eq!(self_heal_amount(&[f32::NAN, 2.0, 0.0, 0.0], 5), 0);
+        assert_eq!(self_heal_amount(&[-4.0, 0.0, 0.0, 0.0], 5), 0);
+    }
+
+    /// The applier does not clamp, so an overshoot would push HP past the
+    /// maximum - the clamp lives here instead.
+    #[test]
+    fn the_heal_is_clamped_to_missing_health() {
+        // 2 x PSI 5 = 10, but only 4 HP are missing.
+        assert_eq!(clamped_self_heal(&[0.0, 2.0, 0.0, 0.0], 5, 96, 100), 4);
+        // At full health the heal is nothing (the cast is refused).
+        assert_eq!(clamped_self_heal(&[0.0, 2.0, 0.0, 0.0], 5, 100, 100), 0);
+        // Over-healed (or a bogus maximum) never produces a negative delta.
+        assert_eq!(clamped_self_heal(&[0.0, 2.0, 0.0, 0.0], 5, 120, 100), 0);
+    }
 
     #[test]
     fn psi_stat_comes_from_the_character_sheet() {

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -32,11 +32,26 @@ use super::{
     weapon_script::{create_muzzle_flash, create_projectile},
 };
 
-/// The caster's effective PSI stat, used to pick the power's projectile
-/// (links are ordered by PSI level 1..8) - a mid-range placeholder until
-/// player stats are tracked (P$BaseStats authors all stats at 1, pending
-/// character creation/training).
-const EFFECTIVE_PSI_STAT: i32 = 5;
+/// The caster's PSI stat from the character sheet, used to pick the power's
+/// projectile (links are ordered by PSI level 1..8) and to scale sustained
+/// durations. Falls back to the sheet's baseline when the scene has no
+/// `QuestInfo` (a bare debug scene).
+fn player_psi_stat(world: &World) -> i32 {
+    world
+        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+        .map(|quests| quests.player_stats().psionic_ability)
+        .unwrap_or_else(|_| crate::player_stats::PlayerStats::default().psionic_ability)
+}
+
+/// The effective PSI a cast resolves at: the character sheet's PSI, plus the
+/// overload bonus when the charge released in the end zone, capped.
+fn effective_psi_for_cast(psi_stat: i32, overload: bool) -> i32 {
+    if overload {
+        (psi_stat + psi::OVERLOAD_PSI_BONUS).min(psi::OVERLOAD_MAX_EFFECTIVE_PSI)
+    } else {
+        psi_stat
+    }
+}
 
 /// The amp's charge/result state while the meter is on screen.
 enum ChargeState {
@@ -120,7 +135,7 @@ impl Script for PsiAmpScript {
                         phase: PsiChargePhase::Charging,
                     }
                 } else {
-                    cast_selected_power(world, entity_id, EFFECTIVE_PSI_STAT)
+                    cast_selected_power(world, entity_id, player_psi_stat(world))
                 }
             }
             MessagePayload::TriggerRelease => {
@@ -144,12 +159,7 @@ impl Script for PsiAmpScript {
                 }
                 let fraction = elapsed / duration;
                 let overload = fraction >= psi::OVERLOAD_ZONE_START;
-                let effective_psi = if overload {
-                    (EFFECTIVE_PSI_STAT + psi::OVERLOAD_PSI_BONUS)
-                        .min(psi::OVERLOAD_MAX_EFFECTIVE_PSI)
-                } else {
-                    EFFECTIVE_PSI_STAT
-                };
+                let effective_psi = effective_psi_for_cast(player_psi_stat(world), overload);
                 let cast = cast_selected_power(world, entity_id, effective_psi);
                 // A successful overload flashes the success art briefly; a
                 // normal cast - or a fizzle (no psi / power not implemented)
@@ -427,4 +437,40 @@ fn amp_cast_flashes(world: &World, amp_entity: EntityId) -> Vec<Effect> {
     .into_iter()
     .map(|(template_id, options)| create_muzzle_flash(world, amp_entity, template_id, &options))
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quest_info::QuestInfo;
+
+    #[test]
+    fn psi_stat_comes_from_the_character_sheet() {
+        let world = World::new();
+        let mut quests = QuestInfo::new();
+        quests.player_stats_mut().psionic_ability = 6;
+        world.add_unique(quests);
+
+        assert_eq!(player_psi_stat(&world), 6);
+    }
+
+    #[test]
+    fn psi_stat_falls_back_to_the_sheet_baseline_without_quest_info() {
+        let world = World::new();
+
+        assert_eq!(
+            player_psi_stat(&world),
+            crate::player_stats::PlayerStats::default().psionic_ability
+        );
+    }
+
+    #[test]
+    fn overload_adds_the_bonus_and_caps() {
+        assert_eq!(effective_psi_for_cast(2, false), 2);
+        assert_eq!(effective_psi_for_cast(2, true), 2 + psi::OVERLOAD_PSI_BONUS);
+        assert_eq!(
+            effective_psi_for_cast(psi::OVERLOAD_MAX_EFFECTIVE_PSI, true),
+            psi::OVERLOAD_MAX_EFFECTIVE_PSI
+        );
+    }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -673,6 +673,30 @@ pub fn player_carried_items(world: &World) -> Vec<EntityId> {
     out
 }
 
+/// The player entity with its current and maximum hit points. `None` when the
+/// scene has no player or the player has no health pool (e.g. a bare debug
+/// scene).
+pub fn player_hit_points(world: &World) -> Option<(EntityId, i32, i32)> {
+    let player = world
+        .borrow::<UniqueView<crate::mission::PlayerInfo>>()
+        .ok()?
+        .entity_id;
+    let current = world
+        .borrow::<View<dark::properties::PropHitPoints>>()
+        .ok()?
+        .get(player)
+        .ok()?
+        .hit_points;
+    let maximum = world
+        .borrow::<View<dark::properties::PropMaxHitPoints>>()
+        .ok()?
+        .get(player)
+        .ok()?
+        .hit_points
+        .min(i32::MAX as u32) as i32;
+    Some((player, current, maximum))
+}
+
 /// The player's persistent nanite stat balance (0 if there is no player /
 /// `QuestInfo`, e.g. a debug scene).
 fn stat_nanite_balance(world: &World) -> i32 {

--- a/tools/shock2-sdk/test/psi-heal.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-heal.e2e.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { selectPsiPower } from "./helpers/psi.js";
+import { pullTrigger } from "./helpers/weapon.js";
+
+// End-to-end test for Cerebro-stimulated Regeneration (PsiHeal), the first
+// instant (activation type 2) psi power: a cast spends the power's tier and
+// heals `data[0] + data[1] x PSI` HP, clamped to the player's missing health.
+// A cast at full health is refused and spends nothing.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** PsiHeal's authored data is `[0, 2]`: 2 HP per point of PSI. */
+const HP_PER_PSI = 2;
+const PSI_STAT = 6;
+const PSI_COST = 2;
+
+test(
+  "Cerebro-stimulated Regeneration heals the caster and spends its tier",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_psi" });
+
+    // The scene auto-equips the Psi Amp on the first update.
+    await game.step({ frames: 10 });
+    await game.player.setStats({ psionic_ability: PSI_STAT });
+
+    // Hurt the player so the heal has room to land.
+    const playerId = (await game.info()).player.entity_id;
+    assert.ok(playerId !== null, "debug_psi should have a player");
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 20.0 });
+    await game.step({ frames: 10 });
+
+    let player = (await game.info()).player;
+    const maxHp = player.max_hit_points;
+    const hurtHp = player.hit_points;
+    const startPsi = player.psi_points;
+    assert.ok(maxHp !== null && hurtHp !== null && startPsi !== null);
+    assert.ok(hurtHp! < maxHp!, `player should be hurt (${hurtHp}/${maxHp})`);
+    assert.ok(maxHp! - hurtHp! > HP_PER_PSI * PSI_STAT, "the heal should not be clamped here");
+
+    await selectPsiPower(game, "PsiHeal");
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+
+    player = (await game.info()).player;
+    assert.equal(
+      player.hit_points,
+      hurtHp! + HP_PER_PSI * PSI_STAT,
+      "the cast heals 2 HP per point of PSI",
+    );
+    assert.equal(player.psi_points, startPsi! - PSI_COST, "a tier 2 cast costs two psi points");
+
+    // Keep casting until the player is topped up. The last cast is clamped
+    // (fewer HP are missing than the heal restores) and still costs its tier.
+    const psiBeforeTopUp = player.psi_points!;
+    let topUpCasts = 0;
+    while (player.hit_points !== maxHp && topUpCasts < 5) {
+      await pullTrigger(game);
+      await game.step({ frames: 30 });
+      player = (await game.info()).player;
+      topUpCasts += 1;
+    }
+    assert.ok(topUpCasts > 0, "the top-up should need at least one clamped cast");
+    assert.equal(player.hit_points, maxHp, "the heal never overshoots the maximum");
+    assert.equal(
+      player.psi_points,
+      psiBeforeTopUp - PSI_COST * topUpCasts,
+      "a clamped cast still costs its tier",
+    );
+    const fullPsi = player.psi_points;
+
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+    player = (await game.info()).player;
+    assert.equal(player.hit_points, maxHp, "a cast at full health heals nothing");
+    assert.equal(player.psi_points, fullPsi, "a cast at full health spends nothing");
+  },
+);

--- a/tools/shock2-sdk/test/psi-overload.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-overload.e2e.test.ts
@@ -17,6 +17,9 @@ import { GameServer } from "../src/index.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
+/** The trainer stat cap - the highest PSI the sheet can reach. */
+const PSI_STAT = 6;
+
 test(
   "psi amp hold-to-overload: normal cast, overload, and burnout",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -26,6 +29,7 @@ test(
     });
 
     await game.step({ frames: 10 });
+    await game.player.setStats({ psionic_ability: PSI_STAT });
     let player = (await game.info()).player;
     assert.equal(player.selected_psi_power, "Cryokinesis");
     const startPsi = player.psi_points!;
@@ -34,7 +38,7 @@ test(
       (await game.entities.list({ limit: 120 })).entities.some((e) => e.name === name);
 
     // 1) Quick click: released long before the zone -> normal cast at the
-    // base effective PSI (5 -> "Cryo PSI 5"), meter cleared immediately.
+    // player's PSI stat ("Cryo PSI 6"), meter cleared immediately.
     await game.input.set("right_hand.trigger", 1.0);
     await game.step({ frames: 3 });
     player = (await game.info()).player;
@@ -44,10 +48,13 @@ test(
     player = (await game.info()).player;
     assert.equal(player.psi_points, startPsi - 1, "normal cast costs the tier");
     assert.equal(player.psi_charge_phase, null, "meter clears on a normal release");
-    assert.ok(await hasProjectile("Cryo PSI 5"), "normal cast fires the PSI-5 projectile");
+    assert.ok(
+      await hasProjectile(`Cryo PSI ${PSI_STAT}`),
+      "normal cast fires the projectile for the player's PSI stat",
+    );
 
     // 2) Overload: hold 110/120 frames (fraction ~0.92, inside the 0.85+
-    // zone), then release -> +2 effective PSI -> "Cryo PSI 7".
+    // zone), then release -> +2 effective PSI -> "Cryo PSI 8".
     await game.step({ frames: 120 }); // let the previous bolt clear frame counts
     await game.input.set("right_hand.trigger", 1.0);
     await game.step({ frames: 110 });
@@ -56,7 +63,10 @@ test(
     player = (await game.info()).player;
     assert.equal(player.psi_points, startPsi - 2, "overload costs the same as a normal cast");
     assert.equal(player.psi_charge_phase, "overloaded", "meter flashes the overload result");
-    assert.ok(await hasProjectile("Cryo PSI 7"), "overload fires the PSI-7 projectile");
+    assert.ok(
+      await hasProjectile(`Cryo PSI ${PSI_STAT + 2}`),
+      "overload fires the +2 projectile",
+    );
 
     // The result flash expires (~0.6s = 36 frames).
     await game.step({ frames: 45 });

--- a/tools/shock2-sdk/test/psi-overload.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-overload.e2e.test.ts
@@ -17,7 +17,7 @@ import { GameServer } from "../src/index.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-/** The trainer stat cap - the highest PSI the sheet can reach. */
+/** STAT_CAP - the highest stat `POST /v1/player/stats` will provision. */
 const PSI_STAT = 6;
 
 test(

--- a/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
@@ -17,7 +17,7 @@ import { fireOnce } from "./helpers/weapon.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const INVISO_COST = 4;
-/** The trainer stat cap - the highest PSI the sheet can reach. */
+/** STAT_CAP - the highest stat `POST /v1/player/stats` will provision. */
 const PSI_STAT = 6;
 /** Inviso duration at `PSI_STAT`: 5 + 5*PSI seconds. */
 const INVISO_DURATION_FRAMES = (5 + 5 * PSI_STAT) * 60;

--- a/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
+import { selectPsiPower } from "./helpers/psi.js";
 import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end tests for sustained (timed) psi powers. Photonic Redirection
@@ -24,17 +25,6 @@ const INVISO_DURATION_FRAMES = (5 + 5 * PSI_STAT) * 60;
 
 function aiProp(detail: EntityDetailResult, name: string): string | undefined {
   return detail.properties.find((p) => p.name === name)?.value;
-}
-
-/** Cycle the psi power selection until Inviso is selected (bounded). */
-async function selectInviso(game: GameServer): Promise<void> {
-  for (let i = 0; i < 40; i++) {
-    const selected = (await game.info()).player.selected_psi_power;
-    if (selected === "Inviso") return;
-    await game.input.trigger("CyclePsiPower");
-    await game.step({ frames: 1 });
-  }
-  assert.fail("could not cycle the psi power selection to Inviso");
 }
 
 /** Step `frames` in chunks so a single /v1/step call stays small. */
@@ -63,7 +53,7 @@ test(
     assert.ok(startPsi !== null && startPsi >= 2 * INVISO_COST);
 
     // Cast Photonic Redirection (tier 4 sustained power).
-    await selectInviso(game);
+    await selectPsiPower(game, "Inviso");
     await fireOnce(game);
     player = (await game.info()).player;
     assert.equal(player.psi_points, startPsi! - INVISO_COST, "Inviso cast costs 4 psi points");
@@ -135,7 +125,7 @@ test(
       assert.ok(camera, "debug_camera should contain a Security Camera");
 
       // Cast Inviso immediately (~0.5 s in, long before the camera reacts).
-      await selectInviso(game);
+      await selectPsiPower(game, "Inviso");
       await fireOnce(game);
       const player = (await game.info()).player;
       assert.deepEqual(player.active_psi_powers, ["Inviso"], "Inviso active in debug_camera");

--- a/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
@@ -8,16 +8,19 @@ import { fireOnce } from "./helpers/weapon.js";
 // End-to-end tests for sustained (timed) psi powers. Photonic Redirection
 // ("Inviso" in the gamesys, tier 4) is the reference power: casting it spends
 // 4 psi points and makes the player invisible to AI/cameras for
-// duration_base + duration_per_psi x PSI = 5 + 5*5 = 30 seconds; the active
-// power list is published via /v1/info as player.active_psi_powers.
+// duration_base + duration_per_psi x PSI seconds (5 + 5*PSI, from the
+// player's PSI stat); the active power list is published via /v1/info as
+// player.active_psi_powers.
 //
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const INVISO_COST = 4;
-/** Inviso duration at the effective PSI stat of 5: 5 + 5*5 seconds. */
-const INVISO_DURATION_FRAMES = 30 * 60;
+/** The trainer stat cap - the highest PSI the sheet can reach. */
+const PSI_STAT = 6;
+/** Inviso duration at `PSI_STAT`: 5 + 5*PSI seconds. */
+const INVISO_DURATION_FRAMES = (5 + 5 * PSI_STAT) * 60;
 
 function aiProp(detail: EntityDetailResult, name: string): string | undefined {
   return detail.properties.find((p) => p.name === name)?.value;
@@ -52,6 +55,7 @@ test(
 
     // The scene auto-equips the Psi Amp on the first update.
     await game.step({ frames: 10 });
+    await game.player.setStats({ psionic_ability: PSI_STAT });
     let player = (await game.info()).player;
     assert.ok(player.wielded_entity_id !== null, "psi amp should be auto-wielded");
     assert.deepEqual(player.active_psi_powers, [], "no sustained powers active at start");
@@ -71,7 +75,7 @@ test(
     assert.equal(player.psi_points, startPsi! - 2 * INVISO_COST, "re-cast spends again");
     assert.deepEqual(player.active_psi_powers, ["Inviso"], "re-cast refreshes, not duplicates");
 
-    // Still active just before the 30 s duration elapses...
+    // Still active just before the duration elapses...
     await stepFrames(game, INVISO_DURATION_FRAMES - 60);
     player = (await game.info()).player;
     assert.deepEqual(player.active_psi_powers, ["Inviso"], "still active before expiry");
@@ -79,7 +83,11 @@ test(
     // ...and expired just after.
     await stepFrames(game, 120);
     player = (await game.info()).player;
-    assert.deepEqual(player.active_psi_powers, [], "Inviso expires after 30 seconds");
+    assert.deepEqual(
+      player.active_psi_powers,
+      [],
+      `Inviso expires after ${INVISO_DURATION_FRAMES / 60} seconds`,
+    );
   },
 );
 
@@ -121,6 +129,7 @@ test(
         mission: "debug_camera",
       });
       await game.step({ frames: 10 });
+      await game.player.setStats({ psionic_ability: PSI_STAT });
       const camera = (await game.entities.list({ filter: "Security Camera", limit: 5 }))
         .entities[0];
       assert.ok(camera, "debug_camera should contain a Security Camera");

--- a/tools/shock2-sdk/test/psi.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi.e2e.test.ts
@@ -15,7 +15,7 @@ import { fireOnce } from "./helpers/weapon.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-/** The trainer stat cap - the highest PSI the sheet can reach. */
+/** STAT_CAP - the highest stat `POST /v1/player/stats` will provision. */
 const PSI_STAT = 6;
 
 test(

--- a/tools/shock2-sdk/test/psi.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi.e2e.test.ts
@@ -6,13 +6,17 @@ import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end test for psi amp casting: the debug_psi scene equips the player
 // with the Psi Amp; firing casts the selected psi power. Projectile powers
-// (Projected Cryokinesis is the default selection) spawn their PSI-scaled
-// projectile and deduct the power's tier from the player's psi pool;
-// not-yet-implemented power types are a no-op that spends nothing.
+// (Projected Cryokinesis is the default selection) spawn the projectile
+// variant matching the caster's PSI stat and deduct the power's tier from the
+// player's psi pool; not-yet-implemented power types are a no-op that spends
+// nothing.
 //
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The trainer stat cap - the highest PSI the sheet can reach. */
+const PSI_STAT = 6;
 
 test(
   "psi amp casts the selected power and drains psi points",
@@ -24,6 +28,8 @@ test(
 
     // The scene auto-equips the Psi Amp on the first update.
     await game.step({ frames: 10 });
+    // Cast at the stat cap so the tier the cast picks is unambiguous.
+    await game.player.setStats({ psionic_ability: PSI_STAT });
     let player = (await game.info()).player;
     assert.ok(player.wielded_entity_id !== null, "psi amp should be auto-wielded");
     assert.equal(
@@ -38,8 +44,8 @@ test(
     );
     assert.equal(player.max_psi_points, 50, "max psi pool comes from The Player template");
 
-    // Cast Cryokinesis (tier 1): one psi point, and the PSI-scaled cryo
-    // projectile appears.
+    // Cast Cryokinesis (tier 1): one psi point, and the cryo projectile for
+    // the caster's PSI stat appears.
     await fireOnce(game);
     await game.step({ frames: 3 });
     player = (await game.info()).player;
@@ -47,7 +53,11 @@ test(
     const cryoBolts = (await game.entities.list({ limit: 100 })).entities.filter((e) =>
       e.name?.startsWith("Cryo PSI"),
     );
-    assert.ok(cryoBolts.length > 0, "cryokinesis cast spawns a Cryo PSI projectile");
+    assert.deepEqual(
+      cryoBolts.map((e) => e.name),
+      [`Cryo PSI ${PSI_STAT}`],
+      "the cast picks the projectile tier matching the player's PSI stat",
+    );
 
     // Cycle to the next power (Codebreaker, an unimplemented non-projectile
     // type): casting is a no-op and spends nothing.
@@ -61,6 +71,33 @@ test(
       player.psi_points,
       startPsi! - 1,
       "casting an unimplemented power spends no psi points",
+    );
+  },
+);
+
+test(
+  "the projectile tier follows the player's PSI stat",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // The same cast from a sheet raised only to PSI 2 fires the PSI-2 bolt,
+    // not the capped one. (`/v1/player/stats` only raises, so the lower stat
+    // needs its own runtime.)
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+    });
+
+    await game.step({ frames: 10 });
+    await game.player.setStats({ psionic_ability: 2 });
+    assert.equal((await game.info()).player.selected_psi_power, "Cryokinesis");
+
+    await fireOnce(game);
+    await game.step({ frames: 3 });
+    const cryoBolts = (await game.entities.list({ limit: 100 })).entities.filter((e) =>
+      e.name?.startsWith("Cryo PSI"),
+    );
+    assert.deepEqual(
+      cryoBolts.map((e) => e.name),
+      ["Cryo PSI 2"],
     );
   },
 );


### PR DESCRIPTION
The psi amp cast with `const EFFECTIVE_PSI_STAT: i32 = 5`, so the projectile
tier (`Cryo PSI 5` regardless of the sheet) and sustained durations
(`duration_base + duration_per_psi × 5`) ignored the character's PSI.

Now the amp reads `PlayerStats::psionic_ability` from `QuestInfo` (falling back
to the sheet baseline when a scene has no `QuestInfo`) and threads it through
`cast_selected_power`, so projectile tier selection *and* sustained durations
follow the stat. Overload is unchanged in behavior, just extracted into
`effective_psi_for_cast` (+2, capped at `OVERLOAD_MAX_EFFECTIVE_PSI`).
Nearest-lower-tier fallback already lives in `psi::projectile_for_psi_stat`,
so a missing link still resolves.

## Verification

Scene: `debug_psi` **from `main`** (not #1272) - the tests raise the sheet
themselves with `POST /v1/player/stats`, so they don't depend on the scene's
stat provisioning.

Unit (`cargo test -p shock2vr psi_amp`): 3 new tests - PSI read from the sheet,
baseline fallback with no `QuestInfo`, overload bonus + cap. All pass.

e2e (`SHOCK2_E2E=1 node --test dist/test/psi*.e2e.test.js`): 7/7 pass.

- `psi.e2e.test.ts`: PSI 6 -> `Cryo PSI 6`; new second test, a fresh runtime at
  PSI 2 -> `Cryo PSI 2`.
- `psi-overload.e2e.test.ts`: normal release -> `Cryo PSI 6`, overload ->
  `Cryo PSI 8` (was 5/7).
- `psi-sustained.e2e.test.ts`: Inviso duration `5 + 5×6 = 35 s` (was 30 s), in
  both the `debug_psi` expiry test and the `debug_camera` invisibility test.

Negative-first: with the Rust change reverted and the updated tests in place,
both `psi.e2e.test.ts` cases fail with `actual 'Cryo PSI 5'` vs the expected
`Cryo PSI 6` / `Cryo PSI 2`; they go green with the fix.

Not visual (projectile *identity* changes, not the rendering), so no
pr-visuals capture.


## Review fixes (`/xreview`)

Codex was out of quota, so the cross-engine pass ran with the two Claude
reviewers (adversarial + de-dup) only.

- **High — PSI had no in-game source.** With the amp reading the sheet, a
  non-OSA playthrough would cast at PSI 1 (weakest bolt, 10 s Inviso) because
  `stat_upgrade_available` refused to sell PSI "until it has a gameplay
  effect". It has one as of this commit, so the trainer now sells it; its
  guard test flipped accordingly (Agility stays unavailable, so
  `trainer.e2e.test.ts`'s refusal case is untouched).
- **Medium — ghost docs.** `projects/psi-powers.md` still described the fixed
  placeholder of 5 and "30 s at PSI 5".
- **Medium — silent fallback.** The `QuestInfo` borrow also fails when
  something holds it mutably, which would quietly cast at the baseline; the
  error path now logs.
- **Low/simplicity.** `effective_psi_for_cast` moved to `psi.rs` beside
  `OVERLOAD_PSI_BONUS` / `OVERLOAD_MAX_EFFECTIVE_PSI` (with its test); the stat
  is read through `PlayerStats::stat_level`, the established gameplay-read
  path; the cap assertion now starts *below* the cap so it can actually fail;
  the e2e constant's doc names the provisioning cap it really is.
- Kept: the three per-file `PSI_STAT` constants (self-contained test files,
  matching the suite's convention). De-dup reported no duplication introduced
  by this change; the pre-existing `player_psi_points` triplication
  (`psi_amp_script` / `mission_core` test copy / `virtual_arms`) is untouched.

Re-validated after the fixes: `RUSTFLAGS="-D warnings" cargo check -p shock2vr
-p debug_runtime` clean, `cargo fmt --check` clean, `cargo test -p shock2vr psi`
25/25 and `trainer` 5/5, and the psi + trainer e2e suites 8/8.

The full SDK e2e suite was also run (151 of the tests completed before the run
was interrupted): the only failures were the 6 known-failing-on-`main` tests
tracked in #1262 (creature-loot, flat/VR dev screens, Earth hacking, hydro3
log, VR wrench melee) — no new failures.

Fixes #1274
