### PR TITLE
feat(ui): repair and modify boards use their own art

### DIFF
--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -112,10 +112,33 @@ pub struct HudStrings {
     /// Modify level is below what the gun's next modification demands.
     pub modify_skill_req: String,
     /// HRM.STR `ModifyResult3`: the gun has had every modification it can take.
+    /// Not part of `hrm_results` despite the shared key family - it is a refusal
+    /// at the panel's door, not the outcome of a board that was played.
     pub modify_maxed: String,
     /// HRM.STR `<mode>Result<n>`: what a finished board says, per mode. Read
     /// through [`HudStrings::hrm_result`] rather than indexed by hand.
     hrm_results: [[String; 3]; 3],
+}
+
+/// Resolve the nine `<mode>result<n>` lines out of HRM.STR, or the English
+/// fallbacks when it has none.
+///
+/// Every slot is addressed by `HrmMode::index`/`HrmResult::index` - the same
+/// pair [`HudStrings::hrm_result`] reads it back with - so a mode can never end
+/// up speaking in another mode's voice through a reordered literal.
+fn hrm_results(strings: Option<&std::collections::HashMap<String, String>>) -> [[String; 3]; 3] {
+    let mut resolved: [[String; 3]; 3] = Default::default();
+    for mode in [HrmMode::Hack, HrmMode::Repair, HrmMode::Modify] {
+        for result in [HrmResult::PlayedOut, HrmResult::Won, HrmResult::Lost] {
+            let fallback = FALLBACK_HRM_RESULTS[mode.index()][result.index()];
+            resolved[mode.index()][result.index()] = crate::ui::resolve_menu_label(
+                strings,
+                &format!("{}result{}", mode.string_prefix(), result.index()),
+                fallback,
+            );
+        }
+    }
+    resolved
 }
 
 impl Default for HudStrings {
@@ -131,12 +154,18 @@ impl Default for HudStrings {
             repair_skill_req: FALLBACK_REPAIR_SKILL_REQ.to_owned(),
             modify_skill_req: FALLBACK_MODIFY_SKILL_REQ.to_owned(),
             modify_maxed: FALLBACK_MODIFY_MAXED.to_owned(),
-            hrm_results: FALLBACK_HRM_RESULTS.map(|mode| mode.map(str::to_owned)),
+            hrm_results: hrm_results(None),
         }
     }
 }
 
 impl HudStrings {
+    /// What the board says when it finishes, in the words of the mode it was
+    /// played in.
+    pub(crate) fn hrm_result(&self, mode: HrmMode, result: HrmResult) -> &str {
+        &self.hrm_results[mode.index()][result.index()]
+    }
+
     pub fn load(asset_cache: &mut AssetCache) -> HudStrings {
         let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "misc.str");
         // The board's own table: everything the HRM's three modes say lives in
@@ -158,16 +187,7 @@ impl HudStrings {
                 "modifyresult3",
                 FALLBACK_MODIFY_MAXED,
             ),
-            hrm_results: [HrmMode::Hack, HrmMode::Repair, HrmMode::Modify].map(|mode| {
-                let fallbacks = FALLBACK_HRM_RESULTS[mode.index()];
-                [0usize, 1, 2].map(|result| {
-                    crate::ui::resolve_menu_label(
-                        hrm_strings.as_deref(),
-                        &format!("{}result{result}", mode.string_prefix()),
-                        fallbacks[result],
-                    )
-                })
-            }),
+            hrm_results: hrm_results(hrm_strings.as_deref()),
             reload_label: crate::ui::resolve_menu_label(
                 strings.as_deref(),
                 "reload",
@@ -207,14 +227,6 @@ impl HudStrings {
     }
 }
 
-impl HudStrings {
-    /// What the board says when it finishes, in the words of the mode it was
-    /// played in.
-    pub(crate) fn hrm_result(&self, mode: HrmMode, result: HrmResult) -> &str {
-        &self.hrm_results[mode.index()][result.index()]
-    }
-}
-
 /// The preloaded HUD strings, or the English defaults in a world that has none
 /// (the unit-test worlds, and any scene loaded without a strings table).
 pub(crate) fn hud_strings(world: &World) -> HudStrings {
@@ -222,4 +234,49 @@ pub(crate) fn hud_strings(world: &World) -> HudStrings {
         .borrow::<UniqueView<HudStrings>>()
         .map(|s| s.clone())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// A localized HRM.STR would silently swap two modes' voices if the table
+    /// were filled positionally, so resolve a stub whose nine values name the
+    /// slot they belong in and check each lands where it is read back from.
+    #[test]
+    fn each_mode_result_resolves_into_its_own_slot() {
+        let table: HashMap<String, String> = [
+            ("hackresult0", "h0"),
+            ("hackresult1", "h1"),
+            ("hackresult2", "h2"),
+            ("repairresult0", "r0"),
+            ("repairresult1", "r1"),
+            ("repairresult2", "r2"),
+            ("modifyresult0", "m0"),
+            ("modifyresult1", "m1"),
+            ("modifyresult2", "m2"),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key.to_owned(), value.to_owned()))
+        .collect();
+
+        let strings = HudStrings {
+            hrm_results: hrm_results(Some(&table)),
+            ..HudStrings::default()
+        };
+        for (mode, prefix) in [
+            (HrmMode::Hack, 'h'),
+            (HrmMode::Repair, 'r'),
+            (HrmMode::Modify, 'm'),
+        ] {
+            for (result, index) in [
+                (HrmResult::PlayedOut, 0),
+                (HrmResult::Won, 1),
+                (HrmResult::Lost, 2),
+            ] {
+                assert_eq!(strings.hrm_result(mode, result), format!("{prefix}{index}"));
+            }
+        }
+    }
 }

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -1,6 +1,8 @@
 use engine::assets::asset_cache::AssetCache;
 use shipyard::{Unique, UniqueView, World};
 
+use crate::scripts::gui::{HrmMode, HrmResult};
+
 mod damage_flash;
 pub use damage_flash::*;
 
@@ -53,6 +55,27 @@ const FALLBACK_WRENCH_UNUSED: &str = "Weapon already in good condition.";
 const FALLBACK_MODIFY_SKILL_REQ: &str = "Modify skill %d required.";
 const FALLBACK_MODIFY_MAXED: &str = "This weapon cannot be modified any further.";
 
+/// The English fallbacks for the board's result lines, verbatim from the
+/// shipped HRM.STR. Indexed `[mode][result]` in `HrmMode`/`HrmResult` order:
+/// hack, repair, modify x played-out, won, lost.
+const FALLBACK_HRM_RESULTS: [[&str; 3]; 3] = [
+    [
+        "You could not break the security on this attempt.",
+        "Hacking successful!",
+        "Hacking failed!",
+    ],
+    [
+        "You were unable to repair the item on this attempt.",
+        "The item has been successfully repaired, and can be used normally.",
+        "You have destroyed the item!",
+    ],
+    [
+        "You did not successfully modify the weapon on this attempt.",
+        "Modification completed!",
+        "Modification Failed!",
+    ],
+];
+
 /// The English fallback for the board's repair skill gate, verbatim from the
 /// shipped HRM.STR (`%d` is the minimum Repair level the object authors).
 const FALLBACK_REPAIR_SKILL_REQ: &str = "Repair skill %d required.";
@@ -90,6 +113,9 @@ pub struct HudStrings {
     pub modify_skill_req: String,
     /// HRM.STR `ModifyResult3`: the gun has had every modification it can take.
     pub modify_maxed: String,
+    /// HRM.STR `<mode>Result<n>`: what a finished board says, per mode. Read
+    /// through [`HudStrings::hrm_result`] rather than indexed by hand.
+    hrm_results: [[String; 3]; 3],
 }
 
 impl Default for HudStrings {
@@ -105,6 +131,7 @@ impl Default for HudStrings {
             repair_skill_req: FALLBACK_REPAIR_SKILL_REQ.to_owned(),
             modify_skill_req: FALLBACK_MODIFY_SKILL_REQ.to_owned(),
             modify_maxed: FALLBACK_MODIFY_MAXED.to_owned(),
+            hrm_results: FALLBACK_HRM_RESULTS.map(|mode| mode.map(str::to_owned)),
         }
     }
 }
@@ -128,9 +155,19 @@ impl HudStrings {
             ),
             modify_maxed: crate::ui::resolve_menu_label(
                 hrm_strings.as_deref(),
-                "ModifyResult3",
+                "modifyresult3",
                 FALLBACK_MODIFY_MAXED,
             ),
+            hrm_results: [HrmMode::Hack, HrmMode::Repair, HrmMode::Modify].map(|mode| {
+                let fallbacks = FALLBACK_HRM_RESULTS[mode.index()];
+                [0usize, 1, 2].map(|result| {
+                    crate::ui::resolve_menu_label(
+                        hrm_strings.as_deref(),
+                        &format!("{}result{result}", mode.string_prefix()),
+                        fallbacks[result],
+                    )
+                })
+            }),
             reload_label: crate::ui::resolve_menu_label(
                 strings.as_deref(),
                 "reload",
@@ -167,6 +204,14 @@ impl HudStrings {
                 FALLBACK_WRENCH_UNUSED,
             ),
         }
+    }
+}
+
+impl HudStrings {
+    /// What the board says when it finishes, in the words of the mode it was
+    /// played in.
+    pub(crate) fn hrm_result(&self, mode: HrmMode, result: HrmResult) -> &str {
+        &self.hrm_results[mode.index()][result.index()]
     }
 }
 

--- a/shock2vr/src/scripts/gui/computer.rs
+++ b/shock2vr/src/scripts/gui/computer.rs
@@ -219,7 +219,7 @@ impl Gui<ComputerState, ComputerMsg> for ComputerGui {
         let Some(diff) = hack_diff(world, entity_id) else {
             return Vec::new();
         };
-        let mut components = draw_hack_board(&state.hack, diff, ComputerMsg::Hack);
+        let mut components = draw_hack_board(&state.hack, diff, HrmMode::Hack, ComputerMsg::Hack);
         for (line, text) in wrap_hack_text(&authored_hack_text(world, entity_id))
             .into_iter()
             .take(3)

--- a/shock2vr/src/scripts/gui/hackable_crate.rs
+++ b/shock2vr/src/scripts/gui/hackable_crate.rs
@@ -157,7 +157,7 @@ impl Gui<HackableCrateState, HackableCrateMsg> for HackableCrateGui {
         } else {
             state.hack.clone()
         };
-        draw_hack_board(&hack, diff, HackableCrateMsg::Hack)
+        draw_hack_board(&hack, diff, HrmMode::Hack, HackableCrateMsg::Hack)
     }
 
     fn get_config(&self) -> GuiConfig {

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -205,6 +205,97 @@ impl HrmMode {
             })
             .unwrap_or(0)
     }
+
+    /// The art this mode's board wears. Retail keeps one board and swaps the
+    /// pictures: the backdrop is named after the mode, and the result overlays
+    /// share a base name with a per-mode suffix.
+    pub(crate) const fn art(self) -> HrmArt {
+        match self {
+            HrmMode::Hack => HrmArt {
+                backdrop: "hack.pcx",
+                won: "winh.pcx",
+                lost: "loseh.pcx",
+                unwinnable: "failh.pcx",
+                unpaid: "payh.pcx",
+            },
+            HrmMode::Repair => HrmArt {
+                // Archive-qualified: `repair.pcx` is one of the seven basenames
+                // the interface art shares with a model texture, and the model
+                // mounts first, so the plain key resolves to the wrong picture.
+                backdrop: "iface/repair.pcx",
+                won: "winr.pcx",
+                lost: "loser.pcx",
+                unwinnable: "failr.pcx",
+                unpaid: "payr.pcx",
+            },
+            HrmMode::Modify => HrmArt {
+                backdrop: "modify.pcx",
+                won: "winm.pcx",
+                lost: "losem.pcx",
+                unwinnable: "failm.pcx",
+                unpaid: "paym.pcx",
+            },
+        }
+    }
+
+    /// Position in the mode-indexed tables, which is also the order the modes
+    /// are numbered in the shipped data.
+    pub(crate) const fn index(self) -> usize {
+        match self {
+            HrmMode::Hack => 0,
+            HrmMode::Repair => 1,
+            HrmMode::Modify => 2,
+        }
+    }
+
+    /// The HRM.STR key prefix; result keys are `<prefix>result<n>`.
+    pub(crate) const fn string_prefix(self) -> &'static str {
+        match self {
+            HrmMode::Hack => "hack",
+            HrmMode::Repair => "repair",
+            HrmMode::Modify => "modify",
+        }
+    }
+}
+
+/// The five pictures a board draws: its backdrop, plus the overlay that covers
+/// the matrix once the board has stopped being playable.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HrmArt {
+    pub(crate) backdrop: &'static str,
+    pub(crate) won: &'static str,
+    pub(crate) lost: &'static str,
+    pub(crate) unwinnable: &'static str,
+    pub(crate) unpaid: &'static str,
+}
+
+/// A finished board's outcome, in the numbering the HRM.STR result keys use.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HrmResult {
+    /// The board ran out of playable squares: the attempt is over, nothing
+    /// happened to the object.
+    PlayedOut,
+    Won,
+    Lost,
+}
+
+impl HrmResult {
+    pub(crate) const fn index(self) -> usize {
+        match self {
+            HrmResult::PlayedOut => 0,
+            HrmResult::Won => 1,
+            HrmResult::Lost => 2,
+        }
+    }
+}
+
+/// The status line a finished board posts, in the mode's own words.
+fn result_message(world: &World, mode: HrmMode, result: HrmResult) -> Effect {
+    Effect::ShowMessage {
+        text: crate::hud::hud_strings(world)
+            .hrm_result(mode, result)
+            .to_owned(),
+    }
 }
 
 fn effective_hack_values(world: &World, diff: PropHackDiff, mode: HrmMode) -> (i32, i32) {
@@ -300,14 +391,16 @@ fn draw_number(num: u32) -> Vec<GuiComponent<KeyPadMsg>> {
 pub(crate) fn draw_hack_board<TMsg, F>(
     state: &HackState,
     diff: PropHackDiff,
+    mode: HrmMode,
     wrap: F,
 ) -> Vec<GuiComponent<TMsg>>
 where
     TMsg: Clone,
     F: Fn(KeyPadMsg) -> TMsg + Copy,
 {
+    let art = mode.art();
     let mut components = vec![
-        gui::image("hack.pcx")
+        gui::image(art.backdrop)
             .with_position(vec2(0.0, 0.0))
             .with_size(vec2(188.0, 296.0)),
     ];
@@ -356,7 +449,7 @@ where
                         .with_size(vec2(16.0, 16.0)),
                 );
             }
-            // The unlit node outline is already part of HACK.PCX. This
+            // The unlit node outline is already part of the backdrop. This
             // zero-alpha button supplies a normal 16x16 hit target without
             // painting a placeholder over that authored art.
             components.push(
@@ -371,10 +464,10 @@ where
     }
 
     let result_texture = match state.phase {
-        HackPhase::Won => Some("winh.pcx"),
-        HackPhase::Lost => Some("loseh.pcx"),
-        HackPhase::Unwinnable => Some("failh.pcx"),
-        HackPhase::InsufficientNanites => Some("payh.pcx"),
+        HackPhase::Won => Some(art.won),
+        HackPhase::Lost => Some(art.lost),
+        HackPhase::Unwinnable => Some(art.unwinnable),
+        HackPhase::InsufficientNanites => Some(art.unpaid),
         HackPhase::Unpaid | HackPhase::Playing => None,
     };
     if let Some(texture) = result_texture {
@@ -385,9 +478,9 @@ where
         );
     }
 
-    // HACK.PCX already supplies the cyan `COST:` label. Retail draws only the
-    // dynamic numeric value in the 48px slot beginning at x=128, after the
-    // result overlay so WINH/LOSEH/PAYH cannot obscure it.
+    // The backdrop already supplies the cyan `COST:` label. Retail draws only
+    // the dynamic numeric value in the 48px slot beginning at x=128, after the
+    // result overlay so the win/lose/pay art cannot obscure it.
     components.push(
         gui::text(&hack_cost(diff).to_string())
             .with_position(vec2(147.0, 158.0))
@@ -488,6 +581,7 @@ pub(crate) fn handle_hack_msg(
             }
 
             let was_mine = node == HackNode::Mine;
+            let mut played_out = false;
             let roll = outcome_roll(&mut new_state.rng_state);
             tracing::debug!(
                 entity = entity_id.inner(),
@@ -510,6 +604,7 @@ pub(crate) fn handle_hack_msg(
                                 name: "hack_success".to_owned(),
                                 spatial: false,
                             },
+                            result_message(world, mode, HrmResult::Won),
                         ]),
                     );
                 }
@@ -525,24 +620,27 @@ pub(crate) fn handle_hack_msg(
                             name: "hack_critical".to_owned(),
                             spatial: false,
                         },
+                        result_message(world, mode, HrmResult::Lost),
                     ]),
                 );
             } else {
                 new_state.nodes[index] = HackNode::Burned;
                 if !board_has_potential_path(&new_state.nodes) {
                     new_state.phase = HackPhase::Unwinnable;
+                    played_out = true;
                 }
             }
 
-            (
-                new_state,
-                Effect::PlaySound {
-                    handle: AudioHandle::new(),
-                    source: Some(entity_id),
-                    name: "hacking".to_owned(),
-                    spatial: false,
-                },
-            )
+            let mut effects = vec![Effect::PlaySound {
+                handle: AudioHandle::new(),
+                source: Some(entity_id),
+                name: "hacking".to_owned(),
+                spatial: false,
+            }];
+            if played_out {
+                effects.push(result_message(world, mode, HrmResult::PlayedOut));
+            }
+            (new_state, Effect::combine(effects))
         }
         _ => (new_state, Effect::NoEffect),
     }
@@ -566,7 +664,7 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
     ) -> Vec<GuiComponent<KeyPadMsg>> {
         let hack_diff = hack_diff_for_entity(_world, _entity_id);
         if let Some(hack_diff) = hack_diff {
-            return draw_hack_board(&_state.hack, hack_diff, |msg| msg);
+            return draw_hack_board(&_state.hack, hack_diff, HrmMode::Hack, |msg| msg);
         }
 
         let button_width = 45.0;
@@ -886,6 +984,164 @@ mod tests {
         assert!(
             hack_diff_for_entity(&world, numeric_with_inherited_hack_diff).is_none(),
             "an authored numeric code must take precedence over inherited HackDiff"
+        );
+    }
+
+    /// Every image the board would draw, in draw order.
+    fn board_images(state: &HackState, mode: HrmMode) -> Vec<String> {
+        let diff = PropHackDiff {
+            success_chance: 50,
+            critical_chance: 1,
+            cost: 3.0,
+        };
+        draw_hack_board::<KeyPadMsg, _>(state, diff, mode, |msg| msg)
+            .into_iter()
+            .filter_map(|component| match component {
+                crate::ui::UiElement::Image { texture, .. } => Some(texture),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn finished_board(phase: HackPhase) -> HackState {
+        HackState {
+            phase,
+            ..HackState::default()
+        }
+    }
+
+    #[test]
+    fn each_mode_wears_its_own_backdrop_and_result_art() {
+        for (mode, backdrop, won, lost, unwinnable, unpaid) in [
+            (
+                HrmMode::Repair,
+                "iface/repair.pcx",
+                "winr.pcx",
+                "loser.pcx",
+                "failr.pcx",
+                "payr.pcx",
+            ),
+            (
+                HrmMode::Modify,
+                "modify.pcx",
+                "winm.pcx",
+                "losem.pcx",
+                "failm.pcx",
+                "paym.pcx",
+            ),
+        ] {
+            let images = board_images(&HackState::default(), mode);
+            assert_eq!(images.first().map(String::as_str), Some(backdrop));
+            for (phase, expected) in [
+                (HackPhase::Won, won),
+                (HackPhase::Lost, lost),
+                (HackPhase::Unwinnable, unwinnable),
+                (HackPhase::InsufficientNanites, unpaid),
+            ] {
+                let images = board_images(&finished_board(phase), mode);
+                assert!(
+                    images.iter().any(|texture| texture == expected),
+                    "{mode:?} in {phase:?} should draw {expected}, drew {images:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hack_mode_art_is_unchanged() {
+        assert_eq!(
+            board_images(&HackState::default(), HrmMode::Hack)
+                .first()
+                .map(String::as_str),
+            Some("hack.pcx")
+        );
+        for (phase, expected) in [
+            (HackPhase::Won, "winh.pcx"),
+            (HackPhase::Lost, "loseh.pcx"),
+            (HackPhase::Unwinnable, "failh.pcx"),
+            (HackPhase::InsufficientNanites, "payh.pcx"),
+        ] {
+            let images = board_images(&finished_board(phase), HrmMode::Hack);
+            assert!(
+                images.iter().any(|texture| texture == expected),
+                "hack in {phase:?} should still draw {expected}, drew {images:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_finished_board_speaks_in_its_own_modes_words() {
+        let strings = crate::hud::HudStrings::default();
+        assert_eq!(
+            strings.hrm_result(HrmMode::Hack, HrmResult::Won),
+            "Hacking successful!"
+        );
+        assert_eq!(
+            strings.hrm_result(HrmMode::Repair, HrmResult::Lost),
+            "You have destroyed the item!"
+        );
+        assert_eq!(
+            strings.hrm_result(HrmMode::Modify, HrmResult::PlayedOut),
+            "You did not successfully modify the weapon on this attempt."
+        );
+        // The nine keys must stay distinct: an index slip would silently make
+        // one mode speak in another's voice.
+        let mut all: Vec<&str> = [HrmMode::Hack, HrmMode::Repair, HrmMode::Modify]
+            .iter()
+            .flat_map(|mode| {
+                [HrmResult::PlayedOut, HrmResult::Won, HrmResult::Lost]
+                    .iter()
+                    .map(|result| strings.hrm_result(*mode, *result))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        all.sort_unstable();
+        all.dedup();
+        assert_eq!(all.len(), 9);
+    }
+
+    #[test]
+    fn a_won_board_posts_its_modes_result_line() {
+        let mut world = World::new();
+        let entity = world.add_entity(());
+        // A board one lit node short of a run of three, so the next successful
+        // node wins it.
+        let mut nodes = base_hack_board();
+        nodes[board_index(2, 0)] = HackNode::Lit;
+        nodes[board_index(3, 0)] = HackNode::Lit;
+        let state = HackState {
+            phase: HackPhase::Playing,
+            nodes,
+            rng_state: 1,
+        };
+        let (after, effect) = handle_hack_msg(
+            entity,
+            &world,
+            &state,
+            &KeyPadMsg::PlayNode { x: 4, y: 0 },
+            // Certain success, so the win is not a coin flip.
+            PropHackDiff {
+                success_chance: 100,
+                critical_chance: 0,
+                cost: 0.0,
+            },
+            HrmMode::Repair,
+            HackOutcomeEffects {
+                success: keypad_hack_success,
+                critical_failure: keypad_hack_critical_failure,
+            },
+        );
+        assert_eq!(after.phase, HackPhase::Won);
+        let messages: Vec<String> = Effect::flatten(vec![effect])
+            .into_iter()
+            .filter_map(|effect| match effect {
+                Effect::ShowMessage { text } => Some(text),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            messages,
+            vec!["The item has been successfully repaired, and can be used normally."]
         );
     }
 

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -132,7 +132,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
     ) -> Vec<GuiComponent<ReplicatorMsg>> {
         if state.panel == ReplicatorPanel::Hacking {
             if let Some(diff) = hack_diff(world, entity_id) {
-                return draw_hack_board(&state.hack, diff, ReplicatorMsg::Hack);
+                return draw_hack_board(&state.hack, diff, HrmMode::Hack, ReplicatorMsg::Hack);
             }
         }
 

--- a/shock2vr/src/scripts/gui/weapon_modify.rs
+++ b/shock2vr/src/scripts/gui/weapon_modify.rs
@@ -237,7 +237,12 @@ impl Gui<WeaponModifyState, WeaponModifyMsg> for WeaponModifyGui {
         let Some(subject) = subject(world) else {
             return Vec::new();
         };
-        let mut components = draw_hack_board(&state.hack, subject.terms, WeaponModifyMsg::Board);
+        let mut components = draw_hack_board(
+            &state.hack,
+            subject.terms,
+            HrmMode::Modify,
+            WeaponModifyMsg::Board,
+        );
 
         // What this modification will do, which is the gun's own
         // `P$Modify1`/`P$Modify2` text - the only place the game ever shows it.

--- a/shock2vr/src/scripts/gui/weapon_repair.rs
+++ b/shock2vr/src/scripts/gui/weapon_repair.rs
@@ -165,7 +165,7 @@ impl Gui<WeaponRepairState, WeaponRepairMsg> for WeaponRepairGui {
         let Some((_, diff)) = subject(world) else {
             return Vec::new();
         };
-        draw_hack_board(&state.hack, diff, WeaponRepairMsg::Board)
+        draw_hack_board(&state.hack, diff, HrmMode::Repair, WeaponRepairMsg::Board)
     }
 
     /// One host serves every gun, so its board must not outlive the opening it

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -546,18 +546,18 @@ async function playRepairBoardToWin(
   ];
   for (let attempt = 0; attempt < 15; attempt += 1) {
     let panel = await repairPanel(game);
-    if (hasTexture(panel, "winh.pcx")) return;
+    if (hasTexture(panel, "winr.pcx")) return;
     assert.ok(
-      !hasTexture(panel, "loseh.pcx"),
+      !hasTexture(panel, "loser.pcx"),
       "a critical failure destroyed the gun; max Repair should leave no mines",
     );
     assert.ok(
-      !hasTexture(panel, "payh.pcx"),
+      !hasTexture(panel, "payr.pcx"),
       "the test wallet should always cover the authored repair cost",
     );
 
     const inPlay = panel.elements.some((el) => el.label === "reset-hack");
-    if (!inPlay || hasTexture(panel, "failh.pcx")) {
+    if (!inPlay || hasTexture(panel, "failr.pcx")) {
       const deal = panel.elements.find(
         (el) => el.label === "start-hack" || el.label === "reset-hack",
       );
@@ -567,8 +567,8 @@ async function playRepairBoardToWin(
 
     for (const label of routes[attempt % routes.length]) {
       panel = await repairPanel(game);
-      if (hasTexture(panel, "winh.pcx")) return;
-      if (hasTexture(panel, "failh.pcx") || hasTexture(panel, "loseh.pcx")) {
+      if (hasTexture(panel, "winr.pcx")) return;
+      if (hasTexture(panel, "failr.pcx") || hasTexture(panel, "loser.pcx")) {
         break;
       }
       await click(boardButton(panel, label));
@@ -595,8 +595,8 @@ test(
 
     const board = await repairPanel(game);
     assert.ok(
-      hasTexture(board, "hack.pcx"),
-      `a broken gun should present the HRM board (got ${JSON.stringify(
+      hasTexture(board, "iface/repair.pcx"),
+      `a broken gun should present the repair board (got ${JSON.stringify(
         board.elements.map((e) => e.texture ?? e.label),
       )})`,
     );
@@ -637,7 +637,7 @@ test(
     const shotgun = await brokenGunInBackpack(game, SHOTGUN);
     await useFromStrip(game, shotgun.id, click);
     assert.ok(
-      hasTexture(await repairPanel(game), "hack.pcx"),
+      hasTexture(await repairPanel(game), "iface/repair.pcx"),
       "a second broken gun should get a board of its own",
     );
     await playRepairBoardToWin(game, click);
@@ -686,8 +686,8 @@ test(
 
     const board = await repairPanel(game);
     assert.ok(
-      hasTexture(board, "hack.pcx"),
-      `the cyber interface should present the HRM board (got ${JSON.stringify(
+      hasTexture(board, "iface/repair.pcx"),
+      `the cyber interface should present the repair board (got ${JSON.stringify(
         board.elements.map((e) => e.texture ?? e.label),
       )})`,
     );
@@ -755,18 +755,18 @@ async function playModifyBoardToWin(
   ];
   for (let attempt = 0; attempt < 15; attempt += 1) {
     let panel = await modifyPanel(game);
-    if (hasTexture(panel, "winh.pcx")) return;
+    if (hasTexture(panel, "winm.pcx")) return;
     assert.ok(
-      !hasTexture(panel, "loseh.pcx"),
+      !hasTexture(panel, "losem.pcx"),
       "a critical failure broke the gun; max Modify should leave no mines",
     );
     assert.ok(
-      !hasTexture(panel, "payh.pcx"),
+      !hasTexture(panel, "paym.pcx"),
       "the test wallet should always cover the authored modify cost",
     );
 
     const inPlay = panel.elements.some((el) => el.label === "reset-hack");
-    if (!inPlay || hasTexture(panel, "failh.pcx")) {
+    if (!inPlay || hasTexture(panel, "failm.pcx")) {
       const deal = panel.elements.find(
         (el) => el.label === "start-hack" || el.label === "reset-hack",
       );
@@ -781,8 +781,8 @@ async function playModifyBoardToWin(
 
     for (const label of routes[attempt % routes.length]) {
       panel = await modifyPanel(game);
-      if (hasTexture(panel, "winh.pcx")) return;
-      if (hasTexture(panel, "failh.pcx") || hasTexture(panel, "loseh.pcx")) {
+      if (hasTexture(panel, "winm.pcx")) return;
+      if (hasTexture(panel, "failm.pcx") || hasTexture(panel, "losem.pcx")) {
         break;
       }
       await click(boardButton(panel, label));
@@ -875,8 +875,8 @@ test(
     await openModifyBoard(game, click);
     const board = await modifyPanel(game);
     assert.ok(
-      hasTexture(board, "hack.pcx"),
-      `MODIFY should present the HRM board (got ${JSON.stringify(
+      hasTexture(board, "modify.pcx"),
+      `MODIFY should present the modify board (got ${JSON.stringify(
         board.elements.map((e) => e.texture ?? e.label),
       )})`,
     );
@@ -939,7 +939,7 @@ test(
     await click(modify);
     await game.step({ frames: 3 });
     assert.ok(
-      !hasTexture(await modifyPanel(game), "hack.pcx"),
+      !hasTexture(await modifyPanel(game), "modify.pcx"),
       "a third modification should be refused, not dealt",
     );
     assert.equal(
@@ -1023,8 +1023,8 @@ test(
     await clickElement(modify);
     await game.step({ frames: 3 });
     assert.ok(
-      hasTexture(await modifyPanel(game), "hack.pcx"),
-      "the cyber interface should present the HRM board",
+      hasTexture(await modifyPanel(game), "modify.pcx"),
+      "the cyber interface should present the modify board",
     );
     await game.screenshot("modify-board-vr.png");
 


### PR DESCRIPTION
Closes #1346

## What

The HRM board hardcoded `HACK.PCX` as its backdrop and `WINH/LOSEH/FAILH/PAYH` as its
result overlays, so the repair and modify boards wore the hack board's pictures. The
shipped data has a full set per mode.

* `HrmMode::art()` is the one place a mode's five pictures are named — backdrop plus the
  win / lose / played-out / unpaid overlay. `draw_hack_board` takes the mode and reads
  them from there; hack's five names are unchanged.
* A finished board now posts the mode's own HRM.STR result line (`<mode>Result0/1/2`,
  numbered played-out / won / lost) through `Effect::ShowMessage`, resolved through
  `HudStrings` with verbatim English fallbacks. The board drew no result text at all
  before, in any mode.
* `repair.pcx` is one of the seven interface basenames that collide with a model texture,
  and the model family mounts first — so the repair backdrop is requested through the
  archive-qualified `iface/repair.pcx` key. Nothing else in the table collides.
* Drive-by, one word: `modify_maxed` looked up `"ModifyResult3"`, but the strings importer
  lowercases its keys, so it could never resolve and always fell back.

### The per-mode table

| mode | backdrop | won | lost | played out | unpaid |
| --- | --- | --- | --- | --- | --- |
| hack | `hack.pcx` | `winh.pcx` | `loseh.pcx` | `failh.pcx` | `payh.pcx` |
| repair | `iface/repair.pcx` | `winr.pcx` | `loser.pcx` | `failr.pcx` | `payr.pcx` |
| modify | `modify.pcx` | `winm.pcx` | `losem.pcx` | `failm.pcx` | `paym.pcx` |

The `HACK_V1/V2/V3.PCX` and `repair_v1/v2/v3.pcx` files #1346 asks about are **not**
difficulty tiers of the board: they are `objicon/` art, the inventory icons for the v1/v2/v3
hacking and repair software items. No board art is selected from them.

## How verified

* Unit tests in `keypad.rs`: the per-mode art table, a hack-mode regression that its five
  names are unchanged, the nine result strings are distinct and mode-correct, and a won
  repair board posts the repair result line. Negative-checked (pointing repair back at
  `hack.pcx`/`winh.pcx` fails the table test).
* `weapon-condition.e2e` — 11/11 pass, asserting the repair board on `iface/repair.pcx` and
  the modify board on `modify.pcx`, flat and VR.
* `hackable-crate.e2e`, `earth-replicator-hacking.e2e` pass unchanged (hack boards).
  `earth-hacking.e2e` fails on the base too (#1262 — a nanite pickup, before any board draws).
* `missions.e2e` — 23/23.

## Visuals

Captured headlessly via the debug runtime (`debug_weapons` scene, `hydro1.mis` for the
crate) — `/v1/step` + `/v1/screenshot`, deterministic fixed-timestep, driven through the
same board-play sequence as the e2e tests above.

![Repair board on a broken pistol](https://gist.githubusercontent.com/tommy-xr/96bb667bfeaca94e1791d0f749c5e050/raw/33b15367db27573743933073d413cd155ae08853/repair-board.png)

<sub>Repair board on a broken pistol — draws the `iface/repair.pcx` backdrop, not `HACK.PCX`.</sub>

![Modify board on a working pistol](https://gist.githubusercontent.com/tommy-xr/96bb667bfeaca94e1791d0f749c5e050/raw/33b15367db27573743933073d413cd155ae08853/modify-board.png)

<sub>Modify board on a working pistol — draws `modify.pcx`, with the pistol's own `P$Modify1` text ("Increase clip size...").</sub>

![Hack board on a hydro1 security crate](https://gist.githubusercontent.com/tommy-xr/96bb667bfeaca94e1791d0f749c5e050/raw/33b15367db27573743933073d413cd155ae08853/hack-board.png)

<sub>Hack board on a hydro1 security crate, for comparison — unchanged, still `hack.pcx`.</sub>

![Repair board played to a win](https://gist.githubusercontent.com/tommy-xr/96bb667bfeaca94e1791d0f749c5e050/raw/33b15367db27573743933073d413cd155ae08853/repair-win.gif)

<sub>Playing the repair board through to a win — the `WINR.PCX` "SUCCESS" overlay appears, not `WINH.PCX`.</sub>

![Repair board won, WINR overlay](https://gist.githubusercontent.com/tommy-xr/96bb667bfeaca94e1791d0f749c5e050/raw/33b15367db27573743933073d413cd155ae08853/repair-win.png)

<sub>Repair board the instant it's won — `winr.pcx` "SUCCESS", confirmed via `/v1/ui`. The same
`/v1/ui` response's `messages` field carries the new per-mode HUD line at this exact frame:
`"The item has been successfully repaired, and can be used normally."` (HRM.STR
`RepairResult1`, posted through `Effect::ShowMessage`). The text itself isn't visible in this
frame because the docked board (and the inventory strip use-mode requires to reach it) render
over the HUD's message line — pre-existing z-order, not something this PR changes.</sub>

![Modify board won, WINM overlay](https://gist.githubusercontent.com/tommy-xr/96bb667bfeaca94e1791d0f749c5e050/raw/33b15367db27573743933073d413cd155ae08853/modify-win.png)

<sub>Modify board the instant it's won — `winm.pcx` "SUCCESS", confirmed via `/v1/ui`, with the
same response's `messages` field carrying `"Modification completed!"` (HRM.STR
`ModifyResult1`). Same message-line caveat as above.</sub>


## Known limitations (both pre-existing, neither introduced here)

* **The result line is posted but not currently visible in flatscreen.** `GET /v1/ui` confirms
  the correct text on the winning frame, but the flat MFD strip is drawn over the HUD and
  covers the message-line rect entirely, so nothing reaches the screen while a board is open.
  Leaving use mode inside the five-second window renders the same text fine on the bare HUD.
  Filed as #1349; fixing it means moving the flat message line or the panel z-order, which is
  the panel-host territory #1347 covers.
* **`loser.pcx` / `losem.pcx` are drawn but unreachable today.** A critical repair failure
  destroys the gun, after which `weapon_repair::subject` finds no subject and the panel draws
  nothing — so the loss overlay never gets a frame. That lifecycle predates this change
  (`loseh.pcx` was equally unreachable); the change only corrects which file *would* be used.
  The new `ShowMessage` does still fire, so a destroyed gun is at least announced now.