### PR TITLE
fix(ai): a head-on neighbour makes the AI sidestep instead of pushing through

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -734,7 +734,20 @@ pub(crate) fn normalized_horizontal(v: Vector3<f32>) -> Option<Vector3<f32>> {
     (length > 1e-6).then(|| vec3(v.x / length, 0.0, v.z / length))
 }
 
-/// Turn a head-on push into a sidestep of the same strength.
+/// Drop whatever part of `v` points against `direction`, keeping the rest.
+/// Used both to keep a bias from pulling a body backwards down its route
+/// and to stop a crowd push from bidding against the whiskers.
+pub(crate) fn drop_opposing(v: Vector3<f32>, direction: Vector3<f32>) -> Vector3<f32> {
+    match normalized_horizontal(direction) {
+        Some(direction) => {
+            let opposing = (v.x * direction.x + v.z * direction.z).min(0.0);
+            v - direction * opposing
+        }
+        None => v,
+    }
+}
+
+/// Turn a head-on crowd push into a sidestep of the same strength.
 ///
 /// A neighbour squarely ahead pushes straight back down the route, and a
 /// bias pointing backwards is worth nothing: the aim point keeps only its
@@ -743,31 +756,58 @@ pub(crate) fn normalized_horizontal(v: Vector3<f32>) -> Option<Vector3<f32>> {
 /// original engine's regulator does, so inside `HEAD_ON_CONE` the push is
 /// rotated onto the perpendicular instead of being thrown away.
 ///
-/// The side is the one the push already leans toward, which for two bodies
-/// approaching each other is mirrored - each sees the other off its own
-/// opposite shoulder, so they pass on opposite sides without talking. For a
-/// dead-centre approach with no lean at all, both fall back to the same
-/// BODY-RELATIVE side, which is again opposite in world space because they
-/// face opposite ways.
-pub fn yield_sideways(push: Vector3<f32>, heading: Vector3<f32>) -> Vector3<f32> {
+/// Apply this to the WHOLE crowd bias, not to one neighbour's share: a
+/// neighbour dead ahead and another abreast would otherwise yield onto the
+/// same axis and cancel, leaving an AI with two neighbours worse off than
+/// with one. Summed first, a push that still has somewhere sideways to go
+/// falls outside the cone and is left exactly as it was.
+///
+/// The side is always the same one relative to the direction of travel,
+/// which is what lets two AIs pass without coordinating: facing opposite
+/// ways, their own sides are opposite sides of the corridor. Leaning toward
+/// whichever side the push already favours reads as more natural and is
+/// wrong - two bodies converging a few degrees off dead-centre lean the
+/// same way in world space and stay nose to nose.
+///
+/// `avoid` is the static-geometry bias (the whiskers), which outranks the
+/// choice of side: if the AI's own side is a wall, the other one is open by
+/// construction, and both AIs of a pair read the same wall the same way.
+pub(crate) fn yield_sideways(
+    push: Vector3<f32>,
+    heading: Vector3<f32>,
+    avoid: Vector3<f32>,
+) -> Vector3<f32> {
     let magnitude = (push.x * push.x + push.z * push.z).sqrt();
     if magnitude < 1e-6 {
         return push;
     }
+    let Some(heading) = normalized_horizontal(heading) else {
+        return push;
+    };
     let along = push.x * heading.x + push.z * heading.z;
     if along >= 0.0 {
         return push; // not pointing back at all
     }
+    // sin of the angle off exactly anti-parallel, ramped so the conversion
+    // eases in rather than stepping the aim point by the whole offset
+    // budget as a neighbour drifts across the edge of the cone.
     let lateral = push - heading * along;
     let lateral_length = (lateral.x * lateral.x + lateral.z * lateral.z).sqrt();
-    // sin of the angle off exactly anti-parallel
-    if lateral_length / magnitude > Rad::from(HEAD_ON_CONE).0.sin() {
+    let head_on = repel_ramp(
+        lateral_length / magnitude,
+        0.0,
+        Rad::from(HEAD_ON_CONE).0.sin(),
+    );
+    if head_on <= 0.0 {
         return push;
     }
-    let side = normalized_horizontal(lateral)
-        // Dead centre: one consistent perpendicular of the heading.
-        .unwrap_or_else(|| vec3(heading.z, 0.0, -heading.x));
-    side * magnitude
+    let side = vec3(heading.z, 0.0, -heading.x);
+    let side = if side.x * avoid.x + side.z * avoid.z < 0.0 {
+        -side
+    } else {
+        side
+    };
+    push + (side * magnitude - push) * head_on
 }
 
 /// Horizontal crowd bias: the sum of repulsions from other LIVING
@@ -791,11 +831,9 @@ pub fn crowd_bias(
     world: &World,
     entity_id: EntityId,
     position: Vector3<f32>,
-    heading: Option<Vector3<f32>>,
     separation_radius: f32,
     repel: Option<CrowdRepel>,
 ) -> Vector3<f32> {
-    let heading = heading.and_then(normalized_horizontal);
     let v_creature = world.borrow::<View<PropCreature>>().unwrap();
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
@@ -835,11 +873,7 @@ pub fn crowd_bias(
         if weight <= 0.0 {
             continue;
         }
-        let push = vec3(dx / distance, 0.0, dz / distance) * weight;
-        bias += match heading {
-            Some(heading) => yield_sideways(push, heading),
-            None => push,
-        };
+        bias += vec3(dx / distance, 0.0, dz / distance) * weight;
     }
     bias
 }
@@ -1276,6 +1310,9 @@ mod separation_tests {
     use cgmath::Matrix4;
     use shipyard::World;
 
+    /// No static geometry nearby, so the whiskers express no preference
+    const NO_WALL: Vector3<f32> = vec3(0.0, 0.0, 0.0);
+
     fn spawn_creature(world: &mut World, at: Vector3<f32>, hit_points: i32) -> EntityId {
         world.add_entity((
             PropCreature(0),
@@ -1290,7 +1327,7 @@ mod separation_tests {
         let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
 
-        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 2.4, None);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
         assert!(
             bias.x < -0.1,
             "neighbor at +x must push toward -x: {bias:?}"
@@ -1307,7 +1344,7 @@ mod separation_tests {
         spawn_creature(&mut world, vec3(10.0, 0.0, 0.0), 10); // out of radius
         spawn_creature(&mut world, vec3(1.0, 5.0, 0.0), 10); // floor above
 
-        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 2.4, None);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
         assert!(
             bias.magnitude() < 1e-6,
             "corpses, far and stacked-floor creatures must not repel: {bias:?}"
@@ -1332,12 +1369,11 @@ mod separation_tests {
         let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(1.5, 0.0, 0.0), 10);
 
-        let separation_only = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 6.0, None);
+        let separation_only = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 6.0, None);
         let with_repel = crowd_bias(
             &world,
             me,
             vec3(0.0, 0.0, 0.0),
-            None,
             6.0,
             Some(CrowdRepel {
                 full: 1.5,
@@ -1356,7 +1392,6 @@ mod separation_tests {
             &world,
             me,
             vec3(0.0, 0.0, 0.0),
-            None,
             6.0,
             Some(CrowdRepel {
                 full: 1.5,
@@ -1377,7 +1412,7 @@ mod separation_tests {
         spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(-1.0, 0.0, 0.0), 10);
 
-        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 2.4, None);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
         assert!(
             bias.x.abs() < 1e-6,
             "symmetric neighbors cancel on x: {bias:?}"
@@ -1388,80 +1423,104 @@ mod separation_tests {
     /// backwards bias is discarded by the aim point - so head-on the crowd
     /// term used to be worth exactly nothing and the two bodies met.
     #[test]
-    fn a_neighbour_squarely_ahead_is_stepped_around() {
-        let mut world = World::new();
-        let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
-        spawn_creature(&mut world, vec3(0.0, 0.0, 1.5), 10);
-
-        let heading = Some(vec3(0.0, 0.0, 1.0));
-        let bias = crowd_bias(
-            &world,
-            me,
-            vec3(0.0, 0.0, 0.0),
-            heading,
-            6.0,
-            Some(CrowdRepel {
-                full: 1.5,
-                none: 4.5,
-                strength: 1.0,
-            }),
-        );
+    fn a_head_on_push_becomes_a_sidestep() {
+        let stepped = yield_sideways(vec3(0.0, 0.0, -2.0), vec3(0.0, 0.0, 1.0), NO_WALL);
         assert!(
-            bias.x.abs() > 0.5,
+            stepped.x.abs() > 1.9,
             "a neighbour dead ahead must be stepped around, not pushed back \
-             through: {bias:?}"
+             through: {stepped:?}"
         );
         assert!(
-            bias.z.abs() < 1e-6,
-            "and the sidestep keeps nothing pointing back down the route: {bias:?}"
+            stepped.z.abs() < 1e-6,
+            "and the sidestep keeps nothing pointing back down the route: {stepped:?}"
         );
     }
 
-    /// Two AIs walking into each other each see the other dead ahead, and
-    /// each yields to its own side - which is opposite in world space,
-    /// because they face opposite ways. Without that they would both step
-    /// the same way and stay nose to nose.
+    /// Two AIs walking into each other each yield to their own side, which
+    /// is the opposite side of the corridor because they face opposite
+    /// ways. This must hold when they are NOT exactly anti-parallel too:
+    /// picking the side the push happens to lean toward looks natural but
+    /// sends both of them the same way in world space (here both headings
+    /// lean +x, e.g. two AIs aiming at the same off-centre doorway), which
+    /// is the very nose-to-nose case this exists to break.
     #[test]
     fn two_ai_meeting_head_on_yield_to_opposite_sides() {
-        let north = yield_sideways(vec3(0.0, 0.0, -1.0), vec3(0.0, 0.0, 1.0));
-        let south = yield_sideways(vec3(0.0, 0.0, 1.0), vec3(0.0, 0.0, -1.0));
-        assert!(
-            north.x * south.x < 0.0,
-            "opposed AIs must pass on opposite sides: {north:?} vs {south:?}"
+        // A stands at -z looking north, B stands at +z looking south, so
+        // A's push (away from B) is -z and B's is its exact opposite.
+        let push_a = vec3(0.0, 0.0, -1.0);
+        let opposite = |heading_a: Vector3<f32>, heading_b: Vector3<f32>| {
+            let a = yield_sideways(push_a, heading_a, NO_WALL);
+            let b = yield_sideways(-push_a, heading_b, NO_WALL);
+            assert!(
+                a.x * b.x < 0.0,
+                "opposed AIs must pass on opposite sides: {a:?} vs {b:?}"
+            );
+        };
+        opposite(vec3(0.0, 0.0, 1.0), vec3(0.0, 0.0, -1.0));
+        // ...and five degrees off, both leaning the same way in world x
+        let lean = Rad::from(Deg(5.0_f32)).0;
+        opposite(
+            vec3(lean.sin(), 0.0, lean.cos()),
+            vec3(lean.sin(), 0.0, -lean.cos()),
         );
     }
 
-    /// ...and a push that already leans to one side keeps that side, so the
-    /// AI slides the short way around rather than crossing the neighbour.
+    /// The whiskers outrank the AI's own side: yielding into the wall they
+    /// just found would be undone by `blend_biases` and the head-on fix
+    /// would do nothing in a doorway, which is where it is needed most.
     #[test]
-    fn a_leaning_head_on_push_keeps_its_own_side() {
+    fn a_wall_flips_the_side_the_ai_yields_to() {
+        let push = vec3(0.0, 0.0, -1.0);
         let heading = vec3(0.0, 0.0, 1.0);
-        let leaning = yield_sideways(vec3(0.2, 0.0, -1.0), heading);
-        assert!(leaning.x > 0.0, "{leaning:?}");
-        let magnitude = (leaning.x * leaning.x + leaning.z * leaning.z).sqrt();
-        let before = (0.2f32 * 0.2 + 1.0).sqrt();
+        let open = yield_sideways(push, heading, NO_WALL);
+        let wall_on_that_side = yield_sideways(push, heading, -open);
         assert!(
-            (magnitude - before).abs() < 1e-5,
-            "yielding must not change how hard the push is: {magnitude} vs {before}"
+            open.x * wall_on_that_side.x < 0.0,
+            "a wall on the AI's own side must send it the other way: \
+             {open:?} vs {wall_on_that_side:?}"
         );
     }
 
     /// A push that is not head-on is left exactly as it was - sideways and
-    /// forward pushes already survive the aim point.
+    /// forward pushes already survive the aim point. This is also what
+    /// keeps a crowd from cancelling itself: applied to the SUM, a
+    /// neighbour dead ahead plus one abreast still has somewhere sideways
+    /// to go and is not rotated onto that neighbour's axis.
     #[test]
     fn a_push_off_the_head_on_cone_is_untouched() {
         let heading = vec3(0.0, 0.0, 1.0);
         assert_eq!(
-            yield_sideways(vec3(1.0, 0.0, 0.0), heading),
+            yield_sideways(vec3(1.0, 0.0, 0.0), heading, NO_WALL),
             vec3(1.0, 0.0, 0.0)
         );
         assert_eq!(
-            yield_sideways(vec3(0.0, 0.0, 1.0), heading),
+            yield_sideways(vec3(0.0, 0.0, 1.0), heading, NO_WALL),
             vec3(0.0, 0.0, 1.0)
         );
-        // 45 degrees off anti-parallel is outside the 30 degree cone
-        let oblique = yield_sideways(vec3(1.0, 0.0, -1.0), heading);
-        assert_eq!(oblique, vec3(1.0, 0.0, -1.0));
+        // one neighbour dead ahead (-z) plus one abreast (-x): 45 degrees
+        // off anti-parallel, outside the cone, lateral escape preserved
+        let crowd = yield_sideways(vec3(-1.0, 0.0, -1.0), heading, NO_WALL);
+        assert_eq!(crowd, vec3(-1.0, 0.0, -1.0));
+    }
+
+    /// The conversion eases in across the cone rather than switching: at
+    /// the edge the push is untouched, just inside it is barely changed.
+    #[test]
+    fn yielding_eases_in_across_the_cone() {
+        let heading = vec3(0.0, 0.0, 1.0);
+        let at_edge = Deg(30.0_f32);
+        let just_inside = Deg(29.0_f32);
+        let push = |off: Deg<f32>| {
+            let off = Rad::from(off).0;
+            vec3(off.sin(), 0.0, -off.cos())
+        };
+        let edge = yield_sideways(push(at_edge), heading, NO_WALL);
+        let inside = yield_sideways(push(just_inside), heading, NO_WALL);
+        assert_eq!(edge, push(at_edge), "untouched at the edge");
+        assert!(
+            (inside - push(just_inside)).magnitude() < 0.1,
+            "and barely changed just inside it: {inside:?}"
+        );
     }
 }
 

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -722,6 +722,54 @@ pub fn repel_ramp(distance: f32, full: f32, none: f32) -> f32 {
     }
 }
 
+/// A push counts as head-on when it points back down the travel direction
+/// within this cone of exactly anti-parallel. Wider and an ordinary
+/// glancing push gets turned sideways; narrower and two bodies converging
+/// a few degrees off dead-centre still cancel each other out.
+const HEAD_ON_CONE: Deg<f32> = Deg(30.0);
+
+/// The XZ direction of `v`, or None when it has no horizontal extent.
+pub(crate) fn normalized_horizontal(v: Vector3<f32>) -> Option<Vector3<f32>> {
+    let length = (v.x * v.x + v.z * v.z).sqrt();
+    (length > 1e-6).then(|| vec3(v.x / length, 0.0, v.z / length))
+}
+
+/// Turn a head-on push into a sidestep of the same strength.
+///
+/// A neighbour squarely ahead pushes straight back down the route, and a
+/// bias pointing backwards is worth nothing: the aim point keeps only its
+/// sideways part (`aim_with_bias`), so the whole push is discarded and two
+/// AIs meeting head-on walk into each other. Yielding around is what the
+/// original engine's regulator does, so inside `HEAD_ON_CONE` the push is
+/// rotated onto the perpendicular instead of being thrown away.
+///
+/// The side is the one the push already leans toward, which for two bodies
+/// approaching each other is mirrored - each sees the other off its own
+/// opposite shoulder, so they pass on opposite sides without talking. For a
+/// dead-centre approach with no lean at all, both fall back to the same
+/// BODY-RELATIVE side, which is again opposite in world space because they
+/// face opposite ways.
+pub fn yield_sideways(push: Vector3<f32>, heading: Vector3<f32>) -> Vector3<f32> {
+    let magnitude = (push.x * push.x + push.z * push.z).sqrt();
+    if magnitude < 1e-6 {
+        return push;
+    }
+    let along = push.x * heading.x + push.z * heading.z;
+    if along >= 0.0 {
+        return push; // not pointing back at all
+    }
+    let lateral = push - heading * along;
+    let lateral_length = (lateral.x * lateral.x + lateral.z * lateral.z).sqrt();
+    // sin of the angle off exactly anti-parallel
+    if lateral_length / magnitude > Rad::from(HEAD_ON_CONE).0.sin() {
+        return push;
+    }
+    let side = normalized_horizontal(lateral)
+        // Dead centre: one consistent perpendicular of the heading.
+        .unwrap_or_else(|| vec3(heading.z, 0.0, -heading.x));
+    side * magnitude
+}
+
 /// Horizontal crowd bias: the sum of repulsions from other LIVING
 /// creatures near `position` (same floor). Returns a direction-and-
 /// magnitude vector in the XZ plane; empty crowd = zero. Callers blend a
@@ -743,9 +791,11 @@ pub fn crowd_bias(
     world: &World,
     entity_id: EntityId,
     position: Vector3<f32>,
+    heading: Option<Vector3<f32>>,
     separation_radius: f32,
     repel: Option<CrowdRepel>,
 ) -> Vector3<f32> {
+    let heading = heading.and_then(normalized_horizontal);
     let v_creature = world.borrow::<View<PropCreature>>().unwrap();
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
@@ -785,7 +835,11 @@ pub fn crowd_bias(
         if weight <= 0.0 {
             continue;
         }
-        bias += vec3(dx / distance, 0.0, dz / distance) * weight;
+        let push = vec3(dx / distance, 0.0, dz / distance) * weight;
+        bias += match heading {
+            Some(heading) => yield_sideways(push, heading),
+            None => push,
+        };
     }
     bias
 }
@@ -1236,7 +1290,7 @@ mod separation_tests {
         let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
 
-        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 2.4, None);
         assert!(
             bias.x < -0.1,
             "neighbor at +x must push toward -x: {bias:?}"
@@ -1253,7 +1307,7 @@ mod separation_tests {
         spawn_creature(&mut world, vec3(10.0, 0.0, 0.0), 10); // out of radius
         spawn_creature(&mut world, vec3(1.0, 5.0, 0.0), 10); // floor above
 
-        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 2.4, None);
         assert!(
             bias.magnitude() < 1e-6,
             "corpses, far and stacked-floor creatures must not repel: {bias:?}"
@@ -1278,11 +1332,12 @@ mod separation_tests {
         let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(1.5, 0.0, 0.0), 10);
 
-        let separation_only = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 6.0, None);
+        let separation_only = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 6.0, None);
         let with_repel = crowd_bias(
             &world,
             me,
             vec3(0.0, 0.0, 0.0),
+            None,
             6.0,
             Some(CrowdRepel {
                 full: 1.5,
@@ -1301,6 +1356,7 @@ mod separation_tests {
             &world,
             me,
             vec3(0.0, 0.0, 0.0),
+            None,
             6.0,
             Some(CrowdRepel {
                 full: 1.5,
@@ -1321,11 +1377,91 @@ mod separation_tests {
         spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
         spawn_creature(&mut world, vec3(-1.0, 0.0, 0.0), 10);
 
-        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), 2.4, None);
+        let bias = crowd_bias(&world, me, vec3(0.0, 0.0, 0.0), None, 2.4, None);
         assert!(
             bias.x.abs() < 1e-6,
             "symmetric neighbors cancel on x: {bias:?}"
         );
+    }
+
+    /// A neighbour squarely ahead pushes straight backwards, and a
+    /// backwards bias is discarded by the aim point - so head-on the crowd
+    /// term used to be worth exactly nothing and the two bodies met.
+    #[test]
+    fn a_neighbour_squarely_ahead_is_stepped_around() {
+        let mut world = World::new();
+        let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
+        spawn_creature(&mut world, vec3(0.0, 0.0, 1.5), 10);
+
+        let heading = Some(vec3(0.0, 0.0, 1.0));
+        let bias = crowd_bias(
+            &world,
+            me,
+            vec3(0.0, 0.0, 0.0),
+            heading,
+            6.0,
+            Some(CrowdRepel {
+                full: 1.5,
+                none: 4.5,
+                strength: 1.0,
+            }),
+        );
+        assert!(
+            bias.x.abs() > 0.5,
+            "a neighbour dead ahead must be stepped around, not pushed back \
+             through: {bias:?}"
+        );
+        assert!(
+            bias.z.abs() < 1e-6,
+            "and the sidestep keeps nothing pointing back down the route: {bias:?}"
+        );
+    }
+
+    /// Two AIs walking into each other each see the other dead ahead, and
+    /// each yields to its own side - which is opposite in world space,
+    /// because they face opposite ways. Without that they would both step
+    /// the same way and stay nose to nose.
+    #[test]
+    fn two_ai_meeting_head_on_yield_to_opposite_sides() {
+        let north = yield_sideways(vec3(0.0, 0.0, -1.0), vec3(0.0, 0.0, 1.0));
+        let south = yield_sideways(vec3(0.0, 0.0, 1.0), vec3(0.0, 0.0, -1.0));
+        assert!(
+            north.x * south.x < 0.0,
+            "opposed AIs must pass on opposite sides: {north:?} vs {south:?}"
+        );
+    }
+
+    /// ...and a push that already leans to one side keeps that side, so the
+    /// AI slides the short way around rather than crossing the neighbour.
+    #[test]
+    fn a_leaning_head_on_push_keeps_its_own_side() {
+        let heading = vec3(0.0, 0.0, 1.0);
+        let leaning = yield_sideways(vec3(0.2, 0.0, -1.0), heading);
+        assert!(leaning.x > 0.0, "{leaning:?}");
+        let magnitude = (leaning.x * leaning.x + leaning.z * leaning.z).sqrt();
+        let before = (0.2f32 * 0.2 + 1.0).sqrt();
+        assert!(
+            (magnitude - before).abs() < 1e-5,
+            "yielding must not change how hard the push is: {magnitude} vs {before}"
+        );
+    }
+
+    /// A push that is not head-on is left exactly as it was - sideways and
+    /// forward pushes already survive the aim point.
+    #[test]
+    fn a_push_off_the_head_on_cone_is_untouched() {
+        let heading = vec3(0.0, 0.0, 1.0);
+        assert_eq!(
+            yield_sideways(vec3(1.0, 0.0, 0.0), heading),
+            vec3(1.0, 0.0, 0.0)
+        );
+        assert_eq!(
+            yield_sideways(vec3(0.0, 0.0, 1.0), heading),
+            vec3(0.0, 0.0, 1.0)
+        );
+        // 45 degrees off anti-parallel is outside the 30 degree cone
+        let oblique = yield_sideways(vec3(1.0, 0.0, -1.0), heading);
+        assert_eq!(oblique, vec3(1.0, 0.0, -1.0));
     }
 }
 

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -747,6 +747,15 @@ pub(crate) fn drop_opposing(v: Vector3<f32>, direction: Vector3<f32>) -> Vector3
     }
 }
 
+/// The AI's own side of the direction of travel: the perpendicular that
+/// `yield_sideways` yields onto and that `blend_biases` applies the
+/// geometry-over-crowd priority along. Both must read the same handedness -
+/// the opposite one would zero exactly the sidesteps it has to preserve -
+/// so they share this. Length follows `heading`'s; only its direction is used.
+pub(crate) fn lateral_axis(heading: Vector3<f32>) -> Vector3<f32> {
+    vec3(heading.z, 0.0, -heading.x)
+}
+
 /// Turn a head-on crowd push into a sidestep of the same strength.
 ///
 /// A neighbour squarely ahead pushes straight back down the route, and a
@@ -801,7 +810,7 @@ pub(crate) fn yield_sideways(
     if head_on <= 0.0 {
         return push;
     }
-    let side = vec3(heading.z, 0.0, -heading.x);
+    let side = lateral_axis(heading);
     let side = if side.x * avoid.x + side.z * avoid.z < 0.0 {
         -side
     } else {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -484,7 +484,16 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
             none: REPEL_RADIUS,
             strength,
         });
-        let crowd = ai_util::crowd_bias(world, entity_id, position, SEPARATION_RADIUS, repel);
+        // The heading lets a push from a neighbour squarely ahead become a
+        // sidestep rather than a backwards shove the aim point discards.
+        let crowd = ai_util::crowd_bias(
+            world,
+            entity_id,
+            position,
+            Some(waypoint - position),
+            SEPARATION_RADIUS,
+            repel,
+        );
         // ...and the same treatment for static geometry the navigation mesh
         // doesn't model (a railing, a crate left on the route): whiskers bend
         // the line around it before the body wedges, without ever taking the
@@ -794,10 +803,23 @@ fn target_awareness_distance(
 /// own, so it is shortened to the offset budget BEFORE the sum: otherwise
 /// a dense crowd - or simply a stronger repel term - buys magnitude out of
 /// the whiskers' share and bends the line into the very geometry the
-/// whiskers are there to avoid. The blend is then shortened once, so two
-/// biases pointing the same way still cannot bend the line further than
-/// one of them may.
+/// whiskers are there to avoid.
+///
+/// Geometry then outranks the crowd outright: whatever part of the crowd
+/// push opposes the whiskers is dropped before the sum, so a neighbour on
+/// the open side can never bid an AI back toward the wall the whiskers are
+/// steering it off. (Two vectors of similar size pointing opposite ways
+/// otherwise cancel to nothing, which is the worst of both - no avoidance
+/// and no yielding.) The blend is shortened once at the end, so two biases
+/// pointing the same way still cannot bend the line further than one may.
 fn blend_biases(crowd: Vector3<f32>, whiskers: Vector3<f32>, max: f32) -> Vector3<f32> {
+    let crowd = match ai_util::normalized_horizontal(whiskers) {
+        Some(wall) => {
+            let opposing = (crowd.x * wall.x + crowd.z * wall.z).min(0.0);
+            crowd - wall * opposing
+        }
+        None => crowd,
+    };
     capped(capped(crowd, max) + whiskers, max)
 }
 
@@ -1147,6 +1169,24 @@ mod tests {
         // A crowd on its own is capped like any other bias
         let alone = blend_biases(vec3(100.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), 2.5);
         assert!((alone.x - 2.5).abs() < 1e-4, "got {alone:?}");
+    }
+
+    /// A neighbour on the open side pushes an AI back at the wall the
+    /// whiskers just found. Summed, two opposite pushes of similar size
+    /// cancel to nothing - no avoidance AND no yielding - so the crowd's
+    /// opposing part is dropped and the wall wins outright.
+    #[test]
+    fn a_wall_outranks_a_crowd_push_into_it() {
+        let wall_push = vec3(2.0, 0.0, 0.0);
+        let crowd_into_wall = vec3(-2.2, 0.0, 0.0);
+        let blended = blend_biases(crowd_into_wall, wall_push, 2.5);
+        assert!(
+            blended.x > 1.0,
+            "the whiskers must still steer away from the wall: {blended:?}"
+        );
+        // A crowd push that does NOT oppose the wall is untouched
+        let alongside = blend_biases(vec3(0.0, 0.0, 1.0), wall_push, 2.5);
+        assert!((alongside.z - 1.0).abs() < 1e-4, "got {alongside:?}");
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, EuclideanSpace, Vector3, vec3, vec4};
+use cgmath::{Deg, EuclideanSpace, Vector3, vec4};
 use dark::SCALE_FACTOR;
 use dark::mission::path_database::MovementBits;
 use rand::Rng;
@@ -497,12 +497,13 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // open side when the whiskers have found a wall. Faded with the
         // melee approach exactly like the repel it mostly comes from: an AI
         // in reach of its target must not be stepped off the blow.
-        let yielded = ai_util::yield_sideways(crowd, waypoint - position, whiskers);
+        let heading = waypoint - position;
+        let yielded = ai_util::yield_sideways(crowd, heading, whiskers);
         let crowd = crowd + (yielded - crowd) * strength;
         let aim = aim_with_bias(
             position,
             waypoint,
-            blend_biases(crowd, whiskers, waypoint - position, SEPARATION_MAX_OFFSET),
+            blend_biases(crowd, whiskers, heading, SEPARATION_MAX_OFFSET),
         );
 
         // Stall escape: if we stop making progress toward the current
@@ -808,11 +809,12 @@ fn target_awareness_distance(
 /// the open side can never bid an AI back toward the wall the whiskers are
 /// steering it off. (Two vectors of similar size pointing opposite ways
 /// otherwise cancel to nothing, which is the worst of both - no avoidance
-/// and no yielding.) The same priority is then applied again across the
-/// direction of travel, which is the only space the aim point keeps, so a
-/// crowd term perpendicular to the whiskers cannot cancel their sidestep
-/// either. The blend is shortened once at the end, so two biases pointing
-/// the same way still cannot bend the line further than one may.
+/// and no yielding.) That rule works along the whiskers' own direction; the
+/// same priority is then applied a second time along the LATERAL axis,
+/// which is the only one the aim point keeps, so a crowd term perpendicular
+/// to the whiskers cannot cancel their sidestep either. The blend is
+/// shortened once at the end, so two biases pointing the same way still
+/// cannot bend the line further than one may.
 fn blend_biases(
     crowd: Vector3<f32>,
     whiskers: Vector3<f32>,
@@ -820,25 +822,17 @@ fn blend_biases(
     max: f32,
 ) -> Vector3<f32> {
     let crowd = capped(ai_util::drop_opposing(crowd, whiskers), max);
-    // Only the part of a bias ACROSS the direction of travel survives the
-    // aim point's forward projection (`aim_with_bias`), so the priority has
-    // to be applied there too, not just between the raw vectors: a diagonal
-    // wall hit and a neighbour off to one side can be perpendicular (so
-    // neither opposes the other) while their sideways parts still cancel,
-    // leaving a sum that is purely backward and is erased whole.
-    let crowd = match ai_util::normalized_horizontal(heading) {
-        Some(heading) => {
-            let side = vec3(heading.z, 0.0, -heading.x);
-            let crowd_side = crowd.x * side.x + crowd.z * side.z;
-            let wall_side = whiskers.x * side.x + whiskers.z * side.z;
-            if crowd_side * wall_side < 0.0 {
-                crowd - side * crowd_side
-            } else {
-                crowd
-            }
-        }
-        None => crowd,
+    // ...and once more along the lateral axis, because that is the only part
+    // the aim point's forward projection (`aim_with_bias`) keeps: a diagonal
+    // wall hit and a neighbour off to one side can be perpendicular - so
+    // neither opposes the other and the rule above passes them both - while
+    // their sideways parts still cancel, leaving a sum that is purely
+    // backward and is erased whole.
+    let wall_side = {
+        let side = ai_util::lateral_axis(heading);
+        side * (whiskers.x * side.x + whiskers.z * side.z)
     };
+    let crowd = ai_util::drop_opposing(crowd, wall_side);
     capped(crowd + whiskers, max)
 }
 

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -484,16 +484,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
             none: REPEL_RADIUS,
             strength,
         });
-        // The heading lets a push from a neighbour squarely ahead become a
-        // sidestep rather than a backwards shove the aim point discards.
-        let crowd = ai_util::crowd_bias(
-            world,
-            entity_id,
-            position,
-            Some(waypoint - position),
-            SEPARATION_RADIUS,
-            repel,
-        );
+        let crowd = ai_util::crowd_bias(world, entity_id, position, SEPARATION_RADIUS, repel);
         // ...and the same treatment for static geometry the navigation mesh
         // doesn't model (a railing, a crate left on the route): whiskers bend
         // the line around it before the body wedges, without ever taking the
@@ -501,6 +492,13 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // biases pointing the same way still cannot bend the line further
         // than one of them may.
         let whiskers = self.whiskers.update(world, physics, entity_id, time);
+        // A crowd squarely ahead pushes straight back down the route, which
+        // the aim point discards - so it becomes a sidestep instead, on the
+        // open side when the whiskers have found a wall. Faded with the
+        // melee approach exactly like the repel it mostly comes from: an AI
+        // in reach of its target must not be stepped off the blow.
+        let yielded = ai_util::yield_sideways(crowd, waypoint - position, whiskers);
+        let crowd = crowd + (yielded - crowd) * strength;
         let aim = aim_with_bias(
             position,
             waypoint,
@@ -813,14 +811,10 @@ fn target_awareness_distance(
 /// and no yielding.) The blend is shortened once at the end, so two biases
 /// pointing the same way still cannot bend the line further than one may.
 fn blend_biases(crowd: Vector3<f32>, whiskers: Vector3<f32>, max: f32) -> Vector3<f32> {
-    let crowd = match ai_util::normalized_horizontal(whiskers) {
-        Some(wall) => {
-            let opposing = (crowd.x * wall.x + crowd.z * wall.z).min(0.0);
-            crowd - wall * opposing
-        }
-        None => crowd,
-    };
-    capped(capped(crowd, max) + whiskers, max)
+    capped(
+        capped(ai_util::drop_opposing(crowd, whiskers), max) + whiskers,
+        max,
+    )
 }
 
 /// Shorten a horizontal bias to at most `max`.
@@ -845,19 +839,7 @@ fn aim_with_bias(
     // obstacle square across the path answers with its own normal, and
     // pulling the aim point backwards would only stop the AI in front of it
     // instead of taking it around (what is left is the sideways part).
-    let toward = waypoint - position;
-    let length = (toward.x * toward.x + toward.z * toward.z).sqrt();
-    let bias = if length > 1e-3 {
-        let toward = Vector3::new(toward.x / length, 0.0, toward.z / length);
-        let along = bias.x * toward.x + bias.z * toward.z;
-        if along < 0.0 {
-            bias - toward * along
-        } else {
-            bias
-        }
-    } else {
-        bias
-    };
+    let bias = ai_util::drop_opposing(bias, waypoint - position);
     let aim = waypoint + bias;
     if xz_distance(position, aim) < WAYPOINT_ADVANCE_DISTANCE {
         waypoint

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, EuclideanSpace, Vector3, vec4};
+use cgmath::{Deg, EuclideanSpace, Vector3, vec3, vec4};
 use dark::SCALE_FACTOR;
 use dark::mission::path_database::MovementBits;
 use rand::Rng;
@@ -502,7 +502,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         let aim = aim_with_bias(
             position,
             waypoint,
-            blend_biases(crowd, whiskers, SEPARATION_MAX_OFFSET),
+            blend_biases(crowd, whiskers, waypoint - position, SEPARATION_MAX_OFFSET),
         );
 
         // Stall escape: if we stop making progress toward the current
@@ -808,13 +808,38 @@ fn target_awareness_distance(
 /// the open side can never bid an AI back toward the wall the whiskers are
 /// steering it off. (Two vectors of similar size pointing opposite ways
 /// otherwise cancel to nothing, which is the worst of both - no avoidance
-/// and no yielding.) The blend is shortened once at the end, so two biases
-/// pointing the same way still cannot bend the line further than one may.
-fn blend_biases(crowd: Vector3<f32>, whiskers: Vector3<f32>, max: f32) -> Vector3<f32> {
-    capped(
-        capped(ai_util::drop_opposing(crowd, whiskers), max) + whiskers,
-        max,
-    )
+/// and no yielding.) The same priority is then applied again across the
+/// direction of travel, which is the only space the aim point keeps, so a
+/// crowd term perpendicular to the whiskers cannot cancel their sidestep
+/// either. The blend is shortened once at the end, so two biases pointing
+/// the same way still cannot bend the line further than one may.
+fn blend_biases(
+    crowd: Vector3<f32>,
+    whiskers: Vector3<f32>,
+    heading: Vector3<f32>,
+    max: f32,
+) -> Vector3<f32> {
+    let crowd = capped(ai_util::drop_opposing(crowd, whiskers), max);
+    // Only the part of a bias ACROSS the direction of travel survives the
+    // aim point's forward projection (`aim_with_bias`), so the priority has
+    // to be applied there too, not just between the raw vectors: a diagonal
+    // wall hit and a neighbour off to one side can be perpendicular (so
+    // neither opposes the other) while their sideways parts still cancel,
+    // leaving a sum that is purely backward and is erased whole.
+    let crowd = match ai_util::normalized_horizontal(heading) {
+        Some(heading) => {
+            let side = vec3(heading.z, 0.0, -heading.x);
+            let crowd_side = crowd.x * side.x + crowd.z * side.z;
+            let wall_side = whiskers.x * side.x + whiskers.z * side.z;
+            if crowd_side * wall_side < 0.0 {
+                crowd - side * crowd_side
+            } else {
+                crowd
+            }
+        }
+        None => crowd,
+    };
+    capped(crowd + whiskers, max)
 }
 
 /// Shorten a horizontal bias to at most `max`.
@@ -1136,11 +1161,12 @@ mod tests {
 
     #[test]
     fn a_crowd_cannot_outbid_the_whiskers() {
+        let heading = vec3(0.0, 0.0, 1.0);
         // A huge crowd push (many neighbors, or a saturated repel) plus a
         // whisker push at right angles: the crowd is shortened to the
         // budget first, so the geometry it is steering around keeps half
         // the blend instead of being rounded away.
-        let blended = blend_biases(vec3(100.0, 0.0, 0.0), vec3(0.0, 0.0, 2.5), 2.5);
+        let blended = blend_biases(vec3(100.0, 0.0, 0.0), vec3(0.0, 0.0, 2.5), heading, 2.5);
         assert!(
             (blended.z - blended.x).abs() < 1e-4,
             "an unbounded crowd must not outweigh the whiskers: {blended:?}"
@@ -1149,7 +1175,7 @@ mod tests {
         let magnitude = (blended.x * blended.x + blended.z * blended.z).sqrt();
         assert!((magnitude - 2.5).abs() < 1e-4, "got {magnitude}");
         // A crowd on its own is capped like any other bias
-        let alone = blend_biases(vec3(100.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), 2.5);
+        let alone = blend_biases(vec3(100.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), heading, 2.5);
         assert!((alone.x - 2.5).abs() < 1e-4, "got {alone:?}");
     }
 
@@ -1159,16 +1185,64 @@ mod tests {
     /// opposing part is dropped and the wall wins outright.
     #[test]
     fn a_wall_outranks_a_crowd_push_into_it() {
+        let heading = vec3(0.0, 0.0, 1.0);
         let wall_push = vec3(2.0, 0.0, 0.0);
         let crowd_into_wall = vec3(-2.2, 0.0, 0.0);
-        let blended = blend_biases(crowd_into_wall, wall_push, 2.5);
+        let blended = blend_biases(crowd_into_wall, wall_push, heading, 2.5);
         assert!(
             blended.x > 1.0,
             "the whiskers must still steer away from the wall: {blended:?}"
         );
         // A crowd push that does NOT oppose the wall is untouched
-        let alongside = blend_biases(vec3(0.0, 0.0, 1.0), wall_push, 2.5);
+        let alongside = blend_biases(vec3(0.0, 0.0, 1.0), wall_push, heading, 2.5);
         assert!((alongside.z - 1.0).abs() < 1e-4, "got {alongside:?}");
+    }
+
+    /// The full composition, travelling +z: a diagonal wall hit and a
+    /// neighbour that sits OUTSIDE the head-on cone (so it is not converted
+    /// to a sidestep). Their sideways parts are opposite, so summed as
+    /// whole vectors they cancel and the aim point's forward projection
+    /// erases what is left - losing the wall avoidance exactly when a
+    /// neighbour is also present.
+    #[test]
+    fn a_wall_survives_the_projection_when_a_crowd_is_present() {
+        let position = vec3(0.0, 0.0, 0.0);
+        let waypoint = vec3(0.0, 0.0, 10.0);
+        let heading = waypoint - position;
+        let whiskers = vec3(1.0, 0.0, -1.0);
+        let crowd = vec3(-1.0, 0.0, -1.0);
+        // outside the head-on cone: the sidestep conversion leaves it alone
+        let yielded = ai_util::yield_sideways(crowd, heading, whiskers);
+        assert!(xz_distance(yielded, crowd) < 1e-4, "got {yielded:?}");
+
+        let aim = aim_with_bias(
+            position,
+            waypoint,
+            blend_biases(yielded, whiskers, heading, 2.5),
+        );
+        assert!(
+            aim.x > 0.5,
+            "the wall's sidestep must survive the projection: {aim:?}"
+        );
+    }
+
+    #[test]
+    fn a_crowd_agreeing_with_the_wall_still_adds() {
+        let heading = vec3(0.0, 0.0, 1.0);
+        // both push +x: the priority rule must not touch them, they sum
+        let blended = blend_biases(vec3(0.5, 0.0, 0.0), vec3(1.0, 0.0, 0.0), heading, 2.5);
+        assert!((blended.x - 1.5).abs() < 1e-4, "got {blended:?}");
+        // ...and the sum is still shortened to the budget
+        let capped_sum = blend_biases(vec3(2.0, 0.0, 0.0), vec3(2.0, 0.0, 0.0), heading, 2.5);
+        assert!((capped_sum.x - 2.5).abs() < 1e-4, "got {capped_sum:?}");
+    }
+
+    #[test]
+    fn a_crowd_with_no_whiskers_is_untouched() {
+        let heading = vec3(0.0, 0.0, 1.0);
+        let crowd = vec3(-1.0, 0.0, -1.0);
+        let blended = blend_biases(crowd, vec3(0.0, 0.0, 0.0), heading, 2.5);
+        assert!(xz_distance(blended, crowd) < 1e-4, "got {blended:?}");
     }
 
     #[test]


### PR DESCRIPTION
Crowd steering had a blind spot exactly where it exists: a neighbour **squarely ahead**. The push is away from the neighbour, so head-on it points straight back down the route — and `aim_with_bias` drops whatever part of a bias points backwards, because turning to a point behind you is not steering. The whole push was therefore discarded, and two AIs walking into each other pushed capsule-to-capsule until one of them wedged.

Inside a 30 degree cone of anti-parallel the crowd bias is now rotated onto the perpendicular at the same strength: the AI **steps around** instead of leaning back. The side is always the same one relative to travel, which is what lets two AIs pass without coordinating — facing opposite ways, their own sides are opposite sides of the corridor. The conversion eases in across the cone (reusing `repel_ramp`) rather than switching at its edge, and fades with the melee approach like the repel it mostly comes from, so an AI in reach of its target is never stepped off the blow.

Two smaller pieces of the same finding:

- **Geometry outranks the crowd — on both axes that matter.** The whisker bias and the crowd bias were summed, so two opposite pushes of similar size cancelled to nothing — no avoidance *and* no yielding. Whatever part of a crowd push opposes the whiskers is now dropped, and the whiskers also pick which way the AI yields: if its own side is a wall, the other one is open by construction, and both AIs of a pair read the same wall the same way. That rule works along the whiskers' own direction, which turned out not to be enough (see **Wall priority in the space that survives**, below).
- **Separation and repel were already one response** — one neighbour walk, one summed bias in `crowd_bias` — so there was nothing to merge there.

Phase 2 item P4 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

## Wall priority in the space that survives

Dropping the crowd's opposing part fixed the *collinear* case and missed the perpendicular one. `aim_with_bias` keeps only what points across the direction of travel, so a bias's lateral component is the only part that reaches the aim point at all — and two vectors can be perpendicular to each other (so neither "opposes" the other, and the rule above passes them both through) while their *lateral* parts are exactly opposite.

Travelling `+z`, a diagonal wall hit `(1,0,-1)` and a neighbour outside the head-on cone at `(-1,0,-1)`: the sum is `(0,0,-2)`, purely backward, and the projection erases it whole. The AI got no wall avoidance at all — precisely when a neighbour was also present, which is when it needs it.

The same priority is now applied a second time along the lateral axis, where it survives. It is the same `drop_opposing` call, aimed along the whiskers' lateral direction instead of the whiskers themselves, so the two rules are one idea applied on two axes rather than two mechanisms. The head-on cone logic and the deterministic side choice are untouched; the perpendicular that `yield_sideways` yields onto and the one the priority is applied along are now literally the same function (`ai_util::lateral_axis`) — the rule is only correct because both read the same handedness.

Unit, negative-first on the full composition (`yield_sideways` → `blend_biases` → `aim_with_bias`) with exactly those vectors:

- `a_wall_survives_the_projection_when_a_crowd_is_present` — pre-fix the aim point came back unbent (`(0,0,10)`, the raw waypoint); it now carries the wall's `+x` sidestep. The test also asserts the neighbour really is outside the cone, so the conversion is not what is doing the work.
- `a_crowd_agreeing_with_the_wall_still_adds` — same-side pushes sum, and the sum is still shortened once to the budget.
- `a_crowd_with_no_whiskers_is_untouched` — a crowd on its own behaves exactly as before.

`medsci2-patrol-railing` (the railing *is* the wall-vs-waypoint case) passes, before and after the review fixes.

## Before / after

The pile-up e2e (`medsci2-doorjamb-chase`, "chasing medsci2 hybrids never grind in one spot" — every AI in the level chases at once, so the pile-up is the thing under test) is nondeterministic, so it is a rate:

| branch | passes |
|---|---|
| base `fix/ai-patrol-temporary-unreachable` | **0 / 6** |
| this branch | **2 / 6** |

It never passed on the base. The second assertion in that file (a chasing hybrid takes the open door, not the sliver beside its jamb) is 6/6 on both.

## Media

Two hybrids spawned facing each other in the medsci2 science corridor (x 38, z -26 / -34), then dragged up and down that corridor by teleporting the player between its ends on a fixed schedule, so the pair repeatedly has to swap places in a one-body-wide passage. Identical request sequence on both branches, captured headlessly through the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed timestep, free camera).

![head-on sidestep, before vs after](https://gist.githubusercontent.com/tommy-xr/8ef1de8f5e381320e58f4ba42a8f1464/raw/demo.gif)

<sub>Left: on the base, once the pair has to cross, the trailing hybrid is left behind down the corridor and never regains contact. Right: with the change it steps around and the two travel abreast.</sub>

![same frame, before and after](https://gist.githubusercontent.com/tommy-xr/8ef1de8f5e381320e58f4ba42a8f1464/raw/still.png)

Gap between the two hybrids over the run, three runs per branch:

![pair separation over time](https://gist.githubusercontent.com/tommy-xr/8ef1de8f5e381320e58f4ba42a8f1464/raw/gap.png)

The two branches agree for the first half and separate once the pair has to cross: mean gap over the last 20 samples is 9.4 / 10.5 / 10.9 on the base and 3.7 / 4.7 / 5.9 on this branch (max gap 11.7-12.5 vs 7.2-8.7) - consistent across three runs each, but note this is one scenario, not a deterministic isolation of the fix (see the pass-rate table above).

## Tests

Unit, on the pure vector functions:

- `a_head_on_push_becomes_a_sidestep` — negative-first: a neighbour dead ahead used to yield exactly zero lateral.
- `two_ai_meeting_head_on_yield_to_opposite_sides` — including headings five degrees off anti-parallel that both lean the same way in world space (the review counterexample below); this fails against the first implementation.
- `a_wall_flips_the_side_the_ai_yields_to`, `a_push_off_the_head_on_cone_is_untouched`, `yielding_eases_in_across_the_cone`, `a_wall_outranks_a_crowd_push_into_it`.

`cargo test -p shock2vr`: 1434 passed. `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

**Reduced validation scope (deliberate).** e2e was cut to the pile-up test above — there is no repel/separation e2e to run. `patrol` 4/4, `force-chase` 1/1, `missions` 23/23 and the medsci2 reachability harness (3 runs per branch, `--pass both`) were run on the first commit of this branch before the review fixes: no regression, and on a single mission the harness buckets are too noisy to show this (the one consistent move was idle `no_route` 1/1/1 -> 0/0/0). They were not re-run after the review fixes.

## Review

`/xreview` — both engines, plus the de-dup reviewer. The first implementation did not survive it; three findings, two raised independently by both engines:

- **High [AGREED]** — the side was the one the push already leaned toward, which is only mirrored between a pair when their headings are exactly anti-parallel. Two AIs converging a few degrees off dead-centre (both aiming at the same off-centre doorway) leaned the same way in world space and stayed nose to nose — the very case the change exists to break. The side is now always the same one relative to travel, which *is* opposite between two bodies facing opposite ways whatever their lean, and the counterexample is a regression test.
- **High** — yielding each neighbour's share separately let a neighbour dead ahead and one abreast rotate onto the same axis and cancel, leaving an AI with two neighbours worse off than before the change. The yield now applies once to the whole crowd bias at the call site — which also removed the `crowd_bias` signature change and every test call-site edit with it, for a materially smaller diff.
- **High** — a sidestep aimed at a door jamb was then deleted outright by the new whisker projection, so the fix was a no-op in a doorway, where it is needed most. The whiskers now choose the side rather than erasing it.
- **Medium** — the cone edge was a hard switch that stepped the aim point by roughly half the offset budget in one frame (the same defect the melee fade in this file already documents). Ramped.
- **Medium** — the sidestep was not melee-faded, so an AI closing on the player with an ally ahead got a new lateral push in exactly the situation the fade protects. It now fades with `strength`.
- **De-dup** — three hand-rolled copies of "remove the part of this vector pointing against that direction" (the new yield, the new whisker projection, and the pre-existing `aim_with_bias`); one `drop_opposing` helper replaces all three.

Not taken: gating the yield on the neighbour actually being *oncoming* (needs neighbour velocity or heading, and the melee fade covers the case that motivated it), and hoisting `normalized_horizontal` into `shock2vr::util` to share with the UI and whisker modules (a different subsystem, out of scope here).

Re-reviewed after the lateral-axis fix — both engines plus the de-dup reviewer, on that commit alone:

- **Codex** — no findings at any severity; it independently confirmed the earlier `drop_opposing(crowd, whiskers)` is *not* redundant given the new rule (heading `+z`, crowd `(0,0,1)`, whiskers `(1,0,-1)` is a case only the old rule catches), so both are kept.
- **De-dup `reuse`** — the lateral projection was hand-rolled in twelve lines that are exactly `drop_opposing` along the lateral axis, degenerate cases included. Collapsed to the one call.
- **Medium, raised by both the correctness and de-dup reviewers** — the `(heading.z, 0, -heading.x)` swizzle was written twice, in two modules, and the priority is only correct because both copies agree on handedness. Extracted as `ai_util::lateral_axis`.
- **Low** — `waypoint - position` was recomputed for the yield and again for the blend; hoisted, so the two cannot drift.
- **Not taken:** grading the drop by the whisker's magnitude, on the argument that a far-edge whisker hit should not veto a saturated crowd push. The premise does not hold — `drop_opposing` normalizes its direction, so it has always removed the *whole* opposing projection whatever the whiskers' length, and `a_wall_outranks_a_crowd_push_into_it` asserts that outright veto deliberately. Making it proportional is a change to the established geometry-first rule, not a fix to this one.

Noted for later, out of scope here: a whisker pointing *straight* back down the route (lateral zero, a wall square across the path) is still erased by `aim_with_bias` — the same class of loss, but it predates this branch.
