### PR TITLE
feat(debug): clip_zone dev param draws every held gun's clip-insert zone

### DIFF
--- a/dark/src/hit_box.rs
+++ b/dark/src/hit_box.rs
@@ -213,7 +213,7 @@ pub fn draw_debug_wire_sphere(
 /// The line segments of [`draw_debug_wire_sphere`], two vertices each: three
 /// closed rings of `WIRE_SEGMENTS` around X, Y and Z.
 fn wire_sphere_segments(center: Vector3<f32>, radius: f32) -> Vec<VertexPosition> {
-    let identity = Matrix4::from_scale(1.0);
+    let identity = Matrix4::identity();
     let mut verts: Vec<VertexPosition> = Vec::new();
     let axes = [
         (Vector3::new(1.0, 0.0, 0.0), Vector3::new(0.0, 1.0, 0.0)),
@@ -221,22 +221,32 @@ fn wire_sphere_segments(center: Vector3<f32>, radius: f32) -> Vec<VertexPosition
         (Vector3::new(0.0, 0.0, 1.0), Vector3::new(1.0, 0.0, 0.0)),
     ];
     for (u, v) in axes {
-        let ring: Vec<Vector3<f32>> = (0..WIRE_SEGMENTS)
-            .map(|k| {
-                let t = (k as f32) / (WIRE_SEGMENTS as f32) * std::f32::consts::TAU;
-                center + (u * t.cos() + v * t.sin()) * radius
-            })
-            .collect();
-        for k in 0..WIRE_SEGMENTS {
-            push_segment(
-                &mut verts,
-                &identity,
-                ring[k],
-                ring[(k + 1) % WIRE_SEGMENTS],
-            );
-        }
+        push_ring(&mut verts, &identity, &ring_points(center, u, v, radius));
     }
     verts
+}
+
+/// `WIRE_SEGMENTS` points around a circle of `radius` at `center`, in the
+/// plane spanned by the unit vectors `u` and `v`.
+fn ring_points(
+    center: Vector3<f32>,
+    u: Vector3<f32>,
+    v: Vector3<f32>,
+    radius: f32,
+) -> Vec<Vector3<f32>> {
+    (0..WIRE_SEGMENTS)
+        .map(|k| {
+            let t = (k as f32) / (WIRE_SEGMENTS as f32) * std::f32::consts::TAU;
+            center + (u * t.cos() + v * t.sin()) * radius
+        })
+        .collect()
+}
+
+/// The closed loop of segments through `ring`'s points, transformed by `xform`.
+fn push_ring(verts: &mut Vec<VertexPosition>, xform: &Matrix4<f32>, ring: &[Vector3<f32>]) {
+    for k in 0..ring.len() {
+        push_segment(verts, xform, ring[k], ring[(k + 1) % ring.len()]);
+    }
 }
 
 /// Transform a joint-local point to world space (homogeneous, w=1).
@@ -320,24 +330,12 @@ fn append_capsule_lines(
     let u = axis.cross(helper).normalize();
     let v = axis.cross(u).normalize();
 
-    let ring = |center: Vector3<f32>| -> Vec<Vector3<f32>> {
-        (0..WIRE_SEGMENTS)
-            .map(|k| {
-                let t = (k as f32) / (WIRE_SEGMENTS as f32) * std::f32::consts::TAU;
-                center + (u * t.cos() + v * t.sin()) * radius
-            })
-            .collect()
-    };
-
-    let ring_a = ring(a);
-    let ring_b = ring(b);
+    let ring_a = ring_points(a, u, v, radius);
+    let ring_b = ring_points(b, u, v, radius);
 
     // End rings.
-    for r in [&ring_a, &ring_b] {
-        for k in 0..WIRE_SEGMENTS {
-            push_segment(verts, xform, r[k], r[(k + 1) % WIRE_SEGMENTS]);
-        }
-    }
+    push_ring(verts, xform, &ring_a);
+    push_ring(verts, xform, &ring_b);
     // Longitudinal lines at 4 evenly spaced angles.
     for k in (0..WIRE_SEGMENTS).step_by(WIRE_SEGMENTS / 4) {
         push_segment(verts, xform, ring_a[k], ring_b[k]);

--- a/dark/src/hit_box.rs
+++ b/dark/src/hit_box.rs
@@ -196,6 +196,49 @@ pub fn draw_debug_hit_box_shapes(
     )]
 }
 
+/// A world-space wire sphere - three orthogonal great circles - as one
+/// `SceneObject` of colored lines. For overlays that mark a spherical volume
+/// (a gesture zone, a trigger radius) rather than a fitted body part.
+pub fn draw_debug_wire_sphere(
+    center: Vector3<f32>,
+    radius: f32,
+    color: Vector3<f32>,
+) -> SceneObject {
+    SceneObject::new(
+        color_material::create(color),
+        Box::new(lines_mesh::create(wire_sphere_segments(center, radius))),
+    )
+}
+
+/// The line segments of [`draw_debug_wire_sphere`], two vertices each: three
+/// closed rings of `WIRE_SEGMENTS` around X, Y and Z.
+fn wire_sphere_segments(center: Vector3<f32>, radius: f32) -> Vec<VertexPosition> {
+    let identity = Matrix4::from_scale(1.0);
+    let mut verts: Vec<VertexPosition> = Vec::new();
+    let axes = [
+        (Vector3::new(1.0, 0.0, 0.0), Vector3::new(0.0, 1.0, 0.0)),
+        (Vector3::new(0.0, 1.0, 0.0), Vector3::new(0.0, 0.0, 1.0)),
+        (Vector3::new(0.0, 0.0, 1.0), Vector3::new(1.0, 0.0, 0.0)),
+    ];
+    for (u, v) in axes {
+        let ring: Vec<Vector3<f32>> = (0..WIRE_SEGMENTS)
+            .map(|k| {
+                let t = (k as f32) / (WIRE_SEGMENTS as f32) * std::f32::consts::TAU;
+                center + (u * t.cos() + v * t.sin()) * radius
+            })
+            .collect();
+        for k in 0..WIRE_SEGMENTS {
+            push_segment(
+                &mut verts,
+                &identity,
+                ring[k],
+                ring[(k + 1) % WIRE_SEGMENTS],
+            );
+        }
+    }
+    verts
+}
+
 /// Transform a joint-local point to world space (homogeneous, w=1).
 fn xform_point(xform: &Matrix4<f32>, p: Vector3<f32>) -> Vector3<f32> {
     let c = xform * Vector4::new(p.x, p.y, p.z, 1.0);
@@ -315,6 +358,25 @@ fn append_capsule_lines(
             for k in 0..WIRE_SEGMENTS {
                 push_segment(verts, xform, pts[k], pts[k + 1]);
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Three great circles, each a closed loop of `WIRE_SEGMENTS` segments -
+    /// two vertices per segment, every vertex on the sphere - so the zone
+    /// reads as a sphere from any angle rather than as a single ring.
+    #[test]
+    fn a_wire_sphere_is_three_closed_rings_on_the_sphere() {
+        let center = Vector3::new(1.0, 2.0, 3.0);
+        let verts = wire_sphere_segments(center, 0.25);
+        assert_eq!(verts.len(), 3 * WIRE_SEGMENTS * 2);
+        for vertex in &verts {
+            let r = (vertex.position - center).magnitude();
+            assert!((r - 0.25).abs() < 1e-5, "vertex off the sphere: r = {r}");
         }
     }
 }

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -197,6 +197,11 @@ dev_params! {
     /// The readout for the hitbox work: which limb a shot or swing actually
     /// hit, and for how much, without reading hit points before and after.
     DAMAGE_NUMBERS = bool("damage_numbers", "Damage numbers", false),
+    /// Draw every held gun's clip-insert zone as world-space wire spheres:
+    /// the enter radius (green, red while a clip is inside) and the larger
+    /// exit radius (dim). Answers "where do I have to bring the clip?" in a
+    /// headset, and shows the per-model magazine anchor the zone sits on.
+    CLIP_ZONE = bool("clip_zone", "Show clip-insert zone", false),
     /// Uniform scale applied to a wielded melee `_h` view model, about the
     /// baked fist so the grip stays on the controller.
     ///

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -198,9 +198,10 @@ dev_params! {
     /// hit, and for how much, without reading hit points before and after.
     DAMAGE_NUMBERS = bool("damage_numbers", "Damage numbers", false),
     /// Draw every held gun's clip-insert zone as world-space wire spheres:
-    /// the enter radius (green, red while a clip is inside) and the larger
-    /// exit radius (dim). Answers "where do I have to bring the clip?" in a
-    /// headset, and shows the per-model magazine anchor the zone sits on.
+    /// the enter radius (green, red while a clip is inside), the larger exit
+    /// radius (dim), and a small blue marker on the model origin the anchor
+    /// is measured from. Answers "where do I have to bring the clip?" in a
+    /// headset, and is how the per-model magazine anchors are placed.
     CLIP_ZONE = bool("clip_zone", "Show clip-insert zone", false),
     /// Uniform scale applied to a wielded melee `_h` view model, about the
     /// baked fist so the grip stays on the controller.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -198,7 +198,9 @@ dev_params! {
     /// hit, and for how much, without reading hit points before and after.
     DAMAGE_NUMBERS = bool("damage_numbers", "Damage numbers", false),
     /// Draw every held gun's clip-insert zone as world-space wire spheres:
-    /// the enter radius (green, red while a clip is inside), the larger exit
+    /// the enter radius (green; red while the other hand's item is inside -
+    /// the gesture latches on any held item and only then asks whether it is
+    /// a clip the gun takes), the larger exit
     /// radius (dim), and a small blue marker on the model origin the anchor
     /// is measured from. Answers "where do I have to bring the clip?" in a
     /// headset, and is how the per-model magazine anchors are placed.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9706,6 +9706,13 @@ impl MissionCore {
                     crate::mission::reload::CLIP_INSERT_EXIT_RADIUS,
                     vec3(0.35, 0.35, 0.2),
                 ));
+                if let Some(origin) = self.entity_world_position(weapon) {
+                    scene.push(dark::hit_box::draw_debug_wire_sphere(
+                        origin,
+                        0.04,
+                        vec3(0.2, 0.4, 1.0),
+                    ));
+                }
             }
         }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9674,8 +9674,10 @@ impl MissionCore {
         }
 
         // Clip-insert zones of held guns, in the same shared world pass. The
-        // zone belongs to the gun; it is engaged by the clip in the OTHER
-        // hand, so its engaged state lives in that hand's slot.
+        // zone belongs to the gun; it is engaged by whatever the OTHER hand
+        // holds, so its engaged state lives in that hand's slot. Rebuilding
+        // the line meshes every frame is the same cost the hurtbox overlay
+        // pays - a debug view, off by default.
         if options.presentation_mode == crate::PresentationMode::Vr
             && crate::dev_params::get_bool(crate::dev_params::CLIP_ZONE)
         {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9673,6 +9673,42 @@ impl MissionCore {
             }
         }
 
+        // Clip-insert zones of held guns, in the same shared world pass. The
+        // zone belongs to the gun; it is engaged by the clip in the OTHER
+        // hand, so its engaged state lives in that hand's slot.
+        if options.presentation_mode == crate::PresentationMode::Vr
+            && crate::dev_params::get_bool(crate::dev_params::CLIP_ZONE)
+        {
+            let (left, right) = self.interaction.held_entities();
+            for (slot, weapon) in [left, right].into_iter().enumerate() {
+                let Some(weapon) = weapon else {
+                    continue;
+                };
+                if self.magazine_capacity(weapon).is_none() {
+                    continue;
+                }
+                let Some(anchor) = self.magazine_anchor_world(weapon) else {
+                    continue;
+                };
+                let engaged = self.vr_clip_insert_engaged[1 - slot];
+                let enter_color = if engaged {
+                    vec3(1.0, 0.2, 0.2)
+                } else {
+                    vec3(0.2, 1.0, 0.3)
+                };
+                scene.push(dark::hit_box::draw_debug_wire_sphere(
+                    anchor,
+                    crate::mission::reload::CLIP_INSERT_ENTER_RADIUS,
+                    enter_color,
+                ));
+                scene.push(dark::hit_box::draw_debug_wire_sphere(
+                    anchor,
+                    crate::mission::reload::CLIP_INSERT_EXIT_RADIUS,
+                    vec3(0.35, 0.35, 0.2),
+                ));
+            }
+        }
+
         // Render debug pathfinding
         if options.debug_pathfinding {
             if let Some(ref path_database) = self.path_database {


### PR DESCRIPTION
Stacked on #1334. A `clip_zone` dev param (`POST /v1/dev-params {"key":"clip_zone","value":1}`, or the dev menu) draws every held gun's clip-insert zone in VR as world-space wire spheres: the **enter** radius in green, turning **red** while a clip is inside; the larger **exit** radius dim; and a small blue marker on the model origin the anchor is measured from. Same shared world pass as the melee hurtbox overlay.

**What it found.** Placing the rings on the rendered wield showed the pistol's zone sitting behind the wrist: its model origin renders there, not at the centre its sub-object bounds suggest, so the dump-derived anchor was wrong. Every anchor in #1334 is now placed against this overlay (that fix is on the #1334 branch): pistol on the grip, shotgun at the loading port, launcher on the drum; the rifle's magazine part and the fusion core were already right. The `--debug-subobjects` dump now poses parts with the renderer's rest-pose palette (same numbers, one source of truth).

![clip zone](https://gist.githubusercontent.com/tommy-xr/008c02d1dd0329f2381147b71c93b46e/raw/clipzone.gif)

<sub>A clip carried up into the pistol's zone: the ring turns red as it enters and the clip loads. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![strip](https://gist.githubusercontent.com/tommy-xr/008c02d1dd0329f2381147b71c93b46e/raw/clipzone-strip.png)

Tuning views (side and top, blue = model origin): [pistol](https://gist.githubusercontent.com/tommy-xr/008c02d1dd0329f2381147b71c93b46e/raw/tune-atek.png), [assault rifle](https://gist.githubusercontent.com/tommy-xr/008c02d1dd0329f2381147b71c93b46e/raw/tune-ar15.png).

Unit test: the wire sphere is three closed rings of vertices on the sphere. The clip-insert e2e passes with the tuned anchors.
