### PR TITLE
fix(vr): catch nearby mantle lips around their corners

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2259,6 +2259,9 @@ impl CollisionGroup {
 /// surface a tracked hand is resting on, small enough that it only finds the
 /// one face the hand is actually against.
 pub const CLIMB_GRIP_RADIUS: f32 = 0.15;
+/// Extra reach around a lip (about 23 cm), separate from direct ladder contact.
+/// The raised approach must be clear, so this cannot reach through a wall.
+pub const CLIMB_LIP_REACH: f32 = 0.3;
 
 /// What a hand found to hold onto.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -5411,7 +5414,64 @@ impl PhysicsWorld {
                 ));
             }
         }
-        nearest.map(|(_, grip)| grip)
+        if let Some((_, grip)) = nearest {
+            return Some(grip);
+        }
+
+        // A fist against the front of a lip has a side/diagonal separation
+        // normal, even when its fingers could hook over the top. Find the
+        // actual walkable surface by approaching above the hand, then down.
+        // Both approach segments must be clear: no grabbing through a wall or
+        // ceiling. Authored ladder masks still decide ladder contacts alone.
+        let hand = point![point.x, point.y, point.z];
+        let raised = hand + Vector::y() * CLIMB_LIP_REACH;
+        if queries
+            .cast_ray(&Ray::new(hand, Vector::y()), CLIMB_LIP_REACH, true)
+            .is_some()
+        {
+            return None;
+        }
+        let mut lip: Option<(f32, ClimbGrip)> = None;
+        for x in [-1.0, 0.0, 1.0] {
+            for z in [-1.0, 0.0, 1.0] {
+                let offset = vector![x * CLIMB_LIP_REACH / 2.0, 0.0, z * CLIMB_LIP_REACH / 2.0];
+                let distance = offset.norm();
+                if distance > 0.0
+                    && queries
+                        .cast_ray(&Ray::new(raised, offset / distance), distance, true)
+                        .is_some()
+                {
+                    continue;
+                }
+                let ray = Ray::new(raised + offset, -Vector::y());
+                let Some((handle, hit)) =
+                    queries.cast_ray_and_get_normal(&ray, 2.0 * CLIMB_LIP_REACH, true)
+                else {
+                    continue;
+                };
+                let collider = &self.collider_set[handle];
+                if !collider_is_not_climbable(collider) || !is_walkable_normal(hit.normal.y) {
+                    continue;
+                }
+                let top = ray.point_at(hit.time_of_impact);
+                let distance = (top - hand).norm();
+                if top.y <= min_ledge_height || distance > CLIMB_LIP_REACH {
+                    continue;
+                }
+                if lip.as_ref().is_none_or(|(nearest, _)| distance < *nearest) {
+                    lip = Some((
+                        distance,
+                        ClimbGrip {
+                            kind: ClimbGripKind::Ledge,
+                            entity_id: EntityId::from_inner(collider.user_data as u64),
+                            point: nvec_to_cgmath(top.coords),
+                            normal: nvec_to_cgmath(hit.normal),
+                        },
+                    ));
+                }
+            }
+        }
+        lip.map(|(_, grip)| grip)
     }
 
     fn move_player(
@@ -9313,6 +9373,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_ceiling_blocks_the_approach_around_a_lip() {
+        let (mut world, mut player) = grip_world();
+        world.add_kinematic(
+            EntityId::from_inner(2012).unwrap(),
+            vec3(0.0, 1.5, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 3.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        let hand = vec3(2.05, 2.99, 0.0);
+        assert!(
+            world
+                .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 0.0)
+                .is_some()
+        );
+        world.add_kinematic(
+            EntityId::from_inner(2013).unwrap(),
+            vec3(2.1, 3.15, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.4, 0.1, 0.4),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        assert!(
+            world
+                .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 0.0)
+                .is_none(),
+            "a ceiling prevents curling fingers over the lip"
+        );
+    }
+
     /// Mantle emulation: the walkable top of a solid block above the player's
     /// feet is a Ledge; the floor they are standing on is not (it is not more
     /// than a step above their feet).
@@ -9329,6 +9426,29 @@ mod tests {
             false,
         );
         step(&mut world, &mut player, 1);
+
+        for hand in [
+            vec3(2.05, 2.99, 0.0),
+            vec3(-2.05, 2.99, 0.0),
+            vec3(0.0, 2.99, 2.05),
+            vec3(0.0, 2.99, -2.05),
+        ] {
+            let lip = world
+                .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 0.0)
+                .expect("fingers can hook around a nearby lip");
+            assert_eq!(lip.kind, ClimbGripKind::Ledge);
+            assert!(lip.normal.y > 0.99);
+            assert!((lip.point.y - 3.0).abs() < 1e-4);
+            assert!((lip.point - hand).magnitude() <= CLIMB_LIP_REACH);
+        }
+        for hand in [vec3(2.05, 2.5, 0.0), vec3(2.5, 2.99, 0.0)] {
+            assert!(
+                world
+                    .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 0.0)
+                    .is_none(),
+                "a remote top cannot turn a wall into a hold"
+            );
+        }
 
         let lip = world
             .climbable_grip_at(vec3(0.0, 3.05, 0.0), CLIMB_GRIP_RADIUS, 0.0)

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -160,6 +160,8 @@ pub struct HandClimb {
     /// lost its hold (over-stretched, or the object went away) must not
     /// silently re-grab while the same squeeze is still held.
     was_squeezing: [bool; 2],
+    /// A fresh squeeze may reach contact a few frames late; never retry a broken hold.
+    grab_grace: [f32; 2],
     /// The anchor hand's recent travel relative to the pawn, in world axes,
     /// newest last - the pull, which a release throws the body with. Cleared
     /// when the anchor changes: the history belongs to the hand that made it.
@@ -214,6 +216,11 @@ impl HandClimb {
         for (index, hand) in hands.iter().enumerate() {
             let squeezing = hand.squeeze > crate::ui::VR_TRIGGER_THRESHOLD;
             let was_squeezing = std::mem::replace(&mut self.was_squeezing[index], squeezing);
+            if !squeezing || !hand.is_empty {
+                self.grab_grace[index] = 0.0;
+            } else if !was_squeezing {
+                self.grab_grace[index] = 0.15;
+            }
             match self.grips[index] {
                 Some(anchor) => {
                     let over_stretched = (hand_world[index] - anchor.hand_world_at_grab)
@@ -224,12 +231,14 @@ impl HandClimb {
                     // took a hold can also close on an item; a full hand lets
                     // go of the ladder rather than holding both.
                     if !squeezing || !hand.is_empty || over_stretched || gone {
+                        self.grab_grace[index] = 0.0;
                         self.grips[index] = None;
                         let_go_cleanly[index] = !squeezing && !over_stretched && !gone;
                     }
                 }
-                None if squeezing && !was_squeezing && hand.is_empty => {
+                None if self.grab_grace[index] > 0.0 => {
                     if let Some(grip) = probe(hand_world[index]) {
+                        self.grab_grace[index] = 0.0;
                         self.grips[index] = Some(GripAnchor {
                             grip,
                             hand_world_at_grab: hand_world[index],
@@ -241,6 +250,7 @@ impl HandClimb {
                 }
                 None => {}
             }
+            self.grab_grace[index] = (self.grab_grace[index] - step_dt.max(0.0)).max(0.0);
         }
 
         // The anchor let go. Hand over to the other hand if it is still on -
@@ -313,6 +323,7 @@ impl HandClimb {
     /// the scripted top-out has finished.
     pub fn release_all(&mut self) {
         self.grips = [None, None];
+        self.grab_grace = [0.0, 0.0];
         self.anchor = None;
         self.recent_anchor_travel.clear();
         self.last_anchor_local = None;
@@ -440,6 +451,75 @@ mod tests {
         assert_eq!(released.translation, None);
         assert_eq!(climb.anchor(), None);
         assert_eq!(climb.grips().count(), 0);
+    }
+
+    #[test]
+    fn a_fresh_squeeze_can_reach_contact_late_but_cannot_regrab_after_a_break() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let reach = vec3(0.0, 1.0, -1.0);
+        for _ in 0..3 {
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(reach, 1.0)],
+                |_| None,
+                |_| true,
+            );
+        }
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(reach, 1.0)],
+            |p| Some(ladder_grip(p)),
+            |_| true,
+        );
+        assert!(climb.anchor().is_some());
+        let broken = reach + vec3(0.0, 1.0, 0.0);
+        for _ in 0..3 {
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(broken, 1.0)],
+                |p| Some(ladder_grip(p)),
+                |_| true,
+            );
+            assert!(climb.anchor().is_none());
+        }
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(reach, 0.0)],
+            |_| None,
+            |_| true,
+        );
+        for _ in 0..12 {
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(reach, 1.0)],
+                |_| None,
+                |_| true,
+            );
+        }
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(reach, 1.0)],
+            |p| Some(ladder_grip(p)),
+            |_| true,
+        );
+        assert!(
+            climb.anchor().is_none(),
+            "expired grace is not a permanent auto-grab"
+        );
     }
 
     #[test]

--- a/tools/shock2-sdk/test/climb-grip.e2e.test.ts
+++ b/tools/shock2-sdk/test/climb-grip.e2e.test.ts
@@ -3,6 +3,8 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
+import { vrClimbPull } from "./helpers/vr-climb.js";
+import { teleportVerified } from "./helpers/teleport.js";
 
 // `GET /v1/physics/grip` answers "could a hand hold on here?" against the
 // debug_ladder stations (see shock2vr/src/scenes/debug_ladder.rs). The two
@@ -32,6 +34,10 @@ const PROBES: Probe[] = [
   { name: "ledge block lip", point: [-7.2, 6.05, 0], expected: "ledge" },
   // The ladderless mantle block: top y = 3.
   { name: "mantle block lip", point: [-7.2, 3.05, 24], expected: "ledge" },
+  { name: "mantle lip from below", point: [-6.95, 2.99, 24], expected: "ledge" },
+  { name: "mantle corner diagonal", point: [-6.9, 3.05, 24], expected: "ledge" },
+  { name: "mantle lip too far below", point: [-6.95, 2.5, 24], expected: null },
+  { name: "mantle lip too far away", point: [-6.5, 2.99, 24], expected: null },
   { name: "plain wall face", point: [-6.9, 3.0, -16], expected: null },
   { name: "floor at the player's feet", point: [0, 0.05, 0], expected: null },
 ];
@@ -121,3 +127,17 @@ test(
     );
   },
 );
+
+
+test("debug_ladder (VR): a hand below the mantle corner can hold and pull", {
+  skip: !e2eEnabled, timeout: 300_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "debug_ladder", debugFlags: ["--vr"] });
+  await game.step({ frames: 5 });
+  await teleportVerified(game, { x: -6.35, y: 1.5, z: 24 });
+  await game.step({ frames: 30 });
+  const pull = await vrClimbPull(game, { grabAt: [-6.95, 2.99, 24], pull: [0, -0.3, 0], frames: 30 });
+  const climb = (await game.info()).player.climb;
+  assert.equal(climb.grips[0]?.kind, "ledge");
+  assert.ok(pull.after[1] - pull.before[1] > 0.2, "corner grip must move the body");
+});


### PR DESCRIPTION
A hand just below and in front of a mantle corner could not grab its top: the closest contact was the vertical wall, so the grip query rejected it. Squeezing slightly before reaching the surface also lost the grab until the player opened and squeezed again.

Find a nearby walkable lip within a bounded 0.3-world-unit reach, validating the approach and clearance while retaining authored ladder faces and the floor-height guard. Keep a squeeze eligible for 150 ms so approaching the surface during that short window can acquire the hold.

This is the second stacked change, based on #1358 (`fix/vr-crouch-tracking`).

Validation:

- Focused grip tests: 10 passed; grab/grace tests: 17 passed; overhead obstruction regression: 1 passed.
- SDK `climb-grip` and `vr-climb` scenarios: all 12 passed.
- Deterministic `debug_ladder --vr` replay: the same hand point `[-6.95, 2.99, 24]` previously acquired no hold. It now acquires the adjacent top at `[-7.1, 3, 24]`; the same downward pull finishes on the block at body height 4.244 instead of staying on the floor at 1.244.
- Captured and inspected both runs from the same camera and request sequence. Headless interaction coverage does not establish comfortable headset reach; the lip tolerance still needs hands-on tuning.

![Mantle corner before and after](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/corner-comparison.gif)

Same squeeze just outside/below the lip, followed by the same downward hand motion. Left: the hand cannot acquire a hold. Right: the nearby top is acquired and the existing mantle finish lands the player on the block. Captured headlessly with fixed-timestep stepping; the detached camera shows the hands and surface.

![Mantle corner landing comparison](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/corner-comparison.png)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
