### PR TITLE
feat(weapons): modify a gun on the hack board

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -380,6 +380,17 @@ pub struct PropObjIcon(pub String);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropObjBrokenIcon(pub String);
 
+/// `P$Modify1` / `P$Modify2` - what a gun's first / second modification does
+/// ("Increase clip size from 12 to 24."), shown on the modify board before the
+/// attempt. Each holds an object string (`key: "fallback"`) resolved against
+/// the matching `MODIFY1`/`MODIFY2` string table, exactly as the fire-setting
+/// text below is.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropModification1Text(pub String);
+
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropModification2Text(pub String);
+
 /// `P$Sett1` / `P$Sett2` - the description text for a gun's first / second fire
 /// setting, and `P$SHead1` / `P$SHead2` - the short header shown beside it
 /// (e.g. "NORM" / "BURST"). Each holds an object string (`key: "fallback"`)
@@ -1592,6 +1603,30 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$ModifyDif",
+            PropModifyDiff::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$Modify2Di",
+            PropModify2Diff::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$Modify1",
+            read_variable_length_string,
+            PropModification1Text,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$Modify2",
+            read_variable_length_string,
+            PropModification2Text,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$HackText",
             read_variable_length_string,
             PropHackText,
@@ -2578,6 +2613,36 @@ pub fn define_link_with_versioned_data<TData: 'static + fmt::Debug + Send + Sync
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The shipped pistol's `P$Modify1` and `P$Modify2` bytes (gamesys
+    /// template -17). Both are the count-prefixed variable-length string the
+    /// fire-setting text uses, so they carry the same `key: "fallback"` object
+    /// string the MODIFY1/MODIFY2 tables are keyed on.
+    #[test]
+    fn parses_the_shipped_pistol_modification_text() {
+        let first = [
+            0x2c, 0x00, 0x00, 0x00, // 44 bytes of string follow
+            0x50, 0x69, 0x73, 0x74, 0x6f, 0x6c, 0x3a, 0x20, 0x22, 0x49, 0x6e, 0x63, 0x72, 0x65,
+            0x61, 0x73, 0x65, 0x20, 0x63, 0x6c, 0x69, 0x70, 0x20, 0x73, 0x69, 0x7a, 0x65, 0x20,
+            0x66, 0x72, 0x6f, 0x6d, 0x20, 0x31, 0x32, 0x20, 0x74, 0x6f, 0x20, 0x32, 0x34, 0x2e,
+            0x22, 0x00,
+        ];
+        let second = [
+            0x20, 0x00, 0x00, 0x00, // 32 bytes of string follow
+            0x50, 0x69, 0x73, 0x74, 0x6f, 0x6c, 0x3a, 0x20, 0x22, 0x44, 0x65, 0x63, 0x72, 0x65,
+            0x61, 0x73, 0x65, 0x20, 0x72, 0x65, 0x6c, 0x6f, 0x61, 0x64, 0x20, 0x74, 0x69, 0x6d,
+            0x65, 0x2e, 0x22, 0x00,
+        ];
+
+        assert_eq!(
+            read_variable_length_string(&mut Cursor::new(first), 48),
+            r#"Pistol: "Increase clip size from 12 to 24.""#
+        );
+        assert_eq!(
+            read_variable_length_string(&mut Cursor::new(second), 36),
+            r#"Pistol: "Decrease reload time.""#
+        );
+    }
 
     #[test]
     fn object_name_type_reads_retail_variants_and_preserves_unknown_values() {

--- a/dark/src/properties/prop_hack_diff.rs
+++ b/dark/src/properties/prop_hack_diff.rs
@@ -43,11 +43,33 @@ impl PropRepairDiff {
     }
 }
 
+/// Dark's `P$ModifyDif` and `P$Modify2Di` - the terms a gun is modified on,
+/// for the first and the second modification. Both are the same 12-byte
+/// `sTechInfo` record `P$HackDiff` is, read against the Modify skill; a gun
+/// that authors no second record cannot be taken past modification one.
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropModifyDiff(pub PropHackDiff);
+
+impl PropModifyDiff {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        Self(PropHackDiff::read(reader, len))
+    }
+}
+
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropModify2Diff(pub PropHackDiff);
+
+impl PropModify2Diff {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        Self(PropHackDiff::read(reader, len))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
 
-    use super::{PropHackDiff, PropRepairDiff};
+    use super::{PropHackDiff, PropModify2Diff, PropModifyDiff, PropRepairDiff};
 
     #[test]
     fn parses_little_endian_tech_info_layout() {
@@ -83,6 +105,41 @@ mod tests {
                 success_chance: 20,
                 critical_chance: 4,
                 cost: 3.0,
+            })
+        );
+    }
+
+    /// The shipped pistol's `P$ModifyDif` and `P$Modify2Di` bytes (gamesys
+    /// template -17): the first modification is a 40% base success chance
+    /// against two mines, the second a harder 30% against four, both twenty
+    /// nanites an attempt.
+    #[test]
+    fn parses_the_shipped_pistol_modify_difficulties() {
+        let first = [
+            0x28, 0x00, 0x00, 0x00, // success chance 40
+            0x02, 0x00, 0x00, 0x00, // critical chance 2
+            0x00, 0x00, 0xa0, 0x41, // cost 20.0
+        ];
+        let second = [
+            0x1e, 0x00, 0x00, 0x00, // success chance 30
+            0x04, 0x00, 0x00, 0x00, // critical chance 4
+            0x00, 0x00, 0xa0, 0x41, // cost 20.0
+        ];
+
+        assert_eq!(
+            PropModifyDiff::read(&mut Cursor::new(first), 12),
+            PropModifyDiff(PropHackDiff {
+                success_chance: 40,
+                critical_chance: 2,
+                cost: 20.0,
+            })
+        );
+        assert_eq!(
+            PropModify2Diff::read(&mut Cursor::new(second), 12),
+            PropModify2Diff(PropHackDiff {
+                success_chance: 30,
+                critical_chance: 4,
+                cost: 20.0,
             })
         );
     }

--- a/dark/src/properties/prop_research.rs
+++ b/dark/src/properties/prop_research.rs
@@ -22,6 +22,10 @@ impl TechSkillValues {
         self.0[1]
     }
 
+    pub fn modify(self) -> i32 {
+        self.0[2]
+    }
+
     pub fn maintenance(self) -> i32 {
         self.0[3]
     }

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -48,6 +48,11 @@ const FALLBACK_WRENCH_ON_BROKEN: &str = "Use repair skill on weapon first.";
 const FALLBACK_WRENCH_SKILL_REQ: &str = "Maintaining this weapon requires a skill of %d.";
 const FALLBACK_WRENCH_UNUSED: &str = "Weapon already in good condition.";
 
+/// The English fallbacks for the board's modify mode, verbatim from the
+/// shipped HRM.STR.
+const FALLBACK_MODIFY_SKILL_REQ: &str = "Modify skill %d required.";
+const FALLBACK_MODIFY_MAXED: &str = "This weapon cannot be modified any further.";
+
 /// The English fallback for the board's repair skill gate, verbatim from the
 /// shipped HRM.STR (`%d` is the minimum Repair level the object authors).
 const FALLBACK_REPAIR_SKILL_REQ: &str = "Repair skill %d required.";
@@ -80,6 +85,11 @@ pub struct HudStrings {
     /// Repair level is below the minimum the object authors, so the board
     /// never opens in repair mode.
     pub repair_skill_req: String,
+    /// HRM.STR `techminskill2` ("Modify skill %d required."): the player's
+    /// Modify level is below what the gun's next modification demands.
+    pub modify_skill_req: String,
+    /// HRM.STR `ModifyResult3`: the gun has had every modification it can take.
+    pub modify_maxed: String,
 }
 
 impl Default for HudStrings {
@@ -93,6 +103,8 @@ impl Default for HudStrings {
             wrench_skill_req: FALLBACK_WRENCH_SKILL_REQ.to_owned(),
             wrench_unused: FALLBACK_WRENCH_UNUSED.to_owned(),
             repair_skill_req: FALLBACK_REPAIR_SKILL_REQ.to_owned(),
+            modify_skill_req: FALLBACK_MODIFY_SKILL_REQ.to_owned(),
+            modify_maxed: FALLBACK_MODIFY_MAXED.to_owned(),
         }
     }
 }
@@ -108,6 +120,16 @@ impl HudStrings {
                 hrm_strings.as_deref(),
                 "techminskill1",
                 FALLBACK_REPAIR_SKILL_REQ,
+            ),
+            modify_skill_req: crate::ui::resolve_menu_label(
+                hrm_strings.as_deref(),
+                "techminskill2",
+                FALLBACK_MODIFY_SKILL_REQ,
+            ),
+            modify_maxed: crate::ui::resolve_menu_label(
+                hrm_strings.as_deref(),
+                "ModifyResult3",
+                FALLBACK_MODIFY_MAXED,
             ),
             reload_label: crate::ui::resolve_menu_label(
                 strings.as_deref(),

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -54,6 +54,12 @@ pub enum InputAction {
     /// Switch the wielded gun between its two fire modes (e.g. the pistol's
     /// single shot and its 3-round burst).
     CycleGunSetting,
+    /// Bring up the wielded weapon's settings panel (fire modes, UNLOAD,
+    /// MODIFY). A tooling affordance: it is bound to no key and no controller
+    /// button, and exists so tests and the debug runtime can open the panel
+    /// directly. Players reach it through the ammo readout's SETTING button in
+    /// flat; VR has no entry of its own yet (see issue #1344).
+    OpenWeaponSettings,
     /// Reload the wielded weapon from compatible backpack reserve.
     Reload,
     /// Eject the loaded magazine back to the backpack reserve, as clips of the
@@ -155,6 +161,7 @@ impl InputAction {
             InputAction::EquipPsiAmp,
             InputAction::CycleAmmo,
             InputAction::CycleGunSetting,
+            InputAction::OpenWeaponSettings,
             InputAction::Reload,
             InputAction::EjectClip,
             InputAction::CyclePsiPower,
@@ -200,6 +207,7 @@ impl InputAction {
             InputAction::EquipPsiAmp => "EquipPsiAmp",
             InputAction::CycleAmmo => "CycleAmmo",
             InputAction::CycleGunSetting => "CycleGunSetting",
+            InputAction::OpenWeaponSettings => "OpenWeaponSettings",
             InputAction::Reload => "Reload",
             InputAction::EjectClip => "EjectClip",
             InputAction::CyclePsiPower => "CyclePsiPower",

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -130,6 +130,9 @@ impl ActionDispatcher {
             // A per-hand press arrives as `Effect::HandButton` instead.
             effects.push(Effect::CycleGunSetting { hand: None });
         }
+        if state.just_triggered(InputAction::OpenWeaponSettings) {
+            effects.push(Effect::OpenWeaponSettings);
+        }
         if state.just_triggered(InputAction::Reload) {
             effects.push(Effect::ReloadWeapon);
         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -6121,17 +6121,19 @@ impl MissionCore {
                     if let (true, Ok(panel)) = (slot_is_presented, panel) {
                         // Removed first: a unique that is only ever added
                         // would keep the gun the panel was opened on last.
+                        let subject = crate::scripts::gui::modify_subject(&self.world, entity_id);
                         let _ = self
                             .world
                             .remove_unique::<crate::scripts::gui::WeaponModifySubject>();
-                        self.world
-                            .add_unique(crate::scripts::gui::WeaponModifySubject(entity_id));
-                        self.script_world.dispatch(Message {
-                            to: panel,
-                            payload: MessagePayload::PanelOpened,
-                        });
-                        self.flat_ui.open_unbound(panel);
-                        self.weapon_modify_gun = Some(entity_id);
+                        if let Some(subject) = subject {
+                            self.world.add_unique(subject);
+                            self.script_world.dispatch(Message {
+                                to: panel,
+                                payload: MessagePayload::PanelOpened,
+                            });
+                            self.flat_ui.open_unbound(panel);
+                            self.weapon_modify_gun = Some(entity_id);
+                        }
                     }
                 }
 
@@ -11430,6 +11432,25 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                         name: "Condition".to_string(),
                         value: format!("{:.2}", gun_state.condition),
                     });
+                    properties.push(DebugPropertyInfo {
+                        name: "Modification".to_string(),
+                        value: gun_state.modification.to_string(),
+                    });
+                    // The *derived* magazine: the authored clip as the gun's
+                    // modification level has it, which is what makes a
+                    // modification observable without firing the gun dry.
+                    if let Some(setting) =
+                        crate::scripts::script_util::active_gun_setting(&self.world, id)
+                    {
+                        properties.push(DebugPropertyInfo {
+                            name: "ClipSize".to_string(),
+                            value: setting.clip.to_string(),
+                        });
+                        properties.push(DebugPropertyInfo {
+                            name: "ReloadTimeMs".to_string(),
+                            value: setting.reload_time_ms.to_string(),
+                        });
+                    }
                 }
 
                 if let Some(state) = object_state {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1368,6 +1368,11 @@ pub struct GlobalGunSettingHeaders(pub [HashMap<String, String>; 2]);
 #[derive(Unique, Clone, Default)]
 pub struct GlobalGunSettingTexts(pub [HashMap<String, String>; 2]);
 
+/// MODIFY1.STR / MODIFY2.STR - what a gun's first and second modification do,
+/// keyed the way the fire-setting text tables are.
+#[derive(Unique, Clone)]
+pub struct GlobalModificationTexts(pub [HashMap<String, String>; 2]);
+
 /// The synthetic player-owned entity hosting the automap panel (`MapGui`).
 /// Created at mission init; `Effect::ToggleMap` opens/closes its panel in the
 /// flat host. See `projects/flat-ui-panels.md` §5.
@@ -1385,6 +1390,11 @@ pub struct MediaPanelEntity(pub EntityId);
 /// every weapon and `Effect::OpenWeaponSettings` binds it to the panel slot.
 #[derive(Unique, Clone, Copy)]
 pub struct WeaponSettingsPanelEntity(pub EntityId);
+
+/// Nonserialized player-owned host for the HRM board in modify mode, on the
+/// same terms as the repair one.
+#[derive(Unique, Clone, Copy)]
+pub struct WeaponModifyPanelEntity(pub EntityId);
 
 /// Nonserialized player-owned host for the HRM board in repair mode. Like the
 /// settings MFD it presents a gun rather than a world object;
@@ -1583,6 +1593,9 @@ pub struct MissionCore {
     /// once a critical failure destroys that gun, and a won repair leaves it
     /// up showing its result.
     weapon_repair_gun: Option<EntityId>,
+    /// The gun an open modify board was opened for; the panel is dropped when
+    /// the slot goes elsewhere, and a won board stays up showing its result.
+    weapon_modify_gun: Option<EntityId>,
 
     /// Which shortcut - if any - brought up the current use-mode session,
     /// rather than a deliberate `ToggleUseMode`. It makes a shortcut a true
@@ -1915,6 +1928,10 @@ impl MissionCore {
             gun_setting_string_table("sett1.str"),
             gun_setting_string_table("sett2.str"),
         ]));
+        world.add_unique(GlobalModificationTexts([
+            gun_setting_string_table("modify1.str"),
+            gun_setting_string_table("modify2.str"),
+        ]));
         // Debug scenes unlock every power (debug_psi exercises the whole
         // registry); real missions start with the player template's learned
         // bits plus the default OSA loadout (Cryokinesis).
@@ -2146,6 +2163,25 @@ impl MissionCore {
             RuntimePropDoNotSerialize,
         ));
         world.add_unique(WeaponRepairPanelEntity(weapon_repair_panel));
+
+        // The modify board's host, on the same terms as the repair board's.
+        let weapon_modify_panel = world.add_entity((
+            Links::empty(),
+            PropScripts {
+                scripts: vec!["internal_weapon_modify".to_owned()],
+                inherits: false,
+            },
+            dark::properties::PropTemplateId { template_id: -1 },
+            PropSymName("Weapon Modify".to_owned()),
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+            RuntimePropTransform(Matrix4::identity()),
+            RuntimePropDoNotSerialize,
+        ));
+        world.add_unique(WeaponModifyPanelEntity(weapon_modify_panel));
 
         // The psi power selection MFD's host, on the same terms: player state,
         // no world object, rebuilt per mission and never serialized.
@@ -2579,6 +2615,7 @@ impl MissionCore {
             use_mode: false,
             weapon_settings_gun: None,
             weapon_repair_gun: None,
+            weapon_modify_gun: None,
             psi_powers_open: false,
             psi_nav_latched: false,
             use_mode_shortcut: None,
@@ -3731,6 +3768,36 @@ impl MissionCore {
                     .world
                     .remove_unique::<crate::scripts::gui::WeaponRepairSubject>();
                 self.weapon_repair_gun = None;
+            }
+        }
+
+        // The modify board belongs to one gun, on the same terms the repair
+        // board does. A lost board only breaks the gun, which the board can
+        // still stand over - but the gun can go away underneath it (dropped
+        // into a level transition, destroyed by something else), and a board
+        // addressing an entity that no longer exists is dismissed.
+        if let Some(opened_for) = self.weapon_modify_gun {
+            let panel = self
+                .world
+                .borrow::<UniqueView<WeaponModifyPanelEntity>>()
+                .map(|panel| panel.0)
+                .ok();
+            let ours_is_docked = panel.is_some() && self.flat_ui.active_panel() == panel;
+            let gone = !self
+                .world
+                .borrow::<shipyard::EntitiesView>()
+                .map(|entities| entities.is_alive(opened_for))
+                .unwrap_or(false);
+            if gone && ours_is_docked {
+                self.flat_ui.close();
+            }
+            if gone || !ours_is_docked {
+                // Drop the subject with the panel: an unowned one would leave
+                // the board addressing a gun nothing is presenting.
+                let _ = self
+                    .world
+                    .remove_unique::<crate::scripts::gui::WeaponModifySubject>();
+                self.weapon_modify_gun = None;
             }
         }
 
@@ -6039,6 +6106,44 @@ impl MissionCore {
                         });
                         self.flat_ui.open_unbound(panel);
                         self.weapon_repair_gun = Some(entity_id);
+                    }
+                }
+
+                Effect::OpenWeaponModify { entity_id } => {
+                    // Same slot contract as the repair board.
+                    let slot_is_presented = game_options.presentation_mode
+                        == crate::PresentationMode::Flat
+                        || self.use_mode;
+                    let panel = self
+                        .world
+                        .borrow::<UniqueView<WeaponModifyPanelEntity>>()
+                        .map(|panel| panel.0);
+                    if let (true, Ok(panel)) = (slot_is_presented, panel) {
+                        // Removed first: a unique that is only ever added
+                        // would keep the gun the panel was opened on last.
+                        let _ = self
+                            .world
+                            .remove_unique::<crate::scripts::gui::WeaponModifySubject>();
+                        self.world
+                            .add_unique(crate::scripts::gui::WeaponModifySubject(entity_id));
+                        self.script_world.dispatch(Message {
+                            to: panel,
+                            payload: MessagePayload::PanelOpened,
+                        });
+                        self.flat_ui.open_unbound(panel);
+                        self.weapon_modify_gun = Some(entity_id);
+                    }
+                }
+
+                Effect::ModifyWeapon { entity_id } => {
+                    let mut v_gun_state = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropGunState>>()
+                        .unwrap();
+
+                    if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
+                        gun_state.modification = (gun_state.modification + 1)
+                            .min(crate::scripts::gun_modifications::MAX_MODIFICATION);
                     }
                 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -272,6 +272,21 @@ pub enum Effect {
         entity_id: EntityId,
     },
 
+    /// Open the HRM board in modify mode on `entity_id`, a gun that can still
+    /// be modified, in the presentation's panel slot. No-op where that slot is
+    /// not presented.
+    OpenWeaponModify {
+        entity_id: EntityId,
+    },
+
+    /// Raise a gun's `PropGunState.modification` by one, up to the last
+    /// modification a gun can carry. How that level changes the way the gun
+    /// fires is derived from it on every read, so this is the whole of the
+    /// change. No-op for entities without a gun state.
+    ModifyWeapon {
+        entity_id: EntityId,
+    },
+
     /// Eject `entity_id`'s magazine back to the backpack, as clips of the ammo
     /// type the rounds already are. No-op for an empty gun, or one whose
     /// projectile has no clip archetype to return to.

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -182,11 +182,12 @@ fn roll_succeeds(roll: i32, chance: i32) -> bool {
 pub(crate) enum HrmMode {
     Hack,
     Repair,
+    Modify,
 }
 
 impl HrmMode {
-    /// The tech level this mode is played at. Repair counts the installed
-    /// repair software on top of the trained skill; the hack mode does not
+    /// The tech level this mode is played at. Repair and modify count their
+    /// installed software on top of the trained skill; the hack mode does not
     /// consult its own software yet. This is the single definition of "how
     /// good is the player at this", so a mode's entry requirement and its
     /// odds can never be judged against different numbers.
@@ -199,6 +200,7 @@ impl HrmMode {
                 match self {
                     HrmMode::Hack => stats.skill_level(Skill::Hack),
                     HrmMode::Repair => stats.skill_level(Skill::Repair) + stats.software.repair,
+                    HrmMode::Modify => stats.skill_level(Skill::Modify) + stats.software.modify,
                 }
             })
             .unwrap_or(0)

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -11,6 +11,7 @@ mod replicator;
 mod research;
 mod trainer;
 mod traits;
+mod weapon_modify;
 mod weapon_repair;
 mod weapon_settings;
 
@@ -27,5 +28,6 @@ pub use replicator::*;
 pub use research::*;
 pub use trainer::*;
 pub use traits::*;
+pub use weapon_modify::*;
 pub use weapon_repair::*;
 pub use weapon_settings::*;

--- a/shock2vr/src/scripts/gui/weapon_modify.rs
+++ b/shock2vr/src/scripts/gui/weapon_modify.rs
@@ -49,10 +49,40 @@ const EFFECT_WRAP: usize = 29;
 /// adds two levels to whatever minimum the gun authors.
 const SECOND_MODIFICATION_SKILL_PREMIUM: i32 = 2;
 
-/// The gun the modify panel is presenting. The panel is synthetic and shared,
-/// so the subject rides beside it rather than being the panel's own entity.
+/// What the modify panel is presenting. The panel is synthetic and shared, so
+/// the subject rides beside it rather than being the panel's own entity.
+///
+/// The modification being played for is pinned here at the moment the board is
+/// dealt, rather than re-read from the gun every frame: a win raises the gun's
+/// level, and a board that re-derived itself would blank (or re-price) the
+/// instant it was won instead of standing there showing the result.
 #[derive(Unique, Clone, Copy, Debug)]
-pub struct WeaponModifySubject(pub EntityId);
+pub struct WeaponModifySubject {
+    pub gun: EntityId,
+    /// The modification level the gun was at when the board was dealt, so the
+    /// board is played for level `level + 1`.
+    pub level: i32,
+    /// The terms that modification is played on.
+    pub terms: PropHackDiff,
+}
+
+/// The subject a board opened on `weapon` right now would be dealt for, or
+/// `None` when a board is not what asking to modify that gun comes to.
+///
+/// Decided by [`modify_entry`], the one place that judgement lives, so a board
+/// can never be dealt on terms the MODIFY control would have refused - a
+/// broken gun, one already fully modified, or one the player's Modify skill
+/// does not reach.
+pub fn modify_subject(world: &World, weapon: EntityId) -> Option<WeaponModifySubject> {
+    if modify_entry(world, weapon) != ModifyEntry::Board {
+        return None;
+    }
+    Some(WeaponModifySubject {
+        gun: weapon,
+        level: modification_level(world, weapon),
+        terms: next_modify_diff(world, weapon)?,
+    })
+}
 
 pub struct WeaponModifyGui;
 
@@ -188,14 +218,12 @@ fn modify_critical_failure(entity_id: EntityId, _world: &World) -> Effect {
     }
 }
 
-/// The gun the panel is presenting and the terms its next modification is
-/// played on - both, or neither.
-fn subject(world: &World) -> Option<(EntityId, PropHackDiff)> {
-    let gun = world
+/// What the panel is presenting, as it was pinned when the board was dealt.
+fn subject(world: &World) -> Option<WeaponModifySubject> {
+    world
         .borrow::<UniqueView<WeaponModifySubject>>()
         .ok()
-        .map(|subject| subject.0)?;
-    Some((gun, next_modify_diff(world, gun)?))
+        .map(|subject| *subject)
 }
 
 impl Gui<WeaponModifyState, WeaponModifyMsg> for WeaponModifyGui {
@@ -206,17 +234,19 @@ impl Gui<WeaponModifyState, WeaponModifyMsg> for WeaponModifyGui {
         world: &World,
         state: &WeaponModifyState,
     ) -> Vec<GuiComponent<WeaponModifyMsg>> {
-        let Some((gun, diff)) = subject(world) else {
+        let Some(subject) = subject(world) else {
             return Vec::new();
         };
-        let mut components = draw_hack_board(&state.hack, diff, WeaponModifyMsg::Board);
+        let mut components = draw_hack_board(&state.hack, subject.terms, WeaponModifyMsg::Board);
 
         // What this modification will do, which is the gun's own
         // `P$Modify1`/`P$Modify2` text - the only place the game ever shows it.
+        // Read off the pinned level, so a won board still names what it did
+        // rather than jumping to the next modification.
         if let Some(effect) = crate::scripts::script_util::modification_description(
             world,
-            gun,
-            modification_level(world, gun) + 1,
+            subject.gun,
+            subject.level + 1,
         ) {
             for (index, line) in super::media::wrap_text(&effect, EFFECT_WRAP)
                 .iter()
@@ -257,21 +287,24 @@ impl Gui<WeaponModifyState, WeaponModifyMsg> for WeaponModifyGui {
         msg: &WeaponModifyMsg,
     ) -> (WeaponModifyState, Effect) {
         let WeaponModifyMsg::Board(board_msg) = msg;
-        let Some((gun, diff)) = subject(world) else {
+        let Some(subject) = subject(world) else {
             return (state.clone(), Effect::NoEffect);
         };
-        // A gun that has since been modified to the last level, or broken by a
-        // failed attempt, has nothing left to play for; ignore stale board
-        // input rather than charging for another attempt.
-        if modify_entry(world, gun) != ModifyEntry::Board {
+        // The board is played for exactly the modification it was dealt for. A
+        // gun that has since been modified - or broken by a failed attempt -
+        // is no longer that gun, so stale input is ignored rather than
+        // charging for another attempt.
+        if modify_entry(world, subject.gun) != ModifyEntry::Board
+            || modification_level(world, subject.gun) != subject.level
+        {
             return (state.clone(), Effect::NoEffect);
         }
         let (hack, effect) = handle_hack_msg(
-            gun,
+            subject.gun,
             world,
             &state.hack,
             board_msg,
-            diff,
+            subject.terms,
             HrmMode::Modify,
             HackOutcomeEffects {
                 success: modify_success,
@@ -325,6 +358,19 @@ mod tests {
         }
         world.add_unique(quests);
         (world, gun)
+    }
+
+    /// A subject pinned to `gun` at `level`, as opening the board does.
+    fn modify_subject_at(gun: EntityId, level: i32) -> WeaponModifySubject {
+        WeaponModifySubject {
+            gun,
+            level,
+            terms: PropHackDiff {
+                success_chance: 40,
+                critical_chance: 2,
+                cost: 20.0,
+            },
+        }
     }
 
     /// The first modification is played on `P$ModifyDif` and the second on the
@@ -387,6 +433,31 @@ mod tests {
             .player_stats_mut()
             .install_software(crate::player_stats::Software::Modify, 1);
         assert_eq!(modify_entry(&world, gun), ModifyEntry::Board);
+    }
+
+    /// Dealing a board and offering the MODIFY control are the same
+    /// judgement, so a gun the control would refuse cannot have a board dealt
+    /// on it either - however the effect that opens one was reached.
+    #[test]
+    fn no_board_is_dealt_on_a_gun_the_control_would_refuse() {
+        // Skill too low for the second modification.
+        let (world, gun) = fixture(1, 1);
+        assert_eq!(
+            modify_entry(&world, gun),
+            ModifyEntry::SkillRequired { level: 3 }
+        );
+        assert!(modify_subject(&world, gun).is_none());
+
+        // Broken, which is repair's problem.
+        let (mut world, gun) = fixture(9, 0);
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+        assert!(modify_subject(&world, gun).is_none());
+
+        // And a gun the control does open a board on.
+        let (world, gun) = fixture(9, 0);
+        let subject = modify_subject(&world, gun).expect("a board");
+        assert_eq!((subject.gun, subject.level), (gun, 0));
+        assert_eq!(subject.terms.success_chance, 40);
     }
 
     /// A gun that has given out is repair's problem: modification offers
@@ -462,7 +533,7 @@ mod tests {
     #[test]
     fn the_board_ignores_input_once_the_gun_is_fully_modified() {
         let (mut world, gun) = fixture(9, 2);
-        world.add_unique(WeaponModifySubject(gun));
+        world.add_unique(modify_subject_at(gun, 2));
         let panel = world.add_entity((PropObjState(ObjectState::Normal),));
 
         let (_, effect) = WeaponModifyGui.handle_msg(

--- a/shock2vr/src/scripts/gui/weapon_modify.rs
+++ b/shock2vr/src/scripts/gui/weapon_modify.rs
@@ -1,0 +1,476 @@
+//! Modify mode on the shared HRM board.
+//!
+//! A gun can be improved twice - a bigger clip, a faster reload, a thriftier
+//! shot - by playing the same node-connecting board the keypads are hacked and
+//! broken guns are repaired on, against the Modify skill and the gun's own
+//! `P$ModifyDif` (first modification) or `P$Modify2Di` (second, always the
+//! harder of the two). Winning raises `PropGunState.modification`, which is
+//! what [`gun_modifications`](crate::scripts::gun_modifications) reads to
+//! decide how the gun fires; losing breaks the gun outright, which then needs
+//! repair before it will fire again.
+//!
+//! The board is hosted the way the repair board is - a synthetic panel with no
+//! world object of its own, presenting whichever gun the player asked about in
+//! [`WeaponModifySubject`] - so flat's MFD slot and VR's cyber interface both
+//! present the one canvas.
+//!
+//! Retail put this board up automatically, as a second overlay beside the
+//! weapon-settings MFD, whenever that MFD opened on a gun that could still be
+//! modified. Both presentations here have a single panel slot, so the settings
+//! panel offers a MODIFY control instead and the board takes the slot when it
+//! is pressed.
+
+use cgmath::{Vector2, Vector3, vec2};
+use dark::properties::{ObjectState, PropGunState, PropHackDiff, PropModify2Diff, PropModifyDiff};
+use shipyard::{EntityId, Get, Unique, UniqueView, View, World};
+
+use crate::gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::scripts::Effect;
+use crate::scripts::gun_modifications::{MAX_MODIFICATION, modification_level};
+
+use super::keypad::{
+    HackOutcomeEffects, HackState, HrmMode, KeyPadMsg, draw_hack_board, handle_hack_msg,
+    object_state,
+};
+
+/// The board's effect text - what this modification will do - in the slot
+/// retail draws the operation's description in, above the node grid (which
+/// starts at y 48).
+const EFFECT_TEXT: (f32, f32) = (15.0, 12.0);
+const EFFECT_TEXT_W: f32 = 137.0;
+const LINE_H: f32 = 11.0;
+/// Lines of effect text the slot above the grid holds.
+const EFFECT_TEXT_LINES: usize = 3;
+/// Characters per line at 137 px, the same conservative greedy-wrap budget the
+/// log reader and the settings rows use.
+const EFFECT_WRAP: usize = 29;
+
+/// The second modification is harder to qualify for than the first: retail
+/// adds two levels to whatever minimum the gun authors.
+const SECOND_MODIFICATION_SKILL_PREMIUM: i32 = 2;
+
+/// The gun the modify panel is presenting. The panel is synthetic and shared,
+/// so the subject rides beside it rather than being the panel's own entity.
+#[derive(Unique, Clone, Copy, Debug)]
+pub struct WeaponModifySubject(pub EntityId);
+
+pub struct WeaponModifyGui;
+
+#[derive(Clone, Debug, Default)]
+pub struct WeaponModifyState {
+    hack: HackState,
+}
+
+#[derive(Clone)]
+pub enum WeaponModifyMsg {
+    Board(KeyPadMsg),
+}
+
+/// The terms `weapon`'s *next* modification is played on: `P$ModifyDif` for the
+/// first, `P$Modify2Di` for the second. A gun already at the last modification
+/// - or one whose data gives no terms for the level it is on - has none.
+pub(crate) fn next_modify_diff(world: &World, weapon: EntityId) -> Option<PropHackDiff> {
+    match modification_level(world, weapon) {
+        0 => world
+            .borrow::<View<PropModifyDiff>>()
+            .ok()
+            .and_then(|diffs| diffs.get(weapon).ok().map(|diff| diff.0)),
+        1 => world
+            .borrow::<View<PropModify2Diff>>()
+            .ok()
+            .and_then(|diffs| diffs.get(weapon).ok().map(|diff| diff.0)),
+        _ => None,
+    }
+}
+
+/// Whether `weapon` is a gun modify mode acts on at all: one that tracks gun
+/// state and authors a modify script. That script is also the table of what a
+/// modification does, so a gun without one has nothing modification could
+/// change. The psi amp and the melee weapons are excluded by the same test -
+/// neither authors one.
+fn is_modifiable_gun(world: &World, weapon: EntityId) -> bool {
+    world
+        .borrow::<View<PropGunState>>()
+        .map(|states| states.get(weapon).is_ok())
+        .unwrap_or(false)
+        && crate::scripts::gun_modifications::has_modify_script(world, weapon)
+}
+
+/// The minimum Modify level `weapon` demands for its next modification. The
+/// second is two levels harder than the first, on top of whatever the gun
+/// authors.
+fn required_modify_level(world: &World, weapon: EntityId) -> i32 {
+    let authored =
+        crate::scripts::script_util::required_tech_level(world, weapon, |tech| tech.modify());
+    if modification_level(world, weapon) >= 1 {
+        authored + SECOND_MODIFICATION_SKILL_PREMIUM
+    } else {
+        authored
+    }
+}
+
+/// What asking to modify a gun comes to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifyEntry {
+    /// Open the board on this gun.
+    Board,
+    /// The gun has had every modification it can take.
+    AlreadyFullyModified,
+    /// The player's Modify skill is below what this modification demands.
+    SkillRequired { level: i32 },
+    /// Not a gun modification does anything to, or one that has given out and
+    /// needs repair before anything else.
+    NotModifiable,
+}
+
+/// Decide what asking to modify `weapon` does.
+pub fn modify_entry(world: &World, weapon: EntityId) -> ModifyEntry {
+    if !is_modifiable_gun(world, weapon)
+        || matches!(
+            object_state(world, weapon),
+            ObjectState::Broken | ObjectState::Destroyed
+        )
+    {
+        return ModifyEntry::NotModifiable;
+    }
+    // Two things end a gun's modifications: reaching the last one, and data
+    // that gives no terms for the next. Both are "there is no more to do here"
+    // rather than a refusal the player can act on.
+    if modification_level(world, weapon) >= MAX_MODIFICATION
+        || next_modify_diff(world, weapon).is_none()
+    {
+        return ModifyEntry::AlreadyFullyModified;
+    }
+    let required = required_modify_level(world, weapon);
+    // Judged with the board's own definition of the player's modify level, so
+    // the door and the odds behind it can never disagree.
+    if HrmMode::Modify.player_level(world) < required {
+        return ModifyEntry::SkillRequired { level: required };
+    }
+    ModifyEntry::Board
+}
+
+/// The effect the settings panel's MODIFY control has, or `None` when the gun
+/// offers no such control at all.
+pub fn use_modify_control(world: &World, weapon: EntityId) -> Option<Effect> {
+    match modify_entry(world, weapon) {
+        ModifyEntry::NotModifiable => None,
+        ModifyEntry::Board => Some(Effect::OpenWeaponModify { entity_id: weapon }),
+        ModifyEntry::AlreadyFullyModified => Some(Effect::ShowMessage {
+            text: crate::hud::hud_strings(world).modify_maxed.clone(),
+        }),
+        ModifyEntry::SkillRequired { level } => Some(Effect::ShowMessage {
+            text: crate::hud::hud_strings(world)
+                .modify_skill_req
+                .replace("%d", &level.to_string()),
+        }),
+    }
+}
+
+/// Whether the settings panel draws a MODIFY control for `weapon` - it does
+/// whenever modification means anything to that gun, so a gun already fully
+/// modified still has somewhere to be told so.
+pub fn offers_modify_control(world: &World, weapon: EntityId) -> bool {
+    modify_entry(world, weapon) != ModifyEntry::NotModifiable
+}
+
+/// A won board is one more modification, up to the last one a gun can take.
+fn modify_success(entity_id: EntityId, _world: &World) -> Effect {
+    Effect::ModifyWeapon { entity_id }
+}
+
+/// A critical failure breaks the gun, which is repair's problem from then on.
+/// Unlike a failed repair, nothing is destroyed - the gun is recoverable.
+fn modify_critical_failure(entity_id: EntityId, _world: &World) -> Effect {
+    Effect::SetObjectState {
+        entity_id,
+        state: ObjectState::Broken,
+    }
+}
+
+/// The gun the panel is presenting and the terms its next modification is
+/// played on - both, or neither.
+fn subject(world: &World) -> Option<(EntityId, PropHackDiff)> {
+    let gun = world
+        .borrow::<UniqueView<WeaponModifySubject>>()
+        .ok()
+        .map(|subject| subject.0)?;
+    Some((gun, next_modify_diff(world, gun)?))
+}
+
+impl Gui<WeaponModifyState, WeaponModifyMsg> for WeaponModifyGui {
+    fn get_components(
+        &self,
+        _cursor: &Option<GuiCursor>,
+        _entity_id: EntityId,
+        world: &World,
+        state: &WeaponModifyState,
+    ) -> Vec<GuiComponent<WeaponModifyMsg>> {
+        let Some((gun, diff)) = subject(world) else {
+            return Vec::new();
+        };
+        let mut components = draw_hack_board(&state.hack, diff, WeaponModifyMsg::Board);
+
+        // What this modification will do, which is the gun's own
+        // `P$Modify1`/`P$Modify2` text - the only place the game ever shows it.
+        if let Some(effect) = crate::scripts::script_util::modification_description(
+            world,
+            gun,
+            modification_level(world, gun) + 1,
+        ) {
+            for (index, line) in super::media::wrap_text(&effect, EFFECT_WRAP)
+                .iter()
+                .take(EFFECT_TEXT_LINES)
+                .enumerate()
+            {
+                components.push(
+                    gui::text(line)
+                        .with_position(vec2(EFFECT_TEXT.0, EFFECT_TEXT.1 + index as f32 * LINE_H))
+                        .with_size(vec2(EFFECT_TEXT_W, LINE_H)),
+                );
+            }
+        }
+        components
+    }
+
+    /// One host serves every gun, so its board must not outlive the opening it
+    /// was dealt for - the same contract the repair board has. Without it a
+    /// finished board would still be sitting there, terminal, when the next
+    /// gun opened the panel.
+    fn resets_state_on_frob(&self) -> bool {
+        true
+    }
+
+    fn get_config(&self) -> GuiConfig {
+        // The board's own 188x296 canvas, the size every HRM presentation uses.
+        GuiConfig {
+            world_offset: Vector3::new(0.0, 0.0, -0.1),
+            screen_size_in_pixels: Vector2::new(188.0, 296.0),
+        }
+    }
+
+    fn handle_msg(
+        &self,
+        _entity_id: EntityId,
+        world: &World,
+        state: &WeaponModifyState,
+        msg: &WeaponModifyMsg,
+    ) -> (WeaponModifyState, Effect) {
+        let WeaponModifyMsg::Board(board_msg) = msg;
+        let Some((gun, diff)) = subject(world) else {
+            return (state.clone(), Effect::NoEffect);
+        };
+        // A gun that has since been modified to the last level, or broken by a
+        // failed attempt, has nothing left to play for; ignore stale board
+        // input rather than charging for another attempt.
+        if modify_entry(world, gun) != ModifyEntry::Board {
+            return (state.clone(), Effect::NoEffect);
+        }
+        let (hack, effect) = handle_hack_msg(
+            gun,
+            world,
+            &state.hack,
+            board_msg,
+            diff,
+            HrmMode::Modify,
+            HackOutcomeEffects {
+                success: modify_success,
+                critical_failure: modify_critical_failure,
+            },
+        );
+        (WeaponModifyState { hack }, effect)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::player_stats::Skill;
+    use dark::properties::{
+        PropObjState, PropRequiredTechDesc, PropScripts, PropSymName, TechSkillValues,
+    };
+
+    /// The shipped pistol: a modify script, both modify difficulties, and the
+    /// authored Modify requirement of one.
+    fn fixture(modify_skill: i32, modification: i32) -> (World, EntityId) {
+        let mut world = World::new();
+        let gun = world.add_entity((
+            PropGunState {
+                ammo: 12,
+                condition: 100.0,
+                setting: 0,
+                modification,
+                silence_value: 0.0,
+            },
+            PropScripts {
+                scripts: vec!["PistolModify".to_owned()],
+                inherits: true,
+            },
+            PropSymName("Pistol".to_owned()),
+            PropModifyDiff(PropHackDiff {
+                success_chance: 40,
+                critical_chance: 2,
+                cost: 20.0,
+            }),
+            PropModify2Diff(PropHackDiff {
+                success_chance: 30,
+                critical_chance: 4,
+                cost: 20.0,
+            }),
+            PropRequiredTechDesc(TechSkillValues([0, 1, 1, 1, 0])),
+        ));
+        let mut quests = crate::quest_info::QuestInfo::new();
+        for _ in 0..modify_skill {
+            quests.player_stats_mut().raise_skill(Skill::Modify);
+        }
+        world.add_unique(quests);
+        (world, gun)
+    }
+
+    /// The first modification is played on `P$ModifyDif` and the second on the
+    /// harder `P$Modify2Di`; there is no third.
+    #[test]
+    fn each_modification_is_played_on_its_own_terms() {
+        let (world, gun) = fixture(3, 0);
+        assert_eq!(next_modify_diff(&world, gun).unwrap().success_chance, 40);
+
+        let (world, gun) = fixture(3, 1);
+        assert_eq!(next_modify_diff(&world, gun).unwrap().success_chance, 30);
+
+        let (world, gun) = fixture(3, 2);
+        assert_eq!(next_modify_diff(&world, gun), None);
+    }
+
+    /// A gun at the last modification is refused rather than charged for an
+    /// attempt that could not do anything.
+    #[test]
+    fn a_fully_modified_gun_cannot_be_modified_again() {
+        let (world, gun) = fixture(9, 2);
+        assert_eq!(modify_entry(&world, gun), ModifyEntry::AlreadyFullyModified);
+        assert!(matches!(
+            use_modify_control(&world, gun),
+            Some(Effect::ShowMessage { text }) if text == "This weapon cannot be modified any further."
+        ));
+        // The control is still offered: it is where the player is told so.
+        assert!(offers_modify_control(&world, gun));
+    }
+
+    /// The second modification demands two levels more than the first.
+    #[test]
+    fn the_second_modification_is_two_levels_harder() {
+        let (world, gun) = fixture(1, 0);
+        assert_eq!(modify_entry(&world, gun), ModifyEntry::Board);
+
+        let (world, gun) = fixture(1, 1);
+        assert_eq!(
+            modify_entry(&world, gun),
+            ModifyEntry::SkillRequired { level: 3 }
+        );
+
+        let (world, gun) = fixture(3, 1);
+        assert_eq!(modify_entry(&world, gun), ModifyEntry::Board);
+    }
+
+    /// Installed modify software counts toward the entry requirement exactly
+    /// as it counts toward the board's odds.
+    #[test]
+    fn modify_software_counts_toward_the_skill_gate() {
+        let (world, gun) = fixture(0, 0);
+        assert_eq!(
+            modify_entry(&world, gun),
+            ModifyEntry::SkillRequired { level: 1 }
+        );
+
+        world
+            .borrow::<shipyard::UniqueViewMut<crate::quest_info::QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .install_software(crate::player_stats::Software::Modify, 1);
+        assert_eq!(modify_entry(&world, gun), ModifyEntry::Board);
+    }
+
+    /// A gun that has given out is repair's problem: modification offers
+    /// nothing at all until it works again.
+    #[test]
+    fn a_broken_gun_is_not_modifiable() {
+        let (mut world, gun) = fixture(9, 0);
+        world.add_component(gun, (PropObjState(ObjectState::Broken),));
+
+        assert_eq!(modify_entry(&world, gun), ModifyEntry::NotModifiable);
+        assert!(use_modify_control(&world, gun).is_none());
+        assert!(!offers_modify_control(&world, gun));
+    }
+
+    /// A weapon that authors no modify script - a melee weapon, the psi amp -
+    /// offers no control at all, even where the data gives modify terms.
+    #[test]
+    fn a_weapon_with_no_modify_script_offers_nothing() {
+        let (mut world, _) = fixture(9, 0);
+        let wrench = world.add_entity((
+            PropGunState {
+                ammo: 0,
+                condition: 100.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+            PropModifyDiff(PropHackDiff {
+                success_chance: 40,
+                critical_chance: 2,
+                cost: 20.0,
+            }),
+        ));
+        assert_eq!(modify_entry(&world, wrench), ModifyEntry::NotModifiable);
+    }
+
+    /// A won board is one more modification; a critical failure breaks the gun
+    /// rather than destroying it, so it can still be repaired.
+    #[test]
+    fn winning_modifies_and_a_critical_failure_breaks_the_gun() {
+        let (world, gun) = fixture(3, 0);
+        assert!(matches!(
+            modify_success(gun, &world),
+            Effect::ModifyWeapon { entity_id } if entity_id == gun
+        ));
+        assert!(matches!(
+            modify_critical_failure(gun, &world),
+            Effect::SetObjectState { entity_id, state: ObjectState::Broken } if entity_id == gun
+        ));
+    }
+
+    /// One panel host serves every gun, so a board must not survive the
+    /// opening it was dealt for.
+    #[test]
+    fn each_opening_deals_a_fresh_board() {
+        assert!(
+            WeaponModifyGui.resets_state_on_frob(),
+            "a shared panel must reset per open"
+        );
+
+        let mut carried = WeaponModifyState::default();
+        carried.hack.phase = super::super::keypad::HackPhase::Won;
+        WeaponModifyGui.prepare_state_on_frob(&mut carried);
+        assert_eq!(
+            carried.hack.phase,
+            super::super::keypad::HackPhase::Unpaid,
+            "the next gun's board must start unpaid, not on the last gun's win"
+        );
+    }
+
+    /// Board input against a gun that can no longer be modified is ignored, so
+    /// a gun cannot be charged for a third attempt.
+    #[test]
+    fn the_board_ignores_input_once_the_gun_is_fully_modified() {
+        let (mut world, gun) = fixture(9, 2);
+        world.add_unique(WeaponModifySubject(gun));
+        let panel = world.add_entity((PropObjState(ObjectState::Normal),));
+
+        let (_, effect) = WeaponModifyGui.handle_msg(
+            panel,
+            &world,
+            &WeaponModifyState::default(),
+            &WeaponModifyMsg::Board(KeyPadMsg::StartHack),
+        );
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/shock2vr/src/scripts/gui/weapon_settings.rs
+++ b/shock2vr/src/scripts/gui/weapon_settings.rs
@@ -73,6 +73,17 @@ const LINE_H: f32 = 11.0;
 /// control actually drawn there.
 const UNLOAD_RECT: Rect = Rect::new(23.0, 278.0, 142.0, 22.0);
 
+/// The MODIFY control, one line below the modification level it acts on, in
+/// the art's otherwise-empty top box.
+///
+/// Retail had no such control: opening this MFD on a modifiable gun put the
+/// HRM board up beside it as a second overlay. Neither presentation here has a
+/// second panel slot, so the board is asked for instead - and there is no
+/// shipped button art to ask with, so the control is its own label over a
+/// hit target, the way the fire-setting rows are hit targets over the
+/// backdrop's painted boxes.
+const MODIFY_RECT: Rect = Rect::new(NAME_POS.0, MOD_LEVEL_Y + LINE_H + 2.0, 64.0, LINE_H);
+
 /// Approximate characters per line at the row text width. `mainfont` is
 /// variable-width; this is the same conservative greedy-wrap budget the log
 /// reader uses (26 chars at 136 px), scaled to this rect.
@@ -87,6 +98,10 @@ const UNLOAD_ART_HOVER: &str = "iface/unload1.pcx";
 /// `/v1/ui` labels, so a client clicks a row by meaning rather than by pixel.
 const ROW_LABELS: [&str; 2] = ["setting_0", "setting_1"];
 const UNLOAD_LABEL: &str = "unload";
+const MODIFY_LABEL: &str = "modify";
+/// The control's own text. MISC.STR names no such control, because retail had
+/// none to name.
+const MODIFY_TEXT: &str = "MODIFY";
 
 pub struct WeaponSettingsGui;
 
@@ -99,6 +114,8 @@ pub enum WeaponSettingsGuiMsg {
     SelectSetting(i32),
     /// Eject the magazine back to the backpack.
     Unload,
+    /// Ask for the HRM board in modify mode on this gun.
+    Modify,
 }
 
 /// Whether an open settings panel must now close. The panel is opened for the
@@ -239,6 +256,24 @@ impl Gui<WeaponSettingsGuiState, WeaponSettingsGuiMsg> for WeaponSettingsGui {
             }
         }
 
+        if super::offers_modify_control(world, weapon) {
+            components.push(
+                gui::text(MODIFY_TEXT)
+                    .with_position(origin_of(MODIFY_RECT))
+                    .with_size(extent_of(MODIFY_RECT)),
+            );
+            // A zero-alpha button over the label: the same "hit target over
+            // drawn art" convention the rows use.
+            components.push(
+                gui::button(WeaponSettingsGuiMsg::Modify)
+                    .with_image(HIGHLIGHT)
+                    .with_alpha(0.0)
+                    .with_label(MODIFY_LABEL)
+                    .with_position(origin_of(MODIFY_RECT))
+                    .with_size(extent_of(MODIFY_RECT)),
+            );
+        }
+
         if shows_unload(world, weapon) {
             components.push(
                 gui::button(WeaponSettingsGuiMsg::Unload)
@@ -278,6 +313,11 @@ impl Gui<WeaponSettingsGuiState, WeaponSettingsGuiMsg> for WeaponSettingsGui {
                 setting: *setting,
             },
             WeaponSettingsGuiMsg::Unload => Effect::UnloadWeapon { entity_id: weapon },
+            // The control is only drawn for a gun modification means something
+            // to, so this always has something to say.
+            WeaponSettingsGuiMsg::Modify => {
+                super::use_modify_control(world, weapon).unwrap_or(Effect::NoEffect)
+            }
         };
         (state.clone(), effect)
     }
@@ -377,6 +417,81 @@ mod tests {
     /// The pistol as the bench hands it out: loaded.
     fn pistol_world(setting: i32) -> (World, EntityId) {
         pistol_world_with_ammo(setting, 6)
+    }
+
+    /// The pistol at `modification`, carrying the modify script and the two
+    /// modify difficulties the shipped template does, for a player trained in
+    /// Modify.
+    fn modifiable_pistol(modification: i32) -> (World, EntityId) {
+        use dark::properties::{PropHackDiff, PropModify2Diff, PropModifyDiff};
+
+        let (mut world, weapon) = pistol_world(0);
+        let terms = PropHackDiff {
+            success_chance: 40,
+            critical_chance: 2,
+            cost: 20.0,
+        };
+        world.add_component(weapon, gun_state(0, modification));
+        world.add_component(
+            weapon,
+            PropScripts {
+                scripts: vec!["PistolModify".to_owned()],
+                inherits: true,
+            },
+        );
+        world.add_component(weapon, PropModifyDiff(terms));
+        world.add_component(weapon, PropModify2Diff(terms));
+        let mut quests = crate::quest_info::QuestInfo::new();
+        for _ in 0..5 {
+            quests
+                .player_stats_mut()
+                .raise_skill(crate::player_stats::Skill::Modify);
+        }
+        world.add_unique(quests);
+        (world, weapon)
+    }
+
+    /// A gun modification means something to offers the control; the plain
+    /// bench pistol, which authors no modify script, does not.
+    #[test]
+    fn only_a_modifiable_gun_offers_the_modify_control() {
+        let (world, _) = modifiable_pistol(0);
+        assert!(labels(&components(&world)).contains(&MODIFY_LABEL.to_owned()));
+
+        let (world, _) = pistol_world(0);
+        assert!(!labels(&components(&world)).contains(&MODIFY_LABEL.to_owned()));
+    }
+
+    /// Pressing it asks for the board on the gun the panel is showing.
+    #[test]
+    fn the_modify_control_opens_the_board_on_the_wielded_gun() {
+        let (world, weapon) = modifiable_pistol(0);
+        let (_, effect) = WeaponSettingsGui.handle_msg(
+            weapon,
+            &world,
+            &WeaponSettingsGuiState,
+            &WeaponSettingsGuiMsg::Modify,
+        );
+        assert!(matches!(
+            effect,
+            Effect::OpenWeaponModify { entity_id } if entity_id == weapon
+        ));
+    }
+
+    /// A gun that has had both modifications still offers the control - that
+    /// is where the player is told there is nothing more to do.
+    #[test]
+    fn a_fully_modified_gun_still_offers_the_control_and_says_so() {
+        let (world, weapon) = modifiable_pistol(2);
+        assert!(labels(&components(&world)).contains(&MODIFY_LABEL.to_owned()));
+
+        let (_, effect) = WeaponSettingsGui.handle_msg(
+            weapon,
+            &world,
+            &WeaponSettingsGuiState,
+            &WeaponSettingsGuiMsg::Modify,
+        );
+        assert!(matches!(effect, Effect::ShowMessage { .. }));
     }
 
     fn components(world: &World) -> Vec<GuiComponent<WeaponSettingsGuiMsg>> {

--- a/shock2vr/src/scripts/gun_modifications.rs
+++ b/shock2vr/src/scripts/gun_modifications.rs
@@ -1,0 +1,456 @@
+//! What a gun's modification level does to the way it fires.
+//!
+//! Every modifiable gun authors its own modify script - `PistolModify`,
+//! `ShotgunModify`, and eight more - and each of those scripts is a fixed set
+//! of changes to the gun's firing description, announced to the player by the
+//! gun's `P$Modify1`/`P$Modify2` text ("Increase clip size from 12 to 24.").
+//! There is no per-gun *behaviour* to run, only per-gun numbers, so the ten
+//! scripts are one table here rather than ten script objects; the names stay
+//! registered in [`crate::scripts`] so the authored script still resolves.
+//!
+//! The numbers are applied where the firing description is *read*
+//! ([`crate::scripts::script_util::active_gun_setting`]), never written into
+//! the gun's `PropBaseGunDesc`. That keeps the authored archetype the one
+//! source of truth: the modification is a function of `PropGunState.modification`
+//! - which already saves and loads - so a modified gun comes back modified with
+//! nothing to migrate, and re-deriving it any number of times cannot compound.
+
+use dark::properties::{GunSettingDesc, PropGunState, PropScripts};
+use shipyard::{EntityId, Get, View, World};
+
+/// The highest modification a gun can reach. Retail refuses a third attempt
+/// outright rather than wasting the nanites.
+pub const MAX_MODIFICATION: i32 = 2;
+
+/// A gun's firing description at one modification level, as multipliers on the
+/// values the gun authors. Each level is expressed against the *unmodified*
+/// gun, not against the level below it, because that is how the shipped
+/// numbers read ("damage up to 25% over the standard") and because deriving
+/// from the base is what makes re-deriving harmless.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Modification {
+    /// Magazine size.
+    clip: f32,
+    /// Time to reload. Below one is faster.
+    reload: f32,
+    /// Ammo units per shot. Below one is thriftier.
+    ammo_usage: f32,
+    /// Projectile speed.
+    speed: f32,
+    /// Projectile stimulus - the gun's damage.
+    damage: f32,
+}
+
+impl Modification {
+    /// The unmodified gun: every value as authored.
+    const NONE: Modification = Modification {
+        clip: 1.0,
+        reload: 1.0,
+        ammo_usage: 1.0,
+        speed: 1.0,
+        damage: 1.0,
+    };
+}
+
+/// Reducing a reload or an ammo cost "by 2/3rds" leaves a third of it.
+const TWO_THIRDS_OFF: f32 = 1.0 / 3.0;
+/// Taking a third off leaves two thirds of it. Only the grenade launcher's
+/// second modification reduces by a third; every other reduction here is a
+/// half or two thirds.
+const ONE_THIRD_OFF: f32 = 2.0 / 3.0;
+/// Every gun's first modification adds a tenth to its damage, and its second
+/// takes that to a quarter over the unmodified gun.
+const DAMAGE_1: f32 = 1.1;
+const DAMAGE_2: f32 = 1.25;
+
+/// One gun's two modification levels, in order.
+struct WeaponModifications {
+    /// The gun's authored modify script, which is what identifies it.
+    script: &'static str,
+    levels: [Modification; MAX_MODIFICATION as usize],
+}
+
+/// Build a level from the unmodified gun, reading as the shipped text does.
+const fn level(clip: f32, reload: f32, ammo_usage: f32, speed: f32, damage: f32) -> Modification {
+    Modification {
+        clip,
+        reload,
+        ammo_usage,
+        speed,
+        damage,
+    }
+}
+
+/// The ten modifiable guns and what each modification does to them.
+///
+/// The effects are the ones the guns' own `MODIFY1.STR`/`MODIFY2.STR` text
+/// announces; where that text gives no magnitude the documented community
+/// figures fill it in (cited in this change's pull request). Two entries the
+/// shipped data settles outright: the pistol's clip goes 12 to 24 and the
+/// assault rifle's 36 to 72, both exactly a doubling. Clip increases the text
+/// does quantify are taken at their word instead - the grenade launcher's 6 to
+/// 9 and the laser's and EMP rifle's charge are half again, not double - and an
+/// unquantified "increase clip size" is read as a doubling.
+///
+/// Damage is not per-gun: every modifiable gun that does damage at all gets the
+/// same [`DAMAGE_1`]/[`DAMAGE_2`] buff at each level, whether or not its own
+/// text mentions it. The stasis field generator is the one exception, because
+/// it does no damage to scale.
+const MODIFICATIONS: [WeaponModifications; 10] = [
+    // Pistol: clip 12 -> 24, then a reload cut to a third.
+    WeaponModifications {
+        script: "PistolModify",
+        levels: [
+            level(2.0, 1.0, 1.0, 1.0, DAMAGE_1),
+            level(2.0, TWO_THIRDS_OFF, 1.0, 1.0, DAMAGE_2),
+        ],
+    },
+    // Assault rifle: the same two effects in the other order, clip 36 -> 72.
+    WeaponModifications {
+        script: "RifleModify",
+        levels: [
+            level(1.0, TWO_THIRDS_OFF, 1.0, 1.0, DAMAGE_1),
+            level(2.0, TWO_THIRDS_OFF, 1.0, 1.0, DAMAGE_2),
+        ],
+    },
+    // Shotgun: a reload cut, then less kick. The kick lives in the unparsed
+    // `P$GunKick`, so the second modification is damage only for now.
+    WeaponModifications {
+        script: "ShotgunModify",
+        levels: [
+            level(1.0, TWO_THIRDS_OFF, 1.0, 1.0, DAMAGE_1),
+            level(1.0, TWO_THIRDS_OFF, 1.0, 1.0, DAMAGE_2),
+        ],
+    },
+    // Laser pistol: charge to 150%, then half of what a shot draws, as its
+    // own text promises. Three units a shot rounds to two.
+    WeaponModifications {
+        script: "LaserModify",
+        levels: [
+            level(1.5, 1.0, 1.0, 1.0, DAMAGE_1),
+            level(1.5, 1.0, 0.5, 1.0, DAMAGE_2),
+        ],
+    },
+    // EMP rifle: charge to 150% and a faster shot, then half the draw.
+    WeaponModifications {
+        script: "EMPModify",
+        levels: [
+            level(1.5, 1.0, 1.0, 1.5, DAMAGE_1),
+            level(1.5, 1.0, 0.5, 1.5, DAMAGE_2),
+        ],
+    },
+    // Grenade launcher: clip 6 -> 9, then faster grenades and a shorter reload.
+    WeaponModifications {
+        script: "GrenadeModify",
+        levels: [
+            level(1.5, 1.0, 1.0, 1.0, DAMAGE_1),
+            level(1.5, ONE_THIRD_OFF, 1.0, 1.5, DAMAGE_2),
+        ],
+    },
+    // Stasis field generator: half again the shot speed, as its own text
+    // promises, then half the prisms. It does no damage, so the blanket damage
+    // buff has nothing to scale and neither level carries one.
+    WeaponModifications {
+        script: "StasisModify",
+        levels: [
+            level(1.0, 1.0, 1.0, 1.5, 1.0),
+            level(1.0, 1.0, 0.5, 1.5, 1.0),
+        ],
+    },
+    // Fusion cannon: clip 40 -> 80, then one prism a shot instead of two.
+    WeaponModifications {
+        script: "FusionModify",
+        levels: [
+            level(2.0, 1.0, 1.0, 1.0, DAMAGE_1),
+            level(2.0, 1.0, 0.5, 1.0, DAMAGE_2),
+        ],
+    },
+    // Annelid (worm) launcher: a bigger clip, then twice the projectile speed.
+    WeaponModifications {
+        script: "AnnelidModify",
+        levels: [
+            level(2.0, 1.0, 1.0, 1.0, DAMAGE_1),
+            level(2.0, 1.0, 1.0, 2.0, DAMAGE_2),
+        ],
+    },
+    // Viral proliferator: a bigger clip, then half the worms a shot.
+    WeaponModifications {
+        script: "ViralModify",
+        levels: [
+            level(2.0, 1.0, 1.0, 1.0, DAMAGE_1),
+            level(2.0, 1.0, 0.5, 1.0, DAMAGE_2),
+        ],
+    },
+];
+
+/// The modification table `weapon` is modified by, or `None` for a gun that
+/// authors no modify script and therefore cannot be modified at all.
+///
+/// The gun's scripts are borrowed once and matched against all ten entries,
+/// rather than borrowing per entry - this is called for every read of a gun's
+/// firing description.
+fn table_for(world: &World, weapon: EntityId) -> Option<&'static WeaponModifications> {
+    let scripts = world.borrow::<View<PropScripts>>().ok()?;
+    let scripts = scripts.get(weapon).ok()?;
+    MODIFICATIONS.iter().find(|entry| {
+        scripts
+            .scripts
+            .iter()
+            .any(|script| script.eq_ignore_ascii_case(entry.script))
+    })
+}
+
+/// Whether `weapon` authors a modify script - the data's own answer to "is
+/// this a gun modification does anything to".
+pub fn has_modify_script(world: &World, weapon: EntityId) -> bool {
+    table_for(world, weapon).is_some()
+}
+
+/// `weapon`'s current modification level, clamped to what a gun can reach.
+pub fn modification_level(world: &World, weapon: EntityId) -> i32 {
+    world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|states| states.get(weapon).ok().map(|state| state.modification))
+        .unwrap_or(0)
+        .clamp(0, MAX_MODIFICATION)
+}
+
+/// The modification `weapon` is currently carrying, as multipliers on what it
+/// authors. The unmodified gun - and any gun with no modify script - gets
+/// [`Modification::NONE`], which leaves every value alone.
+fn current(world: &World, weapon: EntityId) -> Modification {
+    let level = modification_level(world, weapon);
+    if level <= 0 {
+        return Modification::NONE;
+    }
+    table_for(world, weapon)
+        .and_then(|entry| entry.levels.get(level as usize - 1).copied())
+        .unwrap_or(Modification::NONE)
+}
+
+/// Scale a count that has to stay whole and at least one - a magazine, or the
+/// rounds a shot costs. A value that is not positive to begin with is a
+/// setting the gun does not author (the third, unused fire setting every gun
+/// ships carries zeroes) and is left exactly as it is: rounding it up to one
+/// would invent a magazine where the data has none.
+fn scale_count(value: i32, by: f32) -> i32 {
+    if value <= 0 {
+        return value;
+    }
+    ((value as f32) * by).round().max(1.0) as i32
+}
+
+/// `setting` as a gun modified to `level` fires it.
+fn apply(setting: &GunSettingDesc, modification: Modification) -> GunSettingDesc {
+    GunSettingDesc {
+        clip: scale_count(setting.clip, modification.clip),
+        ammo_usage: scale_count(setting.ammo_usage, modification.ammo_usage),
+        reload_time_ms: ((setting.reload_time_ms as f32) * modification.reload).round() as u32,
+        speed_modifier: setting.speed_modifier * modification.speed,
+        stim_modifier: setting.stim_modifier * modification.damage,
+        ..setting.clone()
+    }
+}
+
+/// `setting`, as `weapon`'s modification level has it fire. This is the one
+/// place a modification takes effect; every reader of a gun's firing
+/// description goes through
+/// [`active_gun_setting`](crate::scripts::script_util::active_gun_setting),
+/// which calls it.
+pub fn modified_setting(
+    world: &World,
+    weapon: EntityId,
+    setting: &GunSettingDesc,
+) -> GunSettingDesc {
+    apply(setting, current(world, weapon))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shipped pistol's first fire setting, and the shipped rifle's.
+    fn pistol_setting() -> GunSettingDesc {
+        GunSettingDesc {
+            burst: 1,
+            clip: 12,
+            spray: 1,
+            stim_modifier: 1.0,
+            burst_interval_ms: 0,
+            shot_interval_ms: 500,
+            ammo_usage: 1,
+            speed_modifier: 1.0,
+            reload_time_ms: 500,
+        }
+    }
+
+    fn gun(scripts: &[&str], modification: i32) -> (World, EntityId) {
+        let mut world = World::new();
+        let gun = world.add_entity((
+            PropScripts {
+                scripts: scripts.iter().map(|s| (*s).to_owned()).collect(),
+                inherits: true,
+            },
+            PropGunState {
+                ammo: 0,
+                condition: 100.0,
+                setting: 0,
+                modification,
+                silence_value: 0.0,
+            },
+        ));
+        (world, gun)
+    }
+
+    /// The shipped text names the pistol's numbers outright: clip 12 to 24 at
+    /// the first modification, a reload cut to a third at the second, and the
+    /// clip stays doubled - each level describes the whole gun, not a step.
+    #[test]
+    fn the_pistol_gains_a_clip_then_a_faster_reload() {
+        for (level, clip, reload) in [(0, 12, 500), (1, 24, 500), (2, 24, 167)] {
+            let (world, weapon) = gun(&["PistolModify", "WeaponScript"], level);
+            let modified = modified_setting(&world, weapon, &pistol_setting());
+            assert_eq!((modified.clip, modified.reload_time_ms), (clip, reload));
+        }
+    }
+
+    /// Damage is a tenth over the unmodified gun at the first modification and
+    /// a quarter over it at the second - not a tenth compounded onto a quarter.
+    #[test]
+    fn damage_is_measured_against_the_unmodified_gun() {
+        let base = pistol_setting();
+        for (level, expected) in [(0, 1.0), (1, 1.1), (2, 1.25)] {
+            let (world, weapon) = gun(&["PistolModify"], level);
+            let modified = modified_setting(&world, weapon, &base);
+            assert!((modified.stim_modifier - expected).abs() < 1e-5);
+        }
+    }
+
+    /// The rifle takes the pistol's two effects in the other order, and its
+    /// shipped text names the same doubling: 36 to 72.
+    #[test]
+    fn the_rifle_gains_a_faster_reload_then_a_clip() {
+        let base = GunSettingDesc {
+            clip: 36,
+            reload_time_ms: 1000,
+            ..pistol_setting()
+        };
+        for (level, clip, reload) in [(0, 36, 1000), (1, 36, 333), (2, 72, 333)] {
+            let (world, weapon) = gun(&["RifleModify"], level);
+            let modified = modified_setting(&world, weapon, &base);
+            assert_eq!((modified.clip, modified.reload_time_ms), (clip, reload));
+        }
+    }
+
+    /// The shotgun's kick lives in a property nothing parses yet, so its
+    /// second modification currently only adds damage - but it must not
+    /// silently undo the first one's reload cut.
+    #[test]
+    fn the_shotgun_keeps_its_faster_reload_at_the_second_modification() {
+        let base = GunSettingDesc {
+            reload_time_ms: 1000,
+            ..pistol_setting()
+        };
+        let (world, weapon) = gun(&["ShotgunModify"], 2);
+        let modified = modified_setting(&world, weapon, &base);
+        assert_eq!(modified.reload_time_ms, 333);
+        assert!((modified.stim_modifier - DAMAGE_2).abs() < 1e-5);
+    }
+
+    /// The laser stores half again as much charge, then draws half as much per
+    /// shot - three units a shot rounding to two, the nearest whole draw.
+    #[test]
+    fn the_laser_gains_charge_then_efficiency() {
+        let base = GunSettingDesc {
+            clip: 100,
+            ammo_usage: 3,
+            reload_time_ms: 0,
+            ..pistol_setting()
+        };
+        for (level, clip, usage) in [(0, 100, 3), (1, 150, 3), (2, 150, 2)] {
+            let (world, weapon) = gun(&["LaserModify"], level);
+            let modified = modified_setting(&world, weapon, &base);
+            assert_eq!((modified.clip, modified.ammo_usage), (clip, usage));
+        }
+    }
+
+    /// The stasis generator's own text promises half again the shot speed, and
+    /// no damage change at all - it does none.
+    #[test]
+    fn the_stasis_generator_gains_shot_speed_then_efficiency() {
+        let base = GunSettingDesc {
+            clip: 12,
+            ammo_usage: 4,
+            speed_modifier: 0.6,
+            reload_time_ms: 0,
+            ..pistol_setting()
+        };
+        for (level, speed, usage) in [(0, 0.6, 4), (1, 0.9, 4), (2, 0.9, 2)] {
+            let (world, weapon) = gun(&["StasisModify"], level);
+            let modified = modified_setting(&world, weapon, &base);
+            assert!((modified.speed_modifier - speed).abs() < 1e-5);
+            assert_eq!(modified.ammo_usage, usage);
+            assert!((modified.stim_modifier - 1.0).abs() < 1e-5);
+        }
+    }
+
+    /// The unused third fire setting every gun ships authors zeroes, and the
+    /// psi amp authors a clipless, ammo-free setting outright. Scaling must
+    /// leave those alone rather than inventing a one-round magazine or making
+    /// a free shot cost a point of ammo.
+    #[test]
+    fn a_setting_the_gun_does_not_author_is_left_alone() {
+        let unauthored = GunSettingDesc {
+            burst: 0,
+            clip: 0,
+            ammo_usage: 0,
+            reload_time_ms: 0,
+            ..pistol_setting()
+        };
+        for level in 0..=2 {
+            // A gun whose table would otherwise double the clip and, at the
+            // second level, shorten the reload.
+            let (world, weapon) = gun(&["PistolModify"], level);
+            let modified = modified_setting(&world, weapon, &unauthored);
+            assert_eq!((modified.clip, modified.ammo_usage), (0, 0));
+            assert_eq!(modified.reload_time_ms, 0);
+            // And the psi amp, which authors no modify script at all.
+            let (world, amp) = gun(&["PsiAmpScript"], level);
+            assert_eq!(modified_setting(&world, amp, &unauthored), unauthored);
+        }
+    }
+
+    /// A gun that authors no modify script is left exactly as authored, even
+    /// if something has set a modification level on it.
+    #[test]
+    fn a_gun_with_no_modify_script_is_never_altered() {
+        let (world, weapon) = gun(&["WeaponScript"], 2);
+        assert!(!has_modify_script(&world, weapon));
+        assert_eq!(
+            modified_setting(&world, weapon, &pistol_setting()),
+            pistol_setting()
+        );
+    }
+
+    /// Deriving from the level rather than writing the gun's archetype is what
+    /// makes a modification survive a save and never compound: the same
+    /// authored setting read again gives the same answer.
+    #[test]
+    fn re_deriving_a_modification_gives_the_same_gun() {
+        let (world, weapon) = gun(&["PistolModify"], 2);
+        let once = modified_setting(&world, weapon, &pistol_setting());
+        let twice = modified_setting(&world, weapon, &pistol_setting());
+        assert_eq!(once, twice);
+        assert_eq!(once.clip, 24);
+    }
+
+    /// A level past the second - which nothing should ever write - reads as
+    /// the second rather than falling off the table into an unmodified gun.
+    #[test]
+    fn a_level_past_the_last_reads_as_the_last() {
+        let (world, weapon) = gun(&["PistolModify"], 7);
+        assert_eq!(modification_level(&world, weapon), MAX_MODIFICATION);
+        assert_eq!(modified_setting(&world, weapon, &pistol_setting()).clip, 24);
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -28,6 +28,7 @@ mod energy_weapon;
 mod exp_cookie;
 mod frob_qb;
 pub mod gui;
+pub mod gun_modifications;
 pub mod healing_item;
 mod internal_collision_type;
 mod internal_explosion;
@@ -125,7 +126,7 @@ pub use self::gui::ElevatorContext;
 use self::gui::{
     ComputerGui, ContainerGui, ElevatorGui, GamePigGui, HackableCrateGui, KeyPadGui, MapGui,
     MediaGui, PsiPowersGui, ReplicatorGui, ResearchGui, TrainerGui, TrainerMode, TraitGui,
-    WeaponRepairGui, WeaponSettingsGui,
+    WeaponModifyGui, WeaponRepairGui, WeaponSettingsGui,
 };
 use self::healing_item::{HealingItemKind, HealingItemScript};
 use self::internal_frob_move::InternalFrobMove;
@@ -966,6 +967,7 @@ impl ScriptWorld {
             "internal_media" => gui_script(Box::new(MediaGui)),
             "internal_weapon_settings" => gui_script(Box::new(WeaponSettingsGui)),
             "internal_weapon_repair" => gui_script(Box::new(WeaponRepairGui)),
+            "internal_weapon_modify" => gui_script(Box::new(WeaponModifyGui)),
             "internal_psi_powers" => gui_script(Box::new(PsiPowersGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
@@ -1067,7 +1069,7 @@ impl ScriptWorld {
 
             // weapons:
             "delaygrenade" => Box::new(UnimplementedScript::new(&script_name)),
-            "annelidmodify" => Box::new(UnimplementedScript::new(&script_name)),
+            "annelidmodify" => Box::new(NoopScript::new()),
             "empmodify" => Box::new(NoopScript::new()),
             "lasermodify" => Box::new(NoopScript::new()),
             "fusionmodify" => Box::new(NoopScript::new()),
@@ -1086,7 +1088,7 @@ impl ScriptWorld {
                 Box::new(PsiAmpScript::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),
             ])),
-            "viralmodify" => Box::new(UnimplementedScript::new(&script_name)),
+            "viralmodify" => Box::new(NoopScript::new()),
 
             //goodies:
             "expcookie" => Box::new(ExpCookie::new()), // cyber modules

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -278,6 +278,10 @@ pub fn current_gun_setting(world: &World, weapon: EntityId) -> i32 {
 /// `None` when it is not a gun. The setting comes from the weapon's live
 /// `PropGunState` (0 when it has none), and an index the archetype does not
 /// author falls back to setting 0.
+///
+/// The gun's modification level is applied on the way out, so every reader -
+/// firing, reloading, the energy draw - sees the gun as the player has had it
+/// modified without any of them knowing modification exists.
 pub fn active_gun_setting(world: &World, weapon: EntityId) -> Option<GunSettingDesc> {
     let setting = current_gun_setting(world, weapon);
     world
@@ -289,6 +293,7 @@ pub fn active_gun_setting(world: &World, weapon: EntityId) -> Option<GunSettingD
                 .ok()
                 .map(|desc| desc.setting(setting).clone())
         })
+        .map(|desc| crate::scripts::gun_modifications::modified_setting(world, weapon, &desc))
 }
 
 /// A weapon's selectable `Projectile` links (its ammo types), filtered to the
@@ -457,6 +462,28 @@ pub fn gun_setting_description(world: &World, weapon: EntityId, setting: i32) ->
         .borrow::<UniqueView<crate::mission::mission_core::GlobalGunSettingTexts>>()
         .ok()?;
     resolve_setting_string(world, weapon, raw, tables.0.get(setting as usize)?)
+}
+
+/// What `weapon`'s modification number `level` (1 or 2) does, as the gun's own
+/// `P$Modify1`/`P$Modify2` text resolved against the MODIFY1/MODIFY2 string
+/// tables - exactly as the fire-setting text is resolved. `None` for a level
+/// the gun names no text for.
+pub fn modification_description(world: &World, weapon: EntityId, level: i32) -> Option<String> {
+    let raw = match level {
+        1 => world
+            .borrow::<View<dark::properties::PropModification1Text>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|text| text.0.clone())),
+        2 => world
+            .borrow::<View<dark::properties::PropModification2Text>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|text| text.0.clone())),
+        _ => return None,
+    };
+    let tables = world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalModificationTexts>>()
+        .ok()?;
+    resolve_setting_string(world, weapon, raw, tables.0.get(level as usize - 1)?)
 }
 
 /// The ammo index to select after a fire-mode switch. `order` is the ammo

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -516,7 +516,11 @@ async function useFromStrip(
   assert.ok(
     slot,
     `the strip should list the carried item (got ${JSON.stringify(
-      (await game.ui.state()).strip?.elements.map((e) => e.label),
+      (await game.ui.state()).strip?.elements.map((e) => [
+        e.kind,
+        e.entity_id,
+        e.label,
+      ]),
     )})`,
   );
   await click(slot);
@@ -694,6 +698,341 @@ test(
       objectStateOf(await game.entities.detail(pistol.id)),
       "Normal",
       "a won repair works the same way in VR",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Slice 6: modify.
+//
+// A working gun can be improved twice on the same board, entered from the
+// weapon settings panel's MODIFY control - flat and in the VR cyber interface,
+// which present one canvas. Each win raises the gun's modification level, and
+// the level is what the gun's firing description is derived from, so the
+// magazine and the reload change with it. There is no third modification.
+//
+// Negative-first: on the parent no modify mode exists, the settings panel has
+// no MODIFY control, and the pistol's clip never leaves 12.
+
+/** The pistol's authored `P$ModifyDif` nanite cost, per deal. */
+const MODIFY_COST = "20";
+/** Piles of 50: the board charges 20 a deal and may be re-dealt. */
+const NANITE_PILES = 10;
+/** The pistol's authored magazine, and what each modification makes of it. */
+const PISTOL_CLIP = [12, 24, 24];
+/** The pistol's authored reload, and what each modification makes of it. */
+const PISTOL_RELOAD_MS = [500, 500, 167];
+
+function gunNumber(
+  detail: { properties: { name: string; value: string }[] },
+  name: string,
+): number {
+  const found = detail.properties.find((p) => p.name === name);
+  assert.ok(found, `a gun should expose a ${name} property`);
+  return Number(found.value);
+}
+
+async function modifyPanel(game: GameServer): Promise<UiPanel> {
+  const ui = await game.ui.state();
+  assert.ok(
+    ui.active_panel,
+    `the modify board should be open (mode=${ui.mode})`,
+  );
+  return ui.active_panel;
+}
+
+/** Play the board until the modification lands, exactly as repair does. */
+async function playModifyBoardToWin(
+  game: GameServer,
+  click: (element: UiElement) => Promise<void>,
+): Promise<void> {
+  const routes = [
+    ["node-2-0", "node-3-0", "node-4-0"],
+    ["node-2-1", "node-2-2", "node-2-3"],
+    ["node-0-1", "node-0-2", "node-0-3"],
+    ["node-4-0", "node-4-1", "node-4-2"],
+    ["node-0-3", "node-1-3", "node-2-3"],
+  ];
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    let panel = await modifyPanel(game);
+    if (hasTexture(panel, "winh.pcx")) return;
+    assert.ok(
+      !hasTexture(panel, "loseh.pcx"),
+      "a critical failure broke the gun; max Modify should leave no mines",
+    );
+    assert.ok(
+      !hasTexture(panel, "payh.pcx"),
+      "the test wallet should always cover the authored modify cost",
+    );
+
+    const inPlay = panel.elements.some((el) => el.label === "reset-hack");
+    if (!inPlay || hasTexture(panel, "failh.pcx")) {
+      const deal = panel.elements.find(
+        (el) => el.label === "start-hack" || el.label === "reset-hack",
+      );
+      assert.ok(
+        deal,
+        `an unwon board should offer START/RESET (got ${JSON.stringify(
+          panel.elements.map((e) => e.label ?? e.texture),
+        )})`,
+      );
+      await click(deal);
+    }
+
+    for (const label of routes[attempt % routes.length]) {
+      panel = await modifyPanel(game);
+      if (hasTexture(panel, "winh.pcx")) return;
+      if (hasTexture(panel, "failh.pcx") || hasTexture(panel, "loseh.pcx")) {
+        break;
+      }
+      await click(boardButton(panel, label));
+    }
+  }
+  assert.fail("the modify board should win within the attempt budget");
+}
+
+/** The wielded pistol, plus a wallet the board's per-deal cost comes out of. */
+async function wieldedPistolWithNanites(
+  game: GameServer,
+): Promise<{ id: number }> {
+  await game.input.trigger("DebugCycleWeapon");
+  await game.step({ frames: 5 });
+  const wielded = (await game.info()).player.wielded_entity_id;
+  assert.ok(wielded, "DebugCycleWeapon should wield the bench pistol");
+  for (let i = 0; i < NANITE_PILES; i += 1) {
+    await game.player.spawnItem(BIG_NANITE_PILE);
+  }
+  await game.step({ frames: 5 });
+  return { id: wielded };
+}
+
+/** Open the settings MFD the way a player does: the readout's SETTING button. */
+async function openSettings(
+  game: GameServer,
+  click: (element: UiElement) => Promise<void>,
+): Promise<void> {
+  const setting = ((await game.ui.state()).readout ?? []).find(
+    (e) => e.label === "gun_setting",
+  );
+  assert.ok(setting, "the readout should carry a SETTING button");
+  await click(setting);
+  await game.step({ frames: 3 });
+}
+
+/** SETTING, then MODIFY: the whole way in to the board. */
+async function openModifyBoard(
+  game: GameServer,
+  click: (element: UiElement) => Promise<void>,
+): Promise<void> {
+  await openSettings(game, click);
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "SETTING should dock the settings panel");
+  const modify = panel.elements.find(
+    (e) => e.kind === "button" && e.label === "modify",
+  );
+  assert.ok(
+    modify,
+    `the settings panel should offer MODIFY (got ${JSON.stringify(
+      panel.elements.map((e) => e.label ?? e.texture),
+    )})`,
+  );
+  await click(modify);
+  await game.step({ frames: 3 });
+}
+
+/** Dismiss whatever is docked, so the next SETTING press opens afresh. */
+async function closePanel(
+  game: GameServer,
+  click: (element: UiElement) => Promise<void>,
+): Promise<void> {
+  const panel = (await game.ui.state()).active_panel;
+  if (!panel) return;
+  const close = panel.elements.find((e) => e.label === "close");
+  assert.ok(close, "a docked panel should carry a close button");
+  await click(close);
+  await game.step({ frames: 3 });
+}
+
+test(
+  "the settings panel's MODIFY control opens the board, and winning it modifies the gun",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    const pistol = await wieldedPistolWithNanites(game);
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const click = (element: UiElement) => clickUiElement(game, element);
+
+    const unmodified = await game.entities.detail(pistol.id);
+    assert.equal(gunNumber(unmodified, "Modification"), 0);
+    assert.equal(gunNumber(unmodified, "ClipSize"), PISTOL_CLIP[0]);
+    assert.equal(gunNumber(unmodified, "ReloadTimeMs"), PISTOL_RELOAD_MS[0]);
+
+    // KEY: the settings panel is the way in, and the board it opens is the HRM
+    // board played on the pistol's authored ModifyDiff terms.
+    await openModifyBoard(game, click);
+    const board = await modifyPanel(game);
+    assert.ok(
+      hasTexture(board, "hack.pcx"),
+      `MODIFY should present the HRM board (got ${JSON.stringify(
+        board.elements.map((e) => e.texture ?? e.label),
+      )})`,
+    );
+    assert.equal(
+      board.elements
+        .filter((e) => e.kind === "text")
+        .map((e) => e.text ?? "")
+        .find((text) => /^\d+$/.test(text)),
+      MODIFY_COST,
+      "the board should show the pistol's authored ModifyDiff cost",
+    );
+    // KEY: the board says what this modification will do, which is the only
+    // place the gun's `P$Modify1` text is ever shown.
+    assert.match(
+      board.elements
+        .filter((e) => e.kind === "text")
+        .map((e) => e.text ?? "")
+        .join(" "),
+      /clip size/i,
+      "the board should show the pistol's first modification text",
+    );
+    await game.screenshot("modify-board.png");
+
+    // KEY: a win is one modification, and the gun's magazine follows it.
+    await playModifyBoardToWin(game, click);
+    const once = await game.entities.detail(pistol.id);
+    assert.equal(gunNumber(once, "Modification"), 1);
+    assert.equal(
+      gunNumber(once, "ClipSize"),
+      PISTOL_CLIP[1],
+      "the first modification doubles the pistol's clip",
+    );
+
+    // KEY: a second modification is played on the harder `P$Modify2Di` terms
+    // and changes something else again.
+    await closePanel(game, click);
+    await openModifyBoard(game, click);
+    await playModifyBoardToWin(game, click);
+    const twice = await game.entities.detail(pistol.id);
+    assert.equal(gunNumber(twice, "Modification"), 2);
+    assert.equal(
+      gunNumber(twice, "ClipSize"),
+      PISTOL_CLIP[2],
+      "the clip stays doubled at the second modification",
+    );
+    assert.equal(
+      gunNumber(twice, "ReloadTimeMs"),
+      PISTOL_RELOAD_MS[2],
+      "the second modification cuts the pistol's reload",
+    );
+
+    // KEY: there is no third. The control is still there - it is where the
+    // player is told so - but it refuses rather than dealing a board.
+    await closePanel(game, click);
+    await openSettings(game, click);
+    const settings = (await game.ui.state()).active_panel;
+    assert.ok(settings);
+    const modify = settings.elements.find((e) => e.label === "modify");
+    assert.ok(modify, "a fully modified gun still carries the control");
+    await click(modify);
+    await game.step({ frames: 3 });
+    assert.ok(
+      !hasTexture(await modifyPanel(game), "hack.pcx"),
+      "a third modification should be refused, not dealt",
+    );
+    assert.equal(
+      gunNumber(await game.entities.detail(pistol.id), "Modification"),
+      2,
+      "and the gun is unchanged",
+    );
+  },
+);
+
+test(
+  "the VR cyber interface presents the same modify board",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    // The VR hand takes the pistol off the bench, the way a player does.
+    const bench = await cycleToWeapon(game, (e) => e.template_id === PISTOL);
+    await aimVrHandAt(game, bench.position as Vec3, 0.3);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 8 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      bench.id,
+      "the VR right hand must hold the pistol",
+    );
+    for (let i = 0; i < NANITE_PILES; i += 1) {
+      await game.player.spawnItem(BIG_NANITE_PILE);
+    }
+    await game.step({ frames: 5 });
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.ui.state()).mode,
+      "use",
+      "the cyber interface should be up",
+    );
+
+    /**
+     * Release, then pull: a clean rising edge on the controller trigger. The
+     * panel pose is re-read per click, because the canvas it reports is the
+     * canvas of whatever is currently docked - and the settings panel and the
+     * board are not the same size.
+     */
+    const clickElement = async (element: UiElement) => {
+      const pose = (await game.ui.state()).panel_pose;
+      assert.ok(pose, "the VR cyber interface must report its panel pose");
+      const canvas: [number, number] = [
+        element.rect[0] + element.rect[2] / 2,
+        element.rect[1] + element.rect[3] / 2,
+      ];
+      for (const trigger of [0, 1, 0]) {
+        // Squeeze held throughout: releasing it would drop the pistol, and a
+        // gun that is no longer in hand takes its settings panel with it.
+        await aimVrHandAtCanvas(game, pose, canvas, { trigger, squeeze: 1 });
+        await game.step({ frames: 2 });
+      }
+    };
+
+    // In VR the forearm readout draws no buttons, so the settings panel is
+    // asked for by the action instead - the same panel flat's SETTING button
+    // docks, presented on the cyber interface's canvas.
+    await game.input.trigger("OpenWeaponSettings");
+    await game.step({ frames: 5 });
+    const settings = (await game.ui.state()).active_panel;
+    assert.ok(settings, "the action should dock the gun's settings panel");
+    const modify = settings.elements.find(
+      (e) => e.kind === "button" && e.label === "modify",
+    );
+    assert.ok(
+      modify,
+      `the settings panel should offer MODIFY (got ${JSON.stringify(
+        settings.elements.map((e) => e.label ?? e.texture),
+      )})`,
+    );
+    await clickElement(modify);
+    await game.step({ frames: 3 });
+    assert.ok(
+      hasTexture(await modifyPanel(game), "hack.pcx"),
+      "the cyber interface should present the HRM board",
+    );
+    await game.screenshot("modify-board-vr.png");
+
+    await playModifyBoardToWin(game, clickElement);
+    assert.equal(
+      gunNumber(await game.entities.detail(bench.id), "Modification"),
+      1,
+      "a won modification works the same way in VR",
     );
   },
 );


### PR DESCRIPTION
Slice 6 of the weapon-condition work, on top of #1342 (repair).

## Rules

- Modify is the board's third mode. Terms are the gun's `P$ModifyDif` (first
  modification) or `P$Modify2Di` (second) — the same 12-byte `sTechInfo` record
  hack and repair use. Skill = Modify + installed modify software, one
  definition shared by the entry gate and the odds (`HrmMode::player_level`).
- Gate = `P$RequiredTechDesc`'s modify field, **plus two levels for the second
  modification**. Refusals use HRM.STR `techminskill2` and `ModifyResult3`.
- Only 0→1 and 1→2. A win raises `PropGunState.modification`; a critical failure
  breaks the gun (repairable — unlike a failed repair, which destroys it).
- The board shows the gun's `P$Modify1`/`P$Modify2` text, which is the only
  place retail ever draws it (the settings MFD draws just the level).
- `modify_subject` — what dealing a board needs — is decided by `modify_entry`,
  the same call the MODIFY control uses, so a board can never be dealt on terms
  the control would have refused, however the effect was reached.

## Entry point

Retail put the board up automatically, as a second overlay beside the weapon
settings MFD, whenever that MFD opened on a modifiable gun. Neither presentation
here has a second panel slot, so the settings panel carries a **MODIFY** control
and the board takes the slot when it is pressed. No shipped art names such a
control, so it is a label over a zero-alpha hit target — the same convention the
fire-setting rows use over the backdrop's painted boxes. One canvas, one layout,
both presentations.

Flat reaches the settings panel through the ammo readout's SETTING button. VR
has no entry of its own: the forearm readout draws no buttons, and the VR
pointer only ever reaches the cyber-interface panel slot. This PR adds an
`OpenWeaponSettings` input action as a **tooling affordance** — bound to no key
and no controller button, it exists so the e2e tests and the debug runtime can
dock the panel directly, and it is how the VR case below is driven. A real VR
entry point is a deliberate UX decision rather than a face-button binding
bolted on, and is tracked in #1344.

## Per-gun effects

Applied where the firing description is **read** (`active_gun_setting`), never
written into `PropBaseGunDesc`. The modification is therefore a pure function of
the already-saved `modification` level: nothing to migrate, and re-deriving it
any number of times cannot compound. Each level is expressed against the
*unmodified* gun, which is how the numbers read ("damage up to 25% over the
standard").

Damage is **not** per-gun: every modifiable gun that does damage at all gets the
same ×1.10 / ×1.25 buff at each level, whether or not its own text mentions it.
The stasis field generator is the one exception — it does no damage to scale.

| Gun (modify script) | Modification 1 | Modification 2 |
| --- | --- | --- |
| Pistol (`PistolModify`) | clip 12→24, dmg ×1.10 | + reload ×1/3, dmg ×1.25 |
| Assault rifle (`RifleModify`) | reload ×1/3, dmg ×1.10 | + clip 36→72, dmg ×1.25 |
| Shotgun (`ShotgunModify`) | reload ×1/3, dmg ×1.10 | dmg ×1.25 (kick: see gaps) |
| Laser pistol (`LaserModify`) | clip ×1.5 (100→150), dmg ×1.10 | + ammo ×0.5 (3→2), dmg ×1.25 |
| EMP rifle (`EMPModify`) | clip ×1.5, speed ×1.5, dmg ×1.10 | + ammo ×0.5 (2→1), dmg ×1.25 |
| Grenade launcher (`GrenadeModify`) | clip 6→9, dmg ×1.10 | + speed ×1.5, reload ×2/3, dmg ×1.25 |
| Stasis generator (`StasisModify`) | speed ×1.5 | + ammo ×0.5 (4→2) |
| Fusion cannon (`FusionModify`) | clip 40→80, dmg ×1.10 | + ammo ×0.5 (2→1), dmg ×1.25 |
| Annelid launcher (`AnnelidModify`) | clip ×2, dmg ×1.10 | + speed ×2, dmg ×1.25 |
| Viral proliferator (`ViralModify`) | clip ×2, dmg ×1.10 | + ammo ×0.5 (2→1), dmg ×1.25 |

Sources. The qualitative effect of every entry is the gun's own shipped
`MODIFY1.STR`/`MODIFY2.STR` text, which also settles two magnitudes outright
(pistol "Increase clip size from 12 to 24", rifle "Increase the clip size from
36 to 72"). Clip increases the text does quantify are taken at their word — the
grenade launcher's 6→9, the laser's and EMP rifle's charge — and an unquantified
"increase clip size" is read as a doubling. Damage figures, the "2/3rds"
reload/ammo reductions and the speed multipliers come from:

- https://www.gamebanshee.com/systemshock2/weapons/pistol.php (and the
  `shotgun`, `assaultrifle`, `laserpistol`, `emprifle`, `grenadelauncher`,
  `stasisfieldgenerator`, `fusioncannon`, `annelidlauncher`,
  `viralproliferator` pages in the same directory)
- https://shodan.fandom.com/wiki/Modify
- https://shodan.fandom.com/wiki/M-22_Assault_Rifle
- https://shodan.fandom.com/wiki/TC-11_%22Brick%22_Grenade_Launcher

Every ammo-usage multiplier lands on a whole number against the shipped
`P$BaseGunDe` values, which is a decent check on them. The laser is the one
place a source disagrees with the gun's own text (33% off vs the text's "half"),
and it does not matter: both readings round the shipped 3-unit draw to 2, so the
text is taken at its word.

A gun that does *not* author a setting — the unused third fire setting every gun
ships carries zeroes, and the psi amp's setting is clipless and ammo-free — is
left exactly as authored. Scaling never rounds a zero up to one, so modification
cannot invent a one-round magazine or make a free shot cost ammo.

## Verified

- Unit: mode dispatch and the 0→1→2 sequencing with no third, the two-level
  premium on the second, software counting toward the gate, the effect table for
  pistol/rifle/shotgun/laser/stasis, damage measured against the unmodified gun,
  a zero-valued setting left alone, re-derivation idempotence, no board dealt on
  a gun the MODIFY control would refuse, and the settings panel's control (drawn
  only for a modifiable gun, opens the board, says so when fully modified).
  Property parsing is tested on the shipped pistol's bytes.
- e2e (`tools/shock2-sdk/test/weapon-condition.e2e.test.ts`, both new cases
  pass): flat — wield the pistol, SETTING, MODIFY, play the board to a win →
  `Modification` 1 and `ClipSize` 24; again → 2 and `ReloadTimeMs` 167; a third
  press is refused rather than dealt. VR — the same canvas driven by the
  controller ray in the cyber interface.
- `weapon-condition.e2e` 11/11, `missions.e2e` 23/23,
  `weapon-settings-mfd.e2e` + `ammo-readout.e2e` 7/7, `cargo test -p shock2vr`
  1406/1406, `-p dark` 145/145, `RUSTFLAGS="-D warnings" cargo check` clean.

## Gaps

- The shotgun's second modification is damage only: its kick lives in the
  unparsed `P$GunKick` (96 B). #1345
- The repair and modify boards draw `HACK.PCX`; the shipped data has
  `MODIFY.PCX` and `REPAIR.PCX`. #1346
- `mission_core`'s five synthetic panel hosts duplicate their spawn and
  docked-lifetime blocks; the modify board's missing "close when the gun is
  gone" branch (fixed here) came straight out of that drift. #1347
- VR has no entry to the settings panel, and so none to this board outside the
  tooling action. #1344
- Community sources give the annelid launcher and the viral proliferator a
  modified clip of 18, which does not divide the shipped base of 8; both are
  doubled here, consistent with every other unquantified "increase clip size".
- The Crystal Shard (-28) authors `P$ModifyDif` but no modify script, no
  modification text and no second difficulty; it is not modifiable here.
- `FreeModify` (template -1488) is untouched.


## Visuals

![modify board demo](https://gist.githubusercontent.com/tommy-xr/79a53d58c1bfaa55e0e54ce1aad6a7f2/raw/modify-demo.gif)

<sub>Flat: SETTING docks the gun's settings panel (MODIFY, modification level 0), MODIFY deals the HRM board on the pistol's authored ModifyDiff terms, and three connected nodes win it. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) on `debug_weapons`.</sub>

**Flat — the board, with the gun's modification text and its authored cost**

![modify board, flat](https://gist.githubusercontent.com/tommy-xr/79a53d58c1bfaa55e0e54ce1aad6a7f2/raw/still-flat.png)

**VR — the same board on the cyber interface's canvas**

![modify board, VR cyber interface](https://gist.githubusercontent.com/tommy-xr/79a53d58c1bfaa55e0e54ce1aad6a7f2/raw/still-vr.png)
