### PR TITLE
feat(psi): Adrenaline Overproduction buffs melee damage and drains health

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2918,6 +2918,13 @@ impl MissionCore {
         ) {
             effects.push(radiation);
         }
+        // Runs before the sustained-power countdown below, which is the
+        // decrement the drain's per-second accounting predicts.
+        if let Some(drain) =
+            crate::scripts::berserk::tick_player_drain(&self.world, time.elapsed.as_secs_f32())
+        {
+            effects.push(drain);
+        }
         effects.extend(command_effects);
 
         let player = {

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -30,6 +30,11 @@ const PSI_POWERS_ROOT_TEMPLATE_ID: i32 = -962;
 /// the player is invisible to AI and security devices.
 pub const INVISO_TEMPLATE_ID: i32 = -3157;
 
+/// `Berserk` - Adrenaline Overproduction (tier 2 sustained power): while
+/// active, the player's melee hits do more damage and the adrenaline drains
+/// their health (see `scripts::berserk`).
+pub const BERSERK_TEMPLATE_ID: i32 = -3155;
+
 /// `PropPsiPower::activation_type` for sustained/timed self effects - the
 /// power activates for a duration given by its `P$PsiShield` data
 /// (`duration_base + duration_per_psi × PSI` seconds).

--- a/shock2vr/src/scripts/berserk.rs
+++ b/shock2vr/src/scripts/berserk.rs
@@ -1,0 +1,195 @@
+//! Adrenaline Overproduction (`Berserk`, template -3155): the tier-2
+//! sustained buff that trades health for melee damage.
+//!
+//! The power's `PropPsiPower::data` is `[0.13, 1.0, 0, 0]`. **Assumption**
+//! (nothing in the shipped data labels the floats): `data[0]` is the melee
+//! damage bonus as a fraction, so a hit lands at `× (1 + 0.13)`, and `data[1]`
+//! is the health the adrenaline costs the caster per second. That reading is
+//! what makes the buff's authored numbers work out - +13% melee for 1 HP/s
+//! over `10 × PSI` seconds - and matches the discipline's description (the
+//! rush is self-harming).
+//!
+//! Like the other sustained powers, the hook lives beside the mechanic rather
+//! than in the amp's cast path: the melee damage paths ask
+//! [`melee_damage_multiplier`], and `MissionCore::update` ticks the drain
+//! beside the radiation/healing ticks.
+
+use dark::properties::PropHitPoints;
+use shipyard::{Get, UniqueView, View, World};
+
+use crate::mission::PlayerInfo;
+use crate::psi::{ActivePsiPowers, BERSERK_TEMPLATE_ID, GlobalPsiPowers};
+
+use super::Effect;
+
+/// The floor the drain will not take the player below: Adrenaline
+/// Overproduction hurts, but it must never be the thing that kills you.
+const DRAIN_HP_FLOOR: i32 = 1;
+
+/// The player's authored Berserk floats while the power is active.
+fn active_data(world: &World) -> Option<[f32; 4]> {
+    let active = world.borrow::<UniqueView<ActivePsiPowers>>().ok()?;
+    if !active.is_active(BERSERK_TEMPLATE_ID) {
+        return None;
+    }
+    let powers = world.borrow::<UniqueView<GlobalPsiPowers>>().ok()?;
+    powers
+        .0
+        .iter()
+        .find(|power| power.template_id == BERSERK_TEMPLATE_ID)
+        .map(|power| power.power.data)
+}
+
+/// What to scale a player melee hit by: `1 + data[0]` while Adrenaline
+/// Overproduction is active, and 1 otherwise. Applied where the damage amount
+/// is decided, so both the flat swing's raycast hit and a VR weapon's contact
+/// damage get the bonus. Ranged damage never asks.
+pub fn melee_damage_multiplier(world: &World) -> f32 {
+    match active_data(world) {
+        Some(data) => 1.0 + data[0],
+        None => 1.0,
+    }
+}
+
+/// Whole seconds of the power's duration elapsed during a frame, i.e. how many
+/// 1-second drain ticks the frame owes. `remaining_secs` is the value *before*
+/// `MissionCore` applies this frame's decrement (this tick runs first), so the
+/// frame spans `remaining` down to `remaining - elapsed`.
+fn drain_ticks(remaining_secs: f32, elapsed_secs: f32) -> i32 {
+    let after = (remaining_secs - elapsed_secs).max(0.0);
+    (remaining_secs.floor() - after.floor()).max(0.0) as i32
+}
+
+/// Drain the caster's health while Berserk is active - one `data[1]` HP per
+/// second, floored at [`DRAIN_HP_FLOOR`] so the buff can never kill its own
+/// caster. Called from `MissionCore::update` beside the healing/radiation
+/// ticks, which keeps HP mutation at the mission's single effect choke point.
+pub fn tick_player_drain(world: &World, elapsed_secs: f32) -> Option<Effect> {
+    let data = active_data(world)?;
+    let remaining = world
+        .borrow::<UniqueView<ActivePsiPowers>>()
+        .ok()?
+        .0
+        .iter()
+        .find(|power| power.template_id == BERSERK_TEMPLATE_ID)?
+        .remaining_secs;
+
+    let drain = data[1] * drain_ticks(remaining, elapsed_secs) as f32;
+    if drain <= 0.0 {
+        return None;
+    }
+
+    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
+    let current = world
+        .borrow::<View<PropHitPoints>>()
+        .ok()
+        .and_then(|hit_points| hit_points.get(player).ok().map(|hp| hp.hit_points))?;
+    let delta = -(drain.round() as i32).min(current - DRAIN_HP_FLOOR);
+    (delta < 0).then_some(Effect::AdjustHitPoints {
+        entity_id: player,
+        delta,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_frame_owes_a_drain_tick_only_when_it_crosses_a_whole_second() {
+        // 60Hz frames inside one second owe nothing...
+        assert_eq!(drain_ticks(49.9, 1.0 / 60.0), 0);
+        // ...the frame that crosses the boundary owes one...
+        assert_eq!(drain_ticks(49.01, 1.0 / 60.0), 1);
+        // ...and a long frame owes every second it swallowed.
+        assert_eq!(drain_ticks(50.0, 3.0), 3);
+    }
+
+    #[test]
+    fn a_frame_past_expiry_owes_no_more_than_the_power_had_left() {
+        // The power ends this frame: the drain stops at 0, it does not keep
+        // billing seconds the buff never ran for.
+        assert_eq!(drain_ticks(2.5, 30.0), 2);
+        assert_eq!(drain_ticks(0.5, 5.0), 0);
+        assert_eq!(drain_ticks(0.0, 1.0), 0);
+    }
+
+    /// A world carrying the psi registry, the player, and `Berserk` active
+    /// with `remaining` seconds left. `active: false` leaves it uncast.
+    fn world_with_berserk(active: bool, remaining: f32, hit_points: i32) -> World {
+        let mut world = World::new();
+        let player = world.add_entity(PropHitPoints { hit_points });
+        world.add_unique(PlayerInfo {
+            pos: cgmath::vec3(0.0, 0.0, 0.0),
+            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: player,
+        });
+        world.add_unique(GlobalPsiPowers(vec![crate::psi::PsiPowerInfo {
+            template_id: BERSERK_TEMPLATE_ID,
+            name: "Berserk".to_owned(),
+            display_name: None,
+            power: dark::properties::PropPsiPower {
+                power_id: 10,
+                activation_type: crate::psi::ACTIVATION_TYPE_SUSTAINED,
+                psi_cost: 2,
+                // The authored floats: +13% melee, 1 HP/s.
+                data: [0.13, 1.0, 0.0, 0.0],
+            },
+            projectiles: Vec::new(),
+            overloadable: false,
+            duration: None,
+        }]));
+        let mut powers = ActivePsiPowers::default();
+        if active {
+            powers.0.push(crate::psi::ActivePsiPower {
+                template_id: BERSERK_TEMPLATE_ID,
+                name: "Berserk".to_owned(),
+                remaining_secs: remaining,
+            });
+        }
+        world.add_unique(powers);
+        world
+    }
+
+    #[test]
+    fn an_active_berserk_scales_melee_by_its_authored_bonus() {
+        let world = world_with_berserk(true, 50.0, 30);
+        assert_eq!(melee_damage_multiplier(&world), 1.13);
+        // ...and an uncast power leaves melee alone.
+        let world = world_with_berserk(false, 0.0, 30);
+        assert_eq!(melee_damage_multiplier(&world), 1.0);
+    }
+
+    #[test]
+    fn the_drain_bills_one_hp_a_second_and_never_kills_the_caster() {
+        let world = world_with_berserk(true, 49.01, 30);
+        assert!(matches!(
+            tick_player_drain(&world, 1.0 / 60.0),
+            Some(Effect::AdjustHitPoints { delta: -1, .. })
+        ));
+        // A frame that crosses no second boundary bills nothing.
+        let world = world_with_berserk(true, 49.9, 30);
+        assert!(tick_player_drain(&world, 1.0 / 60.0).is_none());
+        // At 1 HP the drain stops rather than finishing the player off.
+        let world = world_with_berserk(true, 49.01, 1);
+        assert!(tick_player_drain(&world, 1.0 / 60.0).is_none());
+        // ...and a long frame at 2 HP takes only the one point it may.
+        let world = world_with_berserk(true, 50.0, 2);
+        assert!(matches!(
+            tick_player_drain(&world, 3.0),
+            Some(Effect::AdjustHitPoints { delta: -1, .. })
+        ));
+    }
+
+    #[test]
+    fn with_no_active_power_melee_damage_is_unscaled() {
+        // No psi uniques at all (a unit-test world, or a scene without the
+        // registry): the multiplier must be inert, not panic.
+        let world = World::new();
+        assert_eq!(melee_damage_multiplier(&world), 1.0);
+        assert!(tick_player_drain(&world, 1.0).is_none());
+    }
+}

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -155,7 +155,17 @@ impl Script for HeldMeleeWeapon {
                 let damage = self
                     .may_damage(entity_id, owner, physics, *contact)
                     .then(|| authored_contact_damage(world, entity_id, owner))
-                    .flatten();
+                    .flatten()
+                    // Adrenaline Overproduction scales the *player's* swing,
+                    // so only a weapon in their hand gets the bonus (a wrench
+                    // knocked into a creature is nobody's swing).
+                    .map(|amount| {
+                        if self.is_held(world, entity_id) {
+                            amount * crate::scripts::berserk::melee_damage_multiplier(world)
+                        } else {
+                            amount
+                        }
+                    });
 
                 let mut effects = Vec::new();
                 if let Some(amount) = damage {

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -10,6 +10,7 @@ mod base_elevator;
 mod base_light;
 mod base_monster;
 mod base_room;
+pub mod berserk;
 mod burst_fire;
 mod camera_alert;
 mod chemical;

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -464,7 +464,9 @@ fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World
             msg: Message {
                 to: target,
                 payload: MessagePayload::Damage {
-                    amount: MELEE_DAMAGE,
+                    // Adrenaline Overproduction scales the player's melee
+                    // damage while it is active (1.0 otherwise).
+                    amount: MELEE_DAMAGE * crate::scripts::berserk::melee_damage_multiplier(world),
                     // Swing direction + contact point seed the victim's
                     // death-ragdoll reaction. No bone: melee resolves a hitbox
                     // proxy to its parent BEFORE sending (so HitBoxScript

--- a/tools/shock2-sdk/test/psi-berserk.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-berserk.e2e.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+import { pullTrigger } from "./helpers/weapon.js";
+
+// Adrenaline Overproduction ("Berserk" in the gamesys, tier 2 sustained):
+// while it is active the player's melee hits are scaled by its authored
+// data[0] (+13%) and the adrenaline drains data[1] (1 HP) a second, for
+// duration_base + duration_per_psi x PSI = 0 + 10*5 = 50 seconds.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const WRENCH = -928;
+const PSI_AMP = -247;
+const BERSERK_COST = 2;
+/** Flat melee resolves its hit at the swing motion's authored event, 41
+ * simulation frames after the trigger edge (see flat-melee-animation-event). */
+const SWING_FRAMES = 60;
+
+function propOf(detail: EntityDetailResult, name: string): number {
+  const property = detail.properties.find((candidate) => candidate.name === name);
+  assert.ok(property, `entity ${detail.entity_id} should expose ${name}`);
+  return Number(property.value);
+}
+
+/** The nearest creature with live hitboxes - the melee bench's target row. */
+async function nearestCreature(game: GameServer): Promise<EntityDetailResult> {
+  for (const entity of (await game.entities.list({ limit: 300 })).entities) {
+    const detail = await game.entities.detail(entity.id);
+    if ((detail.aim_points ?? []).length > 1) return detail;
+  }
+  assert.fail("expected a creature with hitboxes in debug_melee");
+}
+
+/** Provision and wield the authored player Wrench through production selection. */
+async function wieldWrench(game: GameServer): Promise<void> {
+  await game.input.trigger("EquipWrench");
+  await game.step({ frames: 5 });
+}
+
+/** One flat swing at `target`, returning the hit points it cost the victim. */
+async function swingOnce(game: GameServer, target: EntityDetailResult): Promise<number> {
+  const [x, y, z] = (await game.entities.detail(target.entity_id)).position;
+  await game.player.teleport({ x: x + 1.1, y: y + 1, z });
+  await game.step({ frames: 30 });
+  const aim = await game.player.aimAt(target.entity_id, {
+    hitbox: "torso",
+    visibility: "required",
+  });
+  assert.equal(aim.entity_id, target.entity_id, "the crosshair should be on the creature");
+
+  const before = propOf(await game.entities.detail(target.entity_id), "HitPoints");
+  await pullTrigger(game);
+  await game.step({ frames: SWING_FRAMES });
+  const after = propOf(await game.entities.detail(target.entity_id), "HitPoints");
+  return before - after;
+}
+
+/** Cycle the psi selection onto Berserk and cast it (bounded). */
+async function castBerserk(game: GameServer): Promise<void> {
+  // Unlike debug_psi, this bench stocks no amp - provision one and wield it
+  // through the same production selection the player uses.
+  await game.player.spawnItem(PSI_AMP);
+  await game.input.trigger("EquipPsiAmp");
+  await game.step({ frames: 10 });
+  assert.ok(
+    (await game.info()).player.wielded_entity_id !== null,
+    "the psi amp should be wielded before casting",
+  );
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if ((await game.info()).player.selected_psi_power === "Berserk") break;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 1 });
+  }
+  const psiBefore = (await game.info()).player.psi_points;
+  assert.equal(
+    (await game.info()).player.selected_psi_power,
+    "Berserk",
+    "could not cycle the psi power selection to Berserk",
+  );
+  await pullTrigger(game);
+  await game.step({ frames: 10 });
+  const player = (await game.info()).player;
+  assert.deepEqual(player.active_psi_powers, ["Berserk"], "Berserk should be active");
+  assert.equal(player.psi_points, psiBefore! - BERSERK_COST, "the cast costs 2 psi points");
+}
+
+test(
+  "Adrenaline Overproduction scales the player's melee damage",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // Baseline: one unbuffed swing, in its own runtime so the creature is
+    // fresh and nothing else has touched it.
+    let baseline: number;
+    {
+      await using game = await GameServer.launch({ mission: "debug_melee" });
+      await game.step({ frames: 20 });
+      await game.player.spawnItem(WRENCH);
+      await wieldWrench(game);
+      baseline = await swingOnce(game, await nearestCreature(game));
+      assert.ok(baseline > 0, "the unbuffed swing should damage the creature");
+    }
+
+    // ...and the same swing with Berserk active costs the creature more.
+    {
+      await using game = await GameServer.launch({ mission: "debug_melee" });
+      await game.step({ frames: 20 });
+      await game.player.spawnItem(WRENCH);
+      await castBerserk(game);
+      await wieldWrench(game);
+      const buffed = await swingOnce(game, await nearestCreature(game));
+      assert.deepEqual(
+        (await game.info()).player.active_psi_powers,
+        ["Berserk"],
+        "Berserk should still be running when the blow lands",
+      );
+      // Hit points are integers, so the +13% shows up as the rounded blow:
+      // 6 -> 7 for the Wrench. The load-bearing assertion is that it is bigger.
+      assert.ok(
+        buffed > baseline,
+        `a berserk swing should hurt more than ${baseline}; got ${buffed}`,
+      );
+      assert.equal(
+        buffed,
+        Math.round(baseline * 1.13),
+        `the blow should scale by the authored +13% (baseline ${baseline})`,
+      );
+    }
+  },
+);
+
+test(
+  "Adrenaline Overproduction drains the caster's health while it runs",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_melee" });
+    await game.step({ frames: 20 });
+    // Cast from the spawn bay, out of the penned creatures' reach: the only
+    // thing that may touch the player's health here is the adrenaline.
+    await castBerserk(game);
+    const before = (await game.info()).player.hit_points;
+    assert.ok(before !== null && before > 5);
+
+    // 300 frames = 5 seconds = 5 HP at the authored 1 HP/s.
+    await game.step({ frames: 300 });
+    const after = (await game.info()).player.hit_points;
+    assert.equal(after, before! - 5, "5 seconds of Berserk should cost 5 hit points");
+    assert.deepEqual(
+      (await game.info()).player.active_psi_powers,
+      ["Berserk"],
+      "the 50 s power is still running after 5 s",
+    );
+  },
+);


### PR DESCRIPTION
## What

Adrenaline Overproduction (`Berserk`, template -3155) activated and did nothing. It now:

- **scales the player's melee damage** by its authored `data[0]` while active - applied where the damage amount is decided, so it works in **flat** (`weapon_script`'s aimed swing raycast) and in **VR** (a held weapon's contact damage), and
- **drains the caster's health** at `data[1]` HP a second for the power's `0 + 10 × PSI` seconds, floored at **1 HP**: the adrenaline can hurt you but can never be the thing that kills you.

The hook lives beside the mechanic, not in the amp's cast path: `scripts/berserk.rs` answers `melee_damage_multiplier` for the two melee damage sites and `MissionCore::update` ticks the drain next to the radiation/healing ticks, so HP mutation stays at the mission's single effect choke point. `psi.rs` gains only the template-id const.

## Interpretation of the data (stated as an assumption in the module comment)

`PropPsiPower::data` is `[0.13, 1.0, 0, 0]` and nothing in the shipped data labels the floats. This reads them as **`data[0]` = melee damage bonus** (a hit lands at `× 1.13` - the issue's acceptance number) and **`data[1]` = HP drained per second**, which is the reading that makes the buff's numbers work out and matches the discipline (the rush is self-harming).

The drain's 1-second cadence is likewise not authored anywhere; it is billed by whole seconds of the power's own countdown, so it is deterministic under the fixed timestep.

## Verification

`debug_melee`, headless, flat:

| | creature HP lost to one Wrench swing | player HP over 5 s |
|---|---|---|
| no Berserk | 6 | 30 (unchanged) |
| Berserk active | **7** (`round(6 × 1.13)`) | **29 → 24** |

- New `tools/shock2-sdk/test/psi-berserk.e2e.test.ts` (SHOCK2_E2E=1) walks both: it fails on the base branch (`a berserk swing should hurt more than 6; got 6`, and no health drain) and passes here.
- Also green: `melee-hitbox`, `flat-melee-animation-event`, `psi`, `psi-sustained`.
- New unit tests in `scripts/berserk.rs`: the multiplier from the authored floats, the per-second drain accounting, the 1-HP floor, and inertness in a world with no psi uniques.
- `cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean.

## Left alone deliberately

- `data[1]`'s alternative readings (a per-PSI scale, a defense penalty) - the issue asks not to guess it into the *damage* formula, and it is not in it.
- #1172 (flat melee hardcodes 6.0 and bypasses receptrons) and #1327 (its raycast ignores `MELEE_RANGE`) are untouched: the multiplier is applied at the damage decision, so both fixes compose with it.
- The HUD readout for the buff, and the unregistered `Berserk` object script (nothing needs it - the mechanic is not an object script).

Fixes #1277
