### PR TITLE
fix(ai): the turn clip hands its yaw over on the player's own transition

### DIFF
--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -258,24 +258,13 @@ impl AnimationPlayer {
         new_player
     }
 
-    /// How long the cross-fade currently running still has to go, in seconds
-    /// (0 when nothing is fading) - read immediately after queueing a clip,
-    /// that is the whole window the fade will take. This is the blend the
-    /// player ACTUALLY applies - `queue_animation` takes the incoming clip's
-    /// authored length (often zero), `play_animation` floors it - so a caller
-    /// that must move in step with the fade reads it here rather than
-    /// re-deriving it.
-    pub fn blend_remaining_seconds(&self) -> f32 {
-        self.blend_state
-            .as_ref()
-            .map(|blend| (blend.duration - blend.elapsed).max(0.0))
-            .unwrap_or(0.0)
-    }
-
     /// How much of the pose the INCOMING clip owns right now: the very weight
     /// `get_transforms` blends with, so anything that has to move in step with
     /// the fade (the AI's turn-clip yaw handoff) reads the pose's own number
-    /// rather than integrating a clock of its own. 1.0 when nothing is fading.
+    /// rather than integrating a clock of its own. 1.0 when nothing is fading -
+    /// which, read straight after queueing, is also how a caller learns that
+    /// the clip it just started hard-cuts (`queue_animation` takes the INCOMING
+    /// clip's authored blend length, and a stride clip authors none).
     pub fn blend_alpha_now(&self) -> f32 {
         match &self.blend_state {
             Some(blend) if blend.duration > f32::EPSILON && blend.elapsed < blend.duration => {
@@ -1008,45 +997,24 @@ mod tests {
         }
     }
 
-    /// What the turn-clip yaw handoff reads: the fade the player is really
-    /// running. `queue_animation` takes it from the INCOMING clip - and a
-    /// stride clip authors none - so a caller that assumed the outgoing
-    /// clip's blend would settle over a window nothing is fading across.
+    /// What the turn-clip yaw handoff reads every frame: the weight
+    /// `get_transforms` blends with, so the facing the entity takes and the
+    /// facing the pose gives up are the same number. Read straight after
+    /// queueing, it is also what tells a caller whether there is a fade at all -
+    /// `queue_animation` takes the INCOMING clip's authored length, and a
+    /// stride clip authors none however long the clip it interrupts did.
     #[test]
-    fn blend_remaining_seconds_reports_the_fade_actually_running() {
+    fn blend_alpha_now_is_the_weight_the_fade_has_reached() {
         let mut outgoing = (*clip_with_root_motion()).clone();
         outgoing.blend_length = Duration::from_millis(500);
         let player = AnimationPlayer::queue_animation(&AnimationPlayer::empty(), Rc::new(outgoing));
-        assert_eq!(
-            player.blend_remaining_seconds(),
-            0.0,
-            "nothing to fade from"
-        );
-
-        // A stride clip queued after it: no fade at all, however long the
-        // clip it interrupts authored.
-        let stride = AnimationPlayer::queue_animation(&player, clip_with_root_motion());
-        assert_eq!(stride.blend_remaining_seconds(), 0.0);
-
-        // ...and one that does author a blend fades for exactly that long,
-        // counting down as it runs.
-        let mut incoming = (*clip_with_root_motion()).clone();
-        incoming.blend_length = Duration::from_millis(200);
-        let fading = AnimationPlayer::queue_animation(&player, Rc::new(incoming));
-        assert!((fading.blend_remaining_seconds() - 0.2).abs() < 1e-6);
-        let (fading, _, _, _) = AnimationPlayer::update(&fading, Duration::from_millis(50));
-        assert!((fading.blend_remaining_seconds() - 0.15).abs() < 1e-6);
-    }
-
-    /// The same fade as a pose weight: what `get_transforms` blends with, and
-    /// what the AI's yaw handoff is told every frame so the facing it takes
-    /// and the facing the pose gives up are the same number.
-    #[test]
-    fn blend_alpha_now_is_the_weight_the_fade_has_reached() {
-        let player =
-            AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip_with_root_motion());
         let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(100));
         assert_eq!(player.blend_alpha_now(), 1.0, "nothing is fading");
+
+        // A stride clip queued after it: a hard cut, however long the clip it
+        // interrupts authored.
+        let stride = AnimationPlayer::queue_animation(&player, clip_with_root_motion());
+        assert_eq!(stride.blend_alpha_now(), 1.0, "no fade to ride");
 
         let mut incoming = (*clip_with_root_motion()).clone();
         incoming.blend_length = Duration::from_millis(200);

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -272,6 +272,19 @@ impl AnimationPlayer {
             .unwrap_or(0.0)
     }
 
+    /// How much of the pose the INCOMING clip owns right now: the very weight
+    /// `get_transforms` blends with, so anything that has to move in step with
+    /// the fade (the AI's turn-clip yaw handoff) reads the pose's own number
+    /// rather than integrating a clock of its own. 1.0 when nothing is fading.
+    pub fn blend_alpha_now(&self) -> f32 {
+        match &self.blend_state {
+            Some(blend) if blend.duration > f32::EPSILON && blend.elapsed < blend.duration => {
+                blend_alpha(blend.elapsed / blend.duration)
+            }
+            _ => 1.0,
+        }
+    }
+
     pub fn set_additional_joint_transform(
         player: &AnimationPlayer,
         joint_idx: u32,
@@ -580,8 +593,7 @@ impl AnimationPlayer {
 
         if let Some(blend) = &self.blend_state {
             if blend.duration > f32::EPSILON && blend.elapsed < blend.duration {
-                let t = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
-                let alpha = blend_alpha(t);
+                let alpha = self.blend_alpha_now();
                 // update() keeps from_frame in range (loops wrap, one-shots
                 // clamp), and the fractional position advances smoothly
                 // during the fade.
@@ -1024,6 +1036,30 @@ mod tests {
         assert!((fading.blend_remaining_seconds() - 0.2).abs() < 1e-6);
         let (fading, _, _, _) = AnimationPlayer::update(&fading, Duration::from_millis(50));
         assert!((fading.blend_remaining_seconds() - 0.15).abs() < 1e-6);
+    }
+
+    /// The same fade as a pose weight: what `get_transforms` blends with, and
+    /// what the AI's yaw handoff is told every frame so the facing it takes
+    /// and the facing the pose gives up are the same number.
+    #[test]
+    fn blend_alpha_now_is_the_weight_the_fade_has_reached() {
+        let player =
+            AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip_with_root_motion());
+        let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(100));
+        assert_eq!(player.blend_alpha_now(), 1.0, "nothing is fading");
+
+        let mut incoming = (*clip_with_root_motion()).clone();
+        incoming.blend_length = Duration::from_millis(200);
+        let fading = AnimationPlayer::queue_animation(&player, Rc::new(incoming));
+        assert_eq!(fading.blend_alpha_now(), 0.0, "the fade has not started");
+
+        let (fading, _, _, _) = AnimationPlayer::update(&fading, Duration::from_millis(50));
+        assert!((fading.blend_alpha_now() - blend_alpha(0.25)).abs() < 1e-6);
+
+        // Run past the end: the fade is gone and the incoming clip owns the
+        // whole pose, which is the 1.0 the handover finishes on.
+        let (fading, _, _, _) = AnimationPlayer::update(&fading, Duration::from_millis(200));
+        assert_eq!(fading.blend_alpha_now(), 1.0);
     }
 
     /// The pose's cross-fade weight, which the AI's yaw handoff rides so the

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -12,6 +12,16 @@ pub enum AnimationFlags {
     PlayOnce,
 }
 
+/// The cross-fade weight of the incoming pose at normalized blend progress
+/// `t`. Raised-cosine ease-in/ease-out rather than linear - a linear ramp
+/// starts and stops the correction abruptly, which reads as two small hitches
+/// bracketing the fade. Public so anything that has to move IN STEP with a
+/// blend (the AI's turn-clip yaw handoff) rides the same curve.
+pub fn blend_alpha(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    (1.0 - (std::f32::consts::PI * t).cos()) / 2.0
+}
+
 pub enum AnimationEvent {
     DirectionChanged(Deg<f32>),
     VelocityChanged(Vector3<f32>),
@@ -246,6 +256,18 @@ impl AnimationPlayer {
         let mut new_player = player.clone();
         new_player.cancel_root_motion = true;
         new_player
+    }
+
+    /// How long the cross-fade currently running still has to go, in seconds
+    /// (0 when nothing is fading). This is the blend the player ACTUALLY
+    /// applies - `queue_animation` takes the incoming clip's authored length
+    /// (often zero), `play_animation` floors it - so a caller that must move
+    /// in step with the fade reads it here rather than re-deriving it.
+    pub fn active_blend_seconds(&self) -> f32 {
+        self.blend_state
+            .as_ref()
+            .map(|blend| (blend.duration - blend.elapsed).max(0.0))
+            .unwrap_or(0.0)
     }
 
     pub fn set_additional_joint_transform(
@@ -560,7 +582,7 @@ impl AnimationPlayer {
                 // ramp starts and stops the correction abruptly, which reads
                 // as two small hitches bracketing the fade.
                 let t = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
-                let alpha = (1.0 - (std::f32::consts::PI * t).cos()) / 2.0;
+                let alpha = blend_alpha(t);
                 // update() keeps from_frame in range (loops wrap, one-shots
                 // clamp), and the fractional position advances smoothly
                 // during the fade.
@@ -973,6 +995,46 @@ mod tests {
             assert!(next.snapshot().queue.is_empty());
             assert_eq!(next.snapshot().last_clip.as_deref(), Some("death_pose"));
         }
+    }
+
+    /// What the turn-clip yaw handoff reads: the fade the player is really
+    /// running. `queue_animation` takes it from the INCOMING clip - and a
+    /// stride clip authors none - so a caller that assumed the outgoing
+    /// clip's blend would settle over a window nothing is fading across.
+    #[test]
+    fn active_blend_seconds_reports_the_fade_actually_running() {
+        let mut outgoing = (*clip_with_root_motion()).clone();
+        outgoing.blend_length = Duration::from_millis(500);
+        let player = AnimationPlayer::queue_animation(&AnimationPlayer::empty(), Rc::new(outgoing));
+        assert_eq!(player.active_blend_seconds(), 0.0, "nothing to fade from");
+
+        // A stride clip queued after it: no fade at all, however long the
+        // clip it interrupts authored.
+        let stride = AnimationPlayer::queue_animation(&player, clip_with_root_motion());
+        assert_eq!(stride.active_blend_seconds(), 0.0);
+
+        // ...and one that does author a blend fades for exactly that long,
+        // counting down as it runs.
+        let mut incoming = (*clip_with_root_motion()).clone();
+        incoming.blend_length = Duration::from_millis(200);
+        let fading = AnimationPlayer::queue_animation(&player, Rc::new(incoming));
+        assert!((fading.active_blend_seconds() - 0.2).abs() < 1e-6);
+        let (fading, _, _, _) = AnimationPlayer::update(&fading, Duration::from_millis(50));
+        assert!((fading.active_blend_seconds() - 0.15).abs() < 1e-6);
+    }
+
+    /// The pose's cross-fade weight, which the AI's yaw handoff rides so the
+    /// facing the pose gives up and the facing the entity takes cancel out.
+    #[test]
+    fn blend_alpha_is_a_clamped_raised_cosine() {
+        assert_eq!(blend_alpha(0.0), 0.0);
+        assert!((blend_alpha(0.5) - 0.5).abs() < 1e-6);
+        assert!((blend_alpha(1.0) - 1.0).abs() < 1e-6);
+        assert_eq!(blend_alpha(-1.0), 0.0);
+        assert!((blend_alpha(2.0) - 1.0).abs() < 1e-6);
+        // Eased, not linear: a quarter of the way in it has moved much less.
+        assert!(blend_alpha(0.25) < 0.25);
+        assert!(blend_alpha(0.75) > 0.75);
     }
 
     #[test]

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -259,11 +259,13 @@ impl AnimationPlayer {
     }
 
     /// How long the cross-fade currently running still has to go, in seconds
-    /// (0 when nothing is fading). This is the blend the player ACTUALLY
-    /// applies - `queue_animation` takes the incoming clip's authored length
-    /// (often zero), `play_animation` floors it - so a caller that must move
-    /// in step with the fade reads it here rather than re-deriving it.
-    pub fn active_blend_seconds(&self) -> f32 {
+    /// (0 when nothing is fading) - read immediately after queueing a clip,
+    /// that is the whole window the fade will take. This is the blend the
+    /// player ACTUALLY applies - `queue_animation` takes the incoming clip's
+    /// authored length (often zero), `play_animation` floors it - so a caller
+    /// that must move in step with the fade reads it here rather than
+    /// re-deriving it.
+    pub fn blend_remaining_seconds(&self) -> f32 {
         self.blend_state
             .as_ref()
             .map(|blend| (blend.duration - blend.elapsed).max(0.0))
@@ -578,9 +580,6 @@ impl AnimationPlayer {
 
         if let Some(blend) = &self.blend_state {
             if blend.duration > f32::EPSILON && blend.elapsed < blend.duration {
-                // Raised-cosine ease-in/ease-out rather than linear - a linear
-                // ramp starts and stops the correction abruptly, which reads
-                // as two small hitches bracketing the fade.
                 let t = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
                 let alpha = blend_alpha(t);
                 // update() keeps from_frame in range (loops wrap, one-shots
@@ -1002,25 +1001,29 @@ mod tests {
     /// stride clip authors none - so a caller that assumed the outgoing
     /// clip's blend would settle over a window nothing is fading across.
     #[test]
-    fn active_blend_seconds_reports_the_fade_actually_running() {
+    fn blend_remaining_seconds_reports_the_fade_actually_running() {
         let mut outgoing = (*clip_with_root_motion()).clone();
         outgoing.blend_length = Duration::from_millis(500);
         let player = AnimationPlayer::queue_animation(&AnimationPlayer::empty(), Rc::new(outgoing));
-        assert_eq!(player.active_blend_seconds(), 0.0, "nothing to fade from");
+        assert_eq!(
+            player.blend_remaining_seconds(),
+            0.0,
+            "nothing to fade from"
+        );
 
         // A stride clip queued after it: no fade at all, however long the
         // clip it interrupts authored.
         let stride = AnimationPlayer::queue_animation(&player, clip_with_root_motion());
-        assert_eq!(stride.active_blend_seconds(), 0.0);
+        assert_eq!(stride.blend_remaining_seconds(), 0.0);
 
         // ...and one that does author a blend fades for exactly that long,
         // counting down as it runs.
         let mut incoming = (*clip_with_root_motion()).clone();
         incoming.blend_length = Duration::from_millis(200);
         let fading = AnimationPlayer::queue_animation(&player, Rc::new(incoming));
-        assert!((fading.active_blend_seconds() - 0.2).abs() < 1e-6);
+        assert!((fading.blend_remaining_seconds() - 0.2).abs() < 1e-6);
         let (fading, _, _, _) = AnimationPlayer::update(&fading, Duration::from_millis(50));
-        assert!((fading.active_blend_seconds() - 0.15).abs() < 1e-6);
+        assert!((fading.blend_remaining_seconds() - 0.15).abs() < 1e-6);
     }
 
     /// The pose's cross-fade weight, which the AI's yaw handoff rides so the

--- a/shock2vr/src/message_trace.rs
+++ b/shock2vr/src/message_trace.rs
@@ -82,6 +82,9 @@ fn is_traced(payload: &MessagePayload) -> bool {
             | MessagePayload::Collided { .. }
             | MessagePayload::AnimationFlagTriggered { .. }
             | MessagePayload::AnimationCompleted
+            // One per frame of a pivot's handover fade; it would push the
+            // damage/signal history the trace exists for out of the buffer.
+            | MessagePayload::TurnClipBlend { .. }
     )
 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3991,7 +3991,7 @@ impl MissionCore {
         // The blend the player ACTUALLY started for this clip, when one was
         // applied. Read from the player rather than re-derived, so the pivot's
         // yaw hands over on the transition that is really running.
-        let mut applied_blend = None;
+        let mut applied_fade = None;
         let maybe_player = self.id_to_animation_player.get_mut(&entity_id);
         if let Some(player) = maybe_player {
             let v_creature_type = self.world.borrow::<View<PropCreature>>().unwrap();
@@ -4123,7 +4123,8 @@ impl MissionCore {
                                 Some(dark::motion::signed_end_direction(clip.end_rotation));
                         }
                         *player = apply(player, clip);
-                        applied_blend = Some(player.blend_remaining_seconds());
+                        // 1.0 straight after the apply means no fade at all.
+                        applied_fade = Some(player.blend_alpha_now() < 1.0);
 
                         // The motion query is random, so its resolved clip name
                         // is the only durable identity of the corpse pose.
@@ -4196,7 +4197,7 @@ impl MissionCore {
         // followed, before recording the one it may have started.
         if let Some(payload) =
             self.turn_clips
-                .on_animation_applied(entity_id, applied_blend, turn.is_some())
+                .on_animation_applied(entity_id, applied_fade, turn.is_some())
         {
             self.script_world.dispatch(Message {
                 to: entity_id,
@@ -11054,7 +11055,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         };
         use shipyard::*;
 
-        let snapshot = self.id_to_animation_player.get(&id)?.snapshot();
+        let player = self.id_to_animation_player.get(&id)?;
+        let blend_alpha = player.blend_alpha_now();
+        let snapshot = player.snapshot();
 
         let (transform, joint_transforms) = self.world.run(
             |v_transform: View<crate::runtime_props::RuntimePropTransform>,
@@ -11126,11 +11129,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 elapsed: blend.elapsed,
                 // The pose's actual cross-fade weight, not the linear
                 // progress through the fade - they differ by up to 0.2.
-                alpha: if blend.duration > f32::EPSILON {
-                    dark::motion::blend_alpha(blend.elapsed / blend.duration)
-                } else {
-                    1.0
-                },
+                alpha: blend_alpha,
             }),
             position,
             rotation,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4136,7 +4136,7 @@ impl MissionCore {
                                 Some(dark::motion::signed_end_direction(clip.end_rotation));
                         }
                         *player = apply(player, clip);
-                        applied_blend = Some(player.active_blend_seconds());
+                        applied_blend = Some(player.blend_remaining_seconds());
 
                         // The motion query is random, so its resolved clip name
                         // is the only durable identity of the corpse pose.
@@ -4212,8 +4212,16 @@ impl MissionCore {
         // be dropped. The first clip applied after it completed is the
         // transition its pose swings back to neutral across, so the pivot
         // takes its facing change over exactly that fade.
+        // A `PlayTurnClip` that resolved to nothing still displaces whatever
+        // was tracked, so the entry is taken either way; only a report needs a
+        // clip to have actually started.
+        let previous = if applied_blend.is_some() || turn.is_some() {
+            self.turn_clip_playback.remove(&entity_id)
+        } else {
+            None
+        };
         if let Some(blend) = applied_blend {
-            match self.turn_clip_playback.remove(&entity_id) {
+            match previous {
                 Some(playback) if playback.completed => {
                     self.script_world.dispatch(Message {
                         to: entity_id,
@@ -4234,6 +4242,8 @@ impl MissionCore {
                 }
                 None => {}
             }
+        } else if let Some(playback) = previous {
+            Self::report_turn_clip_abandoned(&mut self.script_world, entity_id, playback);
         }
 
         if let Some((token, _, _)) = turn {
@@ -4258,6 +4268,31 @@ impl MissionCore {
                 to: entity_id,
                 payload,
             });
+        }
+    }
+
+    /// Tell a pivot's requester that its clip is gone. Every path that can end
+    /// a turn clip's playback goes through here, so a `TurnClip` in the script
+    /// is always answered and can hold the creature's heading no longer than
+    /// its clip really plays.
+    fn report_turn_clip_abandoned(
+        script_world: &mut ScriptWorld,
+        entity_id: EntityId,
+        playback: TurnClipPlayback,
+    ) {
+        script_world.dispatch(Message {
+            to: entity_id,
+            payload: MessagePayload::TurnClipCancelled {
+                token: playback.token,
+            },
+        });
+    }
+
+    /// The entity's animation player is being replaced or taken away, so no
+    /// completion can ever arrive for a turn clip it was playing.
+    fn abandon_turn_clip(&mut self, entity_id: EntityId) {
+        if let Some(playback) = self.turn_clip_playback.remove(&entity_id) {
+            Self::report_turn_clip_abandoned(&mut self.script_world, entity_id, playback);
         }
     }
 
@@ -7257,6 +7292,9 @@ impl MissionCore {
                     entity_id,
                     model_name,
                 } => {
+                    // The model swap rebuilds the animation player, so any
+                    // turn clip it was playing is gone with it.
+                    self.abandon_turn_clip(entity_id);
                     // A VR-wielded first-person model loads as authored,
                     // baked hands included (see `VrHeldModel`); the
                     // separate importer is the seam where per-wield mesh
@@ -7506,6 +7544,7 @@ impl MissionCore {
                     }
                 }
                 Effect::ClearModel { entity_id } => {
+                    self.abandon_turn_clip(entity_id);
                     self.id_to_model.remove(&entity_id);
                     self.id_to_animation_player.remove(&entity_id);
                     self.world
@@ -11153,8 +11192,10 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 from_frame: blend.from_frame,
                 duration: blend.duration,
                 elapsed: blend.elapsed,
+                // The pose's actual cross-fade weight, not the linear
+                // progress through the fade - they differ by up to 0.2.
                 alpha: if blend.duration > f32::EPSILON {
-                    (blend.elapsed / blend.duration).clamp(0.0, 1.0)
+                    dark::motion::blend_alpha(blend.elapsed / blend.duration)
                 } else {
                     1.0
                 },

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1469,6 +1469,21 @@ impl EffectQueue {
 }
 
 /// See `MissionCore::failed_animation_queries`.
+/// A turn clip the applier started for an entity, tracked so the requesting
+/// script can tell its own clip's completion from any other.
+///
+/// The applier owns the animation player, so it - not a timer in the script -
+/// is what knows whether the pivot's clip is still the one playing: any other
+/// animation applied to the entity while `completed` is false has preempted
+/// it, and the first one applied after it completed is the transition the
+/// pivot's yaw hands over on.
+struct TurnClipPlayback {
+    /// The `Effect::PlayTurnClip` request this playback answers.
+    token: u64,
+    /// Whether the clip has run to its end (as opposed to still playing).
+    completed: bool,
+}
+
 struct FailedAnimationGuard {
     key: String,
     frames_left: u32,
@@ -1499,6 +1514,10 @@ pub struct MissionCore {
     pub scene_objects: Vec<SceneObject>,
     pub animated_lightmaps: Option<dark::mission::AnimatedLightmapController>,
     pub id_to_animation_player: HashMap<EntityId, AnimationPlayer>,
+    /// The turn clip in flight per entity (see `Effect::PlayTurnClip`). This
+    /// is what identifies a pivot's playback: the requester never has to guess
+    /// from elapsed time which completion is its own.
+    turn_clip_playback: HashMap<EntityId, TurnClipPlayback>,
     /// Failed-animation suppression state per entity: the failing key, a
     /// countdown (frames), and whether a suppressed request is owed a
     /// completion when the window expires. A failed query reports
@@ -2516,6 +2535,7 @@ impl MissionCore {
             script_world,
             id_to_model,
             id_to_animation_player,
+            turn_clip_playback: HashMap::new(),
             failed_animation_queries: HashMap::new(),
             id_to_bitmap,
             id_to_particle_system: HashMap::new(),
@@ -3970,11 +3990,10 @@ impl MissionCore {
         motion_queries: Vec<Vec<MotionQueryItem>>,
         selection_strategy: MotionQuerySelectionStrategy,
         apply: fn(&AnimationPlayer, Rc<AnimationClip>) -> AnimationPlayer,
-        // Pivot in place: pick the stand-schema clip whose authored facing
-        // change is nearest this heading change and that fits in the seconds
-        // the creature can afford to stand still, then report it back (see
-        // `Effect::PlayTurnClip`).
-        turn: Option<(cgmath::Deg<f32>, f32)>,
+        // Pivot in place: the request's token, the heading change to pick the
+        // nearest stand-schema clip for, and the seconds the creature can
+        // afford to stand still (see `Effect::PlayTurnClip`).
+        turn: Option<(u64, cgmath::Deg<f32>, f32)>,
     ) {
         let is_death_query = motion_queries
             .iter()
@@ -3982,6 +4001,10 @@ impl MissionCore {
             .any(|item| item.tag_name() == "crumple");
         let mut resolved_death_pose = None;
         let mut turn_started = None;
+        // The blend the player ACTUALLY started for this clip, when one was
+        // applied. Read from the player rather than re-derived, so the pivot's
+        // yaw hands over on the transition that is really running.
+        let mut applied_blend = None;
         let maybe_player = self.id_to_animation_player.get_mut(&entity_id);
         if let Some(player) = maybe_player {
             let v_creature_type = self.world.borrow::<View<PropCreature>>().unwrap();
@@ -4017,7 +4040,7 @@ impl MissionCore {
                             .get_motion_stuff(name.clone())
                             .end_direction
                     };
-                    let result = if let Some((delta, max_seconds)) = turn {
+                    let result = if let Some((_, delta, max_seconds)) = turn {
                         let options = global_context.motiondb.query_all(query.clone());
                         let clips = options
                             .iter()
@@ -4109,13 +4132,11 @@ impl MissionCore {
                         };
                         self.failed_animation_queries.remove(&entity_id);
                         if turn.is_some() {
-                            turn_started = Some((
-                                dark::motion::signed_end_direction(clip.end_rotation),
-                                clip.duration.as_secs_f32(),
-                                clip.blend_length.as_secs_f32(),
-                            ));
+                            turn_started =
+                                Some(dark::motion::signed_end_direction(clip.end_rotation));
                         }
                         *player = apply(player, clip);
+                        applied_blend = Some(player.active_blend_seconds());
 
                         // The motion query is random, so its resolved clip name
                         // is the only durable identity of the corpse pose.
@@ -4184,14 +4205,58 @@ impl MissionCore {
             self.world.add_component(entity_id, death_pose);
         }
 
-        if let Some((turn, duration, blend)) = turn_started {
+        // Report on the pivot whose clip this apply just displaced or
+        // followed, before recording the one it may have started. A clip
+        // applied while the pivot's own was still playing has preempted it -
+        // nothing turns the body any more, so the authored facing change must
+        // be dropped. The first clip applied after it completed is the
+        // transition its pose swings back to neutral across, so the pivot
+        // takes its facing change over exactly that fade.
+        if let Some(blend) = applied_blend {
+            match self.turn_clip_playback.remove(&entity_id) {
+                Some(playback) if playback.completed => {
+                    self.script_world.dispatch(Message {
+                        to: entity_id,
+                        payload: MessagePayload::TurnClipHandoff {
+                            token: playback.token,
+                            blend,
+                        },
+                    });
+                }
+                Some(playback) => {
+                    tracing::debug!("turn clip for {:?} preempted by another", entity_id);
+                    self.script_world.dispatch(Message {
+                        to: entity_id,
+                        payload: MessagePayload::TurnClipCancelled {
+                            token: playback.token,
+                        },
+                    });
+                }
+                None => {}
+            }
+        }
+
+        if let Some((token, _, _)) = turn {
+            let payload = match turn_started {
+                Some(turn) => {
+                    self.turn_clip_playback.insert(
+                        entity_id,
+                        TurnClipPlayback {
+                            token,
+                            completed: false,
+                        },
+                    );
+                    MessagePayload::TurnClipStarted { token, turn }
+                }
+                // No affordable clip covered the pivot, the creature has no
+                // turn clips, or it has no animation player at all. The
+                // requester is answered either way, so it never waits on a
+                // clip that will not come.
+                None => MessagePayload::TurnClipCancelled { token },
+            };
             self.script_world.dispatch(Message {
                 to: entity_id,
-                payload: MessagePayload::TurnClipStarted {
-                    turn,
-                    duration,
-                    blend,
-                },
+                payload,
             });
         }
     }
@@ -4336,10 +4401,24 @@ impl MissionCore {
 
             for event in events {
                 match event {
-                    AnimationEvent::Completed => self.script_world.dispatch(Message {
-                        to: *id,
-                        payload: MessagePayload::AnimationCompleted,
-                    }),
+                    AnimationEvent::Completed => {
+                        // A pivot's clip reaching its end: from here the next
+                        // clip applied to this entity is its handoff, not a
+                        // preemption.
+                        if let Some(playback) = self.turn_clip_playback.get_mut(id) {
+                            playback.completed = true;
+                            self.script_world.dispatch(Message {
+                                to: *id,
+                                payload: MessagePayload::TurnClipCompleted {
+                                    token: playback.token,
+                                },
+                            });
+                        }
+                        self.script_world.dispatch(Message {
+                            to: *id,
+                            payload: MessagePayload::AnimationCompleted,
+                        })
+                    }
                     AnimationEvent::DirectionChanged(ang) => {
                         game_log!(DEBUG, "Animation direction changed: {:?}", ang);
                         // The events now arrive as small per-tick increments
@@ -5488,6 +5567,7 @@ impl MissionCore {
         // Shipyard recycles entity ids, so stale per-entity animation state
         // must not outlive the entity (a recycled id would inherit it).
         self.id_to_animation_player.remove(&entity_id);
+        self.turn_clip_playback.remove(&entity_id);
         self.failed_animation_queries.remove(&entity_id);
         self.gui.on_entity_destroyed(
             entity_id,
@@ -7003,6 +7083,7 @@ impl MissionCore {
 
                 Effect::PlayTurnClip {
                     entity_id,
+                    token,
                     delta,
                     max_seconds,
                 } => {
@@ -7013,7 +7094,7 @@ impl MissionCore {
                         vec![vec![MotionQueryItem::new("stand")]],
                         MotionQuerySelectionStrategy::Random,
                         AnimationPlayer::play_animation,
-                        Some((delta, max_seconds)),
+                        Some((token, delta, max_seconds)),
                     );
                 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7107,6 +7107,21 @@ impl MissionCore {
                         for entity_id in creature_ids {
                             if let Some(player) = self.id_to_animation_player.get_mut(&entity_id) {
                                 *player = AnimationPlayer::queue_animation(player, clip.clone());
+                                // This replaces whatever fade a pivot may have
+                                // been handing its yaw over across, so the
+                                // pivot has to hear about it like any other
+                                // displacing clip.
+                                let fades = player.blend_alpha_now() < 1.0;
+                                if let Some(payload) = self.turn_clips.on_animation_applied(
+                                    entity_id,
+                                    Some(fades),
+                                    false,
+                                ) {
+                                    self.script_world.dispatch(Message {
+                                        to: entity_id,
+                                        payload,
+                                    });
+                                }
                             }
                         }
                         self.debug_pose_index = self.debug_pose_index.wrapping_add(1);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -16,6 +16,7 @@ use cgmath::{
 
 use collision::Aabb3;
 
+use super::turn_clip::TurnClipTracker;
 use crate::SpawnLocation;
 use crate::game_scene::DebuggableScene;
 use crate::mission::CullingInfo;
@@ -1469,21 +1470,6 @@ impl EffectQueue {
 }
 
 /// See `MissionCore::failed_animation_queries`.
-/// A turn clip the applier started for an entity, tracked so the requesting
-/// script can tell its own clip's completion from any other.
-///
-/// The applier owns the animation player, so it - not a timer in the script -
-/// is what knows whether the pivot's clip is still the one playing: any other
-/// animation applied to the entity while `completed` is false has preempted
-/// it, and the first one applied after it completed is the transition the
-/// pivot's yaw hands over on.
-struct TurnClipPlayback {
-    /// The `Effect::PlayTurnClip` request this playback answers.
-    token: u64,
-    /// Whether the clip has run to its end (as opposed to still playing).
-    completed: bool,
-}
-
 struct FailedAnimationGuard {
     key: String,
     frames_left: u32,
@@ -1516,8 +1502,9 @@ pub struct MissionCore {
     pub id_to_animation_player: HashMap<EntityId, AnimationPlayer>,
     /// The turn clip in flight per entity (see `Effect::PlayTurnClip`). This
     /// is what identifies a pivot's playback: the requester never has to guess
-    /// from elapsed time which completion is its own.
-    turn_clip_playback: HashMap<EntityId, TurnClipPlayback>,
+    /// from elapsed time which completion is its own, nor how far the fade it
+    /// hands its yaw over across has got.
+    turn_clips: TurnClipTracker,
     /// Failed-animation suppression state per entity: the failing key, a
     /// countdown (frames), and whether a suppressed request is owed a
     /// completion when the window expires. A failed query reports
@@ -2535,7 +2522,7 @@ impl MissionCore {
             script_world,
             id_to_model,
             id_to_animation_player,
-            turn_clip_playback: HashMap::new(),
+            turn_clips: TurnClipTracker::new(),
             failed_animation_queries: HashMap::new(),
             id_to_bitmap,
             id_to_particle_system: HashMap::new(),
@@ -4206,64 +4193,21 @@ impl MissionCore {
         }
 
         // Report on the pivot whose clip this apply just displaced or
-        // followed, before recording the one it may have started. A clip
-        // applied while the pivot's own was still playing has preempted it -
-        // nothing turns the body any more, so the authored facing change must
-        // be dropped. The first clip applied after it completed is the
-        // transition its pose swings back to neutral across, so the pivot
-        // takes its facing change over exactly that fade.
-        // A `PlayTurnClip` that resolved to nothing still displaces whatever
-        // was tracked, so the entry is taken either way; only a report needs a
-        // clip to have actually started.
-        let previous = if applied_blend.is_some() || turn.is_some() {
-            self.turn_clip_playback.remove(&entity_id)
-        } else {
-            None
-        };
-        if let Some(blend) = applied_blend {
-            match previous {
-                Some(playback) if playback.completed => {
-                    self.script_world.dispatch(Message {
-                        to: entity_id,
-                        payload: MessagePayload::TurnClipHandoff {
-                            token: playback.token,
-                            blend,
-                        },
-                    });
-                }
-                Some(playback) => {
-                    tracing::debug!("turn clip for {:?} preempted by another", entity_id);
-                    self.script_world.dispatch(Message {
-                        to: entity_id,
-                        payload: MessagePayload::TurnClipCancelled {
-                            token: playback.token,
-                        },
-                    });
-                }
-                None => {}
-            }
-        } else if let Some(playback) = previous {
-            Self::report_turn_clip_abandoned(&mut self.script_world, entity_id, playback);
+        // followed, before recording the one it may have started.
+        if let Some(payload) =
+            self.turn_clips
+                .on_animation_applied(entity_id, applied_blend, turn.is_some())
+        {
+            self.script_world.dispatch(Message {
+                to: entity_id,
+                payload,
+            });
         }
 
         if let Some((token, _, _)) = turn {
-            let payload = match turn_started {
-                Some(turn) => {
-                    self.turn_clip_playback.insert(
-                        entity_id,
-                        TurnClipPlayback {
-                            token,
-                            completed: false,
-                        },
-                    );
-                    MessagePayload::TurnClipStarted { token, turn }
-                }
-                // No affordable clip covered the pivot, the creature has no
-                // turn clips, or it has no animation player at all. The
-                // requester is answered either way, so it never waits on a
-                // clip that will not come.
-                None => MessagePayload::TurnClipCancelled { token },
-            };
+            let payload = self
+                .turn_clips
+                .on_turn_resolved(entity_id, token, turn_started);
             self.script_world.dispatch(Message {
                 to: entity_id,
                 payload,
@@ -4271,28 +4215,14 @@ impl MissionCore {
         }
     }
 
-    /// Tell a pivot's requester that its clip is gone. Every path that can end
-    /// a turn clip's playback goes through here, so a `TurnClip` in the script
-    /// is always answered and can hold the creature's heading no longer than
-    /// its clip really plays.
-    fn report_turn_clip_abandoned(
-        script_world: &mut ScriptWorld,
-        entity_id: EntityId,
-        playback: TurnClipPlayback,
-    ) {
-        script_world.dispatch(Message {
-            to: entity_id,
-            payload: MessagePayload::TurnClipCancelled {
-                token: playback.token,
-            },
-        });
-    }
-
     /// The entity's animation player is being replaced or taken away, so no
     /// completion can ever arrive for a turn clip it was playing.
     fn abandon_turn_clip(&mut self, entity_id: EntityId) {
-        if let Some(playback) = self.turn_clip_playback.remove(&entity_id) {
-            Self::report_turn_clip_abandoned(&mut self.script_world, entity_id, playback);
+        if let Some(payload) = self.turn_clips.abandon(entity_id) {
+            self.script_world.dispatch(Message {
+                to: entity_id,
+                payload,
+            });
         }
     }
 
@@ -4364,6 +4294,14 @@ impl MissionCore {
             let (new_player, flags, events, velocity) =
                 AnimationPlayer::update(player, time.elapsed);
             *player = new_player;
+
+            // A pivot handing its yaw over rides the fade this player is
+            // running, so it is told the pose's own cross-fade weight every
+            // frame - read here, right after the player advanced, so the
+            // facing and the pose it belongs to are never a frame apart.
+            if let Some(payload) = self.turn_clips.on_blend_tick(*id, player) {
+                self.script_world.dispatch(Message { to: *id, payload });
+            }
 
             if let Some(model) = self.id_to_model.get(id) {
                 let joint_transforms = model.get_joint_transforms(player);
@@ -4440,14 +4378,8 @@ impl MissionCore {
                         // A pivot's clip reaching its end: from here the next
                         // clip applied to this entity is its handoff, not a
                         // preemption.
-                        if let Some(playback) = self.turn_clip_playback.get_mut(id) {
-                            playback.completed = true;
-                            self.script_world.dispatch(Message {
-                                to: *id,
-                                payload: MessagePayload::TurnClipCompleted {
-                                    token: playback.token,
-                                },
-                            });
+                        if let Some(payload) = self.turn_clips.on_clip_completed(*id) {
+                            self.script_world.dispatch(Message { to: *id, payload });
                         }
                         self.script_world.dispatch(Message {
                             to: *id,
@@ -5602,7 +5534,7 @@ impl MissionCore {
         // Shipyard recycles entity ids, so stale per-entity animation state
         // must not outlive the entity (a recycled id would inherit it).
         self.id_to_animation_player.remove(&entity_id);
-        self.turn_clip_playback.remove(&entity_id);
+        self.turn_clips.forget(entity_id);
         self.failed_animation_queries.remove(&entity_id);
         self.gui.on_entity_destroyed(
             entity_id,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod reload;
 pub mod spatial_query;
 mod spawn_location;
 pub mod stim_response;
-pub mod turn_clip;
+pub(crate) mod turn_clip;
 pub mod visibility_engine;
 
 pub use mission_core::*;

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod reload;
 pub mod spatial_query;
 mod spawn_location;
 pub mod stim_response;
+pub mod turn_clip;
 pub mod visibility_engine;
 
 pub use mission_core::*;

--- a/shock2vr/src/mission/turn_clip.rs
+++ b/shock2vr/src/mission/turn_clip.rs
@@ -48,26 +48,27 @@ impl TurnClipTracker {
         }
     }
 
-    /// An animation was applied to `entity_id`. `applied_blend` is the fade
-    /// the player is now running (`None` if the request resolved to no clip),
-    /// and `answers_pivot` says whether the apply came from a `PlayTurnClip` -
+    /// An animation was applied to `entity_id`: `applied` says whether the
+    /// clip that started cross-fades in (`Some(true)`) or hard-cuts
+    /// (`Some(false)`), and is `None` when the request resolved to no clip at
+    /// all. `answers_pivot` says whether the apply came from a `PlayTurnClip` -
     /// one that resolved to nothing still displaces whatever was tracked, so
     /// the entry is taken either way.
     pub fn on_animation_applied(
         &mut self,
         entity_id: EntityId,
-        applied_blend: Option<f32>,
+        applied: Option<bool>,
         answers_pivot: bool,
     ) -> Option<MessagePayload> {
-        let previous = if applied_blend.is_some() || answers_pivot {
+        let previous = if applied.is_some() || answers_pivot {
             self.playbacks.remove(&entity_id)?
         } else {
             return None;
         };
         let token = previous.token;
-        match (applied_blend, previous.phase) {
-            (Some(blend), TurnClipPhase::Completed) => {
-                if blend > 0.0 {
+        match (applied, previous.phase) {
+            (Some(fades), TurnClipPhase::Completed) => {
+                if fades {
                     self.playbacks.insert(
                         entity_id,
                         TurnClipPlayback {
@@ -76,7 +77,7 @@ impl TurnClipTracker {
                         },
                     );
                 }
-                Some(MessagePayload::TurnClipHandoff { token, blend })
+                Some(MessagePayload::TurnClipHandoff { token, fades })
             }
             // Preempted while playing, displaced mid-fade, or orphaned by an
             // apply that started nothing: no pose is performing the turn any

--- a/shock2vr/src/mission/turn_clip.rs
+++ b/shock2vr/src/mission/turn_clip.rs
@@ -1,0 +1,162 @@
+//! Ownership of a pivot's turn clip, from the request to the last frame of
+//! the fade its yaw hands over across (`Effect::PlayTurnClip`).
+//!
+//! The applier owns the animation player, so it - not a clock in the script -
+//! is what knows whose clip is playing and how far the fade that follows it
+//! has got. Scripts and the animation player tick at different points in the
+//! frame, so a script integrating its own copy of the fade runs a frame ahead
+//! of the pose; every report below is read off the player itself.
+
+use std::collections::HashMap;
+
+use cgmath::Deg;
+use dark::motion::AnimationPlayer;
+use shipyard::EntityId;
+
+use crate::scripts::MessagePayload;
+
+/// How far a tracked turn clip has got.
+enum TurnClipPhase {
+    /// Still playing: any other animation applied to the entity preempts it.
+    Playing,
+    /// Ran to its end. The next clip applied is the transition its pose gives
+    /// the turn up across, not a preemption.
+    Completed,
+    /// That transition is running and the pivot's yaw is riding it. A clip
+    /// applied now (a wound reaction, a behavior swap) replaces the fade, so
+    /// the rest of the turn is dropped rather than eased against a curve
+    /// nothing is drawing any more.
+    HandingOff,
+}
+
+struct TurnClipPlayback {
+    /// The `Effect::PlayTurnClip` request this playback answers.
+    token: u64,
+    phase: TurnClipPhase,
+}
+
+/// The turn clip in flight per entity. Each method reports what the requester
+/// must be told, if anything; the caller dispatches it.
+pub struct TurnClipTracker {
+    playbacks: HashMap<EntityId, TurnClipPlayback>,
+}
+
+impl TurnClipTracker {
+    pub fn new() -> TurnClipTracker {
+        TurnClipTracker {
+            playbacks: HashMap::new(),
+        }
+    }
+
+    /// An animation was applied to `entity_id`. `applied_blend` is the fade
+    /// the player is now running (`None` if the request resolved to no clip),
+    /// and `answers_pivot` says whether the apply came from a `PlayTurnClip` -
+    /// one that resolved to nothing still displaces whatever was tracked, so
+    /// the entry is taken either way.
+    pub fn on_animation_applied(
+        &mut self,
+        entity_id: EntityId,
+        applied_blend: Option<f32>,
+        answers_pivot: bool,
+    ) -> Option<MessagePayload> {
+        let previous = if applied_blend.is_some() || answers_pivot {
+            self.playbacks.remove(&entity_id)?
+        } else {
+            return None;
+        };
+        let token = previous.token;
+        match (applied_blend, previous.phase) {
+            (Some(blend), TurnClipPhase::Completed) => {
+                if blend > 0.0 {
+                    self.playbacks.insert(
+                        entity_id,
+                        TurnClipPlayback {
+                            token,
+                            phase: TurnClipPhase::HandingOff,
+                        },
+                    );
+                }
+                Some(MessagePayload::TurnClipHandoff { token, blend })
+            }
+            // Preempted while playing, displaced mid-fade, or orphaned by an
+            // apply that started nothing: no pose is performing the turn any
+            // more, so its authored facing change must not be taken.
+            _ => Some(MessagePayload::TurnClipCancelled { token }),
+        }
+    }
+
+    /// A `PlayTurnClip` resolved: `started` carries the facing change the clip
+    /// the applier picked is authored to end on, or `None` when nothing was
+    /// affordable. The requester is answered either way, so it never waits on
+    /// a clip that will not come.
+    pub fn on_turn_resolved(
+        &mut self,
+        entity_id: EntityId,
+        token: u64,
+        started: Option<Deg<f32>>,
+    ) -> MessagePayload {
+        match started {
+            Some(turn) => {
+                self.playbacks.insert(
+                    entity_id,
+                    TurnClipPlayback {
+                        token,
+                        phase: TurnClipPhase::Playing,
+                    },
+                );
+                MessagePayload::TurnClipStarted { token, turn }
+            }
+            None => MessagePayload::TurnClipCancelled { token },
+        }
+    }
+
+    /// An animation on `entity_id` reached its end. Only the pivot's own clip
+    /// is reported - the clips that follow it complete too, and one of those
+    /// completions used to be able to restart the handover.
+    pub fn on_clip_completed(&mut self, entity_id: EntityId) -> Option<MessagePayload> {
+        let playback = self.playbacks.get_mut(&entity_id)?;
+        match playback.phase {
+            TurnClipPhase::Playing => {
+                playback.phase = TurnClipPhase::Completed;
+                Some(MessagePayload::TurnClipCompleted {
+                    token: playback.token,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// One frame of the fade the pivot's yaw hands over across, read off the
+    /// player after it has been advanced. The last report of a fade is 1.0,
+    /// and ends the tracking.
+    pub fn on_blend_tick(
+        &mut self,
+        entity_id: EntityId,
+        player: &AnimationPlayer,
+    ) -> Option<MessagePayload> {
+        let playback = self.playbacks.get(&entity_id)?;
+        if !matches!(playback.phase, TurnClipPhase::HandingOff) {
+            return None;
+        }
+        let token = playback.token;
+        let alpha = player.blend_alpha_now();
+        if alpha >= 1.0 {
+            self.playbacks.remove(&entity_id);
+        }
+        Some(MessagePayload::TurnClipBlend { token, alpha })
+    }
+
+    /// The entity's animation player is being replaced or taken away, so no
+    /// report can ever arrive for a turn clip it was playing.
+    pub fn abandon(&mut self, entity_id: EntityId) -> Option<MessagePayload> {
+        let playback = self.playbacks.remove(&entity_id)?;
+        Some(MessagePayload::TurnClipCancelled {
+            token: playback.token,
+        })
+    }
+
+    /// The entity is gone; there is nobody left to report to.
+    pub fn forget(&mut self, entity_id: EntityId) {
+        self.playbacks.remove(&entity_id);
+    }
+}

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -206,22 +206,25 @@ enum TurnClip {
     HandingOver {
         token: u64,
         turn: Deg<f32>,
-        /// How long this has been waiting. The fade starts when the following
-        /// clip is applied, a frame before its report is handled, so the
-        /// settle picks up where the player's own blend already is.
+        /// How long this has been waiting, purely to bound it: a creature can
+        /// legitimately queue nothing after its pivot.
         waited: f32,
     },
     /// Handing over: the entity takes the clip's authored facing change across
-    /// the very fade the animation player is running, on the same curve, so
-    /// the facing the pose gives up and the facing the entity takes cancel out
-    /// frame for frame.
+    /// the very fade the animation player is running, so the facing the pose
+    /// gives up and the facing the entity takes cancel out frame for frame.
+    /// The fraction is not integrated here - it is the pose's own cross-fade
+    /// weight, reported every frame by the applier (`TurnClipBlend`), because
+    /// the script and the animation player tick at different points in the
+    /// frame and a clock of its own would run a frame ahead of the pose.
     Settling {
+        token: u64,
         turn: Deg<f32>,
-        /// The heading the clip ended on - the anchor the eased fraction of
+        /// The heading the clip ended on - the anchor the reported fraction of
         /// `turn` is added to, so rounding cannot accumulate across the fade.
         base: Deg<f32>,
-        elapsed: f32,
-        window: f32,
+        /// How much of the pose the following clip owns, as last reported.
+        alpha: f32,
     },
 }
 
@@ -931,18 +934,12 @@ impl AnimatedMonsterAI {
                 (Effect::NoEffect, true)
             }
             Some(TurnClip::Settling {
-                turn,
-                base,
-                elapsed: settled,
-                window,
+                turn, base, alpha, ..
             }) => {
-                *settled += elapsed;
-                let t = (*settled / *window).clamp(0.0, 1.0);
-                // The animation player's own cross-fade weight: the pose gives
-                // up `alpha` of the turn it was holding this frame, so the
+                // The pose gave up `alpha` of the turn it was holding, so the
                 // entity takes exactly `alpha` of it back.
-                let heading = Deg(base.0 + turn.0 * dark::motion::blend_alpha(t));
-                if t >= 1.0 {
+                let heading = Deg(base.0 + turn.0 * *alpha);
+                if *alpha >= 1.0 {
                     self.finish_pivot(entity_id, heading);
                 } else {
                     self.current_heading = heading;
@@ -971,15 +968,10 @@ impl AnimatedMonsterAI {
     /// creature that takes a hit, waits at a door or changes behavior is NOT
     /// thereby done pivoting - if nothing displaced the clip, its pose is
     /// still turning the body and the turn is still owed. A pivot already
-    /// `Settling` is past all of this: its facing change is being taken
-    /// against a fade that is really running, so it is left to finish.
+    /// settling is dropped where it stands: the fade it was riding has been
+    /// replaced, so the rest of the turn has no pose behind it either.
     fn cancel_turn_clip(&mut self, entity_id: EntityId, reason: &str) {
-        if matches!(
-            self.turn_clip,
-            Some(TurnClip::Requested { .. })
-                | Some(TurnClip::Playing { .. })
-                | Some(TurnClip::HandingOver { .. })
-        ) {
+        if self.turn_clip.is_some() {
             tracing::debug!("ai {:?} drops its pivot: {}", entity_id, reason);
             self.turn_clip = None;
             self.turn_cooldown = TURN_CLIP_COOLDOWN;
@@ -992,8 +984,9 @@ impl AnimatedMonsterAI {
         match &self.turn_clip {
             Some(TurnClip::Requested { token })
             | Some(TurnClip::Playing { token, .. })
-            | Some(TurnClip::HandingOver { token, .. }) => Some(*token),
-            Some(TurnClip::Settling { .. }) | None => None,
+            | Some(TurnClip::HandingOver { token, .. })
+            | Some(TurnClip::Settling { token, .. }) => Some(*token),
+            None => None,
         }
     }
 
@@ -1818,19 +1811,19 @@ impl Script for AnimatedMonsterAI {
                 if let Some(TurnClip::HandingOver {
                     token: pending,
                     turn,
-                    waited,
+                    ..
                 }) = self.turn_clip
                 {
                     if pending == *token {
-                        if *blend > waited {
+                        if *blend > 0.0 {
+                            // The applier reports the fade's weight from here
+                            // on; the heading starts on the one the clip ended
+                            // on and rides those reports.
                             self.turn_clip = Some(TurnClip::Settling {
+                                token: *token,
                                 turn,
                                 base: self.current_heading,
-                                // The player started this fade when it applied
-                                // the clip, a frame before this report; pick it
-                                // up where its blend already is.
-                                elapsed: waited,
-                                window: *blend,
+                                alpha: 0.0,
                             });
                         } else {
                             // Nothing to spread it over: the pose drops the
@@ -1838,6 +1831,19 @@ impl Script for AnimatedMonsterAI {
                             // same one and the visible facing still matches.
                             self.finish_pivot(entity_id, Deg(self.current_heading.0 + turn.0));
                         }
+                    }
+                }
+                Effect::NoEffect
+            }
+            MessagePayload::TurnClipBlend { token, alpha } => {
+                if let Some(TurnClip::Settling {
+                    token: pending,
+                    alpha: current,
+                    ..
+                }) = &mut self.turn_clip
+                {
+                    if *pending == *token {
+                        *current = *alpha;
                     }
                 }
                 Effect::NoEffect
@@ -2328,6 +2334,162 @@ mod tests {
         }
     }
 
+    /// One frame of the fade the pivot hands over across, as the applier
+    /// reports it: the pose's own weight, then the script's update.
+    fn settle_frame(
+        monster: &mut AnimatedMonsterAI,
+        world: &World,
+        entity_id: EntityId,
+        alpha: f32,
+    ) {
+        let token = pending_token(monster);
+        tell(
+            monster,
+            world,
+            entity_id,
+            MessagePayload::TurnClipBlend { token, alpha },
+        );
+        turn_frame(monster, entity_id, Deg(90.0));
+    }
+
+    /// A clip that runs for `frames` 100ms frames and fades in over
+    /// `blend_ms`.
+    fn test_clip(frames: u32, blend_ms: u64) -> std::rc::Rc<dark::motion::AnimationClip> {
+        let time_per_frame = std::time::Duration::from_millis(100);
+        std::rc::Rc::new(dark::motion::AnimationClip {
+            num_frames: frames,
+            time_per_frame,
+            duration: time_per_frame * frames,
+            blend_length: std::time::Duration::from_millis(blend_ms),
+            end_rotation: Deg(0.0),
+            sliding_velocity: vec3(0.0, 0.0, 0.0),
+            translation: vec3(0.0, 0.0, 0.0),
+            joint_to_frame: std::collections::HashMap::new(),
+            root_transforms: Vec::new(),
+            root_positions: Vec::new(),
+            motion_flags: Vec::new(),
+            name: None,
+        })
+    }
+
+    /// `mission_core`'s frame in miniature, driving the REAL animation player,
+    /// the REAL applier-side tracker and the REAL script in the order the
+    /// mission loop runs them: animations advance first, then the reports they
+    /// produced are delivered, then the script updates, then its effects are
+    /// applied. That order is the whole point - the script's own clock ticks
+    /// after the player's, so anything the script integrates itself runs a
+    /// frame ahead of the pose it is supposed to match.
+    struct PivotHarness {
+        world: World,
+        entity_id: EntityId,
+        monster: AnimatedMonsterAI,
+        player: dark::motion::AnimationPlayer,
+        tracker: crate::mission::turn_clip::TurnClipTracker,
+        /// Reports produced since the script last read its messages.
+        pending: Vec<MessagePayload>,
+    }
+
+    /// The mission loop's fixed timestep.
+    const HARNESS_DT: f32 = 1.0 / 60.0;
+
+    impl PivotHarness {
+        fn new(heading: Deg<f32>) -> PivotHarness {
+            let (world, entity_id, monster) = pivoting_monster(heading);
+            PivotHarness {
+                world,
+                entity_id,
+                monster,
+                player: dark::motion::AnimationPlayer::empty(),
+                tracker: crate::mission::turn_clip::TurnClipTracker::new(),
+                pending: Vec::new(),
+            }
+        }
+
+        /// The applier starting a clip on this entity: what `PlayAnimation`
+        /// and `PlayTurnClip` both come down to.
+        fn apply_clip(
+            &mut self,
+            clip: std::rc::Rc<dark::motion::AnimationClip>,
+            pivot: Option<(u64, Deg<f32>)>,
+        ) {
+            self.player = dark::motion::AnimationPlayer::queue_animation(&self.player, clip);
+            let blend = self.player.blend_remaining_seconds();
+            if let Some(payload) =
+                self.tracker
+                    .on_animation_applied(self.entity_id, Some(blend), pivot.is_some())
+            {
+                self.pending.push(payload);
+            }
+            if let Some((token, turn)) = pivot {
+                self.pending.push(
+                    self.tracker
+                        .on_turn_resolved(self.entity_id, token, Some(turn)),
+                );
+            }
+        }
+
+        /// One mission frame. Returns the pose weight the renderer would use
+        /// for the clip that follows the pivot.
+        fn frame(&mut self) -> f32 {
+            let dt = std::time::Duration::from_secs_f32(HARNESS_DT);
+            let (next, _, events, _) = dark::motion::AnimationPlayer::update(&self.player, dt);
+            self.player = next;
+            if let Some(payload) = self.tracker.on_blend_tick(self.entity_id, &self.player) {
+                self.pending.push(payload);
+            }
+            for event in events {
+                if matches!(event, dark::motion::AnimationEvent::Completed) {
+                    if let Some(payload) = self.tracker.on_clip_completed(self.entity_id) {
+                        self.pending.push(payload);
+                    }
+                }
+            }
+
+            for payload in std::mem::take(&mut self.pending) {
+                tell(&mut self.monster, &self.world, self.entity_id, payload);
+            }
+            let time = Time {
+                elapsed: dt,
+                total: dt,
+            };
+            self.monster
+                .update_turn_clip(self.entity_id, Deg(90.0), &time, true);
+
+            self.player.blend_alpha_now()
+        }
+
+        /// Ask for a pivot and let the applier answer it with a clip authored
+        /// to end on `turn`.
+        fn start_pivot(&mut self, turn: Deg<f32>, clip_frames: u32) {
+            let (effect, _) = self.monster.update_turn_clip(
+                self.entity_id,
+                Deg(90.0),
+                &Time {
+                    elapsed: std::time::Duration::from_secs_f32(HARNESS_DT),
+                    total: std::time::Duration::from_secs_f32(HARNESS_DT),
+                },
+                true,
+            );
+            let token = match effect {
+                Effect::PlayTurnClip { token, .. } => token,
+                other => panic!("expected a pivot request, got {other:?}"),
+            };
+            self.apply_clip(test_clip(clip_frames, 0), Some((token, turn)));
+        }
+
+        /// Run frames until the pivot's clip has ended and the script is
+        /// waiting for whatever follows it.
+        fn play_clip_out(&mut self) {
+            for _ in 0..600 {
+                self.frame();
+                if matches!(self.monster.turn_clip, Some(TurnClip::HandingOver { .. })) {
+                    return;
+                }
+            }
+            panic!("the turn clip never ended");
+        }
+    }
+
     fn locomotion_scale(effects: &[Effect]) -> Option<f32> {
         effects.iter().find_map(|effect| match effect {
             Effect::SetAIProperty {
@@ -2456,10 +2618,15 @@ mod tests {
         complete_clip(&mut monster, &world, entity_id);
         hand_off(&mut monster, &world, entity_id, TEST_BLEND);
 
-        // The settle is the reported fade, in 100ms frames.
-        for _ in 0..5 {
-            assert!(turn_frame(&mut monster, entity_id, Deg(90.0)).1);
-        }
+        // The settle rides the fade the applier reports, half of it and then
+        // all of it.
+        settle_frame(&mut monster, &world, entity_id, 0.5);
+        assert!(
+            (monster.current_heading.0 - (-90.0 - 168.0 * 0.5)).abs() < 1e-3,
+            "half the fade is half the turn, heading is {:?}",
+            monster.current_heading
+        );
+        settle_frame(&mut monster, &world, entity_id, 1.0);
         assert!(
             (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
             "expected the authored turn to land, heading is {:?}",
@@ -2493,9 +2660,7 @@ mod tests {
         start_pivot(&mut monster, &world, entity_id, Deg(-100.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
         hand_off(&mut monster, &world, entity_id, TEST_BLEND);
-        for _ in 0..6 {
-            turn_frame(&mut monster, entity_id, Deg(90.0));
-        }
+        settle_frame(&mut monster, &world, entity_id, 1.0);
         assert!(monster.turn_clip.is_none(), "the first pivot must be over");
         // Still facing a long way from where it wants to be, but it has to
         // steer out of the pivot before performing another.
@@ -2515,9 +2680,10 @@ mod tests {
         let token = start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
         complete_clip(&mut monster, &world, entity_id);
         hand_off(&mut monster, &world, entity_id, TEST_BLEND);
+        settle_frame(&mut monster, &world, entity_id, 1.0);
+        // Everything the behavior's own re-queued clip reports next: its plain
+        // completion, and the pivot's reports replayed.
         for _ in 0..2 {
-            // Everything the behavior's own re-queued clip reports next:
-            // its plain completion, and the pivot's reports replayed.
             tell(
                 &mut monster,
                 &world,
@@ -2689,40 +2855,112 @@ mod tests {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
-        // A 400ms fade, walked in the 100ms frames `turn_frame` uses.
         hand_off(&mut monster, &world, entity_id, 0.4);
 
         for step in 1..=4 {
-            turn_frame(&mut monster, entity_id, Deg(90.0));
-            let t = step as f32 / 4.0;
-            let expected = -90.0 - 168.0 * dark::motion::blend_alpha(t);
+            let alpha = dark::motion::blend_alpha(step as f32 / 4.0);
+            settle_frame(&mut monster, &world, entity_id, alpha);
+            let expected = -90.0 - 168.0 * alpha;
             assert!(
                 (monster.current_heading.0 - expected).abs() < 1e-3,
-                "at t={t} expected {expected}, got {:?}",
+                "expected {expected}, got {:?}",
                 monster.current_heading
             );
         }
         assert!(monster.turn_clip.is_none(), "the handover is complete");
     }
 
-    /// The player starts the fade when it applies the following clip, a frame
-    /// before its report reaches the script - so the settle picks the curve up
-    /// where the pose already is, rather than restarting it a frame behind.
+    /// The load-bearing one: a REAL animation player, the REAL applier-side
+    /// tracker and the REAL script, run in the mission loop's own order over a
+    /// follow-up clip that actually fades.
+    ///
+    /// The script's update runs AFTER the animation player's, so a script that
+    /// integrates the fade itself takes one dt on the frame the clip completes
+    /// and another on the frame the handover report arrives - two dt of yaw
+    /// against one dt of pose, and the gap never closes for the rest of the
+    /// fade. The yaw is read off the player instead, so it cannot lead it by
+    /// even one frame.
     #[test]
-    fn the_settle_picks_up_a_fade_already_running() {
-        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
-        complete_clip(&mut monster, &world, entity_id);
-        // One 100ms frame passes between the clip ending and the report.
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        hand_off(&mut monster, &world, entity_id, 0.4);
+    fn the_yaw_never_leads_the_pose_across_a_real_fade() {
+        const TURN: f32 = -168.0;
+        const BLEND_MS: u64 = 500;
+        let mut harness = PivotHarness::new(Deg(-90.0));
+        harness.start_pivot(Deg(TURN), 3);
+        harness.play_clip_out();
 
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        let expected = -90.0 - 168.0 * dark::motion::blend_alpha(0.2 / 0.4);
+        // The behavior queues its next clip on the frame the pivot's ended,
+        // exactly as the AI's completion handler does.
+        harness.apply_clip(test_clip(30, BLEND_MS), None);
+
+        let mut fade_frames = 0;
+        for _ in 0..120 {
+            let pose = harness.frame();
+            fade_frames += 1;
+            let taken = (harness.monster.current_heading.0 - -90.0) / TURN;
+            assert!(
+                (taken - pose).abs() < 1e-4,
+                "frame {fade_frames}: the pose is {pose} through the fade but the entity has taken {taken} of the turn",
+            );
+            // ...and that shared number is the fade the player is really
+            // running: `blend_alpha` of the elapsed fraction, no lead.
+            let elapsed = fade_frames as f32 * HARNESS_DT;
+            let expected = dark::motion::blend_alpha(elapsed / (BLEND_MS as f32 / 1000.0));
+            assert!(
+                (taken - expected).abs() < 1e-4,
+                "frame {fade_frames}: expected {expected} of the turn, entity has taken {taken}",
+            );
+            if harness.monster.turn_clip.is_none() {
+                break;
+            }
+        }
+
         assert!(
-            (monster.current_heading.0 - expected).abs() < 1e-3,
-            "expected {expected}, got {:?}",
-            monster.current_heading
+            harness.monster.turn_clip.is_none(),
+            "the handover must finish with the fade"
+        );
+        assert!(
+            (harness.monster.current_heading.0 - (-90.0 + TURN)).abs() < 1e-3,
+            "and land the whole authored turn, heading is {:?}",
+            harness.monster.current_heading
+        );
+        // A 500ms fade at 60Hz: the settle lasts the fade, not a frame more.
+        assert_eq!(fade_frames, 30);
+    }
+
+    /// A wound reaction (or any other clip) landing mid-settle replaces the
+    /// fade the yaw was riding: from that frame nothing is giving the turn up,
+    /// so the rest of it must not be taken. The applier keeps ownership of the
+    /// pivot through the settle precisely so it can say so.
+    #[test]
+    fn a_clip_displacing_the_settle_cancels_the_rest_of_the_turn() {
+        let mut harness = PivotHarness::new(Deg(-90.0));
+        harness.start_pivot(Deg(-168.0), 3);
+        harness.play_clip_out();
+        harness.apply_clip(test_clip(30, 500), None);
+
+        for _ in 0..10 {
+            harness.frame();
+        }
+        let taken = harness.monster.current_heading;
+        assert!(
+            matches!(harness.monster.turn_clip, Some(TurnClip::Settling { .. })),
+            "the settle must be running to be displaced"
+        );
+
+        // The wound clip: it is what the player fades now, not the pivot's.
+        harness.apply_clip(test_clip(10, 300), None);
+        harness.frame();
+        assert!(
+            harness.monster.turn_clip.is_none(),
+            "a displaced settle is dropped, not carried on"
+        );
+
+        for _ in 0..40 {
+            harness.frame();
+        }
+        assert_eq!(
+            harness.monster.current_heading, taken,
+            "and the rest of the turn never lands"
         );
     }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -968,10 +968,15 @@ impl AnimatedMonsterAI {
     /// creature that takes a hit, waits at a door or changes behavior is NOT
     /// thereby done pivoting - if nothing displaced the clip, its pose is
     /// still turning the body and the turn is still owed. A pivot already
-    /// settling is dropped where it stands: the fade it was riding has been
-    /// replaced, so the rest of the turn has no pose behind it either.
+    /// settling is not dropped at all - its pose has already given the turn up
+    /// (see the `TurnClipCancelled` handler), so it finishes instead.
     fn cancel_turn_clip(&mut self, entity_id: EntityId, reason: &str) {
-        if self.turn_clip.is_some() {
+        if matches!(
+            self.turn_clip,
+            Some(TurnClip::Requested { .. })
+                | Some(TurnClip::Playing { .. })
+                | Some(TurnClip::HandingOver { .. })
+        ) {
             tracing::debug!("ai {:?} drops its pivot: {}", entity_id, reason);
             self.turn_clip = None;
             self.turn_cooldown = TURN_CLIP_COOLDOWN;
@@ -1803,7 +1808,19 @@ impl Script for AnimatedMonsterAI {
             }
             MessagePayload::TurnClipCancelled { token } => {
                 if self.turn_clip_token() == Some(*token) {
-                    self.cancel_turn_clip(entity_id, "no clip is performing it");
+                    if let Some(TurnClip::Settling { turn, base, .. }) = self.turn_clip {
+                        // The clip that displaced the fade takes the turn
+                        // clip's pose with it: the player cross-fades from the
+                        // FOLLOW-UP clip's own pose, not the blended one on
+                        // screen, so the `turn * (1 - alpha)` the pose was
+                        // still holding is gone this frame. Taking the rest of
+                        // the turn now is what keeps the visible facing
+                        // continuous - dropping it would snap the creature
+                        // back by the remainder.
+                        self.finish_pivot(entity_id, Deg(base.0 + turn.0));
+                    } else {
+                        self.cancel_turn_clip(entity_id, "no clip is performing it");
+                    }
                 }
                 Effect::NoEffect
             }
@@ -2918,11 +2935,14 @@ mod tests {
     }
 
     /// A wound reaction (or any other clip) landing mid-settle replaces the
-    /// fade the yaw was riding: from that frame nothing is giving the turn up,
-    /// so the rest of it must not be taken. The applier keeps ownership of the
-    /// pivot through the settle precisely so it can say so.
+    /// fade the yaw was riding - and takes the turn clip's pose with it, since
+    /// the player fades from the follow-up clip's own pose rather than the
+    /// blended one. The remaining turn has nothing holding it any more, so it
+    /// lands in that frame instead of easing on across a curve nobody is
+    /// drawing. The applier keeps ownership of the pivot through the settle
+    /// precisely so it can say when that happened.
     #[test]
-    fn a_clip_displacing_the_settle_cancels_the_rest_of_the_turn() {
+    fn a_clip_displacing_the_settle_takes_the_rest_of_the_turn_at_once() {
         let mut harness = PivotHarness::new(Deg(-90.0));
         harness.start_pivot(Deg(-168.0), 3);
         harness.play_clip_out();
@@ -2931,10 +2951,14 @@ mod tests {
         for _ in 0..10 {
             harness.frame();
         }
-        let taken = harness.monster.current_heading;
+        let partway = harness.monster.current_heading;
         assert!(
             matches!(harness.monster.turn_clip, Some(TurnClip::Settling { .. })),
             "the settle must be running to be displaced"
+        );
+        assert!(
+            (partway.0 - (-90.0 - 168.0)).abs() > 10.0,
+            "and must be nowhere near finished, at {partway:?}"
         );
 
         // The wound clip: it is what the player fades now, not the pivot's.
@@ -2942,15 +2966,21 @@ mod tests {
         harness.frame();
         assert!(
             harness.monster.turn_clip.is_none(),
-            "a displaced settle is dropped, not carried on"
+            "a displaced settle ends there and then"
+        );
+        assert!(
+            (harness.monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
+            "the whole turn lands with the pose that was holding it, heading is {:?}",
+            harness.monster.current_heading
         );
 
+        let landed = harness.monster.current_heading;
         for _ in 0..40 {
             harness.frame();
         }
         assert_eq!(
-            harness.monster.current_heading, taken,
-            "and the rest of the turn never lands"
+            harness.monster.current_heading, landed,
+            "and nothing moves it afterwards"
         );
     }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -171,20 +171,12 @@ pub(crate) fn frustration_gesture_allowed(
         && !matches!(target_distance, Some(d) if d <= MELEE_ATTACK_RANGE)
 }
 
-/// How long to wait for the applier to report which clip it picked. The report
-/// comes back on the next frame, so this only bounds a pivot that resolves to
-/// no clip at all and never reports one.
-const TURN_CLIP_REPORT_TIMEOUT: f32 = 0.25;
-
-/// How long past its authored length a turn clip may run before the pivot
-/// gives up on ever seeing it complete.
-const TURN_CLIP_OVERRUN_MARGIN: f32 = 0.25;
-
-/// How early a completion may arrive and still be the turn clip's own. Any
-/// other clip that preempted it completes far sooner than this (a run cycle is
-/// a third of a second), and settling on one of those would swing the AI
-/// through the authored turn with a neutral pose.
-const TURN_CLIP_COMPLETION_SLACK: f32 = 0.25;
+/// How long the pivot waits, after its clip has ended, for the applier to name
+/// the fade the following clip starts on. The report arrives as soon as the AI
+/// queues anything at all - normally the very next frame - so this only bounds
+/// a creature that queues nothing (its behavior ended with the pivot), which
+/// would otherwise hold its heading forever.
+const TURN_CLIP_HANDOFF_TIMEOUT: f32 = 0.5;
 
 /// The longest a creature may stand still to perform a pivot. The stock turn
 /// clips run 2.4-5.6 s; one long enough to read as a wedge (the reachability
@@ -198,32 +190,34 @@ const TURN_CLIP_MAX_SECONDS: f32 = 4.0;
 /// window, which has to outlast the path follower's own recovery.
 const TURN_CLIP_COOLDOWN: f32 = 3.0;
 
-/// Fallback for a clip that authors no blend length. The turn clip's pose
-/// swings back to neutral over the blend as the next clip fades in, so the
-/// entity takes the authored facing change over exactly the same window and
-/// the creature's visible facing never jumps.
-const TURN_CLIP_SETTLE_SECONDS: f32 = 0.5;
-
 /// A pivot being played as the creature's own authored turn clip. The clip's
 /// POSE does the visible turning, so the script holds its heading while the
 /// clip runs and only then takes the authored facing change.
+/// Every state carries the request token the applier echoes, so a report about
+/// a pivot this AI has already abandoned is recognised and dropped instead of
+/// committing a turn nothing is performing.
 enum TurnClip {
     /// Asked for; waiting for the applier to say which clip it picked.
-    Requested { remaining: f32 },
+    Requested { token: u64 },
     /// Playing: the pose is doing the turning, so the entity holds still.
-    Playing {
+    Playing { token: u64, turn: Deg<f32> },
+    /// The clip has ended; waiting for the applier to report the fade the
+    /// clip that follows it starts on.
+    HandingOver {
+        token: u64,
         turn: Deg<f32>,
         remaining: f32,
-        /// The clip's authored blend length - the window the pose takes to
-        /// swing back to neutral once it ends.
-        blend: f32,
     },
-    /// Done: the entity takes the clip's authored facing change across the
-    /// blend that swings the pose back to neutral.
+    /// Handing over: the entity takes the clip's authored facing change across
+    /// the very fade the animation player is running, on the same curve, so
+    /// the facing the pose gives up and the facing the entity takes cancel out
+    /// frame for frame.
     Settling {
         turn: Deg<f32>,
-        remaining: f32,
-        /// The blend window this is spread over.
+        /// The heading the clip ended on - the anchor the eased fraction of
+        /// `turn` is added to, so rounding cannot accumulate across the fade.
+        base: Deg<f32>,
+        elapsed: f32,
         window: f32,
     },
 }
@@ -330,6 +324,8 @@ pub struct AnimatedMonsterAI {
     turn_clip: Option<TurnClip>,
     /// Seconds left before this AI may perform another pivot
     turn_cooldown: f32,
+    /// Monotonic identity for pivot requests - see `TurnClip`
+    turn_token: u64,
 }
 
 impl AnimatedMonsterAI {
@@ -357,6 +353,7 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             turn_cooldown: 0.0,
+            turn_token: 0,
         }
     }
 
@@ -385,6 +382,7 @@ impl AnimatedMonsterAI {
             frustration_cooldown: 0.0,
             turn_clip: None,
             turn_cooldown: 0.0,
+            turn_token: 0,
         }
     }
 
@@ -699,6 +697,9 @@ impl AnimatedMonsterAI {
         self.alertness.visible_time = 0.0;
         self.alertness.hidden_time = 0.0;
 
+        // The new behavior wants a different heading, and the clip performing
+        // the old pivot is about to be replaced.
+        self.cancel_turn_clip(entity_id, "its behavior changed");
         self.current_behavior = self.behavior_for_alertness(world, Some(physics), entity_id);
         alertness::sync_alertness_effect(entity_id, &self.alertness)
     }
@@ -739,6 +740,7 @@ impl AnimatedMonsterAI {
     /// re-dispatch queued when no crumple motion is found), so the crumple
     /// and death sound play only once.
     fn enter_death(&mut self, world: &World, entity_id: EntityId) -> Effect {
+        self.cancel_turn_clip(entity_id, "it died mid-turn");
         self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
         self.is_dead = true;
         // Anchor the ragdoll-handoff timer to the crumple's actual start
@@ -897,67 +899,99 @@ impl AnimatedMonsterAI {
                 if !(may_start && stopped && self.turn_cooldown <= 0.0) {
                     return (Effect::NoEffect, false);
                 }
-                tracing::debug!("ai {:?} pivots {:?}", entity_id, delta);
-                self.turn_clip = Some(TurnClip::Requested {
-                    remaining: TURN_CLIP_REPORT_TIMEOUT,
-                });
+                self.turn_token += 1;
+                let token = self.turn_token;
+                tracing::debug!("ai {:?} pivots {:?} (turn {})", entity_id, delta, token);
+                self.turn_clip = Some(TurnClip::Requested { token });
                 (
                     Effect::PlayTurnClip {
                         entity_id,
+                        token,
                         delta,
                         max_seconds: TURN_CLIP_MAX_SECONDS,
                     },
                     true,
                 )
             }
-            Some(TurnClip::Requested { remaining }) => {
-                *remaining -= elapsed;
-                if *remaining > 0.0 {
-                    return (Effect::NoEffect, true);
-                }
-                // No clip covers this pivot - it is bigger than the ones the
-                // creature can afford, or its schema has none. Steer the turn,
-                // and let the cooldown space out the asking.
-                tracing::debug!("ai {:?} has no clip for its pivot", entity_id);
-                self.turn_clip = None;
-                self.turn_cooldown = TURN_CLIP_COOLDOWN;
-                (Effect::NoEffect, false)
+            // Both wait on the applier, which answers every request (with the
+            // clip it started, or a cancellation) and reports the clip's own
+            // completion - so neither needs a clock of its own.
+            Some(TurnClip::Requested { .. }) | Some(TurnClip::Playing { .. }) => {
+                (Effect::NoEffect, true)
             }
-            Some(TurnClip::Playing { remaining, .. }) => {
+            Some(TurnClip::HandingOver {
+                turn, remaining, ..
+            }) => {
                 *remaining -= elapsed;
                 if *remaining > 0.0 {
                     return (Effect::NoEffect, true);
                 }
-                // The completion never came - something preempted the clip.
-                tracing::debug!("ai {:?} lost its turn clip", entity_id);
-                self.turn_clip = None;
-                self.turn_cooldown = TURN_CLIP_COOLDOWN;
-                (Effect::NoEffect, false)
+                // Nothing followed the clip, so there is no fade to spread the
+                // facing change over: take it whole, exactly as a zero-length
+                // fade would.
+                let turn = *turn;
+                self.finish_pivot(entity_id, Deg(self.current_heading.0 + turn.0));
+                (Effect::NoEffect, true)
             }
             Some(TurnClip::Settling {
                 turn,
-                remaining,
+                base,
+                elapsed: settled,
                 window,
             }) => {
-                let step = elapsed.min(*remaining);
-                let turn = *turn;
-                let window = *window;
-                *remaining -= step;
-                // Rounding leaves a sliver of the last frame behind; anything
-                // this short is the end of the blend, not another frame of it.
-                let finished = *remaining <= 1e-4;
-                self.current_heading = Deg(self.current_heading.0 + turn.0 * step / window);
-                if finished {
-                    tracing::debug!(
-                        "ai {:?} finished its pivot facing {:?}",
-                        entity_id,
-                        self.current_heading
-                    );
-                    self.turn_clip = None;
-                    self.turn_cooldown = TURN_CLIP_COOLDOWN;
+                *settled += elapsed;
+                let t = (*settled / *window).clamp(0.0, 1.0);
+                // The animation player's own cross-fade weight: the pose gives
+                // up `alpha` of the turn it was holding this frame, so the
+                // entity takes exactly `alpha` of it back.
+                let heading = Deg(base.0 + turn.0 * dark::motion::blend_alpha(t));
+                if t >= 1.0 {
+                    self.finish_pivot(entity_id, heading);
+                } else {
+                    self.current_heading = heading;
                 }
                 (Effect::NoEffect, true)
             }
+        }
+    }
+
+    /// End the pivot on `heading`, and space the next one out.
+    fn finish_pivot(&mut self, entity_id: EntityId, heading: Deg<f32>) {
+        self.current_heading = heading;
+        tracing::debug!("ai {:?} finished its pivot facing {:?}", entity_id, heading);
+        self.turn_clip = None;
+        self.turn_cooldown = TURN_CLIP_COOLDOWN;
+    }
+
+    /// Drop a pivot in flight without taking its authored facing change.
+    ///
+    /// Whatever preempted the turn clip - a wound reaction, a behavior swap, a
+    /// door to wait at, death - took the pose that was turning the body with
+    /// it, so committing the turn now would swing the creature through it with
+    /// nothing to show for it. A pivot already `Settling` is past that: its
+    /// facing change is being taken against a fade that is really running, so
+    /// it is left to finish.
+    fn cancel_turn_clip(&mut self, entity_id: EntityId, reason: &str) {
+        if matches!(
+            self.turn_clip,
+            Some(TurnClip::Requested { .. })
+                | Some(TurnClip::Playing { .. })
+                | Some(TurnClip::HandingOver { .. })
+        ) {
+            tracing::debug!("ai {:?} drops its pivot: {}", entity_id, reason);
+            self.turn_clip = None;
+            self.turn_cooldown = TURN_CLIP_COOLDOWN;
+        }
+    }
+
+    /// The token of the pivot in flight, if any - a report echoing anything
+    /// else belongs to a pivot already abandoned.
+    fn turn_clip_token(&self) -> Option<u64> {
+        match &self.turn_clip {
+            Some(TurnClip::Requested { token })
+            | Some(TurnClip::Playing { token, .. })
+            | Some(TurnClip::HandingOver { token, .. }) => Some(*token),
+            Some(TurnClip::Settling { .. }) | None => None,
         }
     }
 
@@ -1438,6 +1472,11 @@ impl Script for AnimatedMonsterAI {
         // through it, so heading, whiskers, crowd repel and the route itself
         // stay live while the creature stands.
         let door_wait_seconds = self.update_door_wait(world, entity_id, time);
+        // A door to stand off from outranks a pivot: the AI is no longer
+        // turning toward anything, it is waiting.
+        if door_wait_seconds.is_some() {
+            self.cancel_turn_clip(entity_id, "it is waiting on a door");
+        }
         // The pivot in flight, as of last frame: one started this frame is
         // published on the next, and one ending is held a frame longer. Both
         // edges cost a single 16 ms frame either way.
@@ -1595,6 +1634,9 @@ impl Script for AnimatedMonsterAI {
                 }
                 // TODO: Let behavior handle this?
                 self.took_damage = true;
+                // The wound reaction takes the turn clip's place, so the turn
+                // it was performing must not be taken.
+                self.cancel_turn_clip(entity_id, "it was hit mid-turn");
                 let hit_points_effect = Effect::AdjustHitPoints {
                     entity_id,
                     delta: -(amount.round() as i32),
@@ -1742,59 +1784,70 @@ impl Script for AnimatedMonsterAI {
                 // cancels scripted sequences
                 self.force_alertness(*level, world, physics, entity_id)
             }
-            MessagePayload::TurnClipStarted {
-                turn,
-                duration,
-                blend,
-            } => {
-                if matches!(self.turn_clip, Some(TurnClip::Requested { .. })) {
-                    // Hold the heading for as long as the clip actually runs,
-                    // plus a margin: the completion is what normally ends the
-                    // pivot, this only bounds a clip that is preempted.
-                    self.turn_clip = Some(TurnClip::Playing {
-                        turn: *turn,
-                        remaining: duration + TURN_CLIP_OVERRUN_MARGIN,
-                        blend: if *blend > 0.0 {
-                            *blend
+            MessagePayload::TurnClipStarted { token, turn } => {
+                if let Some(TurnClip::Requested { token: pending }) = self.turn_clip {
+                    if pending == *token {
+                        self.turn_clip = Some(TurnClip::Playing {
+                            token: *token,
+                            turn: *turn,
+                        });
+                    }
+                }
+                Effect::NoEffect
+            }
+            MessagePayload::TurnClipCompleted { token } => {
+                if let Some(TurnClip::Playing {
+                    token: pending,
+                    turn,
+                }) = self.turn_clip
+                {
+                    if pending == *token {
+                        // The clip's pose still holds the full turn; the fade
+                        // into whatever comes next is what gives it up, and
+                        // the applier reports that fade as `TurnClipHandoff`.
+                        self.turn_clip = Some(TurnClip::HandingOver {
+                            token: *token,
+                            turn,
+                            remaining: TURN_CLIP_HANDOFF_TIMEOUT,
+                        });
+                    }
+                }
+                Effect::NoEffect
+            }
+            MessagePayload::TurnClipCancelled { token } => {
+                if self.turn_clip_token() == Some(*token) {
+                    self.cancel_turn_clip(entity_id, "no clip is performing it");
+                }
+                Effect::NoEffect
+            }
+            MessagePayload::TurnClipHandoff { token, blend } => {
+                if let Some(TurnClip::HandingOver {
+                    token: pending,
+                    turn,
+                    ..
+                }) = self.turn_clip
+                {
+                    if pending == *token {
+                        if *blend > 0.0 {
+                            self.turn_clip = Some(TurnClip::Settling {
+                                turn,
+                                base: self.current_heading,
+                                elapsed: 0.0,
+                                window: *blend,
+                            });
                         } else {
-                            TURN_CLIP_SETTLE_SECONDS
-                        },
-                    });
+                            // Nothing to spread it over: the pose drops the
+                            // turn in one frame, so the entity takes it in the
+                            // same one and the visible facing still matches.
+                            self.finish_pivot(entity_id, Deg(self.current_heading.0 + turn.0));
+                        }
+                    }
                 }
                 Effect::NoEffect
             }
             MessagePayload::AnimationCompleted => {
-                // The turn clip is done: take its authored facing change as
-                // the pose blends back to neutral.
-                //
-                // Only the turn clip's OWN completion may do that. The
-                // behavior's clip is re-queued the moment the pivot ends and
-                // completes a fraction of a second later, and anything that
-                // preempts the turn clip (a wound reaction, an alertness
-                // change) completes long before it would have - settling on
-                // one of those swings the AI through the authored turn with a
-                // neutral pose. `remaining` counts down the clip's own
-                // runtime, so only a completion arriving near the end of it is
-                // the clip's own; anything earlier means the pivot's clip is
-                // gone.
-                if let Some(TurnClip::Playing {
-                    turn,
-                    remaining,
-                    blend,
-                }) = self.turn_clip
-                {
-                    if remaining <= TURN_CLIP_OVERRUN_MARGIN + TURN_CLIP_COMPLETION_SLACK {
-                        self.turn_clip = Some(TurnClip::Settling {
-                            turn,
-                            remaining: blend,
-                            window: blend,
-                        });
-                    } else {
-                        tracing::debug!("ai {:?} lost its turn clip to another", entity_id);
-                        self.turn_clip = None;
-                        self.turn_cooldown = TURN_CLIP_COOLDOWN;
-                    }
-                }
+                // A pivot's own completion arrives as `TurnClipCompleted`
+                // instead - only the applier can tell whose clip finished.
                 if self.is_dead {
                     // The crumple->ragdoll handoff is timed from update()
                     // (CRUMPLE_HANDOFF_SECONDS), not completion-driven - a
@@ -2197,34 +2250,63 @@ mod tests {
         (requested, held)
     }
 
+    fn tell(
+        monster: &mut AnimatedMonsterAI,
+        world: &World,
+        entity_id: EntityId,
+        msg: MessagePayload,
+    ) {
+        monster.handle_message(entity_id, world, &PhysicsWorld::new(), &msg);
+    }
+
+    /// The token of the pivot in flight - what the applier echoes back.
+    fn pending_token(monster: &AnimatedMonsterAI) -> u64 {
+        monster
+            .turn_clip_token()
+            .expect("a pivot must be in flight to be reported on")
+    }
+
     /// Report the clip the applier picked for a pivot in flight.
     fn report_clip(
         monster: &mut AnimatedMonsterAI,
         world: &World,
         entity_id: EntityId,
         turn: Deg<f32>,
-        duration: f32,
     ) {
-        monster.handle_message(
-            entity_id,
+        let token = pending_token(monster);
+        tell(
+            monster,
             world,
-            &PhysicsWorld::new(),
-            &MessagePayload::TurnClipStarted {
-                turn,
-                duration,
-                blend: TURN_CLIP_SETTLE_SECONDS,
-            },
+            entity_id,
+            MessagePayload::TurnClipStarted { token, turn },
         );
     }
 
     fn complete_clip(monster: &mut AnimatedMonsterAI, world: &World, entity_id: EntityId) {
-        monster.handle_message(
-            entity_id,
+        let token = pending_token(monster);
+        tell(
+            monster,
             world,
-            &PhysicsWorld::new(),
-            &MessagePayload::AnimationCompleted,
+            entity_id,
+            MessagePayload::TurnClipCompleted { token },
         );
     }
+
+    /// The applier reporting the fade the clip that follows the pivot starts
+    /// on - the window the yaw hands over across.
+    fn hand_off(monster: &mut AnimatedMonsterAI, world: &World, entity_id: EntityId, blend: f32) {
+        let token = pending_token(monster);
+        tell(
+            monster,
+            world,
+            entity_id,
+            MessagePayload::TurnClipHandoff { token, blend },
+        );
+    }
+
+    /// The blend the stock turn clips author, and the window every settling
+    /// test below hands over across.
+    const TEST_BLEND: f32 = 0.5;
 
     /// Hold the pivot for `seconds` of 100ms frames, as the clip plays.
     fn play_out(monster: &mut AnimatedMonsterAI, entity_id: EntityId, seconds: f32) {
@@ -2329,7 +2411,7 @@ mod tests {
     fn the_body_holds_its_heading_and_stride_while_the_clip_plays() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
 
         for _ in 0..10 {
             let (requested, held) = turn_frame(&mut monster, entity_id, Deg(90.0));
@@ -2358,11 +2440,12 @@ mod tests {
     fn the_authored_turn_lands_on_the_entity_once_the_clip_ends() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
         play_out(&mut monster, entity_id, 4.8);
         complete_clip(&mut monster, &world, entity_id);
+        hand_off(&mut monster, &world, entity_id, TEST_BLEND);
 
-        // The settle is the clip's blend length, in 100ms frames.
+        // The settle is the reported fade, in 100ms frames.
         for _ in 0..5 {
             assert!(turn_frame(&mut monster, entity_id, Deg(90.0)).1);
         }
@@ -2382,13 +2465,10 @@ mod tests {
     #[test]
     fn a_pivot_cannot_hold_long_enough_to_look_stuck() {
         // The reachability harness treats holding one spot for 6s as wedged.
-        assert!(
-            TURN_CLIP_REPORT_TIMEOUT
-                + TURN_CLIP_MAX_SECONDS
-                + TURN_CLIP_OVERRUN_MARGIN
-                + TURN_CLIP_SETTLE_SECONDS
-                < 6.0
-        );
+        // The stock clips author blends of at most half a second, which is
+        // the longest fade a handover can be spread over.
+        const LONGEST_STOCK_BLEND: f32 = 0.5;
+        assert!(TURN_CLIP_MAX_SECONDS + TURN_CLIP_HANDOFF_TIMEOUT + LONGEST_STOCK_BLEND < 6.0);
     }
 
     /// Two pivots back to back hold the creature still for longer than either
@@ -2397,9 +2477,10 @@ mod tests {
     fn a_second_pivot_waits_for_the_cooldown() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-100.0), 2.4);
+        report_clip(&mut monster, &world, entity_id, Deg(-100.0));
         play_out(&mut monster, entity_id, 2.4);
         complete_clip(&mut monster, &world, entity_id);
+        hand_off(&mut monster, &world, entity_id, TEST_BLEND);
         for _ in 0..6 {
             turn_frame(&mut monster, entity_id, Deg(90.0));
         }
@@ -2420,10 +2501,35 @@ mod tests {
     fn a_later_clip_completing_does_not_restart_the_blend() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
+        let token = pending_token(&monster);
         play_out(&mut monster, entity_id, 4.8);
+        complete_clip(&mut monster, &world, entity_id);
+        hand_off(&mut monster, &world, entity_id, TEST_BLEND);
         for _ in 0..2 {
-            complete_clip(&mut monster, &world, entity_id);
+            // Everything the behavior's own re-queued clip reports next:
+            // its plain completion, and the pivot's reports replayed.
+            tell(
+                &mut monster,
+                &world,
+                entity_id,
+                MessagePayload::AnimationCompleted,
+            );
+            tell(
+                &mut monster,
+                &world,
+                entity_id,
+                MessagePayload::TurnClipCompleted { token },
+            );
+            tell(
+                &mut monster,
+                &world,
+                entity_id,
+                MessagePayload::TurnClipHandoff {
+                    token,
+                    blend: TEST_BLEND,
+                },
+            );
             for _ in 0..3 {
                 turn_frame(&mut monster, entity_id, Deg(90.0));
             }
@@ -2438,38 +2544,174 @@ mod tests {
         );
     }
 
-    /// Anything that preempts the turn clip - a wound reaction, an alertness
-    /// change - completes long before the clip would have. Taking the authored
-    /// turn then would swing the AI through it with a neutral pose.
+    /// The applier reports on the pivot it was asked for by token. A report
+    /// from an EARLIER pivot - one this AI has already abandoned and asked
+    /// again after - must not settle the one in flight.
     #[test]
-    fn a_completion_that_arrives_early_is_not_the_turn_clip() {
+    fn a_completion_carrying_a_stale_token_is_ignored() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
-        play_out(&mut monster, entity_id, 0.5);
-        complete_clip(&mut monster, &world, entity_id);
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
+        let stale = pending_token(&monster) - 1;
 
-        assert!(monster.turn_clip.is_none(), "the pivot is abandoned");
-        assert_eq!(
-            monster.current_heading,
-            Deg(-90.0),
-            "a turn whose pose never played must not land on the entity"
+        tell(
+            &mut monster,
+            &world,
+            entity_id,
+            MessagePayload::TurnClipCompleted { token: stale },
         );
-    }
-
-    /// A creature whose schema has no turn clip for the pivot never gets a
-    /// report back; it must fall back to steering instead of standing there.
-    #[test]
-    fn an_unanswered_pivot_falls_back_to_steering() {
-        let (_world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        assert!(turn_frame(&mut monster, entity_id, Deg(90.0)).0.is_some());
-        for _ in 0..10 {
+        assert!(
+            matches!(monster.turn_clip, Some(TurnClip::Playing { .. })),
+            "a completion from another pivot must not end this one"
+        );
+        tell(
+            &mut monster,
+            &world,
+            entity_id,
+            MessagePayload::TurnClipHandoff {
+                token: stale,
+                blend: TEST_BLEND,
+            },
+        );
+        for _ in 0..8 {
             turn_frame(&mut monster, entity_id, Deg(90.0));
         }
         assert_eq!(
+            monster.current_heading,
+            Deg(-90.0),
+            "and must not hand the turn over either"
+        );
+    }
+
+    /// Anything that preempts the clip takes the pose that was turning the
+    /// body with it, so the pending turn is dropped rather than committed.
+    #[test]
+    fn a_preempting_clip_drops_the_pending_turn() {
+        for preempt in [
+            MessagePayload::TurnClipCancelled { token: 1 },
+            MessagePayload::Damage {
+                amount: 1.0,
+                impact: None,
+            },
+        ] {
+            let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+            turn_frame(&mut monster, entity_id, Deg(90.0));
+            report_clip(&mut monster, &world, entity_id, Deg(-168.0));
+            play_out(&mut monster, entity_id, 2.0);
+
+            tell(&mut monster, &world, entity_id, preempt);
+            assert!(monster.turn_clip.is_none(), "the pivot is abandoned");
+
+            // Nothing may resurrect it afterwards - not the preempting clip's
+            // own completion, nor a handover report still in flight.
+            tell(
+                &mut monster,
+                &world,
+                entity_id,
+                MessagePayload::AnimationCompleted,
+            );
+            tell(
+                &mut monster,
+                &world,
+                entity_id,
+                MessagePayload::TurnClipHandoff {
+                    token: 1,
+                    blend: TEST_BLEND,
+                },
+            );
+            for _ in 0..8 {
+                turn_frame(&mut monster, entity_id, Deg(90.0));
+            }
+            assert_eq!(
+                monster.current_heading,
+                Deg(-90.0),
+                "a turn whose pose stopped playing must not land on the entity"
+            );
+        }
+    }
+
+    /// The yaw hands over on the fade the animation player is REALLY running -
+    /// which `queue_animation` takes from the INCOMING clip, and a locomotion
+    /// clip authors no blend at all. Over a zero fade the pose drops the turn
+    /// in one frame, so the entity must take it in the same one.
+    #[test]
+    fn a_zero_blend_follow_up_hands_the_turn_over_at_once() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
+        play_out(&mut monster, entity_id, 2.4);
+        complete_clip(&mut monster, &world, entity_id);
+        hand_off(&mut monster, &world, entity_id, 0.0);
+
+        assert!(monster.turn_clip.is_none(), "there is no fade to wait for");
+        assert!(
+            (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
+            "the whole turn lands with the pose that gave it up, heading is {:?}",
+            monster.current_heading
+        );
+    }
+
+    /// ...and over a fade that does run, the yaw tracks the player's own
+    /// cross-fade weight frame for frame - not a linear ramp, which would
+    /// lead the pose by up to a fifth of the turn mid-fade.
+    #[test]
+    fn the_yaw_follows_the_players_blend_curve() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
+        play_out(&mut monster, entity_id, 2.4);
+        complete_clip(&mut monster, &world, entity_id);
+        // A 400ms fade, walked in the 100ms frames `turn_frame` uses.
+        hand_off(&mut monster, &world, entity_id, 0.4);
+
+        for step in 1..=4 {
+            turn_frame(&mut monster, entity_id, Deg(90.0));
+            let t = step as f32 / 4.0;
+            let expected = -90.0 - 168.0 * dark::motion::blend_alpha(t);
+            assert!(
+                (monster.current_heading.0 - expected).abs() < 1e-3,
+                "at t={t} expected {expected}, got {:?}",
+                monster.current_heading
+            );
+        }
+        assert!(monster.turn_clip.is_none(), "the handover is complete");
+    }
+
+    /// A creature whose schema has no turn clip for the pivot is told so; it
+    /// must fall back to steering instead of standing there.
+    #[test]
+    fn a_pivot_with_no_clip_falls_back_to_steering() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        assert!(turn_frame(&mut monster, entity_id, Deg(90.0)).0.is_some());
+        let token = pending_token(&monster);
+        tell(
+            &mut monster,
+            &world,
+            entity_id,
+            MessagePayload::TurnClipCancelled { token },
+        );
+        assert_eq!(
             turn_frame(&mut monster, entity_id, Deg(90.0)),
             (None, false),
-            "an unanswered pivot must give the heading back to steering, and stop asking"
+            "an unplayed pivot must give the heading back to steering, and stop asking"
+        );
+    }
+
+    /// A pivot that is never followed by another clip has no fade to hand
+    /// over across - it must not hold its heading for ever.
+    #[test]
+    fn a_pivot_nothing_follows_still_ends() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
+        play_out(&mut monster, entity_id, 2.4);
+        complete_clip(&mut monster, &world, entity_id);
+
+        play_out(&mut monster, entity_id, TURN_CLIP_HANDOFF_TIMEOUT + 0.1);
+        assert!(monster.turn_clip.is_none(), "the pivot must not hang");
+        assert!(
+            (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
+            "and takes its turn whole, as a zero-length fade would"
         );
     }
 
@@ -2495,9 +2737,8 @@ mod tests {
         step(&mut monster, &world, entity_id);
 
         monster.turn_clip = Some(TurnClip::Playing {
+            token: 1,
             turn: Deg(90.0),
-            remaining: 10.0,
-            blend: TURN_CLIP_SETTLE_SECONDS,
         });
         let effects = step(&mut monster, &world, entity_id);
         assert!(

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -3553,9 +3553,8 @@ mod tests {
 
         let mut pivoting = AnimatedMonsterAI::new();
         pivoting.turn_clip = Some(TurnClip::Playing {
+            token: 1,
             turn: Deg(90.0),
-            remaining: 1.0,
-            blend: TURN_CLIP_SETTLE_SECONDS,
         });
         assert!(
             matches!(

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -206,7 +206,10 @@ enum TurnClip {
     HandingOver {
         token: u64,
         turn: Deg<f32>,
-        remaining: f32,
+        /// How long this has been waiting. The fade starts when the following
+        /// clip is applied, a frame before its report is handled, so the
+        /// settle picks up where the player's own blend already is.
+        waited: f32,
     },
     /// Handing over: the entity takes the clip's authored facing change across
     /// the very fade the animation player is running, on the same curve, so
@@ -697,9 +700,6 @@ impl AnimatedMonsterAI {
         self.alertness.visible_time = 0.0;
         self.alertness.hidden_time = 0.0;
 
-        // The new behavior wants a different heading, and the clip performing
-        // the old pivot is about to be replaced.
-        self.cancel_turn_clip(entity_id, "its behavior changed");
         self.current_behavior = self.behavior_for_alertness(world, Some(physics), entity_id);
         alertness::sync_alertness_effect(entity_id, &self.alertness)
     }
@@ -740,7 +740,6 @@ impl AnimatedMonsterAI {
     /// re-dispatch queued when no crumple motion is found), so the crumple
     /// and death sound play only once.
     fn enter_death(&mut self, world: &World, entity_id: EntityId) -> Effect {
-        self.cancel_turn_clip(entity_id, "it died mid-turn");
         self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
         self.is_dead = true;
         // Anchor the ragdoll-handoff timer to the crumple's actual start
@@ -919,18 +918,16 @@ impl AnimatedMonsterAI {
             Some(TurnClip::Requested { .. }) | Some(TurnClip::Playing { .. }) => {
                 (Effect::NoEffect, true)
             }
-            Some(TurnClip::HandingOver {
-                turn, remaining, ..
-            }) => {
-                *remaining -= elapsed;
-                if *remaining > 0.0 {
+            Some(TurnClip::HandingOver { waited, .. }) => {
+                *waited += elapsed;
+                if *waited < TURN_CLIP_HANDOFF_TIMEOUT {
                     return (Effect::NoEffect, true);
                 }
-                // Nothing followed the clip, so there is no fade to spread the
-                // facing change over: take it whole, exactly as a zero-length
-                // fade would.
-                let turn = *turn;
-                self.finish_pivot(entity_id, Deg(self.current_heading.0 + turn.0));
+                // Nothing followed the clip, so nothing has given the turn
+                // up: the player holds the turn clip's final frame, and its
+                // pose is still facing the creature where the turn ended.
+                // Taking the facing change now would turn it twice.
+                self.cancel_turn_clip(entity_id, "nothing followed its clip");
                 (Effect::NoEffect, true)
             }
             Some(TurnClip::Settling {
@@ -965,12 +962,17 @@ impl AnimatedMonsterAI {
 
     /// Drop a pivot in flight without taking its authored facing change.
     ///
-    /// Whatever preempted the turn clip - a wound reaction, a behavior swap, a
-    /// door to wait at, death - took the pose that was turning the body with
-    /// it, so committing the turn now would swing the creature through it with
-    /// nothing to show for it. A pivot already `Settling` is past that: its
-    /// facing change is being taken against a fade that is really running, so
-    /// it is left to finish.
+    /// Whatever ended the turn clip took the pose that was turning the body
+    /// with it, so committing the turn now would swing the creature through it
+    /// with nothing to show for it.
+    ///
+    /// Only the applier knows whether the pivot's clip is still the one
+    /// playing, so this is driven by its report, never guessed at here: a
+    /// creature that takes a hit, waits at a door or changes behavior is NOT
+    /// thereby done pivoting - if nothing displaced the clip, its pose is
+    /// still turning the body and the turn is still owed. A pivot already
+    /// `Settling` is past all of this: its facing change is being taken
+    /// against a fade that is really running, so it is left to finish.
     fn cancel_turn_clip(&mut self, entity_id: EntityId, reason: &str) {
         if matches!(
             self.turn_clip,
@@ -1472,11 +1474,6 @@ impl Script for AnimatedMonsterAI {
         // through it, so heading, whiskers, crowd repel and the route itself
         // stay live while the creature stands.
         let door_wait_seconds = self.update_door_wait(world, entity_id, time);
-        // A door to stand off from outranks a pivot: the AI is no longer
-        // turning toward anything, it is waiting.
-        if door_wait_seconds.is_some() {
-            self.cancel_turn_clip(entity_id, "it is waiting on a door");
-        }
         // The pivot in flight, as of last frame: one started this frame is
         // published on the next, and one ending is held a frame longer. Both
         // edges cost a single 16 ms frame either way.
@@ -1634,9 +1631,6 @@ impl Script for AnimatedMonsterAI {
                 }
                 // TODO: Let behavior handle this?
                 self.took_damage = true;
-                // The wound reaction takes the turn clip's place, so the turn
-                // it was performing must not be taken.
-                self.cancel_turn_clip(entity_id, "it was hit mid-turn");
                 let hit_points_effect = Effect::AdjustHitPoints {
                     entity_id,
                     delta: -(amount.round() as i32),
@@ -1808,7 +1802,7 @@ impl Script for AnimatedMonsterAI {
                         self.turn_clip = Some(TurnClip::HandingOver {
                             token: *token,
                             turn,
-                            remaining: TURN_CLIP_HANDOFF_TIMEOUT,
+                            waited: 0.0,
                         });
                     }
                 }
@@ -1824,15 +1818,18 @@ impl Script for AnimatedMonsterAI {
                 if let Some(TurnClip::HandingOver {
                     token: pending,
                     turn,
-                    ..
+                    waited,
                 }) = self.turn_clip
                 {
                     if pending == *token {
-                        if *blend > 0.0 {
+                        if *blend > waited {
                             self.turn_clip = Some(TurnClip::Settling {
                                 turn,
                                 base: self.current_heading,
-                                elapsed: 0.0,
+                                // The player started this fade when it applied
+                                // the clip, a frame before this report; pick it
+                                // up where its blend already is.
+                                elapsed: waited,
                                 window: *blend,
                             });
                         } else {
@@ -2308,6 +2305,22 @@ mod tests {
     /// test below hands over across.
     const TEST_BLEND: f32 = 0.5;
 
+    /// Ask for a pivot, have the applier answer with a clip authored to end on
+    /// `turn`, and play `seconds` of it. Returns the pivot's token.
+    fn start_pivot(
+        monster: &mut AnimatedMonsterAI,
+        world: &World,
+        entity_id: EntityId,
+        turn: Deg<f32>,
+        seconds: f32,
+    ) -> u64 {
+        turn_frame(monster, entity_id, Deg(90.0));
+        report_clip(monster, world, entity_id, turn);
+        let token = pending_token(monster);
+        play_out(monster, entity_id, seconds);
+        token
+    }
+
     /// Hold the pivot for `seconds` of 100ms frames, as the clip plays.
     fn play_out(monster: &mut AnimatedMonsterAI, entity_id: EntityId, seconds: f32) {
         for _ in 0..((seconds / 0.1).ceil() as usize) {
@@ -2439,9 +2452,7 @@ mod tests {
     #[test]
     fn the_authored_turn_lands_on_the_entity_once_the_clip_ends() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
-        play_out(&mut monster, entity_id, 4.8);
+        start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
         complete_clip(&mut monster, &world, entity_id);
         hand_off(&mut monster, &world, entity_id, TEST_BLEND);
 
@@ -2460,8 +2471,11 @@ mod tests {
         );
     }
 
-    /// A pivot has a budget: it must be over, blend included, before a held
-    /// spot reads as a wedge.
+    /// A pivot has a budget: it must be over, handover included, before a held
+    /// spot reads as a wedge. The clip's own runtime is bounded when it is
+    /// picked (`TURN_CLIP_MAX_SECONDS`), and the applier answers every request
+    /// and reports every completion or preemption, so the only part of a pivot
+    /// left on a clock is the wait for the following clip's fade.
     #[test]
     fn a_pivot_cannot_hold_long_enough_to_look_stuck() {
         // The reachability harness treats holding one spot for 6s as wedged.
@@ -2476,9 +2490,7 @@ mod tests {
     #[test]
     fn a_second_pivot_waits_for_the_cooldown() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-100.0));
-        play_out(&mut monster, entity_id, 2.4);
+        start_pivot(&mut monster, &world, entity_id, Deg(-100.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
         hand_off(&mut monster, &world, entity_id, TEST_BLEND);
         for _ in 0..6 {
@@ -2500,10 +2512,7 @@ mod tests {
     #[test]
     fn a_later_clip_completing_does_not_restart_the_blend() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
-        let token = pending_token(&monster);
-        play_out(&mut monster, entity_id, 4.8);
+        let token = start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
         complete_clip(&mut monster, &world, entity_id);
         hand_off(&mut monster, &world, entity_id, TEST_BLEND);
         for _ in 0..2 {
@@ -2587,47 +2596,70 @@ mod tests {
     /// body with it, so the pending turn is dropped rather than committed.
     #[test]
     fn a_preempting_clip_drops_the_pending_turn() {
-        for preempt in [
-            MessagePayload::TurnClipCancelled { token: 1 },
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        let token = start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.0);
+
+        tell(
+            &mut monster,
+            &world,
+            entity_id,
+            MessagePayload::TurnClipCancelled { token },
+        );
+        assert!(monster.turn_clip.is_none(), "the pivot is abandoned");
+
+        // Nothing may resurrect it afterwards - not the preempting clip's own
+        // completion, nor a handover report still in flight.
+        tell(
+            &mut monster,
+            &world,
+            entity_id,
+            MessagePayload::AnimationCompleted,
+        );
+        tell(
+            &mut monster,
+            &world,
+            entity_id,
+            MessagePayload::TurnClipHandoff {
+                token,
+                blend: TEST_BLEND,
+            },
+        );
+        for _ in 0..8 {
+            turn_frame(&mut monster, entity_id, Deg(90.0));
+        }
+        assert_eq!(
+            monster.current_heading,
+            Deg(-90.0),
+            "a turn whose pose stopped playing must not land on the entity"
+        );
+    }
+
+    /// ...but a hit is NOT a preemption: the turn clip plays on, its pose is
+    /// still turning the body, and the turn is still owed. Only the applier
+    /// knows when a wound clip has actually displaced it.
+    #[test]
+    fn taking_a_hit_does_not_abandon_a_turn_that_is_still_playing() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.0);
+        tell(
+            &mut monster,
+            &world,
+            entity_id,
             MessagePayload::Damage {
                 amount: 1.0,
                 impact: None,
             },
-        ] {
-            let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-            turn_frame(&mut monster, entity_id, Deg(90.0));
-            report_clip(&mut monster, &world, entity_id, Deg(-168.0));
-            play_out(&mut monster, entity_id, 2.0);
-
-            tell(&mut monster, &world, entity_id, preempt);
-            assert!(monster.turn_clip.is_none(), "the pivot is abandoned");
-
-            // Nothing may resurrect it afterwards - not the preempting clip's
-            // own completion, nor a handover report still in flight.
-            tell(
-                &mut monster,
-                &world,
-                entity_id,
-                MessagePayload::AnimationCompleted,
-            );
-            tell(
-                &mut monster,
-                &world,
-                entity_id,
-                MessagePayload::TurnClipHandoff {
-                    token: 1,
-                    blend: TEST_BLEND,
-                },
-            );
-            for _ in 0..8 {
-                turn_frame(&mut monster, entity_id, Deg(90.0));
-            }
-            assert_eq!(
-                monster.current_heading,
-                Deg(-90.0),
-                "a turn whose pose stopped playing must not land on the entity"
-            );
-        }
+        );
+        assert!(
+            matches!(monster.turn_clip, Some(TurnClip::Playing { .. })),
+            "the clip is still the one playing"
+        );
+        complete_clip(&mut monster, &world, entity_id);
+        hand_off(&mut monster, &world, entity_id, 0.0);
+        assert!(
+            (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
+            "and the turn its pose performed still lands"
+        );
     }
 
     /// The yaw hands over on the fade the animation player is REALLY running -
@@ -2637,9 +2669,7 @@ mod tests {
     #[test]
     fn a_zero_blend_follow_up_hands_the_turn_over_at_once() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
-        play_out(&mut monster, entity_id, 2.4);
+        start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
         hand_off(&mut monster, &world, entity_id, 0.0);
 
@@ -2657,9 +2687,7 @@ mod tests {
     #[test]
     fn the_yaw_follows_the_players_blend_curve() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
-        play_out(&mut monster, entity_id, 2.4);
+        start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
         // A 400ms fade, walked in the 100ms frames `turn_frame` uses.
         hand_off(&mut monster, &world, entity_id, 0.4);
@@ -2675,6 +2703,27 @@ mod tests {
             );
         }
         assert!(monster.turn_clip.is_none(), "the handover is complete");
+    }
+
+    /// The player starts the fade when it applies the following clip, a frame
+    /// before its report reaches the script - so the settle picks the curve up
+    /// where the pose already is, rather than restarting it a frame behind.
+    #[test]
+    fn the_settle_picks_up_a_fade_already_running() {
+        let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
+        start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
+        complete_clip(&mut monster, &world, entity_id);
+        // One 100ms frame passes between the clip ending and the report.
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        hand_off(&mut monster, &world, entity_id, 0.4);
+
+        turn_frame(&mut monster, entity_id, Deg(90.0));
+        let expected = -90.0 - 168.0 * dark::motion::blend_alpha(0.2 / 0.4);
+        assert!(
+            (monster.current_heading.0 - expected).abs() < 1e-3,
+            "expected {expected}, got {:?}",
+            monster.current_heading
+        );
     }
 
     /// A creature whose schema has no turn clip for the pivot is told so; it
@@ -2702,16 +2751,15 @@ mod tests {
     #[test]
     fn a_pivot_nothing_follows_still_ends() {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
-        turn_frame(&mut monster, entity_id, Deg(90.0));
-        report_clip(&mut monster, &world, entity_id, Deg(-168.0));
-        play_out(&mut monster, entity_id, 2.4);
+        start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
 
         play_out(&mut monster, entity_id, TURN_CLIP_HANDOFF_TIMEOUT + 0.1);
         assert!(monster.turn_clip.is_none(), "the pivot must not hang");
-        assert!(
-            (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
-            "and takes its turn whole, as a zero-length fade would"
+        assert_eq!(
+            monster.current_heading,
+            Deg(-90.0),
+            "and must not take a turn its pose is still holding"
         );
     }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1807,7 +1807,7 @@ impl Script for AnimatedMonsterAI {
                 }
                 Effect::NoEffect
             }
-            MessagePayload::TurnClipHandoff { token, blend } => {
+            MessagePayload::TurnClipHandoff { token, fades } => {
                 if let Some(TurnClip::HandingOver {
                     token: pending,
                     turn,
@@ -1815,7 +1815,7 @@ impl Script for AnimatedMonsterAI {
                 }) = self.turn_clip
                 {
                     if pending == *token {
-                        if *blend > 0.0 {
+                        if *fades {
                             // The applier reports the fade's weight from here
                             // on; the heading starts on the one the clip ended
                             // on and rides those reports.
@@ -2295,21 +2295,17 @@ mod tests {
         );
     }
 
-    /// The applier reporting the fade the clip that follows the pivot starts
-    /// on - the window the yaw hands over across.
-    fn hand_off(monster: &mut AnimatedMonsterAI, world: &World, entity_id: EntityId, blend: f32) {
+    /// The applier reporting the clip that follows the pivot, and whether it
+    /// cross-fades in (so the yaw rides the reported weights) or hard-cuts.
+    fn hand_off(monster: &mut AnimatedMonsterAI, world: &World, entity_id: EntityId, fades: bool) {
         let token = pending_token(monster);
         tell(
             monster,
             world,
             entity_id,
-            MessagePayload::TurnClipHandoff { token, blend },
+            MessagePayload::TurnClipHandoff { token, fades },
         );
     }
-
-    /// The blend the stock turn clips author, and the window every settling
-    /// test below hands over across.
-    const TEST_BLEND: f32 = 0.5;
 
     /// Ask for a pivot, have the applier answer with a clip authored to end on
     /// `turn`, and play `seconds` of it. Returns the pivot's token.
@@ -2413,10 +2409,10 @@ mod tests {
             pivot: Option<(u64, Deg<f32>)>,
         ) {
             self.player = dark::motion::AnimationPlayer::queue_animation(&self.player, clip);
-            let blend = self.player.blend_remaining_seconds();
+            let fades = self.player.blend_alpha_now() < 1.0;
             if let Some(payload) =
                 self.tracker
-                    .on_animation_applied(self.entity_id, Some(blend), pivot.is_some())
+                    .on_animation_applied(self.entity_id, Some(fades), pivot.is_some())
             {
                 self.pending.push(payload);
             }
@@ -2616,7 +2612,7 @@ mod tests {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
         complete_clip(&mut monster, &world, entity_id);
-        hand_off(&mut monster, &world, entity_id, TEST_BLEND);
+        hand_off(&mut monster, &world, entity_id, true);
 
         // The settle rides the fade the applier reports, half of it and then
         // all of it.
@@ -2659,7 +2655,7 @@ mod tests {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         start_pivot(&mut monster, &world, entity_id, Deg(-100.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
-        hand_off(&mut monster, &world, entity_id, TEST_BLEND);
+        hand_off(&mut monster, &world, entity_id, true);
         settle_frame(&mut monster, &world, entity_id, 1.0);
         assert!(monster.turn_clip.is_none(), "the first pivot must be over");
         // Still facing a long way from where it wants to be, but it has to
@@ -2679,7 +2675,7 @@ mod tests {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         let token = start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 4.8);
         complete_clip(&mut monster, &world, entity_id);
-        hand_off(&mut monster, &world, entity_id, TEST_BLEND);
+        hand_off(&mut monster, &world, entity_id, true);
         settle_frame(&mut monster, &world, entity_id, 1.0);
         // Everything the behavior's own re-queued clip reports next: its plain
         // completion, and the pivot's reports replayed.
@@ -2700,10 +2696,7 @@ mod tests {
                 &mut monster,
                 &world,
                 entity_id,
-                MessagePayload::TurnClipHandoff {
-                    token,
-                    blend: TEST_BLEND,
-                },
+                MessagePayload::TurnClipHandoff { token, fades: true },
             );
             for _ in 0..3 {
                 turn_frame(&mut monster, entity_id, Deg(90.0));
@@ -2745,7 +2738,7 @@ mod tests {
             entity_id,
             MessagePayload::TurnClipHandoff {
                 token: stale,
-                blend: TEST_BLEND,
+                fades: true,
             },
         );
         for _ in 0..8 {
@@ -2785,10 +2778,7 @@ mod tests {
             &mut monster,
             &world,
             entity_id,
-            MessagePayload::TurnClipHandoff {
-                token,
-                blend: TEST_BLEND,
-            },
+            MessagePayload::TurnClipHandoff { token, fades: true },
         );
         for _ in 0..8 {
             turn_frame(&mut monster, entity_id, Deg(90.0));
@@ -2821,7 +2811,7 @@ mod tests {
             "the clip is still the one playing"
         );
         complete_clip(&mut monster, &world, entity_id);
-        hand_off(&mut monster, &world, entity_id, 0.0);
+        hand_off(&mut monster, &world, entity_id, false);
         assert!(
             (monster.current_heading.0 - (-90.0 - 168.0)).abs() < 1e-3,
             "and the turn its pose performed still lands"
@@ -2837,7 +2827,7 @@ mod tests {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
-        hand_off(&mut monster, &world, entity_id, 0.0);
+        hand_off(&mut monster, &world, entity_id, false);
 
         assert!(monster.turn_clip.is_none(), "there is no fade to wait for");
         assert!(
@@ -2855,7 +2845,7 @@ mod tests {
         let (world, entity_id, mut monster) = pivoting_monster(Deg(-90.0));
         start_pivot(&mut monster, &world, entity_id, Deg(-168.0), 2.4);
         complete_clip(&mut monster, &world, entity_id);
-        hand_off(&mut monster, &world, entity_id, 0.4);
+        hand_off(&mut monster, &world, entity_id, true);
 
         for step in 1..=4 {
             let alpha = dark::motion::blend_alpha(step as f32 / 4.0);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -641,10 +641,15 @@ pub enum Effect {
     /// Pivot in place with the creature's own authored turn clip: the applier
     /// picks the stand-schema clip whose authored facing change is nearest
     /// `delta` and plays it, reporting back with `TurnClipStarted`. No clip
-    /// covers a small pivot, and a creature without turn clips gets none - in
-    /// both cases nothing plays and no report comes back.
+    /// covers a small pivot, and a creature without turn clips gets none -
+    /// then nothing plays and the applier answers `TurnClipCancelled`.
+    ///
+    /// Every answer echoes `token`, so a report belonging to a pivot the
+    /// requester has already abandoned is recognisable and ignorable.
     PlayTurnClip {
         entity_id: EntityId,
+        /// This request's identity, echoed by every report about it.
+        token: u64,
         delta: cgmath::Deg<f32>,
         /// The longest turn the creature can afford to stand still for.
         max_seconds: f32,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -278,13 +278,13 @@ pub enum MessagePayload {
     },
 
     /// The turn clip finished and the animation player has started the clip
-    /// that follows it, cross-fading over `blend` seconds. The turn clip's
-    /// pose swings back to neutral across exactly that fade, so the entity
-    /// takes its authored facing change over it. A `blend` of zero is a hard
-    /// cut: the pose gives the whole turn up in one frame.
+    /// that follows it. The turn clip's pose swings back to neutral across
+    /// that transition, so the entity takes its authored facing change over
+    /// it: across the fade (reported frame by frame as `TurnClipBlend`) when
+    /// `fades`, or in this one frame when the follow-up hard-cuts.
     TurnClipHandoff {
         token: u64,
-        blend: f32,
+        fades: bool,
     },
 
     /// How much of the pose the clip following the pivot owns this frame,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -280,11 +280,23 @@ pub enum MessagePayload {
     /// The turn clip finished and the animation player has started the clip
     /// that follows it, cross-fading over `blend` seconds. The turn clip's
     /// pose swings back to neutral across exactly that fade, so the entity
-    /// takes its authored facing change over the same window and curve
-    /// (`dark::motion::blend_alpha`) and the visible facing never jumps.
+    /// takes its authored facing change over it. A `blend` of zero is a hard
+    /// cut: the pose gives the whole turn up in one frame.
     TurnClipHandoff {
         token: u64,
         blend: f32,
+    },
+
+    /// How much of the pose the clip following the pivot owns this frame,
+    /// straight from the animation player (`blend_alpha_now`). The entity's
+    /// facing takes exactly this fraction of the authored turn, so the facing
+    /// the pose gives up and the facing the entity takes cancel out frame for
+    /// frame. Reported every frame of the fade, ending on 1.0 - the script
+    /// keeps no clock of its own, because the script's clock and the player's
+    /// tick at different points in the frame.
+    TurnClipBlend {
+        token: u64,
+        alpha: f32,
     },
 
     // Gameplay events

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -254,14 +254,36 @@ pub enum MessagePayload {
     AnimationCompleted,
 
     /// A turn clip requested by `Effect::PlayTurnClip` started playing, with
-    /// the facing change it is authored to end on and how long it runs. The
-    /// clip is chosen from the creature's own schema, so only the applier
-    /// knows these until it has resolved one.
+    /// the facing change it is authored to end on. The clip is chosen from
+    /// the creature's own schema, so only the applier knows it until it has
+    /// resolved one.
     TurnClipStarted {
+        token: u64,
         turn: cgmath::Deg<f32>,
-        duration: f32,
-        /// The clip's authored blend length: the window its pose takes to
-        /// swing back to neutral once it ends.
+    },
+
+    /// The turn clip ran to its end. Only the applier knows which clip's
+    /// completion this is, so a completion belonging to anything else can
+    /// never be mistaken for the pivot's own.
+    TurnClipCompleted {
+        token: u64,
+    },
+
+    /// The requested turn clip is not playing (any more): either no affordable
+    /// clip covered the pivot, or something preempted the one that was
+    /// playing. Either way the authored facing change must NOT be taken - the
+    /// pose that would have turned the body is gone.
+    TurnClipCancelled {
+        token: u64,
+    },
+
+    /// The turn clip finished and the animation player has started the clip
+    /// that follows it, cross-fading over `blend` seconds. The turn clip's
+    /// pose swings back to neutral across exactly that fade, so the entity
+    /// takes its authored facing change over the same window and curve
+    /// (`dark::motion::blend_alpha`) and the visible facing never jumps.
+    TurnClipHandoff {
+        token: u64,
         blend: f32,
     },
 


### PR DESCRIPTION
A pivot is performed as the creature's own authored turn clip (#1337): the clip's **pose** does the visible turning, so the entity holds its heading underneath it and then takes the authored facing change as the pose swings back to neutral. Two things about that handover were guesswork.

**The settle window was the wrong clip's blend, and it was clocked by the wrong thing.** The AI spread the facing change over the *outgoing* turn clip's authored `blend_length`. The animation player blends with the *incoming* clip's — `queue_animation` builds no fade at all when the incoming clip authors none, and a stride clip authors none by design (`zero_blend_clip_still_hard_cuts`). So the pose gave the turn up in one frame while the entity took it over half a second, and the heading ramped **linearly** where the pose cross-fades on a **raised cosine**. The handover now rides the transition the player is actually running, read off the player every frame: the applier reports `AnimationPlayer::blend_alpha_now()` — the very weight `get_transforms` blends the two poses with — as `TurnClipBlend`, and the script takes exactly that fraction of the turn. It integrates nothing of its own, because it cannot: animations update before scripts, so any clock the script keeps runs a frame ahead of the pose it is supposed to cancel out.

**Elapsed time cannot identify a playback.** A completion was accepted as the turn clip's own if it arrived within a quarter-second of when the clip *should* have ended, so a late interruption could still commit an abandoned turn, and a pivot that was never answered fell back on a report timeout. Every `PlayTurnClip` now carries a **token**, and the applier — which owns the animation player and is the only thing that knows whose clip is playing — answers all of them, from the request to the last frame of the fade: `TurnClipStarted`, `TurnClipCompleted`, `TurnClipCancelled` when anything displaces the clip, `TurnClipHandoff` when the following clip starts (`fades` distinguishing a cross-fade from a hard cut), and `TurnClipBlend` for each frame of that fade. A report echoing a token the script has moved past is dropped. That bookkeeping is one type, `TurnClipTracker` (`shock2vr/src/mission/turn_clip.rs`), rather than three call sites in `mission_core`.

That makes cancellation explicit rather than inferred, and it cuts three timeouts (`TURN_CLIP_REPORT_TIMEOUT`, `TURN_CLIP_OVERRUN_MARGIN`, `TURN_CLIP_COMPLETION_SLACK`) and the `TURN_CLIP_SETTLE_SECONDS` fallback. One bounded wait survives, and only because a creature can legitimately queue nothing after its pivot: `TURN_CLIP_HANDOFF_TIMEOUT`, after which the pivot is **dropped**, not committed — with no following clip the player is still holding the turn clip's final frame, so taking the facing change there would turn the creature twice.

**The script guesses at nothing.** Damage, a door to stand off from and a behavior swap are no longer treated as preemptions: if nothing actually displaced the clip its pose is still turning the body and the turn is still owed. Only the applier's report ends a pivot — and every path that can take an entity's animation player away (`ChangeModel`, `ClearModel`, entity removal) now answers the pivot it orphans, so a held heading can never outlive its clip.

Ledger step P3 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

## Before / after

Same scenario as #1337 — medsci2, `DebugForceChase`, a chasing hybrid reversing through `ogstu180`, free camera locked to the creature — captured **one sim frame at a time** across the seam so the handover is resolved at 60 Hz.

![before/after at the seam](https://gist.githubusercontent.com/tommy-xr/da66dd314fd56096628fcac398ac981e/raw/turn-handoff-seam.png)

<sub>Top row, before (`fix/ai-movement-hold`): the clip's last frame, then +1, +2, +10, +25 frames. The pose swaps to the run cycle and the creature is suddenly **back-on** — a 171 degree flip in one frame — and then rotates back over the next half second. Bottom row, after: the same five frames, and the facing never leaves the direction the clip ended on.</sub>

Entity yaw, per sim frame, from the clip's final frame:

| | before | after |
|---|---|---|
| pose swaps to the following clip | frame 87 | frame 88 |
| authored turn fully taken | frame 114 | frame 89 |
| frames the entity turns under a pose that is no longer turning | **28 (467 ms)** | **1 (17 ms)** |
| yaw per frame across that window | 5.7 deg | 171 deg, once |
| following clip's authored blend | 0 (`ogsrunl`) | 0 (`ogsrunl`) |

The whole 171 degrees now arrives on the frame the pose gives it up, which is what the sheet shows: no rendered frame in which the facing disagrees. Before, the entity's yaw was up to 171 degrees away from the facing the pose was drawing, for 28 consecutive frames.

![after](https://gist.githubusercontent.com/tommy-xr/da66dd314fd56096628fcac398ac981e/raw/turn-handoff-after.gif)

![before](https://gist.githubusercontent.com/tommy-xr/da66dd314fd56096628fcac398ac981e/raw/turn-handoff-before.gif)

<sub>1.5x slow motion (every 2nd sim frame at 20 fps), windowed on the seam. Clip selection is random per query, so the two runs are the same request sequence rather than the same creature at the same spot. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

One pre-existing artefact is visible in both and is untouched here: the pose *cut* at the seam (the largest single-frame image difference in either run, 6.4 vs 6.5 on a normalized frame diff) is the zero-blend stride clip hard-cutting from the turn clip's final pose. Giving the follow-up an actual cross-fade is a separate change; the point of this one is that whatever fade the player runs, the yaw now rides it.

### A fade that actually runs

The shipping follow-up is a stride clip, which hard-cuts — so the case where a fade *does* run was captured too, by injecting `Damage` during the pivot so the clip that follows it is a wound reaction (`ogprecsw`, floored at a 0.5 s blend). Same scene, one sim frame per step, reading the pose weight the renderer uses (`/v1/entities/{id}/animation` `blend.alpha`) beside the entity's yaw:

| frame | pose weight | fraction of the turn taken |
|---|---|---|
| 108 (fade starts) | 0.0000 | 0.0000 |
| 114 | 0.0955 | 0.0625 |
| 120 | 0.3455 | 0.2939 |
| 123 | 0.5000 | 0.4462 |
| 129 | 0.7939 | 0.7508 |
| 135 | 0.9755 | 0.9592 |
| 138 (fade ends) | 1.0000 | 1.0000 |

Across all 31 frames the yaw equals the pose weight of the frame before it to within **0.005 of the turn (0.86 deg)** — a constant one-frame offset, which is the entity transform's publication lag and shows identically in the zero-blend capture (there the whole -171.01 deg lands in a single frame, one frame after the hard cut). Never a lead, and no drift across the fade.

## Tests

Negative-first, each shown failing before the change that makes it pass:

- `the_yaw_never_leads_the_pose_across_a_real_fade` — a REAL `AnimationPlayer`, the REAL applier-side tracker and the REAL script, run in the mission loop's own order (animations, then reports, then the script, then its effects) over a follow-up clip that actually fades. Restore the script-side clock and it fails on the first frame of the fade: the pose is 0.0027 through it and the entity has taken 0.0109 of the turn.
- `a_clip_displacing_the_settle_takes_the_rest_of_the_turn_at_once` — fails if the applier stops tracking the pivot at the handoff (the settle then eases on across a fade that has been replaced).
- `the_yaw_follows_the_players_blend_curve` — fails with a linear ramp (the old behavior) at every sampled point.
- `a_completion_carrying_a_stale_token_is_ignored` — fails without the token check.
- `a_preempting_clip_drops_the_pending_turn` — fails if a cancel commits the turn.

Also new: `a_zero_blend_follow_up_hands_the_turn_over_at_once`, `taking_a_hit_does_not_abandon_a_turn_that_is_still_playing`, `a_pivot_nothing_follows_still_ends`, `a_pivot_with_no_clip_falls_back_to_steering`; in `dark`, `blend_alpha_now_is_the_weight_the_fade_has_reached` (with the load-bearing fact: a stride clip queued over a 500 ms clip is at full weight immediately — there is no fade to ride) and `blend_alpha_is_a_clamped_raised_cosine`.

- `cargo test -p shock2vr`: 1444 passed. `cargo test -p dark`: 162 passed.
- e2e, scoped to the scenarios that exercise pivoting: `medsci2-doorjamb-chase` 2/2, `medsci2-patrol-railing` 1/1 — doorjamb re-run 2/2 after the amendment below.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
- Pathfinding is untouched (nothing under `shock2vr/src/pathfinding/` or `dark/src/mission/` is in the diff).

## Review

`/xreview`, both engines (Claude adversarial reviewer, Codex CLI) plus the de-dup reviewer, run twice — once on the original change and once on the amendment.

First pass, fixed:

- **High, [AGREED]** — the handover timeout committed a turn the pose was still holding. When nothing follows the pivot the player keeps the turn clip's final frame on screen, so adding the authored turn there reproduced the exact double-turn this work exists to remove. It now drops the pivot.
- **High, [AGREED]** — cancelling a pivot on damage or on a door wait cleared the script's state without stopping the clip: the pose kept performing the about-face while the entity was steered independently, and the completion it eventually reported was ignored. Neither is a preemption; both cancels are gone, along with the ones in `enter_death` and `force_alertness_state` (which play a clip, so the applier reports the preemption itself). The applier is now the sole authority.
- **Medium** — `ChangeModel` and `ClearModel` remove or rebuild the animation player without going through the animation applier, so no completion could ever arrive for a turn clip they orphaned. With the elapsed-time bound on `Playing` gone, that would have held the creature's heading for the rest of the level. Both answer the pivot now.
- **Low** — a `PlayTurnClip` that resolved to no clip left the previous playback entry behind, so a later clip reported a handover for a dead token (harmless only because of the token check). The entry is taken whenever an apply concerns a turn at all.
- **De-dup, `[S3-index, S4-read]`** — the debug animation endpoint's `alpha` field reported linear progress through the fade, not the pose's weight (they differ by up to 0.2). It reads the player's own weight now, so the endpoint and the renderer agree.
- **De-dup, `[S2-clones]`** — the new tests repeated a five-line "ask, answer, play out" pivot preamble; one `start_pivot` helper.

## Amendment — a second review pass

Two findings against the first pass, both fixed here:

- **High — the handoff frame was counted twice.** Animations update before scripts, so the script's own wait advanced on the frame the following clip was applied, and the settle it seeded advanced again on the next: **two dt of yaw against one dt of pose**, a gap that never closed for the rest of the fade (about 9 degrees of a 170 degree turn at mid-fade). Seeding the settle from that wait — which is what the first pass did — only papered over one of the two ticks. The script now keeps no clock: the applier reports the pose's own weight every frame, and the yaw is that number. The test above drives a real animation player through a real fade, which is the only way to see this: the previous test asserted the lead into existence by advancing nothing.
- **Medium — ownership ended at the first handoff.** The playback entry was dropped as soon as the following clip started, and `Settling` carried no token and ignored cancellation, so a wound or behavior clip landing mid-settle went unnoticed and the yaw kept riding a fade the player had already replaced. `TurnClipTracker` keeps the pivot through the settle and reports the displacement; `Settling` answers it like every other state — by **taking the rest of the turn in that frame**. `play_animation` fades from the follow-up clip's *own* pose rather than the blended one on screen (its documented limit), so the `turn * (1 - alpha)` the pose was still holding vanishes on the displacing frame: landing the remainder is what keeps the visible facing continuous, where dropping it would snap the creature back by that remainder. This is the opposite of the handover-timeout case, and for the opposite reason — there the player is still holding the turn clip's final frame, so the pivot is dropped.

Also from that pass's `/xreview`:

- **De-dup, `[S3-index, S4-read]`** — the debug animation endpoint recomputed the cross-fade weight inline; it calls `blend_alpha_now()` now, so there is one definition of the pose's weight and the endpoint, the renderer and the AI cannot drift apart.
- **De-dup, `[S1-names, S4-read]`** — with the curve carried frame by frame, the handoff's `blend` seconds was only ever squashed to `> 0.0`. It is a `fades: bool`, and `blend_remaining_seconds` (whose precision nothing read any more) is gone: one accessor, `blend_alpha_now`.
- **Low (Codex)** — `TurnClipBlend` is dispatched once per frame of a fade and would have pushed the damage/signal history out of the 256-entry message trace; it joins the other high-frequency payloads the trace excludes.
- **Medium (Claude)** — the snap-back above: the first cut of this amendment dropped a displaced settle where it stood. Fixed as described, and the test flipped with it.
- **Low (Claude)** — `DebugCycleHitboxPose` queued clips straight onto every creature's animation player, replacing a pivot's fade without the pivot hearing about it — the very class of bug this amendment fixes. It reports through the tracker now.

Noted, not changed: a pivot that times out waiting for a follow-up leaves its `Completed` entry in the tracker until that entity's next clip, which then reports a handover for a token the script has already dropped. Token matching makes it inert, and the entry is one per entity; bounding it would need exactly the clock this change exists to remove.

Noted, not changed:

- `TurnClip::Settling` is exercised on the *minority* path. Every follow-up the AI queues after a pivot is a stride clip authoring no blend, so the shipping case is a single-frame commit; a nonzero fade only comes from the clips that `play_animation` floors at 0.15 s (a wound reaction, a behavior swap, a handback landing on a completed pivot) — which is what the capture above injects to exercise it. Keeping the eased path is what makes the zero case *correct rather than lucky*, and it is what stops working the moment a follow-up gets a blend.
- Giving the turn clip's follow-up a real cross-fade (so the pose stops hard-cutting at the seam at all) is the obvious next step, and would make the eased handover the common path rather than the rare one.
