### PR TITLE
fix(ai): one movement-hold reason; the impatience gesture only at a door

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -1091,6 +1091,10 @@ pub struct DebugAiPathEntry {
     pub live_target: Option<[f32; 3]>,
     /// Seconds without progress toward the current waypoint
     pub live_stall_seconds: Option<f32>,
+    /// Why the AI is deliberately standing still, if it is ("DoorWait",
+    /// "Pivot") - a held AI stands on purpose and is not a wedged one, and
+    /// its stall clock is frozen for as long as this is set
+    pub movement_hold: Option<String>,
 }
 
 /// Snapshot of the pathfinding service's monotonic query counters.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -12290,6 +12290,10 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     live_path_len: live.map(|l| l.path_len),
                     live_target: live.and_then(|l| l.target).map(Into::into),
                     live_stall_seconds: live.map(|l| l.stall_seconds),
+                    movement_hold: match service.movement_hold(entity) {
+                        crate::pathfinding::MovementHold::None => None,
+                        hold => Some(format!("{hold:?}")),
+                    },
                 }
             })
             .collect()

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -201,6 +201,29 @@ pub struct AiSteeringDebug {
     pub stall_seconds: f32,
 }
 
+/// Why an AI is deliberately standing still this frame. A hold is a decision,
+/// not a failure: the script publishes it BEFORE it steers, and the path
+/// follower answers by suspending its no-progress accounting, so seconds spent
+/// standing on purpose never spend the patience it keeps for a real wedge.
+/// Steering itself keeps running through a hold - heading, whiskers and crowd
+/// repel stay live.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MovementHold {
+    /// Free to move
+    #[default]
+    None,
+    /// Standing off while a door leaf this AI opened travels clear
+    DoorWait,
+    /// Performing an authored turn clip - the pose does the turning
+    Pivot,
+}
+
+impl MovementHold {
+    pub fn is_holding(self) -> bool {
+        self != MovementHold::None
+    }
+}
+
 /// Pathfinding service for AI navigation
 ///
 /// Uses AIPATH cells for navigation mesh queries and A* pathfinding.
@@ -242,6 +265,9 @@ pub struct PathfindingService {
     ai_paths: std::sync::Mutex<HashMap<u64, AiPathRecord>>,
     /// Live steering state per AI (what it is actually following right now)
     ai_steering: std::sync::Mutex<HashMap<u64, AiSteeringDebug>>,
+    /// Whether each AI is deliberately holding position, published by its
+    /// script each frame before it steers (see `MovementHold`)
+    movement_holds: std::sync::Mutex<HashMap<u64, MovementHold>>,
     /// Cell crossings some AI's steering failed to traverse (a stall fired
     /// mid-route): obstacles the mesh doesn't model, e.g. a physical prop
     /// or a scripted stationary NPC sitting on a walkable link. Entries map
@@ -343,6 +369,7 @@ impl PathfindingService {
             relaxed: bridge_islands,
             ai_paths: std::sync::Mutex::new(HashMap::new()),
             ai_steering: std::sync::Mutex::new(HashMap::new()),
+            movement_holds: std::sync::Mutex::new(HashMap::new()),
             blocked_links: std::sync::Mutex::new(HashMap::new()),
             blocked_cells: std::sync::Mutex::new(HashMap::new()),
             blocked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
@@ -376,6 +403,9 @@ impl PathfindingService {
         }
         if let Ok(mut steering) = self.ai_steering.lock() {
             steering.retain(|&entity, _| keep(entity));
+        }
+        if let Ok(mut holds) = self.movement_holds.lock() {
+            holds.retain(|&entity, _| keep(entity));
         }
     }
 
@@ -514,6 +544,24 @@ impl PathfindingService {
         if let Ok(mut steering) = self.ai_steering.lock() {
             steering.insert(entity, debug);
         }
+    }
+
+    /// Publish whether an AI is deliberately standing still. Written by the
+    /// AI script before it steers, read by the path follower's stall
+    /// accounting (see `MovementHold`).
+    pub fn record_movement_hold(&self, entity: u64, hold: MovementHold) {
+        if let Ok(mut holds) = self.movement_holds.lock() {
+            holds.insert(entity, hold);
+        }
+    }
+
+    /// Whether an AI is deliberately standing still, and why
+    pub fn movement_hold(&self, entity: u64) -> MovementHold {
+        self.movement_holds
+            .lock()
+            .ok()
+            .and_then(|holds| holds.get(&entity).copied())
+            .unwrap_or_default()
     }
 
     /// The live steering state for an entity, if it has published any

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -14,7 +14,8 @@ use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, View, World};
 
 use crate::{
     creature,
-    mission::{PlayerInfo, entity_creator::CreateEntityOptions},
+    mission::{GlobalPathfinding, PlayerInfo, entity_creator::CreateEntityOptions},
+    pathfinding::MovementHold,
     physics::{InternalCollisionGroups, PhysicsWorld},
     runtime_props::{RuntimePropJointTransforms, RuntimePropProxyEntity, RuntimePropTransform},
     scripts::{
@@ -29,6 +30,29 @@ use crate::{
 /// random_binomial
 ///
 /// Returns a random number between -1 and 1, where values around 0 are more likely
+/// Tell every watchdog that this AI is standing still on purpose (or is free
+/// to move again). Published by the AI script BEFORE it steers - see
+/// `MovementHold`.
+pub fn publish_movement_hold(world: &World, entity_id: EntityId, hold: MovementHold) {
+    if let Some(service) = world
+        .borrow::<UniqueView<GlobalPathfinding>>()
+        .ok()
+        .and_then(|g| g.0.clone())
+    {
+        service.record_movement_hold(entity_id.inner(), hold);
+    }
+}
+
+/// Why this AI is standing still this frame, if it is.
+pub fn movement_hold(world: &World, entity_id: EntityId) -> MovementHold {
+    world
+        .borrow::<UniqueView<GlobalPathfinding>>()
+        .ok()
+        .and_then(|g| g.0.clone())
+        .map(|service| service.movement_hold(entity_id.inner()))
+        .unwrap_or_default()
+}
+
 pub fn random_binomial() -> f32 {
     let mut rng = thread_rng();
     let a = rng.gen_range(0.0..1.0);

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -2887,22 +2887,49 @@ mod tests {
         assert!(!door_wait_is_thwarting(Some(0.5)));
     }
 
+    /// Publish `seconds` of no-progress stall for `entity_id` on the channel
+    /// the path follower writes and `path_stall_seconds` reads. Without this
+    /// the world has no pathfinding service at all, so a "stalled" AI reads
+    /// zero seconds and every stall assertion is vacuous.
+    fn publish_stall(world: &mut World, entity_id: EntityId, seconds: f32) {
+        let service = std::sync::Arc::new(crate::pathfinding::PathfindingService::new(
+            std::sync::Arc::new(crate::pathfinding::tests::three_cell_db(
+                dark::mission::path_database::PathCellFlags::empty(),
+            )),
+        ));
+        service.record_ai_steering(
+            entity_id.inner(),
+            crate::pathfinding::AiSteeringDebug {
+                next_waypoint: 1,
+                path_len: 3,
+                target: Some(vec3(0.0, 0.0, 5.0)),
+                stall_seconds: seconds,
+            },
+        );
+        world.add_unique(GlobalPathfinding(Some(service)));
+    }
+
     /// USER DECISION (2026-09-05): impatience is a door gesture only. On a
     /// stall the creature is trying to get out of a wedge, and a clip with no
     /// root motion only makes the standstill longer.
     #[test]
     fn a_sustained_stall_draws_no_gesture() {
-        let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
-        // Nothing is holding this AI at a door, however long its route has
-        // been going nowhere.
+        let (mut world, entity_id) = world_with_monster_and_player(Deg(0.0));
+        // A real wedge, banked well past any threshold a stall gesture ever
+        // used - and no door holding this AI.
+        publish_stall(&mut world, entity_id, 10.0);
+        assert!(
+            path_stall_seconds(&world, entity_id) >= 10.0,
+            "the stall the gesture would have read is actually on the wire",
+        );
         let mut stalled = AnimatedMonsterAI::new();
         assert!(matches!(
             stalled.update_frustration(&world, entity_id, None, false, &tick()),
             Effect::NoEffect
         ));
-        // The same AI, kept waiting at a door instead: this is the one block
-        // that still draws the performance, so the case above is a decision,
-        // not a gesture path that has stopped working.
+        // The same stalled AI, kept waiting at a door as well: this is the one
+        // block that still draws the performance, so the case above is a
+        // decision, not a gesture path that has stopped working.
         let mut waiting = AnimatedMonsterAI::new();
         assert!(matches!(
             waiting.update_frustration(&world, entity_id, LONG_WAIT, false, &tick()),
@@ -2958,6 +2985,11 @@ mod tests {
         ));
     }
 
+    /// The gate the locked-door give-up now goes through (it used to emit the
+    /// performance whatever either path had already spent): the rate limit it
+    /// arms refuses the next gesture, and a pivot in flight refuses it too -
+    /// the gesture PLAYS, so firing it over a turn clip would leave the AI
+    /// held on a clip nothing is running.
     #[test]
     fn the_locked_door_give_up_respects_the_shared_limit() {
         let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
@@ -2971,6 +3003,24 @@ mod tests {
             monster.try_frustration_gesture(&world, entity_id),
             Effect::NoEffect
         ));
+
+        let mut pivoting = AnimatedMonsterAI::new();
+        pivoting.turn_clip = Some(TurnClip::Playing {
+            turn: Deg(90.0),
+            remaining: 1.0,
+            blend: TURN_CLIP_SETTLE_SECONDS,
+        });
+        assert!(
+            matches!(
+                pivoting.try_frustration_gesture(&world, entity_id),
+                Effect::NoEffect
+            ),
+            "an unspent limit still yields to a turn in flight",
+        );
+        assert_eq!(
+            pivoting.frustration_cooldown, 0.0,
+            "a gesture that never played must not arm the limit",
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -13,6 +13,7 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
     mission::{GlobalPathfinding, GlobalTemplateIdMap, PlayerInfo},
+    pathfinding::MovementHold,
     physics::{InternalCollisionGroups, PhysicsWorld},
     scripts::script_util,
     time::Time,
@@ -24,7 +25,7 @@ use super::{
     ai_util::*,
     alertness::{self, AlertnessState, AlertnessTimings},
     behavior::*,
-    steering::{Steering, SteeringOutput},
+    steering::{STALL_SECONDS, Steering, SteeringOutput},
 };
 // Default timing constants for monsters (in seconds)
 const DEFAULT_ESCALATE_SECONDS: f32 = 1.5;
@@ -59,12 +60,6 @@ const DOOR_OPEN_FRACTION: f32 = 0.95;
 /// wedge, blacklist the crossing the AI just opened, and route it back away
 /// from the door. Longer than the slowest shipped leaf's travel (~1.6 s).
 const DOOR_WAIT_TIMEOUT: f32 = 2.5;
-/// How long a path-follow stall must persist before it reads as frustration
-/// worth showing - just under the point where the stall system gives up on
-/// the route and retreats. The published counter is reset by that recovery,
-/// so it never climbs past the stall window and a higher threshold here
-/// would simply never fire.
-const FRUSTRATION_STALL_SECONDS: f32 = 2.5;
 /// How long a door has to keep the AI waiting before that reads as
 /// impatience. A shipped sliding leaf clears in about half a second, and an
 /// AI is not thwarted by a door that opens for it - gesturing at every one
@@ -157,15 +152,25 @@ pub(crate) fn door_is_passable(fraction: f32, rise: f32, actor_height: f32) -> b
 /// never over a performance the level authored.
 pub(crate) fn should_gesture_frustration(
     door_wait_seconds: Option<f32>,
-    stall_seconds: f32,
     cooldown_remaining: f32,
     target_distance: Option<f32>,
     scripted: ScriptedState,
 ) -> bool {
-    let blocked = door_wait_seconds.is_some_and(|s| s >= FRUSTRATION_DOOR_WAIT_SECONDS)
-        || stall_seconds >= FRUSTRATION_STALL_SECONDS;
-    blocked
-        && cooldown_remaining <= 0.0
+    door_wait_seconds.is_some_and(|s| s >= FRUSTRATION_DOOR_WAIT_SECONDS)
+        && frustration_gesture_allowed(cooldown_remaining, target_distance, scripted)
+}
+
+/// The limits every gesture path shares, whatever it is frustrated at: the
+/// rate limit, no gesturing over a scripted performance, and none in the
+/// player's face (a creature in reach of its target attacks, it does not
+/// mime). The locked-door give-up goes through this too - two paths playing
+/// the one performance must not take turns past the limit either claims.
+pub(crate) fn frustration_gesture_allowed(
+    cooldown_remaining: f32,
+    target_distance: Option<f32>,
+    scripted: ScriptedState,
+) -> bool {
+    cooldown_remaining <= 0.0
         && scripted != ScriptedState::Running
         && !matches!(target_distance, Some(d) if d <= MELEE_ATTACK_RANGE)
 }
@@ -241,8 +246,23 @@ fn frustration_gesture(entity_id: EntityId) -> Effect {
     }
 }
 
+/// Tell the path follower this AI is standing still on purpose, so the hold
+/// suspends its no-progress accounting instead of reading as a wedge. Written
+/// on the same channel the follower publishes its own state on, and BEFORE the
+/// steer that reads it.
+fn publish_movement_hold(world: &World, entity_id: EntityId, hold: MovementHold) {
+    if let Some(service) = world
+        .borrow::<UniqueView<GlobalPathfinding>>()
+        .ok()
+        .and_then(|g| g.0.clone())
+    {
+        service.record_movement_hold(entity_id.inner(), hold);
+    }
+}
+
 /// How long path-following has been making no progress, as published by the
-/// steering strategy. Zero for an AI that isn't following a route.
+/// steering strategy - and already frozen for the frames this AI published a
+/// hold for. Zero for an AI that isn't following a route.
 fn path_stall_seconds(world: &World, entity_id: EntityId) -> f32 {
     world
         .borrow::<UniqueView<GlobalPathfinding>>()
@@ -251,6 +271,18 @@ fn path_stall_seconds(world: &World, entity_id: EntityId) -> f32 {
         .and_then(|service| service.ai_steering(entity_id.inner()))
         .map(|steering| steering.stall_seconds)
         .unwrap_or(0.0)
+}
+
+/// Why this AI is standing still this frame, if it is. A door wait outranks a
+/// pivot: the AI can be doing both, and the door is what it is waiting on.
+fn movement_hold(door_wait_seconds: Option<f32>, pivoting: bool) -> MovementHold {
+    if door_wait_seconds.is_some() {
+        MovementHold::DoorWait
+    } else if pivoting {
+        MovementHold::Pivot
+    } else {
+        MovementHold::None
+    }
 }
 
 pub(crate) fn locomotion_scale_for_heading_error(delta: Deg<f32>) -> f32 {
@@ -851,7 +883,7 @@ impl AnimatedMonsterAI {
     /// publishes its stall clock only while it steers, and the last value it
     /// published outlives it.
     fn bar_pivot_while_stalled(&mut self, stall_seconds: f32, following_a_route: bool) {
-        if following_a_route && stall_seconds >= FRUSTRATION_STALL_SECONDS {
+        if following_a_route && stall_seconds >= STALL_SECONDS {
             self.turn_cooldown = self.turn_cooldown.max(TURN_CLIP_COOLDOWN);
         }
     }
@@ -953,16 +985,16 @@ impl AnimatedMonsterAI {
         rand::thread_rng().gen_range(FRUSTRATION_COOLDOWN_MIN..FRUSTRATION_COOLDOWN_MAX)
     }
 
-    /// Show frustration at whatever is in the way - a door still opening, or
-    /// a route that has stopped making progress. The gesture is an animation
-    /// only: it plays over the block without touching the wait or the stall
-    /// system's own recovery.
+    /// Show impatience at a door still opening. Only at a door: the gesture
+    /// fits inside a hold the AI is already taking, whereas playing it on a
+    /// stall would add seconds of standing still to a creature that is trying
+    /// to get out of a wedge. The gesture is an animation only - it plays over
+    /// the wait without extending it.
     fn update_frustration(
         &mut self,
         world: &World,
         entity_id: EntityId,
         door_wait_seconds: Option<f32>,
-        stall_seconds: f32,
         started_a_clip: bool,
         time: &Time,
     ) -> Effect {
@@ -975,7 +1007,6 @@ impl AnimatedMonsterAI {
         }
         if !should_gesture_frustration(
             door_wait_seconds,
-            stall_seconds,
             self.frustration_cooldown,
             chase_target_distance(world, entity_id),
             self.current_behavior.borrow().scripted_state(),
@@ -988,6 +1019,21 @@ impl AnimatedMonsterAI {
             entity_id,
             door_wait_seconds
         );
+        frustration_gesture(entity_id)
+    }
+
+    /// The thwarted performance, if the shared limits allow it right now -
+    /// arming the rate limit when it does. Every gesture path goes through
+    /// this or `update_frustration`, which applies the same limits.
+    fn try_frustration_gesture(&mut self, world: &World, entity_id: EntityId) -> Effect {
+        if !frustration_gesture_allowed(
+            self.frustration_cooldown,
+            chase_target_distance(world, entity_id),
+            self.current_behavior.borrow().scripted_state(),
+        ) {
+            return Effect::NoEffect;
+        }
+        self.frustration_cooldown = self.next_frustration_cooldown();
         frustration_gesture(entity_id)
     }
 
@@ -1076,17 +1122,22 @@ impl AnimatedMonsterAI {
                 // Giving up on the door also gives up waiting for it - the
                 // wander this drops to has no business standing at it.
                 self.door_wait = None;
-                // State-only downgrade: the thwarted gesture replaces the
-                // queue this frame (a second Play here would blend from an
-                // unseen frame-0 pose and waste a clip load); the completion
-                // handler starts the Low behavior's clip after the gesture.
-                let downgrade =
-                    self.force_alertness_state(AIAlertLevel::Low, world, physics, entity_id);
-                // Same rate limit as the wait/stall gesture: both paths
-                // emit the one performance, so they must not take turns
-                // playing it past the limit either claims.
-                self.frustration_cooldown = self.next_frustration_cooldown();
-                return Effect::combine(vec![downgrade, frustration_gesture(entity_id)]);
+                // Asked for before the downgrade, so the limits are read
+                // against the behavior that was actually thwarted.
+                let gesture = self.try_frustration_gesture(world, entity_id);
+                let downgrade = if matches!(gesture, Effect::NoEffect) {
+                    // Nothing to carry the change: start the wander's own
+                    // clip, as every other behavior change does.
+                    self.force_alertness(AIAlertLevel::Low, world, physics, entity_id)
+                } else {
+                    // State-only downgrade: the thwarted gesture replaces the
+                    // queue this frame (a second Play here would blend from an
+                    // unseen frame-0 pose and waste a clip load); the
+                    // completion handler starts the Low behavior's clip after
+                    // the gesture.
+                    self.force_alertness_state(AIAlertLevel::Low, world, physics, entity_id)
+                };
+                return Effect::combine(vec![downgrade, gesture]);
             }
             // Unlocked: open it and keep chasing through. The longer cooldown
             // avoids re-sending TurnOn (and replaying the open sound) while
@@ -1398,26 +1449,23 @@ impl Script for AnimatedMonsterAI {
             }
         }
 
-        // A pivot already in flight is a commitment: the behavior is not
-        // steered at all while it plays. Steering a body that is deliberately
-        // standing still would read as a stall - the path follower would
-        // blacklist the cell it is turning on, and a patrol route would give
-        // up on the point it is turning toward.
+        // Both deliberate standstills are decided BEFORE the steer that
+        // reads them: a hold published afterwards would leave the frame it
+        // covers counted as a frame of no progress. The hold suspends the
+        // follower's progress accounting only - the behavior still steers
+        // through it, so heading, whiskers, crowd repel and the route itself
+        // stay live while the creature stands.
+        let door_wait_seconds = self.update_door_wait(world, entity_id, time);
         let pivoting = self.turn_clip.is_some();
-        let (steering_output, steering_effects) = if pivoting {
-            (
+        publish_movement_hold(world, entity_id, movement_hold(door_wait_seconds, pivoting));
+        let (steering_output, steering_effects) = self
+            .current_behavior
+            .borrow_mut()
+            .steer(self.current_heading, world, physics, entity_id, time)
+            .unwrap_or((
                 Steering::from_current(self.current_heading),
                 Effect::NoEffect,
-            )
-        } else {
-            self.current_behavior
-                .borrow_mut()
-                .steer(self.current_heading, world, physics, entity_id, time)
-                .unwrap_or((
-                    Steering::from_current(self.current_heading),
-                    Effect::NoEffect,
-                ))
-        };
+            ));
 
         // Keep looking at a player this creature can actually see, so the
         // sighting survives long enough to escalate (see
@@ -1435,7 +1483,6 @@ impl Script for AnimatedMonsterAI {
             steering_output
         };
 
-        let door_wait_seconds = self.update_door_wait(world, entity_id, time);
         // A pivot big enough to stop the body is played as an authored turn
         // clip. Same gate as the frustration gesture: never over a scripted
         // performance, and never while standing off from a door.
@@ -1484,20 +1531,13 @@ impl Script for AnimatedMonsterAI {
         // reordering also leaves the rate limit unarmed, so the gesture
         // simply comes on a later frame.
         // A pivot is a clip too, for its whole length - not just the frame it
-        // was asked for. Gesturing over it would preempt the turn, and the
-        // stall it is reacting to is a standstill this AI chose.
+        // was asked for: gesturing over it would preempt the turn.
         let started_a_clip = !matches!(behavior_change_effect, Effect::NoEffect)
             || !matches!(handback_effect, Effect::NoEffect)
             || !matches!(turn_clip_effect, Effect::NoEffect)
             || self.turn_clip.is_some();
-        let frustration_effect = self.update_frustration(
-            world,
-            entity_id,
-            door_wait_seconds,
-            stall_seconds,
-            started_a_clip,
-            time,
-        );
+        let frustration_effect =
+            self.update_frustration(world, entity_id, door_wait_seconds, started_a_clip, time);
 
         let sensor_effect = self.try_tickle_sensor(world, physics, entity_id);
 
@@ -2096,6 +2136,17 @@ mod tests {
     /// Flag `entity_id` as a patroller and (when `with_route`) lay down a
     /// two-point `AIPatrol` loop 10 units down +X for it to walk.
     fn make_patroller(world: &mut World, entity_id: EntityId, with_route: bool) {
+        make_patroller_with_points(world, entity_id, with_route, [10.0, 20.0]);
+    }
+
+    /// As `make_patroller`, with the two route points at chosen distances
+    /// down +X - close ones stand the AI on its own goal.
+    fn make_patroller_with_points(
+        world: &mut World,
+        entity_id: EntityId,
+        with_route: bool,
+        xs: [f32; 2],
+    ) {
         world.add_component(entity_id, dark::properties::PropAIPatrol(true));
         if !with_route {
             return;
@@ -2108,8 +2159,8 @@ mod tests {
                 dark::properties::Links::empty(),
             ))
         };
-        let first = point(10.0);
-        let second = point(20.0);
+        let first = point(xs[0]);
+        let second = point(xs[1]);
         let mut v_links = world
             .borrow::<shipyard::ViewMut<dark::properties::Links>>()
             .unwrap();
@@ -2220,7 +2271,7 @@ mod tests {
         // The route stops making progress. Standing still through a turn clip
         // while wedged only lengthens the wedge.
         let (_world, entity_id, mut monster) = pivoting_monster(Deg(0.0));
-        monster.bar_pivot_while_stalled(FRUSTRATION_STALL_SECONDS, true);
+        monster.bar_pivot_while_stalled(STALL_SECONDS, true);
         assert!(
             turn_frame(&mut monster, entity_id, reversal).0.is_none(),
             "a stalled creature steers the turn instead"
@@ -2254,7 +2305,7 @@ mod tests {
         // otherwise re-arm the bar off a frozen reading for the rest of its
         // life.
         let (_world, entity_id, mut monster) = pivoting_monster(Deg(0.0));
-        monster.bar_pivot_while_stalled(FRUSTRATION_STALL_SECONDS, false);
+        monster.bar_pivot_while_stalled(STALL_SECONDS, false);
         assert!(
             turn_frame(&mut monster, entity_id, Deg(180.0)).0.is_some(),
             "a stall nobody is publishing must not bar a pivot"
@@ -2438,6 +2489,44 @@ mod tests {
     /// so a patroller that is never alerted stood on its spawn point for the
     /// whole mission - patrol only ever started after an alert had come and
     /// gone.
+    /// A pivot used to skip the behavior update entirely, purely to keep the
+    /// standstill out of the stall clock - which also stopped the route, the
+    /// whiskers and the crowd repel for the length of the clip. The hold now
+    /// pauses the accounting alone, so the behavior is steered right through
+    /// the pivot: this patroller keeps working its route while it turns.
+    #[test]
+    fn a_pivot_no_longer_freezes_the_behavior() {
+        let (mut world, entity_id) = world_with_monster_and_player(Deg(180.0));
+        // Standing on its own patrol point, so every steered frame arrives
+        // and advances the route - an observable heartbeat of the steer.
+        make_patroller_with_points(&mut world, entity_id, true, [0.0, 0.5]);
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+        assert_eq!(monster.current_behavior.borrow().name(), "Patrol");
+        step(&mut monster, &world, entity_id);
+
+        monster.turn_clip = Some(TurnClip::Playing {
+            turn: Deg(90.0),
+            remaining: 10.0,
+            blend: TURN_CLIP_SETTLE_SECONDS,
+        });
+        let effects = step(&mut monster, &world, entity_id);
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SetAICurrentPatrol { .. })),
+            "a pivoting AI is still steered by its behavior",
+        );
+    }
+
+    #[test]
+    fn a_door_wait_outranks_a_pivot_as_the_hold_reason() {
+        assert_eq!(movement_hold(None, false), MovementHold::None);
+        assert_eq!(movement_hold(None, true), MovementHold::Pivot);
+        // Both at once: the door is what the AI is actually waiting on.
+        assert_eq!(movement_hold(Some(0.2), true), MovementHold::DoorWait);
+    }
+
     #[test]
     fn patroller_starts_its_route_without_ever_being_alerted() {
         let (mut world, entity_id) = world_with_monster_and_player(Deg(180.0));
@@ -2801,13 +2890,11 @@ mod tests {
         assert!(!should_gesture_frustration(
             None,
             0.0,
-            0.0,
             None,
             ScriptedState::NotScripted
         ));
         assert!(should_gesture_frustration(
             LONG_WAIT,
-            0.0,
             0.0,
             None,
             ScriptedState::NotScripted
@@ -2821,27 +2908,23 @@ mod tests {
         assert!(!should_gesture_frustration(
             Some(0.5),
             0.0,
-            0.0,
             None,
             ScriptedState::NotScripted
         ));
     }
 
+    /// USER DECISION (2026-09-05): impatience is a door gesture only. On a
+    /// stall the creature is trying to get out of a wedge, and a clip with no
+    /// root motion only makes the standstill longer.
     #[test]
-    fn a_sustained_stall_draws_a_gesture() {
-        assert!(!should_gesture_frustration(
-            None,
-            FRUSTRATION_STALL_SECONDS - 1.0,
-            0.0,
-            None,
-            ScriptedState::NotScripted
-        ));
-        assert!(should_gesture_frustration(
-            None,
-            FRUSTRATION_STALL_SECONDS,
-            0.0,
-            None,
-            ScriptedState::NotScripted
+    fn a_sustained_stall_draws_no_gesture() {
+        let mut monster = AnimatedMonsterAI::new();
+        let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
+        // Nothing is holding this AI at a door, however long its route has
+        // been going nowhere.
+        assert!(matches!(
+            monster.update_frustration(&world, entity_id, None, false, &tick()),
+            Effect::NoEffect
         ));
     }
 
@@ -2861,18 +2944,9 @@ mod tests {
     }
 
     #[test]
-    fn a_stall_gesture_threshold_the_stall_clock_can_actually_reach() {
-        // The published stall counter is reset by the stall system's own
-        // recovery, so it never climbs past that window - a threshold at or
-        // above it would never fire.
-        assert!(FRUSTRATION_STALL_SECONDS < crate::scripts::ai::steering::STALL_SECONDS);
-    }
-
-    #[test]
     fn frustration_is_rate_limited() {
         assert!(!should_gesture_frustration(
             LONG_WAIT,
-            0.0,
             3.0,
             None,
             ScriptedState::NotScripted
@@ -2886,16 +2960,31 @@ mod tests {
         assert!(!should_gesture_frustration(
             LONG_WAIT,
             0.0,
-            0.0,
             inside,
             ScriptedState::NotScripted
         ));
         assert!(should_gesture_frustration(
             LONG_WAIT,
             0.0,
-            0.0,
             outside,
             ScriptedState::NotScripted
+        ));
+    }
+
+    /// The locked-door give-up plays the same one performance as the door
+    /// wait, and used to play it whatever either path had already spent.
+    #[test]
+    fn the_locked_door_give_up_respects_the_shared_limit() {
+        let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
+        let mut monster = AnimatedMonsterAI::new();
+        assert!(matches!(
+            monster.try_frustration_gesture(&world, entity_id),
+            Effect::PlayAnimationBySchema { .. }
+        ));
+        assert!(monster.frustration_cooldown > 0.0, "the limit is armed");
+        assert!(matches!(
+            monster.try_frustration_gesture(&world, entity_id),
+            Effect::NoEffect
         ));
     }
 
@@ -2903,7 +2992,6 @@ mod tests {
     fn frustration_never_interrupts_an_authored_performance() {
         assert!(!should_gesture_frustration(
             LONG_WAIT,
-            0.0,
             0.0,
             None,
             ScriptedState::Running

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -150,14 +150,10 @@ pub(crate) fn door_is_passable(fraction: f32, rise: f32, actor_height: f32) -> b
 /// the rate limit has expired, never inside melee reach of the believed
 /// target (an AI in a position to swing is fighting, not thwarted), and
 /// never over a performance the level authored.
-pub(crate) fn should_gesture_frustration(
-    door_wait_seconds: Option<f32>,
-    cooldown_remaining: f32,
-    target_distance: Option<f32>,
-    scripted: ScriptedState,
-) -> bool {
-    door_wait_seconds.is_some_and(|s| s >= FRUSTRATION_DOOR_WAIT_SECONDS)
-        && frustration_gesture_allowed(cooldown_remaining, target_distance, scripted)
+/// Whether a door has kept the AI waiting long enough to read as impatience
+/// rather than as a door simply opening for it.
+pub(crate) fn door_wait_is_thwarting(door_wait_seconds: Option<f32>) -> bool {
+    door_wait_seconds.is_some_and(|seconds| seconds >= FRUSTRATION_DOOR_WAIT_SECONDS)
 }
 
 /// The limits every gesture path shares, whatever it is frustrated at: the
@@ -246,20 +242,6 @@ fn frustration_gesture(entity_id: EntityId) -> Effect {
     }
 }
 
-/// Tell the path follower this AI is standing still on purpose, so the hold
-/// suspends its no-progress accounting instead of reading as a wedge. Written
-/// on the same channel the follower publishes its own state on, and BEFORE the
-/// steer that reads it.
-fn publish_movement_hold(world: &World, entity_id: EntityId, hold: MovementHold) {
-    if let Some(service) = world
-        .borrow::<UniqueView<GlobalPathfinding>>()
-        .ok()
-        .and_then(|g| g.0.clone())
-    {
-        service.record_movement_hold(entity_id.inner(), hold);
-    }
-}
-
 /// How long path-following has been making no progress, as published by the
 /// steering strategy - and already frozen for the frames this AI published a
 /// hold for. Zero for an AI that isn't following a route.
@@ -275,7 +257,7 @@ fn path_stall_seconds(world: &World, entity_id: EntityId) -> f32 {
 
 /// Why this AI is standing still this frame, if it is. A door wait outranks a
 /// pivot: the AI can be doing both, and the door is what it is waiting on.
-fn movement_hold(door_wait_seconds: Option<f32>, pivoting: bool) -> MovementHold {
+fn hold_reason(door_wait_seconds: Option<f32>, pivoting: bool) -> MovementHold {
     if door_wait_seconds.is_some() {
         MovementHold::DoorWait
     } else if pivoting {
@@ -1002,30 +984,30 @@ impl AnimatedMonsterAI {
         // suppressed frame doesn't stretch it.
         self.frustration_cooldown =
             (self.frustration_cooldown - time.elapsed.as_secs_f32()).max(0.0);
-        if started_a_clip {
+        if started_a_clip || !door_wait_is_thwarting(door_wait_seconds) {
             return Effect::NoEffect;
         }
-        if !should_gesture_frustration(
-            door_wait_seconds,
-            self.frustration_cooldown,
-            chase_target_distance(world, entity_id),
-            self.current_behavior.borrow().scripted_state(),
-        ) {
-            return Effect::NoEffect;
+        let gesture = self.try_frustration_gesture(world, entity_id);
+        if !matches!(gesture, Effect::NoEffect) {
+            tracing::debug!(
+                "ai {:?} shows impatience at a door (waited {:?}s)",
+                entity_id,
+                door_wait_seconds
+            );
         }
-        self.frustration_cooldown = self.next_frustration_cooldown();
-        tracing::debug!(
-            "ai {:?} shows frustration (door wait: {:?}s)",
-            entity_id,
-            door_wait_seconds
-        );
-        frustration_gesture(entity_id)
+        gesture
     }
 
     /// The thwarted performance, if the shared limits allow it right now -
     /// arming the rate limit when it does. Every gesture path goes through
-    /// this or `update_frustration`, which applies the same limits.
+    /// here; `update_frustration` adds the suppression for a clip started
+    /// earlier in the same frame.
     fn try_frustration_gesture(&mut self, world: &World, entity_id: EntityId) -> Effect {
+        // The gesture PLAYS (it does not queue), so it would drop a pivot
+        // mid-turn and leave the AI held on a clip that is no longer running.
+        if self.turn_clip.is_some() {
+            return Effect::NoEffect;
+        }
         if !frustration_gesture_allowed(
             self.frustration_cooldown,
             chase_target_distance(world, entity_id),
@@ -1456,8 +1438,15 @@ impl Script for AnimatedMonsterAI {
         // through it, so heading, whiskers, crowd repel and the route itself
         // stay live while the creature stands.
         let door_wait_seconds = self.update_door_wait(world, entity_id, time);
+        // The pivot in flight, as of last frame: one started this frame is
+        // published on the next, and one ending is held a frame longer. Both
+        // edges cost a single 16 ms frame either way.
         let pivoting = self.turn_clip.is_some();
-        publish_movement_hold(world, entity_id, movement_hold(door_wait_seconds, pivoting));
+        super::ai_util::publish_movement_hold(
+            world,
+            entity_id,
+            hold_reason(door_wait_seconds, pivoting),
+        );
         let (steering_output, steering_effects) = self
             .current_behavior
             .borrow_mut()
@@ -1484,8 +1473,8 @@ impl Script for AnimatedMonsterAI {
         };
 
         // A pivot big enough to stop the body is played as an authored turn
-        // clip. Same gate as the frustration gesture: never over a scripted
-        // performance, and never while standing off from a door.
+        // clip - never over a scripted performance, and never while standing
+        // off from a door.
         let may_turn = self.current_behavior.borrow().is_locomotion()
             && self.current_behavior.borrow().scripted_state() != ScriptedState::Running
             && door_wait_seconds.is_none();
@@ -2521,10 +2510,10 @@ mod tests {
 
     #[test]
     fn a_door_wait_outranks_a_pivot_as_the_hold_reason() {
-        assert_eq!(movement_hold(None, false), MovementHold::None);
-        assert_eq!(movement_hold(None, true), MovementHold::Pivot);
+        assert_eq!(hold_reason(None, false), MovementHold::None);
+        assert_eq!(hold_reason(None, true), MovementHold::Pivot);
         // Both at once: the door is what the AI is actually waiting on.
-        assert_eq!(movement_hold(Some(0.2), true), MovementHold::DoorWait);
+        assert_eq!(hold_reason(Some(0.2), true), MovementHold::DoorWait);
     }
 
     #[test]
@@ -2887,30 +2876,15 @@ mod tests {
 
     #[test]
     fn frustration_needs_a_block() {
-        assert!(!should_gesture_frustration(
-            None,
-            0.0,
-            None,
-            ScriptedState::NotScripted
-        ));
-        assert!(should_gesture_frustration(
-            LONG_WAIT,
-            0.0,
-            None,
-            ScriptedState::NotScripted
-        ));
+        assert!(!door_wait_is_thwarting(None));
+        assert!(door_wait_is_thwarting(LONG_WAIT));
     }
 
     #[test]
     fn a_door_that_opens_promptly_draws_no_gesture() {
         // Every shipped sliding leaf clears in about half a second; an AI
         // that gestured at each one would dam the doorway behind it.
-        assert!(!should_gesture_frustration(
-            Some(0.5),
-            0.0,
-            None,
-            ScriptedState::NotScripted
-        ));
+        assert!(!door_wait_is_thwarting(Some(0.5)));
     }
 
     /// USER DECISION (2026-09-05): impatience is a door gesture only. On a
@@ -2918,22 +2892,29 @@ mod tests {
     /// root motion only makes the standstill longer.
     #[test]
     fn a_sustained_stall_draws_no_gesture() {
-        let mut monster = AnimatedMonsterAI::new();
         let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
         // Nothing is holding this AI at a door, however long its route has
         // been going nowhere.
+        let mut stalled = AnimatedMonsterAI::new();
         assert!(matches!(
-            monster.update_frustration(&world, entity_id, None, false, &tick()),
+            stalled.update_frustration(&world, entity_id, None, false, &tick()),
             Effect::NoEffect
+        ));
+        // The same AI, kept waiting at a door instead: this is the one block
+        // that still draws the performance, so the case above is a decision,
+        // not a gesture path that has stopped working.
+        let mut waiting = AnimatedMonsterAI::new();
+        assert!(matches!(
+            waiting.update_frustration(&world, entity_id, LONG_WAIT, false, &tick()),
+            Effect::PlayAnimationBySchema { .. }
         ));
     }
 
     #[test]
     fn the_door_wait_can_never_outlast_the_path_follower_patience() {
-        // A held body makes no progress toward its waypoint. If the hold
-        // could outlast the stall window, the stall system would blacklist
-        // the very crossing this AI just opened and route it back away from
-        // the door.
+        // Belt and braces beside the hold: a wait that could outlast the
+        // stall window would be relying on the hold alone to keep the
+        // crossing the AI just opened off the blocked list.
         assert!(DOOR_WAIT_TIMEOUT < crate::scripts::ai::steering::STALL_SECONDS);
     }
 
@@ -2945,8 +2926,7 @@ mod tests {
 
     #[test]
     fn frustration_is_rate_limited() {
-        assert!(!should_gesture_frustration(
-            LONG_WAIT,
+        assert!(!frustration_gesture_allowed(
             3.0,
             None,
             ScriptedState::NotScripted
@@ -2957,22 +2937,27 @@ mod tests {
     fn frustration_is_silent_within_reach_of_the_target() {
         let inside = Some(MELEE_ATTACK_RANGE * 0.5);
         let outside = Some(MELEE_ATTACK_RANGE * 2.0);
-        assert!(!should_gesture_frustration(
-            LONG_WAIT,
+        assert!(!frustration_gesture_allowed(
             0.0,
             inside,
             ScriptedState::NotScripted
         ));
-        assert!(should_gesture_frustration(
-            LONG_WAIT,
+        assert!(frustration_gesture_allowed(
             0.0,
             outside,
             ScriptedState::NotScripted
         ));
     }
 
-    /// The locked-door give-up plays the same one performance as the door
-    /// wait, and used to play it whatever either path had already spent.
+    #[test]
+    fn frustration_never_interrupts_an_authored_performance() {
+        assert!(!frustration_gesture_allowed(
+            0.0,
+            None,
+            ScriptedState::Running
+        ));
+    }
+
     #[test]
     fn the_locked_door_give_up_respects_the_shared_limit() {
         let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
@@ -2985,16 +2970,6 @@ mod tests {
         assert!(matches!(
             monster.try_frustration_gesture(&world, entity_id),
             Effect::NoEffect
-        ));
-    }
-
-    #[test]
-    fn frustration_never_interrupts_an_authored_performance() {
-        assert!(!should_gesture_frustration(
-            LONG_WAIT,
-            0.0,
-            None,
-            ScriptedState::Running
         ));
     }
 

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -227,7 +227,15 @@ impl PatrolBehavior {
 
     /// Whether the AI has failed to cover ground for PATROL_STALL_SECONDS.
     /// Re-anchors (and reports false) as soon as it moves.
-    fn stalled(&mut self, position: Vector3<f32>, time: &Time) -> bool {
+    ///
+    /// A `held` frame is a standstill the AI chose (a door leaf still crossing
+    /// the doorway, an authored pivot) and freezes this clock exactly as it
+    /// freezes the path follower's: the route is not to blame for seconds the
+    /// AI spent standing on purpose, and a pivot may last most of this window.
+    fn stalled(&mut self, position: Vector3<f32>, held: bool, time: &Time) -> bool {
+        if held {
+            return false;
+        }
         let moved = self
             .stall_anchor
             .map(|anchor| {
@@ -304,7 +312,11 @@ impl Behavior for PatrolBehavior {
                 );
                 let temporary_until = self.steering_strategy.goal_unreachable_until();
                 patrol_effects.push(self.give_up_on_point(world, entity_id, temporary_until));
-            } else if self.stalled(position, time) {
+            } else if self.stalled(
+                position,
+                ai_util::movement_hold(world, entity_id).is_holding(),
+                time,
+            ) {
                 // Going nowhere: give up on this point and try the next one.
                 // A wedge is a fact about the body's current spot, not about
                 // the route, so the next leg usually walks straight out of it.
@@ -370,6 +382,7 @@ impl Behavior for PatrolBehavior {
 mod tests {
     use super::*;
     use crate::runtime_props::RuntimePropTransform;
+    use crate::time::Time;
     use cgmath::{Matrix4, vec3};
     use dark::properties::{Link, Links, ToLink, WrappedEntityId};
     use shipyard::{Get, ViewMut};
@@ -910,5 +923,39 @@ mod tests {
                 target: None,
             } if *entity_id == creature
         )));
+    }
+}
+
+#[cfg(test)]
+mod stall_tests {
+    use super::*;
+    use cgmath::vec3;
+
+    fn frame() -> Time {
+        Time {
+            elapsed: std::time::Duration::from_millis(100),
+            total: std::time::Duration::from_millis(100),
+        }
+    }
+
+    /// A pivot holds the body still for most of this window (a turn clip may
+    /// run 4 s), and the AI is steered right through it - so without the hold
+    /// the patrol would retire the very point it is turning toward.
+    #[test]
+    fn a_held_patroller_never_stalls() {
+        let here = vec3(0.0, 0.0, 0.0);
+        let frames = (PATROL_STALL_SECONDS / 0.1).ceil() as u32 + 2;
+
+        let mut control = PatrolBehavior::new(EntityId::dead(), here);
+        let mut stalled = false;
+        for _ in 0..frames {
+            stalled |= control.stalled(here, false, &frame());
+        }
+        assert!(stalled, "control: standing still IS a patrol stall");
+
+        let mut held = PatrolBehavior::new(EntityId::dead(), here);
+        for _ in 0..frames {
+            assert!(!held.stalled(here, true, &frame()));
+        }
     }
 }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -7,7 +7,8 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 use crate::{
     mission::{GlobalAsyncPathfinding, GlobalPathfinding},
     pathfinding::{
-        AiPathOutcome, PathfindingFrameBudget, PathfindingService, async_queries::PathQueryRequest,
+        AiPathOutcome, MovementHold, PathfindingFrameBudget, PathfindingService,
+        async_queries::PathQueryRequest,
     },
     physics::PhysicsWorld,
     scripts::{Effect, ai::ai_util},
@@ -206,6 +207,61 @@ impl PathFollowSteeringStrategy {
         self.next_waypoint = 0;
         self.path_goal = None;
         self.reset_stall();
+    }
+
+    /// Advance - or freeze - the two no-progress clocks for this frame, and
+    /// answer whether the displacement watchdog has fired.
+    ///
+    /// A hold is a standstill the AI CHOSE (a door leaf still crossing the
+    /// doorway, an authored pivot): it ends by itself, so neither clock moves
+    /// through it and the held seconds cannot spend the patience kept for a
+    /// real wedge. Only the accounting pauses - the caller keeps steering, so
+    /// heading, whiskers and crowd repel stay live through the hold.
+    fn advance_stall_clocks(
+        &mut self,
+        hold: MovementHold,
+        position: Vector3<f32>,
+        distance: f32,
+        elapsed: f32,
+    ) -> bool {
+        if hold.is_holding() {
+            // Both clocks freeze where they are; a body that has never been
+            // anchored is anchored now, so the watchdog starts measuring from
+            // where the hold ends rather than from the origin.
+            self.displacement_anchor.get_or_insert((position, 0.0));
+            return false;
+        }
+        if self.next_waypoint != self.stall_waypoint
+            || distance < self.stall_best - STALL_PROGRESS_EPSILON
+        {
+            self.stall_waypoint = self.next_waypoint;
+            self.stall_best = distance;
+            self.stall_seconds = 0.0;
+        } else {
+            self.stall_seconds += elapsed;
+        }
+        // Displacement watchdog: micro-sliding around a blocking capsule can
+        // reset the waypoint-progress check above forever while the body
+        // stays put - fall back to net displacement
+        match self.displacement_anchor {
+            Some((anchor, _)) if xz_distance(position, anchor) >= DISPLACEMENT_STALL_DISTANCE => {
+                self.displacement_anchor = Some((position, 0.0));
+                // Real movement: the next stall (if any) is a fresh incident,
+                // not a continuation of a pinned body
+                self.last_stall_position = None;
+                self.stall_escalations = 0;
+                false
+            }
+            Some((anchor, age)) => {
+                let age = age + elapsed;
+                self.displacement_anchor = Some((anchor, age));
+                age >= DISPLACEMENT_STALL_SECONDS
+            }
+            None => {
+                self.displacement_anchor = Some((position, 0.0));
+                false
+            }
+        }
     }
 
     fn reset_stall(&mut self) {
@@ -511,37 +567,12 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // the path so the next re-path - or wander goal - starts fresh
         // instead of pushing into the obstacle forever.
         let distance = xz_distance(position, waypoint);
-        if self.next_waypoint != self.stall_waypoint
-            || distance < self.stall_best - STALL_PROGRESS_EPSILON
-        {
-            self.stall_waypoint = self.next_waypoint;
-            self.stall_best = distance;
-            self.stall_seconds = 0.0;
-        } else {
-            self.stall_seconds += time.elapsed.as_secs_f32();
-        }
-        // Displacement watchdog: micro-sliding around a blocking capsule can
-        // reset the waypoint-progress check above forever while the body
-        // stays put - fall back to net displacement
-        let displaced_stall = match self.displacement_anchor {
-            Some((anchor, _)) if xz_distance(position, anchor) >= DISPLACEMENT_STALL_DISTANCE => {
-                self.displacement_anchor = Some((position, 0.0));
-                // Real movement: the next stall (if any) is a fresh incident,
-                // not a continuation of a pinned body
-                self.last_stall_position = None;
-                self.stall_escalations = 0;
-                false
-            }
-            Some((anchor, age)) => {
-                let age = age + time.elapsed.as_secs_f32();
-                self.displacement_anchor = Some((anchor, age));
-                age >= DISPLACEMENT_STALL_SECONDS
-            }
-            None => {
-                self.displacement_anchor = Some((position, 0.0));
-                false
-            }
-        };
+        let displaced_stall = self.advance_stall_clocks(
+            service.movement_hold(entity_id.inner()),
+            position,
+            distance,
+            time.elapsed.as_secs_f32(),
+        );
         {
             if self.stall_seconds >= STALL_SECONDS || displaced_stall {
                 // Remember the crossing we could not traverse (TTL'd, per
@@ -1020,6 +1051,77 @@ fn pick_wander_goal(
 mod tests {
     use super::*;
     use cgmath::vec3;
+
+    /// Stand `seconds` in one spot, `distance` from the waypoint, under
+    /// `hold`. Answers whether the displacement watchdog fired.
+    fn stand_still(
+        follower: &mut PathFollowSteeringStrategy,
+        hold: MovementHold,
+        seconds: f32,
+    ) -> bool {
+        let mut displaced = false;
+        for _ in 0..(seconds / 0.1).round() as u32 {
+            displaced |= follower.advance_stall_clocks(hold, vec3(0.0, 0.0, 0.0), 5.0, 0.1);
+        }
+        displaced
+    }
+
+    /// The whole point of a hold: a door leaf the AI is standing off from is
+    /// not a wedge, so the seconds it costs must not spend the patience the
+    /// follower keeps for one. Waiting is bounded well under the stall window,
+    /// but the clock the wait would land in already contains time.
+    #[test]
+    fn a_door_wait_never_advances_the_stall_clock() {
+        // Unheld, standing still IS the stall the follower is looking for.
+        let mut follower = PathFollowSteeringStrategy::to_point(vec3(5.0, 0.0, 0.0));
+        let displaced = stand_still(
+            &mut follower,
+            MovementHold::None,
+            DISPLACEMENT_STALL_SECONDS + 1.0,
+        );
+        assert!(follower.stall_seconds >= STALL_SECONDS, "control");
+        assert!(displaced, "control: the displacement watchdog fires too");
+
+        let mut follower = PathFollowSteeringStrategy::to_point(vec3(5.0, 0.0, 0.0));
+        let displaced = stand_still(
+            &mut follower,
+            MovementHold::DoorWait,
+            DISPLACEMENT_STALL_SECONDS + 1.0,
+        );
+        assert_eq!(
+            follower.stall_seconds, 0.0,
+            "a door wait is not no-progress"
+        );
+        assert!(!displaced, "nor is it displacement");
+    }
+
+    /// A pivot is the other deliberate stop. It used to freeze the whole
+    /// behavior to keep out of the stall clock; now it only pauses the
+    /// accounting, and steering runs through it.
+    #[test]
+    fn a_pivot_never_advances_the_stall_clock() {
+        let mut follower = PathFollowSteeringStrategy::to_point(vec3(5.0, 0.0, 0.0));
+        let displaced = stand_still(
+            &mut follower,
+            MovementHold::Pivot,
+            DISPLACEMENT_STALL_SECONDS + 1.0,
+        );
+        assert_eq!(follower.stall_seconds, 0.0);
+        assert!(!displaced);
+    }
+
+    /// A hold pauses the clock, it does not reset it: seconds a real wedge
+    /// already banked are still there when the hold lifts.
+    #[test]
+    fn a_hold_leaves_the_stall_it_paused_where_it_found_it() {
+        let mut follower = PathFollowSteeringStrategy::to_point(vec3(5.0, 0.0, 0.0));
+        stand_still(&mut follower, MovementHold::None, 1.0);
+        let banked = follower.stall_seconds;
+        stand_still(&mut follower, MovementHold::DoorWait, 1.0);
+        assert!((follower.stall_seconds - banked).abs() < 1e-4);
+        stand_still(&mut follower, MovementHold::None, 1.0);
+        assert!(follower.stall_seconds > banked);
+    }
 
     #[test]
     fn advance_skips_reached_waypoints() {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -225,9 +225,9 @@ impl PathFollowSteeringStrategy {
         elapsed: f32,
     ) -> bool {
         if hold.is_holding() {
-            // Both clocks freeze where they are; a body that has never been
-            // anchored is anchored now, so the watchdog starts measuring from
-            // where the hold ends rather than from the origin.
+            // Both clocks freeze where they are. A body with no anchor yet
+            // takes one here, so the displacement watchdog resumes from where
+            // it stood rather than from wherever it is first seen moving.
             self.displacement_anchor.get_or_insert((position, 0.0));
             return false;
         }


### PR DESCRIPTION
An AI that stops **on purpose** — standing off from a door leaf still crossing the doorway (#1318), performing an authored turn clip (#1337) — was being handled twice by accident, and neither way was right.

- The door wait ran **after** the steer that reads the stall clock, so the seconds of a hold were already in the clock the wait was supposed to stay clear of. `DOOR_WAIT_TIMEOUT 2.5 < STALL_SECONDS 3.0` proves nothing when the counter it is compared against already contains time.
- A pivot avoided the same clock by **skipping the whole behavior update** — route, whiskers, crowd repel and all — for the length of the clip, just to stop progress accounting.

Now there is one explicit reason. The script publishes a `MovementHold` (`DoorWait`, `Pivot`, or `None`) **before** it steers, and the watchdogs answer by freezing their no-progress clocks while it is up. Nothing else pauses: the behavior is steered right through both holds, so heading, whiskers, crowd repel and the route stay live while the creature stands. A hold *pauses* the clock rather than resetting it — seconds a real wedge had already banked are still there when the hold lifts.

Two watchdogs read it: the path follower's waypoint-progress and displacement clocks (`advance_stall_clocks`), and `PatrolBehavior`'s own 5 s stall clock — which matters precisely because the behavior is no longer frozen: a 4 s turn clip would otherwise spend most of that window and retire the point the AI was turning toward.

**The impatience gesture is now a door gesture only** (user decision, 2026-09-05). It fits inside a wait the AI is already taking; on a stall it added seconds of standing still to a creature trying to get out of a wedge — measured on #1318's own door as ~3.3 s → ~6.6 s, which is a real responsiveness regression whatever it does for eventual reachability. The locked-door give-up keeps its performance, but now goes through the same rate limit, melee gate and scripted-performance gate as the wait (it used to play regardless of what either path had spent), and no longer fires over a pivot in flight.

The hold reason is readable over `GET /v1/ai/paths` (`movement_hold`), so a creature standing at a door is distinguishable from a wedged one — including by the reachability harness, whose `wedged` bucket is exactly this confusion.

Phase-2 item P2 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

## Tests

Negative-first — each new test was confirmed to fail on the pre-change behavior (hold ignored / pivot skipping the steer / give-up gesture unlimited):

- `a_door_wait_never_advances_the_stall_clock`, `a_pivot_never_advances_the_stall_clock`, `a_hold_leaves_the_stall_it_paused_where_it_found_it` (path follower).
- `a_held_patroller_never_stalls` (patrol watchdog).
- `a_pivot_no_longer_freezes_the_behavior` — a patroller standing on its point keeps advancing its route while a 10 s pivot plays.
- `a_door_wait_outranks_a_pivot_as_the_hold_reason`, `a_sustained_stall_draws_no_gesture` (with the door case beside it, so the gesture path is proved still live), `the_locked_door_give_up_respects_the_shared_limit` — which also covers the pivot gate: a turn clip in flight refuses the gesture and leaves the rate limit unarmed.
- `cargo test -p shock2vr`: 1437 passed.
- e2e (scoped to the changed behavior): `medsci2-doorjamb-chase` 2/2 twice; after the review fixes `medsci2-doorjamb-chase` 2/2 twice more, `patrol` 4/4, `medsci2-patrol-railing` 1/1.
- medsci1 `DebugForceChase` headless run: 17 door waits, every one resolved on leaf clearance in 0.02–1.45 s, none reaching `DOOR_WAIT_TIMEOUT` — #1318's hold semantics are intact.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

**Evidence correction.** `a_sustained_stall_draws_no_gesture` was not negative-first as first written: it built a world with no pathfinding service, so the “stalled” AI read zero stall seconds and the pre-change code would have kept silent for it too. It now publishes 10 s of no-progress on the channel the path follower writes, and asserts the stall is on the wire before asserting on the gesture — restoring the old stall branch makes it fail. The other claims were re-audited against the pre-change code and stand: the two follower clock tests carry a `MovementHold::None` control that does stall, the patrol one likewise, and `a_pivot_no_longer_freezes_the_behavior` fails on code that skipped the behavior update while a clip played.

## Review

`/xreview` (Claude + Codex). Codex: no findings. The de-dup pass and the Claude reviewer independently raised the same **High**: the patrol watchdog is a second no-progress clock the hold could not reach — fixed here, with a regression test. Also fixed from the review: the give-up gesture no longer stomps a pivot in flight; `update_frustration`'s tail folded into the one `try_frustration_gesture`; a comment that described an anchor the code doesn't take.

Noted, not changed: each AI now takes one extra mutex lock + map insert per frame to publish its hold (negligible on desktop; worth remembering for Quest), and a pivot's leading/trailing edge is published one 16 ms frame late.

## Restack note

This branch is on #1354, which is on #1353 — branched before `feat/ai-turn-clips`' final commit `a824d720`. That commit's `bar_pivot_while_stalled` uses `FRUSTRATION_STALL_SECONDS` and `path_stall_seconds`, both **deleted here** (dead once the stall gesture is gone). Whoever restacks #1353 onto that tip needs to bring them back for it — the failure is a loud compile error, not a silent one.

