### PR TITLE
feat(weapons): guns wear down with each shot

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -18,6 +18,7 @@ mod prop_ecology;
 mod prop_frame_anim_config;
 mod prop_frame_anim_state;
 mod prop_frob_info;
+mod prop_gun_reliability;
 mod prop_gun_state;
 mod prop_hack_diff;
 mod prop_hit_points;
@@ -62,6 +63,7 @@ pub use prop_ecology::*;
 pub use prop_frame_anim_config::*;
 pub use prop_frame_anim_state::*;
 pub use prop_frob_info::*;
+pub use prop_gun_reliability::*;
 pub use prop_gun_state::*;
 pub use prop_hack_diff::*;
 pub use prop_hit_points::*;
@@ -1544,6 +1546,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$GunState",
             PropGunState::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$GunReliab",
+            PropGunReliability::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_gun_reliability.rs
+++ b/dark/src/properties/prop_gun_reliability.rs
@@ -1,0 +1,92 @@
+use std::io::{self, SeekFrom};
+
+use shipyard::Component;
+
+use crate::ss2_common::read_single;
+
+use serde::{Deserialize, Serialize};
+
+/// `P$GunReliab` - how a gun wears and how likely it is to break, in on-disk
+/// field order. Authored on the gun templates (the pistol reads
+/// 0.5 / 5.0 / 1.0 / 10.0); guns without the property never wear.
+///
+/// Records come in two lengths: gamesys templates author 20 bytes (a trailing
+/// float that is 0.0 on every shipped gun), mission overrides 16.
+/// [`PropGunReliability::read`] takes each field only if `len` covers it, then
+/// snaps to the end of the chunk, so both parse.
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropGunReliability {
+    /// Break chance, in percent, at `thresh_break` condition.
+    pub min_break: f32,
+    /// Break chance, in percent, at zero condition.
+    pub max_break: f32,
+    /// Condition points lost per shot fired.
+    pub degrade_rate: f32,
+    /// Condition above which the gun cannot break.
+    pub thresh_break: f32,
+}
+
+impl PropGunReliability {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropGunReliability {
+        let start = reader.stream_position().unwrap();
+        let min_break = if len >= 4 { read_single(reader) } else { 0.0 };
+        let max_break = if len >= 8 { read_single(reader) } else { 0.0 };
+        let degrade_rate = if len >= 12 { read_single(reader) } else { 0.0 };
+        let thresh_break = if len >= 16 { read_single(reader) } else { 0.0 };
+        reader.seek(SeekFrom::Start(start + len as u64)).unwrap();
+        PropGunReliability {
+            min_break,
+            max_break,
+            degrade_rate,
+            thresh_break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn read(hex: &str) -> PropGunReliability {
+        let bytes: Vec<u8> = (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect();
+        let mut cursor = Cursor::new(bytes.clone());
+        let prop = PropGunReliability::read(&mut cursor, bytes.len() as u32);
+        // The reader must land exactly on the end of the record.
+        assert_eq!(cursor.position(), bytes.len() as u64);
+        prop
+    }
+
+    /// The shipped 20-byte gamesys record for the pistol.
+    #[test]
+    fn parses_the_twenty_byte_gamesys_record() {
+        let prop = read("0000003f0000a0400000803f0000204100000000");
+        assert_eq!(prop.min_break, 0.5);
+        assert_eq!(prop.max_break, 5.0);
+        assert_eq!(prop.degrade_rate, 1.0);
+        assert_eq!(prop.thresh_break, 10.0);
+    }
+
+    /// A 16-byte mission override (no trailing float).
+    #[test]
+    fn parses_the_sixteen_byte_mission_record() {
+        let prop = read("0000003f0000a0400000803f00002041");
+        assert_eq!(prop.min_break, 0.5);
+        assert_eq!(prop.max_break, 5.0);
+        assert_eq!(prop.degrade_rate, 1.0);
+        assert_eq!(prop.thresh_break, 10.0);
+    }
+
+    /// The exotic Crystal Shard: always-breaking, heavy wear.
+    #[test]
+    fn parses_the_crystal_shard_record() {
+        let prop = read("0000be420000be42000020410000c84200000000");
+        assert_eq!(prop.min_break, 95.0);
+        assert_eq!(prop.max_break, 95.0);
+        assert_eq!(prop.degrade_rate, 10.0);
+        assert_eq!(prop.thresh_break, 100.0);
+    }
+}

--- a/dark/src/properties/prop_gun_state.rs
+++ b/dark/src/properties/prop_gun_state.rs
@@ -35,7 +35,9 @@ impl PropGunState {
     pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropGunState {
         let start = reader.stream_position().unwrap();
         let ammo = read_i32(reader);
-        let condition = if len >= 8 { read_single(reader) } else { 1.0 };
+        // Condition is a 0..100 percentage; a record too short to carry one
+        // describes an unworn gun.
+        let condition = if len >= 8 { read_single(reader) } else { 100.0 };
         let setting = if len >= 12 { read_i32(reader) } else { 0 };
         let modification = if len >= 16 { read_i32(reader) } else { 0 };
         let silence_value = if len >= 20 { read_single(reader) } else { 0.0 };

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -868,6 +868,9 @@ pub struct PlayerInfo {
     /// Milliseconds left of the wielded gun's between-shots wait (0 = ready to
     /// fire, `null` = nothing wielded). Pulls during the wait are ignored.
     pub wielded_gun_cooldown_ms: Option<i32>,
+    /// The wielded gun's condition, 0..100 (100 = pristine), or `null` when
+    /// nothing with a gun state is wielded. Falls with every shot fired.
+    pub wielded_gun_condition: Option<f32>,
     /// The player's current / maximum hit points, or `null` when the player
     /// has no health pool. See `shock2vr::PlayerStateSnapshot`.
     pub hit_points: Option<i32>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2389,6 +2389,7 @@ fn capture_frame_snapshot(
                     .as_ref()
                     .and_then(|s| s.wielded_gun_setting_header.clone()),
                 wielded_gun_cooldown_ms: state.as_ref().and_then(|s| s.wielded_gun_cooldown_ms),
+                wielded_gun_condition: state.as_ref().and_then(|s| s.wielded_gun_condition),
                 hit_points: state
                     .as_ref()
                     .and_then(|s| s.hit_points.map(|(cur, _)| cur)),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -689,6 +689,10 @@ pub struct PlayerStateSnapshot {
     /// setting imposes - 0 when it is ready to fire, `None` when nothing is
     /// wielded. A trigger pull while this is above zero does nothing.
     pub wielded_gun_cooldown_ms: Option<i32>,
+    /// The wielded gun's condition as a 0..100 percentage (100 = pristine),
+    /// or `None` when nothing with a gun state is wielded. Falls as the gun is
+    /// fired, by the per-shot amount its reliability authors.
+    pub wielded_gun_condition: Option<f32>,
     /// The player's hit points (current, max), or `None` when the player has
     /// no health pool. Seeded from `The Player` template and consumed by every
     /// damage path, with zero entering the player death lifecycle.
@@ -815,6 +819,15 @@ impl Game {
                             .map(|c| (c.remaining * 1000.0).ceil() as i32)
                     })
                     .unwrap_or(0)
+            }),
+            wielded_gun_condition: wielded.and_then(|weapon| {
+                world
+                    .borrow::<shipyard::View<dark::properties::PropGunState>>()
+                    .ok()
+                    .and_then(|v| {
+                        use shipyard::Get;
+                        v.get(weapon).ok().map(|state| state.condition)
+                    })
             }),
             hit_points: (|| {
                 use dark::properties::{PropHitPoints, PropMaxHitPoints};

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5828,6 +5828,17 @@ impl MissionCore {
                     }
                 }
 
+                Effect::DegradeWeaponCondition { entity_id, amount } => {
+                    let mut v_gun_state = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropGunState>>()
+                        .unwrap();
+
+                    if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
+                        crate::scripts::effect::degrade_condition(gun_state, amount);
+                    }
+                }
+
                 Effect::BeginShotCooldown { entity_id, seconds } => {
                     self.world
                         .add_component(entity_id, RuntimePropShotCooldown { remaining: seconds });
@@ -11196,11 +11207,15 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     });
                 }
 
-                // Add weapon ammo (current clip) when present
+                // Add weapon ammo (current clip) and wear when present
                 if let Ok(gun_state) = v_gun_state.get(id) {
                     properties.push(DebugPropertyInfo {
                         name: "Ammo".to_string(),
                         value: gun_state.ammo.to_string(),
+                    });
+                    properties.push(DebugPropertyInfo {
+                        name: "Condition".to_string(),
+                        value: format!("{:.2}", gun_state.condition),
                     });
                 }
 

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -523,7 +523,7 @@ mod tests {
                 },
                 PropGunState {
                     ammo,
-                    condition: 1.0,
+                    condition: 100.0,
                     setting: 0,
                     modification: 0,
                     silence_value: 0.0,

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -214,6 +214,39 @@ mod tests {
         assert_eq!(selected.get(new_entity).unwrap().0, 2);
     }
 
+    /// A gun worn down by firing must load back worn: condition rides the
+    /// generic property save, so this covers the whole `P$GunState` chunk.
+    #[test]
+    fn a_degraded_weapon_condition_survives_a_save_and_load() {
+        let mut source_world = World::new();
+        let gun = source_world.add_entity((dark::properties::PropGunState {
+            ammo: 7,
+            condition: 93.0,
+            setting: 1,
+            modification: 0,
+            silence_value: 0.0,
+        },));
+
+        // The same generic property serialization `to_save_data` performs.
+        let (all_properties, _, _) = dark::properties::get::<File>();
+        let mut save = EntitySaveData::empty();
+        save.all_entities.push(gun.inner());
+        for prop in all_properties {
+            save.properties
+                .insert(prop.name(), prop.serialize(&source_world));
+        }
+
+        let mut loaded_world = World::new();
+        let (_, old_to_new) = save.instantiate(&mut loaded_world);
+
+        let states = loaded_world
+            .borrow::<View<dark::properties::PropGunState>>()
+            .unwrap();
+        let loaded = states.get(old_to_new[&gun]).unwrap();
+        assert_eq!(loaded.condition, 93.0);
+        assert_eq!(loaded.ammo, 7);
+    }
+
     #[test]
     fn selected_ammo_defaults_empty_for_older_saves() {
         let data: EntitySaveData = serde_json::from_value(serde_json::json!({

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -212,6 +212,14 @@ pub enum Effect {
         delta: i32,
     },
 
+    /// Wear a gun down by `amount` condition points (`PropGunState.condition`,
+    /// a 0..100 percentage), floored at 0. No-op for entities without a gun
+    /// state.
+    DegradeWeaponCondition {
+        entity_id: EntityId,
+        amount: f32,
+    },
+
     /// Start the wait a gun's fire setting imposes between shots
     /// (`RuntimePropShotCooldown`), in seconds. Pulls during it do nothing.
     BeginShotCooldown {
@@ -940,16 +948,23 @@ pub(crate) fn recharge_ammo_to_capacity(gun_state: &mut PropGunState, capacity: 
     gun_state.ammo = gun_state.ammo.max(capacity.max(0));
 }
 
+/// Wear a gun down by `amount` condition points. Condition is a 0..100
+/// percentage and never goes below 0 - a worn-out gun stays worn out rather
+/// than accumulating negative condition over the shots it keeps firing.
+pub(crate) fn degrade_condition(gun_state: &mut PropGunState, amount: f32) {
+    gun_state.condition = (gun_state.condition - amount).max(0.0);
+}
+
 #[cfg(test)]
 mod tests {
     use dark::properties::PropGunState;
 
-    use super::recharge_ammo_to_capacity;
+    use super::{degrade_condition, recharge_ammo_to_capacity};
 
     fn gun_state(ammo: i32) -> PropGunState {
         PropGunState {
             ammo,
-            condition: 0.75,
+            condition: 75.0,
             setting: 1,
             modification: 2,
             silence_value: 0.25,
@@ -964,10 +979,34 @@ mod tests {
         recharge_ammo_to_capacity(&mut state, 100);
 
         assert_eq!(state.ammo, 100);
-        assert_eq!(state.condition, 0.75);
+        assert_eq!(state.condition, 75.0);
         assert_eq!(state.setting, 1);
         assert_eq!(state.modification, 2);
         assert_eq!(state.silence_value, 0.25);
+    }
+
+    #[test]
+    fn each_shot_costs_the_authored_condition_points() {
+        let mut state = gun_state(12);
+        state.condition = 100.0;
+
+        degrade_condition(&mut state, 1.0);
+        degrade_condition(&mut state, 1.0);
+        degrade_condition(&mut state, 1.0);
+
+        assert_eq!(state.condition, 97.0);
+        assert_eq!(state.ammo, 12);
+    }
+
+    #[test]
+    fn a_worn_out_gun_never_goes_below_zero_condition() {
+        let mut state = gun_state(12);
+        state.condition = 0.5;
+
+        degrade_condition(&mut state, 1.0);
+        degrade_condition(&mut state, 1.0);
+
+        assert_eq!(state.condition, 0.0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/energy_weapon.rs
+++ b/shock2vr/src/scripts/energy_weapon.rs
@@ -77,7 +77,7 @@ mod tests {
     fn gun_state(ammo: i32) -> PropGunState {
         PropGunState {
             ammo,
-            condition: 0.75,
+            condition: 75.0,
             setting: 1,
             modification: 2,
             silence_value: 0.25,
@@ -112,7 +112,7 @@ mod tests {
         let states = world.borrow::<View<PropGunState>>().unwrap();
         let state = states.get(weapon).unwrap();
         assert_eq!(state.ammo, 37, "the effect pipeline owns ammo mutation");
-        assert_eq!(state.condition, 0.75);
+        assert_eq!(state.condition, 75.0);
         assert_eq!(state.setting, 1);
         assert_eq!(state.modification, 2);
         assert_eq!(state.silence_value, 0.25);

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -143,6 +143,17 @@ fn loaded_ammo(world: &World, entity_id: EntityId) -> Option<i32> {
         .and_then(|v| v.get(entity_id).ok().map(|g| g.ammo))
 }
 
+/// The condition points this weapon loses per shot, or `None` for one that
+/// authors no reliability (melee weapons, the debug weapons) and so never
+/// wears.
+fn degrade_per_shot(world: &World, entity_id: EntityId) -> Option<f32> {
+    let rate = world
+        .borrow::<View<dark::properties::PropGunReliability>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|r| r.degrade_rate))?;
+    (rate > 0.0).then_some(rate)
+}
+
 /// What one shot came to.
 enum ShotOutcome {
     /// The gun fired: these effects are the shot.
@@ -410,6 +421,14 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
             entity_id,
             delta: -rounds,
         });
+    }
+    // Firing wears the gun: each real gunshot costs the authored per-shot
+    // condition points. Guns with no reliability authored (and debug weapons)
+    // never wear, and neither does a projectile-less pull.
+    if is_gunshot {
+        if let Some(amount) = degrade_per_shot(world, entity_id) {
+            effects.push(Effect::DegradeWeaponCondition { entity_id, amount });
+        }
     }
     // Start the setting's between-shots wait. Only a real shot
     // starts one - a melee weapon that reached here has nothing to

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -126,7 +126,7 @@ mod tests {
         let mut gun = |world: &mut World| {
             world.add_entity((PropGunState {
                 ammo: 12,
-                condition: 1.0,
+                condition: 100.0,
                 setting: 0,
                 modification: 0,
                 silence_value: 0.0,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -536,6 +536,10 @@ export interface PlayerSnapshot {
   /** Milliseconds left of the wielded gun's between-shots wait (0 = ready to
    * fire, null = nothing wielded). A pull during the wait is ignored. */
   wielded_gun_cooldown_ms: number | null;
+  /** The wielded gun's condition, 0..100 (100 = pristine), or null when
+   * nothing with a gun state is wielded. Every shot wears it down by the
+   * amount the gun's reliability authors. */
+  wielded_gun_condition: number | null;
   /** The player's current / maximum hit points, or null when the player has
    * no health pool. Drained by psi burnout. */
   hit_points: number | null;

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { cycleToWeapon, fireOnce } from "./helpers/weapon.js";
+
+// Firing wears a gun down: each shot costs the condition points the gun's
+// reliability authors (the pistol loses 1 of its 100 per shot), in flatscreen
+// and in VR alike - both presentations pull the same trigger into the same
+// shared fire path.
+//
+// Negative-first: on the parent the runtime does not parse gun reliability at
+// all, nothing decrements condition, and `/v1/info` has no
+// `wielded_gun_condition` field - so every assertion below fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The pistol: condition 100, 1 point lost per shot. */
+const PISTOL = -17;
+const PISTOL_DEGRADE_PER_SHOT = 1.0;
+
+async function condition(game: GameServer): Promise<number> {
+  const value = (await game.info()).player.wielded_gun_condition;
+  assert.equal(
+    typeof value,
+    "number",
+    "a wielded gun must report its condition",
+  );
+  return value as number;
+}
+
+test(
+  "each flatscreen shot wears the gun down by its authored degrade rate",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    // The pistol is the first weapon DebugCycleWeapon hands out, and flat mode
+    // wields what it spawns.
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+
+    assert.equal(await condition(game), 100, "a shipped gun starts pristine");
+
+    const shots = 3;
+    for (let i = 0; i < shots; i += 1) await fireOnce(game);
+
+    assert.equal(
+      await condition(game),
+      100 - shots * PISTOL_DEGRADE_PER_SHOT,
+      "every shot costs the gun its authored condition points",
+    );
+  },
+);
+
+test(
+  "a VR trigger pull wears the gun down the same way",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // In VR nothing is wielded until a hand grabs it.
+    const weapon = await cycleToWeapon(game, (e) => e.template_id === PISTOL);
+    await aimVrHandAt(game, weapon.position as Vec3, 0.3);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      weapon.id,
+      "the VR right hand must hold the pistol",
+    );
+
+    assert.equal(await condition(game), 100, "a shipped gun starts pristine");
+
+    const shots = 2;
+    for (let i = 0; i < shots; i += 1) await fireOnce(game);
+
+    assert.equal(
+      await condition(game),
+      100 - shots * PISTOL_DEGRADE_PER_SHOT,
+      "the VR trigger reaches the same shared fire path",
+    );
+  },
+);


### PR DESCRIPTION
## What

- Parse `P$GunReliab` into `PropGunReliability` (min break chance, max break chance, degrade rate, break threshold). Gamesys templates author 20-byte records (a trailing float that is 0.0 on every shipped gun); mission overrides author 16. Both parse.
- Every gunshot subtracts the gun's degrade rate from `PropGunState.condition`, floored at 0. Guns with no reliability authored never wear.
- The wear is emitted from the shared fire path as `Effect::DegradeWeaponCondition` and applied centrally beside the ammo decrement, so the flat trigger and the VR trigger cost identically.
- `condition` is now exposed as `wielded_gun_condition` on `/v1/info` and as a `Condition` property on `/v1/entities/:id`; the SDK types follow.
- Fixtures/defaults that seeded condition on an 0..1 scale are corrected - it is a 0..100 percentage (shipped guns author 100.0).

## Retail rule

A gun's condition is a 0..100 percentage that falls by a per-gun amount with each round fired; the pistol loses 1 point per shot, the Crystal Shard 10. The same data carries the break chances and the threshold below which a gun can break - parsed here, unused until the breakage slice.

## Verified

- Parser unit tests on real byte strings from the shipped data (20-byte pistol and Crystal Shard records, a 16-byte mission override); the reader lands exactly on each record's end.
- Unit tests for the clamped per-shot subtraction, and a save/load round trip of a degraded condition through the production property registry.
- `tools/shock2-sdk/test/weapon-condition.e2e.test.ts`: debug_weapons, flat and `--vr`, fires N rounds and asserts condition == 100 - N x rate. Negative-first - both cases fail on the parent (100 vs the expected 97 / 98).
- All 23 missions load (`missions.e2e.test.ts`); 1346 shock2vr + 142 dark unit tests pass; warning-free under CI's `-D warnings`.

## Gaps (later slices)

Breakage rolls and the Broken state, the condition readout in the UI, the maintenance tool, repair and modify. `min_break` / `max_break` / `thresh_break` are parsed but not yet read.