### PR TITLE
feat(vr): a gun wielded in the left hand draws its mirror image

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -225,6 +225,15 @@ fn trigger_safe_mask(use_mode: bool, on_panel: [bool; 2], holds_weapon: [bool; 2
     mask
 }
 
+/// Whether `entity_id` wields as a melee `_h` arm rig (the skinned meshes
+/// carrying `PropLimbModel`) rather than a gun view model.
+fn is_melee_model(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropLimbModel>>()
+        .ok()
+        .is_some_and(|v| v.get(entity_id).is_ok())
+}
+
 /// Freeze each hand's trigger mask for the length of one pull.
 ///
 /// [`trigger_safe_mask`] is a per-frame decision, but a trigger pull is a
@@ -7161,7 +7170,24 @@ impl MissionCore {
                             continue;
                         };
 
-                        let vhots = new_model.vhots();
+                        let mut vhots = new_model.vhots();
+                        // A gun wielded in the LEFT hand draws the mirror
+                        // image of its right-handed model, muzzle vhots
+                        // included, so the baked hand is a left hand and the
+                        // shot still leaves the reflected barrel. Melee rigs
+                        // mirror in their own frame below; a model applied
+                        // while nothing holds it takes the authored right.
+                        if vr_held && !is_melee_model(&self.world, entity_id) {
+                            let hand = self
+                                .interaction
+                                .holding_hand(entity_id)
+                                .unwrap_or(crate::vr_config::Handedness::Right);
+                            let mirror = crate::vr_config::gun_mirror(hand);
+                            new_model.apply_local_transform(mirror);
+                            for vhot in vhots.iter_mut() {
+                                vhot.point = mirror.transform_point(vhot.point);
+                            }
+                        }
                         // An articulated VR-wielded first-person model (hand +
                         // arm + gun as skeleton sub-objects) renders unposed
                         // without a player, so give it the empty bind pose (it
@@ -7189,12 +7215,7 @@ impl MissionCore {
                             // cancelled for the same reason as flat: the
                             // entity transform is re-anchored (there to the
                             // camera, here to the tracked hand) every frame.
-                            let is_melee = self
-                                .world
-                                .borrow::<View<PropLimbModel>>()
-                                .ok()
-                                .is_some_and(|v| v.get(entity_id).is_ok());
-                            if is_melee {
+                            if is_melee_model(&self.world, entity_id) {
                                 let player = asset_cache
                                     .get_opt(
                                         &ANIMATION_CLIP_IMPORTER,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -225,15 +225,6 @@ fn trigger_safe_mask(use_mode: bool, on_panel: [bool; 2], holds_weapon: [bool; 2
     mask
 }
 
-/// Whether `entity_id` wields as a melee `_h` arm rig (the skinned meshes
-/// carrying `PropLimbModel`) rather than a gun view model.
-fn is_melee_model(world: &World, entity_id: EntityId) -> bool {
-    world
-        .borrow::<View<PropLimbModel>>()
-        .ok()
-        .is_some_and(|v| v.get(entity_id).is_ok())
-}
-
 /// Freeze each hand's trigger mask for the length of one pull.
 ///
 /// [`trigger_safe_mask`] is a per-frame decision, but a trigger pull is a
@@ -7171,18 +7162,25 @@ impl MissionCore {
                         };
 
                         let mut vhots = new_model.vhots();
-                        // A gun wielded in the LEFT hand draws the mirror
-                        // image of its right-handed model, muzzle vhots
-                        // included, so the baked hand is a left hand and the
-                        // shot still leaves the reflected barrel. Melee rigs
-                        // mirror in their own frame below; a model applied
-                        // while nothing holds it takes the authored right.
-                        if vr_held && !is_melee_model(&self.world, entity_id) {
-                            let hand = self
-                                .interaction
-                                .holding_hand(entity_id)
-                                .unwrap_or(crate::vr_config::Handedness::Right);
-                            let mirror = crate::vr_config::gun_mirror(hand);
+                        // Which hand a VR wield renders for. The `_h` models
+                        // are all authored right-handed, so a left-hand wield
+                        // draws the mirror image. A model applied while
+                        // nothing holds it (a restore before the grab) has no
+                        // hand yet; the right-handed default matches what the
+                        // rig is authored as, and the grab's own ChangeModel
+                        // re-derives this.
+                        let hand = self
+                            .interaction
+                            .holding_hand(entity_id)
+                            .unwrap_or(crate::vr_config::Handedness::Right);
+                        // A gun in the LEFT hand: reflect across the gun,
+                        // muzzle vhots included, so the baked hand is a left
+                        // hand and the shot still leaves the reflected barrel.
+                        // Melee rigs mirror in their own frame below. The
+                        // model's authored bounding box is left as-is: a held
+                        // gun is unphysical, and nothing frames it by that box.
+                        if vr_held && !is_melee_weapon(&self.world, entity_id) {
+                            let mirror = hand.gun_mirror();
                             new_model.apply_local_transform(mirror);
                             for vhot in vhots.iter_mut() {
                                 vhot.point = mirror.transform_point(vhot.point);
@@ -7215,7 +7213,7 @@ impl MissionCore {
                             // cancelled for the same reason as flat: the
                             // entity transform is re-anchored (there to the
                             // camera, here to the tracked hand) every frame.
-                            if is_melee_model(&self.world, entity_id) {
+                            if is_melee_weapon(&self.world, entity_id) {
                                 let player = asset_cache
                                     .get_opt(
                                         &ANIMATION_CLIP_IMPORTER,
@@ -7243,21 +7241,10 @@ impl MissionCore {
                                     )
                                 });
                                 if let Some(arm) = arm {
-                                    // Which arm to draw. The `_h` rigs are all
-                                    // authored as a right arm, so a left-hand
-                                    // wield renders the mirror image - and the
-                                    // contact offset below is mirrored with
-                                    // it, keeping the collider on the rendered
-                                    // head. A model applied while nothing
-                                    // holds it (a restore before the grab) has
-                                    // no hand yet; the right-handed default
-                                    // matches what the rig is authored as, and
-                                    // the grab's own ChangeModel re-derives
-                                    // this.
-                                    let hand = self
-                                        .interaction
-                                        .holding_hand(entity_id)
-                                        .unwrap_or(crate::vr_config::Handedness::Right);
+                                    // Which arm to draw: the left hand renders
+                                    // the mirror image, and the contact offset
+                                    // below is mirrored with it, keeping the
+                                    // collider on the rendered head.
                                     let correction =
                                         crate::vr_config::melee_wield_pose_correction(arm, hand);
                                     new_model.apply_local_transform(correction);

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -315,7 +315,7 @@ impl VirtualHand {
                         // grip in the palm), so it must rotate with the hand
                         position: hand_position + hand_rotation.rotate_vector(vr_offsets.offset),
                         rotation: hand_rotation * vr_offsets.rotation,
-                        scale: vec3(1.0, 1.0, 1.0), //vr_offsets.scale,
+                        scale: vec3(1.0, 1.0, 1.0),
                     });
 
                     let updated_hand = VirtualHand {

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -24,7 +24,8 @@ impl Handedness {
     /// cannot disagree about which way round the left hand is.
     ///
     /// Held guns reflect across a different plane of their own frame - see
-    /// [`gun_mirror`] - because their authored axes differ from the arm rigs'.
+    /// [`Self::gun_mirror`] - because their authored axes differ from the arm
+    /// rigs'.
     ///
     /// A reflection has a negative determinant, which reverses the triangle
     /// winding the GPU sees. Geometry that culls backfaces must flip its
@@ -46,6 +47,26 @@ impl Handedness {
         use cgmath::Transform;
 
         self.mirror().transform_vector(point)
+    }
+
+    /// The reflection that turns a right-handed 25AE gun view model into this
+    /// hand's, in the model's own frame.
+    ///
+    /// The `_h` guns bake a right hand onto the grip, so a left-hand wield
+    /// draws the mirror image. Their authored frame runs the barrel along -X
+    /// with +Y up, so the mirror plane is the one holding the barrel and the
+    /// sights - it negates Z, "across the gun" - and the barrel keeps pointing
+    /// the same way. The grip's thumb-side offset
+    /// ([`VRHandModelPerHandAdjustments::flip_x`]) and the muzzle vhots
+    /// reflect with it; the negative determinant is what
+    /// [`dark::model::Model::apply_local_transform`] flips the winding for.
+    pub fn gun_mirror(self) -> cgmath::Matrix4<f32> {
+        use cgmath::{Matrix4, SquareMatrix};
+
+        match self {
+            Handedness::Right => Matrix4::identity(),
+            Handedness::Left => Matrix4::from_nonuniform_scale(1.0, 1.0, -1.0),
+        }
     }
 }
 
@@ -84,9 +105,11 @@ impl VRHandModelPerHandAdjustments {
     }
 
     /// The left hand's grip for a gun whose model is drawn reflected by
-    /// [`gun_mirror`]: the thumb-side component of the hand-local offset
-    /// mirrors with the geometry, so the reflected gun seats on the left
-    /// palm exactly where the authored one seats on the right.
+    /// [`Handedness::gun_mirror`]: the thumb-side component of the hand-local
+    /// offset mirrors with the geometry, so the reflected gun seats on the
+    /// left palm exactly where the authored one seats on the right. Only for
+    /// models that ARE reflected (the `_h` set) - an unmirrored world model
+    /// keeps the same grip in both hands.
     pub fn flip_x(self) -> VRHandModelPerHandAdjustments {
         VRHandModelPerHandAdjustments {
             offset: vec3(-self.offset.x, self.offset.y, self.offset.z),
@@ -123,7 +146,9 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     let mut map = HashMap::new();
 
     let held_weapon_right = VRHandModelPerHandAdjustments::new().rotate_y(Deg(-90.0));
-    let held_weapon_left = held_weapon_right.clone().flip_x();
+    // World models are drawn unmirrored in either hand, so the left grip is
+    // the right grip as-is.
+    let held_weapon_left = held_weapon_right.clone();
     let held_weapon = VRHandModelAdjustments::new(held_weapon_left, held_weapon_right.clone());
 
     // The wrench's long axis runs opposite the guns' after the -90 yaw (its
@@ -139,10 +164,16 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     // Hand model adjustments for VR
     // Specify overrides for particular models with how they should be oriented
     // relative ot the virtual hand
-    // A weapon whose left-hand placement is the right-hand adjustments
-    // mirrored (flip_x)
+    // A 25AE `_h` gun: the left hand draws the model reflected
+    // (`Handedness::gun_mirror`), so its grip is the right grip reflected too
+    // (`flip_x`).
     fn symmetric(right: VRHandModelPerHandAdjustments) -> VRHandModelAdjustments {
         VRHandModelAdjustments::new(right.clone().flip_x(), right)
+    }
+    // A world model: drawn unmirrored in either hand, so both grips are the
+    // right-hand one.
+    fn same_grip(right: VRHandModelPerHandAdjustments) -> VRHandModelAdjustments {
+        VRHandModelAdjustments::new(right.clone(), right)
     }
 
     let items = vec![
@@ -222,7 +253,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // this and show the world models grip fine with the same offsets.
         (
             "atek_w",
-            symmetric(
+            same_grip(
                 held_weapon_right
                     .clone()
                     .with_offset(vec3(0.02, 0.04, -0.045)),
@@ -230,7 +261,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ),
         (
             "ar15_w",
-            symmetric(
+            same_grip(
                 held_weapon_right
                     .clone()
                     .with_offset(vec3(-0.19, 0.0, -0.045)),
@@ -238,7 +269,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ),
         (
             "sg_w",
-            symmetric(
+            same_grip(
                 held_weapon_right
                     .clone()
                     .with_offset(vec3(-0.21, 0.0, -0.045)),
@@ -254,7 +285,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ("al_w", held_weapon.clone()),
         // The wrench's handle runs along the weapon axis, so it takes the
         // held-weapon rotation (handle through the fist, head forward)
-        ("wrench_w", symmetric(wrench_right.clone())),
+        ("wrench_w", same_grip(wrench_right.clone())),
         // World items
         ("battery", held_item.clone()),
         ("batteryb", held_item.clone()),
@@ -296,25 +327,6 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
     "atek_h", "ar15_h", "sg_h", "lasehand", "empgun_h", "gren_h", "sfg_h", "fsn_h", "al_h",
     "viro_h", "amp_h", "wrench_h", "rapier_h", "shard_h", "psword_h",
 ];
-
-/// The reflection that turns a right-handed 25AE gun view model into the left
-/// hand's, in the model's own frame.
-///
-/// The `_h` guns bake a right hand onto the grip, so a left-hand wield draws
-/// the mirror image. Their authored frame runs the barrel along -X with +Y up,
-/// so the mirror plane is the one holding the barrel and the sights - it
-/// negates Z, "across the gun" - and the barrel keeps pointing the same way.
-/// The grip's thumb-side offset ([`VRHandModelPerHandAdjustments::flip_x`])
-/// and the muzzle vhots reflect with it; the negative determinant is what
-/// [`dark::model::Model::apply_local_transform`] flips the winding for.
-pub fn gun_mirror(handedness: Handedness) -> cgmath::Matrix4<f32> {
-    use cgmath::{Matrix4, SquareMatrix};
-
-    match handedness {
-        Handedness::Right => Matrix4::identity(),
-        Handedness::Left => Matrix4::from_nonuniform_scale(1.0, 1.0, -1.0),
-    }
-}
 
 /// Whether `model_name` is a first-person view model VR should wield in place
 /// of the world model (only meaningful on a 25AE install, where the remastered
@@ -520,7 +532,7 @@ mod tests {
     fn the_gun_mirror_reflects_across_the_gun_only() {
         use cgmath::{Matrix4, SquareMatrix, Transform};
 
-        let left = gun_mirror(Handedness::Left);
+        let left = Handedness::Left.gun_mirror();
         assert_eq!(
             left.transform_vector(vec3(-1.0, 0.0, 0.0)),
             vec3(-1.0, 0.0, 0.0)
@@ -537,7 +549,7 @@ mod tests {
             left.determinant() < 0.0,
             "a reflection, so the winding must flip"
         );
-        assert_eq!(gun_mirror(Handedness::Right), Matrix4::identity());
+        assert_eq!(Handedness::Right.gun_mirror(), Matrix4::identity());
     }
 
     /// The left grip is the right grip with its thumb-side component

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -23,10 +23,8 @@ impl Handedness {
     /// [`crate::hand_glove`] and the melee wield, so the arm and the glove
     /// cannot disagree about which way round the left hand is.
     ///
-    /// Note this is *not* what held guns do: [`VRHandModelPerHandAdjustments::flip_x`]
-    /// mirrors only a `scale` field that never reaches the world
-    /// (`VirtualHand::SetPositionRotation` hardcodes scale 1), so a held gun is
-    /// drawn unmirrored in both hands.
+    /// Held guns reflect across a different plane of their own frame - see
+    /// [`gun_mirror`] - because their authored axes differ from the arm rigs'.
     ///
     /// A reflection has a negative determinant, which reverses the triangle
     /// winding the GPU sees. Geometry that culls backfaces must flip its
@@ -68,7 +66,6 @@ pub fn hand_slot(hand: Handedness) -> usize {
 pub struct VRHandModelPerHandAdjustments {
     pub offset: Vector3<f32>,
     pub rotation: Quaternion<f32>,
-    pub scale: Vector3<f32>,
 }
 
 impl VRHandModelPerHandAdjustments {
@@ -76,7 +73,6 @@ impl VRHandModelPerHandAdjustments {
         VRHandModelPerHandAdjustments {
             offset: Vector3::new(0.0, 0.0, 0.0),
             rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            scale: Vector3::new(1.0, 1.0, 1.0),
         }
     }
 
@@ -87,14 +83,13 @@ impl VRHandModelPerHandAdjustments {
         }
     }
 
+    /// The left hand's grip for a gun whose model is drawn reflected by
+    /// [`gun_mirror`]: the thumb-side component of the hand-local offset
+    /// mirrors with the geometry, so the reflected gun seats on the left
+    /// palm exactly where the authored one seats on the right.
     pub fn flip_x(self) -> VRHandModelPerHandAdjustments {
-        // NOTE: the scale mirror is currently inert (SetPositionRotation
-        // hardcodes scale 1), so the left hand holds the *unmirrored* model.
-        // The offset must therefore NOT be mirrored - it seats the same
-        // unmirrored geometry at the same hand-local point (verified against
-        // left-hand grip screenshots).
         VRHandModelPerHandAdjustments {
-            scale: vec3(-self.scale.x, self.scale.y, self.scale.z),
+            offset: vec3(-self.offset.x, self.offset.y, self.offset.z),
             ..self
         }
     }
@@ -302,6 +297,25 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
     "viro_h", "amp_h", "wrench_h", "rapier_h", "shard_h", "psword_h",
 ];
 
+/// The reflection that turns a right-handed 25AE gun view model into the left
+/// hand's, in the model's own frame.
+///
+/// The `_h` guns bake a right hand onto the grip, so a left-hand wield draws
+/// the mirror image. Their authored frame runs the barrel along -X with +Y up,
+/// so the mirror plane is the one holding the barrel and the sights - it
+/// negates Z, "across the gun" - and the barrel keeps pointing the same way.
+/// The grip's thumb-side offset ([`VRHandModelPerHandAdjustments::flip_x`])
+/// and the muzzle vhots reflect with it; the negative determinant is what
+/// [`dark::model::Model::apply_local_transform`] flips the winding for.
+pub fn gun_mirror(handedness: Handedness) -> cgmath::Matrix4<f32> {
+    use cgmath::{Matrix4, SquareMatrix};
+
+    match handedness {
+        Handedness::Right => Matrix4::identity(),
+        Handedness::Left => Matrix4::from_nonuniform_scale(1.0, 1.0, -1.0),
+    }
+}
+
 /// Whether `model_name` is a first-person view model VR should wield in place
 /// of the world model (only meaningful on a 25AE install, where the remastered
 /// copy is what resolves).
@@ -499,6 +513,43 @@ mod tests {
     /// Every VR-wieldable 25AE gun must have a grip entry, or it would anchor
     /// at the model origin with no rotation. The melee `_h` are the deliberate
     /// exception - see `melee_view_models_have_no_static_grip`.
+    /// The gun mirror keeps the barrel (-X) and the sights (+Y) and swaps the
+    /// side the baked hand is on, so a left-hand wield still aims where the
+    /// controller points. The right hand is the authored model, untouched.
+    #[test]
+    fn the_gun_mirror_reflects_across_the_gun_only() {
+        use cgmath::{Matrix4, SquareMatrix, Transform};
+
+        let left = gun_mirror(Handedness::Left);
+        assert_eq!(
+            left.transform_vector(vec3(-1.0, 0.0, 0.0)),
+            vec3(-1.0, 0.0, 0.0)
+        );
+        assert_eq!(
+            left.transform_vector(vec3(0.0, 1.0, 0.0)),
+            vec3(0.0, 1.0, 0.0)
+        );
+        assert_eq!(
+            left.transform_vector(vec3(0.0, 0.0, 1.0)),
+            vec3(0.0, 0.0, -1.0)
+        );
+        assert!(
+            left.determinant() < 0.0,
+            "a reflection, so the winding must flip"
+        );
+        assert_eq!(gun_mirror(Handedness::Right), Matrix4::identity());
+    }
+
+    /// The left grip is the right grip with its thumb-side component
+    /// reflected, matching the reflected geometry it seats.
+    #[test]
+    fn the_left_grip_mirrors_the_thumb_side_offset() {
+        let right = VRHandModelPerHandAdjustments::new().with_offset(vec3(0.05, 0.12, 0.10));
+        let left = right.clone().flip_x();
+        assert_eq!(left.offset, vec3(-0.05, 0.12, 0.10));
+        assert_eq!(left.rotation, right.rotation);
+    }
+
     #[test]
     fn every_vr_view_model_has_a_grip_entry() {
         for name in VR_25AE_VIEW_MODELS {

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -2,6 +2,7 @@ import type { GameServer } from "../../src/index.js";
 import type { UiPanelPose, Vec3 } from "../../src/types.js";
 
 export type Quat = [number, number, number, number];
+export type Hand = "left" | "right";
 
 export const add = (a: Vec3, b: Vec3): Vec3 => [
   a[0] + b[0],
@@ -118,7 +119,7 @@ export async function aimVrHandAt(
   standOff = 0.45,
   squeeze = 0,
   trigger = 0,
-  hand: "left" | "right" = "right",
+  { hand = "right" }: { hand?: Hand } = {},
 ): Promise<{ start: Vec3; target: Vec3 }> {
   const snapshot = await game.info();
   const pawn = snapshot.player.position;

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -118,6 +118,7 @@ export async function aimVrHandAt(
   standOff = 0.45,
   squeeze = 0,
   trigger = 0,
+  hand: "left" | "right" = "right",
 ): Promise<{ start: Vec3; target: Vec3 }> {
   const snapshot = await game.info();
   const pawn = snapshot.player.position;
@@ -138,10 +139,10 @@ export async function aimVrHandAt(
   await game.input.lookAtWorldPoint(target, {
     eyeHeight: snapshot.player.camera_offset[1],
   });
-  await game.input.set("right_hand.position", localHand);
-  await game.input.set("right_hand.rotation", localHandRotation);
-  await game.input.set("right_hand.trigger", trigger);
-  await game.input.set("right_hand.squeeze", squeeze);
+  await game.input.set(`${hand}_hand.position`, localHand);
+  await game.input.set(`${hand}_hand.rotation`, localHandRotation);
+  await game.input.set(`${hand}_hand.trigger`, trigger);
+  await game.input.set(`${hand}_hand.squeeze`, squeeze);
   await game.step({ frames: 3 });
   return { start: worldHand, target };
 }

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -77,11 +77,26 @@ async function entityTransform(game: GameServer, id: number): Promise<EntityTran
   };
 }
 
+type Hand = "left" | "right";
+
 /** Reach out with the production VR hand and squeeze to pick `target` up. */
 async function grabWithRightHand(game: GameServer, target: Vec3): Promise<void> {
-  await aimVrHandAt(game, target, 0.3);
-  await game.input.set("right_hand.squeeze", 1);
+  await grabWith(game, "right", target);
+}
+
+async function grabWith(game: GameServer, hand: Hand, target: Vec3): Promise<void> {
+  await aimVrHandAt(game, target, 0.3, 0, 0, hand);
+  await game.input.set(`${hand}_hand.squeeze`, 1);
   await game.step({ frames: 8 });
+}
+
+/** The model's muzzle vhot as the wielding hand renders it: the left hand
+ * draws the right-handed model reflected across the gun (its Z), muzzle
+ * included, so a left-hand shot must leave the reflected point. */
+function muzzleVhotFor(model: string, hand: Hand): Vec3 | undefined {
+  const authored = MUZZLE_VHOT[model];
+  if (!authored) return undefined;
+  return hand === "left" ? [authored[0], authored[1], -authored[2]] : authored;
 }
 
 /**
@@ -101,6 +116,7 @@ async function fireAndTrack(
   handLocalPosition: Vec3,
   aimDirection: Vec3,
   projectileMatches: (entity: EntitySummary) => boolean,
+  hand: Hand = "right",
 ): Promise<{
   barrelDeviationDeg: number;
   lateralError: number;
@@ -108,22 +124,22 @@ async function fireAndTrack(
   frameStep: number;
   distanceTravelled: number;
 }> {
-  await game.input.set("right_hand.position", handLocalPosition);
-  await game.input.set("right_hand.rotation", quatFromTo([0, 0, -1], normalize(aimDirection)));
-  await game.input.set("right_hand.squeeze", 1);
+  await game.input.set(`${hand}_hand.position`, handLocalPosition);
+  await game.input.set(`${hand}_hand.rotation`, quatFromTo([0, 0, -1], normalize(aimDirection)));
+  await game.input.set(`${hand}_hand.squeeze`, 1);
   await game.step({ frames: 5 });
 
   const weapon = await entityTransform(game, weaponId);
-  const vhot = MUZZLE_VHOT[weapon.model];
+  const vhot = muzzleVhotFor(weapon.model, hand);
   assert.ok(vhot, `VR should wield a view model with a known muzzle vhot, got "${weapon.model}"`);
   const muzzle = add(weapon.position, quatRotate(weapon.rotation, vhot));
   // The 25AE view models are authored with the barrel along the model's -X.
   const barrel = quatRotate(weapon.rotation, [-1, 0, 0]);
 
   const before = new Set((await game.entities.list()).entities.map((e) => e.id));
-  await game.input.set("right_hand.trigger", 1);
+  await game.input.set(`${hand}_hand.trigger`, 1);
   await game.step({ frames: 1 });
-  await game.input.set("right_hand.trigger", 0);
+  await game.input.set(`${hand}_hand.trigger`, 0);
   // The trigger frame spawns the projectile and integrates it once; the first
   // loop iteration below steps once more before it can be observed. So the
   // first sample sits FLIGHT_FRAMES_BEFORE_FIRST_SAMPLE frames down the barrel
@@ -210,6 +226,39 @@ test(
       shot.distanceTravelled > 5,
       `the bolt must clear the shooter, only travelled ${shot.distanceTravelled.toFixed(2)}`,
     );
+  },
+);
+
+// A gun wielded in the LEFT hand draws the mirror image of its right-handed
+// model (the baked hand becomes a left hand), and the muzzle reflects with it.
+// Negative-first: unmirrored, the laser's muzzle sits 0.064 units the other
+// side of the barrel plane, so the shot misses the reflected point by 0.128 -
+// past the 0.05 tolerance below.
+test(
+  "a laser pistol wielded in the LEFT hand fires from its mirrored muzzle",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const laser = await cycleToWeapon(game, (e) => e.template_id === LASER_PISTOL);
+    await grabWith(game, "left", laser.position as Vec3);
+    const held = await game.info();
+    assert.equal(held.player.wielded_entity_id, laser.id, "the LEFT hand slot must hold the pistol");
+    assert.equal(held.player.right_hand_entity_id, null, "the right hand stays empty");
+
+    const shot = await fireAndTrack(
+      game,
+      laser.id,
+      [0, 1, -2],
+      [-1, 0, 0],
+      (e) => e.name === "Laser Shot",
+      "left",
+    );
+    assertLeftTheMuzzle(shot, "left-hand bolt");
   },
 );
 

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -14,7 +14,7 @@ import {
   scale,
   sub,
 } from "./helpers/vr-hand.js";
-import type { Quat } from "./helpers/vr-hand.js";
+import type { Hand, Quat } from "./helpers/vr-hand.js";
 
 // A VR-wielded weapon must fire from its model's muzzle vhot, travelling along
 // the rendered barrel. Both are checkable numerically: the runtime reports the
@@ -77,15 +77,9 @@ async function entityTransform(game: GameServer, id: number): Promise<EntityTran
   };
 }
 
-type Hand = "left" | "right";
-
 /** Reach out with the production VR hand and squeeze to pick `target` up. */
-async function grabWithRightHand(game: GameServer, target: Vec3): Promise<void> {
-  await grabWith(game, "right", target);
-}
-
 async function grabWith(game: GameServer, hand: Hand, target: Vec3): Promise<void> {
-  await aimVrHandAt(game, target, 0.3, 0, 0, hand);
+  await aimVrHandAt(game, target, 0.3, 0, 0, { hand });
   await game.input.set(`${hand}_hand.squeeze`, 1);
   await game.step({ frames: 8 });
 }
@@ -205,7 +199,7 @@ test(
     // DebugCycleWeapon drops each weapon in front of the player in VR.
     const laser = await cycleToWeapon(game, (e) => e.template_id === LASER_PISTOL);
 
-    await grabWithRightHand(game, laser.position as Vec3);
+    await grabWith(game, "right", laser.position as Vec3);
     const held = await game.info();
     assert.equal(held.player.right_hand_entity_id, laser.id, "the hand must hold the pistol");
 
@@ -275,7 +269,7 @@ test(
     const amp = (await game.entities.list()).entities.find((e) => e.template_id === PSI_AMP);
     assert.ok(amp, "debug_psi must place the Psi Amp in the scene");
 
-    await grabWithRightHand(game, amp.position as Vec3);
+    await grabWith(game, "right", amp.position as Vec3);
     const held = await game.info();
     assert.equal(held.player.right_hand_entity_id, amp.id, "the hand must hold the amp");
 


### PR DESCRIPTION
The 25AE `_h` gun view models bake a **right** hand onto the grip. The melee arm rigs already mirror for a left-hand wield (#1161); a gun did not, so a pistol grabbed with the left controller rendered a right hand holding it.

**Now** a gun wielded in the left hand draws its mirror image: `Handedness::gun_mirror` reflects the model across its own barrel plane (negating Z in the authored frame, so the barrel keeps -X and the sights +Y), applied in the VR wield swap with the muzzle vhots reflected alongside so a left-hand shot still leaves the reflected muzzle. The grip's thumb-side offset mirrors with the geometry (`flip_x` now does that instead of an inert scale field, which is removed); world models, which are never reflected, keep one grip in both hands (`same_grip`).

Derivation: with the table's -90° yaw grip `R`, reflecting the rendered gun about the hand's own X plane is `R⁻¹·S_x·R = diag(1,1,-1)` in model space and `S_x` on the hand-local offset, which is exactly the pair applied.

**Cost:** a reflected mesh reflects its texture, so decal text on a left-hand gun reads backwards (visible on the laser pistol's serial). Inherent to mirroring a right-only asset.

**Tests:** unit tests for the mirror's fixed axes and the grip reflection; a left-hand muzzle e2e (negative on main: the laser's muzzle sits 0.064 units off the barrel plane, so the unmirrored shot misses the reflected point by 0.128 against a 0.05 tolerance). The right-hand muzzle, handedness, reload, eject and clip-insert e2e files still pass.

## Before → after

Laser pistol grabbed with the LEFT VR hand in `debug_weapons`, free camera from ahead-right and from above (captured headlessly via the debug runtime, deterministic fixed-timestep; BEFORE is main).

![before/after](https://gist.githubusercontent.com/tommy-xr/5231ea3019c04cea798eb5e9de8a6d47/raw/lefthand-beforeafter.png)

![before/after from above](https://gist.githubusercontent.com/tommy-xr/5231ea3019c04cea798eb5e9de8a6d47/raw/lefthand-beforeafter-top.png)

<sub>Before: the baked right hand's fingers hang on the far side and the baked forearm crosses away from the tracked sleeve. After: a left-hand grip with the wrist entering the sleeve cuff.</sub>
