### PR TITLE
fix(pathfinding): never end a partial route in a cell the body cannot fit

### DIFF
--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -878,8 +878,9 @@ impl PathfindingService {
     /// goals with no full route (different island, off-mesh, behind missing
     /// nav data). Explores everything reachable from `start` and routes to
     /// the reachable cell nearest the goal - the counterpart of the original
-    /// engine's pathfind-near facility. Returns None when we're already in
-    /// the closest reachable cell (no progress possible).
+    /// engine's pathfind-near facility. Returns None when there is nowhere
+    /// better to stand: no reachable cell is closer to the goal, or the only
+    /// closer ones are too tight for the body.
     pub fn find_path_toward(
         &self,
         start: Vector3<f32>,
@@ -2997,5 +2998,24 @@ pub(crate) mod tests {
             None,
             "a partial route must not end in a cell the body cannot stand in"
         );
+    }
+
+    #[test]
+    fn a_small_creature_still_gets_a_partial_route_into_a_pinch() {
+        let mut db = pinch_and_detour_db();
+        db.links
+            .retain(|link| ![2, 3].contains(&link.from_cell) && ![2, 3].contains(&link.to_cell));
+        for link in &mut db.links {
+            link.ok_bits |= MovementBits::SMALL_CREATURE;
+        }
+        let service = service(db);
+        let path = service
+            .find_path_toward(
+                vec3(2.0, 0.0, 2.5),
+                vec3(12.0, 0.0, 1.0),
+                MovementBits::SMALL_CREATURE,
+            )
+            .expect("a spider fits in the pinch");
+        assert_eq!(*path.last().expect("waypoints"), vec3(5.0, 0.0, 1.0));
     }
 }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -2985,4 +2985,24 @@ pub(crate) mod tests {
         service.report_blocked_link(BYSTANDER, 0, 1, 0.0);
         assert_eq!(service.stats().blocked_links, 2);
     }
+
+    #[test]
+    fn no_partial_route_when_the_only_progress_is_into_a_pinch() {
+        let mut db = pinch_and_detour_db();
+        // Leave only the wide room (0) and the 0.2-wide pinch (1) reachable.
+        // The pinch is the one cell closer to the goal, and the body does not
+        // fit in it - so there is nowhere better to stand than right here.
+        db.links
+            .retain(|link| ![2, 3].contains(&link.from_cell) && ![2, 3].contains(&link.to_cell));
+        let service = service(db);
+        assert_eq!(
+            service.find_path_toward(
+                vec3(2.0, 0.0, 2.5),
+                vec3(12.0, 0.0, 1.0),
+                MovementBits::WALK,
+            ),
+            None,
+            "a partial route must not end in a cell the body cannot stand in"
+        );
+    }
 }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -911,8 +911,10 @@ impl PathfindingService {
         // center, and the cells nearest an unreachable goal are often the
         // pinch it is unreachable through - the wedge at the bottom of a
         // converging corner, where an AI parks itself against the geometry
-        // and grinds. Cells too tight to stand in are only considered when
-        // nothing roomier is reachable.
+        // and grinds. A cell the body cannot stand in is never a stopping
+        // place: when the only progress on offer is into one, we report no
+        // route (the caller's supported "nowhere better to go" answer)
+        // instead of walking the AI into the pinch it is stuck on.
         let roomy = |cell: u32| -> bool {
             movement_bits.contains(MovementBits::SMALL_CREATURE)
                 || self
@@ -927,15 +929,6 @@ impl PathfindingService {
             if d < best_distance && roomy(cell) {
                 best_distance = d;
                 best = cell;
-            }
-        }
-        if best == start_cell {
-            for &cell in reachable.keys() {
-                let d = distance_to_goal(cell);
-                if d < best_distance {
-                    best_distance = d;
-                    best = cell;
-                }
             }
         }
         if best == start_cell {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -518,10 +518,12 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     self.goal_unreachable_until = None;
                     // The worker computes a full route, or - when the goal
                     // is unreachable (another island, off-mesh) - a partial
-                    // route to the closest reachable point, so the AI
-                    // approaches instead of freezing against the nearest
-                    // wall. The result is adopted (above) on a later frame;
-                    // until then the current path keeps steering.
+                    // route to the closest reachable point the body fits in,
+                    // so the AI approaches instead of freezing against the
+                    // nearest wall. When even that has nowhere to offer it
+                    // answers Failed and the next strategy in the chain
+                    // steers. The result is adopted (above) on a later
+                    // frame; until then the current path keeps steering.
                     async_pathfinding.submit(PathQueryRequest {
                         entity: entity_id.inner(),
                         start: position,


### PR DESCRIPTION
`find_path_toward_avoiding` builds the partial route an AI walks when its goal has no full route — it stops in the reachable cell nearest the goal. #1245 taught it to skip cells the body cannot stand in, because the cells nearest an unreachable goal are usually the pinch it is unreachable *through*, and parking a body there is how an AI ends up grinding against a corner. But the clearance filter had an escape hatch: when no roomy cell was nearer than the one the AI is standing in, it re-searched with the filter off.

That escape hatch could only ever produce the thing the filter exists to avoid. It ran precisely when no roomy cell was closer, so the cell it then picked was, by construction, one the body does not fit in. Instrumented across the sweep below it fired 105 times and landed in a too-narrow cell **105 times out of 105**.

It is gone. When the only progress on offer is into a pinch, the query answers "no route" — `AiPathOutcome::Failed`, which the callers already handle (#1248's unreachable handling, and #1353 retries the temporary ones).

## Measurement

The keep-it argument was that it fails soft where `NavBoundary` over-inflates clearance (#1246, rec2 route inflation +29%): deleting it could freeze AIs in missions with bad boundary data. So all three candidates were measured behind a temporary switch before choosing:

- **A** — filtered results only; return `None` when nothing roomy is closer *(this PR)*
- **B** — fallback allowed, but only into cells with clearance ≥ 0.75 × body radius
- **C** — status quo

Reachability harness (#1242, `--pass both`), 2 runs per candidate per mission, both runs summed. rec2 is the mission with the bad boundary data; eng1 is where the fallback is busiest.

| mission | metric | A (this PR) | B (0.75×) | C (status quo) |
|---|---|---|---|---|
| eng1.mis | wedged | **15** | 19 | 16 |
| eng1.mis | no_route | 3 | 1 | 2 |
| eng1.mis | arrived | 6 | 6 | 6 |
| medsci2.mis | wedged | **6** | 7 | 7 |
| medsci2.mis | no_route | 1 | 0 | 0 |
| medsci2.mis | arrived | **5** | 4 | 4 |
| rec2.mis | wedged | 7 | 7 | 7 |
| rec2.mis | no_route | 0 | 0 | 0 |
| rec2.mis | arrived | 5 | 5 | 5 |
| **all three** | **wedged** | **28** | 33 | 30 |
| **all three** | **no_route** | 4 | 1 | 2 |
| **all three** | **arrived** | **16** | 15 | 15 |

Fallback firings, and how many landed in a cell narrower than the body:

| mission | A | B | C |
|---|---|---|---|
| medsci2.mis | 0 | 0 | 2 / 2 narrow |
| rec2.mis | 0 | 0 | 13 / 13 narrow |
| eng1.mis | 0 | 3 / 3 narrow | 90 / 90 narrow |

**A wins on the metric that matters** — fewest wedges (28 vs 30 and 33) and most arrivals — for two extra `no_route` verdicts, which is the trade the change is *for*: an AI that reports no route instead of walking into a pinch and grinding there.

**The fail-soft worry does not materialise.** rec2 is identical under all three candidates (wedged 7, no_route 0, arrived 5) even though the fallback fires 6–7 times per run there under C. Over-inflated clearance was not being rescued by the fallback; it was just relocating the wedge.

**B is not a middle ground.** Only 3 of C's 105 firings had clearance ≥ 0.75 × radius, so B is A almost everywhere — and where it does fire it is worse than both (eng1 wedged 19).

Ledger P0 (`~/notes/projects/shock2quest/pathfinding-eval-plan.md`).

## Tests

- Unit: `no_partial_route_when_the_only_progress_is_into_a_pinch` — negative-first, and it fails on `main` exactly as predicted: the old code returns a route ending at the pinch cell centre `(5, 0, 1)`.
- `cargo test -p shock2vr`: 1386 passed.
- e2e `medsci2-doorjamb-chase` 2/2 (the jamb is the pinch case this touches). No load-time data changes, so the missions sweep was not re-run.
- `cargo bn path bench medsci2.mis --seed 424242` unchanged: 200/0 found, inflation 1.67, turn 944°, 45.8 waypoints — the bench's `toward` queries all reach a roomy stopping cell, so the deleted branch never ran in it.
- `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Review

`/xreview`, both engines (Claude adversarial reviewer + Codex) plus the de-dup pass. Codex: no findings at any severity. The Claude reviewer reproduced the negative test on the test-only commit and instrumented `cargo bn` to measure the blast radius — over 200 cross-component queries per mission on all 23 missions, `find_path_toward` answering `None` goes from 16/4600 (0.35%) to 48/4600 (1.04%); worst movers ops1 0→7 and rick2 2→6. Findings fixed:

- **Medium** — `find_path_toward`'s doc comment still claimed `None` meant "already in the closest reachable cell". It now also means "the only closer cells are too tight", which is the contract a caller reads.
- **Medium** — the re-path comment in `path_follow_steering_strategy` promised a partial route "so the AI approaches instead of freezing", with no mention that the query can now answer `Failed` and hand the frame to the next strategy in the chain.
- **Low** — the `SMALL_CREATURE` bypass in `roomy` had no coverage on the partial-route path (only on `find_path`). A spider still gets its route into the pinch, now asserted.

Noted, not changed: on `Failed` a chasing AI falls through to `ChasePlayerSteeringStrategy`, i.e. a direct beeline, so the reviewer asked whether this relabels the grind rather than removing it. The harness answers it — wedges fall (28 vs 30), they do not move into another bucket. Checked and clean: no consumer freezes permanently on `Failed` (patrol has a 5 s stall watchdog, search a give-up timer, wander a re-path backoff), and an AI *already* standing in a pinch is unaffected, since the deleted branch also required a strictly closer cell. De-dup: **no actionable duplication** — the change adds one test that reuses the existing fixture. It flagged one pre-existing overlap for the record: `find_closest_reachable_cell` is a second, clearance-blind copy of the same nearest-reachable scan (used only by `pathfinding_test`); this PR removes a third copy rather than adding one.

Coverage: S1-names, S2-clones, S3-index and S4-read all ran; none unavailable (12-line names report / 649-line clone report, 0 pairs in `pathfinding/` / 4296-line index).
