### PR TITLE
feat(psi): Neural Toxin-blocker resists the toxin stim

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4441,11 +4441,19 @@ impl MissionCore {
         }
 
         for (entity_id, felt_intensity) in in_range {
-            let receptrons =
+            let mut receptrons =
                 get_all_links_with_template(&self.world, entity_id, |link| match link {
                     Link::Receptron(options) => Some(options.clone()),
                     _ => None,
                 });
+            // An active Toxin Shield resists the toxin stim, so it has to be
+            // in the chain before either damage or status resolution reads it.
+            receptrons.extend(
+                crate::scripts::toxin_shield::toxin_shield_caster_receptrons(
+                    &self.world,
+                    entity_id,
+                ),
+            );
             let maybe_damage = crate::mission::stim_response::resolve_stim_damage(
                 &receptrons,
                 stim_template_id,

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -87,20 +87,21 @@ pub fn contact_stim_damage(world: &World, emitter_template: i32, victim: EntityI
 }
 
 fn victim_receptrons(world: &World, victim: EntityId) -> Vec<(i32, ReceptronOptions)> {
+    // An active Toxin Shield shields its caster against contact toxin stims
+    // (the arachnid claws, WormGoo) as well as radius ones.
+    let mut receptrons =
+        crate::scripts::toxin_shield::toxin_shield_caster_receptrons(world, victim);
     let Ok(v_links) = world.borrow::<View<Links>>() else {
-        return Vec::new();
+        return receptrons;
     };
     let Ok(links) = v_links.get(victim) else {
-        return Vec::new();
+        return receptrons;
     };
-    links
-        .to_links
-        .iter()
-        .filter_map(|link| match &link.link {
-            Link::Receptron(options) => Some((link.to_template_id, options.clone())),
-            _ => None,
-        })
-        .collect()
+    receptrons.extend(links.to_links.iter().filter_map(|link| match &link.link {
+        Link::Receptron(options) => Some((link.to_template_id, options.clone())),
+        _ => None,
+    }));
+    receptrons
 }
 
 /// Resolve what damage a stim deals to a receiver, given the receiver's

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -39,6 +39,11 @@ pub const INVISO_TEMPLATE_ID: i32 = -3157;
 /// their health (see `scripts::berserk`).
 pub const BERSERK_TEMPLATE_ID: i32 = -3155;
 
+/// `Toxin Shield` - Neural Toxin-blocker (tier 3 sustained power): while
+/// active, the caster resists the toxin stim by the power's authored
+/// `data[0]` percentage (see `scripts::toxin_shield`).
+pub const TOXIN_SHIELD_TEMPLATE_ID: i32 = -1113;
+
 /// `PropPsiPower::activation_type` for sustained/timed self effects - the
 /// power activates for a duration given by its `P$PsiShield` data
 /// (`duration_base + duration_per_psi × PSI` seconds).

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -57,6 +57,20 @@ const PEN_WALL_HEIGHT: f32 = 1.2;
 /// ahead (-X, the default-view forward), behind the pen.
 const WALL_DISTANCE: f32 = 15.0;
 
+/// The toxin hazard patch: `EggGooCloud`, the authored annelid goo cloud
+/// (`StimSource` Venom, intensity 2, radius 4) - the shipped radius toxin
+/// source. Note the port does not pulse ambient radius sources other than
+/// radiation yet (`internal_radiation_source` is attached by stim archetype),
+/// so this station stands the hazard up for the scene rather than dealing
+/// toxin today; see `scripts::toxin_shield`.
+const TOXIN_SOURCE_TEMPLATE_ID: i32 = -438;
+const TOXIN_SOURCE_RADIUS: f32 = 4.0;
+
+/// Where the toxin patch sits, as (x, z): beside the player and off the
+/// firing line, opposite the radiation patch, far enough out that the spawn
+/// point is outside the source's radius.
+const TOXIN_SOURCE_POSITION: (f32, f32) = (0.0, -9.0);
+
 pub fn create_debug_psi_scene(
     global_context: &GlobalContext,
     game_options: &GameOptions,
@@ -90,6 +104,18 @@ pub fn create_debug_psi_scene(
             vec3(-PEN_FAR, PEN_WALL_HEIGHT / 2.0, 0.0),
             vec3(1.0, PEN_WALL_HEIGHT, 2.0 * PEN_HALF_WIDTH),
         ),
+        // toxin hazard patch: a floor marker for the goo cloud. The field is
+        // a 4-unit sphere; the marker is the square inscribed in it, sitting
+        // 2 cm proud of the floor slab so coplanar faces do not z-fight.
+        (
+            vec3(0.13, 0.45, 0.13),
+            vec3(TOXIN_SOURCE_POSITION.0, 0.01, TOXIN_SOURCE_POSITION.1),
+            vec3(
+                TOXIN_SOURCE_RADIUS * std::f32::consts::SQRT_2,
+                0.02,
+                TOXIN_SOURCE_RADIUS * std::f32::consts::SQRT_2,
+            ),
+        ),
         // pen: sides
         (
             pen_wall,
@@ -117,7 +143,8 @@ pub fn create_debug_psi_scene(
     println!(
         "[debug_psi] Player is equipped with the Psi Amp, psi pool full, every stat at cap.\n\
          Select a power with the `CyclePsiPower` input action (`Y` on desktop),\n\
-         then fire to cast it. Two pipe hybrids stand in the pen ahead."
+         then fire to cast it. Two pipe hybrids stand in the pen ahead,\n\
+         and a toxin hazard patch sits to the side (-Z)."
     );
     builder.build_with_hooks(
         DebugSceneBuildOptions {
@@ -167,10 +194,14 @@ impl DebugSceneHooks for PsiHooks {
                 },
             );
 
-            let spawns = TARGET_POSITIONS
+            let mut spawns: Vec<Effect> = TARGET_POSITIONS
                 .iter()
                 .map(|(x, z)| spawn_at(TARGET_CREATURE, Point3::new(-x, 1.0, *z)))
                 .collect();
+            spawns.push(spawn_at(
+                TOXIN_SOURCE_TEMPLATE_ID,
+                Point3::new(TOXIN_SOURCE_POSITION.0, 1.0, TOXIN_SOURCE_POSITION.1),
+            ));
             core.handle_effects(
                 spawns,
                 global_context,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -58,6 +58,7 @@ pub mod script_util;
 mod setup_initial_debrief;
 mod std_door;
 mod tool_consumable;
+pub(crate) mod toxin_shield;
 mod transluce;
 mod trap_delay;
 mod trap_destroyer;

--- a/shock2vr/src/scripts/toxin_shield.rs
+++ b/shock2vr/src/scripts/toxin_shield.rs
@@ -1,0 +1,217 @@
+//! Neural Toxin-blocker (`Toxin Shield`, template -1113): while the sustained
+//! power is active the caster shrugs off toxin.
+//!
+//! Unlike Immolate, the power authors **no** receptron links - its only
+//! tuning is `PropPsiPower::data[0] = 100`, read here as a **percentage of
+//! toxin resistance** (100 = total immunity), which is the reading the
+//! published tier-3 description gives. The block is expressed as a synthetic
+//! `Amplify` receptron on the toxin stim so it composes with the act/react
+//! chain like any authored shield: whatever eventually consumes the toxin
+//! stim (a damage receptron, or a poisoning status like radiation's) sees an
+//! intensity already scaled to zero.
+
+use dark::properties::{ReceptronEffect, ReceptronOptions};
+use shipyard::{EntityId, UniqueView, World};
+
+use crate::{
+    mission::PlayerInfo,
+    psi::{ActivePsiPowers, GlobalPsiPowers, TOXIN_SHIELD_TEMPLATE_ID},
+};
+
+/// `Venom` - the gamesys's toxin stimulus archetype. It is what every toxic
+/// source in the shipped data emits (`WormGoo` and the arachnid claws by
+/// contact, `EggGooCloud` and the `Goo Projectile` at radius), and the only
+/// stim `The Player` answers with a `toxin` receptron.
+pub const VENOM_STIM_TEMPLATE_ID: i32 = -387;
+
+/// Where the shield sits in the receiver's receptron order. Inert today -
+/// `resolve_stim_damage` applies every Amplify before any Damage regardless
+/// of order - but it keeps the shield in the same 78-79 band the shipped
+/// PsiShield/armor Amplify receptrons use.
+const TOXIN_SHIELD_RECEPTRON_ORDER: i32 = 79;
+
+/// Fallback resistance when the power's authored data is unavailable, in
+/// percent. The gamesys authors 100 (total immunity).
+const DEFAULT_TOXIN_RESISTANCE_PERCENT: f32 = 100.0;
+
+/// The receptrons an active Toxin Shield grants `target`: an `Amplify` on the
+/// toxin stim scaled by the power's authored resistance percentage. Retail
+/// attaches the power as a metaproperty on the player; this is that, for a
+/// power whose "metaproperty" carries data instead of links.
+pub fn toxin_shield_caster_receptrons(
+    world: &World,
+    target: EntityId,
+) -> Vec<(i32, ReceptronOptions)> {
+    let is_player = world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .is_ok_and(|player| player.entity_id == target);
+    let active = world
+        .borrow::<UniqueView<ActivePsiPowers>>()
+        .is_ok_and(|powers| powers.is_active(TOXIN_SHIELD_TEMPLATE_ID));
+    if !is_player || !active {
+        return Vec::new();
+    }
+
+    let resistance = world
+        .borrow::<UniqueView<GlobalPsiPowers>>()
+        .ok()
+        .and_then(|powers| {
+            powers
+                .0
+                .iter()
+                .find(|power| power.template_id == TOXIN_SHIELD_TEMPLATE_ID)
+                .map(|power| power.power.data[0])
+        })
+        .unwrap_or(DEFAULT_TOXIN_RESISTANCE_PERCENT);
+
+    vec![(
+        VENOM_STIM_TEMPLATE_ID,
+        ReceptronOptions {
+            order: TOXIN_SHIELD_RECEPTRON_ORDER,
+            effect: ReceptronEffect::Amplify {
+                factor: (1.0 - resistance / 100.0).clamp(0.0, 1.0),
+            },
+        },
+    )]
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{PropPsiPower, ReceptronEffect, ReceptronOptions};
+    use shipyard::World;
+
+    use crate::mission::stim_response::resolve_stim_damage;
+    use crate::psi::{ActivePsiPower, PsiPowerInfo};
+
+    use super::*;
+
+    /// A toxin damage receptron of the shape the player would carry once the
+    /// port answers the toxin stim. The shipped data gives `The Player` a
+    /// `toxin` receptron the port does not implement yet, so this stands in
+    /// for whatever consumes the stim - the shield's job is to zero the
+    /// intensity before it gets there.
+    fn toxin_damage_receptron() -> (i32, ReceptronOptions) {
+        (
+            VENOM_STIM_TEMPLATE_ID,
+            ReceptronOptions {
+                order: 30,
+                effect: ReceptronEffect::Damage {
+                    multiplier: 1.0,
+                    use_intensity: true,
+                },
+            },
+        )
+    }
+
+    fn world_with(resistance_percent: f32, active: bool) -> World {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        world.add_unique(GlobalPsiPowers(vec![PsiPowerInfo {
+            template_id: TOXIN_SHIELD_TEMPLATE_ID,
+            name: "Toxin Shield".to_string(),
+            display_name: None,
+            power: PropPsiPower {
+                power_id: 20,
+                activation_type: 1,
+                psi_cost: 3,
+                data: [resistance_percent, 0.0, 0.0, 0.0],
+            },
+            projectiles: Vec::new(),
+            overloadable: false,
+            duration: None,
+        }]));
+        world.add_unique(ActivePsiPowers(if active {
+            vec![ActivePsiPower {
+                template_id: TOXIN_SHIELD_TEMPLATE_ID,
+                name: "Toxin Shield".to_string(),
+                remaining_secs: 35.0,
+            }]
+        } else {
+            Vec::new()
+        }));
+        world
+    }
+
+    fn player_of(world: &World) -> EntityId {
+        world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id
+    }
+
+    #[test]
+    fn an_inactive_power_grants_nothing() {
+        let world = world_with(100.0, false);
+        let player = player_of(&world);
+        assert!(toxin_shield_caster_receptrons(&world, player).is_empty());
+    }
+
+    #[test]
+    fn only_the_caster_is_shielded() {
+        let mut world = world_with(100.0, true);
+        let bystander = world.add_entity(());
+        assert!(toxin_shield_caster_receptrons(&world, bystander).is_empty());
+    }
+
+    #[test]
+    fn the_authored_hundred_percent_blocks_all_toxin_damage() {
+        let world = world_with(100.0, true);
+        let player = player_of(&world);
+
+        let mut receptrons = vec![toxin_damage_receptron()];
+        assert_eq!(
+            resolve_stim_damage(&receptrons, VENOM_STIM_TEMPLATE_ID, 10.0),
+            Some(10.0),
+            "without the shield a toxin stim lands in full"
+        );
+
+        receptrons.extend(toxin_shield_caster_receptrons(&world, player));
+        assert_eq!(
+            resolve_stim_damage(&receptrons, VENOM_STIM_TEMPLATE_ID, 10.0),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn a_partial_resistance_scales_rather_than_blocks() {
+        let world = world_with(40.0, true);
+        let player = player_of(&world);
+
+        let mut receptrons = vec![toxin_damage_receptron()];
+        receptrons.extend(toxin_shield_caster_receptrons(&world, player));
+        assert_eq!(
+            resolve_stim_damage(&receptrons, VENOM_STIM_TEMPLATE_ID, 10.0),
+            Some(6.0)
+        );
+    }
+
+    #[test]
+    fn other_stims_are_untouched() {
+        const INCENDIARY: i32 = -388;
+        let world = world_with(100.0, true);
+        let player = player_of(&world);
+
+        let mut receptrons = vec![(
+            INCENDIARY,
+            ReceptronOptions {
+                order: 30,
+                effect: ReceptronEffect::Damage {
+                    multiplier: 1.0,
+                    use_intensity: true,
+                },
+            },
+        )];
+        receptrons.extend(toxin_shield_caster_receptrons(&world, player));
+        assert_eq!(
+            resolve_stim_damage(&receptrons, INCENDIARY, 10.0),
+            Some(10.0)
+        );
+    }
+}

--- a/tools/shock2-sdk/test/psi-toxin-shield.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-toxin-shield.e2e.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// End-to-end test for Neural Toxin-blocker ("Toxin Shield" in the gamesys,
+// tier 3 sustained). Casting it spends 3 psi and, while active, the caster
+// resists the toxin (Venom) stim by the power's authored data[0] = 100%.
+//
+// The port has no toxin *consumer* yet: the shipped `The Player` archetype
+// answers the Venom stim with a `toxin` receptron effect the port does not
+// implement (a poisoning status model is out of scope, per issue #1308), and
+// no ambient radius source other than radiation is pulsed. So the HP
+// assertions below are characterization, not proof - the resistance itself is
+// proved by the unit tests in `shock2vr/src/scripts/toxin_shield.rs`, which
+// resolve a toxin damage receptron through the shield.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const TOXIN_SHIELD_COST = 3;
+/** Toxin Shield duration at the effective PSI stat of 5: 10 + 5*5 seconds. */
+const TOXIN_SHIELD_DURATION_FRAMES = 35 * 60;
+
+/** The debug_psi toxin hazard patch (EggGooCloud), as a world position. */
+const TOXIN_PATCH = { x: 0.0, y: 2.0, z: -9.0 };
+
+/** Cycle the psi power selection until `name` is selected (bounded). */
+async function selectPsiPower(game: GameServer, name: string): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    if ((await game.info()).player.selected_psi_power === name) return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 2 });
+  }
+  assert.fail(`could not cycle the psi power selection to ${name}`);
+}
+
+/** Step `frames` in chunks so a single /v1/step call stays small. */
+async function stepFrames(game: GameServer, frames: number): Promise<void> {
+  const chunk = 300;
+  for (let done = 0; done < frames; done += chunk) {
+    await game.step({ frames: Math.min(chunk, frames - done) });
+  }
+}
+
+test(
+  "Neural Toxin-blocker: cast spends psi, shields the caster in the toxin patch, and expires",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_psi" });
+
+    // The scene auto-equips the Psi Amp on the first update.
+    await game.step({ frames: 10 });
+    let player = (await game.info()).player;
+    assert.ok(player.wielded_entity_id !== null, "psi amp should be auto-wielded");
+    assert.deepEqual(player.active_psi_powers, [], "no sustained powers active at start");
+    const startPsi = player.psi_points;
+    assert.ok(startPsi !== null && startPsi >= TOXIN_SHIELD_COST);
+
+    // The scene's toxin hazard station is present.
+    const goo = (await game.entities.list({ filter: "EggGooCloud", limit: 5 })).entities[0];
+    assert.ok(goo, "debug_psi should contain the EggGooCloud toxin source");
+
+    // Baseline: unshielded exposure to the patch. See the header - no toxin
+    // reaches the player today, so this records the rate rather than asserting
+    // it is positive.
+    const unshieldedStart = player.hit_points!;
+    await game.player.teleport(TOXIN_PATCH);
+    await stepFrames(game, 180);
+    const unshieldedLoss = unshieldedStart - (await game.info()).player.hit_points!;
+
+    // Cast Neural Toxin-blocker (tier 3 sustained power).
+    await selectPsiPower(game, "Toxin Shield");
+    await fireOnce(game);
+    player = (await game.info()).player;
+    assert.equal(
+      player.psi_points,
+      startPsi! - TOXIN_SHIELD_COST,
+      "Toxin Shield cast costs 3 psi points",
+    );
+    assert.deepEqual(
+      player.active_psi_powers,
+      ["Toxin Shield"],
+      "Toxin Shield is active after the cast",
+    );
+
+    // Shielded exposure: no toxin damage lands, whatever the baseline was.
+    const shieldedStart = player.hit_points!;
+    await game.player.teleport(TOXIN_PATCH);
+    await stepFrames(game, 300);
+    player = (await game.info()).player;
+    assert.deepEqual(
+      player.active_psi_powers,
+      ["Toxin Shield"],
+      "still active through the exposure window",
+    );
+    assert.equal(
+      player.hit_points,
+      shieldedStart,
+      "the shielded caster takes no toxin damage in the patch",
+    );
+    assert.ok(
+      unshieldedLoss <= 0,
+      "unshielded exposure is inert today; re-check this test when the toxin response lands",
+    );
+
+    // Expiry after 10 + 5*PSI = 35 s.
+    await stepFrames(game, TOXIN_SHIELD_DURATION_FRAMES - 300 + 120);
+    assert.deepEqual(
+      (await game.info()).player.active_psi_powers,
+      [],
+      "Toxin Shield expires after 35 seconds",
+    );
+  },
+);


### PR DESCRIPTION
Stacks on #1272 (`feat/debug-psi-pen`) — review that first; this PR's own diff is the last two commits.

## What

Neural Toxin-blocker (`Toxin Shield`, template -1113) activated and did nothing. While the power is active, the caster now carries a synthetic `Amplify` receptron on the **toxin stim** (`Venom`, -387), so a toxin stim's intensity is scaled by the power's authored resistance *before* anything resolves it.

The hook is the same pair of places #1324 uses for Immolate's self-immunity, so it covers both toxin paths the port already has: `stim_response::victim_receptrons` (contact stims — the arachnid claws, `WormGoo`, the `Goo Projectile`) and `apply_radius_stimulus` (radius stims — `EggGooCloud`). `psi.rs` gains only the template-id const; `scenes/debug_psi.rs` gains one station.

## Which case this is: the mechanic has no consumer yet

Toxin **is** a real stim in the shipped data (`Venom`, -387), emitted by `WormGoo`, `Arachnid Claw`, `Baby Arachnid Claw`, `Goo Projectile` and `EggGooCloud`. What is missing is the *receiving* half: the only receptron `The Player` authors for `Venom` is `toxin`, an act/react effect the port does not implement (`ReceptronEffect::Unhandled("toxin")`), and no archetype anywhere in the gamesys answers `Venom` with a `damage` receptron. **So no toxin damage reaches the player today, with or without this PR.** Adding the poisoning status model that would consume it is explicitly out of scope in #1308, and nothing is filed for it here.

What this PR does is make the shield correct and composable *now*, so the day the toxin response lands (as damage, or as a level like radiation's) it is blocked without touching this power: an `Amplify` sits at the head of the act/react chain and zeroes the intensity that any later consumer reads.

## Interpretation of the data (a comment in the code)

Toxin Shield authors **no receptron links** — unlike Psycho-reflective Screen or Immolate, whose shields are authored. Its only tuning is `PropPsiPower::data = [100, 0, 0, 0]`, read here as a **percentage of toxin resistance** (100 = total immunity), matching the tier-3 description. The percentage is read from the hydrated registry, not hardcoded, so a `data[0]` of 40 would scale a toxin hit to 60% rather than block it (covered by a unit test).

## Scene

`debug_psi` gains the tracker's toxin **hazard patch**: an `EggGooCloud` (-438), the shipped annelid goo cloud (`StimSource` Venom, intensity 2, radius 4), at `(0, -9)` — beside the player, off the firing line, opposite #1321's radiation patch, and far enough out that the spawn point is outside its radius. A green floor marker (the square inscribed in the 4-unit field) marks the footprint. Noted in the scene comment: the port only pulses ambient *radiation* radius sources (`internal_radiation_source` is attached by stim archetype in `entity_creator`), so this station stands the hazard up rather than dealing toxin today.

## Verification

- **Unit tests** (`shock2vr/src/scripts/toxin_shield.rs`) carry the proof, since no live toxin damage exists to observe: a toxin damage receptron of the shape the player would carry resolves to **10 → 0** through the shield and to **10** without it (negative case in the same test); a `data[0]` of 40 scales 10 → 6; an inactive power and a non-caster target grant nothing; other stims (Incendiary) are untouched.
- **`tools/shock2-sdk/test/psi-toxin-shield.e2e.test.ts`** walks the issue's acceptance steps in `debug_psi`: the toxin station exists, the cast spends 3 psi and puts `Toxin Shield` in `active_psi_powers`, HP is unchanged through a 5 s exposure in the patch, and the power expires after `10 + 5×5 = 35` s. Its HP assertions are labelled in the file as *characterization* — the baseline loss is 0 today for the reason above, and the test asserts that too so it fails loudly when the toxin response lands and needs re-checking. It fails on the base branch (no `EggGooCloud` station).
- `psi.e2e.test.ts` and `psi-sustained.e2e.test.ts` still pass.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean, `cargo fmt` applied.

## Out of scope

The poisoning status model and the toxin HUD warning (per the issue). Generalizing `internal_radiation_source` so ambient non-radiation radius sources pulse too — that is what would make the goo cloud emit, and it belongs with whatever implements the toxin response.

Fixes #1308
