### PR TITLE
fix(vr): hook ladder tops and show held grips for descent

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ However, you can play with a keyboard and a mouse, using the following hard-code
   it directly.
 - Quest VR: either lower face button (left `X` / right `A`) jumps, whatever
   your hands are holding.
+- Quest VR: squeeze an empty hand near a ladder to hold it. A cyan marker
+  above the fist confirms the hold. To descend from a deck, crouch and grab
+  near the ladder's top edge, pull the held hand toward your chest to move
+  your body beyond the edge, then raise that hand to lower yourself. Open
+  the hand to release.
 - Quest VR: reload by hand. Pull a clip out of the cyber interface's inventory
   strip with your free hand and bring it to the gun the other hand is holding -
   the clip goes in and the weapon is loaded. A clip of a different ammo type

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -316,6 +316,25 @@ impl PlayerInteraction for VrInteraction {
                 objs.append(&mut self.right_hand.render(world, None));
             }
         }
+        // Feedback comes from the resolved holds, never a second proximity
+        // query: a blocked pull still shows a catch; release/break removes it.
+        // Float just above the fist so the glove cannot hide the marker.
+        for (handedness, _) in self.hand_climb.grips() {
+            let hand = match handedness {
+                Handedness::Left => &self.left_hand,
+                Handedness::Right => &self.right_hand,
+            };
+            let mut marker = SceneObject::new(
+                engine::scene::color_material::create(cgmath::vec3(0.0, 1.0, 1.0)),
+                Box::new(engine::scene::cube::create()),
+            );
+            marker.set_transform(
+                cgmath::Matrix4::from_translation(
+                    hand.get_position() + cgmath::vec3(0.0, 0.18, 0.0),
+                ) * cgmath::Matrix4::from_scale(0.03),
+            );
+            objs.push(marker);
+        }
         // Labelled as the player's hands: that is what `Game` drops while the
         // pause menu is up (issue #1018), and what `/v1/scene` reports. The
         // forearm panels carry their own label from `create_arm_hud_panels`,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -5348,6 +5348,9 @@ impl PhysicsWorld {
     /// solid, player-blocking surface whose face is walkable and sits more
     /// than a step above `feet_y` - the mantle-emulation hold. A wall face,
     /// and the floor the player is standing on, offer neither.
+    /// If direct contact fails, a bounded clear approach can hook a nearby
+    /// ledge lip or an authored ladder side around its top cap. The returned
+    /// point/normal belong to that actual surface, never the refused cap.
     ///
     /// The nearest *qualifying* contact wins: a nearer ungrippable face does
     /// not occlude a grippable one behind it. A hand reaching past a ladder's
@@ -5462,12 +5465,108 @@ impl PhysicsWorld {
             return Some(grip);
         }
 
+        // Descending starts with a hand ABOVE the cap. Hook around it onto
+        // an authored side: the cap itself remains ungrippable. Every segment
+        // of the approach must be clear, and the final hit must be this same
+        // ladder, so an adjacent deck/wall cannot be reached through.
+        let hand = point![point.x, point.y, point.z];
+        let directions = [
+            (1.0, 0.0),
+            (-1.0, 0.0),
+            (0.0, 1.0),
+            (0.0, -1.0),
+            (1.0, 1.0),
+            (1.0, -1.0),
+            (-1.0, 1.0),
+            (-1.0, -1.0),
+        ]
+        .map(|(x, z)| vector![x, 0.0, z].normalize());
+        // A hand can be slightly outside the cap's footprint. Probe nearby
+        // points too; the hook route below still starts at the actual hand.
+        let cap_origins =
+            std::iter::once(hand).chain([0.05, 0.15, 0.25].into_iter().flat_map(|reach| {
+                directions
+                    .into_iter()
+                    .map(move |direction| hand + direction * reach)
+            }));
+        let top = cap_origins.filter_map(|origin| {
+            let ray = Ray::new(origin, -Vector::y());
+            let (handle, hit) = queries.cast_ray_and_get_normal(&ray, CLIMB_LIP_REACH, true)?;
+            let cap = ray.point_at(hit.time_of_impact);
+            (!collider_is_not_climbable(&self.collider_set[handle])
+                && is_walkable_normal(hit.normal.y)
+                && (cap - hand).norm() <= CLIMB_LIP_REACH)
+                .then_some((handle, cap.y))
+        });
+        let mut tried_caps = HashSet::new();
+        for (top_handle, top_y) in top {
+            if !tried_caps.insert(top_handle) {
+                continue;
+            }
+            let collider = &self.collider_set[top_handle];
+            let entity_id = EntityId::from_inner(collider.user_data as u64);
+            let sides = entity_id
+                .and_then(|id| self.climbable_sides.get(&id).copied())
+                .unwrap_or(u32::MAX);
+            let drop = hand.y - top_y + 0.05;
+            let mut hook: Option<(f32, ClimbGrip)> = None;
+            // Try short approaches before the full reach, so a clear
+            // narrow gap beside a ladder is usable too.
+            for (direction, reach) in directions.into_iter().flat_map(|direction| {
+                [0.075, 0.15, CLIMB_LIP_REACH]
+                    .into_iter()
+                    .map(move |reach| (direction, reach))
+            }) {
+                let outside = hand + direction * reach;
+                if queries
+                    .cast_ray(&Ray::new(hand, direction), reach, true)
+                    .is_some()
+                    || queries
+                        .cast_ray(&Ray::new(outside, -Vector::y()), drop, true)
+                        .is_some()
+                {
+                    continue;
+                }
+                let inward = Ray::new(outside - Vector::y() * drop, -direction);
+                // The hand may be outside the footprint too: continue past
+                // its XZ position, keeping the final contact reach-bounded.
+                let Some((handle, hit)) =
+                    queries.cast_ray_and_get_normal(&inward, 2.0 * CLIMB_LIP_REACH, true)
+                else {
+                    continue;
+                };
+                let local = collider.rotation().inverse_transform_vector(&hit.normal);
+                let contact = inward.point_at(hit.time_of_impact);
+                let distance = (contact - hand).norm();
+                if handle != top_handle
+                    || hit.normal.y.abs() > 0.3
+                    || sides & climbable_face_bits(local) == 0
+                    || distance > CLIMB_LIP_REACH
+                {
+                    continue;
+                }
+                if hook.as_ref().is_none_or(|(nearest, _)| distance < *nearest) {
+                    hook = Some((
+                        distance,
+                        ClimbGrip {
+                            kind: ClimbGripKind::Ladder,
+                            entity_id,
+                            point: nvec_to_cgmath(contact.coords),
+                            normal: nvec_to_cgmath(hit.normal),
+                        },
+                    ));
+                }
+            }
+            if let Some((_, grip)) = hook {
+                return Some(grip);
+            }
+        }
+
         // A fist against the front of a lip has a side/diagonal separation
         // normal, even when its fingers could hook over the top. Find the
         // actual walkable surface by approaching above the hand, then down.
         // Both approach segments must be clear: no grabbing through a wall or
         // ceiling. Authored ladder masks still decide ladder contacts alone.
-        let hand = point![point.x, point.y, point.z];
         let raised = hand + Vector::y() * CLIMB_LIP_REACH;
         if queries
             .cast_ray(&Ray::new(hand, Vector::y()), CLIMB_LIP_REACH, true)
@@ -9347,13 +9446,14 @@ mod tests {
             "expected a +X face, got {:?}",
             side.normal
         );
-        // ... and its top cap is not.
-        assert!(
-            world
-                .climbable_grip_at(vec3(-5.0, 6.45, 0.0), CLIMB_GRIP_RADIUS, 0.0)
-                .is_none(),
-            "mask 27 excludes the top cap"
-        );
+        // From above the thin cap, fingers can now hook an authored SIDE.
+        let hook = world
+            .climbable_grip_at(vec3(-5.0, 6.45, 0.0), CLIMB_GRIP_RADIUS, 0.0)
+            .expect("hook around the cap onto a side");
+        assert_eq!(hook.kind, ClimbGripKind::Ladder);
+        assert!(hook.normal.x.abs() > 0.9);
+        assert!(hook.normal.y.abs() < 0.01);
+        assert!(hook.point.y < 6.4);
 
         // The top EDGE, where a hand lands when topping out: its contact
         // normal is diagonal, so a single-dominant-axis pick would call it
@@ -9420,6 +9520,76 @@ mod tests {
                 .climbable_grip_at(vec3(-5.0, 3.0, -0.5), CLIMB_GRIP_RADIUS, 0.0)
                 .is_none(),
             "the opposite edge has no bit"
+        );
+    }
+
+    #[test]
+    fn ladder_cap_hook_respects_reach_masks_and_blocked_approaches() {
+        let (mut world, mut player) = grip_world();
+        let ladder = add_yawed_ladder(&mut world, &mut player, Some(2));
+        let hand = vec3(-5.0, 6.45, 0.0);
+        let hook = world
+            .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 6.0)
+            .unwrap();
+        assert_eq!(hook.entity_id, Some(ladder));
+        assert!(hook.normal.x > 0.9, "only +X is authored after yaw");
+        assert!((hook.point - hand).magnitude() <= CLIMB_LIP_REACH);
+        assert!(
+            world
+                .climbable_grip_at(vec3(-5.0, 6.75, 0.0), CLIMB_GRIP_RADIUS, 6.0)
+                .is_none()
+        );
+
+        let outside_cap = world
+            .climbable_grip_at(vec3(-4.93, 6.56, 0.0), CLIMB_GRIP_RADIUS, 6.0)
+            .expect("a hand just outside the cap footprint can hook the side");
+        assert!(outside_cap.normal.x > 0.9);
+
+        world.set_climbable_sides(ladder, 1); // only a narrow edge, out of reach
+        assert!(
+            world
+                .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 6.0)
+                .is_none()
+        );
+        world.set_climbable_sides(ladder, 0);
+        assert!(
+            world
+                .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 6.0)
+                .is_none()
+        );
+        world.set_climbable_sides(ladder, 2);
+
+        // A narrow clear gap still admits a short hook.
+        world.add_kinematic(
+            EntityId::from_inner(2030).unwrap(),
+            vec3(-4.75, 6.5, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 0.8, 2.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        assert!(
+            world
+                .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 6.0)
+                .is_some()
+        );
+        // Seal that gap. The unobstructed opposite side is not authored.
+        world.add_kinematic(
+            EntityId::from_inner(2031).unwrap(),
+            vec3(-4.9, 6.5, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.1, 0.8, 2.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        assert!(
+            world
+                .climbable_grip_at(hand, CLIMB_GRIP_RADIUS, 6.0)
+                .is_none()
         );
     }
 

--- a/tools/shock2-sdk/test/climb-grip.e2e.test.ts
+++ b/tools/shock2-sdk/test/climb-grip.e2e.test.ts
@@ -9,8 +9,8 @@ import { teleportVerified } from "./helpers/teleport.js";
 // `GET /v1/physics/grip` answers "could a hand hold on here?" against the
 // debug_ladder stations (see shock2vr/src/scenes/debug_ladder.rs). The two
 // classes must be told apart on the SHIPPED geometry: an authored ladder face
-// is a Ladder, a block top above the feet is a Ledge, and a ladder's top cap,
-// a plain wall and the floor are nothing at all.
+// is a Ladder, a block top above the feet is a Ledge, and a plain wall and
+// the floor are nothing. A hand above a thin ladder cap can hook its side.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 type Probe = {
@@ -26,9 +26,9 @@ const PROBES: Probe[] = [
   {
     // The scene's ladders inherit the Ladders template's mask 27 - the four
     // vertical sides, no caps.
-    name: "ledge ladder top cap (mask 27 excludes it)",
+    name: "hook an authored side from above the ladder cap",
     point: [-6.9, 6.45, 0],
-    expected: null,
+    expected: "ladder",
   },
   // The block the ladder leans on: near face x = -7, top y = 6.
   { name: "ledge block lip", point: [-7.2, 6.05, 0], expected: "ledge" },

--- a/tools/shock2-sdk/test/vr-vault.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-vault.e2e.test.ts
@@ -300,3 +300,63 @@ test(
     );
   },
 );
+
+
+test("debug_ladder (VR): crouch on the deck, hook the ladder cap and descend", {
+  skip: !e2eEnabled, timeout: 600_000,
+}, async () => {
+  await using game = await launchVr();
+  await standAt(game, [-7.65, 7.3, LEDGE_Z]);
+  await game.input.set("crouch", 1);
+  await game.step({ frames: 5 });
+  const before = (await game.info()).player.position;
+  const start = await grab(game, "right", [-6.9, 6.45, LEDGE_Z]);
+  const caught = (await game.info()).player;
+  assert.equal(caught.climb.grips.length, 1, "catch from above the cap");
+  assert.equal(caught.climb.grips[0].kind, "ladder");
+  assert.ok(Math.abs(caught.position[0] - before[0]) < 0.05, "catch must not snap the body");
+  const hook = (await game.physics.grip([-6.9, 6.45, LEDGE_Z])).grip!;
+  assert.ok(Math.abs(hook.normal[0]) > 0.9 && Math.abs(hook.normal[1]) < 0.01,
+    `catch an actual side, not the masked cap: ${hook.normal}`);
+
+  // Raising the hand while feet are still on the deck cannot pass through
+  // that deck. The persistent grip (and its marker) distinguishes this from
+  // a failed acquisition.
+  const raised = await vrHandLocalDelta(game, [0, 0.2, 0]);
+  for (let i = 1; i <= 12; i++) {
+    await game.input.set("right_hand.position", start.map((v, j) => v + raised[j] * i / 12) as Vec3);
+    await game.step({ frames: 1 });
+  }
+  const blocked = (await game.info()).player;
+  assert.equal(blocked.climb.grips.length, 1);
+  assert.ok(Math.abs(blocked.position[1] - before[1]) < 0.05, "deck still supports the feet");
+  await game.input.set("right_hand.position", start);
+  await game.step({ frames: 1 });
+
+  // Pull toward the chest first, moving the body beyond the deck edge; then
+  // raise the held hand to lower the body. Every frame must retain the hold.
+  const outward = await vrHandLocalDelta(game, [-1.3, 0, 0]);
+  const lower = await vrHandLocalDelta(game, [0, 0.6, 0]);
+  const heights: number[] = [];
+  for (let phase = 0; phase < 2; phase++) {
+    for (let i = 1; i <= 60; i++) {
+      const t = i / 60;
+      await game.input.set("right_hand.position", start.map((v, j) =>
+        v + outward[j] * (phase === 0 ? t : 1) + lower[j] * (phase === 1 ? t : 0),
+      ) as Vec3);
+      await game.step({ frames: 1 });
+      const player = (await game.info()).player;
+      assert.equal(player.climb.grips.length, 1, `hold survives phase ${phase} frame ${i}`);
+      assert.equal(player.climb.vaulting, false, "descent stays hand-directed");
+      heights.push(player.position[1]);
+    }
+  }
+  const descended = (await game.info()).player.position;
+  assert.ok(descended[0] > -6.5, "body moved outside the deck edge");
+  assert.ok(descended[1] < before[1] - 0.5, "body lowered onto the ladder");
+  assertNoJumps(heights, "deck-to-ladder descent");
+  await game.step({ frames: 10 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 1 });
+  assert.equal((await game.info()).player.climb.grips.length, 0, "opening the hand releases the catch");
+});


### PR DESCRIPTION
Crouching on a deck and squeezing near the ladder cap could miss the grip, with no visible distinction between a missed grab and a held hand whose downward pull was blocked by the deck. A hand near the cap now hooks a reachable authored side, and a cyan marker above each gripping fist confirms the hold until release or break.

The hook uses the existing 0.3-world-unit lip reach, tries nearby cap positions and short approaches, and requires a clear route onto the same ladder's allowed side. The cap remains masked. Descent stays hand-directed: pull the held hand toward the chest to move beyond the deck edge, then raise it to lower the body. README controls document the gesture.

Fourth layer of stack #1360; base is #1361 (`fix/vr-deck-transfer`).

Validation:

- `cargo test -p shock2vr --lib`: 1,393 passed, 2 ignored.
- SDK: all 20 grip, VR climb/vault/descent, and flatscreen climbing scenarios passed. `cargo fmt --all -- --check` passed.
- New regression checks cover outside-cap reach, short clear gaps, sealed approaches, authored masks, and the crouched deck-to-ladder sequence with continuous grip, no catch snap, no deck penetration, and explicit release.
- Cross-review and duplication review; two initial probe-coverage findings fixed and retested.
- Captures use the debug runtime VR harness; physical headset comfort and marker readability still need hands-on testing.

![Deck-to-ladder descent before and after](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/descent-comparison.gif)

Crouch on the deck, squeeze near the cap, pause, pull toward the chest to move off the edge, then raise the held hand to descend. Identical input sequence, fixed 60 Hz stepping in `debug_ladder --vr`. Cyan confirms an actual held grip and disappears on release.

![Grip acquisition before and after](https://gist.githubusercontent.com/tommy-xr/730216619e3c06b8c88e969cad6aeb66/raw/descent-comparison.png)
