### PR TITLE
feat(hud): show a gun's condition, and when it is broken

### DIFF
--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -19,7 +19,8 @@
 //! buttons do not land on top of it.
 
 use cgmath::{Vector2, vec2};
-use shipyard::World;
+use dark::properties::ObjectState;
+use shipyard::{EntityId, World};
 
 use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
 
@@ -31,8 +32,13 @@ pub(crate) const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
 /// Selected ammo type's object icon (P$ObjIcon), at the gauge well's left -
 /// right of the cycle arrow, which claims the well's leading 12 px.
 pub(crate) const ICON: Rect = Rect::new(200.0, 18.0, 24.0, 24.0);
-/// Round count, right of the ammo icon inside the gauge well.
-pub(crate) const COUNT: Rect = Rect::new(224.0, 20.0, 25.0, 20.0);
+/// Round count, right of the ammo icon inside the gauge well - the middle of
+/// the well's three stacked bands (badge, count, ammo type), so the condition
+/// badge above it has the corner the original draws it in to itself.
+pub(crate) const COUNT: Rect = Rect::new(224.0, 28.0, 25.0, 14.0);
+/// The wielded gun's condition badge (`WSTATE*.PCX`, 14x14), in the gauge
+/// well's upper-right corner - where the original draws it.
+pub(crate) const CONDITION: Rect = Rect::new(235.0, 14.0, 14.0, 14.0);
 /// Ammo-type label (std/he/ap), across the bottom of the gauge well.
 pub(crate) const TYPE_LABEL: Rect = Rect::new(198.0, 42.0, 51.0, 13.0);
 
@@ -69,6 +75,40 @@ pub(crate) const PSI_SELECT: Rect = Rect::new(
 
 /// The font every readout label uses (the original's HUD font).
 const FONT: &str = "mainfont.fon";
+
+/// The condition badges, best first: a green "10" down through a red "1", then
+/// a crossed-out badge for a gun that is not in working order. The shipped art
+/// authors all eleven; the tenth is what a gun on its last legs shows and the
+/// eleventh is what a broken one shows.
+const CONDITION_ART: [&str; 11] = [
+    "wstate1.pcx",
+    "wstate2.pcx",
+    "wstate3.pcx",
+    "wstate4.pcx",
+    "wstate5.pcx",
+    "wstate6.pcx",
+    "wstate7.pcx",
+    "wstate8.pcx",
+    "wstate9.pcx",
+    "wstate10.pcx",
+    "wstate11.pcx",
+];
+
+/// Which badge a gun in `state` at `condition` (0..100) shows.
+///
+/// A gun that still works shows the badge for its condition tenth - the same
+/// tenth its name's condition word comes from, counted the other way round,
+/// since the art runs best-first and the words run worst-first. A gun that is
+/// broken or destroyed shows the crossed-out badge instead, so "worn out but
+/// firing" and "will not fire" are never the same picture. Only those two
+/// states change the badge: an unresearched weapon still fires here, so it
+/// still reads as its condition.
+pub(crate) fn condition_badge(state: ObjectState, condition: f32) -> &'static str {
+    if matches!(state, ObjectState::Broken | ObjectState::Destroyed) {
+        return CONDITION_ART[10];
+    }
+    CONDITION_ART[(10 - super::gun_condition_bucket(condition)) as usize]
+}
 
 /// A clickable control on the ammo readout. The layout owns the set, so the
 /// drawn button and the hit-tested rect can never disagree.
@@ -134,6 +174,9 @@ pub(crate) struct AmmoReadout {
     pub ammo_icon: Option<String>,
     /// The selected ammo type's class tag ("std", "he", "ap").
     pub ammo_type: Option<String>,
+    /// The wielded gun's condition badge art. Absent for a weapon that has no
+    /// condition to wear down (the psi amp, a melee weapon).
+    pub gun_condition: Option<&'static str>,
     /// The wielded gun's current fire-mode header ("NORM"/"BURST"/"AUTO") -
     /// the SETTING button's label. Absent when the gun names no header.
     pub gun_setting_header: Option<String>,
@@ -150,6 +193,15 @@ pub(crate) struct AmmoReadout {
     pub show_buttons: bool,
 }
 
+/// `weapon`'s condition badge, if it is the kind of weapon that has one.
+fn wielded_gun_condition(world: &World, weapon: EntityId) -> Option<&'static str> {
+    let condition = crate::scripts::script_util::gun_condition(world, weapon)?;
+    Some(condition_badge(
+        crate::scripts::gui::object_state(world, weapon),
+        condition,
+    ))
+}
+
 impl AmmoReadout {
     /// Read the wielded weapon's readout from the world. `show_buttons` is the
     /// caller's (presentation's) call.
@@ -160,6 +212,7 @@ impl AmmoReadout {
             ammo: super::get_wielded_ammo(world),
             ammo_icon: super::get_wielded_ammo_icon(world),
             ammo_type: super::get_wielded_ammo_type(world),
+            gun_condition: weapon.and_then(|w| wielded_gun_condition(world, w)),
             gun_setting_header: super::get_wielded_gun_setting(world)
                 .and_then(|(_, header)| header),
             can_cycle_ammo: weapon
@@ -291,6 +344,9 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
         if let Some(icon) = &readout.ammo_icon {
             canvas.image(at(origin, ICON), icon);
         }
+        if let Some(badge) = readout.gun_condition {
+            canvas.image(at(origin, CONDITION), badge);
+        }
         if let Some(ammo_type) = &readout.ammo_type {
             // Ellipsized: the class tag is data ("std", but also "lasershot"),
             // and an over-wide label would spill out of the gauge well.
@@ -405,6 +461,59 @@ mod tests {
         assert_eq!(text_of(AmmoReadout::default()), None);
     }
 
+    /// The badge grades a working gun and calls out one that will not fire.
+    #[test]
+    fn the_condition_badge_counts_down_with_the_gun() {
+        let working = |condition| condition_badge(ObjectState::Normal, condition);
+        assert_eq!(working(100.0), "wstate1.pcx", "pristine");
+        assert_eq!(working(91.0), "wstate1.pcx", "barely used");
+        assert_eq!(working(45.0), "wstate6.pcx", "half worn");
+        assert_eq!(working(5.0), "wstate10.pcx", "about to give out");
+        assert_eq!(working(0.0), "wstate10.pcx", "worn out");
+        // A gun that will not fire reads differently from one that barely
+        // will - that is the whole point of the eleventh badge.
+        assert_eq!(condition_badge(ObjectState::Broken, 0.0), "wstate11.pcx");
+        assert_eq!(
+            condition_badge(ObjectState::Destroyed, 90.0),
+            "wstate11.pcx"
+        );
+        // ...but a state that does not stop the gun leaves the grade alone.
+        assert_eq!(
+            condition_badge(ObjectState::Unresearched, 100.0),
+            working(100.0)
+        );
+    }
+
+    /// The badge is emitted with the gun's readout, in its own corner: both
+    /// presentations build this canvas, so neither can place it differently.
+    #[test]
+    fn the_condition_badge_takes_the_wells_corner_clear_of_the_count() {
+        let canvas = build_readout_canvas(&AmmoReadout {
+            gun_condition: Some("wstate11.pcx"),
+            ..gun(12, None, None)
+        });
+        let badge = canvas
+            .elements()
+            .iter()
+            .find_map(|element| match element {
+                crate::ui::UiElement::Image {
+                    texture, position, ..
+                } if texture == "wstate11.pcx" => Some(*position),
+                _ => None,
+            })
+            .expect("the readout draws the badge");
+        assert_eq!(badge, vec2(CONDITION.x, CONDITION.y));
+        // The well stacks three bands, and none of them may sit on another.
+        assert!(
+            CONDITION.y + CONDITION.h <= COUNT.y && COUNT.y + COUNT.h <= TYPE_LABEL.y,
+            "badge/count/type must stack: {CONDITION:?} {COUNT:?} {TYPE_LABEL:?}"
+        );
+        assert!(
+            CONDITION.x + CONDITION.w <= WELL.x + WELL.w,
+            "the badge must stay inside the gauge well"
+        );
+    }
+
     #[test]
     fn the_psi_amp_shows_its_discipline_on_the_forearm_too() {
         // Tier badge + discipline name = 2, and the amp's meaningless clip is
@@ -425,6 +534,7 @@ mod tests {
             COUNT,
             ICON,
             TYPE_LABEL,
+            CONDITION,
             CYCLE_BUTTON,
             SETTING_BUTTON,
             RELOAD_BUTTON,
@@ -456,7 +566,14 @@ mod tests {
     /// it on bare 3D view.
     #[test]
     fn the_readout_sits_inside_the_compact_gauge_well() {
-        for rect in [COUNT, ICON, TYPE_LABEL, PSI_TIER_BADGE, PSI_POWER_NAME] {
+        for rect in [
+            COUNT,
+            ICON,
+            TYPE_LABEL,
+            CONDITION,
+            PSI_TIER_BADGE,
+            PSI_POWER_NAME,
+        ] {
             assert!(
                 rect.x >= WELL.x && rect.x + rect.w <= WELL.x + WELL.w,
                 "{rect:?} leaves the gauge well horizontally"

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -386,6 +386,7 @@ mod tests {
             ammo_panel::COUNT,
             ammo_panel::ICON,
             ammo_panel::TYPE_LABEL,
+            ammo_panel::CONDITION,
             ammo_panel::PSI_TIER_BADGE,
             ammo_panel::PSI_POWER_NAME,
         ] {

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -6,7 +6,7 @@ use dark::{
         resolve_symbolic_name,
     },
     properties::{
-        ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
+        ObjectNameType, ObjectState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
         PropObjName, PropObjectNameType, PropShowHP, PropStackCount, PropSymName, PropTemplateId,
     },
 };
@@ -116,11 +116,10 @@ fn localized_log_title(
         .map(|name| format_inline_localized_text(name))
 }
 
+/// The WEAPON.STR key for a gun's condition word: `GunCondVal1..10`, one per
+/// tenth of the condition ("Terrible: 1" .. "Perfect: 10").
 fn weapon_condition_key(condition: f32) -> String {
-    // Looking Glass's GunGetConditionString truncates the 0..100 condition,
-    // divides it into ten buckets, and fetches GunCondVal1..10.
-    let bucket = ((condition as i32) / 10).clamp(0, 9) + 1;
-    format!("guncondval{bucket}")
+    format!("guncondval{}", super::gun_condition_bucket(condition))
 }
 
 fn localized_weapon_condition(
@@ -128,14 +127,45 @@ fn localized_weapon_condition(
     world: &World,
     entity_id: EntityId,
 ) -> Option<String> {
-    let condition = {
-        let gun_states = world.borrow::<View<PropGunState>>().ok()?;
-        gun_states.get(entity_id).ok()?.condition
-    };
+    let condition = crate::scripts::script_util::gun_condition(world, entity_id)?;
     asset_cache
         .get_opt(&STRINGS_IMPORTER, "weapon.str")?
         .get(&weapon_condition_key(condition))
         .cloned()
+}
+
+/// The parenthetical an object's working order adds to its display name -
+/// "(broken)", "(destroyed)" - from MISC.STR's `ObjState<n>` keys, numbered by
+/// the state itself. `None` for a working object, and for the states the
+/// original leaves off the *name*: an unresearched object has its whole name
+/// replaced by the research interface's own wording rather than suffixed, and
+/// locked/hacked ones say nothing here.
+///
+/// The table's own values lead with a space; the strings importer trims its
+/// values, so the caller supplies the separator.
+pub(crate) fn object_state_suffix(
+    asset_cache: &mut AssetCache,
+    world: &World,
+    entity_id: EntityId,
+) -> Option<String> {
+    let (key, fallback) =
+        object_state_suffix_strings(crate::scripts::gui::object_state(world, entity_id))?;
+    let strings = asset_cache.get_opt(&STRINGS_IMPORTER, "misc.str");
+    Some(crate::ui::resolve_menu_label(
+        strings.as_deref(),
+        key,
+        fallback,
+    ))
+}
+
+/// The MISC.STR key naming `state`'s parenthetical - numbered by the state -
+/// and the English text that key ships with, for an install that lacks it.
+fn object_state_suffix_strings(state: ObjectState) -> Option<(&'static str, &'static str)> {
+    match state {
+        ObjectState::Broken => Some(("objstate1", "(broken)")),
+        ObjectState::Destroyed => Some(("objstate2", "(destroyed)")),
+        _ => None,
+    }
 }
 
 /// An object with no `P$ObjName` of its own (e.g. the Wrench, which inherits
@@ -155,7 +185,8 @@ fn resolve_symname_fallback(
 /// through `objname.str`, falling back to its `P$SymName` when it has no
 /// `P$ObjName` of its own, and then through whatever substitution its
 /// `P$ObjectNameType` asks for (a stack count, a log's title, a gun's
-/// condition word). `None` when the object has no name to show.
+/// condition word), plus whatever its working order adds on the end. `None`
+/// when the object has no name to show.
 ///
 /// The single name resolution the interface has: the rollover label beside the
 /// HUD brackets and the inventory bar's mini-frame name line both read it, so
@@ -201,13 +232,26 @@ pub fn resolve_item_name(
     let weapon_condition = (name_type == ObjectNameType::Weapon)
         .then(|| localized_weapon_condition(asset_cache, world, entity_id))
         .flatten();
-    Some(format_typed_item_name(
+    let named = format_typed_item_name(
         &localized_name,
         name_type,
         stack_count,
         log_title.as_deref(),
         weapon_condition.as_deref(),
+    );
+    Some(append_object_state(
+        named,
+        object_state_suffix(asset_cache, world, entity_id).as_deref(),
     ))
+}
+
+/// Put an object's working order on the end of its name, separated by the space
+/// the shipped table authors and the strings importer trims off.
+fn append_object_state(name: String, suffix: Option<&str>) -> String {
+    match suffix {
+        Some(suffix) => format!("{name} {suffix}"),
+        None => name,
+    }
 }
 
 pub fn draw_item_name(
@@ -462,6 +506,45 @@ mod tests {
         assert_eq!(weapon_condition_key(10.0), "guncondval2");
         assert_eq!(weapon_condition_key(50.0), "guncondval6");
         assert_eq!(weapon_condition_key(100.0), "guncondval10");
+    }
+
+    /// A gun's name says its condition; its working order is a separate word
+    /// on the end, so "worn out" and "will not fire" read differently.
+    #[test]
+    fn only_a_broken_or_destroyed_object_names_its_state() {
+        assert_eq!(
+            object_state_suffix_strings(ObjectState::Broken),
+            Some(("objstate1", "(broken)"))
+        );
+        assert_eq!(
+            object_state_suffix_strings(ObjectState::Destroyed),
+            Some(("objstate2", "(destroyed)"))
+        );
+        // A working object says nothing extra, and neither do the states the
+        // original leaves off the name.
+        for quiet in [
+            ObjectState::Normal,
+            ObjectState::Unresearched,
+            ObjectState::Locked,
+            ObjectState::Hacked,
+        ] {
+            assert_eq!(object_state_suffix_strings(quiet), None, "{quiet:?}");
+        }
+    }
+
+    /// The state joins the name with a space of its own: the shipped strings
+    /// lead with one, but the strings importer trims every value, so a plain
+    /// concatenation would read "A Pistol. (Perfect: 10)(broken)".
+    #[test]
+    fn the_state_is_separated_from_the_name() {
+        assert_eq!(
+            append_object_state("A Pistol. (Perfect: 10)".to_owned(), Some("(broken)")),
+            "A Pistol. (Perfect: 10) (broken)"
+        );
+        assert_eq!(
+            append_object_state("A Pistol.".to_owned(), None),
+            "A Pistol."
+        );
     }
 
     #[test]

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -18,6 +18,16 @@ pub use message_line::HudMessages;
 mod flat_hud;
 pub(crate) use flat_hud::*;
 
+/// Which tenth of its condition a gun is in, 1 (worn out) to 10 (pristine).
+///
+/// The original truncates the 0..100 condition and divides it into ten
+/// buckets. Both readouts of a gun's condition - the word its name carries and
+/// the badge on the ammo gauge - grade it here, so the label and the picture
+/// can never disagree about how worn a gun is.
+pub(crate) fn gun_condition_bucket(condition: f32) -> i32 {
+    (condition as i32 / 10).clamp(0, 9) + 1
+}
+
 /// The English fallback for the reload button, verbatim from the shipped
 /// MISC.STR, for a data install that lacks the table.
 const FALLBACK_RELOAD_LABEL: &str = "RELOAD";
@@ -25,6 +35,10 @@ const FALLBACK_RELOAD_LABEL: &str = "RELOAD";
 /// The English fallback for the weapon-settings modification line, verbatim
 /// from the shipped MISC.STR (`%d` is the gun's `PropGunState.modification`).
 const FALLBACK_MOD_LEVEL_LABEL: &str = "Modification Level %d";
+
+/// The English fallback for the line a gun's owner gets when it breaks,
+/// verbatim from the shipped MISC.STR (`%s` is the gun's short name).
+const FALLBACK_WEAPON_BREAKS: &str = "%s has broken!";
 
 /// HUD label strings preloaded from MISC.STR, stored as a world `Unique`
 /// because the readout layout has no `AssetCache` at draw time (the
@@ -36,6 +50,9 @@ pub struct HudStrings {
     /// MISC.STR `ModLevel` ("Modification Level %d"), the settings MFD's
     /// modification line. The `%d` is substituted at draw time.
     pub mod_level_label: String,
+    /// MISC.STR `WeaponBreaks` ("%s has broken!"), the status line a gun posts
+    /// when it gives out. The `%s` is the gun's short name.
+    pub weapon_breaks_message: String,
 }
 
 impl Default for HudStrings {
@@ -43,6 +60,7 @@ impl Default for HudStrings {
         Self {
             reload_label: FALLBACK_RELOAD_LABEL.to_owned(),
             mod_level_label: FALLBACK_MOD_LEVEL_LABEL.to_owned(),
+            weapon_breaks_message: FALLBACK_WEAPON_BREAKS.to_owned(),
         }
     }
 }
@@ -60,6 +78,11 @@ impl HudStrings {
                 strings.as_deref(),
                 "modlevel",
                 FALLBACK_MOD_LEVEL_LABEL,
+            ),
+            weapon_breaks_message: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "weaponbreaks",
+                FALLBACK_WEAPON_BREAKS,
             ),
         }
     }

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -243,7 +243,7 @@ fn property_fallback(world: &World, entity_id: EntityId, report: bool) -> String
 
 /// The English text out of an object string (`key: "text"`), for a data
 /// install whose string table does not resolve the key.
-pub(super) fn localized_fallback(value: &str) -> String {
+pub(crate) fn localized_fallback(value: &str) -> String {
     value
         .split_once('"')
         .and_then(|(_, tail)| tail.rsplit_once('"').map(|(text, _)| text))

--- a/shock2vr/src/scripts/gui/weapon_settings.rs
+++ b/shock2vr/src/scripts/gui/weapon_settings.rs
@@ -18,15 +18,13 @@
 //! no further wiring.
 
 use cgmath::{Vector2, Vector3, vec2};
-use dark::properties::{PropGunState, PropObjShortName, PropSymName};
+use dark::properties::PropGunState;
 use shipyard::{EntityId, Get, View, World};
 
 use crate::gui::{self, ButtonHoverBehavior, Gui, GuiComponent, GuiConfig, GuiCursor};
 use crate::scripts::Effect;
 use crate::scripts::script_util;
 use crate::ui::Rect;
-
-use super::research::localized_fallback;
 
 /// A panel-local rect's upper-left corner / extent, as the component builders
 /// want them.
@@ -110,22 +108,6 @@ pub fn should_close_settings_panel(opened_for: EntityId, wielded: Option<EntityI
     wielded != Some(opened_for)
 }
 
-/// The gun's display name: its authored short name (an object string), falling
-/// back to the symbolic name every entity has.
-fn display_name(world: &World, weapon: EntityId) -> Option<String> {
-    let short = world
-        .borrow::<View<PropObjShortName>>()
-        .ok()
-        .and_then(|v| v.get(weapon).ok().map(|n| localized_fallback(&n.0)))
-        .filter(|name| !name.is_empty());
-    short.or_else(|| {
-        world
-            .borrow::<View<PropSymName>>()
-            .ok()
-            .and_then(|v| v.get(weapon).ok().map(|n| n.0.clone()))
-    })
-}
-
 /// The line each row shows: "{header}: {description}". A gun that names no
 /// header for a setting has no such setting and draws no row.
 fn row_text(header: Option<&str>, description: Option<&str>) -> Option<String> {
@@ -202,7 +184,7 @@ impl Gui<WeaponSettingsGuiState, WeaponSettingsGuiMsg> for WeaponSettingsGui {
             .with_size(vec2(ROW_TEXT_RIGHT - NAME_POS.0, LINE_H)),
         );
 
-        if let Some(name) = display_name(world, weapon) {
+        if let Some(name) = script_util::object_short_name(world, weapon) {
             components.push(
                 gui::text(&name)
                     .with_position(vec2(NAME_POS.0, NAME_POS.1))
@@ -310,7 +292,8 @@ mod tests {
     use cgmath::{Quaternion, vec3};
     use dark::properties::{
         Link, Links, ProjectileOptions, PropGunSettingHeader1, PropGunSettingHeader2,
-        PropGunSettingText1, PropGunSettingText2, PropScripts, ToLink,
+        PropGunSettingText1, PropGunSettingText2, PropObjShortName, PropScripts, PropSymName,
+        ToLink,
     };
     use std::collections::HashMap;
 

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -10,7 +10,8 @@ use dark::{
     properties::{
         GunSettingDesc, Link, Links, ProjectileOptions, PropBaseGunDesc, PropClassTag,
         PropGunSettingHeader1, PropGunSettingHeader2, PropGunSettingText1, PropGunSettingText2,
-        PropGunState, PropMaterial, PropSymName, PropTemplateId, PropTweqModelConfig, ToLink,
+        PropGunState, PropMaterial, PropObjShortName, PropSymName, PropTemplateId,
+        PropTweqModelConfig, ToLink,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -340,6 +341,37 @@ pub fn can_cycle_gun_setting(world: &World, weapon: EntityId) -> bool {
     let links = all_projectile_links(world, weapon);
     let second_header = gun_setting_header(world, weapon, 1);
     has_second_fire_mode(second_header.as_deref(), &links)
+}
+
+/// A gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
+/// tracks none - a melee weapon, the psi amp.
+pub(crate) fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {
+    world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|g| g.condition))
+}
+
+/// An object's short display name: its authored `P$ObjShortName` (an object
+/// string), falling back to the symbolic name every entity has. This is the
+/// terse name the original uses where a whole sentence will not fit - a panel's
+/// title bar, a status message - as opposed to the rollover's full name.
+pub fn object_short_name(world: &World, entity_id: EntityId) -> Option<String> {
+    let short = world
+        .borrow::<View<PropObjShortName>>()
+        .ok()
+        .and_then(|v| {
+            v.get(entity_id)
+                .ok()
+                .map(|n| crate::scripts::gui::localized_fallback(&n.0))
+        })
+        .filter(|name| !name.is_empty());
+    short.or_else(|| {
+        world
+            .borrow::<View<PropSymName>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|n| n.0.clone()))
+    })
 }
 
 /// The short header for `weapon`'s fire setting `setting` - "NORM" / "BURST" -

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -68,7 +68,7 @@ use super::{
     Effect, Message, MessagePayload, Script,
     burst_fire::{BurstState, BurstStep},
     script_util::{
-        active_gun_setting, get_all_links_with_template, ordered_projectile_links,
+        active_gun_setting, get_all_links_with_template, gun_condition, ordered_projectile_links,
         play_environmental_sound,
     },
 };
@@ -159,15 +159,6 @@ fn degrade_per_shot(world: &World, entity_id: EntityId) -> Option<f32> {
         .ok()
         .and_then(|v| v.get(entity_id).ok().map(|r| r.degrade_rate))?;
     (rate > 0.0).then_some(rate)
-}
-
-/// The gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
-/// tracks none.
-fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {
-    world
-        .borrow::<View<dark::properties::PropGunState>>()
-        .ok()
-        .and_then(|v| v.get(entity_id).ok().map(|g| g.condition))
 }
 
 /// Whether the Anti-entropic Field is running: while it is, a gun neither
@@ -265,8 +256,20 @@ fn roll_for_breakage(world: &World, entity_id: EntityId) -> Option<Effect> {
                 state: ObjectState::Broken,
             },
             play_environmental_sound(world, entity_id, "break", vec![], AudioHandle::new()),
+            Effect::ShowMessage {
+                text: weapon_breaks_message(world, entity_id),
+            },
         ])
     })
+}
+
+/// The status line a gun posts as it gives out: MISC.STR's `WeaponBreaks`
+/// ("%s has broken!") with the gun's short name in it.
+fn weapon_breaks_message(world: &World, entity_id: EntityId) -> String {
+    let name = crate::scripts::script_util::object_short_name(world, entity_id).unwrap_or_default();
+    crate::hud::hud_strings(world)
+        .weapon_breaks_message
+        .replace("%s", &name)
 }
 
 /// What one shot came to.
@@ -1113,6 +1116,16 @@ mod tests {
         }
         world.add_unique(GlobalTemplateClassTags(Default::default()));
         (world, gun)
+    }
+
+    /// A gun that gives out says which gun it was, in the shipped wording.
+    #[test]
+    fn the_break_message_names_the_gun() {
+        let (mut world, gun) = gun_world(None);
+        world.add_component(gun, dark::properties::PropSymName("Pistol".to_owned()));
+        // No strings table loaded, so this exercises the English fallback the
+        // format itself carries - the substitution is what is under test.
+        assert_eq!(weapon_breaks_message(&world, gun), "Pistol has broken!");
     }
 
     /// A broken gun is out of the fight until it is repaired: the trigger


### PR DESCRIPTION
Stacked on #1339 (`feat/weapon-break`). Slice 3 of the weapon-condition work: **showing** what slices 1-2 made true.

## What the original shows, and where (research)

Traced through the shipped data and the engine's own display paths:

- **The ammo/weapon HUD readout is the condition display.** It draws a graphic
  badge in the gauge well's upper-right corner, `WSTATE1..WSTATE11.PCX` - a
  green "10" counting down through a red "1" over the ten condition deciles,
  plus an eleventh, crossed-out badge for a weapon that is not in working
  order. (The text form is `GunGetConditionString` -> `WEAPON.STR`
  `GunCondVal1..10`, "Terrible: 1" .. "Perfect: 10"; the readout's *text*
  condition line is commented out in the shipped code - the badge is what
  actually draws.) One caveat, called out below: the shipped index clamp
  caps the badge at the tenth, so the eleventh art never appears in retail.
- **The full object name carries the state.** The rollover / frob name
  substitutes the condition word into the gun's `%s` name ("A Pistol.
  (Perfect: 10)") and then appends `MISC.STR` `ObjState<n>` -
  `" (broken)"` / `" (destroyed)"` - for any object that is not Normal and not
  Unresearched. The *short* name (settings panel, look panel) gets the
  condition word but **not** the state suffix; that append is commented out.
- **A break announces itself** on the timed status-message channel:
  `MISC.STR` `WeaponBreaks` = `"%s has broken!"` with the gun's short name,
  alongside the break sound.
- **The weapon settings MFD shows no condition at all.** It draws the short
  name, `ModLevel`, and the two fire-setting rows - which is exactly what this
  port's panel already draws. (A broken gun there swaps the whole panel to the
  repair overlay; that is slice 5's job, not this one.) So this PR
  deliberately adds *nothing* to that panel.

## What this adds

- **Condition badge on the ammo readout** (`hud/ammo_panel.rs`), placed once in
  panel pixels, so the flat HUD and the VR forearm draw it in the same corner
  (AGENTS.md section 3). The round count drops into the middle of the well's
  three stacked bands (badge / count / ammo type) to give the badge the corner
  the original puts it in.
- **The eleventh badge is used**, for a gun that is Broken or Destroyed.
  Retail's own index clamp makes that art unreachable, but it is authored, it
  is unmistakably the "not in working order" badge, and "worn out but firing"
  must not look identical to "will not fire". Deliberate, documented departure.
  The gate is Broken|Destroyed rather than the engine's "any non-Normal state"
  for the same reason slice 2's fire gate is: annelid weapons ship
  Unresearched and are still usable here, so they still read as their
  condition.
- **`" (broken)"` on the display name** - appended in the one shared name
  resolution (`hud::resolve_item_name`), so the HUD rollover label and the
  inventory bar's name line get it together and cannot disagree.
- **`"%s has broken!"` on the status line** when a gun gives out, from
  `MISC.STR` via the preloaded `HudStrings`.
- Small tidy-up the above needed: the settings panel's private short-name
  helper moved to `script_util::object_short_name`, since the break message
  wants the same name.

Every string is fetched from the shipped tables; the English text appears only
as the fallback for an install that lacks them.

## Verified

- Unit: badge mapping across the condition range and the two not-working
  states; badge placement (in the panel, in the gauge well, stacked clear of
  the count and the type label, in both the compact and expanded gauge);
  which states name themselves and how the state joins the name; the break
  message's substitution. `cargo test -p shock2vr --lib` green (1356).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
- Render-verified flat in `debug_weapons` at conditions 100 / 45 / 5 and
  Broken, in both the compact (shooter) and expanded (use-mode) readout - see
  Visuals.
- VR (`--vr`): the badge is emitted into the right forearm's canvas - the
  forearm reports five layers over `/v1/scene` (backdrop plus count, icon,
  type, badge) where it reported four. It is not *photographable* in the
  harness: the forearm sleeve mesh encloses the panel from every angle, which
  is equally true of the count and ammo icon that were already there, and is
  why #1267/#1314 are moving this readout off the forearm.
- e2e: `weapon-condition.e2e.test.ts` (4/4), `missions.e2e.test.ts` (23/23).
- `/xreview` (Claude + Codex + a de-dup pass). Fixed before pushing:
  - **the state suffix rendered with no space** - the shipped table authors
    `" (broken)"` but the strings importer trims every value, so a plain
    concatenation read `(Perfect: 10)(broken)`. The join now supplies the
    separator, with a test that pins it.
  - **the badge re-derived the condition bucket** a second, differently-shaped
    way from the one the name's condition word uses. Both now grade through
    one `hud::gun_condition_bucket`, so they cannot drift.
  - the state suffix had no English fallback while every other string in the
    change did; it has one now.
  - `gun_condition` was read three ways; it is one `script_util` helper.
  - `flat_hud`'s parallel containment test now covers the badge too.

## Gaps

- The name suffix is covered by unit tests and the string table, not by a live
  assertion or a screenshot: `debug_weapons` has no backpack, so `/v1/ui`'s
  `name_strip` never populates there, and the HUD's own rollover label needs a
  reticle pick that the bench guns do not produce.
- The break message is not covered end-to-end (the break is a ~5% roll per
  shot); its formatting is unit-tested and its emission is one literal in the
  break bundle.
- Pre-existing, inherited by the break message and flagged in review: the short
  name comes from `P$ObjShortName`'s inline fallback text rather than being
  resolved through `objshort.str`, so a non-English install sees the English
  weapon name inside an otherwise localized line. That is how the settings
  panel already behaves; fixing it wants `objshort.str` preloaded as a world
  `Unique` and belongs in its own change.

## Visuals

![weapon condition HUD badge demo](https://gist.githubusercontent.com/tommy-xr/f6e4174a6dc7d51d8564d66dd8d3693a/raw/condition_hud_demo.gif)

<sub>Condition sweep (100 → 45 → 5 → Broken) then the expanded use-mode readout, captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep, `debug_weapons` scene).</sub>

### Before -> after

![before/after](https://gist.githubusercontent.com/tommy-xr/f6e4174a6dc7d51d8564d66dd8d3693a/raw/before_after.png)

### Condition sweep

![condition sweep strip](https://gist.githubusercontent.com/tommy-xr/f6e4174a6dc7d51d8564d66dd8d3693a/raw/condition_sweep_strip.png)

