### PR TITLE
feat(vr): an off-panel trigger pull throws the cursor item into the world

### DIFF
--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -179,20 +179,12 @@ pub fn vr_canvas_pointer(
     pass: &crate::ui::FrontendPointerPass,
     input_context: &crate::input_context::InputContext,
 ) -> CanvasPointer {
-    // Off the panel there is no owning ray, so the hand is whichever one is
-    // pulling the trigger - the throw of a cursor item aims along its ray.
-    let held =
-        |hand: &crate::input_context::Hand| hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD;
+    // Off the panel no ray owns the point, so the hand is the one the pass
+    // says is claiming the panel - the throw of a cursor item aims along it.
     let hand = pass
         .active_ray()
         .map(|ray| ray.handedness)
-        .unwrap_or_else(|| {
-            if held(&input_context.left_hand) && !held(&input_context.right_hand) {
-                Handedness::Left
-            } else {
-                Handedness::Right
-            }
-        });
+        .unwrap_or(pass.claiming_hand);
     let squeezing = |input_hand: &crate::input_context::Hand| {
         input_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD
     };

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -75,12 +75,18 @@ const NAME_STRIP_FONT: &str = "mainfont.fon";
 /// container** (the host just hides it from the strip while it rides the
 /// cursor), so it is always reachable and serializes correctly on
 /// save/transition. Only committing the drag reaches the world: **Throw**
-/// detaches it and gives it world presence with an impulse along the view ray;
-/// **Wield** equips/uses it (a double-click) via the same effect as a backpack
-/// click, acting on the still-contained item.
+/// detaches it and gives it world presence with an impulse along the aim ray
+/// (flat: the view ray; VR: the throwing hand's controller ray); **Wield**
+/// equips/uses it (a double-click) via the same effect as a backpack click,
+/// acting on the still-contained item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlatUiDragAction {
-    Throw(EntityId),
+    Throw {
+        entity: EntityId,
+        /// The hand whose ray aims the throw. Flat has one pointer, so it is
+        /// always `Right` there and the applier ignores it.
+        hand: Handedness,
+    },
     Wield(EntityId),
     /// One of the AMMOFULL readout's controls was clicked (fire-mode setting,
     /// reload, ammo cycle, psi selector). Not tied to a cursor item - the
@@ -114,8 +120,9 @@ const DOUBLE_CLICK_RADIUS: f32 = 24.0;
 pub enum BareViewPress {
     /// Flat: a press off the widgets is a click on the 3D view behind them.
     Exit,
-    /// VR: a press off the widgets is not an exit gesture. (Throwing a held
-    /// item into the world from the panel is a later slice.)
+    /// VR: a press off the widgets is not an exit gesture. Empty panel
+    /// pixels keep a held item; only a press with the ray *off the panel*
+    /// throws it (the VR reading of "click the world").
     Ignore,
 }
 
@@ -172,10 +179,20 @@ pub fn vr_canvas_pointer(
     pass: &crate::ui::FrontendPointerPass,
     input_context: &crate::input_context::InputContext,
 ) -> CanvasPointer {
+    // Off the panel there is no owning ray, so the hand is whichever one is
+    // pulling the trigger - the throw of a cursor item aims along its ray.
+    let held =
+        |hand: &crate::input_context::Hand| hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD;
     let hand = pass
         .active_ray()
         .map(|ray| ray.handedness)
-        .unwrap_or(Handedness::Right);
+        .unwrap_or_else(|| {
+            if held(&input_context.left_hand) && !held(&input_context.right_hand) {
+                Handedness::Left
+            } else {
+                Handedness::Right
+            }
+        });
     let squeezing = |input_hand: &crate::input_context::Hand| {
         input_hand.squeeze_value > crate::ui::VR_TRIGGER_THRESHOLD
     };
@@ -773,15 +790,25 @@ impl FlatUiHost {
             self.hover_close = false;
         }
 
-        // A press fully outside the canvas (flat: the letterbox bars) is a
-        // bare-view click: throw a held item, else close the panel. In VR the
-        // canvas is the panel, so an off-panel press belongs to the world hand.
+        // A press fully outside the canvas is a click on the world (flat: the
+        // letterbox bars; VR: the ray off the panel): it throws a held item in
+        // both presentations. With nothing held it is flat's exit gesture only
+        // - in VR the off-panel hand is a world hand and the press is its own.
         let Some(canvas_pos) = canvas_pos else {
-            if pressed_edge && pointer.bare_view == BareViewPress::Exit {
+            if pressed_edge {
                 if let Some(held) = self.cursor_item.take() {
-                    return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
+                    self.last_lift = None;
+                    return (
+                        Vec::new(),
+                        vec![FlatUiDragAction::Throw {
+                            entity: held.entity,
+                            hand: pointer.hand,
+                        }],
+                    );
                 }
-                self.close();
+                if pointer.bare_view == BareViewPress::Exit {
+                    self.close();
+                }
             }
             return (Vec::new(), Vec::new());
         };
@@ -867,7 +894,13 @@ impl FlatUiHost {
             // Bare 3D view: throw the held item along the view ray.
             let held = self.cursor_item.take().unwrap();
             self.last_lift = None;
-            return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
+            return (
+                Vec::new(),
+                vec![FlatUiDragAction::Throw {
+                    entity: held.entity,
+                    hand: pointer.hand,
+                }],
+            );
         }
 
         // --- AMMOFULL readout controls (use mode): a click acts on the
@@ -968,6 +1001,12 @@ impl FlatUiHost {
                 && mark.frames_left > 0
                 && (mark.canvas_pos - canvas_pos).magnitude() <= DOUBLE_CLICK_RADIUS
         })
+    }
+
+    /// Whether an item is riding the cursor (VR masks the world trigger while
+    /// one is, so the throw that commits it cannot double as a frob).
+    pub fn has_cursor_item(&self) -> bool {
+        self.cursor_item.is_some()
     }
 
     /// The entity currently hidden from the strip because it is on the cursor.
@@ -2310,7 +2349,13 @@ mod tests {
         press_edge(&mut host, &world, (23.5, 34.0)); // lift
         // Below the strip (y > 121), no panel open: the bare 3D view.
         let actions = press_edge(&mut host, &world, (320.0, 300.0));
-        assert_eq!(actions, vec![FlatUiDragAction::Throw(wrench)]);
+        assert_eq!(
+            actions,
+            vec![FlatUiDragAction::Throw {
+                entity: wrench,
+                hand: Handedness::Right
+            }]
+        );
         assert!(host.cursor_debug().is_none(), "throwing clears the cursor");
     }
 
@@ -2691,7 +2736,10 @@ mod tests {
         let actions = press_edge(&mut host, &world, empty);
         assert_eq!(
             actions,
-            vec![FlatUiDragAction::Throw(wrench)],
+            vec![FlatUiDragAction::Throw {
+                entity: wrench,
+                hand: Handedness::Right
+            }],
             "flat: a click on the bare 3D view throws the held item"
         );
 
@@ -2897,5 +2945,58 @@ mod tests {
             0,
             "sweeping a held squeeze onto another slot must not take it too"
         );
+    }
+
+    /// The VR reading of "click the world": with an item on the cursor, a
+    /// trigger pull with the ray OFF the panel throws it, aimed by the hand
+    /// that pulled - the same commit gesture as flat's bare-view click. Without
+    /// a cursor item the off-panel press is that hand's own world press, so
+    /// the interface must neither close nor act.
+    #[test]
+    fn an_off_panel_press_in_vr_throws_the_cursor_item_along_that_hand() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        // Nothing held: the off-panel press is not an exit gesture in VR.
+        host.update_canvas(&world, Some(vr_pointer(Handedness::Left, None, 0.0, 0.0)));
+        let (_msgs, actions) =
+            host.update_canvas(&world, Some(vr_pointer(Handedness::Left, None, 1.0, 0.0)));
+        assert!(actions.is_empty());
+        assert!(
+            host.strip_item_at(vec2(23.5, 34.0)).is_some(),
+            "the panel stays open"
+        );
+        host.update_canvas(&world, Some(vr_pointer(Handedness::Left, None, 0.0, 0.0)));
+
+        // Lift, then pull the LEFT trigger with its ray off the panel.
+        host.update_canvas(
+            &world,
+            Some(vr_pointer(Handedness::Left, Some((23.5, 34.0)), 1.0, 0.0)),
+        );
+        assert!(
+            host.cursor_debug().is_some(),
+            "the trigger on the slot lifts the item"
+        );
+        host.update_canvas(&world, Some(vr_pointer(Handedness::Left, None, 0.0, 0.0)));
+        let (_msgs, actions) =
+            host.update_canvas(&world, Some(vr_pointer(Handedness::Left, None, 1.0, 0.0)));
+        assert_eq!(
+            actions,
+            vec![FlatUiDragAction::Throw {
+                entity: wrench,
+                hand: Handedness::Left
+            }],
+            "the throw aims along the hand that pulled"
+        );
+        assert!(host.cursor_debug().is_none(), "throwing clears the cursor");
+    }
+
+    /// Off the panel no ray owns the point, so the pointer's hand is the one
+    /// pulling the trigger - otherwise a left-hand throw would launch along
+    /// the idle right controller's ray.
+    #[test]
+    fn off_panel_the_pointer_hand_is_the_one_pulling_the_trigger() {
+        let pointer = vr_pointer(Handedness::Left, None, 1.0, 0.0);
+        assert_eq!(pointer.canvas_pos, None);
+        assert_eq!(pointer.hand, Handedness::Left);
+        assert!(pointer.pressed);
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3974,7 +3974,10 @@ impl MissionCore {
                 self.use_mode,
                 on_panel,
                 holds_weapon,
-                self.flat_ui.has_cursor_item(),
+                // Read before this frame's `update_canvas`, so it lags the
+                // cursor by a frame; the latch covers both edges of a throw.
+                game_options.presentation_mode == crate::PresentationMode::Vr
+                    && self.flat_ui.has_cursor_item(),
             ),
         );
         for safe in trigger_safe.iter_mut() {
@@ -5661,17 +5664,18 @@ impl MissionCore {
         // VR the throwing hand's controller ray off the same pointer pass that
         // resolved the press. Without either, leave the item in the backpack.
         let vr_hand_ray = || {
-            let ray = self
-                .vr_use_mode_pointer
-                .as_ref()?
-                .rays
+            // An untracked throwing hand contributes no ray; rather than
+            // silently un-throw, aim along whichever controller is tracked.
+            let rays = &self.vr_use_mode_pointer.as_ref()?.rays;
+            let ray = rays
                 .iter()
-                .find(|ray| ray.handedness == hand)?;
+                .find(|ray| ray.handedness == hand)
+                .or_else(|| rays.first())?;
             // The pass rays are in pawn space (the tracked controller pose);
-            // the throw lands in the world, so map through the pawn like
-            // `VirtualHand` does.
+            // the throw lands in the world.
             let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-            let origin = player.pos + player.rotation.rotate_vector(ray.origin);
+            let origin =
+                crate::virtual_hand::hand_world_position(player.pos, player.rotation, ray.origin);
             let forward = player.rotation.rotate_vector(ray.direction);
             Some((Point3::from_vec(origin), forward))
         };

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -211,16 +211,23 @@ fn update_squeeze_swallow(
 ///   but cannot fire.
 /// - Any other hand off the panel keeps its own trigger, so an empty hand can
 ///   still Frob the world and a held consumable still works.
+/// - While an item rides the cursor, both triggers belong to the drag: the
+///   off-panel pull that throws it must not also frob whatever it is aimed at.
 ///
 /// This is the per-frame decision only; [`latch_trigger_safe`] freezes it for
 /// the length of a pull, and the caller ORs in `vr_trigger_swallow` afterwards.
 ///
 /// Pure, so the matrix is exercised directly rather than through a mission.
-fn trigger_safe_mask(use_mode: bool, on_panel: [bool; 2], holds_weapon: [bool; 2]) -> [bool; 2] {
+fn trigger_safe_mask(
+    use_mode: bool,
+    on_panel: [bool; 2],
+    holds_weapon: [bool; 2],
+    cursor_loaded: bool,
+) -> [bool; 2] {
     let mut mask = [false; 2];
     if use_mode {
         for slot in 0..mask.len() {
-            mask[slot] = on_panel[slot] || holds_weapon[slot];
+            mask[slot] = on_panel[slot] || holds_weapon[slot] || cursor_loaded;
         }
     }
     mask
@@ -3963,7 +3970,12 @@ impl MissionCore {
         let mut trigger_safe = latch_trigger_safe(
             &mut self.vr_trigger_safe_latch,
             pressed,
-            trigger_safe_mask(self.use_mode, on_panel, holds_weapon),
+            trigger_safe_mask(
+                self.use_mode,
+                on_panel,
+                holds_weapon,
+                self.flat_ui.has_cursor_item(),
+            ),
         );
         for safe in trigger_safe.iter_mut() {
             *safe |= self.vr_trigger_swallow;
@@ -5559,8 +5571,8 @@ impl MissionCore {
     ) -> Vec<Effect> {
         use crate::mission::flat_ui_host::FlatUiDragAction;
         match action {
-            FlatUiDragAction::Throw(entity_id) => {
-                self.throw_entity_into_world(entity_id);
+            FlatUiDragAction::Throw { entity, hand } => {
+                self.throw_entity_into_world(entity, hand);
                 Vec::new()
             }
             // The AMMOFULL readout's controls emit the same effects as their
@@ -5636,7 +5648,7 @@ impl MissionCore {
     /// confirmed, so an aborted throw (no view ray, or a modelless item with no
     /// physics representation) leaves it in the backpack rather than lost or
     /// frozen mid-air.
-    fn throw_entity_into_world(&mut self, entity_id: EntityId) {
+    fn throw_entity_into_world(&mut self, entity_id: EntityId, hand: crate::vr_config::Handedness) {
         /// How far ahead of the camera the item materializes (world units).
         /// The eye sits on the standing capsule's axis, so this must clear the
         /// capsule's radius or a downward throw spawns the item inside the
@@ -5645,9 +5657,25 @@ impl MissionCore {
         /// Launch speed along the view ray (world units/sec).
         const THROW_SPEED: f32 = 6.0;
 
-        // Origin + direction: the flat aim ray (camera + view forward). Only
-        // set in flat presentation; without it, leave the item in the backpack.
-        let Some((origin, forward)) = self.interaction.flat_aim_ray() else {
+        // Origin + direction: the flat aim ray (camera + view forward), or in
+        // VR the throwing hand's controller ray off the same pointer pass that
+        // resolved the press. Without either, leave the item in the backpack.
+        let vr_hand_ray = || {
+            let ray = self
+                .vr_use_mode_pointer
+                .as_ref()?
+                .rays
+                .iter()
+                .find(|ray| ray.handedness == hand)?;
+            // The pass rays are in pawn space (the tracked controller pose);
+            // the throw lands in the world, so map through the pawn like
+            // `VirtualHand` does.
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            let origin = player.pos + player.rotation.rotate_vector(ray.origin);
+            let forward = player.rotation.rotate_vector(ray.direction);
+            Some((Point3::from_vec(origin), forward))
+        };
+        let Some((origin, forward)) = self.interaction.flat_aim_ray().or_else(vr_hand_ray) else {
             return;
         };
 
@@ -13445,7 +13473,7 @@ mod vr_trigger_safe_tests {
     /// the interact with it.
     #[test]
     fn an_off_panel_empty_hand_keeps_its_trigger() {
-        let mask = trigger_safe_mask(true, NEITHER, NEITHER);
+        let mask = trigger_safe_mask(true, NEITHER, NEITHER, false);
         assert_eq!(
             mask, NEITHER,
             "an empty hand off the panel must still be able to frob the world"
@@ -13457,7 +13485,7 @@ mod vr_trigger_safe_tests {
     #[test]
     fn a_hand_on_the_panel_is_masked() {
         assert_eq!(
-            trigger_safe_mask(true, [true, false], NEITHER),
+            trigger_safe_mask(true, [true, false], NEITHER, false),
             [true, false]
         );
     }
@@ -13467,11 +13495,11 @@ mod vr_trigger_safe_tests {
     #[test]
     fn a_wielding_hand_is_safed_wherever_it_points() {
         assert_eq!(
-            trigger_safe_mask(true, NEITHER, [false, true]),
+            trigger_safe_mask(true, NEITHER, [false, true], false),
             [false, true]
         );
         assert_eq!(
-            trigger_safe_mask(true, [false, true], [false, true]),
+            trigger_safe_mask(true, [false, true], [false, true], false),
             [false, true]
         );
     }
@@ -13480,7 +13508,7 @@ mod vr_trigger_safe_tests {
     #[test]
     fn the_hands_are_masked_independently() {
         // Left wields a weapon, right is empty and off the panel.
-        let mask = trigger_safe_mask(true, NEITHER, [true, false]);
+        let mask = trigger_safe_mask(true, NEITHER, [true, false], false);
         assert!(mask[LEFT], "the wielding hand cannot fire");
         assert!(!mask[RIGHT], "the free hand can still frob");
     }
@@ -13489,7 +13517,14 @@ mod vr_trigger_safe_tests {
     /// across-exit swallow is ORed in by the caller, outside this rule).
     #[test]
     fn a_closed_interface_masks_nothing() {
-        assert_eq!(trigger_safe_mask(false, BOTH, BOTH), NEITHER);
+        assert_eq!(trigger_safe_mask(false, BOTH, BOTH, true), NEITHER);
+    }
+
+    /// An item riding the cursor owns both triggers: the off-panel pull that
+    /// throws it must not reach the world as a frob on whatever it is aimed at.
+    #[test]
+    fn a_loaded_cursor_masks_both_triggers() {
+        assert_eq!(trigger_safe_mask(true, NEITHER, NEITHER, true), BOTH);
     }
 
     /// The latch's reason to exist: a click begun on the panel keeps being

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -85,7 +85,9 @@ impl PointerEngagement {
 /// points, and where it lands on the canvas (if it lands at all).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FrontendRay {
-    /// The controller's position, in world space.
+    /// The controller's position, in pawn (tracking) space - the space the
+    /// input hands and the panel are both expressed in. Map through the pawn
+    /// (`virtual_hand::hand_world_position`) before using it in the world.
     pub origin: Vector3<f32>,
     /// The direction the controller points (its local -Z), normalized.
     pub direction: Vector3<f32>,
@@ -137,6 +139,11 @@ pub struct FrontendPointerPass {
     /// Index into `rays` of the controller actually driving the menu, when one
     /// of them is on the panel.
     active: Option<usize>,
+    /// The hand claiming the panel this frame whether or not its ray is on it
+    /// (a held trigger claims it from anywhere; ties and idle triggers fall
+    /// back to the right hand). This is the hand an off-panel gesture belongs
+    /// to - the throw of a cursor item aims along its ray.
+    pub claiming_hand: Handedness,
     /// Whether either trigger is held.
     pub pressed: bool,
 }
@@ -251,6 +258,7 @@ pub fn vr_pointer_pass(
     FrontendPointerPass {
         rays,
         active,
+        claiming_hand: handedness[order[0]],
         // Nothing may be pointing at the screen; report the trigger anyway so a
         // press that starts off-panel is still consumed as "held" rather than
         // becoming a fresh edge the moment the ray crosses onto a button. This

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -7,9 +7,11 @@ use crate::runtime_props::RuntimePropVrGripOffset;
 use once_cell::sync::Lazy;
 use shipyard::{EntityId, Get, View, World};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Defaults to `Right`: it is the fallback hand wherever an arbitration ties.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum Handedness {
     Left,
+    #[default]
     Right,
 }
 

--- a/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
@@ -8,7 +8,7 @@ import {
   clickCanvasWithRay,
   requirePanelPose as requirePanel,
 } from "./helpers/ui.js";
-import { aimVrHandAtCanvas } from "./helpers/vr-hand.js";
+import { aimVrHandAtCanvas, dot, normalize } from "./helpers/vr-hand.js";
 
 // The VR cyber interface's pointer bridge (slice 3): a controller ray meets
 // the anchored panel, and where it lands drives the SAME host the flat mouse
@@ -202,17 +202,62 @@ test(
     const slot = slotFor(ui, wrench.entity_id);
     assert.ok(slot, "the provisioned wrench must occupy a strip slot");
 
-    await clickAt(game, panel, center(slot));
+    await clickCanvasWithRay(game, panel, center(slot));
     ui = await game.ui.state();
     assert.equal(ui.cursor?.entity_id, wrench.entity_id, "the wrench rides the cursor");
 
-    // Point the right controller away from the panel and pull the trigger.
+    // The launch velocity is set on the throw frame, so read it one frame in,
+    // before gravity and the floor have had a say.
+    const launchVelocity = async (entityId: number) => {
+      const launched = await game.physics.bodies({ entityId });
+      assert.ok(launched.bodies.length > 0, "the throw gives the item a body");
+      return normalize(launched.bodies[0].velocity);
+    };
+
+    // Throw 1: the RIGHT hand, past the panel's right edge (its ray misses the
+    // canvas, so it is a world hand) - aimed forward, into the panel plane.
     const playerBefore = await game.player.position();
-    await aimVrHandAtCanvas(game, panel, [320, 240], { facing: "away", trigger: 0 });
+    const rightOff: [number, number] = [1000, 240];
+    await aimVrHandAtCanvas(game, panel, rightOff, { trigger: 0 });
     await game.step({ frames: 2 });
-    await aimVrHandAtCanvas(game, panel, [320, 240], { facing: "away", trigger: 1 });
+    assert.equal(
+      (await game.ui.state()).cursor?.entity_id,
+      wrench.entity_id,
+      "an off-panel hand at rest must not disturb the cursor",
+    );
+    await aimVrHandAtCanvas(game, panel, rightOff, { trigger: 1 });
+    await game.step({ frames: 1 });
+    const forwardThrow = await launchVelocity(wrench.entity_id);
+    await aimVrHandAtCanvas(game, panel, rightOff, { trigger: 0 });
+    await game.step({ frames: 10 });
+
+    // Throw 2: lift a second wrench with the right hand (which then rests on
+    // the panel, trigger up), and throw it with the LEFT hand turned AWAY from
+    // the panel. A throw aimed by the wrong hand - the right one, or the head
+    // - would fly forward like the first; the left hand's own ray points the
+    // other way, so the two throws must be anti-parallel.
+    const second = await game.player.spawnItem("Wrench");
     await game.step({ frames: 2 });
-    await aimVrHandAtCanvas(game, panel, [320, 240], { facing: "away", trigger: 0 });
+    const secondSlot = slotFor(await game.ui.state(), second.entity_id);
+    assert.ok(secondSlot, "the second wrench must occupy a strip slot");
+    await clickCanvasWithRay(game, panel, center(secondSlot));
+    assert.equal((await game.ui.state()).cursor?.entity_id, second.entity_id);
+    await aimVrHandAtCanvas(game, panel, [320, 240], {
+      hand: "left",
+      facing: "away",
+      trigger: 1,
+    });
+    await game.step({ frames: 1 });
+    const backwardThrow = await launchVelocity(second.entity_id);
+    assert.ok(
+      dot(forwardThrow, backwardThrow) < -0.9,
+      `each throw must fly along the ray of the hand that pulled (cos ${dot(forwardThrow, backwardThrow).toFixed(2)})`,
+    );
+    await aimVrHandAtCanvas(game, panel, [320, 240], {
+      hand: "left",
+      facing: "away",
+      trigger: 0,
+    });
     await game.step({ frames: 10 });
 
     ui = await game.ui.state();

--- a/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-pointer.e2e.test.ts
@@ -177,3 +177,63 @@ test(
     );
   },
 );
+
+// The VR reading of flat's "click the bare 3D view": with an item riding the
+// cursor, a trigger pull with the ray OFF the panel throws it into the world
+// along that hand's ray. Negative-first: on the parent an off-panel press is
+// ignored, so the cursor keeps the item and no body ever appears.
+test(
+  "an off-panel trigger pull throws the cursor item into the world",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const wrench = await game.player.spawnItem("Wrench");
+    let ui = await openInterface(game);
+    const panel = requirePanel(ui);
+    await aimVrHandAtCanvas(game, panel, [320, 240], {
+      hand: "left",
+      facing: "away",
+    });
+    const slot = slotFor(ui, wrench.entity_id);
+    assert.ok(slot, "the provisioned wrench must occupy a strip slot");
+
+    await clickAt(game, panel, center(slot));
+    ui = await game.ui.state();
+    assert.equal(ui.cursor?.entity_id, wrench.entity_id, "the wrench rides the cursor");
+
+    // Point the right controller away from the panel and pull the trigger.
+    const playerBefore = await game.player.position();
+    await aimVrHandAtCanvas(game, panel, [320, 240], { facing: "away", trigger: 0 });
+    await game.step({ frames: 2 });
+    await aimVrHandAtCanvas(game, panel, [320, 240], { facing: "away", trigger: 1 });
+    await game.step({ frames: 2 });
+    await aimVrHandAtCanvas(game, panel, [320, 240], { facing: "away", trigger: 0 });
+    await game.step({ frames: 10 });
+
+    ui = await game.ui.state();
+    assert.equal(ui.cursor ?? null, null, "the throw clears the cursor");
+    assert.equal(slotFor(ui, wrench.entity_id), undefined, "the thrown wrench leaves the strip");
+    const carried = await game.player.inventory();
+    assert.ok(
+      !carried.items.some((item) => item.entity_id === wrench.entity_id),
+      "the thrown wrench is no longer carried",
+    );
+    const bodies = await game.physics.bodies({ entityId: wrench.entity_id });
+    assert.ok(bodies.bodies.length > 0, "the thrown wrench has a physics body");
+    const p = bodies.bodies[0].position;
+    const dist = Math.hypot(
+      p[0] - playerBefore.x,
+      p[1] - playerBefore.y,
+      p[2] - playerBefore.z,
+    );
+    assert.ok(
+      Number.isFinite(dist) && dist < 10,
+      `the thrown wrench lands near the player (dist ${dist.toFixed(2)})`,
+    );
+  },
+);


### PR DESCRIPTION
The cyber interface's cursor-is-the-item drag could lift, place, swap and wield in VR, but had no way to commit an item to the world: flat's bare-view click had no VR reading (cyber-interface plan, open thread "drop-into-world from the panel").

**Now:** with an item on the cursor, a trigger pull whose controller ray is **off the panel** throws it along that hand's ray (the pointer pass's own ray, mapped through the pawn with `hand_world_position`). Empty panel pixels still keep the item, as before. An off-panel pull with an empty cursor stays that hand's ordinary world press.

- `FlatUiDragAction::Throw` carries the throwing hand; `FrontendPointerPass` publishes `claiming_hand` (held trigger wins, ties fall to the right hand) so the off-panel hand is decided once, in the pass.
- While an item rides the cursor, both triggers are masked from the world in VR (`trigger_safe_mask`), so the throw cannot double as a frob. The mask reads the cursor one frame late; the latch covers both edges of the pull.
- Flat-facing side effect: the off-canvas throw now also clears the double-click mark, like the in-canvas throw already did (a click on the thrown item's old slot within 20 frames could previously read as a wield).

**Known limits:** the pass reports one aggregate `pressed` edge, so a fresh off-panel pull while the *other* trigger is already held does not throw (nothing misfires; release and pull again). The spawn point is `capsule radius + 0.2` along the hand ray, sized for the flat eye ray; a controller held against the body and aimed back through it can spawn the item inside the capsule and get it ejected.

**Tests:** host unit tests (off-panel throw by hand, off-panel pointer hand, empty-cursor no-op), `trigger_safe_mask` with a loaded cursor, and a VR e2e that throws once with each hand in opposite directions and asserts the launch velocities are anti-parallel (a throw aimed by the wrong hand or the head would fly the same way twice).

![VR panel throw](https://gist.githubusercontent.com/tommy-xr/53dccc2c22d04a8ec5df15320bcad7ba/raw/demo.gif)

<sub>Lift the wrench onto the cursor, swing the ray below the panel, pull: the icon leaves the cursor and the wrench lands on the floor ahead (its name tag flashes as the world hand crosses it). Brightened 1.8x - the comfort dim makes the world dark. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| lifted | thrown |
| --- | --- |
| ![lifted](https://gist.githubusercontent.com/tommy-xr/53dccc2c22d04a8ec5df15320bcad7ba/raw/still-lifted.png) | ![thrown](https://gist.githubusercontent.com/tommy-xr/53dccc2c22d04a8ec5df15320bcad7ba/raw/still-thrown.png) |
