### PR TITLE
fix(vr): keep crouched hands aligned with the tracked head

### DIFF
--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -555,7 +555,7 @@ fn main() {
     let mut last_view_rotation: Option<cgmath::Quaternion<f32>> = None;
     // Where that same view was, already converted to pawn space (the space the
     // hands and the world-anchored frontend panel live in).
-    let mut last_view_position: Option<cgmath::Vector3<f32>> = None;
+    let mut last_head_stage: Option<cgmath::Vector3<f32>> = None;
     println!(
         "SHOCK2QUEST_STARTUP mission={} init_ms={:.3}",
         mission,
@@ -935,13 +935,9 @@ fn main() {
             .or(head_pose_rotation)
             .unwrap_or(aim_rotation);
 
-        // Feed the detector before the poses are transformed so this frame's
-        // physical stance is available to the crouch request below. Tracked
-        // poses are NEVER artificially displaced for a button crouch: the eye
-        // cap in `render_swapchain` alone keeps the view inside the crouched
-        // collider, and it does so continuously (a rigid pose drop keyed on
-        // detector state produced below-floor eyes/hands and frame-size view
-        // pops at the hysteresis thresholds).
+        // Keep calibration warm, but freeze physical stance while gripping.
+        // The shared rig transform applies any crouch correction to head and
+        // hands together; the mission rebases it if stance changes this frame.
         let tracked_head_position = head_location.location_flags.contains(
             xr::SpaceLocationFlags::POSITION_VALID | xr::SpaceLocationFlags::POSITION_TRACKED,
         );
@@ -949,24 +945,42 @@ fn main() {
             tracked_head_position.then_some(head_location.pose.position.y),
             game.player_is_gripping(),
         );
-        let center_above_floor = game.player_center_above_floor();
-        let right_hand_position = stage_to_pawn(
+        let head_stage = if tracked_head_position {
             vec3(
-                right_aim_location.pose.position.x,
-                right_aim_location.pose.position.y,
-                right_aim_location.pose.position.z,
-            ),
-            center_above_floor,
+                head_location.pose.position.x,
+                head_location.pose.position.y,
+                head_location.pose.position.z,
+            )
+        } else {
+            last_head_stage.unwrap_or(vec3(
+                0.0,
+                (shock2vr::input_context::DEFAULT_HEAD_HEIGHT + game.player_center_above_floor())
+                    * shock2vr::METERS_PER_WORLD_UNIT,
+                0.0,
+            ))
+        };
+        if tracked_head_position {
+            last_head_stage = Some(head_stage);
+        }
+        // A single rig correction for input and both rendered eyes. Hanging
+        // capsule compression does not change the physical tracking stance.
+        let tracking = shock2vr::vr_tracking::TrackingTransform::new(
+            game.player_center_above_floor(),
+            game.player_eye_cap_above_center(),
+            head_stage.y,
+            stage_offset_meters(),
         );
+        let right_hand_position = tracking.stage_to_pawn(vec3(
+            right_aim_location.pose.position.x,
+            right_aim_location.pose.position.y,
+            right_aim_location.pose.position.z,
+        ));
 
-        let left_hand_position = stage_to_pawn(
-            vec3(
-                left_aim_location.pose.position.x,
-                left_aim_location.pose.position.y,
-                left_aim_location.pose.position.z,
-            ),
-            center_above_floor,
-        );
+        let left_hand_position = tracking.stage_to_pawn(vec3(
+            left_aim_location.pose.position.x,
+            left_aim_location.pose.position.y,
+            left_aim_location.pose.position.z,
+        ));
         let left_hand_rotation = cgmath::Quaternion::new(
             left_aim_location.pose.orientation.w,
             left_aim_location.pose.orientation.x,
@@ -976,23 +990,8 @@ fn main() {
 
         let mut input_context = InputContext::default();
         input_context.head.rotation = head_rotation;
-        // The tracked eye, in pawn space. The located head space covers frame
-        // 0, before any view has been located; when the head is untracked
-        // entirely this keeps `Head::default`'s fixed eye height, which is
-        // where the camera renders from anyway.
-        let head_pose_position = tracked_head_position.then(|| {
-            stage_to_pawn(
-                vec3(
-                    head_location.pose.position.x,
-                    head_location.pose.position.y,
-                    head_location.pose.position.z,
-                ),
-                center_above_floor,
-            )
-        });
-        if let Some(position) = last_view_position.or(head_pose_position) {
-            input_context.head.position = position;
-        }
+        input_context.head.position = tracking.stage_to_pawn(head_stage);
+        input_context.tracking = Some(tracking);
         input_context.right_hand.rotation = aim_rotation;
         input_context.right_hand.position = right_hand_position;
         input_context.right_hand.trigger_value = right_trigger_value;
@@ -1212,13 +1211,10 @@ fn main() {
 
         // Remember where the head actually is, for next frame's input context.
         if let Some(view) = views.first() {
-            last_view_position = Some(stage_to_pawn(
-                vec3(
-                    view.pose.position.x,
-                    view.pose.position.y,
-                    view.pose.position.z,
-                ),
-                game.player_center_above_floor(),
+            last_head_stage = Some(vec3(
+                (views[0].pose.position.x + views[1].pose.position.x) / 2.0,
+                (views[0].pose.position.y + views[1].pose.position.y) / 2.0,
+                (views[0].pose.position.z + views[1].pose.position.z) / 2.0,
             ));
             last_view_rotation = Some(cgmath::Quaternion::new(
                 view.pose.orientation.w,
@@ -1240,6 +1236,10 @@ fn main() {
         let (scene, camera_pos, camera_rot) = game.render();
         let scene_elapsed = scene_started.elapsed();
 
+        let tracking = tracking.with_stance(
+            game.player_center_above_floor(),
+            game.player_eye_cap_above_center(),
+        );
         // Render to each eye
         let time = now.elapsed().as_secs_f32();
         // The midpoint of the two eyes: what the death camera resolves from, so
@@ -1258,6 +1258,7 @@ fn main() {
             time,
             &views[0],
             head_centre_stage,
+            tracking,
             true,
             &scene,
             false,
@@ -1271,6 +1272,7 @@ fn main() {
             time,
             &views[1],
             head_centre_stage,
+            tracking,
             true,
             &scene,
             true,
@@ -1620,46 +1622,9 @@ fn android_pump_events() -> bool {
     false
 }
 
-/// Convert a floor-origin STAGE-space position (meters) into the game's pawn
-/// space (world units, origin at the player collider's center): scale meters
-/// to world units, then move the anchor from the physical floor up to the
-/// collider center, so a tracked eye or hand N meters above the real floor
-/// lands the equivalent height above the in-game floor. Without this the raw
-/// meters were added to the collider CENTER unscaled, placing the standing
-/// eye ~1.8 SS2 ft above the original game's eye line (and world scale ~31%
-/// large).
-fn stage_to_pawn(position_meters: Vector3<f32>, center_above_floor: f32) -> Vector3<f32> {
-    // The dev-params eye-height offset raises or lowers the whole tracked
-    // stage: every tracked position - head input, both hands, and the per-eye
-    // view - routes through this one mapping, so they move together and the
-    // hands never detach from the raised eye line. See
-    // `stage_offset_above_center` for how the per-eye cap keeps out of its way.
-    (position_meters + vec3(0.0, stage_offset_meters(), 0.0)) / shock2vr::METERS_PER_WORLD_UNIT
-        - vec3(0.0, center_above_floor, 0.0)
-}
-
 /// The dev-params eye-height offset, in meters of STAGE space.
 fn stage_offset_meters() -> f32 {
     shock2vr::dev_params::get(shock2vr::dev_params::EYE_HEIGHT_OFFSET)
-}
-
-/// The same offset expressed in world units, for raising the eye cap by
-/// exactly what [`stage_to_pawn`] already added.
-///
-/// The cap bounds the *tracked body*: a real head is not the game capsule's,
-/// so it is held inside the collider crown. The dev offset is not a tracked
-/// body - it is an explicit authored displacement of the whole stage - so the
-/// cap has to move with it, or it would silently eat the raise: standing
-/// headroom is only ~1.12 wu (0.85 m) above the collider center and an adult's
-/// tracked eye already sits within a few centimeters of it, so an uncapped-cap
-/// `eye_offset` would saturate the VIEW after a couple of centimeters while
-/// the hands kept rising the full half-meter - the head/hand desync this
-/// wiring exists to avoid. Raising the cap by the offset keeps the tracked
-/// portion bounded exactly as before (at the default offset of 0 this is
-/// bit-identical to the pre-existing cap) while letting a deliberate dev
-/// offset through.
-fn stage_offset_above_center() -> f32 {
-    stage_offset_meters() / shock2vr::METERS_PER_WORLD_UNIT
 }
 
 fn render_swapchain(
@@ -1673,6 +1638,7 @@ fn render_swapchain(
     // Midpoint of the two eyes in STAGE space. The death camera resolves from
     // the head centre, never per eye - see the comment on `camera` below.
     head_centre_stage: Vector3<f32>,
+    tracking: shock2vr::vr_tracking::TrackingTransform,
     _log: bool,
     scene: &Vec<SceneObject>,
     is_last: bool,
@@ -1689,28 +1655,11 @@ fn render_swapchain(
     let width = swapchain.width;
     let height = swapchain.height;
 
-    let mut head_offset = stage_to_pawn(
-        cgmath::Vector3::new(
-            view.pose.position.x,
-            view.pose.position.y,
-            view.pose.position.z,
-        ),
-        game.player_center_above_floor(),
-    );
-    // The tracked eye belongs to a real body, not to the game capsule, so it
-    // must be held inside the collider crown: a physically crouched adult's
-    // eye sits well above the short crouched capsule, and uncapped the player
-    // sees over and through the very geometry the capsule clears (looking out
-    // of the world from inside a duct). Only the view is capped - hand poses
-    // have no such clipping concern and clamping them would break reaching up.
-    // The cap binds essentially only while crouched (or button-latched);
-    // standing it sits above any realistic head, so tracking stays 1:1.
-    // The cap rides the dev eye-height offset (see `stage_offset_above_center`)
-    // so the knob moves the view by exactly what it moves the hands by; at the
-    // default offset of 0 this is the plain crown cap it has always been.
-    head_offset.y = head_offset
-        .y
-        .min(game.player_eye_cap_above_center() + stage_offset_above_center());
+    let head_offset = tracking.stage_to_pawn(vec3(
+        view.pose.position.x,
+        view.pose.position.y,
+        view.pose.position.z,
+    ));
     let head_rotation = cgmath::Quaternion::new(
         view.pose.orientation.w,
         view.pose.orientation.x,
@@ -1731,7 +1680,7 @@ fn render_swapchain(
     // monoscopic while the horizon rolls. Instead the eye's own displacement is
     // re-applied afterwards, carried into the fallen camera's frame so the eyes
     // roll with the new horizon rather than staying level with the room.
-    let head_centre_pawn = stage_to_pawn(head_centre_stage, game.player_center_above_floor());
+    let head_centre_pawn = tracking.stage_to_pawn(head_centre_stage);
     let camera = shock2vr::death_camera::reapply_eye_offset(
         game.resolve_camera(camera_pos, camera_rot, head_centre_pawn, head_rotation),
         head_offset - head_centre_pawn,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -158,6 +158,11 @@ pub trait GameScene {
         false
     }
 
+    /// Physical stance for VR tracking; a hanging capsule can shrink independently.
+    fn player_tracking_is_crouched(&self) -> bool {
+        self.player_is_crouched()
+    }
+
     /// Whether a VR hand is holding a climb hold (see `crate::vr_climb`).
     /// VR runtimes freeze their physical-crouch detector while it is true.
     fn player_is_gripping(&self) -> bool {

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -28,6 +28,9 @@ pub struct InputContext {
     // button; the physics controller edge-detects it so holding the button
     // cannot repeatedly add upward velocity.
     pub jump: bool,
+
+    /// Conversion used by a tracked runtime; lets a stance change rebase all poses together.
+    pub tracking: Option<crate::vr_tracking::TrackingTransform>,
 }
 
 impl InputContext {
@@ -40,6 +43,7 @@ impl InputContext {
             pointer: None,
             crouch: false,
             jump: false,
+            tracking: None,
         }
     }
 }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -56,6 +56,7 @@ mod vr_config;
 pub use vr_config::{MeleePosedArm, melee_contact_offset};
 pub mod vr_climb;
 pub mod vr_crouch;
+pub mod vr_tracking;
 mod wielded_weapon;
 pub mod zip_asset_path;
 
@@ -2171,7 +2172,7 @@ impl Game {
     /// the pawn position returned by [`Game::render`] to anchor floor-relative
     /// tracked poses at the player's feet instead of the collider center.
     pub fn player_center_above_floor(&self) -> f32 {
-        physics::player_center_above_floor(self.active_game_scene.player_is_crouched())
+        physics::player_center_above_floor(self.active_game_scene.player_tracking_is_crouched())
     }
 
     /// Whether a VR hand is holding a climb hold. VR runtimes freeze their
@@ -2186,7 +2187,7 @@ impl Game {
     /// this so the camera cannot leave the collider crown; see
     /// [`physics::player_eye_cap_above_center`].
     pub fn player_eye_cap_above_center(&self) -> f32 {
-        physics::player_eye_cap_above_center(self.active_game_scene.player_is_crouched())
+        physics::player_eye_cap_above_center(self.active_game_scene.player_tracking_is_crouched())
     }
 
     /// Fold the death camera into the camera a runtime is about to render

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3060,6 +3060,27 @@ impl MissionCore {
             input_context
         };
 
+        // Resolve ordinary tracked crouch before interpreting a grab. A pose
+        // converted against last frame's stance otherwise jumps on the next
+        // frame. Hanging compression deliberately leaves tracking unchanged.
+        let mut tracked_input = input_context.clone();
+        if tracked_input.tracking.is_some() {
+            if !time.elapsed.is_zero()
+                && !self.player_is_gripping()
+                && !self.player_handle.is_hanging_crouched()
+            {
+                self.physics
+                    .set_player_crouch(tracked_input.crouch, &mut self.player_handle);
+            }
+            let stance = self.player_handle.tracking_is_crouched();
+            crate::vr_tracking::TrackingTransform::rebase_input(
+                &mut tracked_input,
+                crate::physics::player_center_above_floor(stance),
+                crate::physics::player_eye_cap_above_center(stance),
+            );
+        }
+        let input_context = &tracked_input;
+
         let additional_rotation = cgmath::Quaternion::from_axis_angle(
             cgmath::vec3(0.0, 1.0, 0.0),
             cgmath::Rad(input_context.left_hand.thumbstick.x * delta_time * PLAYER_TURN_RATE),
@@ -3409,6 +3430,18 @@ impl MissionCore {
         // after the panel has already been put away (see `render`'s
         // `is_settled_closed()` gate).
         self.use_mode_ramp.update(time.elapsed.as_secs_f32());
+
+        // Landing can change the physical stance too. Use that same rig for
+        // rendered hands/UI and the runtime's post-update eyes this frame.
+        let mut rendered_input = input_context.clone();
+        let stance = self.player_handle.tracking_is_crouched();
+        crate::vr_tracking::TrackingTransform::rebase_input(
+            &mut rendered_input,
+            crate::physics::player_center_above_floor(stance),
+            crate::physics::player_eye_cap_above_center(stance),
+        );
+        let input_context = &rendered_input;
+        self.last_head_position = input_context.head.position;
 
         // VR cyber interface (use mode): follow the head for the anchor's
         // lazy recenter and the comfort dim, resolve this frame's pointer, and
@@ -9897,6 +9930,10 @@ impl MissionCore {
 
     /// Actual crouch state of the player collider (stand-up can be refused
     /// for lack of headroom, so this can lag the crouch input).
+    pub fn player_tracking_is_crouched(&self) -> bool {
+        self.player_handle.tracking_is_crouched()
+    }
+
     pub fn player_is_crouched(&self) -> bool {
         self.player_handle.is_crouched()
     }

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -266,6 +266,10 @@ impl crate::game_scene::GameScene for Mission {
         self.mission_core.player_is_crouched()
     }
 
+    fn player_tracking_is_crouched(&self) -> bool {
+        self.mission_core.player_tracking_is_crouched()
+    }
+
     fn player_is_gripping(&self) -> bool {
         self.mission_core.player_is_gripping()
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2517,6 +2517,8 @@ pub struct PlayerHandle {
     // the body center rather than the feet). It has to be undone the same way,
     // or the body ends up a crouch shift above where it hung.
     is_hanging_crouched: bool,
+    // Physical stance used by the tracked rig; hanging capsule changes leave it alone.
+    tracking_crouched: bool,
     // Live-validated waypoints for an in-progress ladder top-out. This is
     // transient locomotion state: direct relocation and crouching cancel it,
     // while save/load uses the last valid standing pose stored with it.
@@ -2608,6 +2610,11 @@ impl PlayerHandle {
     /// same way it was made.
     pub fn is_hanging_crouched(&self) -> bool {
         self.is_hanging_crouched
+    }
+
+    /// Stance anchoring floor-relative VR tracking, independent of a hanging capsule.
+    pub fn tracking_is_crouched(&self) -> bool {
+        self.tracking_crouched
     }
 
     /// Whether a scripted mantle/top-out currently owns the body. Nothing else
@@ -3273,6 +3280,7 @@ impl PhysicsWorld {
         // Relocated, so they are no longer hanging off anything: the stance
         // they are in is now an ordinary crouch, undone feet-planted.
         player_handle.is_hanging_crouched = false;
+        player_handle.tracking_crouched = player_handle.is_crouched;
         player_handle.slope_displacement = Vector::zeros();
         player_handle.is_grounded = false;
         player_handle.jump_velocity = None;
@@ -4613,6 +4621,7 @@ impl PhysicsWorld {
             character_handle,
             is_crouched: false,
             is_hanging_crouched: false,
+            tracking_crouched: false,
             top_out: None,
             support: None,
             slope_displacement: Vector::zeros(),
@@ -4668,6 +4677,9 @@ impl PhysicsWorld {
         // response to a crouch edge part-way across a lip.
         if player_handle.top_out.is_some() {
             return player_handle.is_crouched;
+        }
+        if anchor == CrouchAnchor::Feet {
+            player_handle.tracking_crouched = player_handle.is_crouched;
         }
         if want_crouch == player_handle.is_crouched {
             // Already in the wanted stance, so nothing moves - but the request
@@ -4781,6 +4793,9 @@ impl PhysicsWorld {
             }
         }
 
+        if anchor == CrouchAnchor::Feet {
+            player_handle.tracking_crouched = player_handle.is_crouched;
+        }
         player_handle.is_crouched
     }
 
@@ -7935,6 +7950,39 @@ mod tests {
     /// the tracked hands ride the body center, and moving it by the ordinary
     /// feet-planted crouch shift (0.64 wu) would exceed the grip's whole
     /// stretch tolerance (0.6 wu) and drop them off the hold.
+    #[test]
+    fn hanging_capsule_keeps_stationary_stage_hands_and_head_in_place() {
+        use crate::vr_tracking::TrackingTransform;
+        for start_crouched in [false, true] {
+            let mut world = PhysicsWorld::new();
+            let mut player =
+                world.create_player(vec3(0.0, 5.0, 0.0), EntityId::from_inner(2107).unwrap());
+            step(&mut world, &mut player, 1);
+            world.set_player_crouch(start_crouched, &mut player);
+            let rig = |player: &PlayerHandle| {
+                TrackingTransform::new(
+                    player_center_above_floor(player.tracking_is_crouched()),
+                    player_eye_cap_above_center(player.tracking_is_crouched()),
+                    1.65,
+                    0.0,
+                )
+            };
+            let before = rig(&player);
+            let center = world.get_player_translation(&player);
+            world.set_player_crouch_hanging(true, &mut player);
+            let after = rig(&player);
+            for tracked in [vec3(0.0, 1.65, 0.0), vec3(0.25, 1.4, -0.4)] {
+                assert_eq!(
+                    before.stage_to_pawn(tracked) + center,
+                    after.stage_to_pawn(tracked) + world.get_player_translation(&player)
+                );
+            }
+            world.set_player_crouch_hanging(false, &mut player);
+            assert_eq!(player.tracking_is_crouched(), start_crouched);
+            assert_eq!(world.get_player_translation(&player), center);
+        }
+    }
+
     #[test]
     fn a_hanging_crouch_shrinks_the_capsule_without_moving_the_body() {
         let mut world = PhysicsWorld::new();

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -331,6 +331,10 @@ impl GameScene for DebugScene {
         self.core.player_is_crouched()
     }
 
+    fn player_tracking_is_crouched(&self) -> bool {
+        self.core.player_tracking_is_crouched()
+    }
+
     fn player_is_gripping(&self) -> bool {
         self.core.player_is_gripping()
     }
@@ -565,6 +569,10 @@ impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
 
     fn player_is_crouched(&self) -> bool {
         self.core.player_is_crouched()
+    }
+
+    fn player_tracking_is_crouched(&self) -> bool {
+        self.core.player_tracking_is_crouched()
     }
 
     fn player_is_gripping(&self) -> bool {

--- a/shock2vr/src/vr_tracking.rs
+++ b/shock2vr/src/vr_tracking.rs
@@ -1,0 +1,134 @@
+//! One translation for the entire tracked rig: lowering the eye for crouch
+//! must lower the hands by the same amount, preserving physical reach and IPD.
+use cgmath::{Vector3, vec3};
+
+#[derive(Clone, Copy, Debug)]
+pub struct TrackingTransform {
+    translation: Vector3<f32>,
+    head_stage_y: f32,
+    stage_offset_meters: f32,
+}
+
+impl TrackingTransform {
+    /// All heights except `head_stage_y` and `stage_offset_meters` are world units.
+    /// Resolve once from the head centre, then apply identically to both eyes,
+    /// both hands, and gameplay's head pose. Never clamp individual tracked parts.
+    pub fn new(
+        center_above_floor: f32,
+        eye_cap: f32,
+        head_stage_y: f32,
+        stage_offset_meters: f32,
+    ) -> Self {
+        let scale = crate::METERS_PER_WORLD_UNIT;
+        let offset = stage_offset_meters / scale;
+        let head_y = head_stage_y / scale - center_above_floor;
+        let lowering = (head_y - eye_cap).max(0.0);
+        Self {
+            translation: vec3(0.0, offset - center_above_floor - lowering, 0.0),
+            head_stage_y,
+            stage_offset_meters,
+        }
+    }
+
+    pub fn with_stance(self, center_above_floor: f32, eye_cap: f32) -> Self {
+        Self::new(
+            center_above_floor,
+            eye_cap,
+            self.head_stage_y,
+            self.stage_offset_meters,
+        )
+    }
+
+    /// Apply a stance transition to an already-converted input, including any
+    /// pawn-local debug overrides, without changing relative tracked geometry.
+    pub fn rebase_input(input: &mut crate::input_context::InputContext, center: f32, cap: f32) {
+        if let Some(old) = input.tracking {
+            let new = old.with_stance(center, cap);
+            let delta = new.translation - old.translation;
+            input.head.position += delta;
+            input.left_hand.position += delta;
+            input.right_hand.position += delta;
+            input.tracking = Some(new);
+        }
+    }
+
+    pub fn stage_to_pawn(self, stage: Vector3<f32>) -> Vector3<f32> {
+        stage / crate::METERS_PER_WORLD_UNIT + self.translation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::InnerSpace;
+
+    #[test]
+    fn crouch_preserves_head_hand_geometry_and_stereo() {
+        for head_height in [1.7, 1.2, 0.8] {
+            for crouched in [false, true] {
+                let head = vec3(0.0, head_height, 0.0);
+                let hand = head + vec3(0.2, -0.15, -0.3);
+                let rig = TrackingTransform::new(
+                    crate::physics::player_center_above_floor(crouched),
+                    crate::physics::player_eye_cap_above_center(crouched),
+                    head_height,
+                    0.0,
+                );
+                let eye = rig.stage_to_pawn(head);
+                assert!(eye.y <= crate::physics::player_eye_cap_above_center(crouched) + 1e-5);
+                assert!(
+                    ((rig.stage_to_pawn(hand) - eye)
+                        - (hand - head) / crate::METERS_PER_WORLD_UNIT)
+                        .magnitude()
+                        < 1e-5
+                );
+                let other_eye = rig.stage_to_pawn(head + vec3(0.064, 0.0, 0.0));
+                assert!(
+                    ((other_eye - eye).magnitude() - 0.064 / crate::METERS_PER_WORLD_UNIT).abs()
+                        < 1e-5
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn eye_height_setting_translates_whole_rig() {
+        let base = TrackingTransform::new(0.6, 0.48, 1.6, 0.0);
+        let raised = TrackingTransform::new(0.6, 0.48, 1.6, 0.1);
+        for pose in [vec3(0.0, 1.6, 0.0), vec3(0.3, 1.3, -0.4)] {
+            assert!(
+                ((raised.stage_to_pawn(pose) - base.stage_to_pawn(pose)).y
+                    - 0.1 / crate::METERS_PER_WORLD_UNIT)
+                    .abs()
+                    < 1e-5
+            );
+        }
+    }
+
+    #[test]
+    fn stance_change_rebases_input_to_the_rendered_rig_on_the_same_frame() {
+        let head = vec3(0.0, 1.65, 0.0);
+        let hand = head + vec3(0.2, -0.15, -0.3);
+        let initial = TrackingTransform::new(
+            crate::physics::player_center_above_floor(false),
+            crate::physics::player_eye_cap_above_center(false),
+            head.y,
+            0.0,
+        );
+        let mut input = crate::input_context::InputContext::default();
+        input.tracking = Some(initial);
+        input.head.position = initial.stage_to_pawn(head);
+        input.right_hand.position = initial.stage_to_pawn(hand);
+        for crouched in [true, false, true] {
+            let center = crate::physics::player_center_above_floor(crouched);
+            let cap = crate::physics::player_eye_cap_above_center(crouched);
+            TrackingTransform::rebase_input(&mut input, center, cap);
+            let rendered = initial.with_stance(center, cap);
+            assert!((input.head.position - rendered.stage_to_pawn(head)).magnitude() < 1e-5);
+            assert!((input.right_hand.position - rendered.stage_to_pawn(hand)).magnitude() < 1e-5);
+            let once = input.right_hand.position;
+            TrackingTransform::rebase_input(&mut input, center, cap);
+            assert_eq!(input.right_hand.position, once);
+        }
+    }
+}


### PR DESCRIPTION
Crouching capped the rendered eye without lowering the hands, making them appear too high. Shrinking the capsule while hanging also changed the tracked floor origin enough to break a stationary grip.

Apply one head-resolved translation to both eyes, both hands, and the gameplay head pose. Preserve the tracked origin through hanging capsule changes and reconcile it when returning to grounded movement.

Validation:

- Host suite: 1,384 passed, 2 ignored before the final transition edits; the focused tracking tests (3) and hanging regression (1) passed after those edits.
- Release APK built successfully; independent fallback review completed.
- Installed release APK on Quest 3 (package update 2026-09-05 10:59:16; no DEBUGGABLE flag). `medsci1.mis` reached FOCUSED with 1680×1760 eyes at 90 Hz and advancing focused frame samples. The APK includes the tracking change but predates the small pause guard.
- Physical crouching and hanging remain unverified on the headset. Its resting orientation points toward the floor; the native capture below is a launch/render smoke check. Device app stopped and Guardian/proximity automation restored afterward.

![Synthetic crouch comparison](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/crouch-comparison.gif)

Synthetic stage-pose replay of the production conversion: identical physical head and hand motion rendered headlessly. Before caps only the eye; after lowers the full tracked rig. This illustrates the mapping and is **not native Quest verification**. Physical head height moves from 1.7 m to 1.2 m and back, with the hands 0.15 m below it.

![Synthetic crouched before and after](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/crouch-comparison.png)

<details><summary>Quest release smoke capture</summary>

![Quest focused medsci1 smoke](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/quest-pr1-focused.png)

Native stereo output from the installed release APK. The headset points at the floor; this does not establish crouch comfort or grip stability.

</details>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
