### PR TITLE
feat(ai): turn in place instead of arcing through a reversal

### DIFF
--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -41,9 +41,8 @@ pub struct RuntimePropAITargetAwareness {
 // each frame: full speed when facing the travel direction, ramping down to
 // a third by 60 degrees of heading error and to zero by 90, where the body
 // turns in place (see locomotion_scale_for_heading_error). The animation
-// velocity write
-// multiplies by this and consumes the component; absent = 1.0 (non-AI
-// animation players are unaffected).
+// velocity write multiplies by this and consumes the component; absent =
+// 1.0 (non-AI animation players are unaffected).
 #[derive(Component, Clone, Copy)]
 pub struct RuntimePropLocomotionScale(pub f32);
 

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -39,8 +39,9 @@ pub struct RuntimePropAITargetAwareness {
 
 // Horizontal locomotion speed scale for an AI, published by its steering
 // each frame: full speed when facing the travel direction, ramping down to
-// a floor of a third as heading error grows (never zero - see
-// locomotion_scale_for_heading_error). The animation velocity write
+// a third by 60 degrees of heading error and to zero by 90, where the body
+// turns in place (see locomotion_scale_for_heading_error). The animation
+// velocity write
 // multiplies by this and consumes the component; absent = 1.0 (non-AI
 // animation players are unaffected).
 #[derive(Component, Clone, Copy)]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -107,16 +107,25 @@ fn should_orient_on_target(
 }
 
 /// Forward-speed multiplier for a given heading error: 1.0 facing the
-/// travel direction, ramping down to a third by 60 degrees of error and
-/// flooring there. The floor is never zero - steering chains (collision
-/// avoidance vs path following) can hold a large transient error, and a
-/// zero scale deadlocks the AI in place.
+/// travel direction, ramping down to a third by 60 degrees of error, then
+/// to a standstill by 90.
+///
+/// Past a right angle the body turns in PLACE. Walking a reversal at a
+/// third speed is a second-long arc that carries the body sideways into
+/// whatever happens to be beside it - a railing, a door frame, the AI it
+/// is trying to get around - which is exactly where patrol reversals wedge.
+/// Turning is unaffected by the scale, so a stopped body still pivots and
+/// walks off again the moment its error is back under 90.
 fn locomotion_scale_for_heading_error(delta: Deg<f32>) -> f32 {
     const TURN_SLOW_ANGLE: f32 = 60.0;
+    const TURN_IN_PLACE_ANGLE: f32 = 90.0;
     const MIN_MOVING_SCALE: f32 = 0.33;
     let error = delta.0.abs();
-    if error >= TURN_SLOW_ANGLE {
-        MIN_MOVING_SCALE
+    if error >= TURN_IN_PLACE_ANGLE {
+        0.0
+    } else if error >= TURN_SLOW_ANGLE {
+        let past_slow = (error - TURN_SLOW_ANGLE) / (TURN_IN_PLACE_ANGLE - TURN_SLOW_ANGLE);
+        MIN_MOVING_SCALE * (1.0 - past_slow)
     } else {
         1.0 - (error / TURN_SLOW_ANGLE) * (1.0 - MIN_MOVING_SCALE)
     }
@@ -328,7 +337,7 @@ impl AnimatedMonsterAI {
         // Couple forward speed to heading error so the body doesn't arc at
         // full stride while the heading catches up (the cause of orbiting a
         // close target): full speed facing the travel direction, ramping to
-        // a third by 60 degrees of error.
+        // a third by 60 degrees of error and to a standstill by 90.
         let scale = locomotion_scale_for_heading_error(delta);
 
         Effect::Multiple(vec![
@@ -1959,16 +1968,26 @@ mod tests {
         assert_eq!(at_30, locomotion_scale_for_heading_error(Deg(-30.0)));
         // A third of full speed by 60 degrees
         assert_eq!(locomotion_scale_for_heading_error(Deg(60.0)), 0.33);
-        assert_eq!(locomotion_scale_for_heading_error(Deg(89.0)), 0.33);
     }
 
     #[test]
-    fn locomotion_scale_floors_at_a_third_never_zero() {
-        // A zero scale can deadlock an AI whose steering chain holds a large
-        // transient error - the floor must stay positive even at 180 degrees
-        assert_eq!(locomotion_scale_for_heading_error(Deg(90.0)), 0.33);
-        assert_eq!(locomotion_scale_for_heading_error(Deg(180.0)), 0.33);
-        assert_eq!(locomotion_scale_for_heading_error(Deg(-135.0)), 0.33);
+    fn locomotion_scale_stops_the_body_past_a_right_angle() {
+        // A reversal pivots in place instead of arcing sideways into
+        // whatever is beside the body
+        assert_eq!(locomotion_scale_for_heading_error(Deg(90.0)), 0.0);
+        assert_eq!(locomotion_scale_for_heading_error(Deg(180.0)), 0.0);
+        assert_eq!(locomotion_scale_for_heading_error(Deg(-135.0)), 0.0);
+    }
+
+    #[test]
+    fn locomotion_scale_eases_to_the_standstill_between_60_and_90() {
+        // No cliff at 60: the third-speed walk fades out over the next 30
+        // degrees rather than dropping to a stop in one frame
+        let at_75 = locomotion_scale_for_heading_error(Deg(75.0));
+        assert!((at_75 - 0.165).abs() < 1e-4, "got {at_75}");
+        let at_89 = locomotion_scale_for_heading_error(Deg(89.0));
+        assert!(at_89 > 0.0 && at_89 < 0.02, "got {at_89}");
+        assert_eq!(at_75, locomotion_scale_for_heading_error(Deg(-75.0)));
     }
 
     /// Every environmental-sound query in `effect`, as its (tag, value) pairs.

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -116,18 +116,18 @@ fn should_orient_on_target(
 /// is trying to get around - which is exactly where patrol reversals wedge.
 /// Turning is unaffected by the scale, so a stopped body still pivots and
 /// walks off again the moment its error is back under 90.
-fn locomotion_scale_for_heading_error(delta: Deg<f32>) -> f32 {
+pub(crate) fn locomotion_scale_for_heading_error(delta: Deg<f32>) -> f32 {
     const TURN_SLOW_ANGLE: f32 = 60.0;
     const TURN_IN_PLACE_ANGLE: f32 = 90.0;
-    const MIN_MOVING_SCALE: f32 = 0.33;
+    const TURN_SLOW_SCALE: f32 = 0.33;
     let error = delta.0.abs();
     if error >= TURN_IN_PLACE_ANGLE {
         0.0
     } else if error >= TURN_SLOW_ANGLE {
         let past_slow = (error - TURN_SLOW_ANGLE) / (TURN_IN_PLACE_ANGLE - TURN_SLOW_ANGLE);
-        MIN_MOVING_SCALE * (1.0 - past_slow)
+        TURN_SLOW_SCALE * (1.0 - past_slow)
     } else {
-        1.0 - (error / TURN_SLOW_ANGLE) * (1.0 - MIN_MOVING_SCALE)
+        1.0 - (error / TURN_SLOW_ANGLE) * (1.0 - TURN_SLOW_SCALE)
     }
 }
 

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -219,7 +219,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
 
     fn steer(
         &mut self,
-        _current_heading: Deg<f32>,
+        current_heading: Deg<f32>,
         world: &World,
         physics: &PhysicsWorld,
         entity_id: EntityId,
@@ -249,15 +249,17 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // know we stood on) so the next route doesn't start from the wedged
         // pose and reproduce the wedge
         if let Some((seconds_left, retreat)) = self.recovery {
-            let seconds_left = seconds_left - time.elapsed.as_secs_f32();
+            let steering =
+                Steering::turn_to_point(vec3_to_point3(position), vec3_to_point3(retreat));
+            let heading_error =
+                ai_util::clamp_to_minimal_delta_angle(steering.desired_heading - current_heading);
+            let seconds_left =
+                seconds_left - retreat_seconds_spent(heading_error, time.elapsed.as_secs_f32());
             if seconds_left <= 0.0 || xz_distance(position, retreat) < WAYPOINT_ADVANCE_DISTANCE {
                 self.recovery = None;
             } else {
                 self.recovery = Some((seconds_left, retreat));
-                return Some((
-                    Steering::turn_to_point(vec3_to_point3(position), vec3_to_point3(retreat)),
-                    Effect::NoEffect,
-                ));
+                return Some((steering, Effect::NoEffect));
             }
         }
 
@@ -741,6 +743,23 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
     }
 }
 
+/// How much of the retreat budget this frame spends. A body that wedged was
+/// pushing AT the obstacle, so backing out starts with a half-turn it cannot
+/// walk through - locomotion is zero above a right angle of heading error -
+/// and a plain wall clock would spend most of the window pivoting on the
+/// spot, leaving the body still in contact when the re-path fires. Spending
+/// the budget only while the body can actually move keeps
+/// `STALL_RECOVERY_SECONDS` worth of real backing out.
+fn retreat_seconds_spent(heading_error: Deg<f32>, elapsed: f32) -> f32 {
+    if crate::scripts::ai::animated_monster_ai::locomotion_scale_for_heading_error(heading_error)
+        > 0.0
+    {
+        elapsed
+    } else {
+        0.0
+    }
+}
+
 /// How far the AI's believed target is, or None when it has no target at
 /// all (nothing has ever published awareness for it).
 fn target_awareness_distance(
@@ -1084,6 +1103,17 @@ mod tests {
             &[vec3(10.0, 0.0, 10.0)],
             vec3(10.0, -4.8, 10.0)
         ));
+    }
+
+    #[test]
+    fn a_pivoting_retreat_does_not_burn_its_budget() {
+        // Backing out of a wedge starts with a half-turn the body cannot
+        // walk through; the clock waits for it
+        assert_eq!(retreat_seconds_spent(Deg(180.0), 0.1), 0.0);
+        assert_eq!(retreat_seconds_spent(Deg(-120.0), 0.1), 0.0);
+        // ...and runs once it is moving again
+        assert_eq!(retreat_seconds_spent(Deg(45.0), 0.1), 0.1);
+        assert_eq!(retreat_seconds_spent(Deg(0.0), 0.1), 0.1);
     }
 
     #[test]


### PR DESCRIPTION
`locomotion_scale_for_heading_error` ramped forward speed down to a third by 60 degrees of heading error and never lower, so a reversal was a second-long arc at walking pace that carried the body sideways into whatever happened to be beside it — a railing, a door frame, the AI it was trying to get around. Patrol reversals are where that shows.

The scale now eases from a third at 60 degrees to zero at 90, and stays zero past a right angle: the body pivots, then walks. Turning is unaffected by the scale, so a stopped body still comes about and moves off the moment its error is back under 90.

One consequence had to be paid for in the same PR: **stall recovery** backs a wedged body out toward the previous waypoint for 0.8 s, and a body that wedged was pushing *at* the obstacle — so backing out now starts with a half-turn it cannot walk through. On a plain wall clock most of that window went to pivoting on the spot and the re-path fired with the body still in contact, reproducing the route it had just stalled on. The retreat budget is now spent only while the body can actually move.

Ledger step 7 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

**Turn clips deferred.** The motion database's `+facing` branch (the authored turn animations) is not wired up here. `cargo dq motion 0 +facing` — and `+facing:0` / `+facing:4`, the two values the tag takes in `references/animation_0.spew` — resolve to nothing playable, and the branch's leaf clips carry no names, so the direction semantics cannot be pinned down from the data we can query. Playing a turn clip while the scale is zero is a follow-up.

## Before / after

Reachability harness (PR #1242, `--pass both`), three runs per branch, base = `feat/ai-repel`:

| mission | pass | metric | before (3 runs) | after (3 runs) |
|---|---|---|---|---|
| medsci2.mis | idle | wedged | 3 / 1 / 1 | 3 / 1 / 1 |
| medsci2.mis | idle | progressing | 8 / 10 / 10 | 8 / 10 / 10 |
| medsci2.mis | chase | wedged | 0 / 0 / 0 | 0 / 0 / 0 |
| medsci2.mis | chase | arrived | 2 / 2 / 2 | 3 / 1 / 2 |

No regression, and no aggregate improvement either: what this changes is the *shape* of a reversal (pivot, then walk) rather than whether a given AI eventually gets there, and the harness's buckets are too coarse to see it. The evidence that matters is the e2e set below staying green — particularly `medsci2-patrol-railing`, whose whole point is a patrol reversal in a converging corner — plus the GIF.

## Tests

- Unit: `locomotion_scale_stops_the_body_past_a_right_angle` (negative-first — the pre-existing test asserted the opposite, 0.33 at 90/180 degrees), `locomotion_scale_eases_to_the_standstill_between_60_and_90` (no cliff at the knee), `a_pivoting_retreat_does_not_burn_its_budget`.
- `cargo test -p shock2vr`: 1234 passed.
- e2e: `patrol` 4/4, `force-chase` 1/1, `chase-last-seen` 1/1, `search-behavior` 2/2, `medsci2-patrol-railing` 4/4, `missions` 23/23.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Media

The reversal happens in an unlit balcony dead end where a camera sees essentially nothing, so the visual here is the AI's **recorded path** rather than a photograph of it: the patrolling hybrid's position sampled every 6 sim frames through the medsci2 balcony's south dead end, same mission and same sampling on both branches.

![reversal path before/after](https://gist.githubusercontent.com/tommy-xr/b6a206928377b9f9f55bececc2f52c62/raw/reversal-track.gif)

<sub>Left: the old third-speed arc swings 2.85 units (7.1 ft) sideways as it comes about — into the railing that wedges it. Right: the same reversal now costs 1.52 units (3.8 ft). Captured headlessly via the debug runtime (`/v1/step` + `/v1/entities`, deterministic fixed-timestep).</sub>

![reversal path still](https://gist.githubusercontent.com/tommy-xr/b6a206928377b9f9f55bececc2f52c62/raw/reversal-track.png)

## Review

`/xreview` (Claude adversarial reviewer + a dedicated de-dup reviewer; the Codex engine is unavailable this week, so this ran single-engine plus de-dup). Fixed:

- **High** — stall recovery's 0.8 s retreat is issued as a heading back toward the previous waypoint, i.e. roughly a half-turn from where a wedged body was pushing. With locomotion zero above 90 degrees, most of that window went to pivoting in place and the re-path fired with the body still in contact, reproducing the route it had just stalled on. The retreat budget is now spent only while the body can actually move (`retreat_seconds_spent`, unit-tested).
- **Low** — `MIN_MOVING_SCALE` is no longer a minimum (it is the knee value at 60 degrees), renamed `TURN_SLOW_SCALE`; re-wrapped a comment this PR had broken.

Noted, not changed: an AI that is already inside melee reach and needs to turn more than 90 degrees onto a circling player now pivots rather than lunging sideways — the intended shape of the change, and combat range gating is unaffected. De-dup reviewer: no actionable duplication (it specifically checked whether this ramp should reuse the sibling PR's `repel_ramp`; different domain, different knees, and the reuse would be shorter but less clear).
