### PR TITLE
feat(psi): Neural Decontamination purges and blocks radiation

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -13426,7 +13426,7 @@ mod radiation_patch_use_tests {
             .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
             .unwrap();
         assert!(radiation.observe_ambient(level));
-        assert_eq!(radiation.advance(0.1, level, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, level, 3.0, 0.0), 0);
     }
 
     #[test]

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -39,6 +39,10 @@ pub const INVISO_TEMPLATE_ID: i32 = -3157;
 /// their health (see `scripts::berserk`).
 pub const BERSERK_TEMPLATE_ID: i32 = -3155;
 
+/// `Rad Shield` - Neural Decontamination (tier 2 sustained power): while
+/// active, accumulated radiation bleeds off and new exposure is ignored.
+pub const RAD_SHIELD_TEMPLATE_ID: i32 = -1114;
+
 /// `PropPsiPower::activation_type` for sustained/timed self effects - the
 /// power activates for a duration given by its `P$PsiShield` data
 /// (`duration_base + duration_per_psi × PSI` seconds).

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -141,7 +141,7 @@ mod tests {
     fn active_radiation_round_trips_and_older_saves_default_clear() {
         let mut original = global_data(Some(sample_vitals()));
         assert!(original.active_radiation.observe_ambient(8.0));
-        assert_eq!(original.active_radiation.advance(0.1, 8.0, 3.0), 0);
+        assert_eq!(original.active_radiation.advance(0.1, 8.0, 3.0, 0.0), 0);
         let encoded = serde_json::to_value(&original).unwrap();
         let decoded: GlobalData = serde_json::from_value(encoded.clone()).unwrap();
         assert_eq!(decoded.active_radiation, original.active_radiation);

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -15,12 +15,12 @@ use engine::{
         light::SpotLight,
     },
 };
-use rapier3d::prelude::{Collider, ColliderBuilder};
+use rapier3d::prelude::{Collider, ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
 use crate::{
     GameOptions,
-    game_scene::GameScene,
+    game_scene::{DebugPlayerStatsRequest, DebugSkillLevelsRequest, DebuggableScene, GameScene},
     input_context::InputContext,
     mission::{
         AbstractMission, AlwaysVisible, GlobalContext, SpawnLocation,
@@ -29,9 +29,68 @@ use crate::{
     },
     quest_info::QuestInfo,
     save_load::HeldItemSaveData,
-    scripts::{Effect, GlobalEffect},
+    scripts::{
+        Effect, GlobalEffect,
+        gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP},
+    },
     time::Time,
 };
+
+/// A box of debug geometry: (color, center, size) in world units.
+pub type DebugBox = (Vector3<f32>, Vector3<f32>, Vector3<f32>);
+
+/// Visuals plus one compound collider for a list of boxes. Every piece is a
+/// (visual, collider) pair built from the same box so the two cannot drift:
+/// the unit cube spans [-0.5, 0.5], so a size is twice the collider
+/// half-extent.
+pub fn boxes_to_geometry(boxes: &[DebugBox]) -> (Vec<SceneObject>, Collider) {
+    let scene_objects = boxes
+        .iter()
+        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
+        .collect();
+    let collider = ColliderBuilder::compound(
+        boxes
+            .iter()
+            .map(|(_, translation, scale)| {
+                (
+                    Isometry::translation(translation.x, translation.y, translation.z),
+                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
+                )
+            })
+            .collect(),
+    )
+    .build();
+    (scene_objects, collider)
+}
+
+/// Max the character sheet (every stat, skill and psi tier at cap) through
+/// the same provisioning path as `POST /v1/player/stats`, so no skill gate
+/// stands between a tester and the scene's content. `scene` tags the warning.
+pub fn max_player_stats(core: &mut MissionCore, scene: &str) {
+    let request = DebugPlayerStatsRequest {
+        strength: Some(STAT_CAP),
+        endurance: Some(STAT_CAP),
+        agility: Some(STAT_CAP),
+        psionic_ability: Some(STAT_CAP),
+        cyber_affinity: Some(STAT_CAP),
+        skills: DebugSkillLevelsRequest {
+            standard_weapons: Some(SKILL_CAP),
+            energy_weapons: Some(SKILL_CAP),
+            heavy_weapons: Some(SKILL_CAP),
+            exotic_weapons: Some(SKILL_CAP),
+            hack: Some(SKILL_CAP),
+            repair: Some(SKILL_CAP),
+            modify: Some(SKILL_CAP),
+            maintenance: Some(SKILL_CAP),
+            research: Some(SKILL_CAP),
+        },
+        psi_tier: Some(PSI_TIER_CAP),
+        cyber_modules: None,
+    };
+    if let Err(err) = core.set_player_stats(&request) {
+        tracing::warn!("[{scene}] failed to max player stats: {err}");
+    }
+}
 
 /// Convenience builder for MissionCore-backed debug scenes that only need a floor and spawn point.
 pub struct DebugSceneBuilder {

--- a/shock2vr/src/scenes/debug_melee.rs
+++ b/shock2vr/src/scenes/debug_melee.rs
@@ -20,9 +20,8 @@
 //! between them is the calibration error, and it is only visible with both on
 //! screen at once.
 
-use cgmath::{Deg, Point3, Quaternion, Rotation3, Vector3, vec3};
+use cgmath::{Deg, Point3, Quaternion, Rotation3, vec3};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
-use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
 use crate::{
@@ -30,8 +29,8 @@ use crate::{
     game_scene::GameScene,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene, cube_object,
-        spawn_at,
+        DebugBox, DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+        boxes_to_geometry, spawn_at,
     },
     scripts::Effect,
 };
@@ -92,10 +91,7 @@ pub fn create_debug_melee_scene(
     dev_params::set(dev_params::MELEE_GLOVE_OVERLAY, 1.0);
     dev_params::set(dev_params::MELEE_VOLUMES, 1.0);
 
-    // The unit cube spans [-0.5, 0.5], so a nonuniform scale is twice the
-    // matching collider half-extent. Every piece is a (visual, collider) pair
-    // built from one box so the two cannot drift.
-    let mut boxes: Vec<(Vector3<f32>, Vector3<f32>, Vector3<f32>)> = vec![
+    let boxes: &[DebugBox] = &[
         // floor
         (
             vec3(0.18, 0.18, 0.22),
@@ -134,22 +130,7 @@ pub fn create_debug_melee_scene(
         ),
     ];
 
-    let scene_objects = boxes
-        .iter()
-        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
-        .collect::<Vec<_>>();
-    let collider = ColliderBuilder::compound(
-        boxes
-            .drain(..)
-            .map(|(_, translation, scale)| {
-                (
-                    Isometry::translation(translation.x, translation.y, translation.z),
-                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
-                )
-            })
-            .collect(),
-    )
-    .build();
+    let (scene_objects, collider) = boxes_to_geometry(boxes);
 
     // Laid out along -X, the default view forward with an identity spawn yaw
     // in both presentations (same convention as `debug_weapons`). Verified by

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -104,18 +104,19 @@ pub fn create_debug_psi_scene(
         ),
         // hazard patch: a floor marker for the (invisible) radiation source.
         // The field is a 6-unit sphere; the marker is the square inscribed in
-        // it, so every point on the marker is inside the field. Sunk into the
-        // floor slab so a walking tester does not step onto a lip.
+        // it, so every point on the marker is inside the field. It sits 2 cm
+        // proud of the floor slab rather than flush with it - coplanar faces
+        // z-fight into stripes, and 2 cm is not a lip anyone walks into.
         (
             vec3(0.15, 0.45, 0.15),
             vec3(
                 RADIATION_SOURCE_POSITION.0,
-                -0.02,
+                0.01,
                 RADIATION_SOURCE_POSITION.1,
             ),
             vec3(
                 RADIATION_SOURCE_RADIUS * std::f32::consts::SQRT_2,
-                0.04,
+                0.02,
                 RADIATION_SOURCE_RADIUS * std::f32::consts::SQRT_2,
             ),
         ),

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -57,6 +57,18 @@ const PEN_WALL_HEIGHT: f32 = 1.2;
 /// ahead (-X, the default-view forward), behind the pen.
 const WALL_DISTANCE: f32 = 15.0;
 
+/// The hazard patch: `Rad Burst`, the persistent radius radiation source the
+/// game spawns from a destroyed rad barrel (`StimSource` Radiation, intensity
+/// 8, radius 6). It renders nothing, so a floor patch marks it.
+const RADIATION_SOURCE_TEMPLATE_ID: i32 = -1219;
+const RADIATION_SOURCE_RADIUS: f32 = 6.0;
+
+/// Where the hazard patch sits, as (x, z): beside the player and off the
+/// firing line, far enough that the spawn point is outside the source's
+/// 6-unit radius - so the player starts clean and only gets irradiated after
+/// a deliberate `POST /v1/player/teleport` into it.
+const RADIATION_SOURCE_POSITION: (f32, f32) = (0.0, 9.0);
+
 pub fn create_debug_psi_scene(
     global_context: &GlobalContext,
     game_options: &GameOptions,
@@ -90,6 +102,20 @@ pub fn create_debug_psi_scene(
             vec3(-PEN_FAR, PEN_WALL_HEIGHT / 2.0, 0.0),
             vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
         ),
+        // hazard patch: a floor marker under the (invisible) radiation source
+        (
+            vec3(0.15, 0.45, 0.15),
+            vec3(
+                RADIATION_SOURCE_POSITION.0,
+                0.02,
+                RADIATION_SOURCE_POSITION.1,
+            ),
+            vec3(
+                2.0 * RADIATION_SOURCE_RADIUS,
+                0.04,
+                2.0 * RADIATION_SOURCE_RADIUS,
+            ),
+        ),
         // pen: sides
         (
             pen_wall,
@@ -117,7 +143,9 @@ pub fn create_debug_psi_scene(
     println!(
         "[debug_psi] Player is equipped with the Psi Amp, psi pool full, every stat at cap.\n\
          Select a power with the `CyclePsiPower` input action (`Y` on desktop),\n\
-         then fire to cast it. Two pipe hybrids stand in the pen ahead."
+         then fire to cast it. Two pipe hybrids stand in the pen ahead,\n\
+         and a radiation hazard patch sits to the side (+Z); teleport into it\n\
+         to accumulate radiation."
     );
     builder.build_with_hooks(
         DebugSceneBuildOptions {
@@ -167,10 +195,18 @@ impl DebugSceneHooks for PsiHooks {
                 },
             );
 
-            let spawns = TARGET_POSITIONS
+            let mut spawns: Vec<Effect> = TARGET_POSITIONS
                 .iter()
                 .map(|(x, z)| spawn_at(TARGET_CREATURE, Point3::new(-x, 1.0, *z)))
                 .collect();
+            spawns.push(spawn_at(
+                RADIATION_SOURCE_TEMPLATE_ID,
+                Point3::new(
+                    RADIATION_SOURCE_POSITION.0,
+                    1.0,
+                    RADIATION_SOURCE_POSITION.1,
+                ),
+            ));
             core.handle_effects(
                 spawns,
                 global_context,

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -102,18 +102,21 @@ pub fn create_debug_psi_scene(
             vec3(-PEN_FAR, PEN_WALL_HEIGHT / 2.0, 0.0),
             vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
         ),
-        // hazard patch: a floor marker under the (invisible) radiation source
+        // hazard patch: a floor marker for the (invisible) radiation source.
+        // The field is a 6-unit sphere; the marker is the square inscribed in
+        // it, so every point on the marker is inside the field. Sunk into the
+        // floor slab so a walking tester does not step onto a lip.
         (
             vec3(0.15, 0.45, 0.15),
             vec3(
                 RADIATION_SOURCE_POSITION.0,
-                0.02,
+                -0.02,
                 RADIATION_SOURCE_POSITION.1,
             ),
             vec3(
-                2.0 * RADIATION_SOURCE_RADIUS,
+                RADIATION_SOURCE_RADIUS * std::f32::consts::SQRT_2,
                 0.04,
-                2.0 * RADIATION_SOURCE_RADIUS,
+                RADIATION_SOURCE_RADIUS * std::f32::consts::SQRT_2,
             ),
         ),
         // pen: sides

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -1,33 +1,61 @@
 //! Debug scene for psi amp / psi power work.
 //!
-//! The player spawns holding the psi amp on a floor facing a flat wall (same
-//! layout as `debug_weapons`), so each power's cast can be observed in
-//! isolation. Select a power with `CyclePsiPower` (`Y` on desktop /
+//! The player spawns holding the psi amp with a full psi pool and a maxed
+//! character sheet, facing a walled pen of creatures straight ahead with a
+//! flat wall behind it. Select a power with `CyclePsiPower` (`Y` on desktop /
 //! `POST /v1/input/action {"action":"CyclePsiPower"}`) and fire; projectile
-//! powers (Cryokinesis, Pyrokinesis, ...) land on the wall, and the psi bar
-//! on the HUD drains by the power's tier per cast.
+//! powers (Cryokinesis, Pyrokinesis, ...) hit the creatures or the wall, the
+//! pen keeps the targets at range so offensive powers can be measured against
+//! a live creature, and the psi bar on the HUD drains by the power's tier per
+//! cast.
 
-use cgmath::{Deg, Quaternion, Rotation3, vec3};
+use cgmath::{Deg, Point3, Quaternion, Rotation3, vec3};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
-use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
-use shipyard::EntityId;
+use shipyard::{EntityId, Get, UniqueView, ViewMut};
 
 use crate::{
     GameOptions,
     game_scene::GameScene,
-    mission::{GlobalContext, SpawnLocation},
+    mission::{
+        GlobalContext, SpawnLocation,
+        mission_core::{MissionCore, PlayerInfo},
+    },
+    scripts::Effect,
 };
 
 use super::debug_common::{
-    AutoEquipHooks, DebugSceneBuildOptions, DebugSceneBuilder, HookedDebugScene, cube_object,
+    AutoEquipHooks, DebugBox, DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks,
+    boxes_to_geometry, max_player_stats, spawn_at,
 };
 
 /// The Psi Amp player weapon.
 const PSI_AMP_TEMPLATE_ID: i32 = -247;
 
-/// Distance (world units) from the player to the test wall, straight ahead
-/// (-X, the default-view forward).
-const WALL_DISTANCE: f32 = 12.0;
+/// The penned creature: -397 = grunt og-pipe (pipe hybrid), the same actor
+/// `debug_melee` and `debug_hitbox` use, so damage/AI observations line up
+/// across scenes.
+const TARGET_CREATURE: i32 = -397;
+
+/// Where the creatures stand inside the pen, as (x, z): world units ahead of
+/// the player along -X, and across the firing line. The near one sits on the
+/// line so a straight cast lands without aiming; the far one is offset so the
+/// near one does not screen it.
+const TARGET_POSITIONS: &[(f32, f32)] = &[(9.0, 0.0), (11.0, 1.8)];
+
+/// The pen: a box closed on all four sides. Debug scenes have no nav mesh, so
+/// a loose creature would walk straight at the player and turn every
+/// measurement into a melee. The wall height is a measurement, not a rule:
+/// 1.2 was verified to hold an alerted pipe hybrid (~3.4 tall, no step over)
+/// while a level cast from the player's eye (~2.3) clears it onto the
+/// creature's torso. Re-check it if `TARGET_CREATURE` changes.
+const PEN_NEAR: f32 = 7.0;
+const PEN_FAR: f32 = 13.0;
+const PEN_HALF_WIDTH: f32 = 3.0;
+const PEN_WALL_HEIGHT: f32 = 1.2;
+
+/// Distance (world units) from the player to the backstop wall, straight
+/// ahead (-X, the default-view forward), behind the pen.
+const WALL_DISTANCE: f32 = 15.0;
 
 pub fn create_debug_psi_scene(
     global_context: &GlobalContext,
@@ -35,53 +63,129 @@ pub fn create_debug_psi_scene(
     asset_cache: &mut AssetCache,
     audio_context: &mut AudioContext<EntityId, String>,
 ) -> Box<dyn GameScene> {
-    // Same controlled environment as debug_weapons: a floor under the player
-    // and a vertical wall straight ahead to catch projectiles.
-    let floor = cube_object(
-        vec3(0.18, 0.18, 0.22),
-        vec3(0.0, -0.5, 0.0),
-        vec3(40.0, 1.0, 40.0),
-    );
-    let wall = cube_object(
-        vec3(0.45, 0.45, 0.5),
-        vec3(-WALL_DISTANCE, 5.0, 0.0),
-        vec3(1.0, 30.0, 30.0),
-    );
-
-    let collider = ColliderBuilder::compound(vec![
+    let pen_wall = vec3(0.55, 0.32, 0.28);
+    let pen_mid_x = -(PEN_NEAR + PEN_FAR) / 2.0;
+    let pen_len = PEN_FAR - PEN_NEAR;
+    let boxes: &[DebugBox] = &[
+        // floor
         (
-            Isometry::translation(0.0, -0.5, 0.0),
-            SharedShape::cuboid(20.0, 0.5, 20.0),
+            vec3(0.18, 0.18, 0.22),
+            vec3(0.0, -0.5, 0.0),
+            vec3(40.0, 1.0, 40.0),
+        ),
+        // backstop wall
+        (
+            vec3(0.45, 0.45, 0.5),
+            vec3(-WALL_DISTANCE, 5.0, 0.0),
+            vec3(1.0, 30.0, 30.0),
+        ),
+        // pen: front and back
+        (
+            pen_wall,
+            vec3(-PEN_NEAR, PEN_WALL_HEIGHT / 2.0, 0.0),
+            vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
         ),
         (
-            Isometry::translation(-WALL_DISTANCE, 5.0, 0.0),
-            SharedShape::cuboid(0.5, 15.0, 15.0),
+            pen_wall,
+            vec3(-PEN_FAR, PEN_WALL_HEIGHT / 2.0, 0.0),
+            vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
         ),
-    ])
-    .build();
+        // pen: sides
+        (
+            pen_wall,
+            vec3(pen_mid_x, PEN_WALL_HEIGHT / 2.0, -PEN_HALF_WIDTH),
+            vec3(pen_len, PEN_WALL_HEIGHT, 1.0),
+        ),
+        (
+            pen_wall,
+            vec3(pen_mid_x, PEN_WALL_HEIGHT / 2.0, PEN_HALF_WIDTH),
+            vec3(pen_len, PEN_WALL_HEIGHT, 1.0),
+        ),
+    ];
+    let (scene_objects, collider) = boxes_to_geometry(boxes);
 
-    let builder = DebugSceneBuilder::new("debug_psi")
+    let mut builder = DebugSceneBuilder::new("debug_psi")
         .with_spawn_location(SpawnLocation::PositionRotation(
             vec3(0.0, 2.0, 0.0),
             Quaternion::from_angle_y(Deg(0.0)),
         ))
-        .with_physics_geometry(collider)
-        .add_scene_object(floor)
-        .add_scene_object(wall);
+        .with_physics_geometry(collider);
+    for scene_object in scene_objects {
+        builder = builder.add_scene_object(scene_object);
+    }
 
-    let core = builder.build_core(DebugSceneBuildOptions {
-        global_context,
-        game_options,
-        asset_cache,
-        audio_context,
-    });
     println!(
-        "[debug_psi] Player is equipped with the Psi Amp.\n\
+        "[debug_psi] Player is equipped with the Psi Amp, psi pool full, every stat at cap.\n\
          Select a power with the `CyclePsiPower` input action (`Y` on desktop),\n\
-         then fire to cast it. Projectile powers land on the wall ahead."
+         then fire to cast it. Two pipe hybrids stand in the pen ahead."
     );
-    Box::new(HookedDebugScene::new(
-        core,
-        AutoEquipHooks::new(PSI_AMP_TEMPLATE_ID),
-    ))
+    builder.build_with_hooks(
+        DebugSceneBuildOptions {
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        },
+        PsiHooks {
+            populated: false,
+            equip: AutoEquipHooks::new(PSI_AMP_TEMPLATE_ID),
+        },
+    )
+}
+
+struct PsiHooks {
+    populated: bool,
+    equip: AutoEquipHooks,
+}
+
+impl DebugSceneHooks for PsiHooks {
+    fn before_handle_effects(
+        &mut self,
+        core: &mut MissionCore,
+        effects: &mut Vec<Effect>,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if !self.populated {
+            self.populated = true;
+
+            // Nothing on the psi cast path reads the character sheet yet
+            // (every power is already known in a debug scene, and the amp's
+            // effective PSI stat is a constant), so this is parity with
+            // `debug_weapons` and future-proofing, not a gate being lifted.
+            max_player_stats(core, "debug_psi");
+            // The psi pool is what actually limits a test session: the player
+            // template seeds it short of its maximum. Start full.
+            core.world.run(
+                |player: UniqueView<PlayerInfo>,
+                 mut psi: ViewMut<dark::properties::PropPsiState>| {
+                    if let Ok(psi) = (&mut psi).get(player.entity_id) {
+                        psi.psi_points = psi.max_psi_points;
+                    }
+                },
+            );
+
+            let spawns = TARGET_POSITIONS
+                .iter()
+                .map(|(x, z)| spawn_at(TARGET_CREATURE, Point3::new(-x, 1.0, *z)))
+                .collect();
+            core.handle_effects(
+                spawns,
+                global_context,
+                game_options,
+                asset_cache,
+                audio_context,
+            );
+        }
+        self.equip.before_handle_effects(
+            core,
+            effects,
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        );
+    }
 }

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -15,18 +15,17 @@
 
 use cgmath::{Deg, Point3, Quaternion, Rotation3, vec3};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
-use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
 use shipyard::EntityId;
 
 use crate::{
     GameOptions,
-    game_scene::{DebugPlayerStatsRequest, DebugSkillLevelsRequest, DebuggableScene, GameScene},
+    game_scene::GameScene,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, cube_object, spawn_at,
+        DebugBox, DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, boxes_to_geometry,
+        max_player_stats, spawn_at,
     },
     scripts::Effect,
-    scripts::gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP},
 };
 
 /// Distance (world units) from the player to the test wall, straight ahead (-X,
@@ -107,11 +106,7 @@ pub fn create_debug_weapons_scene(
     // and a flat table sheds them onto the floor within seconds.
     let lip_color = vec3(0.36, 0.31, 0.24);
     let lip_top = BENCH_HEIGHT + BENCH_LIP_HEIGHT / 2.0;
-    let boxes: &[(
-        cgmath::Vector3<f32>,
-        cgmath::Vector3<f32>,
-        cgmath::Vector3<f32>,
-    )] = &[
+    let boxes: &[DebugBox] = &[
         // floor
         (
             vec3(0.18, 0.18, 0.22),
@@ -174,22 +169,7 @@ pub fn create_debug_weapons_scene(
         ),
     ];
 
-    let scene_objects = boxes
-        .iter()
-        .map(|(color, translation, scale)| cube_object(*color, *translation, *scale))
-        .collect::<Vec<_>>();
-    let collider = ColliderBuilder::compound(
-        boxes
-            .iter()
-            .map(|(_, translation, scale)| {
-                (
-                    Isometry::translation(translation.x, translation.y, translation.z),
-                    SharedShape::cuboid(scale.x / 2.0, scale.y / 2.0, scale.z / 2.0),
-                )
-            })
-            .collect(),
-    )
-    .build();
+    let (scene_objects, collider) = boxes_to_geometry(boxes);
 
     // Spawn at the floor with identity yaw: the default view forward is -X, so
     // the wall sits dead ahead and the bench is a quarter-turn to the left.
@@ -241,32 +221,7 @@ impl DebugSceneHooks for ArsenalHooks {
         }
         self.populated = true;
 
-        // "Full stats": max the character sheet through the same provisioning
-        // path as `POST /v1/player/stats`, so nothing (skill gates, psi tiers)
-        // stands between the tester and any weapon on the bench.
-        let request = DebugPlayerStatsRequest {
-            strength: Some(STAT_CAP),
-            endurance: Some(STAT_CAP),
-            agility: Some(STAT_CAP),
-            psionic_ability: Some(STAT_CAP),
-            cyber_affinity: Some(STAT_CAP),
-            skills: DebugSkillLevelsRequest {
-                standard_weapons: Some(SKILL_CAP),
-                energy_weapons: Some(SKILL_CAP),
-                heavy_weapons: Some(SKILL_CAP),
-                exotic_weapons: Some(SKILL_CAP),
-                hack: Some(SKILL_CAP),
-                repair: Some(SKILL_CAP),
-                modify: Some(SKILL_CAP),
-                maintenance: Some(SKILL_CAP),
-                research: Some(SKILL_CAP),
-            },
-            psi_tier: Some(PSI_TIER_CAP),
-            cyber_modules: None,
-        };
-        if let Err(err) = core.set_player_stats(&request) {
-            tracing::warn!("[debug_weapons] failed to max player stats: {err}");
-        }
+        max_player_stats(core, "debug_weapons");
 
         // Guns on the outer row, ammo on the inner row. Drop heights are
         // load-bearing: a big gun's collider extends below its origin, and a

--- a/shock2vr/src/scripts/radiation.rs
+++ b/shock2vr/src/scripts/radiation.rs
@@ -171,7 +171,7 @@ impl ActiveRadiation {
         let shielded = decontamination_per_sec.is_finite() && decontamination_per_sec > 0.0;
         if shielded {
             self.ambient_level = 0.0;
-            self.level = (self.level - decontamination_per_sec * elapsed_secs).max(0.0);
+            self.clear(decontamination_per_sec * elapsed_secs);
         }
 
         self.seconds_until_check -= elapsed_secs;

--- a/shock2vr/src/scripts/radiation.rs
+++ b/shock2vr/src/scripts/radiation.rs
@@ -20,6 +20,9 @@ pub const RADIATION_DAMAGE_INTERVAL_SECS: f32 = 6.0;
 pub const RADIATION_CHECK_INTERVAL_SECS: f32 = 0.1;
 const RADIATION_DAMAGE_PER_LEVEL: f32 = 0.25;
 const DEFAULT_RADIATION_ABSORB: f32 = 0.05;
+/// Fallback decontamination rate if `Rad Shield`'s authored `data[0]` is
+/// missing, matching the shipped value.
+const DEFAULT_DECONTAMINATION_PER_SEC: f32 = 5.0;
 const DEFAULT_RADIATION_RECOVERY: f32 = 3.0;
 
 /// Retail `RadPatch`: clear part of the player's accumulated radiation and
@@ -119,11 +122,14 @@ impl ActiveRadiation {
 
     /// Advance the retail 6-second damage/recovery clock and return ordinary
     /// hit-point damage for MissionCore's central HP effect handler.
+    /// `decontamination_per_sec` is the active Neural Decontamination
+    /// (`Rad Shield`) purge rate, or 0 when the power is not active.
     pub fn advance(
         &mut self,
         elapsed_secs: f32,
         absorb_per_check: f32,
         recovery_per_tick: f32,
+        decontamination_per_sec: f32,
     ) -> i32 {
         if !elapsed_secs.is_finite() || elapsed_secs <= 0.0 {
             return 0;
@@ -155,6 +161,19 @@ impl ActiveRadiation {
             DEFAULT_RADIATION_RECOVERY
         };
 
+        // Neural Decontamination: while the sustained power is active the
+        // caster is sealed off - ambient exposure never reaches stored level,
+        // the stored level bleeds off, and the 6 s clock deals no damage.
+        // ASSUMPTION: the power's authored `data[0]` (5.0) reads as a
+        // per-second purge rate; retail could instead mean a resistance
+        // percentage. At 5/s any realistic level clears within ~2 s, which is
+        // what "clears accumulated radiation" is asking for either way.
+        let shielded = decontamination_per_sec.is_finite() && decontamination_per_sec > 0.0;
+        if shielded {
+            self.ambient_level = 0.0;
+            self.level = (self.level - decontamination_per_sec * elapsed_secs).max(0.0);
+        }
+
         self.seconds_until_check -= elapsed_secs;
         while self.seconds_until_check <= 0.0 {
             if self.ambient_level > self.level {
@@ -166,7 +185,7 @@ impl ActiveRadiation {
         self.seconds_until_damage -= elapsed_secs;
         let mut damage = 0_i32;
         while self.seconds_until_damage <= 0.0 {
-            if self.level >= 1.0 {
+            if !shielded && self.level >= 1.0 {
                 let pulse = (self.level * RADIATION_DAMAGE_PER_LEVEL)
                     .trunc()
                     .clamp(0.0, i32::MAX as f32) as i32;
@@ -212,6 +231,31 @@ pub fn apply_player_stimulus(
         .is_ok_and(|mut radiation| radiation.observe_ambient(amount))
 }
 
+/// The purge rate of an active Neural Decontamination (`Rad Shield`), read
+/// from the power's authored `data[0]`, or 0 when it is not active. Kept in
+/// the radiation tick rather than the psi code so it composes with the
+/// anti-rad patch and any future radiation-absorb path.
+fn active_decontamination_rate(world: &World) -> f32 {
+    let active = world
+        .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+        .is_ok_and(|active| active.is_active(crate::psi::RAD_SHIELD_TEMPLATE_ID));
+    if !active {
+        return 0.0;
+    }
+    world
+        .borrow::<UniqueView<crate::psi::GlobalPsiPowers>>()
+        .ok()
+        .and_then(|powers| {
+            powers
+                .0
+                .iter()
+                .find(|p| p.template_id == crate::psi::RAD_SHIELD_TEMPLATE_ID)
+                .map(|p| p.power.data[0])
+        })
+        .filter(|rate| rate.is_finite() && *rate > 0.0)
+        .unwrap_or(DEFAULT_DECONTAMINATION_PER_SEC)
+}
+
 pub fn tick_player_radiation(world: &World, elapsed_secs: f32) -> Option<Effect> {
     let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
     let recovery = world
@@ -224,10 +268,11 @@ pub fn tick_player_radiation(world: &World, elapsed_secs: f32) -> Option<Effect>
         .ok()
         .and_then(|values| values.get(player).ok().map(|value| value.0))
         .unwrap_or(DEFAULT_RADIATION_ABSORB);
+    let decontamination = active_decontamination_rate(world);
     let damage = world
         .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
         .ok()
-        .map(|mut radiation| radiation.advance(elapsed_secs, absorb, recovery))
+        .map(|mut radiation| radiation.advance(elapsed_secs, absorb, recovery, decontamination))
         .unwrap_or(0);
     (damage > 0).then_some(Effect::AdjustHitPoints {
         entity_id: player,
@@ -300,12 +345,12 @@ mod tests {
     fn patch_clears_level_without_granting_future_protection() {
         let mut radiation = ActiveRadiation::default();
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(0.1, 8.0, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0, 0.0), 0);
         assert!(radiation.clear(6.0));
         assert_eq!(radiation.level(), 2.0);
 
         assert!(radiation.observe_ambient(6.0));
-        assert_eq!(radiation.advance(0.1, 4.0, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, 4.0, 3.0, 0.0), 0);
         assert_eq!(radiation.level(), 6.0);
     }
 
@@ -313,14 +358,49 @@ mod tests {
     fn damage_and_recovery_follow_the_retail_six_second_clock() {
         let mut radiation = ActiveRadiation::default();
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(0.1, 8.0, 3.0), 0);
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0, 0.0), 0);
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(5.89, 0.05, 3.0), 0);
+        assert_eq!(radiation.advance(5.89, 0.05, 3.0, 0.0), 0);
         assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(0.02, 0.05, 3.0), 2);
+        assert_eq!(radiation.advance(0.02, 0.05, 3.0, 0.0), 2);
         assert_eq!(radiation.level(), 8.0, "active exposure delays recovery");
-        assert_eq!(radiation.advance(6.0, 0.05, 3.0), 2);
+        assert_eq!(radiation.advance(6.0, 0.05, 3.0, 0.0), 2);
         assert_eq!(radiation.level(), 5.0);
+    }
+
+    #[test]
+    fn rad_shield_purges_and_blocks_while_active() {
+        let mut radiation = ActiveRadiation::default();
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0, 0.0), 0);
+        assert_eq!(radiation.level(), 8.0);
+
+        // One second of shielded exposure: ambient is ignored and 5.0 bleeds
+        // off, so a level that would otherwise hold at 8 falls to 3.
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(1.0, 8.0, 3.0, 5.0), 0);
+        assert_eq!(radiation.level(), 3.0);
+
+        // ...and it reaches zero and stays there while the shield holds.
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(1.0, 8.0, 3.0, 5.0), 0);
+        assert_eq!(radiation.level(), 0.0);
+
+        // Expiry: exposure accumulates again from the shipped absorb step.
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(0.1, 0.05, 3.0, 0.0), 0);
+        assert_eq!(radiation.level(), 0.05);
+    }
+
+    #[test]
+    fn rad_shield_suppresses_the_six_second_damage_pulse() {
+        let mut radiation = ActiveRadiation::default();
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(0.1, 8.0, 3.0, 0.0), 0);
+
+        // Unshielded this tick deals 2 damage (see the retail-clock test).
+        assert!(radiation.observe_ambient(8.0));
+        assert_eq!(radiation.advance(6.0, 0.05, 3.0, 5.0), 0);
     }
 
     #[test]
@@ -332,7 +412,7 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(radiation.advance(1.0 / 60.0, 0.05, 3.0), 0);
+        assert_eq!(radiation.advance(1.0 / 60.0, 0.05, 3.0, 0.0), 0);
         assert_eq!(radiation.level(), 8.0);
     }
 
@@ -378,7 +458,7 @@ mod tests {
             world
                 .borrow::<shipyard::UniqueViewMut<ActiveRadiation>>()
                 .unwrap()
-                .advance(0.1, 0.05, 3.0),
+                .advance(0.1, 0.05, 3.0, 0.0),
             0
         );
         assert_eq!(

--- a/shock2vr/src/scripts/radiation.rs
+++ b/shock2vr/src/scripts/radiation.rs
@@ -20,9 +20,6 @@ pub const RADIATION_DAMAGE_INTERVAL_SECS: f32 = 6.0;
 pub const RADIATION_CHECK_INTERVAL_SECS: f32 = 0.1;
 const RADIATION_DAMAGE_PER_LEVEL: f32 = 0.25;
 const DEFAULT_RADIATION_ABSORB: f32 = 0.05;
-/// Fallback decontamination rate if `Rad Shield`'s authored `data[0]` is
-/// missing, matching the shipped value.
-const DEFAULT_DECONTAMINATION_PER_SEC: f32 = 5.0;
 const DEFAULT_RADIATION_RECOVERY: f32 = 3.0;
 
 /// Retail `RadPatch`: clear part of the player's accumulated radiation and
@@ -252,8 +249,7 @@ fn active_decontamination_rate(world: &World) -> f32 {
                 .find(|p| p.template_id == crate::psi::RAD_SHIELD_TEMPLATE_ID)
                 .map(|p| p.power.data[0])
         })
-        .filter(|rate| rate.is_finite() && *rate > 0.0)
-        .unwrap_or(DEFAULT_DECONTAMINATION_PER_SEC)
+        .unwrap_or(0.0)
 }
 
 pub fn tick_player_radiation(world: &World, elapsed_secs: f32) -> Option<Effect> {
@@ -397,10 +393,13 @@ mod tests {
         let mut radiation = ActiveRadiation::default();
         assert!(radiation.observe_ambient(8.0));
         assert_eq!(radiation.advance(0.1, 8.0, 3.0, 0.0), 0);
+        assert_eq!(radiation.advance(5.89, 0.05, 3.0, 0.0), 0);
 
-        // Unshielded this tick deals 2 damage (see the retail-clock test).
-        assert!(radiation.observe_ambient(8.0));
-        assert_eq!(radiation.advance(6.0, 0.05, 3.0, 5.0), 0);
+        // Cross the 6 s boundary shielded, in a step short enough that the
+        // purge leaves the level well above the 1.0 damage threshold: it is
+        // the shield, not an already-zeroed level, that suppresses the pulse.
+        assert_eq!(radiation.advance(0.02, 0.05, 3.0, 5.0), 0);
+        assert!(radiation.level() > 1.0);
     }
 
     #[test]

--- a/tools/shock2-sdk/test/helpers/psi.ts
+++ b/tools/shock2-sdk/test/helpers/psi.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+
+import type { GameServer } from "../../src/index.js";
+
+/** Cycle the psi power selection until `name` is selected (bounded). */
+export async function selectPsiPower(game: GameServer, name: string): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    if ((await game.info()).player.selected_psi_power === name) return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 2 });
+  }
+  assert.fail(`could not cycle the psi power selection to ${name}`);
+}

--- a/tools/shock2-sdk/test/psi-rad-shield.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-rad-shield.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { pullTrigger } from "./helpers/weapon.js";
 
 // End-to-end test for Neural Decontamination (`Rad Shield`, issue #1300).
 // `debug_psi` carries a hazard patch (a `Rad Burst` radius radiation source)
@@ -24,14 +25,6 @@ async function selectPower(game: GameServer, name: string): Promise<void> {
     await game.step({ frames: 2 });
   }
   throw new Error(`never reached psi power "${name}"`);
-}
-
-/** One edge-triggered trigger pull: the psi amp casts on the rising edge. */
-async function castOnce(game: GameServer): Promise<void> {
-  await game.input.set("right_hand.trigger", 1.0);
-  await game.step({ frames: 1 });
-  await game.input.set("right_hand.trigger", 0.0);
-  await game.step({ frames: 30 });
 }
 
 test(
@@ -57,7 +50,9 @@ test(
     const beforePsi = (await game.info()).player.psi_points;
     const beforeHp = (await game.info()).player.hit_points;
 
-    await castOnce(game);
+    // The psi amp casts on the trigger's rising edge; settle for half a second.
+    await pullTrigger(game);
+    await game.step({ frames: 30 });
     let player = (await game.info()).player;
     assert.deepEqual(
       player.active_psi_powers,

--- a/tools/shock2-sdk/test/psi-rad-shield.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-rad-shield.e2e.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for Neural Decontamination (`Rad Shield`, issue #1300).
+// `debug_psi` carries a hazard patch (a `Rad Burst` radius radiation source)
+// beside the player: teleporting into it accumulates radiation, and casting
+// Rad Shield must purge the accumulated level and block further exposure for
+// the power's duration.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The hazard patch's centre in `debug_psi` (RADIATION_SOURCE_POSITION). */
+const HAZARD = { x: 0.0, y: 1.0, z: 9.0 };
+
+/** Select a psi power by name, cycling with `CyclePsiPower`. */
+async function selectPower(game: GameServer, name: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if ((await game.info()).player.selected_psi_power === name) return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 2 });
+  }
+  throw new Error(`never reached psi power "${name}"`);
+}
+
+/** One edge-triggered trigger pull: the psi amp casts on the rising edge. */
+async function castOnce(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.trigger", 1.0);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0.0);
+  await game.step({ frames: 30 });
+}
+
+test(
+  "Rad Shield purges accumulated radiation and blocks new exposure until it expires",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_psi" });
+
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.info()).player.radiation_level,
+      0,
+      "the spawn point is outside the hazard patch's radius",
+    );
+
+    // Baseline: standing in the patch accumulates radiation.
+    await game.player.teleport(HAZARD);
+    await game.step({ frames: 180 });
+    const irradiated = (await game.info()).player.radiation_level;
+    assert.ok(irradiated > 0, `hazard patch should irradiate the player (got ${irradiated})`);
+
+    await selectPower(game, "Rad Shield");
+    const beforePsi = (await game.info()).player.psi_points;
+    const beforeHp = (await game.info()).player.hit_points;
+
+    await castOnce(game);
+    let player = (await game.info()).player;
+    assert.deepEqual(
+      player.active_psi_powers,
+      ["Rad Shield"],
+      "casting Rad Shield activates the sustained power",
+    );
+    assert.equal(player.psi_points, beforePsi! - 2, "tier 2 cast costs two psi points");
+    assert.equal(
+      player.radiation_level,
+      0,
+      "an active Rad Shield purges the accumulated radiation",
+    );
+
+    // ...and it stays purged while the player keeps standing in the hazard.
+    await game.step({ frames: 300 });
+    player = (await game.info()).player;
+    assert.equal(player.radiation_level, 0, "Rad Shield blocks new exposure while active");
+    assert.ok(player.active_psi_powers.includes("Rad Shield"), "the power is still active");
+    assert.equal(player.hit_points, beforeHp, "no radiation damage lands while shielded");
+
+    // Step past expiry (10 + 5 x PSI seconds) in <= 300-frame chunks.
+    for (let chunk = 0; chunk < 12; chunk += 1) {
+      await game.step({ frames: 300 });
+      if (!(await game.info()).player.active_psi_powers.includes("Rad Shield")) break;
+    }
+    player = (await game.info()).player;
+    assert.ok(
+      !player.active_psi_powers.includes("Rad Shield"),
+      "Rad Shield should expire on its own",
+    );
+
+    // Exposure resumes once the shield is gone.
+    await game.step({ frames: 300 });
+    const afterExpiry = (await game.info()).player.radiation_level;
+    assert.ok(
+      afterExpiry > 0,
+      `radiation should accumulate again after expiry (got ${afterExpiry})`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/psi-rad-shield.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-rad-shield.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { selectPsiPower } from "./helpers/psi.js";
 import { pullTrigger } from "./helpers/weapon.js";
 
 // End-to-end test for Neural Decontamination (`Rad Shield`, issue #1300).
@@ -16,16 +17,6 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 /** The hazard patch's centre in `debug_psi` (RADIATION_SOURCE_POSITION). */
 const HAZARD = { x: 0.0, y: 1.0, z: 9.0 };
-
-/** Select a psi power by name, cycling with `CyclePsiPower`. */
-async function selectPower(game: GameServer, name: string): Promise<void> {
-  for (let attempt = 0; attempt < 40; attempt += 1) {
-    if ((await game.info()).player.selected_psi_power === name) return;
-    await game.input.trigger("CyclePsiPower");
-    await game.step({ frames: 2 });
-  }
-  throw new Error(`never reached psi power "${name}"`);
-}
 
 test(
   "Rad Shield purges accumulated radiation and blocks new exposure until it expires",
@@ -46,7 +37,7 @@ test(
     const irradiated = (await game.info()).player.radiation_level;
     assert.ok(irradiated > 0, `hazard patch should irradiate the player (got ${irradiated})`);
 
-    await selectPower(game, "Rad Shield");
+    await selectPsiPower(game, "Rad Shield");
     const beforePsi = (await game.info()).player.psi_points;
     const beforeHp = (await game.info()).player.hit_points;
 

--- a/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
+import { selectPsiPower } from "./helpers/psi.js";
 import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end tests for sustained (timed) psi powers. Photonic Redirection
@@ -21,17 +22,6 @@ const INVISO_DURATION_FRAMES = 30 * 60;
 
 function aiProp(detail: EntityDetailResult, name: string): string | undefined {
   return detail.properties.find((p) => p.name === name)?.value;
-}
-
-/** Cycle the psi power selection until Inviso is selected (bounded). */
-async function selectInviso(game: GameServer): Promise<void> {
-  for (let i = 0; i < 40; i++) {
-    const selected = (await game.info()).player.selected_psi_power;
-    if (selected === "Inviso") return;
-    await game.input.trigger("CyclePsiPower");
-    await game.step({ frames: 1 });
-  }
-  assert.fail("could not cycle the psi power selection to Inviso");
 }
 
 /** Step `frames` in chunks so a single /v1/step call stays small. */
@@ -59,7 +49,7 @@ test(
     assert.ok(startPsi !== null && startPsi >= 2 * INVISO_COST);
 
     // Cast Photonic Redirection (tier 4 sustained power).
-    await selectInviso(game);
+    await selectPsiPower(game, "Inviso");
     await fireOnce(game);
     player = (await game.info()).player;
     assert.equal(player.psi_points, startPsi! - INVISO_COST, "Inviso cast costs 4 psi points");
@@ -126,7 +116,7 @@ test(
       assert.ok(camera, "debug_camera should contain a Security Camera");
 
       // Cast Inviso immediately (~0.5 s in, long before the camera reacts).
-      await selectInviso(game);
+      await selectPsiPower(game, "Inviso");
       await fireOnce(game);
       const player = (await game.info()).player;
       assert.deepEqual(player.active_psi_powers, ["Inviso"], "Inviso active in debug_camera");


### PR DESCRIPTION
Stacks on #1272 (`feat/debug-psi-pen`) — review that first; this PR's own diff is the last two commits.

## What

Neural Decontamination (`Rad Shield`, template -1114) had no effect: casting it spent 2 psi and put the power in `active_psi_powers`, and `radiation_level` kept climbing.

While the power is active, the radiation tick now:

- ignores ambient exposure (nothing reaches the stored level),
- bleeds the stored level off at the power's authored `data[0]`, and
- skips the retail 6 s damage pulse, so no radiation HP loss lands.

The hook lives in `scripts/radiation.rs` (the tick), not in the psi cast path, so it composes with the anti-rad patch and any future radiation-absorb path — as the issue asks.

**Interpretation of `data[0] = 5.0`** (called out as an assumption in a comment): a **per-second purge rate**. It could instead be a resistance percentage; at 5/s any realistic accumulated level clears within ~2 s, which satisfies "accumulated radiation bleeds off" either way. The `10 + 5×PSI` s duration keeps it a crossing-a-hot-zone power rather than a permanent immunity.

## Scene

`debug_psi` gains the tracker's **hazard patch** station: a `Rad Burst` (-1219) radius radiation source — the persistent source the game already spawns from a destroyed rad barrel (`StimSource` Radiation, intensity 8, radius 6). It renders nothing, so a green floor patch marks its footprint. It sits at `(0, 9)`, beside the player and off the firing line, 9 units out so the **spawn point is outside its radius** — the player starts clean and only irradiates after a deliberate `POST /v1/player/teleport` into it.

## Verification

Headless `debug_psi` run (values from the debug runtime):

| step | `radiation_level` | `psi_points` | `active_psi_powers` |
|---|---|---|---|
| spawn | 0.0 | 50 | [] |
| +3 s in the patch | 1.5 | 50 | [] |
| cast Rad Shield, +0.5 s | **0.0** | **48** | `["Rad Shield"]` |
| +5 s still in the patch | 0.0 | 48 | `["Rad Shield"]` |
| after expiry, +5 s | 2.75 → 5.25 | 48 | [] |

- New unit tests in `scripts/radiation.rs` (purge/block/expiry, and damage-pulse suppression) — both fail without the change (`advance` gained the rate parameter).
- New `tools/shock2-sdk/test/psi-rad-shield.e2e.test.ts` walks exactly the issue's acceptance steps.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean, `cargo fmt` applied.

## Out of scope

Radiation damage tuning and the rad HUD warning (per the issue) — the port has no radiation HUD indicator today, so the only new *visual* is the debug scene's hazard-patch marker.

## Visuals

The new hazard-patch station in `debug_psi` — the green square is the marker for the invisible `Rad Burst` source, sized to the square inscribed in its 6-unit field, with the creature pen behind it:

![hazard patch](https://gist.githubusercontent.com/tommy-xr/bc4ad32aa6d77d02cbe8b7f4e3d57413/raw/hazard_patch.png)

Standing in the patch and casting Rad Shield: the psi readout drops 100% -> 96% (50 -> 48 points, the tier-2 cost) and the MFD names the power (`NEURAL...`, cost 2). There is no radiation HUD indicator in the port, so the radiation numbers are in the table above rather than on screen.

![cast](https://gist.githubusercontent.com/tommy-xr/bc4ad32aa6d77d02cbe8b7f4e3d57413/raw/rad_shield.gif)

Fixes #1300

