### PR TITLE
feat(ai): play the authored turn clip when pivoting

### DIFF
--- a/dark/src/motion/mod.rs
+++ b/dark/src/motion/mod.rs
@@ -5,6 +5,7 @@ mod motion_clip;
 mod motion_info;
 pub mod motion_query;
 mod motion_schema;
+mod turn_clips;
 
 pub use animation_clip::*;
 pub use animation_player::*;
@@ -14,6 +15,7 @@ pub use motion_info::*;
 pub use motion_query::*;
 pub use motion_schema::*;
 use rand::{Rng, thread_rng};
+pub use turn_clips::*;
 
 use crate::{
     NameMap, SCALE_FACTOR, TagDatabase, ss2_chunk_file_reader,

--- a/dark/src/motion/turn_clips.rs
+++ b/dark/src/motion/turn_clips.rs
@@ -30,15 +30,22 @@ pub fn is_turn_clip(end_direction: Deg<f32>) -> bool {
 }
 
 /// Index of the turn clip that best covers `delta` degrees of heading change,
-/// or `None` when standing still leaves the creature closer to `delta` than
-/// any authored turn would (small pivots have no clip: the shortest stock
-/// human turn is ~102 degrees).
-pub fn nearest_turn_clip(delta: Deg<f32>, end_directions: &[Deg<f32>]) -> Option<usize> {
-    end_directions
+/// given each clip's authored facing change and how long it runs.
+///
+/// `None` when no clip fits: a turn longer than `max_duration` keeps the
+/// creature standing still for longer than it can afford, and standing still
+/// leaves it closer to `delta` than a badly-matched turn would (small pivots
+/// have no clip at all - the shortest stock human turn is ~102 degrees).
+pub fn nearest_turn_clip(
+    delta: Deg<f32>,
+    clips: &[(Deg<f32>, f32)],
+    max_duration: f32,
+) -> Option<usize> {
+    clips
         .iter()
         .enumerate()
-        .filter(|(_, end)| is_turn_clip(**end))
-        .map(|(index, end)| (index, (signed_end_direction(*end).0 - delta.0).abs()))
+        .filter(|(_, (end, duration))| is_turn_clip(*end) && *duration <= max_duration)
+        .map(|(index, (end, _))| (index, (signed_end_direction(*end).0 - delta.0).abs()))
         .filter(|(_, residual)| *residual < delta.0.abs())
         .min_by(|a, b| a.1.total_cmp(&b.1))
         .map(|(index, _)| index)
@@ -48,8 +55,15 @@ pub fn nearest_turn_clip(delta: Deg<f32>, end_directions: &[Deg<f32>]) -> Option
 mod tests {
     use super::*;
 
-    /// The stock human `+stand` schema: idle, left, right, about-face.
-    const HUMAN_STAND: [Deg<f32>; 4] = [Deg(0.0), Deg(258.15), Deg(102.58), Deg(191.95)];
+    /// The stock human `+stand` schema: idle, left, right, about-face, with
+    /// the seconds each one runs for.
+    const HUMAN_STAND: [(Deg<f32>, f32); 4] = [
+        (Deg(0.0), 5.03),
+        (Deg(258.15), 3.60),
+        (Deg(102.58), 3.83),
+        (Deg(191.95), 4.80),
+    ];
+    const NO_BUDGET_LIMIT: f32 = 1000.0;
 
     #[test]
     fn an_unsigned_heading_reads_as_the_minimal_signed_turn() {
@@ -70,20 +84,46 @@ mod tests {
 
     #[test]
     fn a_pivot_takes_the_clip_nearest_its_heading_change() {
-        assert_eq!(nearest_turn_clip(Deg(95.0), &HUMAN_STAND), Some(2));
-        assert_eq!(nearest_turn_clip(Deg(-95.0), &HUMAN_STAND), Some(1));
-        assert_eq!(nearest_turn_clip(Deg(-170.0), &HUMAN_STAND), Some(3));
+        assert_eq!(
+            nearest_turn_clip(Deg(95.0), &HUMAN_STAND, NO_BUDGET_LIMIT),
+            Some(2)
+        );
+        assert_eq!(
+            nearest_turn_clip(Deg(-95.0), &HUMAN_STAND, NO_BUDGET_LIMIT),
+            Some(1)
+        );
+        assert_eq!(
+            nearest_turn_clip(Deg(-170.0), &HUMAN_STAND, NO_BUDGET_LIMIT),
+            Some(3)
+        );
     }
 
     #[test]
     fn a_small_pivot_has_no_clip_worth_playing() {
-        assert_eq!(nearest_turn_clip(Deg(30.0), &HUMAN_STAND), None);
-        assert_eq!(nearest_turn_clip(Deg(-30.0), &HUMAN_STAND), None);
+        assert_eq!(
+            nearest_turn_clip(Deg(30.0), &HUMAN_STAND, NO_BUDGET_LIMIT),
+            None
+        );
+        assert_eq!(
+            nearest_turn_clip(Deg(-30.0), &HUMAN_STAND, NO_BUDGET_LIMIT),
+            None
+        );
     }
 
     #[test]
     fn a_schema_without_turn_clips_never_pivots() {
-        assert_eq!(nearest_turn_clip(Deg(150.0), &[Deg(0.0)]), None);
-        assert_eq!(nearest_turn_clip(Deg(150.0), &[]), None);
+        assert_eq!(
+            nearest_turn_clip(Deg(150.0), &[(Deg(0.0), 1.0)], NO_BUDGET_LIMIT),
+            None
+        );
+        assert_eq!(nearest_turn_clip(Deg(150.0), &[], NO_BUDGET_LIMIT), None);
+    }
+
+    /// A creature can only stand still for so long: an about-face it cannot
+    /// afford is steered rather than performed.
+    #[test]
+    fn a_turn_the_creature_cannot_afford_is_not_picked() {
+        assert_eq!(nearest_turn_clip(Deg(-170.0), &HUMAN_STAND, 4.0), Some(1));
+        assert_eq!(nearest_turn_clip(Deg(-170.0), &HUMAN_STAND, 3.0), None);
     }
 }

--- a/dark/src/motion/turn_clips.rs
+++ b/dark/src/motion/turn_clips.rs
@@ -1,0 +1,89 @@
+//! Picking the authored turn clip for a pivot.
+//!
+//! Creature schemas file their turn-in-place motions beside the idle stand
+//! clip (human: humstand, humtul, humtur, humtu180); the only thing that
+//! distinguishes them is the authored facing change each one ends on. So a
+//! pivot picks the clip whose authored angle is nearest the heading it needs,
+//! and plain standing picks from the clips that don't turn at all.
+
+use cgmath::Deg;
+
+/// Below this, a clip's authored facing change is incidental drift rather
+/// than a turn (stock idle clips end a fraction of a degree off).
+const TURN_CLIP_MIN_ANGLE: f32 = 20.0;
+
+/// A clip's authored facing change as a signed minimal angle, in (-180, 180].
+/// On disk it is an unsigned 0..360 heading.
+pub fn signed_end_direction(end_direction: Deg<f32>) -> Deg<f32> {
+    let wrapped = end_direction.0.rem_euclid(360.0);
+    Deg(if wrapped > 180.0 {
+        wrapped - 360.0
+    } else {
+        wrapped
+    })
+}
+
+/// Whether a clip turns the creature, rather than leaving it facing the way
+/// it started.
+pub fn is_turn_clip(end_direction: Deg<f32>) -> bool {
+    signed_end_direction(end_direction).0.abs() > TURN_CLIP_MIN_ANGLE
+}
+
+/// Index of the turn clip that best covers `delta` degrees of heading change,
+/// or `None` when standing still leaves the creature closer to `delta` than
+/// any authored turn would (small pivots have no clip: the shortest stock
+/// human turn is ~102 degrees).
+pub fn nearest_turn_clip(delta: Deg<f32>, end_directions: &[Deg<f32>]) -> Option<usize> {
+    end_directions
+        .iter()
+        .enumerate()
+        .filter(|(_, end)| is_turn_clip(**end))
+        .map(|(index, end)| (index, (signed_end_direction(*end).0 - delta.0).abs()))
+        .filter(|(_, residual)| *residual < delta.0.abs())
+        .min_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(index, _)| index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The stock human `+stand` schema: idle, left, right, about-face.
+    const HUMAN_STAND: [Deg<f32>; 4] = [Deg(0.0), Deg(258.15), Deg(102.58), Deg(191.95)];
+
+    #[test]
+    fn an_unsigned_heading_reads_as_the_minimal_signed_turn() {
+        assert_eq!(signed_end_direction(Deg(0.0)), Deg(0.0));
+        assert_eq!(signed_end_direction(Deg(102.58)), Deg(102.58));
+        assert!((signed_end_direction(Deg(258.15)).0 - -101.85).abs() < 1e-3);
+        assert!((signed_end_direction(Deg(191.95)).0 - -168.05).abs() < 1e-3);
+    }
+
+    #[test]
+    fn only_the_pivots_count_as_turn_clips() {
+        assert!(!is_turn_clip(Deg(0.0)));
+        assert!(!is_turn_clip(Deg(359.5)));
+        assert!(is_turn_clip(Deg(102.58)));
+        assert!(is_turn_clip(Deg(258.15)));
+        assert!(is_turn_clip(Deg(191.95)));
+    }
+
+    #[test]
+    fn a_pivot_takes_the_clip_nearest_its_heading_change() {
+        assert_eq!(nearest_turn_clip(Deg(95.0), &HUMAN_STAND), Some(2));
+        assert_eq!(nearest_turn_clip(Deg(-95.0), &HUMAN_STAND), Some(1));
+        assert_eq!(nearest_turn_clip(Deg(-170.0), &HUMAN_STAND), Some(3));
+    }
+
+    #[test]
+    fn a_small_pivot_has_no_clip_worth_playing() {
+        assert_eq!(nearest_turn_clip(Deg(30.0), &HUMAN_STAND), None);
+        assert_eq!(nearest_turn_clip(Deg(-30.0), &HUMAN_STAND), None);
+    }
+
+    #[test]
+    fn a_schema_without_turn_clips_never_pivots() {
+        assert_eq!(nearest_turn_clip(Deg(150.0), &[Deg(0.0)]), None);
+        assert_eq!(nearest_turn_clip(Deg(150.0), &[]), None);
+    }
+}

--- a/dark/src/motion/turn_clips.rs
+++ b/dark/src/motion/turn_clips.rs
@@ -45,7 +45,17 @@ pub fn nearest_turn_clip(
         .iter()
         .enumerate()
         .filter(|(_, (end, duration))| is_turn_clip(*end) && *duration <= max_duration)
-        .map(|(index, (end, _))| (index, (signed_end_direction(*end).0 - delta.0).abs()))
+        // Both the residual and the baseline are minimal angles: an
+        // about-face authored at -177 covers a wanted +175 (8 degrees short),
+        // and reading that as 352 would reject it.
+        .map(|(index, (end, _))| {
+            (
+                index,
+                signed_end_direction(Deg(signed_end_direction(*end).0 - delta.0))
+                    .0
+                    .abs(),
+            )
+        })
         .filter(|(_, residual)| *residual < delta.0.abs())
         .min_by(|a, b| a.1.total_cmp(&b.1))
         .map(|(index, _)| index)
@@ -117,6 +127,22 @@ mod tests {
             None
         );
         assert_eq!(nearest_turn_clip(Deg(150.0), &[], NO_BUDGET_LIMIT), None);
+    }
+
+    /// An about-face authored just the other side of 180 still covers an
+    /// about-face wanted just this side of it.
+    #[test]
+    fn an_about_face_covers_a_pivot_across_the_half_turn() {
+        // 182.97 reads as -177.03; a +175 pivot is 8 degrees away, not 352.
+        let clips = [(Deg(182.97), 2.53), (Deg(112.39), 2.0)];
+        assert_eq!(
+            nearest_turn_clip(Deg(175.0), &clips, NO_BUDGET_LIMIT),
+            Some(0)
+        );
+        assert_eq!(
+            nearest_turn_clip(Deg(-175.0), &clips, NO_BUDGET_LIMIT),
+            Some(0)
+        );
     }
 
     /// A creature can only stand still for so long: an about-face it cannot

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4110,13 +4110,9 @@ impl MissionCore {
                         self.failed_animation_queries.remove(&entity_id);
                         if turn.is_some() {
                             turn_started = Some((
-                                dark::motion::signed_end_direction(
-                                    global_context
-                                        .motiondb
-                                        .get_motion_stuff(next_animation.clone())
-                                        .end_direction,
-                                ),
+                                dark::motion::signed_end_direction(clip.end_rotation),
                                 clip.duration.as_secs_f32(),
+                                clip.blend_length.as_secs_f32(),
                             ));
                         }
                         *player = apply(player, clip);
@@ -4155,6 +4151,11 @@ impl MissionCore {
                             );
                         }
                     }
+                } else if turn.is_some() {
+                    // A pivot with no clip the creature can afford is an
+                    // ordinary outcome, not a failed animation: the AI steers
+                    // the turn instead, and nothing waits on a completion.
+                    tracing::debug!("no turn clip for {:?}: {:?}", entity_id, tried_queries);
                 } else {
                     // Key on the query items only - the selection strategy
                     // carries a per-request counter that would defeat the
@@ -4183,10 +4184,14 @@ impl MissionCore {
             self.world.add_component(entity_id, death_pose);
         }
 
-        if let Some((turn, duration)) = turn_started {
+        if let Some((turn, duration, blend)) = turn_started {
             self.script_world.dispatch(Message {
                 to: entity_id,
-                payload: MessagePayload::TurnClipStarted { turn, duration },
+                payload: MessagePayload::TurnClipStarted {
+                    turn,
+                    duration,
+                    blend,
+                },
             });
         }
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3970,12 +3970,17 @@ impl MissionCore {
         motion_queries: Vec<Vec<MotionQueryItem>>,
         selection_strategy: MotionQuerySelectionStrategy,
         apply: fn(&AnimationPlayer, Rc<AnimationClip>) -> AnimationPlayer,
+        // Pivot in place: pick the stand-schema clip whose authored facing
+        // change is nearest this heading change, and report it back (see
+        // `Effect::PlayTurnClip`).
+        turn: Option<cgmath::Deg<f32>>,
     ) {
         let is_death_query = motion_queries
             .iter()
             .flatten()
             .any(|item| item.tag_name() == "crumple");
         let mut resolved_death_pose = None;
+        let mut turn_started = None;
         let maybe_player = self.id_to_animation_player.get_mut(&entity_id);
         if let Some(player) = maybe_player {
             let v_creature_type = self.world.borrow::<View<PropCreature>>().unwrap();
@@ -3998,11 +4003,36 @@ impl MissionCore {
 
                 let mut tried_queries = Vec::new();
                 let maybe_next_animation = motion_queries.into_iter().find_map(|items| {
+                    // The turn clips sit in the same schema as the idle stand
+                    // clip, told apart only by their authored facing change.
+                    let is_stand_query = items.iter().any(|item| item.tag_name() == "stand");
                     let mut query_items = items;
                     query_items.extend(actor_tags.iter().cloned());
                     let query = MotionQuery::new(actor_type, query_items)
                         .with_selection_strategy(selection_strategy.clone());
-                    let result = if is_death_query {
+                    let end_direction = |name: &String| {
+                        global_context
+                            .motiondb
+                            .get_motion_stuff(name.clone())
+                            .end_direction
+                    };
+                    let result = if let Some(delta) = turn {
+                        let options = global_context.motiondb.query_all(query.clone());
+                        let ends = options.iter().map(end_direction).collect::<Vec<_>>();
+                        dark::motion::nearest_turn_clip(delta, &ends)
+                            .map(|index| options[index].clone())
+                    } else if is_stand_query {
+                        // Standing still must not play a turn: the schema's
+                        // pivots would swing the creature's body with no
+                        // heading change behind it.
+                        let options = global_context
+                            .motiondb
+                            .query_all(query.clone())
+                            .into_iter()
+                            .filter(|name| !dark::motion::is_turn_clip(end_direction(name)))
+                            .collect::<Vec<_>>();
+                        select_motion_option(&options, &selection_strategy)
+                    } else if is_death_query {
                         let options = global_context
                             .motiondb
                             .query_all(query.clone())
@@ -4071,6 +4101,17 @@ impl MissionCore {
                             _ => clip,
                         };
                         self.failed_animation_queries.remove(&entity_id);
+                        if turn.is_some() {
+                            turn_started = Some((
+                                dark::motion::signed_end_direction(
+                                    global_context
+                                        .motiondb
+                                        .get_motion_stuff(next_animation.clone())
+                                        .end_direction,
+                                ),
+                                clip.duration.as_secs_f32(),
+                            ));
+                        }
                         *player = apply(player, clip);
 
                         // The motion query is random, so its resolved clip name
@@ -4133,6 +4174,13 @@ impl MissionCore {
 
         if let Some(death_pose) = resolved_death_pose {
             self.world.add_component(entity_id, death_pose);
+        }
+
+        if let Some((turn, duration)) = turn_started {
+            self.script_world.dispatch(Message {
+                to: entity_id,
+                payload: MessagePayload::TurnClipStarted { turn, duration },
+            });
         }
     }
 
@@ -6921,6 +6969,7 @@ impl MissionCore {
                         motion_queries,
                         selection_strategy,
                         AnimationPlayer::queue_animation,
+                        None,
                     );
                 }
 
@@ -6936,6 +6985,19 @@ impl MissionCore {
                         motion_queries,
                         selection_strategy,
                         AnimationPlayer::play_animation,
+                        None,
+                    );
+                }
+
+                Effect::PlayTurnClip { entity_id, delta } => {
+                    self.apply_animation_by_schema(
+                        global_context,
+                        asset_cache,
+                        entity_id,
+                        vec![vec![MotionQueryItem::new("stand")]],
+                        MotionQuerySelectionStrategy::Random,
+                        AnimationPlayer::play_animation,
+                        Some(delta),
                     );
                 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3971,9 +3971,10 @@ impl MissionCore {
         selection_strategy: MotionQuerySelectionStrategy,
         apply: fn(&AnimationPlayer, Rc<AnimationClip>) -> AnimationPlayer,
         // Pivot in place: pick the stand-schema clip whose authored facing
-        // change is nearest this heading change, and report it back (see
+        // change is nearest this heading change and that fits in the seconds
+        // the creature can afford to stand still, then report it back (see
         // `Effect::PlayTurnClip`).
-        turn: Option<cgmath::Deg<f32>>,
+        turn: Option<(cgmath::Deg<f32>, f32)>,
     ) {
         let is_death_query = motion_queries
             .iter()
@@ -4016,10 +4017,16 @@ impl MissionCore {
                             .get_motion_stuff(name.clone())
                             .end_direction
                     };
-                    let result = if let Some(delta) = turn {
+                    let result = if let Some((delta, max_seconds)) = turn {
                         let options = global_context.motiondb.query_all(query.clone());
-                        let ends = options.iter().map(end_direction).collect::<Vec<_>>();
-                        dark::motion::nearest_turn_clip(delta, &ends)
+                        let clips = options
+                            .iter()
+                            .map(|name| {
+                                let stuff = global_context.motiondb.get_motion_stuff(name.clone());
+                                (stuff.end_direction, stuff.duration)
+                            })
+                            .collect::<Vec<_>>();
+                        dark::motion::nearest_turn_clip(delta, &clips, max_seconds)
                             .map(|index| options[index].clone())
                     } else if is_stand_query {
                         // Standing still must not play a turn: the schema's
@@ -6989,7 +6996,11 @@ impl MissionCore {
                     );
                 }
 
-                Effect::PlayTurnClip { entity_id, delta } => {
+                Effect::PlayTurnClip {
+                    entity_id,
+                    delta,
+                    max_seconds,
+                } => {
                     self.apply_animation_by_schema(
                         global_context,
                         asset_cache,
@@ -6997,7 +7008,7 @@ impl MissionCore {
                         vec![vec![MotionQueryItem::new("stand")]],
                         MotionQuerySelectionStrategy::Random,
                         AnimationPlayer::play_animation,
-                        Some(delta),
+                        Some((delta, max_seconds)),
                     );
                 }
 

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -47,7 +47,7 @@ pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
         .ok()
         .and_then(|v_creature| v_creature.get(entity_id).ok().map(|creature| creature.0))
         .and_then(crate::creature::get_creature_definition)
-        .map(|definition| definition.bounding_size.y / SCALE_FACTOR)
+        .map(|definition| definition.bounding_size.y)
         .unwrap_or(CREATURE_DEFAULT_HEIGHT)
 }
 
@@ -1478,6 +1478,29 @@ mod line_of_fire_tests {
             &physics,
             vec3(0.0, 0.0, 5.0),
         ));
+    }
+}
+
+#[cfg(test)]
+mod creature_height_tests {
+    use super::*;
+
+    /// A creature's authored bounding box is already in world units - the same
+    /// units the no-definition fallback is written in, and the units the
+    /// physics capsule is built from. Measuring a hybrid at a third of its
+    /// height let it walk under a door leaf that had barely left the floor.
+    #[test]
+    fn a_creature_is_measured_in_the_same_units_as_the_fallback() {
+        let mut world = World::new();
+        // 0 is the human schema, whose bounding box is the 6.5 feet the
+        // fallback also uses.
+        let human = world.add_entity((PropCreature(0),));
+        assert!(
+            (creature_height(&world, human) - CREATURE_DEFAULT_HEIGHT).abs() < 1e-3,
+            "human measured {} against a {} fallback",
+            creature_height(&world, human),
+            CREATURE_DEFAULT_HEIGHT
+        );
     }
 }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -196,6 +196,14 @@ const TURN_CLIP_MAX_SECONDS: f32 = 4.0;
 /// the next one.
 const TURN_CLIP_COOLDOWN: f32 = 3.0;
 
+/// How long a stall bars pivoting. A pivot costs seconds of standing still,
+/// so it is only for a creature that is getting somewhere: one that has just
+/// failed to make progress is scrambling out of a wedge, and standing still
+/// through a turn clip only makes the wedge longer. The bar has to outlast the
+/// path follower's own recovery, whose re-path - and the sidestep heading that
+/// would ask for a pivot - lands after the stall clock has been reset.
+const TURN_CLIP_STALL_BLOCK_SECONDS: f32 = 3.0;
+
 /// Fallback for a clip that authors no blend length. The turn clip's pose
 /// swings back to neutral over the blend as the next clip fades in, so the
 /// entity takes the authored facing change over exactly the same window and
@@ -315,6 +323,9 @@ pub struct AnimatedMonsterAI {
     turn_clip: Option<TurnClip>,
     /// Seconds left before this AI may perform another pivot
     turn_cooldown: f32,
+    /// Seconds left of the bar a stall puts on pivoting (see
+    /// `TURN_CLIP_STALL_BLOCK_SECONDS`)
+    turn_stall_block: f32,
 }
 
 impl AnimatedMonsterAI {
@@ -342,6 +353,7 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             turn_cooldown: 0.0,
+            turn_stall_block: 0.0,
         }
     }
 
@@ -370,6 +382,7 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             turn_cooldown: 0.0,
+            turn_stall_block: 0.0,
         }
     }
 
@@ -837,6 +850,19 @@ impl AnimatedMonsterAI {
         }
         self.door_wait = Some((door_ent, waited));
         Some(waited)
+    }
+
+    /// Whether a pivot is affordable this frame, given how long the route has
+    /// been failing to make progress. A stall re-arms the bar every frame it
+    /// is over the mark, so the creature has to be moving again - for the
+    /// whole bar - before it may stand still for a turn clip.
+    fn may_pivot_after_stall(&mut self, stall_seconds: f32, elapsed: f32) -> bool {
+        if stall_seconds >= FRUSTRATION_STALL_SECONDS {
+            self.turn_stall_block = TURN_CLIP_STALL_BLOCK_SECONDS;
+        } else {
+            self.turn_stall_block = (self.turn_stall_block - elapsed).max(0.0);
+        }
+        self.turn_stall_block <= 0.0
     }
 
     /// Pivot with the creature's own authored turn clip rather than sliding
@@ -1420,10 +1446,16 @@ impl Script for AnimatedMonsterAI {
         let door_wait_seconds = self.update_door_wait(world, entity_id, time);
         // A pivot big enough to stop the body is played as an authored turn
         // clip. Same gate as the frustration gesture: never over a scripted
-        // performance, and never while standing off from a door.
+        // performance, and never while standing off from a door - plus one of
+        // its own, since a stalled creature cannot afford to stand still.
+        let may_pivot_after_stall = self.may_pivot_after_stall(
+            path_stall_seconds(world, entity_id),
+            time.elapsed.as_secs_f32(),
+        );
         let may_turn = self.current_behavior.borrow().is_locomotion()
             && self.current_behavior.borrow().scripted_state() != ScriptedState::Running
-            && door_wait_seconds.is_none();
+            && door_wait_seconds.is_none()
+            && may_pivot_after_stall;
         let (turn_clip_effect, heading_held) =
             self.update_turn_clip(entity_id, steering_output.desired_heading, time, may_turn);
         let rotation_effect = self.apply_steering_output(
@@ -2176,6 +2208,31 @@ mod tests {
 
     /// The pivot the AI asks for is the heading change it actually needs; the
     /// applier is what turns that into one of the creature's authored clips.
+    #[test]
+    fn a_stalled_creature_steers_its_turn_instead_of_performing_it() {
+        let mut monster = AnimatedMonsterAI::new();
+        // Getting somewhere: a pivot is affordable.
+        assert!(monster.may_pivot_after_stall(0.0, 0.1));
+
+        // The route stops making progress. Standing still for a turn clip
+        // while wedged only lengthens the wedge.
+        assert!(!monster.may_pivot_after_stall(FRUSTRATION_STALL_SECONDS, 0.1));
+
+        // The stall clock resets the moment the follower recovers, but the
+        // sidestep heading its re-path produces arrives a beat later - the bar
+        // has to still be up then.
+        assert!(
+            !monster.may_pivot_after_stall(0.0, 1.0),
+            "a pivot one second past the stall is still the wedge's own"
+        );
+
+        // Moving again for the whole bar restores pivoting.
+        for _ in 0..TURN_CLIP_STALL_BLOCK_SECONDS.ceil() as u32 {
+            monster.may_pivot_after_stall(0.0, 1.0);
+        }
+        assert!(monster.may_pivot_after_stall(0.0, 1.0));
+    }
+
     #[test]
     fn a_reversal_asks_for_an_authored_turn_clip() {
         let (_world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -170,10 +170,20 @@ pub(crate) fn should_gesture_frustration(
         && !matches!(target_distance, Some(d) if d <= MELEE_ATTACK_RANGE)
 }
 
-/// How long to wait for the applier to report which clip it picked. A pivot
-/// with no clip for it - or a creature whose schema has no turn clips at all -
-/// resolves to nothing and never reports.
-const TURN_CLIP_REPORT_TIMEOUT: f32 = 0.5;
+/// How long to wait for the applier to report which clip it picked. The report
+/// comes back on the next frame, so this only bounds a pivot that resolves to
+/// no clip at all and never reports one.
+const TURN_CLIP_REPORT_TIMEOUT: f32 = 0.25;
+
+/// How long past its authored length a turn clip may run before the pivot
+/// gives up on ever seeing it complete.
+const TURN_CLIP_OVERRUN_MARGIN: f32 = 0.25;
+
+/// How early a completion may arrive and still be the turn clip's own. Any
+/// other clip that preempted it completes far sooner than this (a run cycle is
+/// a third of a second), and settling on one of those would swing the AI
+/// through the authored turn with a neutral pose.
+const TURN_CLIP_COMPLETION_SLACK: f32 = 0.25;
 
 /// The longest a creature may stand still to perform a pivot. The stock turn
 /// clips run 2.4-5.6 s; one long enough to read as a wedge (the reachability
@@ -186,10 +196,10 @@ const TURN_CLIP_MAX_SECONDS: f32 = 4.0;
 /// the next one.
 const TURN_CLIP_COOLDOWN: f32 = 3.0;
 
-/// The stock authored blend length. The turn clip's pose swings back to
-/// neutral over this window as the next clip fades in, so the entity takes the
-/// authored facing change over exactly the same window and the creature's
-/// visible facing never jumps.
+/// Fallback for a clip that authors no blend length. The turn clip's pose
+/// swings back to neutral over the blend as the next clip fades in, so the
+/// entity takes the authored facing change over exactly the same window and
+/// the creature's visible facing never jumps.
 const TURN_CLIP_SETTLE_SECONDS: f32 = 0.5;
 
 /// A pivot being played as the creature's own authored turn clip. The clip's
@@ -199,10 +209,21 @@ enum TurnClip {
     /// Asked for; waiting for the applier to say which clip it picked.
     Requested { remaining: f32 },
     /// Playing: the pose is doing the turning, so the entity holds still.
-    Playing { turn: Deg<f32>, remaining: f32 },
+    Playing {
+        turn: Deg<f32>,
+        remaining: f32,
+        /// The clip's authored blend length - the window the pose takes to
+        /// swing back to neutral once it ends.
+        blend: f32,
+    },
     /// Done: the entity takes the clip's authored facing change across the
     /// blend that swings the pose back to neutral.
-    Settling { turn: Deg<f32>, remaining: f32 },
+    Settling {
+        turn: Deg<f32>,
+        remaining: f32,
+        /// The blend window this is spread over.
+        window: f32,
+    },
 }
 
 /// The "thwarted" performance. The motion database files the tag under
@@ -292,9 +313,6 @@ pub struct AnimatedMonsterAI {
     alertness_pinned: bool,
     /// The authored turn clip playing for the current pivot, if any
     turn_clip: Option<TurnClip>,
-    /// Cleared when a pivot request resolves to no clip, so a creature whose
-    /// schema has none stops asking
-    has_turn_clips: bool,
     /// Seconds left before this AI may perform another pivot
     turn_cooldown: f32,
 }
@@ -323,7 +341,6 @@ impl AnimatedMonsterAI {
             door_wait: None,
             frustration_cooldown: 0.0,
             turn_clip: None,
-            has_turn_clips: true,
             turn_cooldown: 0.0,
         }
     }
@@ -352,7 +369,6 @@ impl AnimatedMonsterAI {
             door_wait: None,
             frustration_cooldown: 0.0,
             turn_clip: None,
-            has_turn_clips: true,
             turn_cooldown: 0.0,
         }
     }
@@ -847,7 +863,7 @@ impl AnimatedMonsterAI {
                 // pivot the creature can walk through needs no clip, and the
                 // shortest stock turn clip is a quarter-circle anyway.
                 let stopped = locomotion_scale_for_heading_error(delta) <= 0.0;
-                if !(may_start && stopped && self.has_turn_clips && self.turn_cooldown <= 0.0) {
+                if !(may_start && stopped && self.turn_cooldown <= 0.0) {
                     return (Effect::NoEffect, false);
                 }
                 tracing::debug!("ai {:?} pivots {:?}", entity_id, delta);
@@ -868,12 +884,12 @@ impl AnimatedMonsterAI {
                 if *remaining > 0.0 {
                     return (Effect::NoEffect, true);
                 }
-                // No clip covers this pivot, or the creature's schema has
-                // none at all. Steer it, and stop asking.
+                // No clip covers this pivot - it is bigger than the ones the
+                // creature can afford, or its schema has none. Steer the turn,
+                // and let the cooldown space out the asking.
                 tracing::debug!("ai {:?} has no clip for its pivot", entity_id);
                 self.turn_clip = None;
                 self.turn_cooldown = TURN_CLIP_COOLDOWN;
-                self.has_turn_clips = false;
                 (Effect::NoEffect, false)
             }
             Some(TurnClip::Playing { remaining, .. }) => {
@@ -887,15 +903,19 @@ impl AnimatedMonsterAI {
                 self.turn_cooldown = TURN_CLIP_COOLDOWN;
                 (Effect::NoEffect, false)
             }
-            Some(TurnClip::Settling { turn, remaining }) => {
+            Some(TurnClip::Settling {
+                turn,
+                remaining,
+                window,
+            }) => {
                 let step = elapsed.min(*remaining);
                 let turn = *turn;
+                let window = *window;
                 *remaining -= step;
                 // Rounding leaves a sliver of the last frame behind; anything
                 // this short is the end of the blend, not another frame of it.
                 let finished = *remaining <= 1e-4;
-                self.current_heading =
-                    Deg(self.current_heading.0 + turn.0 * step / TURN_CLIP_SETTLE_SECONDS);
+                self.current_heading = Deg(self.current_heading.0 + turn.0 * step / window);
                 if finished {
                     tracing::debug!(
                         "ai {:?} finished its pivot facing {:?}",
@@ -1440,9 +1460,13 @@ impl Script for AnimatedMonsterAI {
         // own clip would drop that clip for a frame. Suppressing rather than
         // reordering also leaves the rate limit unarmed, so the gesture
         // simply comes on a later frame.
+        // A pivot is a clip too, for its whole length - not just the frame it
+        // was asked for. Gesturing over it would preempt the turn, and the
+        // stall it is reacting to is a standstill this AI chose.
         let started_a_clip = !matches!(behavior_change_effect, Effect::NoEffect)
             || !matches!(handback_effect, Effect::NoEffect)
-            || !matches!(turn_clip_effect, Effect::NoEffect);
+            || !matches!(turn_clip_effect, Effect::NoEffect)
+            || self.turn_clip.is_some();
         let frustration_effect =
             self.update_frustration(world, entity_id, door_wait_seconds, started_a_clip, time);
 
@@ -1660,29 +1684,58 @@ impl Script for AnimatedMonsterAI {
                 // cancels scripted sequences
                 self.force_alertness(*level, world, physics, entity_id)
             }
-            MessagePayload::TurnClipStarted { turn, duration } => {
+            MessagePayload::TurnClipStarted {
+                turn,
+                duration,
+                blend,
+            } => {
                 if matches!(self.turn_clip, Some(TurnClip::Requested { .. })) {
                     // Hold the heading for as long as the clip actually runs,
                     // plus a margin: the completion is what normally ends the
                     // pivot, this only bounds a clip that is preempted.
                     self.turn_clip = Some(TurnClip::Playing {
                         turn: *turn,
-                        remaining: duration + TURN_CLIP_REPORT_TIMEOUT,
+                        remaining: duration + TURN_CLIP_OVERRUN_MARGIN,
+                        blend: if *blend > 0.0 {
+                            *blend
+                        } else {
+                            TURN_CLIP_SETTLE_SECONDS
+                        },
                     });
                 }
                 Effect::NoEffect
             }
             MessagePayload::AnimationCompleted => {
                 // The turn clip is done: take its authored facing change as
-                // the pose blends back to neutral. The behavior's own clip is
-                // re-queued by the normal completion path below - and its own
-                // completion, a fraction of a second later, must not restart
-                // the blend, so only a PLAYING pivot settles here.
-                if let Some(TurnClip::Playing { turn, .. }) = self.turn_clip {
-                    self.turn_clip = Some(TurnClip::Settling {
-                        turn,
-                        remaining: TURN_CLIP_SETTLE_SECONDS,
-                    });
+                // the pose blends back to neutral.
+                //
+                // Only the turn clip's OWN completion may do that. The
+                // behavior's clip is re-queued the moment the pivot ends and
+                // completes a fraction of a second later, and anything that
+                // preempts the turn clip (a wound reaction, an alertness
+                // change) completes long before it would have - settling on
+                // one of those swings the AI through the authored turn with a
+                // neutral pose. `remaining` counts down the clip's own
+                // runtime, so only a completion arriving near the end of it is
+                // the clip's own; anything earlier means the pivot's clip is
+                // gone.
+                if let Some(TurnClip::Playing {
+                    turn,
+                    remaining,
+                    blend,
+                }) = self.turn_clip
+                {
+                    if remaining <= TURN_CLIP_OVERRUN_MARGIN + TURN_CLIP_COMPLETION_SLACK {
+                        self.turn_clip = Some(TurnClip::Settling {
+                            turn,
+                            remaining: blend,
+                            window: blend,
+                        });
+                    } else {
+                        tracing::debug!("ai {:?} lost its turn clip to another", entity_id);
+                        self.turn_clip = None;
+                        self.turn_cooldown = TURN_CLIP_COOLDOWN;
+                    }
                 }
                 if self.is_dead {
                     // The crumple->ragdoll handoff is timed from update()
@@ -2075,6 +2128,42 @@ mod tests {
         (requested, held)
     }
 
+    /// Report the clip the applier picked for a pivot in flight.
+    fn report_clip(
+        monster: &mut AnimatedMonsterAI,
+        world: &World,
+        entity_id: EntityId,
+        turn: Deg<f32>,
+        duration: f32,
+    ) {
+        monster.handle_message(
+            entity_id,
+            world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnClipStarted {
+                turn,
+                duration,
+                blend: TURN_CLIP_SETTLE_SECONDS,
+            },
+        );
+    }
+
+    fn complete_clip(monster: &mut AnimatedMonsterAI, world: &World, entity_id: EntityId) {
+        monster.handle_message(
+            entity_id,
+            world,
+            &PhysicsWorld::new(),
+            &MessagePayload::AnimationCompleted,
+        );
+    }
+
+    /// Hold the pivot for `seconds` of 100ms frames, as the clip plays.
+    fn play_out(monster: &mut AnimatedMonsterAI, entity_id: EntityId, seconds: f32) {
+        for _ in 0..((seconds / 0.1).ceil() as usize) {
+            turn_frame(monster, entity_id, Deg(90.0));
+        }
+    }
+
     fn locomotion_scale(effects: &[Effect]) -> Option<f32> {
         effects.iter().find_map(|effect| match effect {
             Effect::SetAIProperty {
@@ -2114,17 +2203,8 @@ mod tests {
     #[test]
     fn the_body_holds_its_heading_and_stride_while_the_clip_plays() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        let physics = PhysicsWorld::new();
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::TurnClipStarted {
-                turn: Deg(-168.0),
-                duration: 4.8,
-            },
-        );
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
 
         for _ in 0..10 {
             let (requested, held) = turn_frame(&mut monster, entity_id, Deg(90.0));
@@ -2152,25 +2232,12 @@ mod tests {
     #[test]
     fn the_authored_turn_lands_on_the_entity_once_the_clip_ends() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        let physics = PhysicsWorld::new();
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::TurnClipStarted {
-                turn: Deg(-168.0),
-                duration: 4.8,
-            },
-        );
-        monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::AnimationCompleted,
-        );
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
+        play_out(&mut monster, entity_id, 4.8);
+        complete_clip(&mut monster, &world, entity_id);
 
-        // The settle is TURN_CLIP_SETTLE_SECONDS of 100ms frames.
+        // The settle is the clip's blend length, in 100ms frames.
         for _ in 0..5 {
             assert!(turn_frame(&mut monster, entity_id, Deg(90.0)).1);
         }
@@ -2190,7 +2257,13 @@ mod tests {
     #[test]
     fn a_pivot_cannot_hold_long_enough_to_look_stuck() {
         // The reachability harness treats holding one spot for 6s as wedged.
-        assert!(TURN_CLIP_MAX_SECONDS + TURN_CLIP_SETTLE_SECONDS + TURN_CLIP_REPORT_TIMEOUT < 6.0);
+        assert!(
+            TURN_CLIP_REPORT_TIMEOUT
+                + TURN_CLIP_MAX_SECONDS
+                + TURN_CLIP_OVERRUN_MARGIN
+                + TURN_CLIP_SETTLE_SECONDS
+                < 6.0
+        );
     }
 
     /// Two pivots back to back hold the creature still for longer than either
@@ -2198,23 +2271,10 @@ mod tests {
     #[test]
     fn a_second_pivot_waits_for_the_cooldown() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        let physics = PhysicsWorld::new();
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::TurnClipStarted {
-                turn: Deg(-100.0),
-                duration: 2.4,
-            },
-        );
-        monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::AnimationCompleted,
-        );
+        report_clip(&mut monster, &world, entity_id, Deg(-100.0), 2.4);
+        play_out(&mut monster, entity_id, 2.4);
+        complete_clip(&mut monster, &world, entity_id);
         for _ in 0..6 {
             turn_frame(&mut monster, entity_id, Deg(90.0));
         }
@@ -2234,24 +2294,11 @@ mod tests {
     #[test]
     fn a_later_clip_completing_does_not_restart_the_blend() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        let physics = PhysicsWorld::new();
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::TurnClipStarted {
-                turn: Deg(-168.0),
-                duration: 4.8,
-            },
-        );
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
+        play_out(&mut monster, entity_id, 4.8);
         for _ in 0..2 {
-            monster.handle_message(
-                entity_id,
-                &world,
-                &physics,
-                &MessagePayload::AnimationCompleted,
-            );
+            complete_clip(&mut monster, &world, entity_id);
             for _ in 0..3 {
                 turn_frame(&mut monster, entity_id, Deg(90.0));
             }
@@ -2259,6 +2306,29 @@ mod tests {
         assert!(
             monster.turn_clip.is_none(),
             "the pivot must end, not restart with every clip that completes"
+        );
+        assert!(
+            (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
+            "and it must apply the authored turn exactly once"
+        );
+    }
+
+    /// Anything that preempts the turn clip - a wound reaction, an alertness
+    /// change - completes long before the clip would have. Taking the authored
+    /// turn then would swing the AI through it with a neutral pose.
+    #[test]
+    fn a_completion_that_arrives_early_is_not_the_turn_clip() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
+        play_out(&mut monster, entity_id, 0.5);
+        complete_clip(&mut monster, &world, entity_id);
+
+        assert!(monster.turn_clip.is_none(), "the pivot is abandoned");
+        assert_eq!(
+            monster.current_heading,
+            Deg(-90.0),
+            "a turn whose pose never played must not land on the entity"
         );
     }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -170,6 +170,30 @@ pub(crate) fn should_gesture_frustration(
         && !matches!(target_distance, Some(d) if d <= MELEE_ATTACK_RANGE)
 }
 
+/// How long to wait for the applier to report which clip it picked. A pivot
+/// with no clip for it - or a creature whose schema has no turn clips at all -
+/// resolves to nothing and never reports.
+const TURN_CLIP_REPORT_TIMEOUT: f32 = 0.5;
+
+/// The stock authored blend length. The turn clip's pose swings back to
+/// neutral over this window as the next clip fades in, so the entity takes the
+/// authored facing change over exactly the same window and the creature's
+/// visible facing never jumps.
+const TURN_CLIP_SETTLE_SECONDS: f32 = 0.5;
+
+/// A pivot being played as the creature's own authored turn clip. The clip's
+/// POSE does the visible turning, so the script holds its heading while the
+/// clip runs and only then takes the authored facing change.
+struct TurnClip {
+    /// The clip's authored facing change, once the applier has reported which
+    /// clip it picked; `None` while the request is still in flight.
+    turn: Option<Deg<f32>>,
+    /// Seconds left before an unreported or preempted pivot is abandoned.
+    remaining: f32,
+    /// Seconds left of the blend-out over which `turn` is applied.
+    settle: f32,
+}
+
 /// The "thwarted" performance. The motion database files the tag under
 /// `discover`, so the bare tag resolves to nothing at all - the query has to
 /// name the branch as well as the leaf.
@@ -255,6 +279,11 @@ pub struct AnimatedMonsterAI {
     /// Pinned alertness (DebugForceChase): treated as permanent sight of the
     /// player - no decay, live target position - until cleared
     alertness_pinned: bool,
+    /// The authored turn clip playing for the current pivot, if any
+    turn_clip: Option<TurnClip>,
+    /// Cleared when a pivot request resolves to no clip, so a creature whose
+    /// schema has none stops asking
+    has_turn_clips: bool,
 }
 
 impl AnimatedMonsterAI {
@@ -280,6 +309,8 @@ impl AnimatedMonsterAI {
             door_cooldown: 0.0,
             door_wait: None,
             frustration_cooldown: 0.0,
+            turn_clip: None,
+            has_turn_clips: true,
         }
     }
 
@@ -306,6 +337,8 @@ impl AnimatedMonsterAI {
             door_cooldown: 0.0,
             door_wait: None,
             frustration_cooldown: 0.0,
+            turn_clip: None,
+            has_turn_clips: true,
         }
     }
 
@@ -411,12 +444,19 @@ impl AnimatedMonsterAI {
         time: &Time,
         entity_id: EntityId,
         hold_position: bool,
+        // An authored turn clip owns the heading for the length of the pivot
+        // (see `update_turn_clip`): the script neither slews it nor moves the
+        // body, and re-asserting the held heading every frame keeps the clip's
+        // own root rotation from turning the entity on top of its pose.
+        heading_held: bool,
     ) -> Effect {
         let turn_velocity = self.current_behavior.borrow().turn_speed().0;
         let delta =
             clamp_to_minimal_delta_angle(steering_output.desired_heading - self.current_heading);
 
-        let turn_amount = if delta.0 < 0.0 {
+        let turn_amount = if heading_held {
+            0.0
+        } else if delta.0 < 0.0 {
             (-turn_velocity * time.elapsed.as_secs_f32()).max(delta.0)
         } else {
             (turn_velocity * time.elapsed.as_secs_f32()).min(delta.0)
@@ -430,7 +470,7 @@ impl AnimatedMonsterAI {
         // a third by 60 degrees of error and to a standstill by 90.
         // Holding for a door still turns (so the AI keeps facing the way
         // through) - only the stride is cut.
-        let scale = if hold_position {
+        let scale = if hold_position || heading_held {
             0.0
         } else {
             locomotion_scale_for_heading_error(delta)
@@ -766,6 +806,68 @@ impl AnimatedMonsterAI {
         }
         self.door_wait = Some((door_ent, waited));
         Some(waited)
+    }
+
+    /// Pivot with the creature's own authored turn clip rather than sliding
+    /// the heading around under a walk cycle. Returns the effect to emit and
+    /// whether the pivot owns the heading this frame.
+    ///
+    /// The clip's pose does the visible turning, so the script holds still
+    /// while it plays and takes the authored facing change afterwards, spread
+    /// over the blend that swings the pose back to neutral.
+    fn update_turn_clip(
+        &mut self,
+        entity_id: EntityId,
+        desired_heading: Deg<f32>,
+        time: &Time,
+        may_start: bool,
+    ) -> (Effect, bool) {
+        let elapsed = time.elapsed.as_secs_f32();
+        let delta = clamp_to_minimal_delta_angle(desired_heading - self.current_heading);
+
+        let Some(pivot) = &mut self.turn_clip else {
+            // Only once the heading error has already stopped the body: a
+            // pivot the creature can walk through needs no clip, and the
+            // shortest stock turn clip is a quarter-circle anyway.
+            let stopped = locomotion_scale_for_heading_error(delta) <= 0.0;
+            if !(may_start && stopped && self.has_turn_clips) {
+                return (Effect::NoEffect, false);
+            }
+            self.turn_clip = Some(TurnClip {
+                turn: None,
+                remaining: TURN_CLIP_REPORT_TIMEOUT,
+                settle: 0.0,
+            });
+            return (Effect::PlayTurnClip { entity_id, delta }, true);
+        };
+
+        if pivot.settle > 0.0 {
+            let step = elapsed.min(pivot.settle);
+            let turn = pivot.turn.unwrap_or(Deg(0.0));
+            pivot.settle -= step;
+            // Rounding leaves a sliver of the last frame behind; anything
+            // this short is the end of the blend, not another frame of it.
+            let finished = pivot.settle <= 1e-4;
+            self.current_heading =
+                Deg(self.current_heading.0 + turn.0 * step / TURN_CLIP_SETTLE_SECONDS);
+            if finished {
+                self.turn_clip = None;
+            }
+            return (Effect::NoEffect, true);
+        }
+
+        pivot.remaining -= elapsed;
+        if pivot.remaining <= 0.0 {
+            // Nothing came back: either no clip covers this pivot, or the one
+            // that was playing was preempted. Steer the rest of the way.
+            let unreported = pivot.turn.is_none();
+            self.turn_clip = None;
+            if unreported {
+                self.has_turn_clips = false;
+            }
+            return (Effect::NoEffect, false);
+        }
+        (Effect::NoEffect, true)
     }
 
     /// Jittered rate limit, so a knot of AIs blocked on the same thing does
@@ -1244,11 +1346,20 @@ impl Script for AnimatedMonsterAI {
         };
 
         let door_wait_seconds = self.update_door_wait(world, entity_id, time);
+        // A pivot big enough to stop the body is played as an authored turn
+        // clip. Same gate as the frustration gesture: never over a scripted
+        // performance, and never while standing off from a door.
+        let may_turn = self.current_behavior.borrow().is_locomotion()
+            && self.current_behavior.borrow().scripted_state() != ScriptedState::Running
+            && door_wait_seconds.is_none();
+        let (turn_clip_effect, heading_held) =
+            self.update_turn_clip(entity_id, steering_output.desired_heading, time, may_turn);
         let rotation_effect = self.apply_steering_output(
             steering_output,
             time,
             entity_id,
             door_wait_seconds.is_some(),
+            heading_held,
         );
 
         // A finished scripted sequence (its final queued effects were drained
@@ -1278,7 +1389,8 @@ impl Script for AnimatedMonsterAI {
         // reordering also leaves the rate limit unarmed, so the gesture
         // simply comes on a later frame.
         let started_a_clip = !matches!(behavior_change_effect, Effect::NoEffect)
-            || !matches!(handback_effect, Effect::NoEffect);
+            || !matches!(handback_effect, Effect::NoEffect)
+            || !matches!(turn_clip_effect, Effect::NoEffect);
         let frustration_effect =
             self.update_frustration(world, entity_id, door_wait_seconds, started_a_clip, time);
 
@@ -1322,6 +1434,7 @@ impl Script for AnimatedMonsterAI {
             behavior_publish_effect,
             door_effect,
             frustration_effect,
+            turn_clip_effect,
         ])
     }
 
@@ -1495,7 +1608,27 @@ impl Script for AnimatedMonsterAI {
                 // cancels scripted sequences
                 self.force_alertness(*level, world, physics, entity_id)
             }
+            MessagePayload::TurnClipStarted { turn, duration } => {
+                if let Some(pivot) = &mut self.turn_clip {
+                    pivot.turn = Some(*turn);
+                    // Hold the heading for as long as the clip actually runs,
+                    // plus a margin: the completion is what normally ends the
+                    // pivot, this only bounds a clip that never reports one.
+                    pivot.remaining = duration + TURN_CLIP_REPORT_TIMEOUT;
+                }
+                Effect::NoEffect
+            }
             MessagePayload::AnimationCompleted => {
+                // The turn clip is done: take its authored facing change as
+                // the pose blends back to neutral. The behavior's own clip is
+                // re-queued by the normal completion path below.
+                if let Some(pivot) = &mut self.turn_clip {
+                    if pivot.turn.is_some() {
+                        pivot.settle = TURN_CLIP_SETTLE_SECONDS;
+                    } else {
+                        self.turn_clip = None;
+                    }
+                }
                 if self.is_dead {
                     // The crumple->ragdoll handoff is timed from update()
                     // (CRUMPLE_HANDOFF_SECONDS), not completion-driven - a
@@ -1854,6 +1987,163 @@ mod tests {
                     link: Link::AIPatrol,
                 });
         }
+    }
+
+    /// A monster mid-pivot, its heading `heading` and its behavior asking
+    /// for `desired`.
+    fn pivoting_monster(heading: Deg<f32>) -> (World, EntityId, AnimatedMonsterAI) {
+        let (world, entity_id) = world_with_monster_and_player(heading);
+        let mut monster = AnimatedMonsterAI::new();
+        monster.current_heading = heading;
+        (world, entity_id, monster)
+    }
+
+    fn tick() -> Time {
+        Time {
+            elapsed: std::time::Duration::from_millis(100),
+            total: std::time::Duration::from_millis(100),
+        }
+    }
+
+    /// One frame of the pivot: the effect it emits and whether the clip owns
+    /// the heading.
+    fn turn_frame(
+        monster: &mut AnimatedMonsterAI,
+        entity_id: EntityId,
+        desired: Deg<f32>,
+    ) -> (Option<Deg<f32>>, bool) {
+        let (effect, held) = monster.update_turn_clip(entity_id, desired, &tick(), true);
+        let requested = match effect {
+            Effect::PlayTurnClip { delta, .. } => Some(delta),
+            _ => None,
+        };
+        (requested, held)
+    }
+
+    fn locomotion_scale(effects: &[Effect]) -> Option<f32> {
+        effects.iter().find_map(|effect| match effect {
+            Effect::SetAIProperty {
+                update: crate::scripts::AIPropertyUpdate::LocomotionScale { scale },
+                ..
+            } => Some(*scale),
+            _ => None,
+        })
+    }
+
+    /// The pivot the AI asks for is the heading change it actually needs; the
+    /// applier is what turns that into one of the creature's authored clips.
+    #[test]
+    fn a_reversal_asks_for_an_authored_turn_clip() {
+        let (_world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        let (requested, held) = turn_frame(&mut monster, entity_id, Deg(90.0));
+        assert_eq!(requested, Some(Deg(180.0)));
+        assert!(
+            held,
+            "the clip owns the heading from the moment it is asked for"
+        );
+    }
+
+    /// A pivot the creature can walk through is steered, not performed: the
+    /// shortest stock turn clip is a quarter circle.
+    #[test]
+    fn a_shallow_pivot_is_steered_as_before() {
+        let (_world, entity_id, mut monster) = pivoting_monster(Deg(0.0));
+        assert_eq!(
+            turn_frame(&mut monster, entity_id, Deg(40.0)),
+            (None, false)
+        );
+    }
+
+    /// The clip's pose does the visible turning, so the entity must hold
+    /// still underneath it - rotating as well would turn the creature twice.
+    #[test]
+    fn the_body_holds_its_heading_and_stride_while_the_clip_plays() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        let physics = PhysicsWorld::new();
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnClipStarted {
+                turn: Deg(-168.0),
+                duration: 4.8,
+            },
+        );
+
+        for _ in 0..10 {
+            let (requested, held) = turn_frame(&mut monster, entity_id, Deg(90.0));
+            assert_eq!(requested, None, "one pivot plays one clip");
+            assert!(held);
+            assert_eq!(monster.current_heading, Deg(-90.0));
+            let effects = Effect::flatten(vec![monster.apply_steering_output(
+                Steering::from_current(Deg(90.0)),
+                &tick(),
+                entity_id,
+                false,
+                held,
+            )]);
+            assert_eq!(
+                locomotion_scale(&effects),
+                Some(0.0),
+                "a pivot is performed at a standstill"
+            );
+            assert_eq!(commanded_heading(&effects), Some(Deg(-90.0)));
+        }
+    }
+
+    /// ...and once the clip is done, the entity takes the authored facing
+    /// change over the blend that swings the pose back to neutral.
+    #[test]
+    fn the_authored_turn_lands_on_the_entity_once_the_clip_ends() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        let physics = PhysicsWorld::new();
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnClipStarted {
+                turn: Deg(-168.0),
+                duration: 4.8,
+            },
+        );
+        monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::AnimationCompleted,
+        );
+
+        // The settle is TURN_CLIP_SETTLE_SECONDS of 100ms frames.
+        for _ in 0..5 {
+            assert!(turn_frame(&mut monster, entity_id, Deg(90.0)).1);
+        }
+        assert!(
+            (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
+            "expected the authored turn to land, heading is {:?}",
+            monster.current_heading
+        );
+        assert!(
+            monster.turn_clip.is_none(),
+            "the pivot is over once the turn has landed"
+        );
+    }
+
+    /// A creature whose schema has no turn clip for the pivot never gets a
+    /// report back; it must fall back to steering instead of standing there.
+    #[test]
+    fn an_unanswered_pivot_falls_back_to_steering() {
+        let (_world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        assert!(turn_frame(&mut monster, entity_id, Deg(90.0)).0.is_some());
+        for _ in 0..10 {
+            turn_frame(&mut monster, entity_id, Deg(90.0));
+        }
+        assert_eq!(
+            turn_frame(&mut monster, entity_id, Deg(90.0)),
+            (None, false),
+            "an unanswered pivot must give the heading back to steering, and stop asking"
+        );
     }
 
     /// #807: a creature flagged to patrol must walk its authored route from

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -175,6 +175,17 @@ pub(crate) fn should_gesture_frustration(
 /// resolves to nothing and never reports.
 const TURN_CLIP_REPORT_TIMEOUT: f32 = 0.5;
 
+/// The longest a creature may stand still to perform a pivot. The stock turn
+/// clips run 2.4-5.6 s; one long enough to read as a wedge (the reachability
+/// harness calls holding one spot for 6 s stuck, and it is right to) is worse
+/// than steering the turn, so it is simply not picked.
+const TURN_CLIP_MAX_SECONDS: f32 = 4.0;
+
+/// Two pivots back to back would hold the creature still for longer than
+/// either of them, so a pivot has to walk (or at least steer) it off before
+/// the next one.
+const TURN_CLIP_COOLDOWN: f32 = 3.0;
+
 /// The stock authored blend length. The turn clip's pose swings back to
 /// neutral over this window as the next clip fades in, so the entity takes the
 /// authored facing change over exactly the same window and the creature's
@@ -284,6 +295,8 @@ pub struct AnimatedMonsterAI {
     /// Cleared when a pivot request resolves to no clip, so a creature whose
     /// schema has none stops asking
     has_turn_clips: bool,
+    /// Seconds left before this AI may perform another pivot
+    turn_cooldown: f32,
 }
 
 impl AnimatedMonsterAI {
@@ -311,6 +324,7 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             has_turn_clips: true,
+            turn_cooldown: 0.0,
         }
     }
 
@@ -339,6 +353,7 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             has_turn_clips: true,
+            turn_cooldown: 0.0,
         }
     }
 
@@ -827,18 +842,26 @@ impl AnimatedMonsterAI {
 
         match &mut self.turn_clip {
             None => {
+                self.turn_cooldown = (self.turn_cooldown - elapsed).max(0.0);
                 // Only once the heading error has already stopped the body: a
                 // pivot the creature can walk through needs no clip, and the
                 // shortest stock turn clip is a quarter-circle anyway.
                 let stopped = locomotion_scale_for_heading_error(delta) <= 0.0;
-                if !(may_start && stopped && self.has_turn_clips) {
+                if !(may_start && stopped && self.has_turn_clips && self.turn_cooldown <= 0.0) {
                     return (Effect::NoEffect, false);
                 }
                 tracing::debug!("ai {:?} pivots {:?}", entity_id, delta);
                 self.turn_clip = Some(TurnClip::Requested {
                     remaining: TURN_CLIP_REPORT_TIMEOUT,
                 });
-                (Effect::PlayTurnClip { entity_id, delta }, true)
+                (
+                    Effect::PlayTurnClip {
+                        entity_id,
+                        delta,
+                        max_seconds: TURN_CLIP_MAX_SECONDS,
+                    },
+                    true,
+                )
             }
             Some(TurnClip::Requested { remaining }) => {
                 *remaining -= elapsed;
@@ -849,6 +872,7 @@ impl AnimatedMonsterAI {
                 // none at all. Steer it, and stop asking.
                 tracing::debug!("ai {:?} has no clip for its pivot", entity_id);
                 self.turn_clip = None;
+                self.turn_cooldown = TURN_CLIP_COOLDOWN;
                 self.has_turn_clips = false;
                 (Effect::NoEffect, false)
             }
@@ -860,6 +884,7 @@ impl AnimatedMonsterAI {
                 // The completion never came - something preempted the clip.
                 tracing::debug!("ai {:?} lost its turn clip", entity_id);
                 self.turn_clip = None;
+                self.turn_cooldown = TURN_CLIP_COOLDOWN;
                 (Effect::NoEffect, false)
             }
             Some(TurnClip::Settling { turn, remaining }) => {
@@ -878,6 +903,7 @@ impl AnimatedMonsterAI {
                         self.current_heading
                     );
                     self.turn_clip = None;
+                    self.turn_cooldown = TURN_CLIP_COOLDOWN;
                 }
                 (Effect::NoEffect, true)
             }
@@ -2156,6 +2182,48 @@ mod tests {
         assert!(
             monster.turn_clip.is_none(),
             "the pivot is over once the turn has landed"
+        );
+    }
+
+    /// A pivot has a budget: it must be over, blend included, before a held
+    /// spot reads as a wedge.
+    #[test]
+    fn a_pivot_cannot_hold_long_enough_to_look_stuck() {
+        // The reachability harness treats holding one spot for 6s as wedged.
+        assert!(TURN_CLIP_MAX_SECONDS + TURN_CLIP_SETTLE_SECONDS + TURN_CLIP_REPORT_TIMEOUT < 6.0);
+    }
+
+    /// Two pivots back to back hold the creature still for longer than either
+    /// of them - which is exactly what a wedge looks like.
+    #[test]
+    fn a_second_pivot_waits_for_the_cooldown() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        let physics = PhysicsWorld::new();
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnClipStarted {
+                turn: Deg(-100.0),
+                duration: 2.4,
+            },
+        );
+        monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::AnimationCompleted,
+        );
+        for _ in 0..6 {
+            turn_frame(&mut monster, entity_id, Deg(90.0));
+        }
+        assert!(monster.turn_clip.is_none(), "the first pivot must be over");
+        // Still facing a long way from where it wants to be, but it has to
+        // steer out of the pivot before performing another.
+        assert_eq!(
+            turn_frame(&mut monster, entity_id, Deg(90.0)),
+            (None, false)
         );
     }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -191,18 +191,11 @@ const TURN_CLIP_COMPLETION_SLACK: f32 = 0.25;
 /// than steering the turn, so it is simply not picked.
 const TURN_CLIP_MAX_SECONDS: f32 = 4.0;
 
-/// Two pivots back to back would hold the creature still for longer than
-/// either of them, so a pivot has to walk (or at least steer) it off before
-/// the next one.
+/// How long a pivot is barred for. Two pivots back to back would hold the
+/// creature still for longer than either of them, so a pivot has to walk (or
+/// at least steer) it off before the next one - and a stall arms the same
+/// window, which has to outlast the path follower's own recovery.
 const TURN_CLIP_COOLDOWN: f32 = 3.0;
-
-/// How long a stall bars pivoting. A pivot costs seconds of standing still,
-/// so it is only for a creature that is getting somewhere: one that has just
-/// failed to make progress is scrambling out of a wedge, and standing still
-/// through a turn clip only makes the wedge longer. The bar has to outlast the
-/// path follower's own recovery, whose re-path - and the sidestep heading that
-/// would ask for a pivot - lands after the stall clock has been reset.
-const TURN_CLIP_STALL_BLOCK_SECONDS: f32 = 3.0;
 
 /// Fallback for a clip that authors no blend length. The turn clip's pose
 /// swings back to neutral over the blend as the next clip fades in, so the
@@ -323,9 +316,6 @@ pub struct AnimatedMonsterAI {
     turn_clip: Option<TurnClip>,
     /// Seconds left before this AI may perform another pivot
     turn_cooldown: f32,
-    /// Seconds left of the bar a stall puts on pivoting (see
-    /// `TURN_CLIP_STALL_BLOCK_SECONDS`)
-    turn_stall_block: f32,
 }
 
 impl AnimatedMonsterAI {
@@ -353,7 +343,6 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             turn_cooldown: 0.0,
-            turn_stall_block: 0.0,
         }
     }
 
@@ -382,7 +371,6 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             turn_cooldown: 0.0,
-            turn_stall_block: 0.0,
         }
     }
 
@@ -852,17 +840,20 @@ impl AnimatedMonsterAI {
         Some(waited)
     }
 
-    /// Whether a pivot is affordable this frame, given how long the route has
-    /// been failing to make progress. A stall re-arms the bar every frame it
-    /// is over the mark, so the creature has to be moving again - for the
-    /// whole bar - before it may stand still for a turn clip.
-    fn may_pivot_after_stall(&mut self, stall_seconds: f32, elapsed: f32) -> bool {
-        if stall_seconds >= FRUSTRATION_STALL_SECONDS {
-            self.turn_stall_block = TURN_CLIP_STALL_BLOCK_SECONDS;
-        } else {
-            self.turn_stall_block = (self.turn_stall_block - elapsed).max(0.0);
+    /// A pivot costs seconds of standing still, so it belongs to a creature
+    /// that is getting somewhere: one scrambling out of a wedge only makes the
+    /// wedge longer by standing through a turn clip. A stall therefore arms the
+    /// pivot cooldown, whose window outlasts the path follower's own recovery -
+    /// the re-path that asks for the sidestep, and so reads as a pivot, lands
+    /// after the stall clock has already been reset.
+    ///
+    /// `following_a_route` gates the reading, not just the arming: the follower
+    /// publishes its stall clock only while it steers, and the last value it
+    /// published outlives it.
+    fn bar_pivot_while_stalled(&mut self, stall_seconds: f32, following_a_route: bool) {
+        if following_a_route && stall_seconds >= FRUSTRATION_STALL_SECONDS {
+            self.turn_cooldown = self.turn_cooldown.max(TURN_CLIP_COOLDOWN);
         }
-        self.turn_stall_block <= 0.0
     }
 
     /// Pivot with the creature's own authored turn clip rather than sliding
@@ -971,6 +962,7 @@ impl AnimatedMonsterAI {
         world: &World,
         entity_id: EntityId,
         door_wait_seconds: Option<f32>,
+        stall_seconds: f32,
         started_a_clip: bool,
         time: &Time,
     ) -> Effect {
@@ -983,7 +975,7 @@ impl AnimatedMonsterAI {
         }
         if !should_gesture_frustration(
             door_wait_seconds,
-            path_stall_seconds(world, entity_id),
+            stall_seconds,
             self.frustration_cooldown,
             chase_target_distance(world, entity_id),
             self.current_behavior.borrow().scripted_state(),
@@ -1446,16 +1438,15 @@ impl Script for AnimatedMonsterAI {
         let door_wait_seconds = self.update_door_wait(world, entity_id, time);
         // A pivot big enough to stop the body is played as an authored turn
         // clip. Same gate as the frustration gesture: never over a scripted
-        // performance, and never while standing off from a door - plus one of
-        // its own, since a stalled creature cannot afford to stand still.
-        let may_pivot_after_stall = self.may_pivot_after_stall(
-            path_stall_seconds(world, entity_id),
-            time.elapsed.as_secs_f32(),
-        );
+        // performance, and never while standing off from a door.
         let may_turn = self.current_behavior.borrow().is_locomotion()
             && self.current_behavior.borrow().scripted_state() != ScriptedState::Running
-            && door_wait_seconds.is_none()
-            && may_pivot_after_stall;
+            && door_wait_seconds.is_none();
+        // `is_locomotion` is exactly the set of behaviors that steer with the
+        // path follower, so under `may_turn` the stall clock this reads was
+        // published by the steer above.
+        let stall_seconds = path_stall_seconds(world, entity_id);
+        self.bar_pivot_while_stalled(stall_seconds, may_turn);
         let (turn_clip_effect, heading_held) =
             self.update_turn_clip(entity_id, steering_output.desired_heading, time, may_turn);
         let rotation_effect = self.apply_steering_output(
@@ -1499,8 +1490,14 @@ impl Script for AnimatedMonsterAI {
             || !matches!(handback_effect, Effect::NoEffect)
             || !matches!(turn_clip_effect, Effect::NoEffect)
             || self.turn_clip.is_some();
-        let frustration_effect =
-            self.update_frustration(world, entity_id, door_wait_seconds, started_a_clip, time);
+        let frustration_effect = self.update_frustration(
+            world,
+            entity_id,
+            door_wait_seconds,
+            stall_seconds,
+            started_a_clip,
+            time,
+        );
 
         let sensor_effect = self.try_tickle_sensor(world, physics, entity_id);
 
@@ -2210,27 +2207,58 @@ mod tests {
     /// applier is what turns that into one of the creature's authored clips.
     #[test]
     fn a_stalled_creature_steers_its_turn_instead_of_performing_it() {
-        let mut monster = AnimatedMonsterAI::new();
-        // Getting somewhere: a pivot is affordable.
-        assert!(monster.may_pivot_after_stall(0.0, 0.1));
+        let (_world, entity_id, mut monster) = pivoting_monster(Deg(0.0));
+        let reversal = Deg(180.0);
 
-        // The route stops making progress. Standing still for a turn clip
-        // while wedged only lengthens the wedge.
-        assert!(!monster.may_pivot_after_stall(FRUSTRATION_STALL_SECONDS, 0.1));
-
-        // The stall clock resets the moment the follower recovers, but the
-        // sidestep heading its re-path produces arrives a beat later - the bar
-        // has to still be up then.
+        // Getting somewhere: the reversal is performed.
+        monster.bar_pivot_while_stalled(0.0, true);
         assert!(
-            !monster.may_pivot_after_stall(0.0, 1.0),
-            "a pivot one second past the stall is still the wedge's own"
+            turn_frame(&mut monster, entity_id, reversal).0.is_some(),
+            "a creature making progress performs its pivot"
         );
 
-        // Moving again for the whole bar restores pivoting.
-        for _ in 0..TURN_CLIP_STALL_BLOCK_SECONDS.ceil() as u32 {
-            monster.may_pivot_after_stall(0.0, 1.0);
+        // The route stops making progress. Standing still through a turn clip
+        // while wedged only lengthens the wedge.
+        let (_world, entity_id, mut monster) = pivoting_monster(Deg(0.0));
+        monster.bar_pivot_while_stalled(FRUSTRATION_STALL_SECONDS, true);
+        assert!(
+            turn_frame(&mut monster, entity_id, reversal).0.is_none(),
+            "a stalled creature steers the turn instead"
+        );
+
+        // The stall clock resets the moment the follower recovers, but the
+        // sidestep heading its re-path produces arrives a beat later - and the
+        // recovery it has to outlast is itself most of a second.
+        assert!(
+            TURN_CLIP_COOLDOWN > crate::scripts::ai::steering::STALL_RECOVERY_SECONDS,
+            "the bar must outlast the follower's recovery"
+        );
+        for _ in 0..(TURN_CLIP_COOLDOWN / 0.1).ceil() as u32 - 1 {
+            monster.bar_pivot_while_stalled(0.0, true);
+            assert!(
+                turn_frame(&mut monster, entity_id, reversal).0.is_none(),
+                "still barred before the window is out"
+            );
         }
-        assert!(monster.may_pivot_after_stall(0.0, 1.0));
+        monster.bar_pivot_while_stalled(0.0, true);
+        assert!(
+            turn_frame(&mut monster, entity_id, reversal).0.is_some(),
+            "moving again for the whole window restores pivoting"
+        );
+    }
+
+    #[test]
+    fn a_stall_a_route_follower_did_not_publish_bars_nothing() {
+        // The follower publishes its stall clock only while it steers, so the
+        // last value it published outlives it - a melee or idle AI would
+        // otherwise re-arm the bar off a frozen reading for the rest of its
+        // life.
+        let (_world, entity_id, mut monster) = pivoting_monster(Deg(0.0));
+        monster.bar_pivot_while_stalled(FRUSTRATION_STALL_SECONDS, false);
+        assert!(
+            turn_frame(&mut monster, entity_id, Deg(180.0)).0.is_some(),
+            "a stall nobody is publishing must not bar a pivot"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1320,26 +1320,38 @@ impl Script for AnimatedMonsterAI {
             }
         }
 
-        // Temporary steering behavior
-        let (steering_output, steering_effects) = self
-            .current_behavior
-            .borrow_mut()
-            .steer(self.current_heading, world, physics, entity_id, time)
-            .unwrap_or((
+        // A pivot already in flight is a commitment: the behavior is not
+        // steered at all while it plays. Steering a body that is deliberately
+        // standing still would read as a stall - the path follower would
+        // blacklist the cell it is turning on, and a patrol route would give
+        // up on the point it is turning toward.
+        let pivoting = self.turn_clip.is_some();
+        let (steering_output, steering_effects) = if pivoting {
+            (
                 Steering::from_current(self.current_heading),
                 Effect::NoEffect,
-            ));
+            )
+        } else {
+            self.current_behavior
+                .borrow_mut()
+                .steer(self.current_heading, world, physics, entity_id, time)
+                .unwrap_or((
+                    Steering::from_current(self.current_heading),
+                    Effect::NoEffect,
+                ))
+        };
 
         // Keep looking at a player this creature can actually see, so the
         // sighting survives long enough to escalate (see
         // `should_orient_on_target`). The behavior's own steering effects
         // still apply - only the heading is overridden.
-        let steering_output = if should_orient_on_target(
-            self.config.is_some(),
-            self.alertness.current_level,
-            is_visible,
-            self.current_behavior.borrow().scripted_state(),
-        ) {
+        let steering_output = if !pivoting
+            && should_orient_on_target(
+                self.config.is_some(),
+                self.alertness.current_level,
+                is_visible,
+                self.current_behavior.borrow().scripted_state(),
+            ) {
             orient_toward_player(world, entity_id).unwrap_or(steering_output)
         } else {
             steering_output

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -184,14 +184,14 @@ const TURN_CLIP_SETTLE_SECONDS: f32 = 0.5;
 /// A pivot being played as the creature's own authored turn clip. The clip's
 /// POSE does the visible turning, so the script holds its heading while the
 /// clip runs and only then takes the authored facing change.
-struct TurnClip {
-    /// The clip's authored facing change, once the applier has reported which
-    /// clip it picked; `None` while the request is still in flight.
-    turn: Option<Deg<f32>>,
-    /// Seconds left before an unreported or preempted pivot is abandoned.
-    remaining: f32,
-    /// Seconds left of the blend-out over which `turn` is applied.
-    settle: f32,
+enum TurnClip {
+    /// Asked for; waiting for the applier to say which clip it picked.
+    Requested { remaining: f32 },
+    /// Playing: the pose is doing the turning, so the entity holds still.
+    Playing { turn: Deg<f32>, remaining: f32 },
+    /// Done: the entity takes the clip's authored facing change across the
+    /// blend that swings the pose back to neutral.
+    Settling { turn: Deg<f32>, remaining: f32 },
 }
 
 /// The "thwarted" performance. The motion database files the tag under
@@ -825,49 +825,63 @@ impl AnimatedMonsterAI {
         let elapsed = time.elapsed.as_secs_f32();
         let delta = clamp_to_minimal_delta_angle(desired_heading - self.current_heading);
 
-        let Some(pivot) = &mut self.turn_clip else {
-            // Only once the heading error has already stopped the body: a
-            // pivot the creature can walk through needs no clip, and the
-            // shortest stock turn clip is a quarter-circle anyway.
-            let stopped = locomotion_scale_for_heading_error(delta) <= 0.0;
-            if !(may_start && stopped && self.has_turn_clips) {
-                return (Effect::NoEffect, false);
+        match &mut self.turn_clip {
+            None => {
+                // Only once the heading error has already stopped the body: a
+                // pivot the creature can walk through needs no clip, and the
+                // shortest stock turn clip is a quarter-circle anyway.
+                let stopped = locomotion_scale_for_heading_error(delta) <= 0.0;
+                if !(may_start && stopped && self.has_turn_clips) {
+                    return (Effect::NoEffect, false);
+                }
+                tracing::debug!("ai {:?} pivots {:?}", entity_id, delta);
+                self.turn_clip = Some(TurnClip::Requested {
+                    remaining: TURN_CLIP_REPORT_TIMEOUT,
+                });
+                (Effect::PlayTurnClip { entity_id, delta }, true)
             }
-            self.turn_clip = Some(TurnClip {
-                turn: None,
-                remaining: TURN_CLIP_REPORT_TIMEOUT,
-                settle: 0.0,
-            });
-            return (Effect::PlayTurnClip { entity_id, delta }, true);
-        };
-
-        if pivot.settle > 0.0 {
-            let step = elapsed.min(pivot.settle);
-            let turn = pivot.turn.unwrap_or(Deg(0.0));
-            pivot.settle -= step;
-            // Rounding leaves a sliver of the last frame behind; anything
-            // this short is the end of the blend, not another frame of it.
-            let finished = pivot.settle <= 1e-4;
-            self.current_heading =
-                Deg(self.current_heading.0 + turn.0 * step / TURN_CLIP_SETTLE_SECONDS);
-            if finished {
+            Some(TurnClip::Requested { remaining }) => {
+                *remaining -= elapsed;
+                if *remaining > 0.0 {
+                    return (Effect::NoEffect, true);
+                }
+                // No clip covers this pivot, or the creature's schema has
+                // none at all. Steer it, and stop asking.
+                tracing::debug!("ai {:?} has no clip for its pivot", entity_id);
                 self.turn_clip = None;
-            }
-            return (Effect::NoEffect, true);
-        }
-
-        pivot.remaining -= elapsed;
-        if pivot.remaining <= 0.0 {
-            // Nothing came back: either no clip covers this pivot, or the one
-            // that was playing was preempted. Steer the rest of the way.
-            let unreported = pivot.turn.is_none();
-            self.turn_clip = None;
-            if unreported {
                 self.has_turn_clips = false;
+                (Effect::NoEffect, false)
             }
-            return (Effect::NoEffect, false);
+            Some(TurnClip::Playing { remaining, .. }) => {
+                *remaining -= elapsed;
+                if *remaining > 0.0 {
+                    return (Effect::NoEffect, true);
+                }
+                // The completion never came - something preempted the clip.
+                tracing::debug!("ai {:?} lost its turn clip", entity_id);
+                self.turn_clip = None;
+                (Effect::NoEffect, false)
+            }
+            Some(TurnClip::Settling { turn, remaining }) => {
+                let step = elapsed.min(*remaining);
+                let turn = *turn;
+                *remaining -= step;
+                // Rounding leaves a sliver of the last frame behind; anything
+                // this short is the end of the blend, not another frame of it.
+                let finished = *remaining <= 1e-4;
+                self.current_heading =
+                    Deg(self.current_heading.0 + turn.0 * step / TURN_CLIP_SETTLE_SECONDS);
+                if finished {
+                    tracing::debug!(
+                        "ai {:?} finished its pivot facing {:?}",
+                        entity_id,
+                        self.current_heading
+                    );
+                    self.turn_clip = None;
+                }
+                (Effect::NoEffect, true)
+            }
         }
-        (Effect::NoEffect, true)
     }
 
     /// Jittered rate limit, so a knot of AIs blocked on the same thing does
@@ -1621,25 +1635,28 @@ impl Script for AnimatedMonsterAI {
                 self.force_alertness(*level, world, physics, entity_id)
             }
             MessagePayload::TurnClipStarted { turn, duration } => {
-                if let Some(pivot) = &mut self.turn_clip {
-                    pivot.turn = Some(*turn);
+                if matches!(self.turn_clip, Some(TurnClip::Requested { .. })) {
                     // Hold the heading for as long as the clip actually runs,
                     // plus a margin: the completion is what normally ends the
-                    // pivot, this only bounds a clip that never reports one.
-                    pivot.remaining = duration + TURN_CLIP_REPORT_TIMEOUT;
+                    // pivot, this only bounds a clip that is preempted.
+                    self.turn_clip = Some(TurnClip::Playing {
+                        turn: *turn,
+                        remaining: duration + TURN_CLIP_REPORT_TIMEOUT,
+                    });
                 }
                 Effect::NoEffect
             }
             MessagePayload::AnimationCompleted => {
                 // The turn clip is done: take its authored facing change as
                 // the pose blends back to neutral. The behavior's own clip is
-                // re-queued by the normal completion path below.
-                if let Some(pivot) = &mut self.turn_clip {
-                    if pivot.turn.is_some() {
-                        pivot.settle = TURN_CLIP_SETTLE_SECONDS;
-                    } else {
-                        self.turn_clip = None;
-                    }
+                // re-queued by the normal completion path below - and its own
+                // completion, a fraction of a second later, must not restart
+                // the blend, so only a PLAYING pivot settles here.
+                if let Some(TurnClip::Playing { turn, .. }) = self.turn_clip {
+                    self.turn_clip = Some(TurnClip::Settling {
+                        turn,
+                        remaining: TURN_CLIP_SETTLE_SECONDS,
+                    });
                 }
                 if self.is_dead {
                     // The crumple->ragdoll handoff is timed from update()
@@ -2139,6 +2156,41 @@ mod tests {
         assert!(
             monster.turn_clip.is_none(),
             "the pivot is over once the turn has landed"
+        );
+    }
+
+    /// The behavior's own clip is re-queued the moment the turn clip ends,
+    /// and a run cycle is a third of a second long - so its completion lands
+    /// inside the blend. Restarting the blend on it left the AI turning on
+    /// the spot forever, never taking another step.
+    #[test]
+    fn a_later_clip_completing_does_not_restart_the_blend() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        let physics = PhysicsWorld::new();
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnClipStarted {
+                turn: Deg(-168.0),
+                duration: 4.8,
+            },
+        );
+        for _ in 0..2 {
+            monster.handle_message(
+                entity_id,
+                &world,
+                &physics,
+                &MessagePayload::AnimationCompleted,
+            );
+            for _ in 0..3 {
+                turn_frame(&mut monster, entity_id, Deg(90.0));
+            }
+        }
+        assert!(
+            monster.turn_clip.is_none(),
+            "the pivot must end, not restart with every clip that completes"
         );
     }
 

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -58,7 +58,7 @@ pub(crate) const STALL_SECONDS: f32 = 3.0;
 /// pressed against a door frame - or two AIs pressed against each other -
 /// repeated the wedge forever (issue #481). Jittered per stall so mutually
 /// blocking AIs unstick on different frames.
-const STALL_RECOVERY_SECONDS: f32 = 0.8;
+pub(crate) const STALL_RECOVERY_SECONDS: f32 = 0.8;
 /// Progress smaller than this doesn't count toward un-stalling (jitter)
 const STALL_PROGRESS_EPSILON: f32 = 0.25 / SCALE_FACTOR;
 /// Displacement watchdog: with an active waypoint, failing to move this far

--- a/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
+++ b/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
@@ -281,4 +281,26 @@ mod tests {
         assert!(boxed_in.magnitude() <= WHISKER_MAX_OFFSET + 1e-5);
         assert!(boxed_in.magnitude() > 0.0);
     }
+
+    /// A bias needs BOTH rays blocked, so the two must straddle a real
+    /// obstacle: roughly a hybrid's knee and its chest, which is where the
+    /// fixed offsets these fractions replaced put them. Measuring the creature
+    /// at a third of its height once bunched both of them at chest level.
+    #[test]
+    fn the_probes_straddle_knee_and_chest() {
+        let mut world = World::new();
+        // 0 is the human schema a hybrid animates on.
+        let creature = world.add_entity((dark::properties::PropCreature(0),));
+        let hybrid = ai_util::creature_height(&world, creature);
+        let knee = hybrid * WHISKER_KNEE_FRACTION;
+        let chest = hybrid * WHISKER_CHEST_FRACTION;
+        assert!(
+            (0.8..1.1).contains(&knee),
+            "knee ray {knee} is not about 3 feet below the body origin"
+        );
+        assert!(
+            (0.3..0.5).contains(&chest),
+            "chest ray {chest} is not about 1 foot below the body origin"
+        );
+    }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -646,6 +646,8 @@ pub enum Effect {
     PlayTurnClip {
         entity_id: EntityId,
         delta: cgmath::Deg<f32>,
+        /// The longest turn the creature can afford to stand still for.
+        max_seconds: f32,
     },
 
     ReplaceEntity {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -638,6 +638,16 @@ pub enum Effect {
         motion_queries: Vec<Vec<MotionQueryItem>>,
     },
 
+    /// Pivot in place with the creature's own authored turn clip: the applier
+    /// picks the stand-schema clip whose authored facing change is nearest
+    /// `delta` and plays it, reporting back with `TurnClipStarted`. No clip
+    /// covers a small pivot, and a creature without turn clips gets none - in
+    /// both cases nothing plays and no report comes back.
+    PlayTurnClip {
+        entity_id: EntityId,
+        delta: cgmath::Deg<f32>,
+    },
+
     ReplaceEntity {
         entity_id: EntityId,
         template_id: i32,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -253,6 +253,15 @@ pub enum MessagePayload {
     },
     AnimationCompleted,
 
+    /// A turn clip requested by `Effect::PlayTurnClip` started playing, with
+    /// the facing change it is authored to end on and how long it runs. The
+    /// clip is chosen from the creature's own schema, so only the applier
+    /// knows these until it has resolved one.
+    TurnClipStarted {
+        turn: cgmath::Deg<f32>,
+        duration: f32,
+    },
+
     // Gameplay events
     Recharge,
     ProvideForConsumption {

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -260,6 +260,9 @@ pub enum MessagePayload {
     TurnClipStarted {
         turn: cgmath::Deg<f32>,
         duration: f32,
+        /// The clip's authored blend length: the window its pose takes to
+        /// swing back to neutral once it ends.
+        blend: f32,
     },
 
     // Gameplay events

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -216,6 +216,26 @@ impl MotionAnalyzer {
                     .fold((f32::MAX, f32::MIN), |(a, b), y| (a.min(*y), b.max(*y)));
                 println!("                min {:.3}  max {:.3}", min, max);
             }
+            // SCRATCH: net pose yaw per joint (frame0 -> last)
+            {
+                let mut rows: Vec<(usize, f32)> = Vec::new();
+                for (j, frames) in clip.animation.iter().enumerate() {
+                    if frames.len() < 2 {
+                        continue;
+                    }
+                    let a = frames[0];
+                    let b = frames[frames.len() - 1];
+                    let d = b.x.z.atan2(b.x.x).to_degrees() - a.x.z.atan2(a.x.x).to_degrees();
+                    let d = ((d + 180.0).rem_euclid(360.0)) - 180.0;
+                    if d.abs() > 5.0 {
+                        rows.push((j, d));
+                    }
+                }
+                rows.sort_by(|a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap());
+                for (j, d) in rows.iter().take(5) {
+                    println!("  joint {:>3} net yaw: {:.1}", j, d);
+                }
+            }
             // Horizontal root motion: net displacement, and how long the
             // root is still (per-frame delta < 1cm) at the clip's tail
             let ps = &clip.root_positions;

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -216,7 +216,9 @@ impl MotionAnalyzer {
                     .fold((f32::MAX, f32::MIN), |(a, b), y| (a.min(*y), b.max(*y)));
                 println!("                min {:.3}  max {:.3}", min, max);
             }
-            // SCRATCH: net pose yaw per joint (frame0 -> last)
+            // Net pose yaw per joint, first frame to last. A turn clip does
+            // its pivot in the pose - the hip joint carries the whole turn,
+            // and its net yaw is the clip's `end_dir` read as a signed angle.
             {
                 let mut rows: Vec<(usize, f32)> = Vec::new();
                 for (j, frames) in clip.animation.iter().enumerate() {


### PR DESCRIPTION
A pivot past a right angle already stops the body (#1313). It now performs the creature's own authored turn clip instead of sliding the heading around underneath a run cycle.

The clips were there all along, filed beside the idle stand clip — human `humstand`/`humtul`/`humtur`/`humtu180`, hybrid `ogptu90l`/`ogptu90r`/`ogstu180` — and the only thing that tells a turn apart from an idle is the facing change it is authored to end on. So a pivot picks the clip whose authored angle is nearest the heading it needs and that it can afford to stand still for; plain standing picks from the clips that don't turn at all.

**The pose does the turning.** Measured across the stock clips, the hip joint's net yaw over a turn clip *equals* that clip's signed `end_direction`: `humtur` +102.58° authored, +102.3° in the pose; `ogptu90l` +91.83° / +91.8°. The body is turned by the animation, so the entity must hold still underneath it — rotating as well would turn the creature twice — and take the authored facing change afterwards, spread over the blend that swings the pose back to neutral. That is what keeps the visible facing continuous across the handoff.

The AI script stays pure: it emits `Effect::PlayTurnClip { delta, max_seconds }`, the effect applier resolves the creature's schema and reports back with `MessagePayload::TurnClipStarted { turn, duration, blend }`, and the pivot runs as a small `Requested → Playing → Settling` state machine. While it runs, the behavior is **not steered at all** — a body that is deliberately standing still would otherwise read as no progress, and the path follower would blacklist the cell it is turning on while the patrol route gave up on the point it is turning toward.

Two numbers, both load-bearing:

- `TURN_CLIP_MAX_SECONDS = 4.0` — the stock turn clips run 2.4–5.6 s. A pivot long enough to read as a wedge (the reachability harness calls holding one spot for 6 s stuck, and it is right to) is worse than steering the turn, so clips longer than this are simply not picked. `humtu180` (4.8 s) and `ogptu90l` (5.6 s) don't qualify; the rest do.
- `TURN_CLIP_COOLDOWN = 3.0` — two pivots back to back hold the creature still for longer than either of them, which is exactly what a wedge looks like.

Ledger step 11 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`), and it closes out the "turn clips deferred" note on #1313: the `+facing` branch really is empty, but the turn clips are reachable under `+stand` with the creature's own actor tags.

**Bonus bug, same PR:** because the turn clips sit in the `+stand` schema, plain idle selection was picking them at random — idlers swung their bodies through a 100° turn with no heading change behind it. A `stand` query now excludes anything that turns.

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/71aea846a56520d957a16da6c499c04d/raw/turn-clip-beforeafter.png)

![turn clip demo](https://gist.githubusercontent.com/tommy-xr/71aea846a56520d957a16da6c499c04d/raw/turn-clip-after.gif)

<sub>After: a chasing hybrid reverses in place through `ogstu180` — its yaw is held at 207.3° for the whole clip (frames 1→53) and then takes the authored −180° across the blend. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep), free camera locked to the creature.</sub>

![before](https://gist.githubusercontent.com/tommy-xr/71aea846a56520d957a16da6c499c04d/raw/turn-clip-before.gif)

<sub>Before, on `feat/ai-door-wait`: the same scenario (medsci2, `DebugForceChase`, same capture script) — the reversal is 95° of yaw in 0.7 s with the run cycle still playing. Clip selection is random per query, so the two runs are the same request sequence rather than the same creature at the same spot.</sub>

## Tests

- Unit, `dark`: `an_about_face_covers_a_pivot_across_the_half_turn`, `a_turn_the_creature_cannot_afford_is_not_picked`, `a_pivot_takes_the_clip_nearest_its_heading_change`, `a_small_pivot_has_no_clip_worth_playing`, `only_the_pivots_count_as_turn_clips` (the idle-selection bug), `signed_end_direction`.
- Unit, `shock2vr`: `a_reversal_asks_for_an_authored_turn_clip`, `a_shallow_pivot_is_steered_as_before`, `the_body_holds_its_heading_and_stride_while_the_clip_plays`, `the_authored_turn_lands_on_the_entity_once_the_clip_ends`, `a_later_clip_completing_does_not_restart_the_blend`, `a_completion_that_arrives_early_is_not_the_turn_clip`, `a_second_pivot_waits_for_the_cooldown`, `a_pivot_cannot_hold_long_enough_to_look_stuck`, `an_unanswered_pivot_falls_back_to_steering`, `a_stalled_creature_steers_its_turn_instead_of_performing_it`, `a_creature_is_measured_in_the_same_units_as_the_fallback`.
- `cargo test -p shock2vr`: 1421 passed.
- e2e on the fix: `medsci2-doorjamb-chase` 5/5 (five separate runs), `patrol` 4/4, `force-chase` 1/1, `medsci2-patrol-railing` 2/2, `missions` 23/23.
- e2e re-run after the review restructure, reduced to the pivot-heavy scenarios: `medsci2-doorjamb-chase` 3/3, `medsci2-patrol-railing` 1/1.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
- Pathfinding is untouched (no file under `shock2vr/src/pathfinding/` or `dark/src/mission/` is in the diff), so `cargo bn path bench` is unaffected by construction.

## Two regressions found and fixed while building this

Both were caught by the e2e set, not by unit tests, and both have a test now:

1. **The pivot never ended.** The behavior's own clip is re-queued the moment a turn clip completes, and a run cycle is a third of a second long — so its completion landed inside the settle and restarted it. Patrollers turned on the spot forever and never took another step (`patrol` e2e: `traveled 0.0`). Fixed by the explicit state machine: only a `Playing` pivot settles.
2. **A long pivot looked like a wedge.** `ogptu90l` runs 5.6 s; held one spot for 6–11 s, the railing e2e failed. Fixed by the affordability budget plus the cooldown above.

## The pile-up e2e failure, and two more fixes

`medsci2-doorjamb-chase`'s pile-up test was failing, and a per-frame trace found two causes - neither of them the pivot state machine. It was already failing on this stack's **parent**, so it is not purely a turn-clip regression.

- **A pivot performed while scrambling out of a wedge.** The path follower's stall recovery re-paths into a sidestep, that reads as a >90 degree pivot, and the creature stands through a 2.7 s turn clip plus its blend before taking it - turning a recovery into a longer wedge. A stall now bars pivoting, for long enough to cover the recovery's re-path (which lands after the stall clock has already been reset).
- **`creature_height` divided by `SCALE_FACTOR` twice** (pre-existing, and the dominant cause). The authored bounding box is already in world units - as its doc comment, the no-definition fallback and the physics capsule all say - so a hybrid measured 2.6 feet instead of 6.5. `door_is_passable` then called a leaf risen 2.7 feet clear, and the AI walked under a still-rising door that carried it off the floor and dropped it. The same bug had collapsed the whisker knee and chest probes to nearly one height.

Six runs per variant through a harness mirroring the test's exact request sequence:

| build | pile-up test |
| --- | --- |
| parent `ab8a51de` (pre-turn-clip) | 5/6 fail |
| `feat/ai-turn-clips` before these fixes | 4/6 fail |
| + pivot barred after a stall | 2/6 fail |
| + creature height in world units | 0/6 fail |

0/6 again after the review restructure.

## Review

`/xreview` — Claude adversarial reviewer plus the dedicated de-dup reviewer. **The Codex engine is unavailable until Sep 6, so this ran single-engine**; nothing here carries cross-engine agreement.

Fixed:

- **High** — `nearest_turn_clip` compared an *unwrapped* residual, so an about-face authored just past 180° (midwife `humuntu180` = 182.97° → −177.03°) was rejected for a pivot just short of it (+175°) as if it were 352° away. Wrapped, with a test.
- **High** — any completion settled the pivot, including one belonging to a clip that had *preempted* the turn (a wound reaction, an alertness change). The AI would then swing through the full authored turn with a neutral pose. Only a completion arriving at the end of the turn clip's own runtime settles now; anything earlier abandons the pivot.
- **Medium** — the frustration gesture could fire mid-pivot (it was suppressed only on the frame the pivot was requested), preempting the clip and reporting frustration at a standstill the AI chose.
- **Medium** — a single unanswered request latched the creature out of pivoting for the rest of its life. Removed; the cooldown spaces out the asking instead, and a pivot with no affordable clip is no longer reported as a failed animation.
- **Medium-Low** — the settle window was hardcoded at 500 ms, but the monkey turns author a 100 ms blend. It is now the clip's own `blend_length`.
- **Low** — the wedge-budget assertion didn't model the overrun margin.

Noted, not changed:

- **`mission_core`'s `DirectionChanged` applier is wrong** — it applies `end_rotation * -0.5`, i.e. half the *unsigned* on-disk heading, negated. It has no effect on any AI creature (the script re-asserts `SetRotation` every frame, after `update_animations`), which is presumably why it survived; this PR relies on that. Auditing what it does to non-AI entities, and making it apply the signed authored angle, is a follow-up.
- De-dup reviewer suggested merging `signed_end_direction` with `ai_util::clamp_to_minimal_delta_angle`. Declined: they live in different crates (`dark` cannot call `shock2vr`), and they disagree at exactly ±180°, so the merge is a behavior change to twenty-odd existing call sites for no gain here.
- Two turn clips per human schema now go unused (`humtu180`, `ogptu90l`) because they exceed the standstill budget. Playing a clip's turn portion only, or time-scaling it, is the obvious follow-up if reversals should always be performed.


