### PR TITLE
fix(melee): free-swing speed is measured relative to the player

### DIFF
--- a/shock2vr/src/physics/held_melee_drive.rs
+++ b/shock2vr/src/physics/held_melee_drive.rs
@@ -445,6 +445,83 @@ fn melee_drive_trace() {
     }
 }
 
+/// Walking is not swinging. A held weapon rides the player, so a player who
+/// simply walks a still hand into a creature moves the weapon exactly as fast
+/// as a swing does - and billed the same authored blow for it.
+///
+/// Negative-first: with the player's own motion left in, the sweep reports the
+/// full walking speed here, five times the gate.
+#[test]
+fn walking_a_weapon_into_a_limb_is_not_a_swing() {
+    let (mut world, mut player) = world_with_floor();
+    let (weapon, _) = spawn_held_wrench(&mut world, vec3(0.0, 1.2, 0.0));
+
+    let limb = EntityId::from_inner(7).unwrap();
+    world.add_kinematic(
+        limb,
+        vec3(0.0, 1.2, 1.5),
+        identity_quat(),
+        Vector3::new(0.0, 0.0, 0.0),
+        vec3(0.6, 0.6, 0.6),
+        CollisionGroup::hitbox(),
+        false,
+    );
+
+    // The hand holds still in front of the player; the player walks it into
+    // the limb at the shipped walking speed (10 units/s at 60 Hz).
+    let step = 10.0 / 60.0;
+    let mut reported = None;
+    for frame in 0..30 {
+        let z = step * frame as f32;
+        world.set_position_rotation2(weapon, vec3(0.0, 1.2, z), identity_quat());
+        let (_, events) = world.update(vec3(0.0, 0.0, step), &mut player);
+        for event in events {
+            if let super::CollisionEvent::CollisionStarted {
+                entity1_id,
+                entity2_id,
+                contact: Some(contact),
+            } = event
+            {
+                if entity1_id == weapon && entity2_id == limb {
+                    reported = Some(contact);
+                }
+            }
+        }
+        if reported.is_some() {
+            break;
+        }
+    }
+
+    let contact = reported.expect("the carried weapon should still report the limb it stopped on");
+    let gate = crate::dev_params::spec(crate::dev_params::MELEE_FREE_SWING_SPEED).default;
+    let speed = contact.closing_speed.unwrap_or(0.0);
+    assert!(
+        speed < gate,
+        "walking must read below the swing gate {gate}, got {speed}"
+    );
+}
+
+/// A relocation is not travel. The swing gate divides the player's own motion
+/// out of a held weapon's, so a teleport that jumped the sampler would read as
+/// hundreds of units/s for a frame and bill a free blow on arrival.
+///
+/// Negative-first: without re-seating the sampler this reads the whole jump
+/// divided by one frame.
+#[test]
+fn relocating_the_player_is_not_player_velocity() {
+    let (mut world, mut player) = world_with_floor();
+    world.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+    world.set_player_translation(vec3(1050.0, 1000.0, 1000.0), &mut player);
+    world.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+    let speed = world.player_velocity().magnitude();
+    assert!(
+        speed < 1.0,
+        "a relocation must not register as player velocity, read {speed}"
+    );
+}
+
 /// A swing stopped by a limb reports the blow, and reports it pointing the way
 /// the weapon was going. The contact's normal drives the killing blow's ragdoll
 /// impulse (`rag_doll::apply_killing_blow`), so an inverted one throws the

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2243,6 +2243,47 @@ pub struct CollisionContact {
     pub closing_speed: Option<f32>,
 }
 
+/// How hard a swing landed: the smaller of two readings, because a blow has to
+/// be both.
+///
+/// - **A real closing speed** (`weapon - victim`). Two bodies keeping station
+///   are not hitting each other however fast they travel - a player
+///   backpedalling from a creature that chases at the same speed is not
+///   swinging at it.
+/// - **Not merely the player's own locomotion** (`weapon - player - victim`).
+///   A held weapon rides the player, so walking carries it at ~10 world
+///   units/s, five times the gate; that alone billed a free authored hit on
+///   anything walked into.
+///
+/// Each is wrong by itself in one direction, and the smaller of the two is
+/// right in every case: a hand swing clears the gate whether the player is
+/// walking or standing, while walking, riding and backpedalling all read ~0.
+/// A creature charging onto a held blade still impales itself - both readings
+/// see its approach.
+///
+/// The velocities are taken along the surface that was touched, because
+/// sliding a weapon *along* something is fast but closes on nothing. `abs`
+/// because the normal's orientation depends on which collider Rapier listed
+/// first; with no contact geometry there is no surface to project onto, so the
+/// speeds are taken whole.
+///
+/// Only *translation* is divided out - a player who turns on the spot still
+/// swings the weapon head around at arm's length, and that reads as the swing
+/// it looks like.
+pub fn relative_swing_speed(
+    weapon_velocity: Vector3<f32>,
+    player_velocity: Vector3<f32>,
+    victim_velocity: Vector3<f32>,
+    normal: Option<Vector3<f32>>,
+) -> f32 {
+    let speed_of = |velocity: Vector3<f32>| match normal {
+        Some(normal) => velocity.dot(normal).abs(),
+        None => velocity.magnitude(),
+    };
+    let closing = weapon_velocity - victim_velocity;
+    speed_of(closing).min(speed_of(closing - player_velocity))
+}
+
 /// Predicate selecting *only* sensor colliders - the volumes the player's
 /// ENTER/EXIT tracking is built from. Shared by the per-frame poll in
 /// [`PhysicsWorld::move_player`] and the swept poll in
@@ -2460,6 +2501,18 @@ pub struct PhysicsWorld {
     // Rapier joint motors. Keyed by the weapon body handle so the normal
     // set_position_rotation path can redirect hand poses to the target.
     held_melee_drives: HashMap<RigidBodyHandle, HeldMeleeDrive>,
+
+    // The player's travel over the previous frame, in world units per second,
+    // and where they were when it was sampled. A held weapon rides the player,
+    // so this is what the melee swing gate divides out of the weapon's motion
+    // (see [`relative_swing_speed`]).
+    //
+    // Sampled at the top of a frame rather than when the player moves, because
+    // the hand poses this is subtracted from are one frame old: they were
+    // composed onto the player's position as of the END of the previous frame.
+    // Derived per-frame state, so nothing saves it.
+    player_velocity: Vector3<f32>,
+    last_player_translation: Option<Vector3<f32>>,
 
     // TODO:
     // physics_hooks: Box<dyn PhysicsHooks>,
@@ -3040,6 +3093,11 @@ impl PhysicsWorld {
             .unwrap();
         character_body.enable_ccd(true);
         character_body.set_translation(vec_to_nvec(position), true);
+        // A relocation is not travel. Re-seat the swing gate's sampler on the
+        // destination, or the jump reads as hundreds of units/s of "player
+        // motion" for one frame - which, subtracted from a still weapon, bills
+        // a free blow on whatever the player lands touching.
+        self.last_player_translation = Some(position);
         // Whatever the player was riding, they are not standing on it here.
         // Re-probe now rather than just forgetting: a stale support would carry
         // them by a platform's next step from clear across the level, and an
@@ -3605,6 +3663,43 @@ impl PhysicsWorld {
         }
     }
 
+    /// How fast the player themselves travelled over the previous frame, in
+    /// world units per second. A held melee weapon rides the player, so a
+    /// swing gate must divide this out: walking carries a wrench at ~10 u/s,
+    /// five times the swing threshold.
+    pub fn player_velocity(&self) -> Vector3<f32> {
+        self.player_velocity
+    }
+
+    /// The velocity the player's hand is driving a held melee weapon at, at a
+    /// world-space point on it - read from the invisible controller target
+    /// rather than the weapon body.
+    ///
+    /// The two differ whenever the drive is catching up: a weapon held back by
+    /// world geometry and then released covers the accumulated error in one
+    /// step, and the weapon body reports that catch-up as speed the hand never
+    /// had. `None` when this entity is not a driven held melee weapon.
+    pub fn held_melee_target_velocity_at_point(
+        &self,
+        entity_id: EntityId,
+        point: Vector3<f32>,
+    ) -> Option<Vector3<f32>> {
+        let handle = self.entity_id_to_body.get(&entity_id)?;
+        let target = self.held_melee_drives.get(handle)?.target;
+        self.body_velocity_at_point(target, point)
+    }
+
+    fn body_velocity_at_point(
+        &self,
+        handle: RigidBodyHandle,
+        point: Vector3<f32>,
+    ) -> Option<Vector3<f32>> {
+        let body = self.rigid_body_set.get(handle)?;
+        Some(nvec_to_cgmath(
+            body.velocity_at_point(&Point::from(vec_to_nvec(point))),
+        ))
+    }
+
     /// Velocity of `entity_id`'s body at a world-space point on it.
     ///
     /// Differs from [`Self::get_velocity`] by including the `omega x r` term:
@@ -3616,11 +3711,8 @@ impl PhysicsWorld {
         entity_id: EntityId,
         point: Vector3<f32>,
     ) -> Option<Vector3<f32>> {
-        let handle = self.entity_id_to_body.get(&entity_id)?;
-        let rigid_body = self.rigid_body_set.get(*handle)?;
-        Some(nvec_to_cgmath(
-            rigid_body.velocity_at_point(&Point::from(vec_to_nvec(point))),
-        ))
+        let handle = *self.entity_id_to_body.get(&entity_id)?;
+        self.body_velocity_at_point(handle, point)
     }
 
     pub fn set_velocity(&mut self, entity_id: EntityId, velocity: Vector3<f32>) {
@@ -4004,6 +4096,23 @@ impl PhysicsWorld {
     /// movement volume wider than the creature, and stopping on it would halt
     /// the weapon in the air beside its target. Loose props are likewise
     /// better swept through than treated as walls.
+    /// Record how far the player travelled over the previous frame, as the
+    /// velocity a held weapon rides along with.
+    ///
+    /// Measured from the character body's own displacement, so it covers every
+    /// way the player moves - walking, a moving platform, a relocation - which
+    /// is what the hand poses composed onto it did too. Whatever this misses
+    /// is billed as a swing, so it deliberately over-covers.
+    fn sample_player_velocity(&mut self, player_handle: &PlayerHandle) {
+        let translation = self.get_player_translation(player_handle);
+        let dt = self.integration_parameters.dt;
+        self.player_velocity = match self.last_player_translation {
+            Some(previous) if dt > 0.0 => (translation - previous) / dt,
+            _ => Vector3::new(0.0, 0.0, 0.0),
+        };
+        self.last_player_translation = Some(translation);
+    }
+
     fn drive_held_melee(&mut self) {
         let max_step = crate::dev_params::get(crate::dev_params::MELEE_MAX_SPEED)
             * self.integration_parameters.dt;
@@ -4085,7 +4194,18 @@ impl PhysicsWorld {
                     0.0
                 };
                 let heading = delta / distance;
-                let speed = travel * heading.dot(&vec_to_nvec(stop.normal)).abs();
+                // Minus the player's own motion: the target pose is world
+                // space, so walking a weapon into a creature moves it just as
+                // fast as swinging it does. The travel itself is still the
+                // drive's - it carries whatever error the weapon had accrued
+                // behind the hand - which is why the script path reads the
+                // hand target instead of a body that has been obstructed.
+                let speed = relative_swing_speed(
+                    nvec_to_cgmath(heading * travel),
+                    self.player_velocity,
+                    Vector3::new(0.0, 0.0, 0.0),
+                    Some(stop.normal),
+                );
                 self.pending_melee_sweep_events
                     .push(CollisionEvent::CollisionStarted {
                         entity1_id: weapon_entity,
@@ -4462,6 +4582,8 @@ impl PhysicsWorld {
             pending_player_push_velocity: HashMap::new(),
             kinematic_attachments: HashMap::new(),
             held_melee_drives: HashMap::new(),
+            player_velocity: Vector3::new(0.0, 0.0, 0.0),
+            last_player_translation: None,
 
             debug_pipeline,
 
@@ -4691,6 +4813,7 @@ impl PhysicsWorld {
         // (tram floor + walls/buttons) therefore advance as one physical body,
         // matching Dark's source->destination attachment flow.
         self.update_kinematic_attachments();
+        self.sample_player_velocity(player_handle);
         self.drive_held_melee();
 
         // Attribute any non-finite body state to its entity before the step

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cgmath::{EuclideanSpace, InnerSpace, vec3};
+use cgmath::{EuclideanSpace, InnerSpace, Vector3, vec3};
 use dark::properties::{CollisionType, PropCollisionType};
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
@@ -141,8 +141,9 @@ impl Script for HeldMeleeWeapon {
                 // - keeps being hit, and heard, on its capsule.
                 let owner = crate::util::resolve_proxy_entity(world, *with);
                 let is_capsule_contact = owner == *with;
+                let is_held = self.is_held(world, entity_id);
                 if is_capsule_contact
-                    && self.is_held(world, entity_id)
+                    && is_held
                     && crate::creature::has_live_hit_boxes(world, owner)
                 {
                     return Effect::NoEffect;
@@ -152,8 +153,17 @@ impl Script for HeldMeleeWeapon {
                 // by the swing threshold and the victim's authored receptrons;
                 // *hitting something* is audible regardless - a wrench on a
                 // bulkhead or a bench does nothing but must still clang.
+
+                // A held weapon rides the player, so the player's own motion
+                // is not part of the swing. A loose one on the floor does not
+                // ride anything, and nothing may be subtracted from it.
+                let player_velocity = if is_held {
+                    physics.player_velocity()
+                } else {
+                    vec3(0.0, 0.0, 0.0)
+                };
                 let damage = self
-                    .may_damage(entity_id, owner, physics, *contact)
+                    .may_damage(entity_id, owner, physics, *contact, player_velocity)
                     .then(|| authored_contact_damage(world, entity_id, owner))
                     .flatten();
 
@@ -207,11 +217,14 @@ impl HeldMeleeWeapon {
         with: EntityId,
         physics: &PhysicsWorld,
         contact: Option<crate::physics::CollisionContact>,
+        player_velocity: Vector3<f32>,
     ) -> bool {
         if self.free_swing_cooldowns.contains_key(&with) {
             return false;
         }
-        if closing_speed(entity_id, with, physics, contact) < free_swing_speed_threshold() {
+        if closing_speed(entity_id, with, physics, contact, player_velocity)
+            < free_swing_speed_threshold()
+        {
             return false;
         }
         self.free_swing_cooldowns
@@ -232,11 +245,13 @@ impl HeldMeleeWeapon {
     /// every 0.15 s for the length of the corridor. `abs` because the normal's
     /// orientation depends on which collider Rapier listed first.
     ///
-    /// The damage rule above now measures the same way, via [`closing_speed`],
-    /// which additionally subtracts the victim's own motion. The two stay
-    /// separate functions because they answer different questions at different
-    /// thresholds - audible is a much lower bar than damaging, and a contact
-    /// that is too gentle to bill should still clink.
+    /// The damage rule above projects the same way but measures a different
+    /// quantity - it also divides out the victim's motion and the player's own
+    /// locomotion, and reads the hand rather than the weapon body. The two
+    /// stay separate because they answer different questions at different
+    /// thresholds: audible is a much lower bar than damaging, a contact too
+    /// gentle to bill should still clink, and a wrench carried head-on into a
+    /// bulkhead should clang even though walking is not a swing.
     /// Whether this contact thuds. Same speed question as [`Self::may_damage`],
     /// a lower bar - and the same reason for reading the sweep's own
     /// measurement: a swing stopped on a limb has no live velocity left to
@@ -278,30 +293,29 @@ fn is_vr(world: &World) -> bool {
 /// How fast the two bodies were closing on each other, at the point where they
 /// touched, along the surface they touched on.
 ///
-/// Three things this is not, each of which was wrong in a way that showed:
+/// Four things this is not, each of which was wrong in a way that showed:
 ///
 /// - **Not the weapon's centre-of-mass velocity.** A weapon swung about the
 ///   wrist moves its *head* fast while its centre barely moves, so a wrist
 ///   flick under-read badly. `velocity_at_point` carries the `omega x r` term.
-/// - **Not the weapon's velocity alone.** A held weapon rides the player, so
+/// - **Not the weapon's world velocity.** A held weapon rides the player, so
 ///   walking into a creature read as a full-speed swing and billed a free hit.
-///   Subtracting the victim's velocity also makes a creature that charges onto
-///   a held blade impale itself, which is the same rule read the other way and
-///   is worth having.
+/// - **Not the weapon body's own velocity.** It lags the hand and then catches
+///   up in one step, which is speed the player never produced; the driven hand
+///   target is what the player actually did.
 /// - **Not a raw magnitude.** Sliding a weapon *along* a surface is fast but
-///   closes on nothing.
+///   closes on nothing. Subtracting the victim's motion also makes a creature
+///   that charges onto a held blade impale itself.
 ///
 /// The exception is a contact that already knows: see `closing_speed` on
-/// [`crate::physics::CollisionContact`].
-///
-/// `abs` because the normal's orientation depends on which collider Rapier
-/// listed first. With no contact geometry there is no surface to project onto,
-/// so the relative speed is taken whole.
+/// [`crate::physics::CollisionContact`]. The arithmetic itself lives in
+/// [`crate::physics::relative_swing_speed`].
 fn closing_speed(
     weapon: EntityId,
     victim: EntityId,
     physics: &PhysicsWorld,
     contact: Option<crate::physics::CollisionContact>,
+    player_velocity: Vector3<f32>,
 ) -> f32 {
     // A blow the swing sweep found carries the speed it measured. It has to:
     // the sweep stops the weapon on the limb, so by the time this runs the
@@ -316,14 +330,37 @@ fn closing_speed(
         let victim_velocity = physics
             .get_velocity(victim)
             .unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
-        return (weapon_velocity - victim_velocity).magnitude();
+        return crate::physics::relative_swing_speed(
+            weapon_velocity,
+            player_velocity,
+            victim_velocity,
+            None,
+        );
     };
     let at = |entity| {
         physics
             .velocity_at_point(entity, contact.point)
             .unwrap_or_else(|| vec3(0.0, 0.0, 0.0))
     };
-    (at(weapon) - at(victim)).dot(contact.normal).abs()
+    let speed_of = |weapon_velocity| {
+        crate::physics::relative_swing_speed(
+            weapon_velocity,
+            player_velocity,
+            at(victim),
+            Some(contact.normal),
+        )
+    };
+    // A held weapon is billed on the SLOWER of two readings - what the hand
+    // did, and what the weapon did - because each alone is wrong in one
+    // direction. The weapon body reports its own catch-up after an obstruction
+    // lets go (measured at 34 u/s against a hand doing 10); the hand keeps
+    // reading a swing while the weapon is pinned against the body it already
+    // struck, which bills leaning on a creature as a second blow. A loose
+    // weapon has no hand and answers for itself.
+    match physics.held_melee_target_velocity_at_point(weapon, contact.point) {
+        Some(hand) => speed_of(hand).min(speed_of(at(weapon))),
+        None => speed_of(at(weapon)),
+    }
 }
 
 /// Damage the weapon's own authored `Contact` stims deal to this victim,
@@ -459,6 +496,9 @@ mod tests {
         physics.set_velocity(entity, velocity);
     }
 
+    /// The player standing still: whatever the weapon is doing is the swing.
+    const STILL_PLAYER: cgmath::Vector3<f32> = cgmath::Vector3::new(0.0, 0.0, 0.0);
+
     fn head_on_contact(point: cgmath::Vector3<f32>) -> Option<crate::physics::CollisionContact> {
         Some(crate::physics::CollisionContact {
             point,
@@ -484,7 +524,10 @@ mod tests {
             closing_speed: Some(7.5),
         });
 
-        assert_eq!(closing_speed(weapon, victim, &physics, swept), 7.5);
+        assert_eq!(
+            closing_speed(weapon, victim, &physics, swept, STILL_PLAYER),
+            7.5
+        );
         // Neither body exists in this world, so an ordinary contact - which
         // reads the live bodies - has nothing to report.
         let _ = &mut physics;
@@ -493,7 +536,8 @@ mod tests {
                 weapon,
                 victim,
                 &physics,
-                head_on_contact(vec3(0.0, 0.0, 0.0))
+                head_on_contact(vec3(0.0, 0.0, 0.0)),
+                STILL_PLAYER
             ),
             0.0
         );
@@ -534,11 +578,83 @@ mod tests {
             victim,
             &physics,
             head_on_contact(vec3(0.5, 0.0, 0.0)),
+            STILL_PLAYER,
         );
 
         assert!(
             speed < gate,
             "walking pace must fall below the swing gate {gate}, read {speed}"
+        );
+    }
+
+    /// Walking a held weapon into something is not a swing. The weapon rides
+    /// the player, so its world velocity is the player's - measured at 10
+    /// units/s, five times the gate.
+    ///
+    /// Negative-first: without the player's motion divided out this reads the
+    /// full 10.
+    #[test]
+    fn walking_a_weapon_into_a_still_victim_is_not_a_swing() {
+        let gate = crate::dev_params::spec(crate::dev_params::MELEE_FREE_SWING_SPEED).default;
+        let mut physics = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(1).unwrap();
+        let victim = EntityId::from_inner(2).unwrap();
+        let walking = vec3(10.0, 0.0, 0.0);
+        moving_body(&mut physics, weapon, vec3(0.0, 0.0, 0.0), walking);
+        moving_body(
+            &mut physics,
+            victim,
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+        );
+
+        let speed = closing_speed(
+            weapon,
+            victim,
+            &physics,
+            head_on_contact(vec3(0.5, 0.0, 0.0)),
+            walking,
+        );
+
+        assert!(
+            speed < gate,
+            "a carried weapon must fall below the swing gate {gate}, read {speed}"
+        );
+    }
+
+    /// The other half: a real swing thrown while walking still bills, because
+    /// only the player's share comes out.
+    #[test]
+    fn swinging_while_walking_is_still_a_swing() {
+        let gate = crate::dev_params::spec(crate::dev_params::MELEE_FREE_SWING_SPEED).default;
+        let mut physics = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(1).unwrap();
+        let victim = EntityId::from_inner(2).unwrap();
+        let walking = vec3(10.0, 0.0, 0.0);
+        moving_body(
+            &mut physics,
+            weapon,
+            vec3(0.0, 0.0, 0.0),
+            walking + vec3(4.0, 0.0, 0.0),
+        );
+        moving_body(
+            &mut physics,
+            victim,
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+        );
+
+        let speed = closing_speed(
+            weapon,
+            victim,
+            &physics,
+            head_on_contact(vec3(0.5, 0.0, 0.0)),
+            walking,
+        );
+
+        assert!(
+            speed > gate,
+            "a swing thrown while walking must clear the gate {gate}, read {speed}"
         );
     }
 
@@ -568,11 +684,42 @@ mod tests {
             victim,
             &physics,
             head_on_contact(vec3(0.5, 0.0, 0.0)),
+            STILL_PLAYER,
         );
 
         assert!(
             speed > 2.5,
             "a charging victim must register as an impact, read {speed}"
+        );
+    }
+
+    /// Backing away from a creature that chases at the same speed: the weapon
+    /// and the victim keep station, so nothing is closing and nothing may be
+    /// billed - however fast both are travelling through the world.
+    ///
+    /// Negative-first: subtracting the player's motion from a world-frame
+    /// victim reads the full chase speed here.
+    #[test]
+    fn retreating_from_a_creature_that_keeps_pace_is_not_a_blow() {
+        let gate = crate::dev_params::spec(crate::dev_params::MELEE_FREE_SWING_SPEED).default;
+        let mut physics = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(1).unwrap();
+        let victim = EntityId::from_inner(2).unwrap();
+        let retreat = vec3(-10.0, 0.0, 0.0);
+        moving_body(&mut physics, weapon, vec3(0.0, 0.0, 0.0), retreat);
+        moving_body(&mut physics, victim, vec3(1.0, 0.0, 0.0), retreat);
+
+        let speed = closing_speed(
+            weapon,
+            victim,
+            &physics,
+            head_on_contact(vec3(0.5, 0.0, 0.0)),
+            retreat,
+        );
+
+        assert!(
+            speed < gate,
+            "two bodies keeping station must fall below the swing gate {gate}, read {speed}"
         );
     }
 
@@ -603,6 +750,7 @@ mod tests {
             victim,
             &physics,
             head_on_contact(vec3(0.5, 0.0, 0.0)),
+            STILL_PLAYER,
         );
 
         assert!(

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -42,6 +42,8 @@ const HAND_Y = 0.45;
 // body origin, clears the pane before the next contact edge.
 const HAND_REST: Vec3 = [0.7, HAND_Y, 0.3];
 const HAND_SWEEP_END: Vec3 = [0.05, HAND_Y, 3.4];
+// 3.2 units in one second: a 3.2 u/s swing, clear of the free-swing gate
+// (`melee_free_swing`, 2.0 world units/s).
 const HAND_SWEEP_FRAMES = 60;
 
 async function sweepHeldWrench(game: GameServer): Promise<void> {
@@ -67,7 +69,7 @@ async function paneStillExists(game: GameServer, runtimeId: number): Promise<boo
 }
 
 test(
-  "VR authored melee damages only during a trigger-gated physical contact window",
+  "a VR swing deals the Wrench's authored damage, and a dropped one does not",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -119,18 +121,17 @@ test(
     await game.input.set("right_hand.position", HAND_REST);
     await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
     await game.input.set("right_hand.squeeze", 1);
-    await game.input.set("right_hand.trigger", 0);
     await game.step({ frames: 30 });
 
-    // Negative first: physically sweep through the pane without pulling the
-    // trigger. Before the fix the authored Wrench had no collision damage at
-    // all; an always-hot workaround would incorrectly destroy it here.
+    // Swing the wrench through the pane. The blow is billed on the swing's
+    // own closing speed - there is no button to arm it - so what this proves
+    // is that the authored WeaponBash reaches a shipped one-HP pane at all.
+    // (That it is NOT billed for merely being carried into one is the walking
+    // regression below.)
+    const beforeAttack =
+      (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
     await sweepHeldWrench(game);
-    assert.equal(
-      await paneStillExists(game, pane.id),
-      true,
-      "idle held-Wrench contact must remain harmless",
-    );
+
     const sweptWrench = (await game.physics.bodies({ entityId: wrench.id }))
       .bodies[0];
     assert.ok(sweptWrench, "the held Wrench should retain its physics body");
@@ -138,8 +139,7 @@ test(
     // pane is an entity, and deliberately does not block: a swing has to
     // travel *into* what it is hitting, and a pane you are meant to smash
     // would otherwise stop the swing dead. So the weapon reaches its tracked
-    // target here - being harmless without the trigger is what the assertion
-    // above already proves.
+    // target here.
     //
     // An earlier revision drove a fully dynamic body and asserted the
     // opposite (that the pane held the weapon back). That drive spun the
@@ -149,22 +149,12 @@ test(
       `the swept Wrench should reach its tracked target through a non-world pane: ${JSON.stringify(sweptWrench)}`,
     );
 
-    // Leave contact, open the attack window with the production VR trigger,
-    // then make a fresh controller-driven physics contact.
-    await game.input.set("right_hand.position", HAND_REST);
-    await game.step({ frames: 30 });
-    const beforeAttack =
-      (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
-    await game.input.set("right_hand.trigger", 1);
-    await game.step({ frames: 2 });
-    await sweepHeldWrench(game);
-
     const attackMessages = (await game.messages.recent()).messages.filter(
       (message) => message.sequence > beforeAttack && message.to.entity_id === pane.id,
     );
     assert.ok(
       attackMessages.some((message) => message.payload === "Damage"),
-      `trigger + physical contact should damage the pane: ${JSON.stringify(attackMessages)}`,
+      `a swung physical contact should damage the pane: ${JSON.stringify(attackMessages)}`,
     );
     assert.ok(
       attackMessages.some((message) => message.payload === "Slay"),
@@ -173,7 +163,7 @@ test(
     assert.equal(
       await paneStillExists(game, pane.id),
       false,
-      "the armed wrench contact should remove the pane",
+      "the swung wrench contact should remove the pane",
     );
 
     // A drop closes the window and restores the Wrench's ordinary dynamic
@@ -184,8 +174,6 @@ test(
       "Window 2",
       DROP_PANE_MISSION_ID,
     );
-    await game.input.set("right_hand.trigger", 0);
-    await game.step({ frames: 2 });
     await game.player.teleport({
       x: dropPane.position[0] + 2,
       y: dropPane.position[1] - 1.6,
@@ -211,6 +199,82 @@ test(
       await paneStillExists(game, dropPane.id),
       true,
       "drop contact must remain harmless",
+    );
+  },
+);
+
+// Regression for the free-swing measurement: a held weapon rides the player, so
+// its world velocity is the player's own locomotion (measured at 10 units/s,
+// five times the swing gate). Walking a still hand into a shipped one-HP pane
+// therefore destroyed it - a free authored WeaponBash for walking down a
+// corridor with a wrench out.
+test(
+  "walking a held wrench into a pane is not a swing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    const wrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
+    const pane = await byMissionId(game, "Window 2", BREAKABLE_PANE_MISSION_ID);
+
+    await game.player.teleport({
+      x: wrench.position[0],
+      y: wrench.position[1] - 1.4,
+      z: wrench.position[2] + 1.2,
+    });
+    await game.input.lookAtWorldPoint(wrench.position);
+    await game.input.set("right_hand.position", [0, 1.4, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.id,
+      "the real authored Wrench should be grabbed",
+    );
+
+    // Stand back from the pane with the wrench held out ahead, and hold the
+    // hand perfectly still for the rest of the run: every unit the weapon
+    // covers from here is the player walking, not the player swinging.
+    await game.player.teleport({
+      x: pane.position[0],
+      y: pane.position[1] - 1.04,
+      z: pane.position[2] - 5.0,
+    });
+    await game.input.lookAtWorldPoint(pane.position);
+    await game.input.set("right_hand.position", [0.05, HAND_Y, 1.2]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.step({ frames: 30 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.id,
+      "the Wrench should still be held at the walk-in staging pose",
+    );
+
+    // Walk into it, then keep walking after the pane is reached - the frame
+    // the player is stopped by the wall behind it is the awkward one.
+    await game.input.set("right_hand.thumbstick", [0.0, 1.0]);
+    await game.step({ frames: 90 });
+
+    // The wrench must have been carried THROUGH the pane, or "nothing was
+    // billed" would be satisfied by never touching it.
+    const carriedWrench = (await game.physics.bodies({ entityId: wrench.id }))
+      .bodies[0];
+    assert.ok(carriedWrench, "the held Wrench should retain its physics body");
+    assert.ok(
+      carriedWrench.position[2] > pane.position[2],
+      `the walk should carry the Wrench past the pane plane: ${JSON.stringify(carriedWrench)}`,
+    );
+    assert.equal(
+      await paneStillExists(game, pane.id),
+      true,
+      "walking a still hand into the pane must not bill a swing",
     );
   },
 );


### PR DESCRIPTION
## Cause

A held weapon rides the player, so its world velocity is the player's own locomotion **plus** the swing. `HeldMeleeWeapon::may_damage` billed on that world velocity, and locomotion measures **10 world units/s** — five times the 2.0 `melee_free_swing` gate. Walking a still hand with a wrench into anything therefore billed the authored WeaponBash.

Reproduced end to end before touching anything: in `command2.mis`, holding the shipped Wrench out ahead and walking into a shipped one-HP pane destroyed it, hand motionless (`impact` at the pane, `Damage` + `Slay`). The held body read `10.00` u/s the whole walk.

Two further readings had to be dealt with to make that measurement honest:

- On the frame the player is stopped by the wall behind the pane, the weapon body reported **33.9 u/s** — the swept drive lagging behind the hand and then covering the accrued error in one step. The hand's own controller target read **9.99** on that frame.
- Subtracting the player from a world-frame victim introduces a *new* false positive (found by review): backpedalling from a creature chasing at the same speed reads the full chase speed, though nothing is closing.

## Fix

A blow is billed on the **smaller of two readings**, because it has to be both:

- **a real closing speed** (`weapon - victim`) — two bodies keeping station are not hitting each other;
- **not merely the player's own locomotion** (`weapon - player - victim`) — walking, riding and cornering read ~0.

Each is wrong alone in one direction; the minimum is correct in every case, and a creature charging onto a held blade still impales itself. Both are projected on the contact normal as before. Only *translation* is divided out — turning on the spot still swings the weapon head at arm's length.

Supporting changes the measurement needs:

- `PhysicsWorld::sample_player_velocity` records the player's own travel at the **top** of a frame, in phase with the one-frame-old hand poses it is subtracted from (the drive runs before `move_player`, and scripts read contacts after the step). `set_player_translation` re-seats it, so a relocation is not read as ~3000 u/s of "player motion" on arrival.
- For a held weapon the swing reading comes from the **hand's controller target**, not the weapon body. The weapon body is still read as the other half of the minimum: it is what stops a weapon pinned against a creature from billing a second blow while the hand travels on.

`MELEE_FREE_SWING_SPEED` and `melee_scale` are untouched. The impact-**sound** path is deliberately unchanged (a wrench carried head-on into a bulkhead should still clang).

## Tests

Negative-first, all four fail on the base build and pass here:

- `walking_a_weapon_into_a_limb_is_not_a_swing` (`held_melee_drive.rs`) — hand still, player walking at 10 u/s into a hitbox: without the fix the sweep reports `10.000004` against a gate of `2`.
- `walking_a_weapon_into_a_still_victim_is_not_a_swing` (`melee_weapon.rs`) — `read 10` without the fix.
- `retreating_from_a_creature_that_keeps_pace_is_not_a_blow` — `read 10` with the player term subtracted from a world-frame victim.
- `relocating_the_player_is_not_player_velocity` — `read 2999.9998` without re-seating the sampler.

Plus `swinging_while_walking_is_still_a_swing` (the other half: a swing thrown while walking clears the gate).

The stale assertion `idle held-Wrench contact must remain harmless` in `vr-melee-contact.e2e.test.ts` — which fails on `main` — encoded the **trigger gate deleted in #1173**, not this bug: its "idle" sweep is a 3.2 u/s hand motion, a genuine swing under the shipped rule (verified: it damages with a stationary player, before and after this change). It is replaced by the rule that actually ships — a swing damages the pane — plus a new `walking a held wrench into a pane is not a swing`, which asserts the wrench was carried **past the pane plane** while the pane survives, so it cannot pass by never touching it.

### Verification

- `cargo fmt --check`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo test -p shock2vr --lib` — **1261 passed, 0 failed, 2 ignored**.
- e2e: `vr-melee-contact` **4/4**; `melee-hitbox` 2/2 (x4 runs); `melee-swing-stop`, `melee-impact-sound`, `flat-melee-animation-event`, `damage-overlay`, `hitbox-coverage`, `ranged-hitbox` pass; `teleport-position`, `climbing`, `save-load`, `elevator-panel`, `command-tram`, `montage-teleport-loop` **10/10**; `missions.e2e.test.ts` **23/23**.
- Known pre-existing failure, verified failing on a base build in this same worktree: `medsci-saved-vr-melee` › *MedSci saved mission Wrench keeps canonical 9-damage VR melee across decks and saves* — `corpse frob should open one VR loot panel`, `0 !== 1` (a looting/UI issue, not melee).

No rendered change, so no visuals.
