### PR TITLE
feat(psi): instant self-cast branch, Cerebro-stimulated Regeneration heals

### DIFF
--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -35,10 +35,15 @@ pub const INVISO_TEMPLATE_ID: i32 = -3157;
 /// (`duration_base + duration_per_psi × PSI` seconds).
 pub const ACTIVATION_TYPE_SUSTAINED: i32 = 1;
 
-/// `PropPsiPower::activation_type` for instant self-targeted effects - the
-/// power resolves immediately on cast, with no duration and no projectile
-/// (e.g. PsiHeal, Major Heal, SomaDrain).
+/// `PropPsiPower::activation_type` for instant/special powers - they resolve
+/// immediately on cast, with no duration and no projectile. Self-targeted
+/// (the heals, SomaDrain) and remote (CyberHack, ForceWall) powers both land
+/// here.
 pub const ACTIVATION_TYPE_INSTANT: i32 = 2;
+
+/// `PsiHeal` - Cerebro-stimulated Regeneration (tier 2 instant power): heals
+/// the caster.
+pub const PSI_HEAL_TEMPLATE_ID: i32 = -1017;
 
 /// The powers that support hold-to-overload (per the published gameplay
 /// tables), by template id. Comments give the gamesys name and the

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -35,6 +35,11 @@ pub const INVISO_TEMPLATE_ID: i32 = -3157;
 /// (`duration_base + duration_per_psi × PSI` seconds).
 pub const ACTIVATION_TYPE_SUSTAINED: i32 = 1;
 
+/// `PropPsiPower::activation_type` for instant self-targeted effects - the
+/// power resolves immediately on cast, with no duration and no projectile
+/// (e.g. PsiHeal, Major Heal, SomaDrain).
+pub const ACTIVATION_TYPE_INSTANT: i32 = 2;
+
 /// The powers that support hold-to-overload (per the published gameplay
 /// tables), by template id. Comments give the gamesys name and the
 /// discipline name players know it by.

--- a/shock2vr/src/scripts/healing_item.rs
+++ b/shock2vr/src/scripts/healing_item.rs
@@ -1,8 +1,7 @@
-use dark::properties::{PropHitPoints, PropMaxHitPoints};
 use serde::{Deserialize, Serialize};
-use shipyard::{Get, Unique, UniqueView, View, World};
+use shipyard::{Unique, UniqueView, World};
 
-use crate::{mission::PlayerInfo, physics::PhysicsWorld, quest_info::QuestInfo};
+use crate::{physics::PhysicsWorld, quest_info::QuestInfo};
 
 use super::{Effect, MessagePayload, Script};
 use crate::scripts::gui::TRAIT_PHARMO_FRIENDLY;
@@ -173,20 +172,7 @@ impl ActiveHealing {
 /// effect. `MissionCore` remains the only place that mutates HP, preserving its
 /// player-death guard and the shared HP trace.
 pub fn tick_player_healing(world: &World, elapsed_secs: f32) -> Option<Effect> {
-    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
-    let current = world
-        .borrow::<View<PropHitPoints>>()
-        .ok()
-        .and_then(|hit_points| hit_points.get(player).ok().map(|hp| hp.hit_points))?;
-    let maximum = world
-        .borrow::<View<PropMaxHitPoints>>()
-        .ok()
-        .and_then(|max_hit_points| {
-            max_hit_points
-                .get(player)
-                .ok()
-                .map(|hp| hp.hit_points.min(i32::MAX as u32) as i32)
-        })?;
+    let (player, current, maximum) = crate::scripts::script_util::player_hit_points(world)?;
     let delta = world
         .borrow::<shipyard::UniqueViewMut<ActiveHealing>>()
         .ok()

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -471,7 +471,8 @@ fn cast_self_heal(
     power: &PsiPowerInfo,
     effective_psi: i32,
 ) -> Effect {
-    let Some((player_entity, current_hp, max_hp)) = player_hit_points(world) else {
+    let Some((player_entity, current_hp, max_hp)) = super::script_util::player_hit_points(world)
+    else {
         game_log!(WARN, "No player hit points for {}", power.name);
         return Effect::NoEffect;
     };
@@ -524,25 +525,6 @@ fn self_heal_amount(data: &[f32; 4], effective_psi: i32, current_hp: i32, max_hp
     }
     let missing = (max_hp - current_hp).max(0);
     (amount.floor() as i32).clamp(0, missing)
-}
-
-/// The player entity with its (current, maximum) hit points.
-fn player_hit_points(world: &World) -> Option<(EntityId, i32, i32)> {
-    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
-    let current = world
-        .borrow::<View<dark::properties::PropHitPoints>>()
-        .ok()?
-        .get(player)
-        .ok()?
-        .hit_points;
-    let max = world
-        .borrow::<View<dark::properties::PropMaxHitPoints>>()
-        .ok()?
-        .get(player)
-        .ok()?
-        .hit_points
-        .min(i32::MAX as u32) as i32;
-    Some((player, current, max))
 }
 
 /// The amp's `GunFlash` links supply the cast visual (Spinning Psi Ring).

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -125,6 +125,13 @@ impl Script for PsiAmpScript {
                         );
                         return Effect::NoEffect;
                     }
+                    // Nor charge a cast that would resolve to nothing (a heal
+                    // at full health): over-holding it would burn out for a
+                    // cast the release refuses anyway.
+                    if instant_cast_is_futile(world, &power, player_psi_stat(world)) {
+                        game_log!(INFO, "{} would do nothing right now", power.name);
+                        return Effect::NoEffect;
+                    }
                     // Cast happens on release; start the meter.
                     let duration = charge_duration_secs(power.power.psi_cost);
                     self.charge = Some(ChargeState::Charging {
@@ -437,19 +444,19 @@ fn cast_sustained_power(
     Effect::Multiple(effects)
 }
 
-/// Cast an instant (activation type 2) self-targeted power: it resolves on
-/// the spot, with no duration and no projectile. Dispatch is by the power's
-/// gamesys name so the remaining instant powers (Major Heal, SomaDrain) slot
-/// in beside this one.
+/// Cast an instant (activation type 2) power: it resolves on the spot, with
+/// no duration and no projectile. Dispatch is by template id so the remaining
+/// instant powers (Major Heal, SomaDrain, ForceWall, CyberHack) slot in
+/// beside this one.
 fn cast_instant_power(
     world: &World,
     amp_entity: EntityId,
     power: &PsiPowerInfo,
     effective_psi: i32,
 ) -> Effect {
-    match power.name.as_str() {
+    match power.template_id {
         // Cerebro-stimulated Regeneration: restores the caster's health.
-        "PsiHeal" => cast_self_heal(world, amp_entity, power, effective_psi),
+        psi::PSI_HEAL_TEMPLATE_ID => cast_self_heal(world, amp_entity, power, effective_psi),
         _ => {
             game_log!(
                 INFO,
@@ -476,7 +483,12 @@ fn cast_self_heal(
         game_log!(WARN, "No player hit points for {}", power.name);
         return Effect::NoEffect;
     };
-    let heal = self_heal_amount(&power.power.data, effective_psi, current_hp, max_hp);
+    let amount = self_heal_amount(&power.power.data, effective_psi);
+    if amount <= 0 {
+        game_log!(INFO, "{} has no heal data (P$PsiPower)", power.name);
+        return Effect::NoEffect;
+    }
+    let heal = clamped_self_heal(&power.power.data, effective_psi, current_hp, max_hp);
     if heal <= 0 {
         game_log!(
             INFO,
@@ -491,9 +503,9 @@ fn cast_self_heal(
         Effect::SpendPsiPoints {
             amount: power.power.psi_cost,
         },
-        // The player entity has no scripts, so a heal message would be
-        // dropped - AdjustHitPoints edits PropHitPoints directly (and does
-        // not clamp to the maximum, hence the clamp in self_heal_amount).
+        // PlayerScript handles only Damage - there is no heal message - so
+        // adjust HP directly. The applier does not clamp to the maximum,
+        // hence the clamp above.
         Effect::AdjustHitPoints {
             entity_id: player_entity,
             delta: heal,
@@ -512,19 +524,38 @@ fn cast_self_heal(
     Effect::Multiple(effects)
 }
 
-/// The HP an instant self-heal restores: `data[0] + data[1] x effective PSI`,
-/// clamped to the caster's missing health.
+/// The HP an instant self-heal restores at full strength (the caller clamps
+/// it to the caster's missing health): `data[0] + data[1] x effective PSI`.
+/// 0 for a power with no (or unusable) heal data.
 ///
 /// Assumption: the two floats split base / per-PSI the way the sustained
 /// powers' `P$PsiShield` duration data does. PsiHeal's `[0, 2]` therefore
-/// reads as 2 HP per point of PSI.
-fn self_heal_amount(data: &[f32; 4], effective_psi: i32, current_hp: i32, max_hp: i32) -> i32 {
+/// reads as 2 HP per point of PSI (Major Heal's `[5, 5]` as 5 + 5 x PSI).
+fn self_heal_amount(data: &[f32; 4], effective_psi: i32) -> i32 {
     let amount = data[0] + data[1] * effective_psi as f32;
     if !amount.is_finite() || amount <= 0.0 {
         return 0;
     }
-    let missing = (max_hp - current_hp).max(0);
-    (amount.floor() as i32).clamp(0, missing)
+    amount.floor().min(i32::MAX as f32) as i32
+}
+
+/// Whether an instant cast would resolve to nothing right now (a heal with
+/// no health missing). Checked before a charge starts so a pointless cast
+/// cannot be over-held into a burnout, which spends points and deals damage.
+fn instant_cast_is_futile(world: &World, power: &PsiPowerInfo, effective_psi: i32) -> bool {
+    if power.template_id != psi::PSI_HEAL_TEMPLATE_ID {
+        return false;
+    }
+    let Some((_, current_hp, max_hp)) = super::script_util::player_hit_points(world) else {
+        return false;
+    };
+    clamped_self_heal(&power.power.data, effective_psi, current_hp, max_hp) <= 0
+}
+
+/// The HP a cast actually restores: [`self_heal_amount`] clamped to the
+/// caster's missing health.
+fn clamped_self_heal(data: &[f32; 4], effective_psi: i32, current_hp: i32, max_hp: i32) -> i32 {
+    self_heal_amount(data, effective_psi).min((max_hp - current_hp).max(0))
 }
 
 /// The amp's `GunFlash` links supply the cast visual (Spinning Psi Ring).
@@ -546,26 +577,29 @@ mod tests {
     #[test]
     fn self_heal_scales_with_psi() {
         // PsiHeal's authored data: 0 base + 2 HP per PSI point.
-        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 10, 100), 10);
-        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 7, 10, 100), 14);
-        // A base term adds on top of the per-PSI term.
-        assert_eq!(self_heal_amount(&[3.0, 2.0, 0.0, 0.0], 5, 10, 100), 13);
-    }
-
-    #[test]
-    fn self_heal_is_clamped_to_missing_health() {
-        // 2 x PSI 5 = 10, but only 4 HP are missing.
-        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 96, 100), 4);
-        // At full health the heal is nothing (the cast is refused).
-        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 100, 100), 0);
-        // Over-healed (or a bogus maximum) never produces a negative delta.
-        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 120, 100), 0);
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5), 10);
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 7), 14);
+        // A base term adds on top of the per-PSI term (Major Heal's shape).
+        assert_eq!(self_heal_amount(&[5.0, 5.0, 0.0, 0.0], 5), 30);
     }
 
     #[test]
     fn self_heal_ignores_powers_with_no_heal_data() {
-        assert_eq!(self_heal_amount(&[0.0, 0.0, 0.0, 0.0], 5, 10, 100), 0);
-        assert_eq!(self_heal_amount(&[f32::NAN, 2.0, 0.0, 0.0], 5, 10, 100), 0);
+        assert_eq!(self_heal_amount(&[0.0, 0.0, 0.0, 0.0], 5), 0);
+        assert_eq!(self_heal_amount(&[f32::NAN, 2.0, 0.0, 0.0], 5), 0);
+        assert_eq!(self_heal_amount(&[-4.0, 0.0, 0.0, 0.0], 5), 0);
+    }
+
+    /// The applier does not clamp, so an overshoot would push HP past the
+    /// maximum - the clamp lives here instead.
+    #[test]
+    fn the_heal_is_clamped_to_missing_health() {
+        // 2 x PSI 5 = 10, but only 4 HP are missing.
+        assert_eq!(clamped_self_heal(&[0.0, 2.0, 0.0, 0.0], 5, 96, 100), 4);
+        // At full health the heal is nothing (the cast is refused).
+        assert_eq!(clamped_self_heal(&[0.0, 2.0, 0.0, 0.0], 5, 100, 100), 0);
+        // Over-healed (or a bogus maximum) never produces a negative delta.
+        assert_eq!(clamped_self_heal(&[0.0, 2.0, 0.0, 0.0], 5, 120, 100), 0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -12,8 +12,8 @@
 //! full bar is a psi burnout - the cast fails, the points are spent, and the
 //! player takes damage. Non-overloadable powers cast immediately on pull.
 //!
-//! Only projectile ("shot") powers actually fire so far - sustained, shield,
-//! and cursor-targeted powers are logged and skipped without spending points.
+//! Projectile ("shot"), sustained, and instant self-targeted powers cast so
+//! far - the remaining kinds are logged and skipped without spending points.
 
 use engine::{audio::AudioHandle, game_log};
 use shipyard::{EntityId, Get, UniqueView, View, World};
@@ -344,6 +344,12 @@ fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) 
         return cast_sustained_power(world, amp_entity, &power, effective_psi);
     }
 
+    // Instant (self-targeted) powers resolve immediately - no duration, no
+    // projectile.
+    if power.power.activation_type == psi::ACTIVATION_TYPE_INSTANT {
+        return cast_instant_power(world, amp_entity, &power, effective_psi);
+    }
+
     let Some(projectile_template) = power.projectile_for_psi_stat(effective_psi) else {
         game_log!(
             INFO,
@@ -431,6 +437,114 @@ fn cast_sustained_power(
     Effect::Multiple(effects)
 }
 
+/// Cast an instant (activation type 2) self-targeted power: it resolves on
+/// the spot, with no duration and no projectile. Dispatch is by the power's
+/// gamesys name so the remaining instant powers (Major Heal, SomaDrain) slot
+/// in beside this one.
+fn cast_instant_power(
+    world: &World,
+    amp_entity: EntityId,
+    power: &PsiPowerInfo,
+    effective_psi: i32,
+) -> Effect {
+    match power.name.as_str() {
+        // Cerebro-stimulated Regeneration: restores the caster's health.
+        "PsiHeal" => cast_self_heal(world, amp_entity, power, effective_psi),
+        _ => {
+            game_log!(
+                INFO,
+                "Instant psi power {} is not implemented yet",
+                power.name
+            );
+            Effect::NoEffect
+        }
+    }
+}
+
+/// Heal the caster by [`self_heal_amount`], spending the power's tier. A cast
+/// at full health is refused and spends nothing, matching the empty-pool
+/// guard - the player keeps their points rather than burning them on a cast
+/// that could do nothing.
+fn cast_self_heal(
+    world: &World,
+    amp_entity: EntityId,
+    power: &PsiPowerInfo,
+    effective_psi: i32,
+) -> Effect {
+    let Some((player_entity, current_hp, max_hp)) = player_hit_points(world) else {
+        game_log!(WARN, "No player hit points for {}", power.name);
+        return Effect::NoEffect;
+    };
+    let heal = self_heal_amount(&power.power.data, effective_psi, current_hp, max_hp);
+    if heal <= 0 {
+        game_log!(
+            INFO,
+            "{} would heal nothing (already at full health)",
+            power.name
+        );
+        return Effect::NoEffect;
+    }
+
+    let mut effects = vec![
+        play_environmental_sound(world, amp_entity, "shoot", vec![], AudioHandle::new()),
+        Effect::SpendPsiPoints {
+            amount: power.power.psi_cost,
+        },
+        // The player entity has no scripts, so a heal message would be
+        // dropped - AdjustHitPoints edits PropHitPoints directly (and does
+        // not clamp to the maximum, hence the clamp in self_heal_amount).
+        Effect::AdjustHitPoints {
+            entity_id: player_entity,
+            delta: heal,
+        },
+    ];
+    effects.extend(amp_cast_flashes(world, amp_entity));
+
+    game_log!(
+        INFO,
+        "Cast psi power: {} (tier {}, healed {} HP at effective PSI {})",
+        power.name,
+        power.power.psi_cost,
+        heal,
+        effective_psi
+    );
+    Effect::Multiple(effects)
+}
+
+/// The HP an instant self-heal restores: `data[0] + data[1] x effective PSI`,
+/// clamped to the caster's missing health.
+///
+/// Assumption: the two floats split base / per-PSI the way the sustained
+/// powers' `P$PsiShield` duration data does. PsiHeal's `[0, 2]` therefore
+/// reads as 2 HP per point of PSI.
+fn self_heal_amount(data: &[f32; 4], effective_psi: i32, current_hp: i32, max_hp: i32) -> i32 {
+    let amount = data[0] + data[1] * effective_psi as f32;
+    if !amount.is_finite() || amount <= 0.0 {
+        return 0;
+    }
+    let missing = (max_hp - current_hp).max(0);
+    (amount.floor() as i32).clamp(0, missing)
+}
+
+/// The player entity with its (current, maximum) hit points.
+fn player_hit_points(world: &World) -> Option<(EntityId, i32, i32)> {
+    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
+    let current = world
+        .borrow::<View<dark::properties::PropHitPoints>>()
+        .ok()?
+        .get(player)
+        .ok()?
+        .hit_points;
+    let max = world
+        .borrow::<View<dark::properties::PropMaxHitPoints>>()
+        .ok()?
+        .get(player)
+        .ok()?
+        .hit_points
+        .min(i32::MAX as u32) as i32;
+    Some((player, current, max))
+}
+
 /// The amp's `GunFlash` links supply the cast visual (Spinning Psi Ring).
 fn amp_cast_flashes(world: &World, amp_entity: EntityId) -> Vec<Effect> {
     super::script_util::get_all_links_with_template(world, amp_entity, |link| match link {
@@ -446,6 +560,31 @@ fn amp_cast_flashes(world: &World, amp_entity: EntityId) -> Vec<Effect> {
 mod tests {
     use super::*;
     use crate::quest_info::QuestInfo;
+
+    #[test]
+    fn self_heal_scales_with_psi() {
+        // PsiHeal's authored data: 0 base + 2 HP per PSI point.
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 10, 100), 10);
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 7, 10, 100), 14);
+        // A base term adds on top of the per-PSI term.
+        assert_eq!(self_heal_amount(&[3.0, 2.0, 0.0, 0.0], 5, 10, 100), 13);
+    }
+
+    #[test]
+    fn self_heal_is_clamped_to_missing_health() {
+        // 2 x PSI 5 = 10, but only 4 HP are missing.
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 96, 100), 4);
+        // At full health the heal is nothing (the cast is refused).
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 100, 100), 0);
+        // Over-healed (or a bogus maximum) never produces a negative delta.
+        assert_eq!(self_heal_amount(&[0.0, 2.0, 0.0, 0.0], 5, 120, 100), 0);
+    }
+
+    #[test]
+    fn self_heal_ignores_powers_with_no_heal_data() {
+        assert_eq!(self_heal_amount(&[0.0, 0.0, 0.0, 0.0], 5, 10, 100), 0);
+        assert_eq!(self_heal_amount(&[f32::NAN, 2.0, 0.0, 0.0], 5, 10, 100), 0);
+    }
 
     #[test]
     fn psi_stat_comes_from_the_character_sheet() {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -632,6 +632,30 @@ pub fn player_carried_items(world: &World) -> Vec<EntityId> {
     out
 }
 
+/// The player entity with its current and maximum hit points. `None` when the
+/// scene has no player or the player has no health pool (e.g. a bare debug
+/// scene).
+pub fn player_hit_points(world: &World) -> Option<(EntityId, i32, i32)> {
+    let player = world
+        .borrow::<UniqueView<crate::mission::PlayerInfo>>()
+        .ok()?
+        .entity_id;
+    let current = world
+        .borrow::<View<dark::properties::PropHitPoints>>()
+        .ok()?
+        .get(player)
+        .ok()?
+        .hit_points;
+    let maximum = world
+        .borrow::<View<dark::properties::PropMaxHitPoints>>()
+        .ok()?
+        .get(player)
+        .ok()?
+        .hit_points
+        .min(i32::MAX as u32) as i32;
+    Some((player, current, maximum))
+}
+
 /// The player's persistent nanite stat balance (0 if there is no player /
 /// `QuestInfo`, e.g. a debug scene).
 fn stat_nanite_balance(world: &World) -> i32 {

--- a/tools/shock2-sdk/test/helpers/psi.ts
+++ b/tools/shock2-sdk/test/helpers/psi.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+
+import type { GameServer } from "../../src/index.js";
+
+/** Cycle the psi power selection until `name` is selected (bounded). */
+export async function selectPsiPower(game: GameServer, name: string): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    if ((await game.info()).player.selected_psi_power === name) return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 2 });
+  }
+  assert.fail(`could not cycle the psi power selection to ${name}`);
+}

--- a/tools/shock2-sdk/test/psi-heal.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-heal.e2e.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { GameServer } from "../src/index.js";
+import { GameServer as Server } from "../src/index.js";
+import { pullTrigger } from "./helpers/weapon.js";
+
+// End-to-end test for Cerebro-stimulated Regeneration (PsiHeal), the first
+// instant (activation type 2) psi power: a cast spends the power's tier and
+// heals `data[0] + data[1] x PSI` HP, clamped to the player's missing health.
+// A cast at full health is refused and spends nothing.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** PsiHeal's authored data is `[0, 2]`: 2 HP per point of PSI. */
+const HP_PER_PSI = 2;
+const PSI_STAT = 6;
+const PSI_COST = 2;
+
+/** Cycle the psi selection until `name` is selected. */
+async function selectPower(game: GameServer, name: string): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    if ((await game.info()).player.selected_psi_power === name) return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 2 });
+  }
+  throw new Error(`CyclePsiPower never reached ${name}`);
+}
+
+test(
+  "Cerebro-stimulated Regeneration heals the caster and spends its tier",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await Server.launch({ mission: "debug_psi" });
+
+    // The scene auto-equips the Psi Amp on the first update.
+    await game.step({ frames: 10 });
+    await game.player.setStats({ psionic_ability: PSI_STAT });
+
+    // Hurt the player so the heal has room to land.
+    const playerId = (await game.info()).player.entity_id;
+    assert.ok(playerId !== null, "debug_psi should have a player");
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 20.0 });
+    await game.step({ frames: 10 });
+
+    let player = (await game.info()).player;
+    const maxHp = player.max_hit_points;
+    const hurtHp = player.hit_points;
+    const startPsi = player.psi_points;
+    assert.ok(maxHp !== null && hurtHp !== null && startPsi !== null);
+    assert.ok(hurtHp! < maxHp!, `player should be hurt (${hurtHp}/${maxHp})`);
+    assert.ok(maxHp! - hurtHp! > HP_PER_PSI * PSI_STAT, "the heal should not be clamped here");
+
+    await selectPower(game, "PsiHeal");
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+
+    player = (await game.info()).player;
+    assert.equal(
+      player.hit_points,
+      hurtHp! + HP_PER_PSI * PSI_STAT,
+      "the cast heals 2 HP per point of PSI",
+    );
+    assert.equal(player.psi_points, startPsi! - PSI_COST, "a tier 2 cast costs two psi points");
+
+    // Keep casting until the player is topped up (the last cast clamps), then
+    // cast at full health: refused, and nothing is spent.
+    for (let i = 0; i < 5 && player.hit_points !== maxHp; i += 1) {
+      await pullTrigger(game);
+      await game.step({ frames: 30 });
+      player = (await game.info()).player;
+    }
+    assert.equal(player.hit_points, maxHp, "repeated casts top the player up to the maximum");
+    const fullPsi = player.psi_points;
+
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+    player = (await game.info()).player;
+    assert.equal(player.hit_points, maxHp, "a cast at full health heals nothing");
+    assert.equal(player.psi_points, fullPsi, "a cast at full health spends nothing");
+  },
+);
+
+test(
+  "the heal is clamped to the player's missing health",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await Server.launch({ mission: "debug_psi" });
+
+    await game.step({ frames: 10 });
+    await game.player.setStats({ psionic_ability: PSI_STAT });
+
+    // Only a few HP missing: the 12-HP heal tops out at the maximum.
+    const playerId = (await game.info()).player.entity_id;
+    assert.ok(playerId !== null);
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 3.0 });
+    await game.step({ frames: 10 });
+
+    let player = (await game.info()).player;
+    const maxHp = player.max_hit_points;
+    const startPsi = player.psi_points;
+    assert.ok(maxHp !== null && player.hit_points !== null && startPsi !== null);
+    assert.ok(
+      maxHp! - player.hit_points! < HP_PER_PSI * PSI_STAT,
+      "fewer HP should be missing than the heal would restore",
+    );
+
+    await selectPower(game, "PsiHeal");
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
+
+    player = (await game.info()).player;
+    assert.equal(player.hit_points, maxHp, "the heal never overshoots the maximum");
+    assert.equal(player.psi_points, startPsi! - PSI_COST, "a clamped cast still costs its tier");
+  },
+);

--- a/tools/shock2-sdk/test/psi-heal.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-heal.e2e.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { GameServer } from "../src/index.js";
-import { GameServer as Server } from "../src/index.js";
+import { GameServer } from "../src/index.js";
+import { selectPsiPower } from "./helpers/psi.js";
 import { pullTrigger } from "./helpers/weapon.js";
 
 // End-to-end test for Cerebro-stimulated Regeneration (PsiHeal), the first
@@ -19,21 +19,11 @@ const HP_PER_PSI = 2;
 const PSI_STAT = 6;
 const PSI_COST = 2;
 
-/** Cycle the psi selection until `name` is selected. */
-async function selectPower(game: GameServer, name: string): Promise<void> {
-  for (let i = 0; i < 40; i += 1) {
-    if ((await game.info()).player.selected_psi_power === name) return;
-    await game.input.trigger("CyclePsiPower");
-    await game.step({ frames: 2 });
-  }
-  throw new Error(`CyclePsiPower never reached ${name}`);
-}
-
 test(
   "Cerebro-stimulated Regeneration heals the caster and spends its tier",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    await using game = await Server.launch({ mission: "debug_psi" });
+    await using game = await GameServer.launch({ mission: "debug_psi" });
 
     // The scene auto-equips the Psi Amp on the first update.
     await game.step({ frames: 10 });
@@ -53,7 +43,7 @@ test(
     assert.ok(hurtHp! < maxHp!, `player should be hurt (${hurtHp}/${maxHp})`);
     assert.ok(maxHp! - hurtHp! > HP_PER_PSI * PSI_STAT, "the heal should not be clamped here");
 
-    await selectPower(game, "PsiHeal");
+    await selectPsiPower(game, "PsiHeal");
     await pullTrigger(game);
     await game.step({ frames: 30 });
 
@@ -87,7 +77,7 @@ test(
   "the heal is clamped to the player's missing health",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    await using game = await Server.launch({ mission: "debug_psi" });
+    await using game = await GameServer.launch({ mission: "debug_psi" });
 
     await game.step({ frames: 10 });
     await game.player.setStats({ psionic_ability: PSI_STAT });
@@ -107,7 +97,7 @@ test(
       "fewer HP should be missing than the heal would restore",
     );
 
-    await selectPower(game, "PsiHeal");
+    await selectPsiPower(game, "PsiHeal");
     await pullTrigger(game);
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/psi-heal.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-heal.e2e.test.ts
@@ -55,14 +55,23 @@ test(
     );
     assert.equal(player.psi_points, startPsi! - PSI_COST, "a tier 2 cast costs two psi points");
 
-    // Keep casting until the player is topped up (the last cast clamps), then
-    // cast at full health: refused, and nothing is spent.
-    for (let i = 0; i < 5 && player.hit_points !== maxHp; i += 1) {
+    // Keep casting until the player is topped up. The last cast is clamped
+    // (fewer HP are missing than the heal restores) and still costs its tier.
+    const psiBeforeTopUp = player.psi_points!;
+    let topUpCasts = 0;
+    while (player.hit_points !== maxHp && topUpCasts < 5) {
       await pullTrigger(game);
       await game.step({ frames: 30 });
       player = (await game.info()).player;
+      topUpCasts += 1;
     }
-    assert.equal(player.hit_points, maxHp, "repeated casts top the player up to the maximum");
+    assert.ok(topUpCasts > 0, "the top-up should need at least one clamped cast");
+    assert.equal(player.hit_points, maxHp, "the heal never overshoots the maximum");
+    assert.equal(
+      player.psi_points,
+      psiBeforeTopUp - PSI_COST * topUpCasts,
+      "a clamped cast still costs its tier",
+    );
     const fullPsi = player.psi_points;
 
     await pullTrigger(game);
@@ -70,39 +79,5 @@ test(
     player = (await game.info()).player;
     assert.equal(player.hit_points, maxHp, "a cast at full health heals nothing");
     assert.equal(player.psi_points, fullPsi, "a cast at full health spends nothing");
-  },
-);
-
-test(
-  "the heal is clamped to the player's missing health",
-  { skip: !e2eEnabled, timeout: 600_000 },
-  async () => {
-    await using game = await GameServer.launch({ mission: "debug_psi" });
-
-    await game.step({ frames: 10 });
-    await game.player.setStats({ psionic_ability: PSI_STAT });
-
-    // Only a few HP missing: the 12-HP heal tops out at the maximum.
-    const playerId = (await game.info()).player.entity_id;
-    assert.ok(playerId !== null);
-    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 3.0 });
-    await game.step({ frames: 10 });
-
-    let player = (await game.info()).player;
-    const maxHp = player.max_hit_points;
-    const startPsi = player.psi_points;
-    assert.ok(maxHp !== null && player.hit_points !== null && startPsi !== null);
-    assert.ok(
-      maxHp! - player.hit_points! < HP_PER_PSI * PSI_STAT,
-      "fewer HP should be missing than the heal would restore",
-    );
-
-    await selectPsiPower(game, "PsiHeal");
-    await pullTrigger(game);
-    await game.step({ frames: 30 });
-
-    player = (await game.info()).player;
-    assert.equal(player.hit_points, maxHp, "the heal never overshoots the maximum");
-    assert.equal(player.psi_points, startPsi! - PSI_COST, "a clamped cast still costs its tier");
   },
 );

--- a/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
+import { selectPsiPower } from "./helpers/psi.js";
 import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end tests for sustained (timed) psi powers. Photonic Redirection
@@ -24,17 +25,6 @@ const INVISO_DURATION_FRAMES = (5 + 5 * PSI_STAT) * 60;
 
 function aiProp(detail: EntityDetailResult, name: string): string | undefined {
   return detail.properties.find((p) => p.name === name)?.value;
-}
-
-/** Cycle the psi power selection until Inviso is selected (bounded). */
-async function selectInviso(game: GameServer): Promise<void> {
-  for (let i = 0; i < 40; i++) {
-    const selected = (await game.info()).player.selected_psi_power;
-    if (selected === "Inviso") return;
-    await game.input.trigger("CyclePsiPower");
-    await game.step({ frames: 1 });
-  }
-  assert.fail("could not cycle the psi power selection to Inviso");
 }
 
 /** Step `frames` in chunks so a single /v1/step call stays small. */
@@ -63,7 +53,7 @@ test(
     assert.ok(startPsi !== null && startPsi >= 2 * INVISO_COST);
 
     // Cast Photonic Redirection (tier 4 sustained power).
-    await selectInviso(game);
+    await selectPsiPower(game, "Inviso");
     await fireOnce(game);
     player = (await game.info()).player;
     assert.equal(player.psi_points, startPsi! - INVISO_COST, "Inviso cast costs 4 psi points");
@@ -135,7 +125,7 @@ test(
       assert.ok(camera, "debug_camera should contain a Security Camera");
 
       // Cast Inviso immediately (~0.5 s in, long before the camera reacts).
-      await selectInviso(game);
+      await selectPsiPower(game, "Inviso");
       await fireOnce(game);
       const player = (await game.info()).player;
       assert.deepEqual(player.active_psi_powers, ["Inviso"], "Inviso active in debug_camera");


### PR DESCRIPTION
Cerebro-stimulated Regeneration (PsiHeal) cast nothing and spent nothing: `activation_type == 2` is not `ACTIVATION_TYPE_SUSTAINED`, so `cast_selected_power` fell through to the projectile lookup, found no `Projectile` links, logged "not implemented yet" and returned `NoEffect` before spending.

## What changed

- `psi::ACTIVATION_TYPE_INSTANT` (2) and an instant, self-targeted branch in `cast_selected_power`. It dispatches by the power's gamesys name so the remaining instant powers (Major Heal #1289, SomaDrain #1303) slot in beside this one; anything else keeps the existing "not implemented yet" no-op.
- `PsiHeal` as the first instance: spends the power's `psi_cost` (2) and heals `data[0] + data[1] × effective PSI` HP through `Effect::AdjustHitPoints`, clamped to the caster's missing health (the applier does not clamp to the maximum). PsiHeal's authored data is `[0, 2]` → **2 HP per point of PSI**.
- The split of the two `data` floats into base / per-PSI is an **assumption**, stated in a comment on `self_heal_amount`: it mirrors the `P$PsiShield` duration data the sustained powers use.
- **A cast at full health is refused and spends nothing**, matching the empty-pool guard — the player keeps their points rather than burning them on a cast that could do nothing. PsiHeal is overloadable, so the same check also gates the *charge*: a futile heal can't be over-held into a burnout (which spends points and deals damage).
- Drive-by: the player's current/max hit-point read moves to `script_util::player_hit_points`, shared with `healing_item::tick_player_healing`, which had the same read inline.

The heal scales with the player's real PSI stat via #1274 (this PR stacks on `fix/1274-psi-stat`).

## Tests

- Unit (`shock2vr`): `self_heal_amount` scaling, base+per-PSI, clamp to missing health, zero at full health, no negative delta when over-healed, and no heal for powers with no heal data.
- e2e `tools/shock2-sdk/test/psi-heal.e2e.test.ts` (`SHOCK2_E2E=1`), in `debug_psi`: damage the player 20, select PsiHeal, one trigger pull → `hit_points` +12 at PSI 6 and `psi_points` −2; keep casting to full (the last cast clamps and still costs its tier); then a cast at full health changes neither.

```
$ SHOCK2_E2E=1 node --test dist/test/psi*.e2e.test.js \
    dist/test/healing-items.e2e.test.js dist/test/health.e2e.test.js
# pass 12  # fail 0
$ SHOCK2_E2E=1 node --test dist/test/missions.e2e.test.js
# pass 23  # fail 0   (all 23 missions still load)
```

Review pass (`/xreview`; Codex was unavailable — usage limit — so this was the Claude reviewers only) also moved the dispatch to the stable template id (`psi::PSI_HEAL_TEMPLATE_ID`) rather than the gamesys name string, and split the refusal logs so "no heal data" and "already at full health" are distinguishable.

Negative-checked: with `shock2vr` reverted to the base commit, both new e2e tests fail.

## Visuals

![PsiHeal demo](https://gist.githubusercontent.com/tommy-xr/a62e4716c615fadcfba8aef6b4edff4e/raw/psiheal.gif)

<sub>Cerebro-stimulated Regeneration: casting at 6 PSI heals 12 HP - the HUD health readout goes 33 -> 73 (10 -> 22 of 30 HP) and the red damage tint clears. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before / after

![before and after](https://gist.githubusercontent.com/tommy-xr/a62e4716c615fadcfba8aef6b4edff4e/raw/beforeafter.png)

Fixes #1293
