### PR TITLE
fix(psi): register the PsiMine script and detonate on proximity

### DIFF
--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -47,6 +47,7 @@ mod picture_swap;
 pub mod player_script;
 mod psi_amp_script;
 mod psi_kit;
+mod psi_mine;
 mod put_bomb_in_replicator;
 pub mod radiation;
 mod reduce_psi;
@@ -128,6 +129,7 @@ use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::picture_swap::PictureSwap;
 use self::psi_amp_script::PsiAmpScript;
 use self::psi_kit::PsiKitScript;
+use self::psi_mine::PsiMine;
 use self::put_bomb_in_replicator::PutBombInReplicator;
 use self::radiation::RadPatchScript;
 use self::reduce_psi::ReducePsi;
@@ -1100,6 +1102,7 @@ impl ScriptWorld {
             "ectoplasm" => Box::new(UnimplementedScript::new(&script_name)),
             "medpatchscript" => Box::new(HealingItemScript::new(HealingItemKind::MedPatch)),
             "psikitscript" => Box::new(PsiKitScript::new()),
+            "psimine" => Box::new(PsiMine::new()),
             "computer" => gui_script(Box::new(ComputerGui)),
             "lightsoundon" => Box::new(NoopScript::new()),
             "hackablecrate" => gui_script(Box::new(HackableCrateGui::new())),

--- a/shock2vr/src/scripts/psi_mine.rs
+++ b/shock2vr/src/scripts/psi_mine.rs
@@ -1,0 +1,212 @@
+//! Script `PsiMine`: the projectile lobbed by the tier-5 psi power PsiMines
+//! (External Psionic Detonation).
+//!
+//! The mine (`PsiMine Projectile`, -3397) is a slow physics projectile -
+//! unlike the other psi bolts it has no `SLAY_ON_IMPACT`, so it comes to rest
+//! where it lands. It arms shortly after the cast, then detonates when a
+//! creature comes within its trigger radius or when it is damaged. The blast
+//! itself is authored data, not code: slaying the mine spawns its
+//! `Corpse -> Psi Mine Explosion`(-3756), whose radius stim source
+//! (30.0 @ r4.0 of `Psi Stim`) is resolved by `internal_explosion` like any
+//! other explosion.
+
+use cgmath::{InnerSpace, Transform, point3};
+use dark::properties::{PropAI, PropHitPoints};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
+use std::time::Duration;
+
+use crate::{physics::PhysicsWorld, runtime_props::RuntimePropTransform, time::Time};
+
+use super::{Effect, MessagePayload, Script};
+
+/// How long after the cast the mine starts sensing. The mine leaves the amp at
+/// the caster's own position, so it must not trip on whatever the caster is
+/// standing next to; this is also roughly the time it takes to land.
+const ARM_DELAY: Duration = Duration::from_millis(750);
+
+/// How close a creature must come to set the mine off. Matched to the authored
+/// blast radius (`Psi Mine Explosion`'s stim source, 4.0) so anything that
+/// trips the mine is inside the blast.
+const TRIGGER_RADIUS: f32 = 4.0;
+
+/// How long an untripped mine lasts before it quietly expires, so a cast that
+/// found nothing does not leave a live sensor in the level forever.
+const LIFETIME: Duration = Duration::from_secs(60);
+
+pub struct PsiMine {
+    age: Duration,
+}
+
+impl PsiMine {
+    pub fn new() -> PsiMine {
+        PsiMine {
+            age: Duration::ZERO,
+        }
+    }
+}
+
+impl Script for PsiMine {
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        self.age += time.elapsed;
+
+        if self.age < ARM_DELAY {
+            return Effect::NoEffect;
+        }
+        if self.age >= LIFETIME {
+            return Effect::DestroyEntity { entity_id };
+        }
+
+        if creature_in_range(world, entity_id, TRIGGER_RADIUS) {
+            Effect::SlayEntity { entity_id }
+        } else {
+            Effect::NoEffect
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        // A shot mine goes off where it lies.
+        match msg {
+            MessagePayload::Damage { .. } => Effect::SlayEntity { entity_id },
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+/// Whether a living creature stands within `radius` of the mine. Creatures are
+/// the AI-driven entities (`P$AI`); a corpse - hit points spent - no longer
+/// trips a mine.
+fn creature_in_range(world: &World, mine_entity_id: EntityId, radius: f32) -> bool {
+    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+    let Ok(mine_transform) = v_transform.get(mine_entity_id) else {
+        return false;
+    };
+    let mine_position = mine_transform.0.transform_point(point3(0.0, 0.0, 0.0));
+
+    let v_ai = world.borrow::<View<PropAI>>().unwrap();
+    let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
+
+    (&v_ai, &v_hit_points, &v_transform).iter().with_id().any(
+        |(entity_id, (_ai, hit_points, transform))| {
+            entity_id != mine_entity_id
+                && hit_points.hit_points > 0
+                && (transform.0.transform_point(point3(0.0, 0.0, 0.0)) - mine_position).magnitude()
+                    <= radius
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Matrix4, vec3};
+
+    fn mine_world(creature_position: cgmath::Vector3<f32>, hit_points: i32) -> (World, EntityId) {
+        let mut world = World::new();
+        let mine = world.add_entity(RuntimePropTransform(Matrix4::from_translation(vec3(
+            0.0, 0.0, 0.0,
+        ))));
+        world.add_entity((
+            PropAI("Grunt".to_owned()),
+            PropHitPoints { hit_points },
+            RuntimePropTransform(Matrix4::from_translation(creature_position)),
+        ));
+        (world, mine)
+    }
+
+    fn update(script: &mut PsiMine, world: &World, mine: EntityId, elapsed: Duration) -> Effect {
+        script.update(
+            mine,
+            world,
+            &PhysicsWorld::new(),
+            &Time {
+                elapsed,
+                total: Duration::ZERO,
+            },
+        )
+    }
+
+    #[test]
+    fn an_armed_mine_detonates_on_a_creature_within_its_radius() {
+        let (world, mine) = mine_world(vec3(2.0, 0.0, 0.0), 12);
+        let mut script = PsiMine::new();
+
+        let effect = update(&mut script, &world, mine, ARM_DELAY);
+
+        assert!(
+            matches!(effect, Effect::SlayEntity { entity_id } if entity_id == mine),
+            "a creature inside the trigger radius sets the mine off, spawning its authored corpse explosion",
+        );
+    }
+
+    /// The mine leaves the amp at the caster's own position: it must not trip
+    /// on whatever stands there before it has left the hand.
+    #[test]
+    fn an_unarmed_mine_ignores_a_creature_on_top_of_it() {
+        let (world, mine) = mine_world(vec3(0.5, 0.0, 0.0), 12);
+        let mut script = PsiMine::new();
+
+        let effect = update(&mut script, &world, mine, ARM_DELAY / 2);
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    #[test]
+    fn an_armed_mine_ignores_a_creature_out_of_range() {
+        let (world, mine) = mine_world(vec3(TRIGGER_RADIUS + 1.0, 0.0, 0.0), 12);
+        let mut script = PsiMine::new();
+
+        let effect = update(&mut script, &world, mine, ARM_DELAY);
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    #[test]
+    fn a_corpse_does_not_trip_a_mine() {
+        let (world, mine) = mine_world(vec3(1.0, 0.0, 0.0), 0);
+        let mut script = PsiMine::new();
+
+        let effect = update(&mut script, &world, mine, ARM_DELAY);
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    #[test]
+    fn an_untripped_mine_expires() {
+        let (world, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let mut script = PsiMine::new();
+
+        let effect = update(&mut script, &world, mine, LIFETIME);
+
+        assert!(matches!(effect, Effect::DestroyEntity { entity_id } if entity_id == mine));
+    }
+
+    #[test]
+    fn a_damaged_mine_detonates() {
+        let (world, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let mut script = PsiMine::new();
+
+        let effect = script.handle_message(
+            mine,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Damage {
+                amount: 1.0,
+                impact: None,
+            },
+        );
+
+        assert!(matches!(effect, Effect::SlayEntity { entity_id } if entity_id == mine));
+    }
+}

--- a/shock2vr/src/scripts/psi_mine.rs
+++ b/shock2vr/src/scripts/psi_mine.rs
@@ -1,41 +1,54 @@
 //! Script `PsiMine`: the projectile lobbed by the tier-5 psi power PsiMines
 //! (External Psionic Detonation).
 //!
-//! The mine (`PsiMine Projectile`, -3397) is a slow physics projectile -
-//! unlike the other psi bolts it has no `SLAY_ON_IMPACT`, so it comes to rest
-//! where it lands. It arms shortly after the cast, then detonates when a
-//! creature comes within its trigger radius or when it is damaged. The blast
-//! itself is authored data, not code: slaying the mine spawns its
+//! The mine (`PsiMine Projectile`, -3397) is a slow physics projectile that,
+//! unlike the other psi bolts, is not slain on impact (`BOUNCE`, no
+//! `SLAY_ON_IMPACT`) and is authored weightless (`gravity_scale 0.0`): it
+//! drifts and bounces rather than falling. It arms shortly after the cast,
+//! then detonates when a creature comes within reach of its body or when it is
+//! damaged, and expires if nothing trips it.
+//!
+//! The blast is authored data, not code: slaying the mine spawns its
 //! `Corpse -> Psi Mine Explosion`(-3756), whose radius stim source
 //! (30.0 @ r4.0 of `Psi Stim`) is resolved by `internal_explosion` like any
 //! other explosion.
 
-use cgmath::{InnerSpace, Transform, point3};
-use dark::properties::{PropAI, PropHitPoints};
+use cgmath::{InnerSpace, Point3, Transform, point3};
+use collision::Aabb3;
+use dark::properties::{PropCreature, PropPhysDimensions};
+use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
 use std::time::Duration;
 
 use crate::{physics::PhysicsWorld, runtime_props::RuntimePropTransform, time::Time};
 
-use super::{Effect, MessagePayload, Script};
+use super::{
+    Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
+    ai::ai_util::is_killed,
+};
 
-/// How long after the cast the mine starts sensing: long enough to leave the
-/// caster (it is lobbed from their own position, and the blast reaches them
-/// too), short enough that a mine thrown at a creature a few paces away is
-/// live by the time it gets there.
-const ARM_DELAY: Duration = Duration::from_millis(250);
+/// How long after the cast the mine starts sensing: enough to clear the
+/// caster's own body (it is lobbed from their position, and the blast reaches
+/// them too), short enough that a mine thrown at a creature a pace away is
+/// live by the time it arrives.
+const ARM_DELAY: Duration = Duration::from_millis(100);
 
-/// How close a creature must come to set the mine off, measured to the
-/// creature's origin. Inside the authored blast radius (`Psi Mine Explosion`'s
-/// stim source is 30.0 @ r4.0), whose damage falls off linearly to nothing at
-/// its edge - a mine that tripped at the full radius would deal nothing to
-/// what tripped it - but with room for the body's own extent around that
-/// origin.
-const TRIGGER_RADIUS: f32 = 3.0;
+/// Sensing reach when the mine authors no physics dimensions, which the shipped
+/// `PsiMine Projectile` does (`radius0` 1.4 - seven times the projectile
+/// default, the mine's own body).
+const DEFAULT_TRIGGER_RADIUS: f32 = 1.4;
 
 /// How long an untripped mine lasts before it quietly expires, so a cast that
-/// found nothing does not leave a live sensor in the level forever.
+/// found nothing does not leave a live sensor drifting through the level
+/// forever.
 const LIFETIME: Duration = Duration::from_secs(60);
+
+const SCRIPT_STATE_KEY: &str = "shock2vr.psi_mine";
+
+#[derive(Serialize, Deserialize)]
+struct PsiMineState {
+    age_secs: f32,
+}
 
 pub struct PsiMine {
     age: Duration,
@@ -54,7 +67,7 @@ impl Script for PsiMine {
         &mut self,
         entity_id: EntityId,
         world: &World,
-        _physics: &PhysicsWorld,
+        physics: &PhysicsWorld,
         time: &Time,
     ) -> Effect {
         self.age += time.elapsed;
@@ -66,7 +79,7 @@ impl Script for PsiMine {
             return Effect::DestroyEntity { entity_id };
         }
 
-        if creature_in_range(world, entity_id, TRIGGER_RADIUS) {
+        if creature_in_reach(world, physics, entity_id) {
             Effect::SlayEntity { entity_id }
         } else {
             Effect::NoEffect
@@ -86,54 +99,130 @@ impl Script for PsiMine {
             _ => Effect::NoEffect,
         }
     }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(SCRIPT_STATE_KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &PsiMineState {
+                age_secs: self.age.as_secs_f32(),
+            },
+            SCRIPT_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: PsiMineState = state.decode(1, SCRIPT_STATE_KEY)?;
+        self.age = Duration::from_secs_f32(restored.age_secs.max(0.0));
+        Ok(())
+    }
 }
 
-/// Whether a living creature stands within `radius` of the mine. Creatures are
-/// the AI-driven entities (`P$AI`); a corpse - hit points spent - no longer
-/// trips a mine.
-fn creature_in_range(world: &World, mine_entity_id: EntityId, radius: f32) -> bool {
+/// Whether a living creature has come within the mine's sensing reach - its own
+/// authored body radius, measured to the creature's collider rather than to its
+/// origin, so a body standing beside the mine trips it and one across the room
+/// does not.
+fn creature_in_reach(world: &World, physics: &PhysicsWorld, mine_entity_id: EntityId) -> bool {
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let Ok(mine_transform) = v_transform.get(mine_entity_id) else {
         return false;
     };
     let mine_position = mine_transform.0.transform_point(point3(0.0, 0.0, 0.0));
+    let radius = world
+        .borrow::<View<PropPhysDimensions>>()
+        .ok()
+        .and_then(|dimensions| dimensions.get(mine_entity_id).ok().map(|d| d.radius0.abs()))
+        .filter(|radius| *radius > 0.0)
+        .unwrap_or(DEFAULT_TRIGGER_RADIUS);
 
-    let v_ai = world.borrow::<View<PropAI>>().unwrap();
-    let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
+    let v_creature = world.borrow::<View<PropCreature>>().unwrap();
 
-    (&v_ai, &v_hit_points, &v_transform).iter().with_id().any(
-        |(entity_id, (_ai, hit_points, transform))| {
-            entity_id != mine_entity_id
-                && hit_points.hit_points > 0
-                && (transform.0.transform_point(point3(0.0, 0.0, 0.0)) - mine_position).magnitude()
-                    <= radius
+    v_creature.iter().with_id().any(
+        |(entity_id, _creature)| match physics.get_aabb2(entity_id) {
+            Some(bounds) => {
+                !is_killed(entity_id, world) && distance_to_bounds(mine_position, &bounds) <= radius
+            }
+            // A creature with no live collider (contained, not yet in the
+            // world) is nothing to trip on.
+            None => false,
         },
     )
+}
+
+/// Distance from a point to the nearest point of a box - zero inside it.
+fn distance_to_bounds(point: Point3<f32>, bounds: &Aabb3<f32>) -> f32 {
+    let nearest = point3(
+        point.x.clamp(bounds.min.x, bounds.max.x),
+        point.y.clamp(bounds.min.y, bounds.max.y),
+        point.z.clamp(bounds.min.z, bounds.max.z),
+    );
+    (point - nearest).magnitude()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::{Matrix4, vec3};
+    use crate::physics::CollisionGroup;
+    use cgmath::{Matrix4, Quaternion, vec3};
+    use dark::properties::PropHitPoints;
+    use std::collections::HashMap;
 
-    fn mine_world(creature_position: cgmath::Vector3<f32>, hit_points: i32) -> (World, EntityId) {
+    /// A mine at the origin and one human creature, its collider a 1-unit cube
+    /// centered on `creature_position`.
+    fn mine_world(
+        creature_position: cgmath::Vector3<f32>,
+        hit_points: i32,
+    ) -> (World, PhysicsWorld, EntityId) {
         let mut world = World::new();
-        let mine = world.add_entity(RuntimePropTransform(Matrix4::from_translation(vec3(
-            0.0, 0.0, 0.0,
-        ))));
-        world.add_entity((
-            PropAI("Grunt".to_owned()),
-            PropHitPoints { hit_points },
-            RuntimePropTransform(Matrix4::from_translation(creature_position)),
+        let mut physics = PhysicsWorld::new();
+
+        let mine = world.add_entity((
+            RuntimePropTransform(Matrix4::from_translation(vec3(0.0, 0.0, 0.0))),
+            PropPhysDimensions {
+                radius0: DEFAULT_TRIGGER_RADIUS,
+                radius1: 0.0,
+                offset0: vec3(0.0, 0.0, 0.0),
+                offset1: vec3(0.0, 0.0, 0.0),
+                size: vec3(0.0, 0.0, 0.0),
+                unk1: 1,
+                unk2: 1,
+            },
         ));
-        (world, mine)
+        let creature = world.add_entity((PropCreature(0), PropHitPoints { hit_points }));
+        physics.add_kinematic(
+            creature,
+            creature_position,
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 1.0),
+            CollisionGroup::actor(),
+            false,
+        );
+        let mut player =
+            physics.create_player(vec3(0.0, 0.0, -50.0), EntityId::from_inner(9).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        (world, physics, mine)
     }
 
-    fn update(script: &mut PsiMine, world: &World, mine: EntityId, elapsed: Duration) -> Effect {
+    fn update(
+        script: &mut PsiMine,
+        world: &World,
+        physics: &PhysicsWorld,
+        mine: EntityId,
+        elapsed: Duration,
+    ) -> Effect {
         script.update(
             mine,
             world,
-            &PhysicsWorld::new(),
+            physics,
             &Time {
                 elapsed,
                 total: Duration::ZERO,
@@ -142,15 +231,16 @@ mod tests {
     }
 
     #[test]
-    fn an_armed_mine_detonates_on_a_creature_within_its_radius() {
-        let (world, mine) = mine_world(vec3(2.0, 0.0, 0.0), 12);
+    fn an_armed_mine_detonates_on_a_creature_within_reach() {
+        // Collider face at x = 1.4, exactly the mine's authored reach.
+        let (world, physics, mine) = mine_world(vec3(1.9, 0.0, 0.0), 12);
         let mut script = PsiMine::new();
 
-        let effect = update(&mut script, &world, mine, ARM_DELAY);
+        let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
 
         assert!(
             matches!(effect, Effect::SlayEntity { entity_id } if entity_id == mine),
-            "a creature inside the trigger radius sets the mine off, spawning its authored corpse explosion",
+            "a creature within reach sets the mine off, spawning its authored corpse explosion",
         );
     }
 
@@ -158,53 +248,53 @@ mod tests {
     /// on whatever stands there before it has left the hand.
     #[test]
     fn an_unarmed_mine_ignores_a_creature_on_top_of_it() {
-        let (world, mine) = mine_world(vec3(0.5, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(0.5, 0.0, 0.0), 12);
         let mut script = PsiMine::new();
 
-        let effect = update(&mut script, &world, mine, ARM_DELAY / 2);
+        let effect = update(&mut script, &world, &physics, mine, ARM_DELAY / 2);
 
         assert!(matches!(effect, Effect::NoEffect));
     }
 
     #[test]
-    fn an_armed_mine_ignores_a_creature_out_of_range() {
-        let (world, mine) = mine_world(vec3(TRIGGER_RADIUS + 1.0, 0.0, 0.0), 12);
+    fn an_armed_mine_ignores_a_creature_out_of_reach() {
+        let (world, physics, mine) = mine_world(vec3(3.0, 0.0, 0.0), 12);
         let mut script = PsiMine::new();
 
-        let effect = update(&mut script, &world, mine, ARM_DELAY);
+        let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
 
         assert!(matches!(effect, Effect::NoEffect));
     }
 
     #[test]
     fn a_corpse_does_not_trip_a_mine() {
-        let (world, mine) = mine_world(vec3(1.0, 0.0, 0.0), 0);
+        let (world, physics, mine) = mine_world(vec3(1.0, 0.0, 0.0), 0);
         let mut script = PsiMine::new();
 
-        let effect = update(&mut script, &world, mine, ARM_DELAY);
+        let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
 
         assert!(matches!(effect, Effect::NoEffect));
     }
 
     #[test]
     fn an_untripped_mine_expires() {
-        let (world, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
         let mut script = PsiMine::new();
 
-        let effect = update(&mut script, &world, mine, LIFETIME);
+        let effect = update(&mut script, &world, &physics, mine, LIFETIME);
 
         assert!(matches!(effect, Effect::DestroyEntity { entity_id } if entity_id == mine));
     }
 
     #[test]
     fn a_damaged_mine_detonates() {
-        let (world, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
         let mut script = PsiMine::new();
 
         let effect = script.handle_message(
             mine,
             &world,
-            &PhysicsWorld::new(),
+            &physics,
             &MessagePayload::Damage {
                 amount: 1.0,
                 impact: None,
@@ -212,5 +302,38 @@ mod tests {
         );
 
         assert!(matches!(effect, Effect::SlayEntity { entity_id } if entity_id == mine));
+    }
+
+    /// A mine live in the world when the game is saved keeps its fuse: it is
+    /// still armed on load, and still expires on schedule.
+    #[test]
+    fn the_fuse_survives_save_and_load() {
+        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let mut before_save = PsiMine::new();
+        update(
+            &mut before_save,
+            &world,
+            &physics,
+            mine,
+            LIFETIME - Duration::from_millis(10),
+        );
+
+        let state = before_save.save_state().unwrap();
+        let mut after_load = PsiMine::new();
+        after_load
+            .restore_state(&state, &ScriptRestoreContext::new(&HashMap::new()))
+            .unwrap();
+
+        let effect = update(
+            &mut after_load,
+            &world,
+            &physics,
+            mine,
+            Duration::from_millis(10),
+        );
+        assert!(
+            matches!(effect, Effect::DestroyEntity { entity_id } if entity_id == mine),
+            "a restored mine expires on its original schedule, not 60s after the load",
+        );
     }
 }

--- a/shock2vr/src/scripts/psi_mine.rs
+++ b/shock2vr/src/scripts/psi_mine.rs
@@ -15,17 +15,14 @@
 
 use cgmath::{InnerSpace, Point3, Transform, point3};
 use collision::Aabb3;
-use dark::properties::{PropCreature, PropPhysDimensions};
+use dark::properties::{PropAI, PropHitPoints, PropPhysDimensions};
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
 use std::time::Duration;
 
 use crate::{physics::PhysicsWorld, runtime_props::RuntimePropTransform, time::Time};
 
-use super::{
-    Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
-    ai::ai_util::is_killed,
-};
+use super::{Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError};
 
 /// How long after the cast the mine starts sensing: enough to clear the
 /// caster's own body (it is lobbed from their position, and the blast reaches
@@ -33,9 +30,9 @@ use super::{
 /// live by the time it arrives.
 const ARM_DELAY: Duration = Duration::from_millis(100);
 
-/// Sensing reach when the mine authors no physics dimensions, which the shipped
-/// `PsiMine Projectile` does (`radius0` 1.4 - seven times the projectile
-/// default, the mine's own body).
+/// Sensing reach for a mine that authors no physics dimensions. The shipped
+/// `PsiMine Projectile` authors `radius0` 1.4 - seven times the projectile
+/// default, the mine's own body - and that authored value is what is used.
 const DEFAULT_TRIGGER_RADIUS: f32 = 1.4;
 
 /// How long an untripped mine lasts before it quietly expires, so a cast that
@@ -125,10 +122,14 @@ impl Script for PsiMine {
     }
 }
 
-/// Whether a living creature has come within the mine's sensing reach - its own
-/// authored body radius, measured to the creature's collider rather than to its
-/// origin, so a body standing beside the mine trips it and one across the room
-/// does not.
+/// Whether a live AI has come within the mine's sensing reach - its own
+/// authored body radius, measured to the bounds of the creature's collider
+/// rather than to its origin, so a body standing beside the mine trips it and
+/// one across the room does not.
+///
+/// "Live AI" is `P$AI` plus hit points left, not `PropCreature`: the authored
+/// corpses scattered through the levels carry `PropCreature` with no hit
+/// points at all, and a mine must not go off on the scenery.
 fn creature_in_reach(world: &World, physics: &PhysicsWorld, mine_entity_id: EntityId) -> bool {
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let Ok(mine_transform) = v_transform.get(mine_entity_id) else {
@@ -142,18 +143,20 @@ fn creature_in_reach(world: &World, physics: &PhysicsWorld, mine_entity_id: Enti
         .filter(|radius| *radius > 0.0)
         .unwrap_or(DEFAULT_TRIGGER_RADIUS);
 
-    let v_creature = world.borrow::<View<PropCreature>>().unwrap();
+    let v_ai = world.borrow::<View<PropAI>>().unwrap();
+    let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
 
-    v_creature.iter().with_id().any(
-        |(entity_id, _creature)| match physics.get_aabb2(entity_id) {
-            Some(bounds) => {
-                !is_killed(entity_id, world) && distance_to_bounds(mine_position, &bounds) <= radius
-            }
-            // A creature with no live collider (contained, not yet in the
-            // world) is nothing to trip on.
-            None => false,
-        },
-    )
+    (&v_ai, &v_hit_points)
+        .iter()
+        .with_id()
+        .any(|(entity_id, (_ai, hit_points))| {
+            hit_points.hit_points > 0
+                // No live collider (contained, not yet in the world) is
+                // nothing to trip on.
+                && physics
+                    .get_aabb2(entity_id)
+                    .is_some_and(|bounds| distance_to_bounds(mine_position, &bounds) <= radius)
+        })
 }
 
 /// Distance from a point to the nearest point of a box - zero inside it.
@@ -171,45 +174,62 @@ mod tests {
     use super::*;
     use crate::physics::CollisionGroup;
     use cgmath::{Matrix4, Quaternion, vec3};
-    use dark::properties::PropHitPoints;
+    use dark::properties::PropCreature;
     use std::collections::HashMap;
 
-    /// A mine at the origin and one human creature, its collider a 1-unit cube
-    /// centered on `creature_position`.
+    fn dimensions(radius0: f32) -> PropPhysDimensions {
+        PropPhysDimensions {
+            radius0,
+            radius1: 0.0,
+            offset0: vec3(0.0, 0.0, 0.0),
+            offset1: vec3(0.0, 0.0, 0.0),
+            size: vec3(0.0, 0.0, 0.0),
+            unk1: 1,
+            unk2: 1,
+        }
+    }
+
+    /// A mine at the origin with the authored sensing radius, and one live AI
+    /// whose collider is a 1-unit cube centered on `creature_position`.
     fn mine_world(
         creature_position: cgmath::Vector3<f32>,
         hit_points: i32,
+        mine_radius: f32,
     ) -> (World, PhysicsWorld, EntityId) {
-        let mut world = World::new();
-        let mut physics = PhysicsWorld::new();
+        let (mut world, mut physics, mine) = empty_mine_world(mine_radius);
+        let creature = world.add_entity((PropAI("Grunt".to_owned()), PropHitPoints { hit_points }));
+        add_body(&mut physics, creature, creature_position);
+        settle(&mut physics);
+        (world, physics, mine)
+    }
 
+    fn empty_mine_world(mine_radius: f32) -> (World, PhysicsWorld, EntityId) {
+        let mut world = World::new();
+        let physics = PhysicsWorld::new();
         let mine = world.add_entity((
             RuntimePropTransform(Matrix4::from_translation(vec3(0.0, 0.0, 0.0))),
-            PropPhysDimensions {
-                radius0: DEFAULT_TRIGGER_RADIUS,
-                radius1: 0.0,
-                offset0: vec3(0.0, 0.0, 0.0),
-                offset1: vec3(0.0, 0.0, 0.0),
-                size: vec3(0.0, 0.0, 0.0),
-                unk1: 1,
-                unk2: 1,
-            },
+            dimensions(mine_radius),
         ));
-        let creature = world.add_entity((PropCreature(0), PropHitPoints { hit_points }));
+        (world, physics, mine)
+    }
+
+    fn add_body(physics: &mut PhysicsWorld, entity_id: EntityId, position: cgmath::Vector3<f32>) {
         physics.add_kinematic(
-            creature,
-            creature_position,
+            entity_id,
+            position,
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             vec3(0.0, 0.0, 0.0),
             vec3(1.0, 1.0, 1.0),
             CollisionGroup::actor(),
             false,
         );
+    }
+
+    /// One step so the broad phase sees the fresh bodies.
+    fn settle(physics: &mut PhysicsWorld) {
         let mut player =
             physics.create_player(vec3(0.0, 0.0, -50.0), EntityId::from_inner(9).unwrap());
         physics.update(vec3(0.0, 0.0, 0.0), &mut player);
-
-        (world, physics, mine)
     }
 
     fn update(
@@ -233,7 +253,7 @@ mod tests {
     #[test]
     fn an_armed_mine_detonates_on_a_creature_within_reach() {
         // Collider face at x = 1.4, exactly the mine's authored reach.
-        let (world, physics, mine) = mine_world(vec3(1.9, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(1.9, 0.0, 0.0), 12, DEFAULT_TRIGGER_RADIUS);
         let mut script = PsiMine::new();
 
         let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
@@ -248,7 +268,7 @@ mod tests {
     /// on whatever stands there before it has left the hand.
     #[test]
     fn an_unarmed_mine_ignores_a_creature_on_top_of_it() {
-        let (world, physics, mine) = mine_world(vec3(0.5, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(0.5, 0.0, 0.0), 12, DEFAULT_TRIGGER_RADIUS);
         let mut script = PsiMine::new();
 
         let effect = update(&mut script, &world, &physics, mine, ARM_DELAY / 2);
@@ -258,7 +278,7 @@ mod tests {
 
     #[test]
     fn an_armed_mine_ignores_a_creature_out_of_reach() {
-        let (world, physics, mine) = mine_world(vec3(3.0, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(3.0, 0.0, 0.0), 12, DEFAULT_TRIGGER_RADIUS);
         let mut script = PsiMine::new();
 
         let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
@@ -266,9 +286,36 @@ mod tests {
         assert!(matches!(effect, Effect::NoEffect));
     }
 
+    /// The reach is the mine's own authored radius, not a constant: the same
+    /// creature that is out of reach above trips a wider-bodied mine.
     #[test]
-    fn a_corpse_does_not_trip_a_mine() {
-        let (world, physics, mine) = mine_world(vec3(1.0, 0.0, 0.0), 0);
+    fn the_reach_comes_from_the_mines_authored_dimensions() {
+        let (world, physics, mine) = mine_world(vec3(3.0, 0.0, 0.0), 12, 3.0);
+        let mut script = PsiMine::new();
+
+        let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
+
+        assert!(matches!(effect, Effect::SlayEntity { entity_id } if entity_id == mine));
+    }
+
+    #[test]
+    fn a_dead_creature_does_not_trip_a_mine() {
+        let (world, physics, mine) = mine_world(vec3(1.0, 0.0, 0.0), 0, DEFAULT_TRIGGER_RADIUS);
+        let mut script = PsiMine::new();
+
+        let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    /// The levels are littered with authored corpse props: `PropCreature` with
+    /// no AI and no hit points. A mine must not go off on the scenery.
+    #[test]
+    fn an_authored_corpse_does_not_trip_a_mine() {
+        let (mut world, mut physics, mine) = empty_mine_world(DEFAULT_TRIGGER_RADIUS);
+        let corpse = world.add_entity(PropCreature(0));
+        add_body(&mut physics, corpse, vec3(1.0, 0.0, 0.0));
+        settle(&mut physics);
         let mut script = PsiMine::new();
 
         let effect = update(&mut script, &world, &physics, mine, ARM_DELAY);
@@ -278,7 +325,7 @@ mod tests {
 
     #[test]
     fn an_untripped_mine_expires() {
-        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12, DEFAULT_TRIGGER_RADIUS);
         let mut script = PsiMine::new();
 
         let effect = update(&mut script, &world, &physics, mine, LIFETIME);
@@ -288,7 +335,7 @@ mod tests {
 
     #[test]
     fn a_damaged_mine_detonates() {
-        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12, DEFAULT_TRIGGER_RADIUS);
         let mut script = PsiMine::new();
 
         let effect = script.handle_message(
@@ -308,7 +355,7 @@ mod tests {
     /// still armed on load, and still expires on schedule.
     #[test]
     fn the_fuse_survives_save_and_load() {
-        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12);
+        let (world, physics, mine) = mine_world(vec3(100.0, 0.0, 0.0), 12, DEFAULT_TRIGGER_RADIUS);
         let mut before_save = PsiMine::new();
         update(
             &mut before_save,

--- a/shock2vr/src/scripts/psi_mine.rs
+++ b/shock2vr/src/scripts/psi_mine.rs
@@ -19,15 +19,19 @@ use crate::{physics::PhysicsWorld, runtime_props::RuntimePropTransform, time::Ti
 
 use super::{Effect, MessagePayload, Script};
 
-/// How long after the cast the mine starts sensing. The mine leaves the amp at
-/// the caster's own position, so it must not trip on whatever the caster is
-/// standing next to; this is also roughly the time it takes to land.
-const ARM_DELAY: Duration = Duration::from_millis(750);
+/// How long after the cast the mine starts sensing: long enough to leave the
+/// caster (it is lobbed from their own position, and the blast reaches them
+/// too), short enough that a mine thrown at a creature a few paces away is
+/// live by the time it gets there.
+const ARM_DELAY: Duration = Duration::from_millis(250);
 
-/// How close a creature must come to set the mine off. Matched to the authored
-/// blast radius (`Psi Mine Explosion`'s stim source, 4.0) so anything that
-/// trips the mine is inside the blast.
-const TRIGGER_RADIUS: f32 = 4.0;
+/// How close a creature must come to set the mine off, measured to the
+/// creature's origin. Inside the authored blast radius (`Psi Mine Explosion`'s
+/// stim source is 30.0 @ r4.0), whose damage falls off linearly to nothing at
+/// its edge - a mine that tripped at the full radius would deal nothing to
+/// what tripped it - but with room for the body's own extent around that
+/// origin.
+const TRIGGER_RADIUS: f32 = 3.0;
 
 /// How long an untripped mine lasts before it quietly expires, so a cast that
 /// found nothing does not leave a live sensor in the level forever.

--- a/tools/shock2-sdk/test/helpers/entity.ts
+++ b/tools/shock2-sdk/test/helpers/entity.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+
+import type { EntityDetailResult } from "../../src/index.js";
+
+/** An entity's current `HitPoints` property. */
+export function hitPoints(detail: EntityDetailResult): number {
+  const property = detail.properties.find((p) => p.name === "HitPoints");
+  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
+  return Number(property.value);
+}

--- a/tools/shock2-sdk/test/helpers/psi.ts
+++ b/tools/shock2-sdk/test/helpers/psi.ts
@@ -1,0 +1,11 @@
+import type { GameServer } from "../../src/index.js";
+
+/** Cycle the psi power selection until `name` is the selected power. */
+export async function selectPsiPower(game: GameServer, name: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if ((await game.info()).player.selected_psi_power === name) return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 1 });
+  }
+  throw new Error(`psi power ${name} was never selected`);
+}

--- a/tools/shock2-sdk/test/psi-mines.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-mines.e2e.test.ts
@@ -2,10 +2,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntityDetailResult } from "../src/index.js";
+import { hitPoints } from "./helpers/entity.js";
+import { selectPsiPower } from "./helpers/psi.js";
 import { fireOnce } from "./helpers/weapon.js";
 
-// End-to-end test for PsiMines (External Psionic Detonation, tier 5).
+// End-to-end test for PsiMines (External Psionic Detonation, tier 5): the cast
+// lobs a mine, the mine trips on a creature, and the authored explosion hurts
+// it.
 //
 // Negative-first: before the `PsiMine` script was registered, the cast spawned
 // `PsiMine Projectile`, whose authored script fell through to
@@ -16,51 +19,30 @@ import { fireOnce } from "./helpers/weapon.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-/** Cycle the psi power selection until `name` is selected. */
-async function selectPower(game: GameServer, name: string): Promise<void> {
-  for (let attempt = 0; attempt < 40; attempt += 1) {
-    if ((await game.info()).player.selected_psi_power === name) return;
-    await game.input.trigger("CyclePsiPower");
-    await game.step({ frames: 1 });
-  }
-  throw new Error(`psi power ${name} was never selected`);
-}
-
-function hitPoints(detail: EntityDetailResult): number {
-  const property = detail.properties.find((p) => p.name === "HitPoints");
-  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
-  return Number(property.value);
-}
-
 test(
-  "casting PsiMines survives, spends its tier, and the mine detonates",
+  "a psi mine detonates on the creature it is thrown at",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({ mission: "debug_psi" });
 
     // The scene auto-equips the Psi Amp on the first update.
     await game.step({ frames: 10 });
-    await selectPower(game, "PsiMines");
+    await selectPsiPower(game, "PsiMines");
+
+    // Something to trip the mine: the debug spawn drops an OG-Pipe hybrid a
+    // few units ahead of the player.
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const [creature] = (await game.entities.list({ filter: "OG-Pipe", limit: 10 })).entities;
+    assert.ok(creature, "SpawnDebugMonster should put a creature in front of the player");
+    const healthBefore = hitPoints(await game.entities.detail(creature.id));
 
     const startPsi = (await game.info()).player.psi_points;
     assert.ok(startPsi !== null && startPsi >= 5, `need psi to cast (got ${startPsi})`);
 
-    // Baseline health of whatever creatures the scene pens up ahead of the
-    // player, before anything explodes.
-    const creatures = (await game.entities.list({ filter: "OG-Pipe", limit: 50 })).entities;
-    const healthBefore = new Map<number, number>();
-    for (const creature of creatures) {
-      healthBefore.set(creature.id, hitPoints(await game.entities.detail(creature.id)));
-    }
-    // Lob the mine over the pen wall at the nearest creature's head, so the
-    // mine's flight brings it inside its own trigger radius.
-    if (creatures[0]) {
-      const [x, y, z] = creatures[0].position;
-      await game.input.lookAtWorldPoint([x, y + 1.7, z]);
-    }
-
+    // `fireOnce` steps two frames, so the mine is still in its arming delay
+    // here - a creature this close trips it as soon as it goes live.
     await fireOnce(game);
-    await game.step({ frames: 4 });
 
     // The runtime is still alive to answer at all - the regression test for the
     // panic - and the cast spent the power's authored tier.
@@ -76,40 +58,27 @@ test(
     assert.equal(mines.length, 1, "the cast lobs one PsiMine Projectile");
     const mineId = mines[0].id;
 
-    const stillFlying = async () =>
-      (await game.entities.list({ limit: 200 })).entities.some((e) => e.id === mineId);
-
-    // Give the mine time to reach the creatures and trip on one of them...
-    for (let waited = 0; waited < 8 && (await stillFlying()); waited += 1) {
+    // The mine reaches the creature and trips on it.
+    let entities = (await game.entities.list({ limit: 200 })).entities;
+    for (let waited = 0; waited < 8 && entities.some((e) => e.id === mineId); waited += 1) {
       await game.step({ frames: 15 });
+      entities = (await game.entities.list({ limit: 200 })).entities;
     }
-    const trippedOnACreature = !(await stillFlying());
-    if (!trippedOnACreature) {
-      // ...and if the scene has nothing to trip it, a damaged mine goes off
-      // where it lies.
-      await game.entities.sendMessage(mineId, { type: "Damage", amount: 1 });
-      await game.step({ frames: 5 });
-    }
-
-    const entities = (await game.entities.list({ limit: 200 })).entities;
     assert.ok(
       !entities.some((entity) => entity.id === mineId),
-      "the detonated mine is gone",
+      "the mine detonates on the creature instead of drifting past it",
     );
     assert.ok(
       entities.some((entity) => entity.name === "Psi Mine Explosion"),
       "slaying the mine spawns its authored Psi Mine Explosion",
     );
 
-    // Only a creature can have tripped the mine, and the blast it spawns
-    // (30 @ r4 of Psi Stim) reaches whatever was that close.
-    if (trippedOnACreature) {
-      let damaged = 0;
-      for (const [id, before] of healthBefore) {
-        const detail = await game.entities.detail(id).catch(() => null);
-        if (detail && hitPoints(detail) < before) damaged += 1;
-      }
-      assert.ok(damaged > 0, "the blast damages the creature that tripped the mine");
-    }
+    // ...and the blast it spawns (30 @ r4 of Psi Stim) hurts what tripped it.
+    const detail = await game.entities.detail(creature.id).catch(() => null);
+    const healthAfter = detail === null ? 0 : hitPoints(detail);
+    assert.ok(
+      healthAfter < healthBefore,
+      `the blast damages the creature (${healthBefore} -> ${healthAfter})`,
+    );
   },
 );

--- a/tools/shock2-sdk/test/psi-mines.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-mines.e2e.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// End-to-end test for PsiMines (External Psionic Detonation, tier 5).
+//
+// Negative-first: before the `PsiMine` script was registered, the cast spawned
+// `PsiMine Projectile`, whose authored script fell through to
+// `PanicOnLoadScript` and killed the process - so every request after the cast
+// here failed outright (#1295).
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** Cycle the psi power selection until `name` is selected. */
+async function selectPower(game: GameServer, name: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if ((await game.info()).player.selected_psi_power === name) return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 1 });
+  }
+  throw new Error(`psi power ${name} was never selected`);
+}
+
+function hitPoints(detail: EntityDetailResult): number {
+  const property = detail.properties.find((p) => p.name === "HitPoints");
+  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
+  return Number(property.value);
+}
+
+test(
+  "casting PsiMines survives, spends its tier, and the mine detonates",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_psi" });
+
+    // The scene auto-equips the Psi Amp on the first update.
+    await game.step({ frames: 10 });
+    await selectPower(game, "PsiMines");
+
+    const startPsi = (await game.info()).player.psi_points;
+    assert.ok(startPsi !== null && startPsi >= 5, `need psi to cast (got ${startPsi})`);
+
+    // Baseline health of whatever creatures the scene pens up ahead of the
+    // player, before anything explodes.
+    const creatures = (await game.entities.list({ filter: "OG-Pipe", limit: 50 })).entities;
+    const healthBefore = new Map<number, number>();
+    for (const creature of creatures) {
+      healthBefore.set(creature.id, hitPoints(await game.entities.detail(creature.id)));
+    }
+    // Lob the mine over the pen wall at the nearest creature's head, so the
+    // mine's flight brings it inside its own trigger radius.
+    if (creatures[0]) {
+      const [x, y, z] = creatures[0].position;
+      await game.input.lookAtWorldPoint([x, y + 1.7, z]);
+    }
+
+    await fireOnce(game);
+    await game.step({ frames: 4 });
+
+    // The runtime is still alive to answer at all - the regression test for the
+    // panic - and the cast spent the power's authored tier.
+    assert.equal(
+      (await game.info()).player.psi_points,
+      startPsi! - 5,
+      "a tier 5 cast costs five psi points",
+    );
+
+    const mines = (await game.entities.list({ limit: 200 })).entities.filter(
+      (entity) => entity.name === "PsiMine Projectile",
+    );
+    assert.equal(mines.length, 1, "the cast lobs one PsiMine Projectile");
+    const mineId = mines[0].id;
+
+    const stillFlying = async () =>
+      (await game.entities.list({ limit: 200 })).entities.some((e) => e.id === mineId);
+
+    // Give the mine time to reach the creatures and trip on one of them...
+    for (let waited = 0; waited < 8 && (await stillFlying()); waited += 1) {
+      await game.step({ frames: 15 });
+    }
+    const trippedOnACreature = !(await stillFlying());
+    if (!trippedOnACreature) {
+      // ...and if the scene has nothing to trip it, a damaged mine goes off
+      // where it lies.
+      await game.entities.sendMessage(mineId, { type: "Damage", amount: 1 });
+      await game.step({ frames: 5 });
+    }
+
+    const entities = (await game.entities.list({ limit: 200 })).entities;
+    assert.ok(
+      !entities.some((entity) => entity.id === mineId),
+      "the detonated mine is gone",
+    );
+    assert.ok(
+      entities.some((entity) => entity.name === "Psi Mine Explosion"),
+      "slaying the mine spawns its authored Psi Mine Explosion",
+    );
+
+    // Only a creature can have tripped the mine, and the blast it spawns
+    // (30 @ r4 of Psi Stim) reaches whatever was that close.
+    if (trippedOnACreature) {
+      let damaged = 0;
+      for (const [id, before] of healthBefore) {
+        const detail = await game.entities.detail(id).catch(() => null);
+        if (detail && hitPoints(detail) < before) damaged += 1;
+      }
+      assert.ok(damaged > 0, "the blast damages the creature that tripped the mine");
+    }
+  },
+);


### PR DESCRIPTION
Casting PsiMines took the process down: the cast spawns `PsiMine Projectile`(-3397), whose authored `PropScripts ["PsiMine"]` had no arm in `ScriptWorld::create_script` and fell through to `PanicOnLoadScript`.

## What the mine does now

`shock2vr/src/scripts/psi_mine.rs`, registered as `"psimine"`:

- arms 100 ms after the cast (it is lobbed from the caster's own position, and the blast reaches them too),
- detonates when a live AI (`P$AI` with hit points left — never an authored corpse prop) comes within reach of its body — the mine's own authored `PropPhysDimensions` radius (1.4, seven times the projectile default), measured to the creature's collider rather than to its origin — or when the mine is damaged,
- expires after 60 s if nothing trips it,
- keeps its fuse across save/load through the `script_state_key`/`save_state`/`restore_state` hooks.

Detonation is `Effect::SlayEntity` on itself: the authored `Corpse -> Psi Mine Explosion`(-3756) spawns, and `internal_explosion` already resolves its `StimSource(30.0, Radius 4.0) -> Psi Stim`. No new blast code.

## Verification

![PsiMines demo](https://gist.githubusercontent.com/tommy-xr/d7193bb93e7ec7fa981b2fe6f5b16982/raw/psi-mine.gif)

<sub>debug_psi: a hybrid is spawned ahead of the player (`SpawnDebugMonster`), the mine is cast at it, trips on it, and the authored Psi Mine Explosion takes it from 12 HP to 0. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) — same sequence as the e2e test. No before/after: the previous behavior was a dead process.</sub>

![PsiMines still](https://gist.githubusercontent.com/tommy-xr/d7193bb93e7ec7fa981b2fe6f5b16982/raw/psi-mine-still.png)

- `tools/shock2-sdk/test/psi-mines.e2e.test.ts` (new): spawns a creature, casts, and asserts the runtime is still alive, 5 psi spent, one mine lobbed, the mine consumed into its authored explosion, and the creature damaged. Negative-first — with the script unregistered it fails at the first `/v1/step` after the cast (`Game loop dropped the Step reply`).
- Nine unit tests in `psi_mine.rs` cover arming, in/out of reach, the authored radius, dead creatures, corpse props, damage, expiry and the save/load round trip.
- `missions.e2e.test.js` 23/23 and `psi.e2e.test.js` pass.

## Notes

- The mine floats: `PsiMine Projectile` authors `gravity_scale 0.0` (grenades author 0.7) and `elasticity 1.0`, so it drifts and bounces rather than coming to rest. That is the shipped data, left alone here.

Fixes #1295
