### PR TITLE
feat(vr): the forearms stop duplicating the interface readouts

### DIFF
--- a/shock2vr/src/hud/readouts.rs
+++ b/shock2vr/src/hud/readouts.rs
@@ -75,10 +75,21 @@ pub(crate) fn emit_bio(
     size: Vector2<f32>,
     readout: &BioReadout,
 ) {
+    // Backdrop first; the bars and numbers render on top of it.
+    canvas.image(Rect::new(origin.x, origin.y, size.x, size.y), art);
+    emit_bio_overlays(canvas, origin, readout);
+}
+
+/// The bio monitor's bars and numbers alone, with the panel's upper-left corner
+/// at `origin` - everything [`emit_bio`] draws except the backdrop art.
+///
+/// Split out for the VR forearm, which wears the BIOFULL art as its own lit
+/// panel quad and composites only the live overlays onto it, exactly as the
+/// right forearm does with [`ammo_panel::emit`]. One layout, two presentations
+/// (AGENTS.md section 3).
+fn emit_bio_overlays(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &BioReadout) {
     let at = |rect| ammo_panel::at(origin, rect);
     canvas
-        // Backdrop first; the bars and numbers render on top of it.
-        .image(Rect::new(origin.x, origin.y, size.x, size.y), art)
         .bar(at(HEALTH_BAR), "HPBAR.PCX", readout.health_fraction)
         .bar(at(PSI_BAR), "PSIBAR.PCX", readout.psi_fraction);
     let pct = |f: f32| (f.clamp(0.0, 1.0) * 100.0).round() as i32;
@@ -97,6 +108,15 @@ pub(crate) fn emit_bio(
             HAlign::Left,
             VAlign::Middle,
         );
+}
+
+/// The bio overlays on a panel-sized canvas at panel origin (0,0), for a
+/// presentation that supplies its own BIOFULL backdrop - the VR left forearm.
+/// The counterpart of [`ammo_panel::build_readout_canvas`].
+pub(crate) fn build_bio_readout_canvas(readout: &BioReadout) -> UiCanvas {
+    let mut canvas = UiCanvas::new(BIO_FULL_SIZE);
+    emit_bio_overlays(&mut canvas, vec2(0.0, 0.0), readout);
+    canvas
 }
 
 /// Both use-mode readouts, as the interface canvas carries them.
@@ -232,6 +252,40 @@ mod tests {
             let placed = ammo_panel::at(AMMO_ORIGIN, rect);
             assert!(AMMO_ORIGIN.x <= placed.x, "{placed:?}");
             assert!(placed.x + placed.w <= AMMO_ORIGIN.x + ammo_panel::PANEL_W);
+        }
+    }
+
+    /// The VR left forearm and the interface canvas draw ONE bio layout: the
+    /// forearm's panel-local canvas carries exactly the elements `emit_bio`
+    /// places (minus the backdrop art the forearm wears as its own quad), at
+    /// the same rects relative to the panel origin. A forearm that re-derived
+    /// its bars would drift from the interface silently (issue #1268).
+    #[test]
+    fn the_forearm_canvas_is_the_interface_bio_layout_at_panel_origin() {
+        let bio = BioReadout {
+            health_fraction: 0.4,
+            psi_fraction: 0.9,
+        };
+
+        let mut interface = UiCanvas::new(vec2(640.0, 480.0));
+        emit_bio(
+            &mut interface,
+            BIO_ORIGIN,
+            "BIOFULL.PCX",
+            BIO_FULL_SIZE,
+            &bio,
+        );
+
+        let forearm = build_bio_readout_canvas(&bio);
+        assert_eq!(forearm.size(), BIO_FULL_SIZE);
+        // The backdrop is the interface's first element and the forearm's quad.
+        assert_eq!(forearm.element_count(), interface.element_count() - 1);
+
+        for (on_arm, on_panel) in forearm.elements().iter().zip(&interface.elements()[1..]) {
+            let (arm, panel) = (on_arm.rect(), on_panel.rect());
+            assert_eq!(arm.x + BIO_ORIGIN.x, panel.x, "{arm:?} vs {panel:?}");
+            assert_eq!(arm.y + BIO_ORIGIN.y, panel.y, "{arm:?} vs {panel:?}");
+            assert_eq!((arm.w, arm.h), (panel.w, panel.h));
         }
     }
 

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -6,7 +6,12 @@ use dark::{
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
 use shipyard::{Get, UniqueView, View, World};
 
-use crate::{mission::PlayerInfo, vr_config::Handedness};
+use crate::{
+    hud::{ammo_panel, readouts},
+    mission::PlayerInfo,
+    ui::UiCanvas,
+    vr_config::Handedness,
+};
 
 /// Offset from hand position to forearm HUD panel *centre*. The panel's width
 /// axis runs along the arm (hand-local +Z), so it spans
@@ -19,48 +24,46 @@ pub(crate) const FOREARM_OFFSET: Vector3<f32> = vec3(0.0, 0.0, 0.25); // world u
 pub(crate) const HUD_PANEL_WIDTH: f32 = 0.26; // world units: 0.26 * 0.762 = 20 cm along the arm
 const HUD_PANEL_HEIGHT: f32 = 0.064; // 6.4cm tall (260:64 = 4.0625:1 ratio)
 
-/// BIOFULL.PCX texture dimensions
-const BIOFULL_WIDTH: f32 = 260.0;
-const BIOFULL_HEIGHT: f32 = 64.0;
-
-const BAR_VERTICAL_OFFSET: f32 = -8.0;
-const BAR_HORIZONTAL_OFFSET: f32 = 1.0;
-
-/// Health bar overlay coordinates (pixel space on BIOFULL.PCX)
-const HEALTH_BAR_START: (f32, f32) = (BAR_HORIZONTAL_OFFSET + 8.0, 40.0 + BAR_VERTICAL_OFFSET);
-const HEALTH_BAR_END: (f32, f32) = (BAR_HORIZONTAL_OFFSET + 88.0, 54.0 + BAR_VERTICAL_OFFSET);
-
-/// Psi bar overlay coordinates (pixel space on BIOFULL.PCX)
-const PSI_BAR_START: (f32, f32) = (BAR_HORIZONTAL_OFFSET + 8.0, 17.0 + BAR_VERTICAL_OFFSET);
-const PSI_BAR_END: (f32, f32) = (BAR_HORIZONTAL_OFFSET + 88.0, 31.0 + BAR_VERTICAL_OFFSET);
-
 /// Z-offset for overlay layers to ensure proper rendering order
 const OVERLAY_Z_OFFSET: f32 = 0.001;
 
-/// Create HUD panels for both arms with health/psi overlays
+/// Create the forearm HUD panels: BIOFULL (health/psi) on the left arm,
+/// AMMOFULL (the live ammo readout) on the right.
+///
+/// `use_mode` silences both: the cyber interface carries the expanded BIOFULL
+/// and AMMOFULL readouts on its canvas while it is up (`hud::readouts`), so
+/// leaving the arms lit would show a VR player the same numbers twice, at two
+/// scales and orientations (issue #1268). Flat drops its compact overlay in
+/// use mode for the same reason (`hud::flat_hud`).
 pub fn create_arm_hud_panels(
     asset_cache: &mut AssetCache,
     world: &World,
+    use_mode: bool,
     left_hand_position: Vector3<f32>,
     left_hand_rotation: Quaternion<f32>,
     right_hand_position: Vector3<f32>,
     right_hand_rotation: Quaternion<f32>,
 ) -> Vec<SceneObject> {
-    let mut scene_objects = Vec::new();
+    if use_mode {
+        return Vec::new();
+    }
 
-    // Create left arm HUD with health/psi overlays (BIOFULL base)
-    let mut left_hud_layers = create_forearm_hud_with_overlays(
+    // The bio monitor on the left arm, the ammo gauge on the right - each the
+    // shared layout's own canvas, hung by the one compositor below.
+    let mut scene_objects = forearm_readout_panel(
         asset_cache,
-        world,
         left_hand_position,
         left_hand_rotation,
+        Handedness::Left,
+        readouts::build_bio_readout_canvas(&readouts::BioReadout::from_world(world)),
     );
-    scene_objects.append(&mut left_hud_layers);
-
-    // Create right arm HUD (AMMOFULL) with the live ammo readout on it
-    let mut right_hud_layers =
-        create_ammo_forearm_panel(asset_cache, world, right_hand_position, right_hand_rotation);
-    scene_objects.append(&mut right_hud_layers);
+    scene_objects.append(&mut forearm_readout_panel(
+        asset_cache,
+        right_hand_position,
+        right_hand_rotation,
+        Handedness::Right,
+        ammo_panel::build_readout_canvas(&ammo_panel::AmmoReadout::from_world(world, false)),
+    ));
 
     // Part of the player's hand visuals: labelled here rather than at the call
     // sites so the `debug_hud` scene, which emits these without an interaction
@@ -68,51 +71,6 @@ pub fn create_arm_hud_panels(
     crate::util::tag_render_source(&mut scene_objects, crate::util::render_source::PLAYER_HANDS);
 
     scene_objects
-}
-
-/// Convert pixel coordinates to UV coordinates (0.0 to 1.0)
-fn pixel_to_uv(pixel_coords: (f32, f32)) -> (f32, f32) {
-    (
-        pixel_coords.0 / BIOFULL_WIDTH,
-        pixel_coords.1 / BIOFULL_HEIGHT,
-    )
-}
-
-/// Calculate overlay quad dimensions and position in world space
-fn create_overlay_transform(
-    base_position: Vector3<f32>,
-    base_rotation: Quaternion<f32>,
-    pixel_start: (f32, f32),
-    pixel_end: (f32, f32),
-    z_offset: f32,
-) -> (Matrix4<f32>, f32, f32) {
-    // Convert pixel coordinates to UV space
-    let uv_start = pixel_to_uv(pixel_start);
-    let uv_end = pixel_to_uv(pixel_end);
-
-    // Calculate overlay dimensions as fraction of base HUD
-    let overlay_width = (uv_end.0 - uv_start.0) * HUD_PANEL_WIDTH;
-    let overlay_height = (uv_end.1 - uv_start.1) * HUD_PANEL_HEIGHT;
-
-    // Calculate center offset relative to base HUD center
-    let center_u = (uv_start.0 + uv_end.0) / 2.0 - 0.5; // -0.5 to center
-    let center_v = (uv_start.1 + uv_end.1) / 2.0 - 0.5; // -0.5 to center
-
-    // Convert UV offsets to world space offsets
-    let offset_x = center_u * HUD_PANEL_WIDTH;
-    let offset_y = -center_v * HUD_PANEL_HEIGHT; // Flip Y for correct orientation
-
-    // Apply base rotation to offsets
-    let local_offset = vec3(offset_x, offset_y, z_offset);
-    let world_offset = base_rotation.rotate_vector(local_offset);
-
-    let overlay_position = base_position + world_offset;
-
-    let transform = Matrix4::from_translation(overlay_position)
-        * Matrix4::from(base_rotation)
-        * Matrix4::from_nonuniform_scale(overlay_width, overlay_height, 1.0);
-
-    (transform, overlay_width, overlay_height)
 }
 
 /// Get player health percentage (0.0 to 1.0)
@@ -254,99 +212,45 @@ pub(crate) fn get_wielded_ammo_icon(world: &World) -> Option<String> {
     icons.0.get(&template_id).cloned()
 }
 
-/// Create the left forearm's layered BIOFULL HUD with health and psi bar
-/// overlays. (The right forearm is [`create_ammo_forearm_panel`]'s.)
-fn create_forearm_hud_with_overlays(
+/// One forearm panel: the backdrop art for `handedness` with `readout` - a
+/// panel-sized canvas drawn at panel origin (0,0) - composited one overlay step
+/// in front of it.
+///
+/// The backdrop stays a plain lit quad rather than a canvas element (the canvas
+/// presenter draws its elements fully emissive, which suits a readout but would
+/// make the panel glow), and `readout` is whatever the SHARED presentation-
+/// agnostic layout emitted, so an arm cannot drift from the interface canvas or
+/// the flat HUD (AGENTS.md section 3). Both arms composite identically here, so
+/// a change to how one is hung cannot miss the other.
+///
+/// No controls on either arm: the VR pointer only hits the cyber-interface
+/// panel, never these quads, so drawing a SETTING/RELOAD/cycle button nobody can
+/// press would be a lie. Only the interactive layer differs, and it differs by
+/// whether a pointer can reach it, not by presentation.
+fn forearm_readout_panel(
     asset_cache: &mut AssetCache,
-    world: &World,
     hand_position: Vector3<f32>,
     hand_rotation: Quaternion<f32>,
+    handedness: Handedness,
+    readout: UiCanvas,
 ) -> Vec<SceneObject> {
-    let mut layers = Vec::new();
-
-    // Calculate base HUD position and rotation
-    let (forearm_position, final_rotation) =
-        forearm_pose(hand_position, hand_rotation, Handedness::Left);
-
-    // Layer 1: Base BIOFULL panel
-    let base_panel =
-        create_forearm_hud_panel(asset_cache, hand_position, hand_rotation, Handedness::Left);
-    layers.push(base_panel);
-
-    // Layer 2: Health bar overlay
-    let health_percentage = get_health_percentage(world);
-    if let Some(health_overlay) = create_bar_overlay(
+    let mut objects = vec![create_forearm_hud_panel(
         asset_cache,
-        "HPBAR.PCX",
-        forearm_position,
-        final_rotation,
-        HEALTH_BAR_START,
-        HEALTH_BAR_END,
-        health_percentage,
+        hand_position,
+        hand_rotation,
+        handedness,
+    )];
+
+    objects.append(&mut readout.render_world_space(
+        asset_cache,
+        forearm_panel_transform(hand_position, hand_rotation, handedness)
+            * Matrix4::from_translation(vec3(0.0, 0.0, OVERLAY_Z_OFFSET)),
+        None,
+        None,
         OVERLAY_Z_OFFSET,
-    ) {
-        layers.push(health_overlay);
-    }
+    ));
 
-    // Layer 3: Psi bar overlay
-    let psi_percentage = get_psi_percentage(world);
-    if let Some(psi_overlay) = create_bar_overlay(
-        asset_cache,
-        "PSIBAR.PCX",
-        forearm_position,
-        final_rotation,
-        PSI_BAR_START,
-        PSI_BAR_END,
-        psi_percentage,
-        OVERLAY_Z_OFFSET * 2.0, // Stack above health bar
-    ) {
-        layers.push(psi_overlay);
-    }
-
-    layers
-}
-
-/// Create a clipped bar overlay at specific pixel coordinates
-fn create_bar_overlay(
-    asset_cache: &mut AssetCache,
-    texture_name: &str,
-    base_position: Vector3<f32>,
-    base_rotation: Quaternion<f32>,
-    pixel_start: (f32, f32),
-    pixel_end: (f32, f32),
-    clip_percentage: f32,
-    z_offset: f32,
-) -> Option<SceneObject> {
-    // Load bar texture
-    let texture_options = TextureOptions {
-        wrap: false,
-        ..Default::default()
-    };
-    let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, texture_name, &texture_options);
-
-    // Create clipped screen material
-    let material = engine::scene::clipped_screen_material::create(
-        texture.clone() as std::rc::Rc<dyn engine::texture::TextureTrait>,
-        clip_percentage,
-    );
-
-    // Create geometry
-    let geometry = Box::new(engine::scene::quad::create());
-
-    // Calculate overlay transform
-    let (transform, _width, _height) = create_overlay_transform(
-        base_position,
-        base_rotation,
-        pixel_start,
-        pixel_end,
-        z_offset,
-    );
-
-    // Create scene object
-    let mut scene_object = SceneObject::new(material, geometry);
-    scene_object.set_transform(transform);
-
-    Some(scene_object)
+    objects
 }
 
 /// Create a single forearm HUD panel
@@ -423,48 +327,32 @@ fn forearm_panel_transform(
         * Matrix4::from_nonuniform_scale(HUD_PANEL_WIDTH, HUD_PANEL_HEIGHT, 1.0)
 }
 
-/// The right forearm's AMMOFULL panel, with the live ammo readout composited
-/// on it - the VR counterpart of the flat HUD's ammo gauge.
-///
-/// The backdrop stays the plain panel quad the left forearm uses, so both
-/// forearm panels are lit identically (the canvas presenter draws its elements
-/// fully emissive, which suits a readout but would make this panel glow beside
-/// its BIOFULL twin). The readout itself is a panel-sized canvas laid one
-/// overlay step in front, drawn by the shared [`crate::hud::ammo_panel`]
-/// layout at panel origin (0,0) - flat emits the identical elements at the
-/// panel's origin on its 640x480 canvas (AGENTS.md section 3 - one layout, two
-/// presentations).
-fn create_ammo_forearm_panel(
-    asset_cache: &mut AssetCache,
-    world: &World,
-    hand_position: Vector3<f32>,
-    hand_rotation: Quaternion<f32>,
-) -> Vec<SceneObject> {
-    use crate::hud::ammo_panel;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::assets::asset_paths::AssetPath;
 
-    let mut objects = vec![create_forearm_hud_panel(
-        asset_cache,
-        hand_position,
-        hand_rotation,
-        Handedness::Right,
-    )];
-
-    // No controls on the forearm: the VR pointer only hits the cyber-interface
-    // panel, never this quad, so drawing a SETTING/RELOAD/cycle button nobody
-    // can press would be a lie. The readout itself is placed identically to
-    // flat's (AGENTS.md section 3) - only the interactive layer differs, and
-    // it differs by whether a pointer can reach it, not by presentation.
-    let readout = ammo_panel::AmmoReadout::from_world(world, false);
-    objects.append(
-        &mut ammo_panel::build_readout_canvas(&readout).render_world_space(
-            asset_cache,
-            forearm_panel_transform(hand_position, hand_rotation, Handedness::Right)
-                * Matrix4::from_translation(vec3(0.0, 0.0, OVERLAY_Z_OFFSET)),
-            None,
-            None,
-            OVERLAY_Z_OFFSET,
-        ),
-    );
-
-    objects
+    /// With the cyber interface up, the forearms emit nothing at all - the
+    /// interface canvas is the single copy of both readouts (issue #1268).
+    ///
+    /// The gate short-circuits before the world or the asset cache is touched,
+    /// which is what makes an empty `World` (no `PlayerInfo`) and an asset path
+    /// that resolves nothing a sufficient fixture: an ungated build reaches
+    /// both and fails.
+    #[test]
+    fn the_forearms_go_quiet_while_use_mode_is_up() {
+        // No mounts: every lookup misses, so touching the cache is the failure
+        // this test is looking for.
+        let mut assets = AssetCache::new(String::new(), AssetPath::combine(vec![]));
+        let objects = create_arm_hud_panels(
+            &mut assets,
+            &World::new(),
+            true,
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::from(Euler::new(Deg(0.0), Deg(0.0), Deg(0.0))),
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::from(Euler::new(Deg(0.0), Deg(0.0), Deg(0.0))),
+        );
+        assert!(objects.is_empty());
+    }
 }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -100,7 +100,15 @@ pub trait PlayerInteraction {
     /// 3D visuals owned by the controller (VR: hand models + forearm HUD
     /// panels). Flat draws nothing here; its weapon is drawn from
     /// `viewmodel_entity`.
-    fn render(&self, _asset_cache: &mut AssetCache, _world: &World) -> Vec<SceneObject> {
+    ///
+    /// `use_mode` is the cyber interface's state: the forearm readouts go quiet
+    /// while the interface carries them (issue #1268).
+    fn render(
+        &self,
+        _asset_cache: &mut AssetCache,
+        _world: &World,
+        _use_mode: bool,
+    ) -> Vec<SceneObject> {
         Vec::new()
     }
 
@@ -279,7 +287,12 @@ impl PlayerInteraction for VrInteraction {
         }
     }
 
-    fn render(&self, asset_cache: &mut AssetCache, world: &World) -> Vec<SceneObject> {
+    fn render(
+        &self,
+        asset_cache: &mut AssetCache,
+        world: &World,
+        use_mode: bool,
+    ) -> Vec<SceneObject> {
         let mut glove_slot = self.glove_renderer.borrow_mut();
         let glove_renderer = glove_slot
             .get_or_insert_with(|| GloveRenderer::new(asset_cache))
@@ -304,6 +317,7 @@ impl PlayerInteraction for VrInteraction {
         objs.append(&mut create_arm_hud_panels(
             asset_cache,
             world,
+            use_mode,
             self.left_hand.get_position(),
             self.left_hand.get_rotation(),
             self.right_hand.get_position(),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9628,7 +9628,11 @@ impl MissionCore {
         // + forearm HUD panels; flat draws nothing here (its weapon viewmodel is
         // drawn on top in `render_per_eye`). They are labelled `PLAYER_HANDS_SOURCE`
         // so `Game` can drop them while the pause menu is up (issue #1018).
-        scene.append(&mut self.interaction.render(asset_cache, &self.world));
+        scene.append(
+            &mut self
+                .interaction
+                .render(asset_cache, &self.world, self.use_mode),
+        );
 
         // The old synthetic blue inventory cube remains a desktop diagnostic.
         // VR presents the authored INVBACK canvas through GuiManager instead.

--- a/shock2vr/src/scenes/debug_hud.rs
+++ b/shock2vr/src/scenes/debug_hud.rs
@@ -203,6 +203,9 @@ impl GameScene for DebugHudScene {
         let hud_panels = create_arm_hud_panels(
             asset_cache,
             &self.world,
+            // The debug scene has no cyber interface, so the arms are never
+            // duplicating it.
+            false,
             self.left_hand_position,
             self.left_hand_rotation,
             self.right_hand_position,

--- a/tools/shock2-sdk/test/vr-forearm-readouts.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-forearm-readouts.e2e.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// The VR forearm HUD panels and the cyber interface must never show the same
+// readout at once (issue #1268). Since #1267 the interface canvas carries the
+// expanded BIOFULL/AMMOFULL pair; the forearms carry them in shooter mode. So
+// in EITHER mode there is exactly one copy of each readout in the frame.
+//
+// Negative-first: on the parent branch `create_arm_hud_panels` is not gated on
+// use mode, so opening the interface leaves the forearm panels drawn and the
+// player sees both copies - the `player_hands` object count does not drop at
+// all, and the "drops by at least the bio panel" assertions below fail.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_VR_FOREARM_PORT ?? 8741);
+
+/** The debug pistol: a magazine, two fire modes, and more than one ammo type. */
+const PISTOL = -17;
+
+/**
+ * The BIOFULL forearm panel's own draws: the backdrop quad plus the four
+ * elements `hud::readouts::emit_bio` overlays on it (two bars, two numbers).
+ * The left arm alone, so the assertion holds however the right arm's ammo
+ * gauge is populated.
+ */
+const BIO_FOREARM_OBJECTS = 5;
+
+/** Objects the VR hand path submitted on the last frame. */
+async function handObjectCount(game: GameServer): Promise<number> {
+  return (await game.scene.fromSource("player_hands")).length;
+}
+
+test(
+  "the forearm readouts go quiet while the cyber interface carries them",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // Shooter mode: the forearms are the only copy - the interface is down, so
+    // its canvas draws no readout at all.
+    const shooter = await game.ui.state();
+    assert.deepEqual(
+      shooter.readout_elements,
+      [],
+      "no interface readout while the interface is down",
+    );
+    const withForearms = await handObjectCount(game);
+    assert.ok(
+      withForearms >= BIO_FOREARM_OBJECTS,
+      `the forearms should be drawn in shooter mode, got ${withForearms} hand objects`,
+    );
+
+    // Use mode: the interface canvas takes over, and the arms go quiet.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 8 });
+    const inUse = await game.ui.state();
+    assert.equal(inUse.mode, "use");
+    assert.ok(
+      inUse.readout_elements.some((e) => e.label === "biofull"),
+      `expected the interface to carry BIOFULL, got ${inUse.readout_elements.map((e) => e.label)}`,
+    );
+
+    const withoutForearms = await handObjectCount(game);
+    assert.ok(
+      withForearms - withoutForearms >= BIO_FOREARM_OBJECTS,
+      `the forearm panels must stop drawing in use mode: ${withForearms} -> ${withoutForearms} hand objects`,
+    );
+
+    // Leaving use mode hands them back, so the readout is never absent from
+    // both places.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 8 });
+    assert.equal((await game.ui.state()).mode, "shooter");
+    assert.equal(
+      await handObjectCount(game),
+      withForearms,
+      "the forearm panels return when the interface goes away",
+    );
+  },
+);
+
+test(
+  "a held gun's ammo is on the forearm or the interface, never both",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = (await game.entities.list()).entities.find(
+      (e) => e.template_id === PISTOL,
+    );
+    assert.ok(pistol, "the scene should stock the debug pistol");
+    await aimVrHandAt(game, pistol.position as Vec3, 0.35);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol.id,
+      "the VR right hand must hold the pistol",
+    );
+
+    // Wielding it adds the ammo gauge to the right forearm, on top of the bio
+    // panel the left arm always wears.
+    const armed = await handObjectCount(game);
+    assert.deepEqual(
+      (await game.ui.state()).readout_elements,
+      [],
+      "the interface draws nothing while the arms carry the gauge",
+    );
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 8 });
+    const inUse = await game.ui.state();
+    assert.ok(
+      inUse.readout_elements.some((e) => e.label === "ammofull"),
+      `expected the interface to carry AMMOFULL, got ${inUse.readout_elements.map((e) => e.label)}`,
+    );
+    assert.ok(
+      armed - (await handObjectCount(game)) >= BIO_FOREARM_OBJECTS,
+      "both forearm panels must stop drawing while the interface shows them",
+    );
+  },
+);


### PR DESCRIPTION
Closes #1268. Stacked on #1267.

## What

Two things, both about VR showing one readout where it showed two:

- **`create_arm_hud_panels` is gated on `use_mode`.** While the cyber interface is up it emits nothing, so the interface canvas is the single copy of BIOFULL and AMMOFULL. Flat already drops its compact overlay in use mode for exactly this reason (`hud/flat_hud.rs`); VR now matches.
- **The left forearm's bio panel draws the shared layout.** Its hand-rolled bar overlays — `pixel_to_uv` / `create_overlay_transform` / `create_bar_overlay`, panel-bottom-relative pixel offsets, a second layout of art `hud::readouts` already owns — are gone. Both arms now hang the shared emit's own panel-sized canvas through one `forearm_readout_panel`.

## Why the ammo readout stays on the arm

The owner decision is that ammo becomes ambient **on the weapon** and the right-forearm AMMOFULL retires with it. That is PR #1091, which is still a **draft and not merged** — there is no on-weapon readout on `main` (`grep WEAPON_METER_ANCHORS\|weapon_meter\|ambient_meters shock2vr/src runtimes` finds nothing). So this PR does not retire the forearm ammo readout and does not re-implement #1091; it only **gates it off in use mode**, which is all #1268 asks for. Retiring it belongs with #1091.

**Glance-gating the wrist health panel is likewise deferred.** It is not the ≤20-line dot product it looks like: `create_arm_hud_panels` has no head pose, so it needs the eye position threaded through `PlayerInteraction::render` and the `debug_hud` scene, plus hysteresis (a bare threshold flickers at the boundary) and an untracked-pose guard (vr-ui-design rule 7). #1091 already prototypes it with those pieces; this PR leaves it there rather than shipping a worse copy.

## The two layouts did NOT agree

The issue said the forearm and interface rects "agree today". They did not. Reading them off the code:

| | health bar | psi bar | numbers |
| --- | --- | --- | --- |
| old forearm | panel y `32..46` | panel y `9..23` | none |
| shared (`readouts.rs`) | panel y `18..32` | panel y `41..55` | drawn |

Psi was **above** health — the transpose of what flat and the interface draw — and offset ~9 px up the panel, and the numeric health/psi values were missing. The before/after below shows it: the medical-cross and psi glyphs live in the bar *textures*, so they move with the bar, and they swap wells between the two shots.

## Visuals

**Left forearm BIOFULL, base vs branch** (VR `debug_weapons`, free camera along the panel normal; the panel's long axis runs vertically in frame). Before: psi (red, psi glyph) in the first well, health (green, cross) in the second, both numeric wells empty. After: health first, psi second, `100` / `80` drawn.

![bio panel before/after](https://gist.githubusercontent.com/tommy-xr/7338966974b0381611a99a1891307257/raw/pr_bio_panel.png)

**Use mode, base vs branch** (VR `debug_weapons`, head pitched down 35°, interface open — same deterministic sequence on both refs). Before: the interface canvas is up **and** both forearm panels are drawn on the arms. After: hands and cuffs only; the interface is unchanged.

![use mode before/after](https://gist.githubusercontent.com/tommy-xr/7338966974b0381611a99a1891307257/raw/pr_usemode.png)

**Toggling, on this branch** — shooter mode with the arms lit, the interface opens and the arms go quiet, then it closes and they come back. Captured headlessly (`/v1/step` + `/v1/screenshot`, fixed 60 Hz).

![toggle](https://gist.githubusercontent.com/tommy-xr/7338966974b0381611a99a1891307257/raw/pr_toggle.gif)

Scene-object counts agree with the pictures: `player_hands` objects in use mode go **8 → 4** (both forearm panels and their overlays gone, hand models untouched).

## Tests

**Unit** (`cargo test -p shock2vr --lib`, 1302 passed):

- `hud::readouts::the_forearm_canvas_is_the_interface_bio_layout_at_panel_origin` — the forearm's panel-local canvas carries exactly the elements `emit_bio` places (minus the backdrop the forearm wears as its own quad), at the same rects relative to the panel origin. This is the assertion the old hand-rolled layout would have failed.
- `hud::virtual_arms::the_forearms_go_quiet_while_use_mode_is_up` — with use mode up the gate short-circuits before the world or the asset cache is touched, so an empty `World` and a zero-mount asset path are a sufficient fixture.

Negative-first: both tests reference API this PR introduces (`build_bio_readout_canvas`, the `use_mode` parameter), so on the base ref they do not compile — that is their negative. The behavioral negative is the e2e below, which runs unmodified against a base-ref binary.

**E2E** `tools/shock2-sdk/test/vr-forearm-readouts.e2e.test.ts` (`--vr`, `debug_weapons`) — **negative-first, verified**. Same test binary, `shock2vr/` reverted to the base ref:

```
not ok 1 - the forearm readouts go quiet while the cyber interface carries them
  error: 'the forearm panels must stop drawing in use mode: 8 -> 8 hand objects'
not ok 2 - a held gun's ammo is on the forearm or the interface, never both
  error: 'both forearm panels must stop drawing while the interface shows them'
# pass 0
# fail 2
```

On this branch:

```
ok 1 - the forearm readouts go quiet while the cyber interface carries them
ok 2 - a held gun's ammo is on the forearm or the interface, never both
# pass 2
# fail 0
```

It asserts both directions — leaving use mode hands the panels back, so the readout is never absent from *both* places — and covers the held-gun case so the right arm's ammo gauge is exercised too.

Full re-run after the review fixes — **20 tests, 0 failures**:

```
vr-forearm-readouts, vr-interface-readouts, vr-cyber-interface,
vr-cyber-interface-pointer, vr-cyber-interface-deposit,
vr-cyber-interface-frob, vr-held-model, bio-ammo-full, flat-hud
```

`flat-hud` and `bio-ammo-full` are there to prove flat is untouched — it is; the only Rust change flat sees is `emit_bio` splitting its backdrop from its overlays, which emits the same elements in the same order.

`missions.e2e.test.ts`: all 23 `.mis` load — `# pass 23 / # fail 0`. (An earlier run reported `not ok 23 - mission loads: shodan.mis`; that was a port/CPU flake from an unrelated full e2e suite running concurrently on the same machine — shodan passes in isolation and the clean re-run above is with that contention gone.)

## Review (`/xreview --media`, single-engine — Codex is rate-limited until Sep 6)

A Claude adversarial reviewer plus the dedicated de-dup pass, both given the before/after images. **No correctness findings.** Everything raised was addressed:

- **Two forearm panels, one compositor written twice** (de-dup, `extract` [S1-names 0.70, S4-read]). `create_bio_forearm_panel` was `create_ammo_forearm_panel` with three substitutions; the backdrop seed, the `render_world_space` call and the append were line-identical. Exactly the drift class both functions' doc comments warn about. **Fixed**: one `forearm_readout_panel(asset_cache, pos, rot, handedness, canvas)`; each arm supplies its own shared-layout canvas and nothing else. The *layout* split stays two (the panels genuinely say different things); only the compositing merged.
- **A 20-line no-op `AbstractAssetPath` test stub** (de-dup, `reuse` [S3-index, S1-names]). `AssetPath::combine(vec![])` already is one — zero mounts, every lookup misses. **Fixed.**
- **`handObjectCount` re-implemented `SceneApi.fromSource`, with a truncation hazard** (Low). `scene.objects({limit: 1000})` truncates server-side over an *unordered* list, so in a big scene the hand objects could silently fall off the end and the counts would be meaningless. **Fixed**: `game.scene.fromSource("player_hands")`, which passes no limit.
- **`emit_bio_overlays` was `pub(crate)` with no caller outside its module** (Low). **Fixed**: private; `emit_bio` and `build_bio_readout_canvas` stay the crate-facing pair.

Cleared by the reviewer on inspection, with reasoning worth recording:

- **`self.use_mode` is the right gate, and there is no frame skew in either direction.** `refresh_readouts` runs from `enter_use_mode`/`leave_use_mode` as well as per update, so the canvas gains and loses the readouts on the same frame `use_mode` flips, and the gate is the same predicate `flat_hud.rs` already uses. The trailing exit ramp keeps `render_vr_use_mode` alive past `use_mode == false`, but by its own documentation the canvas is empty once the strip is cleared, so only the dim lingers — nothing to double up with.
- **`debug_hud` passing `false` is right** — the scene has no cyber interface.
- **The `emit_bio` split is exact** — element order and rects unchanged, so the interface and flat draws are byte-identical.
- **The forearm canvas render is equivalent to the ammo arm's**, and `BIO_FULL_SIZE` 260×64 matches `HUD_PANEL_WIDTH/HEIGHT` 0.26/0.064, so no aspect distortion.
- **Visual axis**: the reviewer confirmed the transposition and the missing numbers independently from the code, and confirmed the gate does not eat the hands or gloves.

De-dup coverage, verbatim: S1-names ran (10 queries, 8270 candidates, min-score 0.3); S2-clones ran (633-line whole-repo report, 3 pairs intersecting changed files, all pre-existing); S3-index ran (4181-line API index); S4-read ran over the full Rust diff plus the real source of `create_ammo_forearm_panel`, `ammo_panel::emit`/`build_readout_canvas`, `forearm_panel_transform`, `flat_hud`, and `MultipleAssetPaths`. None unavailable.

## Validation

```
cargo fmt --check                                                     clean
RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime   clean
cargo test -p shock2vr --lib                                          1302 passed, 0 failed
```
