### PR TITLE
fix(ai): a patrol given up under a temporary exclusion resumes when it expires

### DIFF
--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -44,9 +44,10 @@ pub struct PathQueryResponse {
     pub outcome: AiPathOutcome,
     /// Route waypoints; empty when `outcome` is `Failed`
     pub waypoints: Vec<Vector3<f32>>,
-    /// When the query ran against live steering-reported exclusions, the
-    /// mission time the last of them expires at. A failure under one may be
-    /// temporary - the consumer can retry rather than write the goal off.
+    /// For a query that did not reach its goal, the mission time the last
+    /// excluded crossing comes back into play at (if any is live). The
+    /// failure may be temporary - the consumer can retry rather than write
+    /// the goal off.
     pub exclusion_expires_at: Option<f32>,
 }
 
@@ -84,7 +85,6 @@ impl AsyncPathfinding {
                     // including fresh arrivals' - route around the obstacle
                     // instead of piling into it
                     let avoid = service.avoidance(request.now_seconds);
-                    let exclusion_expires_at = avoid.expires_at;
                     let path = service
                         .find_path_avoiding(
                             request.start,
@@ -108,6 +108,10 @@ impl AsyncPathfinding {
                             Vec::new()
                         }
                     };
+                    // Only a query that fell short can be waiting on one
+                    let exclusion_expires_at = (outcome != AiPathOutcome::Full)
+                        .then(|| service.blocked_link_expiry(request.now_seconds))
+                        .flatten();
                     service.record_ai_path(
                         request.entity,
                         AiPathRecord {

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -118,6 +118,7 @@ impl AsyncPathfinding {
                                 request.start,
                                 request.goal,
                                 request.movement_bits,
+                                &avoid,
                                 request.now_seconds,
                             )
                         })
@@ -306,8 +307,8 @@ mod tests {
         let service = Arc::new(PathfindingService::new(Arc::new(
             crate::pathfinding::tests::island_db(),
         )));
-        service.report_blocked_link(0, 1, 0.0);
         service.report_blocked_link(1, 2, 0.0);
+        service.report_blocked_link(0, 1, 2.0);
         service.report_blocked_link(3, 2, 5.0);
         let async_pf = AsyncPathfinding::spawn(service.clone());
 
@@ -336,9 +337,9 @@ mod tests {
         assert_ne!(response.outcome, AiPathOutcome::Full);
         assert_eq!(
             response.exclusion_expires_at,
-            Some(crate::pathfinding::BLOCKED_LINK_TTL_SECONDS),
-            "wait for the crossings on the route it becomes reachable by, not \
-             for the level's latest blockage (5 s later, on the detour)"
+            Some(2.0 + crate::pathfinding::BLOCKED_LINK_TTL_SECONDS),
+            "wait for the LAST crossing on the route it becomes reachable by, \
+             neither the level's earliest nor its latest (the detour's)"
         );
     }
 

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -44,6 +44,10 @@ pub struct PathQueryResponse {
     pub outcome: AiPathOutcome,
     /// Route waypoints; empty when `outcome` is `Failed`
     pub waypoints: Vec<Vector3<f32>>,
+    /// When the query ran against live steering-reported exclusions, the
+    /// mission time the last of them expires at. A failure under one may be
+    /// temporary - the consumer can retry rather than write the goal off.
+    pub exclusion_expires_at: Option<f32>,
 }
 
 struct SharedState {
@@ -80,6 +84,7 @@ impl AsyncPathfinding {
                     // including fresh arrivals' - route around the obstacle
                     // instead of piling into it
                     let avoid = service.avoidance(request.now_seconds);
+                    let exclusion_expires_at = avoid.expires_at;
                     let path = service
                         .find_path_avoiding(
                             request.start,
@@ -118,6 +123,7 @@ impl AsyncPathfinding {
                                 goal: request.goal,
                                 outcome,
                                 waypoints,
+                                exclusion_expires_at,
                             },
                         );
                     }

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -44,10 +44,11 @@ pub struct PathQueryResponse {
     pub outcome: AiPathOutcome,
     /// Route waypoints; empty when `outcome` is `Failed`
     pub waypoints: Vec<Vector3<f32>>,
-    /// For a query that did not reach its goal, the mission time the last
-    /// excluded crossing comes back into play at (if any is live). The
-    /// failure may be temporary - the consumer can retry rather than write
-    /// the goal off.
+    /// For a query that did not reach its goal *only because* steering
+    /// reported crossings on its route blocked, the mission time the last of
+    /// those comes back into play at. `None` when the goal is unreachable on
+    /// the raw mesh too - waiting cannot help. See
+    /// `PathfindingService::exclusion_expiry_for_unreached_goal`.
     pub exclusion_expires_at: Option<f32>,
 }
 
@@ -108,9 +109,18 @@ impl AsyncPathfinding {
                             Vec::new()
                         }
                     };
-                    // Only a query that fell short can be waiting on one
+                    // Only a query that fell short can be waiting on one, and
+                    // only when the goal IS reachable once the exclusions are
+                    // lifted - otherwise this goal is simply off the graph
                     let exclusion_expires_at = (outcome != AiPathOutcome::Full)
-                        .then(|| service.blocked_link_expiry(request.now_seconds))
+                        .then(|| {
+                            service.exclusion_expiry_for_unreached_goal(
+                                request.start,
+                                request.goal,
+                                request.movement_bits,
+                                request.now_seconds,
+                            )
+                        })
                         .flatten();
                     service.record_ai_path(
                         request.entity,
@@ -286,6 +296,50 @@ mod tests {
         }));
         let response = wait_for_result(&async_pf, 12).expect("worker must respond");
         assert_eq!(response.outcome, AiPathOutcome::Partial);
+    }
+
+    #[test]
+    fn worker_reports_a_deadline_only_for_an_exclusion_caused_shortfall() {
+        // One service, two shortfalls: entity 31's goal sits on an island no
+        // route ever reached, entity 32's is cut off purely by the excluded
+        // crossings. Only the second is worth waiting out.
+        let service = Arc::new(PathfindingService::new(Arc::new(
+            crate::pathfinding::tests::island_db(),
+        )));
+        service.report_blocked_link(0, 1, 0.0);
+        service.report_blocked_link(1, 2, 0.0);
+        service.report_blocked_link(3, 2, 5.0);
+        let async_pf = AsyncPathfinding::spawn(service.clone());
+
+        assert!(async_pf.submit(PathQueryRequest {
+            entity: 31,
+            start: cgmath::vec3(1.0, 0.0, 1.0),
+            goal: cgmath::vec3(21.0, 0.0, 1.0),
+            movement_bits: MovementBits::WALK,
+            now_seconds: 0.0,
+        }));
+        let response = wait_for_result(&async_pf, 31).expect("worker must respond");
+        assert_ne!(response.outcome, AiPathOutcome::Full);
+        assert_eq!(
+            response.exclusion_expires_at, None,
+            "an island goal is unreachable with or without the exclusions"
+        );
+
+        assert!(async_pf.submit(PathQueryRequest {
+            entity: 32,
+            start: cgmath::vec3(1.0, 0.0, 1.0),
+            goal: cgmath::vec3(5.0, 0.0, 1.0),
+            movement_bits: MovementBits::WALK,
+            now_seconds: 0.0,
+        }));
+        let response = wait_for_result(&async_pf, 32).expect("worker must respond");
+        assert_ne!(response.outcome, AiPathOutcome::Full);
+        assert_eq!(
+            response.exclusion_expires_at,
+            Some(crate::pathfinding::BLOCKED_LINK_TTL_SECONDS),
+            "wait for the crossings on the route it becomes reachable by, not \
+             for the level's latest blockage (5 s later, on the detour)"
+        );
     }
 
     #[test]

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -145,11 +145,6 @@ pub struct NavAvoidance {
     pub links: std::collections::HashSet<(u32, u32)>,
     /// Cells some AI is (or recently was) stalled in
     pub cells: std::collections::HashSet<u32>,
-    /// Mission time the last of these entries expires at, when any is live.
-    /// A query that failed while this was set may well succeed after it: the
-    /// failure is temporary (something is in the way right now), not a fact
-    /// about the map's topology.
-    pub expires_at: Option<f32>,
 }
 
 /// Monotonic query counters, for load measurement and budget verification.
@@ -447,26 +442,21 @@ impl PathfindingService {
         NavAvoidance {
             links: self.blocked_links(now_seconds),
             cells: self.blocked_cells(now_seconds),
-            expires_at: self.exclusion_expiry(now_seconds),
         }
     }
 
-    /// The latest expiry among the live steering-reported exclusions - when
-    /// everything currently being avoided is back in play.
-    fn exclusion_expiry(&self, now_seconds: f32) -> Option<f32> {
-        let mut latest: Option<f32> = None;
-        let mut consider = |expiry: f32| {
-            if expiry > now_seconds {
-                latest = Some(latest.map_or(expiry, |l: f32| l.max(expiry)));
-            }
+    /// When the last of the currently excluded crossings comes back into
+    /// play. A query that failed while one was live may well succeed after
+    /// it: the failure is something in the way right now, not a fact about
+    /// the map. Stalled *cells* are deliberately not counted - they are only
+    /// a cost penalty (see `report_blocked_cell`), so they can never be why
+    /// a goal came back unreachable.
+    pub fn blocked_link_expiry(&self, now_seconds: f32) -> Option<f32> {
+        let Ok(mut blocked) = self.blocked_links.lock() else {
+            return None;
         };
-        if let Ok(blocked) = self.blocked_links.lock() {
-            blocked.values().copied().for_each(&mut consider);
-        }
-        if let Ok(blocked) = self.blocked_cells.lock() {
-            blocked.values().copied().for_each(&mut consider);
-        }
-        latest
+        blocked.retain(|_, &mut expiry| expiry > now_seconds);
+        blocked.values().copied().reduce(f32::max)
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -2401,22 +2391,26 @@ pub(crate) mod tests {
         );
     }
 
-    /// A query run against a live exclusion can fail for a reason that
-    /// lapses. `avoidance` says when, so the caller can retry rather than
+    /// A query run against an excluded crossing can fail for a reason that
+    /// lapses. The service says when, so the caller can retry rather than
     /// write the goal off (a patrol otherwise retires for good).
     #[test]
-    fn avoidance_reports_when_its_exclusions_lapse() {
+    fn blocked_link_expiry_reports_when_the_exclusions_lapse() {
         let service = service(detour_db());
-        assert_eq!(service.avoidance(0.0).expires_at, None);
+        assert_eq!(service.blocked_link_expiry(0.0), None);
+        // A stalled cell is only a cost penalty - it can never be why a goal
+        // is unreachable, so it is not something to wait out.
         service.report_blocked_cell(1, 0.0);
+        assert_eq!(service.blocked_link_expiry(0.0), None);
         service.report_blocked_link(0, 1, 0.0);
+        service.report_blocked_link(1, 2, 5.0);
         assert_eq!(
-            service.avoidance(0.0).expires_at,
-            Some(BLOCKED_LINK_TTL_SECONDS),
+            service.blocked_link_expiry(0.0),
+            Some(5.0 + BLOCKED_LINK_TTL_SECONDS),
             "the LAST exclusion to lapse is what a retry has to wait for"
         );
         assert_eq!(
-            service.avoidance(BLOCKED_LINK_TTL_SECONDS + 1.0).expires_at,
+            service.blocked_link_expiry(5.0 + BLOCKED_LINK_TTL_SECONDS + 1.0),
             None,
             "and nothing is left to wait for once they have all expired"
         );

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -399,11 +399,9 @@ impl PathfindingService {
     /// queries (unexpired steering-reported blockages). Expired entries are
     /// dropped.
     pub fn blocked_links(&self, now_seconds: f32) -> std::collections::HashSet<(u32, u32)> {
-        let Ok(mut blocked) = self.blocked_links.lock() else {
-            return std::collections::HashSet::new();
-        };
-        blocked.retain(|_, &mut expiry| expiry > now_seconds);
-        blocked.keys().copied().collect()
+        self.blocked_link_expiries(now_seconds)
+            .into_keys()
+            .collect()
     }
 
     /// Remember that an AI stalled inside `cell`. The cell stays expensive
@@ -452,6 +450,9 @@ impl PathfindingService {
     /// wait it out. `None` when the goal is unreachable with the exclusions
     /// lifted too: a fact about the map, which waiting cannot change.
     ///
+    /// The route measured is the cheapest one the raw mesh offers, so the
+    /// deadline is an upper bound - a pricier route may reopen sooner.
+    ///
     /// Stalled *cells* are deliberately not part of this - they are only a
     /// cost penalty (see `report_blocked_cell`), so they can never be why a
     /// goal came back unreachable.
@@ -460,10 +461,10 @@ impl PathfindingService {
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
+        avoid: &NavAvoidance,
         now_seconds: f32,
     ) -> Option<f32> {
-        let expiries = self.blocked_link_expiries(now_seconds);
-        if expiries.is_empty() {
+        if avoid.links.is_empty() {
             return None;
         }
         // Re-run the same search on the raw mesh. If it still cannot reach
@@ -471,29 +472,22 @@ impl PathfindingService {
         // dropped too: this is a question about reachability, and the route it
         // answers with is the one the AI will take once the crossings lapse.
         let unexcluded = NavAvoidance::default();
-        let cell_path = self
-            .cell_path_with_bits(start, goal, movement_bits, &unexcluded)
-            .or_else(|| {
-                // Mirror `find_path_avoiding`'s stressed second pass, so the
-                // two searches agree on what "reachable" means
-                if movement_bits.contains(MovementBits::SMALL_CREATURE)
-                    || movement_bits.contains(MovementBits::STRESSED)
-                {
-                    return None;
-                }
-                self.cell_path_with_bits(
-                    start,
-                    goal,
-                    movement_bits | MovementBits::STRESSED,
-                    &unexcluded,
-                )
-            })?;
-        // The route the goal is reachable by crosses at least one excluded
-        // crossing (otherwise the excluded search would have found it); wait
-        // for the last of those, not for the whole level's blacklist.
+        let cell_path = self.cell_path_avoiding(start, goal, movement_bits, &unexcluded)?;
+        // The route the goal is reachable by crosses at least one of THIS
+        // query's excluded crossings (otherwise the excluded search would have
+        // found it); wait for the last of those, not for the whole level's
+        // blacklist. A crossing another thread has since pruned already lapsed,
+        // so it contributes `now`.
+        let expiries = self.blocked_link_expiries(now_seconds);
         cell_path
             .windows(2)
-            .filter_map(|pair| expiries.get(&(pair[0], pair[1])).copied())
+            .filter(|pair| avoid.links.contains(&(pair[0], pair[1])))
+            .map(|pair| {
+                expiries
+                    .get(&(pair[0], pair[1]))
+                    .copied()
+                    .unwrap_or(now_seconds)
+            })
             .reduce(f32::max)
     }
 
@@ -646,9 +640,25 @@ impl PathfindingService {
         movement_bits: MovementBits,
         avoid: &NavAvoidance,
     ) -> Option<Vec<Vector3<f32>>> {
+        let cell_path = self.cell_path_avoiding(start, goal, movement_bits, avoid)?;
+        Some(self.waypoints_for_cell_path(&cell_path, start, goal, movement_bits))
+    }
+
+    /// The cell path `find_path_avoiding` follows: A* under `avoid`, then the
+    /// stressed second pass. One place, so a caller asking whether a goal is
+    /// reachable at all cannot drift from the caller asking for the route.
+    /// Every pass through here counts in `PathfindingStats`, including a
+    /// reachability re-run - it is a real search on the worker either way.
+    fn cell_path_avoiding(
+        &self,
+        start: Vector3<f32>,
+        goal: Vector3<f32>,
+        movement_bits: MovementBits,
+        avoid: &NavAvoidance,
+    ) -> Option<Vec<u32>> {
         self.queries.fetch_add(1, Ordering::Relaxed);
-        if let Some(path) = self.find_path_with_bits(start, goal, movement_bits, avoid) {
-            return Some(path);
+        if let Some(cells) = self.cell_path_with_bits(start, goal, movement_bits, avoid) {
+            return Some(cells);
         }
         // Second pass: a failed pathfind is retried with the stressed
         // condition added (small creatures excepted), so a calm AI still
@@ -657,10 +667,10 @@ impl PathfindingService {
             && !movement_bits.contains(MovementBits::STRESSED)
         {
             self.stressed_retries.fetch_add(1, Ordering::Relaxed);
-            if let Some(path) =
-                self.find_path_with_bits(start, goal, movement_bits | MovementBits::STRESSED, avoid)
+            if let Some(cells) =
+                self.cell_path_with_bits(start, goal, movement_bits | MovementBits::STRESSED, avoid)
             {
-                return Some(path);
+                return Some(cells);
             }
         }
         self.no_route.fetch_add(1, Ordering::Relaxed);
@@ -746,17 +756,6 @@ impl PathfindingService {
 
         let end = self.path_database.cells[best as usize].center;
         Some(self.waypoints_for_cell_path(&cell_path, start, end, movement_bits))
-    }
-
-    fn find_path_with_bits(
-        &self,
-        start: Vector3<f32>,
-        goal: Vector3<f32>,
-        movement_bits: MovementBits,
-        avoid: &NavAvoidance,
-    ) -> Option<Vec<Vector3<f32>>> {
-        let cell_path = self.cell_path_with_bits(start, goal, movement_bits, avoid)?;
-        Some(self.waypoints_for_cell_path(&cell_path, start, goal, movement_bits))
     }
 
     /// The A* cell path itself, before it is turned into waypoints.
@@ -2487,7 +2486,13 @@ pub(crate) mod tests {
             "the island goal must be unreachable to begin with"
         );
         assert_eq!(
-            service.exclusion_expiry_for_unreached_goal(start, island, MovementBits::WALK, 0.0,),
+            service.exclusion_expiry_for_unreached_goal(
+                start,
+                island,
+                MovementBits::WALK,
+                &service.avoidance(0.0),
+                0.0
+            ),
             None,
             "a goal off the graph is not waiting for anyone's blockage to lapse"
         );
@@ -2502,6 +2507,7 @@ pub(crate) mod tests {
         // and a stalled cell contributes nothing either way
         service.report_blocked_cell(1, 0.0);
         service.report_blocked_link(1, 2, 0.0);
+        service.report_blocked_link(0, 1, 2.0);
         service.report_blocked_link(3, 2, 5.0);
         let avoid = service.avoidance(0.0);
         assert!(
@@ -2511,10 +2517,17 @@ pub(crate) mod tests {
             "the goal must be cut off while both crossings are excluded"
         );
         assert_eq!(
-            service.exclusion_expiry_for_unreached_goal(start, goal, MovementBits::WALK, 0.0,),
-            Some(BLOCKED_LINK_TTL_SECONDS),
-            "wait for the exclusion on the route the goal is reachable by - \
-             not for the level's latest blockage (5 s later, on the detour)"
+            service.exclusion_expiry_for_unreached_goal(
+                start,
+                goal,
+                MovementBits::WALK,
+                &avoid,
+                0.0
+            ),
+            Some(2.0 + BLOCKED_LINK_TTL_SECONDS),
+            "wait for the LAST exclusion on the route the goal is reachable by \
+             (0 -> 1 -> 2), neither the level's earliest (1 -> 2) nor its \
+             latest (3 -> 2, on the detour the AI will not take)"
         );
     }
 
@@ -2527,6 +2540,7 @@ pub(crate) mod tests {
                 vec3(1.0, 0.0, 1.0),
                 vec3(5.0, 0.0, 1.0),
                 MovementBits::WALK,
+                &service.avoidance(0.0),
                 0.0,
             ),
             None,

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -145,6 +145,11 @@ pub struct NavAvoidance {
     pub links: std::collections::HashSet<(u32, u32)>,
     /// Cells some AI is (or recently was) stalled in
     pub cells: std::collections::HashSet<u32>,
+    /// Mission time the last of these entries expires at, when any is live.
+    /// A query that failed while this was set may well succeed after it: the
+    /// failure is temporary (something is in the way right now), not a fact
+    /// about the map's topology.
+    pub expires_at: Option<f32>,
 }
 
 /// Monotonic query counters, for load measurement and budget verification.
@@ -442,7 +447,26 @@ impl PathfindingService {
         NavAvoidance {
             links: self.blocked_links(now_seconds),
             cells: self.blocked_cells(now_seconds),
+            expires_at: self.exclusion_expiry(now_seconds),
         }
+    }
+
+    /// The latest expiry among the live steering-reported exclusions - when
+    /// everything currently being avoided is back in play.
+    fn exclusion_expiry(&self, now_seconds: f32) -> Option<f32> {
+        let mut latest: Option<f32> = None;
+        let mut consider = |expiry: f32| {
+            if expiry > now_seconds {
+                latest = Some(latest.map_or(expiry, |l: f32| l.max(expiry)));
+            }
+        };
+        if let Ok(blocked) = self.blocked_links.lock() {
+            blocked.values().copied().for_each(&mut consider);
+        }
+        if let Ok(blocked) = self.blocked_cells.lock() {
+            blocked.values().copied().for_each(&mut consider);
+        }
+        latest
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -2374,6 +2398,27 @@ pub(crate) mod tests {
         assert!(
             !took_the_detour(&restored),
             "the straight route must come back once the entry expired: {restored:?}"
+        );
+    }
+
+    /// A query run against a live exclusion can fail for a reason that
+    /// lapses. `avoidance` says when, so the caller can retry rather than
+    /// write the goal off (a patrol otherwise retires for good).
+    #[test]
+    fn avoidance_reports_when_its_exclusions_lapse() {
+        let service = service(detour_db());
+        assert_eq!(service.avoidance(0.0).expires_at, None);
+        service.report_blocked_cell(1, 0.0);
+        service.report_blocked_link(0, 1, 0.0);
+        assert_eq!(
+            service.avoidance(0.0).expires_at,
+            Some(BLOCKED_LINK_TTL_SECONDS),
+            "the LAST exclusion to lapse is what a retry has to wait for"
+        );
+        assert_eq!(
+            service.avoidance(BLOCKED_LINK_TTL_SECONDS + 1.0).expires_at,
+            None,
+            "and nothing is left to wait for once they have all expired"
         );
     }
 

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -445,18 +445,66 @@ impl PathfindingService {
         }
     }
 
-    /// When the last of the currently excluded crossings comes back into
-    /// play. A query that failed while one was live may well succeed after
-    /// it: the failure is something in the way right now, not a fact about
-    /// the map. Stalled *cells* are deliberately not counted - they are only
-    /// a cost penalty (see `report_blocked_cell`), so they can never be why
-    /// a goal came back unreachable.
-    pub fn blocked_link_expiry(&self, now_seconds: f32) -> Option<f32> {
-        let Ok(mut blocked) = self.blocked_links.lock() else {
+    /// Why an AI's query fell short: `Some(expiry)` when the goal IS
+    /// reachable on the raw mesh and only the steering-reported exclusions
+    /// (see `report_blocked_link`) cut it off - the mission time the last
+    /// such crossing ON THAT ROUTE comes back into play at, so a caller can
+    /// wait it out. `None` when the goal is unreachable with the exclusions
+    /// lifted too: a fact about the map, which waiting cannot change.
+    ///
+    /// Stalled *cells* are deliberately not part of this - they are only a
+    /// cost penalty (see `report_blocked_cell`), so they can never be why a
+    /// goal came back unreachable.
+    pub fn exclusion_expiry_for_unreached_goal(
+        &self,
+        start: Vector3<f32>,
+        goal: Vector3<f32>,
+        movement_bits: MovementBits,
+        now_seconds: f32,
+    ) -> Option<f32> {
+        let expiries = self.blocked_link_expiries(now_seconds);
+        if expiries.is_empty() {
             return None;
+        }
+        // Re-run the same search on the raw mesh. If it still cannot reach
+        // the goal, the exclusions were never the reason. Stall penalties are
+        // dropped too: this is a question about reachability, and the route it
+        // answers with is the one the AI will take once the crossings lapse.
+        let unexcluded = NavAvoidance::default();
+        let cell_path = self
+            .cell_path_with_bits(start, goal, movement_bits, &unexcluded)
+            .or_else(|| {
+                // Mirror `find_path_avoiding`'s stressed second pass, so the
+                // two searches agree on what "reachable" means
+                if movement_bits.contains(MovementBits::SMALL_CREATURE)
+                    || movement_bits.contains(MovementBits::STRESSED)
+                {
+                    return None;
+                }
+                self.cell_path_with_bits(
+                    start,
+                    goal,
+                    movement_bits | MovementBits::STRESSED,
+                    &unexcluded,
+                )
+            })?;
+        // The route the goal is reachable by crosses at least one excluded
+        // crossing (otherwise the excluded search would have found it); wait
+        // for the last of those, not for the whole level's blacklist.
+        cell_path
+            .windows(2)
+            .filter_map(|pair| expiries.get(&(pair[0], pair[1])).copied())
+            .reduce(f32::max)
+    }
+
+    /// Live (unexpired) blocked crossings and the mission time each lapses
+    /// at. Expired entries are dropped.
+    fn blocked_link_expiries(&self, now_seconds: f32) -> HashMap<(u32, u32), f32> {
+        let Ok(mut blocked) = self.blocked_links.lock() else {
+            return HashMap::new();
         };
         blocked.retain(|_, &mut expiry| expiry > now_seconds);
-        blocked.values().copied().reduce(f32::max)
+        blocked.clone()
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -707,6 +755,18 @@ impl PathfindingService {
         movement_bits: MovementBits,
         avoid: &NavAvoidance,
     ) -> Option<Vec<Vector3<f32>>> {
+        let cell_path = self.cell_path_with_bits(start, goal, movement_bits, avoid)?;
+        Some(self.waypoints_for_cell_path(&cell_path, start, goal, movement_bits))
+    }
+
+    /// The A* cell path itself, before it is turned into waypoints.
+    fn cell_path_with_bits(
+        &self,
+        start: Vector3<f32>,
+        goal: Vector3<f32>,
+        movement_bits: MovementBits,
+        avoid: &NavAvoidance,
+    ) -> Option<Vec<u32>> {
         // Find start and goal cells
         let start_cell_id = self.cell_from_position(start)?;
         let goal_cell_id = self.cell_from_position(goal)?;
@@ -719,7 +779,7 @@ impl PathfindingService {
             |&cell_id| cell_id == goal_cell_id,
         )?;
 
-        Some(self.waypoints_for_cell_path(&result.0, start, goal, movement_bits))
+        Some(result.0)
     }
 
     /// Convert a cell-id path into world-space waypoints.
@@ -2394,25 +2454,83 @@ pub(crate) mod tests {
     /// A query run against an excluded crossing can fail for a reason that
     /// lapses. The service says when, so the caller can retry rather than
     /// write the goal off (a patrol otherwise retires for good).
+    /// `detour_db` plus cell 4, a square with no links at all - a goal on
+    /// its own island, unreachable no matter what is or is not excluded.
+    pub(crate) fn island_db() -> PathDatabase {
+        let mut db = detour_db();
+        let base = db.vertices.len() as u32;
+        db.vertices.push(vec3(20.0, 0.0, 0.0));
+        db.vertices.push(vec3(22.0, 0.0, 0.0));
+        db.vertices.push(vec3(22.0, 0.0, 2.0));
+        db.vertices.push(vec3(20.0, 0.0, 2.0));
+        db.cells.push(PathCell {
+            id: 4,
+            center: vec3(21.0, 0.0, 1.0),
+            vertex_indices: vec![base, base + 1, base + 2, base + 3],
+            flags: PathCellFlags::empty(),
+        });
+        db
+    }
+
     #[test]
-    fn blocked_link_expiry_reports_when_the_exclusions_lapse() {
-        let service = service(detour_db());
-        assert_eq!(service.blocked_link_expiry(0.0), None);
-        // A stalled cell is only a cost penalty - it can never be why a goal
-        // is unreachable, so it is not something to wait out.
-        service.report_blocked_cell(1, 0.0);
-        assert_eq!(service.blocked_link_expiry(0.0), None);
+    fn an_unreachable_goal_is_not_made_temporary_by_an_unrelated_exclusion() {
+        let service = service(island_db());
+        let start = vec3(1.0, 0.0, 1.0);
+        let island = vec3(21.0, 0.0, 1.0);
+        // Somebody stalled on the other side of the level - nothing to do
+        // with this query's goal, which is on an island of its own
         service.report_blocked_link(0, 1, 0.0);
-        service.report_blocked_link(1, 2, 5.0);
-        assert_eq!(
-            service.blocked_link_expiry(0.0),
-            Some(5.0 + BLOCKED_LINK_TTL_SECONDS),
-            "the LAST exclusion to lapse is what a retry has to wait for"
+        assert!(
+            service
+                .find_path(start, island, MovementBits::WALK)
+                .is_none(),
+            "the island goal must be unreachable to begin with"
         );
         assert_eq!(
-            service.blocked_link_expiry(5.0 + BLOCKED_LINK_TTL_SECONDS + 1.0),
+            service.exclusion_expiry_for_unreached_goal(start, island, MovementBits::WALK, 0.0,),
             None,
-            "and nothing is left to wait for once they have all expired"
+            "a goal off the graph is not waiting for anyone's blockage to lapse"
+        );
+    }
+
+    #[test]
+    fn a_goal_cut_off_only_by_exclusions_reports_its_own_route_s_deadline() {
+        let service = service(detour_db());
+        let start = vec3(1.0, 0.0, 1.0);
+        let goal = vec3(5.0, 0.0, 1.0);
+        // Both ways into the goal cell are blocked, the second one later -
+        // and a stalled cell contributes nothing either way
+        service.report_blocked_cell(1, 0.0);
+        service.report_blocked_link(1, 2, 0.0);
+        service.report_blocked_link(3, 2, 5.0);
+        let avoid = service.avoidance(0.0);
+        assert!(
+            service
+                .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
+                .is_none(),
+            "the goal must be cut off while both crossings are excluded"
+        );
+        assert_eq!(
+            service.exclusion_expiry_for_unreached_goal(start, goal, MovementBits::WALK, 0.0,),
+            Some(BLOCKED_LINK_TTL_SECONDS),
+            "wait for the exclusion on the route the goal is reachable by - \
+             not for the level's latest blockage (5 s later, on the detour)"
+        );
+    }
+
+    #[test]
+    fn a_stalled_cell_alone_is_never_something_to_wait_for() {
+        let service = service(detour_db());
+        service.report_blocked_cell(1, 0.0);
+        assert_eq!(
+            service.exclusion_expiry_for_unreached_goal(
+                vec3(1.0, 0.0, 1.0),
+                vec3(5.0, 0.0, 1.0),
+                MovementBits::WALK,
+                0.0,
+            ),
+            None,
+            "cells are a cost penalty, so they can never be why a goal is unreachable"
         );
     }
 

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -38,6 +38,11 @@ const PATROL_STALL_SECONDS: f32 = 5.0;
 /// the stall watchdog. A patrolling AI clears this in a fraction of a second,
 /// so only a body that is genuinely going nowhere trips the timer.
 const PATROL_STALL_PROGRESS: f32 = 2.0 / SCALE_FACTOR;
+/// How many times in a row the route may be waited out (see `paused_until`)
+/// with no point reached in between. Bounded so an AI on a deck where
+/// something is always blocked somewhere eventually hands back to idle
+/// instead of waiting for the rest of the mission.
+const PATROL_TEMPORARY_RETRIES: u32 = 3;
 
 /// Walk an authored patrol route: head to the current patrol point, and on
 /// arrival advance to the next one along the `AIPatrol` link chain. Routes are
@@ -65,14 +70,13 @@ pub struct PatrolBehavior {
     /// reaching anything, and the route ends there. A single wedge must not
     /// retire a route the AI walks fine the rest of the way round.
     given_up_points: Vec<EntityId>,
-    /// The latest mission time a *temporary* exclusion behind one of those
-    /// give-ups lapses at (a stalled-cell penalty, a blocked crossing).
-    /// Cleared on a real arrival, like the give-up list itself.
-    temporary_until: Option<f32>,
-    /// Set when the whole lap was given up on temporary exclusions alone:
-    /// the route pauses until this mission time and then runs again, rather
-    /// than retiring the patrol for good over something in the way right now.
+    /// Set when the route ran out under a live path exclusion: the mission
+    /// time to run it again at, rather than retiring the patrol for good
+    /// over a crossing that is only blocked right now.
     paused_until: Option<f32>,
+    /// Waits so far with no point reached in between (see
+    /// `PATROL_TEMPORARY_RETRIES`).
+    pauses: u32,
     /// The runtime AICurrentPatrol link must be published once for a fresh
     /// behavior and whenever the target changes.
     target_dirty: bool,
@@ -99,8 +103,8 @@ impl PatrolBehavior {
             stall_anchor: None,
             stall_seconds: 0.0,
             given_up_points: Vec::new(),
-            temporary_until: None,
             paused_until: None,
+            pauses: 0,
             target_dirty: true,
             walked_an_edge: false,
         }
@@ -182,18 +186,31 @@ impl PatrolBehavior {
     /// the route, so one bad point (or one wedge the AI walks out of on the
     /// next leg) never retires a patrol, while a route with nothing reachable
     /// left stops instead of cycling (and re-querying A*) forever.
-    fn give_up_on_point(&mut self, world: &World, entity_id: EntityId, now: f32) -> Effect {
-        if self.given_up_points.contains(&self.target_point) {
-            // ...unless every failure was under a live exclusion (a cell or
-            // crossing steering reported as blocked). Those lapse on their
-            // own, so the route is not gone - wait it out and run again.
-            if let Some(until) = self.temporary_until.filter(|until| *until > now) {
+    fn give_up_on_point(
+        &mut self,
+        world: &World,
+        entity_id: EntityId,
+        temporary_until: Option<f32>,
+    ) -> Effect {
+        let lap_exhausted = self.given_up_points.contains(&self.target_point);
+        // A chain that simply runs out leaves the route just as empty as a
+        // lap that comes back around to a point already given up on.
+        let route_exhausted = lap_exhausted
+            || ai_util::next_patrol_point(world, entity_id, self.target_point).is_none();
+        // ...but a route that ran out under a live exclusion is not gone: the
+        // exclusion lapses on its own, so wait it out and run the route again
+        // rather than retiring the patrol for the rest of the mission.
+        if route_exhausted && self.pauses < PATROL_TEMPORARY_RETRIES {
+            if let Some(until) = temporary_until {
                 tracing::debug!(
-                    "patrol {entity_id:?}: whole loop blocked, waiting until {until} to retry"
+                    "patrol {entity_id:?}: whole route blocked, waiting until {until} to retry"
                 );
+                self.pauses += 1;
                 self.paused_until = Some(until);
                 return Effect::NoEffect;
             }
+        }
+        if lap_exhausted {
             tracing::debug!(
                 "patrol {entity_id:?}: gave up on the whole loop, retiring at {:?}",
                 self.target_point
@@ -260,7 +277,6 @@ impl Behavior for PatrolBehavior {
             }
             // The exclusion has lapsed: give the whole route a fresh try.
             self.paused_until = None;
-            self.temporary_until = None;
             self.given_up_points.clear();
             self.steering_strategy = (self.make_steering)(self.goal);
             self.stall_anchor = None;
@@ -272,7 +288,7 @@ impl Behavior for PatrolBehavior {
             let position = position.to_vec();
             if self.arrived(position) {
                 self.given_up_points.clear();
-                self.temporary_until = None;
+                self.pauses = 0;
                 patrol_effects.push(self.advance(world, entity_id, true));
             } else if self.steering_strategy.goal_unreachable() {
                 // No route to this point (shipped routes include points on a
@@ -286,11 +302,8 @@ impl Behavior for PatrolBehavior {
                     "patrol {entity_id:?}: no route to point {:?}, skipping to the next one",
                     self.target_point
                 );
-                self.temporary_until = self
-                    .steering_strategy
-                    .goal_unreachable_until()
-                    .map(|until| self.temporary_until.map_or(until, |t| t.max(until)));
-                patrol_effects.push(self.give_up_on_point(world, entity_id, now));
+                let temporary_until = self.steering_strategy.goal_unreachable_until();
+                patrol_effects.push(self.give_up_on_point(world, entity_id, temporary_until));
             } else if self.stalled(position, time) {
                 // Going nowhere: give up on this point and try the next one.
                 // A wedge is a fact about the body's current spot, not about
@@ -299,7 +312,9 @@ impl Behavior for PatrolBehavior {
                     "patrol {entity_id:?}: stalled on point {:?}",
                     self.target_point
                 );
-                patrol_effects.push(self.give_up_on_point(world, entity_id, now));
+                // Nothing to wait out: a wedge is a fact about the spot the
+                // body is standing in, not about the route.
+                patrol_effects.push(self.give_up_on_point(world, entity_id, None));
             }
         }
 
@@ -696,6 +711,29 @@ mod tests {
                 }
             )),
             "and the patrol takes a point back up, got {emitted:?}"
+        );
+    }
+
+    /// ...but the wait is bounded: on a deck where something is always
+    /// blocked somewhere the exclusion keeps re-arming, and an AI that waits
+    /// for it every lap would stand there for the rest of the mission.
+    #[test]
+    fn an_always_blocked_route_stops_waiting_and_retires() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::with_steering(first, goal, |_| Box::new(ExcludedSteering));
+
+        // Ten simulated minutes, with a fresh 30-second exclusion live the
+        // whole way.
+        let mut now = 0.0;
+        while now < 600.0 && !patrol.finished {
+            EXCLUSION_UNTIL.with(|until| until.set(Some(now + 30.0)));
+            patrol.steer(Deg(0.0), &world, &physics, creature, &at(now));
+            now += 0.5;
+        }
+        assert!(
+            patrol.finished,
+            "the route must stop waiting, still patrolling after {now}s"
         );
     }
 

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -65,6 +65,14 @@ pub struct PatrolBehavior {
     /// reaching anything, and the route ends there. A single wedge must not
     /// retire a route the AI walks fine the rest of the way round.
     given_up_points: Vec<EntityId>,
+    /// The latest mission time a *temporary* exclusion behind one of those
+    /// give-ups lapses at (a stalled-cell penalty, a blocked crossing).
+    /// Cleared on a real arrival, like the give-up list itself.
+    temporary_until: Option<f32>,
+    /// Set when the whole lap was given up on temporary exclusions alone:
+    /// the route pauses until this mission time and then runs again, rather
+    /// than retiring the patrol for good over something in the way right now.
+    paused_until: Option<f32>,
     /// The runtime AICurrentPatrol link must be published once for a fresh
     /// behavior and whenever the target changes.
     target_dirty: bool,
@@ -91,6 +99,8 @@ impl PatrolBehavior {
             stall_anchor: None,
             stall_seconds: 0.0,
             given_up_points: Vec::new(),
+            temporary_until: None,
+            paused_until: None,
             target_dirty: true,
             walked_an_edge: false,
         }
@@ -172,8 +182,18 @@ impl PatrolBehavior {
     /// the route, so one bad point (or one wedge the AI walks out of on the
     /// next leg) never retires a patrol, while a route with nothing reachable
     /// left stops instead of cycling (and re-querying A*) forever.
-    fn give_up_on_point(&mut self, world: &World, entity_id: EntityId) -> Effect {
+    fn give_up_on_point(&mut self, world: &World, entity_id: EntityId, now: f32) -> Effect {
         if self.given_up_points.contains(&self.target_point) {
+            // ...unless every failure was under a live exclusion (a cell or
+            // crossing steering reported as blocked). Those lapse on their
+            // own, so the route is not gone - wait it out and run again.
+            if let Some(until) = self.temporary_until.filter(|until| *until > now) {
+                tracing::debug!(
+                    "patrol {entity_id:?}: whole loop blocked, waiting until {until} to retry"
+                );
+                self.paused_until = Some(until);
+                return Effect::NoEffect;
+            }
             tracing::debug!(
                 "patrol {entity_id:?}: gave up on the whole loop, retiring at {:?}",
                 self.target_point
@@ -228,11 +248,31 @@ impl Behavior for PatrolBehavior {
                 target: Some(self.target_point),
             });
         }
+        let now = time.total.as_secs_f32();
+        if let Some(until) = self.paused_until {
+            if now < until {
+                // Waiting the blockage out - stand rather than steer at a
+                // point nothing can route to yet.
+                return Some((
+                    Steering::from_current(current_heading),
+                    Effect::combine(patrol_effects),
+                ));
+            }
+            // The exclusion has lapsed: give the whole route a fresh try.
+            self.paused_until = None;
+            self.temporary_until = None;
+            self.given_up_points.clear();
+            self.steering_strategy = (self.make_steering)(self.goal);
+            self.stall_anchor = None;
+            self.stall_seconds = 0.0;
+            self.target_dirty = true;
+        }
         if !self.finished {
             let (position, _) = ai_util::get_position_and_forward(world, entity_id);
             let position = position.to_vec();
             if self.arrived(position) {
                 self.given_up_points.clear();
+                self.temporary_until = None;
                 patrol_effects.push(self.advance(world, entity_id, true));
             } else if self.steering_strategy.goal_unreachable() {
                 // No route to this point (shipped routes include points on a
@@ -246,7 +286,11 @@ impl Behavior for PatrolBehavior {
                     "patrol {entity_id:?}: no route to point {:?}, skipping to the next one",
                     self.target_point
                 );
-                patrol_effects.push(self.give_up_on_point(world, entity_id));
+                self.temporary_until = self
+                    .steering_strategy
+                    .goal_unreachable_until()
+                    .map(|until| self.temporary_until.map_or(until, |t| t.max(until)));
+                patrol_effects.push(self.give_up_on_point(world, entity_id, now));
             } else if self.stalled(position, time) {
                 // Going nowhere: give up on this point and try the next one.
                 // A wedge is a fact about the body's current spot, not about
@@ -255,7 +299,7 @@ impl Behavior for PatrolBehavior {
                     "patrol {entity_id:?}: stalled on point {:?}",
                     self.target_point
                 );
-                patrol_effects.push(self.give_up_on_point(world, entity_id));
+                patrol_effects.push(self.give_up_on_point(world, entity_id, now));
             }
         }
 
@@ -288,7 +332,7 @@ impl Behavior for PatrolBehavior {
     }
 
     fn animation(&self) -> Vec<MotionQueryItem> {
-        if self.finished {
+        if self.finished || self.paused_until.is_some() {
             return vec![MotionQueryItem::new("idlegesture").optional()];
         }
         vec![
@@ -298,7 +342,7 @@ impl Behavior for PatrolBehavior {
     }
 
     fn is_locomotion(&self) -> bool {
-        !self.finished
+        !self.finished && self.paused_until.is_none()
     }
 
     #[cfg(test)]
@@ -464,6 +508,23 @@ mod tests {
 
     /// Steering that reports no route to whatever goal it was given.
     struct UnreachableSteering;
+    thread_local! {
+        /// Mission time the test's exclusion lapses at, while it is live.
+        static EXCLUSION_UNTIL: std::cell::Cell<Option<f32>> =
+            const { std::cell::Cell::new(None) };
+    }
+
+    /// Steering blocked only while the test's exclusion is live: exactly what
+    /// a stalled-cell penalty or a blocked crossing does to a real query.
+    struct ExcludedSteering;
+    impl SteeringStrategy for ExcludedSteering {
+        fn goal_unreachable(&self) -> bool {
+            EXCLUSION_UNTIL.with(|until| until.get()).is_some()
+        }
+        fn goal_unreachable_until(&self) -> Option<f32> {
+            EXCLUSION_UNTIL.with(|until| until.get())
+        }
+    }
     /// ...and its counterpart, which has a route.
     struct ReachableSteering;
     impl SteeringStrategy for ReachableSteering {}
@@ -587,6 +648,72 @@ mod tests {
         assert_eq!(skips, 2, "the initial target, then one skip");
     }
 
+    /// Every point unroutable *right now* because something is in the way -
+    /// a stalled-cell penalty or a blocked crossing, which lapse on their own
+    /// - must not retire the route for the rest of the mission. The patrol
+    /// waits the exclusion out and picks its route back up.
+    #[test]
+    fn a_patrol_given_up_under_a_temporary_exclusion_resumes_when_it_expires() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        const EXPIRES_AT: f32 = 30.0;
+        EXCLUSION_UNTIL.with(|until| until.set(Some(EXPIRES_AT)));
+        let mut patrol = PatrolBehavior::with_steering(first, goal, |_| Box::new(ExcludedSteering));
+
+        // Well past a whole lap of give-ups, but before the exclusion lapses.
+        for _ in 0..20 {
+            patrol.steer(Deg(0.0), &world, &physics, creature, &at(10.0));
+        }
+        assert!(
+            !patrol.finished,
+            "a temporary blockage must not retire the route"
+        );
+        assert!(
+            matches!(
+                patrol.next_behavior(&world, &physics, creature),
+                NextBehavior::Stay
+            ),
+            "and the AI stays in the patrol behavior while it waits"
+        );
+
+        // Once it lapses the goal routes again, and so must the patrol.
+        EXCLUSION_UNTIL.with(|until| until.set(None));
+        let mut emitted = Vec::new();
+        for _ in 0..5 {
+            if let Some((_, effect)) =
+                patrol.steer(Deg(0.0), &world, &physics, creature, &at(EXPIRES_AT + 0.1))
+            {
+                emitted.extend(Effect::flatten(vec![effect]));
+            }
+        }
+        assert!(!patrol.finished, "the route is still live after the wait");
+        assert!(
+            emitted.iter().any(|effect| matches!(
+                effect,
+                Effect::SetAICurrentPatrol {
+                    target: Some(_),
+                    ..
+                }
+            )),
+            "and the patrol takes a point back up, got {emitted:?}"
+        );
+    }
+
+    /// A goal with no route *at all* (a point on a disconnected part of the
+    /// navigation graph) is not waited out - nothing about it will change.
+    #[test]
+    fn a_topologically_unreachable_route_still_retires() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        let mut patrol =
+            PatrolBehavior::with_steering(first, goal, |_| Box::new(UnreachableSteering));
+
+        for _ in 0..20 {
+            patrol.steer(Deg(0.0), &world, &physics, creature, &at(10.0));
+        }
+        assert!(patrol.finished, "a route with no reachable point ends");
+    }
+
     #[test]
     fn patrol_publishes_its_live_target_relation() {
         let (world, creature, first, goal) = world_with_unreachable_route();
@@ -630,6 +757,15 @@ mod tests {
             },
         ));
         (world, creature, first, final_point)
+    }
+
+    /// A tick at a given mission time (the clock the path exclusions expire
+    /// against).
+    fn at(total_seconds: f32) -> Time {
+        Time {
+            elapsed: std::time::Duration::from_millis(100),
+            total: std::time::Duration::from_secs_f32(total_seconds),
+        }
     }
 
     fn tick() -> Time {

--- a/shock2vr/src/scripts/ai/steering/chained_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/chained_steering_strategy.rs
@@ -15,6 +15,12 @@ impl SteeringStrategy for ChainedSteeringStrategy {
         self.strategies.iter().any(|s| s.goal_unreachable())
     }
 
+    fn goal_unreachable_until(&self) -> Option<f32> {
+        self.strategies
+            .iter()
+            .find_map(|s| s.goal_unreachable_until())
+    }
+
     fn steer(
         &mut self,
         _current_heading: Deg<f32>,

--- a/shock2vr/src/scripts/ai/steering/chained_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/chained_steering_strategy.rs
@@ -18,7 +18,11 @@ impl SteeringStrategy for ChainedSteeringStrategy {
     fn goal_unreachable_until(&self) -> Option<f32> {
         self.strategies
             .iter()
-            .find_map(|s| s.goal_unreachable_until())
+            .filter(|s| s.goal_unreachable())
+            .filter_map(|s| s.goal_unreachable_until())
+            .fold(None, |latest, until| {
+                Some(latest.map_or(until, |l: f32| l.max(until)))
+            })
     }
 
     fn steer(

--- a/shock2vr/src/scripts/ai/steering/mod.rs
+++ b/shock2vr/src/scripts/ai/steering/mod.rs
@@ -61,6 +61,15 @@ pub trait SteeringStrategy {
         false
     }
 
+    /// When `goal_unreachable` is a *temporary* verdict - the query ran
+    /// against a live exclusion (a crossing or cell steering reported as
+    /// blocked), so the goal may be routable again once it lapses - the
+    /// mission time that exclusion expires at. `None` means the failure is
+    /// about the map itself and retrying buys nothing.
+    fn goal_unreachable_until(&self) -> Option<f32> {
+        None
+    }
+
     fn steer(
         &mut self,
         _current_heading: Deg<f32>,

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -149,6 +149,9 @@ pub struct PathFollowSteeringStrategy {
     last_stall_position: Option<Vector3<f32>>,
     /// Last query said the goal has no route (see `goal_unreachable`)
     goal_unreachable: bool,
+    /// ...and, when that query ran against a live exclusion, when that
+    /// exclusion expires (see `goal_unreachable_until`)
+    goal_unreachable_until: Option<f32>,
     /// Static-geometry whiskers, biasing the aim point (see `aim_with_bias`)
     whiskers: WhiskerAvoidance,
     /// The leading CELLS of the route that was in force when the last stall
@@ -191,6 +194,7 @@ impl PathFollowSteeringStrategy {
             displacement_anchor: None,
             last_stall_position: None,
             goal_unreachable: false,
+            goal_unreachable_until: None,
             whiskers: WhiskerAvoidance::new(),
             stall_route_cells: None,
             stall_escalations: 0,
@@ -215,6 +219,10 @@ impl PathFollowSteeringStrategy {
 impl SteeringStrategy for PathFollowSteeringStrategy {
     fn goal_unreachable(&self) -> bool {
         self.goal_unreachable
+    }
+
+    fn goal_unreachable_until(&self) -> Option<f32> {
+        self.goal_unreachable_until
     }
 
     fn steer(
@@ -291,6 +299,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 match response.outcome {
                     AiPathOutcome::Failed if goal_current => {
                         self.goal_unreachable = true;
+                        self.goal_unreachable_until = response.exclusion_expires_at;
                         self.clear_path();
                         // Nothing to compare a stalled route against
                         self.stall_route_cells = None;
@@ -305,6 +314,10 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         // reachability: it is A*'s "closest I could get".
                         self.goal_unreachable = response.outcome == AiPathOutcome::Partial
                             && !route_reaches_goal(&response.waypoints, response.goal);
+                        self.goal_unreachable_until = self
+                            .goal_unreachable
+                            .then_some(response.exclusion_expires_at)
+                            .flatten();
                         self.path = response.waypoints;
                         self.path_goal = Some(response.goal);
                         // waypoint 0 is the position the query started from
@@ -401,6 +414,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     // reachability no longer stands (goals move, and blocked
                     // crossings expire)
                     self.goal_unreachable = false;
+                    self.goal_unreachable_until = None;
                     // The worker computes a full route, or - when the goal
                     // is unreachable (another island, off-mesh) - a partial
                     // route to the closest reachable point, so the AI


### PR DESCRIPTION
A patrolling AI gives up on a route point when the path query says the goal has no route, and once it has come back around to a point it already gave up on - the whole lap tried, nothing reached - the patrol retires and hands back to Idle for the rest of the mission.

That verdict does not distinguish *why* the query failed. The stall system blacklists crossings an AI physically could not traverse (`report_blocked_link`, 30 s TTL) and penalizes cells an AI is wedged in, so a route can be unroutable purely because something is in the way *right now*. A patrol unlucky enough to run its lap inside that window retired permanently over a blockage that cleared 30 seconds later.

So a query that fell short is asked *why*: `PathfindingService::exclusion_expiry_for_unreached_goal` re-runs the same search on the raw mesh, with the exclusions lifted. Only if the goal is reachable that way was the shortfall caused by them, and the deadline is then the expiry of the excluded crossings **on that recovered route** - not the level's blacklist at large, so a stall on the other side of the deck is not mistaken for this patrol's problem. A goal unreachable on the raw mesh too - a point on a disconnected part of the navigation graph - reports no deadline and retires exactly as before.

The worker attaches that deadline to any query that fell short, and `PathFollowSteeringStrategy` exposes it beside `goal_unreachable` as `goal_unreachable_until`. A patrol whose route ran out with a deadline in hand waits it out and runs the route again instead of retiring.

The re-run costs one more A* on a query that already failed, and only while some crossing is excluded at all (the common case skips it outright). The deadline is an upper bound: it measures the cheapest raw route, so a pricier route that reopens sooner is not noticed.

Stalled *cells* are deliberately not part of the signal: they are a cost penalty, not an exclusion, so they can never be why a goal came back unreachable.

The wait is bounded (`PATROL_TEMPORARY_RETRIES`, 3 waits with no point reached in between), so an AI on a deck where something is always blocked somewhere eventually hands back to idle rather than standing there for the mission. Reaching a point resets the count, as it already does the give-up list.

While waiting the AI stands - no steering at a goal nothing can route to - and animates idle rather than locomotion. Alertness still replaces the behavior normally, so a waiting patroller is not deaf to the player.

Ledger item P1 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

## Tests

- Pathfinding, negative-first (both fail against the previous level-wide signal): `an_unreachable_goal_is_not_made_temporary_by_an_unrelated_exclusion` (a goal on a linkless island, with an unrelated crossing excluded elsewhere: was `Some(30)`, now `None`) and `a_goal_cut_off_only_by_exclusions_reports_its_own_route_s_deadline` (two exclusions on the route it reopens by, a third later one on the detour it will not take, plus a stalled cell: `Some(32)` - so a level-wide `max` (35) and a level-wide `min` (30) both fail).
- Propagation with a **real worker** (not a stub): `worker_reports_a_deadline_only_for_an_exclusion_caused_shortfall` submits two queries through `AsyncPathfinding` against one service and asserts `PathQueryResponse::exclusion_expires_at` is `None` for the island goal and the route's own deadline for the cut-off one. The last hop - worker response to `goal_unreachable_until` - stays covered by the steering unit tests; driving a real AI into a real stall from outside the game is not deterministic (see below).
- Retry policy, unchanged from the first round: `a_patrol_given_up_under_a_temporary_exclusion_resumes_when_it_expires`, `an_always_blocked_route_stops_waiting_and_retires`, `a_topologically_unreachable_route_still_retires`, `a_stalled_cell_alone_is_never_something_to_wait_for`.
- `cargo test -p shock2vr`: 1428 passed.
- e2e: `patrol` 4/4 (again after the fix). Earlier rounds: `medsci2-patrol-railing` 1/1 (x2), `force-chase` 1/1, `missions` 23/23.
- `cargo bn path bench medsci2.mis --seed 424242` unchanged: 200/0 found, inflation 1.67, turn 944 deg.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

**No e2e for the fix itself.** Nothing outside the game can put a crossing on the blacklist - exclusions are only ever produced by an AI actually stalling mid-route, and there is no debug endpoint for `report_blocked_link`. A test that waits for the right AI to wedge itself in the right place would not be deterministic, so the coverage here is the unit + worker tests plus the existing patrol e2e as a no-regression check.

No media: nothing visible changes except that an AI which used to stand idle forever eventually walks again.

## Review

`/xreview` - all three reviewers ran (Claude adversarial, Codex, and the de-dup pass). Both engines independently raised the same central finding. Fixed:

- **High [AGREED]** - the temporary/topological signal was the *whole level's* blacklist, so any creature stalling anywhere made an unrelated patrol's genuinely disconnected route look temporary, and a busy deck could keep it retrying indefinitely. Now it reads blocked *crossings* only (cells cannot cause unreachability), it is computed only for a query that fell short, and the wait is capped at 3 - so the retry is bounded by construction rather than by hoping the blacklist empties.
- **Medium** - the stall give-up inherited a `temporary_until` left behind by an earlier point's routing verdict, so a lap closed by a physical wedge waited on a routing exclusion. The verdict is now passed per give-up (`None` from the stall branch), which also deleted the accumulator field and its two clear sites.
- **Medium (Codex)** - an open patrol chain that simply ran out of points never reached the pause check and retired regardless. Running out of chain is now treated as the same empty route as a completed lap.
- **Medium (Codex)** - a deadline that had already lapsed by the time the response was adopted fell through to retirement; it now pauses and resumes on the next frame.
- **Low** - `ChainedSteeringStrategy::goal_unreachable_until` took the first `Some` regardless of which strategy actually reported the goal unreachable; it now takes the latest deadline among the strategies that did.

Noted, not changed: the de-dup reviewer asked whether the existing `REPATH_FAILURE_BACKOFF_SECONDS` re-query already covers this. It does not - it makes steering ask again, but the patrol has already retired by then; what is missing is precisely the *verdict* (is waiting worth anything at all), which the backoff cannot express. Otherwise: no actionable duplication.



### Second round (re-review of the claim)

The temporary/topological distinction was still only *bounded*, not *made*: the deadline was the latest excluded crossing anywhere in the level, so an unrelated stall made a disconnected patrol point look temporary and the 3-wait cap merely limited the damage. Fixed by proving the verdict against the raw mesh (above), with the deadline scoped to the recovered route. A second `/xreview` over that commit:

- **Medium [AGREED]** - the exclusion set the search used and the expiry map were read at two different moments, so a crossing reported in between could invent or extend a deadline (or a pruned one erase it). The deadline is now scoped to the query's own avoidance snapshot, with a crossing since pruned counting as already lapsed.
- **Medium** - neither test distinguished "max over the recovered route" from "min over the level" (the numbers coincided). Both now carry two exclusions with different expiries on the recovered route.
- **Low, both engines** - the stressed second pass was copy-pasted into the re-run, and `blocked_links` repeated the retain-under-lock. Both searches now share `cell_path_avoiding`, and `blocked_links` derives from the expiry map.
- Noted, not changed: the re-run costs an extra failing A* on the worker in exactly the disconnected case, which a per-component index could answer in O(1) - not worth a bits-aware component index for a search that runs only when something is excluded and only off the frame thread. The extra pass counts in `PathfindingStats` (it is a real search).