### PR TITLE
feat(weapons): a worn gun can break, and a broken gun will not fire

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -220,6 +220,13 @@ pub struct PropDestLoc(pub i32);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropExp(pub i32);
 
+/// Which weapon skill a gun is used with (`P$ShockWeap`): 0 conventional,
+/// 1 energy, 2 heavy, 3 annelid, 4 psi amp. Authored on the weapon-class
+/// archetypes (Conventional, Energy, ...) and inherited by every gun under
+/// them; a gun without it counts as conventional.
+#[derive(Debug, Component, Clone, Copy, Serialize, Deserialize)]
+pub struct PropWeaponType(pub i32);
+
 /// The count of a stackable object (e.g. how many cyber modules an EXP-cookie
 /// pile is worth - the retail engine stores an EXP cookie's module value as its
 /// stack count, `P$StackCoun`). A 4-byte signed int.
@@ -1466,6 +1473,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$ExP",
             |reader, _len| read_i32(reader),
             PropExp,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$ShockWeap",
+            |reader, _len| read_i32(reader),
+            PropWeaponType,
             accumulator::latest,
         ),
         define_prop(

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -1143,6 +1143,15 @@ pub enum DebugEntityMessage {
     TurnOn,
     /// Switch-link deactivate.
     TurnOff,
+    /// Set a gun's condition (`P$GunState`, 0..100). Not a script message:
+    /// it writes the property directly, so a test can put a gun at the wear
+    /// it wants without firing hundreds of rounds into it.
+    SetGunCondition { condition: f32 },
+    /// Set an object's `P$ObjState` (Normal, Broken, ...) directly - e.g. to
+    /// break a gun outright rather than waiting on its break roll.
+    SetObjectState {
+        state: dark::properties::ObjectState,
+    },
 }
 
 /// Status of the interactive pathfinding test system

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -11081,6 +11081,21 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .or(v_ecology.get(id).ok().map(|_| 0))
             },
         );
+        // Working order (Broken guns refuse to fire; hacked / unresearched
+        // objects report here too). A gun that authors no state of its own is
+        // in working order, which is what the engine assumes of it - report
+        // that rather than nothing, so "is it broken?" always has an answer.
+        // Read outside the big `run` below, whose borrow list is already full.
+        let object_state = self.world.run(
+            |v_state: View<PropObjState>, v_gun: View<dark::properties::PropGunState>| {
+                v_state.get(id).ok().map(|state| state.0).or_else(|| {
+                    v_gun
+                        .get(id)
+                        .ok()
+                        .map(|_| dark::properties::ObjectState::Normal)
+                })
+            },
+        );
         let animated_light = self.world.run(|v: View<PropAnimLight>| {
             v.get(id)
                 .ok()
@@ -11216,6 +11231,13 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "Condition".to_string(),
                         value: format!("{:.2}", gun_state.condition),
+                    });
+                }
+
+                if let Some(state) = object_state {
+                    properties.push(DebugPropertyInfo {
+                        name: "ObjectState".to_string(),
+                        value: format!("{state:?}"),
                     });
                 }
 
@@ -12204,6 +12226,29 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             return false;
         }
 
+        // Two of these are not script messages at all: they write a property
+        // the way the effect appliers do, so a test can put an object into a
+        // state that normally takes a long detour to reach.
+        match message {
+            DebugEntityMessage::SetGunCondition { condition } => {
+                let mut v_gun_state = self
+                    .world
+                    .borrow::<ViewMut<dark::properties::PropGunState>>()
+                    .unwrap();
+                let Ok(gun_state) = (&mut v_gun_state).get(id) else {
+                    tracing::warn!("send_entity_message: entity {:?} has no gun state", id);
+                    return false;
+                };
+                gun_state.condition = condition.clamp(0.0, 100.0);
+                return true;
+            }
+            DebugEntityMessage::SetObjectState { state } => {
+                self.world.add_component(id, PropObjState(state));
+                return true;
+            }
+            _ => {}
+        }
+
         let payload = match message {
             DebugEntityMessage::Damage {
                 amount,
@@ -12245,6 +12290,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             // Debug injections have no real sender; use the target itself.
             DebugEntityMessage::TurnOn => MessagePayload::TurnOn { from: id },
             DebugEntityMessage::TurnOff => MessagePayload::TurnOff { from: id },
+            // Handled above: these write state instead of dispatching.
+            DebugEntityMessage::SetGunCondition { .. }
+            | DebugEntityMessage::SetObjectState { .. } => {
+                tracing::error!("send_entity_message: {:?} reached the dispatch path", id);
+                return false;
+            }
         };
 
         self.script_world.dispatch(Message { to: id, payload });

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -39,6 +39,10 @@ pub const INVISO_TEMPLATE_ID: i32 = -3157;
 /// their health (see `scripts::berserk`).
 pub const BERSERK_TEMPLATE_ID: i32 = -3155;
 
+/// `Stability` - Anti-entropic Field (tier 3 sustained power): while active,
+/// the player's guns neither wear nor break (see `scripts::weapon_script`).
+pub const STABILITY_TEMPLATE_ID: i32 = -3148;
+
 /// `PropPsiPower::activation_type` for sustained/timed self effects - the
 /// power activates for a duration given by its `P$PsiShield` data
 /// (`duration_base + duration_per_psi × PSI` seconds).

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -3,13 +3,20 @@ use cgmath::{
 };
 use dark::{
     SCALE_FACTOR,
-    properties::{GunFlashOptions, GunSettingDesc, Link, ProjectileOptions},
+    properties::{
+        GunFlashOptions, GunSettingDesc, Link, ObjectState, ProjectileOptions, PropGunReliability,
+        PropWeaponType,
+    },
 };
 use engine::audio::AudioHandle;
+use rand::Rng;
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
-    mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateClassTags},
+    mission::{
+        entity_creator::CreateEntityOptions,
+        mission_core::{GlobalSkillParams, GlobalTemplateClassTags},
+    },
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::{
         RuntimePropFlatAim, RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropShotCooldown,
@@ -154,12 +161,125 @@ fn degrade_per_shot(world: &World, entity_id: EntityId) -> Option<f32> {
     (rate > 0.0).then_some(rate)
 }
 
+/// The gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
+/// tracks none.
+fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {
+    world
+        .borrow::<View<dark::properties::PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|g| g.condition))
+}
+
+/// Whether the Anti-entropic Field is running: while it is, a gun neither
+/// breaks nor wears. The power's own casting behaviour is still being sorted
+/// out (#1304) - this only asks whether it is active.
+fn is_weapon_stability_active(world: &World) -> bool {
+    world
+        .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+        .is_ok_and(|active| active.is_active(crate::psi::STABILITY_TEMPLATE_ID))
+}
+
+/// The player's skill level for the class of weapon `entity_id` belongs to.
+/// The class is authored on the weapon archetypes and inherited by every gun
+/// under them (0 conventional, 1 energy, 2 heavy, 3 annelid); a gun that
+/// authors none counts as conventional, as the retail engine does.
+fn weapon_skill_level(world: &World, entity_id: EntityId) -> i32 {
+    use crate::player_stats::Skill;
+
+    let skill = match world
+        .borrow::<View<PropWeaponType>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|t| t.0))
+        .unwrap_or(0)
+    {
+        1 => Skill::EnergyWeapons,
+        2 => Skill::HeavyWeapons,
+        3 => Skill::ExoticWeapons,
+        // 4 is the psi amp, which has no gun skill and never wears.
+        _ => Skill::StandardWeapons,
+    };
+
+    world
+        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+        .ok()
+        .map(|quests| quests.player_stats().skill_level(skill))
+        .unwrap_or(0)
+}
+
+/// The chance, 0..1, that the shot about to be fired breaks the gun. Zero at
+/// or above the reliability's break threshold: a gun in good condition cannot
+/// break at all. Below the threshold the authored min/max percentages are
+/// interpolated over the remaining condition, and the player's skill with that
+/// class of weapon scales the result down by the gamesys break factor.
+///
+/// The interpolation is the engine's own, and it is blunter than the two
+/// authored numbers suggest: the span is a *hundred* condition points while
+/// the threshold sits at ten, so a gun that has just crossed the threshold is
+/// already at its authored maximum (the pistol: 5% a shot) and only creeps
+/// past it as the last points go. `min_break` is effectively the value the
+/// curve would reach a hundred points below the threshold - i.e. never.
+fn break_chance(
+    reliability: &PropGunReliability,
+    condition: f32,
+    break_factor: f32,
+    weapon_skill: i32,
+) -> f32 {
+    if condition >= reliability.thresh_break {
+        return 0.0;
+    }
+    let min = reliability.min_break / 100.0;
+    let max = reliability.max_break / 100.0;
+    let wear = 1.0 - (condition - reliability.thresh_break) / 100.0;
+    let skill_relief = 1.0 - break_factor * weapon_skill as f32;
+    ((min + wear * (max - min)) * skill_relief).clamp(0.0, 1.0)
+}
+
+/// Roll this shot against the gun's break chance. `Some` = the gun just broke:
+/// it goes to `Broken` (which stops it firing until it is repaired) and plays
+/// its authored break event.
+fn roll_for_breakage(world: &World, entity_id: EntityId) -> Option<Effect> {
+    if is_weapon_stability_active(world) {
+        return None;
+    }
+    let reliability = world
+        .borrow::<View<PropGunReliability>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().copied())?;
+    let condition = gun_condition(world, entity_id)?;
+    let break_factor = world
+        .borrow::<UniqueView<GlobalSkillParams>>()
+        .ok()
+        .and_then(|params| params.0.as_ref().map(|params| params.weapon_break_factor))
+        .unwrap_or(0.0);
+    let chance = break_chance(
+        &reliability,
+        condition,
+        break_factor,
+        weapon_skill_level(world, entity_id),
+    );
+
+    (rand::thread_rng().r#gen::<f32>() < chance).then(|| {
+        Effect::Multiple(vec![
+            Effect::SetObjectState {
+                entity_id,
+                state: ObjectState::Broken,
+            },
+            play_environmental_sound(world, entity_id, "break", vec![], AudioHandle::new()),
+        ])
+    })
+}
+
 /// What one shot came to.
 enum ShotOutcome {
     /// The gun fired: these effects are the shot.
     Fired(Effect),
     /// The magazine cannot pay for the shot.
     Empty,
+    /// The gun is not in working order (broken by wear, or by a botched
+    /// repair): it cannot fire at all until it is repaired.
+    NotWorking,
+    /// This shot broke the gun instead of firing it.
+    Broke(Effect),
     /// Not a gun at all - a flat-aimed melee weapon, whose trigger starts a
     /// swing instead of firing.
     FlatMeleeSwing,
@@ -220,9 +340,14 @@ impl Script for WeaponScript {
                 // Unreachable in practice - `can_fire` covers the magazine and
                 // a melee weapon authors no burst - but a burst that cannot
                 // fire is over either way.
-                ShotOutcome::Empty | ShotOutcome::FlatMeleeSwing => {
+                ShotOutcome::Empty | ShotOutcome::FlatMeleeSwing | ShotOutcome::NotWorking => {
                     self.burst = None;
                     Effect::NoEffect
+                }
+                // The burst broke the gun: it owes no more rounds.
+                ShotOutcome::Broke(effect) => {
+                    self.burst = None;
+                    effect
                 }
             },
         }
@@ -259,7 +384,9 @@ impl Script for WeaponScript {
 
                 match fire_one_shot(world, entity_id, &setting) {
                     ShotOutcome::FlatMeleeSwing => Effect::FlatMeleeSwing { entity_id },
-                    ShotOutcome::Empty => dry_fire(world, entity_id),
+                    // A broken gun clicks like an empty one: nothing leaves it.
+                    ShotOutcome::Empty | ShotOutcome::NotWorking => dry_fire(world, entity_id),
+                    ShotOutcome::Broke(effect) => effect,
                     ShotOutcome::Fired(effect) => {
                         // A burst setting owes more rounds than the one just
                         // fired; `update` pays them out.
@@ -339,6 +466,25 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
         }
     }
 
+    // Only a real gunshot (a fired projectile) wears the gun, raises
+    // noise or can break it - a projectile-less weapon that falls
+    // through the melee gate must not emit a phantom gunshot.
+    let is_gunshot = maybe_projectile.is_some();
+
+    // A gun that is not in working order refuses to fire, ahead of the
+    // magazine: an empty broken gun is broken, not empty. The engine refuses
+    // on any state but Normal; the gate is narrower here because the annelid
+    // weapons ship Unresearched and the port cannot research them yet, so the
+    // wider gate would leave them permanently unusable.
+    if is_gunshot
+        && matches!(
+            crate::scripts::gui::object_state(world, entity_id),
+            ObjectState::Broken | ObjectState::Destroyed
+        )
+    {
+        return ShotOutcome::NotWorking;
+    }
+
     // Ammo gating: weapons that carry a `PropGunState` are limited by
     // their clip. A magazine that cannot pay the setting's per-shot
     // cost dry-fires (no shot/flash). Weapons without a gun state
@@ -347,6 +493,24 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
     let rounds = rounds_per_shot(setting);
     if !can_pay_for_shot(maybe_ammo, rounds) {
         return ShotOutcome::Empty;
+    }
+
+    // Firing wears the gun: each gunshot costs the authored per-shot
+    // condition points. Guns with no reliability authored (and debug
+    // weapons) never wear, and neither does a projectile-less pull.
+    let wear = (is_gunshot && !is_weapon_stability_active(world))
+        .then(|| degrade_per_shot(world, entity_id))
+        .flatten()
+        .map(|amount| Effect::DegradeWeaponCondition { entity_id, amount });
+
+    // A worn gun can break as the trigger comes back, spending the shot
+    // without firing it. The shot still wears the gun down.
+    if is_gunshot {
+        if let Some(broke) = roll_for_breakage(world, entity_id) {
+            return ShotOutcome::Broke(Effect::Multiple(
+                std::iter::once(broke).chain(wear).collect(),
+            ));
+        }
     }
 
     // Include projectile class tags (ie, ammotype) and weaponmode for sound lookup
@@ -378,10 +542,6 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
         AudioHandle::new(),
     );
 
-    // Only a real gunshot (a fired projectile) raises noise - a
-    // projectile-less weapon that falls through the melee gate
-    // must not emit a phantom gunshot.
-    let is_gunshot = maybe_projectile.is_some();
     let projectile_effect = Effect::Multiple(
         maybe_projectile
             .into_iter()
@@ -422,14 +582,7 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
             delta: -rounds,
         });
     }
-    // Firing wears the gun: each real gunshot costs the authored per-shot
-    // condition points. Guns with no reliability authored (and debug weapons)
-    // never wear, and neither does a projectile-less pull.
-    if is_gunshot {
-        if let Some(amount) = degrade_per_shot(world, entity_id) {
-            effects.push(Effect::DegradeWeaponCondition { entity_id, amount });
-        }
-    }
+    effects.extend(wear);
     // Start the setting's between-shots wait. Only a real shot
     // starts one - a melee weapon that reached here has nothing to
     // pace.
@@ -877,6 +1030,185 @@ mod tests {
         assert!(
             includes_damage_to(effect, target),
             "leftswing's MF_TRIGGER1 frame must resolve the aimed melee hit"
+        );
+    }
+
+    /// The pistol's shipped reliability: it cannot break above 10 condition,
+    /// and below that it breaks on roughly 5% of shots.
+    fn pistol_reliability() -> PropGunReliability {
+        PropGunReliability {
+            min_break: 0.5,
+            max_break: 5.0,
+            degrade_rate: 1.0,
+            thresh_break: 10.0,
+        }
+    }
+
+    /// The break chance across the condition range, for a player with no skill
+    /// in the weapon: nothing at all while the gun is in good condition, and
+    /// the authored maximum once it wears past the threshold.
+    #[test]
+    fn break_chance_over_the_condition_range() {
+        let r = pistol_reliability();
+        for (condition, expected) in [
+            // Well above the threshold a gun cannot break.
+            (100.0, 0.0),
+            (10.5, 0.0),
+            // The threshold itself is still safe: the roll wants condition
+            // strictly below it.
+            (10.0, 0.0),
+            // Just past it the chance is already the authored maximum...
+            (9.9, 0.050045),
+            // ...and creeps a little higher as the last condition goes.
+            (0.0, 0.0545),
+        ] {
+            let chance = break_chance(&r, condition, 0.0, 0);
+            assert!(
+                (chance - expected).abs() < 1.0e-5,
+                "condition {condition}: expected {expected}, got {chance}",
+            );
+        }
+    }
+
+    /// Skill with the weapon holds it together: the gamesys break factor scales
+    /// the chance down per level of skill, and can only ever remove it.
+    #[test]
+    fn weapon_skill_reduces_the_break_chance() {
+        let r = pistol_reliability();
+        let unskilled = break_chance(&r, 0.0, 0.1, 0);
+        let skilled = break_chance(&r, 0.0, 0.1, 3);
+
+        assert!(skilled < unskilled, "skill must make breakage less likely");
+        assert!((skilled - unskilled * 0.7).abs() < 1.0e-6);
+        assert_eq!(break_chance(&r, 0.0, 0.1, 20), 0.0);
+    }
+
+    /// A loaded gun with one standard ammo link, in the object state given.
+    fn gun_world(state: Option<ObjectState>) -> (World, EntityId) {
+        use dark::properties::{Links, PropGunState, PropObjState, ToLink};
+
+        let mut world = World::new();
+        let gun = world.add_entity((
+            PropGunState {
+                ammo: 12,
+                condition: 100.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+            Links {
+                to_links: vec![ToLink {
+                    link: Link::Projectile(ProjectileOptions {
+                        order: 0,
+                        setting: -1,
+                    }),
+                    to_entity_id: None,
+                    to_template_id: -1,
+                }],
+            },
+            RuntimePropTransform(Matrix4::from_scale(1.0)),
+        ));
+        if let Some(state) = state {
+            world.add_component(gun, PropObjState(state));
+        }
+        world.add_unique(GlobalTemplateClassTags(Default::default()));
+        (world, gun)
+    }
+
+    /// A broken gun is out of the fight until it is repaired: the trigger
+    /// clicks and nothing leaves the barrel.
+    #[test]
+    fn a_broken_gun_does_not_fire() {
+        let (world, gun) = gun_world(Some(ObjectState::Broken));
+
+        assert!(
+            matches!(
+                fire_one_shot(&world, gun, &GunSettingDesc::default()),
+                ShotOutcome::NotWorking
+            ),
+            "a broken gun must refuse the shot"
+        );
+
+        // The same gun in working order fires, so the refusal is the object
+        // state and not the fixture.
+        let (world, gun) = gun_world(Some(ObjectState::Normal));
+        assert!(matches!(
+            fire_one_shot(&world, gun, &GunSettingDesc::default()),
+            ShotOutcome::Fired(_)
+        ));
+    }
+
+    /// A gun that authors no object state at all is in working order.
+    #[test]
+    fn a_gun_without_an_object_state_fires() {
+        let (world, gun) = gun_world(None);
+
+        assert!(matches!(
+            fire_one_shot(&world, gun, &GunSettingDesc::default()),
+            ShotOutcome::Fired(_)
+        ));
+    }
+
+    /// A shot that breaks the gun: it does not fire - no projectile, no ammo
+    /// spent - but it still wears the gun down, as the engine does.
+    #[test]
+    fn a_breaking_shot_marks_the_gun_broken_and_does_not_fire() {
+        let (mut world, gun) = gun_world(Some(ObjectState::Normal));
+        // A worn gun whose reliability always breaks it: it is below the
+        // threshold and the chance saturates at 1.
+        world.add_component(
+            gun,
+            dark::properties::PropGunState {
+                ammo: 12,
+                condition: 50.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+        );
+        world.add_component(
+            gun,
+            PropGunReliability {
+                min_break: 100.0,
+                max_break: 100.0,
+                degrade_rate: 1.0,
+                thresh_break: 100.0,
+            },
+        );
+
+        let ShotOutcome::Broke(effect) = fire_one_shot(&world, gun, &GunSettingDesc::default())
+        else {
+            panic!("a gun that always breaks must break on the shot");
+        };
+
+        let effects = Effect::flatten(vec![effect]);
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::SetObjectState {
+                    state: ObjectState::Broken,
+                    ..
+                }
+            )),
+            "the gun must go to Broken"
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::DegradeWeaponCondition { .. })),
+            "the breaking shot still wears the gun"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::CreateEntity { .. })),
+            "nothing leaves the barrel"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::AdjustAmmo { .. })),
+            "and the round is not spent"
         );
     }
 }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -112,7 +112,23 @@ export type DebugEntityMessage =
   | { type: "SetAlertness"; level: "Lowest" | "Low" | "Moderate" | "High" }
   // Switch-link activate/deactivate - what a tripwire/button sends to its targets.
   | { type: "TurnOn" }
-  | { type: "TurnOff" };
+  | { type: "TurnOff" }
+  /**
+   * Set a gun's condition (0..100) directly, so a test can put a gun at the
+   * wear it wants without firing hundreds of rounds into it.
+   */
+  | { type: "SetGunCondition"; condition: number }
+  /** Set an object's state directly - e.g. break a gun outright. */
+  | {
+      type: "SetObjectState";
+      state:
+        | "Normal"
+        | "Broken"
+        | "Destroyed"
+        | "Unresearched"
+        | "Locked"
+        | "Hacked";
+    };
 
 export interface EntitySummary {
   id: number;

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
-import { cycleToWeapon, fireOnce } from "./helpers/weapon.js";
+import { ammoOf, cycleToWeapon, fireOnce } from "./helpers/weapon.js";
 
 // Firing wears a gun down: each shot costs the condition points the gun's
 // reliability authors (the pistol loses 1 of its 100 per shot), in flatscreen
@@ -85,6 +85,132 @@ test(
       await condition(game),
       100 - shots * PISTOL_DEGRADE_PER_SHOT,
       "the VR trigger reaches the same shared fire path",
+    );
+  },
+);
+
+/** The `ObjectState` property of an entity detail - its working order. */
+function objectStateOf(detail: {
+  properties: { name: string; value: string }[];
+}): string {
+  const state = detail.properties.find((p) => p.name === "ObjectState");
+  assert.ok(state, "a gun should expose an ObjectState property");
+  return state.value;
+}
+
+/** Break `gun` outright and confirm the runtime says so. */
+async function breakGun(game: GameServer, gun: number): Promise<void> {
+  await game.entities.sendMessage(gun, {
+    type: "SetObjectState",
+    state: "Broken",
+  });
+  await game.step({ frames: 1 });
+  assert.equal(
+    objectStateOf(await game.entities.detail(gun)),
+    "Broken",
+    "the debug hook must break the gun",
+  );
+}
+
+test(
+  "a broken gun refuses to fire in flatscreen",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+
+    const gun = (await game.info()).player.wielded_entity_id;
+    assert.ok(gun, "flat mode must wield the pistol it spawned");
+
+    // Wear it down to where breakage becomes possible at all...
+    await game.entities.sendMessage(gun, {
+      type: "SetGunCondition",
+      condition: 5,
+    });
+    await game.step({ frames: 1 });
+    assert.equal((await game.info()).player.wielded_gun_condition, 5);
+    assert.equal(objectStateOf(await game.entities.detail(gun)), "Normal");
+
+    // ...then back above the pistol's break threshold (10), so the control
+    // shot below cannot roll a break and make the test flaky.
+    await game.entities.sendMessage(gun, {
+      type: "SetGunCondition",
+      condition: 50,
+    });
+    await game.step({ frames: 1 });
+
+    // A working gun spends a round, so what follows is the breakage and not a
+    // fixture that never fired.
+    const loaded = ammoOf(await game.entities.detail(gun));
+    await fireOnce(game);
+    assert.equal(
+      ammoOf(await game.entities.detail(gun)),
+      loaded - 1,
+      "a working gun spends a round",
+    );
+
+    await breakGun(game, gun);
+    const ammo = ammoOf(await game.entities.detail(gun));
+    const condition = (await game.info()).player.wielded_gun_condition;
+
+    for (let i = 0; i < 3; i += 1) await fireOnce(game);
+
+    const detail = await game.entities.detail(gun);
+    assert.equal(ammoOf(detail), ammo, "a broken gun spends no ammo");
+    assert.equal(
+      (await game.info()).player.wielded_gun_condition,
+      condition,
+      "a broken gun does not wear any further",
+    );
+    assert.equal(objectStateOf(detail), "Broken", "and it stays broken");
+  },
+);
+
+test(
+  "a broken gun refuses a VR trigger pull too",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const weapon = await cycleToWeapon(game, (e) => e.template_id === PISTOL);
+    await aimVrHandAt(game, weapon.position as Vec3, 0.3);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      weapon.id,
+      "the VR right hand must hold the pistol",
+    );
+
+    const loaded = ammoOf(await game.entities.detail(weapon.id));
+    await fireOnce(game);
+    assert.equal(
+      ammoOf(await game.entities.detail(weapon.id)),
+      loaded - 1,
+      "a working gun spends a round",
+    );
+
+    await breakGun(game, weapon.id);
+    const ammo = ammoOf(await game.entities.detail(weapon.id));
+    const condition = (await game.info()).player.wielded_gun_condition;
+
+    for (let i = 0; i < 3; i += 1) await fireOnce(game);
+
+    assert.equal(
+      ammoOf(await game.entities.detail(weapon.id)),
+      ammo,
+      "a broken gun spends no ammo in VR either",
+    );
+    assert.equal(
+      (await game.info()).player.wielded_gun_condition,
+      condition,
+      "and does not wear any further",
     );
   },
 );


### PR DESCRIPTION
Stacks on #1338 (base `feat/weapon-reliability`).

## What

- **Breakage roll before every player gunshot**, in the shared fire path (flat + VR). A gun cannot break while its condition is above the authored break threshold; below it the chance runs between the gun's authored min/max break percentages, scaled down by the player's skill with that class of weapon and the gamesys break factor. A shot that breaks the gun is spent, not fired: the gun goes to `Broken`, plays its authored break event, and still takes that shot's wear (as the original does).
- **A broken gun refuses the trigger**: the pull clicks like an empty magazine, and nothing leaves the barrel, costs ammo, or wears the gun further.
- **Anti-entropic Field gate**: while that sustained power is running, a gun neither breaks nor wears. Wired to `ActivePsiPowers` rather than stubbed; the power's own casting behaviour is #1304.
- **`P$ShockWeap` parsed** (weapon-skill class: conventional / energy / heavy / annelid), so the roll can ask for the right one of the player's four weapon skills. A gun that authors none counts as conventional.
- **Debug hooks for tests**: `DebugEntityMessage::SetGunCondition` and `SetObjectState` write the property directly (no script message carries them), and `/v1/entities/:id` now reports `ObjectState`.

Deliberately narrower than the original in one place: the original refuses to fire on *any* non-Normal state, but the annelid weapons ship `Unresearched` and the port cannot research them yet, so the gate is `Broken | Destroyed`. Widen it when weapon research works.

Not in scope: HUD readout, maintenance tool, repair, modify.

## Verified

- Unit: break-chance table across the condition range (zero above the threshold, authored maximum below it, skill reduces it); a breaking shot emits Broken + wear and no projectile/ammo; a broken gun returns the refusal, a working one fires.
- e2e (`tools/shock2-sdk/test/weapon-condition.e2e.test.ts`, `SHOCK2_E2E=1`): flat and `--vr` - drive condition with the debug hook, break the gun, then assert three trigger pulls spend no ammo, cost no condition, and leave it Broken. 4/4 pass.
- Hand-driven probe against a live runtime: a pistol at condition 0 broke on its own after 20 shots, so the roll really fires.
- `cargo test -p shock2vr` (1351) and `-p dark` green; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; all 23 missions load.

## Gaps

- Nothing repairs a broken gun yet, so breakage is currently one-way for the player. Repair is the later slice in this stack; do not land this ahead of it without that in mind.
- A broken gun plays the empty-magazine click rather than a separate broken-gun sound.
