### PR TITLE
feat(vr): per-model magazine anchors for the clip-insert gesture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,10 @@ For debugging visual/rendering changes without a full interactive session:
    # Overlay the fitted per-joint hitbox shapes (capsules/boxes) on the animated
    # mesh - physics-free, animatable - to eyeball fit across poses:
    cargo dv grunt_p.bin --animation <clip> --debug-hitboxes --debug-skeletons
+   # Dump a .bin object model's sub-objects with their model-space bounds, to
+   # read a per-model anchor (a magazine, a grip) off the art instead of
+   # eyeballing it - see `vr_config::MAGAZINE_ANCHORS`:
+   cargo dv ar15_h.bin --debug-subobjects
    ```
 
 2. **Debug Runtime** (see `projects/debug-runtime.md`): HTTP-controlled game runtime for programmatic control and introspection:

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -635,6 +635,35 @@ pub fn sub_object_transforms(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Matr
         .collect()
 }
 
+/// The model-space bounding box of every sub-object's own vertices, paired
+/// with its name - where each authored part actually sits once its transform
+/// chain is applied. Empty parts (pure pivots) report `None`.
+///
+/// This is how a per-model anchor gets derived from the art (a magazine, a
+/// grip, a sight) instead of eyeballed in a debug scene.
+pub fn sub_object_bounds(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Option<Aabb3<f32>>)> {
+    let transforms = sub_object_transforms(mesh);
+    mesh.sub_objects
+        .iter()
+        .zip(transforms)
+        .map(|(sub_object, (name, transform))| {
+            use collision::Aabb as _;
+            let mut bounds: Option<Aabb3<f32>> = None;
+            for index in sub_object.point_start..sub_object.point_stop {
+                let Some(vertex) = mesh.vertices.get(index as usize) else {
+                    continue;
+                };
+                let point = transform.transform_point(point3(vertex.x, vertex.y, vertex.z));
+                bounds = Some(match bounds {
+                    None => Aabb3::new(point, point),
+                    Some(aabb) => aabb.grow(point),
+                });
+            }
+            (name, bounds)
+        })
+        .collect()
+}
+
 pub fn to_vertices(
     mesh: &SystemShock2ObjectMesh,
 ) -> HashMap<u16, Vec<VertexPositionTextureSkinnedNormal>> {

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -619,9 +619,7 @@ fn wrist_and_fingertip(points: &[Point3<f32>]) -> Option<(Point3<f32>, Point3<f3
 /// sub-objects (`@s01_han`, `@s02_han`) are posed onto the weapon by hand, so
 /// their transforms say exactly where a hand belongs on that gun.
 pub fn sub_object_transforms(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Matrix4<f32>)> {
-    let mut bones = Vec::new();
-    build_skeleton_for_obj_mesh(mesh, 0, None, &mut bones);
-    let skeleton = Skeleton::create_from_bones(bones);
+    let skeleton = obj_skeleton(mesh);
 
     mesh.sub_objects
         .iter()
@@ -635,18 +633,35 @@ pub fn sub_object_transforms(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Matr
         .collect()
 }
 
+/// The sub-object tree as the skeleton the renderer poses it with (joint index
+/// = sub-object index).
+pub fn obj_skeleton(mesh: &SystemShock2ObjectMesh) -> Skeleton {
+    let mut bones = Vec::new();
+    build_skeleton_for_obj_mesh(mesh, 0, None, &mut bones);
+    Skeleton::create_from_bones(bones)
+}
+
 /// The model-space bounding box of every sub-object's own vertices, paired
-/// with its name - where each authored part actually sits once its transform
-/// chain is applied. Empty parts (pure pivots) report `None`.
+/// with its name - where each authored part actually sits under `palette`,
+/// the per-joint transforms the renderer skins with (index = sub-object
+/// index; for the rest pose, `AnimationPlayer::empty().get_transforms`).
+/// Empty parts (pure pivots) report `None`.
 ///
 /// This is how a per-model anchor gets derived from the art (a magazine, a
 /// grip, a sight) instead of eyeballed in a debug scene.
-pub fn sub_object_bounds(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Option<Aabb3<f32>>)> {
-    let transforms = sub_object_transforms(mesh);
+pub fn sub_object_bounds(
+    mesh: &SystemShock2ObjectMesh,
+    palette: &[Matrix4<f32>],
+) -> Vec<(String, Option<Aabb3<f32>>)> {
     mesh.sub_objects
         .iter()
-        .zip(transforms)
-        .map(|(sub_object, (name, transform))| {
+        .enumerate()
+        .map(|(index, sub_object)| {
+            let name = sub_object.name.clone();
+            let transform = palette
+                .get(index)
+                .copied()
+                .unwrap_or_else(Matrix4::identity);
             use collision::Aabb as _;
             let mut bounds: Option<Aabb3<f32>> = None;
             for index in sub_object.point_start..sub_object.point_stop {

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -729,6 +729,9 @@ pub struct EntityDetailResult {
     /// entity: the union of its hitboxes where it has them, otherwise its own
     /// collider.
     pub selection_bounds: Option<[[f32; 3]; 2]>,
+    /// World-space centre of a gun's magazine zone (VR clip insert); None
+    /// when the entity takes no magazine.
+    pub magazine_anchor: Option<[f32; 3]>,
 }
 
 #[derive(Debug, Serialize)]

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1656,6 +1656,7 @@ fn process_command(
                             })
                             .collect(),
                         selection_bounds: detail.selection_bounds,
+                        magazine_anchor: detail.magazine_anchor,
                     })
             } else {
                 None

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -293,6 +293,9 @@ pub struct DebugEntityDetail {
     /// this entity lives inside a container.
     pub contained_by: Option<i32>,
     pub aim_points: Vec<DebugAimPoint>,
+    /// World-space centre of a gun's magazine zone - where a held clip must
+    /// reach to load it in VR. Null for anything that takes no magazine.
+    pub magazine_anchor: Option<[f32; 3]>,
     /// World-space bounds the HUD highlight frames: the union of the
     /// creature's hitboxes where it has them, otherwise the entity's own
     /// collider. `[min, max]`, or null for an entity with neither.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8576,22 +8576,22 @@ impl MissionCore {
     /// Where `weapon`'s magazine zone is centred in the world: its per-model
     /// anchor (`vr_config`) carried by the live transform.
     fn magazine_anchor_world(&self, weapon: EntityId) -> Option<Vector3<f32>> {
-        use cgmath::Transform as _;
         let anchor = crate::vr_config::magazine_anchor_from_entity(&self.world, weapon);
-        let transforms = self.world.borrow::<View<RuntimePropTransform>>().ok()?;
-        let transform = transforms.get(weapon).ok()?;
-        Some(crate::util::point3_to_vec3(
-            transform.0.transform_point(Point3::from_vec(anchor)),
-        ))
+        self.entity_point_world(weapon, anchor)
     }
 
     /// The world position of `entity`'s live transform.
     fn entity_world_position(&self, entity: EntityId) -> Option<Vector3<f32>> {
+        self.entity_point_world(entity, vec3(0.0, 0.0, 0.0))
+    }
+
+    /// A point in `entity`'s local frame, carried by its live transform.
+    fn entity_point_world(&self, entity: EntityId, local: Vector3<f32>) -> Option<Vector3<f32>> {
         use cgmath::Transform as _;
         let transforms = self.world.borrow::<View<RuntimePropTransform>>().ok()?;
         let transform = transforms.get(entity).ok()?;
         Some(crate::util::point3_to_vec3(
-            transform.0.transform_point(Point3::new(0.0, 0.0, 0.0)),
+            transform.0.transform_point(Point3::from_vec(local)),
         ))
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8541,10 +8541,10 @@ impl MissionCore {
             let engaged = pair
                 .and_then(|(clip, weapon, _)| {
                     let clip_position = self.entity_world_position(clip)?;
-                    let weapon_position = self.entity_world_position(weapon)?;
+                    let magazine = self.magazine_anchor_world(weapon)?;
                     Some(crate::mission::reload::clip_insert_zone_engaged(
                         self.vr_clip_insert_engaged[slot],
-                        (clip_position - weapon_position).magnitude(),
+                        (clip_position - magazine).magnitude(),
                     ))
                 })
                 .unwrap_or(false);
@@ -8571,6 +8571,18 @@ impl MissionCore {
             .ok()
             .and_then(|states| states.get(weapon).ok().map(|state| state.ammo))
             .unwrap_or(0)
+    }
+
+    /// Where `weapon`'s magazine zone is centred in the world: its per-model
+    /// anchor (`vr_config`) carried by the live transform.
+    fn magazine_anchor_world(&self, weapon: EntityId) -> Option<Vector3<f32>> {
+        use cgmath::Transform as _;
+        let anchor = crate::vr_config::magazine_anchor_from_entity(&self.world, weapon);
+        let transforms = self.world.borrow::<View<RuntimePropTransform>>().ok()?;
+        let transform = transforms.get(weapon).ok()?;
+        Some(crate::util::point3_to_vec3(
+            transform.0.transform_point(Point3::from_vec(anchor)),
+        ))
     }
 
     /// The world position of `entity`'s live transform.
@@ -11249,6 +11261,10 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .map(|link| link.target_id);
 
                 let selection_bounds = self.selection_bounds(id);
+                let magazine_anchor = self
+                    .magazine_capacity(id)
+                    .and_then(|_| self.magazine_anchor_world(id))
+                    .map(|anchor| [anchor.x, anchor.y, anchor.z]);
                 Some(DebugEntityDetail {
                     entity_id: id.inner() as i32,
                     name,
@@ -11265,6 +11281,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     incoming_links,
                     contained_by,
                     aim_points: aim_points.clone(),
+                    magazine_anchor,
                     selection_bounds: selection_bounds.map(|bounds| {
                         [
                             [bounds.min.x, bounds.min.y, bounds.min.z],

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -242,11 +242,9 @@ pub(crate) fn load_from_held_clip(
 
 /// Enter/exit radii (world units) of a weapon's magazine zone - the volume a
 /// held clip is inserted by entering. One world unit is ~0.76 m, so this is a
-/// generous ~19 cm sphere around the weapon's origin, entered deliberately but
-/// not requiring the player to thread a needle in mid-air.
-///
-/// v1 centres the zone on the weapon's own transform; a per-model magazine
-/// anchor is a follow-up.
+/// generous ~19 cm sphere around the weapon's magazine anchor
+/// (`vr_config::magazine_anchor_from_entity`), entered deliberately but not
+/// requiring the player to thread a needle in mid-air.
 pub(crate) const CLIP_INSERT_ENTER_RADIUS: f32 = 0.25;
 pub(crate) const CLIP_INSERT_EXIT_RADIUS: f32 = 0.35;
 

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -302,6 +302,59 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
     "viro_h", "amp_h", "wrench_h", "rapier_h", "shard_h", "psword_h",
 ];
 
+// --- Magazine anchors ---------------------------------------------------------
+//
+// Where a held clip has to reach to load a wielded gun, in the *weapon's*
+// local frame - the authored frame the grip table above works in: barrel
+// along -X, +X back toward the shooter, +Y up out of the gun body, +Z across
+// it. World units (1 unit = 0.762 m), the space `RuntimePropTransform` lives in.
+
+/// Per-model magazine anchors, keyed like [`HAND_MODEL_POSITIONING`]
+/// (lowercased `PropModelName`). Read off each 25AE view model's own art with
+/// `cargo dv <model>.bin --debug-subobjects`: the centre of the authored clip
+/// part where the model has one (`ar15_h`'s `@s02_cli`, `fsn_h`'s `@01_core`,
+/// `sfg_h`'s `@01_cyli`), otherwise the underside of the grip or receiver
+/// the classic reload feeds. A weapon with no entry (a classic install's
+/// world model, the exotic launchers) keeps the zone on its own origin.
+static MAGAZINE_ANCHORS: Lazy<HashMap<&str, Vector3<f32>>> = Lazy::new(|| {
+    HashMap::from([
+        ("atek_h", vec3(0.10, -0.18, 0.0)),
+        ("ar15_h", vec3(-0.04, -0.20, 0.0)),
+        ("sg_h", vec3(0.20, -0.20, 0.0)),
+        ("empgun_h", vec3(0.10, -0.25, 0.0)),
+        ("lasehand", vec3(0.0, -0.25, 0.0)),
+        ("gren_h", vec3(0.0, -0.20, 0.0)),
+        ("sfg_h", vec3(-0.24, 0.12, 0.27)),
+        ("fsn_h", vec3(-0.65, 0.0, 0.0)),
+    ])
+});
+
+/// Where `entity_id`'s magazine is, in its model's local frame - the origin
+/// for a model with no entry. Mirrors
+/// [`get_vr_hand_model_adjustments_from_entity`]'s lookup by lowercased
+/// `PropModelName`.
+pub fn magazine_anchor_from_entity(world: &World, entity_id: EntityId) -> Vector3<f32> {
+    world
+        .borrow::<View<PropModelName>>()
+        .ok()
+        .and_then(|names| {
+            names
+                .get(entity_id)
+                .ok()
+                .map(|name| name.0.to_ascii_lowercase())
+        })
+        .map(|name| magazine_anchor_from_model(&name))
+        .unwrap_or(vec3(0.0, 0.0, 0.0))
+}
+
+/// [`magazine_anchor_from_entity`] by model name.
+pub fn magazine_anchor_from_model(model_name: &str) -> Vector3<f32> {
+    MAGAZINE_ANCHORS
+        .get(model_name)
+        .copied()
+        .unwrap_or(vec3(0.0, 0.0, 0.0))
+}
+
 /// Whether `model_name` is a first-person view model VR should wield in place
 /// of the world model (only meaningful on a 25AE install, where the remastered
 /// copy is what resolves).
@@ -499,6 +552,25 @@ mod tests {
     /// Every VR-wieldable 25AE gun must have a grip entry, or it would anchor
     /// at the model origin with no rotation. The melee `_h` are the deliberate
     /// exception - see `melee_view_models_have_no_static_grip`.
+    /// A typo'd anchor key would silently leave that gun's zone on its
+    /// origin instead of failing.
+    #[test]
+    fn every_magazine_anchor_names_a_known_gun_model() {
+        for name in MAGAZINE_ANCHORS.keys() {
+            assert!(
+                VR_25AE_VIEW_MODELS.contains(name) && !MELEE_VIEW_MODELS.contains(name),
+                "MAGAZINE_ANCHORS key {name} is not a known gun model"
+            );
+        }
+    }
+
+    /// A model without an entry keeps the v1 behaviour: the zone on its origin.
+    #[test]
+    fn an_unknown_model_keeps_its_magazine_on_the_origin() {
+        assert_eq!(magazine_anchor_from_model("atek"), vec3(0.0, 0.0, 0.0));
+        assert_ne!(magazine_anchor_from_model("ar15_h"), vec3(0.0, 0.0, 0.0));
+    }
+
     #[test]
     fn every_vr_view_model_has_a_grip_entry() {
         for name in VR_25AE_VIEW_MODELS {

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -311,10 +311,13 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
 // 0.762 m), the space `RuntimePropTransform` lives in.
 
 /// Per-model magazine anchors, keyed like [`HAND_MODEL_POSITIONING`]
-/// (lowercased `PropModelName`). Read off each 25AE view model's own art with
-/// `cargo dv <model>.bin --debug-subobjects`: the centre of the authored clip
-/// part where the model has one (`ar15_h`'s `@s02_cli`, `fsn_h`'s `@01_core`),
-/// otherwise the underside of the grip or receiver the classic reload feeds.
+/// (lowercased `PropModelName`). Where the art has a clip part (`ar15_h`'s
+/// `@s02_cli`, `fsn_h`'s `@01_core`, found with `cargo dv <model>.bin
+/// --debug-subobjects`) the anchor is its centre; the rest sit on the grip or
+/// loading port. Every value is placed against the rendered wield with the
+/// `clip_zone` dev param (which also marks the model origin), not from the
+/// dump alone - the pistol's origin, for one, renders at the wrist, well
+/// behind where its sub-object bounds suggest.
 ///
 /// A model with no entry keeps the zone on its own origin: a classic install's
 /// world models; the energy weapons (`lasehand`, `empgun_h`), which recharge
@@ -322,10 +325,10 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
 /// model and is not trusted yet; and `al_h` / `viro_h`, not measured yet.
 static MAGAZINE_ANCHORS: Lazy<HashMap<&str, Vector3<f32>>> = Lazy::new(|| {
     HashMap::from([
-        ("atek_h", vec3(0.10, -0.18, 0.0)),
+        ("atek_h", vec3(-0.20, -0.15, 0.0)),
         ("ar15_h", vec3(-0.04, -0.20, 0.0)),
-        ("sg_h", vec3(0.20, -0.20, 0.0)),
-        ("gren_h", vec3(0.0, -0.20, 0.0)),
+        ("sg_h", vec3(0.08, -0.10, 0.0)),
+        ("gren_h", vec3(0.10, -0.05, 0.0)),
         ("fsn_h", vec3(-0.65, 0.0, 0.0)),
     ])
 });

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -304,36 +304,51 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
 
 // --- Magazine anchors ---------------------------------------------------------
 //
-// Where a held clip has to reach to load a wielded gun, in the *weapon's*
-// local frame - the authored frame the grip table above works in: barrel
-// along -X, +X back toward the shooter, +Y up out of the gun body, +Z across
-// it. World units (1 unit = 0.762 m), the space `RuntimePropTransform` lives in.
+// Where a held clip has to reach to load a wielded gun, in the *weapon's own
+// authored model frame* - NOT the hand-local space the grip offsets above use.
+// The 25AE guns are authored barrel along -X, so +X is back toward the
+// shooter, +Y up out of the gun body, +Z across it. World units (1 unit =
+// 0.762 m), the space `RuntimePropTransform` lives in.
 
 /// Per-model magazine anchors, keyed like [`HAND_MODEL_POSITIONING`]
 /// (lowercased `PropModelName`). Read off each 25AE view model's own art with
 /// `cargo dv <model>.bin --debug-subobjects`: the centre of the authored clip
-/// part where the model has one (`ar15_h`'s `@s02_cli`, `fsn_h`'s `@01_core`,
-/// `sfg_h`'s `@01_cyli`), otherwise the underside of the grip or receiver
-/// the classic reload feeds. A weapon with no entry (a classic install's
-/// world model, the exotic launchers) keeps the zone on its own origin.
+/// part where the model has one (`ar15_h`'s `@s02_cli`, `fsn_h`'s `@01_core`),
+/// otherwise the underside of the grip or receiver the classic reload feeds.
+///
+/// A model with no entry keeps the zone on its own origin: a classic install's
+/// world models; the energy weapons (`lasehand`, `empgun_h`), which recharge
+/// rather than take a clip; `sfg_h`, whose dump shows a stray part 5 m off the
+/// model and is not trusted yet; and `al_h` / `viro_h`, not measured yet.
 static MAGAZINE_ANCHORS: Lazy<HashMap<&str, Vector3<f32>>> = Lazy::new(|| {
     HashMap::from([
         ("atek_h", vec3(0.10, -0.18, 0.0)),
         ("ar15_h", vec3(-0.04, -0.20, 0.0)),
         ("sg_h", vec3(0.20, -0.20, 0.0)),
-        ("empgun_h", vec3(0.10, -0.25, 0.0)),
-        ("lasehand", vec3(0.0, -0.25, 0.0)),
         ("gren_h", vec3(0.0, -0.20, 0.0)),
-        ("sfg_h", vec3(-0.24, 0.12, 0.27)),
         ("fsn_h", vec3(-0.65, 0.0, 0.0)),
     ])
 });
 
 /// Where `entity_id`'s magazine is, in its model's local frame - the origin
-/// for a model with no entry. Mirrors
-/// [`get_vr_hand_model_adjustments_from_entity`]'s lookup by lowercased
-/// `PropModelName`.
+/// for a model with no entry.
 pub fn magazine_anchor_from_entity(world: &World, entity_id: EntityId) -> Vector3<f32> {
+    model_name_lower(world, entity_id)
+        .map(|name| magazine_anchor_from_model(&name))
+        .unwrap_or(vec3(0.0, 0.0, 0.0))
+}
+
+/// [`magazine_anchor_from_entity`] by model name (any case).
+fn magazine_anchor_from_model(model_name: &str) -> Vector3<f32> {
+    MAGAZINE_ANCHORS
+        .get(model_name.to_ascii_lowercase().as_str())
+        .copied()
+        .unwrap_or(vec3(0.0, 0.0, 0.0))
+}
+
+/// `entity_id`'s `PropModelName`, lowercased - the key every per-model table
+/// in this file is looked up by.
+fn model_name_lower(world: &World, entity_id: EntityId) -> Option<String> {
     world
         .borrow::<View<PropModelName>>()
         .ok()
@@ -343,16 +358,6 @@ pub fn magazine_anchor_from_entity(world: &World, entity_id: EntityId) -> Vector
                 .ok()
                 .map(|name| name.0.to_ascii_lowercase())
         })
-        .map(|name| magazine_anchor_from_model(&name))
-        .unwrap_or(vec3(0.0, 0.0, 0.0))
-}
-
-/// [`magazine_anchor_from_entity`] by model name.
-pub fn magazine_anchor_from_model(model_name: &str) -> Vector3<f32> {
-    MAGAZINE_ANCHORS
-        .get(model_name)
-        .copied()
-        .unwrap_or(vec3(0.0, 0.0, 0.0))
 }
 
 /// Whether `model_name` is a first-person view model VR should wield in place
@@ -508,15 +513,9 @@ pub fn get_vr_hand_model_adjustments_from_entity(
         return VRHandModelPerHandAdjustments::new().with_offset(grip);
     }
 
-    let v_model_name = world.borrow::<View<PropModelName>>().unwrap();
-    let maybe_model_name = v_model_name
-        .get(entity_id)
-        .map(|sz| sz.0.to_ascii_lowercase());
-
-    if let Ok(model_name) = maybe_model_name {
-        get_vr_hand_model_adjustments_from_model(&model_name, handedness)
-    } else {
-        VRHandModelPerHandAdjustments::new()
+    match model_name_lower(world, entity_id) {
+        Some(model_name) => get_vr_hand_model_adjustments_from_model(&model_name, handedness),
+        None => VRHandModelPerHandAdjustments::new(),
     }
 }
 
@@ -549,9 +548,6 @@ mod tests {
     /// from the posed skeleton rather than from a static grip entry.
     const MELEE_VIEW_MODELS: &[&str] = &["wrench_h", "rapier_h", "shard_h", "psword_h"];
 
-    /// Every VR-wieldable 25AE gun must have a grip entry, or it would anchor
-    /// at the model origin with no rotation. The melee `_h` are the deliberate
-    /// exception - see `melee_view_models_have_no_static_grip`.
     /// A typo'd anchor key would silently leave that gun's zone on its
     /// origin instead of failing.
     #[test]
@@ -569,8 +565,16 @@ mod tests {
     fn an_unknown_model_keeps_its_magazine_on_the_origin() {
         assert_eq!(magazine_anchor_from_model("atek"), vec3(0.0, 0.0, 0.0));
         assert_ne!(magazine_anchor_from_model("ar15_h"), vec3(0.0, 0.0, 0.0));
+        // Any case, like the other by-name lookups in this file.
+        assert_eq!(
+            magazine_anchor_from_model("AR15_h"),
+            magazine_anchor_from_model("ar15_h")
+        );
     }
 
+    /// Every VR-wieldable 25AE gun must have a grip entry, or it would anchor
+    /// at the model origin with no rotation. The melee `_h` are the deliberate
+    /// exception - see `melee_view_models_have_no_static_grip`.
     #[test]
     fn every_vr_view_model_has_a_grip_entry() {
         for name in VR_25AE_VIEW_MODELS {

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -483,12 +483,16 @@ fn print_sub_objects(filename: &str) -> i32 {
         return 1;
     }
     let mesh = dark::ss2_bin_obj_loader::read(&mut *reader, &common_header);
+    // The pose the game renders an unanimated model in: the same palette
+    // `to_animated_scene_objects` skins with, not the raw sub-object tree.
+    let skeleton = dark::ss2_bin_obj_loader::obj_skeleton(&mesh);
+    let palette = dark::motion::AnimationPlayer::empty().get_transforms(&skeleton);
     let bb = mesh.bounding_box;
     println!(
         "{filename}: bbox min ({:.3}, {:.3}, {:.3}) max ({:.3}, {:.3}, {:.3})",
         bb.min.x, bb.min.y, bb.min.z, bb.max.x, bb.max.y, bb.max.z
     );
-    for (name, bounds) in dark::ss2_bin_obj_loader::sub_object_bounds(&mesh) {
+    for (name, bounds) in dark::ss2_bin_obj_loader::sub_object_bounds(&mesh, &palette) {
         match bounds {
             Some(aabb) => println!(
                 "  {name:<16} min ({:>7.3}, {:>7.3}, {:>7.3}) max ({:>7.3}, {:>7.3}, {:>7.3})",

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -291,6 +291,12 @@ pub fn main() {
         println!("Debug no-render mode enabled.");
     }
 
+    // A model dump needs the asset mounts and nothing else: no audio device,
+    // no window, no GL - so it runs headless (and exits nonzero on failure).
+    if cli.debug_subobjects {
+        std::process::exit(print_sub_objects(&filename));
+    }
+
     let mut audio_context: AudioContext<(), String> = AudioContext::new();
 
     tracing_subscriber::fmt::init();
@@ -332,11 +338,6 @@ pub fn main() {
     let engine = engine::opengl();
     let bundle_storage = engine.get_storage();
     let mut game = shock2vr::Game::init(GameOptions::default(), bundle_storage);
-
-    if cli.debug_subobjects {
-        print_sub_objects(&filename, &game.asset_cache);
-        return;
-    }
 
     if cli.debug_no_render {
         match create_scene(
@@ -457,17 +458,29 @@ fn process_events(
 }
 
 /// `--debug-subobjects`: dump a .bin object model's sub-objects and their
-/// model-space bounds, so an anchor can be read off the art.
-fn print_sub_objects(filename: &str, asset_cache: &engine::assets::asset_cache::AssetCache) {
+/// model-space bounds, so an anchor can be read off the art. Returns the
+/// process exit code.
+fn print_sub_objects(filename: &str) -> i32 {
+    let storage =
+        engine::file_system::storage::init(Box::new(engine::file_system::DefaultFileSystem {
+            root_path: Box::new(std::path::Path::new("./assets/")),
+        }));
+    let asset_cache = engine::assets::asset_cache::AssetCache::new(
+        shock2vr::paths::data_root().to_string_lossy().into_owned(),
+        shock2vr::game_asset_mounts(storage),
+    );
     let Some(reader) = asset_cache.get_raw_reader(filename) else {
-        println!("Could not open {filename}");
-        return;
+        eprintln!("Could not open {filename}");
+        return 1;
     };
     let mut reader = reader.borrow_mut();
     let common_header = dark::ss2_bin_header::read(&mut *reader);
-    if !matches!(common_header.bin_type, dark::ss2_bin_header::BinFileType::Obj) {
-        println!("{filename} is not an object (.bin LGMD) model");
-        return;
+    if !matches!(
+        common_header.bin_type,
+        dark::ss2_bin_header::BinFileType::Obj
+    ) {
+        eprintln!("{filename} is not an object (.bin LGMD) model");
+        return 1;
     }
     let mesh = dark::ss2_bin_obj_loader::read(&mut *reader, &common_header);
     let bb = mesh.bounding_box;
@@ -484,4 +497,5 @@ fn print_sub_objects(filename: &str, asset_cache: &engine::assets::asset_cache::
             None => println!("  {name:<16} (no vertices)"),
         }
     }
+    0
 }

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -76,6 +76,11 @@ struct Cli {
     #[arg(long)]
     debug_no_render: bool,
 
+    /// Print every sub-object of a .bin object model with its model-space
+    /// bounding box (for deriving per-model anchors from the art), then exit.
+    #[arg(long)]
+    debug_subobjects: bool,
+
     /// Overlay skeleton joints for supported model files (.bin/.ai).
     #[arg(long)]
     debug_skeletons: bool,
@@ -328,6 +333,11 @@ pub fn main() {
     let bundle_storage = engine.get_storage();
     let mut game = shock2vr::Game::init(GameOptions::default(), bundle_storage);
 
+    if cli.debug_subobjects {
+        print_sub_objects(&filename, &game.asset_cache);
+        return;
+    }
+
     if cli.debug_no_render {
         match create_scene(
             &filename,
@@ -444,4 +454,34 @@ fn process_events(
     }
 
     InputContext::default()
+}
+
+/// `--debug-subobjects`: dump a .bin object model's sub-objects and their
+/// model-space bounds, so an anchor can be read off the art.
+fn print_sub_objects(filename: &str, asset_cache: &engine::assets::asset_cache::AssetCache) {
+    let Some(reader) = asset_cache.get_raw_reader(filename) else {
+        println!("Could not open {filename}");
+        return;
+    };
+    let mut reader = reader.borrow_mut();
+    let common_header = dark::ss2_bin_header::read(&mut *reader);
+    if !matches!(common_header.bin_type, dark::ss2_bin_header::BinFileType::Obj) {
+        println!("{filename} is not an object (.bin LGMD) model");
+        return;
+    }
+    let mesh = dark::ss2_bin_obj_loader::read(&mut *reader, &common_header);
+    let bb = mesh.bounding_box;
+    println!(
+        "{filename}: bbox min ({:.3}, {:.3}, {:.3}) max ({:.3}, {:.3}, {:.3})",
+        bb.min.x, bb.min.y, bb.min.z, bb.max.x, bb.max.y, bb.max.z
+    );
+    for (name, bounds) in dark::ss2_bin_obj_loader::sub_object_bounds(&mesh) {
+        match bounds {
+            Some(aabb) => println!(
+                "  {name:<16} min ({:>7.3}, {:>7.3}, {:>7.3}) max ({:>7.3}, {:>7.3}, {:>7.3})",
+                aabb.min.x, aabb.min.y, aabb.min.z, aabb.max.x, aabb.max.y, aabb.max.z
+            ),
+            None => println!("  {name:<16} (no vertices)"),
+        }
+    }
 }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -166,6 +166,9 @@ export interface EntityDetailResult {
    * the entity's hitboxes where it has them, otherwise its own collider.
    */
   selection_bounds?: [[number, number, number], [number, number, number]] | null;
+  /** World-space centre of a gun's magazine zone (VR clip insert); null when
+   * the entity takes no magazine. */
+  magazine_anchor?: Vec3 | null;
 }
 
 export interface AimPoint {

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -211,29 +211,33 @@ async function takeClipIntoOffHand(
     "closing the interface must not take the clip back",
   );
 
-  // Park it a comfortable arm's drop below the gun.
-  const weaponPosition = async (): Promise<Vec3> => {
-    const weapon = await entityById(game, weaponId);
-    assert.ok(weapon, "the weapon must still be held");
-    return weapon.position as Vec3;
-  };
+  // Park it a comfortable arm's drop below the gun's magazine.
   const parked = await steerHeldClip(
     game,
     "left",
     [0, 0, 0],
     clipId,
-    async () => add(await weaponPosition(), [0, -1.2, 0]),
+    async () => add(await magazineAnchor(game, weaponId), [0, -1.2, 0]),
   );
   assert.equal(parked.consumed, false, "parking the clip must not insert it");
 
   const clip = await entityById(game, clipId);
   assert.ok(clip);
   assert.ok(
-    magnitude(sub(clip.position as Vec3, await weaponPosition())) >
+    magnitude(sub(clip.position as Vec3, await magazineAnchor(game, weaponId))) >
       CLIP_INSERT_EXIT_RADIUS,
     "the clip must start outside the magazine zone, or the insert proves nothing",
   );
   return parked.handPosition;
+}
+
+/** Where the weapon's magazine zone is centred: its per-model anchor, carried
+ * by the live transform, as the runtime reports it. Read live, since the gun
+ * rides the hand. */
+async function magazineAnchor(game: GameServer, weaponId: number): Promise<Vec3> {
+  const weapon = await game.entities.detail(weaponId);
+  assert.ok(weapon.magazine_anchor, "a held gun must report its magazine anchor");
+  return weapon.magazine_anchor;
 }
 
 /** Carry the parked clip into the weapon's magazine zone. */
@@ -243,11 +247,9 @@ async function insertClip(
   clipId: number,
   weaponId: number,
 ): Promise<void> {
-  await steerHeldClip(game, "left", handPosition, clipId, async () => {
-    const weapon = await entityById(game, weaponId);
-    assert.ok(weapon, "the weapon must still be held");
-    return weapon.position as Vec3;
-  });
+  await steerHeldClip(game, "left", handPosition, clipId, () =>
+    magazineAnchor(game, weaponId),
+  );
   await game.step({ frames: 5 });
 }
 
@@ -274,6 +276,16 @@ test(
     await game.step({ frames: 30 });
 
     const pistol = await grabPistol(game);
+    // The magazine is the pistol's grip, not its model origin: the zone the
+    // clip has to reach sits away from where the gun itself is reported.
+    const anchorOffset = sub(
+      await magazineAnchor(game, pistol.id),
+      (await entityById(game, pistol.id))!.position as Vec3,
+    );
+    assert.ok(
+      magnitude(anchorOffset) > 0.1,
+      `the pistol's magazine anchor must sit off its origin (offset ${JSON.stringify(anchorOffset)})`,
+    );
     // The debug pistol spawns with a FULL magazine, so what it holds now is its
     // capacity - the number the insert has to restore. Pinned as a precondition
     // rather than assumed, so a data change fails here and not three asserts

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   add,
   quatConjugate,
   quatRotate,
+  scale,
   sub,
   type Quat,
 } from "./helpers/vr-hand.js";
@@ -283,7 +284,7 @@ test(
       (await entityById(game, pistol.id))!.position as Vec3,
     );
     assert.ok(
-      magnitude(anchorOffset) > 0.1,
+      2 * magnitude(anchorOffset) > CLIP_INSERT_EXIT_RADIUS,
       `the pistol's magazine anchor must sit off its origin (offset ${JSON.stringify(anchorOffset)})`,
     );
     // The debug pistol spawns with a FULL magazine, so what it holds now is its
@@ -305,8 +306,28 @@ test(
       clip.rounds >= capacity,
       `this scenario needs a clip that can fill the magazine (${clip.rounds} vs ${capacity})`,
     );
-    const parked = await takeClipIntoOffHand(game, clip.id, pistol.id);
+    let parked = await takeClipIntoOffHand(game, clip.id, pistol.id);
     const before = await lastSound(game);
+
+    // The zone moved with the anchor: the point mirrored across the model
+    // origin is twice the anchor's offset from it - reaching it must NOT
+    // load. Approached along the ray out of the anchor (from well beyond the
+    // mirror point), so the clip never strays inside the zone on the way.
+    const alongAnchorRay = async (steps: number): Promise<Vec3> =>
+      sub(await magazineAnchor(game, pistol.id), scale(anchorOffset, steps));
+    const far = await steerHeldClip(game, "left", parked, clip.id, () =>
+      alongAnchorRay(8),
+    );
+    const mirrored = await steerHeldClip(game, "left", far.handPosition, clip.id, () =>
+      alongAnchorRay(2),
+    );
+    await game.step({ frames: 5 });
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      0,
+      "a clip carried to the far side of the gun's origin must miss the magazine",
+    );
+    parked = mirrored.handPosition;
 
     await insertClip(game, parked, clip.id, pistol.id);
 


### PR DESCRIPTION
The VR clip-insert zone (#1165) sat on every gun's model origin. Now each 25AE view model carries a **magazine anchor** in its authored frame, and the zone is centred on that anchor carried by the live transform.

**Update:** the anchor values were re-placed against the rendered wield with the `clip_zone` overlay (next PR up the stack): the pistol's model origin renders at the wrist, so its dump-derived anchor sat behind the hand. Pistol now on the grip, shotgun at the loading port, launcher on the drum; rifle and fusion cannon unchanged.

**How the anchors were derived.** New `cargo dv <model>.bin --debug-subobjects` (headless, no window) prints every sub-object of an object model with its model-space bounds, via a new `ss2_bin_obj_loader::sub_object_bounds`. Where the art has a clip part (`ar15_h`'s `@s02_cli`, `fsn_h`'s `@01_core`) the anchor is its centre; otherwise the underside of the grip/receiver (`atek_h`, `sg_h`, `gren_h`). Not anchored yet, so they keep the origin: the energy weapons (`lasehand`, `empgun_h`, which recharge), `sfg_h` (its dump shows a stray part 5 m off the model, so the derivation is not trusted), and `al_h` / `viro_h` (not measured).

**Agent-verifiable.** `/v1/entities/:id` reports a gun's `magazine_anchor` in world space (null when it takes no magazine). The insert e2e now steers the clip to that anchor, and first carries it to the point mirrored across the model origin (twice the anchor offset, approached along the anchor ray) and asserts nothing loads there, so the test proves the zone moved rather than that the origin still works.

**Review notes.** Both engines ran; no Critical/High. Applied: dump runs before any audio/GL init and exits nonzero on failure; `entity_point_world` replaces a copy of the origin lookup; one shared lowercased-model-name helper in `vr_config`; the by-name lookup accepts any case like its siblings. Pre-existing, left alone: `magazine_capacity` treats every gun as magazine-fed, so energy weapons still own a (origin-centred) zone and refuse clips - dropping their anchor entries here does not change that gate.

No visible change to capture: the zone is invisible, and the gesture's feedback is the same reload cue.

