### PR TITLE
feat(ai): wait for a door to clear, and look impatient doing it

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -36,6 +36,21 @@ pub fn random_binomial() -> f32 {
     a - b
 }
 
+/// Height to fall back on when the creature has no definition (world units)
+const CREATURE_DEFAULT_HEIGHT: f32 = 6.5 / SCALE_FACTOR;
+
+/// The creature's height in world units. Fractions of it (rather than fixed
+/// feet) are what let the same reasoning work on a monkey and on a hybrid.
+pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
+    world
+        .borrow::<View<PropCreature>>()
+        .ok()
+        .and_then(|v_creature| v_creature.get(entity_id).ok().map(|creature| creature.0))
+        .and_then(crate::creature::get_creature_definition)
+        .map(|definition| definition.bounding_size.y / SCALE_FACTOR)
+        .unwrap_or(CREATURE_DEFAULT_HEIGHT)
+}
+
 pub fn get_position_and_forward(
     world: &shipyard::World,
     entity_id: shipyard::EntityId,

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -60,6 +60,12 @@ const DOOR_WAIT_TIMEOUT: f32 = 10.0;
 /// worth showing. Longer than the stall system's own recovery window, so the
 /// gesture marks a body that is genuinely stuck rather than every hitch.
 const FRUSTRATION_STALL_SECONDS: f32 = 5.0;
+/// How long a door has to keep the AI waiting before that reads as
+/// impatience. A shipped sliding leaf clears in about half a second, and an
+/// AI is not thwarted by a door that opens for it - gesturing at every one
+/// would also park a body in the doorway (the gesture has no root motion)
+/// long enough to dam the creatures queued behind it.
+const FRUSTRATION_DOOR_WAIT_SECONDS: f32 = 2.5;
 /// Rate limit on the frustration gesture, jittered per play so a knot of
 /// AIs blocked on the same thing doesn't gesture in unison.
 const FRUSTRATION_COOLDOWN_MIN: f32 = 20.0;
@@ -145,11 +151,14 @@ pub(crate) fn door_is_passable(fraction: f32, rise: f32, actor_height: f32) -> b
 /// target (an AI in a position to swing is fighting, not thwarted), and
 /// never over a performance the level authored.
 pub(crate) fn should_gesture_frustration(
-    blocked: bool,
+    door_wait_seconds: Option<f32>,
+    stall_seconds: f32,
     cooldown_remaining: f32,
     target_distance: Option<f32>,
     scripted: ScriptedState,
 ) -> bool {
+    let blocked = door_wait_seconds.is_some_and(|s| s >= FRUSTRATION_DOOR_WAIT_SECONDS)
+        || stall_seconds >= FRUSTRATION_STALL_SECONDS;
     blocked
         && cooldown_remaining <= 0.0
         && scripted != ScriptedState::Running
@@ -731,10 +740,8 @@ impl AnimatedMonsterAI {
     /// Hold position while a door this AI just opened travels clear, rather
     /// than walking into a leaf still crossing the doorway. Returns whether
     /// the AI is holding this frame.
-    fn update_door_wait(&mut self, world: &World, entity_id: EntityId, time: &Time) -> bool {
-        let Some((door_ent, waited)) = self.door_wait else {
-            return false;
-        };
+    fn update_door_wait(&mut self, world: &World, entity_id: EntityId, time: &Time) -> Option<f32> {
+        let (door_ent, waited) = self.door_wait?;
         let waited = waited + time.elapsed.as_secs_f32();
         // No progress to read (not a door any more, or one that cannot move)
         // means there is nothing to wait for.
@@ -755,10 +762,10 @@ impl AnimatedMonsterAI {
                 progress
             );
             self.door_wait = None;
-            return false;
+            return None;
         }
         self.door_wait = Some((door_ent, waited));
-        true
+        Some(waited)
     }
 
     /// Show frustration at whatever is in the way - a door still opening, or
@@ -769,15 +776,14 @@ impl AnimatedMonsterAI {
         &mut self,
         world: &World,
         entity_id: EntityId,
-        holding_for_door: bool,
+        door_wait_seconds: Option<f32>,
         time: &Time,
     ) -> Effect {
         self.frustration_cooldown =
             (self.frustration_cooldown - time.elapsed.as_secs_f32()).max(0.0);
-        let blocked =
-            holding_for_door || path_stall_seconds(world, entity_id) >= FRUSTRATION_STALL_SECONDS;
         if !should_gesture_frustration(
-            blocked,
+            door_wait_seconds,
+            path_stall_seconds(world, entity_id),
             self.frustration_cooldown,
             target_awareness_distance(world, entity_id),
             self.current_behavior.borrow().scripted_state(),
@@ -786,6 +792,11 @@ impl AnimatedMonsterAI {
         }
         self.frustration_cooldown =
             rand::thread_rng().gen_range(FRUSTRATION_COOLDOWN_MIN..FRUSTRATION_COOLDOWN_MAX);
+        tracing::debug!(
+            "ai {:?} shows frustration (door wait: {:?}s)",
+            entity_id,
+            door_wait_seconds
+        );
         frustration_gesture(entity_id)
     }
 
@@ -1208,10 +1219,14 @@ impl Script for AnimatedMonsterAI {
             steering_output
         };
 
-        let holding_for_door = self.update_door_wait(world, entity_id, time);
-        let rotation_effect =
-            self.apply_steering_output(steering_output, time, entity_id, holding_for_door);
-        let frustration_effect = self.update_frustration(world, entity_id, holding_for_door, time);
+        let door_wait_seconds = self.update_door_wait(world, entity_id, time);
+        let rotation_effect = self.apply_steering_output(
+            steering_output,
+            time,
+            entity_id,
+            door_wait_seconds.is_some(),
+        );
+        let frustration_effect = self.update_frustration(world, entity_id, door_wait_seconds, time);
 
         // A finished scripted sequence (its final queued effects were drained
         // by the steer above - scripted_state only reports Finished once they
@@ -2167,16 +2182,52 @@ mod tests {
         assert!(door_is_passable(1.0, 0.0, TEST_ACTOR_HEIGHT));
     }
 
+    /// A door wait long enough to read as impatience.
+    const LONG_WAIT: Option<f32> = Some(FRUSTRATION_DOOR_WAIT_SECONDS + 1.0);
+
     #[test]
     fn frustration_needs_a_block() {
         assert!(!should_gesture_frustration(
-            false,
+            None,
+            0.0,
             0.0,
             None,
             ScriptedState::NotScripted
         ));
         assert!(should_gesture_frustration(
-            true,
+            LONG_WAIT,
+            0.0,
+            0.0,
+            None,
+            ScriptedState::NotScripted
+        ));
+    }
+
+    #[test]
+    fn a_door_that_opens_promptly_draws_no_gesture() {
+        // Every shipped sliding leaf clears in about half a second; an AI
+        // that gestured at each one would dam the doorway behind it.
+        assert!(!should_gesture_frustration(
+            Some(0.5),
+            0.0,
+            0.0,
+            None,
+            ScriptedState::NotScripted
+        ));
+    }
+
+    #[test]
+    fn a_sustained_stall_draws_a_gesture() {
+        assert!(!should_gesture_frustration(
+            None,
+            FRUSTRATION_STALL_SECONDS - 1.0,
+            0.0,
+            None,
+            ScriptedState::NotScripted
+        ));
+        assert!(should_gesture_frustration(
+            None,
+            FRUSTRATION_STALL_SECONDS,
             0.0,
             None,
             ScriptedState::NotScripted
@@ -2186,7 +2237,8 @@ mod tests {
     #[test]
     fn frustration_is_rate_limited() {
         assert!(!should_gesture_frustration(
-            true,
+            LONG_WAIT,
+            0.0,
             3.0,
             None,
             ScriptedState::NotScripted
@@ -2198,13 +2250,15 @@ mod tests {
         let inside = Some(MELEE_ATTACK_RANGE * 0.5);
         let outside = Some(MELEE_ATTACK_RANGE * 2.0);
         assert!(!should_gesture_frustration(
-            true,
+            LONG_WAIT,
+            0.0,
             0.0,
             inside,
             ScriptedState::NotScripted
         ));
         assert!(should_gesture_frustration(
-            true,
+            LONG_WAIT,
+            0.0,
             0.0,
             outside,
             ScriptedState::NotScripted
@@ -2214,7 +2268,8 @@ mod tests {
     #[test]
     fn frustration_never_interrupts_an_authored_performance() {
         assert!(!should_gesture_frustration(
-            true,
+            LONG_WAIT,
+            0.0,
             0.0,
             None,
             ScriptedState::Running

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -52,20 +52,25 @@ const DOOR_INTERACT_COOLDOWN: f32 = 2.0;
 /// that slides sideways never gains height, so height clearance alone would
 /// hold an AI at it forever.
 const DOOR_OPEN_FRACTION: f32 = 0.95;
-/// Ceiling on the door wait, so a leaf that stops halfway (halted, or shoved
-/// by something) can never park an AI in a doorway for the rest of the
-/// mission. Comfortably longer than the slowest shipped door's travel.
-const DOOR_WAIT_TIMEOUT: f32 = 10.0;
+/// Ceiling on the door wait, so a leaf that stops halfway (halted, jammed,
+/// or frobbed shut again) can never park an AI in a doorway. It is also
+/// deliberately SHORTER than the path-follower's stall window: a held body
+/// makes no progress toward its waypoint, so a longer hold would read as a
+/// wedge, blacklist the crossing the AI just opened, and route it back away
+/// from the door. Longer than the slowest shipped leaf's travel (~1.6 s).
+const DOOR_WAIT_TIMEOUT: f32 = 2.5;
 /// How long a path-follow stall must persist before it reads as frustration
-/// worth showing. Longer than the stall system's own recovery window, so the
-/// gesture marks a body that is genuinely stuck rather than every hitch.
-const FRUSTRATION_STALL_SECONDS: f32 = 5.0;
+/// worth showing - just under the point where the stall system gives up on
+/// the route and retreats. The published counter is reset by that recovery,
+/// so it never climbs past the stall window and a higher threshold here
+/// would simply never fire.
+const FRUSTRATION_STALL_SECONDS: f32 = 2.5;
 /// How long a door has to keep the AI waiting before that reads as
 /// impatience. A shipped sliding leaf clears in about half a second, and an
 /// AI is not thwarted by a door that opens for it - gesturing at every one
 /// would also park a body in the doorway (the gesture has no root motion)
 /// long enough to dam the creatures queued behind it.
-const FRUSTRATION_DOOR_WAIT_SECONDS: f32 = 2.5;
+const FRUSTRATION_DOOR_WAIT_SECONDS: f32 = 1.75;
 /// Rate limit on the frustration gesture, jittered per play so a knot of
 /// AIs blocked on the same thing doesn't gesture in unison.
 const FRUSTRATION_COOLDOWN_MIN: f32 = 20.0;
@@ -189,18 +194,6 @@ fn path_stall_seconds(world: &World, entity_id: EntityId) -> f32 {
         .and_then(|service| service.ai_steering(entity_id.inner()))
         .map(|steering| steering.stall_seconds)
         .unwrap_or(0.0)
-}
-
-/// How far away the AI believes its target is, or `None` when nothing has
-/// ever published awareness for it.
-fn target_awareness_distance(world: &World, entity_id: EntityId) -> Option<f32> {
-    let v_awareness = world
-        .borrow::<View<crate::runtime_props::RuntimePropAITargetAwareness>>()
-        .ok()?;
-    let last_known = v_awareness.get(entity_id).ok()?.last_known_pos;
-    let (position, _) = get_position_and_forward(world, entity_id);
-    let delta = position.to_vec() - last_known;
-    Some((delta.x * delta.x + delta.z * delta.z).sqrt())
 }
 
 pub(crate) fn locomotion_scale_for_heading_error(delta: Deg<f32>) -> f32 {
@@ -742,6 +735,13 @@ impl AnimatedMonsterAI {
     /// the AI is holding this frame.
     fn update_door_wait(&mut self, world: &World, entity_id: EntityId, time: &Time) -> Option<f32> {
         let (door_ent, waited) = self.door_wait?;
+        // Only a pursuing behavior opens doors, so only a pursuing behavior
+        // waits at one; anything else (a scripted performance takes over, the
+        // AI calms down) walks away from the doorway rather than holding.
+        if !matches!(self.current_behavior.borrow().name(), "Chase" | "Search") {
+            self.door_wait = None;
+            return None;
+        }
         let waited = waited + time.elapsed.as_secs_f32();
         // No progress to read (not a door any more, or one that cannot move)
         // means there is nothing to wait for.
@@ -768,6 +768,12 @@ impl AnimatedMonsterAI {
         Some(waited)
     }
 
+    /// Jittered rate limit, so a knot of AIs blocked on the same thing does
+    /// not gesture in unison.
+    fn next_frustration_cooldown(&self) -> f32 {
+        rand::thread_rng().gen_range(FRUSTRATION_COOLDOWN_MIN..FRUSTRATION_COOLDOWN_MAX)
+    }
+
     /// Show frustration at whatever is in the way - a door still opening, or
     /// a route that has stopped making progress. The gesture is an animation
     /// only: it plays over the block without touching the wait or the stall
@@ -777,21 +783,26 @@ impl AnimatedMonsterAI {
         world: &World,
         entity_id: EntityId,
         door_wait_seconds: Option<f32>,
+        started_a_clip: bool,
         time: &Time,
     ) -> Effect {
+        // The rate limit ticks whether or not a gesture is due, so a
+        // suppressed frame doesn't stretch it.
         self.frustration_cooldown =
             (self.frustration_cooldown - time.elapsed.as_secs_f32()).max(0.0);
+        if started_a_clip {
+            return Effect::NoEffect;
+        }
         if !should_gesture_frustration(
             door_wait_seconds,
             path_stall_seconds(world, entity_id),
             self.frustration_cooldown,
-            target_awareness_distance(world, entity_id),
+            chase_target_distance(world, entity_id),
             self.current_behavior.borrow().scripted_state(),
         ) {
             return Effect::NoEffect;
         }
-        self.frustration_cooldown =
-            rand::thread_rng().gen_range(FRUSTRATION_COOLDOWN_MIN..FRUSTRATION_COOLDOWN_MAX);
+        self.frustration_cooldown = self.next_frustration_cooldown();
         tracing::debug!(
             "ai {:?} shows frustration (door wait: {:?}s)",
             entity_id,
@@ -882,12 +893,19 @@ impl AnimatedMonsterAI {
                 // pursuing level.
                 self.door_cooldown = DOOR_GIVEUP_COOLDOWN;
                 self.last_known_player_pos = None;
+                // Giving up on the door also gives up waiting for it - the
+                // wander this drops to has no business standing at it.
+                self.door_wait = None;
                 // State-only downgrade: the thwarted gesture replaces the
                 // queue this frame (a second Play here would blend from an
                 // unseen frame-0 pose and waste a clip load); the completion
                 // handler starts the Low behavior's clip after the gesture.
                 let downgrade =
                     self.force_alertness_state(AIAlertLevel::Low, world, physics, entity_id);
+                // Same rate limit as the wait/stall gesture: both paths
+                // emit the one performance, so they must not take turns
+                // playing it past the limit either claims.
+                self.frustration_cooldown = self.next_frustration_cooldown();
                 return Effect::combine(vec![downgrade, frustration_gesture(entity_id)]);
             }
             // Unlocked: open it and keep chasing through. The longer cooldown
@@ -896,8 +914,14 @@ impl AnimatedMonsterAI {
             self.door_cooldown = DOOR_INTERACT_COOLDOWN;
             // Stand off until the leaf has travelled clear (#1255): the AI
             // used to keep walking into a leaf still crossing the doorway.
-            tracing::debug!("ai {:?} waits for door {:?} to clear", entity_id, door_ent);
-            self.door_wait = Some((door_ent, 0.0));
+            // Re-sending TurnOn to a leaf that has not left its closed half
+            // is idempotent, but restarting the clock here is not: the wait
+            // would never age out and a jammed door could hold the AI for
+            // good. Only a DIFFERENT door starts a fresh wait.
+            if !matches!(self.door_wait, Some((waiting_on, _)) if waiting_on == door_ent) {
+                tracing::debug!("ai {:?} waits for door {:?} to clear", entity_id, door_ent);
+                self.door_wait = Some((door_ent, 0.0));
+            }
             return Effect::Send {
                 msg: Message {
                     to: door_ent,
@@ -1226,7 +1250,6 @@ impl Script for AnimatedMonsterAI {
             entity_id,
             door_wait_seconds.is_some(),
         );
-        let frustration_effect = self.update_frustration(world, entity_id, door_wait_seconds, time);
 
         // A finished scripted sequence (its final queued effects were drained
         // by the steer above - scripted_state only reports Finished once they
@@ -1247,6 +1270,17 @@ impl Script for AnimatedMonsterAI {
         } else {
             Effect::NoEffect
         };
+
+        // Emitted last of the animation effects, so it is checked against
+        // every clip this frame may already have started: the gesture PLAYS
+        // (it does not queue), so firing it on the same frame as a behavior's
+        // own clip would drop that clip for a frame. Suppressing rather than
+        // reordering also leaves the rate limit unarmed, so the gesture
+        // simply comes on a later frame.
+        let started_a_clip = !matches!(behavior_change_effect, Effect::NoEffect)
+            || !matches!(handback_effect, Effect::NoEffect);
+        let frustration_effect =
+            self.update_frustration(world, entity_id, door_wait_seconds, started_a_clip, time);
 
         let sensor_effect = self.try_tickle_sensor(world, physics, entity_id);
 
@@ -2232,6 +2266,29 @@ mod tests {
             None,
             ScriptedState::NotScripted
         ));
+    }
+
+    #[test]
+    fn the_door_wait_can_never_outlast_the_path_follower_patience() {
+        // A held body makes no progress toward its waypoint. If the hold
+        // could outlast the stall window, the stall system would blacklist
+        // the very crossing this AI just opened and route it back away from
+        // the door.
+        assert!(DOOR_WAIT_TIMEOUT < crate::scripts::ai::steering::STALL_SECONDS);
+    }
+
+    #[test]
+    fn impatience_is_reached_before_the_wait_times_out() {
+        // A threshold above the ceiling would be a gesture that never plays.
+        assert!(FRUSTRATION_DOOR_WAIT_SECONDS < DOOR_WAIT_TIMEOUT);
+    }
+
+    #[test]
+    fn a_stall_gesture_threshold_the_stall_clock_can_actually_reach() {
+        // The published stall counter is reset by the stall system's own
+        // recovery, so it never climbs past that window - a threshold at or
+        // above it would never fire.
+        assert!(FRUSTRATION_STALL_SECONDS < crate::scripts::ai::steering::STALL_SECONDS);
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -8,7 +8,7 @@ use dark::{
         AIAlertLevel, Link, PropAIAlertCap, PropAIAwareDelay, PropAISignalResponse, PropPosition,
     },
 };
-use rand;
+use rand::Rng;
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
@@ -48,6 +48,22 @@ const DOOR_POLL_INTERVAL: f32 = 0.3;
 /// enough that the door has left its closed position, so TurnOn (and its
 /// sound) isn't re-sent while it swings.
 const DOOR_INTERACT_COOLDOWN: f32 = 2.0;
+/// A door is passable once its leaf has travelled at least this far. A leaf
+/// that slides sideways never gains height, so height clearance alone would
+/// hold an AI at it forever.
+const DOOR_OPEN_FRACTION: f32 = 0.95;
+/// Ceiling on the door wait, so a leaf that stops halfway (halted, or shoved
+/// by something) can never park an AI in a doorway for the rest of the
+/// mission. Comfortably longer than the slowest shipped door's travel.
+const DOOR_WAIT_TIMEOUT: f32 = 10.0;
+/// How long a path-follow stall must persist before it reads as frustration
+/// worth showing. Longer than the stall system's own recovery window, so the
+/// gesture marks a body that is genuinely stuck rather than every hitch.
+const FRUSTRATION_STALL_SECONDS: f32 = 5.0;
+/// Rate limit on the frustration gesture, jittered per play so a knot of
+/// AIs blocked on the same thing doesn't gesture in unison.
+const FRUSTRATION_COOLDOWN_MIN: f32 = 20.0;
+const FRUSTRATION_COOLDOWN_MAX: f32 = 45.0;
 /// After giving up at a locked door, wait this long before re-frustrating -
 /// bounds the "thwarted" gesture for an AI whose alert cap keeps it in a
 /// pursuing state even after the give-up's alertness drop.
@@ -116,6 +132,68 @@ fn should_orient_on_target(
 /// is trying to get around - which is exactly where patrol reversals wedge.
 /// Turning is unaffected by the scale, so a stopped body still pivots and
 /// walks off again the moment its error is back under 90.
+/// Whether a door's leaf has travelled far enough for a creature of
+/// `actor_height` to walk under (or past) it: either the leaf has finished
+/// its travel, or it has risen clear of the creature's head. A closed leaf
+/// starts at floor level, so its rise IS the height of the gap beneath it.
+pub(crate) fn door_is_passable(fraction: f32, rise: f32, actor_height: f32) -> bool {
+    fraction >= DOOR_OPEN_FRACTION || rise >= actor_height
+}
+
+/// Whether to show frustration now: only while actually blocked, only once
+/// the rate limit has expired, never inside melee reach of the believed
+/// target (an AI in a position to swing is fighting, not thwarted), and
+/// never over a performance the level authored.
+pub(crate) fn should_gesture_frustration(
+    blocked: bool,
+    cooldown_remaining: f32,
+    target_distance: Option<f32>,
+    scripted: ScriptedState,
+) -> bool {
+    blocked
+        && cooldown_remaining <= 0.0
+        && scripted != ScriptedState::Running
+        && !matches!(target_distance, Some(d) if d <= MELEE_ATTACK_RANGE)
+}
+
+/// The "thwarted" performance. The motion database files the tag under
+/// `discover`, so the bare tag resolves to nothing at all - the query has to
+/// name the branch as well as the leaf.
+fn frustration_gesture(entity_id: EntityId) -> Effect {
+    Effect::PlayAnimationBySchema {
+        entity_id,
+        motion_queries: vec![vec![
+            MotionQueryItem::new("discover"),
+            MotionQueryItem::new("thwarted"),
+        ]],
+        selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
+    }
+}
+
+/// How long path-following has been making no progress, as published by the
+/// steering strategy. Zero for an AI that isn't following a route.
+fn path_stall_seconds(world: &World, entity_id: EntityId) -> f32 {
+    world
+        .borrow::<UniqueView<GlobalPathfinding>>()
+        .ok()
+        .and_then(|g| g.0.clone())
+        .and_then(|service| service.ai_steering(entity_id.inner()))
+        .map(|steering| steering.stall_seconds)
+        .unwrap_or(0.0)
+}
+
+/// How far away the AI believes its target is, or `None` when nothing has
+/// ever published awareness for it.
+fn target_awareness_distance(world: &World, entity_id: EntityId) -> Option<f32> {
+    let v_awareness = world
+        .borrow::<View<crate::runtime_props::RuntimePropAITargetAwareness>>()
+        .ok()?;
+    let last_known = v_awareness.get(entity_id).ok()?.last_known_pos;
+    let (position, _) = get_position_and_forward(world, entity_id);
+    let delta = position.to_vec() - last_known;
+    Some((delta.x * delta.x + delta.z * delta.z).sqrt())
+}
+
 pub(crate) fn locomotion_scale_for_heading_error(delta: Deg<f32>) -> f32 {
     const TURN_SLOW_ANGLE: f32 = 60.0;
     const TURN_IN_PLACE_ANGLE: f32 = 90.0;
@@ -167,6 +245,11 @@ pub struct AnimatedMonsterAI {
     published_awareness: Option<(cgmath::Vector3<f32>, bool)>,
     /// Throttle between door interactions (open / locked-door give-up)
     door_cooldown: f32,
+    /// The door this AI is standing off from, and how long it has waited, while
+    /// the leaf travels clear (see `update_door_wait`)
+    door_wait: Option<(EntityId, f32)>,
+    /// Seconds left before this AI may show frustration again
+    frustration_cooldown: f32,
     /// Pinned alertness (DebugForceChase): treated as permanent sight of the
     /// player - no decay, live target position - until cleared
     alertness_pinned: bool,
@@ -193,6 +276,8 @@ impl AnimatedMonsterAI {
             last_known_player_pos: None,
             published_awareness: None,
             door_cooldown: 0.0,
+            door_wait: None,
+            frustration_cooldown: 0.0,
         }
     }
 
@@ -217,6 +302,8 @@ impl AnimatedMonsterAI {
             last_known_player_pos: None,
             published_awareness: None,
             door_cooldown: 0.0,
+            door_wait: None,
+            frustration_cooldown: 0.0,
         }
     }
 
@@ -321,6 +408,7 @@ impl AnimatedMonsterAI {
         steering_output: SteeringOutput,
         time: &Time,
         entity_id: EntityId,
+        hold_position: bool,
     ) -> Effect {
         let turn_velocity = self.current_behavior.borrow().turn_speed().0;
         let delta =
@@ -338,7 +426,13 @@ impl AnimatedMonsterAI {
         // full stride while the heading catches up (the cause of orbiting a
         // close target): full speed facing the travel direction, ramping to
         // a third by 60 degrees of error and to a standstill by 90.
-        let scale = locomotion_scale_for_heading_error(delta);
+        // Holding for a door still turns (so the AI keeps facing the way
+        // through) - only the stride is cut.
+        let scale = if hold_position {
+            0.0
+        } else {
+            locomotion_scale_for_heading_error(delta)
+        };
 
         Effect::Multiple(vec![
             Effect::SetRotation {
@@ -634,6 +728,58 @@ impl AnimatedMonsterAI {
         }
     }
 
+    /// Hold position while a door this AI just opened travels clear, rather
+    /// than walking into a leaf still crossing the doorway. Returns whether
+    /// the AI is holding this frame.
+    fn update_door_wait(&mut self, world: &World, entity_id: EntityId, time: &Time) -> bool {
+        let Some((door_ent, waited)) = self.door_wait else {
+            return false;
+        };
+        let waited = waited + time.elapsed.as_secs_f32();
+        // No progress to read (not a door any more, or one that cannot move)
+        // means there is nothing to wait for.
+        let clear = match script_util::door_open_progress(world, door_ent) {
+            None => true,
+            Some((fraction, rise)) => {
+                door_is_passable(fraction, rise, creature_height(world, entity_id))
+            }
+        };
+        if clear || waited >= DOOR_WAIT_TIMEOUT {
+            self.door_wait = None;
+            return false;
+        }
+        self.door_wait = Some((door_ent, waited));
+        true
+    }
+
+    /// Show frustration at whatever is in the way - a door still opening, or
+    /// a route that has stopped making progress. The gesture is an animation
+    /// only: it plays over the block without touching the wait or the stall
+    /// system's own recovery.
+    fn update_frustration(
+        &mut self,
+        world: &World,
+        entity_id: EntityId,
+        holding_for_door: bool,
+        time: &Time,
+    ) -> Effect {
+        self.frustration_cooldown =
+            (self.frustration_cooldown - time.elapsed.as_secs_f32()).max(0.0);
+        let blocked =
+            holding_for_door || path_stall_seconds(world, entity_id) >= FRUSTRATION_STALL_SECONDS;
+        if !should_gesture_frustration(
+            blocked,
+            self.frustration_cooldown,
+            target_awareness_distance(world, entity_id),
+            self.current_behavior.borrow().scripted_state(),
+        ) {
+            return Effect::NoEffect;
+        }
+        self.frustration_cooldown =
+            rand::thread_rng().gen_range(FRUSTRATION_COOLDOWN_MIN..FRUSTRATION_COOLDOWN_MAX);
+        frustration_gesture(entity_id)
+    }
+
     /// While pursuing, open the (unlocked) door gating the AI's route so it
     /// can follow the player through, or give up at a locked one. The graph
     /// treats doors as passable, so the AI paths straight at a closed door
@@ -722,17 +868,15 @@ impl AnimatedMonsterAI {
                 // handler starts the Low behavior's clip after the gesture.
                 let downgrade =
                     self.force_alertness_state(AIAlertLevel::Low, world, physics, entity_id);
-                let thwarted = Effect::PlayAnimationBySchema {
-                    entity_id,
-                    motion_queries: vec![vec![MotionQueryItem::new("thwarted")]],
-                    selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
-                };
-                return Effect::combine(vec![downgrade, thwarted]);
+                return Effect::combine(vec![downgrade, frustration_gesture(entity_id)]);
             }
             // Unlocked: open it and keep chasing through. The longer cooldown
             // avoids re-sending TurnOn (and replaying the open sound) while
             // the door is still swinging.
             self.door_cooldown = DOOR_INTERACT_COOLDOWN;
+            // Stand off until the leaf has travelled clear (#1255): the AI
+            // used to keep walking into a leaf still crossing the doorway.
+            self.door_wait = Some((door_ent, 0.0));
             return Effect::Send {
                 msg: Message {
                     to: door_ent,
@@ -1054,7 +1198,10 @@ impl Script for AnimatedMonsterAI {
             steering_output
         };
 
-        let rotation_effect = self.apply_steering_output(steering_output, time, entity_id);
+        let holding_for_door = self.update_door_wait(world, entity_id, time);
+        let rotation_effect =
+            self.apply_steering_output(steering_output, time, entity_id, holding_for_door);
+        let frustration_effect = self.update_frustration(world, entity_id, holding_for_door, time);
 
         // A finished scripted sequence (its final queued effects were drained
         // by the steer above - scripted_state only reports Finished once they
@@ -1115,6 +1262,7 @@ impl Script for AnimatedMonsterAI {
             fov_debug_effect,
             behavior_publish_effect,
             door_effect,
+            frustration_effect,
         ])
     }
 
@@ -1968,6 +2116,99 @@ mod tests {
         assert_eq!(at_30, locomotion_scale_for_heading_error(Deg(-30.0)));
         // A third of full speed by 60 degrees
         assert_eq!(locomotion_scale_for_heading_error(Deg(60.0)), 0.33);
+    }
+
+    /// A hybrid is ~6.5 ft tall; the door leaf it walks under has to have
+    /// risen at least that far before the gap is worth entering.
+    const TEST_ACTOR_HEIGHT: f32 = 6.5 / SCALE_FACTOR;
+
+    #[test]
+    fn a_barely_open_door_is_not_passable() {
+        // The leaf has just left its closed pose: the doorway is still solid
+        // at head height, so the AI must wait rather than walk into it.
+        assert!(!door_is_passable(
+            0.05,
+            0.2 / SCALE_FACTOR,
+            TEST_ACTOR_HEIGHT
+        ));
+        assert!(!door_is_passable(
+            0.5,
+            3.0 / SCALE_FACTOR,
+            TEST_ACTOR_HEIGHT
+        ));
+    }
+
+    #[test]
+    fn a_leaf_risen_clear_of_the_head_is_passable() {
+        assert!(door_is_passable(0.6, 7.0 / SCALE_FACTOR, TEST_ACTOR_HEIGHT));
+    }
+
+    #[test]
+    fn a_short_creature_clears_a_leaf_a_hybrid_still_waits_for() {
+        let rise = 4.0 / SCALE_FACTOR;
+        assert!(door_is_passable(0.5, rise, 3.0 / SCALE_FACTOR));
+        assert!(!door_is_passable(0.5, rise, TEST_ACTOR_HEIGHT));
+    }
+
+    #[test]
+    fn a_fully_travelled_leaf_is_passable_without_gaining_height() {
+        // A door that slides sideways never rises, so height clearance alone
+        // would hold an AI at it forever.
+        assert!(door_is_passable(1.0, 0.0, TEST_ACTOR_HEIGHT));
+    }
+
+    #[test]
+    fn frustration_needs_a_block() {
+        assert!(!should_gesture_frustration(
+            false,
+            0.0,
+            None,
+            ScriptedState::NotScripted
+        ));
+        assert!(should_gesture_frustration(
+            true,
+            0.0,
+            None,
+            ScriptedState::NotScripted
+        ));
+    }
+
+    #[test]
+    fn frustration_is_rate_limited() {
+        assert!(!should_gesture_frustration(
+            true,
+            3.0,
+            None,
+            ScriptedState::NotScripted
+        ));
+    }
+
+    #[test]
+    fn frustration_is_silent_within_reach_of_the_target() {
+        let inside = Some(MELEE_ATTACK_RANGE * 0.5);
+        let outside = Some(MELEE_ATTACK_RANGE * 2.0);
+        assert!(!should_gesture_frustration(
+            true,
+            0.0,
+            inside,
+            ScriptedState::NotScripted
+        ));
+        assert!(should_gesture_frustration(
+            true,
+            0.0,
+            outside,
+            ScriptedState::NotScripted
+        ));
+    }
+
+    #[test]
+    fn frustration_never_interrupts_an_authored_performance() {
+        assert!(!should_gesture_frustration(
+            true,
+            0.0,
+            None,
+            ScriptedState::Running
+        ));
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -738,13 +738,22 @@ impl AnimatedMonsterAI {
         let waited = waited + time.elapsed.as_secs_f32();
         // No progress to read (not a door any more, or one that cannot move)
         // means there is nothing to wait for.
-        let clear = match script_util::door_open_progress(world, door_ent) {
+        let progress = script_util::door_open_progress(world, door_ent);
+        let clear = match progress {
             None => true,
             Some((fraction, rise)) => {
                 door_is_passable(fraction, rise, creature_height(world, entity_id))
             }
         };
         if clear || waited >= DOOR_WAIT_TIMEOUT {
+            tracing::debug!(
+                "ai {:?} resumes past door {:?} after {:.2}s (clear: {}, progress: {:?})",
+                entity_id,
+                door_ent,
+                waited,
+                clear,
+                progress
+            );
             self.door_wait = None;
             return false;
         }
@@ -876,6 +885,7 @@ impl AnimatedMonsterAI {
             self.door_cooldown = DOOR_INTERACT_COOLDOWN;
             // Stand off until the leaf has travelled clear (#1255): the AI
             // used to keep walking into a leaf still crossing the doorway.
+            tracing::debug!("ai {:?} waits for door {:?} to clear", entity_id, door_ent);
             self.door_wait = Some((door_ent, 0.0));
             return Effect::Send {
                 msg: Message {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -51,7 +51,7 @@ const REPATH_COOLDOWN_SECONDS: f32 = 0.5;
 const REPATH_FAILURE_BACKOFF_SECONDS: f32 = 2.0;
 /// Drop the path when we can't get closer to the current waypoint for this
 /// long (blocked by a prop, another AI, or unreachable geometry)
-const STALL_SECONDS: f32 = 3.0;
+pub(crate) const STALL_SECONDS: f32 = 3.0;
 /// After a stall, back out toward the previous waypoint for about this long
 /// before re-pathing. Without the retreat, the fresh route is identical to
 /// the one that just wedged (same start cell, same taut corners), so an AI

--- a/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
+++ b/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
@@ -1,7 +1,6 @@
 use cgmath::{Deg, InnerSpace, Quaternion, Rotation, Rotation3, Vector3, vec3};
 use dark::SCALE_FACTOR;
-use dark::properties::PropCreature;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, World};
 
 use crate::{
     physics::{InternalCollisionGroups, PhysicsWorld},
@@ -26,8 +25,6 @@ const WHISKER_SPREAD: Deg<f32> = Deg(30.0);
 /// a hybrid's height and fixed offsets would put both its probes underground.
 const WHISKER_KNEE_FRACTION: f32 = 0.35;
 const WHISKER_CHEST_FRACTION: f32 = 0.15;
-/// Height to fall back on when the creature has no definition (world units)
-const WHISKER_DEFAULT_HEIGHT: f32 = 6.5 / SCALE_FACTOR;
 /// Seconds between probes. Static geometry doesn't move and every
 /// path-following AI runs this, so the rays are cast a few times a second
 /// and the bias is held in between (the original engine's wall regulator
@@ -97,7 +94,7 @@ impl WhiskerAvoidance {
         entity_id: EntityId,
     ) -> Vec<WhiskerReading> {
         let rotation = get_rotation_from_transform(world, entity_id);
-        let height = creature_height(world, entity_id);
+        let height = ai_util::creature_height(world, entity_id);
         let knee = get_position_from_transform(
             world,
             entity_id,
@@ -158,18 +155,6 @@ impl WhiskerAvoidance {
         }
         readings
     }
-}
-
-/// The creature's height in world units, for placing the probes on a body
-/// that is not a 6.5-foot hybrid.
-fn creature_height(world: &World, entity_id: EntityId) -> f32 {
-    world
-        .borrow::<View<PropCreature>>()
-        .ok()
-        .and_then(|v_creature| v_creature.get(entity_id).ok().map(|creature| creature.0))
-        .and_then(crate::creature::get_creature_definition)
-        .map(|definition| definition.bounding_size.y / SCALE_FACTOR)
-        .unwrap_or(WHISKER_DEFAULT_HEIGHT)
 }
 
 /// Sum the whiskers into a horizontal push away from the geometry ahead:

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -211,6 +211,36 @@ pub fn door_is_closed(world: &World, entity_id: EntityId) -> Option<bool> {
     Some(to_closed <= to_open)
 }
 
+/// How far a translating door's leaf has travelled away from its closed
+/// pose: `(fraction, vertical_rise)`, where the fraction is 0 at closed and
+/// 1 at fully open and the rise is how much height the leaf has gained in
+/// world units. `None` for entities that are not translating doors, and for
+/// a door with no travel (its endpoints coincide, so there is no progress to
+/// measure and nothing to wait for).
+///
+/// The rise is what tells an approaching actor whether the gap under a
+/// raising leaf is tall enough to walk through yet; a leaf that slides
+/// sideways never gains any, so a caller must also accept a full fraction.
+pub fn door_open_progress(world: &World, entity_id: EntityId) -> Option<(f32, f32)> {
+    use cgmath::InnerSpace;
+    let v_door = world
+        .borrow::<View<dark::properties::PropTranslatingDoor>>()
+        .unwrap();
+    let door = v_door.get(entity_id).ok()?;
+    if !door.has_travel() {
+        return None;
+    }
+    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+    let current = v_transform
+        .get(entity_id)
+        .ok()
+        .map(|t| point3_to_vec3(t.0.transform_point(point3(0.0, 0.0, 0.0))))?;
+    let travel = door.base_open_location - door.base_closed_location;
+    let from_closed = current - door.base_closed_location;
+    let fraction = (from_closed.dot(travel) / travel.magnitude2()).clamp(0.0, 1.0);
+    Some((fraction, from_closed.y))
+}
+
 /// Whether a cell-gating entity is an obstacle A* must not cross.
 ///
 /// Closed-but-unlocked translating doors stay pathable because a pursuing AI
@@ -1143,8 +1173,9 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 mod tests {
     use super::{
         active_gun_setting, debit_player_nanites, door_blocks_pathfinding, door_is_closed,
-        has_second_fire_mode, is_always_collected, is_nanite_pickup, plan_stack_payment,
-        player_nanite_total, remap_selected_ammo, spend_player_nanites, stat_nanite_balance,
+        door_open_progress, has_second_fire_mode, is_always_collected, is_nanite_pickup,
+        plan_stack_payment, player_nanite_total, remap_selected_ammo, spend_player_nanites,
+        stat_nanite_balance,
     };
     use crate::mission::PlayerInfo;
     use crate::quest_info::QuestInfo;
@@ -1345,6 +1376,37 @@ mod tests {
 
         assert_eq!(door_is_closed(&closed_world, at_closed), Some(true));
         assert_eq!(door_is_closed(&open_world, at_open), Some(false));
+    }
+
+    #[test]
+    fn a_rising_leaf_reports_its_progress_and_the_gap_beneath_it() {
+        let closed = vec3(39.2, 0.5, -37.6);
+        let open = vec3(39.2, 4.1, -37.6);
+        let half = vec3(39.2, 2.3, -37.6);
+        let (world, door) = door_world(closed, open, 0, half);
+
+        let (fraction, rise) = door_open_progress(&world, door).unwrap();
+        assert!((fraction - 0.5).abs() < 1e-4, "fraction {fraction}");
+        assert!((rise - 1.8).abs() < 1e-4, "rise {rise}");
+    }
+
+    #[test]
+    fn a_sideways_leaf_reports_progress_but_no_gain_in_height() {
+        let closed = vec3(10.3, -0.4, 42.0);
+        let open = vec3(10.3, -0.4, 44.3);
+        let (world, door) = door_world(closed, open, 0, open);
+
+        let (fraction, rise) = door_open_progress(&world, door).unwrap();
+        assert!((fraction - 1.0).abs() < 1e-4, "fraction {fraction}");
+        assert_eq!(rise, 0.0);
+    }
+
+    #[test]
+    fn a_door_with_nowhere_to_go_has_no_progress_to_report() {
+        let at = vec3(18.0, -0.4, 41.8);
+        let (world, door) = door_world(at, at, 1, at);
+
+        assert_eq!(door_open_progress(&world, door), None);
     }
 
     #[test]

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -188,27 +188,51 @@ pub fn set_entity_locked(world: &mut World, entity_id: EntityId, locked: bool) {
 /// from its authored state. `None` for entities that aren't translating doors.
 pub fn door_is_closed(world: &World, entity_id: EntityId) -> Option<bool> {
     use cgmath::InnerSpace;
-    let v_door = world
-        .borrow::<View<dark::properties::PropTranslatingDoor>>()
-        .unwrap();
-    let door = v_door.get(entity_id).ok()?;
     // A door with no travel can never leave its authored pose, and both
     // endpoints sit on top of each other - the distance test below is
     // degenerate there (equal distances always read as "closed"). Answer from
     // the authored state instead, so a permanently open doorway isn't
     // reported shut (#602).
-    if !door.has_travel() {
-        return Some(!door.is_permanently_open());
+    let no_travel_state = {
+        let v_door = world
+            .borrow::<View<dark::properties::PropTranslatingDoor>>()
+            .unwrap();
+        let door = v_door.get(entity_id).ok()?;
+        (!door.has_travel()).then(|| !door.is_permanently_open())
+    };
+    if let Some(closed) = no_travel_state {
+        return Some(closed);
     }
-    // StdDoor drives the live transform via SetPosition each frame.
+    let (from_closed, travel) = door_travel(world, entity_id)?;
+    let to_open = (from_closed - travel).magnitude2();
+    Some(from_closed.magnitude2() <= to_open)
+}
+
+/// Where a travelling door's leaf currently sits, as `(from_closed, travel)`:
+/// the offset of the live leaf from its closed pose, and the full closed ->
+/// open vector. `None` for entities that are not translating doors and for a
+/// door with no travel (both endpoints coincide, so neither vector says
+/// anything).
+///
+/// StdDoor drives the live transform via SetPosition each frame, so the
+/// transform - not the property - is where the leaf actually is.
+fn door_travel(world: &World, entity_id: EntityId) -> Option<(Vector3<f32>, Vector3<f32>)> {
+    let v_door = world
+        .borrow::<View<dark::properties::PropTranslatingDoor>>()
+        .unwrap();
+    let door = v_door.get(entity_id).ok()?;
+    if !door.has_travel() {
+        return None;
+    }
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let current = v_transform
         .get(entity_id)
         .ok()
         .map(|t| point3_to_vec3(t.0.transform_point(point3(0.0, 0.0, 0.0))))?;
-    let to_closed = (current - door.base_closed_location).magnitude2();
-    let to_open = (current - door.base_open_location).magnitude2();
-    Some(to_closed <= to_open)
+    Some((
+        current - door.base_closed_location,
+        door.base_open_location - door.base_closed_location,
+    ))
 }
 
 /// How far a translating door's leaf has travelled away from its closed
@@ -223,20 +247,7 @@ pub fn door_is_closed(world: &World, entity_id: EntityId) -> Option<bool> {
 /// sideways never gains any, so a caller must also accept a full fraction.
 pub fn door_open_progress(world: &World, entity_id: EntityId) -> Option<(f32, f32)> {
     use cgmath::InnerSpace;
-    let v_door = world
-        .borrow::<View<dark::properties::PropTranslatingDoor>>()
-        .unwrap();
-    let door = v_door.get(entity_id).ok()?;
-    if !door.has_travel() {
-        return None;
-    }
-    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
-    let current = v_transform
-        .get(entity_id)
-        .ok()
-        .map(|t| point3_to_vec3(t.0.transform_point(point3(0.0, 0.0, 0.0))))?;
-    let travel = door.base_open_location - door.base_closed_location;
-    let from_closed = current - door.base_closed_location;
+    let (from_closed, travel) = door_travel(world, entity_id)?;
     let fraction = (from_closed.dot(travel) / travel.magnitude2()).clamp(0.0, 1.0);
     Some((fraction, from_closed.y))
 }


### PR DESCRIPTION
An AI that reached a closed door on its route opened it and kept walking, pressing into a leaf that was still crossing the doorway — the body ground against the moving door for the whole of its travel and then squeezed through, or wedged.

After opening a door on its route the AI now **holds position** until the leaf is actually out of the way: risen above its own head, or, for a leaf that slides sideways rather than rising, finished its travel. Only the stride is cut — turning is untouched, so the body keeps facing the way through and moves off the instant the gap exists. The hold is bounded (and is deliberately shorter than the path-follower's stall window, so a held body is never mistaken for a wedged one), and a locked door still takes the existing give-up path.

While waiting on a door that is genuinely keeping it out, and on a sustained path-follow stall, the AI plays the **thwarted** performance — rate-limited to one per 20–45 s (jittered), never within melee reach of its believed target, never over an authored performance, and never touching the wait or the stall recovery. A door that opens promptly draws no gesture.

**The thwarted query was broken.** The motion database files the tag under `discover`, so the bare `thwarted` query the locked-door give-up has always used matched nothing and that gesture has never played. The query now names the branch as well as the leaf (`+discover +thwarted`), which resolves to one clip per creature family (`ogpthwtd`, `zkythwtd`, `rmbthwt`, `bh114730`).

**On the door lift.** Earlier in this stack an AI could also be *lifted* by a leaf it
walked into. On the medsci2 chase trace that is gone — a chasing hybrid's y stays within
0.09–0.14 while the leaf travels 0.5 → 4.1. It is not gone everywhere: at medsci1's
rising security door an AI standing at the threshold is still carried up to y ≈ 1.5 as
the leaf rises, **identically on this branch and on its base**, so that one is
pre-existing (#1255) and untouched here. What this PR fixes is the other half of the
interaction — walking into a leaf that is still crossing the doorway.

Ledger step 8 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

## Before / after

Reachability harness (PR #1242, `--pass both`), three runs per branch, base = `feat/ai-turn-in-place`:

| mission | pass | metric | before (3 runs) | after (3 runs) |
|---|---|---|---|---|
| medsci2.mis | idle | wedged | 2 / 1 / 2 | 1 / 2 / 2 |
| medsci2.mis | idle | progressing | 9 / 10 / 9 | 10 / 9 / 9 |
| medsci2.mis | chase | wedged | 0 / 0 / 1 | 1 / 2 / 2 |
| medsci2.mis | chase | arrived | 3 / 2 / 3 | 1 / 3 / 2 |

The idle pass is unchanged. The chase pass's `wedged` count goes up, and it is worth
saying exactly what that is: the classifier calls an AI wedged when it stays inside a
1-unit circle for 6 s with a route or a stall live. The two AIs it now catches stall in
the *same spots on both branches* — the door-jamb chaser halts at the same locked
security door and ends at the same 38.2 from the player in all six runs; the lower-deck
Blue Monkey halts at the same corner and ends 2-5 units farther out. What changed is
how long each halt lasts: a stall there now carries the impatience performance, which
pushes a standstill that used to sit just under the 6 s window just over it (measured
at that door: ~3.3 s before, ~6.6 s after). Nothing is newly stuck; the classifier's
bucket boundary moved across an existing standstill.

The sharper measurements are the AI e2e set below (the door-jamb chase and the
balcony-railing patrol are exactly the wedge cases these PRs exist for) and the
capture in **Media**.

## Tests

- Unit: 15 new (`a_barely_open_door_is_not_passable`, `a_leaf_risen_clear_of_the_head_is_passable`, `a_short_creature_clears_a_leaf_a_hybrid_still_waits_for`, `a_fully_travelled_leaf_is_passable_without_gaining_height`, `frustration_needs_a_block`, `a_door_that_opens_promptly_draws_no_gesture`, `a_sustained_stall_draws_a_gesture`, `the_door_wait_can_never_outlast_the_path_follower_patience`, `impatience_is_reached_before_the_wait_times_out`, `a_stall_gesture_threshold_the_stall_clock_can_actually_reach`, `frustration_is_rate_limited`, `frustration_is_silent_within_reach_of_the_target`, `frustration_never_interrupts_an_authored_performance`, `a_rising_leaf_reports_its_progress_and_the_gap_beneath_it`, `a_sideways_leaf_reports_progress_but_no_gain_in_height`).
- `cargo test -p shock2vr`: 1250 passed.
- e2e, each file alone on the final binary: `medsci2-doorjamb-chase` 1/1, `force-chase` 1/1, `patrol` 4/4, `door-frob` 1/1, `medsci2-patrol-railing` 4/4 runs, `missions` 23/23.
- Full e2e suite: the known-failing set on `main` (issue #1262) plus three extras, all triaged: the `medsci-saved-vr-melee` death-ragdoll case fails identically on the base branch (pre-existing, same file as a listed #1262 failure); `melee-hitbox` "a VR swing lands on the limb it struck" and the `station-flow` Marine chain both pass alone, 3/3 and 1/1 (flaky under the chunked run). No regressions.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Media

medsci1, `DebugForceChase` from spawn, free camera pinned over the AI's shoulder at a
sliding door on its route. Same request sequence on both branches (deterministic
fixed-timestep stepping), so the two panels are frame-comparable.

![AI door wait before/after](https://gist.githubusercontent.com/tommy-xr/4448e5fdb25dbff4c54608b8211a4514/raw/door-wait.gif)

<sub>Left (base): the leaf is still crossing the doorway (its travel runs from z −54.5 to
−52.1 over 6 frames) and the hybrid walks straight into it. Right (this PR): the hybrid
holds its stride at the threshold for ~0.5 s until the leaf has finished travelling,
then walks through. Captured headlessly via the debug runtime (`/v1/step` +
`/v1/screenshot`).</sub>

![AI door wait still](https://gist.githubusercontent.com/tommy-xr/4448e5fdb25dbff4c54608b8211a4514/raw/door-wait.png)

## Review

`/xreview` (Claude adversarial reviewer; the Codex engine is unavailable until Sep 6, so this ran single-engine). Four defects fixed in 80226f7d:

- **The hold outlasted the path-follower's patience.** A held body makes no progress toward its waypoint, so a long hold read as a wedge and blacklisted the crossing the AI had just opened. The wait is now bounded below that window (unit-tested).
- **A re-sent `TurnOn` restarted the wait clock**, so a leaf jammed in its closed half could park an AI at the door forever; the wait now ages out.
- **The stall gesture's threshold was unreachable** — the stall system's own recovery resets the published counter before it got there. It is now a value the counter can actually reach, and the locked-door give-up and the wait/stall gesture share one rate limit instead of each keeping its own.
- **Melee suppression asked the wrong question** — a private awareness-only copy answered `None` (never suppressing) for an AI with no awareness yet. It now asks `chase_target_distance`, the same question the attack behavior asks.

Also from the review: giving up on a door or leaving a pursuing behavior drops the wait; the gesture is skipped on a frame that already started a behavior clip; `door_is_closed` and `door_open_progress` share one leaf-position reader.
