### PR TITLE
fix(ai): a stalled crossing is excluded for the AI that stalled, not the level

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -1111,7 +1111,9 @@ pub struct DebugPathfindingStats {
     pub stressed_retries: u64,
     pub no_route: u64,
     /// Cell crossings currently excluded because an AI's steering stalled
-    /// on them (see `PathfindingService::report_blocked_link`)
+    /// on them, summed over every AI holding one - each exclusion applies
+    /// only to the AI that reported it (see
+    /// `PathfindingService::report_blocked_link`)
     pub blocked_links: usize,
     /// Cells currently penalized because an AI stalled inside them
     pub blocked_cells: usize,

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -29,7 +29,7 @@ pub struct PathQueryRequest {
     pub start: Vector3<f32>,
     pub goal: Vector3<f32>,
     pub movement_bits: MovementBits,
-    /// Mission time (seconds) at submit, for expiring the entity's
+    /// Mission time (seconds) at submit, for expiring the entity's own
     /// steering-reported blocked crossings (see
     /// `PathfindingService::report_blocked_link`)
     pub now_seconds: f32,
@@ -80,12 +80,13 @@ impl AsyncPathfinding {
             .spawn(move || {
                 while let Ok(request) = rx.recv() {
                     let mut outcome = AiPathOutcome::Full;
-                    // Crossings ANY AI's steering reported as physically
-                    // blocked (stall mid-route) are excluded, and cells an
-                    // AI is stalled in are made expensive, so re-paths -
-                    // including fresh arrivals' - route around the obstacle
-                    // instead of piling into it
-                    let avoid = service.avoidance(request.now_seconds);
+                    // Crossings THIS AI's steering reported as physically
+                    // blocked (stall mid-route) are excluded from its own
+                    // search, and cells any AI is stalled in are made
+                    // expensive, so the re-path routes around the obstacle
+                    // instead of grinding on it - without cutting the
+                    // crossing out from under every other AI
+                    let avoid = service.avoidance(request.entity, request.now_seconds);
                     let path = service
                         .find_path_avoiding(
                             request.start,
@@ -115,6 +116,7 @@ impl AsyncPathfinding {
                     let exclusion_expires_at = (outcome != AiPathOutcome::Full)
                         .then(|| {
                             service.exclusion_expiry_for_unreached_goal(
+                                request.entity,
                                 request.start,
                                 request.goal,
                                 request.movement_bits,
@@ -261,16 +263,16 @@ mod tests {
 
     #[test]
     fn worker_applies_blocked_links() {
-        // Cell 0 -> goal in cell 2, but an AI reported the 1 -> 2 crossing
-        // blocked: the worker must return a PARTIAL route ending at cell 1
-        // instead of the full route through the obstacle - for EVERY AI,
-        // not just the reporter.
+        // Cell 0 -> goal in cell 2, but entity 11 reported the 1 -> 2
+        // crossing blocked: ITS query must come back with a PARTIAL route
+        // ending at cell 1 instead of the full route through the obstacle
+        // it could not walk - and every other AI's must be untouched.
         let service = Arc::new(PathfindingService::new(Arc::new(
             crate::pathfinding::tests::three_cell_db(
                 dark::mission::path_database::PathCellFlags::empty(),
             ),
         )));
-        service.report_blocked_link(1, 2, 0.0);
+        service.report_blocked_link(11, 1, 2, 0.0);
         let async_pf = AsyncPathfinding::spawn(service.clone());
         assert!(async_pf.submit(PathQueryRequest {
             entity: 11,
@@ -287,7 +289,14 @@ mod tests {
             "partial route must end at cell 1's center, before the blockage"
         );
 
-        // The exclusion is shared: another entity's query avoids it too
+        assert_eq!(
+            response.exclusion_expires_at,
+            Some(super::super::BLOCKED_LINK_TTL_SECONDS),
+            "the shortfall is the reporter's own exclusion, so it can wait it out"
+        );
+
+        // The exclusion belongs to the AI that stalled: another entity's
+        // query still crosses, and has nothing to wait for.
         assert!(async_pf.submit(PathQueryRequest {
             entity: 12,
             start: cgmath::vec3(1.0, 0.0, 1.0),
@@ -296,7 +305,12 @@ mod tests {
             now_seconds: 1.0,
         }));
         let response = wait_for_result(&async_pf, 12).expect("worker must respond");
-        assert_eq!(response.outcome, AiPathOutcome::Partial);
+        assert_eq!(
+            response.outcome,
+            AiPathOutcome::Full,
+            "one AI's stall must not cut the crossing out from under another"
+        );
+        assert_eq!(response.exclusion_expires_at, None);
     }
 
     #[test]
@@ -307,9 +321,13 @@ mod tests {
         let service = Arc::new(PathfindingService::new(Arc::new(
             crate::pathfinding::tests::island_db(),
         )));
-        service.report_blocked_link(1, 2, 0.0);
-        service.report_blocked_link(0, 1, 2.0);
-        service.report_blocked_link(3, 2, 5.0);
+        // Exclusions are per-AI, so both queriers must carry the same set
+        // for the two shortfalls to be comparable
+        for entity in [31, 32] {
+            service.report_blocked_link(entity, 1, 2, 0.0);
+            service.report_blocked_link(entity, 0, 1, 2.0);
+            service.report_blocked_link(entity, 3, 2, 5.0);
+        }
         let async_pf = AsyncPathfinding::spawn(service.clone());
 
         assert!(async_pf.submit(PathQueryRequest {

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -73,17 +73,14 @@ const BLOCKING_CELL_COST_PENALTY: u32 = 4;
 /// route; short enough that a transient blocker (a shoved crate) is
 /// retried within a minute.
 const BLOCKED_LINK_TTL_SECONDS: f32 = 30.0;
-/// Cap on the crossings ONE AI can have excluded at a time (its oldest
-/// report is forgotten to make room) - bounds memory; entries also expire
-/// on their TTL, and go with the AI when it despawns.
-const MAX_BLOCKED_LINKS_PER_AI: usize = 8;
 
 /// How long a cell an AI stalled in stays expensive to enter. Shorter than
 /// the crossing TTL: a whole cell is a much blunter instrument, and the
 /// common cause (an AI wedged in it right now) clears as soon as that AI
 /// frees itself.
 const STALLED_CELL_TTL_SECONDS: f32 = 10.0;
-/// Cap on remembered stalled cells (see `MAX_BLOCKED_LINKS_PER_AI`)
+/// Cap on remembered stalled cells (new reports dropped while full of
+/// live entries) - bounds memory; entries expire on their TTL
 const MAX_BLOCKED_CELLS: usize = 64;
 /// Extra cost (Dark feet, the unit link costs and the heuristic use) for
 /// ENTERING a cell an AI recently stalled in. Deliberately a penalty and
@@ -158,8 +155,9 @@ pub struct PathfindingStats {
     pub stressed_retries: u64,
     /// Queries that found no route at all (the most expensive outcome)
     pub no_route: u64,
-    /// Crossings currently excluded by steering reports, summed over every
-    /// AI holding one (see `report_blocked_link`). Pruned as queries run,
+    /// Crossings currently excluded by steering reports, counted once per
+    /// AI holding one - two AIs excluding the same crossing are two
+    /// entries (see `report_blocked_link`). Pruned as their owners query,
     /// so this is the count as of the last query rather than as of this
     /// instant.
     pub blocked_links: usize,
@@ -273,18 +271,20 @@ pub struct PathfindingService {
     /// Cell crossings an AI's steering failed to traverse (a stall fired
     /// mid-route): obstacles the mesh doesn't model, e.g. a physical prop
     /// or a scripted stationary NPC sitting on a walkable link. Entries map
-    /// `(reporting AI, (from_cell, to_cell)) -> expiry in mission seconds`.
+    /// `reporting AI -> (from_cell, to_cell) -> expiry in mission seconds`.
     /// Scoped to the AI THAT STALLED, because this is a hard cut in A* and
     /// nothing else the steering reports is: level-wide, one wedged
     /// creature removed a crossing for every other AI, the set only grew
     /// over a pass (the TTL is as long as an engagement), and where
     /// crossings are few - a narrow bridge between nav islands - that left
     /// the rest of the level with no route at all. What warns the OTHERS
-    /// off is the shared cell penalty (`blocked_cells`), a cost that can
-    /// never make a goal unreachable. Directed-link granularity (not whole
-    /// cells) so one blocked doorway can't seal every other entrance into
-    /// a large cell.
-    blocked_links: std::sync::Mutex<HashMap<(u64, (u32, u32)), f32>>,
+    /// off is the shared cell penalty (`blocked_cells`), refreshed for as
+    /// long as the blocked AI keeps stalling there: a cost that can never
+    /// make a goal unreachable. Directed-link granularity (not whole cells)
+    /// so one blocked doorway can't seal every other entrance into a large
+    /// cell. An AI's entries expire on their TTL and go with it when it
+    /// despawns, so nothing accumulates across a mission.
+    blocked_links: std::sync::Mutex<HashMap<u64, HashMap<(u32, u32), f32>>>,
     /// Cells an AI's steering stalled in, mapped to their expiry in mission
     /// seconds. Two jobs, one input: a stall that happens INSIDE a single
     /// cell has no crossing to blacklist (the AI never reached the edge),
@@ -397,10 +397,9 @@ impl PathfindingService {
         self.bridge_links.len()
     }
 
-    /// Drop AI path and steering records whose entity no longer satisfies
-    /// `keep` (it despawned, or died - a corpse keeps its entity), so
-    /// introspection doesn't report ghosts. Blocked crossings are world
-    /// facts, not per-entity records - they expire on their own TTL.
+    /// Drop the records of AIs whose entity no longer satisfies `keep` (it
+    /// despawned, or died - a corpse keeps its entity), so introspection
+    /// doesn't report ghosts and a dead AI's exclusions don't outlive it.
     pub fn prune_ai_paths(&self, keep: impl Fn(u64) -> bool) {
         if let Ok(mut paths) = self.ai_paths.lock() {
             paths.retain(|&entity, _| keep(entity));
@@ -414,7 +413,7 @@ impl PathfindingService {
         // An AI's exclusions are its own memory of a route it could not
         // walk - they die with it rather than outliving it as a world fact.
         if let Ok(mut blocked) = self.blocked_links.lock() {
-            blocked.retain(|&(entity, _), _| keep(entity));
+            blocked.retain(|&entity, _| keep(entity));
         }
     }
 
@@ -429,37 +428,35 @@ impl PathfindingService {
         let Ok(mut blocked) = self.blocked_links.lock() else {
             return;
         };
-        blocked.retain(|_, &mut expiry| expiry > now_seconds);
-        let key = (entity, (from_cell, to_cell));
-        if !blocked.contains_key(&key) {
-            let live = blocked.keys().filter(|(who, _)| *who == entity).count();
-            if live >= MAX_BLOCKED_LINKS_PER_AI {
-                // Full: forget this AI's oldest report rather than refuse
-                // the new one - the crossing it just stalled on is the one
-                // its next query has to avoid.
-                let oldest = blocked
-                    .iter()
-                    .filter(|((who, _), _)| *who == entity)
-                    .min_by(|a, b| a.1.total_cmp(b.1))
-                    .map(|(key, _)| *key);
-                if let Some(oldest) = oldest {
-                    blocked.remove(&oldest);
-                }
-            }
-        }
-        blocked.insert(key, now_seconds + BLOCKED_LINK_TTL_SECONDS);
+        let mine = blocked.entry(entity).or_default();
+        mine.retain(|_, &mut expiry| expiry > now_seconds);
+        mine.insert((from_cell, to_cell), now_seconds + BLOCKED_LINK_TTL_SECONDS);
+    }
+
+    /// `entity`'s own unexpired exclusions, as `(crossing, expiry)`. Its
+    /// expired entries are dropped (another AI's are dropped when it next
+    /// reports or queries).
+    fn live_links_for(&self, entity: u64, now_seconds: f32) -> Vec<((u32, u32), f32)> {
+        let Ok(mut blocked) = self.blocked_links.lock() else {
+            return Vec::new();
+        };
+        let Some(mine) = blocked.get_mut(&entity) else {
+            return Vec::new();
+        };
+        mine.retain(|_, &mut expiry| expiry > now_seconds);
+        mine.iter().map(|(link, expiry)| (*link, *expiry)).collect()
     }
 
     /// The `(from_cell, to_cell)` crossings currently excluded from
     /// `entity`'s path queries (its own unexpired steering reports).
-    /// Expired entries are dropped, for every AI.
     pub fn blocked_links(
         &self,
         entity: u64,
         now_seconds: f32,
     ) -> std::collections::HashSet<(u32, u32)> {
-        self.blocked_link_expiries(entity, now_seconds)
-            .into_keys()
+        self.live_links_for(entity, now_seconds)
+            .into_iter()
+            .map(|(link, _)| link)
             .collect()
     }
 
@@ -540,7 +537,10 @@ impl PathfindingService {
         // found it); wait for the last of those, not for the whole level's
         // blacklist. A crossing another thread has since pruned already lapsed,
         // so it contributes `now`.
-        let expiries = self.blocked_link_expiries(entity, now_seconds);
+        let expiries: HashMap<(u32, u32), f32> = self
+            .live_links_for(entity, now_seconds)
+            .into_iter()
+            .collect();
         cell_path
             .windows(2)
             .filter(|pair| avoid.links.contains(&(pair[0], pair[1])))
@@ -551,21 +551,6 @@ impl PathfindingService {
                     .unwrap_or(now_seconds)
             })
             .reduce(f32::max)
-    }
-
-    /// `entity`'s own live (unexpired) blocked crossings and the mission
-    /// time each lapses at. Another AI's exclusions have no bearing on this
-    /// AI's queries. Expired entries are dropped, for every AI.
-    fn blocked_link_expiries(&self, entity: u64, now_seconds: f32) -> HashMap<(u32, u32), f32> {
-        let Ok(mut blocked) = self.blocked_links.lock() else {
-            return HashMap::new();
-        };
-        blocked.retain(|_, &mut expiry| expiry > now_seconds);
-        blocked
-            .iter()
-            .filter(|((who, _), _)| *who == entity)
-            .map(|((_, link), expiry)| (*link, *expiry))
-            .collect()
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -674,7 +659,11 @@ impl PathfindingService {
             queries: self.queries.load(Ordering::Relaxed),
             stressed_retries: self.stressed_retries.load(Ordering::Relaxed),
             no_route: self.no_route.load(Ordering::Relaxed),
-            blocked_links: self.blocked_links.lock().map(|b| b.len()).unwrap_or(0),
+            blocked_links: self
+                .blocked_links
+                .lock()
+                .map(|b| b.values().map(HashMap::len).sum())
+                .unwrap_or(0),
             blocked_cells: self.blocked_cells.lock().map(|b| b.len()).unwrap_or(0),
         }
     }
@@ -2403,10 +2392,15 @@ pub(crate) mod tests {
 
         // Entity 7 died (or despawned): its records go with it, exclusions
         // included - they were its memory of a route it could not walk
+        service.report_blocked_link(BYSTANDER, 1, 2, 0.0);
         service.prune_ai_paths(|entity| entity != 7);
         assert!(service.ai_paths().is_empty());
         assert!(service.ai_steering(7).is_none());
         assert!(service.blocked_links(7, 0.0).is_empty());
+        assert!(
+            service.blocked_links(BYSTANDER, 0.0).contains(&(1, 2)),
+            "a surviving AI keeps its own exclusions"
+        );
     }
 
     #[test]
@@ -2683,29 +2677,26 @@ pub(crate) mod tests {
         );
     }
 
-    /// One AI cannot hoard the blacklist: its oldest report makes way for
-    /// the crossing it just stalled on, and other AIs are unaffected.
+    /// An AI's own set is bounded by the TTL alone: what it reported more
+    /// than a TTL ago is gone the next time it asks, and its live reports
+    /// (and every other AI's) are untouched.
     #[test]
-    fn an_ais_exclusions_are_capped_at_its_own_oldest() {
+    fn an_ais_exclusions_outlive_only_their_ttl() {
         let service = service(three_cell_db(PathCellFlags::empty()));
-        for i in 0..MAX_BLOCKED_LINKS_PER_AI as u32 {
-            service.report_blocked_link(STALLER, i, i + 1, i as f32);
-        }
-        service.report_blocked_link(BYSTANDER, 99, 100, 0.0);
-        let overflow = MAX_BLOCKED_LINKS_PER_AI as u32;
-        service.report_blocked_link(STALLER, overflow, overflow + 1, overflow as f32);
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        service.report_blocked_link(BYSTANDER, 0, 1, 0.0);
+        let later = BLOCKED_LINK_TTL_SECONDS + 1.0;
+        service.report_blocked_link(STALLER, 1, 2, later);
 
-        let live = service.blocked_links(STALLER, 0.0);
-        assert_eq!(live.len(), MAX_BLOCKED_LINKS_PER_AI);
-        assert!(
-            live.contains(&(overflow, overflow + 1)),
-            "the newest report is the one that matters: {live:?}"
+        assert_eq!(
+            service.blocked_links(STALLER, later),
+            std::collections::HashSet::from([(1, 2)]),
+            "the lapsed report is dropped, the fresh one kept"
         );
-        assert!(!live.contains(&(0, 1)), "the oldest made way: {live:?}");
         assert_eq!(
             service.blocked_links(BYSTANDER, 0.0),
-            std::collections::HashSet::from([(99, 100)]),
-            "one AI filling up must not evict another's"
+            std::collections::HashSet::from([(0, 1)]),
+            "one AI's pruning must not touch another's"
         );
     }
 

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -67,22 +67,23 @@ const BRIDGE_BUCKET: f32 = 12.0 / SCALE_FACTOR;
 /// prefer clear floor, but allow squeezing past baked furniture
 const BLOCKING_CELL_COST_PENALTY: u32 = 4;
 
-/// How long a steering-reported blocked crossing stays excluded from an
-/// AI's path queries. Long enough that the re-path (and several after it)
-/// route around the obstacle instead of reproducing the blocked route;
-/// short enough that a transient blocker (a shoved crate) is retried
-/// within a minute.
+/// How long a steering-reported blocked crossing stays excluded from the
+/// reporting AI's path queries. Long enough that the re-path (and several
+/// after it) route around the obstacle instead of reproducing the blocked
+/// route; short enough that a transient blocker (a shoved crate) is
+/// retried within a minute.
 const BLOCKED_LINK_TTL_SECONDS: f32 = 30.0;
-/// Cap on remembered blocked crossings (new reports dropped while full of
-/// live entries) - bounds memory; entries expire on their TTL.
-const MAX_BLOCKED_LINKS: usize = 64;
+/// Cap on the crossings ONE AI can have excluded at a time (its oldest
+/// report is forgotten to make room) - bounds memory; entries also expire
+/// on their TTL, and go with the AI when it despawns.
+const MAX_BLOCKED_LINKS_PER_AI: usize = 8;
 
 /// How long a cell an AI stalled in stays expensive to enter. Shorter than
 /// the crossing TTL: a whole cell is a much blunter instrument, and the
 /// common cause (an AI wedged in it right now) clears as soon as that AI
 /// frees itself.
 const STALLED_CELL_TTL_SECONDS: f32 = 10.0;
-/// Cap on remembered stalled cells (see `MAX_BLOCKED_LINKS`)
+/// Cap on remembered stalled cells (see `MAX_BLOCKED_LINKS_PER_AI`)
 const MAX_BLOCKED_CELLS: usize = 64;
 /// Extra cost (Dark feet, the unit link costs and the heuristic use) for
 /// ENTERING a cell an AI recently stalled in. Deliberately a penalty and
@@ -141,7 +142,7 @@ impl Default for PathfindingFrameBudget {
 /// `STALLED_CELL_COST_PENALTY`).
 #[derive(Debug, Clone, Default)]
 pub struct NavAvoidance {
-    /// Directed cell crossings some AI failed to traverse
+    /// Directed cell crossings the QUERYING AI failed to traverse
     pub links: std::collections::HashSet<(u32, u32)>,
     /// Cells some AI is (or recently was) stalled in
     pub cells: std::collections::HashSet<u32>,
@@ -157,9 +158,10 @@ pub struct PathfindingStats {
     pub stressed_retries: u64,
     /// Queries that found no route at all (the most expensive outcome)
     pub no_route: u64,
-    /// Crossings currently excluded by steering reports (see
-    /// `report_blocked_link`). Pruned as queries run, so this is the count
-    /// as of the last query rather than as of this instant.
+    /// Crossings currently excluded by steering reports, summed over every
+    /// AI holding one (see `report_blocked_link`). Pruned as queries run,
+    /// so this is the count as of the last query rather than as of this
+    /// instant.
     pub blocked_links: usize,
     /// Cells currently penalized by steering reports (see
     /// `report_blocked_cell`), pruned the same way.
@@ -268,19 +270,21 @@ pub struct PathfindingService {
     /// Whether each AI is deliberately holding position, published by its
     /// script each frame before it steers (see `MovementHold`)
     movement_holds: std::sync::Mutex<HashMap<u64, MovementHold>>,
-    /// Cell crossings some AI's steering failed to traverse (a stall fired
+    /// Cell crossings an AI's steering failed to traverse (a stall fired
     /// mid-route): obstacles the mesh doesn't model, e.g. a physical prop
     /// or a scripted stationary NPC sitting on a walkable link. Entries map
-    /// `(from_cell, to_cell) -> expiry in mission seconds`. SHARED across
-    /// AIs: the blockage is a physical fact about the world, and per-AI
-    /// memory let a capture pocket re-trap every fresh arrival while each
-    /// separately re-learned it (measured at medsci1's FemaleMedsci
-    /// pocket). All AI path queries skip unexpired crossings, so after the
-    /// first capture the re-paths - everyone's - route around the obstacle
-    /// (issue #481's grind loop). Directed-link granularity (not whole
+    /// `(reporting AI, (from_cell, to_cell)) -> expiry in mission seconds`.
+    /// Scoped to the AI THAT STALLED, because this is a hard cut in A* and
+    /// nothing else the steering reports is: level-wide, one wedged
+    /// creature removed a crossing for every other AI, the set only grew
+    /// over a pass (the TTL is as long as an engagement), and where
+    /// crossings are few - a narrow bridge between nav islands - that left
+    /// the rest of the level with no route at all. What warns the OTHERS
+    /// off is the shared cell penalty (`blocked_cells`), a cost that can
+    /// never make a goal unreachable. Directed-link granularity (not whole
     /// cells) so one blocked doorway can't seal every other entrance into
     /// a large cell.
-    blocked_links: std::sync::Mutex<HashMap<(u32, u32), f32>>,
+    blocked_links: std::sync::Mutex<HashMap<(u64, (u32, u32)), f32>>,
     /// Cells an AI's steering stalled in, mapped to their expiry in mission
     /// seconds. Two jobs, one input: a stall that happens INSIDE a single
     /// cell has no crossing to blacklist (the AI never reached the edge),
@@ -407,29 +411,54 @@ impl PathfindingService {
         if let Ok(mut holds) = self.movement_holds.lock() {
             holds.retain(|&entity, _| keep(entity));
         }
+        // An AI's exclusions are its own memory of a route it could not
+        // walk - they die with it rather than outliving it as a world fact.
+        if let Ok(mut blocked) = self.blocked_links.lock() {
+            blocked.retain(|&(entity, _), _| keep(entity));
+        }
     }
 
-    /// Remember that an AI could not physically traverse the crossing
-    /// `from_cell -> to_cell` (its steering stalled mid-route): the
-    /// crossing is excluded from ALL AI path queries until the entry
-    /// expires, so re-paths route around the obstacle - including for
-    /// fresh arrivals that haven't hit it yet.
-    pub fn report_blocked_link(&self, from_cell: u32, to_cell: u32, now_seconds: f32) {
+    /// Remember that `entity`'s steering could not physically traverse the
+    /// crossing `from_cell -> to_cell` (it stalled mid-route): the crossing
+    /// is excluded from THAT AI's path queries until the entry expires, so
+    /// its re-path routes around the obstacle instead of reproducing the
+    /// route it could not walk (issue #481's grind loop). Other AIs keep
+    /// the crossing and are steered off it by the cell penalty instead -
+    /// see the `blocked_links` field.
+    pub fn report_blocked_link(&self, entity: u64, from_cell: u32, to_cell: u32, now_seconds: f32) {
         let Ok(mut blocked) = self.blocked_links.lock() else {
             return;
         };
         blocked.retain(|_, &mut expiry| expiry > now_seconds);
-        if blocked.len() >= MAX_BLOCKED_LINKS && !blocked.contains_key(&(from_cell, to_cell)) {
-            return; // full of live entries - drop rather than grow unbounded
+        let key = (entity, (from_cell, to_cell));
+        if !blocked.contains_key(&key) {
+            let live = blocked.keys().filter(|(who, _)| *who == entity).count();
+            if live >= MAX_BLOCKED_LINKS_PER_AI {
+                // Full: forget this AI's oldest report rather than refuse
+                // the new one - the crossing it just stalled on is the one
+                // its next query has to avoid.
+                let oldest = blocked
+                    .iter()
+                    .filter(|((who, _), _)| *who == entity)
+                    .min_by(|a, b| a.1.total_cmp(b.1))
+                    .map(|(key, _)| *key);
+                if let Some(oldest) = oldest {
+                    blocked.remove(&oldest);
+                }
+            }
         }
-        blocked.insert((from_cell, to_cell), now_seconds + BLOCKED_LINK_TTL_SECONDS);
+        blocked.insert(key, now_seconds + BLOCKED_LINK_TTL_SECONDS);
     }
 
-    /// The `(from_cell, to_cell)` crossings currently excluded from AI path
-    /// queries (unexpired steering-reported blockages). Expired entries are
-    /// dropped.
-    pub fn blocked_links(&self, now_seconds: f32) -> std::collections::HashSet<(u32, u32)> {
-        self.blocked_link_expiries(now_seconds)
+    /// The `(from_cell, to_cell)` crossings currently excluded from
+    /// `entity`'s path queries (its own unexpired steering reports).
+    /// Expired entries are dropped, for every AI.
+    pub fn blocked_links(
+        &self,
+        entity: u64,
+        now_seconds: f32,
+    ) -> std::collections::HashSet<(u32, u32)> {
+        self.blocked_link_expiries(entity, now_seconds)
             .into_keys()
             .collect()
     }
@@ -465,10 +494,12 @@ impl PathfindingService {
     }
 
     /// Everything steering has reported as physically impassable or
-    /// expensive right now, for one path query.
-    pub fn avoidance(&self, now_seconds: f32) -> NavAvoidance {
+    /// expensive right now, for one path query by `entity`. The impassable
+    /// crossings are `entity`'s own reports; the expensive cells are every
+    /// AI's (occupancy is shared - see `report_blocked_cell`).
+    pub fn avoidance(&self, entity: u64, now_seconds: f32) -> NavAvoidance {
         NavAvoidance {
-            links: self.blocked_links(now_seconds),
+            links: self.blocked_links(entity, now_seconds),
             cells: self.blocked_cells(now_seconds),
         }
     }
@@ -488,6 +519,7 @@ impl PathfindingService {
     /// goal came back unreachable.
     pub fn exclusion_expiry_for_unreached_goal(
         &self,
+        entity: u64,
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
@@ -508,7 +540,7 @@ impl PathfindingService {
         // found it); wait for the last of those, not for the whole level's
         // blacklist. A crossing another thread has since pruned already lapsed,
         // so it contributes `now`.
-        let expiries = self.blocked_link_expiries(now_seconds);
+        let expiries = self.blocked_link_expiries(entity, now_seconds);
         cell_path
             .windows(2)
             .filter(|pair| avoid.links.contains(&(pair[0], pair[1])))
@@ -521,14 +553,19 @@ impl PathfindingService {
             .reduce(f32::max)
     }
 
-    /// Live (unexpired) blocked crossings and the mission time each lapses
-    /// at. Expired entries are dropped.
-    fn blocked_link_expiries(&self, now_seconds: f32) -> HashMap<(u32, u32), f32> {
+    /// `entity`'s own live (unexpired) blocked crossings and the mission
+    /// time each lapses at. Another AI's exclusions have no bearing on this
+    /// AI's queries. Expired entries are dropped, for every AI.
+    fn blocked_link_expiries(&self, entity: u64, now_seconds: f32) -> HashMap<(u32, u32), f32> {
         let Ok(mut blocked) = self.blocked_links.lock() else {
             return HashMap::new();
         };
         blocked.retain(|_, &mut expiry| expiry > now_seconds);
-        blocked.clone()
+        blocked
+            .iter()
+            .filter(|((who, _), _)| *who == entity)
+            .map(|((_, link), expiry)| (*link, *expiry))
+            .collect()
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -1845,6 +1882,11 @@ pub(crate) mod tests {
         waypoints.iter().any(|w| w.z > 1.9)
     }
 
+    /// The AI whose steering reports a stall in these tests
+    const STALLER: u64 = 11;
+    /// Any other AI querying the same mesh
+    const BYSTANDER: u64 = 22;
+
     fn service(db: PathDatabase) -> PathfindingService {
         PathfindingService::new(Arc::new(db))
     }
@@ -2259,12 +2301,11 @@ pub(crate) mod tests {
         assert!(service.find_path(start, goal, MovementBits::WALK).is_some());
 
         // A stall reported against the 0 -> 1 crossing severs the only
-        // route: the full search fails and the partial fallback reports no
-        // progress possible (the AI parks instead of grinding into the
-        // obstacle - issue #481). The exclusion is SHARED - the blockage is
-        // a physical fact, and it must protect fresh arrivals too.
-        service.report_blocked_link(0, 1, 0.0);
-        let avoid = service.avoidance(1.0);
+        // route FOR THE AI THAT STALLED: the full search fails and the
+        // partial fallback reports no progress possible (it parks instead
+        // of grinding into the obstacle - issue #481).
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        let avoid = service.avoidance(STALLER, 1.0);
         assert!(avoid.links.contains(&(0, 1)));
         assert!(
             service
@@ -2286,16 +2327,44 @@ pub(crate) mod tests {
         );
     }
 
+    /// One AI's stall must not disconnect the level for everybody else. The
+    /// exclusion is a hard cut in A*, so shared it fed back on itself: the
+    /// blacklist only grew over an engagement, and where a crossing is the
+    /// only way through, every other AI lost the route as well.
+    #[test]
+    fn a_stalled_ais_exclusion_leaves_every_other_ais_route_intact() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        let start = vec3(1.0, 0.0, 1.0);
+        let goal = vec3(5.0, 0.0, 1.0);
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
+
+        let bystander = service.avoidance(BYSTANDER, 1.0);
+        assert!(
+            bystander.links.is_empty(),
+            "another AI's stall is not this AI's exclusion: {bystander:?}"
+        );
+        assert!(
+            service
+                .find_path_avoiding(start, goal, MovementBits::WALK, &bystander)
+                .is_some(),
+            "the crossing must still be routable for an AI that never stalled"
+        );
+        // ...but the cell the staller is wedged in IS shared, as a cost -
+        // that is what warns the bystander off without cutting it off.
+        service.report_blocked_cell(0, 0.0);
+        assert!(service.avoidance(BYSTANDER, 1.0).cells.contains(&0));
+    }
+
     #[test]
     fn blocked_links_expire_after_their_ttl() {
         let service = service(three_cell_db(PathCellFlags::empty()));
-        service.report_blocked_link(0, 1, 100.0);
+        service.report_blocked_link(STALLER, 0, 1, 100.0);
         assert!(
             service
-                .blocked_links(100.0 + BLOCKED_LINK_TTL_SECONDS - 1.0)
+                .blocked_links(STALLER, 100.0 + BLOCKED_LINK_TTL_SECONDS - 1.0)
                 .contains(&(0, 1))
         );
-        let expired = service.avoidance(100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
+        let expired = service.avoidance(STALLER, 100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
         assert!(expired.links.is_empty(), "entries must expire: {expired:?}");
         // The route is usable again once the entry expired
         assert!(
@@ -2330,14 +2399,14 @@ pub(crate) mod tests {
                 stall_seconds: 0.0,
             },
         );
-        service.report_blocked_link(0, 1, 0.0);
+        service.report_blocked_link(7, 0, 1, 0.0);
 
-        // Entity 7 died (or despawned): its per-AI records go with it, but
-        // reported blockages are world facts and stay until their TTL
+        // Entity 7 died (or despawned): its records go with it, exclusions
+        // included - they were its memory of a route it could not walk
         service.prune_ai_paths(|entity| entity != 7);
         assert!(service.ai_paths().is_empty());
         assert!(service.ai_steering(7).is_none());
-        assert!(service.blocked_links(0.0).contains(&(0, 1)));
+        assert!(service.blocked_links(7, 0.0).is_empty());
     }
 
     #[test]
@@ -2394,7 +2463,7 @@ pub(crate) mod tests {
         // An AI wedged INSIDE cell 1 has no crossing to blacklist - the
         // cell itself is the report.
         service.report_blocked_cell(1, 0.0);
-        let avoid = service.avoidance(1.0);
+        let avoid = service.avoidance(STALLER, 1.0);
         assert!(avoid.cells.contains(&1));
         let rerouted = service
             .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
@@ -2458,7 +2527,7 @@ pub(crate) mod tests {
             .retain(|link| link.from_cell != 3 && link.to_cell != 3);
         let service = service(db);
         service.report_blocked_cell(1, 0.0);
-        let avoid = service.avoidance(1.0);
+        let avoid = service.avoidance(STALLER, 1.0);
         assert!(
             service
                 .find_path_avoiding(
@@ -2482,7 +2551,7 @@ pub(crate) mod tests {
                 .contains(&1),
             "the entry must outlive its jitter floor"
         );
-        let expired = service.avoidance(100.0 + STALLED_CELL_TTL_SECONDS * 1.3);
+        let expired = service.avoidance(STALLER, 100.0 + STALLED_CELL_TTL_SECONDS * 1.3);
         assert!(expired.cells.is_empty(), "entries must expire: {expired:?}");
         let restored = service
             .find_path_avoiding(
@@ -2524,9 +2593,9 @@ pub(crate) mod tests {
         let service = service(island_db());
         let start = vec3(1.0, 0.0, 1.0);
         let island = vec3(21.0, 0.0, 1.0);
-        // Somebody stalled on the other side of the level - nothing to do
+        // The AI stalled on the other side of the level - nothing to do
         // with this query's goal, which is on an island of its own
-        service.report_blocked_link(0, 1, 0.0);
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
         assert!(
             service
                 .find_path(start, island, MovementBits::WALK)
@@ -2535,10 +2604,11 @@ pub(crate) mod tests {
         );
         assert_eq!(
             service.exclusion_expiry_for_unreached_goal(
+                STALLER,
                 start,
                 island,
                 MovementBits::WALK,
-                &service.avoidance(0.0),
+                &service.avoidance(STALLER, 0.0),
                 0.0
             ),
             None,
@@ -2554,10 +2624,10 @@ pub(crate) mod tests {
         // Both ways into the goal cell are blocked, the second one later -
         // and a stalled cell contributes nothing either way
         service.report_blocked_cell(1, 0.0);
-        service.report_blocked_link(1, 2, 0.0);
-        service.report_blocked_link(0, 1, 2.0);
-        service.report_blocked_link(3, 2, 5.0);
-        let avoid = service.avoidance(0.0);
+        service.report_blocked_link(STALLER, 1, 2, 0.0);
+        service.report_blocked_link(STALLER, 0, 1, 2.0);
+        service.report_blocked_link(STALLER, 3, 2, 5.0);
+        let avoid = service.avoidance(STALLER, 0.0);
         assert!(
             service
                 .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
@@ -2566,6 +2636,7 @@ pub(crate) mod tests {
         );
         assert_eq!(
             service.exclusion_expiry_for_unreached_goal(
+                STALLER,
                 start,
                 goal,
                 MovementBits::WALK,
@@ -2577,6 +2648,21 @@ pub(crate) mod tests {
              (0 -> 1 -> 2), neither the level's earliest (1 -> 2) nor its \
              latest (3 -> 2, on the detour the AI will not take)"
         );
+        // Another AI's exclusions are not this query's deadline: the
+        // bystander's own route is intact, so it has nothing to wait for.
+        let bystander = service.avoidance(BYSTANDER, 0.0);
+        assert!(bystander.links.is_empty());
+        assert_eq!(
+            service.exclusion_expiry_for_unreached_goal(
+                BYSTANDER,
+                start,
+                goal,
+                MovementBits::WALK,
+                &bystander,
+                0.0
+            ),
+            None
+        );
     }
 
     #[test]
@@ -2585,14 +2671,41 @@ pub(crate) mod tests {
         service.report_blocked_cell(1, 0.0);
         assert_eq!(
             service.exclusion_expiry_for_unreached_goal(
+                STALLER,
                 vec3(1.0, 0.0, 1.0),
                 vec3(5.0, 0.0, 1.0),
                 MovementBits::WALK,
-                &service.avoidance(0.0),
+                &service.avoidance(STALLER, 0.0),
                 0.0,
             ),
             None,
             "cells are a cost penalty, so they can never be why a goal is unreachable"
+        );
+    }
+
+    /// One AI cannot hoard the blacklist: its oldest report makes way for
+    /// the crossing it just stalled on, and other AIs are unaffected.
+    #[test]
+    fn an_ais_exclusions_are_capped_at_its_own_oldest() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        for i in 0..MAX_BLOCKED_LINKS_PER_AI as u32 {
+            service.report_blocked_link(STALLER, i, i + 1, i as f32);
+        }
+        service.report_blocked_link(BYSTANDER, 99, 100, 0.0);
+        let overflow = MAX_BLOCKED_LINKS_PER_AI as u32;
+        service.report_blocked_link(STALLER, overflow, overflow + 1, overflow as f32);
+
+        let live = service.blocked_links(STALLER, 0.0);
+        assert_eq!(live.len(), MAX_BLOCKED_LINKS_PER_AI);
+        assert!(
+            live.contains(&(overflow, overflow + 1)),
+            "the newest report is the one that matters: {live:?}"
+        );
+        assert!(!live.contains(&(0, 1)), "the oldest made way: {live:?}");
+        assert_eq!(
+            service.blocked_links(BYSTANDER, 0.0),
+            std::collections::HashSet::from([(99, 100)]),
+            "one AI filling up must not evict another's"
         );
     }
 
@@ -2602,8 +2715,12 @@ pub(crate) mod tests {
         assert_eq!(service.stats().blocked_cells, 0);
         assert_eq!(service.stats().blocked_links, 0);
         service.report_blocked_cell(1, 0.0);
-        service.report_blocked_link(0, 1, 0.0);
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
         assert_eq!(service.stats().blocked_cells, 1);
         assert_eq!(service.stats().blocked_links, 1);
+        // The count is level-wide even though each exclusion applies to one
+        // AI: two AIs excluding the same crossing are two live entries.
+        service.report_blocked_link(BYSTANDER, 0, 1, 0.0);
+        assert_eq!(service.stats().blocked_links, 2);
     }
 }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -426,12 +426,18 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                                     self.stall_escalations + 1
                                 );
                                 // The cell penalty alone was outbid. Cut the
-                                // crossing this route opens with, so the next
-                                // query cannot answer with it again - one per
-                                // escalation, or a single creature's bad
-                                // minute would seal a corridor for everyone.
+                                // crossing this route opens with out of THIS
+                                // AI's queries, so its next one cannot answer
+                                // with it again - one per escalation, bounded
+                                // so a genuinely one-way corridor still gets
+                                // walked.
                                 self.stall_escalations += 1;
-                                report_stall(&service, &fresh, time.total.as_secs_f32());
+                                report_stall(
+                                    &service,
+                                    entity_id.inner(),
+                                    &fresh,
+                                    time.total.as_secs_f32(),
+                                );
                                 self.clear_path();
                                 self.repath_cooldown = REPATH_COOLDOWN_SECONDS
                                     * rand::thread_rng().gen_range(0.8..1.2);
@@ -667,7 +673,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     _ => route,
                 };
                 tracing::debug!("ai {:?}: blocked report cells={:?}", entity_id, route);
-                report_stall(&service, &route, now_seconds);
+                report_stall(&service, entity_id.inner(), &route, now_seconds);
                 // Remember how the route that failed began, so the re-path
                 // can be checked against it when it lands
                 self.stall_route_cells = Some(route);
@@ -1166,7 +1172,12 @@ fn repeats_route(stalled: &[u32], fresh: &[u32]) -> bool {
 /// the first crossing along the route that is a real mesh link. Only real
 /// links: a pair named from waypoints need not be one, and an inert entry
 /// would hold one of the bounded blacklist slots while excluding nothing.
-fn report_stall(service: &crate::pathfinding::PathfindingService, route: &[u32], now_seconds: f32) {
+fn report_stall(
+    service: &crate::pathfinding::PathfindingService,
+    entity: u64,
+    route: &[u32],
+    now_seconds: f32,
+) {
     let Some(&from) = route.first() else {
         return;
     };
@@ -1176,7 +1187,7 @@ fn report_stall(service: &crate::pathfinding::PathfindingService, route: &[u32],
         .map(|pair| (pair[0], pair[1]))
         .find(|&(from, to)| service.has_link(from, to))
     {
-        service.report_blocked_link(from, to, now_seconds);
+        service.report_blocked_link(entity, from, to, now_seconds);
     }
 }
 
@@ -1886,8 +1897,8 @@ mod tests {
         let service = PathfindingService::new(Arc::new(crate::pathfinding::tests::three_cell_db(
             dark::mission::path_database::PathCellFlags::empty(),
         )));
-        report_stall(&service, &[0, 2, 1], 0.0);
-        let avoidance = service.avoidance(1.0);
+        report_stall(&service, 7, &[0, 2, 1], 0.0);
+        let avoidance = service.avoidance(7, 1.0);
         assert!(avoidance.cells.contains(&0), "the stalled cell is reported");
         assert_eq!(
             avoidance.links.into_iter().collect::<Vec<_>>(),
@@ -1895,7 +1906,11 @@ mod tests {
             "0 -> 2 is not a link, and 2 -> 1 is not a crossing this route makes first"
         );
 
-        report_stall(&service, &[0, 1], 0.0);
-        assert!(service.avoidance(1.0).links.contains(&(0, 1)));
+        report_stall(&service, 7, &[0, 1], 0.0);
+        assert!(service.avoidance(7, 1.0).links.contains(&(0, 1)));
+        assert!(
+            service.avoidance(8, 1.0).links.is_empty(),
+            "the crossing is excluded for the AI that stalled on it, not the level"
+        );
     }
 }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -80,7 +80,11 @@ export interface PathfindingStats {
   queries: number;
   stressed_retries: number;
   no_route: number;
-  /** Cell crossings currently excluded because an AI stalled on them. */
+  /**
+   * Cell crossings currently excluded because an AI stalled on them,
+   * counted once per AI holding one (an exclusion applies only to the AI
+   * that reported it).
+   */
   blocked_links: number;
   /** Cells currently penalized because an AI stalled inside them. */
   blocked_cells: number;


### PR DESCRIPTION
When an AI's steering stalls mid-route it blacklists the crossing it could not walk, so its re-path routes around the obstacle instead of grinding on it (#481). That blacklist was **level-wide**: one `Mutex<HashMap<(from,to), expiry>>` handed to *every* AI's query, and unlike the stalled-cell report beside it — a cost penalty — a blacklisted crossing is a **hard cut** in A*. With a 30-second TTL, as long as an engagement, the set only ever grew over a pass. One creature wedged in a doorway removed that crossing for the other twenty, and where crossings are few — a narrow bridge between navigation islands — that left the rest of the level with no route at all.

Exclusions are now keyed by the AI that reported them and only that AI's queries carry them. Other AIs are still steered off the obstacle by the **shared cell penalty**, which is a cost and can never make a goal unreachable — occupancy is meant to be global, and stays so. An AI's set is bounded by the 30-second TTL alone and is dropped when the entity despawns, so nothing ratchets across a pass.

The steering comment at the report site claimed the exclusion was already "per AI"; it had been level-wide since the sharing landed. It is now true.

## What this does and does not move

Measured live on hydro2 and ops4 with `--experimental nav_bridges` + `DebugForceChase`, 30 s per pass, from one binary with the old level-wide behaviour behind a temporary switch. The pathfinding worker was instrumented to re-run every shortfall (a non-`Full` outcome) twice in the same frame: once with **all** exclusions lifted, once with only the **querying AI's own** — so "who cut this route" is answered per query rather than inferred.

| arm | hydro2 shortfalls | route existed with exclusions lifted | cut by *another* AI's exclusion | max exclusions on one query | AI path outcomes at pass end | `no_route` |
|---|---|---|---|---|---|---|
| level-wide (before) | 37 / 37 | 22 / 21 | 1 / 0 | 21 | 16 Full, 4 Partial, 2 Failed | 90 |
| per-AI (this PR) | 35 / 36 / 36 | 20 / 20 / 21 | **0** (by construction) | **4** | 17 Full, 3 Partial, 2 Failed | 87 |

ops4, two runs per arm: shortfalls 20/18 → 18/19, route-existed 5/2 → 2/4, `no_route` 55/52 → 52/53.

So the ratchet is gone and no query is ever cut by a stall it did not suffer — but the **shortfall count barely moves**, and that is the finding worth recording: in ~20 of hydro2's ~36 shortfalls the AI is severed by its **own single** exclusion, on a crossing that is its only way through. The level-wide sharing was not the dominant driver; the **hard cut itself** is.

A third arm settles it. Keeping the per-AI scoping and making an exclusion a heavy **cost** instead of a cut (the same shape as the stalled-cell penalty) gives hydro2 **15 shortfalls, 0 of them with a route available**, 21 Full / 0 Partial / 1 Failed, `no_route` 45 — the remaining 15 are one authored-disconnected creature that fails from t=0.32 s with an empty exclusion set. ops4 lands the same way (15 shortfalls, 0 recoverable, `no_route` 45).

That change is **deliberately not in this PR**: it trades a parked AI for a possibly grinding one where a pocket has a single exit — the exact case #481 chose parking for — and it would make #1353's temporary-unreachable machinery inert, since an exclusion could then never be why a goal is unreachable. It wants its own PR, with the medsci1 capture-pocket and door-jamb scenarios as the evidence.

## Tests

Negative-first: with the entity filter neutered (the old shared read, same keys), `a_stalled_ais_exclusion_leaves_every_other_ais_route_intact`, `an_ais_exclusions_are_capped_at_its_own_oldest`, `blocked_link_expiry_reports_when_the_exclusions_lapse` and `worker_applies_blocked_links` all fail; with it, they pass.

- `a_stalled_ais_exclusion_leaves_every_other_ais_route_intact` — X's report severs X's only route; Y still routes through it, and the shared *cell* penalty is what Y sees instead.
- `worker_applies_blocked_links` — the reporter's query comes back `Partial` with a deadline to wait out; the bystander's comes back `Full` with none.
- `an_ais_exclusions_outlive_only_their_ttl` — a lapsed report is dropped on the AI's next read, its live one kept, and its pruning leaves another AI's set alone.
- `blocked_link_expiry_reports_when_the_exclusions_lapse` (#1353's deadline) — extended: another AI's exclusions are not this query's deadline. #1353's patrol retry path is unchanged and its tests are untouched.
- `prune_drops_steering_with_the_path_record` — a despawned AI's exclusions go with it (previously asserted to survive), while a surviving AI keeps its own.
- `stats_report_the_live_blacklists` — the count stays level-wide; two AIs excluding one crossing are two live entries.

`cargo test -p shock2vr` 1450 passed. `cargo fmt`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean. `cargo bn path bench medsci2.mis --seed 424242` unchanged (200/0 found, inflation 1.67, 45.8 waypoints — A* itself is untouched). e2e: `medsci2-patrol-railing` 2/2, `patrol` 4/4.

## Review

`/xreview`, both engines plus the de-dup pass. Codex: no findings at any severity. Applied from the Claude reviewer and the de-dup pass, which agreed on the shape:

- **Medium (both)** — the flat composite key `HashMap<(u64,(u32,u32)), f32>` forced an entity filter in four places; it is now `HashMap<u64, HashMap<(u32,u32), f32>>`, the shape the sibling per-entity maps (`ai_paths`, `ai_steering`, `movement_holds`) already use. Reporting, reading and pruning are direct lookups and `prune_ai_paths` is a one-line `retain` like its neighbours.
- **Medium (scope)** — the per-AI cap and its oldest-eviction are gone. The TTL and the despawn prune already bound the set (a stall can only report every 3 s), and evicting the oldest handed back a crossing the AI still could not walk. That removed the tie-break non-determinism flagged separately.
- **Medium** — `merge`: `blocked_links` and `blocked_link_expiry` were the same lock/prune/filter body with different projections; one private `live_links_for` serves both.
- **Medium** — `prune_ai_paths`' doc still said blocked crossings were world facts that expire only on their TTL, which this change makes false. The stat's meaning (per AI, so one crossing can count twice) is now stated in the Rust doc and the SDK type.

**Noted, and the reason it is not a blocker.** The reviewer's strongest objection is that a *fresh* AI arriving at the same physical blocker no longer inherits a cut, only the shared cell penalty (a cost, 10 s) — the case the sharing was introduced for (medsci1's stationary-NPC pocket). Two things bound it: the penalty is refreshed on **every** stall, so it stays live for as long as anything is actually blocked there, and the worst case for a new arrival is one 3 s stall before it holds its own exclusion — against a level-wide cut that measurably disconnected hydro2 for everyone. A 60 s medsci1 forced chase (no bridges) shows no divergence between the arms — 13 vs 11 `Partial`, 1 vs 3 `Failed`, and exclusions applied to one query 29 → 7.

Declined: narrowing the retry deadline to the crossings the failed search actually touched (`blocked_link_expiry` still returns the max over the AI's own set, so a patrol can over-wait) — that is #1353's own follow-up and lands there.
