### PR TITLE
feat(weapons): repair a broken gun on the hack board

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -375,6 +375,11 @@ impl PropInventoryDimensions {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropObjIcon(pub String);
 
+/// `P$ObjBroken` ("Obj/Broken icon") - the inventory art an object shows once
+/// it has broken, in place of its `P$ObjIcon`.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropObjBrokenIcon(pub String);
+
 /// `P$Sett1` / `P$Sett2` - the description text for a gun's first / second fire
 /// setting, and `P$SHead1` / `P$SHead2` - the short header shown beside it
 /// (e.g. "NORM" / "BURST"). Each holds an object string (`key: "fallback"`)
@@ -1572,6 +1577,18 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$HackDiff",
             PropHackDiff::read,
             identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RepairDif",
+            PropRepairDiff::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$ObjBroken",
+            read_prop_string,
+            PropObjBrokenIcon,
             accumulator::latest,
         ),
         define_prop(

--- a/dark/src/properties/prop_hack_diff.rs
+++ b/dark/src/properties/prop_hack_diff.rs
@@ -18,7 +18,10 @@ pub struct PropHackDiff {
 
 impl PropHackDiff {
     pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
-        assert_eq!(len, 12, "P$HackDiff must be a 12-byte sTechInfo record");
+        assert_eq!(
+            len, 12,
+            "a tech difficulty must be a 12-byte sTechInfo record"
+        );
         Self {
             success_chance: read_i32(reader),
             critical_chance: read_i32(reader),
@@ -27,11 +30,24 @@ impl PropHackDiff {
     }
 }
 
+/// Dark's `P$RepairDif` - the terms a broken object is repaired on. The same
+/// 12-byte `sTechInfo` record as `P$HackDiff`, read against the Repair skill
+/// rather than the Hack one, so the board can charge and roll for a repair the
+/// way it does for a hack.
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropRepairDiff(pub PropHackDiff);
+
+impl PropRepairDiff {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        Self(PropHackDiff::read(reader, len))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
 
-    use super::PropHackDiff;
+    use super::{PropHackDiff, PropRepairDiff};
 
     #[test]
     fn parses_little_endian_tech_info_layout() {
@@ -48,6 +64,26 @@ mod tests {
                 critical_chance: 2,
                 cost: 15.5,
             }
+        );
+    }
+
+    /// The shipped pistol's `P$RepairDif` bytes (gamesys template -17): a 20%
+    /// base success chance, four criticals, three nanites an attempt.
+    #[test]
+    fn parses_the_shipped_pistol_repair_difficulty() {
+        let bytes = [
+            0x14, 0x00, 0x00, 0x00, // success chance 20
+            0x04, 0x00, 0x00, 0x00, // critical chance 4
+            0x00, 0x00, 0x40, 0x40, // cost 3.0
+        ];
+
+        assert_eq!(
+            PropRepairDiff::read(&mut Cursor::new(bytes), 12),
+            PropRepairDiff(PropHackDiff {
+                success_chance: 20,
+                critical_chance: 4,
+                cost: 3.0,
+            })
         );
     }
 }

--- a/dark/src/properties/prop_research.rs
+++ b/dark/src/properties/prop_research.rs
@@ -18,6 +18,10 @@ impl TechSkillValues {
         Self(std::array::from_fn(|_| read_i32(reader)))
     }
 
+    pub fn repair(self) -> i32 {
+        self.0[1]
+    }
+
     pub fn maintenance(self) -> i32 {
         self.0[3]
     }

--- a/dark/src/properties/prop_research.rs
+++ b/dark/src/properties/prop_research.rs
@@ -18,6 +18,10 @@ impl TechSkillValues {
         Self(std::array::from_fn(|_| read_i32(reader)))
     }
 
+    pub fn maintenance(self) -> i32 {
+        self.0[3]
+    }
+
     pub fn research(self) -> i32 {
         self.0[4]
     }

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -19,7 +19,8 @@
 //! buttons do not land on top of it.
 
 use cgmath::{Vector2, vec2};
-use shipyard::World;
+use dark::properties::ObjectState;
+use shipyard::{EntityId, World};
 
 use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
 
@@ -31,8 +32,13 @@ pub(crate) const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
 /// Selected ammo type's object icon (P$ObjIcon), at the gauge well's left -
 /// right of the cycle arrow, which claims the well's leading 12 px.
 pub(crate) const ICON: Rect = Rect::new(200.0, 18.0, 24.0, 24.0);
-/// Round count, right of the ammo icon inside the gauge well.
-pub(crate) const COUNT: Rect = Rect::new(224.0, 20.0, 25.0, 20.0);
+/// Round count, right of the ammo icon inside the gauge well - the middle of
+/// the well's three stacked bands (badge, count, ammo type), so the condition
+/// badge above it has the corner the original draws it in to itself.
+pub(crate) const COUNT: Rect = Rect::new(224.0, 28.0, 25.0, 14.0);
+/// The wielded gun's condition badge (`WSTATE*.PCX`, 14x14), in the gauge
+/// well's upper-right corner - where the original draws it.
+pub(crate) const CONDITION: Rect = Rect::new(235.0, 14.0, 14.0, 14.0);
 /// Ammo-type label (std/he/ap), across the bottom of the gauge well.
 pub(crate) const TYPE_LABEL: Rect = Rect::new(198.0, 42.0, 51.0, 13.0);
 
@@ -69,6 +75,40 @@ pub(crate) const PSI_SELECT: Rect = Rect::new(
 
 /// The font every readout label uses (the original's HUD font).
 const FONT: &str = "mainfont.fon";
+
+/// The condition badges, best first: a green "10" down through a red "1", then
+/// a crossed-out badge for a gun that is not in working order. The shipped art
+/// authors all eleven; the tenth is what a gun on its last legs shows and the
+/// eleventh is what a broken one shows.
+const CONDITION_ART: [&str; 11] = [
+    "wstate1.pcx",
+    "wstate2.pcx",
+    "wstate3.pcx",
+    "wstate4.pcx",
+    "wstate5.pcx",
+    "wstate6.pcx",
+    "wstate7.pcx",
+    "wstate8.pcx",
+    "wstate9.pcx",
+    "wstate10.pcx",
+    "wstate11.pcx",
+];
+
+/// Which badge a gun in `state` at `condition` (0..100) shows.
+///
+/// A gun that still works shows the badge for its condition tenth - the same
+/// tenth its name's condition word comes from, counted the other way round,
+/// since the art runs best-first and the words run worst-first. A gun that is
+/// broken or destroyed shows the crossed-out badge instead, so "worn out but
+/// firing" and "will not fire" are never the same picture. Only those two
+/// states change the badge: an unresearched weapon still fires here, so it
+/// still reads as its condition.
+pub(crate) fn condition_badge(state: ObjectState, condition: f32) -> &'static str {
+    if matches!(state, ObjectState::Broken | ObjectState::Destroyed) {
+        return CONDITION_ART[10];
+    }
+    CONDITION_ART[(10 - super::gun_condition_bucket(condition)) as usize]
+}
 
 /// A clickable control on the ammo readout. The layout owns the set, so the
 /// drawn button and the hit-tested rect can never disagree.
@@ -134,6 +174,9 @@ pub(crate) struct AmmoReadout {
     pub ammo_icon: Option<String>,
     /// The selected ammo type's class tag ("std", "he", "ap").
     pub ammo_type: Option<String>,
+    /// The wielded gun's condition badge art. Absent for a weapon that has no
+    /// condition to wear down (the psi amp, a melee weapon).
+    pub gun_condition: Option<&'static str>,
     /// The wielded gun's current fire-mode header ("NORM"/"BURST"/"AUTO") -
     /// the SETTING button's label. Absent when the gun names no header.
     pub gun_setting_header: Option<String>,
@@ -150,6 +193,15 @@ pub(crate) struct AmmoReadout {
     pub show_buttons: bool,
 }
 
+/// `weapon`'s condition badge, if it is the kind of weapon that has one.
+fn wielded_gun_condition(world: &World, weapon: EntityId) -> Option<&'static str> {
+    let condition = crate::scripts::script_util::gun_condition(world, weapon)?;
+    Some(condition_badge(
+        crate::scripts::gui::object_state(world, weapon),
+        condition,
+    ))
+}
+
 impl AmmoReadout {
     /// Read the wielded weapon's readout from the world. `show_buttons` is the
     /// caller's (presentation's) call.
@@ -160,6 +212,7 @@ impl AmmoReadout {
             ammo: super::get_wielded_ammo(world),
             ammo_icon: super::get_wielded_ammo_icon(world),
             ammo_type: super::get_wielded_ammo_type(world),
+            gun_condition: weapon.and_then(|w| wielded_gun_condition(world, w)),
             gun_setting_header: super::get_wielded_gun_setting(world)
                 .and_then(|(_, header)| header),
             can_cycle_ammo: weapon
@@ -291,6 +344,9 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
         if let Some(icon) = &readout.ammo_icon {
             canvas.image(at(origin, ICON), icon);
         }
+        if let Some(badge) = readout.gun_condition {
+            canvas.image(at(origin, CONDITION), badge);
+        }
         if let Some(ammo_type) = &readout.ammo_type {
             // Ellipsized: the class tag is data ("std", but also "lasershot"),
             // and an over-wide label would spill out of the gauge well.
@@ -405,6 +461,59 @@ mod tests {
         assert_eq!(text_of(AmmoReadout::default()), None);
     }
 
+    /// The badge grades a working gun and calls out one that will not fire.
+    #[test]
+    fn the_condition_badge_counts_down_with_the_gun() {
+        let working = |condition| condition_badge(ObjectState::Normal, condition);
+        assert_eq!(working(100.0), "wstate1.pcx", "pristine");
+        assert_eq!(working(91.0), "wstate1.pcx", "barely used");
+        assert_eq!(working(45.0), "wstate6.pcx", "half worn");
+        assert_eq!(working(5.0), "wstate10.pcx", "about to give out");
+        assert_eq!(working(0.0), "wstate10.pcx", "worn out");
+        // A gun that will not fire reads differently from one that barely
+        // will - that is the whole point of the eleventh badge.
+        assert_eq!(condition_badge(ObjectState::Broken, 0.0), "wstate11.pcx");
+        assert_eq!(
+            condition_badge(ObjectState::Destroyed, 90.0),
+            "wstate11.pcx"
+        );
+        // ...but a state that does not stop the gun leaves the grade alone.
+        assert_eq!(
+            condition_badge(ObjectState::Unresearched, 100.0),
+            working(100.0)
+        );
+    }
+
+    /// The badge is emitted with the gun's readout, in its own corner: both
+    /// presentations build this canvas, so neither can place it differently.
+    #[test]
+    fn the_condition_badge_takes_the_wells_corner_clear_of_the_count() {
+        let canvas = build_readout_canvas(&AmmoReadout {
+            gun_condition: Some("wstate11.pcx"),
+            ..gun(12, None, None)
+        });
+        let badge = canvas
+            .elements()
+            .iter()
+            .find_map(|element| match element {
+                crate::ui::UiElement::Image {
+                    texture, position, ..
+                } if texture == "wstate11.pcx" => Some(*position),
+                _ => None,
+            })
+            .expect("the readout draws the badge");
+        assert_eq!(badge, vec2(CONDITION.x, CONDITION.y));
+        // The well stacks three bands, and none of them may sit on another.
+        assert!(
+            CONDITION.y + CONDITION.h <= COUNT.y && COUNT.y + COUNT.h <= TYPE_LABEL.y,
+            "badge/count/type must stack: {CONDITION:?} {COUNT:?} {TYPE_LABEL:?}"
+        );
+        assert!(
+            CONDITION.x + CONDITION.w <= WELL.x + WELL.w,
+            "the badge must stay inside the gauge well"
+        );
+    }
+
     #[test]
     fn the_psi_amp_shows_its_discipline_on_the_forearm_too() {
         // Tier badge + discipline name = 2, and the amp's meaningless clip is
@@ -425,6 +534,7 @@ mod tests {
             COUNT,
             ICON,
             TYPE_LABEL,
+            CONDITION,
             CYCLE_BUTTON,
             SETTING_BUTTON,
             RELOAD_BUTTON,
@@ -456,7 +566,14 @@ mod tests {
     /// it on bare 3D view.
     #[test]
     fn the_readout_sits_inside_the_compact_gauge_well() {
-        for rect in [COUNT, ICON, TYPE_LABEL, PSI_TIER_BADGE, PSI_POWER_NAME] {
+        for rect in [
+            COUNT,
+            ICON,
+            TYPE_LABEL,
+            CONDITION,
+            PSI_TIER_BADGE,
+            PSI_POWER_NAME,
+        ] {
             assert!(
                 rect.x >= WELL.x && rect.x + rect.w <= WELL.x + WELL.w,
                 "{rect:?} leaves the gauge well horizontally"

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -386,6 +386,7 @@ mod tests {
             ammo_panel::COUNT,
             ammo_panel::ICON,
             ammo_panel::TYPE_LABEL,
+            ammo_panel::CONDITION,
             ammo_panel::PSI_TIER_BADGE,
             ammo_panel::PSI_POWER_NAME,
         ] {

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -6,7 +6,7 @@ use dark::{
         resolve_symbolic_name,
     },
     properties::{
-        ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
+        ObjectNameType, ObjectState, PropHUDSelect, PropHitPoints, PropLog, PropMaxHitPoints,
         PropObjName, PropObjectNameType, PropShowHP, PropStackCount, PropSymName, PropTemplateId,
     },
 };
@@ -116,11 +116,10 @@ fn localized_log_title(
         .map(|name| format_inline_localized_text(name))
 }
 
+/// The WEAPON.STR key for a gun's condition word: `GunCondVal1..10`, one per
+/// tenth of the condition ("Terrible: 1" .. "Perfect: 10").
 fn weapon_condition_key(condition: f32) -> String {
-    // Looking Glass's GunGetConditionString truncates the 0..100 condition,
-    // divides it into ten buckets, and fetches GunCondVal1..10.
-    let bucket = ((condition as i32) / 10).clamp(0, 9) + 1;
-    format!("guncondval{bucket}")
+    format!("guncondval{}", super::gun_condition_bucket(condition))
 }
 
 fn localized_weapon_condition(
@@ -128,14 +127,45 @@ fn localized_weapon_condition(
     world: &World,
     entity_id: EntityId,
 ) -> Option<String> {
-    let condition = {
-        let gun_states = world.borrow::<View<PropGunState>>().ok()?;
-        gun_states.get(entity_id).ok()?.condition
-    };
+    let condition = crate::scripts::script_util::gun_condition(world, entity_id)?;
     asset_cache
         .get_opt(&STRINGS_IMPORTER, "weapon.str")?
         .get(&weapon_condition_key(condition))
         .cloned()
+}
+
+/// The parenthetical an object's working order adds to its display name -
+/// "(broken)", "(destroyed)" - from MISC.STR's `ObjState<n>` keys, numbered by
+/// the state itself. `None` for a working object, and for the states the
+/// original leaves off the *name*: an unresearched object has its whole name
+/// replaced by the research interface's own wording rather than suffixed, and
+/// locked/hacked ones say nothing here.
+///
+/// The table's own values lead with a space; the strings importer trims its
+/// values, so the caller supplies the separator.
+pub(crate) fn object_state_suffix(
+    asset_cache: &mut AssetCache,
+    world: &World,
+    entity_id: EntityId,
+) -> Option<String> {
+    let (key, fallback) =
+        object_state_suffix_strings(crate::scripts::gui::object_state(world, entity_id))?;
+    let strings = asset_cache.get_opt(&STRINGS_IMPORTER, "misc.str");
+    Some(crate::ui::resolve_menu_label(
+        strings.as_deref(),
+        key,
+        fallback,
+    ))
+}
+
+/// The MISC.STR key naming `state`'s parenthetical - numbered by the state -
+/// and the English text that key ships with, for an install that lacks it.
+fn object_state_suffix_strings(state: ObjectState) -> Option<(&'static str, &'static str)> {
+    match state {
+        ObjectState::Broken => Some(("objstate1", "(broken)")),
+        ObjectState::Destroyed => Some(("objstate2", "(destroyed)")),
+        _ => None,
+    }
 }
 
 /// An object with no `P$ObjName` of its own (e.g. the Wrench, which inherits
@@ -155,7 +185,8 @@ fn resolve_symname_fallback(
 /// through `objname.str`, falling back to its `P$SymName` when it has no
 /// `P$ObjName` of its own, and then through whatever substitution its
 /// `P$ObjectNameType` asks for (a stack count, a log's title, a gun's
-/// condition word). `None` when the object has no name to show.
+/// condition word), plus whatever its working order adds on the end. `None`
+/// when the object has no name to show.
 ///
 /// The single name resolution the interface has: the rollover label beside the
 /// HUD brackets and the inventory bar's mini-frame name line both read it, so
@@ -201,13 +232,26 @@ pub fn resolve_item_name(
     let weapon_condition = (name_type == ObjectNameType::Weapon)
         .then(|| localized_weapon_condition(asset_cache, world, entity_id))
         .flatten();
-    Some(format_typed_item_name(
+    let named = format_typed_item_name(
         &localized_name,
         name_type,
         stack_count,
         log_title.as_deref(),
         weapon_condition.as_deref(),
+    );
+    Some(append_object_state(
+        named,
+        object_state_suffix(asset_cache, world, entity_id).as_deref(),
     ))
+}
+
+/// Put an object's working order on the end of its name, separated by the space
+/// the shipped table authors and the strings importer trims off.
+fn append_object_state(name: String, suffix: Option<&str>) -> String {
+    match suffix {
+        Some(suffix) => format!("{name} {suffix}"),
+        None => name,
+    }
 }
 
 pub fn draw_item_name(
@@ -462,6 +506,45 @@ mod tests {
         assert_eq!(weapon_condition_key(10.0), "guncondval2");
         assert_eq!(weapon_condition_key(50.0), "guncondval6");
         assert_eq!(weapon_condition_key(100.0), "guncondval10");
+    }
+
+    /// A gun's name says its condition; its working order is a separate word
+    /// on the end, so "worn out" and "will not fire" read differently.
+    #[test]
+    fn only_a_broken_or_destroyed_object_names_its_state() {
+        assert_eq!(
+            object_state_suffix_strings(ObjectState::Broken),
+            Some(("objstate1", "(broken)"))
+        );
+        assert_eq!(
+            object_state_suffix_strings(ObjectState::Destroyed),
+            Some(("objstate2", "(destroyed)"))
+        );
+        // A working object says nothing extra, and neither do the states the
+        // original leaves off the name.
+        for quiet in [
+            ObjectState::Normal,
+            ObjectState::Unresearched,
+            ObjectState::Locked,
+            ObjectState::Hacked,
+        ] {
+            assert_eq!(object_state_suffix_strings(quiet), None, "{quiet:?}");
+        }
+    }
+
+    /// The state joins the name with a space of its own: the shipped strings
+    /// lead with one, but the strings importer trims every value, so a plain
+    /// concatenation would read "A Pistol. (Perfect: 10)(broken)".
+    #[test]
+    fn the_state_is_separated_from_the_name() {
+        assert_eq!(
+            append_object_state("A Pistol. (Perfect: 10)".to_owned(), Some("(broken)")),
+            "A Pistol. (Perfect: 10) (broken)"
+        );
+        assert_eq!(
+            append_object_state("A Pistol.".to_owned(), None),
+            "A Pistol."
+        );
     }
 
     #[test]

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -48,6 +48,10 @@ const FALLBACK_WRENCH_ON_BROKEN: &str = "Use repair skill on weapon first.";
 const FALLBACK_WRENCH_SKILL_REQ: &str = "Maintaining this weapon requires a skill of %d.";
 const FALLBACK_WRENCH_UNUSED: &str = "Weapon already in good condition.";
 
+/// The English fallback for the board's repair skill gate, verbatim from the
+/// shipped HRM.STR (`%d` is the minimum Repair level the object authors).
+const FALLBACK_REPAIR_SKILL_REQ: &str = "Repair skill %d required.";
+
 /// HUD label strings preloaded from MISC.STR, stored as a world `Unique`
 /// because the readout layout has no `AssetCache` at draw time (the
 /// `ElevatorContext` pattern).
@@ -72,6 +76,10 @@ pub struct HudStrings {
     pub wrench_skill_req: String,
     /// MISC.STR `WrenchUnused`: the weapon is already at full condition.
     pub wrench_unused: String,
+    /// HRM.STR `techminskill1` ("Repair skill %d required."): the player's
+    /// Repair level is below the minimum the object authors, so the board
+    /// never opens in repair mode.
+    pub repair_skill_req: String,
 }
 
 impl Default for HudStrings {
@@ -84,6 +92,7 @@ impl Default for HudStrings {
             wrench_on_broken: FALLBACK_WRENCH_ON_BROKEN.to_owned(),
             wrench_skill_req: FALLBACK_WRENCH_SKILL_REQ.to_owned(),
             wrench_unused: FALLBACK_WRENCH_UNUSED.to_owned(),
+            repair_skill_req: FALLBACK_REPAIR_SKILL_REQ.to_owned(),
         }
     }
 }
@@ -91,7 +100,15 @@ impl Default for HudStrings {
 impl HudStrings {
     pub fn load(asset_cache: &mut AssetCache) -> HudStrings {
         let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "misc.str");
+        // The board's own table: everything the HRM's three modes say lives in
+        // HRM.STR, not in the general HUD one.
+        let hrm_strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "hrm.str");
         HudStrings {
+            repair_skill_req: crate::ui::resolve_menu_label(
+                hrm_strings.as_deref(),
+                "techminskill1",
+                FALLBACK_REPAIR_SKILL_REQ,
+            ),
             reload_label: crate::ui::resolve_menu_label(
                 strings.as_deref(),
                 "reload",

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -40,6 +40,14 @@ const FALLBACK_MOD_LEVEL_LABEL: &str = "Modification Level %d";
 /// verbatim from the shipped MISC.STR (`%s` is the gun's short name).
 const FALLBACK_WEAPON_BREAKS: &str = "%s has broken!";
 
+/// The English fallbacks for the maintenance tool's four refusals, verbatim
+/// from the shipped MISC.STR. `%d` in the skill line is the minimum Maintain
+/// level the weapon authors.
+const FALLBACK_WRENCH_ON_NON_GUN: &str = "Drag tool to ranged weapon to use.";
+const FALLBACK_WRENCH_ON_BROKEN: &str = "Use repair skill on weapon first.";
+const FALLBACK_WRENCH_SKILL_REQ: &str = "Maintaining this weapon requires a skill of %d.";
+const FALLBACK_WRENCH_UNUSED: &str = "Weapon already in good condition.";
+
 /// HUD label strings preloaded from MISC.STR, stored as a world `Unique`
 /// because the readout layout has no `AssetCache` at draw time (the
 /// `ElevatorContext` pattern).
@@ -53,6 +61,17 @@ pub struct HudStrings {
     /// MISC.STR `WeaponBreaks` ("%s has broken!"), the status line a gun posts
     /// when it gives out. The `%s` is the gun's short name.
     pub weapon_breaks_message: String,
+    /// MISC.STR `WrenchOnNonGun`: the maintenance tool was used on something
+    /// that is not a ranged weapon.
+    pub wrench_on_non_gun: String,
+    /// MISC.STR `WrenchOnBroken`: a broken weapon needs repairing, not
+    /// maintaining.
+    pub wrench_on_broken: String,
+    /// MISC.STR `WrenchSkillReq` ("... a skill of %d"): the player's Maintain
+    /// level is below the minimum this weapon authors.
+    pub wrench_skill_req: String,
+    /// MISC.STR `WrenchUnused`: the weapon is already at full condition.
+    pub wrench_unused: String,
 }
 
 impl Default for HudStrings {
@@ -61,6 +80,10 @@ impl Default for HudStrings {
             reload_label: FALLBACK_RELOAD_LABEL.to_owned(),
             mod_level_label: FALLBACK_MOD_LEVEL_LABEL.to_owned(),
             weapon_breaks_message: FALLBACK_WEAPON_BREAKS.to_owned(),
+            wrench_on_non_gun: FALLBACK_WRENCH_ON_NON_GUN.to_owned(),
+            wrench_on_broken: FALLBACK_WRENCH_ON_BROKEN.to_owned(),
+            wrench_skill_req: FALLBACK_WRENCH_SKILL_REQ.to_owned(),
+            wrench_unused: FALLBACK_WRENCH_UNUSED.to_owned(),
         }
     }
 }
@@ -83,6 +106,26 @@ impl HudStrings {
                 strings.as_deref(),
                 "weaponbreaks",
                 FALLBACK_WEAPON_BREAKS,
+            ),
+            wrench_on_non_gun: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchonnongun",
+                FALLBACK_WRENCH_ON_NON_GUN,
+            ),
+            wrench_on_broken: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchonbroken",
+                FALLBACK_WRENCH_ON_BROKEN,
+            ),
+            wrench_skill_req: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchskillreq",
+                FALLBACK_WRENCH_SKILL_REQ,
+            ),
+            wrench_unused: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "wrenchunused",
+                FALLBACK_WRENCH_UNUSED,
             ),
         }
     }

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -18,6 +18,16 @@ pub use message_line::HudMessages;
 mod flat_hud;
 pub(crate) use flat_hud::*;
 
+/// Which tenth of its condition a gun is in, 1 (worn out) to 10 (pristine).
+///
+/// The original truncates the 0..100 condition and divides it into ten
+/// buckets. Both readouts of a gun's condition - the word its name carries and
+/// the badge on the ammo gauge - grade it here, so the label and the picture
+/// can never disagree about how worn a gun is.
+pub(crate) fn gun_condition_bucket(condition: f32) -> i32 {
+    (condition as i32 / 10).clamp(0, 9) + 1
+}
+
 /// The English fallback for the reload button, verbatim from the shipped
 /// MISC.STR, for a data install that lacks the table.
 const FALLBACK_RELOAD_LABEL: &str = "RELOAD";
@@ -25,6 +35,10 @@ const FALLBACK_RELOAD_LABEL: &str = "RELOAD";
 /// The English fallback for the weapon-settings modification line, verbatim
 /// from the shipped MISC.STR (`%d` is the gun's `PropGunState.modification`).
 const FALLBACK_MOD_LEVEL_LABEL: &str = "Modification Level %d";
+
+/// The English fallback for the line a gun's owner gets when it breaks,
+/// verbatim from the shipped MISC.STR (`%s` is the gun's short name).
+const FALLBACK_WEAPON_BREAKS: &str = "%s has broken!";
 
 /// HUD label strings preloaded from MISC.STR, stored as a world `Unique`
 /// because the readout layout has no `AssetCache` at draw time (the
@@ -36,6 +50,9 @@ pub struct HudStrings {
     /// MISC.STR `ModLevel` ("Modification Level %d"), the settings MFD's
     /// modification line. The `%d` is substituted at draw time.
     pub mod_level_label: String,
+    /// MISC.STR `WeaponBreaks` ("%s has broken!"), the status line a gun posts
+    /// when it gives out. The `%s` is the gun's short name.
+    pub weapon_breaks_message: String,
 }
 
 impl Default for HudStrings {
@@ -43,6 +60,7 @@ impl Default for HudStrings {
         Self {
             reload_label: FALLBACK_RELOAD_LABEL.to_owned(),
             mod_level_label: FALLBACK_MOD_LEVEL_LABEL.to_owned(),
+            weapon_breaks_message: FALLBACK_WEAPON_BREAKS.to_owned(),
         }
     }
 }
@@ -60,6 +78,11 @@ impl HudStrings {
                 strings.as_deref(),
                 "modlevel",
                 FALLBACK_MOD_LEVEL_LABEL,
+            ),
+            weapon_breaks_message: crate::ui::resolve_menu_label(
+                strings.as_deref(),
+                "weaponbreaks",
+                FALLBACK_WEAPON_BREAKS,
             ),
         }
     }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -25,7 +25,7 @@ use crate::{
     hud::create_arm_hud_panels,
     input_context::InputContext,
     physics::PhysicsWorld,
-    virtual_hand::{VirtualHand, VirtualHandEffect},
+    virtual_hand::{VirtualHand, VirtualHandEffect, hand_world_position},
     vr_config::Handedness,
 };
 
@@ -226,6 +226,14 @@ impl PlayerInteraction for VrInteraction {
 
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
         let left_held_entity = self.left_hand.get_held_entity();
+        // Both hands' positions come from this frame's input, before either
+        // update: the two-hand gesture must read the same distance whichever
+        // hand releases.
+        let hand_position = |hand: &crate::input_context::Hand| {
+            hand_world_position(ctx.player_pos, ctx.player_rotation, hand.position)
+        };
+        let left_position = hand_position(&ctx.input.left_hand);
+        let right_position = hand_position(&ctx.input.right_hand);
         let (right_hand, mut right_msgs) = VirtualHand::update(
             &self.right_hand,
             ctx.physics,
@@ -234,6 +242,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.right_hand,
             left_held_entity,
+            left_position,
         );
         self.right_hand = right_hand;
 
@@ -248,6 +257,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.left_hand,
             right_held_entity,
+            right_position,
         );
         self.left_hand = left_hand;
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -1308,10 +1308,7 @@ fn close_button_canvas_rect(panel: Rect) -> Rect {
 /// Resolve a lifted item's cursor art (`objicon`) and label (`SymName`) for
 /// the cursor-is-the-item drag.
 fn make_cursor_item(world: &World, entity: EntityId) -> CursorItem {
-    let icon = world
-        .borrow::<View<dark::properties::PropObjIcon>>()
-        .ok()
-        .and_then(|v| v.get(entity).ok().map(|i| format!("{}.pcx", i.0)));
+    let icon = crate::scripts::gui::inventory_icon(world, entity).map(|icon| format!("{icon}.pcx"));
     CursorItem {
         entity,
         icon,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1386,6 +1386,13 @@ pub struct MediaPanelEntity(pub EntityId);
 #[derive(Unique, Clone, Copy)]
 pub struct WeaponSettingsPanelEntity(pub EntityId);
 
+/// Nonserialized player-owned host for the HRM board in repair mode. Like the
+/// settings MFD it presents a gun rather than a world object;
+/// `Effect::OpenWeaponRepair` names that gun and binds this host to the panel
+/// slot.
+#[derive(Unique, Clone, Copy)]
+pub struct WeaponRepairPanelEntity(pub EntityId);
+
 /// Which shortcut opened the current use-mode session, when one did.
 /// See [`MissionCore::use_mode_shortcut`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1572,6 +1579,10 @@ pub struct MissionCore {
     /// The gun an open weapon settings panel was opened for; the panel is
     /// dismissed as soon as that gun stops being wielded.
     weapon_settings_gun: Option<EntityId>,
+    /// The gun an open repair board was opened for; the panel is dismissed
+    /// once a critical failure destroys that gun, and a won repair leaves it
+    /// up showing its result.
+    weapon_repair_gun: Option<EntityId>,
 
     /// Which shortcut - if any - brought up the current use-mode session,
     /// rather than a deliberate `ToggleUseMode`. It makes a shortcut a true
@@ -2116,6 +2127,26 @@ impl MissionCore {
         ));
         world.add_unique(WeaponSettingsPanelEntity(weapon_settings_panel));
 
+        // The repair board's host, on the same terms: it presents whichever
+        // broken gun the player used, so it belongs to no world object.
+        let weapon_repair_panel = world.add_entity((
+            Links::empty(),
+            PropScripts {
+                scripts: vec!["internal_weapon_repair".to_owned()],
+                inherits: false,
+            },
+            dark::properties::PropTemplateId { template_id: -1 },
+            PropSymName("Weapon Repair".to_owned()),
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+            RuntimePropTransform(Matrix4::identity()),
+            RuntimePropDoNotSerialize,
+        ));
+        world.add_unique(WeaponRepairPanelEntity(weapon_repair_panel));
+
         // The psi power selection MFD's host, on the same terms: player state,
         // no world object, rebuilt per mission and never serialized.
         let psi_powers_panel = world.add_entity((
@@ -2547,6 +2578,7 @@ impl MissionCore {
             flat_melee_anim: None,
             use_mode: false,
             weapon_settings_gun: None,
+            weapon_repair_gun: None,
             psi_powers_open: false,
             psi_nav_latched: false,
             use_mode_shortcut: None,
@@ -3670,6 +3702,35 @@ impl MissionCore {
                 self.weapon_settings_gun = None;
             } else if !ours_is_docked {
                 self.weapon_settings_gun = None;
+            }
+        }
+
+        // The repair board belongs to one gun. A critical failure destroys
+        // that gun, so the board has nothing left to present and is dismissed;
+        // a won repair leaves it up showing the result, as the other HRM
+        // panels do. As above, the flag means "our panel is docked".
+        if let Some(opened_for) = self.weapon_repair_gun {
+            let panel = self
+                .world
+                .borrow::<UniqueView<WeaponRepairPanelEntity>>()
+                .map(|panel| panel.0)
+                .ok();
+            let ours_is_docked = panel.is_some() && self.flat_ui.active_panel() == panel;
+            let destroyed = !self
+                .world
+                .borrow::<shipyard::EntitiesView>()
+                .map(|entities| entities.is_alive(opened_for))
+                .unwrap_or(false);
+            if destroyed && ours_is_docked {
+                self.flat_ui.close();
+            }
+            if destroyed || !ours_is_docked {
+                // Drop the subject with the panel: an unowned one would leave
+                // the board addressing a gun nothing is presenting.
+                let _ = self
+                    .world
+                    .remove_unique::<crate::scripts::gui::WeaponRepairSubject>();
+                self.weapon_repair_gun = None;
             }
         }
 
@@ -5948,6 +6009,36 @@ impl MissionCore {
                             self.flat_ui.open_unbound(panel);
                             self.weapon_settings_gun = Some(weapon);
                         }
+                    }
+                }
+
+                Effect::OpenWeaponRepair { entity_id } => {
+                    // Same slot contract as the settings MFD: flat always
+                    // presents it, VR only inside the cyber interface - which
+                    // is also the only place a VR player can use a carried
+                    // item in the first place.
+                    let slot_is_presented = game_options.presentation_mode
+                        == crate::PresentationMode::Flat
+                        || self.use_mode;
+                    let panel = self
+                        .world
+                        .borrow::<UniqueView<WeaponRepairPanelEntity>>()
+                        .map(|panel| panel.0);
+                    if let (true, Ok(panel)) = (slot_is_presented, panel) {
+                        // Removed first: the subject is rebound on every open,
+                        // and a unique that is only ever added would keep the
+                        // gun the panel was opened on the *last* time.
+                        let _ = self
+                            .world
+                            .remove_unique::<crate::scripts::gui::WeaponRepairSubject>();
+                        self.world
+                            .add_unique(crate::scripts::gui::WeaponRepairSubject(entity_id));
+                        self.script_world.dispatch(Message {
+                            to: panel,
+                            payload: MessagePayload::PanelOpened,
+                        });
+                        self.flat_ui.open_unbound(panel);
+                        self.weapon_repair_gun = Some(entity_id);
                     }
                 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3726,7 +3726,10 @@ impl MissionCore {
             self.script_world.dispatch(msg);
         }
         for action in ui_drag_actions {
-            let drag_effects = self.apply_flat_drag_action(action);
+            // Flattened: an action can answer with a composite (using a
+            // maintenance tool is a restore plus a consume plus a sound), and
+            // this list is applied one variant at a time.
+            let drag_effects = Effect::flatten(self.apply_flat_drag_action(action));
             effects.extend(drag_effects);
         }
 
@@ -4987,25 +4990,16 @@ impl MissionCore {
                 }
             }
             // Double-click = equip/use, acting on the still-contained item -
-            // identical to the ContainerGui backpack click (shared weapon test,
-            // shared effects): a weapon (gun or melee) wields via `GrabEntity`
-            // (which also clears its Contains link and holsters any displaced
-            // weapon back to the grid), anything else gets a `Frob` (use).
+            // literally the ContainerGui backpack click, through the one
+            // routine both share: a weapon (gun or melee) wields via
+            // `GrabEntity` (which also clears its Contains link and holsters
+            // any displaced weapon back to the grid), anything else is used
+            // where it stands.
             FlatUiDragAction::Wield(entity_id) => {
-                if crate::virtual_hand::is_wieldable_weapon(&self.world, entity_id) {
-                    vec![Effect::GrabEntity {
-                        entity_id,
-                        hand: crate::vr_config::Handedness::Right,
-                        current_parent_id: None,
-                    }]
-                } else {
-                    vec![Effect::Send {
-                        msg: Message {
-                            payload: MessagePayload::Frob,
-                            to: entity_id,
-                        },
-                    }]
-                }
+                vec![crate::scripts::maintenance::use_carried_item(
+                    &self.world,
+                    entity_id,
+                )]
             }
         }
     }
@@ -5828,14 +5822,14 @@ impl MissionCore {
                     }
                 }
 
-                Effect::DegradeWeaponCondition { entity_id, amount } => {
+                Effect::AdjustWeaponCondition { entity_id, delta } => {
                     let mut v_gun_state = self
                         .world
                         .borrow::<ViewMut<dark::properties::PropGunState>>()
                         .unwrap();
 
                     if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
-                        crate::scripts::effect::degrade_condition(gun_state, amount);
+                        crate::scripts::effect::adjust_condition(gun_state, delta);
                     }
                 }
 

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -68,6 +68,11 @@ const BENCH_AMMO: &[(i32, &str)] = &[
     (-1264, "Large Worm Beaker"),
 ];
 
+/// The maintenance tool, in its own slot down the middle of the bench: worn
+/// guns are restored by releasing it onto them (VR) or using it from the
+/// inventory (flat).
+const BENCH_TOOL: i32 = -2949;
+
 /// The bench sits beside the firing lane on the player's left (+Z with the -X
 /// forward), long axis along X: guns on the outer row, ammo on the inner row.
 const BENCH_HEIGHT: f32 = 1.1;
@@ -237,6 +242,11 @@ impl DebugSceneHooks for ArsenalHooks {
                 Point3::new(x, BENCH_HEIGHT + 0.4, BENCH_Z + 0.5),
             ));
         }
+        // The middle strip of the bench is clear between the two rows.
+        effects.push(spawn_at(
+            BENCH_TOOL,
+            Point3::new(BENCH_NEAR_X, BENCH_HEIGHT + 0.15, BENCH_Z),
+        ));
         for (index, (template_id, _)) in BENCH_AMMO.iter().enumerate() {
             let x = BENCH_NEAR_X - index as f32 * AMMO_SPACING;
             // Zigzag so a bouncing neighbor can't billiard the whole row.

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -266,6 +266,12 @@ pub enum Effect {
     /// panel slot. No-op when nothing is wielded.
     OpenWeaponSettings,
 
+    /// Open the HRM board in repair mode on `entity_id`, a broken gun, in the
+    /// presentation's panel slot. No-op where that slot is not presented.
+    OpenWeaponRepair {
+        entity_id: EntityId,
+    },
+
     /// Eject `entity_id`'s magazine back to the backpack, as clips of the ammo
     /// type the rounds already are. No-op for an empty gun, or one whose
     /// projectile has no clip archetype to return to.

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -212,12 +212,13 @@ pub enum Effect {
         delta: i32,
     },
 
-    /// Wear a gun down by `amount` condition points (`PropGunState.condition`,
-    /// a 0..100 percentage), floored at 0. No-op for entities without a gun
-    /// state.
-    DegradeWeaponCondition {
+    /// Move a gun's condition (`PropGunState.condition`, a 0..100 percentage)
+    /// by `delta`, clamped to that range: negative for the wear a shot costs,
+    /// positive for the points the maintenance tool restores. No-op for
+    /// entities without a gun state.
+    AdjustWeaponCondition {
         entity_id: EntityId,
-        amount: f32,
+        delta: f32,
     },
 
     /// Start the wait a gun's fire setting imposes between shots
@@ -948,18 +949,19 @@ pub(crate) fn recharge_ammo_to_capacity(gun_state: &mut PropGunState, capacity: 
     gun_state.ammo = gun_state.ammo.max(capacity.max(0));
 }
 
-/// Wear a gun down by `amount` condition points. Condition is a 0..100
-/// percentage and never goes below 0 - a worn-out gun stays worn out rather
-/// than accumulating negative condition over the shots it keeps firing.
-pub(crate) fn degrade_condition(gun_state: &mut PropGunState, amount: f32) {
-    gun_state.condition = (gun_state.condition - amount).max(0.0);
+/// Move a gun's condition by `delta` (negative wears it, positive restores
+/// it). Condition is a 0..100 percentage and stays inside it: a worn-out gun
+/// does not accumulate negative condition over the shots it keeps firing, and
+/// a maintained one never reads better than new.
+pub(crate) fn adjust_condition(gun_state: &mut PropGunState, delta: f32) {
+    gun_state.condition = (gun_state.condition + delta).clamp(0.0, 100.0);
 }
 
 #[cfg(test)]
 mod tests {
     use dark::properties::PropGunState;
 
-    use super::{degrade_condition, recharge_ammo_to_capacity};
+    use super::{adjust_condition, recharge_ammo_to_capacity};
 
     fn gun_state(ammo: i32) -> PropGunState {
         PropGunState {
@@ -990,9 +992,9 @@ mod tests {
         let mut state = gun_state(12);
         state.condition = 100.0;
 
-        degrade_condition(&mut state, 1.0);
-        degrade_condition(&mut state, 1.0);
-        degrade_condition(&mut state, 1.0);
+        adjust_condition(&mut state, -1.0);
+        adjust_condition(&mut state, -1.0);
+        adjust_condition(&mut state, -1.0);
 
         assert_eq!(state.condition, 97.0);
         assert_eq!(state.ammo, 12);
@@ -1003,10 +1005,20 @@ mod tests {
         let mut state = gun_state(12);
         state.condition = 0.5;
 
-        degrade_condition(&mut state, 1.0);
-        degrade_condition(&mut state, 1.0);
+        adjust_condition(&mut state, -1.0);
+        adjust_condition(&mut state, -1.0);
 
         assert_eq!(state.condition, 0.0);
+    }
+
+    #[test]
+    fn a_restored_gun_never_reads_better_than_new() {
+        let mut state = gun_state(12);
+        state.condition = 95.0;
+
+        adjust_condition(&mut state, 10.0);
+
+        assert_eq!(state.condition, 100.0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/gui/computer.rs
+++ b/shock2vr/src/scripts/gui/computer.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 use super::keypad::{
-    HackOutcomeEffects, HackPhase, HackState, KeyPadMsg, draw_hack_board, hack_diff,
+    HackOutcomeEffects, HackPhase, HackState, HrmMode, KeyPadMsg, draw_hack_board, hack_diff,
     handle_hack_msg, object_state,
 };
 
@@ -258,6 +258,7 @@ impl Gui<ComputerState, ComputerMsg> for ComputerGui {
             &state.hack,
             msg,
             diff,
+            HrmMode::Hack,
             HackOutcomeEffects {
                 success: computer_hack_success,
                 critical_failure: computer_hack_critical_failure,

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -1,7 +1,5 @@
 use cgmath::{Vector2, Vector3, vec2};
-use dark::properties::{
-    FrobFlag, Link, PropFrobInfo, PropInventoryDimensions, PropObjIcon, ReceptronEffect,
-};
+use dark::properties::{FrobFlag, Link, PropFrobInfo, PropInventoryDimensions, ReceptronEffect};
 
 use shipyard::{EntityId, Get, View, World};
 
@@ -202,20 +200,15 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
         let initial_offset_y = self.inv_offset_y;
         let initial_offset_x = self.inv_offset_x;
 
-        let v_obj_icon = world.borrow::<View<PropObjIcon>>().unwrap();
         for contained_entity_info in inventory.all_items() {
             let ent = contained_entity_info.entity;
-            let maybe_obj_icon = v_obj_icon.get(ent);
-
-            if maybe_obj_icon.is_err() {
+            let Some(obj_icon) = super::inventory_icon(world, ent) else {
                 continue;
-            }
+            };
 
             let inv_dims = (contained_entity_info.width, contained_entity_info.height);
             let position_x = slot_pixel_width * contained_entity_info.x as f32;
             let position_y = slot_pixel_height * contained_entity_info.y as f32;
-
-            let obj_icon = &maybe_obj_icon.unwrap().0;
 
             // TODO: Fix this issue:
             // thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidInput, error: "pcx::Reader::next_row_paletted called on non-paletted image" }', engine/src/texture_format.rs:81:45
@@ -250,15 +243,13 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
 
         if let Some(cursor) = maybe_cursor {
             if let Some(ent) = cursor.held_entity_id {
-                let maybe_obj_icon = v_obj_icon.get(ent);
-
-                if let Ok(obj_icon) = maybe_obj_icon {
+                if let Some(obj_icon) = super::inventory_icon(world, ent) {
                     let inv_dims = v_inv_dims
                         .get(ent)
                         .map(|dims| (dims.width, dims.height))
                         .unwrap_or((1, 1));
                     components.push(
-                        gui::image(&format!("{}.pcx", obj_icon.0))
+                        gui::image(&format!("{obj_icon}.pcx"))
                             .with_object_icon()
                             .with_position(vec2(cursor.position.x, cursor.position.y))
                             .with_size(vec2(
@@ -445,7 +436,8 @@ mod tests {
     use crate::mission::PlayerInfo;
     use cgmath::{Quaternion, point2, vec3};
     use dark::properties::{
-        FrobFlag, KeyCard, Links, PropFrobInfo, PropHitPoints, PropKeySrc, ToLink, WrappedEntityId,
+        FrobFlag, KeyCard, Links, PropFrobInfo, PropHitPoints, PropKeySrc, PropObjIcon, ToLink,
+        WrappedEntityId,
     };
 
     /// The load-bearing invariant `backpack_cell_at`'s doc comment claims: it

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -329,31 +329,14 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // (PropPlayerGun) or melee (PropLimbModel) - is wielded through
             // `GrabEntity` (flat: the first-person viewmodel wield path,
             // which also restores world refs and clears the Contains link;
-            // VR: a grab into the hand). Anything else gets its own Frob
-            // (use) action, e.g. a hypo consumes.
-            ContainerGuiMsg::Frob(ent) => {
-                let is_weapon = crate::virtual_hand::is_wieldable_weapon(world, *ent);
-                if is_weapon {
-                    (
-                        state.clone(),
-                        Effect::GrabEntity {
-                            entity_id: *ent,
-                            hand: crate::vr_config::Handedness::Right,
-                            current_parent_id: None,
-                        },
-                    )
-                } else {
-                    (
-                        state.clone(),
-                        Effect::Send {
-                            msg: Message {
-                                payload: MessagePayload::Frob,
-                                to: *ent,
-                            },
-                        },
-                    )
-                }
-            }
+            // VR: a grab into the hand). Anything else is used where it stands
+            // - a hypo consumes, a maintenance tool goes to the wielded
+            // weapon. Shared with the inventory strip's double-click, which is
+            // the same gesture (`maintenance::use_carried_item`).
+            ContainerGuiMsg::Frob(ent) => (
+                state.clone(),
+                crate::scripts::maintenance::use_carried_item(world, *ent),
+            ),
             // Transfer the clicked item's `Contains` link to the player's
             // backpack - the same `DropEntityInfo` path used when a VR hand
             // feeds an item into a container (drop_entity_into_container).

--- a/shock2vr/src/scripts/gui/hackable_crate.rs
+++ b/shock2vr/src/scripts/gui/hackable_crate.rs
@@ -35,7 +35,7 @@ use crate::scripts::Effect;
 
 use super::container::{ContainerGui, ContainerGuiMsg, ContainerGuiState};
 use super::keypad::{
-    HackOutcomeEffects, HackPhase, HackState, KeyPadMsg, draw_hack_board, hack_diff,
+    HackOutcomeEffects, HackPhase, HackState, HrmMode, KeyPadMsg, draw_hack_board, hack_diff,
     handle_hack_msg, object_state,
 };
 
@@ -196,6 +196,7 @@ impl Gui<HackableCrateState, HackableCrateMsg> for HackableCrateGui {
                     &state.hack,
                     hack_msg,
                     diff,
+                    HrmMode::Hack,
                     HackOutcomeEffects {
                         success: crate_hack_success,
                         critical_failure: crate_hack_critical_failure,

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -175,15 +175,43 @@ fn roll_succeeds(roll: i32, chance: i32) -> bool {
     roll < chance
 }
 
-fn effective_hack_values(world: &World, diff: PropHackDiff) -> (i32, i32) {
-    let (skill, stat) = world
+/// Which operation the board is running. One board, one set of odds; the mode
+/// only picks the tech skill those odds are computed against and what a win or
+/// a critical failure does to the object.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum HrmMode {
+    Hack,
+    Repair,
+}
+
+impl HrmMode {
+    /// The tech level this mode is played at. Repair counts the installed
+    /// repair software on top of the trained skill; the hack mode does not
+    /// consult its own software yet. This is the single definition of "how
+    /// good is the player at this", so a mode's entry requirement and its
+    /// odds can never be judged against different numbers.
+    pub(crate) fn player_level(self, world: &World) -> i32 {
+        world
+            .borrow::<UniqueView<QuestInfo>>()
+            .ok()
+            .map(|quest| {
+                let stats = quest.player_stats();
+                match self {
+                    HrmMode::Hack => stats.skill_level(Skill::Hack),
+                    HrmMode::Repair => stats.skill_level(Skill::Repair) + stats.software.repair,
+                }
+            })
+            .unwrap_or(0)
+    }
+}
+
+fn effective_hack_values(world: &World, diff: PropHackDiff, mode: HrmMode) -> (i32, i32) {
+    let skill = mode.player_level(world);
+    let stat = world
         .borrow::<UniqueView<QuestInfo>>()
         .ok()
-        .map(|quest| {
-            let stats = quest.player_stats();
-            (stats.skill_level(Skill::Hack), stats.cyber_affinity)
-        })
-        .unwrap_or((0, 0));
+        .map(|quest| quest.player_stats().cyber_affinity)
+        .unwrap_or(0);
     world
         .borrow::<UniqueView<GlobalHrmParams>>()
         .ok()
@@ -394,6 +422,7 @@ pub(crate) fn handle_hack_msg(
     state: &HackState,
     msg: &KeyPadMsg,
     diff: PropHackDiff,
+    mode: HrmMode,
     outcomes: HackOutcomeEffects,
 ) -> (HackState, Effect) {
     let mut new_state = state.clone();
@@ -412,7 +441,7 @@ pub(crate) fn handle_hack_msg(
                     },
                 );
             };
-            let (_, mine_count) = effective_hack_values(world, diff);
+            let (_, mine_count) = effective_hack_values(world, diff, mode);
             let mut rng_state = hack_seed(world, entity_id);
             tracing::debug!(entity = entity_id.inner(), rng_state, "HRM rng seed");
             let nodes = board_with_mines(mine_count, &mut rng_state);
@@ -464,7 +493,7 @@ pub(crate) fn handle_hack_msg(
                 rng_state = new_state.rng_state,
                 "HRM rng outcome"
             );
-            let (chance, _) = effective_hack_values(world, diff);
+            let (chance, _) = effective_hack_values(world, diff, mode);
             if roll_succeeds(roll, chance) {
                 new_state.nodes[index] = HackNode::Lit;
                 if has_connected_three(&new_state.nodes) {
@@ -670,6 +699,7 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
                 &state.hack,
                 msg,
                 hack_diff,
+                HrmMode::Hack,
                 HackOutcomeEffects {
                     success: keypad_hack_success,
                     critical_failure: keypad_hack_critical_failure,
@@ -877,6 +907,7 @@ mod tests {
             &state,
             &KeyPadMsg::StartHack,
             diff,
+            HrmMode::Hack,
             HackOutcomeEffects {
                 success: keypad_hack_success,
                 critical_failure: keypad_hack_critical_failure,

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -11,6 +11,7 @@ mod replicator;
 mod research;
 mod trainer;
 mod traits;
+mod weapon_repair;
 mod weapon_settings;
 
 pub use computer::*;
@@ -26,4 +27,5 @@ pub use replicator::*;
 pub use research::*;
 pub use trainer::*;
 pub use traits::*;
+pub use weapon_repair::*;
 pub use weapon_settings::*;

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -18,7 +18,7 @@ use crate::scripts::{Effect, script_util::*};
 
 use super::{
     keypad::{
-        HackOutcomeEffects, HackPhase, HackState, KeyPadMsg, draw_hack_board, hack_diff,
+        HackOutcomeEffects, HackPhase, HackState, HrmMode, KeyPadMsg, draw_hack_board, hack_diff,
         handle_hack_msg, object_state,
     },
     traits::TRAIT_REPLICATOR_EXPERT,
@@ -420,6 +420,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                     &state.hack,
                     hack_msg,
                     diff,
+                    HrmMode::Hack,
                     HackOutcomeEffects {
                         success: replicator_hack_success,
                         critical_failure: replicator_hack_critical_failure,

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -243,7 +243,7 @@ fn property_fallback(world: &World, entity_id: EntityId, report: bool) -> String
 
 /// The English text out of an object string (`key: "text"`), for a data
 /// install whose string table does not resolve the key.
-pub(super) fn localized_fallback(value: &str) -> String {
+pub(crate) fn localized_fallback(value: &str) -> String {
     value
         .split_once('"')
         .and_then(|(_, tail)| tail.rsplit_once('"').map(|(text, _)| text))

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -71,10 +71,7 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
             .get(entity_id)
             .map(|required| required.0.research().max(1))
             .unwrap_or(1);
-        let player_skill = world
-            .borrow::<UniqueView<QuestInfo>>()
-            .map(|quests| quests.player_stats().skill_level(Skill::Research))
-            .unwrap_or(0);
+        let player_skill = crate::scripts::script_util::player_skill_level(world, Skill::Research);
         let status = world
             .borrow::<UniqueView<QuestInfo>>()
             .map(|quests| quests.research().status(template_id, chemicals))

--- a/shock2vr/src/scripts/gui/weapon_repair.rs
+++ b/shock2vr/src/scripts/gui/weapon_repair.rs
@@ -1,0 +1,511 @@
+//! Repair mode on the shared HRM board.
+//!
+//! A gun that has broken cannot be fired, and no amount of maintenance brings
+//! it back - it has to be repaired, which is the same node-connecting board the
+//! keypads, computers, crates and replicators are hacked on, played against the
+//! Repair skill and the object's own `P$RepairDif` terms instead of Hack and
+//! `P$HackDiff`. Winning returns the gun to working order and gives ten
+//! condition points back; landing on a mine destroys it outright.
+//!
+//! The board is presented by a synthetic panel that belongs to no world object,
+//! the way the weapon-settings MFD is: the subject is whichever gun the player
+//! used, held in [`WeaponRepairSubject`]. That is what gives it a way in from
+//! both presentations at once - flat docks the panel in the MFD slot, VR
+//! presents the same canvas in the cyber interface.
+
+use cgmath::{Vector2, Vector3};
+use dark::properties::{ObjectState, PropGunState, PropHackDiff, PropRepairDiff};
+use shipyard::{EntityId, Get, Unique, UniqueView, View, World};
+
+use crate::gui::{Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::scripts::Effect;
+
+use super::keypad::{
+    HackOutcomeEffects, HackState, HrmMode, KeyPadMsg, draw_hack_board, handle_hack_msg,
+    object_state,
+};
+
+/// Condition points a successful repair gives back, on top of returning the
+/// gun to working order.
+const REPAIR_CONDITION_BONUS: f32 = 10.0;
+
+/// The gun the repair panel is presenting. The panel itself is synthetic and
+/// shared, so the subject rides beside it rather than being the panel's own
+/// entity.
+#[derive(Unique, Clone, Copy, Debug)]
+pub struct WeaponRepairSubject(pub EntityId);
+
+pub struct WeaponRepairGui;
+
+#[derive(Clone, Debug, Default)]
+pub struct WeaponRepairState {
+    hack: HackState,
+}
+
+#[derive(Clone)]
+pub enum WeaponRepairMsg {
+    Board(KeyPadMsg),
+}
+
+/// The object's authored `P$RepairDif` - the terms it is repaired on.
+pub(crate) fn repair_diff(world: &World, entity_id: EntityId) -> Option<PropHackDiff> {
+    world
+        .borrow::<View<PropRepairDiff>>()
+        .ok()
+        .and_then(|diffs| diffs.get(entity_id).ok().map(|diff| diff.0))
+}
+
+/// Whether `entity_id` has given out - the working order repair mode applies
+/// to, and the one a broken icon is drawn for.
+fn is_out_of_order(world: &World, entity_id: EntityId) -> bool {
+    matches!(
+        object_state(world, entity_id),
+        ObjectState::Broken | ObjectState::Destroyed
+    )
+}
+
+/// Whether `entity_id` is a gun that has given out - the one thing repair mode
+/// applies to. The condition itself does not matter: a gun breaks by state,
+/// not by wearing all the way down. The psi amp is excluded on the same terms
+/// the maintenance tool excludes it: it inherits a gun state that means
+/// nothing, so it is not a ranged weapon for this purpose.
+fn is_broken_gun(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropGunState>>()
+        .map(|v| v.get(entity_id).is_ok())
+        .unwrap_or(false)
+        && !crate::wielded_weapon::is_psi_amp(world, entity_id)
+        && is_out_of_order(world, entity_id)
+}
+
+/// What using a broken gun comes to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepairEntry {
+    /// Open the board on this gun.
+    Board,
+    /// The player's Repair skill is below the level the gun authors.
+    SkillRequired { level: i32 },
+    /// Not a broken gun, or one the data gives no repair terms for - there is
+    /// nothing to open a board over.
+    NotRepairable,
+}
+
+/// Decide what using `item` from the inventory does about its being broken.
+pub fn repair_entry(world: &World, item: EntityId) -> RepairEntry {
+    if !is_broken_gun(world, item) || repair_diff(world, item).is_none() {
+        return RepairEntry::NotRepairable;
+    }
+    let required =
+        crate::scripts::script_util::required_tech_level(world, item, |tech| tech.repair());
+    // Judged with the board's own definition of the player's repair level, so
+    // the door and the odds behind it can never disagree.
+    if HrmMode::Repair.player_level(world) < required {
+        return RepairEntry::SkillRequired { level: required };
+    }
+    RepairEntry::Board
+}
+
+/// The effect using a carried `item` has when it is a broken gun, or `None`
+/// when it is not one and the ordinary use gesture applies. This is the entry
+/// point both presentations share: the flat inventory's use gesture and the VR
+/// cyber interface both run it through
+/// [`maintenance::use_carried_item`](crate::scripts::maintenance::use_carried_item).
+pub fn use_broken_weapon(world: &World, item: EntityId) -> Option<Effect> {
+    match repair_entry(world, item) {
+        RepairEntry::NotRepairable => None,
+        RepairEntry::Board => Some(Effect::OpenWeaponRepair { entity_id: item }),
+        RepairEntry::SkillRequired { level } => Some(Effect::ShowMessage {
+            text: crate::hud::hud_strings(world)
+                .repair_skill_req
+                .replace("%d", &level.to_string()),
+        }),
+    }
+}
+
+/// A repaired gun works again, and comes back ten condition points better off
+/// than it broke.
+fn repair_success(entity_id: EntityId, _world: &World) -> Effect {
+    Effect::combine(vec![
+        Effect::SetObjectState {
+            entity_id,
+            state: ObjectState::Normal,
+        },
+        Effect::AdjustWeaponCondition {
+            entity_id,
+            delta: REPAIR_CONDITION_BONUS,
+        },
+    ])
+}
+
+/// A critical failure destroys what was being repaired. Destroying the entity
+/// also takes it out of whatever hand or backpack held it, so a gun cannot be
+/// left wielded after it ceases to exist.
+fn repair_critical_failure(entity_id: EntityId, _world: &World) -> Effect {
+    Effect::DestroyEntity { entity_id }
+}
+
+/// The gun the panel is presenting, and the terms it is repaired on - both, or
+/// neither: a panel with no live subject draws nothing and accepts nothing.
+fn subject(world: &World) -> Option<(EntityId, PropHackDiff)> {
+    let gun = world
+        .borrow::<UniqueView<WeaponRepairSubject>>()
+        .ok()
+        .map(|subject| subject.0)?;
+    Some((gun, repair_diff(world, gun)?))
+}
+
+impl Gui<WeaponRepairState, WeaponRepairMsg> for WeaponRepairGui {
+    fn get_components(
+        &self,
+        _cursor: &Option<GuiCursor>,
+        _entity_id: EntityId,
+        world: &World,
+        state: &WeaponRepairState,
+    ) -> Vec<GuiComponent<WeaponRepairMsg>> {
+        let Some((_, diff)) = subject(world) else {
+            return Vec::new();
+        };
+        draw_hack_board(&state.hack, diff, WeaponRepairMsg::Board)
+    }
+
+    /// One host serves every gun, so its board must not outlive the opening it
+    /// was dealt for: without this, a won or lost board would still be sitting
+    /// there - terminal, and refusing to start - when the next broken gun
+    /// opened the panel, and a part-played board would carry its paid nodes
+    /// onto a different gun. Reopening on the same gun therefore deals afresh
+    /// and charges again, which is how the board behaves everywhere else.
+    fn resets_state_on_frob(&self) -> bool {
+        true
+    }
+
+    fn get_config(&self) -> GuiConfig {
+        // The board's own 188x296 canvas, the size every HRM presentation uses.
+        GuiConfig {
+            world_offset: Vector3::new(0.0, 0.0, -0.1),
+            screen_size_in_pixels: Vector2::new(188.0, 296.0),
+        }
+    }
+
+    fn handle_msg(
+        &self,
+        _entity_id: EntityId,
+        world: &World,
+        state: &WeaponRepairState,
+        msg: &WeaponRepairMsg,
+    ) -> (WeaponRepairState, Effect) {
+        let WeaponRepairMsg::Board(board_msg) = msg;
+        let Some((gun, diff)) = subject(world) else {
+            return (state.clone(), Effect::NoEffect);
+        };
+        // A gun that is no longer broken has nothing left to repair; ignore
+        // stale board input rather than charging for another attempt.
+        if !is_broken_gun(world, gun) {
+            return (state.clone(), Effect::NoEffect);
+        }
+        // The board is played against the *gun*, not the panel presenting it:
+        // that is what keys the deal off the gun's own stable id and sources
+        // the board's sounds at the object being worked on.
+        let (hack, effect) = handle_hack_msg(
+            gun,
+            world,
+            &state.hack,
+            board_msg,
+            diff,
+            HrmMode::Repair,
+            HackOutcomeEffects {
+                success: repair_success,
+                critical_failure: repair_critical_failure,
+            },
+        );
+        (WeaponRepairState { hack }, effect)
+    }
+}
+
+/// An item's inventory art: its broken icon while it has given out and authors
+/// one, and its ordinary `P$ObjIcon` otherwise. The backpack grid, the loot
+/// panel and the drag cursor all resolve their art here, so an item cannot
+/// look intact in the backpack and broken on the cursor. (The VR arm HUD's
+/// ammo icons come from a per-template table and are not item art.)
+pub fn inventory_icon(world: &World, entity_id: EntityId) -> Option<String> {
+    if is_out_of_order(world, entity_id) {
+        if let Some(icon) = world
+            .borrow::<View<dark::properties::PropObjBrokenIcon>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|icon| icon.0.clone()))
+            .filter(|icon| !icon.is_empty())
+        {
+            return Some(icon);
+        }
+    }
+    world
+        .borrow::<View<dark::properties::PropObjIcon>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|icon| icon.0.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::player_stats::Skill;
+    use dark::properties::{
+        PropObjBrokenIcon, PropObjIcon, PropObjState, PropRepairDiff, PropRequiredTechDesc,
+        TechSkillValues,
+    };
+
+    /// A pistol at full condition with the shipped repair terms (success 20,
+    /// four criticals, three nanites) and the shipped required Repair level of
+    /// one, plus a player trained to `repair`.
+    fn fixture(repair: i32) -> (World, EntityId) {
+        let mut world = World::new();
+        let gun = world.add_entity((
+            PropGunState {
+                ammo: 12,
+                condition: 40.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+            PropRepairDiff(PropHackDiff {
+                success_chance: 20,
+                critical_chance: 4,
+                cost: 3.0,
+            }),
+            PropRequiredTechDesc(TechSkillValues([0, 1, 1, 1, 0])),
+        ));
+        let mut quests = crate::quest_info::QuestInfo::new();
+        for _ in 0..repair {
+            quests.player_stats_mut().raise_skill(Skill::Repair);
+        }
+        world.add_unique(quests);
+        (world, gun)
+    }
+
+    fn break_gun(world: &mut World, gun: EntityId) {
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+    }
+
+    fn effects(effect: Effect) -> Vec<Effect> {
+        Effect::flatten(vec![effect])
+    }
+
+    /// The dispatch: a working gun is used normally, a broken one goes to the
+    /// board.
+    #[test]
+    fn only_a_broken_gun_opens_the_repair_board() {
+        let (mut world, gun) = fixture(1);
+        assert_eq!(repair_entry(&world, gun), RepairEntry::NotRepairable);
+        assert!(use_broken_weapon(&world, gun).is_none());
+
+        break_gun(&mut world, gun);
+        assert_eq!(repair_entry(&world, gun), RepairEntry::Board);
+        assert!(matches!(
+            use_broken_weapon(&world, gun),
+            Some(Effect::OpenWeaponRepair { entity_id }) if entity_id == gun
+        ));
+    }
+
+    /// A broken object the data gives no repair terms for cannot be worked on
+    /// at all - the board would have nothing to charge or roll against.
+    #[test]
+    fn a_broken_object_with_no_repair_terms_is_not_repairable() {
+        let (mut world, _) = fixture(1);
+        let junk = world.add_entity((
+            PropGunState {
+                ammo: 0,
+                condition: 0.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+            PropObjState(ObjectState::Broken),
+        ));
+        assert_eq!(repair_entry(&world, junk), RepairEntry::NotRepairable);
+    }
+
+    #[test]
+    fn repairing_below_the_authored_skill_requirement_refuses() {
+        let (mut world, gun) = fixture(0);
+        break_gun(&mut world, gun);
+
+        assert_eq!(
+            repair_entry(&world, gun),
+            RepairEntry::SkillRequired { level: 1 }
+        );
+        assert!(
+            matches!(use_broken_weapon(&world, gun), Some(Effect::ShowMessage { text })
+                if text == "Repair skill 1 required."),
+        );
+    }
+
+    #[test]
+    fn a_won_repair_restores_working_order_and_ten_condition_points() {
+        let (mut world, gun) = fixture(1);
+        break_gun(&mut world, gun);
+
+        let effects = effects(repair_success(gun, &world));
+        assert!(effects.iter().any(|e| matches!(
+            e,
+            Effect::SetObjectState { entity_id, state: ObjectState::Normal } if *entity_id == gun
+        )));
+        assert!(effects.iter().any(|e| matches!(
+            e,
+            Effect::AdjustWeaponCondition { entity_id, delta }
+                if *entity_id == gun && *delta == 10.0
+        )));
+    }
+
+    /// A critical failure destroys the gun. Destroying it is also what takes
+    /// it out of the hand holding it, so no unequip step of its own is needed.
+    #[test]
+    fn a_critical_failure_destroys_the_gun() {
+        let (mut world, gun) = fixture(1);
+        break_gun(&mut world, gun);
+
+        assert!(matches!(
+            repair_critical_failure(gun, &world),
+            Effect::DestroyEntity { entity_id } if entity_id == gun
+        ));
+    }
+
+    /// Board input against a gun that is no longer broken is ignored, so a
+    /// repaired gun cannot be charged for another attempt.
+    #[test]
+    fn the_board_ignores_input_once_the_gun_works_again() {
+        let (mut world, gun) = fixture(1);
+        world.add_unique(WeaponRepairSubject(gun));
+        let panel = world.add_entity((PropObjState(ObjectState::Normal),));
+
+        let (_, effect) = WeaponRepairGui.handle_msg(
+            panel,
+            &world,
+            &WeaponRepairState::default(),
+            &WeaponRepairMsg::Board(KeyPadMsg::StartHack),
+        );
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    /// One panel host serves every gun, so a board must not survive the
+    /// opening it was dealt for. A finished board is terminal - it refuses to
+    /// start again - so a board left standing would make the *next* broken gun
+    /// unrepairable for the rest of the mission.
+    #[test]
+    fn each_opening_deals_a_fresh_board() {
+        assert!(
+            WeaponRepairGui.resets_state_on_frob(),
+            "a shared panel must reset per open"
+        );
+
+        let mut finished = WeaponRepairState::default();
+        finished.hack.phase = super::super::keypad::HackPhase::Won;
+        let mut carried = finished.clone();
+        WeaponRepairGui.prepare_state_on_frob(&mut carried);
+        assert_eq!(
+            carried.hack.phase,
+            super::super::keypad::HackPhase::Unpaid,
+            "the next gun's board must start unpaid, not on the last gun's win"
+        );
+    }
+
+    /// The psi amp inherits a gun state that means nothing, so it is not a gun
+    /// repair mode acts on - the same exclusion the maintenance tool makes.
+    #[test]
+    fn a_broken_psi_amp_is_not_a_repair_job() {
+        /// Any template the class tags mark `weapontype psiamp`.
+        const PSI_AMP_TEMPLATE: i32 = -42;
+
+        let (mut world, _) = fixture(1);
+        let amp = world.add_entity((
+            PropGunState {
+                ammo: 0,
+                condition: 0.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+            PropRepairDiff(PropHackDiff {
+                success_chance: 20,
+                critical_chance: 4,
+                cost: 3.0,
+            }),
+            PropObjState(ObjectState::Broken),
+            dark::properties::PropTemplateId {
+                template_id: PSI_AMP_TEMPLATE,
+            },
+        ));
+        world.add_unique(crate::mission::mission_core::GlobalTemplateClassTags(
+            std::collections::HashMap::from([(
+                PSI_AMP_TEMPLATE,
+                std::collections::HashMap::from([("weapontype".to_owned(), "psiamp".to_owned())]),
+            )]),
+        ));
+
+        assert_eq!(repair_entry(&world, amp), RepairEntry::NotRepairable);
+    }
+
+    /// A gun the data has marked `Destroyed` is out of order too: every other
+    /// working-order check in the game treats the two states alike, and a gun
+    /// that repair refused would be an item nothing could act on at all.
+    #[test]
+    fn a_destroyed_gun_is_repairable_and_draws_its_broken_icon() {
+        let (mut world, gun) = fixture(1);
+        world.add_component(
+            gun,
+            (
+                PropObjState(ObjectState::Destroyed),
+                PropObjIcon("icn_pist".to_owned()),
+                PropObjBrokenIcon("icn_pistb".to_owned()),
+            ),
+        );
+
+        assert_eq!(repair_entry(&world, gun), RepairEntry::Board);
+        assert_eq!(inventory_icon(&world, gun).as_deref(), Some("icn_pistb"));
+    }
+
+    /// Installed repair software counts toward the entry requirement exactly
+    /// as it counts toward the board's odds - one definition of "how good is
+    /// the player at this", so the door and the board cannot disagree.
+    #[test]
+    fn repair_software_counts_toward_the_skill_gate() {
+        let (mut world, gun) = fixture(0);
+        break_gun(&mut world, gun);
+        assert_eq!(
+            repair_entry(&world, gun),
+            RepairEntry::SkillRequired { level: 1 }
+        );
+
+        world
+            .borrow::<shipyard::UniqueViewMut<crate::quest_info::QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .install_software(crate::player_stats::Software::Repair, 1);
+        assert_eq!(repair_entry(&world, gun), RepairEntry::Board);
+    }
+
+    /// The inventory art follows the object's working order.
+    #[test]
+    fn a_broken_gun_draws_its_broken_icon() {
+        let (mut world, gun) = fixture(1);
+        world.add_component(
+            gun,
+            (
+                PropObjIcon("icn_pist".to_owned()),
+                PropObjBrokenIcon("icn_pistb".to_owned()),
+            ),
+        );
+
+        assert_eq!(inventory_icon(&world, gun).as_deref(), Some("icn_pist"));
+        break_gun(&mut world, gun);
+        assert_eq!(inventory_icon(&world, gun).as_deref(), Some("icn_pistb"));
+    }
+
+    /// A broken object that authors no broken art keeps its ordinary icon
+    /// rather than drawing nothing.
+    #[test]
+    fn a_broken_object_with_no_broken_art_keeps_its_icon() {
+        let (mut world, gun) = fixture(1);
+        world.add_component(gun, (PropObjIcon("icn_pist".to_owned()),));
+        break_gun(&mut world, gun);
+
+        assert_eq!(inventory_icon(&world, gun).as_deref(), Some("icn_pist"));
+    }
+}

--- a/shock2vr/src/scripts/gui/weapon_settings.rs
+++ b/shock2vr/src/scripts/gui/weapon_settings.rs
@@ -18,15 +18,13 @@
 //! no further wiring.
 
 use cgmath::{Vector2, Vector3, vec2};
-use dark::properties::{PropGunState, PropObjShortName, PropSymName};
+use dark::properties::PropGunState;
 use shipyard::{EntityId, Get, View, World};
 
 use crate::gui::{self, ButtonHoverBehavior, Gui, GuiComponent, GuiConfig, GuiCursor};
 use crate::scripts::Effect;
 use crate::scripts::script_util;
 use crate::ui::Rect;
-
-use super::research::localized_fallback;
 
 /// A panel-local rect's upper-left corner / extent, as the component builders
 /// want them.
@@ -110,22 +108,6 @@ pub fn should_close_settings_panel(opened_for: EntityId, wielded: Option<EntityI
     wielded != Some(opened_for)
 }
 
-/// The gun's display name: its authored short name (an object string), falling
-/// back to the symbolic name every entity has.
-fn display_name(world: &World, weapon: EntityId) -> Option<String> {
-    let short = world
-        .borrow::<View<PropObjShortName>>()
-        .ok()
-        .and_then(|v| v.get(weapon).ok().map(|n| localized_fallback(&n.0)))
-        .filter(|name| !name.is_empty());
-    short.or_else(|| {
-        world
-            .borrow::<View<PropSymName>>()
-            .ok()
-            .and_then(|v| v.get(weapon).ok().map(|n| n.0.clone()))
-    })
-}
-
 /// The line each row shows: "{header}: {description}". A gun that names no
 /// header for a setting has no such setting and draws no row.
 fn row_text(header: Option<&str>, description: Option<&str>) -> Option<String> {
@@ -202,7 +184,7 @@ impl Gui<WeaponSettingsGuiState, WeaponSettingsGuiMsg> for WeaponSettingsGui {
             .with_size(vec2(ROW_TEXT_RIGHT - NAME_POS.0, LINE_H)),
         );
 
-        if let Some(name) = display_name(world, weapon) {
+        if let Some(name) = script_util::object_short_name(world, weapon) {
             components.push(
                 gui::text(&name)
                     .with_position(vec2(NAME_POS.0, NAME_POS.1))
@@ -310,7 +292,8 @@ mod tests {
     use cgmath::{Quaternion, vec3};
     use dark::properties::{
         Link, Links, ProjectileOptions, PropGunSettingHeader1, PropGunSettingHeader2,
-        PropGunSettingText1, PropGunSettingText2, PropScripts, ToLink,
+        PropGunSettingText1, PropGunSettingText2, PropObjShortName, PropScripts, PropSymName,
+        ToLink,
     };
     use std::collections::HashMap;
 

--- a/shock2vr/src/scripts/maintenance.rs
+++ b/shock2vr/src/scripts/maintenance.rs
@@ -1,0 +1,471 @@
+//! The maintenance tool (gamesys template -2949, `P$Scripts ["Wrench"]`, class
+//! tag `device2type mainttool`).
+//!
+//! Applying one to a ranged weapon restores condition points and uses the tool
+//! up. How many points is the player's Maintain skill, ten points a level, and
+//! a weapon never reads better than new. Each weapon also authors the minimum
+//! Maintain level it can be worked on at, in `P$RequiredTechDesc`; the tool
+//! refuses - and survives - below it, as it does on something that is not a
+//! ranged weapon at all, on a weapon that has already broken (that wants the
+//! repair skill), and on one already in good condition.
+//!
+//! The offer arrives on the port's tool channel,
+//! [`MessagePayload::ProvideForConsumption`](crate::scripts::MessagePayload),
+//! which is sent *to the target*: a VR hand releasing the tool onto a gun, or
+//! the flat use-mode click on a carried tool. The decision therefore lives on
+//! the receiving weapon (`WeaponScript`), keyed off the tool's authored script
+//! the way the security crate recognizes an ICE Pick.
+
+use dark::properties::{ObjectState, PropGunState, PropRequiredTechDesc, PropStackCount};
+use engine::audio::AudioHandle;
+use shipyard::{EntityId, Get, View, World};
+
+use crate::player_stats::Skill;
+use crate::scripts::Effect;
+
+/// The maintenance tool's authored script name (`P$Scripts` on gamesys
+/// template -2949). Identifying the tool by its authored script - not by a
+/// hardcoded template id - keeps any object the data marks as one working.
+const MAINTENANCE_TOOL_SCRIPT: &str = "Wrench";
+
+/// Condition points one level of Maintain restores.
+const POINTS_PER_MAINTAIN_LEVEL: f32 = 10.0;
+
+/// Full condition: the ceiling a restore clamps to, and the level at which the
+/// tool refuses as unnecessary.
+const FULL_CONDITION: f32 = 100.0;
+
+/// The sound the tool makes when it is used, from the `mainttool` class tag's
+/// activation schema.
+const MAINTENANCE_TOOL_SOUND: &str = "act_mainttool";
+
+/// Whether `entity_id` is a maintenance tool.
+pub fn is_maintenance_tool(world: &World, entity_id: EntityId) -> bool {
+    crate::scripts::script_util::entity_has_script(world, entity_id, MAINTENANCE_TOOL_SCRIPT)
+}
+
+/// What using a maintenance tool on a target comes to.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MaintenanceOutcome {
+    /// `weapon` is worked on, gaining `points` condition (already capped at
+    /// what full condition leaves room for). Naming the weapon here is what
+    /// makes a success the only outcome that can be acted on.
+    Restored { weapon: EntityId, points: f32 },
+    /// The target is not a ranged weapon.
+    NotAGun,
+    /// The weapon has broken; maintenance cannot bring it back.
+    Broken,
+    /// The player's Maintain skill is below the level the weapon authors.
+    SkillRequired { level: i32 },
+    /// The weapon is already at full condition.
+    AlreadyGood,
+}
+
+/// The minimum Maintain level `weapon` can be worked on at, or 0 for one that
+/// authors no requirement.
+/// The minimum Maintain level `weapon` can be worked on at. At least one: the
+/// tool restores ten points a level, so a level-zero player working a weapon
+/// that authors no requirement would spend it on nothing at all.
+fn required_maintain_level(world: &World, weapon: EntityId) -> i32 {
+    world
+        .borrow::<View<PropRequiredTechDesc>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|req| req.0.maintenance()))
+        .unwrap_or(0)
+        .max(1)
+}
+
+/// Decide what the tool does to `target`. `None` is "the gesture named no
+/// target at all", which reads the same as pointing it at something that is
+/// not a weapon.
+pub fn maintenance_outcome(world: &World, target: Option<EntityId>) -> MaintenanceOutcome {
+    let Some(target) = target else {
+        return MaintenanceOutcome::NotAGun;
+    };
+    // The psi amp inherits a gun state whose condition means nothing, and
+    // authors its own script in place of the weapon one that would take this
+    // offer - so it is not a ranged weapon for this purpose.
+    let Some(condition) = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(target).ok().map(|gun| gun.condition))
+        .filter(|_| !crate::wielded_weapon::is_psi_amp(world, target))
+    else {
+        return MaintenanceOutcome::NotAGun;
+    };
+    // Checked before the skill and the condition: a broken weapon is a repair
+    // job whatever the player's Maintain level, and its condition may well
+    // still be above zero.
+    if matches!(
+        crate::scripts::gui::object_state(world, target),
+        ObjectState::Broken | ObjectState::Destroyed
+    ) {
+        return MaintenanceOutcome::Broken;
+    }
+    let required = required_maintain_level(world, target);
+    let skill = crate::scripts::script_util::player_skill_level(world, Skill::Maintenance);
+    if skill < required {
+        return MaintenanceOutcome::SkillRequired { level: required };
+    }
+    if condition >= FULL_CONDITION {
+        return MaintenanceOutcome::AlreadyGood;
+    }
+    let points = (skill as f32 * POINTS_PER_MAINTAIN_LEVEL).min(FULL_CONDITION - condition);
+    MaintenanceOutcome::Restored {
+        weapon: target,
+        points,
+    }
+}
+
+/// The line a refusal puts on the status channel.
+fn refusal_message(world: &World, outcome: MaintenanceOutcome) -> String {
+    let strings = crate::hud::hud_strings(world);
+    match outcome {
+        MaintenanceOutcome::NotAGun => strings.wrench_on_non_gun,
+        MaintenanceOutcome::Broken => strings.wrench_on_broken,
+        MaintenanceOutcome::SkillRequired { level } => {
+            strings.wrench_skill_req.replace("%d", &level.to_string())
+        }
+        MaintenanceOutcome::AlreadyGood => strings.wrench_unused,
+        // A restore is not a refusal; `apply` matches it first.
+        MaintenanceOutcome::Restored { .. } => strings.wrench_on_non_gun,
+    }
+}
+
+/// Use one of `tool` up. The tool stacks (`P$StackCoun`), so a stack of more
+/// than one loses a unit and only the last one destroys the object.
+fn consume_tool(world: &World, tool: EntityId) -> Effect {
+    let stack = world
+        .borrow::<View<PropStackCount>>()
+        .ok()
+        .and_then(|v| v.get(tool).ok().map(|s| s.0))
+        .unwrap_or(1);
+    if stack > 1 {
+        Effect::AdjustStackCount {
+            entity_id: tool,
+            delta: -1,
+        }
+    } else {
+        Effect::DestroyEntity { entity_id: tool }
+    }
+}
+
+/// Apply `tool` to `target` - the whole gesture, from either presentation:
+/// the condition it restores and the tool it uses up, or the line explaining
+/// why it did neither.
+pub fn apply(world: &World, tool: EntityId, target: Option<EntityId>) -> Effect {
+    match maintenance_outcome(world, target) {
+        MaintenanceOutcome::Restored { weapon, points } => Effect::combine(vec![
+            Effect::AdjustWeaponCondition {
+                entity_id: weapon,
+                delta: points,
+            },
+            consume_tool(world, tool),
+            Effect::PlaySound {
+                handle: AudioHandle::new(),
+                source: Some(weapon),
+                name: MAINTENANCE_TOOL_SOUND.to_owned(),
+                spatial: false,
+            },
+        ]),
+        outcome => Effect::ShowMessage {
+            text: refusal_message(world, outcome),
+        },
+    }
+}
+
+/// Whether releasing `tool` against `target` is a maintenance gesture at all -
+/// the guard the VR two-hand release uses before offering the tool to what the
+/// other hand holds. A refusable weapon still counts: the player gets told
+/// why, which is the feedback the gesture owes them.
+pub fn offers_to(world: &World, tool: EntityId, target: EntityId) -> bool {
+    is_maintenance_tool(world, tool)
+        && !matches!(
+            maintenance_outcome(world, Some(target)),
+            MaintenanceOutcome::NotAGun
+        )
+}
+
+/// What using one carried item does: wield a weapon, apply a maintenance tool
+/// to the weapon already wielded, or Frob anything else where it stands.
+///
+/// This is the whole of the flat inventory's use gesture - the strip's
+/// double-click and the backpack panel's click, which are the same action and
+/// share it. Flat has no way to drag one carried item onto another (#817), so
+/// the wielded weapon is the one target a tool can name; the tool is applied
+/// here rather than offered over the message channel, so a target that runs no
+/// weapon script still gets its refusal instead of silence.
+pub fn use_carried_item(world: &World, item: EntityId) -> Effect {
+    if crate::virtual_hand::is_wieldable_weapon(world, item) {
+        return Effect::GrabEntity {
+            entity_id: item,
+            hand: crate::vr_config::Handedness::Right,
+            current_parent_id: None,
+        };
+    }
+    if is_maintenance_tool(world, item) {
+        return apply(world, item, crate::wielded_weapon::wielded_weapon(world));
+    }
+    Effect::Send {
+        msg: crate::scripts::Message {
+            payload: crate::scripts::MessagePayload::Frob,
+            to: item,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::{PropObjState, PropScripts};
+
+    /// A pistol at `condition`, the tool, and a player with `maintain` levels
+    /// of Maintain. The pistol authors the shipped requirement (Maintain 1).
+    fn fixture(condition: f32, maintain: i32) -> (World, EntityId, EntityId) {
+        let mut world = World::new();
+        let gun = world.add_entity((
+            PropGunState {
+                ammo: 12,
+                condition,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+            PropRequiredTechDesc(dark::properties::TechSkillValues([0, 1, 1, 1, 0])),
+        ));
+        let tool = world.add_entity((PropScripts {
+            scripts: vec!["Wrench".to_owned()],
+            inherits: true,
+        },));
+        let mut quests = crate::quest_info::QuestInfo::new();
+        for _ in 0..maintain {
+            quests.player_stats_mut().raise_skill(Skill::Maintenance);
+        }
+        world.add_unique(quests);
+        (world, gun, tool)
+    }
+
+    fn effects(effect: Effect) -> Vec<Effect> {
+        Effect::flatten(vec![effect])
+    }
+
+    #[test]
+    fn the_tool_is_recognized_by_its_authored_script() {
+        let (world, gun, tool) = fixture(50.0, 1);
+        assert!(is_maintenance_tool(&world, tool));
+        assert!(!is_maintenance_tool(&world, gun));
+    }
+
+    #[test]
+    fn maintaining_restores_ten_points_per_maintain_level() {
+        let (world, gun, _) = fixture(40.0, 1);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Restored {
+                weapon: gun,
+                points: 10.0
+            }
+        );
+
+        let (world, gun, _) = fixture(40.0, 3);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Restored {
+                weapon: gun,
+                points: 30.0
+            }
+        );
+    }
+
+    #[test]
+    fn a_restore_never_takes_a_weapon_past_full_condition() {
+        let (world, gun, _) = fixture(95.0, 4);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Restored {
+                weapon: gun,
+                points: 5.0
+            }
+        );
+    }
+
+    #[test]
+    fn using_the_tool_on_a_non_weapon_refuses() {
+        let (mut world, _, _) = fixture(40.0, 1);
+        let rock = world.add_entity((PropObjState(ObjectState::Normal),));
+        assert_eq!(
+            maintenance_outcome(&world, Some(rock)),
+            MaintenanceOutcome::NotAGun
+        );
+        assert_eq!(
+            maintenance_outcome(&world, None),
+            MaintenanceOutcome::NotAGun
+        );
+    }
+
+    /// The two-hand release guard: only a maintenance tool, and only against
+    /// something that can be maintained. A weapon that will refuse still
+    /// counts - the player is owed the reason.
+    #[test]
+    fn the_two_hand_guard_admits_only_a_tool_and_a_weapon() {
+        let (mut world, gun, tool) = fixture(40.0, 1);
+        let rock = world.add_entity((PropObjState(ObjectState::Normal),));
+
+        assert!(offers_to(&world, tool, gun));
+        assert!(!offers_to(&world, tool, rock), "a tool needs a weapon");
+        assert!(!offers_to(&world, rock, gun), "only the tool applies");
+
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+        assert!(
+            offers_to(&world, tool, gun),
+            "a broken weapon still earns the refusal line"
+        );
+    }
+
+    #[test]
+    fn a_broken_weapon_wants_repairing_not_maintaining() {
+        let (mut world, gun, _) = fixture(40.0, 1);
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Broken
+        );
+    }
+
+    /// The broken check comes first: an unskilled player working on a broken
+    /// weapon is told to repair it, not to train.
+    #[test]
+    fn a_broken_weapon_reports_broken_even_below_the_skill_requirement() {
+        let (mut world, gun, _) = fixture(40.0, 0);
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::Broken
+        );
+    }
+
+    #[test]
+    fn maintaining_below_the_authored_skill_requirement_refuses() {
+        let (world, gun, _) = fixture(40.0, 0);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::SkillRequired { level: 1 }
+        );
+    }
+
+    /// A weapon that authors no requirement still needs Maintain 1: the tool
+    /// restores ten points a level, so a level-zero use would spend it for
+    /// nothing at all.
+    #[test]
+    fn maintaining_at_skill_zero_is_always_refused() {
+        let (mut world, _, _) = fixture(40.0, 0);
+        let gun = world.add_entity((PropGunState {
+            ammo: 1,
+            condition: 40.0,
+            setting: 0,
+            modification: 0,
+            silence_value: 0.0,
+        },));
+
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::SkillRequired { level: 1 },
+            "a zero-point restore would consume the tool and do nothing"
+        );
+    }
+
+    /// Using a carried item: a weapon wields, a tool works on the wielded
+    /// weapon, and anything else keeps its plain Frob.
+    #[test]
+    fn using_a_tool_with_nothing_wielded_refuses_instead_of_going_nowhere() {
+        let (world, _, tool) = fixture(40.0, 1);
+
+        let effect = use_carried_item(&world, tool);
+        assert!(
+            matches!(&effect, Effect::ShowMessage { text }
+                if text == "Drag tool to ranged weapon to use."),
+            "got {effect:?}"
+        );
+    }
+
+    #[test]
+    fn using_an_ordinary_item_still_frobs_it() {
+        let (mut world, _, _) = fixture(40.0, 1);
+        let hypo = world.add_entity((PropObjState(ObjectState::Normal),));
+
+        assert!(
+            matches!(
+                use_carried_item(&world, hypo),
+                Effect::Send {
+                    msg: crate::scripts::Message {
+                        payload: crate::scripts::MessagePayload::Frob,
+                        to,
+                    }
+                } if to == hypo
+            ),
+            "an item that is neither a weapon nor a tool keeps its own Frob"
+        );
+    }
+
+    #[test]
+    fn a_weapon_already_in_good_condition_refuses() {
+        let (world, gun, _) = fixture(100.0, 1);
+        assert_eq!(
+            maintenance_outcome(&world, Some(gun)),
+            MaintenanceOutcome::AlreadyGood
+        );
+    }
+
+    #[test]
+    fn a_successful_use_restores_the_weapon_and_destroys_a_single_tool() {
+        let (world, gun, tool) = fixture(40.0, 1);
+        let effects = effects(apply(&world, tool, Some(gun)));
+
+        assert!(effects.iter().any(|e| matches!(
+            e,
+            Effect::AdjustWeaponCondition { entity_id, delta }
+                if *entity_id == gun && *delta == 10.0
+        )));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::DestroyEntity { entity_id } if *entity_id == tool))
+        );
+    }
+
+    /// The tool stacks, so a stack of more than one loses a unit instead of
+    /// being destroyed outright.
+    #[test]
+    fn a_stack_of_tools_loses_one_unit_per_use() {
+        let (mut world, gun, tool) = fixture(40.0, 1);
+        world.add_component(tool, (PropStackCount(3),));
+        let effects = effects(apply(&world, tool, Some(gun)));
+
+        assert!(effects.iter().any(|e| matches!(
+            e,
+            Effect::AdjustStackCount { entity_id, delta }
+                if *entity_id == tool && *delta == -1
+        )));
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::DestroyEntity { .. }))
+        );
+    }
+
+    /// Every refusal keeps the tool: it is only spent by work actually done.
+    #[test]
+    fn a_refused_use_only_posts_a_message_and_keeps_the_tool() {
+        for (condition, maintain, expected) in [
+            (100.0, 1, "Weapon already in good condition."),
+            (40.0, 0, "Maintaining this weapon requires a skill of 1."),
+        ] {
+            let (world, gun, tool) = fixture(condition, maintain);
+            let effect = apply(&world, tool, Some(gun));
+            assert!(
+                matches!(&effect, Effect::ShowMessage { text } if text == expected),
+                "got {effect:?}"
+            );
+        }
+    }
+}

--- a/shock2vr/src/scripts/maintenance.rs
+++ b/shock2vr/src/scripts/maintenance.rs
@@ -16,7 +16,7 @@
 //! the receiving weapon (`WeaponScript`), keyed off the tool's authored script
 //! the way the security crate recognizes an ICE Pick.
 
-use dark::properties::{ObjectState, PropGunState, PropRequiredTechDesc, PropStackCount};
+use dark::properties::{ObjectState, PropGunState, PropStackCount};
 use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, View, World};
 
@@ -67,11 +67,7 @@ pub enum MaintenanceOutcome {
 /// tool restores ten points a level, so a level-zero player working a weapon
 /// that authors no requirement would spend it on nothing at all.
 fn required_maintain_level(world: &World, weapon: EntityId) -> i32 {
-    world
-        .borrow::<View<PropRequiredTechDesc>>()
-        .ok()
-        .and_then(|v| v.get(weapon).ok().map(|req| req.0.maintenance()))
-        .unwrap_or(0)
+    crate::scripts::script_util::required_tech_level(world, weapon, |tech| tech.maintenance())
         .max(1)
 }
 
@@ -186,8 +182,9 @@ pub fn offers_to(world: &World, tool: EntityId, target: EntityId) -> bool {
         )
 }
 
-/// What using one carried item does: wield a weapon, apply a maintenance tool
-/// to the weapon already wielded, or Frob anything else where it stands.
+/// What using one carried item does: open the repair board on a broken gun,
+/// wield a working weapon, apply a maintenance tool to the weapon already
+/// wielded, or Frob anything else where it stands.
 ///
 /// This is the whole of the flat inventory's use gesture - the strip's
 /// double-click and the backpack panel's click, which are the same action and
@@ -196,6 +193,11 @@ pub fn offers_to(world: &World, tool: EntityId, target: EntityId) -> bool {
 /// here rather than offered over the message channel, so a target that runs no
 /// weapon script still gets its refusal instead of silence.
 pub fn use_carried_item(world: &World, item: EntityId) -> Effect {
+    // A broken gun is not wielded: it opens the repair board instead, which is
+    // the only thing that can put it back into working order.
+    if let Some(effect) = crate::scripts::gui::use_broken_weapon(world, item) {
+        return effect;
+    }
     if crate::virtual_hand::is_wieldable_weapon(world, item) {
         return Effect::GrabEntity {
             entity_id: item,
@@ -231,7 +233,9 @@ mod tests {
                 modification: 0,
                 silence_value: 0.0,
             },
-            PropRequiredTechDesc(dark::properties::TechSkillValues([0, 1, 1, 1, 0])),
+            dark::properties::PropRequiredTechDesc(dark::properties::TechSkillValues([
+                0, 1, 1, 1, 0,
+            ])),
         ));
         let tool = world.add_entity((PropScripts {
             scripts: vec!["Wrench".to_owned()],

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -16,15 +16,6 @@ use super::{
     script_util::{entity_class_template_id, play_impact_sound},
 };
 
-// Script to handle collision type
-pub struct MeleeWeapon {}
-
-impl MeleeWeapon {
-    pub fn new() -> MeleeWeapon {
-        MeleeWeapon {}
-    }
-}
-
 /// Contact damage for the player's authored melee weapons (`PropLimbModel`).
 ///
 /// The rule is physical: a swing damages because the weapon was closing on
@@ -423,44 +414,6 @@ fn impact_sound_effect(entity_id: EntityId, with: EntityId, world: &World) -> Ef
     }
     let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
     play_impact_sound(world, entity_id, with, position.to_vec())
-}
-
-fn melee_impact(
-    entity_id: EntityId,
-    with: EntityId,
-    world: &World,
-    amount: f32,
-    contact: Option<crate::physics::CollisionContact>,
-) -> Effect {
-    Effect::Multiple(vec![
-        contact_damage_effect(with, amount, contact),
-        impact_sound_effect(entity_id, with, world),
-    ])
-}
-
-impl Script for MeleeWeapon {
-    fn handle_message(
-        &mut self,
-        entity_id: EntityId,
-        world: &World,
-        _physics: &PhysicsWorld,
-        msg: &MessagePayload,
-    ) -> Effect {
-        // The legacy literal `wrench` script can still back a VR physical
-        // weapon, but contact is never a flat damage source. Flat player melee
-        // resolves once from WeaponScript at the authored swing event.
-        if !is_vr(world) {
-            return Effect::NoEffect;
-        }
-
-        match msg {
-            // Legacy literal `wrench` script (Maintenance Tool -2949).
-            MessagePayload::Collided { with, contact } => {
-                melee_impact(entity_id, *with, world, 1.0, *contact)
-            }
-            _ => Effect::NoEffect,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1182,26 +1135,5 @@ mod tests {
             collide(&mut script, &world, weapon, target),
             Effect::NoEffect
         ));
-    }
-
-    #[test]
-    fn legacy_melee_collision_is_inert_outside_vr() {
-        let (world, weapon, target) = test_world(PresentationMode::Flat);
-
-        let effect = MeleeWeapon::new().handle_message(
-            weapon,
-            &world,
-            &PhysicsWorld::new(),
-            &MessagePayload::Collided {
-                with: target,
-                contact: Some(crate::physics::CollisionContact {
-                    point: vec3(2.0, 3.0, 4.0),
-                    normal: vec3(1.0, 0.0, 0.0),
-                    closing_speed: None,
-                }),
-            },
-        );
-
-        assert!(matches!(effect, Effect::NoEffect));
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -125,7 +125,7 @@ pub use self::gui::ElevatorContext;
 use self::gui::{
     ComputerGui, ContainerGui, ElevatorGui, GamePigGui, HackableCrateGui, KeyPadGui, MapGui,
     MediaGui, PsiPowersGui, ReplicatorGui, ResearchGui, TrainerGui, TrainerMode, TraitGui,
-    WeaponSettingsGui,
+    WeaponRepairGui, WeaponSettingsGui,
 };
 use self::healing_item::{HealingItemKind, HealingItemScript};
 use self::internal_frob_move::InternalFrobMove;
@@ -965,6 +965,7 @@ impl ScriptWorld {
             "internal_map" => gui_script(Box::new(MapGui)),
             "internal_media" => gui_script(Box::new(MediaGui)),
             "internal_weapon_settings" => gui_script(Box::new(WeaponSettingsGui)),
+            "internal_weapon_repair" => gui_script(Box::new(WeaponRepairGui)),
             "internal_psi_powers" => gui_script(Box::new(PsiPowersGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod internal_radiation_source;
 mod internal_simple_health;
 mod internal_switch_held_model;
 mod level_change_button;
+pub mod maintenance;
 mod many_ride;
 mod melee_weapon;
 mod obj_consume_button;
@@ -168,7 +169,7 @@ use self::{
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
     many_ride::{ParalyzePlayers, SitDownRightNow, StandUpAgain, WhiteOut},
-    melee_weapon::{HeldMeleeWeapon, MeleeWeapon},
+    melee_weapon::HeldMeleeWeapon,
     obj_consume_button::ObjConsumeButton,
     once_room::OnceRoom,
     once_router::OnceRouter,
@@ -1075,10 +1076,11 @@ impl ScriptWorld {
             "energyweapon" => Box::new(EnergyWeapon::new()),
             "grenademodify" => Box::new(NoopScript::new()),
             "weapontrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Weapons))),
-            "wrench" => Box::new(CompositeScript::new(vec![
-                Box::new(MeleeWeapon::new()),
-                Box::new(InternalSwitchHeldModelScript::new()),
-            ])),
+            // The maintenance tool (gamesys -2949 - not the melee wrench,
+            // which is an ordinary `WeaponScript`). It carries no behavior of
+            // its own: the weapon it is applied to claims it off the tool
+            // channel (see `scripts::maintenance`).
+            "wrench" => Box::new(NoopScript::new()),
             "psiampscript" => Box::new(CompositeScript::new(vec![
                 Box::new(PsiAmpScript::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -343,6 +343,15 @@ pub fn can_cycle_gun_setting(world: &World, weapon: EntityId) -> bool {
     has_second_fire_mode(second_header.as_deref(), &links)
 }
 
+/// The player's level in one skill, or 0 in a world with no character sheet
+/// (the unit-test worlds). Every skill gate reads it the same way.
+pub(crate) fn player_skill_level(world: &World, skill: crate::player_stats::Skill) -> i32 {
+    world
+        .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
+        .map(|quests| quests.player_stats().skill_level(skill))
+        .unwrap_or(0)
+}
+
 /// A gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
 /// tracks none - a melee weapon, the psi amp.
 pub(crate) fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -10,7 +10,8 @@ use dark::{
     properties::{
         GunSettingDesc, Link, Links, ProjectileOptions, PropBaseGunDesc, PropClassTag,
         PropGunSettingHeader1, PropGunSettingHeader2, PropGunSettingText1, PropGunSettingText2,
-        PropGunState, PropMaterial, PropSymName, PropTemplateId, PropTweqModelConfig, ToLink,
+        PropGunState, PropMaterial, PropObjShortName, PropSymName, PropTemplateId,
+        PropTweqModelConfig, ToLink,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -340,6 +341,37 @@ pub fn can_cycle_gun_setting(world: &World, weapon: EntityId) -> bool {
     let links = all_projectile_links(world, weapon);
     let second_header = gun_setting_header(world, weapon, 1);
     has_second_fire_mode(second_header.as_deref(), &links)
+}
+
+/// A gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
+/// tracks none - a melee weapon, the psi amp.
+pub(crate) fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {
+    world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|g| g.condition))
+}
+
+/// An object's short display name: its authored `P$ObjShortName` (an object
+/// string), falling back to the symbolic name every entity has. This is the
+/// terse name the original uses where a whole sentence will not fit - a panel's
+/// title bar, a status message - as opposed to the rollover's full name.
+pub fn object_short_name(world: &World, entity_id: EntityId) -> Option<String> {
+    let short = world
+        .borrow::<View<PropObjShortName>>()
+        .ok()
+        .and_then(|v| {
+            v.get(entity_id)
+                .ok()
+                .map(|n| crate::scripts::gui::localized_fallback(&n.0))
+        })
+        .filter(|name| !name.is_empty());
+    short.or_else(|| {
+        world
+            .borrow::<View<PropSymName>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|n| n.0.clone()))
+    })
 }
 
 /// The short header for `weapon`'s fire setting `setting` - "NORM" / "BURST" -

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -352,6 +352,21 @@ pub(crate) fn player_skill_level(world: &World, skill: crate::player_stats::Skil
         .unwrap_or(0)
 }
 
+/// The minimum tech level an object authors for one operation, in its
+/// `P$RequiredTechDesc` - `of` picks the operation's field. Zero for an object
+/// that authors no requirement at all.
+pub(crate) fn required_tech_level(
+    world: &World,
+    entity_id: EntityId,
+    of: impl Fn(dark::properties::TechSkillValues) -> i32,
+) -> i32 {
+    world
+        .borrow::<View<dark::properties::PropRequiredTechDesc>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|req| of(req.0)))
+        .unwrap_or(0)
+}
+
 /// A gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
 /// tracks none - a melee weapon, the psi amp.
 pub(crate) fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -190,11 +190,7 @@ fn weapon_skill_level(world: &World, entity_id: EntityId) -> i32 {
         _ => Skill::StandardWeapons,
     };
 
-    world
-        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
-        .ok()
-        .map(|quests| quests.player_stats().skill_level(skill))
-        .unwrap_or(0)
+    crate::scripts::script_util::player_skill_level(world, skill)
 }
 
 /// The chance, 0..1, that the shot about to be fired breaks the gun. Zero at
@@ -413,6 +409,18 @@ impl Script for WeaponScript {
                 };
                 flat_melee_hit(physics, aim, world)
             }
+            // The maintenance tool, offered to this weapon on the port's tool
+            // channel: a VR hand releasing it onto the gun, or the flat
+            // use-mode click on a carried one. The decision lives here, on the
+            // receiving weapon, because everything it turns on - the gun's
+            // condition, its broken state, the Maintain level it authors - is
+            // the weapon's own, and because a gun runs no GuiScript that could
+            // claim the offer the way the security crate claims an ICE Pick.
+            MessagePayload::ProvideForConsumption { entity }
+                if crate::scripts::maintenance::is_maintenance_tool(world, *entity) =>
+            {
+                crate::scripts::maintenance::apply(world, *entity, Some(entity_id))
+            }
             MessagePayload::TriggerRelease => {
                 // An unlimited burst ends with the trigger. A finite one plays
                 // out regardless - letting go of the pistol's BURST one frame
@@ -504,7 +512,10 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
     let wear = (is_gunshot && !is_weapon_stability_active(world))
         .then(|| degrade_per_shot(world, entity_id))
         .flatten()
-        .map(|amount| Effect::DegradeWeaponCondition { entity_id, amount });
+        .map(|amount| Effect::AdjustWeaponCondition {
+            entity_id,
+            delta: -amount,
+        });
 
     // A worn gun can break as the trigger comes back, spending the shot
     // without firing it. The shot still wears the gun down.
@@ -1208,7 +1219,7 @@ mod tests {
         assert!(
             effects
                 .iter()
-                .any(|effect| matches!(effect, Effect::DegradeWeaponCondition { .. })),
+                .any(|effect| matches!(effect, Effect::AdjustWeaponCondition { .. })),
             "the breaking shot still wears the gun"
         );
         assert!(

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -68,7 +68,7 @@ use super::{
     Effect, Message, MessagePayload, Script,
     burst_fire::{BurstState, BurstStep},
     script_util::{
-        active_gun_setting, get_all_links_with_template, ordered_projectile_links,
+        active_gun_setting, get_all_links_with_template, gun_condition, ordered_projectile_links,
         play_environmental_sound,
     },
 };
@@ -159,15 +159,6 @@ fn degrade_per_shot(world: &World, entity_id: EntityId) -> Option<f32> {
         .ok()
         .and_then(|v| v.get(entity_id).ok().map(|r| r.degrade_rate))?;
     (rate > 0.0).then_some(rate)
-}
-
-/// The gun's condition (`PropGunState`, 0..100), or `None` for a weapon that
-/// tracks none.
-fn gun_condition(world: &World, entity_id: EntityId) -> Option<f32> {
-    world
-        .borrow::<View<dark::properties::PropGunState>>()
-        .ok()
-        .and_then(|v| v.get(entity_id).ok().map(|g| g.condition))
 }
 
 /// Whether the Anti-entropic Field is running: while it is, a gun neither
@@ -265,8 +256,20 @@ fn roll_for_breakage(world: &World, entity_id: EntityId) -> Option<Effect> {
                 state: ObjectState::Broken,
             },
             play_environmental_sound(world, entity_id, "break", vec![], AudioHandle::new()),
+            Effect::ShowMessage {
+                text: weapon_breaks_message(world, entity_id),
+            },
         ])
     })
+}
+
+/// The status line a gun posts as it gives out: MISC.STR's `WeaponBreaks`
+/// ("%s has broken!") with the gun's short name in it.
+fn weapon_breaks_message(world: &World, entity_id: EntityId) -> String {
+    let name = crate::scripts::script_util::object_short_name(world, entity_id).unwrap_or_default();
+    crate::hud::hud_strings(world)
+        .weapon_breaks_message
+        .replace("%s", &name)
 }
 
 /// What one shot came to.
@@ -1113,6 +1116,16 @@ mod tests {
         }
         world.add_unique(GlobalTemplateClassTags(Default::default()));
         (world, gun)
+    }
+
+    /// A gun that gives out says which gun it was, in the shipped wording.
+    #[test]
+    fn the_break_message_names_the_gun() {
+        let (mut world, gun) = gun_world(None);
+        world.add_component(gun, dark::properties::PropSymName("Pistol".to_owned()));
+        // No strings table loaded, so this exercises the English fallback the
+        // format itself carries - the substitution is what is under test.
+        assert_eq!(weapon_breaks_message(&world, gun), "Pistol has broken!");
     }
 
     /// A broken gun is out of the fight until it is repaired: the trigger

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -40,6 +40,12 @@ pub fn hand_world_position(
 /// divides authored world geometry by [`SCALE_FACTOR`].
 pub(crate) const FROB_REACH: f32 = 7.071_068 / SCALE_FACTOR;
 
+/// How close the two hands must come for releasing a tool held in one to count
+/// as applying it to what the other holds. About a foot: close enough that the
+/// player has deliberately brought the two together, loose enough that they do
+/// not have to touch.
+const TWO_HAND_TOOL_REACH: f32 = 0.3;
+
 #[derive(Clone)]
 pub struct VirtualHand {
     position: Vector3<f32>,
@@ -233,6 +239,7 @@ impl VirtualHand {
         pawn_rot: Quaternion<f32>,
         input_hand: &Hand,
         held_by_other_hand: Option<EntityId>,
+        other_hand_position: Vector3<f32>,
     ) -> (VirtualHand, Vec<VirtualHandEffect>) {
         let handedness = prev.handedness;
         let hand_position = hand_world_position(pawn_pos, pawn_rot, input_hand.position);
@@ -253,19 +260,35 @@ impl VirtualHand {
                 if input_hand.squeeze_value < 0.5 {
                     let mut msgs = vec![VirtualHandEffect::DropItem { entity_id }];
 
-                    let result_copy = result.clone();
-                    if let Some(ray_cast_result) = result_copy {
-                        if let Some(hit_entity_id) = ray_cast_result.maybe_entity_id {
-                            msgs.push(VirtualHandEffect::OutMessage {
-                                message: Message {
-                                    to: hit_entity_id,
-                                    payload: MessagePayload::ProvideForConsumption {
-                                        entity: entity_id,
-                                    },
+                    // Releasing a tool against the weapon in the other hand is
+                    // the natural two-hand gesture, and it is the one target
+                    // the release ray usually misses: the hands are alongside
+                    // each other, not one pointed at the other. So the tool is
+                    // offered to what the other hand holds once it has been
+                    // brought to it - only for a pairing that item can take,
+                    // since offering on every release near the other hand would
+                    // e.g. post any dropped item into a held container.
+                    let two_hand_target = held_by_other_hand.filter(|other_held| {
+                        (hand_position - other_hand_position).magnitude() <= TWO_HAND_TOOL_REACH
+                            && crate::scripts::maintenance::offers_to(world, entity_id, *other_held)
+                    });
+
+                    // Exactly one recipient: a deliberate two-hand gesture wins
+                    // over whatever the ray happened to be pointing at, so one
+                    // tool can never be spent on two weapons (a released tool
+                    // over a weapons bench sees a second gun most of the time).
+                    let target = two_hand_target
+                        .or_else(|| result.clone().and_then(|hit| hit.maybe_entity_id));
+                    if let Some(target) = target {
+                        msgs.push(VirtualHandEffect::OutMessage {
+                            message: Message {
+                                to: target,
+                                payload: MessagePayload::ProvideForConsumption {
+                                    entity: entity_id,
                                 },
-                            });
-                        }
-                    };
+                            },
+                        });
+                    }
 
                     let updated_hand = VirtualHand {
                         position: hand_position,
@@ -789,6 +812,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             &input,
             None,
+            Vector3::zero(),
         );
 
         effects
@@ -1215,6 +1239,7 @@ mod tests {
             identity,
             &input,
             None,
+            Vector3::zero(),
         );
         assert_eq!(far_hand.get_raytraced_entity(), None);
         assert!(
@@ -1231,6 +1256,7 @@ mod tests {
             identity,
             &input,
             None,
+            Vector3::zero(),
         );
         assert_eq!(near_hand.get_raytraced_entity(), Some(near_target));
         assert!(

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -109,7 +109,7 @@ export async function aimVrHandAtCanvas(
   await game.input.set(`${hand}_hand.squeeze`, squeeze);
 }
 
-/** Aim the production VR hand ray at a world point without direct entity
+/** Aim one production VR hand's ray at a world point without direct entity
  * messages. Pass `squeeze = 1` to preserve an already-held item while aiming,
  * and `trigger = 1` to keep a pull in flight across the re-aim (releasing it
  * would end the gesture, which matters wherever a latch spans the movement). */
@@ -120,7 +120,7 @@ export async function aimVrHandAt(
   squeeze = 0,
   trigger = 0,
   { hand = "right" }: { hand?: Hand } = {},
-): Promise<{ start: Vec3; target: Vec3 }> {
+): Promise<{ start: Vec3; target: Vec3; local: Vec3 }> {
   const snapshot = await game.info();
   const pawn = snapshot.player.position;
   const pawnRotation = snapshot.player.rotation;
@@ -145,7 +145,7 @@ export async function aimVrHandAt(
   await game.input.set(`${hand}_hand.trigger`, trigger);
   await game.input.set(`${hand}_hand.squeeze`, squeeze);
   await game.step({ frames: 3 });
-  return { start: worldHand, target };
+  return { start: worldHand, target, local: localHand };
 }
 
 /** One canvas pixel of a world panel in world units (`gui::GUI_PIXEL_TO_WORLD_SIZE`). */

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { clickUiElement } from "./helpers/ui.js";
 import { ammoOf, cycleToWeapon, fireOnce } from "./helpers/weapon.js";
 
 // Firing wears a gun down: each shot costs the condition points the gun's
@@ -211,6 +212,206 @@ test(
       (await game.info()).player.wielded_gun_condition,
       condition,
       "and does not wear any further",
+    );
+  },
+);
+
+// --- Slice 4: the maintenance tool ---
+//
+// Using a maintenance tool on a gun restores 10 condition points per level of
+// the player's Maintain skill (debug_weapons maxes the sheet at 6, so 60),
+// capped at full condition, and uses the tool up. VR applies it as a physical
+// gesture - the tool is released against the gun held in the other hand; flat
+// has no drag, so using the tool from the inventory strip applies it to the
+// wielded gun (#817, partially).
+//
+// Negative-first: on the parent nothing recognizes the tool at all - the flat
+// double-click just Frobs it (a no-op), the VR release drops it, and the gun's
+// condition never moves.
+
+const MAINTENANCE_TOOL = -2949;
+/** debug_weapons maxes every skill, so Maintain is 6: ten points a level. */
+const RESTORED_POINTS = 60;
+
+async function toolInWorld(game: GameServer) {
+  const tools = await game.entities.byTemplate(MAINTENANCE_TOOL);
+  assert.equal(
+    tools.length,
+    1,
+    "debug_weapons should bench one maintenance tool",
+  );
+  return tools[0];
+}
+
+test(
+  "releasing the maintenance tool onto the gun in the other hand restores its condition",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // Right hand: the pistol, worn down to 20.
+    const weapon = await cycleToWeapon(game, (e) => e.template_id === PISTOL);
+    const gunHand = await aimVrHandAt(game, weapon.position as Vec3, 0.3);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      weapon.id,
+      "the VR right hand must hold the pistol",
+    );
+    await game.entities.sendMessage(weapon.id, {
+      type: "SetGunCondition",
+      condition: 20,
+    });
+    await game.step({ frames: 1 });
+    assert.equal(await condition(game), 20, "the gun starts worn");
+
+    // Left hand: the tool off the bench.
+    const tool = await toolInWorld(game);
+    await aimVrHandAt(game, tool.position as Vec3, 0.3, 0, 0, { hand: "left" });
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    const carried = await game.player.inventory();
+    assert.ok(
+      carried.items.some(
+        (i) => i.entity_id === tool.id && i.location === "left_hand",
+      ),
+      `the VR left hand must hold the maintenance tool (got ${JSON.stringify(
+        carried.items,
+      )})`,
+    );
+
+    // KEY: bring the tool to the gun and let go. The release ray is not
+    // pointed at the gun - the hands are simply side by side, which is the
+    // gesture a player makes.
+    await game.input.set("left_hand.position", [
+      gunHand.local[0] + 0.1,
+      gunHand.local[1],
+      gunHand.local[2],
+    ]);
+    await game.step({ frames: 2 });
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 8 });
+
+    assert.equal(
+      await condition(game),
+      20 + RESTORED_POINTS,
+      "the released tool should restore ten condition points per Maintain level",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(MAINTENANCE_TOOL)).length,
+      0,
+      "the tool is used up by the work it does",
+    );
+  },
+);
+
+test(
+  "using the maintenance tool from the flat inventory restores the wielded gun",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+    const gun = (await game.info()).player.wielded_entity_id;
+    assert.ok(gun, "flat mode must wield the pistol it spawned");
+    await game.entities.sendMessage(gun, {
+      type: "SetGunCondition",
+      condition: 20,
+    });
+    await game.step({ frames: 1 });
+
+    const tool = await toolInWorld(game);
+    await game.player.give(tool.id);
+    await game.step({ frames: 5 });
+
+    // KEY: the strip's use gesture (double-click) on the tool.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const toolEl = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && e.entity_id === tool.id,
+    );
+    assert.ok(
+      toolEl,
+      `the strip should list the carried tool (got ${JSON.stringify(
+        (await game.ui.state()).strip?.elements,
+      )})`,
+    );
+    await clickUiElement(game, toolEl); // lift...
+    await clickUiElement(game, toolEl); // ...and use
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await condition(game),
+      20 + RESTORED_POINTS,
+      "using the tool should restore the wielded gun",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.filter(
+        (i) => i.entity_id === tool.id,
+      ).length,
+      0,
+      "and use the tool up",
+    );
+    const sounds = await game.audio.recent();
+    assert.ok(
+      sounds.sounds.some((s) => s.sample === "maintool"),
+      `the use should play the tool's activation schema (got ${JSON.stringify(
+        sounds.sounds.map((s) => s.sample),
+      )})`,
+    );
+  },
+);
+
+test(
+  "the maintenance tool refuses a gun already in good condition, and survives",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 10 });
+    const gun = (await game.info()).player.wielded_entity_id;
+    assert.ok(gun, "flat mode must wield the pistol it spawned");
+    assert.equal(await condition(game), 100, "a shipped gun starts pristine");
+
+    const tool = await toolInWorld(game);
+    await game.player.give(tool.id);
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const toolEl = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && e.entity_id === tool.id,
+    );
+    assert.ok(toolEl, "the strip should list the carried tool");
+    await clickUiElement(game, toolEl);
+    await clickUiElement(game, toolEl);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await condition(game),
+      100,
+      "a gun in good condition is left alone",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.filter(
+        (i) => i.entity_id === tool.id,
+      ).length,
+      1,
+      "and the refused tool is not spent",
+    );
+    const messages = await game.ui.state();
+    assert.ok(
+      (messages.messages ?? []).some((m) =>
+        m.includes("already in good condition"),
+      ),
+      `the refusal should say why (got ${JSON.stringify(messages.messages)})`,
     );
   },
 );

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -3,7 +3,8 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
-import { aimVrHandAt } from "./helpers/vr-hand.js";
+import type { UiElement, UiPanel } from "../src/types.js";
+import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
 import { clickUiElement } from "./helpers/ui.js";
 import { ammoOf, cycleToWeapon, fireOnce } from "./helpers/weapon.js";
 
@@ -412,6 +413,287 @@ test(
         m.includes("already in good condition"),
       ),
       `the refusal should say why (got ${JSON.stringify(messages.messages)})`,
+    );
+  },
+);
+
+// --- Slice 5: repairing a broken gun on the HRM board ---
+//
+// A broken gun cannot be fired and cannot be maintained; it is repaired on the
+// same node-connecting board a crate or a keypad is hacked on, played against
+// the Repair skill and the gun's own `P$RepairDif` terms. Using a broken gun
+// from the inventory opens that board instead of wielding it - in flat and in
+// the VR cyber interface, which present one canvas. Winning returns the gun to
+// working order plus ten condition points.
+//
+// Negative-first: on the parent `P$RepairDif` is not parsed and no repair mode
+// exists, so using a broken pistol just wields it and no panel ever opens.
+
+/** A big nanite pile: the board charges the pistol's authored cost per deal. */
+const BIG_NANITE_PILE = -1591;
+/** The pistol's authored `P$RepairDif` nanite cost. */
+const REPAIR_COST = "3";
+/** A second bench gun, for the "one panel, many guns" case. */
+const SHOTGUN = -19;
+/** Points a won repair gives back on top of restoring working order. */
+const REPAIR_BONUS = 10;
+
+function hasTexture(panel: UiPanel, texture: string): boolean {
+  return panel.elements.some(
+    (element) => element.texture?.toLowerCase() === texture,
+  );
+}
+
+function boardButton(panel: UiPanel, label: string): UiElement {
+  const found = panel.elements.find(
+    (element) => element.kind === "button" && element.label === label,
+  );
+  assert.ok(
+    found,
+    `the board should expose ${label} (got ${JSON.stringify(
+      panel.elements.map((e) => e.label ?? e.texture),
+    )})`,
+  );
+  return found;
+}
+
+async function repairPanel(game: GameServer): Promise<UiPanel> {
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "using a broken gun should keep the repair board open");
+  return panel;
+}
+
+function conditionOf(detail: {
+  properties: { name: string; value: string }[];
+}): number {
+  const condition = detail.properties.find((p) => p.name === "Condition");
+  assert.ok(condition, "a gun should expose a Condition property");
+  return Number(condition.value);
+}
+
+/**
+ * Take one bench gun into the backpack and break it. It is worn to 20 first,
+ * so the ten points a win gives back are visible against a value that is not
+ * already full.
+ */
+async function brokenGunInBackpack(
+  game: GameServer,
+  template: number,
+): Promise<{ id: number }> {
+  const [gun] = await game.entities.byTemplate(template);
+  assert.ok(gun, `debug_weapons should bench template ${template}`);
+  await game.player.give(gun.id);
+  await game.step({ frames: 5 });
+
+  await game.entities.sendMessage(gun.id, {
+    type: "SetGunCondition",
+    condition: 20,
+  });
+  await breakGun(game, gun.id);
+  await game.step({ frames: 5 });
+  return gun;
+}
+
+/** A broken pistol plus the wallet the board's per-deal cost comes out of. */
+async function brokenPistolInBackpack(
+  game: GameServer,
+): Promise<{ id: number }> {
+  const pistol = await brokenGunInBackpack(game, PISTOL);
+  await game.player.spawnItem(BIG_NANITE_PILE);
+  await game.step({ frames: 5 });
+  return pistol;
+}
+
+/** The strip's use gesture on one carried item: lift it, then use it. */
+async function useFromStrip(
+  game: GameServer,
+  entityId: number,
+  click: (element: UiElement) => Promise<void>,
+): Promise<void> {
+  const slot = (await game.ui.state()).strip?.elements.find(
+    (e) => e.kind === "button" && e.entity_id === entityId,
+  );
+  assert.ok(
+    slot,
+    `the strip should list the carried item (got ${JSON.stringify(
+      (await game.ui.state()).strip?.elements.map((e) => e.label),
+    )})`,
+  );
+  await click(slot);
+  await click(slot);
+  await game.step({ frames: 5 });
+}
+
+/**
+ * Genuinely play the board until the repair lands. debug_weapons maxes Repair
+ * and Cyber Affinity, so the deal carries no mines; a board that burns itself
+ * out is re-dealt, exactly as retail does, at the authored cost again.
+ */
+async function playRepairBoardToWin(
+  game: GameServer,
+  click: (element: UiElement) => Promise<void>,
+): Promise<void> {
+  const routes = [
+    ["node-2-0", "node-3-0", "node-4-0"],
+    ["node-2-1", "node-2-2", "node-2-3"],
+    ["node-0-1", "node-0-2", "node-0-3"],
+    ["node-4-0", "node-4-1", "node-4-2"],
+    ["node-0-3", "node-1-3", "node-2-3"],
+  ];
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    let panel = await repairPanel(game);
+    if (hasTexture(panel, "winh.pcx")) return;
+    assert.ok(
+      !hasTexture(panel, "loseh.pcx"),
+      "a critical failure destroyed the gun; max Repair should leave no mines",
+    );
+    assert.ok(
+      !hasTexture(panel, "payh.pcx"),
+      "the test wallet should always cover the authored repair cost",
+    );
+
+    const inPlay = panel.elements.some((el) => el.label === "reset-hack");
+    if (!inPlay || hasTexture(panel, "failh.pcx")) {
+      const deal = panel.elements.find(
+        (el) => el.label === "start-hack" || el.label === "reset-hack",
+      );
+      assert.ok(deal, "an unwon board should offer START/RESET");
+      await click(deal);
+    }
+
+    for (const label of routes[attempt % routes.length]) {
+      panel = await repairPanel(game);
+      if (hasTexture(panel, "winh.pcx")) return;
+      if (hasTexture(panel, "failh.pcx") || hasTexture(panel, "loseh.pcx")) {
+        break;
+      }
+      await click(boardButton(panel, label));
+    }
+  }
+  assert.fail("the repair board should win within the attempt budget");
+}
+
+test(
+  "using a broken gun from the flat inventory opens the repair board, and winning it repairs the gun",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    const pistol = await brokenPistolInBackpack(game);
+
+    // KEY: the strip's use gesture on a BROKEN gun opens the board rather than
+    // wielding it.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const click = (element: UiElement) => clickUiElement(game, element);
+    await useFromStrip(game, pistol.id, click);
+
+    const board = await repairPanel(game);
+    assert.ok(
+      hasTexture(board, "hack.pcx"),
+      `a broken gun should present the HRM board (got ${JSON.stringify(
+        board.elements.map((e) => e.texture ?? e.label),
+      )})`,
+    );
+    assert.equal(
+      board.elements
+        .filter((e) => e.kind === "text")
+        .map((e) => e.text ?? "")
+        .find((text) => /^\d+$/.test(text)),
+      REPAIR_COST,
+      "the board should show the pistol's authored RepairDiff cost",
+    );
+    assert.equal(
+      (await game.info()).player.wielded_entity_id ?? null,
+      null,
+      "a broken gun opens the board instead of being wielded",
+    );
+    await game.screenshot("repair-board.png");
+
+    // KEY: three connected nodes put the gun back into working order, ten
+    // condition points better off than it broke.
+    await playRepairBoardToWin(game, click);
+
+    const detail = await game.entities.detail(pistol.id);
+    assert.equal(
+      objectStateOf(detail),
+      "Normal",
+      "a won repair should return the gun to working order",
+    );
+    assert.equal(
+      conditionOf(detail),
+      20 + REPAIR_BONUS,
+      "a won repair should give condition points back",
+    );
+
+    // KEY: one synthetic panel host serves every gun, so a finished board must
+    // not be left standing on it. A second broken gun in the same session gets
+    // its own fresh board and repairs just as well.
+    const shotgun = await brokenGunInBackpack(game, SHOTGUN);
+    await useFromStrip(game, shotgun.id, click);
+    assert.ok(
+      hasTexture(await repairPanel(game), "hack.pcx"),
+      "a second broken gun should get a board of its own",
+    );
+    await playRepairBoardToWin(game, click);
+    assert.equal(
+      objectStateOf(await game.entities.detail(shotgun.id)),
+      "Normal",
+      "the second gun should repair as well as the first",
+    );
+  },
+);
+
+test(
+  "the VR cyber interface presents the same repair board",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = await brokenPistolInBackpack(game);
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const ui = await game.ui.state();
+    assert.equal(ui.mode, "use", "the cyber interface should be up");
+    const panelPose = ui.panel_pose;
+    assert.ok(panelPose, "the VR cyber interface must report its panel pose");
+
+    /** Release, then pull: a clean rising edge on the controller trigger. */
+    const clickAt = async (canvas: [number, number]) => {
+      for (const trigger of [0, 1, 0]) {
+        await aimVrHandAtCanvas(game, panelPose, canvas, { trigger });
+        await game.step({ frames: 2 });
+      }
+    };
+    const clickElement = (element: UiElement) =>
+      clickAt([
+        element.rect[0] + element.rect[2] / 2,
+        element.rect[1] + element.rect[3] / 2,
+      ]);
+
+    // KEY: the same use gesture on the same canvas, driven by a controller ray.
+    await useFromStrip(game, pistol.id, clickElement);
+
+    const board = await repairPanel(game);
+    assert.ok(
+      hasTexture(board, "hack.pcx"),
+      `the cyber interface should present the HRM board (got ${JSON.stringify(
+        board.elements.map((e) => e.texture ?? e.label),
+      )})`,
+    );
+    await game.screenshot("repair-board-vr.png");
+
+    await playRepairBoardToWin(game, clickElement);
+    assert.equal(
+      objectStateOf(await game.entities.detail(pistol.id)),
+      "Normal",
+      "a won repair works the same way in VR",
     );
   },
 );


### PR DESCRIPTION
Slice 5 of the weapon-condition work, on top of #1341.

A gun that has broken cannot be fired and cannot be maintained. It is repaired
on the same node-connecting board the keypads, computers, crates and
replicators are hacked on - one board, three modes; this adds the repair one.

## Rules

- Difficulty comes from the object's own `P$RepairDif` (the same 12-byte
  record `P$HackDiff` uses; the pistol authors 20% success, 4 criticals,
  3 nanites). Odds and mine count are the board's existing math, played
  against the Repair skill plus the installed repair software, and Cyber
  Affinity.
- A gun also authors the minimum Repair level it can be worked on at, in
  `P$RequiredTechDesc`. Below it the board never opens and the player gets the
  data's own line ("Repair skill %d required.", from HRM.STR).
- Win: the gun returns to working order (`ObjState` Normal) and gets ten
  condition points back.
- Critical failure: the gun is destroyed, which is also what takes it out of
  the hand or backpack holding it.
- `P$ObjBroken` ("Obj/Broken icon") is parsed and used: a broken gun draws its
  broken art in the backpack and on the drag cursor, both through one icon
  resolution so they cannot disagree.

## Entry points

Using a broken gun from the inventory opens the board instead of wielding it -
the shared `maintenance::use_carried_item` gesture, so both presentations get
it at once. Flat docks the board in the MFD slot; VR presents the same canvas
in the cyber interface, exactly as the weapon-settings MFD does (a synthetic
panel host plus the gun it is presenting).

## How repair was threaded through the board

`HrmMode` in `keypad.rs` names the operation, picks the tech skill the odds are
computed against, and is passed to `handle_hack_msg`; the win/loss effects stay
per-caller in `HackOutcomeEffects`. Modify (slice 6) adds a third variant and
its own outcomes the same way - the board itself does not change again.

## Verified

- Unit: `P$RepairDif` on the shipped pistol bytes; mode dispatch (working gun
  is used normally, broken gun goes to the board), the skill gate, win effects,
  the destroy on a critical failure, stale board input after a repair, and the
  broken-icon swap (including a broken object that authors no broken art).
- e2e (`weapon-condition.e2e.test.ts`, two new cases): break a pistol, use it
  from the flat inventory strip and from the VR cyber interface, assert the
  board opens with the authored cost, genuinely play it to a win, and assert
  `ObjectState` Normal + condition 20 -> 30. The flat case then breaks and
  repairs a *second* gun in the same session, which is what proves the one
  shared panel host deals afresh each time. Negative-first: with the entry
  point disabled the flat case fails at "using a broken gun should keep the
  repair board open"; that second-gun step also caught a real defect (the
  subject was not rebound on reopen), fixed here.
- `weapon-condition.e2e.test.ts` 9/9 and `missions.e2e.test.ts` 23/23 pass.

## Gaps

- The loss path (a mine destroying the gun) is unit-tested only: forcing a
  mine hit through the real board is not deterministic, and the skill gate
  keeps the low-skill setup that would produce mines from opening a board.
- HRM.STR's per-mode result strings (`RepairResult0..2`) are not drawn - the
  port shows the board's authored result art (WINH/LOSEH/FAILH) instead, which
  is mode-agnostic. Only the skill-gate line is read from that table.
- The hack mode still does not add its own installed software to its skill;
  only the repair mode does.
- The synthetic panel host, its open path and its per-frame dismissal are the
  fourth copy of a pattern the settings and psi MFDs already have. Left as-is
  deliberately: sharing them means touching those two panels, which other
  branches are editing.
- Modify mode is slice 6 and is not implemented here.


## Visuals

![repair board demo](https://gist.githubusercontent.com/tommy-xr/3cc6ab761211e8292bb3430b9a163133/raw/repair-board-flat.gif)

<sub>Flat `debug_weapons`: a broken pistol in the top-docked inventory strip (note the JAM icon), used from the strip - which opens the HRM board in repair mode instead of wielding it - then played to SUCCESS, after which the strip icon is the intact pistol again. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### The board, flat and in the VR cyber interface

![repair board flat vs VR](https://gist.githubusercontent.com/tommy-xr/3cc6ab761211e8292bb3430b9a163133/raw/repair-board-flat-vs-vr.png)

<sub>The same canvas: `hack.pcx` board, the pistol's authored `RepairDif` cost (COST: 3), START. Left is flatscreen, right is the same board inside the VR cyber interface (`--vr`), driven by the controller ray.</sub>

### Broken gun inventory icon (before / after)

![inventory icon, working vs broken](https://gist.githubusercontent.com/tommy-xr/3cc6ab761211e8292bb3430b9a163133/raw/icon-before-after.png)

<sub>The strip element's texture switches from `icn_pist.pcx` to the authored broken-gun icon `icn_pistb.pcx` when the pistol's `ObjectState` goes Broken (same runtime, same slot; verified in `/v1/ui`).</sub>

Stills: [board opened](https://gist.githubusercontent.com/tommy-xr/3cc6ab761211e8292bb3430b9a163133/raw/repair-board-flat.png) - [board won](https://gist.githubusercontent.com/tommy-xr/3cc6ab761211e8292bb3430b9a163133/raw/repair-board-won-flat.png) - [VR board](https://gist.githubusercontent.com/tommy-xr/3cc6ab761211e8292bb3430b9a163133/raw/repair-board-vr.png)

