### PR TITLE
fix(vr): pull from ladder holds onto the adjacent deck

### DIFF
--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -211,9 +211,16 @@ impl PlayerInteraction for VrInteraction {
                 hand_input(&self.left_hand, &ctx.input.left_hand),
                 hand_input(&self.right_hand, &ctx.input.right_hand),
             ],
-            |point| {
-                ctx.physics
-                    .climbable_grip_at(point, crate::physics::CLIMB_GRIP_RADIUS, ctx.feet_y)
+            |point, from_ladder| {
+                if from_ladder {
+                    ctx.physics.climbable_grip_from_ladder_at(point, ctx.feet_y)
+                } else {
+                    ctx.physics.climbable_grip_at(
+                        point,
+                        crate::physics::CLIMB_GRIP_RADIUS,
+                        ctx.feet_y,
+                    )
+                }
             },
             // "Cannot check" is not "gone" - a failed borrow keeps the hold.
             |entity_id| {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3193,10 +3193,10 @@ impl MissionCore {
             // the planner cannot find is simply not taken - the holds stay and
             // the player keeps pulling.
             let mut hand_climb = hand_climb;
-            if let Some(direction) = self.hand_vault_direction() {
+            if let Some(grip) = self.hand_vault_target(input_context.head.position) {
                 if self
                     .physics
-                    .plan_hand_top_out(direction, &mut self.player_handle)
+                    .plan_hand_top_out(grip, &mut self.player_handle)
                 {
                     self.interaction.release_climb_grips();
                     hand_climb.translation = None;
@@ -9938,35 +9938,31 @@ impl MissionCore {
         self.player_handle.is_crouched()
     }
 
-    /// Where to throw the body if the player has pulled their head over the
-    /// ledge their anchor hand is lying on, or `None` if they have not (see
-    /// [`crate::vr_climb::vault_ready`]).
-    ///
-    /// The eye is taken at the STANDING line above the body center, whatever
-    /// stance the collider is in: a VR player's real head does not shrink when
-    /// their capsule balls up, and it is the center the tracked head rides.
-    fn hand_vault_direction(&self) -> Option<Vector3<f32>> {
+    /// The actual held surface, after a deliberate upward or inward pull.
+    /// Preserve this target across ladder-to-deck transfer; head height at the
+    /// moment of grabbing does not disqualify the new hold.
+    fn hand_vault_target(&self, head_local: Vector3<f32>) -> Option<crate::physics::ClimbGrip> {
         let anchor = self.interaction.hand_climb()?.anchor_grip()?;
-        // The pose the coming step will land on, as the grip itself is resolved
-        // against - judging the eye against the superseded one lags the pull.
         let center = self
             .physics
             .get_player_next_translation(&self.player_handle);
-        let eye_above_center = crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
-        if !crate::vr_climb::vault_ready(
-            center.y + eye_above_center,
-            anchor.pawn_at_grab.y + eye_above_center,
+        let toward = anchor.grip.point - anchor.pawn_at_grab;
+        let horizontal = cgmath::vec3(toward.x, 0.0, toward.z);
+        let distance = horizontal.magnitude();
+        let traveled = center - anchor.pawn_at_grab;
+        let inward = if distance > 1e-4 {
+            traveled.dot(horizontal / distance)
+        } else {
+            0.0
+        };
+        crate::vr_climb::vault_ready(
+            center.y + head_local.y,
+            traveled.y.max(inward),
             anchor.grip.point.y,
             anchor.grip.kind,
             crate::physics::is_walkable_normal(anchor.grip.normal.y),
-        ) {
-            return None;
-        }
-        // Over the lip, toward the hand: the landing is whatever the planner
-        // finds that way.
-        let toward = anchor.grip.point - center;
-        let direction = cgmath::vec3(toward.x, 0.0, toward.z);
-        (direction.magnitude() > 1.0e-4).then_some(direction)
+        )
+        .then_some(anchor.grip)
     }
 
     /// Whether either VR hand currently holds a climb hold.

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -689,6 +689,10 @@ struct ClimbPass<'a> {
 
 #[derive(Clone, Copy)]
 struct ClimbTopOut {
+    /// Hand vaults follow a real clear route; flat retains Dark jump-through semantics.
+    collide_terrain: bool,
+    /// Expand at the validated final center, without a feet-planted camera jump.
+    stand_on_completion: bool,
     waypoints: [Vector<Real>; 7],
     next_waypoint: usize,
     save_pose: Vector<Real>,
@@ -966,6 +970,19 @@ fn shape_sweep_is_clear(
             },
         )
         .is_none()
+}
+
+/// Static overlap alone can miss the underside of one-sided ceiling triangles.
+/// Sweeping the capsule's generating sphere upward covers that same volume
+/// from the blocking side. Shared by ordinary stand-up and hand-vault landing.
+fn capsule_pose_is_clear(queries: &QueryPipeline, center: Vector<Real>, capsule: &Capsule) -> bool {
+    !shape_intersects(queries, center, capsule)
+        && shape_sweep_is_clear(
+            queries,
+            center + capsule.segment.a.coords,
+            center + capsule.segment.b.coords,
+            &Ball::new(capsule.radius),
+        )
 }
 
 fn ray_segment_is_clear(queries: &QueryPipeline, from: Vector<Real>, to: Vector<Real>) -> bool {
@@ -1269,6 +1286,8 @@ fn plan_climb_top_out(
         self_translation: first_step,
         is_climbing: true,
         top_out: Some(ClimbTopOut {
+            collide_terrain: false,
+            stand_on_completion: false,
             waypoints,
             next_waypoint: 0,
             save_pose: pos.translation.vector,
@@ -1538,6 +1557,8 @@ fn plan_jump_mantle(
         self_translation: first_movement,
         is_climbing: true,
         top_out: Some(ClimbTopOut {
+            collide_terrain: false,
+            stand_on_completion: false,
             waypoints,
             next_waypoint: 0,
             save_pose: pos.translation.vector,
@@ -1607,7 +1628,8 @@ fn advance_climb_top_out(
     mut top_out: ClimbTopOut,
     dt: Real,
 ) -> (EffectiveCharacterMovement, Option<ClimbTopOut>) {
-    let final_shape = if top_out.is_crouched {
+    let final_shape = if top_out.is_crouched && (!top_out.stand_on_completion || top_out.reversing)
+    {
         crouched_player_capsule()
     } else {
         standing_player_capsule()
@@ -1620,7 +1642,11 @@ fn advance_climb_top_out(
             }
         } else if let Some(target) = top_out.waypoints.get(top_out.next_waypoint) {
             *target
-        } else if shape_intersects(validation_queries, pos.translation.vector, &final_shape) {
+        } else if if top_out.collide_terrain {
+            !capsule_pose_is_clear(validation_queries, pos.translation.vector, &final_shape)
+        } else {
+            shape_intersects(validation_queries, pos.translation.vector, &final_shape)
+        } {
             top_out.reversing = true;
             continue;
         } else {
@@ -1632,7 +1658,17 @@ fn advance_climb_top_out(
         }
         if top_out.reversing {
             if top_out.next_waypoint == 0 {
-                if shape_intersects(validation_queries, top_out.save_pose, &final_shape) {
+                let recovery_queries = if top_out.collide_terrain {
+                    scripted_queries
+                } else {
+                    validation_queries
+                };
+                let recovery_shape = if top_out.is_crouched {
+                    crouched_player_capsule()
+                } else {
+                    standing_player_capsule()
+                };
+                if shape_intersects(recovery_queries, top_out.save_pose, &recovery_shape) {
                     return (scripted_character_movement(Vector::zeros()), Some(top_out));
                 }
                 return (scripted_character_movement(Vector::zeros()), None);
@@ -4739,36 +4775,8 @@ impl PhysicsWorld {
                 &self.collider_set,
                 filter,
             );
-            let overlaps_final_pose = queries
-                .intersect_shape(standing_pos, &test_shape)
-                .next()
-                .is_some();
-            // Level ceilings are authored as one-sided triangles facing down.
-            // A static overlap against their underside can miss them, even
-            // though an upward movement cast correctly blocks. Sweep a sphere
-            // from the standing capsule's bottom axis endpoint to its top
-            // endpoint: the swept sphere is exactly the capsule volume and
-            // approaches those ceiling faces from below. Keep the final-pose
-            // overlap above as well, because a cast configured to leave an
-            // initial penetration may not report a prop already intersecting
-            // the bottom sphere.
-            let bottom_sphere_pos =
-                Translation::from(Vector::y() * test_shape.segment.a.y) * standing_pos;
-            let axis_length = (test_shape.segment.b - test_shape.segment.a).norm();
-            let crown_sweep = Ball::new(test_shape.radius);
-            let blocked_by_crown_sweep = queries
-                .cast_shape(
-                    &bottom_sphere_pos,
-                    &Vector::y(),
-                    &crown_sweep,
-                    rapier3d::parry::query::ShapeCastOptions {
-                        max_time_of_impact: axis_length,
-                        target_distance: 0.0,
-                        stop_at_penetration: false,
-                        compute_impact_geometry_on_penetration: true,
-                    },
-                )
-                .is_some();
+            let pose_is_clear =
+                capsule_pose_is_clear(&queries, standing_pos.translation.vector, &test_shape);
             // Both probes above are spatial queries, and Rapier only builds the
             // broad-phase BVH inside `PhysicsPipeline::step`. On a world that
             // has never been stepped they therefore match nothing and report
@@ -4783,7 +4791,7 @@ impl PhysicsWorld {
             // Room" ledge, issue #773). A standing capsule embedded in level
             // geometry is unrecoverable: the character controller resolves zero
             // movement in every direction for the rest of the session.
-            let blocked = !self.has_stepped || overlaps_final_pose || blocked_by_crown_sweep;
+            let blocked = !self.has_stepped || !pose_is_clear;
 
             if !blocked {
                 self.collider_set[collider_handle].set_shape(standing_player_shared_shape());
@@ -5109,82 +5117,100 @@ impl PhysicsWorld {
         player_handle.support = None;
     }
 
-    /// Start the scripted top-out (Dark's crouched up-and-forward mantle
-    /// waypoints, the same sequence flat runs at a ladder top) from wherever
-    /// the player currently hangs, heading `direction`.
-    ///
-    /// This is how a VR hand vault finishes: once the eye clears the lip
-    /// ([`crate::vr_climb::vault_ready`]) the hands have done all they can,
-    /// and the body is thrown over by the planner rather than hauled. Returns
-    /// whether a route was found - if not, nothing changes and the player
-    /// keeps climbing.
-    pub fn plan_hand_top_out(
-        &mut self,
-        direction: Vector3<f32>,
-        player_handle: &mut PlayerHandle,
-    ) -> bool {
-        if player_handle.top_out.is_some() {
+    /// Plan a short, collision-checked route onto the surface actually held.
+    /// Stay compressed along the route, expanding only at the validated landing.
+    /// This reuses the scripted mover/reversal without requiring a standing
+    /// capsule to fit at the hanging start or choosing a different floor ahead.
+    pub fn plan_hand_top_out(&mut self, grip: ClimbGrip, player: &mut PlayerHandle) -> bool {
+        if player.top_out.is_some() || grip.kind != ClimbGripKind::Ledge {
             return false;
         }
-        let character_handle = player_handle.character_handle;
-        let character_pos = *self.rigid_body_set[character_handle].position();
-        let movement_filter = player_movement_filter(character_handle);
-        // The same three pipelines the flat ladder top-out plans against: the
-        // probes ignore the climbable the player is hanging off, and the
-        // scripted route may cross parentless terrain (see `ClimbPass`).
+        let start = *self.rigid_body_set[player.character_handle].translation();
+        let toward = vec_to_nvec(grip.point) - start;
+        let horizontal = vector![toward.x, 0.0, toward.z];
+        if horizontal.norm() < 1e-4 {
+            return false;
+        }
+        let direction = horizontal.normalize();
+        let filter = player_movement_filter(player.character_handle);
         let not_climbable =
             |_handle: ColliderHandle, collider: &Collider| collider_is_not_climbable(collider);
-        let parented_non_climbable = |_handle: ColliderHandle, collider: &Collider| {
-            collider.parent().is_some() && collider_is_not_climbable(collider)
-        };
-        // The route is planned for, and ends by expanding, the STANDING
-        // capsule, so a balled-up body has to fit one where it hangs. Test that
-        // first - it is one query, against the planner's hundreds - and refuse
-        // the vault if it does not; the player keeps pulling instead.
-        let stand_anchor = if player_handle.is_hanging_crouched {
-            CrouchAnchor::Center
-        } else {
-            CrouchAnchor::Feet
-        };
-        let standing_center = nvec_to_cgmath(character_pos.translation.vector)
-            + vec3(0.0, stand_anchor.center_shift(), 0.0);
-        if player_handle.is_crouched
-            && !self.standing_player_pose_is_clear(standing_center, player_handle)
-        {
-            return false;
-        }
-        // Plan before committing to anything: a refused route must leave the
-        // player exactly as they were, still holding on.
         let planned = {
-            let dispatcher = self.narrow_phase.query_dispatcher();
-            let queries = self.player_movement_queries(dispatcher, movement_filter);
-            plan_climb_top_out(
-                &player_handle.controller,
-                &queries,
-                &queries.with_filter(movement_filter.predicate(&not_climbable)),
-                &queries.with_filter(movement_filter.predicate(&parented_non_climbable)),
-                &character_pos,
-                vec_to_nvec(direction),
-                0.0,
-                self.integration_parameters.dt,
-            )
+            let queries =
+                self.player_movement_queries(self.narrow_phase.query_dispatcher(), filter);
+            let route_queries = queries.with_filter(filter.predicate(&not_climbable));
+            let crouched = crouched_player_capsule();
+            let stand_on_completion = !player.tracking_is_crouched();
+            let final_shape = if stand_on_completion {
+                standing_player_capsule()
+            } else {
+                crouched_player_capsule()
+            };
+            let compressed = Ball::new(PLAYER_CROUCH_RADIUS / SCALE_FACTOR);
+            if shape_intersects(&route_queries, start, &crouched) {
+                return false;
+            }
+            let mut route = None;
+            // Bounded inset search: a fist can hold an edge that cannot support
+            // the body, so prove the landing capsule fits and stays supported.
+            for inset in [0.4, 0.8] {
+                let above = vec_to_nvec(grip.point) + direction * inset + Vector::y() * 0.3;
+                let ray = Ray::new(Point::from(above), -Vector::y());
+                let Some((handle, hit)) = route_queries.cast_ray_and_get_normal(&ray, 0.6, true)
+                else {
+                    continue;
+                };
+                let floor = ray.point_at(hit.time_of_impact).coords;
+                if !is_walkable_normal(hit.normal.y)
+                    || (floor.y - grip.point.y).abs() > 0.1
+                    || EntityId::from_inner(self.collider_set[handle].user_data as u64)
+                        != grip.entity_id
+                {
+                    continue;
+                }
+                let landing = floor + Vector::y() * player_center_above_floor(!stand_on_completion);
+                if !capsule_pose_is_clear(&queries, landing, &final_shape)
+                    || !shape_has_stable_support(
+                        &player.controller,
+                        &queries,
+                        &final_shape,
+                        landing,
+                        self.integration_parameters.dt,
+                    )
+                {
+                    continue;
+                }
+                let raised = vector![start.x, start.y.max(landing.y), start.z];
+                let crossed = vector![landing.x, raised.y, landing.z];
+                if !shape_sweep_is_clear(&route_queries, start, raised, &compressed)
+                    || !shape_sweep_is_clear(&route_queries, raised, crossed, &compressed)
+                    || !shape_sweep_is_clear(&route_queries, crossed, landing, &compressed)
+                {
+                    continue;
+                }
+                route = Some(ClimbTopOut {
+                    collide_terrain: true,
+                    stand_on_completion,
+                    waypoints: [start, raised, crossed, landing, landing, landing, landing],
+                    next_waypoint: 0,
+                    save_pose: start,
+                    reversing: false,
+                    is_crouched: true,
+                });
+                break;
+            }
+            route
         };
-        let Some(planned) = planned else {
+        let Some(route) = planned else {
             return false;
         };
-        // Un-ball on the anchor the crouch was made with, so the body ends up
-        // where the pre-check said the standing capsule fits.
-        if player_handle.is_crouched
-            && self.set_player_crouch_anchored(false, stand_anchor, player_handle)
-        {
-            return false;
-        }
-        player_handle.top_out = planned.top_out;
+        self.set_player_crouch_hanging(true, player);
+        player.top_out = Some(route);
         sync_top_out_collider(
             &mut self.collider_set,
             &mut self.rigid_body_set,
             false,
-            player_handle,
+            player,
         );
         true
     }
@@ -5337,6 +5363,25 @@ impl PhysicsWorld {
         radius: f32,
         feet_y: f32,
     ) -> Option<ClimbGrip> {
+        self.climbable_grip_above(point, radius, feet_y + PLAYER_STEP_HEIGHT / SCALE_FACTOR)
+    }
+
+    /// Near a held ladder, the deck can be less than a step above the feet.
+    /// It must still be above them, so ordinary floor support is never a grip.
+    pub fn climbable_grip_from_ladder_at(
+        &self,
+        point: Vector3<f32>,
+        feet_y: f32,
+    ) -> Option<ClimbGrip> {
+        self.climbable_grip_above(point, CLIMB_GRIP_RADIUS, feet_y + 0.1)
+    }
+
+    fn climbable_grip_above(
+        &self,
+        point: Vector3<f32>,
+        radius: f32,
+        min_ledge_height: f32,
+    ) -> Option<ClimbGrip> {
         let ball = Ball::new(radius.max(1.0e-3));
         let ball_pos = Isometry::translation(point.x, point.y, point.z);
         // Probe AS the player, so only geometry that blocks the player can be
@@ -5361,7 +5406,6 @@ impl PhysicsWorld {
             filter,
         );
 
-        let min_ledge_height = feet_y + PLAYER_STEP_HEIGHT / SCALE_FACTOR;
         let mut nearest: Option<(f32, ClimbGrip)> = None;
         for (_handle, collider) in queries.intersect_shape(ball_pos, &ball) {
             let Ok(Some(contact)) = rapier3d::parry::query::contact(
@@ -5684,7 +5728,7 @@ impl PhysicsWorld {
                 let (movement, top_out) = advance_climb_top_out(
                     &player_handle.controller,
                     &queries,
-                    &queries.with_filter(scripted_top_out_filter),
+                    &queries.with_filter(if top_out.collide_terrain { climb_pass_filter } else { scripted_top_out_filter }),
                     &character_pos,
                     top_out,
                     self.integration_parameters.dt,
@@ -5774,6 +5818,17 @@ impl PhysicsWorld {
         let self_translation = player_movement.self_translation;
         player_handle.self_translation = nvec_to_cgmath(self_translation);
         player_handle.is_climbing = player_movement.is_climbing;
+        if player_movement.top_out.is_none()
+            && player_handle
+                .top_out
+                .is_some_and(|route| route.stand_on_completion && !route.reversing)
+        {
+            // The route already moved to a full-height supported center.
+            // Expand there; a feet-planted crouch toggle would add another 0.64.
+            player_handle.is_crouched = false;
+            player_handle.is_hanging_crouched = false;
+            player_handle.tracking_crouched = false;
+        }
         player_handle.top_out = player_movement.top_out;
         player_handle.slope_displacement = player_movement.slope_displacement;
         let is_top_out = player_handle.top_out.is_some();
@@ -9054,6 +9109,8 @@ mod tests {
         let controller = KinematicCharacterController::default();
         let mut pos = Isometry::translation(0.0, 0.0, 0.0);
         let top_out = ClimbTopOut {
+            collide_terrain: false,
+            stand_on_completion: false,
             waypoints: test_waypoints(),
             next_waypoint: 2,
             save_pose: vector![-1.0, 0.0, 0.0],
@@ -9107,6 +9164,8 @@ mod tests {
         let controller = KinematicCharacterController::default();
         let mut pos = Isometry::translation(0.0, 0.0, 0.0);
         let mut active = ClimbTopOut {
+            collide_terrain: false,
+            stand_on_completion: false,
             waypoints: test_waypoints(),
             next_waypoint: 2,
             save_pose: vector![-1.0, 0.0, 0.0],
@@ -9160,6 +9219,8 @@ mod tests {
         let controller = KinematicCharacterController::default();
         let pos = Isometry::identity();
         let completed = ClimbTopOut {
+            collide_terrain: false,
+            stand_on_completion: false,
             waypoints: test_waypoints(),
             next_waypoint: test_waypoints().len(),
             save_pose: Vector::zeros(),
@@ -9198,6 +9259,8 @@ mod tests {
         world.collider_set[collider_handle].set_shape(SharedShape::ball(CLIMB_TOP_OUT_RADIUS));
         world.rigid_body_set[player.character_handle].enable_ccd(false);
         player.top_out = Some(ClimbTopOut {
+            collide_terrain: false,
+            stand_on_completion: false,
             waypoints: [compressed_pose; 7],
             next_waypoint: 3,
             save_pose,
@@ -9374,6 +9437,188 @@ mod tests {
     }
 
     #[test]
+    fn hand_top_out_tucks_past_the_wall_and_expands_only_at_the_landing() {
+        for physically_crouched in [false, true] {
+            let (mut world, mut player) = grip_world();
+            let block = EntityId::from_inner(2020).unwrap();
+            world.add_kinematic(
+                block,
+                vec3(0.0, 1.5, 0.0),
+                identity_quat(),
+                vec3(0.0, 0.0, 0.0),
+                vec3(4.0, 3.0, 4.0),
+                CollisionGroup::entity(),
+                false,
+            );
+            step(&mut world, &mut player, 1);
+            world.set_player_crouch(physically_crouched, &mut player);
+            world.set_player_translation(vec3(2.4, 2.4, 0.0), &mut player);
+            let grip = ClimbGrip {
+                kind: ClimbGripKind::Ledge,
+                entity_id: Some(block),
+                point: vec3(2.0, 3.0, 0.0),
+                normal: vec3(0.0, 1.0, 0.0),
+            };
+            assert!(!world.standing_player_pose_is_clear(vec3(2.4, 2.4, 0.0), &player));
+            assert!(world.plan_hand_top_out(grip, &mut player));
+            assert!(player.is_crouched());
+            let mut previous = world.get_player_translation(&player);
+            for _ in 0..180 {
+                step(&mut world, &mut player, 1);
+                let position = world.get_player_translation(&player);
+                assert!(
+                    (position - previous).magnitude() < 0.1,
+                    "landing must not add a stance jump"
+                );
+                previous = position;
+                if !player.is_topping_out() {
+                    break;
+                }
+            }
+            assert!(!player.is_topping_out());
+            assert_eq!(player.is_crouched(), physically_crouched);
+            assert!(
+                (previous.y - (3.0 + player_center_above_floor(physically_crouched))).abs() < 0.05
+            );
+            assert!(previous.x <= 2.01, "landing {previous:?}");
+        }
+    }
+
+    #[test]
+    fn hand_vault_does_not_expand_through_a_one_sided_ceiling() {
+        let (mut world, mut player) = grip_world();
+        let block = EntityId::from_inner(2025).unwrap();
+        world.add_kinematic(
+            block,
+            vec3(0.0, 1.5, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 3.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        world.set_player_translation(vec3(2.4, 2.4, 0.0), &mut player);
+        let grip = ClimbGrip {
+            kind: ClimbGripKind::Ledge,
+            entity_id: Some(block),
+            point: vec3(2.0, 3.0, 0.0),
+            normal: vec3(0.0, 1.0, 0.0),
+        };
+        // The sphere can pass underneath y=5, but the standing crown cannot.
+        world.add_collider(
+            EntityId::from_inner(2026).unwrap(),
+            ColliderBuilder::trimesh(
+                vec![
+                    point![-2.0, 5.0, -2.0],
+                    point![2.0, 5.0, -2.0],
+                    point![2.0, 5.0, 2.0],
+                    point![-2.0, 5.0, 2.0],
+                ],
+                vec![[0, 1, 2], [0, 2, 3]],
+            )
+            .unwrap()
+            .build(),
+        );
+        step(&mut world, &mut player, 1);
+        assert!(!world.plan_hand_top_out(grip, &mut player));
+        assert!(!player.is_crouched());
+        assert!(!player.is_topping_out());
+    }
+
+    #[test]
+    fn a_new_blocker_reverses_a_hand_vault_to_its_crouched_source() {
+        let (mut world, mut player) = grip_world();
+        let block = EntityId::from_inner(2023).unwrap();
+        world.add_kinematic(
+            block,
+            vec3(0.0, 1.5, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 3.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        let start = vec3(2.4, 2.4, 0.0);
+        world.set_player_translation(start, &mut player);
+        assert!(world.plan_hand_top_out(
+            ClimbGrip {
+                kind: ClimbGripKind::Ledge,
+                entity_id: Some(block),
+                point: vec3(2.0, 3.0, 0.0),
+                normal: vec3(0.0, 1.0, 0.0),
+            },
+            &mut player
+        ));
+        step(&mut world, &mut player, 10);
+        world.add_kinematic(
+            EntityId::from_inner(2024).unwrap(),
+            vec3(1.5, 3.6, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 3.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        for _ in 0..180 {
+            step(&mut world, &mut player, 1);
+            if !player.is_topping_out() {
+                break;
+            }
+        }
+        assert!(!player.is_topping_out(), "blocked route must recover");
+        assert!(
+            player.is_crouched(),
+            "reversal must not expand into the source wall"
+        );
+        assert!((world.get_player_translation(&player) - start).magnitude() < 0.05);
+    }
+
+    #[test]
+    fn hand_top_out_rejects_a_blocked_or_different_height_landing_without_resizing() {
+        let (mut world, mut player) = grip_world();
+        let block = EntityId::from_inner(2021).unwrap();
+        world.add_kinematic(
+            block,
+            vec3(0.0, 1.5, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 3.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        world.set_player_translation(vec3(2.6, 2.4, 0.0), &mut player);
+        let mut grip = ClimbGrip {
+            kind: ClimbGripKind::Ledge,
+            entity_id: Some(block),
+            point: vec3(2.0, 3.8, 0.0),
+            normal: vec3(0.0, 1.0, 0.0),
+        };
+        assert!(
+            !world.plan_hand_top_out(grip, &mut player),
+            "must not choose another floor"
+        );
+        grip.point.y = 3.0;
+        world.add_kinematic(
+            EntityId::from_inner(2022).unwrap(),
+            vec3(0.0, 4.6, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 0.2, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        let before = world.get_player_translation(&player);
+        assert!(!world.plan_hand_top_out(grip, &mut player));
+        assert_eq!(world.get_player_translation(&player), before);
+        assert!(!player.is_crouched());
+        assert!(!player.is_topping_out());
+    }
+
+    #[test]
     fn a_ceiling_blocks_the_approach_around_a_lip() {
         let (mut world, mut player) = grip_world();
         world.add_kinematic(
@@ -9453,6 +9698,23 @@ mod tests {
         let lip = world
             .climbable_grip_at(vec3(0.0, 3.05, 0.0), CLIMB_GRIP_RADIUS, 0.0)
             .expect("a block top above the feet is grippable");
+        assert!(
+            world
+                .climbable_grip_at(vec3(0.0, 3.05, 0.0), CLIMB_GRIP_RADIUS, 2.5)
+                .is_none()
+        );
+        assert!(
+            world
+                .climbable_grip_from_ladder_at(vec3(0.0, 3.05, 0.0), 2.5)
+                .is_some(),
+            "a nearby deck within a step is available during ladder transfer"
+        );
+        assert!(
+            world
+                .climbable_grip_from_ladder_at(vec3(0.0, 3.05, 0.0), 3.0)
+                .is_none(),
+            "even a transfer must not grip the floor under the feet"
+        );
         assert_eq!(lip.kind, ClimbGripKind::Ledge);
         assert!(
             lip.normal.y > 0.9,
@@ -11175,6 +11437,8 @@ mod tests {
         world.collider_set[collider_handle].set_shape(SharedShape::ball(CLIMB_TOP_OUT_RADIUS));
         world.rigid_body_set[player.character_handle].enable_ccd(false);
         player.top_out = Some(ClimbTopOut {
+            collide_terrain: false,
+            stand_on_completion: false,
             waypoints: [compressed_pose; 7],
             next_waypoint: 3,
             save_pose,

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -42,31 +42,19 @@ pub(crate) const CLIMB_RELEASE_MIN_SPEED: f32 = 0.5;
 /// climber commits, and waiting longer just makes the pull feel sticky.
 pub const VAULT_EYE_MARGIN: f32 = 0.1;
 
-/// Whether the player has pulled far enough up a ledge to be thrown onto it.
-///
-/// The head-over-the-lip convention (Boneworks, Blade & Sorcery): once the eye
-/// clears the surface the anchor hand is lying ON, the climb is over and the
-/// scripted top-out takes the body the rest of the way. A ladder rail offers no
-/// vault - a hand reaching over a ladder's top onto the deck behind it takes a
-/// `Ledge` grip on that deck, and vaults from there.
-///
-/// `anchor_on_top_surface` is the hand's contact normal being walkable: a hand
-/// hooked on a lip's vertical face is not yet on top of anything.
-///
-/// The vault has to be EARNED, hence `eye_y_at_grab`: the eye must have risen
-/// past the lip while the hand held it. Without that, every crate, console and
-/// railing a standing player can already see over would throw them on top of
-/// it the instant they squeezed - leaning on a chest-high box is not a mantle.
+/// A deliberate pull commits a ledge hold once the tracked eye clears it.
+/// A grab by itself never vaults, but grabbing after looking over the deck is
+/// valid: what matters is pulling on this hold, not the eye height at acquisition.
 pub fn vault_ready(
     eye_y: f32,
-    eye_y_at_grab: f32,
+    pull_progress: f32,
     lip_y: f32,
     anchor_kind: ClimbGripKind,
     anchor_on_top_surface: bool,
 ) -> bool {
     anchor_kind == ClimbGripKind::Ledge
         && anchor_on_top_surface
-        && eye_y_at_grab <= lip_y
+        && pull_progress >= 0.15
         && eye_y > lip_y + VAULT_EYE_MARGIN
 }
 
@@ -174,7 +162,8 @@ impl HandClimb {
     /// Advance one frame and return the body translation the anchor hand
     /// demands, or `None` when no hand holds anything.
     ///
-    /// `probe` answers "what could a hand at this world point grab?" (see
+    /// `probe` answers "what could a hand at this world point grab?"; its bool
+    /// enables a nearby deck transfer from the other valid ladder hand (see
     /// [`crate::physics::PhysicsWorld::climbable_grip_at`]) and `is_alive`
     /// whether a gripped entity still exists.
     pub fn update(
@@ -183,7 +172,7 @@ impl HandClimb {
         pawn_rotation: Quaternion<f32>,
         step_dt: f32,
         hands: [ClimbHandInput; 2],
-        probe: impl Fn(Vector3<f32>) -> Option<ClimbGrip>,
+        probe: impl Fn(Vector3<f32>, bool) -> Option<ClimbGrip>,
         is_alive: impl Fn(shipyard::EntityId) -> bool,
     ) -> ClimbFrame {
         let previous_anchor = self.anchor;
@@ -236,19 +225,27 @@ impl HandClimb {
                         let_go_cleanly[index] = !squeezing && !over_stretched && !gone;
                     }
                 }
-                None if self.grab_grace[index] > 0.0 => {
-                    if let Some(grip) = probe(hand_world[index]) {
-                        self.grab_grace[index] = 0.0;
-                        self.grips[index] = Some(GripAnchor {
-                            grip,
-                            hand_world_at_grab: hand_world[index],
-                            pawn_at_grab: pawn_pos,
-                        });
-                        // Last hand to grab drives the body.
-                        self.anchor = Some(HANDS[index]);
-                    }
-                }
                 None => {}
+            }
+        }
+        // Invalidate BOTH old holds before granting a contextual deck grab:
+        // a broken, deleted, released or newly occupied ladder hand cannot
+        // authorize the free hand's transfer, regardless of hand iteration order.
+        for index in 0..HANDS.len() {
+            if self.grips[index].is_none() && self.grab_grace[index] > 0.0 {
+                let from_ladder = self.grips[1 - index].is_some_and(|other| {
+                    other.grip.kind == ClimbGripKind::Ladder
+                        && (hand_world[index] - other.grip.point).magnitude() <= 1.5
+                });
+                if let Some(grip) = probe(hand_world[index], from_ladder) {
+                    self.grab_grace[index] = 0.0;
+                    self.grips[index] = Some(GripAnchor {
+                        grip,
+                        hand_world_at_grab: hand_world[index],
+                        pawn_at_grab: pawn_pos,
+                    });
+                    self.anchor = Some(HANDS[index]);
+                }
             }
             self.grab_grace[index] = (self.grab_grace[index] - step_dt.max(0.0)).max(0.0);
         }
@@ -264,6 +261,7 @@ impl HandClimb {
             for index in 0..HANDS.len() {
                 if let Some(anchor) = self.grips[index].as_mut() {
                     anchor.hand_world_at_grab = hand_world[index];
+                    anchor.pawn_at_grab = pawn_pos;
                     self.anchor = Some(HANDS[index]);
                 }
             }
@@ -422,7 +420,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
-            |point| Some(ladder_grip(point)),
+            |point, _| Some(ladder_grip(point)),
             |_| true,
         );
         assert_translation(first, Vector3::zero());
@@ -434,7 +432,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach - vec3(0.0, 0.4, 0.0), 1.0)],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
         assert_translation(pull, vec3(0.0, 0.4, 0.0));
@@ -445,12 +443,55 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 0.0)],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
         assert_eq!(released.translation, None);
         assert_eq!(climb.anchor(), None);
         assert_eq!(climb.grips().count(), 0);
+    }
+
+    #[test]
+    fn deck_transfer_grace_requires_the_other_ladder_hold_to_remain_valid() {
+        for break_hold in [false, true] {
+            let mut climb = HandClimb::default();
+            let pawn = Vector3::zero();
+            let rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+            let reach = vec3(0.0, 1.0, -1.0);
+            climb.update(
+                pawn,
+                rotation,
+                DT,
+                [hand(reach, 1.0), no_hand()],
+                |p, _| Some(ladder_grip(p)),
+                |_| true,
+            );
+            // Squeeze free hand before contact, starting the grace window.
+            climb.update(
+                pawn,
+                rotation,
+                DT,
+                [hand(reach, 1.0), hand(reach, 1.0)],
+                |_, _| None,
+                |_| true,
+            );
+            let moved = reach + vec3(0.0, if break_hold { 1.0 } else { 0.0 }, 0.0);
+            climb.update(
+                pawn,
+                rotation,
+                DT,
+                [hand(moved, 1.0), hand(reach, 1.0)],
+                |p, from_ladder| {
+                    from_ladder.then_some(ClimbGrip {
+                        kind: ClimbGripKind::Ledge,
+                        normal: vec3(0.0, 1.0, 0.0),
+                        ..ladder_grip(p)
+                    })
+                },
+                |_| true,
+            );
+            assert_eq!(climb.holds_a_ledge(), !break_hold);
+        }
     }
 
     #[test]
@@ -465,7 +506,7 @@ mod tests {
                 identity,
                 DT,
                 [no_hand(), hand(reach, 1.0)],
-                |_| None,
+                |_, _| None,
                 |_| true,
             );
         }
@@ -474,7 +515,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
-            |p| Some(ladder_grip(p)),
+            |p, _| Some(ladder_grip(p)),
             |_| true,
         );
         assert!(climb.anchor().is_some());
@@ -485,7 +526,7 @@ mod tests {
                 identity,
                 DT,
                 [no_hand(), hand(broken, 1.0)],
-                |p| Some(ladder_grip(p)),
+                |p, _| Some(ladder_grip(p)),
                 |_| true,
             );
             assert!(climb.anchor().is_none());
@@ -495,7 +536,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 0.0)],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
         for _ in 0..12 {
@@ -504,7 +545,7 @@ mod tests {
                 identity,
                 DT,
                 [no_hand(), hand(reach, 1.0)],
-                |_| None,
+                |_, _| None,
                 |_| true,
             );
         }
@@ -513,7 +554,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
-            |p| Some(ladder_grip(p)),
+            |p, _| Some(ladder_grip(p)),
             |_| true,
         );
         assert!(
@@ -538,7 +579,7 @@ mod tests {
                     identity,
                     DT,
                     [no_hand(), full],
-                    |p| Some(ladder_grip(p)),
+                    |p, _| Some(ladder_grip(p)),
                     |_| true
                 )
                 .translation,
@@ -554,7 +595,7 @@ mod tests {
                     identity,
                     DT,
                     [no_hand(), hand(reach, 1.0)],
-                    |p| Some(ladder_grip(p)),
+                    |p, _| Some(ladder_grip(p)),
                     |_| true
                 )
                 .translation,
@@ -573,7 +614,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
-            |p| Some(ladder_grip(p)),
+            |p, _| Some(ladder_grip(p)),
             |_| true,
         );
 
@@ -587,7 +628,7 @@ mod tests {
                 no_hand(),
                 hand(reach - vec3(0.0, CLIMB_STRETCH_BREAK - 0.05, 0.0), 1.0),
             ],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
         assert!(held.translation.is_some());
@@ -603,7 +644,7 @@ mod tests {
                         no_hand(),
                         hand(reach - vec3(0.0, CLIMB_STRETCH_BREAK + 0.05, 0.0), 1.0)
                     ],
-                    |_| None,
+                    |_, _| None,
                     |_| true
                 )
                 .translation,
@@ -624,7 +665,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(right, 1.0)],
-            |p| Some(ladder_grip(p)),
+            |p, _| Some(ladder_grip(p)),
             |_| true,
         );
         climb.update(
@@ -632,7 +673,7 @@ mod tests {
             identity,
             DT,
             [hand(left, 1.0), hand(right, 1.0)],
-            |p| Some(ladder_grip(p)),
+            |p, _| Some(ladder_grip(p)),
             |_| true,
         );
         assert_eq!(climb.anchor(), Some(Handedness::Left), "last grab wins");
@@ -645,33 +686,38 @@ mod tests {
             identity,
             DT,
             [hand(left + travel, 1.0), hand(right + travel, 1.0)],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
 
         // Letting the left go must not yank the body back to the right hand's
         // stale grab point: the handoff frame asks for no motion at all.
         let handoff = climb.update(
-            pawn,
+            pawn - travel,
             identity,
             DT,
             [hand(left + travel, 0.0), hand(right + travel, 1.0)],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
         assert_eq!(climb.anchor(), Some(Handedness::Right));
+        assert_eq!(
+            climb.anchor_grip().unwrap().pawn_at_grab,
+            pawn - travel,
+            "handoff starts a fresh deliberate pull, not the passive hold's old progress"
+        );
         assert_translation(handoff, Vector3::zero());
 
         // ... and the right hand then drives from where it actually is.
         let after = climb.update(
-            pawn,
+            pawn - travel,
             identity,
             DT,
             [
                 hand(left + travel, 0.0),
                 hand(right + travel - vec3(0.0, 0.2, 0.0), 1.0),
             ],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
         assert_translation(after, vec3(0.0, 0.2, 0.0));
@@ -744,7 +790,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
-            |p| Some(ladder_grip(p)),
+            |p, _| Some(ladder_grip(p)),
             |_| true,
         );
         let mut at = reach;
@@ -755,7 +801,7 @@ mod tests {
                 identity,
                 DT,
                 [no_hand(), hand(at, 1.0)],
-                |_| None,
+                |_, _| None,
                 |_| true,
             );
         }
@@ -768,7 +814,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             DT,
             [no_hand(), hand(at, 0.0)],
-            |_| None,
+            |_, _| None,
             |_| true,
         )
     }
@@ -805,7 +851,7 @@ mod tests {
                     Quaternion::new(1.0, 0.0, 0.0, 0.0),
                     DT,
                     [no_hand(), hand(at, 1.0)],
-                    |_| None,
+                    |_, _| None,
                     |_| true,
                 );
                 broke
@@ -828,7 +874,7 @@ mod tests {
                 identity,
                 DT,
                 hands,
-                |p| probe.then(|| ladder_grip(p)),
+                |p, _| probe.then(|| ladder_grip(p)),
                 |_| true,
             )
         };
@@ -847,24 +893,24 @@ mod tests {
 
     #[test]
     fn the_eye_must_clear_the_lip_of_a_ledge_the_hand_is_lying_on() {
-        // Grabbed from below the lip, pulled until the eye cleared it: vault.
-        assert!(vault_ready(6.2, 5.0, 6.0, ClimbGripKind::Ledge, true));
+        // A deliberate pull with the eye over the lip: vault, including late grabs.
+        assert!(vault_ready(6.2, 0.2, 6.0, ClimbGripKind::Ledge, true));
         // Still below it, or only just level with it: keep pulling.
-        assert!(!vault_ready(5.9, 5.0, 6.0, ClimbGripKind::Ledge, true));
+        assert!(!vault_ready(5.9, 0.2, 6.0, ClimbGripKind::Ledge, true));
         assert!(!vault_ready(
             6.0 + VAULT_EYE_MARGIN,
-            5.0,
+            0.2,
             6.0,
             ClimbGripKind::Ledge,
             true
         ));
         // Never pulled at all: a standing player who grabs a chest-high crate
         // was already looking over it, and leaning on it is not a mantle.
-        assert!(!vault_ready(6.2, 6.2, 6.0, ClimbGripKind::Ledge, true));
+        assert!(!vault_ready(6.2, 0.0, 6.0, ClimbGripKind::Ledge, true));
         // Hooked on the lip's vertical face, not lying on the top.
-        assert!(!vault_ready(6.2, 5.0, 6.0, ClimbGripKind::Ledge, false));
+        assert!(!vault_ready(6.2, 0.2, 6.0, ClimbGripKind::Ledge, false));
         // A ladder rail is never a vault, however high the eye gets.
-        assert!(!vault_ready(9.0, 5.0, 6.0, ClimbGripKind::Ladder, true));
+        assert!(!vault_ready(9.0, 0.2, 6.0, ClimbGripKind::Ladder, true));
     }
 
     #[test]
@@ -885,7 +931,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
-            |p| Some(ladder_grip(p)),
+            |p, _| Some(ladder_grip(p)),
             |_| true,
         );
         assert!(!climb.holds_a_ledge());
@@ -897,7 +943,7 @@ mod tests {
             identity,
             DT,
             [hand(reach, 1.0), hand(reach, 1.0)],
-            |p| Some(ledge(p)),
+            |p, _| Some(ledge(p)),
             |_| true,
         );
         assert!(climb.holds_a_ledge());
@@ -912,7 +958,7 @@ mod tests {
             identity,
             DT,
             [hand(reach, 1.0), hand(reach, 1.0)],
-            |_| None,
+            |_, _| None,
             |_| true,
         );
         assert_eq!(climb.anchor_grip().unwrap().pawn_at_grab, pawn);
@@ -930,7 +976,7 @@ mod tests {
                 identity,
                 DT,
                 [no_hand(), hand(at, 1.0)],
-                |p| probe.then(|| ladder_grip(p)),
+                |p, _| probe.then(|| ladder_grip(p)),
                 |_| true,
             )
         };
@@ -965,7 +1011,7 @@ mod tests {
             identity,
             DT,
             [no_hand(), hand(reach, 1.0)],
-            |point| {
+            |point, _| {
                 ClimbGrip {
                     entity_id: Some(entity),
                     ..ladder_grip(point)
@@ -983,7 +1029,7 @@ mod tests {
                     identity,
                     DT,
                     [no_hand(), hand(reach, 1.0)],
-                    |_| None,
+                    |_, _| None,
                     |_| false
                 )
                 .translation,

--- a/tools/shock2-sdk/test/vr-vault.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-vault.e2e.test.ts
@@ -78,7 +78,7 @@ test(
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await launchVr();
-    await standAt(game, [-5.5, 1.5, MANTLE_Z]);
+    await standAt(game, [-6.35, 1.5, MANTLE_Z]);
 
     const atGrab = await grab(game, "right", [-7.2, 3.05, MANTLE_Z]);
     const grabbed = (await game.info()).player.climb;
@@ -131,12 +131,13 @@ test(
   },
 );
 
+for (const transferHeight of [4.5, 5.1]) {
 test(
-  "debug_ladder (VR): a hand on the ledge top vaults off the ladder",
+  `debug_ladder (VR): a deck grab at body height ${transferHeight} vaults off the ladder`,
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await launchVr();
-    await standAt(game, [-5.5, 1.5, LEDGE_Z]);
+    await standAt(game, [-6.35, 1.5, LEDGE_Z]);
 
     // Hand over hand up the near-face ladder. Hands are tracked in PAWN space,
     // so one reach height serves every cycle - the same reach lands on a
@@ -154,7 +155,7 @@ test(
     let pulling: "left" | "right" = "right";
     await grab(game, pulling, [-6.8, 2.6, LEDGE_Z]);
     for (let half = 0; half < 8; half += 1) {
-      if ((await game.info()).player.position[1] > 4.5) break;
+      if ((await game.info()).player.position[1] > transferHeight) break;
       for (let frame = 1; frame <= FRAMES; frame += 1) {
         await game.input.set(`${pulling}_hand.position`, [
           reach[0] + (down[0] * frame) / FRAMES,
@@ -163,6 +164,7 @@ test(
         ]);
         await game.step({ frames: 1 });
       }
+      if ((await game.info()).player.position[1] > transferHeight) break;
       const other: "left" | "right" = pulling === "right" ? "left" : "right";
       await game.input.set(`${other}_hand.position`, reach);
       await game.input.set(`${other}_hand.squeeze`, 0);
@@ -176,18 +178,19 @@ test(
     }
     const climbed = (await game.info()).player;
     assert.ok(
-      climbed.position[1] > 4.7,
+      climbed.position[1] > transferHeight,
       `hand over hand only reached ${climbed.position[1]}`,
     );
     assert.equal(climbed.climb.grips[0].kind, "ladder");
     assert.equal(climbed.climb.vaulting, false, "a ladder rail never vaults");
 
-    // Reach over the ladder's top onto the block's top surface: that is a
-    // ledge, and the eye is still under it, so the vault waits for the pull.
+    // Reach onto the deck AFTER the head clears it: this used to permanently
+    // fail the historical eye-at-grab gate. The new grip still waits for a pull.
     const other: "left" | "right" = pulling === "right" ? "left" : "right";
-    const onTop = await grab(game, other, [-7.6, 6.05, LEDGE_Z]);
+    const onTop = await grab(game, other, [-7.1, 6.05, LEDGE_Z]);
     const held = (await game.info()).player.climb;
     assert.equal(held.anchor_hand, other);
+    assert.equal(held.vaulting, false, "resting the hand on the deck is not a vault");
     assert.equal(
       held.grips.find((grip) => grip.hand === other)?.kind,
       "ledge",
@@ -224,6 +227,8 @@ test(
   },
 );
 
+}
+
 test(
   "debug_ladder (VR): a plain wall and a low eye never vault",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -231,7 +236,7 @@ test(
     await using game = await launchVr();
 
     // The plain wall offers no hold at all, so there is nothing to vault from.
-    await standAt(game, [-5.5, 1.5, WALL_Z]);
+    await standAt(game, [-6.35, 1.5, WALL_Z]);
     await grab(game, "right", [-6.9, 2.6, WALL_Z]);
     let climb = (await game.info()).player.climb;
     assert.equal(climb.grips.length, 0);
@@ -241,7 +246,7 @@ test(
 
     // On the ledge ladder with the eye far below the block top, pulling climbs
     // and nothing else.
-    await standAt(game, [-5.5, 1.5, LEDGE_Z]);
+    await standAt(game, [-6.35, 1.5, LEDGE_Z]);
     const atGrab = await grab(game, "right", [-6.8, 2.6, LEDGE_Z]);
     const down = await vrHandLocalDelta(game, [0, -1.0, 0]);
     for (let frame = 1; frame <= 30; frame += 1) {
@@ -268,7 +273,7 @@ test(
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await launchVr();
-    await standAt(game, [-5.5, 1.5, MANTLE_Z]);
+    await standAt(game, [-6.35, 1.5, MANTLE_Z]);
     const floorY = (await game.info()).player.position[1];
 
     const atGrab = await grab(game, "right", [-7.2, 3.05, MANTLE_Z]);


### PR DESCRIPTION
Reaching a ladder top with the head already above the deck permanently disqualified the second hand’s deck grip from finishing a mantle. The player could pull upward and remain stuck hanging beside a surface they should be able to climb onto.

Let a deliberate pull on the held walkable top finish onto that surface even when the head was already above it at acquisition. A valid other-hand hold remains available during acquisition; changing the anchor hand resets pull progress so a grab or handoff alone does not trigger the finish.

The landing planner uses the held surface, validates support and clearance, and moves the compressed capsule through the full route before expanding at the standing center. Crouched players land crouched. A new obstruction reverses the assisted route; standing-up clearance also rejects one-sided ceiling geometry.

Third change in [stack #1360](https://github.com/tommy-xr/shock2quest/pull/1360), based on #1359 (`fix/vr-lip-grabs`). Kept draft pending hands-on reach and comfort testing.

Validation:

- Full host suite: 1,392 passed, 2 ignored; 68 affected hand tests passed after the last patch.
- Final SDK grip/climb/vault scenarios: 17 passed, including early and late deck grabs. The separate mixed regression run included 3 passing flatscreen climbing scenarios.
- Deterministic `debug_ladder --vr` replay against the exact parent: both versions climb to body y=5.744, acquire the deck with the second hand, release the rail, and perform the same downward pull. The parent stays hanging at x=-6.348, y=6.544; this change finishes on the held deck at x=-8, y=7.244 with grips cleared.
- Release APK at `f294da57` built and signed successfully. Final device install was attempted but ADB reported no connected devices, so the headset still has the earlier PR1 build from its successful smoke check. Final-stack native device verification remains outstanding.
- Headless footage and state traces verify the interaction and landing. They do not establish physical headset comfort or hand tracking through a real climb.

![Late ladder-to-deck transfer comparison](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/transfer-comparison.gif)

Same ladder climb, late second-hand deck grab, rail release and pull. Before remains hanging beside the deck; after finishes onto the supported surface. Captured headlessly with deterministic fixed-timestep stepping, using the detached camera to show both hands and the deck.

![Late transfer landing comparison](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/transfer-comparison.png)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
