### PR TITLE
feat(weapons): the maintenance tool restores a gun's condition

### DIFF
--- a/dark/src/properties/prop_research.rs
+++ b/dark/src/properties/prop_research.rs
@@ -18,6 +18,10 @@ impl TechSkillValues {
         Self(std::array::from_fn(|_| read_i32(reader)))
     }
 
+    pub fn maintenance(self) -> i32 {
+        self.0[3]
+    }
+
     pub fn research(self) -> i32 {
         self.0[4]
     }

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -40,6 +40,14 @@ const FALLBACK_MOD_LEVEL_LABEL: &str = "Modification Level %d";
 /// verbatim from the shipped MISC.STR (`%s` is the gun's short name).
 const FALLBACK_WEAPON_BREAKS: &str = "%s has broken!";
 
+/// The English fallbacks for the maintenance tool's four refusals, verbatim
+/// from the shipped MISC.STR. `%d` in the skill line is the minimum Maintain
+/// level the weapon authors.
+const FALLBACK_WRENCH_ON_NON_GUN: &str = "Drag tool to ranged weapon to use.";
+const FALLBACK_WRENCH_ON_BROKEN: &str = "Use repair skill on weapon first.";
+const FALLBACK_WRENCH_SKILL_REQ: &str = "Maintaining this weapon requires a skill of %d.";
+const FALLBACK_WRENCH_UNUSED: &str = "Weapon already in good condition.";
+
 /// HUD label strings preloaded from MISC.STR, stored as a world `Unique`
 /// because the readout layout has no `AssetCache` at draw time (the
 /// `ElevatorContext` pattern).
@@ -53,6 +61,17 @@ pub struct HudStrings {
     /// MISC.STR `WeaponBreaks` ("%s has broken!"), the status line a gun posts
     /// when it gives out. The `%s` is the gun's short name.
     pub weapon_breaks_message: String,
+    /// MISC.STR `WrenchOnNonGun`: the maintenance tool was used on something
+    /// that is not a ranged weapon.
+    pub wrench_on_non_gun: String,
+    /// MISC.STR `WrenchOnBroken`: a broken weapon needs repairing, not
+    /// maintaining.
+    pub wrench_on_broken: String,
+    /// MISC.STR `WrenchSkillReq` ("... a skill of %d"): the player's Maintain
+    /// level is below the minimum this weapon authors.
+    pub wrench_skill_req: String,
+    /// MISC.STR `WrenchUnused`: the weapon is already at full condition.
+    pub wrench_unused: String,
 }
 
 impl Default for HudStrings {
@@ -61,6 +80,10 @@ impl Default for HudStrings {
             reload_label: FALLBACK_RELOAD_LABEL.to_owned(),
             mod_level_label: FALLBACK_MOD_LEVEL_LABEL.to_owned(),
             weapon_breaks_message: FALLBACK_WEAPON_BREAKS.to_owned(),
+            wrench_on_non_gun: FALLBACK_WRENCH_ON_NON_GUN.to_owned(),
+            wrench_on_broken: FALLBACK_WRENCH_ON_BROKEN.to_owned(),
+            wrench_skill_req: FALLBACK_WRENCH_SKILL_REQ.to_owned(),
+            wrench_unused: FALLBACK_WRENCH_UNUSED.to_owned(),
         }
     }
 }
@@ -83,6 +106,26 @@ impl HudStrings {
                 strings.as_deref(),
                 "weaponbreaks",
                 FALLBACK_WEAPON_BREAKS,
+            ),
+            wrench_on_non_gun: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchonnongun",
+                FALLBACK_WRENCH_ON_NON_GUN,
+            ),
+            wrench_on_broken: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchonbroken",
+                FALLBACK_WRENCH_ON_BROKEN,
+            ),
+            wrench_skill_req: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchskillreq",
+                FALLBACK_WRENCH_SKILL_REQ,
+            ),
+            wrench_unused: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchunused",
+                FALLBACK_WRENCH_UNUSED,
             ),
         }
     }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -25,7 +25,7 @@ use crate::{
     hud::create_arm_hud_panels,
     input_context::InputContext,
     physics::PhysicsWorld,
-    virtual_hand::{VirtualHand, VirtualHandEffect},
+    virtual_hand::{VirtualHand, VirtualHandEffect, hand_world_position},
     vr_config::Handedness,
 };
 
@@ -226,6 +226,14 @@ impl PlayerInteraction for VrInteraction {
 
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
         let left_held_entity = self.left_hand.get_held_entity();
+        // Both hands' positions come from this frame's input, before either
+        // update: the two-hand gesture must read the same distance whichever
+        // hand releases.
+        let hand_position = |hand: &crate::input_context::Hand| {
+            hand_world_position(ctx.player_pos, ctx.player_rotation, hand.position)
+        };
+        let left_position = hand_position(&ctx.input.left_hand);
+        let right_position = hand_position(&ctx.input.right_hand);
         let (right_hand, mut right_msgs) = VirtualHand::update(
             &self.right_hand,
             ctx.physics,
@@ -234,6 +242,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.right_hand,
             left_held_entity,
+            left_position,
         );
         self.right_hand = right_hand;
 
@@ -248,6 +257,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.left_hand,
             right_held_entity,
+            right_position,
         );
         self.left_hand = left_hand;
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3726,7 +3726,10 @@ impl MissionCore {
             self.script_world.dispatch(msg);
         }
         for action in ui_drag_actions {
-            let drag_effects = self.apply_flat_drag_action(action);
+            // Flattened: an action can answer with a composite (using a
+            // maintenance tool is a restore plus a consume plus a sound), and
+            // this list is applied one variant at a time.
+            let drag_effects = Effect::flatten(self.apply_flat_drag_action(action));
             effects.extend(drag_effects);
         }
 
@@ -4987,25 +4990,16 @@ impl MissionCore {
                 }
             }
             // Double-click = equip/use, acting on the still-contained item -
-            // identical to the ContainerGui backpack click (shared weapon test,
-            // shared effects): a weapon (gun or melee) wields via `GrabEntity`
-            // (which also clears its Contains link and holsters any displaced
-            // weapon back to the grid), anything else gets a `Frob` (use).
+            // literally the ContainerGui backpack click, through the one
+            // routine both share: a weapon (gun or melee) wields via
+            // `GrabEntity` (which also clears its Contains link and holsters
+            // any displaced weapon back to the grid), anything else is used
+            // where it stands.
             FlatUiDragAction::Wield(entity_id) => {
-                if crate::virtual_hand::is_wieldable_weapon(&self.world, entity_id) {
-                    vec![Effect::GrabEntity {
-                        entity_id,
-                        hand: crate::vr_config::Handedness::Right,
-                        current_parent_id: None,
-                    }]
-                } else {
-                    vec![Effect::Send {
-                        msg: Message {
-                            payload: MessagePayload::Frob,
-                            to: entity_id,
-                        },
-                    }]
-                }
+                vec![crate::scripts::maintenance::use_carried_item(
+                    &self.world,
+                    entity_id,
+                )]
             }
         }
     }
@@ -5828,14 +5822,14 @@ impl MissionCore {
                     }
                 }
 
-                Effect::DegradeWeaponCondition { entity_id, amount } => {
+                Effect::AdjustWeaponCondition { entity_id, delta } => {
                     let mut v_gun_state = self
                         .world
                         .borrow::<ViewMut<dark::properties::PropGunState>>()
                         .unwrap();
 
                     if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
-                        crate::scripts::effect::degrade_condition(gun_state, amount);
+                        crate::scripts::effect::adjust_condition(gun_state, delta);
                     }
                 }
 

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -68,6 +68,11 @@ const BENCH_AMMO: &[(i32, &str)] = &[
     (-1264, "Large Worm Beaker"),
 ];
 
+/// The maintenance tool, in its own slot down the middle of the bench: worn
+/// guns are restored by releasing it onto them (VR) or using it from the
+/// inventory (flat).
+const BENCH_TOOL: i32 = -2949;
+
 /// The bench sits beside the firing lane on the player's left (+Z with the -X
 /// forward), long axis along X: guns on the outer row, ammo on the inner row.
 const BENCH_HEIGHT: f32 = 1.1;
@@ -237,6 +242,11 @@ impl DebugSceneHooks for ArsenalHooks {
                 Point3::new(x, BENCH_HEIGHT + 0.4, BENCH_Z + 0.5),
             ));
         }
+        // The middle strip of the bench is clear between the two rows.
+        effects.push(spawn_at(
+            BENCH_TOOL,
+            Point3::new(BENCH_NEAR_X, BENCH_HEIGHT + 0.15, BENCH_Z),
+        ));
         for (index, (template_id, _)) in BENCH_AMMO.iter().enumerate() {
             let x = BENCH_NEAR_X - index as f32 * AMMO_SPACING;
             // Zigzag so a bouncing neighbor can't billiard the whole row.

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -212,12 +212,13 @@ pub enum Effect {
         delta: i32,
     },
 
-    /// Wear a gun down by `amount` condition points (`PropGunState.condition`,
-    /// a 0..100 percentage), floored at 0. No-op for entities without a gun
-    /// state.
-    DegradeWeaponCondition {
+    /// Move a gun's condition (`PropGunState.condition`, a 0..100 percentage)
+    /// by `delta`, clamped to that range: negative for the wear a shot costs,
+    /// positive for the points the maintenance tool restores. No-op for
+    /// entities without a gun state.
+    AdjustWeaponCondition {
         entity_id: EntityId,
-        amount: f32,
+        delta: f32,
     },
 
     /// Start the wait a gun's fire setting imposes between shots
@@ -948,18 +949,19 @@ pub(crate) fn recharge_ammo_to_capacity(gun_state: &mut PropGunState, capacity: 
     gun_state.ammo = gun_state.ammo.max(capacity.max(0));
 }
 
-/// Wear a gun down by `amount` condition points. Condition is a 0..100
-/// percentage and never goes below 0 - a worn-out gun stays worn out rather
-/// than accumulating negative condition over the shots it keeps firing.
-pub(crate) fn degrade_condition(gun_state: &mut PropGunState, amount: f32) {
-    gun_state.condition = (gun_state.condition - amount).max(0.0);
+/// Move a gun's condition by `delta` (negative wears it, positive restores
+/// it). Condition is a 0..100 percentage and stays inside it: a worn-out gun
+/// does not accumulate negative condition over the shots it keeps firing, and
+/// a maintained one never reads better than new.
+pub(crate) fn adjust_condition(gun_state: &mut PropGunState, delta: f32) {
+    gun_state.condition = (gun_state.condition + delta).clamp(0.0, 100.0);
 }
 
 #[cfg(test)]
 mod tests {
     use dark::properties::PropGunState;
 
-    use super::{degrade_condition, recharge_ammo_to_capacity};
+    use super::{adjust_condition, recharge_ammo_to_capacity};
 
     fn gun_state(ammo: i32) -> PropGunState {
         PropGunState {
@@ -990,9 +992,9 @@ mod tests {
         let mut state = gun_state(12);
         state.condition = 100.0;
 
-        degrade_condition(&mut state, 1.0);
-        degrade_condition(&mut state, 1.0);
-        degrade_condition(&mut state, 1.0);
+        adjust_condition(&mut state, -1.0);
+        adjust_condition(&mut state, -1.0);
+        adjust_condition(&mut state, -1.0);
 
         assert_eq!(state.condition, 97.0);
         assert_eq!(state.ammo, 12);
@@ -1003,10 +1005,20 @@ mod tests {
         let mut state = gun_state(12);
         state.condition = 0.5;
 
-        degrade_condition(&mut state, 1.0);
-        degrade_condition(&mut state, 1.0);
+        adjust_condition(&mut state, -1.0);
+        adjust_condition(&mut state, -1.0);
 
         assert_eq!(state.condition, 0.0);
+    }
+
+    #[test]
+    fn a_restored_gun_never_reads_better_than_new() {
+        let mut state = gun_state(12);
+        state.condition = 95.0;
+
+        adjust_condition(&mut state, 10.0);
+
+        assert_eq!(state.condition, 100.0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -329,31 +329,14 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // (PropPlayerGun) or melee (PropLimbModel) - is wielded through
             // `GrabEntity` (flat: the first-person viewmodel wield path,
             // which also restores world refs and clears the Contains link;
-            // VR: a grab into the hand). Anything else gets its own Frob
-            // (use) action, e.g. a hypo consumes.
-            ContainerGuiMsg::Frob(ent) => {
-                let is_weapon = crate::virtual_hand::is_wieldable_weapon(world, *ent);
-                if is_weapon {
-                    (
-                        state.clone(),
-                        Effect::GrabEntity {
-                            entity_id: *ent,
-                            hand: crate::vr_config::Handedness::Right,
-                            current_parent_id: None,
-                        },
-                    )
-                } else {
-                    (
-                        state.clone(),
-                        Effect::Send {
-                            msg: Message {
-                                payload: MessagePayload::Frob,
-                                to: *ent,
-                            },
-                        },
-                    )
-                }
-            }
+            // VR: a grab into the hand). Anything else is used where it stands
+            // - a hypo consumes, a maintenance tool goes to the wielded
+            // weapon. Shared with the inventory strip's double-click, which is
+            // the same gesture (`maintenance::use_carried_item`).
+            ContainerGuiMsg::Frob(ent) => (
+                state.clone(),
+                crate::scripts::maintenance::use_carried_item(world, *ent),
+            ),
             // Transfer the clicked item's `Contains` link to the player's
             // backpack - the same `DropEntityInfo` path used when a VR hand
             // feeds an item into a container (drop_entity_into_container).

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -71,10 +71,7 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
             .get(entity_id)
             .map(|required| required.0.research().max(1))
             .unwrap_or(1);
-        let player_skill = world
-            .borrow::<UniqueView<QuestInfo>>()
-            .map(|quests| quests.player_stats().skill_level(Skill::Research))
-            .unwrap_or(0);
+        let player_skill = crate::scripts::script_util::player_skill_level(world, Skill::Research);
         let status = world
             .borrow::<UniqueView<QuestInfo>>()
             .map(|quests| quests.research().status(template_id, chemicals))

--- a/shock2vr/src/scripts/maintenance.rs
+++ b/shock2vr/src/scripts/maintenance.rs
@@ -1,0 +1,471 @@
+//! The maintenance tool (gamesys template -2949, `P$Scripts ["Wrench"]`, class
+//! tag `device2type mainttool`).
+//!
+//! Applying one to a ranged weapon restores condition points and uses the tool
+//! up. How many points is the player's Maintain skill, ten points a level, and
+//! a weapon never reads better than new. Each weapon also authors the minimum
+//! Maintain level it can be worked on at, in `P$RequiredTechDesc`; the tool
+//! refuses - and survives - below it, as it does on something that is not a
+//! ranged weapon at all, on a weapon that has already broken (that wants the
+//! repair skill), and on one already in good condition.
+//!
+//! The offer arrives on the port's tool channel,
+//! [`MessagePayload::ProvideForConsumption`](crate::scripts::MessagePayload),
+//! which is sent *to the target*: a VR hand releasing the tool onto a gun, or
+//! the flat use-mode click on a carried tool. The decision therefore lives on
+//! the receiving weapon (`WeaponScript`), keyed off the tool's authored script
+//! the way the security crate recognizes an ICE Pick.
+
+use dark::properties::{ObjectState, PropGunState, PropRequiredTechDesc, PropStackCount};
+use engine::audio::AudioHandle;
+use shipyard::{EntityId, Get, View, World};
+
+use crate::player_stats::Skill;
+use crate::scripts::Effect;
+
+/// The maintenance tool's authored script name (`P$Scripts` on gamesys
+/// template -2949). Identifying the tool by its authored script - not by a
+/// hardcoded template id - keeps any object the data marks as one working.
+const MAINTENANCE_TOOL_SCRIPT: &str = "Wrench";
+
+/// Condition points one level of Maintain restores.
+const POINTS_PER_MAINTAIN_LEVEL: f32 = 10.0;
+
+/// Full condition: the ceiling a restore clamps to, and the level at which the
+/// tool refuses as unnecessary.
+const FULL_CONDITION: f32 = 100.0;
+
+/// The sound the tool makes when it is used, from the `mainttool` class tag's
+/// activation schema.
+const MAINTENANCE_TOOL_SOUND: &str = "act_mainttool";
+
+/// Whether `entity_id` is a maintenance tool.
+pub fn is_maintenance_tool(world: &World, entity_id: EntityId) -> bool {
+    crate::scripts::script_util::entity_has_script(world, entity_id, MAINTENANCE_TOOL_SCRIPT)
+}
+
+/// What using a maintenance tool on a target comes to.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MaintenanceOutcome {
+    /// `weapon` is worked on, gaining `points` condition (already capped at
+    /// what full condition leaves room for). Naming the weapon here is what
+    /// makes a success the only outcome that can be acted on.
+    Restored { weapon: EntityId, points: f32 },
+    /// The target is not a ranged weapon.
+    NotAGun,
+    /// The weapon has broken; maintenance cannot bring it back.
+    Broken,
+    /// The player's Maintain skill is below the level the weapon authors.
+    SkillRequired { level: i32 },
+    /// The weapon is already at full condition.
+    AlreadyGood,
+}
+
+/// The minimum Maintain level `weapon` can be worked on at, or 0 for one that
+/// authors no requirement.
+/// The minimum Maintain level `weapon` can be worked on at. At least one: the
+/// tool restores ten points a level, so a level-zero player working a weapon
+/// that authors no requirement would spend it on nothing at all.
+fn required_maintain_level(world: &World, weapon: EntityId) -> i32 {
+    world
+        .borrow::<View<PropRequiredTechDesc>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|req| req.0.maintenance()))
+        .unwrap_or(0)
+        .max(1)
+}
+
+/// Decide what the tool does to `target`. `None` is "the gesture named no
+/// target at all", which reads the same as pointing it at something that is
+/// not a weapon.
+pub fn maintenance_outcome(world: &World, target: Option<EntityId>) -> MaintenanceOutcome {
+    let Some(target) = target else {
+        return MaintenanceOutcome::NotAGun;
+    };
+    // The psi amp inherits a gun state whose condition means nothing, and
+    // authors its own script in place of the weapon one that would take this
+    // offer - so it is not a ranged weapon for this purpose.
+    let Some(condition) = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(target).ok().map(|gun| gun.condition))
+        .filter(|_| !crate::wielded_weapon::is_psi_amp(world, target))
+    else {
+        return MaintenanceOutcome::NotAGun;
+    };
+    // Checked before the skill and the condition: a broken weapon is a repair
+    // job whatever the player's Maintain level, and its condition may well
+    // still be above zero.
+    if matches!(
+        crate::scripts::gui::object_state(world, target),
+        ObjectState::Broken | ObjectState::Destroyed
+    ) {
+        return MaintenanceOutcome::Broken;
+    }
+    let required = required_maintain_level(world, target);
+    let skill = crate::scripts::script_util::player_skill_level(world, Skill::Maintenance);
+    if skill < required {
+        return MaintenanceOutcome::SkillRequired { level: required };
+    }
+    if condition >= FULL_CONDITION {
+        return MaintenanceOutcome::AlreadyGood;
+    }
+    let points = (skill as f32 * POINTS_PER_MAINTAIN_LEVEL).min(FULL_CONDITION - condition);
+    MaintenanceOutcome::Restored {
+        weapon: target,
+        points,
+    }
+}
+
+/// The line a refusal puts on the status channel.
+fn refusal_message(world: &World, outcome: MaintenanceOutcome) -> String {
+    let strings = crate::hud::hud_strings(world);
+    match outcome {
+        MaintenanceOutcome::NotAGun => strings.wrench_on_non_gun,
+        MaintenanceOutcome::Broken => strings.wrench_on_broken,
+        MaintenanceOutcome::SkillRequired { level } => {
+            strings.wrench_skill_req.replace("%d", &level.to_string())
+        }
+        MaintenanceOutcome::AlreadyGood => strings.wrench_unused,
+        // A restore is not a refusal; `apply` matches it first.
+        MaintenanceOutcome::Restored { .. } => strings.wrench_on_non_gun,
+    }
+}
+
+/// Use one of `tool` up. The tool stacks (`P$StackCoun`), so a stack of more
+/// than one loses a unit and only the last one destroys the object.
+fn consume_tool(world: &World, tool: EntityId) -> Effect {
+    let stack = world
+        .borrow::<View<PropStackCount>>()
+        .ok()
+        .and_then(|v| v.get(tool).ok().map(|s| s.0))
+        .unwrap_or(1);
+    if stack > 1 {
+        Effect::AdjustStackCount {
+            entity_id: tool,
+            delta: -1,
+        }
+    } else {
+        Effect::DestroyEntity { entity_id: tool }
+    }
+}
+
+/// Apply `tool` to `target` - the whole gesture, from either presentation:
+/// the condition it restores and the tool it uses up, or the line explaining
+/// why it did neither.
+pub fn apply(world: &World, tool: EntityId, target: Option<EntityId>) -> Effect {
+    match maintenance_outcome(world, target) {
+        MaintenanceOutcome::Restored { weapon, points } => Effect::combine(vec![
+            Effect::AdjustWeaponCondition {
+                entity_id: weapon,
+                delta: points,
+            },
+            consume_tool(world, tool),
+            Effect::PlaySound {
+                handle: AudioHandle::new(),
+                source: Some(weapon),
+                name: MAINTENANCE_TOOL_SOUND.to_owned(),
+                spatial: false,
+            },
+        ]),
+        outcome => Effect::ShowMessage {
+            text: refusal_message(world, outcome),
+        },
+    }
+}
+
+/// Whether releasing `tool` against `target` is a maintenance gesture at all -
+/// the guard the VR two-hand release uses before offering the tool to what the
+/// other hand holds. A refusable weapon still counts: the player gets told
+/// why, which is the feedback the gesture owes them.
+pub fn offers_to(world: &World, tool: EntityId, target: EntityId) -> bool {
+    is_maintenance_tool(world, tool)
+        && !matches!(
+            maintenance_outcome(world, Some(target)),
+            MaintenanceOutcome::NotAGun
+        )
+}
+
+/// What using one carried item does: wield a weapon, apply a maintenance tool
+/// to the weapon already wielded, or Frob anything else where it stands.
+///
+/// This is the whole of the flat inventory's use gesture - the strip's
+/// double-click and the backpack panel's click, which are the same action and
+/// share it. Flat has no way to drag one carried item onto another (#817), so
+/// the wielded weapon is the one target a tool can name; the tool is applied
+/// here rather than offered over the message channel, so a target that runs no
+/// weapon script still gets its refusal instead of silence.
+pub fn use_carried_item(world: &World, item: EntityId) -> Effect {
+    if crate::virtual_hand::is_wieldable_weapon(world, item) {
+        return Effect::GrabEntity {
+            entity_id: item,
+            hand: crate::vr_config::Handedness::Right,
+            current_parent_id: None,
+        };
+    }
+    if is_maintenance_tool(world, item) {
+        return apply(world, item, crate::wielded_weapon::wielded_weapon(world));
+    }
+    Effect::Send {
+        msg: crate::scripts::Message {
+            payload: crate::scripts::MessagePayload::Frob,
+            to: item,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::{PropObjState, PropScripts};
+
+    /// A pistol at `condition`, the tool, and a player with `maintain` levels
+    /// of Maintain. The pistol authors the shipped requirement (Maintain 1).
+    fn fixture(condition: f32, maintain: i32) -> (World, EntityId, EntityId) {
+        let mut world = World::new();
+        let gun = world.add_entity((
+            PropGunState {
+                ammo: 12,
+                condition,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+            PropRequiredTechDesc(dark::properties::TechSkillValues([0, 1, 1, 1, 0])),
+        ));
+        let tool = world.add_entity((PropScripts {
+            scripts: vec!["Wrench".to_owned()],
+            inherits: true,
+        },));
+        let mut quests = crate::quest_info::QuestInfo::new();
+        for _ in 0..maintain {
+            quests.player_stats_mut().raise_skill(Skill::Maintenance);
+        }
+        world.add_unique(quests);
+        (world, gun, tool)
+    }
+
+    fn effects(effect: Effect) -> Vec<Effect> {
+        Effect::flatten(vec![effect])
+    }
+
+    #[test]
+    fn the_tool_is_recognized_by_its_authored_script() {
+        let (world, gun, tool) = fixture(50.0, 1);
+        assert!(is_maintenance_tool(&world, tool));
+        assert!(!is_maintenance_tool(&world, gun));
+    }
+
+    #[test]
+    fn maintaining_restores_ten_points_per_maintain_level() {
+        let (world, gun, _) = fixture(40.0, 1);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Restored {
+                weapon: gun,
+                points: 10.0
+            }
+        );
+
+        let (world, gun, _) = fixture(40.0, 3);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Restored {
+                weapon: gun,
+                points: 30.0
+            }
+        );
+    }
+
+    #[test]
+    fn a_restore_never_takes_a_weapon_past_full_condition() {
+        let (world, gun, _) = fixture(95.0, 4);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Restored {
+                weapon: gun,
+                points: 5.0
+            }
+        );
+    }
+
+    #[test]
+    fn using_the_tool_on_a_non_weapon_refuses() {
+        let (mut world, _, _) = fixture(40.0, 1);
+        let rock = world.add_entity((PropObjState(ObjectState::Normal),));
+        assert_eq!(
+            maintenance_outcome(&world, Some(rock)),
+            MaintenanceOutcome::NotAGun
+        );
+        assert_eq!(
+            maintenance_outcome(&world, None),
+            MaintenanceOutcome::NotAGun
+        );
+    }
+
+    /// The two-hand release guard: only a maintenance tool, and only against
+    /// something that can be maintained. A weapon that will refuse still
+    /// counts - the player is owed the reason.
+    #[test]
+    fn the_two_hand_guard_admits_only_a_tool_and_a_weapon() {
+        let (mut world, gun, tool) = fixture(40.0, 1);
+        let rock = world.add_entity((PropObjState(ObjectState::Normal),));
+
+        assert!(offers_to(&world, tool, gun));
+        assert!(!offers_to(&world, tool, rock), "a tool needs a weapon");
+        assert!(!offers_to(&world, rock, gun), "only the tool applies");
+
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+        assert!(
+            offers_to(&world, tool, gun),
+            "a broken weapon still earns the refusal line"
+        );
+    }
+
+    #[test]
+    fn a_broken_weapon_wants_repairing_not_maintaining() {
+        let (mut world, gun, _) = fixture(40.0, 1);
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Broken
+        );
+    }
+
+    /// The broken check comes first: an unskilled player working on a broken
+    /// weapon is told to repair it, not to train.
+    #[test]
+    fn a_broken_weapon_reports_broken_even_below_the_skill_requirement() {
+        let (mut world, gun, _) = fixture(40.0, 0);
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Broken
+        );
+    }
+
+    #[test]
+    fn maintaining_below_the_authored_skill_requirement_refuses() {
+        let (world, gun, _) = fixture(40.0, 0);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::SkillRequired { level: 1 }
+        );
+    }
+
+    /// A weapon that authors no requirement still needs Maintain 1: the tool
+    /// restores ten points a level, so a level-zero use would spend it for
+    /// nothing at all.
+    #[test]
+    fn maintaining_at_skill_zero_is_always_refused() {
+        let (mut world, _, _) = fixture(40.0, 0);
+        let gun = world.add_entity((PropGunState {
+            ammo: 1,
+            condition: 40.0,
+            setting: 0,
+            modification: 0,
+            silence_value: 0.0,
+        },));
+
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::SkillRequired { level: 1 },
+            "a zero-point restore would consume the tool and do nothing"
+        );
+    }
+
+    /// Using a carried item: a weapon wields, a tool works on the wielded
+    /// weapon, and anything else keeps its plain Frob.
+    #[test]
+    fn using_a_tool_with_nothing_wielded_refuses_instead_of_going_nowhere() {
+        let (world, _, tool) = fixture(40.0, 1);
+
+        let effect = use_carried_item(&world, tool);
+        assert!(
+            matches!(&effect, Effect::ShowMessage { text }
+                if text == "Drag tool to ranged weapon to use."),
+            "got {effect:?}"
+        );
+    }
+
+    #[test]
+    fn using_an_ordinary_item_still_frobs_it() {
+        let (mut world, _, _) = fixture(40.0, 1);
+        let hypo = world.add_entity((PropObjState(ObjectState::Normal),));
+
+        assert!(
+            matches!(
+                use_carried_item(&world, hypo),
+                Effect::Send {
+                    msg: crate::scripts::Message {
+                        payload: crate::scripts::MessagePayload::Frob,
+                        to,
+                    }
+                } if to == hypo
+            ),
+            "an item that is neither a weapon nor a tool keeps its own Frob"
+        );
+    }
+
+    #[test]
+    fn a_weapon_already_in_good_condition_refuses() {
+        let (world, gun, _) = fixture(100.0, 1);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::AlreadyGood
+        );
+    }
+
+    #[test]
+    fn a_successful_use_restores_the_weapon_and_destroys_a_single_tool() {
+        let (world, gun, tool) = fixture(40.0, 1);
+        let effects = effects(apply(&world, tool, Some(gun)));
+
+        assert!(effects.iter().any(|e| matches!(
+            e,
+            Effect::AdjustWeaponCondition { entity_id, delta }
+                if *entity_id == gun && *delta == 10.0
+        )));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::DestroyEntity { entity_id } if *entity_id == tool))
+        );
+    }
+
+    /// The tool stacks, so a stack of more than one loses a unit instead of
+    /// being destroyed outright.
+    #[test]
+    fn a_stack_of_tools_loses_one_unit_per_use() {
+        let (mut world, gun, tool) = fixture(40.0, 1);
+        world.add_component(tool, (PropStackCount(3),));
+        let effects = effects(apply(&world, tool, Some(gun)));
+
+        assert!(effects.iter().any(|e| matches!(
+            e,
+            Effect::AdjustStackCount { entity_id, delta }
+                if *entity_id == tool && *delta == -1
+        )));
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::DestroyEntity { .. }))
+        );
+    }
+
+    /// Every refusal keeps the tool: it is only spent by work actually done.
+    #[test]
+    fn a_refused_use_only_posts_a_message_and_keeps_the_tool() {
+        for (condition, maintain, expected) in [
+            (100.0, 1, "Weapon already in good condition."),
+            (40.0, 0, "Maintaining this weapon requires a skill of 1."),
+        ] {
+            let (world, gun, tool) = fixture(condition, maintain);
+            let effect = apply(&world, tool, Some(gun));
+            assert!(
+                matches!(&effect, Effect::ShowMessage { text } if text == expected),
+                "got {effect:?}"
+            );
+        }
+    }
+}

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -16,15 +16,6 @@ use super::{
     script_util::{entity_class_template_id, play_impact_sound},
 };
 
-// Script to handle collision type
-pub struct MeleeWeapon {}
-
-impl MeleeWeapon {
-    pub fn new() -> MeleeWeapon {
-        MeleeWeapon {}
-    }
-}
-
 /// Contact damage for the player's authored melee weapons (`PropLimbModel`).
 ///
 /// The rule is physical: a swing damages because the weapon was closing on
@@ -423,44 +414,6 @@ fn impact_sound_effect(entity_id: EntityId, with: EntityId, world: &World) -> Ef
     }
     let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
     play_impact_sound(world, entity_id, with, position.to_vec())
-}
-
-fn melee_impact(
-    entity_id: EntityId,
-    with: EntityId,
-    world: &World,
-    amount: f32,
-    contact: Option<crate::physics::CollisionContact>,
-) -> Effect {
-    Effect::Multiple(vec![
-        contact_damage_effect(with, amount, contact),
-        impact_sound_effect(entity_id, with, world),
-    ])
-}
-
-impl Script for MeleeWeapon {
-    fn handle_message(
-        &mut self,
-        entity_id: EntityId,
-        world: &World,
-        _physics: &PhysicsWorld,
-        msg: &MessagePayload,
-    ) -> Effect {
-        // The legacy literal `wrench` script can still back a VR physical
-        // weapon, but contact is never a flat damage source. Flat player melee
-        // resolves once from WeaponScript at the authored swing event.
-        if !is_vr(world) {
-            return Effect::NoEffect;
-        }
-
-        match msg {
-            // Legacy literal `wrench` script (Maintenance Tool -2949).
-            MessagePayload::Collided { with, contact } => {
-                melee_impact(entity_id, *with, world, 1.0, *contact)
-            }
-            _ => Effect::NoEffect,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1182,26 +1135,5 @@ mod tests {
             collide(&mut script, &world, weapon, target),
             Effect::NoEffect
         ));
-    }
-
-    #[test]
-    fn legacy_melee_collision_is_inert_outside_vr() {
-        let (world, weapon, target) = test_world(PresentationMode::Flat);
-
-        let effect = MeleeWeapon::new().handle_message(
-            weapon,
-            &world,
-            &PhysicsWorld::new(),
-            &MessagePayload::Collided {
-                with: target,
-                contact: Some(crate::physics::CollisionContact {
-                    point: vec3(2.0, 3.0, 4.0),
-                    normal: vec3(1.0, 0.0, 0.0),
-                    closing_speed: None,
-                }),
-            },
-        );
-
-        assert!(matches!(effect, Effect::NoEffect));
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod internal_radiation_source;
 mod internal_simple_health;
 mod internal_switch_held_model;
 mod level_change_button;
+pub mod maintenance;
 mod many_ride;
 mod melee_weapon;
 mod obj_consume_button;
@@ -168,7 +169,7 @@ use self::{
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
     many_ride::{ParalyzePlayers, SitDownRightNow, StandUpAgain, WhiteOut},
-    melee_weapon::{HeldMeleeWeapon, MeleeWeapon},
+    melee_weapon::HeldMeleeWeapon,
     obj_consume_button::ObjConsumeButton,
     once_room::OnceRoom,
     once_router::OnceRouter,
@@ -1075,10 +1076,11 @@ impl ScriptWorld {
             "energyweapon" => Box::new(EnergyWeapon::new()),
             "grenademodify" => Box::new(NoopScript::new()),
             "weapontrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Weapons))),
-            "wrench" => Box::new(CompositeScript::new(vec![
-                Box::new(MeleeWeapon::new()),
-                Box::new(InternalSwitchHeldModelScript::new()),
-            ])),
+            // The maintenance tool (gamesys -2949 - not the melee wrench,
+            // which is an ordinary `WeaponScript`). It carries no behavior of
+            // its own: the weapon it is applied to claims it off the tool
+            // channel (see `scripts::maintenance`).
+            "wrench" => Box::new(NoopScript::new()),
             "psiampscript" => Box::new(CompositeScript::new(vec![
                 Box::new(PsiAmpScript::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -343,6 +343,15 @@ pub fn can_cycle_gun_setting(world: &World, weapon: EntityId) -> bool {
     has_second_fire_mode(second_header.as_deref(), &links)
 }
 
+/// The player's level in one skill, or 0 in a world with no character sheet
+/// (the unit-test worlds). Every skill gate reads it the same way.
+pub(crate) fn player_skill_level(world: &World, skill: crate::player_stats::Skill) -> i32 {
+    world
+        .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
+        .map(|quests| quests.player_stats().skill_level(skill))
+        .unwrap_or(0)
+}
+
 /// A gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
 /// tracks none - a melee weapon, the psi amp.
 pub(crate) fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -190,11 +190,7 @@ fn weapon_skill_level(world: &World, entity_id: EntityId) -> i32 {
         _ => Skill::StandardWeapons,
     };
 
-    world
-        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
-        .ok()
-        .map(|quests| quests.player_stats().skill_level(skill))
-        .unwrap_or(0)
+    crate::scripts::script_util::player_skill_level(world, skill)
 }
 
 /// The chance, 0..1, that the shot about to be fired breaks the gun. Zero at
@@ -413,6 +409,18 @@ impl Script for WeaponScript {
                 };
                 flat_melee_hit(physics, aim, world)
             }
+            // The maintenance tool, offered to this weapon on the port's tool
+            // channel: a VR hand releasing it onto the gun, or the flat
+            // use-mode click on a carried one. The decision lives here, on the
+            // receiving weapon, because everything it turns on - the gun's
+            // condition, its broken state, the Maintain level it authors - is
+            // the weapon's own, and because a gun runs no GuiScript that could
+            // claim the offer the way the security crate claims an ICE Pick.
+            MessagePayload::ProvideForConsumption { entity }
+                if crate::scripts::maintenance::is_maintenance_tool(world, *entity) =>
+            {
+                crate::scripts::maintenance::apply(world, *entity, Some(entity_id))
+            }
             MessagePayload::TriggerRelease => {
                 // An unlimited burst ends with the trigger. A finite one plays
                 // out regardless - letting go of the pistol's BURST one frame
@@ -504,7 +512,10 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
     let wear = (is_gunshot && !is_weapon_stability_active(world))
         .then(|| degrade_per_shot(world, entity_id))
         .flatten()
-        .map(|amount| Effect::DegradeWeaponCondition { entity_id, amount });
+        .map(|amount| Effect::AdjustWeaponCondition {
+            entity_id,
+            delta: -amount,
+        });
 
     // A worn gun can break as the trigger comes back, spending the shot
     // without firing it. The shot still wears the gun down.
@@ -1208,7 +1219,7 @@ mod tests {
         assert!(
             effects
                 .iter()
-                .any(|effect| matches!(effect, Effect::DegradeWeaponCondition { .. })),
+                .any(|effect| matches!(effect, Effect::AdjustWeaponCondition { .. })),
             "the breaking shot still wears the gun"
         );
         assert!(

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -40,6 +40,12 @@ pub fn hand_world_position(
 /// divides authored world geometry by [`SCALE_FACTOR`].
 pub(crate) const FROB_REACH: f32 = 7.071_068 / SCALE_FACTOR;
 
+/// How close the two hands must come for releasing a tool held in one to count
+/// as applying it to what the other holds. About a foot: close enough that the
+/// player has deliberately brought the two together, loose enough that they do
+/// not have to touch.
+const TWO_HAND_TOOL_REACH: f32 = 0.3;
+
 #[derive(Clone)]
 pub struct VirtualHand {
     position: Vector3<f32>,
@@ -233,6 +239,7 @@ impl VirtualHand {
         pawn_rot: Quaternion<f32>,
         input_hand: &Hand,
         held_by_other_hand: Option<EntityId>,
+        other_hand_position: Vector3<f32>,
     ) -> (VirtualHand, Vec<VirtualHandEffect>) {
         let handedness = prev.handedness;
         let hand_position = hand_world_position(pawn_pos, pawn_rot, input_hand.position);
@@ -253,19 +260,35 @@ impl VirtualHand {
                 if input_hand.squeeze_value < 0.5 {
                     let mut msgs = vec![VirtualHandEffect::DropItem { entity_id }];
 
-                    let result_copy = result.clone();
-                    if let Some(ray_cast_result) = result_copy {
-                        if let Some(hit_entity_id) = ray_cast_result.maybe_entity_id {
-                            msgs.push(VirtualHandEffect::OutMessage {
-                                message: Message {
-                                    to: hit_entity_id,
-                                    payload: MessagePayload::ProvideForConsumption {
-                                        entity: entity_id,
-                                    },
+                    // Releasing a tool against the weapon in the other hand is
+                    // the natural two-hand gesture, and it is the one target
+                    // the release ray usually misses: the hands are alongside
+                    // each other, not one pointed at the other. So the tool is
+                    // offered to what the other hand holds once it has been
+                    // brought to it - only for a pairing that item can take,
+                    // since offering on every release near the other hand would
+                    // e.g. post any dropped item into a held container.
+                    let two_hand_target = held_by_other_hand.filter(|other_held| {
+                        (hand_position - other_hand_position).magnitude() <= TWO_HAND_TOOL_REACH
+                            && crate::scripts::maintenance::offers_to(world, entity_id, *other_held)
+                    });
+
+                    // Exactly one recipient: a deliberate two-hand gesture wins
+                    // over whatever the ray happened to be pointing at, so one
+                    // tool can never be spent on two weapons (a released tool
+                    // over a weapons bench sees a second gun most of the time).
+                    let target = two_hand_target
+                        .or_else(|| result.clone().and_then(|hit| hit.maybe_entity_id));
+                    if let Some(target) = target {
+                        msgs.push(VirtualHandEffect::OutMessage {
+                            message: Message {
+                                to: target,
+                                payload: MessagePayload::ProvideForConsumption {
+                                    entity: entity_id,
                                 },
-                            });
-                        }
-                    };
+                            },
+                        });
+                    }
 
                     let updated_hand = VirtualHand {
                         position: hand_position,
@@ -789,6 +812,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             &input,
             None,
+            Vector3::zero(),
         );
 
         effects
@@ -1215,6 +1239,7 @@ mod tests {
             identity,
             &input,
             None,
+            Vector3::zero(),
         );
         assert_eq!(far_hand.get_raytraced_entity(), None);
         assert!(
@@ -1231,6 +1256,7 @@ mod tests {
             identity,
             &input,
             None,
+            Vector3::zero(),
         );
         assert_eq!(near_hand.get_raytraced_entity(), Some(near_target));
         assert!(

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -109,7 +109,7 @@ export async function aimVrHandAtCanvas(
   await game.input.set(`${hand}_hand.squeeze`, squeeze);
 }
 
-/** Aim the production VR hand ray at a world point without direct entity
+/** Aim one production VR hand's ray at a world point without direct entity
  * messages. Pass `squeeze = 1` to preserve an already-held item while aiming,
  * and `trigger = 1` to keep a pull in flight across the re-aim (releasing it
  * would end the gesture, which matters wherever a latch spans the movement). */
@@ -120,7 +120,7 @@ export async function aimVrHandAt(
   squeeze = 0,
   trigger = 0,
   { hand = "right" }: { hand?: Hand } = {},
-): Promise<{ start: Vec3; target: Vec3 }> {
+): Promise<{ start: Vec3; target: Vec3; local: Vec3 }> {
   const snapshot = await game.info();
   const pawn = snapshot.player.position;
   const pawnRotation = snapshot.player.rotation;
@@ -145,7 +145,7 @@ export async function aimVrHandAt(
   await game.input.set(`${hand}_hand.trigger`, trigger);
   await game.input.set(`${hand}_hand.squeeze`, squeeze);
   await game.step({ frames: 3 });
-  return { start: worldHand, target };
+  return { start: worldHand, target, local: localHand };
 }
 
 /** One canvas pixel of a world panel in world units (`gui::GUI_PIXEL_TO_WORLD_SIZE`). */

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { clickUiElement } from "./helpers/ui.js";
 import { ammoOf, cycleToWeapon, fireOnce } from "./helpers/weapon.js";
 
 // Firing wears a gun down: each shot costs the condition points the gun's
@@ -211,6 +212,206 @@ test(
       (await game.info()).player.wielded_gun_condition,
       condition,
       "and does not wear any further",
+    );
+  },
+);
+
+// --- Slice 4: the maintenance tool ---
+//
+// Using a maintenance tool on a gun restores 10 condition points per level of
+// the player's Maintain skill (debug_weapons maxes the sheet at 6, so 60),
+// capped at full condition, and uses the tool up. VR applies it as a physical
+// gesture - the tool is released against the gun held in the other hand; flat
+// has no drag, so using the tool from the inventory strip applies it to the
+// wielded gun (#817, partially).
+//
+// Negative-first: on the parent nothing recognizes the tool at all - the flat
+// double-click just Frobs it (a no-op), the VR release drops it, and the gun's
+// condition never moves.
+
+const MAINTENANCE_TOOL = -2949;
+/** debug_weapons maxes every skill, so Maintain is 6: ten points a level. */
+const RESTORED_POINTS = 60;
+
+async function toolInWorld(game: GameServer) {
+  const tools = await game.entities.byTemplate(MAINTENANCE_TOOL);
+  assert.equal(
+    tools.length,
+    1,
+    "debug_weapons should bench one maintenance tool",
+  );
+  return tools[0];
+}
+
+test(
+  "releasing the maintenance tool onto the gun in the other hand restores its condition",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // Right hand: the pistol, worn down to 20.
+    const weapon = await cycleToWeapon(game, (e) => e.template_id === PISTOL);
+    const gunHand = await aimVrHandAt(game, weapon.position as Vec3, 0.3);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      weapon.id,
+      "the VR right hand must hold the pistol",
+    );
+    await game.entities.sendMessage(weapon.id, {
+      type: "SetGunCondition",
+      condition: 20,
+    });
+    await game.step({ frames: 1 });
+    assert.equal(await condition(game), 20, "the gun starts worn");
+
+    // Left hand: the tool off the bench.
+    const tool = await toolInWorld(game);
+    await aimVrHandAt(game, tool.position as Vec3, 0.3, 0, 0, { hand: "left" });
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    const carried = await game.player.inventory();
+    assert.ok(
+      carried.items.some(
+        (i) => i.entity_id === tool.id && i.location === "left_hand",
+      ),
+      `the VR left hand must hold the maintenance tool (got ${JSON.stringify(
+        carried.items,
+      )})`,
+    );
+
+    // KEY: bring the tool to the gun and let go. The release ray is not
+    // pointed at the gun - the hands are simply side by side, which is the
+    // gesture a player makes.
+    await game.input.set("left_hand.position", [
+      gunHand.local[0] + 0.1,
+      gunHand.local[1],
+      gunHand.local[2],
+    ]);
+    await game.step({ frames: 2 });
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 8 });
+
+    assert.equal(
+      await condition(game),
+      20 + RESTORED_POINTS,
+      "the released tool should restore ten condition points per Maintain level",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(MAINTENANCE_TOOL)).length,
+      0,
+      "the tool is used up by the work it does",
+    );
+  },
+);
+
+test(
+  "using the maintenance tool from the flat inventory restores the wielded gun",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+    const gun = (await game.info()).player.wielded_entity_id;
+    assert.ok(gun, "flat mode must wield the pistol it spawned");
+    await game.entities.sendMessage(gun, {
+      type: "SetGunCondition",
+      condition: 20,
+    });
+    await game.step({ frames: 1 });
+
+    const tool = await toolInWorld(game);
+    await game.player.give(tool.id);
+    await game.step({ frames: 5 });
+
+    // KEY: the strip's use gesture (double-click) on the tool.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const toolEl = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && e.entity_id === tool.id,
+    );
+    assert.ok(
+      toolEl,
+      `the strip should list the carried tool (got ${JSON.stringify(
+        (await game.ui.state()).strip?.elements,
+      )})`,
+    );
+    await clickUiElement(game, toolEl); // lift...
+    await clickUiElement(game, toolEl); // ...and use
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await condition(game),
+      20 + RESTORED_POINTS,
+      "using the tool should restore the wielded gun",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.filter(
+        (i) => i.entity_id === tool.id,
+      ).length,
+      0,
+      "and use the tool up",
+    );
+    const sounds = await game.audio.recent();
+    assert.ok(
+      sounds.sounds.some((s) => s.sample === "maintool"),
+      `the use should play the tool's activation schema (got ${JSON.stringify(
+        sounds.sounds.map((s) => s.sample),
+      )})`,
+    );
+  },
+);
+
+test(
+  "the maintenance tool refuses a gun already in good condition, and survives",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+    const gun = (await game.info()).player.wielded_entity_id;
+    assert.ok(gun, "flat mode must wield the pistol it spawned");
+    assert.equal(await condition(game), 100, "a shipped gun starts pristine");
+
+    const tool = await toolInWorld(game);
+    await game.player.give(tool.id);
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const toolEl = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && e.entity_id === tool.id,
+    );
+    assert.ok(toolEl, "the strip should list the carried tool");
+    await clickUiElement(game, toolEl);
+    await clickUiElement(game, toolEl);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await condition(game),
+      100,
+      "a gun in good condition is left alone",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.filter(
+        (i) => i.entity_id === tool.id,
+      ).length,
+      1,
+      "and the refused tool is not spent",
+    );
+    const messages = await game.ui.state();
+    assert.ok(
+      (messages.messages ?? []).some((m) =>
+        m.includes("already in good condition"),
+      ),
+      `the refusal should say why (got ${JSON.stringify(messages.messages)})`,
     );
   },
 );


### PR DESCRIPTION
Fourth of the weapon-condition slices, on top of #1340.

## The rule

A maintenance tool applied to a ranged weapon restores **ten condition points per level of the player's Maintain skill**, capped at as-new, and is consumed (a stack loses one unit). It refuses, and is *not* consumed, when:

| refusal | shipped line |
| --- | --- |
| the target is not a ranged weapon (the psi amp included - it inherits a gun state whose condition means nothing) | "Drag tool to ranged weapon to use." |
| the weapon has broken | "Use repair skill on weapon first." |
| Maintain is below the level the weapon authors (`P$RequiredTechDesc` index 3: pistol 1, shotgun 2, assault rifle 4, fusion 3) - at least 1, so a use can never spend the tool on nothing | "Maintaining this weapon requires a skill of %d." |
| the weapon is already at full condition | "Weapon already in good condition." |

Every line comes from the shipped MISC.STR, with the English text only as a fallback.

## Where the decision lives

The offer arrives on the port's existing tool channel (`ProvideForConsumption`), which is sent **to the target**. So the receiving weapon claims it, keyed off the tool's authored script - exactly how the security crate claims an ICE Pick. A gun runs no panel that could hold an `on_provide_for_consumption`, so `WeaponScript` takes the message and calls one pure decision function.

## The two gestures

- **VR** - release the tool onto the gun. The existing release ray already covers a gun lying in the world; the natural gesture is the gun in the *other hand*, where the hands sit side by side rather than pointed at each other, so a release brought to the other hand offers **there instead**. Exactly one weapon is offered to per release, so a release over a rack of guns cannot spend one tool twice. Contextual, so it stays in `VirtualHand` rather than becoming an input action.
- **Flat** - there is no way to drag one carried item onto another (#817), so the inventory's use gesture on a tool applies it to the wielded weapon: the one target a flat player can name without a drag. Applied directly rather than posted over the message channel, so a target that runs no weapon script gets its refusal instead of silence. This addresses #817 **only for that target**; a general flat tool-drag is still missing.

## Also

`"wrench"` in the scripts table was wired to the melee contact script on the assumption it was the melee wrench - the melee wrench is an ordinary `WeaponScript`, and that name is only ever the maintenance tool. With the tool's real behaviour in place, that script and the melee-contact path only it reached are gone.

The inventory strip's double-click and the backpack panel's click are one gesture and now run one routine (`maintenance::use_carried_item`), instead of two byte-identical copies this change had to edit in lockstep. `script_util::player_skill_level` likewise replaces the third copy of the "borrow QuestInfo, read a skill" idiom.

`DegradeWeaponCondition` becomes `AdjustWeaponCondition` (signed, clamped to 0..100), matching the `AdjustAmmo`/`AdjustStackCount` convention, since wearing and restoring are the same operation.

The use plays the activation schema the tool's class tag names (`act_mainttool` -> the `maintool` sample).

## Verified

- Unit tests on the pure decision: all four refusals, the amount, the cap, single and stacked consumption, and that a refusal spends nothing. Mutating the points-per-level constant fails them.
- `tools/shock2-sdk/test/weapon-condition.e2e.test.ts` (debug_weapons now benches a tool): the VR two-hand release (20 -> 80), the flat inventory use (20 -> 80), and the full-condition refusal (unchanged, tool still carried, the line on the status channel). Suppressing the other-hand offer fails the VR case, so it is that path and not the ray.
- `cargo test -p shock2vr` (1371) + `cargo test -p dark`, `missions.e2e.test.ts` (23/23), and the inventory-drag / inventory-strip / container-loot / comestible / VR-release scenarios that share the touched paths.

## Review

`/xreview` (Claude + Codex + a duplication pass) found, and this branch fixes: one release could offer to both the ray target and the other hand and spend the tool twice (now exactly one recipient, the two-hand gesture winning); the psi amp was a valid target whose offer vanished silently; a Maintain-0 use could consume the tool for zero points; the flat drag pipeline dropped the composite effect unflattened; and the other-hand distance was read one frame stale on one side only (both hand positions now come from the same frame's input). The duplication pass also drove the two `extract` cleanups above.

## Not here

Repair and modify (slices 5-6).


## Media

![maintenance tool release demo](https://gist.githubusercontent.com/tommy-xr/1d7bd6c792009ba4ce1f29beee862c7c/raw/demo.gif)

<sub>VR: the maintenance tool grabbed off the bench and released against the pistol held in the other hand - the tool is consumed and the gun's condition restores. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep, `debug_weapons --vr`).</sub>

## Before → after

![before/after condition badge](https://gist.githubusercontent.com/tommy-xr/1d7bd6c792009ba4ce1f29beee862c7c/raw/beforeafter.png)

<sub>Flat mode, same pistol: the ammo HUD's condition badge (bottom-right of the gun readout) before and after using the maintenance tool from the inventory strip - orange "3" (condition 20) jumps to green "9" (condition 80).</sub>

