### PR TITLE
feat(traits): Speedy, Lethal Weapon, Power Psi, Strong Metabolism, Spatially Aware

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -904,6 +904,10 @@ pub struct PlayerInfo {
     /// Climb state: whether the player is on a ladder/hand hold at all, and
     /// (VR) which hands hold what. See `shock2vr::vr_climb`.
     pub climb: shock2vr::game_scene::DebugClimbState,
+    /// How many automap locations the current mission defines (locations run
+    /// `0..count`), so a caller can tell a partly-explored map from a fully
+    /// revealed one. 0 when the mission has no automap.
+    pub map_location_count: usize,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2424,6 +2424,10 @@ fn capture_frame_snapshot(
                     .debug_scene()
                     .and_then(|scene| scene.player_climb())
                     .unwrap_or_default(),
+                map_location_count: state
+                    .as_ref()
+                    .map(|s| s.map_location_count)
+                    .unwrap_or_default(),
             }
         },
         entity_count,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -565,6 +565,9 @@ pub struct DebugPlayerStatsRequest {
     pub psi_tier: Option<i32>,
     /// Target cyber-module balance (the upgrade currency).
     pub cyber_modules: Option<i32>,
+    /// O/S upgrade trait ids to grant (1..=16), as if picked at a machine.
+    /// Already-owned ids are ignored; the slot cap still applies.
+    pub os_traits: Option<Vec<u8>>,
 }
 
 /// Target skill levels, mirroring `player.stats.skills`. Named fields (rather

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -721,6 +721,10 @@ pub struct PlayerStateSnapshot {
     /// Empty when the scene has no `QuestInfo` or no automap. Persisted per
     /// mission in `QuestInfo`. See `projects/flat-ui-panels.md` §5.
     pub explored_map_locations: Vec<i32>,
+    /// How many automap locations the current mission defines (locations run
+    /// `0..count`), so a caller can tell a partly-explored map from a fully
+    /// revealed one. 0 when the scene has no automap.
+    pub map_location_count: usize,
 }
 
 /// Live player pose attached to a save refusal so automation can diagnose and
@@ -880,6 +884,10 @@ impl Game {
                 .ok()
                 .map(|q| q.explored_map_locations(self.scene_name()))
                 .unwrap_or_default(),
+            map_location_count: world
+                .borrow::<UniqueView<crate::mission::MapLocationCount>>()
+                .map(|count| count.0)
+                .unwrap_or(0),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1411,6 +1411,21 @@ pub struct PsiPowersPanelEntity(pub EntityId);
 #[derive(Unique, Clone, Copy, Default)]
 pub struct PlayerMapLocation(pub Option<i32>);
 
+/// Reveal every automap location of `mission` (Spatially Aware). Shared by the
+/// mission-load re-derive and the live grant, so the two cannot drift.
+fn reveal_whole_map(quests: &mut QuestInfo, mission: &str, location_count: usize) {
+    for location in 0..location_count as i32 {
+        quests.reveal_map_location(mission, location);
+    }
+}
+
+/// How many automap locations this mission's page art defines (locations are
+/// `0..count`). Resolved in both presentations - the flat panel needs the art
+/// itself, and the Spatially Aware O/S upgrade needs the count to reveal
+/// every location whether or not a map panel exists.
+#[derive(Unique, Clone, Copy, Default)]
+pub struct MapLocationCount(pub usize);
+
 /// Global template inheritance hierarchy (template id -> MetaProp parents),
 /// so scripts can answer class questions about entities at runtime - e.g.
 /// picking a projectile's hit spang by whether the victim descends from the
@@ -1771,7 +1786,7 @@ impl MissionCore {
         audio_context: &mut AudioContext<EntityId, String>,
         global_context: &GlobalContext,
         spawn_loc: SpawnLocation,
-        quest_info: QuestInfo,
+        mut quest_info: QuestInfo,
         entity_populator: Box<dyn EntityPopulator>,
         held_item_save_data: HeldItemSaveData,
         game_options: &GameOptions,
@@ -2041,12 +2056,25 @@ impl MissionCore {
         // per-frame SetUI would otherwise materialize an undismissable world
         // quad at the origin.
         world.add_unique(PlayerMapLocation::default());
+        let level_stem = mission.split('.').next().unwrap_or(&mission).to_uppercase();
+        let (map_location_count, revealed_rects, explored_rects) =
+            dark::map::MapChunkData::load_from_mission(asset_cache, &level_stem)
+                .map(|data| (data.chunk_count(), data.revealed_rects, data.explored_rects))
+                .unwrap_or_default();
+        world.add_unique(MapLocationCount(map_location_count));
+        // Spatially Aware (Trait16) re-derives like the other trait bonuses:
+        // every location of the mission being loaded is already explored.
+        if quest_info
+            .player_stats()
+            .has_os_trait(crate::scripts::gui::TRAIT_SPATIALLY_AWARE)
+        {
+            reveal_whole_map(&mut quest_info, &mission, map_location_count);
+            info!(
+                "Applied Spatially Aware O/S trait: revealed {} automap locations",
+                map_location_count
+            );
+        }
         if game_options.presentation_mode == crate::PresentationMode::Flat {
-            let level_stem = mission.split('.').next().unwrap_or(&mission).to_uppercase();
-            let (revealed_rects, explored_rects) =
-                dark::map::MapChunkData::load_from_mission(asset_cache, &level_stem)
-                    .map(|data| (data.revealed_rects, data.explored_rects))
-                    .unwrap_or_default();
             let entity = world.add_entity((
                 Links::empty(),
                 PropScripts {
@@ -3061,10 +3089,19 @@ impl MissionCore {
         let dir = new_rotation * input_context.head.rotation;
         let facing = dir.rotate_vector(cgmath::vec3(0.0, 0.0, -1.0));
         let move_thumbstick_value = input_context.right_hand.thumbstick;
+        // Speedy (Trait4) scales stick locomotion only; VR room-scale walking
+        // is the player's own legs and no upgrade reaches it.
+        let move_speed = crate::scripts::gui::speedy_move_speed(
+            PLAYER_MOVE_SPEED,
+            crate::scripts::gui::player_has_os_trait(
+                &self.world,
+                crate::scripts::gui::TRAIT_SPEEDY,
+            ),
+        );
         let forward = dir.rotate_vector(cgmath::vec3(
-            -delta_time * move_thumbstick_value.x * PLAYER_MOVE_SPEED / dark::SCALE_FACTOR,
+            -delta_time * move_thumbstick_value.x * move_speed / dark::SCALE_FACTOR,
             0.0,
-            -delta_time * move_thumbstick_value.y * PLAYER_MOVE_SPEED / dark::SCALE_FACTOR,
+            -delta_time * move_thumbstick_value.y * move_speed / dark::SCALE_FACTOR,
         ));
 
         let up_value = input_context.left_hand.thumbstick.y / dark::SCALE_FACTOR;
@@ -4751,6 +4788,51 @@ impl MissionCore {
             self.make_un_physical(dropped_entity_id);
         }
         moved
+    }
+
+    /// The world-facing half of acquiring an O/S trait - the grants that touch
+    /// components or quest state rather than `PlayerStats`. Every one of these
+    /// is also re-derived at mission load, so it cannot double-apply.
+    fn apply_os_trait_world_grants(&mut self, trait_id: u8) {
+        use crate::scripts::gui::{TANK_HP_BONUS, TRAIT_SPATIALLY_AWARE, TRAIT_TANK};
+        if trait_id == TRAIT_TANK {
+            // Tank (Trait8): the original raises the ceiling AND current HP by
+            // the bonus.
+            let player_entity = self
+                .world
+                .borrow::<UniqueView<PlayerInfo>>()
+                .unwrap()
+                .entity_id;
+            self.world.run(
+                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
+                 mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
+                    let new_max = (&mut v_max)
+                        .get(player_entity)
+                        .map(|max| {
+                            max.hit_points += TANK_HP_BONUS as u32;
+                            max.hit_points
+                        })
+                        .ok();
+                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
+                        hp.hit_points += TANK_HP_BONUS;
+                        if let Some(new_max) = new_max {
+                            hp.hit_points = hp.hit_points.min(new_max as i32);
+                        }
+                    }
+                },
+            );
+        }
+        if trait_id == TRAIT_SPATIALLY_AWARE {
+            let mission = self.level_name.to_ascii_lowercase();
+            let count = self
+                .world
+                .borrow::<UniqueView<MapLocationCount>>()
+                .map(|count| count.0)
+                .unwrap_or(0);
+            if let Ok(mut quests) = self.world.borrow::<UniqueViewMut<QuestInfo>>() {
+                reveal_whole_map(&mut quests, &mission, count);
+            }
+        }
     }
 
     /// Re-encode the backpack's stored cells after effective Strength changes.
@@ -7981,10 +8063,7 @@ impl MissionCore {
                 }
 
                 Effect::AcquireOsTrait { trait_id, machine } => {
-                    use crate::scripts::gui::{
-                        NATURALLY_ABLE_MODULES, TANK_HP_BONUS, TRAIT_NATURALLY_ABLE, TRAIT_TANK,
-                        live_effect_note, trait_name, used_bit_name,
-                    };
+                    use crate::scripts::gui::{live_effect_note, trait_name, used_bit_name};
                     // The machine's stable mission object id keys its used bit.
                     let machine_template_id = self
                         .world
@@ -8015,11 +8094,10 @@ impl MissionCore {
                                 &used_bit_name(machine_id),
                                 dark::properties::QuestBitValue::COMPLETE,
                             );
-                            if trait_id == TRAIT_NATURALLY_ABLE {
-                                quests
-                                    .player_stats_mut()
-                                    .award_cyber_modules(NATURALLY_ABLE_MODULES);
-                            }
+                            crate::scripts::gui::apply_os_trait_stats_grants(
+                                quests.player_stats_mut(),
+                                trait_id,
+                            );
                             let new_width = crate::inventory::backpack_width(quests.player_stats());
                             (true, old_width, new_width)
                         }
@@ -8027,35 +8105,7 @@ impl MissionCore {
 
                     if acquired {
                         self.resize_player_backpack(old_width, new_width);
-                        if trait_id == TRAIT_TANK {
-                            // Tank (Trait8): the original raises the ceiling
-                            // AND current HP by the bonus. Loads first re-derive
-                            // the trait-adjusted default, so this live grant
-                            // cannot double-apply.
-                            let player_entity = self
-                                .world
-                                .borrow::<UniqueView<PlayerInfo>>()
-                                .unwrap()
-                                .entity_id;
-                            self.world.run(
-                                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
-                                 mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
-                                    let new_max = (&mut v_max)
-                                        .get(player_entity)
-                                        .map(|max| {
-                                            max.hit_points += TANK_HP_BONUS as u32;
-                                            max.hit_points
-                                        })
-                                        .ok();
-                                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
-                                        hp.hit_points += TANK_HP_BONUS;
-                                        if let Some(new_max) = new_max {
-                                            hp.hit_points = hp.hit_points.min(new_max as i32);
-                                        }
-                                    }
-                                },
-                            );
-                        }
+                        self.apply_os_trait_world_grants(trait_id);
                         info!(
                             "O/S trait acquired: {} ({}){}",
                             trait_id,
@@ -11935,7 +11985,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         &mut self,
         request: &crate::game_scene::DebugPlayerStatsRequest,
     ) -> Result<crate::player_stats::PlayerStats, String> {
-        use crate::player_stats::{Skill, Stat};
+        use crate::player_stats::{OS_TRAIT_SLOTS, Skill, Stat};
         use crate::scripts::gui::{
             PSI_TIER_CAP, SKILL_CAP, STAT_CAP, TrainerTarget, apply_purchase,
         };
@@ -12033,6 +12083,24 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 ));
             }
         }
+        if let Some(traits) = request.os_traits.as_ref() {
+            let mut requested = stats.os_traits.clone();
+            for trait_id in traits.iter().copied() {
+                if !(1..=16).contains(&trait_id) {
+                    return Err(format!("no such O/S trait: {} (ids are 1..=16)", trait_id));
+                }
+                if !requested.contains(&trait_id) {
+                    requested.push(trait_id);
+                }
+            }
+            if requested.len() > OS_TRAIT_SLOTS {
+                return Err(format!(
+                    "{} O/S traits requested but the character sheet has {} slots",
+                    requested.len(),
+                    OS_TRAIT_SLOTS
+                ));
+            }
+        }
 
         // Apply through the same `PlayerStats` mutations a trainer purchase
         // performs, one level at a time - just without the module cost.
@@ -12056,6 +12124,17 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 apply_purchase(stats, TrainerTarget::PsiTier(tier));
             }
         }
+        // Traits are granted the way the machine grants them, minus the
+        // machine: the sheet half here, the world half below. Ahead of the
+        // module target so Naturally Able's one-time award cannot push the
+        // balance past the level the caller asked to establish.
+        let mut granted_traits = Vec::new();
+        for trait_id in request.os_traits.iter().flatten().copied() {
+            if stats.add_os_trait(trait_id) {
+                crate::scripts::gui::apply_os_trait_stats_grants(stats, trait_id);
+                granted_traits.push(trait_id);
+            }
+        }
         if let Some(target) = request.cyber_modules {
             stats.award_cyber_modules(target.saturating_sub(stats.cyber_modules));
         }
@@ -12063,6 +12142,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         let new_backpack_width = crate::inventory::backpack_width(stats);
         let result = stats.clone();
         drop(quests);
+        for trait_id in granted_traits {
+            self.apply_os_trait_world_grants(trait_id);
+        }
         self.resize_player_backpack(old_backpack_width, new_backpack_width);
         info!("Debug provisioning set player stats: {:?}", result);
         Ok(result)
@@ -13426,7 +13508,7 @@ mod radiation_patch_use_tests {
             .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
             .unwrap();
         assert!(radiation.observe_ambient(level));
-        assert_eq!(radiation.advance(0.1, level, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, level, 3.0, 1.0), 0);
     }
 
     #[test]

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -141,7 +141,7 @@ mod tests {
     fn active_radiation_round_trips_and_older_saves_default_clear() {
         let mut original = global_data(Some(sample_vitals()));
         assert!(original.active_radiation.observe_ambient(8.0));
-        assert_eq!(original.active_radiation.advance(0.1, 8.0, 3.0), 0);
+        assert_eq!(original.active_radiation.advance(0.1, 8.0, 3.0, 1.0), 0);
         let encoded = serde_json::to_value(&original).unwrap();
         let decoded: GlobalData = serde_json::from_value(encoded.clone()).unwrap();
         assert_eq!(decoded.active_radiation, original.active_radiation);

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -263,6 +263,7 @@ impl DebugSceneHooks for ArsenalHooks {
             },
             psi_tier: Some(PSI_TIER_CAP),
             cyber_modules: None,
+            os_traits: None,
         };
         if let Err(err) = core.set_player_stats(&request) {
             tracing::warn!("[debug_weapons] failed to max player stats: {err}");

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -8,7 +8,6 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 use crate::{
     gui::{ButtonHoverBehavior, Gui, GuiComponent, GuiConfig, GuiCursor},
     mission::GlobalEntityMetadata,
-    quest_info::QuestInfo,
     util::{get_position_from_transform, get_rotation_from_transform},
 };
 
@@ -441,11 +440,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
 /// this from the persistent character sheet for both rendering and purchase
 /// handling so the quoted and charged prices cannot diverge.
 fn effective_replicator_cost(world: &World, authored_cost: i32) -> i32 {
-    let has_expert = world
-        .borrow::<UniqueView<QuestInfo>>()
-        .map(|quests| quests.player_stats().has_os_trait(TRAIT_REPLICATOR_EXPERT))
-        .unwrap_or(false);
-    if has_expert {
+    if super::player_has_os_trait(world, TRAIT_REPLICATOR_EXPERT) {
         ((i64::from(authored_cost) * 8) / 10) as i32
     } else {
         authored_cost
@@ -461,6 +456,7 @@ mod tests {
     use crate::gui::GuiScript;
     use crate::mission::{EntityMetadata, PlayerInfo};
     use crate::physics::PhysicsWorld;
+    use crate::quest_info::QuestInfo;
     use crate::runtime_props::RuntimePropTransform;
     use crate::scripts::{MessagePayload, Script};
     use cgmath::{Matrix4, Quaternion};

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -11,8 +11,8 @@
 //! flag is a quest bit keyed by the machine's stable mission object id (also
 //! `QuestInfo`, so it survives save/load and deck re-entry), and
 //! `Effect::AcquireOsTrait` applies the pick atomically. Live effects are
-//! implemented for the subset with existing consumers (Tank, Naturally Able,
-//! Pack-Rat, Pharmo-Friendly, Replicator Expert - see [`live_effect_note`]); everything else stays visible
+//! implemented for the subset with existing consumers (see
+//! [`live_effect_note`] for the current list); everything else stays visible
 //! but cannot consume a one-shot machine or trait slot until its effect exists.
 
 use cgmath::{Vector2, Vector3, vec2};
@@ -48,11 +48,16 @@ pub const OS_TRAITS: [(u8, &str); 16] = [
 ];
 
 /// Retail trait ids with live gameplay effects here (see the effect handler).
-pub const TRAIT_NATURALLY_ABLE: u8 = 6;
-pub const TRAIT_PACK_RAT: u8 = 3;
+pub const TRAIT_STRONG_METABOLISM: u8 = 1;
 pub const TRAIT_PHARMO_FRIENDLY: u8 = 2;
+pub const TRAIT_PACK_RAT: u8 = 3;
+pub const TRAIT_SPEEDY: u8 = 4;
+pub const TRAIT_NATURALLY_ABLE: u8 = 6;
 pub const TRAIT_TANK: u8 = 8;
+pub const TRAIT_LETHAL_WEAPON: u8 = 9;
 pub const TRAIT_REPLICATOR_EXPERT: u8 = 13;
+pub const TRAIT_POWER_PSI: u8 = 14;
+pub const TRAIT_SPATIALLY_AWARE: u8 = 16;
 
 /// Tank: "+5 maximum hit points" (TRAITS.STR Trait8). The original raises the
 /// ceiling AND current HP by the bonus on purchase (buying at 25/30 yields
@@ -62,6 +67,83 @@ pub const TANK_HP_BONUS: i32 = 5;
 
 /// Naturally Able: "One-time bonus of 8 Cyber Enhancement Units" (Trait6).
 pub const NATURALLY_ABLE_MODULES: i32 = 8;
+
+/// Speedy: the player moves 15% faster (Trait4). Only smooth locomotion is
+/// scaled - room-scale walking in VR is the player's own legs, which no
+/// character upgrade can touch.
+pub const SPEEDY_MOVE_SCALE: f32 = 1.15;
+
+/// Lethal Weapon: hand-to-hand blows land 35% harder (Trait9). The player's
+/// melee only - AI melee resolves through its own attack path.
+pub const LETHAL_WEAPON_DAMAGE_SCALE: f32 = 1.35;
+
+/// Strong Metabolism: radiation damage is cut by a quarter (Trait1). The
+/// retail trait also resists toxins; this port has no toxin system yet, so
+/// only the radiation half has anything to scale.
+pub const STRONG_METABOLISM_DAMAGE_SCALE: f32 = 0.75;
+
+/// Speedy-adjusted locomotion speed.
+pub fn speedy_move_speed(base: f32, has_trait: bool) -> f32 {
+    if has_trait {
+        base * SPEEDY_MOVE_SCALE
+    } else {
+        base
+    }
+}
+
+/// Lethal Weapon-adjusted player melee damage.
+pub fn lethal_weapon_damage(base: f32, has_trait: bool) -> f32 {
+    if has_trait {
+        base * LETHAL_WEAPON_DAMAGE_SCALE
+    } else {
+        base
+    }
+}
+
+/// Strong Metabolism-adjusted radiation exposure damage.
+pub fn strong_metabolism_damage(base: f32, has_trait: bool) -> f32 {
+    if has_trait {
+        base * STRONG_METABOLISM_DAMAGE_SCALE
+    } else {
+        base
+    }
+}
+
+/// Pharmo-Friendly-adjusted item strength: the original multiplies a medical
+/// or psi item's amount by 1.2 and converts back to an integer, so integer
+/// arithmetic reproduces the truncation exactly (a 10-point patch heals 12,
+/// a 20-point psi hypo restores 24).
+pub fn pharmo_friendly_amount(base: i32, has_trait: bool) -> i32 {
+    if has_trait {
+        base.saturating_mul(6) / 5
+    } else {
+        base
+    }
+}
+
+/// Power Psi-adjusted burnout damage: over-holding the amp past the player's
+/// psi points costs them nothing (Trait14).
+pub fn power_psi_burnout_damage(base: i32, has_trait: bool) -> i32 {
+    if has_trait { 0 } else { base }
+}
+
+/// Whether the player's character sheet carries `trait_id`. Reads the same
+/// `QuestInfo` sheet every trait consumer does; a world without one (a bare
+/// debug scene) reads as "no traits".
+pub fn player_has_os_trait(world: &World, trait_id: u8) -> bool {
+    world
+        .borrow::<UniqueView<QuestInfo>>()
+        .is_ok_and(|quests| quests.player_stats().has_os_trait(trait_id))
+}
+
+/// The character-sheet half of acquiring a trait (the part that lives in
+/// `PlayerStats` itself). World-facing grants - Tank's hit points, Spatially
+/// Aware's map reveal - are applied by the mission's effect handler.
+pub fn apply_os_trait_stats_grants(stats: &mut crate::player_stats::PlayerStats, trait_id: u8) {
+    if trait_id == TRAIT_NATURALLY_ABLE {
+        stats.award_cyber_modules(NATURALLY_ABLE_MODULES);
+    }
+}
 
 /// Display name of a trait id, or "?" for an out-of-range id.
 pub fn trait_name(trait_id: u8) -> &'static str {
@@ -398,11 +480,16 @@ fn hovered_trait(cursor: cgmath::Point2<f32>) -> Option<u8> {
 /// One-line note of a trait's live effect, if implemented (for logs).
 pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
     match trait_id {
-        TRAIT_TANK => Some("+5 max hit points"),
-        TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
+        TRAIT_STRONG_METABOLISM => Some("25% less radiation damage"),
+        TRAIT_PHARMO_FRIENDLY => Some("20% med and psi hypo bonus"),
         TRAIT_PACK_RAT => Some("+3 backpack slots"),
-        TRAIT_PHARMO_FRIENDLY => Some("20% healing-item bonus"),
+        TRAIT_SPEEDY => Some("15% faster movement"),
+        TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
+        TRAIT_TANK => Some("+5 max hit points"),
+        TRAIT_LETHAL_WEAPON => Some("35% more melee damage"),
         TRAIT_REPLICATOR_EXPERT => Some("20% replicator discount"),
+        TRAIT_POWER_PSI => Some("no psi burnout damage"),
+        TRAIT_SPATIALLY_AWARE => Some("automap fully revealed"),
         _ => None,
     }
 }
@@ -475,7 +562,7 @@ mod tests {
             machine,
             &world,
             &TraitGuiState::default(),
-            &TraitGuiMsg::Pick(4), // Speedy has no locomotion consumer yet.
+            &TraitGuiMsg::Pick(5), // Sharpshooter has no aiming consumer yet.
         );
 
         assert!(matches!(effect, Effect::NoEffect));
@@ -511,5 +598,73 @@ mod tests {
             } if selected_machine == machine
         ));
         assert_eq!(state.message.as_deref(), Some("Pack-Rat installed."));
+    }
+
+    #[test]
+    fn the_round_one_traits_are_selectable_now_that_they_have_consumers() {
+        for trait_id in [
+            TRAIT_STRONG_METABOLISM,
+            TRAIT_SPEEDY,
+            TRAIT_LETHAL_WEAPON,
+            TRAIT_POWER_PSI,
+            TRAIT_SPATIALLY_AWARE,
+        ] {
+            let mut world = World::new();
+            world.add_unique(QuestInfo::new());
+            let machine =
+                world.add_entity((dark::properties::PropTemplateId { template_id: 133 },));
+
+            let (_, effect) = TraitGui.handle_msg(
+                machine,
+                &world,
+                &TraitGuiState::default(),
+                &TraitGuiMsg::Pick(trait_id),
+            );
+            assert!(
+                matches!(effect, Effect::AcquireOsTrait { trait_id: picked, .. } if picked == trait_id),
+                "trait {} should be purchasable",
+                trait_id
+            );
+        }
+    }
+
+    #[test]
+    fn traits_without_an_effect_are_still_refused() {
+        // 5 Sharpshooter, 7 Cybernetically Enhanced, 10 Security Expert,
+        // 11 Smasher, 12 Cyber-Assimilation, 15 Tinker.
+        for trait_id in [5, 7, 10, 11, 12, 15] {
+            let mut world = World::new();
+            world.add_unique(QuestInfo::new());
+            let machine =
+                world.add_entity((dark::properties::PropTemplateId { template_id: 133 },));
+
+            let (state, effect) = TraitGui.handle_msg(
+                machine,
+                &world,
+                &TraitGuiState::default(),
+                &TraitGuiMsg::Pick(trait_id),
+            );
+            assert!(
+                matches!(effect, Effect::NoEffect),
+                "trait {} has no effect and must not vend",
+                trait_id
+            );
+            assert_eq!(state.message.as_deref(), Some(UNAVAILABLE_LABEL));
+        }
+    }
+
+    #[test]
+    fn trait_multipliers_are_identity_without_the_trait() {
+        assert_eq!(speedy_move_speed(25.0, false), 25.0);
+        assert_eq!(speedy_move_speed(25.0, true), 28.75);
+
+        assert_eq!(lethal_weapon_damage(6.0, false), 6.0);
+        assert!((lethal_weapon_damage(6.0, true) - 8.1).abs() < 1e-5);
+
+        assert_eq!(strong_metabolism_damage(4.0, false), 4.0);
+        assert_eq!(strong_metabolism_damage(4.0, true), 3.0);
+
+        assert_eq!(power_psi_burnout_damage(9, false), 9);
+        assert_eq!(power_psi_burnout_damage(9, true), 0);
     }
 }

--- a/shock2vr/src/scripts/healing_item.rs
+++ b/shock2vr/src/scripts/healing_item.rs
@@ -2,10 +2,10 @@ use dark::properties::{PropHitPoints, PropMaxHitPoints};
 use serde::{Deserialize, Serialize};
 use shipyard::{Get, Unique, UniqueView, View, World};
 
-use crate::{mission::PlayerInfo, physics::PhysicsWorld, quest_info::QuestInfo};
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script};
-use crate::scripts::gui::TRAIT_PHARMO_FRIENDLY;
+use crate::scripts::gui::{TRAIT_PHARMO_FRIENDLY, pharmo_friendly_amount, player_has_os_trait};
 
 /// Retail `MedPatchScript` / `MedKitScript` cadence recovered from the shipped
 /// `allobjs.osm`: `DoHeal` first runs after 0.1s, then reschedules every 1.5s
@@ -45,22 +45,6 @@ impl HealingItemScript {
     pub fn new(kind: HealingItemKind) -> Self {
         Self { kind }
     }
-
-    fn pharmo_friendly(world: &World) -> bool {
-        world
-            .borrow::<UniqueView<QuestInfo>>()
-            .is_ok_and(|quests| quests.player_stats().has_os_trait(TRAIT_PHARMO_FRIENDLY))
-    }
-
-    /// The original multiplies both values by 1.2 and converts back to an
-    /// integer. Integer arithmetic preserves that truncation exactly.
-    fn retail_amount(base: i32, pharmo_friendly: bool) -> i32 {
-        if pharmo_friendly {
-            base.saturating_mul(6) / 5
-        } else {
-            base
-        }
-    }
 }
 
 impl Script for HealingItemScript {
@@ -75,11 +59,11 @@ impl Script for HealingItemScript {
             return Effect::NoEffect;
         }
 
-        let pharmo_friendly = Self::pharmo_friendly(world);
+        let pharmo_friendly = player_has_os_trait(world, TRAIT_PHARMO_FRIENDLY);
         Effect::UseHealingItem {
             entity_id,
-            total: Self::retail_amount(self.kind.base_total(), pharmo_friendly),
-            pulse: Self::retail_amount(self.kind.base_pulse(), pharmo_friendly),
+            total: pharmo_friendly_amount(self.kind.base_total(), pharmo_friendly),
+            pulse: pharmo_friendly_amount(self.kind.base_pulse(), pharmo_friendly),
             first_pulse_secs: HEALING_FIRST_PULSE_SECS,
             pulse_interval_secs: HEALING_PULSE_INTERVAL_SECS,
         }

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -164,13 +164,13 @@ impl Script for HeldMeleeWeapon {
                 };
                 let damage = self
                     .may_damage(entity_id, owner, physics, *contact, player_velocity)
-                    .then(|| authored_contact_damage(world, entity_id, owner))
+                    .then(|| authored_contact_damage(world, entity_id, owner, is_held))
                     .flatten()
                     // Adrenaline Overproduction scales the *player's* swing,
                     // so only a weapon in their hand gets the bonus (a wrench
                     // knocked into a creature is nobody's swing).
                     .map(|amount| {
-                        if self.is_held(world, entity_id) {
+                        if is_held {
                             amount * crate::scripts::berserk::melee_damage_multiplier(world)
                         } else {
                             amount
@@ -382,9 +382,25 @@ fn closing_speed(
 /// `None` means "this contact does no authored damage" (a wall, a victim with
 /// no receptron for the stim): the caller emits nothing at all, so a swing at
 /// scenery is silent rather than a free 1-point tap.
-fn authored_contact_damage(world: &World, weapon: EntityId, victim: EntityId) -> Option<f32> {
+///
+/// Lethal Weapon scales a *held* weapon's blow - that is the player's own
+/// swing. A loose weapon something else blunders into is not.
+fn authored_contact_damage(
+    world: &World,
+    weapon: EntityId,
+    victim: EntityId,
+    is_held: bool,
+) -> Option<f32> {
     let template_id = entity_class_template_id(world, weapon)?;
     let damage = contact_stim_damage(world, template_id, victim);
+    let damage = crate::scripts::gui::lethal_weapon_damage(
+        damage,
+        is_held
+            && crate::scripts::gui::player_has_os_trait(
+                world,
+                crate::scripts::gui::TRAIT_LETHAL_WEAPON,
+            ),
+    );
     (damage > 0.0).then_some(damage)
 }
 
@@ -855,6 +871,54 @@ mod tests {
         assert!(
             (amount - WEAPON_BASH_INTENSITY).abs() < f32::EPSILON,
             "got {amount}"
+        );
+    }
+
+    /// Lethal Weapon scales the player's own swing - a held weapon - and
+    /// leaves a loose one alone.
+    #[test]
+    fn lethal_weapon_scales_a_held_swing_only() {
+        let landed_damage = |held: bool, traited: bool| {
+            let (mut world, weapon, target) = test_world(PresentationMode::Vr);
+            if held {
+                world.add_component(
+                    weapon,
+                    crate::runtime_props::RuntimePropVrGripOffset(vec3(0.0, 0.0, 0.0)),
+                );
+            }
+            let mut quests = crate::quest_info::QuestInfo::new();
+            if traited {
+                quests
+                    .player_stats_mut()
+                    .add_os_trait(crate::scripts::gui::TRAIT_LETHAL_WEAPON);
+            }
+            world.add_unique(quests);
+
+            let mut script = HeldMeleeWeapon::new();
+            let Effect::Multiple(effects) = collide(&mut script, &world, weapon, target) else {
+                panic!("expected melee impact effects");
+            };
+            effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::Send { msg } => match msg.payload {
+                        MessagePayload::Damage { amount, .. } => Some(amount),
+                        _ => None,
+                    },
+                    _ => None,
+                })
+                .expect("a landed swing should send Damage")
+        };
+
+        assert_eq!(landed_damage(true, false), WEAPON_BASH_INTENSITY);
+        assert!(
+            (landed_damage(true, true) - WEAPON_BASH_INTENSITY * 1.35).abs() < 1e-4,
+            "a held swing bills 1.35x with the trait"
+        );
+        assert_eq!(
+            landed_damage(false, true),
+            WEAPON_BASH_INTENSITY,
+            "a loose weapon is not the player's swing"
         );
     }
 

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -18,6 +18,8 @@
 use engine::{audio::AudioHandle, game_log};
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
+use crate::scripts::gui::{TRAIT_POWER_PSI, player_has_os_trait, power_psi_burnout_damage};
+
 use crate::{
     mission::PlayerInfo,
     physics::PhysicsWorld,
@@ -254,7 +256,9 @@ fn player_psi_points(world: &World) -> i32 {
 
 /// Resolve a psi burnout: the power fails, its points are spent, and the
 /// player takes damage (3 per tier - PSI/Endurance mitigation comes later
-/// with player stats). The meter flashes red.
+/// with player stats). The Power Psi O/S upgrade removes the damage entirely.
+/// The meter flashes red either way: the cast still fails and the points are
+/// still spent.
 fn burnout(world: &World, amp_entity: EntityId) -> Effect {
     let Some(power) = selected_power(world) else {
         return Effect::ClearPsiCharge {
@@ -262,14 +266,21 @@ fn burnout(world: &World, amp_entity: EntityId) -> Effect {
         };
     };
     let player_entity = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
-    let damage = psi::BURNOUT_DAMAGE_PER_TIER * power.power.psi_cost;
+    let damage = power_psi_burnout_damage(
+        psi::BURNOUT_DAMAGE_PER_TIER * power.power.psi_cost,
+        player_has_os_trait(world, TRAIT_POWER_PSI),
+    );
     game_log!(
         WARN,
-        "Psi burnout! {} failed ({} damage)",
+        "Psi burnout! {} failed ({})",
         power.name,
-        damage
+        if damage > 0 {
+            format!("{} damage", damage)
+        } else {
+            "no damage - Power Psi".to_string()
+        }
     );
-    Effect::Multiple(vec![
+    let mut effects = vec![
         Effect::SetPsiCharge {
             entity_id: amp_entity,
             fraction: 1.0,
@@ -278,14 +289,17 @@ fn burnout(world: &World, amp_entity: EntityId) -> Effect {
         Effect::SpendPsiPoints {
             amount: power.power.psi_cost,
         },
+    ];
+    if damage > 0 {
         // Direct HP adjustment: the player entity has no scripts, so a
         // Damage message would be dropped - AdjustHitPoints edits the
         // (template-seeded) PropHitPoints component directly.
-        Effect::AdjustHitPoints {
+        effects.push(Effect::AdjustHitPoints {
             entity_id: player_entity,
             delta: -damage,
-        },
-    ])
+        });
+    }
+    Effect::Multiple(effects)
 }
 
 /// Whether the player has been trained in the power. Selection gating

--- a/shock2vr/src/scripts/psi_kit.rs
+++ b/shock2vr/src/scripts/psi_kit.rs
@@ -3,6 +3,7 @@ use shipyard::{EntityId, World};
 use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script};
+use crate::scripts::gui::{TRAIT_PHARMO_FRIENDLY, pharmo_friendly_amount, player_has_os_trait};
 
 /// The retail psi hypo (`PsiKitScript`): inventory use restores 20 psi and
 /// consumes one unit from its stack.
@@ -26,7 +27,7 @@ impl Script for PsiKitScript {
     fn handle_message(
         &mut self,
         entity_id: EntityId,
-        _world: &World,
+        world: &World,
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
@@ -36,7 +37,10 @@ impl Script for PsiKitScript {
 
         Effect::UsePsiKit {
             entity_id,
-            amount: Self::RESTORE_AMOUNT,
+            amount: pharmo_friendly_amount(
+                Self::RESTORE_AMOUNT,
+                player_has_os_trait(world, TRAIT_PHARMO_FRIENDLY),
+            ),
         }
     }
 }
@@ -74,6 +78,30 @@ mod tests {
                 amount: 20
             } if entity_id == booster
         ));
+    }
+
+    #[test]
+    fn pharmo_friendly_boosts_the_hypo_by_a_fifth() {
+        use crate::quest_info::QuestInfo;
+        use crate::scripts::gui::TRAIT_PHARMO_FRIENDLY;
+
+        let (world, booster) = world_with_booster();
+        let mut quests = QuestInfo::new();
+        quests
+            .player_stats_mut()
+            .add_os_trait(TRAIT_PHARMO_FRIENDLY);
+        world.add_unique(quests);
+
+        let effect = PsiKitScript::new().handle_message(
+            booster,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(
+            matches!(effect, Effect::UsePsiKit { amount: 24, .. }),
+            "Pharmo-Friendly turns the 20-point hypo into 24"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/radiation.rs
+++ b/shock2vr/src/scripts/radiation.rs
@@ -2,10 +2,12 @@ use dark::properties::{PropRadiationAbsorb, PropRadiationRecovery, ReceptronOpti
 use serde::{Deserialize, Serialize};
 use shipyard::{Get, Unique, UniqueView, View, World};
 
-use crate::{mission::PlayerInfo, physics::PhysicsWorld, quest_info::QuestInfo};
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script};
-use crate::scripts::gui::TRAIT_PHARMO_FRIENDLY;
+use crate::scripts::gui::{
+    TRAIT_PHARMO_FRIENDLY, TRAIT_STRONG_METABOLISM, player_has_os_trait, strong_metabolism_damage,
+};
 
 /// Amount removed by retail `RadPatch`, recovered from the shipped
 /// `allobjs` module. Pharmo-Friendly applies the same 20% item bonus as the
@@ -26,14 +28,6 @@ const DEFAULT_RADIATION_RECOVERY: f32 = 3.0;
 /// consume one patch only when radiation is actually present.
 pub struct RadPatchScript;
 
-impl RadPatchScript {
-    fn pharmo_friendly(world: &World) -> bool {
-        world
-            .borrow::<UniqueView<QuestInfo>>()
-            .is_ok_and(|quests| quests.player_stats().has_os_trait(TRAIT_PHARMO_FRIENDLY))
-    }
-}
-
 impl Script for RadPatchScript {
     fn handle_message(
         &mut self,
@@ -46,7 +40,7 @@ impl Script for RadPatchScript {
             return Effect::NoEffect;
         }
 
-        let amount = if Self::pharmo_friendly(world) {
+        let amount = if player_has_os_trait(world, TRAIT_PHARMO_FRIENDLY) {
             RAD_PATCH_PHARMO_CLEAR_AMOUNT
         } else {
             RAD_PATCH_CLEAR_AMOUNT
@@ -76,6 +70,12 @@ pub struct ActiveRadiation {
     seconds_until_check: f32,
     #[serde(default = "default_damage_timer")]
     seconds_until_damage: f32,
+    /// Damage a resistance has taken off, below the whole point that could be
+    /// subtracted. Carried between pulses so resistance is worth its stated
+    /// fraction of the damage dealt: without it, a 25% cut of a 1-point pulse
+    /// truncates to either nothing at all or total immunity.
+    #[serde(default)]
+    resisted_fraction: f32,
 }
 
 impl Default for ActiveRadiation {
@@ -85,6 +85,7 @@ impl Default for ActiveRadiation {
             ambient_level: 0.0,
             seconds_until_check: RADIATION_CHECK_INTERVAL_SECS,
             seconds_until_damage: RADIATION_DAMAGE_INTERVAL_SECS,
+            resisted_fraction: 0.0,
         }
     }
 }
@@ -119,11 +120,16 @@ impl ActiveRadiation {
 
     /// Advance the retail 6-second damage/recovery clock and return ordinary
     /// hit-point damage for MissionCore's central HP effect handler.
+    /// `damage_scale` is the player's resistance to the damage a pulse deals
+    /// (1.0 = none), read from the character sheet by the caller like the
+    /// absorb/recovery rates it sits beside. Accumulation and recovery are
+    /// untouched.
     pub fn advance(
         &mut self,
         elapsed_secs: f32,
         absorb_per_check: f32,
         recovery_per_tick: f32,
+        damage_scale: f32,
     ) -> i32 {
         if !elapsed_secs.is_finite() || elapsed_secs <= 0.0 {
             return 0;
@@ -170,7 +176,7 @@ impl ActiveRadiation {
                 let pulse = (self.level * RADIATION_DAMAGE_PER_LEVEL)
                     .trunc()
                     .clamp(0.0, i32::MAX as f32) as i32;
-                damage = damage.saturating_add(pulse);
+                damage = damage.saturating_add(self.resist(pulse, damage_scale));
             }
             if self.ambient_level <= 0.0 {
                 self.level = (self.level - recovery).max(0.0);
@@ -181,6 +187,23 @@ impl ActiveRadiation {
         // lets the following frame faithfully represent leaving the source.
         self.ambient_level = 0.0;
         damage
+    }
+
+    /// Take `1 - damage_scale` off one pulse, banking the sub-point remainder
+    /// for later pulses. A quarter off a 1-point pulse is a whole point saved
+    /// every fourth pulse, not a quarter of a hit point that rounds away.
+    fn resist(&mut self, pulse: i32, damage_scale: f32) -> i32 {
+        if !damage_scale.is_finite() || damage_scale >= 1.0 || pulse <= 0 {
+            return pulse;
+        }
+        let scale = damage_scale.max(0.0);
+        if !self.resisted_fraction.is_finite() || self.resisted_fraction < 0.0 {
+            self.resisted_fraction = 0.0;
+        }
+        self.resisted_fraction += pulse as f32 * (1.0 - scale);
+        let saved = self.resisted_fraction.floor().min(pulse as f32);
+        self.resisted_fraction -= saved;
+        pulse - saved as i32
     }
 }
 
@@ -224,10 +247,14 @@ pub fn tick_player_radiation(world: &World, elapsed_secs: f32) -> Option<Effect>
         .ok()
         .and_then(|values| values.get(player).ok().map(|value| value.0))
         .unwrap_or(DEFAULT_RADIATION_ABSORB);
+    // Strong Metabolism resists the damage exposure deals (the retail trait
+    // resists toxins too; this port has no toxin system to scale).
+    let damage_scale =
+        strong_metabolism_damage(1.0, player_has_os_trait(world, TRAIT_STRONG_METABOLISM));
     let damage = world
         .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
         .ok()
-        .map(|mut radiation| radiation.advance(elapsed_secs, absorb, recovery))
+        .map(|mut radiation| radiation.advance(elapsed_secs, absorb, recovery, damage_scale))
         .unwrap_or(0);
     (damage > 0).then_some(Effect::AdjustHitPoints {
         entity_id: player,
@@ -300,12 +327,12 @@ mod tests {
     fn patch_clears_level_without_granting_future_protection() {
         let mut radiation = ActiveRadiation::default();
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(0.1, 8.0, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0, 1.0), 0);
         assert!(radiation.clear(6.0));
         assert_eq!(radiation.level(), 2.0);
 
         assert!(radiation.observe_ambient(6.0));
-        assert_eq!(radiation.advance(0.1, 4.0, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, 4.0, 3.0, 1.0), 0);
         assert_eq!(radiation.level(), 6.0);
     }
 
@@ -313,14 +340,33 @@ mod tests {
     fn damage_and_recovery_follow_the_retail_six_second_clock() {
         let mut radiation = ActiveRadiation::default();
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(0.1, 8.0, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0, 1.0), 0);
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(5.89, 0.05, 3.0), 0);
+        assert_eq!(radiation.advance(5.89, 0.05, 3.0, 1.0), 0);
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(0.02, 0.05, 3.0), 2);
+        assert_eq!(radiation.advance(0.02, 0.05, 3.0, 1.0), 2);
         assert_eq!(radiation.level(), 8.0, "active exposure delays recovery");
-        assert_eq!(radiation.advance(6.0, 0.05, 3.0), 2);
+        assert_eq!(radiation.advance(6.0, 0.05, 3.0, 1.0), 2);
         assert_eq!(radiation.level(), 5.0);
+    }
+
+    #[test]
+    fn strong_metabolism_cuts_a_quarter_off_the_damage_actually_dealt() {
+        // The shipped sources plateau where a pulse bills 1, so a quarter has
+        // to accumulate: four resisted 1-point pulses cost 3, not 4 (and never
+        // 0, which a per-pulse multiply would truncate them to).
+        let scale = crate::scripts::gui::strong_metabolism_damage(1.0, true);
+        let soak = |damage_scale: f32| {
+            let mut radiation = ActiveRadiation::default();
+            let mut total = 0;
+            for _ in 0..4 {
+                assert!(radiation.observe_ambient(6.5));
+                total += radiation.advance(6.0, 6.5, 3.0, damage_scale);
+            }
+            total
+        };
+        assert_eq!(soak(1.0), 4);
+        assert_eq!(soak(scale), 3);
     }
 
     #[test]
@@ -332,7 +378,7 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(radiation.advance(1.0 / 60.0, 0.05, 3.0), 0);
+        assert_eq!(radiation.advance(1.0 / 60.0, 0.05, 3.0, 1.0), 0);
         assert_eq!(radiation.level(), 8.0);
     }
 
@@ -378,7 +424,7 @@ mod tests {
             world
                 .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
                 .unwrap()
-                .advance(0.1, 0.05, 3.0),
+                .advance(0.1, 0.05, 3.0, 1.0),
             0
         );
         assert_eq!(

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -446,6 +446,12 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
 /// distance along the current crosshair ray and damage the hit entity (hitbox
 /// proxies resolve to their parent).
 fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World) -> Effect {
+    // Flat melee is only ever the player's own swing, so Lethal Weapon
+    // applies unconditionally here.
+    let amount = crate::scripts::gui::lethal_weapon_damage(
+        MELEE_DAMAGE,
+        crate::scripts::gui::player_has_os_trait(world, crate::scripts::gui::TRAIT_LETHAL_WEAPON),
+    );
     let hit = physics.ray_cast(
         aim.origin,
         aim.forward.normalize() * MELEE_RANGE,
@@ -466,7 +472,7 @@ fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World
                 payload: MessagePayload::Damage {
                     // Adrenaline Overproduction scales the player's melee
                     // damage while it is active (1.0 otherwise).
-                    amount: MELEE_DAMAGE * crate::scripts::berserk::melee_damage_multiplier(world),
+                    amount: amount * crate::scripts::berserk::melee_damage_multiplier(world),
                     // Swing direction + contact point seed the victim's
                     // death-ragdoll reaction. No bone: melee resolves a hitbox
                     // proxy to its parent BEFORE sending (so HitBoxScript

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -566,6 +566,9 @@ export interface PlayerSnapshot {
   /** The automap locations explored in the current mission (ascending).
    * Persisted per mission in QuestInfo; survives save/load. */
   explored_map_locations: number[];
+  /** How many automap locations the current mission defines (locations run
+   * 0..count). 0 when the mission has no automap. */
+  map_location_count: number;
   /** Climb state: ladder/hand climbing, and (VR) the hands holding on. */
   climb: ClimbState;
 }
@@ -772,6 +775,9 @@ export interface PlayerStatsRequest {
   psi_tier?: number;
   /** Target cyber-module balance (the upgrade currency). */
   cyber_modules?: number;
+  /** O/S upgrade trait ids to grant (1..=16), as if picked at a machine.
+   * Already-owned ids are ignored; the four-slot cap still applies. */
+  os_traits?: number[];
 }
 
 /**

--- a/tools/shock2-sdk/test/os-traits.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-traits.e2e.test.ts
@@ -109,9 +109,9 @@ test(
       traitButton(name, els);
     }
 
-    // --- A storage-only trait refuses clearly and leaves this one-shot
-    // machine available for a live choice. ---
-    await clickElement(game, traitButton("Speedy", els));
+    // --- A trait with no live effect yet refuses clearly and leaves this
+    // one-shot machine available for a live choice. ---
+    await clickElement(game, traitButton("Sharpshooter", els));
     await game.step({ frames: 3 });
     assert.deepEqual((await stats()).os_traits, [], "unsupported trait is not recorded");
     let refreshed = await game.ui.state();

--- a/tools/shock2-sdk/test/os-upgrades.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-upgrades.e2e.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end coverage for the round-1 O/S upgrade effects: Speedy (4),
+// Lethal Weapon (9), Power Psi (14), Spatially Aware (16), and
+// Pharmo-Friendly's (2) psi-hypo half. (Strong Metabolism is unit-tested only;
+// see the note further down.)
+//
+// Traits are granted through the debug provisioning path
+// (`POST /v1/player/stats` `os_traits`), which applies exactly what the trait
+// machine applies - the machine itself is one-shot per level and cannot vend
+// the several traits these cases need. `os-traits.e2e.test.ts` covers the
+// machine.
+//
+// Negative-first: every case measures the untraited behavior first in the same
+// run (or, where the effect is not reversible, in a paired run) and asserts the
+// traited measurement differs by the trait's magnitude. On the base commit the
+// grants are refused outright ("Upgrade unavailable in this build"), so
+// `os_traits` stays empty and every assertion below fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const TRAIT_PHARMO_FRIENDLY = 2;
+const TRAIT_SPEEDY = 4;
+const TRAIT_LETHAL_WEAPON = 9;
+const TRAIT_POWER_PSI = 14;
+const TRAIT_SPATIALLY_AWARE = 16;
+
+const TRAINING_DROID = 593;
+const WRENCH = -928;
+
+function hitPoints(detail: EntityDetailResult): number {
+  const property = detail.properties.find(
+    (candidate) => candidate.name === "HitPoints",
+  );
+  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
+  return Number(property.value);
+}
+
+test(
+  "Speedy: stick locomotion covers 15% more ground",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_minimal" });
+    await game.step({ frames: 30 });
+
+    // The default debug floor is 48 world units across and empty, so a straight
+    // run is limited by speed alone.
+    const start = (await game.info()).player.position;
+    const walk = async () => {
+      await game.player.teleport({ x: start[0], y: start[1], z: start[2] });
+      await game.step({ frames: 20 });
+      const from = (await game.info()).player.position;
+      await game.input.set("right_hand.thumbstick", [0, 1]);
+      await game.step({ frames: 60 });
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      await game.step({ frames: 2 });
+      const to = (await game.info()).player.position;
+      return Math.hypot(to[0] - from[0], to[2] - from[2]);
+    };
+
+    const plain = await walk();
+    assert.ok(plain > 1.0, `the player should actually walk; covered ${plain}`);
+
+    const stats = await game.player.setStats({ os_traits: [TRAIT_SPEEDY] });
+    assert.deepEqual(stats.os_traits, [TRAIT_SPEEDY], "Speedy is recorded");
+
+    const speedy = await walk();
+    const ratio = speedy / plain;
+    assert.ok(
+      Math.abs(ratio - 1.15) < 0.02,
+      `Speedy should cover 1.15x the ground; ${plain} -> ${speedy} (${ratio})`,
+    );
+  },
+);
+
+test(
+  "Lethal Weapon: a flat wrench swing hits 35% harder",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "earth.mis" });
+    await game.step({ frames: 5 });
+
+    await game.player.spawnItem(WRENCH);
+    await game.input.trigger("EquipWrench");
+    await game.step({ frames: 5 });
+    const [droid] = await game.entities.byTemplate(TRAINING_DROID);
+    assert.ok(droid, "Earth should contain its authored Training Droid");
+
+    const [x, y, z] = (await game.entities.detail(droid.id)).position;
+    await game.player.teleport({ x: x + 1.2, y: y + 1, z });
+    await game.step({ frames: 60 });
+
+    // One full swing: the aimed hit resolves at the authored MF_TRIGGER1 event,
+    // 41 simulation frames after the trigger edge (see
+    // flat-melee-animation-event.e2e.test.ts).
+    const swing = async () => {
+      const aim = await game.player.aimAt(droid, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      assert.equal(aim.entity_id, droid.id);
+      await game.step({ frames: 3 });
+      const before = hitPoints(await game.entities.detail(droid.id));
+      await game.input.set("right_hand.trigger", 1);
+      await game.step({ frames: 45 });
+      await game.input.set("right_hand.trigger", 0);
+      await game.step({ frames: 60 });
+      const after = hitPoints(await game.entities.detail(droid.id));
+      return before - after;
+    };
+
+    const plain = await swing();
+    assert.equal(plain, 6, "the untraited flat Wrench swing deals its authored 6");
+
+    await game.player.setStats({ os_traits: [TRAIT_LETHAL_WEAPON] });
+    const lethal = await swing();
+    assert.ok(
+      lethal > plain,
+      `Lethal Weapon must raise melee damage; ${plain} -> ${lethal}`,
+    );
+    // 6 * 1.35 = 8.1, applied to an integer hit-point pool.
+    assert.equal(lethal, 8, `Lethal Weapon should bill 6 * 1.35; got ${lethal}`);
+  },
+);
+
+test(
+  "Power Psi removes burnout damage; Pharmo-Friendly boosts the psi hypo",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_psi" });
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).player.selected_psi_power, "Cryokinesis");
+
+    // Over-hold the amp past a full charge bar (tier 1 = 120 frames): the cast
+    // fails and the points are spent either way; only the damage is at issue.
+    const burnout = async () => {
+      const before = (await game.info()).player;
+      await game.input.set("right_hand.trigger", 1.0);
+      await game.step({ frames: 130 });
+      const after = (await game.info()).player;
+      await game.input.set("right_hand.trigger", 0.0);
+      await game.step({ frames: 45 });
+      assert.equal(after.psi_charge_phase, "burnout", "over-holding burns out");
+      assert.ok(
+        after.psi_points! < before.psi_points!,
+        "a burnout spends its points regardless",
+      );
+      return before.hit_points! - after.hit_points!;
+    };
+
+    assert.equal(await burnout(), 3, "a tier-1 burnout normally costs 3 hit points");
+
+    // Drain enough psi that a 24-point refill is not clipped by the ceiling,
+    // then measure what one hypo restores.
+    const drain = async (target: number) => {
+      for (let attempt = 0; attempt < 60; attempt += 1) {
+        const psi = (await game.info()).player;
+        if (psi.psi_points! <= psi.max_psi_points! - target) return;
+        await game.input.set("right_hand.trigger", 1.0);
+        await game.step({ frames: 3 });
+        await game.input.set("right_hand.trigger", 0.0);
+        await game.step({ frames: 3 });
+      }
+      assert.fail(`could not drain ${target} psi points`);
+    };
+    const useHypo = async () => {
+      const hypo = await game.player.spawnItem("Psi Booster");
+      const before = (await game.info()).player.psi_points!;
+      await game.entities.sendMessage(hypo.entity_id, { type: "Frob" });
+      await game.step({ frames: 5 });
+      return (await game.info()).player.psi_points! - before;
+    };
+
+    await drain(30);
+    assert.equal(await useHypo(), 20, "the psi hypo normally restores 20 points");
+
+    const stats = await game.player.setStats({
+      os_traits: [TRAIT_POWER_PSI, TRAIT_PHARMO_FRIENDLY],
+    });
+    assert.deepEqual(stats.os_traits, [TRAIT_POWER_PSI, TRAIT_PHARMO_FRIENDLY]);
+
+    assert.equal(await burnout(), 0, "Power Psi removes the burnout damage entirely");
+    await drain(30);
+    assert.equal(await useHypo(), 24, "Pharmo-Friendly makes the hypo restore 24");
+  },
+);
+
+// Strong Metabolism (1) has no end-to-end case here. The only shipped
+// radiation source reachable in a test is medsci2's Rad Barrel, whose burst
+// puts the stored level on a ~6.5 plateau; a 6-second tick there bills
+// trunc(6.5 * 0.25) = 1 with the trait and without it, so the quarter cut is
+// below what an integer hit-point pool can show. The arithmetic is covered by
+// `strong_metabolism_cuts_the_radiation_pulse_by_a_quarter` in
+// `shock2vr/src/scripts/radiation.rs`.
+
+test(
+  "Spatially Aware reveals the whole automap, on acquire and on every load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `os_upgrades_map_${Date.now()}`;
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 5 });
+
+    const map = async () => {
+      const player = (await game.info()).player;
+      return {
+        explored: player.explored_map_locations.length,
+        total: player.map_location_count,
+      };
+    };
+
+    const before = await map();
+    assert.ok(before.total > 0, "medsci1 ships an automap with locations");
+    assert.ok(
+      before.explored < before.total,
+      `a fresh arrival has not explored the level; ${before.explored}/${before.total}`,
+    );
+
+    await game.player.setStats({ os_traits: [TRAIT_SPATIALLY_AWARE] });
+    await game.step({ frames: 5 });
+    const acquired = await map();
+    assert.equal(
+      acquired.explored,
+      acquired.total,
+      "buying the upgrade reveals every location of the current level",
+    );
+
+    // The reveal re-derives at load, like the other trait bonuses.
+    await game.save(saveName);
+    await game.load(saveName);
+    await game.step({ frames: 5 });
+    const loaded = await map();
+    assert.equal(
+      loaded.explored,
+      loaded.total,
+      "the reveal survives save/load",
+    );
+
+    // ...and covers a level the player has never set foot on.
+    await game.transitionLevel("medsci2.mis");
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).mission, "medsci2.mis");
+    const next = await map();
+    assert.ok(next.total > 0, "medsci2 ships an automap too");
+    assert.equal(
+      next.explored,
+      next.total,
+      "arriving on a new deck arrives with its map already revealed",
+    );
+  },
+);


### PR DESCRIPTION
Five O/S upgrades had no consumer, so the trait machine refused them outright rather than waste its one-shot pick. Each now has one, and Pharmo-Friendly's existing 20% item bonus extends to the psi hypo.

| id | Trait | Effect | Call site |
| --- | --- | --- | --- |
| 4 | Speedy | stick locomotion x1.15 | `mission/mission_core.rs` - `PLAYER_MOVE_SPEED` at the locomotion vector |
| 9 | Lethal Weapon | player melee damage x1.35 | `scripts/weapon_script.rs` `flat_melee_hit` + `scripts/melee_weapon.rs` `authored_contact_damage` (held weapon only, so a loose one a creature blunders into is unaffected) |
| 14 | Power Psi | psi burnout damage -> 0 | `scripts/psi_amp_script.rs` `burnout` (the cast still fails and the points are still spent) |
| 1 | Strong Metabolism | radiation damage x0.75 | `scripts/radiation.rs` `ActiveRadiation::advance` / `resist` |
| 16 | Spatially Aware | automap fully revealed | `mission_core.rs` at load, and on acquire via `apply_os_trait_world_grants` |
| 2 | Pharmo-Friendly | psi hypo 20 -> 24 | `scripts/psi_kit.rs`, through the same truncating x6/5 `pharmo_friendly_amount` the med items use |

Each effect is a pure helper beside the trait ids in `scripts/gui/traits.rs` (`speedy_move_speed`, `lethal_weapon_damage`, `strong_metabolism_damage`, `power_psi_burnout_damage`, `pharmo_friendly_amount`), read at the call site through the character sheet, so it re-derives after save/load and a level change the way the existing Tank and Pack-Rat bonuses do. The GUI stops refusing these six ids; 5, 7, 10, 11, 12 and 15 still refuse.

**Radiation resistance banks its fraction.** The shipped sources plateau where a 6-second tick bills one hit point, so multiplying each pulse by 0.75 and truncating would turn the trait into either a no-op or total immunity depending on the level. `ActiveRadiation` carries the sub-point remainder instead, so a quarter off is a whole point saved every fourth pulse. Unresisted behavior is byte-identical (the scale is 1.0 and the remainder never accrues).

**Toxin caveat:** Strong Metabolism resists toxins as well in the original. This port has no toxin system, so only the radiation half exists to scale.

**Spatially Aware in VR:** the reveal is recorded on the character sheet in both presentations, but this port's automap panel is flat-only, so in VR the upgrade has nothing to draw until a VR map exists. It is not refused - the data is right and a save moved to flat shows it.

Two supporting bits: Tank's acquire-time hit-point grant moved into a shared `apply_os_trait_world_grants` (so the trait machine and the debug provisioning path can't drift), and `POST /v1/player/stats` accepts `os_traits` so automation can grant traits without a one-shot machine. `/v1/info` now also reports `map_location_count`.

## Tests

Unit, negative-first per trait:

- `scripts/gui/traits.rs`: `the_round_one_traits_are_selectable_now_that_they_have_consumers`, `traits_without_an_effect_are_still_refused` (drives the panel and asserts the refusal), `trait_multipliers_are_identity_without_the_trait`
- `scripts/radiation.rs`: `strong_metabolism_cuts_a_quarter_off_the_damage_actually_dealt` (four 1-point pulses cost 4 unresisted, 3 resisted)
- `scripts/psi_kit.rs`: `pharmo_friendly_boosts_the_hypo_by_a_fifth`
- `scripts/melee_weapon.rs`: `lethal_weapon_scales_a_held_swing_only`

`cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; `cargo test -p shock2vr --lib` -> 1267 passed, 0 failed.

New e2e `tools/shock2-sdk/test/os-upgrades.e2e.test.ts` grants traits through `POST /v1/player/stats` (`os_traits`) and measures the untraited behavior first in the same run:

```
ok 1 - Speedy: stick locomotion covers 15% more ground
ok 2 - Lethal Weapon: a flat wrench swing hits 35% harder
ok 3 - Power Psi removes burnout damage; Pharmo-Friendly boosts the psi hypo
ok 4 - Spatially Aware reveals the whole automap, on acquire and on every load
# pass 4
# fail 0
```

Strong Metabolism has no e2e case: the only reachable shipped radiation source (medsci2's Rad Barrel) plateaus the stored level near 6.5, where the difference is one hit point over the better part of a minute, under the noise of the barrel's own blast. The arithmetic is unit-tested instead.

`os-traits.e2e.test.ts` now clicks Sharpshooter (still stubbed) for its "upgrade unavailable" case, since Speedy is purchasable now.

Regression sweep over the touched systems - `os-traits`, `cyber-modules`, `save-load`, `melee-hitbox`, `vr-melee-contact`, `flat-melee-animation-event`, `psi`, `psi-overload`, `psi-sustained`, `psi-trained`, `rad-patch`, `map`, `healing-items`, `inventory-strength`, `provisioning`, `trainer`, `missions`, plus the new file: **56 pass, 0 fail**. (`melee-hitbox`'s limb case, listed as flaky, passed here.)
