### PR TITLE
feat(vr): jump on the lower buttons, the menu button jacks in, long-press pauses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,9 +224,16 @@ Quest button/chord paths live beside their actions in
 mapping is host-testable even though `oculus_runtime` only builds for Android.
 The four Touch **face buttons** are bound there RAW, by hand and position
 (`LeftHandLowerButton` .. `RightHandUpperButton`); what a press means is
-resolved per hand against what that hand holds, by the pure table in
-`shock2vr/src/hand_buttons.rs` (`resolve_hand_button`), which the mission
-applies. The current key and controller bindings are listed in
+resolved per hand by the pure table in `shock2vr/src/hand_buttons.rs`
+(`resolve_hand_button`), which the mission applies. The **lower** button (left
+`X` / right `A`) is `Jump` on both hands whatever they hold - a hand full of gun
+still has to be able to jump - and only the **upper** one (left `Y` / right `B`)
+is contextual: the log reader with a free hand, the gun's fire mode with a gun,
+the psi selection MFD with the amp. While the cyber interface is up, lower
+closes it instead. The left **Menu** button is raw too (`MenuButton`): `Game`
+splits it with `input::MenuHold` into a short press (toggle the cyber interface)
+and a 0.5 s hold (the pause menu, with the cutscene skip's ring as its hold
+readout). The current key and controller bindings are listed in
 [DEVELOPMENT.md](DEVELOPMENT.md#debug--developer-keys).
 
 - **`InputAction`** (`input/actions.rs`) - serde-enabled enum of all discrete actions

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,14 +119,15 @@ Debug bindings take `Alt` (`Option` on macOS) to keep them clear of gameplay key
 | --- | ------ | ----- |
 | `P` | `PathfindingTestCycle` | set start → set goal → show path |
 | `B` | `DebugCycleWeapon` | spawns and wields the next weapon (unlike the number row) |
-| `Alt+X` | `EjectClip` | magazine back to the backpack reserve; Quest: the gun hand's *lower* face button |
-| `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | ammo has no Quest binding (a clip is inserted by hand); on Quest the amp hand's *upper* face button quick-cycles the power |
-| - | `SelectPsiPower` | opens the psi power selection MFD; flat clicks the readout's power badge instead, Quest: the amp hand's *lower* face button |
+| `Alt+X` | `EjectClip` | magazine back to the backpack reserve; no Quest button - in VR it is the settings MFD's UNLOAD |
+| `T` / `Y` | `CycleAmmo` / `CyclePsiPower` | no Quest binding: a clip is inserted by hand, and the psi MFD's stick navigation steps the power |
+| - | `SelectPsiPower` | opens the psi power selection MFD; flat clicks the readout's power badge instead, Quest: the amp hand's *upper* face button |
 | `F` | `CycleGunSetting` | switch the wielded gun's fire mode (e.g. NORM / BURST); Quest: the gun hand's *upper* face button |
-| `U` | `ReadLastUnreadLog` | on Quest an *upper* face button resolves to this - see below |
+| `U` | `ReadLastUnreadLog` | on Quest a free hand's *upper* face button resolves to this - see below |
 | `M` | `ToggleMap` | flat only |
-| `Tab` / `I` | `ToggleUseMode` | the cyber interface; on Quest a *lower* face button resolves to this |
-| `Esc` | `TogglePauseMenu` | Quest: left `Menu` |
+| `Tab` / `I` | `ToggleUseMode` | the cyber interface; Quest: a **short** press of left `Menu` |
+| `Space` | `Jump` | the flat key is the held jump channel, not this action; Quest: either *lower* face button |
+| `Esc` | `TogglePauseMenu` | Quest: left `Menu` held ~0.5 s, or the interface's MENU button |
 | `Alt+S` / `Alt+L` | `QuickSave` / `QuickLoad` | |
 | `Alt+G` | `DebugForceChase` | every monster hunts the player, pinned |
 | `Alt+C` | `DebugCalmAll` | clears the pin |
@@ -162,22 +163,49 @@ right `A`, upper is left `Y` / right `B` (`LeftHandLowerButton` ..
 `RightHandUpperButton`). What a press does is resolved per hand against what
 that hand holds (`shock2vr/src/hand_buttons.rs`):
 
-| that hand holds | lower | upper |
+| that hand holds | lower (`X`/`A`) | upper (`Y`/`B`) |
 | --- | --- | --- |
-| nothing, a melee weapon, or any other item | `ToggleUseMode` (cyber interface) | `ReadLastUnreadLog` |
-| a gun | `EjectClip` - that hand's gun, so dual wielding ejects the one pressed | `CycleGunSetting` - likewise that hand's gun; a gun with one mode is a no-op |
-| the psi amp | `SelectPsiPower` - the power selection MFD, in the cyber interface | `CyclePsiPower` - step to the next trained power, no panel |
+| nothing, a melee weapon, or any other item | `Jump` | `ReadLastUnreadLog` |
+| a gun | `Jump` | `CycleGunSetting` - that hand's gun, so dual wielding switches the one pressed; a gun with one mode is a no-op |
+| the psi amp | `Jump` | `SelectPsiPower` - the power selection MFD, in the cyber interface |
 
-Mode first: while the cyber interface is up both buttons keep their interface
-meaning on both hands whatever is held, so it can always be closed. With a gun
-in each hand neither panel is reachable until a hand is free. While the **Free
-camera** developer option is on, the right hand's two buttons are the chord and
-nothing else - they resolve to nothing at all.
+The lower button is jump unconditionally: it is the one control a player reaches
+for with both hands full, so a held weapon must not take it away. Only the upper
+button is contextual. `EjectClip` and `CyclePsiPower` therefore have no button
+any more - the settings MFD's UNLOAD and the psi MFD's stick navigation cover
+them - though both actions keep their flat keys and HTTP/SDK paths.
+
+Mode first: while the cyber interface is up the lower button keeps its close
+(rather than jumping) and the upper one the log reader, on both hands whatever
+is held, so the interface can always be shut. While the **Free camera**
+developer option is on, the right hand's two buttons are the chord and nothing
+else - they resolve to nothing at all.
+
+#### The left Menu button: short press jacks in, long press pauses
+
+The Touch has one Menu button to give (the right one is the Quest system UI's),
+so it is bound raw (`MenuButton`) and split by how long it is held
+(`shock2vr/src/input/menu_hold.rs`):
+
+- **short press** (released under 0.5 s) - toggle the cyber interface, which is
+  what the left `X` button used to do. It fires on *release*, so a long press
+  never also jacks in on its way past the threshold.
+- **long press** (held 0.5 s) - open the pause menu, fired the moment the
+  threshold is crossed. The release that follows is swallowed.
+
+While the button is held, the same circular hold readout the cutscene skip uses
+fills up head-locked in front of the player, so the pause menu is a visible
+promise rather than a surprise. Because the hold is not discoverable on its own,
+the cyber interface canvas also carries a **MENU** button (rect `(288, 372,
+64x36)`, in the free column between the inventory strip, the MFD slot and the
+bottom readouts) that opens the pause menu directly - drawn and hit-tested
+through the same readout-control list, so it is there in both presentations
+(flat's `Esc` still works too).
 
 #### The psi selection MFD captures a thumbstick
 
 While the psi power selection MFD is docked - opened from the flat readout's
-power badge, or from the amp hand's lower face button in VR - **one** thumbstick
+power badge, or from the amp hand's upper face button in VR - **one** thumbstick
 is captured: up/down step the tier, left/right step the power inside it, and
 that stick stops driving the player until the panel closes.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `Space` - jump
 - `Tab` / `I` - toggle the cyber interface ("use" mode): a cursor-driven UI over the 3D view
 - `Alt+S` / `Alt+L` - quick save / quick load
-- Quest VR: press the left controller's `X` button to toggle the cyber interface.
+- Quest VR: press the left controller's `Menu` button to toggle the cyber
+  interface; hold it for half a second - a ring fills in front of you - to open
+  the pause menu instead. The interface also carries a `MENU` button that opens
+  it directly.
+- Quest VR: either lower face button (left `X` / right `A`) jumps, whatever
+  your hands are holding.
 - Quest VR: reload by hand. Pull a clip out of the cyber interface's inventory
   strip with your free hand and bring it to the gun the other hand is holding -
   the clip goes in and the weapon is loaded. A clip of a different ammo type
@@ -51,9 +56,11 @@ However, you can play with a keyboard and a mouse, using the following hard-code
   insert is the only way to change ammo type in the headset, so the types you
   can select are the ones you are carrying clips for. There is no reload or
   ammo-swap button on the controllers; the gesture is the control.
-- Quest VR: press the left controller's `Y` button to open the newest unread
-  audio log. Press `Y` again to close it; after every log is read, `Y` replays
-  the most recently collected log.
+- Quest VR: with that hand free, press an upper face button (left `Y` / right
+  `B`) to open the newest unread audio log. Press it again to close it; after
+  every log is read, it replays the most recently collected log. Holding a
+  weapon, that hand's upper button is the weapon's instead: a gun's fire mode,
+  the psi amp's power selector.
 - Directly equip a matching carried weapon with the original number-row bindings:
   `1` Wrench, `2` Pistol, `3` Shotgun, `4` Assault Rifle, `5` Laser Pistol,
   `6` EMP Rifle, `7` Electro Shock, `8` Grenade Launcher, `9` Stasis Field

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -124,7 +124,12 @@ pub enum RuntimeCommand {
     PathfindingTest(String, oneshot::Sender<CommandResult>),
 
     /// Trigger a discrete input action (as if a bound key was pressed)
-    TriggerAction(InputAction, oneshot::Sender<CommandResult>),
+    /// Fire a discrete action. `hold` is the button's level: `None` presses
+    /// and releases it in one frame (the ordinary single-shot injection),
+    /// `Some(true)` presses and keeps it down, `Some(false)` releases it -
+    /// which is how a hold-to-activate button (the Menu button's long press)
+    /// is driven without a controller.
+    TriggerAction(InputAction, Option<bool>, oneshot::Sender<CommandResult>),
 
     /// Get the current pathfinding test status
     GetPathfindingTestStatus(oneshot::Sender<PathfindingTestStatusResult>),

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1517,13 +1517,26 @@ fn process_command(
                 tracing::warn!("Failed to send pathfinding test result - receiver dropped");
             }
         }
-        RuntimeCommand::TriggerAction(action, reply) => {
-            action_state.trigger(action);
-            // Single-shot semantics: don't leave the action held
-            action_state.release(action);
+        RuntimeCommand::TriggerAction(action, hold, reply) => {
+            let message = match hold {
+                // Single-shot semantics: don't leave the action held.
+                None => {
+                    action_state.trigger(action);
+                    action_state.release(action);
+                    format!("Triggered action '{}' - applies on next update", action)
+                }
+                Some(true) => {
+                    action_state.trigger(action);
+                    format!("Holding action '{}' until it is released", action)
+                }
+                Some(false) => {
+                    action_state.release(action);
+                    format!("Released action '{}'", action)
+                }
+            };
             let result = CommandResult {
                 success: true,
-                message: format!("Triggered action '{}' - applies on next update", action),
+                message,
                 data: None,
             };
             if let Err(_) = reply.send(result) {
@@ -4088,6 +4101,10 @@ async fn ai_paths(
 #[derive(Deserialize)]
 struct TriggerActionRequest {
     action: String,
+    /// Hold the button rather than tapping it: `true` presses and keeps it
+    /// down, `false` releases it. Omitted = a single-shot press.
+    #[serde(default)]
+    hold: Option<bool>,
 }
 
 /// HTTP endpoint handler: Trigger a discrete input action
@@ -4114,7 +4131,11 @@ async fn trigger_input_action(
     let (reply_tx, reply_rx) = oneshot::channel();
 
     if command_tx
-        .send(RuntimeCommand::TriggerAction(action, reply_tx))
+        .send(RuntimeCommand::TriggerAction(
+            action,
+            request.hold,
+            reply_tx,
+        ))
         .is_err()
     {
         tracing::error!("Failed to send TriggerAction command - game loop receiver dropped");

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -341,10 +341,6 @@ fn main() {
         .create_action::<xr::Vector2f>("right_hand_thumbstick", "Right Hand Thumbstick", &[])
         .unwrap();
 
-    let jump_action = action_set
-        .create_action::<bool>("jump", "Jump", &[])
-        .unwrap();
-
     let crouch_action = action_set
         .create_action::<bool>("crouch", "Crouch Toggle", &[])
         .unwrap();
@@ -372,7 +368,7 @@ fn main() {
     // The left controller's Menu button. (The right controller's is reserved
     // by the Quest system UI, so it can never be the app's.)
     let menu_action = action_set
-        .create_action::<bool>("menu", "Pause Menu", &[])
+        .create_action::<bool>("menu", "Interface / Pause Menu", &[])
         .unwrap();
 
     // Bind our actions to input devices using the given profile
@@ -444,12 +440,9 @@ fn main() {
                         .string_to_path("/user/hand/right/input/thumbstick")
                         .unwrap(),
                 ),
-                xr::Binding::new(
-                    &jump_action,
-                    xr_instance
-                        .string_to_path("/user/hand/right/input/thumbstick/click")
-                        .unwrap(),
-                ),
+                // The RIGHT thumbstick click is deliberately unbound: jump
+                // moved to the lower face buttons, where it is reachable
+                // whatever the hands hold.
                 xr::Binding::new(
                     &crouch_action,
                     xr_instance
@@ -500,9 +493,9 @@ fn main() {
                     &menu_action,
                     xr_instance
                         .string_to_path(
-                            shock2vr::input::InputAction::TogglePauseMenu
+                            shock2vr::input::InputAction::MenuButton
                                 .quest_touch_click_path()
-                                .expect("Quest pause-menu binding"),
+                                .expect("Quest menu-button binding"),
                         )
                         .unwrap(),
                 ),
@@ -581,9 +574,9 @@ fn main() {
     let mut vr_crouch = VrCrouchDetector::default();
     let mut pending_stage_change_time = None;
     // Button-crouch alternative to the physical detector: left thumbstick
-    // click toggles a latched crouch request (mirroring jump on the right
-    // stick). Either source requests the crouch; the game's headroom-gated
-    // stand-up still decides when standing is actually possible.
+    // click toggles a latched crouch request. Either source requests the
+    // crouch; the game's headroom-gated stand-up still decides when standing
+    // is actually possible.
     let mut crouch_toggled = false;
     let mut crouch_button_was_pressed = false;
 
@@ -697,6 +690,11 @@ fn main() {
                                 .release(shock2vr::input::InputAction::RightHandLowerButton);
                             action_state
                                 .release(shock2vr::input::InputAction::RightHandUpperButton);
+                            // The Menu button is a HOLD, so releasing it is not
+                            // enough: the release would read as its short press.
+                            // Forget the press instead.
+                            action_state.release(shock2vr::input::InputAction::MenuButton);
+                            game.cancel_menu_hold();
                         }
                         xr::SessionState::STOPPING => {
                             session.end().unwrap();
@@ -808,10 +806,6 @@ fn main() {
             .state(&session, xr::Path::NULL)
             .unwrap()
             .current_state;
-        let jump_pressed = jump_action
-            .state(&session, xr::Path::NULL)
-            .unwrap()
-            .current_state;
         let crouch_state = crouch_action.state(&session, xr::Path::NULL).unwrap();
         let left_lower_state = left_lower_action.state(&session, xr::Path::NULL).unwrap();
         let left_upper_state = left_upper_action.state(&session, xr::Path::NULL).unwrap();
@@ -853,8 +847,12 @@ fn main() {
                 state.current_state,
             );
         }
+        // Raw, like the face buttons: a short press jacks into the cyber
+        // interface and a long one opens the pause menu, and only `Game` (via
+        // `MenuHold`) can tell those apart - so both the press and the release
+        // have to reach it.
         action_state.sync_discrete_button(
-            shock2vr::input::InputAction::TogglePauseMenu,
+            shock2vr::input::InputAction::MenuButton,
             menu_state.is_active,
             menu_state.changed_since_last_sync,
             menu_state.current_state,
@@ -1008,7 +1006,9 @@ fn main() {
         input_context.left_hand.squeeze_value = left_squeeze_value;
         input_context.left_hand.thumbstick =
             vec2(-left_thumbstick_value.x, left_thumbstick_value.y);
-        input_context.jump = jump_pressed;
+        // Jump is a hand's LOWER face button now, which arrives as an action
+        // and is resolved per hand - so no runtime channel drives it in VR.
+        input_context.jump = false;
         // The detector was already fed exactly once above (it keeps its
         // standing calibration warm even while the button latch is active).
         input_context.crouch = physically_crouched || crouch_toggled;

--- a/shock2vr/src/hand_buttons.rs
+++ b/shock2vr/src/hand_buttons.rs
@@ -2,10 +2,10 @@
 //!
 //! The Touch controllers offer two face buttons per hand (left X/Y, right
 //! A/B), which this module treats as one symmetric pair per hand: a **lower**
-//! button (left X, right A) and an **upper** one (left Y, right B). What the
-//! pair does depends on what that hand is holding, so a gun can carry its own
-//! handling controls on the controller wielding it while the other hand keeps
-//! the player-owned panels.
+//! button (left X, right A) and an **upper** one (left Y, right B). The lower
+//! button is jump on both hands whatever they hold; the upper one depends on
+//! what that hand is holding, so a gun carries its own handling control on the
+//! controller wielding it while a free hand keeps the log reader.
 //!
 //! Only the Quest binds these (`InputAction::quest_touch_click_path`); flat
 //! has no face buttons and binds no key to them. That matters because in flat
@@ -62,24 +62,25 @@ pub enum HandButtonMode {
 
 /// The action a face button means for the hand that pressed it.
 ///
-/// | hand holds | lower | upper |
+/// | hand holds | lower (X/A) | upper (Y/B) |
 /// |---|---|---|
-/// | nothing, melee, or any other item | `ToggleUseMode` | `ReadLastUnreadLog` |
-/// | a gun | `EjectClip` (that hand's gun) | `CycleGunSetting` (that hand's gun) |
-/// | the psi amp | `SelectPsiPower` (the selection MFD) | `CyclePsiPower` |
+/// | nothing, melee, or any other item | `Jump` | `ReadLastUnreadLog` |
+/// | a gun | `Jump` | `CycleGunSetting` (that hand's gun) |
+/// | the psi amp | `Jump` | `SelectPsiPower` (the selection MFD) |
 ///
-/// **Mode first.** While the interface is up both buttons keep their interface
-/// meaning on both hands whatever is held, so grabbing a gun off the inventory
-/// strip cannot strand the player inside the interface.
+/// **Lower is jump, on both hands, whatever they hold.** Jumping is the one
+/// control a player reaches for mid-fight with both hands full, so it cannot
+/// be something a held weapon takes away; the upper button carries the
+/// context-dependent half of the pair alone.
 ///
-/// Consequence: with a gun in each hand neither the interface nor the log
-/// reader is reachable until a hand is free. That is the point of a per-hand
-/// mapping - free a hand, or use the one that is already free.
+/// **Mode first.** While the interface is up, lower keeps the close it always
+/// had - the press that opened the interface can always shut it, and jumping
+/// out of a menu means nothing anyway - and upper keeps the log reader.
 ///
 /// `hand` does not change which action is returned (the mapping is symmetric);
-/// it is taken because a gun/psi row resolves to an action *about that hand's
-/// weapon* - `EjectClip` and `CycleGunSetting` act on the gun in the hand that
-/// pressed, so the caller must carry the hand through.
+/// it is taken because the gun row resolves to an action *about that hand's
+/// weapon* - `CycleGunSetting` acts on the gun in the hand that pressed, so
+/// the caller must carry the hand through.
 pub fn resolve_hand_button(
     mode: HandButtonMode,
     hand: Handedness,
@@ -88,31 +89,25 @@ pub fn resolve_hand_button(
 ) -> Option<InputAction> {
     let _ = hand;
 
-    let interface_action = match button {
-        HandButton::Lower => InputAction::ToggleUseMode,
-        HandButton::Upper => InputAction::ReadLastUnreadLog,
-    };
-
     if mode == HandButtonMode::Interface {
-        return Some(interface_action);
+        return Some(match button {
+            HandButton::Lower => InputAction::ToggleUseMode,
+            HandButton::Upper => InputAction::ReadLastUnreadLog,
+        });
     }
 
-    match held {
-        HeldKind::Empty | HeldKind::Melee | HeldKind::Other => Some(interface_action),
-        // The gun hand's own handling controls: lower ejects that gun's
-        // magazine, upper toggles its fire mode.
-        HeldKind::Gun => match button {
-            HandButton::Lower => Some(InputAction::EjectClip),
-            HandButton::Upper => Some(InputAction::CycleGunSetting),
-        },
-        // The amp hand's own power controls: lower opens the selection MFD
-        // (where a power is *chosen* from a described grid), upper quick-cycles
-        // to the next trained power without a panel. Neither names a hand -
-        // there is one psi selection, not one per amp.
-        HeldKind::PsiAmp => match button {
-            HandButton::Lower => Some(InputAction::SelectPsiPower),
-            HandButton::Upper => Some(InputAction::CyclePsiPower),
-        },
+    match button {
+        // Unconditional: a hand with a gun in it still has to be able to jump.
+        HandButton::Lower => Some(InputAction::Jump),
+        HandButton::Upper => Some(match held {
+            HeldKind::Empty | HeldKind::Melee | HeldKind::Other => InputAction::ReadLastUnreadLog,
+            // The gun hand's own handling control: its fire mode.
+            HeldKind::Gun => InputAction::CycleGunSetting,
+            // The amp hand's own control: the power selection MFD, where a
+            // power is *chosen* from a described grid. It names no hand -
+            // there is one psi selection, not one per amp.
+            HeldKind::PsiAmp => InputAction::SelectPsiPower,
+        }),
     }
 }
 
@@ -147,23 +142,39 @@ mod tests {
     use super::*;
 
     const HANDS: [Handedness; 2] = [Handedness::Left, Handedness::Right];
-    const BUTTONS: [HandButton; 2] = [HandButton::Lower, HandButton::Upper];
+    const HELD: [HeldKind; 5] = [
+        HeldKind::Empty,
+        HeldKind::Melee,
+        HeldKind::Gun,
+        HeldKind::PsiAmp,
+        HeldKind::Other,
+    ];
 
     fn resolve(held: HeldKind, hand: Handedness, button: HandButton) -> Option<InputAction> {
         resolve_hand_button(HandButtonMode::World, hand, held, button)
     }
 
-    /// Row 1, on both hands: an empty hand (or one holding anything that is
-    /// not a weapon of its own) reaches the player-owned panels.
+    /// The whole lower column: jump, on either hand, holding anything. A gun
+    /// in each hand is the case that motivates it - the player must still be
+    /// able to jump without stowing a weapon first.
     #[test]
-    fn a_hand_without_a_weapon_owns_the_panels() {
+    fn the_lower_button_jumps_whatever_the_hand_holds() {
         for hand in HANDS {
-            for held in [HeldKind::Empty, HeldKind::Melee, HeldKind::Other] {
+            for held in HELD {
                 assert_eq!(
                     resolve(held, hand, HandButton::Lower),
-                    Some(InputAction::ToggleUseMode),
+                    Some(InputAction::Jump),
                     "{held:?} in {hand:?}"
                 );
+            }
+        }
+    }
+
+    /// Upper, row 1: a hand holding nothing of its own reaches the log reader.
+    #[test]
+    fn a_hand_without_a_weapon_reads_the_log_on_its_upper_button() {
+        for hand in HANDS {
+            for held in [HeldKind::Empty, HeldKind::Melee, HeldKind::Other] {
                 assert_eq!(
                     resolve(held, hand, HandButton::Upper),
                     Some(InputAction::ReadLastUnreadLog),
@@ -173,58 +184,7 @@ mod tests {
         }
     }
 
-    /// Row 3: the psi amp hand's buttons are the amp's - lower opens the
-    /// power selection MFD, upper quick-cycles the selection. Symmetric, since
-    /// there is one psi selection however many hands hold an amp.
-    #[test]
-    fn a_psi_amp_hands_buttons_select_its_power() {
-        for hand in HANDS {
-            assert_eq!(
-                resolve(HeldKind::PsiAmp, hand, HandButton::Lower),
-                Some(InputAction::SelectPsiPower),
-                "{hand:?}"
-            );
-            assert_eq!(
-                resolve(HeldKind::PsiAmp, hand, HandButton::Upper),
-                Some(InputAction::CyclePsiPower),
-                "{hand:?}"
-            );
-        }
-    }
-
-    /// Rows 2 and 3: a weapon hand's buttons are its weapon's, so neither
-    /// reaches a panel - whether or not the weapon's own action is bound yet.
-    #[test]
-    fn a_weapon_hand_reaches_neither_panel() {
-        for hand in HANDS {
-            for held in [HeldKind::Gun, HeldKind::PsiAmp] {
-                for button in BUTTONS {
-                    let resolved = resolve(held, hand, button);
-                    assert!(
-                        resolved != Some(InputAction::ToggleUseMode)
-                            && resolved != Some(InputAction::ReadLastUnreadLog),
-                        "{held:?} in {hand:?} reached a panel: {resolved:?}"
-                    );
-                }
-            }
-        }
-    }
-
-    /// Row 2, lower: the gun hand's lower button ejects the magazine - on
-    /// either hand, since the action is resolved against the hand that pressed
-    /// it.
-    #[test]
-    fn a_gun_hands_lower_button_ejects_its_clip() {
-        for hand in HANDS {
-            assert_eq!(
-                resolve(HeldKind::Gun, hand, HandButton::Lower),
-                Some(InputAction::EjectClip),
-                "{hand:?}"
-            );
-        }
-    }
-
-    /// Row 2, upper: the gun hand's upper button toggles that gun's fire mode
+    /// Upper, row 2: the gun hand's upper button toggles that gun's fire mode
     /// - on either hand, resolved against the hand that pressed it.
     #[test]
     fn a_gun_hands_upper_button_toggles_its_fire_mode() {
@@ -237,19 +197,63 @@ mod tests {
         }
     }
 
+    /// Upper, row 3: the amp hand's upper button opens the power selection
+    /// MFD - the selector moved up from the lower button, which is now jump.
+    #[test]
+    fn a_psi_amp_hands_upper_button_opens_the_selector() {
+        for hand in HANDS {
+            assert_eq!(
+                resolve(HeldKind::PsiAmp, hand, HandButton::Upper),
+                Some(InputAction::SelectPsiPower),
+                "{hand:?}"
+            );
+        }
+    }
+
+    /// A weapon hand's upper button is its weapon's, so it reaches neither
+    /// player-owned panel.
+    #[test]
+    fn a_weapon_hands_upper_button_reaches_neither_panel() {
+        for hand in HANDS {
+            for held in [HeldKind::Gun, HeldKind::PsiAmp] {
+                let resolved = resolve(held, hand, HandButton::Upper);
+                assert!(
+                    resolved != Some(InputAction::ToggleUseMode)
+                        && resolved != Some(InputAction::ReadLastUnreadLog),
+                    "{held:?} in {hand:?} reached a panel: {resolved:?}"
+                );
+            }
+        }
+    }
+
+    /// The eject and quick-cycle controls lost their buttons: the settings
+    /// MFD's UNLOAD and the psi MFD's stick navigation cover them, and a
+    /// button that unloads a gun on a mis-press is worse than no button.
+    #[test]
+    fn no_button_ejects_a_clip_or_quick_cycles_a_power() {
+        for mode in [HandButtonMode::World, HandButtonMode::Interface] {
+            for hand in HANDS {
+                for held in HELD {
+                    for button in [HandButton::Lower, HandButton::Upper] {
+                        let resolved = resolve_hand_button(mode, hand, held, button);
+                        assert!(
+                            resolved != Some(InputAction::EjectClip)
+                                && resolved != Some(InputAction::CyclePsiPower),
+                            "{mode:?}/{held:?}/{hand:?}/{button:?} resolved to {resolved:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     /// Mode first: the interface takes both buttons back on both hands, so the
-    /// press that opened it always closes it - even if a gun was grabbed off
-    /// the inventory strip in between.
+    /// press that opened it always closes it - even if a gun was taken off the
+    /// inventory strip in between, and even though lower is otherwise jump.
     #[test]
     fn the_open_interface_outranks_whatever_is_held() {
         for hand in HANDS {
-            for held in [
-                HeldKind::Empty,
-                HeldKind::Melee,
-                HeldKind::Gun,
-                HeldKind::PsiAmp,
-                HeldKind::Other,
-            ] {
+            for held in HELD {
                 assert_eq!(
                     resolve_hand_button(HandButtonMode::Interface, hand, held, HandButton::Lower),
                     Some(InputAction::ToggleUseMode),

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -86,6 +86,11 @@ pub enum ReadoutButton {
     PsiPowerNext,
     /// Open the psi power selection MFD.
     PsiSelect,
+    /// Open the pause / system menu. Not part of the ammo gauge - it belongs
+    /// to the interface canvas as a whole (see [`super::readouts`]) - but it
+    /// is a control on that canvas, so it travels with the rest through the
+    /// one list the host draws and hit-tests.
+    SystemMenu,
 }
 
 impl ReadoutButton {
@@ -100,6 +105,7 @@ impl ReadoutButton {
             ReadoutButton::PsiPowerPrev => "psi_power_prev",
             ReadoutButton::PsiPowerNext => "psi_power_next",
             ReadoutButton::PsiSelect => "psi_select",
+            ReadoutButton::SystemMenu => "system_menu",
         }
     }
 }
@@ -114,6 +120,23 @@ pub struct ReadoutButtonSpec {
     pub rect: Rect,
     pub texture: Option<&'static str>,
     pub text: Option<String>,
+}
+
+/// Draw one control at `rect`: its art, then its label centred on it.
+///
+/// The single drawing routine for every [`ReadoutButtonSpec`] the interface
+/// canvas carries - the gauge's own controls here and the system button in
+/// [`super::readouts`] - so a control cannot be drawn one way in one place and
+/// hit-tested from another.
+pub(crate) fn draw_button(canvas: &mut UiCanvas, button: &ReadoutButtonSpec, rect: Rect) {
+    if let Some(texture) = button.texture {
+        canvas.image(rect, texture);
+    }
+    if let Some(text) = &button.text {
+        // Ellipsized: labels are data (a localized MISC.STR string, an authored
+        // `P$SHead` header), and an over-wide one would spill onto the gauge.
+        canvas.text_native_fit(rect, text, FONT, HAlign::Center, VAlign::Middle);
+    }
 }
 
 /// Place a panel-local rect into a canvas whose panel origin is `origin`.
@@ -307,16 +330,7 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
     }
 
     for button in buttons(readout) {
-        let rect = at(origin, button.rect);
-        if let Some(texture) = button.texture {
-            canvas.image(rect, texture);
-        }
-        if let Some(text) = &button.text {
-            // Ellipsized like the ammo-type label: both labels are data (a
-            // localized MISC.STR string, an authored `P$SHead` header), and an
-            // over-wide one would spill onto the gauge.
-            canvas.text_native_fit(rect, text, FONT, HAlign::Center, VAlign::Middle);
-        }
+        draw_button(canvas, &button, at(origin, button.rect));
     }
 }
 

--- a/shock2vr/src/hud/readouts.rs
+++ b/shock2vr/src/hud/readouts.rs
@@ -17,7 +17,7 @@
 use cgmath::{Vector2, vec2};
 use shipyard::World;
 
-use super::ammo_panel::{self, AmmoReadout, ReadoutButtonSpec};
+use super::ammo_panel::{self, AmmoReadout, ReadoutButton, ReadoutButtonSpec};
 use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
 
 /// The font the bio numbers use (the original's HUD font).
@@ -47,6 +47,30 @@ pub(crate) const PSI_TEXT: Rect = Rect::new(92.0, 40.0, TEXT_W, BAR_H);
 /// AMMOFULL 260).
 pub(crate) const BIO_ORIGIN: Vector2<f32> = vec2(2.0, 414.0);
 pub(crate) const AMMO_ORIGIN: Vector2<f32> = vec2(378.0, 414.0);
+
+/// The system-menu affordance: the pause menu's only *discoverable* control in
+/// VR, since the Menu button's long press advertises nothing until it is held.
+/// IFBTN00.PCX is the original's blank 38x36 interface button.
+///
+/// Placed in the empty column between the interface's occupied regions - below
+/// the inventory strip (`(2,0)`, 636x121), right of the left MFD slot
+/// (`(2,124)`, 188x300) and its close gadget, left of the reserved right slot
+/// (x 450), and above both bottom readouts (y 414) - and horizontally centred
+/// on the canvas.
+pub(crate) const SYSTEM_BUTTON: Rect = Rect::new(288.0, 372.0, 64.0, 36.0);
+
+/// The system button as one spec, so [`emit_use_mode`] draws exactly what
+/// [`buttons`] hit-tests.
+fn system_button() -> ReadoutButtonSpec {
+    ReadoutButtonSpec {
+        button: ReadoutButton::SystemMenu,
+        rect: SYSTEM_BUTTON,
+        // The original's blank interface-button plate, widened from its
+        // authored 38 px so the label sits inside the bevel rather than on it.
+        texture: Some("IFBTN00.PCX"),
+        text: Some("MENU".to_owned()),
+    }
+}
 
 /// What the bio monitor says this frame. Presentation-agnostic, like
 /// [`AmmoReadout`].
@@ -162,6 +186,9 @@ pub(crate) fn emit_use_mode(canvas: &mut UiCanvas, readouts: &UseModeReadouts) {
         );
         ammo_panel::emit(canvas, AMMO_ORIGIN, &readouts.ammo);
     }
+    // Always: the way out of the game does not depend on what is wielded.
+    let system = system_button();
+    ammo_panel::draw_button(canvas, &system, system.rect);
 }
 
 /// The readout's clickable controls on the 640x480 canvas.
@@ -171,9 +198,11 @@ pub(crate) fn emit_use_mode(canvas: &mut UiCanvas, readouts: &UseModeReadouts) {
 /// through the same panel origin, so the drawn and clickable regions cannot
 /// diverge - in either presentation.
 pub(crate) fn buttons(readouts: &UseModeReadouts) -> Vec<ReadoutButtonSpec> {
+    // Drawn unconditionally above, so it is clickable unconditionally.
+    let system = system_button();
     if readouts.ammo.is_empty() {
         // The gauge is not drawn, so nothing on it is clickable.
-        return Vec::new();
+        return vec![system];
     }
     ammo_panel::buttons(&readouts.ammo)
         .into_iter()
@@ -181,6 +210,7 @@ pub(crate) fn buttons(readouts: &UseModeReadouts) -> Vec<ReadoutButtonSpec> {
             rect: ammo_panel::at(AMMO_ORIGIN, spec.rect),
             ..spec
         })
+        .chain([system])
         .collect()
 }
 
@@ -203,12 +233,15 @@ mod tests {
         }
     }
 
+    /// The system button's art + label, drawn whatever else the canvas shows.
+    const SYSTEM_ELEMENTS: usize = 2;
+
     #[test]
     fn the_bio_monitor_is_always_drawn() {
         // Backdrop + 2 bars + 2 numbers, with no weapon wielded.
         let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
         emit_use_mode(&mut canvas, &readouts(None, false));
-        assert_eq!(canvas.element_count(), 5);
+        assert_eq!(canvas.element_count(), 5 + SYSTEM_ELEMENTS);
     }
 
     #[test]
@@ -216,7 +249,47 @@ mod tests {
         // ...plus the AMMOFULL backdrop + the round count.
         let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
         emit_use_mode(&mut canvas, &readouts(Some(12), false));
-        assert_eq!(canvas.element_count(), 7);
+        assert_eq!(canvas.element_count(), 7 + SYSTEM_ELEMENTS);
+    }
+
+    /// The interface's way to the pause menu is on the canvas whatever is
+    /// wielded, and is hit-tested at exactly the rect it was drawn at - one
+    /// list for both, so a VR ray reaches what a flat cursor does.
+    #[test]
+    fn the_system_button_is_drawn_and_clickable_at_the_same_rect() {
+        for readouts in [readouts(None, false), readouts(Some(12), true)] {
+            let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
+            emit_use_mode(&mut canvas, &readouts);
+
+            let drawn: Vec<_> = canvas
+                .elements()
+                .iter()
+                .filter(|element| element.rect() == SYSTEM_BUTTON)
+                .collect();
+            assert_eq!(drawn.len(), 2, "art + label");
+
+            let clickable = buttons(&readouts)
+                .into_iter()
+                .find(|spec| spec.button == ReadoutButton::SystemMenu)
+                .expect("the system button is always clickable");
+            assert_eq!(clickable.rect, SYSTEM_BUTTON);
+        }
+    }
+
+    /// It sits in the canvas's one free column: clear of the strip, the left
+    /// MFD slot, the reserved right slot and both bottom readouts.
+    #[test]
+    fn the_system_button_collides_with_nothing_on_the_canvas() {
+        assert!(SYSTEM_BUTTON.y >= 121.0, "below the inventory strip");
+        assert!(SYSTEM_BUTTON.x >= 190.0, "right of the left MFD slot");
+        assert!(
+            SYSTEM_BUTTON.x + SYSTEM_BUTTON.w <= 450.0,
+            "left of the right slot"
+        );
+        assert!(
+            SYSTEM_BUTTON.y + SYSTEM_BUTTON.h <= BIO_ORIGIN.y,
+            "above the bottom readouts"
+        );
     }
 
     #[test]
@@ -292,8 +365,14 @@ mod tests {
     /// A readout with nothing to say offers no controls, even though the
     /// composition is only ever drawn in use mode.
     #[test]
-    fn an_empty_gauge_offers_no_buttons() {
-        assert!(buttons(&readouts(None, true)).is_empty());
-        assert_eq!(buttons(&readouts(Some(0), true)).len(), 1);
+    fn an_empty_gauge_offers_no_gauge_buttons() {
+        let gauge = |r| {
+            buttons(&r)
+                .into_iter()
+                .filter(|spec| spec.button != ReadoutButton::SystemMenu)
+                .count()
+        };
+        assert_eq!(gauge(readouts(None, true)), 0);
+        assert_eq!(gauge(readouts(Some(0), true)), 1);
     }
 }

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -125,6 +125,20 @@ pub enum InputAction {
     LeftHandUpperButton,
     RightHandLowerButton,
     RightHandUpperButton,
+
+    /// Jump once. The ordinary jump is a *held* runtime channel
+    /// (`InputContext::jump`, edge-detected by the physics controller); this is
+    /// the discrete form a button resolution can produce, which is what a
+    /// Quest hand's LOWER face button means whatever that hand holds (see
+    /// [`crate::hand_buttons`]). It is bound raw there, so it carries no Quest
+    /// click path of its own.
+    Jump,
+
+    /// The left controller's Menu button, bound RAW like the face buttons:
+    /// a short press jacks into the cyber interface and a long one opens the
+    /// pause menu, which is a *hold* and so cannot be one action's edge. The
+    /// split lives in [`crate::input::MenuHold`].
+    MenuButton,
 }
 
 impl InputAction {
@@ -172,6 +186,8 @@ impl InputAction {
             InputAction::LeftHandUpperButton,
             InputAction::RightHandLowerButton,
             InputAction::RightHandUpperButton,
+            InputAction::Jump,
+            InputAction::MenuButton,
         ]
     }
 
@@ -217,6 +233,8 @@ impl InputAction {
             InputAction::LeftHandUpperButton => "LeftHandUpperButton",
             InputAction::RightHandLowerButton => "RightHandLowerButton",
             InputAction::RightHandUpperButton => "RightHandUpperButton",
+            InputAction::Jump => "Jump",
+            InputAction::MenuButton => "MenuButton",
         }
     }
 
@@ -235,17 +253,22 @@ impl InputAction {
             InputAction::LeftHandUpperButton => Some("/user/hand/left/input/y/click"),
             InputAction::RightHandLowerButton => Some("/user/hand/right/input/a/click"),
             InputAction::RightHandUpperButton => Some("/user/hand/right/input/b/click"),
-            // The right controller's menu button is reserved by the Quest
-            // system UI; the left one is the app's.
-            InputAction::TogglePauseMenu => Some("/user/hand/left/input/menu/click"),
+            // The left controller's Menu button, also raw: its press and its
+            // release mean different things, so the semantic actions it can
+            // resolve to (`ToggleUseMode`, `TogglePauseMenu`) own no Quest
+            // binding either. (The right controller's Menu is reserved by the
+            // Quest system UI, so it can never be the app's.)
+            InputAction::MenuButton => Some("/user/hand/left/input/menu/click"),
             // `Reload`, `CycleAmmo`, `EjectClip`, `CycleGunSetting`,
-            // `CyclePsiPower` and `SelectPsiPower` deliberately have NO Quest
-            // binding of their own: in VR reloading is the physical
-            // clip-insert gesture, and the rest are reached through the face
-            // button of the hand actually holding the weapon - which names a
-            // hand, where a hand-agnostic binding could not say which weapon
-            // it meant. All remain reachable everywhere else (flat keys, HTTP,
-            // the SDK).
+            // `CyclePsiPower`, `SelectPsiPower` and `Jump` deliberately have
+            // NO Quest binding of their own: in VR reloading is the physical
+            // clip-insert gesture, and the rest are reached through the raw
+            // face button of the hand actually holding the weapon - which
+            // names a hand, where a hand-agnostic binding could not say which
+            // weapon it meant. `EjectClip` and `CyclePsiPower` are reached in
+            // VR through the settings MFD's UNLOAD and the psi MFD's stick
+            // navigation instead of a button. All remain reachable everywhere
+            // else (flat keys, HTTP, the SDK).
             _ => None,
         }
     }
@@ -254,9 +277,9 @@ impl InputAction {
     /// **chord** rather than a button of their own.
     ///
     /// The Touch has few buttons to give: every face button is a per-hand
-    /// contextual button, the left `Menu` is the pause menu, both thumbstick
-    /// clicks are jump and crouch, and the right `Menu` belongs to the Quest
-    /// system UI. A debug toggle takes a *pair* rather than a scarce single
+    /// contextual button, the left `Menu` is the interface/pause pair, the
+    /// left thumbstick click is crouch, and the right `Menu` belongs to the
+    /// Quest system UI. A debug toggle takes a *pair* rather than a scarce single
     /// button - here right `A`+`B`. The pair's edge is resolved by
     /// [`InputActionState::sync_chord`].
     ///
@@ -352,7 +375,7 @@ mod tests {
             Some("/user/hand/right/input/b/click")
         );
         assert_eq!(
-            InputAction::TogglePauseMenu.quest_touch_click_path(),
+            InputAction::MenuButton.quest_touch_click_path(),
             Some("/user/hand/left/input/menu/click")
         );
     }
@@ -367,6 +390,10 @@ mod tests {
             InputAction::ReadLastUnreadLog.quest_touch_click_path(),
             None
         );
+        // The pause menu is the Menu button's LONG press, not its edge.
+        assert_eq!(InputAction::TogglePauseMenu.quest_touch_click_path(), None);
+        // Jump is what a lower face button resolves to, not a binding.
+        assert_eq!(InputAction::Jump.quest_touch_click_path(), None);
     }
 
     /// The free camera is a chord, not a button, and must never quietly

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -181,6 +181,9 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::ReadLastUnreadLog) {
             effects.push(Effect::ReadLastUnreadLog);
         }
+        if state.just_triggered(InputAction::Jump) {
+            effects.push(Effect::Jump);
+        }
         // The face buttons are forwarded RAW, hand and position intact: what a
         // press means depends on what that hand is holding, which only the
         // mission can see. This dispatcher stays non-contextual; the table
@@ -190,6 +193,10 @@ impl ActionDispatcher {
                 effects.push(Effect::HandButton { hand, button });
             }
         }
+        // `InputAction::MenuButton` deliberately produces no effect either:
+        // it is raw, and `Game` splits it into a short press (the interface)
+        // and a long one (the pause menu) before dispatching.
+        //
         // `InputAction::TogglePauseMenu` deliberately produces no effect: the
         // pause overlay is owned by `Game`, which reads the action directly
         // before dispatching. Routing it through the scene would make it

--- a/shock2vr/src/input/menu_hold.rs
+++ b/shock2vr/src/input/menu_hold.rs
@@ -1,0 +1,240 @@
+//! What the left controller's Menu button means: a short press or a long one.
+//!
+//! The Touch has one Menu button to give (the right one belongs to the Quest
+//! system UI) and two things to reach with it: jacking into the cyber
+//! interface, which is a frequent in-game gesture, and the pause menu, which
+//! is rare. So the button carries both - a short press jacks in, a hold of
+//! [`MENU_LONG_PRESS`] pauses.
+//!
+//! The rule the machine below enforces, in order:
+//!
+//! * the short press fires on **release**, never on press, so a long press
+//!   cannot also toggle the interface on its way past the threshold;
+//! * the long press fires the moment the threshold is **crossed**, not on
+//!   release, so the hold has a visible end (with the ring at
+//!   [`crate::scenes::cutscene_skip`] filling up to it);
+//! * the release that follows a long press is swallowed.
+//!
+//! Pure, so the whole timing rule is host-testable.
+
+use std::time::Duration;
+
+/// How long the Menu button must be held to reach the pause menu. Long enough
+/// that jacking in never pauses by accident, short enough to sit out.
+pub const MENU_LONG_PRESS: Duration = Duration::from_millis(500);
+
+/// The most one frame can credit toward the hold. A frame longer than this is a
+/// hitch (a level parse, a stall), not time the player spent on the button -
+/// without the cap a tap landing on one would pause instantly.
+const MAX_FRAME_CREDIT: Duration = Duration::from_millis(100);
+
+/// What one Menu button press turned out to be.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MenuPress {
+    /// Nothing decided this frame.
+    None,
+    /// Released before the threshold: jack in / out of the cyber interface.
+    Short,
+    /// Held past the threshold: open the pause menu.
+    Long,
+}
+
+/// The Menu button's short/long press latch.
+#[derive(Debug, Default)]
+pub struct MenuHold {
+    /// How long the button has been down, `None` while it is up.
+    held: Option<Duration>,
+    /// The long press already fired for this press, so the release is spent.
+    fired_long: bool,
+}
+
+impl MenuHold {
+    /// The button went down.
+    pub fn press(&mut self) {
+        self.held = Some(Duration::ZERO);
+        self.fired_long = false;
+    }
+
+    /// Advance a held button by one frame, firing [`MenuPress::Long`] on the
+    /// frame the threshold is crossed and nothing afterwards.
+    pub fn tick(&mut self, elapsed: Duration) -> MenuPress {
+        let Some(held) = self.held.as_mut() else {
+            return MenuPress::None;
+        };
+        *held = held.saturating_add(elapsed.min(MAX_FRAME_CREDIT));
+        if !self.fired_long && *held >= MENU_LONG_PRESS {
+            self.fired_long = true;
+            return MenuPress::Long;
+        }
+        MenuPress::None
+    }
+
+    /// The button came up: a short press unless the long one already fired.
+    pub fn release(&mut self) -> MenuPress {
+        let was_held = self.held.take().is_some();
+        if self.fired_long || !was_held {
+            self.fired_long = false;
+            return MenuPress::None;
+        }
+        MenuPress::Short
+    }
+
+    /// Forget the press in flight without deciding anything: neither a short
+    /// press nor a long one. For a button whose release can never arrive - an
+    /// OpenXR session restart (a doff/don) makes the action inactive, so the
+    /// runtime stops reporting edges for a button that may still be down - and
+    /// for a scene where the hold means nothing. A plain `release` here would
+    /// mint the short press nobody made.
+    pub fn cancel(&mut self) {
+        self.held = None;
+        self.fired_long = false;
+    }
+
+    /// Hold progress toward the long press, `None` while the button is up or
+    /// once the long press has fired - the readout is the *promise* of the
+    /// pause menu, so it stops the moment the promise is kept.
+    pub fn progress(&self) -> Option<f32> {
+        if self.fired_long {
+            return None;
+        }
+        let held = self.held?;
+        Some((held.as_secs_f32() / MENU_LONG_PRESS.as_secs_f32()).clamp(0.0, 1.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FRAME: Duration = Duration::from_millis(100);
+
+    /// Hold for `total`, a frame at a time (no frame may exceed
+    /// [`MAX_FRAME_CREDIT`], so a test cannot hold for half a second in one
+    /// tick any more than the game can). Returns the first press it decides.
+    fn hold_for(hold: &mut MenuHold, total: Duration) -> MenuPress {
+        let mut elapsed = Duration::ZERO;
+        let mut decided = MenuPress::None;
+        while elapsed < total {
+            let step = FRAME.min(total - elapsed);
+            let press = hold.tick(step);
+            if decided == MenuPress::None {
+                decided = press;
+            }
+            elapsed += step;
+        }
+        decided
+    }
+
+    #[test]
+    fn a_quick_press_is_short_and_fires_on_release() {
+        let mut hold = MenuHold::default();
+        hold.press();
+        assert_eq!(hold.tick(FRAME), MenuPress::None, "nothing fires on press");
+        assert_eq!(hold.release(), MenuPress::Short);
+    }
+
+    /// The defect a naive "toggle on press, pause on hold" would have: the
+    /// interface would open on the way to every pause.
+    #[test]
+    fn a_long_press_pauses_and_never_also_toggles_the_interface() {
+        let mut hold = MenuHold::default();
+        hold.press();
+
+        let mut elapsed = Duration::ZERO;
+        while elapsed + FRAME < MENU_LONG_PRESS {
+            assert_eq!(
+                hold.tick(FRAME),
+                MenuPress::None,
+                "paused early at {elapsed:?}"
+            );
+            elapsed += FRAME;
+        }
+        assert_eq!(
+            hold.tick(FRAME),
+            MenuPress::Long,
+            "the threshold must fire it"
+        );
+
+        // Held on past the threshold: it fires once, not every frame.
+        assert_eq!(hold_for(&mut hold, MENU_LONG_PRESS * 4), MenuPress::None);
+        // ...and the release it was already spent on is swallowed.
+        assert_eq!(hold.release(), MenuPress::None);
+    }
+
+    #[test]
+    fn a_release_just_under_the_threshold_is_still_short() {
+        let mut hold = MenuHold::default();
+        hold.press();
+        assert_eq!(
+            hold_for(&mut hold, MENU_LONG_PRESS - Duration::from_millis(1)),
+            MenuPress::None
+        );
+        assert_eq!(hold.release(), MenuPress::Short);
+    }
+
+    /// A fresh press after a long one runs the full duration again, rather
+    /// than inheriting the spent latch.
+    #[test]
+    fn a_press_after_a_long_one_starts_over() {
+        let mut hold = MenuHold::default();
+        hold.press();
+        assert_eq!(hold_for(&mut hold, MENU_LONG_PRESS), MenuPress::Long);
+        hold.release();
+
+        hold.press();
+        assert_eq!(hold.tick(FRAME), MenuPress::None);
+        assert_eq!(hold.release(), MenuPress::Short);
+    }
+
+    /// Ticking or releasing a button nobody pressed decides nothing - a
+    /// runtime that reports a stale release (focus lost, hand dropped) must
+    /// not mint a press.
+    #[test]
+    fn an_unpressed_button_decides_nothing() {
+        let mut hold = MenuHold::default();
+        assert_eq!(hold_for(&mut hold, MENU_LONG_PRESS * 4), MenuPress::None);
+        assert_eq!(hold.release(), MenuPress::None);
+        assert_eq!(hold.progress(), None);
+    }
+
+    /// A press that spans a hitch (a level parse, a stall: wall `elapsed` in
+    /// the hundreds of milliseconds) is still a tap, not a hold.
+    #[test]
+    fn one_enormous_frame_cannot_complete_a_hold() {
+        let mut hold = MenuHold::default();
+        hold.press();
+        assert_eq!(hold.tick(Duration::from_secs(4)), MenuPress::None);
+        assert_eq!(hold.release(), MenuPress::Short);
+    }
+
+    /// Cancelling decides nothing - the defect a plain `release` would have,
+    /// which would mint a cyber-interface toggle nobody asked for.
+    #[test]
+    fn cancelling_a_press_in_flight_decides_nothing() {
+        let mut hold = MenuHold::default();
+        hold.press();
+        hold.tick(FRAME);
+        hold.cancel();
+        assert_eq!(hold.progress(), None);
+        assert_eq!(hold.release(), MenuPress::None);
+        assert_eq!(hold_for(&mut hold, MENU_LONG_PRESS * 4), MenuPress::None);
+
+        // ...and the next press is unaffected.
+        hold.press();
+        assert_eq!(hold_for(&mut hold, MENU_LONG_PRESS), MenuPress::Long);
+    }
+
+    #[test]
+    fn progress_runs_to_one_then_stops_once_the_menu_is_promised() {
+        let mut hold = MenuHold::default();
+        assert_eq!(hold.progress(), None, "nothing to show while it is up");
+
+        hold.press();
+        assert_eq!(hold.progress(), Some(0.0));
+        hold_for(&mut hold, MENU_LONG_PRESS / 2);
+        assert_eq!(hold.progress(), Some(0.5));
+
+        hold_for(&mut hold, MENU_LONG_PRESS);
+        assert_eq!(hold.progress(), None, "the ring stops when the menu opens");
+    }
+}

--- a/shock2vr/src/input/mod.rs
+++ b/shock2vr/src/input/mod.rs
@@ -1,8 +1,10 @@
 mod actions;
 mod dispatcher;
+mod menu_hold;
 pub mod remote;
 mod state;
 
 pub use actions::*;
 pub use dispatcher::*;
+pub use menu_hold::*;
 pub use state::*;

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -144,7 +144,7 @@ use std::{
     thread,
 };
 
-use cgmath::{Matrix4, Quaternion, Vector2, Vector3, vec3};
+use cgmath::{Matrix4, Quaternion, Rotation, Vector2, Vector3, vec3};
 use dark::{
     gamesys,
     importers::{AUDIO_IMPORTER, FONT_IMPORTER, STRINGS_IMPORTER},
@@ -605,6 +605,13 @@ pub struct Game {
     /// so the paused scene keeps rendering while its update is skipped.
     pause_menu: pause_menu::PauseMenu,
 
+    /// The Menu button's short/long split (jack in vs. pause) and the hold
+    /// readout that promises the long one. Here beside the pause menu for the
+    /// same reason: it decides `Game`'s own overlay, and must keep running on
+    /// a frame the scene is not updated at all.
+    menu_hold: input::MenuHold,
+    menu_hold_ring: scenes::cutscene_skip::RingArt,
+
     /// Wall-clock time spent with the simulation suspended, subtracted from the
     /// clock the scene sees. See [`Game::scene_time`].
     time_suspended: std::time::Duration,
@@ -748,6 +755,14 @@ impl std::fmt::Display for SaveGameError {
 }
 
 impl std::error::Error for SaveGameError {}
+
+/// Where the Menu button's hold ring hangs: straight ahead of the eye, a
+/// little below the gaze so it never sits on what the player is looking at,
+/// and sized as a fraction of that distance so it subtends the same angle
+/// whatever the presentation.
+const MENU_HOLD_RING_DISTANCE: f32 = 1.5;
+const MENU_HOLD_RING_SIZE: f32 = 0.09;
+const MENU_HOLD_RING_DROP: f32 = 0.12;
 
 impl Game {
     /// True while a deferred level transition is in flight.
@@ -1345,6 +1360,8 @@ impl Game {
             should_quit: false,
             campaign_completed: false,
             pause_menu: pause_menu::PauseMenu::new(),
+            menu_hold: input::MenuHold::default(),
+            menu_hold_ring: scenes::cutscene_skip::RingArt::default(),
             time_suspended: std::time::Duration::ZERO,
             hit_feedback: hit_feedback::HitFeedback::new(),
             head_pose: (
@@ -1422,6 +1439,10 @@ impl Game {
                 scene.set_progress(progress);
             }
         }
+
+        // Split the raw Menu button into the actions it can mean, before
+        // either is looked at below.
+        self.resolve_menu_button(time.elapsed, actions);
 
         // The pause menu is a Game-level overlay, so its toggle is consumed
         // here instead of being dispatched into the scene: while paused the
@@ -1585,6 +1606,73 @@ impl Game {
             .borrow::<UniqueView<PlayerLifeState>>()
             .map(|state| state.is_alive())
             .unwrap_or(true)
+    }
+
+    /// Turn the raw left Menu button into what its press meant: a short press
+    /// jacks in or out of the cyber interface (what the left face button used
+    /// to do), a hold of [`input::MENU_LONG_PRESS`] opens the pause menu.
+    ///
+    /// Both arrive as ordinary triggered actions, so every path below - the
+    /// pause toggle here, the dispatcher's `ToggleUseMode` - stays unaware
+    /// that one button fed it. Run before the pause menu is updated, and
+    /// before the suspended-scene early return, so a button released inside
+    /// the pause menu is still accounted for.
+    fn resolve_menu_button(
+        &mut self,
+        elapsed: std::time::Duration,
+        actions: &mut input::InputActionState,
+    ) {
+        // Where the pause menu cannot open - a frontend screen, a transition in
+        // flight, a dead player - the hold means nothing, so it is not run at
+        // all: no ring promising a menu that will not come, and no long press
+        // minted for `update_pause_menu` to drop. (The cutscene player is one
+        // of these, and draws this very ring for its own hold-to-skip.)
+        if !self.pause_is_allowed() {
+            self.menu_hold.cancel();
+            return;
+        }
+        if actions.just_triggered(InputAction::MenuButton) {
+            self.menu_hold.press();
+        }
+        // A single-shot injection (`/v1/input/action`) triggers and releases in
+        // one frame, so it lands here as a short press - the button's ordinary
+        // meaning.
+        let press = if actions.is_held(InputAction::MenuButton) {
+            self.menu_hold.tick(elapsed)
+        } else {
+            self.menu_hold.release()
+        };
+        let resolved = match press {
+            // The pause menu swallows the scene's actions while it is up, so
+            // its own button must close it rather than emit an interface
+            // toggle nothing would ever see.
+            input::MenuPress::Short if self.pause_menu.is_open() => {
+                Some(InputAction::TogglePauseMenu)
+            }
+            input::MenuPress::Short => Some(InputAction::ToggleUseMode),
+            input::MenuPress::Long => Some(InputAction::TogglePauseMenu),
+            input::MenuPress::None => None,
+        };
+        if let Some(action) = resolved {
+            actions.trigger(action);
+            // Released straight away: what the Menu button synthesizes is an
+            // EDGE, and neither of these has a Quest binding to deliver the
+            // release that would otherwise clear the latch - it would sit in
+            // the held set for the rest of the session.
+            actions.release(action);
+        }
+    }
+
+    /// Forget any Menu button press in flight, deciding neither a short press
+    /// nor a long one.
+    ///
+    /// For a runtime whose session restarted (a doff/don): OpenXR stops
+    /// reporting edges for an inactive action, so the release of a button that
+    /// is still physically down never arrives - and an accumulating hold would
+    /// then pause the game on its own the moment focus came back. Releasing it
+    /// instead would mint the short press nobody made.
+    pub fn cancel_menu_hold(&mut self) {
+        self.menu_hold.cancel();
     }
 
     /// Apply the pause toggle and, while open, drive the overlay.
@@ -1849,6 +1937,11 @@ impl Game {
                     entities_to_trigger,
                     vitals_transition,
                 );
+            }
+            GlobalEffect::OpenPauseMenu => {
+                if self.pause_is_allowed() && !self.pause_menu.is_open() {
+                    self.open_pause_menu();
+                }
             }
             GlobalEffect::TestReload => {
                 let (position, rotation) = match self.player_standing_transform() {
@@ -2208,6 +2301,42 @@ impl Game {
             scene.push(layer);
         }
 
+        // The Menu button's hold readout: the same ring the cutscene skip
+        // draws, head-locked at the centre of the picture and a little low, so
+        // a button held anywhere in the room shows its progress toward the
+        // pause menu. Transient and small - unlike a panel, which is placed
+        // and left world-locked - so it rides the eye directly.
+        if let Some(progress) = self.menu_hold.progress() {
+            let size = MENU_HOLD_RING_SIZE * MENU_HOLD_RING_DISTANCE;
+            let mut ring = self.menu_hold_ring.quad(progress, 1.0);
+            // Down in VIEW space: a pawn-space drop collapses onto the gaze
+            // axis as the head pitches, putting the ring back on exactly what
+            // the player is looking at. An untracked head has no usable
+            // rotation, so it falls back to the world down `eye_pose` implies.
+            let down = util::tracked_gaze(rendered_eye.head_offset, rendered_eye.head_rotation)
+                .map(|_| {
+                    rendered_eye
+                        .head_rotation
+                        .rotate_vector(vec3(0.0, -1.0, 0.0))
+                })
+                .unwrap_or_else(|| vec3(0.0, -1.0, 0.0));
+            let centre = eye_position
+                + eye_forward * MENU_HOLD_RING_DISTANCE
+                + down * (MENU_HOLD_RING_DROP * MENU_HOLD_RING_DISTANCE);
+            ring.set_transform(
+                pawn_to_world
+                    * Matrix4::from_translation(centre)
+                    * Matrix4::from(util::get_rotation_from_forward_vector(-eye_forward))
+                    * Matrix4::from_nonuniform_scale(size, size, 1.0),
+            );
+            ring.set_depth_write(false);
+            ring.set_render_layer(RenderLayer::SystemOverlay);
+            ring.set_debug_tag(Some(util::render_source_tag(
+                util::render_source::MENU_HOLD_RING,
+            )));
+            scene.push(ring);
+        }
+
         let mut pause_objects =
             self.pause_menu
                 .render(&mut self.asset_cache, &self.options, pawn_to_world);
@@ -2556,6 +2685,12 @@ impl App {
         match self {
             App::Ready(game) => game.should_quit(),
             App::MissingAssets(_) => false,
+        }
+    }
+
+    pub fn cancel_menu_hold(&mut self) {
+        if let App::Ready(game) = self {
+            game.cancel_menu_hold();
         }
     }
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -2382,12 +2382,19 @@ mod tests {
                 .iter()
                 .map(|e| e.label.as_deref().unwrap())
                 .collect::<Vec<_>>(),
-            vec!["gun_setting", "cycle_ammo"]
+            vec!["gun_setting", "cycle_ammo", "system_menu"]
         );
         assert_eq!(elements[0].text.as_deref(), Some("NORM"));
         assert!(elements.iter().all(|e| e.kind == "button"));
         let el = host.ammo_cycle_debug().expect("the arrow is exposed");
         assert_eq!(el.label.as_deref(), Some("cycle_ammo"));
+        // ...and one on the system button (centre 320, 390) asks for the
+        // pause menu - the interface's only visible way out of the game.
+        let actions = press_edge(&mut host, &world, (320.0, 390.0));
+        assert_eq!(
+            actions,
+            vec![FlatUiDragAction::Readout(ReadoutButton::SystemMenu)]
+        );
         // A click elsewhere in the bare view does not cycle.
         let actions = press_edge(&mut host, &world, (300.0, 300.0));
         assert!(actions.is_empty());

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1594,6 +1594,10 @@ pub struct MissionCore {
     /// held stick steps once rather than every frame.
     psi_nav_latched: bool,
 
+    /// A discrete [`Effect::Jump`] waiting for the next movement pass. One
+    /// frame of the held jump channel; see where it is consumed in `update`.
+    button_jump: bool,
+
     /// Entry/exit feel for `use_mode`: one eased 0..1 ramp driving the rim
     /// vignette (both presentations), the VR comfort dim's strength, and the
     /// flat FOV pull - see [`crate::ui::entry_ramp`]. Advanced every update
@@ -2549,6 +2553,7 @@ impl MissionCore {
             weapon_settings_gun: None,
             psi_powers_open: false,
             psi_nav_latched: false,
+            button_jump: false,
             use_mode_shortcut: None,
             use_mode_ramp: crate::ui::entry_ramp::EntryExitRamp::new(),
             vr_use_mode_anchor: crate::ui::FrontendPanelAnchor::new(),
@@ -2874,6 +2879,10 @@ impl MissionCore {
         let input_context = if self.player_is_alive() && self.player_controls_enabled {
             input_context
         } else {
+            // The discrete jump is latched separately from the context, so it
+            // has to be dropped here too - otherwise a face button pressed as
+            // the player died would hop the corpse.
+            self.button_jump = false;
             &suppressed_input
         };
         // Refill the per-frame AI pathfind budget - only on advancing frames,
@@ -3177,12 +3186,17 @@ impl MissionCore {
             if let Some(launch) = hand_climb.launch {
                 self.physics.launch_player(launch, &mut self.player_handle);
             }
+            // A discrete jump (a Quest hand's lower face button, an injected
+            // `Jump` action) rides the same held channel the runtimes drive,
+            // for exactly one frame - so the controller's edge detection sees
+            // one jump per press however the request arrived.
+            let jump = input_context.jump || std::mem::take(&mut self.button_jump);
             let request = match hand_climb.translation {
                 Some(translation) => crate::physics::PlayerMoveRequest::HandClimb { translation },
                 None => crate::physics::PlayerMoveRequest::Walk {
                     movement: forward + cgmath::vec3(0.0, up_value, 0.0),
                     facing,
-                    jump_pressed: input_context.jump,
+                    jump_pressed: jump,
                     // Push-to-climb is the FLAT climb input; VR's hands are
                     // its own (see `vr_climb`).
                     push_to_climb: game_options.presentation_mode == crate::PresentationMode::Flat,
@@ -4980,6 +4994,11 @@ impl MissionCore {
                     // SETTING opens the weapon settings one: the arrows step,
                     // the readout itself offers the described grid.
                     ReadoutButton::PsiSelect => vec![Effect::OpenPsiPowers],
+                    // The pause menu lives above the scene, so it is reached
+                    // through a global effect rather than opened from here.
+                    ReadoutButton::SystemMenu => {
+                        vec![Effect::GlobalEffect(GlobalEffect::OpenPauseMenu)]
+                    }
                 }
             }
             // Double-click = equip/use, acting on the still-contained item -
@@ -5964,6 +5983,11 @@ impl MissionCore {
                     }
                 }
 
+                // One frame of the held jump channel, consumed by the next
+                // movement pass - the effect is handled after this frame's,
+                // and the physics controller wants a rising edge, not a level.
+                Effect::Jump => self.button_jump = true,
+
                 Effect::EjectClip { hand } => {
                     if let Some(weapon) =
                         crate::wielded_weapon::hand_weapon_target(&self.world, hand)
@@ -5994,25 +6018,18 @@ impl MissionCore {
                         Some(crate::input::InputAction::ReadLastUnreadLog) => {
                             effects.push_front(Effect::ReadLastUnreadLog)
                         }
+                        // The lower button, whatever the hand holds.
+                        Some(crate::input::InputAction::Jump) => effects.push_front(Effect::Jump),
                         // The gun goes with the hand that pressed, so a
-                        // dual-wielding player ejects the magazine they meant.
-                        Some(crate::input::InputAction::EjectClip) => {
-                            effects.push_front(Effect::EjectClip { hand: Some(hand) })
-                        }
+                        // dual-wielding player switches the mode they meant.
                         Some(crate::input::InputAction::CycleGunSetting) => {
                             effects.push_front(Effect::CycleGunSetting { hand: Some(hand) })
                         }
-                        // The amp's buttons: lower opens the selection MFD,
-                        // upper quick-cycles. Neither names a hand - there is
-                        // one psi selection however many amps are held.
+                        // The amp hand's upper button opens the selection MFD.
+                        // It names no hand - there is one psi selection
+                        // however many amps are held.
                         Some(crate::input::InputAction::SelectPsiPower) => {
                             effects.push_front(Effect::OpenPsiPowers)
-                        }
-                        Some(crate::input::InputAction::CyclePsiPower) => {
-                            effects.push_front(Effect::StepPsiSelection {
-                                axis: crate::psi::PsiSelectionAxis::Any,
-                                forward: true,
-                            })
                         }
                         None => {}
                         Some(action) => warn!("unroutable hand button action: {action}"),

--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -27,7 +27,7 @@ use crate::{
     },
 };
 
-use super::cutscene_skip::{self, SkipHold};
+use super::cutscene_skip::{RingArt, SkipHold};
 
 #[cfg(feature = "ffmpeg")]
 use engine_ffmpeg::{AudioPlayer, VideoPlayer};
@@ -58,9 +58,9 @@ pub struct CutscenePlayerScene {
     completion_emitted: bool,
     /// Holding either trigger finishes the cutscene early.
     skip_hold: SkipHold,
-    /// The generated progress-ring art, keyed on the fill step it was built
+    /// The generated progress-ring art, cached by the fill step it was built
     /// for, so a held trigger does not re-upload it every frame.
-    ring_art: Option<(u32, Rc<dyn TextureTrait>)>,
+    ring_art: RingArt,
     #[cfg(feature = "ffmpeg")]
     audio_handle: engine::audio::AudioHandle,
     #[cfg(feature = "ffmpeg")]
@@ -187,7 +187,7 @@ impl CutscenePlayerScene {
                 on_complete,
                 completion_emitted: false,
                 skip_hold: SkipHold::default(),
-                ring_art: None,
+                ring_art: RingArt::default(),
                 audio_handle,
                 video_player,
             });
@@ -208,7 +208,7 @@ impl CutscenePlayerScene {
                 on_complete,
                 completion_emitted: false,
                 skip_hold: SkipHold::default(),
-                ring_art: None,
+                ring_art: RingArt::default(),
             })
         }
     }
@@ -281,32 +281,10 @@ impl CutscenePlayerScene {
     }
 
     /// The radial hold-to-skip progress ring, drawn on the video screen while
-    /// the trigger is touched.
+    /// the trigger is touched. The ring is the shared hold readout; only where
+    /// it hangs is the cutscene's own.
     fn build_skip_ring(&mut self, basis: &ScreenBasis, alpha: f32) -> SceneObject {
-        // The art changes only when the fill crosses a step, so a held trigger
-        // rasterizes and uploads a few dozen textures rather than one a frame.
-        let step = cutscene_skip::ring_step(self.skip_hold.progress());
-        let texture = match &self.ring_art {
-            Some((cached_step, texture)) if *cached_step == step => texture.clone(),
-            _ => {
-                let texture: Rc<dyn TextureTrait> = Rc::new(init_from_memory2(
-                    cutscene_skip::ring_texture_for_step(step),
-                    &TextureOptions {
-                        wrap: false,
-                        ..Default::default()
-                    },
-                ));
-                self.ring_art = Some((step, texture.clone()));
-                texture
-            }
-        };
-
-        // Held just under fully opaque: the material only joins the blended
-        // pass when it is transparent at all, and the ring is nothing but
-        // per-pixel alpha.
-        let transparency = (1.0 - alpha).max(0.02);
-        let material = basic_material::create(texture, 1.0, transparency);
-        let mut quad = SceneObject::new(material, Box::new(engine::scene::quad::create()));
+        let mut quad = self.ring_art.quad(self.skip_hold.progress(), alpha);
 
         let size = basis.height * RING_SIZE;
         let center = basis.panel.center

--- a/shock2vr/src/scenes/cutscene_skip.rs
+++ b/shock2vr/src/scenes/cutscene_skip.rs
@@ -1,10 +1,19 @@
 //! Hold-to-skip for the cutscene player: the hold latch and the radial progress
 //! art it draws. Both are pure, so the timing rule and the ring are testable
 //! without a running game.
+//!
+//! The ring itself is the game's one hold-progress readout: [`RingArt`] draws
+//! it for the cutscene skip (on the video screen) and for the Menu button's
+//! long press (head-locked). Only the placement differs.
 
+use std::rc::Rc;
 use std::time::Duration;
 
-use engine::texture_format::{PixelFormat, RawTextureData};
+use engine::{
+    scene::{SceneObject, basic_material},
+    texture::{TextureOptions, TextureTrait, init_from_memory2},
+    texture_format::{PixelFormat, RawTextureData},
+};
 
 /// How long either trigger must be held to skip. Long enough that a trigger
 /// brushed on the way into a cutscene does not dismiss it.
@@ -70,22 +79,63 @@ impl SkipHold {
     }
 }
 
+/// The ring's art, rasterized on demand and cached by fill step, plus the quad
+/// that carries it. Shared by every hold in the game, so the readout cannot
+/// look like two different things - the caller supplies only the transform.
+#[derive(Default)]
+pub struct RingArt {
+    cached: Option<(u32, Rc<dyn TextureTrait>)>,
+}
+
+impl RingArt {
+    /// A UNIT quad (1x1, centered, facing +Z) showing the ring filled to
+    /// `progress` at `alpha` opacity. The caller places and scales it.
+    pub fn quad(&mut self, progress: f32, alpha: f32) -> SceneObject {
+        // The art changes only when the fill crosses a step, so a held button
+        // rasterizes and uploads a few dozen textures rather than one a frame.
+        let step = ring_step(progress);
+        let texture = match &self.cached {
+            Some((cached_step, texture)) if *cached_step == step => texture.clone(),
+            _ => {
+                let texture: Rc<dyn TextureTrait> = Rc::new(init_from_memory2(
+                    ring_texture_for_step(step),
+                    &TextureOptions {
+                        wrap: false,
+                        ..Default::default()
+                    },
+                ));
+                self.cached = Some((step, texture.clone()));
+                texture
+            }
+        };
+
+        // Held just under fully opaque: the material only joins the blended
+        // pass when it is transparent at all, and the ring is nothing but
+        // per-pixel alpha.
+        let transparency = (1.0 - alpha).max(0.02);
+        SceneObject::new(
+            basic_material::create(texture, 1.0, transparency),
+            Box::new(engine::scene::quad::create()),
+        )
+    }
+}
+
 /// Edge length of the generated ring texture. Small: the ring draws a few dozen
 /// pixels across, so anything larger is only oversampling.
 const RING_TEXTURE_SIZE: usize = 64;
 
-/// Steps the fill is drawn in. The art changes only when the arc crosses one, so
-/// a caller keyed on [`ring_step`] rebuilds and re-uploads the texture this many
-/// times over a hold rather than once per frame.
-pub const RING_STEPS: u32 = 48;
+/// Steps the fill is drawn in. The art changes only when the arc crosses one,
+/// so a hold rebuilds and re-uploads the texture this many times rather than
+/// once per frame.
+const RING_STEPS: u32 = 48;
 
 /// Which step `progress` falls in - the cache key for [`ring_texture`].
-pub fn ring_step(progress: f32) -> u32 {
+fn ring_step(progress: f32) -> u32 {
     (progress.clamp(0.0, 1.0) * RING_STEPS as f32).round() as u32
 }
 
 /// The ring art for a step from [`ring_step`].
-pub fn ring_texture_for_step(step: u32) -> RawTextureData {
+fn ring_texture_for_step(step: u32) -> RawTextureData {
     ring_texture(step as f32 / RING_STEPS as f32)
 }
 
@@ -99,7 +149,7 @@ const TRACK_ALPHA: u8 = 90;
 /// The radial progress ring for a hold `progress` in 0.0..=1.0: a white arc
 /// filling clockwise from twelve o'clock over a faint full-circle track,
 /// transparent everywhere else.
-pub fn ring_texture(progress: f32) -> RawTextureData {
+fn ring_texture(progress: f32) -> RawTextureData {
     let progress = progress.clamp(0.0, 1.0);
     let size = RING_TEXTURE_SIZE;
     let half = size as f32 / 2.0;

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -63,6 +63,11 @@ pub enum GlobalEffect {
     /// Return to the main menu, replacing whatever scene is active.
     ShowMainMenu,
 
+    /// Open the pause menu over the active scene. The scene cannot open it
+    /// itself - the overlay is `Game`'s, and a paused scene is not updated at
+    /// all - so the cyber interface's system button asks for it this way.
+    OpenPauseMenu,
+
     /// Open the Developer screen (live-tunable runtime parameters), replacing
     /// whatever scene is active. Reached from the main menu; the pause menu
     /// hosts the same panel as an overlay page instead, so a mission is never
@@ -391,6 +396,13 @@ pub enum Effect {
     /// interface around the panel (the slot is only presented there), and a
     /// second press is its own inverse - see `Effect::ReadLastUnreadLog`.
     OpenPsiPowers,
+
+    /// Jump once, as [`crate::input::InputAction::Jump`] means it: a Quest
+    /// hand's lower face button, or an injected `Jump` action. The ordinary
+    /// jump is the held `InputContext::jump` channel every runtime provides;
+    /// this latches one frame of it, so the physics controller sees exactly
+    /// one rising edge whichever way the request arrived.
+    Jump,
 
     /// Train the player in a psi power (insert its template id into
     /// `PlayerPsiKnownPowers`), making it selectable and castable - for

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -366,6 +366,8 @@ pub mod render_source {
     /// entry/exit ramp - layered alongside (not merged with) [`HIT_FEEDBACK`],
     /// so a hit still reads while the interface is open.
     pub const USE_MODE_VIGNETTE: &str = "use_mode_vignette";
+    /// The Menu button's hold-progress ring, promising the pause menu.
+    pub const MENU_HOLD_RING: &str = "menu_hold_ring";
 }
 
 /// A tag that records only which render path produced an object.

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -417,6 +417,30 @@ export class InputApi {
     );
   }
 
+  /**
+   * Press a discrete action and KEEP it held, so a hold-to-activate button can
+   * be driven without a controller (the Menu button's long press). Step to let
+   * the hold accumulate, then `release`.
+   */
+  async hold(action: InputAction): Promise<CommandResult> {
+    return unwrap(
+      await this.client.post<CommandResult>("/v1/input/action", {
+        action,
+        hold: true,
+      }),
+    );
+  }
+
+  /** Release an action held by `hold`. */
+  async release(action: InputAction): Promise<CommandResult> {
+    return unwrap(
+      await this.client.post<CommandResult>("/v1/input/action", {
+        action,
+        hold: false,
+      }),
+    );
+  }
+
   /** List action names accepted by trigger(). */
   async actions(): Promise<string[]> {
     const result = await this.client.get<{ actions: string[] }>("/v1/input/actions");

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -32,6 +32,10 @@ export type InputAction =
   | "LeftHandUpperButton"
   | "RightHandLowerButton"
   | "RightHandUpperButton"
+  // The raw left Menu button: a short press toggles the cyber interface, a
+  // long one (>= 0.5 s, held via input.hold) opens the pause menu.
+  | "MenuButton"
+  | "Jump"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 

--- a/tools/shock2-sdk/test/ammo-readout.e2e.test.ts
+++ b/tools/shock2-sdk/test/ammo-readout.e2e.test.ts
@@ -33,8 +33,16 @@ async function button(game: GameServer, label: string): Promise<UiElement> {
   return found;
 }
 
+/**
+ * The GAUGE's controls. The interface canvas also carries a `system_menu`
+ * button (the pause menu's visible way in), which is always there whatever is
+ * wielded and so says nothing about the readout - `vr-buttons-v2.e2e.test.ts`
+ * covers it.
+ */
 async function labels(game: GameServer): Promise<string[]> {
-  return (await readout(game)).map((e) => e.label ?? "");
+  return (await readout(game))
+    .map((e) => e.label ?? "")
+    .filter((label) => label !== "system_menu");
 }
 
 test(

--- a/tools/shock2-sdk/test/psi-powers-mfd.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-powers-mfd.e2e.test.ts
@@ -246,7 +246,7 @@ test(
 );
 
 test(
-  "in VR the amp hand's lower button opens the cyber interface onto the panel",
+  "in VR the amp hand's upper button opens the cyber interface onto the panel",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -271,7 +271,7 @@ test(
     );
 
     assert.equal((await game.ui.state()).mode, "shooter");
-    await game.input.trigger("RightHandLowerButton");
+    await game.input.trigger("RightHandUpperButton");
     await game.step({ frames: 8 });
 
     const ui = await game.ui.state();
@@ -289,12 +289,13 @@ test(
     await flick(game, "left", [0, 1]);
     assert.equal(await browsedTier(game), 2, "up steps the tier");
 
-    // The button is a true inverse of itself: it opened the interface, so it
-    // closes the whole thing rather than leaving the inventory strip up.
+    // The interface takes both buttons back while it is up, so the LOWER
+    // button closes the whole thing rather than jumping - the upper one is the
+    // log reader in there, not a second way out.
     await game.input.trigger("RightHandLowerButton");
     await game.step({ frames: 8 });
     const closed = await game.ui.state();
-    assert.equal(closed.mode, "shooter", "a second press closes the interface");
+    assert.equal(closed.mode, "shooter", "the lower button closes the interface");
     assert.equal(closed.active_panel, null);
   },
 );

--- a/tools/shock2-sdk/test/vr-buttons-v2.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-buttons-v2.e2e.test.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiState, Vec3 } from "../src/index.js";
+import { canvasCenter, clickCanvasWithRay, requirePanelPose } from "./helpers/ui.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// The v2 Touch mapping:
+//
+//   | hand holds | lower (X/A) | upper (Y/B) |
+//   |------------|-------------|-------------|
+//   | anything   | jump        | -           |
+//   | empty/melee/other | jump | last unread log |
+//   | gun        | jump        | toggle fire mode |
+//   | psi amp    | jump        | open the psi selector |
+//
+// ...plus the left Menu button, which is now BOTH the way in and out of the
+// cyber interface (short press) and the way to the pause menu (held 0.5 s).
+//
+// Negative-first: on the parent branch the lower buttons open the cyber
+// interface (they never jump), the amp's selector is on the LOWER button, the
+// Menu button toggles the pause menu on its edge with no short/long split at
+// all, and the interface canvas carries no system button - so every assertion
+// below fails there.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_BUTTONS_V2_PORT ?? 8742);
+
+/** The debug pistol `DebugCycleWeapon` spawns first. */
+const PISTOL = -17;
+/** The Psi Amp player weapon. */
+const PSI_AMP = -247;
+
+/** How long a hold must run to cross `MENU_LONG_PRESS` (0.5 s at 60 Hz). */
+const LONG_PRESS_FRAMES = 40;
+/** Comfortably under it. */
+const SHORT_PRESS_FRAMES = 6;
+
+async function uiMode(game: GameServer): Promise<string> {
+  return (await game.ui.state()).mode;
+}
+
+async function press(game: GameServer, action: string): Promise<void> {
+  await game.input.trigger(action);
+  await game.step({ frames: 5 });
+}
+
+/** Hold the Menu button for `frames`, then let it go. */
+async function holdMenu(game: GameServer, frames: number): Promise<void> {
+  await game.input.hold("MenuButton");
+  await game.step({ frames });
+  await game.input.release("MenuButton");
+  await game.step({ frames: 5 });
+}
+
+/** The highest the player's feet reach over the next `frames` frames. */
+async function peakHeight(game: GameServer, frames: number): Promise<number> {
+  let peak = (await game.player.position()).y;
+  for (let i = 0; i < frames; i++) {
+    await game.step({ frames: 1 });
+    peak = Math.max(peak, (await game.player.position()).y);
+  }
+  return peak;
+}
+
+/** Take `template` in the VR right hand. */
+async function grabWeapon(game: GameServer, template: number): Promise<number> {
+  // Diffed against the entity list: the debug scenes already stock one of every
+  // gun, so a plain template search could hand back the scenery one.
+  const weapon = await cycleToWeapon(game, (e) => e.template_id === template);
+  await aimVrHandAt(game, weapon.position as Vec3, 0.3);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    weapon.id,
+    "the VR right hand must hold the weapon",
+  );
+  return weapon.id;
+}
+
+function control(ui: UiState, label: string): UiElement {
+  const found = ui.readout.find((e) => e.label === label);
+  assert.ok(
+    found,
+    `expected a "${label}" readout control, got ${ui.readout.map((e) => e.label)}`,
+  );
+  return found;
+}
+
+test(
+  "a lower button jumps - empty-handed, and with a gun in that hand",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 60 });
+
+    // Grounded and settled: whatever height the player rises to next came from
+    // the button.
+    const resting = (await game.player.position()).y;
+    assert.ok(
+      (await peakHeight(game, 20)) - resting < 0.05,
+      "the player must be standing still before the button is pressed",
+    );
+
+    await game.input.trigger("RightHandLowerButton");
+    const empty = await peakHeight(game, 30);
+    assert.ok(
+      empty > resting + 0.2,
+      `right A with an empty hand must jump (rested ${resting}, peaked ${empty})`,
+    );
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "and it must NOT open the cyber interface any more",
+    );
+
+    // The whole point of the row: a hand full of gun still jumps.
+    await game.step({ frames: 60 });
+    await grabWeapon(game, PISTOL);
+    await game.step({ frames: 30 });
+    const armed = (await game.player.position()).y;
+    await game.input.trigger("RightHandLowerButton");
+    const withGun = await peakHeight(game, 30);
+    assert.ok(
+      withGun > armed + 0.2,
+      `the gun hand's lower button must still jump (rested ${armed}, peaked ${withGun})`,
+    );
+
+    // ...and so does the other hand's, with the gun still held.
+    await game.step({ frames: 60 });
+    const before = (await game.player.position()).y;
+    await game.input.trigger("LeftHandLowerButton");
+    assert.ok(
+      (await peakHeight(game, 30)) > before + 0.2,
+      "the free hand's lower button jumps too",
+    );
+  },
+);
+
+test(
+  "the Menu button jacks in on a short press and pauses on a long one",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    assert.equal(await uiMode(game), "shooter");
+
+    await holdMenu(game, SHORT_PRESS_FRAMES);
+    assert.equal(
+      await uiMode(game),
+      "use",
+      "a short Menu press must open the cyber interface",
+    );
+    assert.equal((await game.info()).paused, false, "and must not pause");
+
+    await holdMenu(game, SHORT_PRESS_FRAMES);
+    assert.equal(await uiMode(game), "shooter", "a second short press closes it");
+
+    // The long press: the pause menu opens the moment the threshold is
+    // crossed, and the release that follows must NOT then toggle the
+    // interface - the defect a press-toggle plus a hold would have.
+    await game.input.hold("MenuButton");
+    await game.step({ frames: LONG_PRESS_FRAMES });
+    assert.equal(
+      (await game.info()).paused,
+      true,
+      "holding the Menu button past the threshold must open the pause menu",
+    );
+    await game.input.release("MenuButton");
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).paused,
+      true,
+      "the release must be swallowed, not close the menu it just opened",
+    );
+
+    // Leaving the menu the same way, and the interface was never toggled.
+    await holdMenu(game, SHORT_PRESS_FRAMES);
+    assert.equal((await game.info()).paused, false, "a short press closes it again");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "the whole long press must never have opened the interface",
+    );
+
+    // A single-shot injection (no hold at all) is the ordinary short press.
+    await press(game, "MenuButton");
+    assert.equal(await uiMode(game), "use");
+    await press(game, "MenuButton");
+    assert.equal(await uiMode(game), "shooter");
+  },
+);
+
+test(
+  "an upper button belongs to the weapon in its own hand",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 2,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    await grabWeapon(game, PISTOL);
+
+    const before = (await game.info()).player.wielded_gun_setting_header;
+    await press(game, "RightHandUpperButton");
+    assert.notEqual(
+      (await game.info()).player.wielded_gun_setting_header,
+      before,
+      "right B on the gun hand must toggle that gun's fire mode",
+    );
+
+    // The free hand's upper button is still the log reader, not the gun's.
+    const header = (await game.info()).player.wielded_gun_setting_header;
+    await press(game, "LeftHandUpperButton");
+    assert.equal(
+      (await game.info()).player.wielded_gun_setting_header,
+      header,
+      "the free hand's button must not reach the other hand's gun",
+    );
+  },
+);
+
+test(
+  "the psi amp's upper button opens the power selection MFD",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+      port: basePort + 3,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    await grabWeapon(game, PSI_AMP);
+
+    assert.equal((await game.ui.state()).active_panel, null);
+    // The selector moved UP from the lower button, which is jump now.
+    await press(game, "RightHandUpperButton");
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.ui.state()).active_panel?.name,
+      "Psi Powers",
+      "the amp hand's upper button must dock the psi selection MFD",
+    );
+  },
+);
+
+test(
+  "the interface's system button opens the pause menu under the VR ray",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 4,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    await press(game, "MenuButton");
+    const ui = await game.ui.state();
+    assert.equal(ui.mode, "use");
+
+    // Drawn where it is clickable: one list feeds both.
+    const button = control(ui, "system_menu");
+    assert.deepEqual(button.rect, [288, 372, 64, 36]);
+    assert.ok(
+      ui.readout_elements.some(
+        (e) => JSON.stringify(e.rect) === JSON.stringify(button.rect),
+      ),
+      "the system button must be drawn at the rect it is hit-tested at",
+    );
+
+    assert.equal((await game.info()).paused, false);
+    await clickCanvasWithRay(
+      game,
+      requirePanelPose(ui),
+      canvasCenter(button),
+      "left",
+    );
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).paused,
+      true,
+      "the ray on the system button must open the pause menu",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
@@ -6,13 +6,14 @@ import type { Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
 import { cycleToWeapon } from "./helpers/weapon.js";
 
-// The Touch face buttons are per-hand and contextual: lower (left X / right A)
-// and upper (left Y / right B) mean the player-owned panels while that hand is
-// free, and belong to the weapon while it holds one. The interface outranks
-// both, so the press that opened it always closes it.
+// The Touch face buttons: the LOWER one (left X / right A) is jump on both
+// hands whatever they hold, and the UPPER one (left Y / right B) is contextual
+// - the log reader while that hand is free, the weapon's own control while it
+// holds one. The cyber interface outranks both, so the buttons can always shut
+// it again.
 //
-// Negative-first: on the parent these actions do not exist at all
-// (`/v1/input/action` rejects the name), and right A/B carried nothing.
+// The interface itself is reached from the Menu button now
+// (`vr-buttons-v2.e2e.test.ts`), which is what these tests use to open it.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8656);
 
@@ -46,7 +47,7 @@ async function grabPistol(game: GameServer): Promise<number> {
 }
 
 test(
-  "a free right hand's lower button opens and closes the cyber interface",
+  "a free hand's upper button reaches the log reader, on either hand",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
   async () => {
     await using game = await GameServer.launch({
@@ -57,31 +58,30 @@ test(
     await game.step({ frames: 30 });
     assert.equal(await uiMode(game), "shooter");
 
-    // Right A, mirroring left X - the new half of the symmetry.
-    await press(game, "RightHandLowerButton");
-    assert.equal(
-      await uiMode(game),
-      "use",
-      "right A with an empty hand must open the cyber interface",
-    );
-
+    // No lower button opens the interface any more: they jump.
     await press(game, "RightHandLowerButton");
     assert.equal(
       await uiMode(game),
       "shooter",
-      "right A must close what it opened",
+      "right A must not open the cyber interface",
+    );
+    await press(game, "LeftHandLowerButton");
+    assert.equal(
+      await uiMode(game),
+      "shooter",
+      "and neither must left X",
     );
 
-    // The left hand's own buttons are unchanged.
-    await press(game, "LeftHandLowerButton");
-    assert.equal(await uiMode(game), "use", "left X must still open it");
-    await press(game, "LeftHandLowerButton");
+    // The Menu button is the way in and out.
+    await press(game, "MenuButton");
+    assert.equal(await uiMode(game), "use");
+    await press(game, "MenuButton");
     assert.equal(await uiMode(game), "shooter");
   },
 );
 
 test(
-  "a gun takes its own hand's buttons, and only its own",
+  "a gun takes its own hand's upper button, and only its own",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
   async () => {
     await using game = await GameServer.launch({
@@ -92,27 +92,23 @@ test(
     await game.step({ frames: 30 });
     await grabPistol(game);
 
-    // The gun hand's buttons are the gun's now - they handle the weapon
-    // (eject, fire mode) rather than reaching the panels.
-    await press(game, "RightHandLowerButton");
-    assert.equal(
-      await uiMode(game),
-      "shooter",
-      "right A must not open the interface while that hand holds a gun",
-    );
+    // The gun hand's upper button handles the weapon rather than reaching a
+    // player-owned panel.
+    const header = (await game.info()).player.wielded_gun_setting_header;
     await press(game, "RightHandUpperButton");
-    assert.equal(
-      await uiMode(game),
-      "shooter",
-      "right B must not open the reader while that hand holds a gun",
+    assert.notEqual(
+      (await game.info()).player.wielded_gun_setting_header,
+      header,
+      "right B must switch the fire mode of the gun in that hand",
     );
 
-    // The free hand still owns the panels: per-hand, not per-player.
-    await press(game, "LeftHandLowerButton");
+    // The free hand keeps its own: per-hand, not per-player.
+    const switched = (await game.info()).player.wielded_gun_setting_header;
+    await press(game, "LeftHandUpperButton");
     assert.equal(
-      await uiMode(game),
-      "use",
-      "the free left hand must still reach the interface",
+      (await game.info()).player.wielded_gun_setting_header,
+      switched,
+      "the free left hand must not reach the right hand's gun",
     );
   },
 );
@@ -129,17 +125,17 @@ test(
     await game.step({ frames: 30 });
     const pistol = await grabPistol(game);
 
-    await press(game, "LeftHandLowerButton");
-    assert.equal(await uiMode(game), "use", "the free hand opens it");
+    await press(game, "MenuButton");
+    assert.equal(await uiMode(game), "use", "the Menu button opens it");
     assert.equal(
       (await game.info()).player.right_hand_entity_id,
       pistol,
       "the gun stays held while the interface is up (it is safed, not taken)",
     );
 
-    // Mode first: the gun hand's own button closes the interface rather than
-    // being swallowed by the weapon it holds - otherwise picking a gun up
-    // inside the interface could strand the player in it.
+    // Mode first: the gun hand's own lower button closes the interface rather
+    // than jumping - otherwise the buttons would mean one thing inside a menu
+    // and another outside it, on a canvas the player is pointing at.
     await press(game, "RightHandLowerButton");
     assert.equal(
       await uiMode(game),
@@ -147,12 +143,12 @@ test(
       "right A must close the interface even with a gun in that hand",
     );
 
-    // ...and once it is closed, that button belongs to the gun again.
+    // ...and once it is closed, that button is jump again, not a re-open.
     await press(game, "RightHandLowerButton");
     assert.equal(
       await uiMode(game),
       "shooter",
-      "with the interface down the gun hand's button is the gun's again",
+      "with the interface down the lower button jumps rather than re-opening it",
     );
   },
 );
@@ -167,29 +163,31 @@ test(
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
+    await press(game, "MenuButton");
+    assert.equal(await uiMode(game), "use");
 
-    // The chord IS right A+B, and a chord is pressed one button at a time -
-    // so while its developer option is on, A must not open the interface on
-    // the way to A+B.
+    // The chord IS right A+B, and a chord is pressed one button at a time - so
+    // while its developer option is on, A must not close the interface on the
+    // way to A+B.
     await game.devParams.set("free_camera", 1);
     await game.step({ frames: 2 });
     await press(game, "RightHandLowerButton");
     assert.equal(
       await uiMode(game),
-      "shooter",
+      "use",
       "right A must be inert while the free-camera chord is armed",
     );
     await press(game, "RightHandUpperButton");
-    assert.equal(await uiMode(game), "shooter", "and so must right B");
+    assert.equal(await uiMode(game), "use", "and so must right B");
 
     // The left hand keeps its buttons - the chord is right-handed.
     await press(game, "LeftHandLowerButton");
     assert.equal(
       await uiMode(game),
-      "use",
+      "shooter",
       "the left hand is unaffected by the chord",
     );
-    await press(game, "LeftHandLowerButton");
+    await press(game, "MenuButton");
 
     // Disarmed again, the right hand gets them back.
     await game.devParams.set("free_camera", 0);
@@ -197,8 +195,8 @@ test(
     await press(game, "RightHandLowerButton");
     assert.equal(
       await uiMode(game),
-      "use",
-      "right A works again once the chord is disarmed",
+      "shooter",
+      "right A closes the interface again once the chord is disarmed",
     );
   },
 );

--- a/tools/shock2-sdk/test/vr-eject-clip.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-eject-clip.e2e.test.ts
@@ -6,13 +6,13 @@ import type { EntitySummary, Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
 import { cycleToWeapon } from "./helpers/weapon.js";
 
-// The gun hand's LOWER face button (right A / left X) ejects that gun's
-// magazine: the rounds go back to the backpack reserve as clips of the ammo
-// type they already are, and nothing is dropped on the floor.
+// Ejecting a magazine puts its rounds back in the backpack reserve as clips of
+// the ammo type they already are, and drops nothing on the floor.
 //
-// Negative-first: on the parent a gun hand's buttons resolve to nothing at all
-// (`vr-contextual-buttons` asserts exactly that), so every assertion below
-// fails - the magazine stays full and no clip reaches the backpack.
+// It has NO controller button: the lower face buttons are jump now, and in VR
+// the eject is reached through the weapon settings MFD's UNLOAD. The action
+// itself is unchanged and still reachable from the flat key, HTTP and the SDK,
+// which is what these tests drive.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8676);
 
@@ -82,13 +82,13 @@ async function grabWeapon(
   return weapon;
 }
 
-async function pressRightLower(game: GameServer): Promise<void> {
-  await game.input.trigger("RightHandLowerButton");
+async function eject(game: GameServer): Promise<void> {
+  await game.input.trigger("EjectClip");
   await game.step({ frames: 5 });
 }
 
 test(
-  "the gun hand's lower button ejects that gun's magazine into the backpack",
+  "ejecting a gun's magazine puts its rounds in the backpack",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
   async () => {
     await using game = await GameServer.launch({
@@ -108,7 +108,17 @@ test(
       "and carries no reserve of its own",
     );
 
-    await pressRightLower(game);
+    // No face button ejects any more - the gun hand's lower button jumps -
+    // so a press must leave the magazine exactly where it is.
+    await game.input.trigger("RightHandLowerButton");
+    await game.step({ frames: 5 });
+    assert.equal(
+      await ammoOf(game, pistol),
+      loaded,
+      "the gun hand's lower button must not eject anything",
+    );
+
+    await eject(game);
     assert.equal(await ammoOf(game, pistol), 0, "the magazine is emptied");
     assert.equal(
       await reserveRounds(game),
@@ -126,8 +136,8 @@ test(
       "the eject leaves no clip lying in the world",
     );
 
-    // Pressing an empty gun's button again is a no-op, not a second free clip.
-    await pressRightLower(game);
+    // Ejecting an empty gun again is a no-op, not a second free clip.
+    await eject(game);
     assert.equal(await ammoOf(game, pistol), 0);
     assert.equal(
       await reserveRounds(game),
@@ -144,25 +154,11 @@ test(
     const refilled = await ammoOf(game, pistol);
     assert.ok(refilled > 0, "the pistol refills from its own ejected rounds");
 
-    // The button belongs to the hand that PRESSED it: the empty left hand's
-    // lower button reaches the interface, and leaves the right gun loaded.
-    await game.input.trigger("LeftHandLowerButton");
-    await game.step({ frames: 5 });
-    assert.equal((await game.ui.state()).mode, "use");
-    assert.equal(
-      await ammoOf(game, pistol),
-      refilled,
-      "the free hand's button must not eject the other hand's gun",
-    );
-    await game.input.trigger("LeftHandLowerButton");
-    await game.step({ frames: 5 });
-    assert.equal((await game.ui.state()).mode, "shooter");
-
     // The merge path: with a stack already carried the rounds join it instead
     // of minting a second clip.
     const stacksBefore = (await carriedClips(game)).length;
     const reserveBefore = await reserveRounds(game);
-    await pressRightLower(game);
+    await eject(game);
     assert.equal(await ammoOf(game, pistol), 0);
     assert.equal(
       await reserveRounds(game),
@@ -192,7 +188,7 @@ test(
     const before = await ammoOf(game, laser);
     const carriedBefore = (await game.player.inventory()).items.length;
 
-    await pressRightLower(game);
+    await eject(game);
     assert.equal(
       await ammoOf(game, laser),
       before,

--- a/tools/shock2-sdk/test/vr-interface-readouts.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-interface-readouts.e2e.test.ts
@@ -117,7 +117,7 @@ test(
     // ...and every control the pistol offers is on it, clickable.
     assert.deepEqual(
       ui.readout.map((e) => e.label),
-      ["gun_setting", "reload", "cycle_ammo"],
+      ["gun_setting", "reload", "cycle_ammo", "system_menu"],
     );
     assert.equal(
       control(ui, "gun_setting").text,


### PR DESCRIPTION
The Touch's lower face buttons were the way into the cyber interface and, on a
gun hand, the way to eject its magazine. Both were wrong for the button a player
reaches for with both hands full: jumping was on the right thumbstick click,
where it competes with locomotion, and an eject on a mis-press unloads the gun
you are fighting with. So the pair is re-cut around one rule - **lower is jump,
always** - and the left Menu button, which the Quest gives us exactly one of,
carries the interface and the pause menu on a short/long split.

## The v2 table

| that hand holds | lower (X/A) | upper (Y/B) |
| --- | --- | --- |
| **anything at all** | `Jump` | - |
| nothing, melee, or any other item | `Jump` | `ReadLastUnreadLog` |
| a gun | `Jump` | `CycleGunSetting` - that hand's gun |
| the psi amp | `Jump` | `SelectPsiPower` - the selection MFD |

Lower is unconditional, so two guns no longer cost the player their jump; only
the upper button is contextual. **Mode first** is unchanged: while the cyber
interface is up, lower keeps its close (rather than jumping) and upper the log
reader, on both hands whatever is held, so the interface can always be shut.
The free-camera chord still suppresses the right hand's two buttons while its
developer option is on - `A` is jump now, and must not fire on the way to A+B.

## The Menu button's hold rule

`MenuButton` is bound raw and split by `input::MenuHold`
(`shock2vr/src/input/menu_hold.rs`, threshold `MENU_LONG_PRESS` = **0.5 s**):

- **short press** - toggle the cyber interface (what left `X` used to do). It
  fires on **release**, so a long press never also jacks in on its way past the
  threshold.
- **long press** - open the pause menu, fired the moment the threshold is
  **crossed**, not on release; the release that follows is swallowed.
- pressed while the pause menu is already up, a short press closes it (the
  paused scene swallows every other action, so nothing else could).

While it is held, the **cutscene skip's own progress ring** fills head-locked in
front of the player, 1.5 units ahead and slightly below the gaze. The drawing is
shared, not copied: `cutscene_skip::RingArt` now owns the cached texture and the
unit quad, and both callers supply only a transform.

## What lost its button, and why

- **`EjectClip`** - the settings MFD's UNLOAD covers it, and an accidental
  unload mid-fight is worse than no button at all.
- **`CyclePsiPower`** - the psi MFD's stick navigation covers it.

Both actions are untouched and still reachable from their flat keys, HTTP and
the SDK; only the Quest resolution rows changed. The **right thumbstick click**
is now deliberately unbound (jump moved off it); the left click is still crouch.

## The interface's pause affordance

A hold is not discoverable, so the interface canvas carries a visible **MENU**
button at **`(288, 372)` 64x36** (IFBTN00.PCX + label) - the free column between
the inventory strip (`(2,0)` 636x121), the left MFD slot (`(2,124)` 188x300),
the reserved right slot (x 450) and the bottom readouts (y 414), centred on the
640-wide canvas. It is emitted by `hud/readouts.rs` and hit-tested from the same
`readouts::buttons` list #1267 unified, so the drawn rect and the clickable rect
cannot diverge, both presentations get it (flat as a harmless extra - `Esc`
still works), and `/v1/ui` reports it as `readout` label `system_menu`. It asks
for the menu through the new `GlobalEffect::OpenPauseMenu`, since the overlay is
`Game`'s, not the scene's.

## Tests

Unit (`cargo test -p shock2vr --lib`: **1311 passed, 0 failed**):

- `hand_buttons`: `the_lower_button_jumps_whatever_the_hand_holds` (both hands x
  all five held kinds), the three upper rows, the interface override, and
  `no_button_ejects_a_clip_or_quick_cycles_a_power`.
- `menu_hold`: short fires on release, a long press fires once at the threshold
  and swallows its release, a release just under is still short, a press after a
  long one starts over, an unpressed button decides nothing, one enormous frame
  cannot complete a hold, cancelling a press in flight decides nothing, progress
  runs 0..1 and stops once the menu is promised.
- `readouts`: `the_system_button_is_drawn_and_clickable_at_the_same_rect` and
  `the_system_button_collides_with_nothing_on_the_canvas`.

e2e - new `tools/shock2-sdk/test/vr-buttons-v2.e2e.test.ts` (5 tests, VR,
`debug_weapons` / `debug_psi`): a lower button jumps empty-handed, with a gun in
that hand, and from the other hand while the gun is held; the Menu button jacks
in short / pauses long with the release swallowed and the interface never
toggled; the gun hand's upper button switches its fire mode and the free hand's
does not; the amp hand's upper button docks the psi MFD; the interface's system
button opens the pause menu under the VR ray. **Negative-first: 4 of the 5 fail
on `feat/vr-forearm-readout-retire`** (the 5th is #1263's fire-mode row, kept as
a regression guard).

Driving a *hold* over HTTP needed one small addition: `POST /v1/input/action`
takes an optional `hold` (`true` presses and keeps it down, `false` releases,
omitted = the previous single-shot press), surfaced as `game.input.hold/release`.

Suites run: `vr-buttons-v2` (5/5), `vr-contextual-buttons` (4/4, rewritten for
v2), `vr-eject-clip` (2/2, its button case now asserts the lower button does
*not* eject and the flat/HTTP path still does), `vr-fire-mode-button` (2/2),
`psi-powers-mfd` (3/3, the amp's VR entry moved to the upper button),
`vr-cyber-interface*` (4 files, 10/10), `vr-audio-log-reader` (3/3),
`vr-interface-readouts` (3/3), `vr-forearm-readouts` (2/2), `ammo-readout`
(4/4), `bio-ammo-full`, `flat-hud`, `weapon-settings-mfd`, `pause-menu`,
`free-camera`, `dev-menu` (**2 known-broken subtests, pre-existing**),
`missions.e2e.test.ts` (**23/23**).

Build: `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p
desktop_runtime -p debug_runtime`, and `cargo apk check` all clean.

## From review

`/xreview` ran single-engine (Codex is rate-limited until Sep 6) plus the
dedicated de-dup pass. No Critical findings; everything below is fixed:

- **The Quest session restart released the four face buttons but not the Menu
  button**, which is now a *stateful hold* - a doff/don with it down would have
  minted a spurious pause menu, and a plain `release` there would have minted a
  spurious interface toggle instead. Added `MenuHold::cancel()` (forget the
  press, decide nothing) and called it alongside the existing latch resets.
- **The ring was drawn where the long press can do nothing** - a frontend
  screen, a transition in flight, a dead player - including a *second* ring
  beside the cutscene player's own. `resolve_menu_button` now cancels and
  returns unless `pause_is_allowed()`, so neither the ring nor the long press
  exists there.
- **A hitch frame could pause on a tap**: wall `elapsed` after a level parse can
  be hundreds of ms, and one such frame crossed the 0.5 s threshold on its own.
  A tick now credits at most `MAX_FRAME_CREDIT` (100 ms).
- **The synthesized `ToggleUseMode`/`TogglePauseMenu` edges leaked into the held
  set** (`InputActionState::trigger` inserts into both, and neither has a Quest
  binding to deliver a release), so they are released immediately after
  triggering.
- **The ring's drop was applied along pawn -Y**, which collapses onto the gaze
  axis when the player looks down - it is view-relative now, falling back to
  world down for an untracked head.
- **The MENU label overran its 38 px plate** in both captures, so the plate is
  64 px wide (which is why its rect is `(288, 372)` rather than `(301, 372)`).
- De-dup: the system button was drawing its own art+label by hand. Both it and
  the gauge's controls now go through one `ammo_panel::draw_button`, so a
  control cannot be drawn one way and hit-tested from another - divergence made
  impossible rather than tested for. (The pass also flagged the eye-locked quad
  transform as a third near-copy of `hit_feedback`'s and `world_dim`'s; left
  alone deliberately - the view-relative drop above makes it a different
  transform, and hoisting a helper would drag two out-of-scope files in.)
- Also: a face button pressed as the player dies no longer hops the corpse (the
  latch is cleared with the rest of the suppressed input), and the ring's
  now-internal helpers dropped their `pub`.


## Media

![Menu button hold — progress ring fills and opens the pause menu](https://gist.githubusercontent.com/tommy-xr/5c0f2643e364c1358f84a220890d14db/raw/menu_hold_demo.gif)

<sub>Holding the left Menu button (VR) fills a head-locked circular progress ring; at 0.5s it opens the pause menu. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep, `hold: true` on `MenuButton`).</sub>

**Cyber interface MENU button — flat/VR parity**

| VR | Flat |
| --- | --- |
| ![MENU button, VR](https://gist.githubusercontent.com/tommy-xr/5c0f2643e364c1358f84a220890d14db/raw/menu-button-vr.png) | ![MENU button, flat](https://gist.githubusercontent.com/tommy-xr/5c0f2643e364c1358f84a220890d14db/raw/menu-button-flat.png) |

<sub>A single (non-held) `MenuButton` press jacks into the cyber interface; the new MENU button renders at the same canvas position (288, 372) in both presentations.</sub>


