### PR TITLE
feat(traits): Sharpshooter scales the player's ranged damage

### DIFF
--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -52,6 +52,7 @@ pub const TRAIT_STRONG_METABOLISM: u8 = 1;
 pub const TRAIT_PHARMO_FRIENDLY: u8 = 2;
 pub const TRAIT_PACK_RAT: u8 = 3;
 pub const TRAIT_SPEEDY: u8 = 4;
+pub const TRAIT_SHARPSHOOTER: u8 = 5;
 pub const TRAIT_NATURALLY_ABLE: u8 = 6;
 pub const TRAIT_TANK: u8 = 8;
 pub const TRAIT_LETHAL_WEAPON: u8 = 9;
@@ -77,6 +78,11 @@ pub const SPEEDY_MOVE_SCALE: f32 = 1.15;
 /// melee only - AI melee resolves through its own attack path.
 pub const LETHAL_WEAPON_DAMAGE_SCALE: f32 = 1.35;
 
+/// Sharpshooter: ranged weapons hit 15% harder (Trait5). The player's own
+/// shots only. 15% is the figure the trait's own description states; retail
+/// play measures a larger bonus, and this port implements the stated 15%.
+pub const SHARPSHOOTER_DAMAGE_SCALE: f32 = 1.15;
+
 /// Strong Metabolism: radiation damage is cut by a quarter (Trait1). The
 /// retail trait also resists toxins; this port has no toxin system yet, so
 /// only the radiation half has anything to scale.
@@ -97,6 +103,16 @@ pub fn lethal_weapon_damage(base: f32, has_trait: bool) -> f32 {
         base * LETHAL_WEAPON_DAMAGE_SCALE
     } else {
         base
+    }
+}
+
+/// Sharpshooter's multiplier on a player-fired shot's damage - folded into the
+/// projectile's fire-time stim modifier so every impact path bills it once.
+pub fn sharpshooter_damage_scale(has_trait: bool) -> f32 {
+    if has_trait {
+        SHARPSHOOTER_DAMAGE_SCALE
+    } else {
+        1.0
     }
 }
 
@@ -484,6 +500,7 @@ pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
         TRAIT_PHARMO_FRIENDLY => Some("20% med and psi hypo bonus"),
         TRAIT_PACK_RAT => Some("+3 backpack slots"),
         TRAIT_SPEEDY => Some("15% faster movement"),
+        TRAIT_SHARPSHOOTER => Some("15% more ranged damage"),
         TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
         TRAIT_TANK => Some("+5 max hit points"),
         TRAIT_LETHAL_WEAPON => Some("35% more melee damage"),
@@ -562,7 +579,7 @@ mod tests {
             machine,
             &world,
             &TraitGuiState::default(),
-            &TraitGuiMsg::Pick(5), // Sharpshooter has no aiming consumer yet.
+            &TraitGuiMsg::Pick(7), // Cybernetically Enhanced has no consumer yet.
         );
 
         assert!(matches!(effect, Effect::NoEffect));
@@ -605,6 +622,7 @@ mod tests {
         for trait_id in [
             TRAIT_STRONG_METABOLISM,
             TRAIT_SPEEDY,
+            TRAIT_SHARPSHOOTER,
             TRAIT_LETHAL_WEAPON,
             TRAIT_POWER_PSI,
             TRAIT_SPATIALLY_AWARE,
@@ -630,9 +648,9 @@ mod tests {
 
     #[test]
     fn traits_without_an_effect_are_still_refused() {
-        // 5 Sharpshooter, 7 Cybernetically Enhanced, 10 Security Expert,
-        // 11 Smasher, 12 Cyber-Assimilation, 15 Tinker.
-        for trait_id in [5, 7, 10, 11, 12, 15] {
+        // 7 Cybernetically Enhanced, 10 Security Expert, 11 Smasher,
+        // 12 Cyber-Assimilation, 15 Tinker.
+        for trait_id in [7, 10, 11, 12, 15] {
             let mut world = World::new();
             world.add_unique(QuestInfo::new());
             let machine =
@@ -663,6 +681,9 @@ mod tests {
 
         assert_eq!(strong_metabolism_damage(4.0, false), 4.0);
         assert_eq!(strong_metabolism_damage(4.0, true), 3.0);
+
+        assert_eq!(sharpshooter_damage_scale(false), 1.0);
+        assert_eq!(sharpshooter_damage_scale(true), 1.15);
 
         assert_eq!(power_psi_burnout_damage(9, false), 9);
         assert_eq!(power_psi_burnout_damage(9, true), 0);

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -108,12 +108,34 @@ fn shot_multiplier(raw: f32) -> f32 {
 
 /// The damage and speed multipliers this fire setting puts on the projectile it
 /// launches (the EMP rifle's overcharge hits 3x; the fusion cannon's DEATH lob
-/// travels at 0.4x).
-fn shot_modifiers(setting: &GunSettingDesc) -> RuntimePropShotModifiers {
+/// travels at 0.4x), times the shooter's own damage scale.
+///
+/// Sharpshooter rides here rather than at the impact: the projectile carries
+/// one damage scale, so the two impact paths bill the upgrade exactly once
+/// without either of them knowing who fired.
+fn shot_modifiers(setting: &GunSettingDesc, shooter_damage_scale: f32) -> RuntimePropShotModifiers {
     RuntimePropShotModifiers {
-        stim: shot_multiplier(setting.stim_modifier),
+        stim: shot_multiplier(setting.stim_modifier) * shooter_damage_scale,
         speed: shot_multiplier(setting.speed_modifier),
     }
+}
+
+/// The damage scale the entity firing `weapon` applies to its shots. Only a
+/// weapon in the player's own hands earns Sharpshooter - an AI's, a turret's
+/// and the psi amp's shots all launch with the neutral default modifiers and
+/// never reach this path, and a loose gun going off is nobody's aim.
+///
+/// Note the slow (physics) projectile path bills its placeholder 1.0 damage
+/// through this scale, so 1.15 still rounds to 1 there until that damage is
+/// resolved from authored data (the TODO in `internal_collision_type`).
+fn shooter_damage_scale(world: &World, weapon: EntityId) -> f32 {
+    crate::scripts::gui::sharpshooter_damage_scale(
+        crate::wielded_weapon::held_in_hand(world, weapon)
+            && crate::scripts::gui::player_has_os_trait(
+                world,
+                crate::scripts::gui::TRAIT_SHARPSHOOTER,
+            ),
+    )
 }
 
 /// Whether `entity_id` is still inside the wait its last shot imposed.
@@ -380,7 +402,7 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
                     entity_id,
                     template_id,
                     &options,
-                    shot_modifiers(setting),
+                    shot_modifiers(setting, shooter_damage_scale(world, entity_id)),
                 )
             })
             .collect(),
@@ -815,7 +837,7 @@ mod tests {
             speed_modifier: 0.8,
             ..GunSettingDesc::default()
         };
-        let modifiers = shot_modifiers(&emp_over);
+        let modifiers = shot_modifiers(&emp_over, 1.0);
         assert_eq!(modifiers.stim, 3.0);
         assert_eq!(modifiers.speed, 0.8);
 
@@ -826,9 +848,60 @@ mod tests {
             speed_modifier: 0.0,
             ..GunSettingDesc::default()
         };
-        let modifiers = shot_modifiers(&unauthored);
+        let modifiers = shot_modifiers(&unauthored, 1.0);
         assert_eq!(modifiers.stim, 1.0);
         assert_eq!(modifiers.speed, 1.0);
+    }
+
+    /// Sharpshooter reaches a shot only when the gun is in the player's own
+    /// hands. A gun nobody is holding - and an AI's, which never comes down
+    /// this path at all - fires at its authored damage.
+    #[test]
+    fn only_the_players_own_gun_earns_sharpshooter() {
+        let scale = |held: bool, traited: bool| {
+            let mut world = World::new();
+            let weapon = world.add_entity(());
+            let player = world.add_entity(());
+            world.add_unique(crate::mission::PlayerInfo {
+                pos: vec3(0.0, 0.0, 0.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                entity_id: player,
+                left_hand_entity_id: None,
+                right_hand_entity_id: held.then_some(weapon),
+                inventory_entity_id: player,
+            });
+            let mut quests = crate::quest_info::QuestInfo::new();
+            if traited {
+                quests
+                    .player_stats_mut()
+                    .add_os_trait(crate::scripts::gui::TRAIT_SHARPSHOOTER);
+            }
+            world.add_unique(quests);
+            shooter_damage_scale(&world, weapon)
+        };
+
+        assert_eq!(scale(true, false), 1.0);
+        assert_eq!(scale(true, true), 1.15);
+        assert_eq!(
+            scale(false, true),
+            1.0,
+            "a gun nobody holds is nobody's aim"
+        );
+    }
+
+    /// Sharpshooter multiplies the setting's own damage modifier rather than
+    /// replacing it, and leaves launch speed alone.
+    #[test]
+    fn the_shooters_damage_scale_compounds_with_the_settings() {
+        let emp_over = GunSettingDesc {
+            stim_modifier: 3.0,
+            speed_modifier: 0.8,
+            ..GunSettingDesc::default()
+        };
+        let scale = crate::scripts::gui::sharpshooter_damage_scale(true);
+        let modifiers = shot_modifiers(&emp_over, scale);
+        assert!((modifiers.stim - 3.45).abs() < 1e-5, "3.0 * 1.15");
+        assert_eq!(modifiers.speed, 0.8);
     }
 
     #[test]

--- a/tools/shock2-sdk/test/os-traits.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-traits.e2e.test.ts
@@ -111,7 +111,7 @@ test(
 
     // --- A trait with no live effect yet refuses clearly and leaves this
     // one-shot machine available for a live choice. ---
-    await clickElement(game, traitButton("Sharpshooter", els));
+    await clickElement(game, traitButton("Cybernetically Enhanced", els));
     await game.step({ frames: 3 });
     assert.deepEqual((await stats()).os_traits, [], "unsupported trait is not recorded");
     let refreshed = await game.ui.state();

--- a/tools/shock2-sdk/test/os-upgrades.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-upgrades.e2e.test.ts
@@ -3,10 +3,11 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end coverage for the round-1 O/S upgrade effects: Speedy (4),
-// Lethal Weapon (9), Power Psi (14), Spatially Aware (16), and
-// Pharmo-Friendly's (2) psi-hypo half. (Strong Metabolism is unit-tested only;
+// Sharpshooter (5), Lethal Weapon (9), Power Psi (14), Spatially Aware (16),
+// and Pharmo-Friendly's (2) psi-hypo half. (Strong Metabolism is unit-tested only;
 // see the note further down.)
 //
 // Traits are granted through the debug provisioning path
@@ -24,12 +25,14 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const TRAIT_PHARMO_FRIENDLY = 2;
 const TRAIT_SPEEDY = 4;
+const TRAIT_SHARPSHOOTER = 5;
 const TRAIT_LETHAL_WEAPON = 9;
 const TRAIT_POWER_PSI = 14;
 const TRAIT_SPATIALLY_AWARE = 16;
 
 const TRAINING_DROID = 593;
 const WRENCH = -928;
+const PISTOL = -17;
 
 function hitPoints(detail: EntityDetailResult): number {
   const property = detail.properties.find(
@@ -250,5 +253,52 @@ test(
       next.total,
       "arriving on a new deck arrives with its map already revealed",
     );
+  },
+);
+
+test(
+  "Sharpshooter: a pistol shot lands 15% harder",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "earth.mis" });
+    await game.step({ frames: 5 });
+
+    await game.player.spawnItem(PISTOL);
+    await game.player.spawnItem("Small Standard Clip");
+    await game.input.trigger("EquipPistol");
+    await game.step({ frames: 10 });
+
+    const [droid] = await game.entities.byTemplate(TRAINING_DROID);
+    assert.ok(droid, "Earth should contain its authored Training Droid");
+    const [x, y, z] = (await game.entities.detail(droid.id)).position;
+    await game.player.teleport({ x: x + 2.5, y: y + 1, z });
+    await game.step({ frames: 60 });
+
+    // One aimed round, measured on the victim's own hit points - the same pool
+    // the projectile's impact paths bill.
+    const shoot = async () => {
+      const aim = await game.player.aimAt(droid, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      assert.equal(aim.entity_id, droid.id);
+      await game.step({ frames: 3 });
+      const before = hitPoints(await game.entities.detail(droid.id));
+      await fireOnce(game);
+      await game.step({ frames: 30 });
+      const after = hitPoints(await game.entities.detail(droid.id));
+      // A dead droid's pool clamps at zero, which would under-report the
+      // second shot and read exactly like "the trait did nothing".
+      assert.ok(after > 0, "the droid must survive the shot being measured");
+      return before - after;
+    };
+
+    const plain = await shoot();
+    assert.equal(plain, 6, "the untraited pistol shot deals the flat path's 6");
+
+    await game.player.setStats({ os_traits: [TRAIT_SHARPSHOOTER] });
+    const sharp = await shoot();
+    // 6 * 1.15 = 6.9, on an integer hit-point pool.
+    assert.equal(sharp, 7, `Sharpshooter should bill 6 * 1.15; got ${sharp}`);
   },
 );


### PR DESCRIPTION
**Sharpshooter (O/S trait 5): the player's ranged weapon damage x1.15.**

Every shot fired from a gun in the player's own hands lands 15% harder - bullets
and energy shots alike, since they all leave through the same gun fire path.
Melee is Lethal Weapon's domain and is untouched.

Two pre-existing damage-model gaps, both unchanged here and both noted at
`shooter_damage_scale`:

- A projectile's *radius blast* (a grenade, the fusion cannon) is billed by
  `internal_explosion` straight from the authored StimSource intensity and
  honours no shot modifiers at all - so today it ignores the fire setting's own
  `stim_modifier` exactly as it ignores Sharpshooter.
- The slow (physics) projectile impact path still bills a placeholder damage of
  `1.0 * stim` (`internal_collision_type.rs`, its own TODO), so 1.15 rounds back
  to 1 there: the bonus is only *observable* on the fast (raycast) path until
  that damage is resolved from authored data.

Both belong with #1251's modifier / the damage TODO rather than with this trait.

### One damage-scale path

The scale rides the projectile's fire-time `RuntimePropShotModifiers.stim` (#1251)
rather than being re-applied at the impact. The projectile already carries one
damage multiplier that the two impact paths honour, so folding Sharpshooter into
it at fire time bills the upgrade exactly once, and no impact code has to know who
fired.

`shot_modifiers` now takes the shooter's own damage scale and multiplies the fire
setting's authored modifier by it, so the EMP rifle's 3x overcharge becomes 3.45x
rather than being replaced.

Only a gun `held_in_hand` by the player earns it: AI and turret shots are created
with `CreateEntityOptions::default()` and never come down this path at all, and a
loose gun going off is nobody's aim.

`sharp_mult` is not read from the gamesys - `dark/` does not parse the TRAITPARAM
chunk, so the value is hardcoded 1.15 the way #1320 hardcodes Lethal Weapon's
1.35.

Fidelity note: 15% is the figure the trait's own description states, and it is
what this port implements - retail play measures a larger bonus than its own
description promises, and that divergence is deliberate rather than matched.

Trait 5 is un-refused in `traits.rs`, so the trait machine vends it.

### Tests

Unit (`cargo test -p shock2vr --lib`, 1268 passed / 0 failed):

- `trait_multipliers_are_identity_without_the_trait` - `sharpshooter_damage_scale`
  is 1.0 without the trait, 1.15 with it.
- `only_the_players_own_gun_earns_sharpshooter` - held + trait is 1.15; held
  without it, and traited-but-unheld, are both 1.0.
- `the_shooters_damage_scale_compounds_with_the_settings` - 3.0 stim modifier x
  1.15 = 3.45, launch speed untouched.
- `the_round_one_traits_are_selectable_now_that_they_have_consumers` /
  `traits_without_an_effect_are_still_refused` - 5 moves from the refused list to
  the selectable one.

e2e (`os-upgrades.e2e.test.ts`, new case "Sharpshooter: a pistol shot lands 15%
harder"): on earth.mis, a spawned Pistol is aimed at the authored Training Droid's
torso and one round fired, measured on the droid's own hit points. Untraited the
shot costs it 6; with the trait granted through the debug provisioning path it
costs 7 (6 * 1.15 = 6.9 on an integer hit-point pool).

Watched fail first: with the scale forced to 1.0 the case fails
`Sharpshooter must raise ranged damage; 6 -> 6`.

The turret/AI non-scaling half is covered by the unit test rather than a
`debug_turret` e2e: a turret's hit rate over a fixed window is noisy enough that a
15% damage assertion would be flaky, and the AI fire path provably never builds a
`RuntimePropShotModifiers` at all.

`os-traits.e2e.test.ts` used Sharpshooter as its "not yet implemented" example;
that moves to Cybernetically Enhanced (7), as do the equivalent unit tests.

Verified: `cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p
desktop_runtime -p debug_runtime`; `cargo test -p shock2vr --lib`; e2e
`os-upgrades`, `os-traits`, `weapon-fire-mode-stats`, `weapon-fire-mode`,
`weapon-burst-fire`, `blood-spang`, `ranged-hitbox`, `energy-weapon-recharge`
(18/18 after the os-traits update), and `save-load` + `missions` (27/27).
