### PR TITLE
fix(ui): show the board's loss overlay before the gun is destroyed

### DIFF
--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -233,6 +233,16 @@ dev_params! {
     /// something. Inert while the camera is attached (the two poses are the
     /// same pose).
     FREE_CAMERA_CULL_FROM_CAMERA = bool("free_camera_cull", "Cull from cam", false),
+    /// Forces every HRM board dealt from now on to be all mines with no chance
+    /// of a successful node, so the very next node played is a critical
+    /// failure - which, in repair mode, DESTROYS the gun. A test hook: the
+    /// loss branch is otherwise a coin flip nothing headless can drive, and it
+    /// is the branch with the destructive consequence.
+    ///
+    /// Read where the board's odds are: once when a board is dealt (the mine
+    /// count) and again on every node played (the success chance), so turning
+    /// it on mid-board burns the rest of that board too.
+    HRM_FORCE_CRITICAL = bool("hrm_force_critical", "HRM force fail", false),
     /// How fast the free camera flies, in the player's own speed units - the
     /// default IS [`PLAYER_MOVE_SPEED`], so "walking pace" cannot drift from
     /// what walking actually is. These are pre-scale SS2 units, not world

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1589,10 +1589,12 @@ pub struct MissionCore {
     /// The gun an open weapon settings panel was opened for; the panel is
     /// dismissed as soon as that gun stops being wielded.
     weapon_settings_gun: Option<EntityId>,
-    /// The gun an open repair board was opened for; the panel is dismissed
-    /// once a critical failure destroys that gun, and a won repair leaves it
-    /// up showing its result.
-    weapon_repair_gun: Option<EntityId>,
+    /// Whether the repair board is the panel we docked; a finished board - won
+    /// or lost - stays up showing its result, and this is dropped when the
+    /// slot goes elsewhere. Unlike the settings and modify latches this holds
+    /// no gun, because nothing about dismissing it depends on which gun it
+    /// was: a lost board has already destroyed its own subject.
+    repair_panel_docked: bool,
     /// The gun an open modify board was opened for; the panel is dropped when
     /// the slot goes elsewhere, and a won board stays up showing its result.
     weapon_modify_gun: Option<EntityId>,
@@ -2614,7 +2616,7 @@ impl MissionCore {
             flat_melee_anim: None,
             use_mode: false,
             weapon_settings_gun: None,
-            weapon_repair_gun: None,
+            repair_panel_docked: false,
             weapon_modify_gun: None,
             psi_powers_open: false,
             psi_nav_latched: false,
@@ -3742,40 +3744,36 @@ impl MissionCore {
             }
         }
 
-        // The repair board belongs to one gun. A critical failure destroys
-        // that gun, so the board has nothing left to present and is dismissed;
-        // a won repair leaves it up showing the result, as the other HRM
-        // panels do. As above, the flag means "our panel is docked".
-        if let Some(opened_for) = self.weapon_repair_gun {
+        // The repair board belongs to one gun, and a finished board stays up
+        // showing its result, as the other HRM panels do - including a lost
+        // one, whose result is that the gun it was played on no longer exists.
+        // That is why the board is NOT dismissed when its gun dies: it draws
+        // from what it pinned when it was dealt, and the loss is the one
+        // result the player would otherwise never see. So the only thing that
+        // drops it is the slot going elsewhere (close button, Tab, another
+        // panel opening); as above, the flag means "our panel is docked".
+        if self.repair_panel_docked {
             let panel = self
                 .world
                 .borrow::<UniqueView<WeaponRepairPanelEntity>>()
                 .map(|panel| panel.0)
                 .ok();
-            let ours_is_docked = panel.is_some() && self.flat_ui.active_panel() == panel;
-            let destroyed = !self
-                .world
-                .borrow::<shipyard::EntitiesView>()
-                .map(|entities| entities.is_alive(opened_for))
-                .unwrap_or(false);
-            if destroyed && ours_is_docked {
-                self.flat_ui.close();
-            }
-            if destroyed || !ours_is_docked {
+            if panel.is_none() || self.flat_ui.active_panel() != panel {
                 // Drop the subject with the panel: an unowned one would leave
                 // the board addressing a gun nothing is presenting.
                 let _ = self
                     .world
                     .remove_unique::<crate::scripts::gui::WeaponRepairSubject>();
-                self.weapon_repair_gun = None;
+                self.repair_panel_docked = false;
             }
         }
 
-        // The modify board belongs to one gun, on the same terms the repair
-        // board does. A lost board only breaks the gun, which the board can
-        // still stand over - but the gun can go away underneath it (dropped
-        // into a level transition, destroyed by something else), and a board
-        // addressing an entity that no longer exists is dismissed.
+        // The modify board belongs to one gun. A lost board only breaks the
+        // gun, which the board can still stand over - but the gun can go away
+        // underneath it (dropped into a level transition, destroyed by
+        // something else), and a board addressing an entity that no longer
+        // exists is dismissed. Repair, just above, deliberately does NOT do
+        // that: its loss *is* the gun's destruction.
         if let Some(opened_for) = self.weapon_modify_gun {
             let panel = self
                 .world
@@ -6092,20 +6090,21 @@ impl MissionCore {
                         .borrow::<UniqueView<WeaponRepairPanelEntity>>()
                         .map(|panel| panel.0);
                     if let (true, Ok(panel)) = (slot_is_presented, panel) {
-                        // Removed first: the subject is rebound on every open,
-                        // and a unique that is only ever added would keep the
-                        // gun the panel was opened on the *last* time.
+                        // Removed first: a unique that is only ever added
+                        // would keep the gun the panel was opened on last.
+                        let subject = crate::scripts::gui::repair_subject(&self.world, entity_id);
                         let _ = self
                             .world
                             .remove_unique::<crate::scripts::gui::WeaponRepairSubject>();
-                        self.world
-                            .add_unique(crate::scripts::gui::WeaponRepairSubject(entity_id));
-                        self.script_world.dispatch(Message {
-                            to: panel,
-                            payload: MessagePayload::PanelOpened,
-                        });
-                        self.flat_ui.open_unbound(panel);
-                        self.weapon_repair_gun = Some(entity_id);
+                        if let Some(subject) = subject {
+                            self.world.add_unique(subject);
+                            self.script_world.dispatch(Message {
+                                to: panel,
+                                payload: MessagePayload::PanelOpened,
+                            });
+                            self.flat_ui.open_unbound(panel);
+                            self.repair_panel_docked = true;
+                        }
                     }
                 }
 

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -299,6 +299,11 @@ fn result_message(world: &World, mode: HrmMode, result: HrmResult) -> Effect {
 }
 
 fn effective_hack_values(world: &World, diff: PropHackDiff, mode: HrmMode) -> (i32, i32) {
+    // Test hook: a board of nothing but mines that no node can survive, so the
+    // critical-failure branch is reachable headlessly.
+    if crate::dev_params::get_bool(crate::dev_params::HRM_FORCE_CRITICAL) {
+        return (0, (BOARD_WIDTH * BOARD_HEIGHT) as i32);
+    }
     let skill = mode.player_level(world);
     let stat = world
         .borrow::<UniqueView<QuestInfo>>()

--- a/shock2vr/src/scripts/gui/weapon_repair.rs
+++ b/shock2vr/src/scripts/gui/weapon_repair.rs
@@ -21,7 +21,7 @@ use crate::gui::{Gui, GuiComponent, GuiConfig, GuiCursor};
 use crate::scripts::Effect;
 
 use super::keypad::{
-    HackOutcomeEffects, HackState, HrmMode, KeyPadMsg, draw_hack_board, handle_hack_msg,
+    HackOutcomeEffects, HackPhase, HackState, HrmMode, KeyPadMsg, draw_hack_board, handle_hack_msg,
     object_state,
 };
 
@@ -29,11 +29,34 @@ use super::keypad::{
 /// gun to working order.
 const REPAIR_CONDITION_BONUS: f32 = 10.0;
 
-/// The gun the repair panel is presenting. The panel itself is synthetic and
+/// What the repair panel is presenting. The panel itself is synthetic and
 /// shared, so the subject rides beside it rather than being the panel's own
 /// entity.
+///
+/// The terms are pinned here at the moment the board is dealt rather than
+/// re-read from the gun every frame, because a critical failure destroys that
+/// gun: a board that re-derived itself from the subject would lose everything
+/// it needs to draw in the same instant it lost, and the player would never
+/// see the result it lost with.
 #[derive(Unique, Clone, Copy, Debug)]
-pub struct WeaponRepairSubject(pub EntityId);
+pub struct WeaponRepairSubject {
+    pub gun: EntityId,
+    /// The terms the repair is played on.
+    pub terms: PropHackDiff,
+}
+
+/// The subject a board opened on `gun` right now would be dealt for, or `None`
+/// when a board is not what asking to repair it comes to. Decided by
+/// [`repair_entry`], the one place that judgement lives.
+pub fn repair_subject(world: &World, gun: EntityId) -> Option<WeaponRepairSubject> {
+    if repair_entry(world, gun) != RepairEntry::Board {
+        return None;
+    }
+    Some(WeaponRepairSubject {
+        gun,
+        terms: repair_diff(world, gun)?,
+    })
+}
 
 pub struct WeaponRepairGui;
 
@@ -53,6 +76,14 @@ pub(crate) fn repair_diff(world: &World, entity_id: EntityId) -> Option<PropHack
         .borrow::<View<PropRepairDiff>>()
         .ok()
         .and_then(|diffs| diffs.get(entity_id).ok().map(|diff| diff.0))
+}
+
+/// Whether the world still holds `entity_id`.
+fn is_alive(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<shipyard::EntitiesView>()
+        .map(|entities| entities.is_alive(entity_id))
+        .unwrap_or(false)
 }
 
 /// Whether `entity_id` has given out - the working order repair mode applies
@@ -137,21 +168,21 @@ fn repair_success(entity_id: EntityId, _world: &World) -> Effect {
     ])
 }
 
-/// A critical failure destroys what was being repaired. Destroying the entity
-/// also takes it out of whatever hand or backpack held it, so a gun cannot be
-/// left wielded after it ceases to exist.
+/// A critical failure destroys what was being repaired, at the moment it
+/// fails. Destroying the entity also takes it out of whatever hand or backpack
+/// held it, so a gun cannot be left wielded after it ceases to exist. The
+/// board stands over the wreck showing the loss because it holds everything it
+/// draws in [`WeaponRepairSubject`] rather than reading it back off the gun.
 fn repair_critical_failure(entity_id: EntityId, _world: &World) -> Effect {
     Effect::DestroyEntity { entity_id }
 }
 
-/// The gun the panel is presenting, and the terms it is repaired on - both, or
-/// neither: a panel with no live subject draws nothing and accepts nothing.
-fn subject(world: &World) -> Option<(EntityId, PropHackDiff)> {
-    let gun = world
+/// What the panel is presenting, as it was pinned when the board was dealt.
+fn subject(world: &World) -> Option<WeaponRepairSubject> {
+    world
         .borrow::<UniqueView<WeaponRepairSubject>>()
         .ok()
-        .map(|subject| subject.0)?;
-    Some((gun, repair_diff(world, gun)?))
+        .map(|subject| *subject)
 }
 
 impl Gui<WeaponRepairState, WeaponRepairMsg> for WeaponRepairGui {
@@ -162,10 +193,29 @@ impl Gui<WeaponRepairState, WeaponRepairMsg> for WeaponRepairGui {
         world: &World,
         state: &WeaponRepairState,
     ) -> Vec<GuiComponent<WeaponRepairMsg>> {
-        let Some((_, diff)) = subject(world) else {
+        let Some(subject) = subject(world) else {
             return Vec::new();
         };
-        draw_hack_board(&state.hack, diff, HrmMode::Repair, WeaponRepairMsg::Board)
+        // A gun that no longer exists was destroyed by a critical failure -
+        // the one thing that destroys one - so the board wears the terminal
+        // loss face and offers no deal, driven by the world rather than the
+        // in-memory phase (the crate's ruined face works the same way). That
+        // covers a subject taken away by anything else too: a board that can
+        // never act again must not look live.
+        let hack = if is_alive(world, subject.gun) {
+            state.hack.clone()
+        } else {
+            HackState {
+                phase: HackPhase::Lost,
+                ..state.hack.clone()
+            }
+        };
+        draw_hack_board(
+            &hack,
+            subject.terms,
+            HrmMode::Repair,
+            WeaponRepairMsg::Board,
+        )
     }
 
     /// One host serves every gun, so its board must not outlive the opening it
@@ -194,23 +244,24 @@ impl Gui<WeaponRepairState, WeaponRepairMsg> for WeaponRepairGui {
         msg: &WeaponRepairMsg,
     ) -> (WeaponRepairState, Effect) {
         let WeaponRepairMsg::Board(board_msg) = msg;
-        let Some((gun, diff)) = subject(world) else {
+        let Some(subject) = subject(world) else {
             return (state.clone(), Effect::NoEffect);
         };
-        // A gun that is no longer broken has nothing left to repair; ignore
-        // stale board input rather than charging for another attempt.
-        if !is_broken_gun(world, gun) {
+        // A gun that is no longer broken - repaired, or destroyed by the
+        // failure this board is still showing - has nothing left to repair;
+        // ignore stale board input rather than charging for another attempt.
+        if !is_broken_gun(world, subject.gun) {
             return (state.clone(), Effect::NoEffect);
         }
         // The board is played against the *gun*, not the panel presenting it:
         // that is what keys the deal off the gun's own stable id and sources
         // the board's sounds at the object being worked on.
         let (hack, effect) = handle_hack_msg(
-            gun,
+            subject.gun,
             world,
             &state.hack,
             board_msg,
-            diff,
+            subject.terms,
             HrmMode::Repair,
             HackOutcomeEffects {
                 success: repair_success,
@@ -367,13 +418,112 @@ mod tests {
         ));
     }
 
+    /// Every image a board in `state` would draw, in draw order.
+    fn drawn(world: &World, panel: EntityId, state: &WeaponRepairState) -> Vec<String> {
+        WeaponRepairGui
+            .get_components(&None, panel, world, state)
+            .into_iter()
+            .filter_map(|component| match component {
+                crate::ui::UiElement::Image { texture, .. } => Some(texture),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The whole point: playing a mine destroys the gun *and* leaves a board
+    /// that still draws the loss art over the wreck. The board draws from what
+    /// it pinned when it was dealt, so losing its subject does not blank it -
+    /// re-reading the gun would, and then the player would never see the one
+    /// result that matters.
+    #[test]
+    fn a_lost_board_still_draws_its_loss_art_once_the_gun_is_gone() {
+        let (mut world, gun) = fixture(1);
+        break_gun(&mut world, gun);
+        // No node can survive, so the mine below is played for certain.
+        world.add_component(
+            gun,
+            (PropRepairDiff(PropHackDiff {
+                success_chance: 0,
+                critical_chance: 4,
+                cost: 3.0,
+            }),),
+        );
+        world.add_unique(repair_subject(&world, gun).expect("a broken gun is a repair job"));
+        let panel = world.add_entity((PropObjState(ObjectState::Normal),));
+
+        let mut dealt = WeaponRepairState::default();
+        dealt.hack.phase = super::super::keypad::HackPhase::Playing;
+        dealt.hack.nodes[super::super::keypad::board_index(0, 0)] =
+            super::super::keypad::HackNode::Mine;
+
+        let (after, effect) = WeaponRepairGui.handle_msg(
+            panel,
+            &world,
+            &dealt,
+            &WeaponRepairMsg::Board(KeyPadMsg::PlayNode { x: 0, y: 0 }),
+        );
+
+        assert_eq!(after.hack.phase, super::super::keypad::HackPhase::Lost);
+        assert!(
+            effects(effect)
+                .iter()
+                .any(|e| matches!(e, Effect::DestroyEntity { entity_id } if *entity_id == gun)),
+            "a lost repair should destroy the gun"
+        );
+
+        // The effect is applied by the mission loop after the script returns;
+        // do here what it does, then ask the panel what it draws.
+        world.delete_entity(gun);
+        let drawn = drawn(&world, panel, &after);
+        assert!(
+            !WeaponRepairGui
+                .get_components(&None, panel, &world, &after)
+                .iter()
+                .any(|component| matches!(
+                    component,
+                    crate::ui::UiElement::Button { label, .. } if label.as_deref() == Some("start-hack")
+                )),
+            "a board that can never act again must offer no deal"
+        );
+        assert!(
+            drawn.contains(&HrmMode::Repair.art().lost.to_owned()),
+            "the lost board should still draw the repair loss art (got {drawn:?})"
+        );
+        assert!(
+            drawn.contains(&HrmMode::Repair.art().backdrop.to_owned()),
+            "and its backdrop with it (got {drawn:?})"
+        );
+    }
+
+    /// The board over a destroyed gun accepts nothing: it is a picture of a
+    /// result, not a live board that could charge for another attempt.
+    #[test]
+    fn a_lost_board_accepts_no_further_input() {
+        let (mut world, gun) = fixture(1);
+        break_gun(&mut world, gun);
+        world.add_unique(repair_subject(&world, gun).expect("a broken gun is a repair job"));
+        let panel = world.add_entity((PropObjState(ObjectState::Normal),));
+        world.delete_entity(gun);
+
+        let (_, effect) = WeaponRepairGui.handle_msg(
+            panel,
+            &world,
+            &WeaponRepairState::default(),
+            &WeaponRepairMsg::Board(KeyPadMsg::StartHack),
+        );
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
     /// Board input against a gun that is no longer broken is ignored, so a
     /// repaired gun cannot be charged for another attempt.
     #[test]
     fn the_board_ignores_input_once_the_gun_works_again() {
         let (mut world, gun) = fixture(1);
-        world.add_unique(WeaponRepairSubject(gun));
+        break_gun(&mut world, gun);
+        world.add_unique(repair_subject(&world, gun).expect("a broken gun is a repair job"));
         let panel = world.add_entity((PropObjState(ObjectState::Normal),));
+        // Repaired between the board being dealt and this input landing.
+        world.add_component(gun, (PropObjState(ObjectState::Normal),));
 
         let (_, effect) = WeaponRepairGui.handle_msg(
             panel,

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -577,6 +577,23 @@ async function playRepairBoardToWin(
   assert.fail("the repair board should win within the attempt budget");
 }
 
+/**
+ * The whole way in, as a player takes it: enter use mode, then use the broken
+ * gun from the strip - which opens the board rather than wielding it.
+ */
+async function openRepairBoard(
+  game: GameServer,
+  gun: number,
+  click: (element: UiElement) => Promise<void>,
+): Promise<UiPanel> {
+  if ((await game.ui.state()).mode !== "use") {
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+  }
+  await useFromStrip(game, gun, click);
+  return repairPanel(game);
+}
+
 test(
   "using a broken gun from the flat inventory opens the repair board, and winning it repairs the gun",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
@@ -588,12 +605,8 @@ test(
 
     // KEY: the strip's use gesture on a BROKEN gun opens the board rather than
     // wielding it.
-    await game.input.trigger("ToggleUseMode");
-    await game.step({ frames: 5 });
     const click = (element: UiElement) => clickUiElement(game, element);
-    await useFromStrip(game, pistol.id, click);
-
-    const board = await repairPanel(game);
+    const board = await openRepairBoard(game, pistol.id, click);
     assert.ok(
       hasTexture(board, "iface/repair.pcx"),
       `a broken gun should present the repair board (got ${JSON.stringify(
@@ -713,6 +726,100 @@ test(
 //
 // Negative-first: on the parent no modify mode exists, the settings panel has
 // no MODIFY control, and the pistol's clip never leaves 12.
+
+/** Whether the runtime still knows about `id` at all. */
+async function stillExists(game: GameServer, id: number): Promise<boolean> {
+  const all = await game.entities.list({ limit: 5_000 });
+  return all.entities.some((entity) => entity.id === id);
+}
+
+test(
+  "a lost repair destroys the gun and leaves the board's loss art standing over it",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons" });
+    await game.step({ frames: 30 });
+
+    const pistol = await brokenPistolInBackpack(game);
+    const click = (element: UiElement) => clickUiElement(game, element);
+    assert.ok(
+      hasTexture(
+        await openRepairBoard(game, pistol.id, click),
+        "iface/repair.pcx",
+      ),
+      "a broken gun should present the repair board",
+    );
+
+    // debug_weapons maxes Repair, so an honest deal carries no mines at all.
+    // This deals a board that is nothing but mines, which is the only way to
+    // reach the critical-failure branch deterministically.
+    await game.devParams.set("hrm_force_critical", 1);
+    await click(boardButton(await repairPanel(game), "start-hack"));
+    await click(boardButton(await repairPanel(game), "node-2-0"));
+
+    // KEY: the gun is destroyed at the moment it fails, as it always was -
+    // and the board is STILL there, drawing its loss art over the wreck.
+    // Before this change the board read its terms back off the gun, so losing
+    // the gun blanked the panel and the result was never seen.
+    assert.equal(
+      await stillExists(game, pistol.id),
+      false,
+      "a critical failure destroys the gun",
+    );
+    assert.equal(
+      (await game.info()).player.wielded_entity_id ?? null,
+      null,
+      "a destroyed gun cannot be left wielded",
+    );
+    const lost = await repairPanel(game);
+    assert.ok(
+      hasTexture(lost, "loser.pcx"),
+      `a critical failure should draw the repair loss art (got ${JSON.stringify(
+        lost.elements.map((e) => e.texture ?? e.label),
+      )})`,
+    );
+    assert.ok(
+      hasTexture(lost, "iface/repair.pcx"),
+      "and keep the board it lost on underneath it",
+    );
+    await game.screenshot("repair-loss.png");
+
+    // KEY: the board over a wreck is a picture of a result, not a live board -
+    // it offers no deal at all, so nothing can charge for a second attempt.
+    assert.equal(
+      lost.elements.find(
+        (e) => e.label === "start-hack" || e.label === "reset-hack",
+      ),
+      undefined,
+      "a board whose gun is gone should offer no START/RESET",
+    );
+    await click(boardButton(await repairPanel(game), "node-2-1"));
+    assert.ok(
+      hasTexture(await repairPanel(game), "loser.pcx"),
+      "and stay lost when its nodes are clicked",
+    );
+
+    // Dismissing it leaves nothing behind: a second broken gun gets a board
+    // of its own.
+    await closePanel(game, click);
+    await game.devParams.reset("hrm_force_critical");
+
+    const shotgun = await brokenGunInBackpack(game, SHOTGUN);
+    assert.ok(
+      hasTexture(
+        await openRepairBoard(game, shotgun.id, click),
+        "iface/repair.pcx",
+      ),
+      "a later gun should get a fresh board after a loss",
+    );
+    await playRepairBoardToWin(game, click);
+    assert.equal(
+      objectStateOf(await game.entities.detail(shotgun.id)),
+      "Normal",
+      "and repair normally",
+    );
+  },
+);
 
 /** The pistol's authored `P$ModifyDif` nanite cost, per deal. */
 const MODIFY_COST = "20";


### PR DESCRIPTION
A critical failure on the repair board destroys the gun. The board read its
terms back off that gun every frame, so the same instant it lost it also lost
everything it needed to draw: `loser.pcx` and the mode's result line were
unreachable, and the panel was dismissed as having no subject.

Retail destroys at result time too; its overlay survives because the MFD is a
separate surface. Here the panel **is** the surface, so it is given what it
draws instead: `WeaponRepairSubject` now pins the repair terms when the board
is dealt — exactly what the modify board already does with
`WeaponModifySubject` — and the panel is no longer dismissed when its gun dies.
The destroy stays where retail put it; only the board's dependence on the gun
goes.

A board over a wreck is a picture of a result: `is_broken_gun` is false, so it
takes no further input, and `resets_state_on_frob` still deals the next gun a
fresh board.

`hrm_force_critical` (dev param, default off) deals an all-mine board with no
survivable node, so the loss branch — the branch with the destructive
consequence — is drivable headlessly.

Hack and modify losses were already reachable (their objects survive the
failure); only repair was not.

### Before / after

Same deterministic request sequence. Watch the strip: the JAM-iconed pistol is
there while the board is live and gone once it fails - and the board is still
there with it.

| board dealt (gun in the strip) | after the mine, before | after the mine, flat | after the mine, VR |
| --- | --- | --- | --- |
| ![dealt](https://gist.githubusercontent.com/tommy-xr/62c5211adfc9d81e4cdadf02d7f5d8e5/raw/repair-loss-dealt.png) | ![before](https://gist.githubusercontent.com/tommy-xr/62c5211adfc9d81e4cdadf02d7f5d8e5/raw/repair-loss-before.png) | ![flat](https://gist.githubusercontent.com/tommy-xr/62c5211adfc9d81e4cdadf02d7f5d8e5/raw/repair-loss-flat.png) | ![vr](https://gist.githubusercontent.com/tommy-xr/62c5211adfc9d81e4cdadf02d7f5d8e5/raw/repair-loss-vr.png) |
| gun present, board live | panel blank, board gone | CRITICAL FAILURE over the REPAIR board, gun gone | same canvas, same placement |

![flat run](https://gist.githubusercontent.com/tommy-xr/62c5211adfc9d81e4cdadf02d7f5d8e5/raw/repair-loss-flat.gif)
![vr run](https://gist.githubusercontent.com/tommy-xr/62c5211adfc9d81e4cdadf02d7f5d8e5/raw/repair-loss-vr.gif)

### Verification

- Unit: a played mine destroys the gun *and* the board still draws its loss art
  and backdrop with the gun deleted, offering no deal; a lost board accepts no
  further input. Both fail on the parent.
- e2e (`weapon-condition.e2e`, deterministic via `hrm_force_critical`): broken
  pistol → board → mine → gun gone from `/v1/entities` and unwielded, `loser.pcx`
  + `iface/repair.pcx` still drawn, no START/RESET offered, further clicks
  inert, dismiss, a second broken gun gets a fresh board and repairs.
- `weapon-condition.e2e` 12/12, `hackable-crate.e2e` 1/1, `missions.e2e` 23/23,
  `cargo test -p shock2vr` 1413 passed.

### Known gap

The result line (`ShowMessage`) is still occluded by the inventory strip in
both presentations — pre-existing, tracked in #1349. The loss *art* is the part
this PR makes visible.
