### PR TITLE
feat(harness): wedge verdicts respect no-route, holds, and later travel

### DIFF
--- a/tools/shock2-sdk/scripts/ai-reachability.ts
+++ b/tools/shock2-sdk/scripts/ai-reachability.ts
@@ -19,7 +19,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { findRepoRoot, GameServer, HttpError } from "../src/index.js";
@@ -56,6 +56,8 @@ interface Args {
   sampleEvery: number;
   experimental: string[];
   pass: PassSelector;
+  /** Re-classify the stored JSON in this directory instead of running the game. */
+  reclassify?: string;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -98,6 +100,9 @@ function parseArgs(argv: string[]): Args {
       case "--experimental":
         args.experimental.push(...value().split(","));
         break;
+      case "--reclassify":
+        args.reclassify = value();
+        break;
       case "--pass": {
         const v = value();
         if (v !== "idle" && v !== "chase" && v !== "both") {
@@ -111,6 +116,8 @@ function parseArgs(argv: string[]): Args {
     }
   }
   if (all) args.missions = missionsInData();
+  // Re-classification reads stored runs; it needs no mission list.
+  if (args.reclassify) return args;
   if (args.missions.length === 0) throw new Error("pass --mission <name> or --all");
   // A pass shorter than one sample would report every AI as "no samples".
   for (const [name, frames] of [
@@ -250,6 +257,7 @@ async function runPass(
         live_path_len: route?.live_path_len ?? null,
         live_target: route?.live_target ?? null,
         live_stall_seconds: route?.live_stall_seconds ?? null,
+        movement_hold: route?.movement_hold ?? null,
         distance: distance3(detail.position, playerNow),
       };
       track.samples.push(sample);
@@ -309,8 +317,75 @@ function wedgeLines(pass: PassResult): string[] {
     );
 }
 
+/** A stored pass, as written by a previous run. */
+interface StoredReport {
+  mission: string;
+  passes: {
+    pass: string;
+    tracks: (AiTrack & { classification: Classification })[];
+  }[];
+}
+
+function countsRow(label: string, counts: Record<string, number>): string {
+  return `| ${label} | ${VERDICTS.map((v) => counts[v] ?? 0).join(" | ")} |`;
+}
+
+/**
+ * Re-run the classifier over a stored run's JSON - no game, no runtime. The
+ * stored samples carry whatever fields the runtime published when they were
+ * taken, so a re-classification of an older run simply sees no movement_hold.
+ */
+async function reclassify(dir: string): Promise<void> {
+  const files = (await readdir(dir))
+    .filter((f) => f.endsWith(".mis.json"))
+    .sort();
+  const header = `| mission/pass | ${VERDICTS.join(" | ")} |`;
+  const divider = `|${"---|".repeat(VERDICTS.length + 1)}`;
+  const rows: string[] = [];
+  const oldTotals: Record<string, number> = {};
+  const newTotals: Record<string, number> = {};
+
+  for (const file of files) {
+    const report = JSON.parse(await readFile(path.join(dir, file), "utf8")) as StoredReport;
+    for (const pass of report.passes) {
+      const passName = pass.pass.startsWith("chase") ? "chase" : "idle";
+      const before = tally(pass.tracks.map((t) => t.classification));
+      const after = tally(
+        pass.tracks.map((t) => classifyTrack(t, { pass: passName as "idle" | "chase" })),
+      );
+      for (const v of VERDICTS) {
+        oldTotals[v] = (oldTotals[v] ?? 0) + (before[v] ?? 0);
+        newTotals[v] = (newTotals[v] ?? 0) + (after[v] ?? 0);
+      }
+      const cells = VERDICTS.map((v) => {
+        const a = before[v] ?? 0;
+        const b = after[v] ?? 0;
+        return a === b ? `${a}` : `${a}→${b}`;
+      }).join(" | ");
+      rows.push(`| ${report.mission} ${pass.pass} | ${cells} |`);
+    }
+  }
+
+  console.log(
+    [
+      `# Re-classified ${dir}`,
+      "",
+      header,
+      divider,
+      ...rows,
+      countsRow("**stored total**", oldTotals),
+      countsRow("**re-classified total**", newTotals),
+      "",
+    ].join("\n"),
+  );
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  if (args.reclassify) {
+    await reclassify(args.reclassify);
+    return;
+  }
   await mkdir(args.out, { recursive: true });
 
   const header = `| mission | pass | AIs | ${VERDICTS.join(" | ")} |`;

--- a/tools/shock2-sdk/scripts/ai-reachability.ts
+++ b/tools/shock2-sdk/scripts/ai-reachability.ts
@@ -32,6 +32,7 @@ import {
   type AiSample,
   type AiTrack,
   type Classification,
+  type Verdict,
 } from "../src/ai-reachability.js";
 import type { EntityDetailResult, Vec3 } from "../src/types.js";
 
@@ -117,7 +118,12 @@ function parseArgs(argv: string[]): Args {
   }
   if (all) args.missions = missionsInData();
   // Re-classification reads stored runs; it needs no mission list.
-  if (args.reclassify) return args;
+  if (args.reclassify) {
+    if (all || args.missions.length > 0) {
+      throw new Error("--reclassify reads stored runs; it takes no --mission/--all");
+    }
+    return args;
+  }
   if (args.missions.length === 0) throw new Error("pass --mission <name> or --all");
   // A pass shorter than one sample would report every AI as "no samples".
   for (const [name, frames] of [
@@ -308,26 +314,19 @@ function passTable(mission: string, pass: PassResult): string {
 
 function wedgeLines(pass: PassResult): string[] {
   return pass.tracks
-    .filter((t) => t.classification.verdict === "wedged")
+    .filter((t) => t.classification.verdict === "wedged" || t.classification.verdict === "wedged_then_freed")
     .map(
       (t) =>
-        `  - ${t.name} (template ${t.template_id}) wedged ${t.classification.wedge_seconds?.toFixed(1)}s at (${t.classification
+        `  - ${t.name} (template ${t.template_id}) ${t.classification.verdict} ${t.classification.wedge_seconds?.toFixed(1)}s at (${t.classification
           .wedge_at!.map((c) => c.toFixed(2))
           .join(", ")}) [${pass.pass}]`,
     );
 }
 
-/** A stored pass, as written by a previous run. */
+/** A stored run, as written by a previous pass over the missions. */
 interface StoredReport {
   mission: string;
-  passes: {
-    pass: string;
-    tracks: (AiTrack & { classification: Classification })[];
-  }[];
-}
-
-function countsRow(label: string, counts: Record<string, number>): string {
-  return `| ${label} | ${VERDICTS.map((v) => counts[v] ?? 0).join(" | ")} |`;
+  passes: PassResult[];
 }
 
 /**
@@ -335,34 +334,42 @@ function countsRow(label: string, counts: Record<string, number>): string {
  * stored samples carry whatever fields the runtime published when they were
  * taken, so a re-classification of an older run simply sees no movement_hold.
  */
+function row(label: string, cells: string[]): string {
+  return `| ${label} | ${cells.join(" | ")} |`;
+}
+
+function totalRow(label: string, counts: Record<Verdict, number>): string {
+  return row(label, VERDICTS.map((v) => `${counts[v]}`));
+}
+
 async function reclassify(dir: string): Promise<void> {
-  const files = (await readdir(dir))
-    .filter((f) => f.endsWith(".mis.json"))
-    .sort();
+  // `<mission>.json` is the report; the sibling `-cells`/`-pass` dumps are not.
+  const files = (await readdir(dir)).filter((f) => f.endsWith(".mis.json")).sort();
+  if (files.length === 0) throw new Error(`no stored mission reports in ${dir}`);
   const header = `| mission/pass | ${VERDICTS.join(" | ")} |`;
   const divider = `|${"---|".repeat(VERDICTS.length + 1)}`;
   const rows: string[] = [];
-  const oldTotals: Record<string, number> = {};
-  const newTotals: Record<string, number> = {};
+  const stored: Classification[] = [];
+  const redone: Classification[] = [];
 
   for (const file of files) {
-    const report = JSON.parse(await readFile(path.join(dir, file), "utf8")) as StoredReport;
+    let report: StoredReport;
+    try {
+      report = JSON.parse(await readFile(path.join(dir, file), "utf8")) as StoredReport;
+    } catch (error) {
+      console.warn(`  skipping ${file}: ${error instanceof Error ? error.message : error}`);
+      continue;
+    }
     for (const pass of report.passes) {
-      const passName = pass.pass.startsWith("chase") ? "chase" : "idle";
-      const before = tally(pass.tracks.map((t) => t.classification));
-      const after = tally(
-        pass.tracks.map((t) => classifyTrack(t, { pass: passName as "idle" | "chase" })),
-      );
-      for (const v of VERDICTS) {
-        oldTotals[v] = (oldTotals[v] ?? 0) + (before[v] ?? 0);
-        newTotals[v] = (newTotals[v] ?? 0) + (after[v] ?? 0);
-      }
-      const cells = VERDICTS.map((v) => {
-        const a = before[v] ?? 0;
-        const b = after[v] ?? 0;
-        return a === b ? `${a}` : `${a}→${b}`;
-      }).join(" | ");
-      rows.push(`| ${report.mission} ${pass.pass} | ${cells} |`);
+      const passName: "idle" | "chase" = pass.pass.startsWith("chase") ? "chase" : "idle";
+      const passStored = pass.tracks.map((t) => t.classification);
+      const passRedone = pass.tracks.map((t) => classifyTrack(t, { pass: passName }));
+      stored.push(...passStored);
+      redone.push(...passRedone);
+      const before = tally(passStored);
+      const after = tally(passRedone);
+      const cells = VERDICTS.map((v) => (before[v] === after[v] ? `${before[v]}` : `${before[v]}→${after[v]}`));
+      rows.push(row(`${report.mission} ${pass.pass}`, cells));
     }
   }
 
@@ -373,8 +380,8 @@ async function reclassify(dir: string): Promise<void> {
       header,
       divider,
       ...rows,
-      countsRow("**stored total**", oldTotals),
-      countsRow("**re-classified total**", newTotals),
+      totalRow("**stored total**", tally(stored)),
+      totalRow("**re-classified total**", tally(redone)),
       "",
     ].join("\n"),
   );

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -87,8 +87,12 @@ export interface HaltEvidence {
   at: Vec3;
   /** Farthest the AI later got from `at`, world units. */
   escape_distance: number;
-  /** Seconds of the halt spent under a published movement hold. */
-  held_seconds: number;
+  /**
+   * Seconds of the surrounding stationary window spent under a published
+   * movement hold. The halt itself is by construction entirely unheld, so this
+   * says how much waiting sat on either side of it.
+   */
+  window_held_seconds: number;
   /** Path outcome in effect during the halt, if the AI had ever pathed. */
   outcome?: string;
 }
@@ -130,7 +134,7 @@ export function distance3(a: Vec3, b: Vec3): number {
  * judged against the outcome that was live during the halt.
  */
 function outcomeThrough(samples: AiSample[], through: number): string | undefined {
-  for (let i = Math.min(through, samples.length - 1); i >= 0; i--) {
+  for (let i = through; i >= 0; i--) {
     if (samples[i].outcome) return samples[i].outcome;
   }
   return undefined;
@@ -151,7 +155,7 @@ interface StationarySpan {
   at: Vec3;
   seconds: number;
   /** Seconds of the stationary window spent under a movement hold. */
-  heldSeconds: number;
+  windowHeldSeconds: number;
 }
 
 /** Is this sample reporting a deliberate hold (door wait, pivot)? */
@@ -217,9 +221,9 @@ function findWedges(
     const stalls = new Set(window.map((s) => s.live_stall_seconds ?? 0));
     const blocked = stalls.size > 1 && Math.max(...stalls) > 0;
     if (traveling && blocked) {
-      let heldSeconds = 0;
+      let windowHeldSeconds = 0;
       for (let k = i; k < j; k++) {
-        if (isHeld(samples[k])) heldSeconds += samples[k + 1].t - samples[k].t;
+        if (isHeld(samples[k])) windowHeldSeconds += samples[k + 1].t - samples[k].t;
       }
       spans.push({
         start: i + unheld.from,
@@ -227,7 +231,7 @@ function findWedges(
         windowEnd: j,
         at: window[unheld.from].position,
         seconds: unheld.seconds,
-        heldSeconds,
+        windowHeldSeconds,
       });
       // Spans starting inside this one are the same halt seen later.
       i = j;
@@ -297,7 +301,7 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     seconds: span.seconds,
     at: span.at,
     escape_distance: escapes[i],
-    held_seconds: span.heldSeconds,
+    window_held_seconds: span.windowHeldSeconds,
     outcome: outcomeThrough(samples, span.end),
   }));
   const evidence = halts.length > 0 ? { halts } : {};
@@ -353,20 +357,18 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     };
   }
 
-  // The halt this AI is judged on: the first one it does NOT get clear of,
-  // else the first halt at all, else the pass as a whole.
+  // The halt this AI is judged on: the first one it does NOT get clear of.
+  // A halt it walked out of proves it had somewhere to go, so it is judged on
+  // the pass as a whole instead.
   const stuckIndex = escapes.findIndex((escape) => escape <= freedTravelUnits);
-  const judgedIndex = stuckIndex >= 0 ? stuckIndex : spans.length > 0 ? 0 : -1;
 
   // No route means no wedge - but only if the route was missing WHILE the AI
   // stood there. Outcomes are sticky, so an early Partial used to outrank a
   // genuine wedge that happened later with a full route in hand.
   const outcome =
-    judgedIndex >= 0
-      ? outcomeThrough(samples, spans[judgedIndex].end)
-      : outcomeThrough(samples, samples.length - 1);
+    stuckIndex >= 0 ? halts[stuckIndex].outcome : outcomeThrough(samples, samples.length - 1);
   if (outcome === "Partial" || outcome === "Failed") {
-    const when = judgedIndex >= 0 ? "during the halt" : "at pass end";
+    const when = stuckIndex >= 0 ? "during the halt" : "at pass end";
     return { verdict: "no_route", reason: `path outcome ${outcome} ${when}`, ...base };
   }
 

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -140,11 +140,17 @@ function outcomeThrough(samples: AiSample[], through: number): string | undefine
 interface StationarySpan {
   /** First sample of the unheld stationary stretch. */
   start: number;
-  /** Last sample of the stationary span - escape is measured from here. */
+  /**
+   * Last sample of the unheld stretch - the halt being judged ends here, so
+   * the route it was judged under is the one live at this sample and not one
+   * published during a hold that merely followed it.
+   */
   end: number;
+  /** Last sample of the whole stationary window - escape is measured from here. */
+  windowEnd: number;
   at: Vec3;
   seconds: number;
-  /** Seconds of the span spent under a movement hold. */
+  /** Seconds of the stationary window spent under a movement hold. */
   heldSeconds: number;
 }
 
@@ -162,8 +168,8 @@ function isHeld(sample: AiSample): boolean {
  * The hold reported at a sample describes the interval that follows it, so a
  * held sample ends the stretch it starts.
  */
-function longestUnheldRun(window: AiSample[]): { from: number; seconds: number } {
-  let best = { from: 0, seconds: 0 };
+function longestUnheldRun(window: AiSample[]): { from: number; to: number; seconds: number } {
+  let best = { from: 0, to: 0, seconds: 0 };
   let runStart = 0;
   for (let k = 0; k < window.length; k++) {
     if (isHeld(window[k])) {
@@ -171,7 +177,7 @@ function longestUnheldRun(window: AiSample[]): { from: number; seconds: number }
       continue;
     }
     const seconds = window[k].t - window[runStart].t;
-    if (seconds > best.seconds) best = { from: runStart, seconds };
+    if (seconds > best.seconds) best = { from: runStart, to: k, seconds };
   }
   return best;
 }
@@ -217,7 +223,8 @@ function findWedges(
       }
       spans.push({
         start: i + unheld.from,
-        end: j,
+        end: i + unheld.to,
+        windowEnd: j,
         at: window[unheld.from].position,
         seconds: unheld.seconds,
         heldSeconds,
@@ -248,7 +255,7 @@ export function pathLength(samples: AiSample[], from = 0): number {
  */
 function escapedBy(samples: AiSample[], span: StationarySpan): number {
   let farthest = 0;
-  for (let k = span.end; k < samples.length; k++) {
+  for (let k = span.windowEnd; k < samples.length; k++) {
     farthest = Math.max(farthest, distance3(span.at, samples[k].position));
   }
   return farthest;
@@ -280,9 +287,24 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     };
   }
 
+  // Halts are found up front so that every verdict - not only a wedge - can
+  // carry the evidence, and so the no-route check can be asked about the
+  // moment being judged rather than about the end of the pass.
+  const spans = findWedges(samples, windowSeconds, wedgeDisplacement);
+  const escapes = spans.map((span) => escapedBy(samples, span));
+  const halts: HaltEvidence[] = spans.map((span, i) => ({
+    start_t: samples[span.start].t,
+    seconds: span.seconds,
+    at: span.at,
+    escape_distance: escapes[i],
+    held_seconds: span.heldSeconds,
+    outcome: outcomeThrough(samples, span.end),
+  }));
+  const evidence = halts.length > 0 ? { halts } : {};
+
   const closest = Math.min(...samples.map((s) => s.distance));
   const final = samples[samples.length - 1].distance;
-  const base = { closest_distance: closest, final_distance: final };
+  const base = { closest_distance: closest, final_distance: final, ...evidence };
 
   // Arrival means the AI CLOSED on the player: one that started inside melee
   // reach and never moved must still be able to come out as wedged.
@@ -331,20 +353,6 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     };
   }
 
-  // Halts first, so the no-route check can be asked about the moment being
-  // judged rather than about the end of the pass.
-  const spans = findWedges(samples, windowSeconds, wedgeDisplacement);
-  const escapes = spans.map((span) => escapedBy(samples, span));
-  const halts: HaltEvidence[] = spans.map((span, i) => ({
-    start_t: samples[span.start].t,
-    seconds: span.seconds,
-    at: span.at,
-    escape_distance: escapes[i],
-    held_seconds: span.heldSeconds,
-    outcome: outcomeThrough(samples, span.end),
-  }));
-  const evidence = halts.length > 0 ? { halts } : {};
-
   // The halt this AI is judged on: the first one it does NOT get clear of,
   // else the first halt at all, else the pass as a whole.
   const stuckIndex = escapes.findIndex((escape) => escape <= freedTravelUnits);
@@ -359,7 +367,7 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
       : outcomeThrough(samples, samples.length - 1);
   if (outcome === "Partial" || outcome === "Failed") {
     const when = judgedIndex >= 0 ? "during the halt" : "at pass end";
-    return { verdict: "no_route", reason: `path outcome ${outcome} ${when}`, ...base, ...evidence };
+    return { verdict: "no_route", reason: `path outcome ${outcome} ${when}`, ...base };
   }
 
   // A halt the AI walks out of is not a wedge: report the first span it does
@@ -377,7 +385,6 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
       wedge_at: stuck.at,
       wedge_seconds: stuck.seconds,
       ...base,
-      ...evidence,
     };
   }
   if (spans.length > 0) {
@@ -392,7 +399,6 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
       wedge_seconds: span.seconds,
       freed_travel: freed,
       ...base,
-      ...evidence,
     };
   }
 

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -68,8 +68,29 @@ export interface Classification {
   wedge_seconds?: number;
   /** How far it got from the halt afterwards (wedged_then_freed only). */
   freed_travel?: number;
+  /**
+   * Every halt found in the pass, in order - the raw evidence behind the
+   * verdict, kept in the stored JSON so a reviewer can audit a bucket without
+   * re-running the pass.
+   */
+  halts?: HaltEvidence[];
   closest_distance: number;
   final_distance: number;
+}
+
+/** One halt, as observed - the audit trail behind a wedge verdict. */
+export interface HaltEvidence {
+  /** Seconds into the pass at which the unheld stationary stretch started. */
+  start_t: number;
+  /** Length of that stretch, seconds. */
+  seconds: number;
+  at: Vec3;
+  /** Farthest the AI later got from `at`, world units. */
+  escape_distance: number;
+  /** Seconds of the halt spent under a published movement hold. */
+  held_seconds: number;
+  /** Path outcome in effect during the halt, if the AI had ever pathed. */
+  outcome?: string;
 }
 
 export interface ClassifyOptions {
@@ -101,9 +122,15 @@ export function distance3(a: Vec3, b: Vec3): number {
   return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
 }
 
-/** Latest non-null path outcome in the pass, if the AI ever pathed. */
-function lastOutcome(samples: AiSample[]): string | undefined {
-  for (let i = samples.length - 1; i >= 0; i--) {
+/**
+ * The path outcome in effect at sample `through` - the latest non-null outcome
+ * at or before it. Outcomes are sticky (the runtime republishes the last query
+ * result), so reading the LAST one in the pass answers "did this AI ever end up
+ * without a route", not "did it have a route while it was halted". A wedge is
+ * judged against the outcome that was live during the halt.
+ */
+function outcomeThrough(samples: AiSample[], through: number): string | undefined {
+  for (let i = Math.min(through, samples.length - 1); i >= 0; i--) {
     if (samples[i].outcome) return samples[i].outcome;
   }
   return undefined;
@@ -111,10 +138,14 @@ function lastOutcome(samples: AiSample[]): string | undefined {
 
 /** A halt: where it happened, how long, and where the AI stood still until. */
 interface StationarySpan {
+  /** First sample of the unheld stationary stretch. */
+  start: number;
   /** Last sample of the stationary span - escape is measured from here. */
   end: number;
   at: Vec3;
   seconds: number;
+  /** Seconds of the span spent under a movement hold. */
+  heldSeconds: number;
 }
 
 /** Is this sample reporting a deliberate hold (door wait, pivot)? */
@@ -180,7 +211,17 @@ function findWedges(
     const stalls = new Set(window.map((s) => s.live_stall_seconds ?? 0));
     const blocked = stalls.size > 1 && Math.max(...stalls) > 0;
     if (traveling && blocked) {
-      spans.push({ end: j, at: window[unheld.from].position, seconds: unheld.seconds });
+      let heldSeconds = 0;
+      for (let k = i; k < j; k++) {
+        if (isHeld(samples[k])) heldSeconds += samples[k + 1].t - samples[k].t;
+      }
+      spans.push({
+        start: i + unheld.from,
+        end: j,
+        at: window[unheld.from].position,
+        seconds: unheld.seconds,
+        heldSeconds,
+      });
       // Spans starting inside this one are the same halt seen later.
       i = j;
     }
@@ -220,7 +261,8 @@ function escapedBy(samples: AiSample[], span: StationarySpan): number {
  * unreachable") or has no route to the player ("no route") is judged as such
  * BEFORE the wedge check - standing still without a route is not a wedge, and
  * letting `wedged` outrank them made the headline wedge count absorb whole
- * buckets of non-defects.
+ * buckets of non-defects. The no-route test reads the outcome that was live
+ * during the halt being judged, not the last one of the pass.
  */
 export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classification {
   const arriveRadius = options.arriveRadius ?? 3.2;
@@ -289,9 +331,35 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     };
   }
 
-  const outcome = lastOutcome(samples);
+  // Halts first, so the no-route check can be asked about the moment being
+  // judged rather than about the end of the pass.
+  const spans = findWedges(samples, windowSeconds, wedgeDisplacement);
+  const escapes = spans.map((span) => escapedBy(samples, span));
+  const halts: HaltEvidence[] = spans.map((span, i) => ({
+    start_t: samples[span.start].t,
+    seconds: span.seconds,
+    at: span.at,
+    escape_distance: escapes[i],
+    held_seconds: span.heldSeconds,
+    outcome: outcomeThrough(samples, span.end),
+  }));
+  const evidence = halts.length > 0 ? { halts } : {};
+
+  // The halt this AI is judged on: the first one it does NOT get clear of,
+  // else the first halt at all, else the pass as a whole.
+  const stuckIndex = escapes.findIndex((escape) => escape <= freedTravelUnits);
+  const judgedIndex = stuckIndex >= 0 ? stuckIndex : spans.length > 0 ? 0 : -1;
+
+  // No route means no wedge - but only if the route was missing WHILE the AI
+  // stood there. Outcomes are sticky, so an early Partial used to outrank a
+  // genuine wedge that happened later with a full route in hand.
+  const outcome =
+    judgedIndex >= 0
+      ? outcomeThrough(samples, spans[judgedIndex].end)
+      : outcomeThrough(samples, samples.length - 1);
   if (outcome === "Partial" || outcome === "Failed") {
-    return { verdict: "no_route", reason: `last path outcome ${outcome}`, ...base };
+    const when = judgedIndex >= 0 ? "during the halt" : "at pass end";
+    return { verdict: "no_route", reason: `path outcome ${outcome} ${when}`, ...base, ...evidence };
   }
 
   // A halt the AI walks out of is not a wedge: report the first span it does
@@ -299,9 +367,8 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
   // land in the separate `wedged_then_freed` bucket (still visible, but not
   // counted against the headline wedge number). "Walked out" means it got
   // clear of the spot, not that it covered distance near it.
-  const spans = findWedges(samples, windowSeconds, wedgeDisplacement);
-  const stuck = spans.find((span) => escapedBy(samples, span) <= freedTravelUnits);
-  if (stuck) {
+  if (stuckIndex >= 0) {
+    const stuck = spans[stuckIndex];
     return {
       verdict: "wedged",
       reason: `stationary ${stuck.seconds.toFixed(1)}s at (${stuck.at
@@ -310,11 +377,12 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
       wedge_at: stuck.at,
       wedge_seconds: stuck.seconds,
       ...base,
+      ...evidence,
     };
   }
   if (spans.length > 0) {
     const span = spans[0];
-    const freed = escapedBy(samples, span);
+    const freed = escapes[0];
     return {
       verdict: "wedged_then_freed",
       reason: `stationary ${span.seconds.toFixed(1)}s at (${span.at
@@ -324,6 +392,7 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
       wedge_seconds: span.seconds,
       freed_travel: freed,
       ...base,
+      ...evidence,
     };
   }
 

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -66,7 +66,7 @@ export interface Classification {
   wedge_at?: Vec3;
   /** How long it was stuck there, seconds. */
   wedge_seconds?: number;
-  /** Units traveled after the stuck span ended (wedged_then_freed only). */
+  /** How far it got from the halt afterwards (wedged_then_freed only). */
   freed_travel?: number;
   closest_distance: number;
   final_distance: number;
@@ -84,8 +84,9 @@ export interface ClassifyOptions {
   /** Displacement below which the AI counts as not moving, world units. */
   wedgeDisplacement?: number;
   /**
-   * Travel after a stationary span that means the AI walked out of it, world
-   * units. Such a span is reported as `wedged_then_freed`, not `wedged`.
+   * How far from the halt the AI must get for it to count as having walked
+   * out, world units. Such a span is reported as `wedged_then_freed`, not
+   * `wedged`.
    */
   freedTravelUnits?: number;
 }
@@ -108,13 +109,12 @@ function lastOutcome(samples: AiSample[]): string | undefined {
   return undefined;
 }
 
-/** A stationary span: sample indices, where, and how long it lasted. */
+/** A halt: where it happened, how long, and where the AI stood still until. */
 interface StationarySpan {
-  start: number;
+  /** Last sample of the stationary span - escape is measured from here. */
   end: number;
   at: Vec3;
   seconds: number;
-  heldSeconds: number;
 }
 
 /** Is this sample reporting a deliberate hold (door wait, pivot)? */
@@ -123,19 +123,38 @@ function isHeld(sample: AiSample): boolean {
 }
 
 /**
- * Every span in which the AI stayed put while it was actively trying to
- * move: stationary for long enough, with stall time that CHANGES across the
- * window.
+ * The longest unbroken stretch of the window in which the AI was NOT under a
+ * published movement hold, as [firstSample, seconds]. Time waiting on a door
+ * or turning in place is an intentional pause, and a long one used to cross
+ * the wedge window on its own.
+ *
+ * The hold reported at a sample describes the interval that follows it, so a
+ * held sample ends the stretch it starts.
+ */
+function longestUnheldRun(window: AiSample[]): { from: number; seconds: number } {
+  let best = { from: 0, seconds: 0 };
+  let runStart = 0;
+  for (let k = 0; k < window.length; k++) {
+    if (isHeld(window[k])) {
+      runStart = k + 1;
+      continue;
+    }
+    const seconds = window[k].t - window[runStart].t;
+    if (seconds > best.seconds) best = { from: runStart, seconds };
+  }
+  return best;
+}
+
+/**
+ * Every halt in which the AI stayed put while it was actively trying to
+ * move: stationary for long enough with no hold to explain it, and with
+ * stall time that CHANGES across the window.
  *
  * The change requirement matters - the steering's live record is only
  * refreshed while path-following runs, so an AI that stopped following a path
  * (reached its patrol end, switched to attacking) keeps its last snapshot
  * forever. A frozen snapshot is not evidence of a wedge; a stall clock that
  * ticks (or resets on a backout) is.
- *
- * Time the AI spends under a published movement hold (waiting on a door,
- * turning in place) does not count toward the window - those are intentional
- * pauses, and a long one used to cross the window on its own.
  */
 function findWedges(
   samples: AiSample[],
@@ -148,15 +167,12 @@ function findWedges(
     while (j + 1 < samples.length && distance3(samples[i].position, samples[j + 1].position) < displacement) {
       j++;
     }
-    const seconds = samples[j].t - samples[i].t;
-    // The hold reported at a sample describes the interval that follows it.
-    let heldSeconds = 0;
-    for (let k = i; k < j; k++) {
-      if (isHeld(samples[k])) heldSeconds += samples[k + 1].t - samples[k].t;
-    }
-    if (seconds - heldSeconds < windowSeconds) continue;
+    if (samples[j].t - samples[i].t < windowSeconds) continue;
 
     const window = samples.slice(i, j + 1);
+    const unheld = longestUnheldRun(window);
+    if (unheld.seconds < windowSeconds) continue;
+
     const behaviors = window.map((s) => s.behavior).filter((b): b is string => Boolean(b));
     // No behavior data at all is not evidence of standing by design - the
     // runtime sometimes omits AIBehavior - so fall back to the path evidence.
@@ -164,7 +180,7 @@ function findWedges(
     const stalls = new Set(window.map((s) => s.live_stall_seconds ?? 0));
     const blocked = stalls.size > 1 && Math.max(...stalls) > 0;
     if (traveling && blocked) {
-      spans.push({ start: i, end: j, at: samples[i].position, seconds, heldSeconds });
+      spans.push({ end: j, at: window[unheld.from].position, seconds: unheld.seconds });
       // Spans starting inside this one are the same halt seen later.
       i = j;
     }
@@ -172,13 +188,29 @@ function findWedges(
   return spans;
 }
 
-/** Path length walked after the span ended. */
-function travelAfter(samples: AiSample[], span: StationarySpan): number {
+/**
+ * Path length walked from `from` onwards - not start-to-end displacement, so
+ * a loop patrol that returns to where it started still reads as travel.
+ */
+export function pathLength(samples: AiSample[], from = 0): number {
   let sum = 0;
-  for (let k = span.end; k + 1 < samples.length; k++) {
+  for (let k = from; k + 1 < samples.length; k++) {
     sum += distance3(samples[k].position, samples[k + 1].position);
   }
   return sum;
+}
+
+/**
+ * How far the AI got from a halt after it ended. Distance from the halt, not
+ * path length: an AI oscillating inside its pocket racks up path length
+ * without ever leaving.
+ */
+function escapedBy(samples: AiSample[], span: StationarySpan): number {
+  let farthest = 0;
+  for (let k = span.end; k < samples.length; k++) {
+    farthest = Math.max(farthest, distance3(span.at, samples[k].position));
+  }
+  return farthest;
 }
 
 /**
@@ -265,16 +297,16 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
   // A halt the AI walks out of is not a wedge: report the first span it does
   // NOT walk out of, and only if every span was walked out of does the AI
   // land in the separate `wedged_then_freed` bucket (still visible, but not
-  // counted against the headline wedge number).
+  // counted against the headline wedge number). "Walked out" means it got
+  // clear of the spot, not that it covered distance near it.
   const spans = findWedges(samples, windowSeconds, wedgeDisplacement);
-  const stuck = spans.find((span) => travelAfter(samples, span) <= freedTravelUnits);
+  const stuck = spans.find((span) => escapedBy(samples, span) <= freedTravelUnits);
   if (stuck) {
-    const held = stuck.heldSeconds > 0 ? `, ${stuck.heldSeconds.toFixed(1)}s of it held` : "";
     return {
       verdict: "wedged",
       reason: `stationary ${stuck.seconds.toFixed(1)}s at (${stuck.at
         .map((c) => c.toFixed(2))
-        .join(", ")}) with a route or stall active${held}`,
+        .join(", ")}) with a route or stall active`,
       wedge_at: stuck.at,
       wedge_seconds: stuck.seconds,
       ...base,
@@ -282,12 +314,12 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
   }
   if (spans.length > 0) {
     const span = spans[0];
-    const freed = travelAfter(samples, span);
+    const freed = escapedBy(samples, span);
     return {
       verdict: "wedged_then_freed",
       reason: `stationary ${span.seconds.toFixed(1)}s at (${span.at
         .map((c) => c.toFixed(2))
-        .join(", ")}), then traveled ${freed.toFixed(1)}`,
+        .join(", ")}), then moved ${freed.toFixed(1)} away`,
       wedge_at: span.at,
       wedge_seconds: span.seconds,
       freed_travel: freed,
@@ -295,11 +327,7 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     };
   }
 
-  // Path length, not start-to-end displacement: a loop patrol returns to where
-  // it started and would otherwise read as "never moved".
-  const traveled = samples
-    .slice(1)
-    .reduce((sum, s, i) => sum + distance3(samples[i].position, s.position), 0);
+  const traveled = pathLength(samples);
   const everPathed = samples.some(
     (s) => Boolean(s.outcome) || (s.live_path_len ?? 0) > 0 || (s.live_stall_seconds ?? 0) > 0,
   );

--- a/tools/shock2-sdk/src/ai-reachability.ts
+++ b/tools/shock2-sdk/src/ai-reachability.ts
@@ -26,6 +26,11 @@ export interface AiSample {
   live_path_len?: number | null;
   live_target?: Vec3 | null;
   live_stall_seconds?: number | null;
+  /**
+   * Why the AI is deliberately standing still ("DoorWait" | "Pivot"), null
+   * when it is not. Absent on runtimes older than the field.
+   */
+  movement_hold?: string | null;
   /** Distance to the player at this sample. */
   distance: number;
 }
@@ -48,6 +53,7 @@ export type Verdict =
   | "arrived"
   | "progressing"
   | "wedged"
+  | "wedged_then_freed"
   | "no_route"
   | "expected_unreachable"
   | "idle_by_design";
@@ -56,10 +62,12 @@ export interface Classification {
   verdict: Verdict;
   /** One line saying which rule fired, with the numbers behind it. */
   reason: string;
-  /** Where the AI was stuck (wedged only) - a reproducible seed position. */
+  /** Where the AI was stuck - a reproducible seed position. */
   wedge_at?: Vec3;
-  /** How long it was stuck there, seconds (wedged only). */
+  /** How long it was stuck there, seconds. */
   wedge_seconds?: number;
+  /** Units traveled after the stuck span ended (wedged_then_freed only). */
+  freed_travel?: number;
   closest_distance: number;
   final_distance: number;
 }
@@ -75,6 +83,11 @@ export interface ClassifyOptions {
   wedgeWindowSeconds?: number;
   /** Displacement below which the AI counts as not moving, world units. */
   wedgeDisplacement?: number;
+  /**
+   * Travel after a stationary span that means the AI walked out of it, world
+   * units. Such a span is reported as `wedged_then_freed`, not `wedged`.
+   */
+  freedTravelUnits?: number;
 }
 
 /** Behaviors that mean the AI is trying to travel somewhere. */
@@ -95,8 +108,22 @@ function lastOutcome(samples: AiSample[]): string | undefined {
   return undefined;
 }
 
+/** A stationary span: sample indices, where, and how long it lasted. */
+interface StationarySpan {
+  start: number;
+  end: number;
+  at: Vec3;
+  seconds: number;
+  heldSeconds: number;
+}
+
+/** Is this sample reporting a deliberate hold (door wait, pivot)? */
+function isHeld(sample: AiSample): boolean {
+  return Boolean(sample.movement_hold);
+}
+
 /**
- * The first span in which the AI stayed put while it was actively trying to
+ * Every span in which the AI stayed put while it was actively trying to
  * move: stationary for long enough, with stall time that CHANGES across the
  * window.
  *
@@ -105,19 +132,29 @@ function lastOutcome(samples: AiSample[]): string | undefined {
  * (reached its patrol end, switched to attacking) keeps its last snapshot
  * forever. A frozen snapshot is not evidence of a wedge; a stall clock that
  * ticks (or resets on a backout) is.
+ *
+ * Time the AI spends under a published movement hold (waiting on a door,
+ * turning in place) does not count toward the window - those are intentional
+ * pauses, and a long one used to cross the window on its own.
  */
-function findWedge(
+function findWedges(
   samples: AiSample[],
   windowSeconds: number,
   displacement: number,
-): { at: Vec3; seconds: number } | undefined {
+): StationarySpan[] {
+  const spans: StationarySpan[] = [];
   for (let i = 0; i < samples.length; i++) {
     let j = i;
     while (j + 1 < samples.length && distance3(samples[i].position, samples[j + 1].position) < displacement) {
       j++;
     }
     const seconds = samples[j].t - samples[i].t;
-    if (seconds < windowSeconds) continue;
+    // The hold reported at a sample describes the interval that follows it.
+    let heldSeconds = 0;
+    for (let k = i; k < j; k++) {
+      if (isHeld(samples[k])) heldSeconds += samples[k + 1].t - samples[k].t;
+    }
+    if (seconds - heldSeconds < windowSeconds) continue;
 
     const window = samples.slice(i, j + 1);
     const behaviors = window.map((s) => s.behavior).filter((b): b is string => Boolean(b));
@@ -127,24 +164,37 @@ function findWedge(
     const stalls = new Set(window.map((s) => s.live_stall_seconds ?? 0));
     const blocked = stalls.size > 1 && Math.max(...stalls) > 0;
     if (traveling && blocked) {
-      return { at: samples[i].position, seconds };
+      spans.push({ start: i, end: j, at: samples[i].position, seconds, heldSeconds });
+      // Spans starting inside this one are the same halt seen later.
+      i = j;
     }
   }
-  return undefined;
+  return spans;
+}
+
+/** Path length walked after the span ended. */
+function travelAfter(samples: AiSample[], span: StationarySpan): number {
+  let sum = 0;
+  for (let k = span.end; k + 1 < samples.length; k++) {
+    sum += distance3(samples[k].position, samples[k + 1].position);
+  }
+  return sum;
 }
 
 /**
  * Classify one AI's pass.
  *
- * Order matters: a wedge is reported even for an AI that could never have
- * reached the player anyway (being physically stuck is a defect on its own),
- * and "expected unreachable" outranks the routing verdicts so a sealed-off
- * or alert-capped AI is not counted as a pathfinding failure.
+ * Order matters: an AI that was never going anywhere ("expected
+ * unreachable") or has no route to the player ("no route") is judged as such
+ * BEFORE the wedge check - standing still without a route is not a wedge, and
+ * letting `wedged` outrank them made the headline wedge count absorb whole
+ * buckets of non-defects.
  */
 export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classification {
   const arriveRadius = options.arriveRadius ?? 3.2;
   const windowSeconds = options.wedgeWindowSeconds ?? 6.0;
   const wedgeDisplacement = options.wedgeDisplacement ?? 1.0;
+  const freedTravelUnits = options.freedTravelUnits ?? 5.0;
   const samples = track.samples;
 
   if (samples.length === 0) {
@@ -167,17 +217,6 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     return {
       verdict: "arrived",
       reason: `closed from ${start.toFixed(1)} to ${closest.toFixed(1)} (<= ${arriveRadius})`,
-      ...base,
-    };
-  }
-
-  const wedge = findWedge(samples, windowSeconds, wedgeDisplacement);
-  if (wedge) {
-    return {
-      verdict: "wedged",
-      reason: `stationary ${wedge.seconds.toFixed(1)}s at (${wedge.at.map((c) => c.toFixed(2)).join(", ")}) with a route or stall active`,
-      wedge_at: wedge.at,
-      wedge_seconds: wedge.seconds,
       ...base,
     };
   }
@@ -223,6 +262,39 @@ export function classifyTrack(track: AiTrack, options: ClassifyOptions): Classif
     return { verdict: "no_route", reason: `last path outcome ${outcome}`, ...base };
   }
 
+  // A halt the AI walks out of is not a wedge: report the first span it does
+  // NOT walk out of, and only if every span was walked out of does the AI
+  // land in the separate `wedged_then_freed` bucket (still visible, but not
+  // counted against the headline wedge number).
+  const spans = findWedges(samples, windowSeconds, wedgeDisplacement);
+  const stuck = spans.find((span) => travelAfter(samples, span) <= freedTravelUnits);
+  if (stuck) {
+    const held = stuck.heldSeconds > 0 ? `, ${stuck.heldSeconds.toFixed(1)}s of it held` : "";
+    return {
+      verdict: "wedged",
+      reason: `stationary ${stuck.seconds.toFixed(1)}s at (${stuck.at
+        .map((c) => c.toFixed(2))
+        .join(", ")}) with a route or stall active${held}`,
+      wedge_at: stuck.at,
+      wedge_seconds: stuck.seconds,
+      ...base,
+    };
+  }
+  if (spans.length > 0) {
+    const span = spans[0];
+    const freed = travelAfter(samples, span);
+    return {
+      verdict: "wedged_then_freed",
+      reason: `stationary ${span.seconds.toFixed(1)}s at (${span.at
+        .map((c) => c.toFixed(2))
+        .join(", ")}), then traveled ${freed.toFixed(1)}`,
+      wedge_at: span.at,
+      wedge_seconds: span.seconds,
+      freed_travel: freed,
+      ...base,
+    };
+  }
+
   // Path length, not start-to-end displacement: a loop patrol returns to where
   // it started and would otherwise read as "never moved".
   const traveled = samples
@@ -247,6 +319,7 @@ export const VERDICTS: Verdict[] = [
   "arrived",
   "progressing",
   "wedged",
+  "wedged_then_freed",
   "no_route",
   "expected_unreachable",
   "idle_by_design",

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -86,6 +86,11 @@ export interface AiPathEntry {
   live_target?: [number, number, number] | null;
   /** Seconds without progress toward the current waypoint. */
   live_stall_seconds?: number | null;
+  /**
+   * Why the AI is deliberately standing still ("DoorWait" | "Pivot"), null
+   * when it is moving freely. Absent on runtimes that predate the field.
+   */
+  movement_hold?: string | null;
 }
 
 /** One-off walk-graph query between two positions (GET /v1/pathfinding/route). */

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -238,6 +238,25 @@ test("a halt the AI walks out of is 'wedged_then_freed', not 'wedged'", () => {
   assert.ok((result.freed_travel ?? 0) > 5);
 });
 
+test("oscillating in place after a halt is still 'wedged', not freed", () => {
+  // Path length racks up, but the AI never gets clear of the pocket.
+  const result = classifyTrack(
+    track([
+      ...stationary(16, { behavior: "Patrol", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+      })),
+      ...Array.from({ length: 20 }, (_, i) => ({
+        position: [49 + (i % 2) * 1.1, 0.1, -98.5] as [number, number, number],
+        behavior: "Patrol",
+        outcome: "Full",
+      })),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+});
+
 test("an AI that walks out of one halt and into a real one is 'wedged'", () => {
   const held = (i: number) => ({ live_stall_seconds: i % 6, behavior: "Patrol", outcome: "Full" });
   const result = classifyTrack(
@@ -262,6 +281,22 @@ test("time spent under a movement hold does not count toward the wedge window", 
         ...s,
         live_stall_seconds: i % 6,
         movement_hold: i < 16 ? "DoorWait" : null,
+      })),
+    ),
+    { pass: "idle" },
+  );
+  assert.notEqual(result.verdict, "wedged");
+});
+
+test("short unheld pauses on either side of a long hold do not add up to a wedge", () => {
+  // 3.5s stalled, a 30s door wait, 3.5s stalled: 7s unheld in total, but no
+  // 6s stretch of it - and the whole thing is one stationary span.
+  const result = classifyTrack(
+    track(
+      stationary(80, { behavior: "Chase", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+        movement_hold: i >= 8 && i < 68 ? "DoorWait" : null,
       })),
     ),
     { pass: "idle" },

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -250,7 +250,7 @@ test("a Partial published during a hold after the halt does not rewrite it", () 
   );
   assert.equal(result.verdict, "wedged");
   assert.equal(result.halts?.[0].outcome, "Full");
-  assert.ok((result.halts?.[0].held_seconds ?? 0) > 0);
+  assert.ok((result.halts?.[0].window_held_seconds ?? 0) > 0);
 });
 
 test("halt evidence survives a non-wedge verdict", () => {
@@ -267,6 +267,27 @@ test("halt evidence survives a non-wedge verdict", () => {
   );
   assert.equal(result.verdict, "arrived");
   assert.equal(result.halts?.length, 1);
+});
+
+test("a Partial during a halt the AI walked out of does not make it 'no_route'", () => {
+  // It left, so it plainly had somewhere to go: the halt it escaped does not
+  // get to decide the verdict, and pass-end is what answers "no route".
+  const result = classifyTrack(
+    track([
+      ...stationary(16, { behavior: "Patrol", outcome: "Partial" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: (i % 6) * 0.5,
+      })),
+      ...Array.from({ length: 12 }, (_, i) => ({
+        position: [49 + (i + 1) * 5, 0.1, -98.5] as [number, number, number],
+        behavior: "Patrol",
+        outcome: "Full",
+      })),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged_then_freed");
+  assert.equal(result.halts?.[0].outcome, "Partial");
 });
 
 test("a halt that happens while the route is Partial is still 'no_route'", () => {
@@ -298,7 +319,7 @@ test("a classified halt carries its raw evidence", () => {
   const halts = result.halts ?? [];
   assert.equal(halts.length, 1);
   assert.equal(halts[0].outcome, "Full");
-  assert.equal(halts[0].held_seconds, 0);
+  assert.equal(halts[0].window_held_seconds, 0);
   assert.deepEqual(halts[0].at, [49, 0.1, -98.5]);
   assert.ok(halts[0].start_t >= 0.5);
   assert.ok(halts[0].seconds >= 6);

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -206,6 +206,65 @@ test("an AI with no route to the player is not a wedge, even while it stalls", (
   assert.equal(result.verdict, "no_route");
 });
 
+test("a Partial outside the halt does not outrank a wedge that happened with a route", () => {
+  // Path outcomes are sticky: an early Partial, and a late Partial published
+  // once the AI shuffles and re-queries, both sit outside the halt itself -
+  // which the AI spent with a Full route in hand and never got clear of.
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], distance: 50, behavior: "Chase", outcome: "Partial" },
+      { position: [4, 0, 0], distance: 46, behavior: "Chase", outcome: "Full" },
+      ...stationary(18, { behavior: "Chase", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: (i % 6) * 0.5,
+      })),
+      // Shuffles 2 units - never gets clear (the freed threshold is 5).
+      { position: [51, 0.1, -98.5], distance: 50, behavior: "Chase", outcome: "Partial" },
+      { position: [51, 0.1, -98.5], distance: 50, behavior: "Chase", outcome: "Partial" },
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+  assert.ok((result.wedge_seconds ?? 0) >= 6);
+  assert.equal(result.halts?.[0].outcome, "Full");
+});
+
+test("a halt that happens while the route is Partial is still 'no_route'", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], distance: 50, behavior: "Chase", outcome: "Full" },
+      ...stationary(20, { behavior: "Chase", outcome: "Partial" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: (i % 6) * 0.5,
+      })),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "no_route");
+});
+
+test("a classified halt carries its raw evidence", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], distance: 50, behavior: "Patrol", outcome: "Full" },
+      ...stationary(16, { behavior: "Patrol", outcome: "Full", movement_hold: null }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: (i % 6) * 0.5,
+      })),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+  const halts = result.halts ?? [];
+  assert.equal(halts.length, 1);
+  assert.equal(halts[0].outcome, "Full");
+  assert.equal(halts[0].held_seconds, 0);
+  assert.deepEqual(halts[0].at, [49, 0.1, -98.5]);
+  assert.ok(halts[0].start_t >= 0.5);
+  assert.ok(halts[0].seconds >= 6);
+  assert.equal(halts[0].escape_distance, 0);
+});
+
 test("an AI that was never coming is expected-unreachable, not a wedge", () => {
   const result = classifyTrack(
     track(

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -229,6 +229,46 @@ test("a Partial outside the halt does not outrank a wedge that happened with a r
   assert.equal(result.halts?.[0].outcome, "Full");
 });
 
+test("a Partial published during a hold after the halt does not rewrite it", () => {
+  // The halt being judged is the unheld stretch; a route re-query while the
+  // AI waits on a door afterwards belongs to the wait, not to the halt.
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], distance: 50, behavior: "Patrol", outcome: "Full" },
+      ...stationary(18, { behavior: "Patrol", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: (i % 6) * 0.5,
+      })),
+      ...stationary(6, {
+        behavior: "Patrol",
+        outcome: "Partial",
+        movement_hold: "DoorWait",
+        live_stall_seconds: 1,
+      }),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+  assert.equal(result.halts?.[0].outcome, "Full");
+  assert.ok((result.halts?.[0].held_seconds ?? 0) > 0);
+});
+
+test("halt evidence survives a non-wedge verdict", () => {
+  const result = classifyTrack(
+    track([
+      { position: [0, 0, 0], distance: 50, behavior: "Chase" },
+      ...stationary(16, { behavior: "Chase", outcome: "Full", distance: 50 }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: (i % 6) * 0.5,
+      })),
+      { position: [1, 0, 0], distance: 1, behavior: "Chase", outcome: "Full" },
+    ]),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "arrived");
+  assert.equal(result.halts?.length, 1);
+});
+
 test("a halt that happens while the route is Partial is still 'no_route'", () => {
   const result = classifyTrack(
     track([

--- a/tools/shock2-sdk/test/ai-reachability.test.ts
+++ b/tools/shock2-sdk/test/ai-reachability.test.ts
@@ -191,6 +191,98 @@ test("a loop patrol that returns to its start is not 'never moved'", () => {
   assert.equal(result.verdict, "progressing");
 });
 
+test("an AI with no route to the player is not a wedge, even while it stalls", () => {
+  // A stall clock that ticks under a Failed path is a routing failure, not a
+  // physical wedge - `no_route` outranks `wedged`.
+  const result = classifyTrack(
+    track(
+      stationary(20, { behavior: "Chase", alertness: "High", outcome: "Failed" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+      })),
+    ),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "no_route");
+});
+
+test("an AI that was never coming is expected-unreachable, not a wedge", () => {
+  const result = classifyTrack(
+    track(
+      stationary(20, { behavior: "Chase", alertness: "High", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+      })),
+      { reachable: false },
+    ),
+    { pass: "chase" },
+  );
+  assert.equal(result.verdict, "expected_unreachable");
+});
+
+test("a halt the AI walks out of is 'wedged_then_freed', not 'wedged'", () => {
+  const result = classifyTrack(
+    track([
+      ...stationary(20, { behavior: "Patrol", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+      })),
+      // Walks 30 units away over the next 3 samples.
+      { position: [59, 0.1, -98.5], behavior: "Patrol", outcome: "Full" },
+      { position: [69, 0.1, -98.5], behavior: "Patrol", outcome: "Full" },
+      { position: [79, 0.1, -98.5], behavior: "Patrol", outcome: "Full" },
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged_then_freed");
+  assert.ok((result.freed_travel ?? 0) > 5);
+});
+
+test("an AI that walks out of one halt and into a real one is 'wedged'", () => {
+  const held = (i: number) => ({ live_stall_seconds: i % 6, behavior: "Patrol", outcome: "Full" });
+  const result = classifyTrack(
+    track([
+      ...Array.from({ length: 16 }, (_, i) => ({ position: [0, 0, 0] as [number, number, number], ...held(i) })),
+      { position: [10, 0, 0], ...held(1) },
+      { position: [20, 0, 0], ...held(2) },
+      ...Array.from({ length: 16 }, (_, i) => ({ position: [30, 0, 0] as [number, number, number], ...held(i) })),
+    ]),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+  assert.deepEqual(result.wedge_at, [30, 0, 0]);
+});
+
+test("time spent under a movement hold does not count toward the wedge window", () => {
+  // 10s parked, 8s of it waiting on a door: only 2s of unheld stall, so the
+  // 6s window is never met.
+  const result = classifyTrack(
+    track(
+      stationary(20, { behavior: "Chase", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+        movement_hold: i < 16 ? "DoorWait" : null,
+      })),
+    ),
+    { pass: "idle" },
+  );
+  assert.notEqual(result.verdict, "wedged");
+});
+
+test("a hold that ends well before the window closes still leaves a wedge", () => {
+  const result = classifyTrack(
+    track(
+      stationary(30, { behavior: "Chase", outcome: "Full" }).map((s, i) => ({
+        ...s,
+        live_stall_seconds: i % 6,
+        movement_hold: i < 4 ? "Pivot" : null,
+      })),
+    ),
+    { pass: "idle" },
+  );
+  assert.equal(result.verdict, "wedged");
+});
+
 test("tally counts every verdict bucket", () => {
   const counts = tally([
     { verdict: "arrived", reason: "", closest_distance: 1, final_distance: 1 },


### PR DESCRIPTION
Wedge verdicts drifted away from the thing the harness is supposed to measure: the last measurement round (#1242 comment, 2026-09-04) showed 39 of 58 new "wedged" AIs had simply moved out of `expected_unreachable`/`no_route`, and two-thirds of them walk on after the halt. Four classifier rules, pure TypeScript in `tools/shock2-sdk`, no runtime changes.

## Rules

1. **`expected_unreachable` and `no_route` outrank `wedged`.** An AI with no route to the goal is not a wedge - it is judged as the non-defect it is before the wedge check runs. Previously `wedged` outranked both, so #1264's stall instrumentation (which makes the `blocked` precondition true where the snapshot used to be frozen) silently migrated whole buckets into the headline number.
2. **A halt the AI gets clear of is `wedged_then_freed`, not `wedged`.** Of the two options, the "discount spans followed by travel" rule was chosen over "must still be stationary at pass end": the pass-end rule hides an AI that is genuinely stuck for 20 s and then frees itself, and a separate bucket keeps that case counted and visible. `wedged` is now the first halt the AI does **not** get clear of; only when every halt was escaped does the AI land in `wedged_then_freed`. "Got clear" is measured as distance from the halt (default > 5 units), not path length - an AI oscillating in its pocket racks up odometer without leaving.
3. **Time under a movement hold does not count toward the 6 s window.** `movement_hold` (`DoorWait`/`Pivot`, published on `GET /v1/ai/paths` by #1355) marks a deliberate pause; the window must be met by a contiguous *unheld* stretch, so a long door wait no longer crosses it on its own, and two short stalls either side of a 30 s wait no longer add up to one. The field is optional throughout - a runtime that does not publish it classifies exactly as before, which is why the reclassification below is unaffected by rule 3.
4. **The no-route test reads the outcome that was live during the halt, not the last one of the pass.** Path outcomes are sticky, so a `Partial` recorded before or after a halt used to outrank the halt itself. `no_route` is now derived from the outcome in effect during the halt being judged - the first halt the AI does **not** get clear of, bounded by that halt's unheld stretch so a route re-queried during a following door wait cannot rewrite it. A halt that happened with a full route in hand stays a wedge; one that happened under a `Partial` is still `no_route`. An AI that walked out of every halt has demonstrably got somewhere to go, so it is judged on the pass-end outcome instead.

Every classification also carries its **raw halt evidence** - one entry per halt, with the time it started, its unheld duration, its position, how far the AI later got from it, how much of the span sat under a movement hold, and the path outcome live during it. It is written into the stored per-mission JSON, so a bucket can be audited (or a rule re-argued) from a stored run without re-running the game.

`--reclassify <dir>` re-runs the classifier over a stored run's JSON offline (no game, no runtime) and prints the stored-vs-new table.

## Re-classified stored runs

The four stored runs in the notes repo (2026-09-02 baselines, 2026-09-04 after-measurement), re-classified offline with the new rules. Columns: arrived / progressing / wedged / wedged_then_freed / no_route / expected_unreachable / idle_by_design.

| set | stored | re-classified |
|---|---|---|
| plain baseline (`--pass both`) | 14 / 215 / 170 / - / 19 / 324 / 240 | 14 / 215 / **41** / 21 / 32 / 419 / 240 |
| plain after | 15 / 194 / 187 / - / 26 / 309 / 251 | 15 / 194 / **39** / 27 / 36 / 420 / 251 |
| nav_bridges baseline (chase) | 15 / 43 / 125 / - / 0 / 308 / - | 15 / 43 / **29** / 2 / 1 / 401 / - |
| nav_bridges after (chase) | 14 / 28 / 163 / - / 1 / 285 / - | 14 / 28 / **38** / 1 / 9 / 401 / - |

What the corrected buckets say about the stack, both numbers side by side:

| set | unresolved wedges (`wedged`) | all halts (`wedged` + `wedged_then_freed`) |
|---|---|---|
| plain, baseline -> after | 41 -> **39** | 62 -> **66** |
| nav_bridges chase, baseline -> after | 29 -> **38** | 31 -> **39** |

Read neutrally: in the plain set the stack leaves **slightly fewer AIs unresolved** (41 -> 39) while producing **more halts overall** (62 -> 66) - consistent with the deliberate pauses the stack introduces, since a halt the AI later walks out of still counts in the second column. That is a mixed result, not the "170 -> 187 regression" the old buckets reported and not an unqualified improvement either. The nav_bridges chase set worsens on **both** counts (29 -> 38 and 31 -> 39) and remains a real regression worth chasing.

Per-mission, new classifier, baseline -> after (rows where every count is zero are omitted):

| mission/pass | wedged | wedged_then_freed | nav wedged | nav freed |
|---|---|---|---|---|
| command1.mis chase | 3 | 0 | 2 | 0 |
| command1.mis idle | 1 | 0 | - | - |
| command2.mis chase | 0 | 0 | 2 | 0 |
| command2.mis idle | 1→0 | 1→5 | - | - |
| eng1.mis chase | 0→1 | 0 | 0→1 | 0 |
| eng1.mis idle | 2 | 3→4 | - | - |
| eng2.mis chase | 0 | 0 | 0→1 | 0 |
| eng2.mis idle | 0 | 1 | - | - |
| hydro1.mis idle | 0 | 3 | - | - |
| hydro2.mis chase | 6 | 0 | 7→12 | 0 |
| hydro2.mis idle | 6→1 | 0→2 | - | - |
| hydro3.mis chase | 0 | 0 | 1 | 0 |
| hydro3.mis idle | 0 | 1 | - | - |
| many.mis idle | 3→4 | 1→0 | - | - |
| medsci1.mis idle | 1 | 0 | - | - |
| medsci2.mis chase | 0→1 | 0 | 2 | 0 |
| medsci2.mis idle | 2→1 | 2→0 | - | - |
| ops2.mis chase | 0 | 0 | 2 | 0 |
| ops3.mis chase | 0 | 2→0 | 0 | 1→0 |
| ops3.mis idle | 0→1 | 1→0 | - | - |
| ops4.mis chase | 3→5 | 0 | 5→6 | 0 |
| ops4.mis idle | 0 | 1→0 | - | - |
| rec1.mis chase | 3→2 | 0→1 | 4 | 1 |
| rec1.mis idle | 1→0 | 0→3 | - | - |
| rec2.mis idle | 1→2 | 0 | - | - |
| rec3.mis chase | 2→4 | 1→0 | 4→5 | 0 |
| rec3.mis idle | 1 | 1→2 | - | - |
| rick1.mis idle | 5→3 | 2→5 | - | - |
| shodan.mis idle | 0 | 1→0 | - | - |

## Validation

- `npm test` 60/60 (unit); `npm run build` clean.
- Negative-tested first: reverting each rule in turn fails exactly its own tests (precedence 2, freed-travel/escape 3, hold discount 2, halt-scoped outcome 1 - the last reproduced with a synthetic series whose halt runs under a `Full` route while a `Partial` sits on either side of it).
- Live sanity run against a prebuilt runtime: `--mission medsci2.mis --pass idle --idle-frames 900` -> 18 AIs, 8 progressing / 1 no_route / 9 idle_by_design, no wedges, harness end-to-end green.
- Both `/xreview` engines agreed on one High (travel-vs-escape), fixed with an oscillation test; also applied their Mediums (contiguous unheld window; drop the dead span field; `--reclassify` rejects `--mission/--all`, warns and skips an unparsable report, errors on an empty directory) and the de-dup pass's `reuse`/`extract` findings (`pathLength` shared with the traveled-distance sum, `PassResult` reused for the stored shape, `tally` reused for the totals).
