### PR TITLE
fix(ai): probe the unstick nudge before taking it

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1555,7 +1555,9 @@ fn create_physics_representation_with_options(
     }
 }
 
-fn live_creature_shape(
+/// The collision shape a live creature is given: its authored sphere
+/// submodel radii where they exist, and the animation bounding box otherwise.
+pub fn live_creature_shape(
     creature_def: &crate::creature::CreatureDefinition,
     phys_type: Option<&PropPhysType>,
     dimensions: Option<&PropPhysDimensions>,

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -66,29 +66,50 @@ const CREATURE_DEFAULT_HEIGHT: f32 = 6.5 / SCALE_FACTOR;
 /// ...and the body radius to fall back on (half a human's 3.5-foot width)
 const CREATURE_DEFAULT_RADIUS: f32 = 1.75 / SCALE_FACTOR;
 
-/// The creature's height in world units. Fractions of it (rather than fixed
-/// feet) are what let the same reasoning work on a monkey and on a hybrid.
-pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
+/// The creature's own definition, or None when it has no `PropCreature`.
+fn creature_definition(
+    world: &World,
+    entity_id: EntityId,
+) -> Option<std::sync::Arc<crate::creature::CreatureDefinition>> {
     world
         .borrow::<View<PropCreature>>()
         .ok()
         .and_then(|v_creature| v_creature.get(entity_id).ok().map(|creature| creature.0))
         .and_then(crate::creature::get_creature_definition)
+}
+
+/// The creature's height in world units. Fractions of it (rather than fixed
+/// feet) are what let the same reasoning work on a monkey and on a hybrid.
+pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
+    creature_definition(world, entity_id)
         .map(|definition| definition.bounding_size.y)
         .unwrap_or(CREATURE_DEFAULT_HEIGHT)
 }
 
-/// The creature's body radius in world units - the half-width its capsule is
-/// built from (`live_creature_shape`'s fallback radius), so a probe asks for
-/// the room this creature actually occupies.
+/// The radius of the capsule this creature actually collides with - the same
+/// resolution its body is built from, authored sphere dimensions included, so
+/// a probe asks for the room the creature really occupies rather than for a
+/// bounding box it may be much narrower than.
 pub fn creature_radius(world: &World, entity_id: EntityId) -> f32 {
-    world
-        .borrow::<View<PropCreature>>()
-        .ok()
-        .and_then(|v_creature| v_creature.get(entity_id).ok().map(|creature| creature.0))
-        .and_then(crate::creature::get_creature_definition)
-        .map(|definition| definition.bounding_size.x.max(definition.bounding_size.z) / 2.0)
-        .unwrap_or(CREATURE_DEFAULT_RADIUS)
+    let Some(definition) = creature_definition(world, entity_id) else {
+        return CREATURE_DEFAULT_RADIUS;
+    };
+    let v_phys_type = world.borrow::<View<PropPhysType>>().ok();
+    let v_dimensions = world.borrow::<View<PropPhysDimensions>>().ok();
+    let shape = crate::mission::entity_creator::live_creature_shape(
+        &definition,
+        v_phys_type
+            .as_ref()
+            .and_then(|view| view.get(entity_id).ok()),
+        v_dimensions
+            .as_ref()
+            .and_then(|view| view.get(entity_id).ok()),
+    );
+    match shape {
+        crate::physics::PhysicsShape::Capsule { radius, .. } => radius,
+        crate::physics::PhysicsShape::Sphere(radius) => radius,
+        crate::physics::PhysicsShape::Cuboid(half_extents) => half_extents.x.max(half_extents.z),
+    }
 }
 
 pub fn get_position_and_forward(

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -63,6 +63,9 @@ pub fn random_binomial() -> f32 {
 /// Height to fall back on when the creature has no definition (world units)
 const CREATURE_DEFAULT_HEIGHT: f32 = 6.5 / SCALE_FACTOR;
 
+/// ...and the body radius to fall back on (half a human's 3.5-foot width)
+const CREATURE_DEFAULT_RADIUS: f32 = 1.75 / SCALE_FACTOR;
+
 /// The creature's height in world units. Fractions of it (rather than fixed
 /// feet) are what let the same reasoning work on a monkey and on a hybrid.
 pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
@@ -73,6 +76,19 @@ pub fn creature_height(world: &World, entity_id: EntityId) -> f32 {
         .and_then(crate::creature::get_creature_definition)
         .map(|definition| definition.bounding_size.y)
         .unwrap_or(CREATURE_DEFAULT_HEIGHT)
+}
+
+/// The creature's body radius in world units - the half-width its capsule is
+/// built from (`live_creature_shape`'s fallback radius), so a probe asks for
+/// the room this creature actually occupies.
+pub fn creature_radius(world: &World, entity_id: EntityId) -> f32 {
+    world
+        .borrow::<View<PropCreature>>()
+        .ok()
+        .and_then(|v_creature| v_creature.get(entity_id).ok().map(|creature| creature.0))
+        .and_then(crate::creature::get_creature_definition)
+        .map(|definition| definition.bounding_size.x.max(definition.bounding_size.z) / 2.0)
+        .unwrap_or(CREATURE_DEFAULT_RADIUS)
 }
 
 pub fn get_position_and_forward(

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, EuclideanSpace, Vector3, vec3, vec4};
+use cgmath::{Deg, EuclideanSpace, InnerSpace, Vector3, vec3, vec4};
 use dark::SCALE_FACTOR;
 use dark::mission::path_database::MovementBits;
 use rand::Rng;
@@ -81,15 +81,26 @@ const DISPLACEMENT_STALL_SECONDS: f32 = 4.0;
 /// break the equilibrium. A rare small pop beats a monster frozen forever
 /// (issue #481's terminal pocket).
 const UNSTICK_NUDGE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
-/// Room a nudge landing must have, and how far past it the traverse probe
-/// looks (2 Dark feet, about one body radius)
-const NUDGE_CLEARANCE: f32 = 2.0 / SCALE_FACTOR;
+/// Room a nudge landing must have to either side, and how far past it the
+/// traverse probe looks: a hybrid's own body radius (half of HUMAN_WIDTH,
+/// 3.5 Dark feet). Demanding more would refuse the doorways and jambs an
+/// unstick is most often needed in.
+const NUDGE_CLEARANCE: f32 = 1.75 / SCALE_FACTOR;
 /// How far below a nudge landing to look for a floor (8 Dark feet - more
 /// than a body's origin sits above its own floor)
 const NUDGE_FLOOR_PROBE: f32 = 8.0 / SCALE_FACTOR;
 /// ...and how far that floor may sit from the one the body is standing on
 /// (2 Dark feet, a step). A landing over a ledge or a stairwell is refused.
 const NUDGE_MAX_STEP: f32 = 2.0 / SCALE_FACTOR;
+/// Height of the second (knee) probe ray, as a fraction of how far the body's
+/// origin sits above its own floor - the same discrimination the whiskers
+/// make, without depending on a creature's authored dimensions.
+const NUDGE_KNEE_FRACTION: f32 = 0.35;
+/// A probe hit closer than this to its own origin means the ray STARTED
+/// inside a collider (the queries are solid), which a body embedded in
+/// geometry always does - and that body is exactly what the unstick is for,
+/// so such a reading blocks nothing.
+const NUDGE_EMBEDDED_DISTANCE: f32 = 0.1 / SCALE_FACTOR;
 /// How far past the stalled waypoint (XZ) to probe for the cell on the far
 /// side of the crossing when reporting a blocked link - just enough to step
 /// off the shared edge without skipping a narrow destination cell (0.5
@@ -700,9 +711,9 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     // are probed (see `probe_nudge`): an unchecked one aimed
                     // through a wall drops the body out of the level entirely.
                     // Candidates, best first - a step toward the retreat
-                    // point, then a step toward the middle of the cell the
-                    // body is in. Both are route ground, away from whatever
-                    // the body is pressed against.
+                    // point (the previous waypoint, or simply backwards when
+                    // there is none), then a step toward the middle of the
+                    // cell the body is in.
                     let cell = service.cell_from_position(position);
                     let step_toward = |target: Vector3<f32>| {
                         let len = xz_distance(target, position);
@@ -722,17 +733,25 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         .into_iter()
                         .flatten()
                         .filter_map(step_toward)
-                        .find(|candidate| {
+                        .find_map(|candidate| {
                             // A body ALREADY off the mesh is the case the
                             // unstick exists for - there is no cell to keep it
                             // in - but it still has to reach the landing and
                             // stand there, so only THIS check is waived.
                             let navigable =
-                                cell.is_none() || on_mesh(&service, *candidate).is_some();
-                            nudge_is_safe(
-                                &probe_nudge(physics, entity_id, position, *candidate, navigable),
-                                NUDGE_MAX_STEP,
-                            )
+                                cell.is_none() || on_mesh(&service, candidate).is_some();
+                            let probe =
+                                probe_nudge(physics, entity_id, position, candidate, navigable);
+                            // The candidate kept the body's own height, so a
+                            // landing whose floor is a step up would bury the
+                            // capsule in it: ride the floor difference.
+                            nudge_is_safe(&probe).then(|| {
+                                Vector3::new(
+                                    candidate.x,
+                                    candidate.y + probe.floor_step.unwrap_or(0.0),
+                                    candidate.z,
+                                )
+                            })
                         });
                     match landing {
                         Some(landing) => {
@@ -934,17 +953,20 @@ struct NudgeProbe {
 
 /// A nudge candidate is only taken when every probe passes and its floor is
 /// within a step of the body's own.
-fn nudge_is_safe(probe: &NudgeProbe, max_step: f32) -> bool {
+fn nudge_is_safe(probe: &NudgeProbe) -> bool {
     probe.navigable
         && probe.path_clear
         && probe.clearance
-        && probe.floor_step.is_some_and(|step| step.abs() <= max_step)
+        && probe
+            .floor_step
+            .is_some_and(|step| step.abs() <= NUDGE_MAX_STEP)
 }
 
 /// Probe a nudge candidate: can the body get there, is there room, and is
-/// there a floor within a step? Rays at body-origin height, the way the
-/// whiskers probe - a nudge is only two feet, so a wall across that span
-/// crosses the body's own center.
+/// there a floor within a step? Rays go at the body's origin AND at knee
+/// height - a low slab (a railing, a kerb) passes under a single center ray,
+/// the same reason the whiskers probe two heights. Knee height is derived
+/// from the floor each end actually has, so it is never underground.
 fn probe_nudge(
     physics: &PhysicsWorld,
     entity_id: EntityId,
@@ -959,31 +981,56 @@ fn probe_nudge(
         - InternalCollisionGroups::PLAYER
         - InternalCollisionGroups::ACTOR;
     let cast = |origin: Vector3<f32>, direction: Vector3<f32>, distance: f32| {
-        physics.ray_cast2_as_actor(
-            vec3_to_point3(origin),
-            direction,
-            distance,
-            groups,
-            Some(entity_id),
-            true,
-        )
+        physics
+            .ray_cast2_as_actor(
+                vec3_to_point3(origin),
+                direction,
+                distance,
+                groups,
+                Some(entity_id),
+                true,
+            )
+            .filter(|hit| {
+                (hit.hit_point - vec3_to_point3(origin)).magnitude() > NUDGE_EMBEDDED_DISTANCE
+            })
     };
-    let distance = xz_distance(to, from);
-    let direction = vec3((to.x - from.x) / distance, 0.0, (to.z - from.z) / distance);
-    let side = vec3(-direction.z, 0.0, direction.x);
     let floor = |at: Vector3<f32>| {
         cast(at, vec3(0.0, -1.0, 0.0), NUDGE_FLOOR_PROBE).map(|hit| hit.hit_point.y)
     };
+    let standing_floor = floor(from);
+    let landing_floor = floor(to);
+    let heights = |at: Vector3<f32>, floor_y: Option<f32>| {
+        let knee = floor_y
+            .map(|floor_y| floor_y + (at.y - floor_y) * NUDGE_KNEE_FRACTION)
+            .unwrap_or(at.y);
+        [at, Vector3::new(at.x, knee, at.z)]
+    };
+    let distance = xz_distance(to, from);
+    if distance <= NUDGE_EMBEDDED_DISTANCE {
+        // Nowhere to go: refuse rather than normalize a zero vector
+        return NudgeProbe {
+            navigable,
+            path_clear: false,
+            clearance: false,
+            floor_step: None,
+        };
+    }
+    let direction = vec3((to.x - from.x) / distance, 0.0, (to.z - from.z) / distance);
+    let side = vec3(-direction.z, 0.0, direction.x);
     NudgeProbe {
         navigable,
         // Out PAST the landing by the body's own room, so a wall just beyond
         // it refuses the nudge as well
-        path_clear: cast(from, direction, distance + NUDGE_CLEARANCE).is_none(),
-        clearance: [side, -side]
+        path_clear: heights(from, standing_floor)
             .into_iter()
-            .all(|direction| cast(to, direction, NUDGE_CLEARANCE).is_none()),
-        floor_step: floor(to)
-            .zip(floor(from))
+            .all(|origin| cast(origin, direction, distance + NUDGE_CLEARANCE).is_none()),
+        clearance: heights(to, landing_floor).into_iter().all(|origin| {
+            [side, -side]
+                .into_iter()
+                .all(|direction| cast(origin, direction, NUDGE_CLEARANCE).is_none())
+        }),
+        floor_step: landing_floor
+            .zip(standing_floor)
             .map(|(landing, standing)| landing - standing),
     }
 }
@@ -1437,57 +1484,46 @@ mod tests {
 
     #[test]
     fn a_clear_supported_landing_is_taken() {
-        assert!(nudge_is_safe(&safe_probe(), NUDGE_MAX_STEP));
-    }
-
-    #[test]
-    fn a_landing_behind_a_wall_is_refused() {
-        let probe = NudgeProbe {
-            path_clear: false,
-            ..safe_probe()
-        };
-        assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
-    }
-
-    #[test]
-    fn a_landing_without_room_is_refused() {
-        let probe = NudgeProbe {
-            clearance: false,
-            ..safe_probe()
-        };
-        assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
-    }
-
-    #[test]
-    fn a_landing_over_a_ledge_is_refused() {
-        // No floor within reach at all, and a floor a whole storey down
-        for floor_step in [None, Some(-10.0 / SCALE_FACTOR)] {
-            let probe = NudgeProbe {
-                floor_step,
-                ..safe_probe()
-            };
-            assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
-        }
-    }
-
-    #[test]
-    fn a_landing_a_step_up_or_down_is_still_taken() {
+        assert!(nudge_is_safe(&safe_probe()));
+        // ...including one a step up or down, which the nudge rides
         for floor_step in [NUDGE_MAX_STEP, -NUDGE_MAX_STEP] {
-            let probe = NudgeProbe {
+            assert!(nudge_is_safe(&NudgeProbe {
                 floor_step: Some(floor_step),
                 ..safe_probe()
-            };
-            assert!(nudge_is_safe(&probe, NUDGE_MAX_STEP));
+            }));
         }
     }
 
     #[test]
-    fn a_landing_off_the_mesh_is_refused() {
-        let probe = NudgeProbe {
-            navigable: false,
-            ..safe_probe()
-        };
-        assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
+    fn every_failed_probe_refuses_the_nudge() {
+        // A nudge is a teleport: off the mesh, through a wall, into a body's
+        // width of geometry, over a ledge, or into thin air are all refusals,
+        // and the body grinds on until the re-path frees it instead.
+        let refusals = [
+            NudgeProbe {
+                navigable: false,
+                ..safe_probe()
+            },
+            NudgeProbe {
+                path_clear: false,
+                ..safe_probe()
+            },
+            NudgeProbe {
+                clearance: false,
+                ..safe_probe()
+            },
+            NudgeProbe {
+                floor_step: Some(-10.0 / SCALE_FACTOR),
+                ..safe_probe()
+            },
+            NudgeProbe {
+                floor_step: None,
+                ..safe_probe()
+            },
+        ];
+        for probe in &refusals {
+            assert!(!nudge_is_safe(probe));
+        }
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -81,26 +81,26 @@ const DISPLACEMENT_STALL_SECONDS: f32 = 4.0;
 /// break the equilibrium. A rare small pop beats a monster frozen forever
 /// (issue #481's terminal pocket).
 const UNSTICK_NUDGE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
-/// Room a nudge landing must have to either side, and how far past it the
-/// traverse probe looks: a hybrid's own body radius (half of HUMAN_WIDTH,
-/// 3.5 Dark feet). Demanding more would refuse the doorways and jambs an
-/// unstick is most often needed in.
-const NUDGE_CLEARANCE: f32 = 1.75 / SCALE_FACTOR;
 /// How far below a nudge landing to look for a floor (8 Dark feet - more
 /// than a body's origin sits above its own floor)
 const NUDGE_FLOOR_PROBE: f32 = 8.0 / SCALE_FACTOR;
 /// ...and how far that floor may sit from the one the body is standing on
 /// (2 Dark feet, a step). A landing over a ledge or a stairwell is refused.
 const NUDGE_MAX_STEP: f32 = 2.0 / SCALE_FACTOR;
-/// Height of the second (knee) probe ray, as a fraction of how far the body's
-/// origin sits above its own floor - the same discrimination the whiskers
-/// make, without depending on a creature's authored dimensions.
+/// Height of the second (knee) probe ray, below the body's origin, as a
+/// fraction of the creature's own height - the same fraction (and the same
+/// discrimination) the whiskers use, so a monkey's second ray is not put
+/// underground by a hybrid's offset.
 const NUDGE_KNEE_FRACTION: f32 = 0.35;
 /// A probe hit closer than this to its own origin means the ray STARTED
 /// inside a collider (the queries are solid), which a body embedded in
 /// geometry always does - and that body is exactly what the unstick is for,
-/// so such a reading blocks nothing.
+/// so the probe steps this far past such a reading and looks again.
 const NUDGE_EMBEDDED_DISTANCE: f32 = 0.1 / SCALE_FACTOR;
+/// How many such steps a probe takes before it gives up: 1.6 Dark feet of
+/// continuous embedding, past which the ray is reported embedded and the
+/// nudge refused rather than guessed at.
+const NUDGE_EMBEDDED_STEPS: usize = 16;
 /// How far past the stalled waypoint (XZ) to probe for the cell on the far
 /// side of the crossing when reporting a blocked link - just enough to step
 /// off the shared edge without skipping a narrow destination cell (0.5
@@ -740,18 +740,13 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                             // stand there, so only THIS check is waived.
                             let navigable =
                                 cell.is_none() || on_mesh(&service, candidate).is_some();
-                            let probe =
-                                probe_nudge(physics, entity_id, position, candidate, navigable);
-                            // The candidate kept the body's own height, so a
-                            // landing whose floor is a step up would bury the
-                            // capsule in it: ride the floor difference.
-                            nudge_is_safe(&probe).then(|| {
-                                Vector3::new(
-                                    candidate.x,
-                                    candidate.y + probe.floor_step.unwrap_or(0.0),
-                                    candidate.z,
-                                )
-                            })
+                            let probe = probe_nudge(
+                                world, physics, entity_id, position, candidate, navigable,
+                            );
+                            // The landing the probes were taken at - the
+                            // candidate riding the floor it lands on, so a
+                            // step up does not bury the capsule in it.
+                            nudge_is_safe(&probe).then_some(probe.landing)
                         });
                     match landing {
                         Some(landing) => {
@@ -946,9 +941,14 @@ struct NudgeProbe {
     path_clear: bool,
     /// The body has room to either side at the landing
     clearance: bool,
+    /// The landing has a creature's height of open space above its floor
+    headroom: bool,
     /// How far the landing's floor sits from the one the body stands on;
     /// None when either has no floor beneath it
     floor_step: Option<f32>,
+    /// The landing the probes were actually taken at: the candidate riding
+    /// the floor it lands on, which is where the body would stand.
+    landing: Vector3<f32>,
 }
 
 /// A nudge candidate is only taken when every probe passes and its floor is
@@ -957,17 +957,32 @@ fn nudge_is_safe(probe: &NudgeProbe) -> bool {
     probe.navigable
         && probe.path_clear
         && probe.clearance
+        && probe.headroom
         && probe
             .floor_step
             .is_some_and(|step| step.abs() <= NUDGE_MAX_STEP)
 }
 
+/// One probe ray's verdict.
+enum ProbeRay {
+    /// Nothing solid on the segment
+    Clear,
+    /// Something solid, at this reading
+    Blocked(crate::physics::RayCastResult),
+    /// The ray never got clear of whatever the body is embedded in
+    Embedded,
+}
+
 /// Probe a nudge candidate: can the body get there, is there room, and is
-/// there a floor within a step? Rays go at the body's origin AND at knee
-/// height - a low slab (a railing, a kerb) passes under a single center ray,
-/// the same reason the whiskers probe two heights. Knee height is derived
-/// from the floor each end actually has, so it is never underground.
+/// there a floor within a step? The probe is a set of rays, not a sweep of
+/// the body's capsule - the physics view a script holds offers no shape cast
+/// - so it is an approximation of clearance: two heights (origin and knee,
+/// as fractions of the creature's OWN height, so a monkey is not probed like
+/// a hybrid) each way at the creature's own body radius, plus a creature's
+/// height of headroom above the landing's floor. Geometry that fits between
+/// those rays is not seen.
 fn probe_nudge(
+    world: &World,
     physics: &PhysicsWorld,
     entity_id: EntityId,
     from: Vector3<f32>,
@@ -980,30 +995,65 @@ fn probe_nudge(
     let groups = InternalCollisionGroups::ALL_COLLIDABLE
         - InternalCollisionGroups::PLAYER
         - InternalCollisionGroups::ACTOR;
+    // The queries are solid, so a ray whose origin lies inside a collider -
+    // which a pinned body's does - reads a hit at zero range. Such a reading
+    // is not evidence of a clear segment and not evidence of an obstacle
+    // either: step past it and judge the REST of the segment, so a wall
+    // behind the prop the body is embedded in is still seen. Bounded, so a
+    // body buried deeper than NUDGE_EMBEDDED_STEPS of tolerance is reported
+    // embedded (and refuses the nudge) rather than looping.
     let cast = |origin: Vector3<f32>, direction: Vector3<f32>, distance: f32| {
-        physics
-            .ray_cast2_as_actor(
+        let mut origin = origin;
+        let mut remaining = distance;
+        for _ in 0..NUDGE_EMBEDDED_STEPS {
+            if remaining <= 0.0 {
+                return ProbeRay::Clear;
+            }
+            let Some(hit) = physics.ray_cast2_as_actor(
                 vec3_to_point3(origin),
                 direction,
-                distance,
+                remaining,
                 groups,
                 Some(entity_id),
                 true,
-            )
-            .filter(|hit| {
-                (hit.hit_point - vec3_to_point3(origin)).magnitude() > NUDGE_EMBEDDED_DISTANCE
-            })
+            ) else {
+                return ProbeRay::Clear;
+            };
+            let range = (hit.hit_point - vec3_to_point3(origin)).magnitude();
+            if range > NUDGE_EMBEDDED_DISTANCE {
+                return ProbeRay::Blocked(hit);
+            }
+            let advance = range + NUDGE_EMBEDDED_DISTANCE;
+            origin += direction * advance;
+            remaining -= advance;
+        }
+        ProbeRay::Embedded
     };
-    let floor = |at: Vector3<f32>| {
-        cast(at, vec3(0.0, -1.0, 0.0), NUDGE_FLOOR_PROBE).map(|hit| hit.hit_point.y)
+    let clear = |origin: Vector3<f32>, direction: Vector3<f32>, distance: f32| {
+        matches!(cast(origin, direction, distance), ProbeRay::Clear)
     };
+    let floor = |at: Vector3<f32>| match cast(at, vec3(0.0, -1.0, 0.0), NUDGE_FLOOR_PROBE) {
+        ProbeRay::Blocked(hit) => Some(hit.hit_point.y),
+        _ => None,
+    };
+    let height = ai_util::creature_height(world, entity_id);
+    let radius = ai_util::creature_radius(world, entity_id);
+    // The floors come FIRST: an accepted landing rides its own floor, so
+    // that - not the body's current height - is where clearance and headroom
+    // have to be measured.
     let standing_floor = floor(from);
     let landing_floor = floor(to);
-    let heights = |at: Vector3<f32>, floor_y: Option<f32>| {
-        let knee = floor_y
-            .map(|floor_y| floor_y + (at.y - floor_y) * NUDGE_KNEE_FRACTION)
-            .unwrap_or(at.y);
-        [at, Vector3::new(at.x, knee, at.z)]
+    let floor_step = landing_floor
+        .zip(standing_floor)
+        .map(|(landing, standing)| landing - standing);
+    let landing = Vector3::new(to.x, to.y + floor_step.unwrap_or(0.0), to.z);
+    // Origin and knee - a low slab (a railing, a kerb) passes under a single
+    // centre ray, the same reason the whiskers probe two heights.
+    let heights = |at: Vector3<f32>| {
+        [
+            at,
+            Vector3::new(at.x, at.y - height * NUDGE_KNEE_FRACTION, at.z),
+        ]
     };
     let distance = xz_distance(to, from);
     if distance <= NUDGE_EMBEDDED_DISTANCE {
@@ -1012,7 +1062,9 @@ fn probe_nudge(
             navigable,
             path_clear: false,
             clearance: false,
+            headroom: false,
             floor_step: None,
+            landing,
         };
     }
     let direction = vec3((to.x - from.x) / distance, 0.0, (to.z - from.z) / distance);
@@ -1021,17 +1073,23 @@ fn probe_nudge(
         navigable,
         // Out PAST the landing by the body's own room, so a wall just beyond
         // it refuses the nudge as well
-        path_clear: heights(from, standing_floor)
+        path_clear: heights(from)
             .into_iter()
-            .all(|origin| cast(origin, direction, distance + NUDGE_CLEARANCE).is_none()),
-        clearance: heights(to, landing_floor).into_iter().all(|origin| {
+            .all(|origin| clear(origin, direction, distance + radius)),
+        clearance: heights(landing).into_iter().all(|origin| {
             [side, -side]
                 .into_iter()
-                .all(|direction| cast(origin, direction, NUDGE_CLEARANCE).is_none())
+                .all(|direction| clear(origin, direction, radius))
         }),
-        floor_step: landing_floor
-            .zip(standing_floor)
-            .map(|(landing, standing)| landing - standing),
+        headroom: landing_floor.is_some_and(|floor_y| {
+            clear(
+                Vector3::new(landing.x, floor_y + NUDGE_EMBEDDED_DISTANCE, landing.z),
+                vec3(0.0, 1.0, 0.0),
+                height,
+            )
+        }),
+        floor_step,
+        landing,
     }
 }
 
@@ -1478,7 +1536,9 @@ mod tests {
             navigable: true,
             path_clear: true,
             clearance: true,
+            headroom: true,
             floor_step: Some(0.0),
+            landing: vec3(0.0, 0.0, 0.0),
         }
     }
 
@@ -1513,6 +1573,10 @@ mod tests {
                 ..safe_probe()
             },
             NudgeProbe {
+                headroom: false,
+                ..safe_probe()
+            },
+            NudgeProbe {
                 floor_step: Some(-10.0 / SCALE_FACTOR),
                 ..safe_probe()
             },
@@ -1524,6 +1588,149 @@ mod tests {
         for probe in &refusals {
             assert!(!nudge_is_safe(probe));
         }
+    }
+
+    /// Dark feet -> world units, so the synthetic probe worlds below read in
+    /// the same units the constants are written in.
+    fn ft(feet: f32) -> f32 {
+        feet / SCALE_FACTOR
+    }
+
+    /// A creature (the human schema a hybrid animates on) and an empty
+    /// physics world to build probe geometry in.
+    fn probe_world() -> (World, EntityId, PhysicsWorld) {
+        let mut world = World::new();
+        let creature = world.add_entity((dark::properties::PropCreature(0),));
+        (world, creature, PhysicsWorld::new())
+    }
+
+    /// Colliders only enter the broad phase on a step, and every query reads
+    /// the broad phase - so geometry added to a fresh world is invisible to
+    /// rays until this runs.
+    fn settle(physics: &mut PhysicsWorld) {
+        let mut player = physics.create_player(
+            vec3(ft(1000.0), ft(1000.0), ft(1000.0)),
+            EntityId::from_inner(1001).unwrap(),
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+    }
+
+    /// A static box, centre and half-extents in world units.
+    fn add_box(physics: &mut PhysicsWorld, center: Vector3<f32>, half: Vector3<f32>) {
+        use rapier3d::prelude::*;
+        let body = physics.create_static_body(
+            rapier3d::na::Isometry3::translation(center.x, center.y, center.z),
+            None,
+        );
+        physics.attach_collider(
+            body,
+            SharedShape::cuboid(half.x, half.y, half.z),
+            1.0,
+            crate::physics::CollisionGroup::entity(),
+        );
+    }
+
+    /// Floor slab with its top surface at `top_y`, over the whole test area.
+    fn add_floor(physics: &mut PhysicsWorld, top_y: f32) {
+        add_box(
+            physics,
+            vec3(0.0, top_y - ft(1.0), 0.0),
+            vec3(ft(50.0), ft(1.0), ft(50.0)),
+        );
+    }
+
+    /// The body's origin sits inside a prop (which is what being pinned
+    /// means), and a wall stands just past the landing. The solid queries
+    /// report the prop at zero range; discarding that reading as "embedded"
+    /// without looking past it hid the wall and called the trip clear.
+    #[test]
+    fn a_wall_behind_the_prop_the_body_is_embedded_in_refuses_the_nudge() {
+        let (world, creature, mut physics) = probe_world();
+        add_floor(&mut physics, 0.0);
+        let from = vec3(0.0, ft(3.0), 0.0);
+        let to = vec3(ft(2.0), ft(3.0), 0.0);
+        // The prop the body is embedded in, centred on its origin
+        add_box(&mut physics, from, vec3(ft(0.5), ft(0.5), ft(0.5)));
+        // ...and a wall a foot beyond the landing
+        add_box(
+            &mut physics,
+            vec3(ft(3.25), ft(5.0), 0.0),
+            vec3(ft(0.25), ft(5.0), ft(10.0)),
+        );
+
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+        assert!(
+            !probe.path_clear,
+            "the wall past the landing must be seen through the prop the body is embedded in"
+        );
+        assert!(!nudge_is_safe(&probe));
+    }
+
+    /// A landing a step up rides that floor - so the room it needs is the
+    /// room ABOVE the raised floor. Probing at the body's old height cleared
+    /// a landing whose ceiling the body would not fit under.
+    #[test]
+    fn a_step_up_under_an_overhang_refuses_the_nudge() {
+        let (world, creature, mut physics) = probe_world();
+        add_floor(&mut physics, 0.0);
+        // A half-foot step up, low enough that it does not block the trip
+        add_box(
+            &mut physics,
+            vec3(ft(6.0), ft(0.25), 0.0),
+            vec3(ft(5.0), ft(0.25), ft(10.0)),
+        );
+        // ...with an overhang four feet above it - short of a hybrid
+        add_box(
+            &mut physics,
+            vec3(ft(6.0), ft(5.5), 0.0),
+            vec3(ft(5.0), ft(1.0), ft(10.0)),
+        );
+        let from = vec3(0.0, ft(3.0), 0.0);
+        let to = vec3(ft(2.0), ft(3.0), 0.0);
+
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+
+        assert!(
+            probe.path_clear,
+            "the trip itself is clear - the refusal must come from the landing"
+        );
+        assert!(
+            !probe.headroom,
+            "a landing the body does not fit under must be refused"
+        );
+        assert!(!nudge_is_safe(&probe));
+    }
+
+    /// The positive control, and the landing the call site takes: open floor,
+    /// nothing in the way, and a landing that rides its own floor.
+    #[test]
+    fn an_open_landing_is_probed_safe_and_rides_its_floor() {
+        let (world, creature, mut physics) = probe_world();
+        add_floor(&mut physics, 0.0);
+        let from = vec3(0.0, ft(3.0), 0.0);
+        let to = vec3(ft(2.0), ft(3.0), 0.0);
+
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+        assert!(nudge_is_safe(&probe));
+        assert!((probe.landing.y - from.y).abs() < 1.0e-3);
+
+        // ...and half a foot up, the landing rises with the floor
+        add_box(
+            &mut physics,
+            vec3(ft(6.0), ft(0.25), 0.0),
+            vec3(ft(5.0), ft(0.25), ft(10.0)),
+        );
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+        assert!(nudge_is_safe(&probe));
+        assert!(
+            (probe.landing.y - (from.y + ft(0.5))).abs() < 1.0e-2,
+            "landing y {} did not ride the half-foot step",
+            probe.landing.y
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -87,21 +87,21 @@ const NUDGE_FLOOR_PROBE: f32 = 8.0 / SCALE_FACTOR;
 /// ...and how far that floor may sit from the one the body is standing on
 /// (2 Dark feet, a step). A landing over a ledge or a stairwell is refused.
 const NUDGE_MAX_STEP: f32 = 2.0 / SCALE_FACTOR;
-/// Height of the second (knee) probe ray, below the body's origin, as a
-/// fraction of the creature's own height - the same fraction (and the same
-/// discrimination) the whiskers use, so a monkey's second ray is not put
-/// underground by a hybrid's offset.
-const NUDGE_KNEE_FRACTION: f32 = 0.35;
+/// Height of the second (knee) probe ray, below the body's origin: the
+/// whiskers' own knee fraction, so the two cannot drift apart. A fraction of
+/// the creature's height rather than fixed feet, so a monkey's second ray is
+/// not put underground by a hybrid's offset.
+use super::whisker_avoidance::WHISKER_KNEE_FRACTION as NUDGE_KNEE_FRACTION;
 /// A probe hit closer than this to its own origin means the ray STARTED
 /// inside a collider (the queries are solid), which a body embedded in
 /// geometry always does - and that body is exactly what the unstick is for,
 /// so the probe steps this far past such a reading and looks again.
 const NUDGE_EMBEDDED_DISTANCE: f32 = 0.1 / SCALE_FACTOR;
-/// How many such steps a probe takes before it gives up: 6.4 Dark feet of
-/// continuous embedding - longer than any probe segment - past which the ray
-/// is reported embedded and the nudge refused rather than guessed at. The
-/// steps only happen while a ray is inside geometry, which only a pinned
-/// body's are, and a nudge is attempted about once a minute.
+/// A loop guard on that stepping, so a ray inside a pile of colliders cannot
+/// spin: a probe that has not got clear of geometry after this many steps
+/// reports embedded, which refuses the nudge. Stepping only happens inside
+/// geometry, which only a pinned body's rays are, and a nudge is attempted
+/// about once a minute.
 const NUDGE_EMBEDDED_STEPS: usize = 64;
 /// How far past the stalled waypoint (XZ) to probe for the cell on the far
 /// side of the crossing when reporting a blocked link - just enough to step
@@ -943,7 +943,8 @@ struct NudgeProbe {
     path_clear: bool,
     /// The body has room to either side at the landing
     clearance: bool,
-    /// The landing has a creature's height of open space above its floor
+    /// The landing has room above its floor for the body: a creature's
+    /// height, or at least as much as the spot it is leaving has
     headroom: bool,
     /// How far the landing's floor sits from the one the body stands on;
     /// None when either has no floor beneath it
@@ -1001,15 +1002,22 @@ fn probe_nudge(
     // which a pinned body's does - reads a hit at zero range. Such a reading
     // is not evidence of a clear segment and not evidence of an obstacle
     // either: step past it and judge the REST of the segment, so a wall
-    // behind the prop the body is embedded in is still seen. Bounded, so a
-    // body buried deeper than NUDGE_EMBEDDED_STEPS of tolerance is reported
-    // embedded (and refuses the nudge) rather than looping.
+    // behind the prop the body is embedded in is still seen. A segment spent
+    // entirely inside geometry is reported embedded (which refuses) rather
+    // than clear.
     let cast = |origin: Vector3<f32>, direction: Vector3<f32>, distance: f32| {
         let mut origin = origin;
         let mut remaining = distance;
-        for _ in 0..NUDGE_EMBEDDED_STEPS {
+        for step in 0..NUDGE_EMBEDDED_STEPS {
             if remaining <= 0.0 {
-                return ProbeRay::Clear;
+                // Stepping consumed the whole segment without ever getting
+                // clear of geometry: the body is inside something for the
+                // length of the probe, which is not a clear ray.
+                return if step == 0 {
+                    ProbeRay::Clear
+                } else {
+                    ProbeRay::Embedded
+                };
             }
             let Some(hit) = physics.ray_cast2_as_actor(
                 vec3_to_point3(origin),
@@ -1039,6 +1047,17 @@ fn probe_nudge(
         _ => None,
     };
     let height = ai_util::creature_height(world, entity_id);
+    // Open space above a floor, up to a creature's height (which is all the
+    // room that can matter).
+    let headroom_above = |x: f32, z: f32, floor_y: f32| match cast(
+        Vector3::new(x, floor_y + NUDGE_EMBEDDED_DISTANCE, z),
+        vec3(0.0, 1.0, 0.0),
+        height,
+    ) {
+        ProbeRay::Clear => height,
+        ProbeRay::Blocked(hit) => hit.hit_point.y - floor_y,
+        ProbeRay::Embedded => 0.0,
+    };
     let radius = ai_util::creature_radius(world, entity_id);
     // The floors come FIRST: an accepted landing rides its own floor, so
     // that - not the body's current height - is where clearance and headroom
@@ -1083,13 +1102,19 @@ fn probe_nudge(
                 .into_iter()
                 .all(|direction| clear(origin, direction, radius))
         }),
-        headroom: landing_floor.is_some_and(|floor_y| {
-            clear(
-                Vector3::new(landing.x, floor_y + NUDGE_EMBEDDED_DISTANCE, landing.z),
-                vec3(0.0, 1.0, 0.0),
-                height,
-            )
-        }),
+        // Comparative, not absolute: a nudge moves two feet, so the landing
+        // shares its ceiling with where the body already is. Demanding a full
+        // standing height would refuse every candidate for a body pinned in a
+        // low pocket - the population the unstick exists for - so the landing
+        // only has to be no tighter than the spot being left.
+        headroom: landing_floor.zip(standing_floor).is_some_and(
+            |(landing_floor, standing_floor)| {
+                let landing_room = headroom_above(landing.x, landing.z, landing_floor);
+                landing_room >= height
+                    || landing_room + NUDGE_EMBEDDED_DISTANCE
+                        >= headroom_above(from.x, from.z, standing_floor)
+            },
+        ),
         floor_step,
         landing,
     }
@@ -1632,6 +1657,16 @@ mod tests {
         );
     }
 
+    /// A half-foot step up, everywhere past a foot along +x. Low enough that
+    /// it does not block the trip itself.
+    fn add_step(physics: &mut PhysicsWorld) {
+        add_box(
+            physics,
+            vec3(ft(6.0), ft(0.25), 0.0),
+            vec3(ft(5.0), ft(0.25), ft(10.0)),
+        );
+    }
+
     /// Floor slab with its top surface at `top_y`, over the whole test area.
     fn add_floor(physics: &mut PhysicsWorld, top_y: f32) {
         add_box(
@@ -1670,19 +1705,80 @@ mod tests {
         assert!(!nudge_is_safe(&probe));
     }
 
+    /// The other half of the embedded case: with room beyond the prop, the
+    /// body the unstick exists for is still nudged. Seeing past the prop must
+    /// not turn into refusing everyone who is inside one.
+    #[test]
+    fn a_body_embedded_in_a_prop_is_still_nudged_when_the_way_is_clear() {
+        let (world, creature, mut physics) = probe_world();
+        add_floor(&mut physics, 0.0);
+        let from = vec3(0.0, ft(3.0), 0.0);
+        let to = vec3(ft(2.0), ft(3.0), 0.0);
+        add_box(&mut physics, from, vec3(ft(0.5), ft(2.5), ft(0.5)));
+
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+
+        assert!(nudge_is_safe(&probe));
+    }
+
+    /// Headroom is comparative: a body already pinned under something low
+    /// must still be nudgeable, or the unstick refuses the one population it
+    /// exists for. The landing only has to be no tighter than the spot left.
+    #[test]
+    fn a_landing_no_tighter_than_the_spot_left_is_still_nudged() {
+        let (world, creature, mut physics) = probe_world();
+        add_floor(&mut physics, 0.0);
+        // A ceiling too low for a hybrid, over the body AND the landing
+        add_box(
+            &mut physics,
+            vec3(0.0, ft(5.5), 0.0),
+            vec3(ft(50.0), ft(1.0), ft(50.0)),
+        );
+        let from = vec3(0.0, ft(3.0), 0.0);
+        let to = vec3(ft(2.0), ft(3.0), 0.0);
+
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+
+        assert!(probe.headroom);
+        assert!(nudge_is_safe(&probe));
+    }
+
+    /// ...and a body inside geometry for the WHOLE probe segment is not a
+    /// clear ray either - the stepping runs out of segment without ever
+    /// getting outside, which refuses.
+    #[test]
+    fn a_segment_that_never_leaves_the_geometry_refuses_the_nudge() {
+        let (world, creature, mut physics) = probe_world();
+        add_floor(&mut physics, 0.0);
+        let from = vec3(0.0, ft(3.0), 0.0);
+        let to = vec3(ft(2.0), ft(3.0), 0.0);
+        // One solid block swallowing the body, the trip and the landing
+        add_box(
+            &mut physics,
+            vec3(ft(1.0), ft(3.0), 0.0),
+            vec3(ft(6.0), ft(3.0), ft(6.0)),
+        );
+
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+
+        assert!(
+            !probe.path_clear,
+            "a segment spent entirely inside geometry is not a clear trip"
+        );
+        assert!(!nudge_is_safe(&probe));
+    }
+
     /// A landing a step up rides that floor - so the room it needs is the
-    /// room ABOVE the raised floor. Probing at the body's old height cleared
-    /// a landing whose ceiling the body would not fit under.
+    /// room ABOVE the raised floor. Nothing measured that before the headroom
+    /// probe, and a body does not fit where its head does not.
     #[test]
     fn a_step_up_under_an_overhang_refuses_the_nudge() {
         let (world, creature, mut physics) = probe_world();
         add_floor(&mut physics, 0.0);
-        // A half-foot step up, low enough that it does not block the trip
-        add_box(
-            &mut physics,
-            vec3(ft(6.0), ft(0.25), 0.0),
-            vec3(ft(5.0), ft(0.25), ft(10.0)),
-        );
+        add_step(&mut physics);
         // ...with an overhang four feet above it - short of a hybrid
         add_box(
             &mut physics,
@@ -1713,12 +1809,7 @@ mod tests {
     fn a_step_up_alongside_geometry_refuses_the_nudge() {
         let (world, creature, mut physics) = probe_world();
         add_floor(&mut physics, 0.0);
-        // The same half-foot step up
-        add_box(
-            &mut physics,
-            vec3(ft(6.0), ft(0.25), 0.0),
-            vec3(ft(5.0), ft(0.25), ft(10.0)),
-        );
+        add_step(&mut physics);
         // ...beside a slab that starts just above the body's current origin
         add_box(
             &mut physics,
@@ -1754,11 +1845,7 @@ mod tests {
         assert!((probe.landing.y - from.y).abs() < 1.0e-3);
 
         // ...and half a foot up, the landing rises with the floor
-        add_box(
-            &mut physics,
-            vec3(ft(6.0), ft(0.25), 0.0),
-            vec3(ft(5.0), ft(0.25), ft(10.0)),
-        );
+        add_step(&mut physics);
         settle(&mut physics);
         let probe = probe_nudge(&world, &physics, creature, from, to, true);
         assert!(nudge_is_safe(&probe));

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, EuclideanSpace, Vector3, vec4};
+use cgmath::{Deg, EuclideanSpace, Vector3, vec3, vec4};
 use dark::SCALE_FACTOR;
 use dark::mission::path_database::MovementBits;
 use rand::Rng;
@@ -10,7 +10,7 @@ use crate::{
         AiPathOutcome, MovementHold, PathfindingFrameBudget, PathfindingService,
         async_queries::PathQueryRequest,
     },
-    physics::PhysicsWorld,
+    physics::{InternalCollisionGroups, PhysicsWorld},
     scripts::{Effect, ai::ai_util},
     time::Time,
     util::vec3_to_point3,
@@ -81,6 +81,15 @@ const DISPLACEMENT_STALL_SECONDS: f32 = 4.0;
 /// break the equilibrium. A rare small pop beats a monster frozen forever
 /// (issue #481's terminal pocket).
 const UNSTICK_NUDGE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
+/// Room a nudge landing must have, and how far past it the traverse probe
+/// looks (2 Dark feet, about one body radius)
+const NUDGE_CLEARANCE: f32 = 2.0 / SCALE_FACTOR;
+/// How far below a nudge landing to look for a floor (8 Dark feet - more
+/// than a body's origin sits above its own floor)
+const NUDGE_FLOOR_PROBE: f32 = 8.0 / SCALE_FACTOR;
+/// ...and how far that floor may sit from the one the body is standing on
+/// (2 Dark feet, a step). A landing over a ledge or a stairwell is refused.
+const NUDGE_MAX_STEP: f32 = 2.0 / SCALE_FACTOR;
 /// How far past the stalled waypoint (XZ) to probe for the cell on the far
 /// side of the crossing when reporting a blocked link - just enough to step
 /// off the shared edge without skipping a narrow destination cell (0.5
@@ -687,80 +696,68 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     pinned
                 );
                 let unstick_effect = if pinned {
-                    let dir = retreat - position;
-                    let len = xz_distance(retreat, position);
-                    if len > 1e-3 {
-                        let step = UNSTICK_NUDGE_DISTANCE.min(len);
-                        let nudged = Vector3::new(
-                            position.x + dir.x / len * step,
-                            position.y,
-                            position.z + dir.z / len * step,
-                        );
-                        // Only onto navigable floor. A nudge is a teleport,
-                        // and one aimed through a wall drops the body out of
-                        // the level entirely (a creature a thousand units
-                        // from everything, once stalls became easier to
-                        // detect). When the retreat direction leaves the
-                        // mesh, step toward the current cell's middle
-                        // instead - still away from whatever the body is
-                        // pressed against, and known-navigable.
-                        let landing = on_mesh(&service, nudged)
-                            .or_else(|| {
-                                let cell = service.cell_from_position(position)?;
-                                let center = service.path_database.cells.get(cell as usize)?.center;
-                                let len = xz_distance(center, position);
-                                if len <= 1e-3 {
-                                    return None;
-                                }
-                                let step = UNSTICK_NUDGE_DISTANCE.min(len);
-                                on_mesh(
-                                    &service,
-                                    Vector3::new(
-                                        position.x + (center.x - position.x) / len * step,
-                                        position.y,
-                                        position.z + (center.z - position.z) / len * step,
-                                    ),
-                                )
-                            })
+                    // A nudge is a teleport, so both the trip and the landing
+                    // are probed (see `probe_nudge`): an unchecked one aimed
+                    // through a wall drops the body out of the level entirely.
+                    // Candidates, best first - a step toward the retreat
+                    // point, then a step toward the middle of the cell the
+                    // body is in. Both are route ground, away from whatever
+                    // the body is pressed against.
+                    let cell = service.cell_from_position(position);
+                    let step_toward = |target: Vector3<f32>| {
+                        let len = xz_distance(target, position);
+                        (len > 1e-3).then(|| {
+                            let step = UNSTICK_NUDGE_DISTANCE.min(len);
+                            Vector3::new(
+                                position.x + (target.x - position.x) / len * step,
+                                position.y,
+                                position.z + (target.z - position.z) / len * step,
+                            )
+                        })
+                    };
+                    let cell_center = cell
+                        .and_then(|cell| service.path_database.cells.get(cell as usize))
+                        .map(|cell| cell.center);
+                    let landing = [Some(retreat), cell_center]
+                        .into_iter()
+                        .flatten()
+                        .filter_map(step_toward)
+                        .find(|candidate| {
                             // A body ALREADY off the mesh is the case the
-                            // unstick exists for; refusing to move it is the
-                            // permanent freeze, not a safeguard. It cannot be
-                            // made worse by a step toward route ground.
-                            .or_else(|| {
-                                service
-                                    .cell_from_position(position)
-                                    .is_none()
-                                    .then_some(nudged)
-                            });
-                        match landing {
-                            Some(landing) => {
-                                tracing::debug!(
-                                    "ai {:?}: nudge {:.2},{:.2} -> {:.2},{:.2}",
-                                    entity_id,
-                                    position.x,
-                                    position.z,
-                                    landing.x,
-                                    landing.z
-                                );
-                                Effect::SetPositionRotation {
-                                    entity_id,
-                                    position: landing,
-                                    rotation: crate::util::get_rotation_from_transform(
-                                        world, entity_id,
-                                    ),
-                                }
-                            }
-                            None => {
-                                tracing::debug!(
-                                    "ai {:?}: nudge refused, no navigable landing",
-                                    entity_id
-                                );
-                                Effect::NoEffect
+                            // unstick exists for - there is no cell to keep it
+                            // in - but it still has to reach the landing and
+                            // stand there, so only THIS check is waived.
+                            let navigable =
+                                cell.is_none() || on_mesh(&service, *candidate).is_some();
+                            nudge_is_safe(
+                                &probe_nudge(physics, entity_id, position, *candidate, navigable),
+                                NUDGE_MAX_STEP,
+                            )
+                        });
+                    match landing {
+                        Some(landing) => {
+                            tracing::debug!(
+                                "ai {:?}: nudge {:.2},{:.2} -> {:.2},{:.2}",
+                                entity_id,
+                                position.x,
+                                position.z,
+                                landing.x,
+                                landing.z
+                            );
+                            Effect::SetPositionRotation {
+                                entity_id,
+                                position: landing,
+                                rotation: crate::util::get_rotation_from_transform(
+                                    world, entity_id,
+                                ),
                             }
                         }
-                    } else {
-                        tracing::debug!("ai {:?}: nudge refused, retreat is here", entity_id);
-                        Effect::NoEffect
+                        None => {
+                            // Re-path is the only recovery left; grinding in
+                            // place beats a body shoved through a wall.
+                            tracing::debug!("ai {:?}: nudge refused, no safe landing", entity_id);
+                            Effect::NoEffect
+                        }
                     }
                 } else {
                     Effect::NoEffect
@@ -918,6 +915,76 @@ fn answers_goal(
         (PathTarget::Point(point), None) => response_goal == *point,
         // Wander picks its goal inside this strategy, so any answer is its own
         (_, None) => true,
+    }
+}
+
+/// What one nudge candidate's probes found (see `probe_nudge`).
+struct NudgeProbe {
+    /// The landing is on a navigable cell (or the body is already off the
+    /// mesh, where no cell can be demanded of it)
+    navigable: bool,
+    /// Nothing solid stands between the body and the landing
+    path_clear: bool,
+    /// The body has room to either side at the landing
+    clearance: bool,
+    /// How far the landing's floor sits from the one the body stands on;
+    /// None when either has no floor beneath it
+    floor_step: Option<f32>,
+}
+
+/// A nudge candidate is only taken when every probe passes and its floor is
+/// within a step of the body's own.
+fn nudge_is_safe(probe: &NudgeProbe, max_step: f32) -> bool {
+    probe.navigable
+        && probe.path_clear
+        && probe.clearance
+        && probe.floor_step.is_some_and(|step| step.abs() <= max_step)
+}
+
+/// Probe a nudge candidate: can the body get there, is there room, and is
+/// there a floor within a step? Rays at body-origin height, the way the
+/// whiskers probe - a nudge is only two feet, so a wall across that span
+/// crosses the body's own center.
+fn probe_nudge(
+    physics: &PhysicsWorld,
+    entity_id: EntityId,
+    from: Vector3<f32>,
+    to: Vector3<f32>,
+    navigable: bool,
+) -> NudgeProbe {
+    // Static geometry and props, not living bodies: being pressed against a
+    // neighbour is exactly what the unstick exists for, and its capsule is
+    // not a wall.
+    let groups = InternalCollisionGroups::ALL_COLLIDABLE
+        - InternalCollisionGroups::PLAYER
+        - InternalCollisionGroups::ACTOR;
+    let cast = |origin: Vector3<f32>, direction: Vector3<f32>, distance: f32| {
+        physics.ray_cast2_as_actor(
+            vec3_to_point3(origin),
+            direction,
+            distance,
+            groups,
+            Some(entity_id),
+            true,
+        )
+    };
+    let distance = xz_distance(to, from);
+    let direction = vec3((to.x - from.x) / distance, 0.0, (to.z - from.z) / distance);
+    let side = vec3(-direction.z, 0.0, direction.x);
+    let floor = |at: Vector3<f32>| {
+        cast(at, vec3(0.0, -1.0, 0.0), NUDGE_FLOOR_PROBE).map(|hit| hit.hit_point.y)
+    };
+    NudgeProbe {
+        navigable,
+        // Out PAST the landing by the body's own room, so a wall just beyond
+        // it refuses the nudge as well
+        path_clear: cast(from, direction, distance + NUDGE_CLEARANCE).is_none(),
+        clearance: [side, -side]
+            .into_iter()
+            .all(|direction| cast(to, direction, NUDGE_CLEARANCE).is_none()),
+        floor_step: floor(to)
+            .zip(floor(from))
+            .map(|(landing, standing)| landing - standing),
     }
 }
 
@@ -1356,6 +1423,71 @@ mod tests {
         // reached by standing beneath it
         let path = vec![vec3(0.0, 5.0, 0.0), vec3(10.0, 5.0, 0.0)];
         assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 0);
+    }
+
+    /// A safe landing: on the mesh, reachable, roomy, level floor.
+    fn safe_probe() -> NudgeProbe {
+        NudgeProbe {
+            navigable: true,
+            path_clear: true,
+            clearance: true,
+            floor_step: Some(0.0),
+        }
+    }
+
+    #[test]
+    fn a_clear_supported_landing_is_taken() {
+        assert!(nudge_is_safe(&safe_probe(), NUDGE_MAX_STEP));
+    }
+
+    #[test]
+    fn a_landing_behind_a_wall_is_refused() {
+        let probe = NudgeProbe {
+            path_clear: false,
+            ..safe_probe()
+        };
+        assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
+    }
+
+    #[test]
+    fn a_landing_without_room_is_refused() {
+        let probe = NudgeProbe {
+            clearance: false,
+            ..safe_probe()
+        };
+        assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
+    }
+
+    #[test]
+    fn a_landing_over_a_ledge_is_refused() {
+        // No floor within reach at all, and a floor a whole storey down
+        for floor_step in [None, Some(-10.0 / SCALE_FACTOR)] {
+            let probe = NudgeProbe {
+                floor_step,
+                ..safe_probe()
+            };
+            assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
+        }
+    }
+
+    #[test]
+    fn a_landing_a_step_up_or_down_is_still_taken() {
+        for floor_step in [NUDGE_MAX_STEP, -NUDGE_MAX_STEP] {
+            let probe = NudgeProbe {
+                floor_step: Some(floor_step),
+                ..safe_probe()
+            };
+            assert!(nudge_is_safe(&probe, NUDGE_MAX_STEP));
+        }
+    }
+
+    #[test]
+    fn a_landing_off_the_mesh_is_refused() {
+        let probe = NudgeProbe {
+            navigable: false,
+            ..safe_probe()
+        };
+        assert!(!nudge_is_safe(&probe, NUDGE_MAX_STEP));
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -97,10 +97,12 @@ const NUDGE_KNEE_FRACTION: f32 = 0.35;
 /// geometry always does - and that body is exactly what the unstick is for,
 /// so the probe steps this far past such a reading and looks again.
 const NUDGE_EMBEDDED_DISTANCE: f32 = 0.1 / SCALE_FACTOR;
-/// How many such steps a probe takes before it gives up: 1.6 Dark feet of
-/// continuous embedding, past which the ray is reported embedded and the
-/// nudge refused rather than guessed at.
-const NUDGE_EMBEDDED_STEPS: usize = 16;
+/// How many such steps a probe takes before it gives up: 6.4 Dark feet of
+/// continuous embedding - longer than any probe segment - past which the ray
+/// is reported embedded and the nudge refused rather than guessed at. The
+/// steps only happen while a ray is inside geometry, which only a pinned
+/// body's are, and a nudge is attempted about once a minute.
+const NUDGE_EMBEDDED_STEPS: usize = 64;
 /// How far past the stalled waypoint (XZ) to probe for the cell on the far
 /// side of the crossing when reporting a blocked link - just enough to step
 /// off the shared edge without skipping a narrow destination cell (0.5
@@ -1649,8 +1651,9 @@ mod tests {
         add_floor(&mut physics, 0.0);
         let from = vec3(0.0, ft(3.0), 0.0);
         let to = vec3(ft(2.0), ft(3.0), 0.0);
-        // The prop the body is embedded in, centred on its origin
-        add_box(&mut physics, from, vec3(ft(0.5), ft(0.5), ft(0.5)));
+        // The prop the body is embedded in, centred on its origin and deep
+        // enough that BOTH probe heights start inside it
+        add_box(&mut physics, from, vec3(ft(0.5), ft(2.5), ft(0.5)));
         // ...and a wall a foot beyond the landing
         add_box(
             &mut physics,
@@ -1699,6 +1702,39 @@ mod tests {
         assert!(
             !probe.headroom,
             "a landing the body does not fit under must be refused"
+        );
+        assert!(!nudge_is_safe(&probe));
+    }
+
+    /// Clearance belongs to the landing the body would stand at, not to the
+    /// height it currently occupies: a step up puts its shoulders alongside
+    /// geometry that its old height cleared.
+    #[test]
+    fn a_step_up_alongside_geometry_refuses_the_nudge() {
+        let (world, creature, mut physics) = probe_world();
+        add_floor(&mut physics, 0.0);
+        // The same half-foot step up
+        add_box(
+            &mut physics,
+            vec3(ft(6.0), ft(0.25), 0.0),
+            vec3(ft(5.0), ft(0.25), ft(10.0)),
+        );
+        // ...beside a slab that starts just above the body's current origin
+        add_box(
+            &mut physics,
+            vec3(ft(2.0), ft(4.6), ft(1.5)),
+            vec3(ft(2.0), ft(1.4), ft(0.5)),
+        );
+        let from = vec3(0.0, ft(3.0), 0.0);
+        let to = vec3(ft(2.0), ft(3.0), 0.0);
+
+        settle(&mut physics);
+        let probe = probe_nudge(&world, &physics, creature, from, to, true);
+
+        assert!(probe.path_clear && probe.headroom);
+        assert!(
+            !probe.clearance,
+            "the slab beside the RAISED landing must refuse it"
         );
         assert!(!nudge_is_safe(&probe));
     }

--- a/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
+++ b/shock2vr/src/scripts/ai/steering/whisker_avoidance.rs
@@ -23,7 +23,7 @@ const WHISKER_SPREAD: Deg<f32> = Deg(30.0);
 /// blocked, so climbable steps don't push AIs sideways off staircases the
 /// route chose. Fractions rather than fixed feet, because a monkey is half
 /// a hybrid's height and fixed offsets would put both its probes underground.
-const WHISKER_KNEE_FRACTION: f32 = 0.35;
+pub const WHISKER_KNEE_FRACTION: f32 = 0.35;
 const WHISKER_CHEST_FRACTION: f32 = 0.15;
 /// Seconds between probes. Static geometry doesn't move and every
 /// path-following AI runs this, so the rays are cast a few times a second


### PR DESCRIPTION
The stall-recovery unstick nudge is a **teleport**: after two consecutive stalls from the same spot, a pinned creature is moved about two Dark feet toward its retreat point. Its only check was that the destination belonged to a navigation cell — nothing about the wall in between, whether the body fits where it lands, or whether there is a floor under it — and a body *already* off the mesh skipped even that, taking the move unconditionally.

The destination is now probed before it is taken, and a candidate that fails any probe is simply not moved: the body grinds on until the re-path frees it, which is strictly what the pre-nudge code did.

## What the probes establish — and what they do not

They are **rays, not a sweep of the body's capsule**: the physics view a script holds exposes no shape cast, so this is an *approximation* of clearance and geometry that fits between the rays is not seen. What they do establish, measured from the creature's own dimensions (`ai_util::creature_height` and the new `creature_radius`, which resolves the same capsule the body actually collides with — authored sphere dimensions included, not a bounding box):

- **`floor_step`** — a downward ray at both ends; the landing's floor must be within a step (2 Dark feet) of the one the body stands on. The floors are measured **first** and the landing rides that difference, so every other probe is taken where the body would actually stand rather than at the height it is leaving.
- **`path_clear`** — rays from the body to the landing and out *past* it by a body radius, so a wall just beyond refuses the move too.
- **`clearance`** — rays to either side at the landing, one body radius each way.
- **`headroom`** — an upward ray at the landing, **comparative rather than absolute**: a two-foot nudge shares its ceiling with the spot being left, so the landing only has to be no tighter than that spot. Demanding a full standing height would refuse every candidate for a body pinned under a duct or a catwalk — the population the unstick exists for.
- Rays go at the body's origin **and** at the whiskers' own knee fraction of the creature's height (the constant is now shared with them, so the two cannot drift): a low slab passes under a single centre ray.
- The queries are **solid**, so a ray whose origin lies inside a collider — as a pinned body's does — reads a hit at zero range. That is neither a clear segment nor an obstacle: the probe steps past it and judges the **rest** of the segment, so a wall behind the prop the body is embedded in is still seen. A segment spent entirely inside geometry reports *embedded*, which refuses.
- The off-mesh skip is gone. Being off the mesh now waives only the *cell* check — there is no cell to keep such a body in — while the physical probes still apply.

## Was it still needed?

It fires rarely, so the first question was whether #1264's physics fix had made it dead code. It has not: it is rare **and** load-bearing.

| scenario | stalls | pinned | nudges |
|---|---|---|---|
| medsci2, 60 s patrol, no input | 13 | 0 | 0 |
| medsci2, forced chase, 41 s | 1 | 0 | 0 |
| medsci2, forced chase, 35 s (x2) | 1 / 1 | 0 / 0 | 0 / 0 |
| eng1, forced chase, 90 s (~20 AIs) | 5 | 1 | 1 |

**About one nudge per 90 s of a whole-deck chase, none at all in medsci2.** The one eng1 firing is a hybrid pinned on a ledge at `-58.77, -15.37, -49.88`, whose route waypoint sits a metre below it. A/B at that spot, same seed, same scene, position sampled once a second:

| | outcome |
|---|---|
| nudge on | pinned 8 s, freed at t=11 s, walks on |
| nudge off (build-time gate) | pinned for **every one of the 18 samples** it had a path for — never moves a millimetre |

So the re-path alone does not recover it, and cutting the nudge would trade a rare small pop for a creature frozen for the rest of the mission. Kept and hardened. (18 stationary samples are evidence that the re-path does not free it *within the run*, not a proof of permanent freezing.)

After the change the nudge still fires at that ledge and still frees the creature — re-checked at the final commit, same forced chase: 5 stalls, 1 pinned, **1 nudge taken, 0 refused**, `-58.77,-49.88 -> -59.50,-49.84`, the creature then walking on under its own locomotion. It takes the *cell-centre* candidate because the retreat-direction one fails its probes, which is the intended behavior.

## Tests

Unit, on `nudge_is_safe`: `every_failed_probe_refuses_the_nudge` (red when any single clause is dropped) and `a_clear_supported_landing_is_taken`.

Geometry, driving `probe_nudge` itself against a synthetic physics world (a floor slab plus the case's own boxes, one `PhysicsWorld::update` so the broad phase sees them). Each was verified red against the specific behavior it guards:

- `a_wall_behind_the_prop_the_body_is_embedded_in_refuses_the_nudge` — red with the near reading discarded instead of stepped past.
- `a_segment_that_never_leaves_the_geometry_refuses_the_nudge` — a probe spent wholly inside a block is not a clear ray.
- `a_body_embedded_in_a_prop_is_still_nudged_when_the_way_is_clear` — the counterweight: seeing past a prop must not become refusing everyone inside one.
- `a_step_up_alongside_geometry_refuses_the_nudge` — red when clearance is probed at the old height instead of the landing's.
- `a_step_up_under_an_overhang_refuses_the_nudge` — red without the headroom probe.
- `a_landing_no_tighter_than_the_spot_left_is_still_nudged` — red when headroom is absolute rather than comparative.
- `an_open_landing_is_probed_safe_and_rides_its_floor` — the positive control, including a landing half a foot up.

`cargo test -p shock2vr`: 1452 passed. `cargo fmt` and `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

e2e, **reduced scope by request** — only the scenarios that exercise stall recovery: `medsci2-patrol-railing` passes (run again after the review fixes). `medsci2-doorjamb-chase`'s first case is flaky on both branches at its marginal 6 s threshold; instrumentation settles the attribution — **zero pinned bodies and zero nudges in medsci2**, so this code path never executes there.

No media: the nudge is a two-foot pop in an unlit engineering corridor, and the change makes an existing move *refusable* rather than adding anything to look at.

## Review

Two rounds of `/xreview` (Claude adversarial reviewer, Codex, and a dedicated de-dup reviewer), plus an external claims re-review between them.

First round, fixed: an accepted landing kept the body's old `y` while `floor_step` allowed a two-foot rise; centre-height rays alone do not see a low slab; a zero-range reading from the body's own embedding would have refused every nudge for the most deeply pinned bodies; the clearance radius was a fixed 2 ft.

Second round — the external re-review's two HIGH findings and what both engines then agreed on:

- **High** — the near-origin reading was discarded *without querying beyond it*, so a wall behind the prop a body is embedded in was invisible. The probe now steps past such readings and judges the rest of the segment.
- **High** — the landing `y` was adjusted *after* the clearance probes ran at the old `y`, so a step-up could land in an overhang. Floors are measured first; clearance and the new headroom probe run at the landing the body would ride to.
- **High [AGREED, both engines]** — with the stepping in place, a ray that consumed its whole segment while still inside geometry returned *clear*. It now returns embedded, which refuses.
- **Medium [AGREED, both engines]** — `creature_radius` re-derived only `live_creature_shape`'s *fallback* half-width, so a creature with authored sphere dimensions was probed at a radius its capsule does not have. Both now share `live_creature_shape`.
- **Medium (Claude)** — an absolute headroom demand would freeze an AI pinned in a low pocket forever. Made comparative.
- De-dup pass: `creature_height`/`creature_radius` now share one definition lookup; the knee fraction is the whiskers' constant rather than a copy of its value; the repeated step-box setup is one test helper. Declined, with reasons: threading a `solid` flag through the shared raycast choke point (a one-query alternative to the stepping loop, but it changes the engine-wide query path for a probe that runs about once a minute), and hoisting a crate-wide `#[cfg(test)]` physics-world module (four call sites in three unrelated modules — its own change, not this one's).
