### PR TITLE
fix(ai): a stalled crossing costs more before it is cut

### DIFF
--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -44,9 +44,11 @@ pub struct PathQueryResponse {
     pub outcome: AiPathOutcome,
     /// Route waypoints; empty when `outcome` is `Failed`
     pub waypoints: Vec<Vector3<f32>>,
-    /// For a query that did not reach its goal *only because* steering
-    /// reported crossings on its route blocked, the mission time the last of
-    /// those comes back into play at. `None` when the goal is unreachable on
+    /// For a query that did not reach its goal *only because* crossings on
+    /// its route were CUT (this AI stalled on each of them twice), the
+    /// mission time the last of those comes back into play at. A crossing
+    /// that is merely expensive can never be why a goal was unreachable, so
+    /// it is never a deadline. `None` when the goal is unreachable on
     /// the raw mesh too - waiting cannot help. See
     /// `PathfindingService::exclusion_expiry_for_unreached_goal`.
     pub exclusion_expires_at: Option<f32>,
@@ -81,11 +83,12 @@ impl AsyncPathfinding {
                 while let Ok(request) = rx.recv() {
                     let mut outcome = AiPathOutcome::Full;
                     // Crossings THIS AI's steering reported as physically
-                    // blocked (stall mid-route) are excluded from its own
-                    // search, and cells any AI is stalled in are made
-                    // expensive, so the re-path routes around the obstacle
-                    // instead of grinding on it - without cutting the
-                    // crossing out from under every other AI
+                    // blocked (stall mid-route) are expensive in its own
+                    // search - impassable where it stalled twice - and cells
+                    // any AI is stalled in are expensive for everyone, so the
+                    // re-path prefers a way round the obstacle instead of
+                    // grinding on it, without cutting the crossing out from
+                    // under every other AI
                     let avoid = service.avoidance(request.entity, request.now_seconds);
                     let path = service
                         .find_path_avoiding(
@@ -272,7 +275,9 @@ mod tests {
                 dark::mission::path_database::PathCellFlags::empty(),
             ),
         )));
+        // Twice: one stall only prices a crossing, two cut it
         service.report_blocked_link(11, 1, 2, 0.0);
+        service.report_blocked_link(11, 1, 2, 0.5);
         let async_pf = AsyncPathfinding::spawn(service.clone());
         assert!(async_pf.submit(PathQueryRequest {
             entity: 11,
@@ -291,7 +296,7 @@ mod tests {
 
         assert_eq!(
             response.exclusion_expires_at,
-            Some(super::super::BLOCKED_LINK_TTL_SECONDS),
+            Some(0.5 + super::super::BLOCKED_LINK_CUT_SECONDS),
             "the shortfall is the reporter's own exclusion, so it can wait it out"
         );
 
@@ -324,9 +329,11 @@ mod tests {
         // Exclusions are per-AI, so both queriers must carry the same set
         // for the two shortfalls to be comparable
         for entity in [31, 32] {
-            service.report_blocked_link(entity, 1, 2, 0.0);
-            service.report_blocked_link(entity, 0, 1, 2.0);
-            service.report_blocked_link(entity, 3, 2, 5.0);
+            for _ in 0..super::super::STALLS_BEFORE_CUT {
+                service.report_blocked_link(entity, 1, 2, 0.0);
+                service.report_blocked_link(entity, 0, 1, 2.0);
+                service.report_blocked_link(entity, 3, 2, 5.0);
+            }
         }
         let async_pf = AsyncPathfinding::spawn(service.clone());
 
@@ -355,7 +362,7 @@ mod tests {
         assert_ne!(response.outcome, AiPathOutcome::Full);
         assert_eq!(
             response.exclusion_expires_at,
-            Some(2.0 + crate::pathfinding::BLOCKED_LINK_TTL_SECONDS),
+            Some(2.0 + crate::pathfinding::BLOCKED_LINK_CUT_SECONDS),
             "wait for the LAST crossing on the route it becomes reachable by, \
              neither the level's earliest nor its latest (the detour's)"
         );

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -254,10 +254,17 @@ struct LinkStall {
     /// is in the future the crossing is impassable to this AI; before and
     /// after, it is merely expensive.
     cut_until: Option<f32>,
-    /// Physical stalls on this crossing since the AI last made route
-    /// progress (see `clear_link_stall_history`). Re-queries don't count:
-    /// only a body that tried and failed again.
+    /// Physical stalls on this crossing since the AI last covered ground
+    /// (see `clear_link_stall_history`). Re-queries don't count: only a
+    /// body that tried and failed again.
     stalls: u32,
+}
+
+impl LinkStall {
+    /// Impassable right now, rather than merely expensive
+    fn is_cut(&self, now_seconds: f32) -> bool {
+        self.cut_until.is_some_and(|until| until > now_seconds)
+    }
 }
 
 /// Pathfinding service for AI navigation
@@ -506,21 +513,26 @@ impl PathfindingService {
         let entry = mine
             .entry((from_cell, to_cell))
             .or_insert_with(|| LinkStall {
-                expiry: now_seconds,
+                expiry: now_seconds + BLOCKED_LINK_TTL_SECONDS,
                 cut_until: None,
                 stalls: 0,
             });
+        // Re-reporting extends the memory, never shortens it
         entry.expiry = now_seconds + BLOCKED_LINK_TTL_SECONDS;
         if physical {
             entry.stalls += 1;
+            // A count that has already earned a cut re-arms one on every
+            // further stall while the AI stays stuck there: after the second
+            // failure the evidence stands until the body covers ground
+            // (which resets the count) or the memory lapses.
             if entry.stalls >= STALLS_BEFORE_CUT {
                 entry.cut_until = Some(now_seconds + BLOCKED_LINK_CUT_SECONDS);
             }
         }
     }
 
-    /// Forget how many times `entity` has stalled on each crossing: it has
-    /// walked a leg of its route, so the next stall is a fresh incident
+    /// Forget how many times `entity` has stalled on each crossing: its
+    /// body has covered ground, so the next stall is a fresh incident
     /// rather than the second failure of a pinned body. The cost memories
     /// stay (the obstacle may well still be there) and a cut already
     /// escalated lives out its short TTL.
@@ -558,21 +570,7 @@ impl PathfindingService {
     ) -> std::collections::HashSet<(u32, u32)> {
         self.live_links_for(entity, now_seconds)
             .into_iter()
-            .filter(|(_, entry)| entry.cut_until.is_some_and(|until| until > now_seconds))
-            .map(|(link, _)| link)
-            .collect()
-    }
-
-    /// The crossings currently expensive for `entity` (stalled on, but not
-    /// cut): a cost penalty on top of the link's own, never impassable.
-    pub fn costly_links(
-        &self,
-        entity: u64,
-        now_seconds: f32,
-    ) -> std::collections::HashSet<(u32, u32)> {
-        self.live_links_for(entity, now_seconds)
-            .into_iter()
-            .filter(|(_, entry)| !entry.cut_until.is_some_and(|until| until > now_seconds))
+            .filter(|(_, entry)| entry.is_cut(now_seconds))
             .map(|(link, _)| link)
             .collect()
     }
@@ -617,9 +615,7 @@ impl PathfindingService {
         let (cut, costly) = self
             .live_links_for(entity, now_seconds)
             .into_iter()
-            .partition::<Vec<_>, _>(|(_, entry)| {
-                entry.cut_until.is_some_and(|until| until > now_seconds)
-            });
+            .partition::<Vec<_>, _>(|(_, entry)| entry.is_cut(now_seconds));
         NavAvoidance {
             links: cut.into_iter().map(|(link, _)| link).collect(),
             costly_links: costly.into_iter().map(|(link, _)| link).collect(),

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -67,12 +67,22 @@ const BRIDGE_BUCKET: f32 = 12.0 / SCALE_FACTOR;
 /// prefer clear floor, but allow squeezing past baked furniture
 const BLOCKING_CELL_COST_PENALTY: u32 = 4;
 
-/// How long a steering-reported blocked crossing stays excluded from the
-/// reporting AI's path queries. Long enough that the re-path (and several
-/// after it) route around the obstacle instead of reproducing the blocked
-/// route; short enough that a transient blocker (a shoved crate) is
-/// retried within a minute.
+/// How long a crossing an AI stalled on stays remembered by that AI. Long
+/// enough that the re-path (and several after it) prefer another way round
+/// instead of reproducing the blocked route; short enough that a transient
+/// blocker (a shoved crate) is retried within a minute.
 const BLOCKED_LINK_TTL_SECONDS: f32 = 30.0;
+/// Physical stalls on one directed crossing before the AI stops paying to
+/// try it and cuts it outright. The first stall is one ambiguous failure -
+/// a neighbour passing through, a door still swinging - and a cut on that
+/// evidence severs crossings that are an AI's only way through (measured on
+/// hydro2: about 20 of ~36 search shortfalls were an AI's own single cut).
+/// The second says the obstacle is still there and the cost was outbid.
+const STALLS_BEFORE_CUT: u32 = 2;
+/// How long an escalated crossing stays CUT from the AI's queries. Far
+/// shorter than the memory above: a cut can make a goal unreachable, so it
+/// buys one detour's worth of time and then lets the AI look again.
+const BLOCKED_LINK_CUT_SECONDS: f32 = 5.0;
 
 /// How long a cell an AI stalled in stays expensive to enter. Shorter than
 /// the crossing TTL: a whole cell is a much blunter instrument, and the
@@ -88,6 +98,11 @@ const MAX_BLOCKED_CELLS: usize = 64;
 /// through the only cell it has, and a corridor everyone must cross stays
 /// usable. Worth about a 200-foot detour, so any real alternative wins.
 const STALLED_CELL_COST_PENALTY: u32 = 200;
+/// Extra cost for the AI that stalled to TRY a crossing again - the same
+/// weight as the cell penalty, so a stalled crossing and a stalled cell
+/// bias a route by the same amount. Any real alternative wins; a crossing
+/// that is the AI's only way through stays walkable.
+const STALLED_LINK_COST_PENALTY: u32 = STALLED_CELL_COST_PENALTY;
 
 /// Per-frame cap on AI-initiated pathfind queries. A slot now covers the
 /// full fallback chain (A* + stressed retry + partial-route Dijkstra when
@@ -135,12 +150,18 @@ impl Default for PathfindingFrameBudget {
 }
 
 /// Steering-reported obstacles the navigation mesh doesn't model, applied to
-/// one path query. Links are impassable; cells are merely expensive (see
-/// `STALLED_CELL_COST_PENALTY`).
+/// one path query. Cells and most crossings are merely expensive (see
+/// `STALLED_CELL_COST_PENALTY`, `STALLED_LINK_COST_PENALTY`); only a
+/// crossing the querying AI stalled on twice is impassable.
 #[derive(Debug, Clone, Default)]
 pub struct NavAvoidance {
-    /// Directed cell crossings the QUERYING AI failed to traverse
+    /// Directed cell crossings CUT from this query: the querying AI stalled
+    /// on each of them twice without getting through (see
+    /// `STALLS_BEFORE_CUT`)
     pub links: std::collections::HashSet<(u32, u32)>,
+    /// Directed cell crossings the querying AI stalled on once - expensive
+    /// to try again, never impassable
+    pub costly_links: std::collections::HashSet<(u32, u32)>,
     /// Cells some AI is (or recently was) stalled in
     pub cells: std::collections::HashSet<u32>,
 }
@@ -155,8 +176,8 @@ pub struct PathfindingStats {
     pub stressed_retries: u64,
     /// Queries that found no route at all (the most expensive outcome)
     pub no_route: u64,
-    /// Crossings currently excluded by steering reports, counted once per
-    /// AI holding one - two AIs excluding the same crossing are two
+    /// Crossings currently penalized or cut by steering reports, counted
+    /// once per AI holding one - two AIs avoiding the same crossing are two
     /// entries (see `report_blocked_link`). Pruned as their owners query,
     /// so this is the count as of the last query rather than as of this
     /// instant.
@@ -224,6 +245,21 @@ impl MovementHold {
     }
 }
 
+/// One AI's memory of a directed crossing its body could not get through.
+#[derive(Debug, Clone, Copy)]
+struct LinkStall {
+    /// Mission seconds this memory lapses at (the whole entry goes)
+    expiry: f32,
+    /// Mission seconds the hard cut lapses at, once escalated. While this
+    /// is in the future the crossing is impassable to this AI; before and
+    /// after, it is merely expensive.
+    cut_until: Option<f32>,
+    /// Physical stalls on this crossing since the AI last made route
+    /// progress (see `clear_link_stall_history`). Re-queries don't count:
+    /// only a body that tried and failed again.
+    stalls: u32,
+}
+
 /// Pathfinding service for AI navigation
 ///
 /// Uses AIPATH cells for navigation mesh queries and A* pathfinding.
@@ -271,20 +307,26 @@ pub struct PathfindingService {
     /// Cell crossings an AI's steering failed to traverse (a stall fired
     /// mid-route): obstacles the mesh doesn't model, e.g. a physical prop
     /// or a scripted stationary NPC sitting on a walkable link. Entries map
-    /// `reporting AI -> (from_cell, to_cell) -> expiry in mission seconds`.
-    /// Scoped to the AI THAT STALLED, because this is a hard cut in A* and
-    /// nothing else the steering reports is: level-wide, one wedged
-    /// creature removed a crossing for every other AI, the set only grew
-    /// over a pass (the TTL is as long as an engagement), and where
-    /// crossings are few - a narrow bridge between nav islands - that left
-    /// the rest of the level with no route at all. What warns the OTHERS
-    /// off is the shared cell penalty (`blocked_cells`), refreshed for as
-    /// long as the blocked AI keeps stalling there: a cost that can never
-    /// make a goal unreachable. Directed-link granularity (not whole cells)
-    /// so one blocked doorway can't seal every other entrance into a large
+    /// `reporting AI -> (from_cell, to_cell) -> LinkStall`.
+    ///
+    /// Scoped to the AI THAT STALLED: level-wide, one wedged creature
+    /// removed a crossing for every other AI, the set only grew over a pass
+    /// (the memory is as long as an engagement), and where crossings are
+    /// few - a narrow bridge between nav islands - that left the rest of
+    /// the level with no route at all. What warns the OTHERS off is the
+    /// shared cell penalty (`blocked_cells`), refreshed for as long as the
+    /// blocked AI keeps stalling there.
+    ///
+    /// The first stall makes the crossing EXPENSIVE for that AI, not
+    /// impassable: one failure is ambiguous, and a cut on that evidence
+    /// severs crossings that are the AI's only way through. A second
+    /// physical stall on the same crossing says the obstacle is still there
+    /// and the cost was outbid, and escalates to a short cut (see
+    /// `STALLS_BEFORE_CUT`). Directed-link granularity (not whole cells) so
+    /// one blocked doorway can't seal every other entrance into a large
     /// cell. An AI's entries expire on their TTL and go with it when it
     /// despawns, so nothing accumulates across a mission.
-    blocked_links: std::sync::Mutex<HashMap<u64, HashMap<(u32, u32), f32>>>,
+    blocked_links: std::sync::Mutex<HashMap<u64, HashMap<(u32, u32), LinkStall>>>,
     /// Cells an AI's steering stalled in, mapped to their expiry in mission
     /// seconds. Two jobs, one input: a stall that happens INSIDE a single
     /// cell has no crossing to blacklist (the AI never reached the edge),
@@ -417,38 +459,98 @@ impl PathfindingService {
         }
     }
 
-    /// Remember that `entity`'s steering could not physically traverse the
-    /// crossing `from_cell -> to_cell` (it stalled mid-route): the crossing
-    /// is excluded from THAT AI's path queries until the entry expires, so
-    /// its re-path routes around the obstacle instead of reproducing the
-    /// route it could not walk (issue #481's grind loop). Other AIs keep
-    /// the crossing and are steered off it by the cell penalty instead -
-    /// see the `blocked_links` field.
+    /// Remember that `entity`'s body could not physically traverse the
+    /// crossing `from_cell -> to_cell` (a stall fired mid-route). The first
+    /// such stall makes the crossing expensive for THAT AI, so its re-path
+    /// prefers any other way round instead of reproducing the route it
+    /// could not walk (issue #481's grind loop); a second physical stall on
+    /// the same crossing, with no route progress since, cuts it for
+    /// `BLOCKED_LINK_CUT_SECONDS`. Other AIs keep the crossing at full
+    /// price and are steered off it by the cell penalty instead - see the
+    /// `blocked_links` field.
+    ///
+    /// Only a body's failed attempt belongs here. A re-query that answers
+    /// with the same route has not tried anything, and reports its route
+    /// through `refresh_link_penalty`.
     pub fn report_blocked_link(&self, entity: u64, from_cell: u32, to_cell: u32, now_seconds: f32) {
+        self.record_link_stall(entity, from_cell, to_cell, now_seconds, true);
+    }
+
+    /// Refresh the cost penalty on a crossing without counting a physical
+    /// attempt: the AI's re-path came back with the route that already
+    /// stalled, which says the penalty was outbid, not that the body tried
+    /// again.
+    pub fn refresh_link_penalty(
+        &self,
+        entity: u64,
+        from_cell: u32,
+        to_cell: u32,
+        now_seconds: f32,
+    ) {
+        self.record_link_stall(entity, from_cell, to_cell, now_seconds, false);
+    }
+
+    fn record_link_stall(
+        &self,
+        entity: u64,
+        from_cell: u32,
+        to_cell: u32,
+        now_seconds: f32,
+        physical: bool,
+    ) {
         let Ok(mut blocked) = self.blocked_links.lock() else {
             return;
         };
         let mine = blocked.entry(entity).or_default();
-        mine.retain(|_, &mut expiry| expiry > now_seconds);
-        mine.insert((from_cell, to_cell), now_seconds + BLOCKED_LINK_TTL_SECONDS);
+        mine.retain(|_, entry| entry.expiry > now_seconds);
+        let entry = mine
+            .entry((from_cell, to_cell))
+            .or_insert_with(|| LinkStall {
+                expiry: now_seconds,
+                cut_until: None,
+                stalls: 0,
+            });
+        entry.expiry = now_seconds + BLOCKED_LINK_TTL_SECONDS;
+        if physical {
+            entry.stalls += 1;
+            if entry.stalls >= STALLS_BEFORE_CUT {
+                entry.cut_until = Some(now_seconds + BLOCKED_LINK_CUT_SECONDS);
+            }
+        }
     }
 
-    /// `entity`'s own unexpired exclusions, as `(crossing, expiry)`. Its
-    /// expired entries are dropped (another AI's are dropped when it next
-    /// reports or queries).
-    fn live_links_for(&self, entity: u64, now_seconds: f32) -> Vec<((u32, u32), f32)> {
+    /// Forget how many times `entity` has stalled on each crossing: it has
+    /// walked a leg of its route, so the next stall is a fresh incident
+    /// rather than the second failure of a pinned body. The cost memories
+    /// stay (the obstacle may well still be there) and a cut already
+    /// escalated lives out its short TTL.
+    pub fn clear_link_stall_history(&self, entity: u64) {
+        let Ok(mut blocked) = self.blocked_links.lock() else {
+            return;
+        };
+        if let Some(mine) = blocked.get_mut(&entity) {
+            for entry in mine.values_mut() {
+                entry.stalls = 0;
+            }
+        }
+    }
+
+    /// `entity`'s own unexpired stall memories. Its expired entries are
+    /// dropped (another AI's are dropped when it next reports or queries).
+    fn live_links_for(&self, entity: u64, now_seconds: f32) -> Vec<((u32, u32), LinkStall)> {
         let Ok(mut blocked) = self.blocked_links.lock() else {
             return Vec::new();
         };
         let Some(mine) = blocked.get_mut(&entity) else {
             return Vec::new();
         };
-        mine.retain(|_, &mut expiry| expiry > now_seconds);
-        mine.iter().map(|(link, expiry)| (*link, *expiry)).collect()
+        mine.retain(|_, entry| entry.expiry > now_seconds);
+        mine.iter().map(|(link, entry)| (*link, *entry)).collect()
     }
 
-    /// The `(from_cell, to_cell)` crossings currently excluded from
-    /// `entity`'s path queries (its own unexpired steering reports).
+    /// The `(from_cell, to_cell)` crossings currently CUT from `entity`'s
+    /// path queries - the ones it stalled on twice, until their short cut
+    /// lapses.
     pub fn blocked_links(
         &self,
         entity: u64,
@@ -456,6 +558,21 @@ impl PathfindingService {
     ) -> std::collections::HashSet<(u32, u32)> {
         self.live_links_for(entity, now_seconds)
             .into_iter()
+            .filter(|(_, entry)| entry.cut_until.is_some_and(|until| until > now_seconds))
+            .map(|(link, _)| link)
+            .collect()
+    }
+
+    /// The crossings currently expensive for `entity` (stalled on, but not
+    /// cut): a cost penalty on top of the link's own, never impassable.
+    pub fn costly_links(
+        &self,
+        entity: u64,
+        now_seconds: f32,
+    ) -> std::collections::HashSet<(u32, u32)> {
+        self.live_links_for(entity, now_seconds)
+            .into_iter()
+            .filter(|(_, entry)| !entry.cut_until.is_some_and(|until| until > now_seconds))
             .map(|(link, _)| link)
             .collect()
     }
@@ -463,8 +580,9 @@ impl PathfindingService {
     /// Remember that an AI stalled inside `cell`. The cell stays expensive
     /// to ENTER for ~10 seconds, so other AIs' routes prefer
     /// another way round and the stalled AI's own re-path does not turn
-    /// back into it. Unlike a blocked crossing this is a cost penalty, not
-    /// an exclusion - a wholly blocked-in AI must still be able to leave.
+    /// back into it. Like a first stall on a crossing this is a cost
+    /// penalty, never a cut - a wholly blocked-in AI must still be able to
+    /// leave.
     pub fn report_blocked_cell(&self, cell: u32, now_seconds: f32) {
         let Ok(mut blocked) = self.blocked_cells.lock() else {
             return;
@@ -491,12 +609,20 @@ impl PathfindingService {
     }
 
     /// Everything steering has reported as physically impassable or
-    /// expensive right now, for one path query by `entity`. The impassable
-    /// crossings are `entity`'s own reports; the expensive cells are every
-    /// AI's (occupancy is shared - see `report_blocked_cell`).
+    /// expensive right now, for one path query by `entity`. The crossings
+    /// are `entity`'s own reports (cut where it stalled twice, expensive
+    /// where once); the expensive cells are every AI's (occupancy is shared
+    /// - see `report_blocked_cell`).
     pub fn avoidance(&self, entity: u64, now_seconds: f32) -> NavAvoidance {
+        let (cut, costly) = self
+            .live_links_for(entity, now_seconds)
+            .into_iter()
+            .partition::<Vec<_>, _>(|(_, entry)| {
+                entry.cut_until.is_some_and(|until| until > now_seconds)
+            });
         NavAvoidance {
-            links: self.blocked_links(entity, now_seconds),
+            links: cut.into_iter().map(|(link, _)| link).collect(),
+            costly_links: costly.into_iter().map(|(link, _)| link).collect(),
             cells: self.blocked_cells(now_seconds),
         }
     }
@@ -540,6 +666,7 @@ impl PathfindingService {
         let expiries: HashMap<(u32, u32), f32> = self
             .live_links_for(entity, now_seconds)
             .into_iter()
+            .filter_map(|(link, entry)| Some((link, entry.cut_until?)))
             .collect();
         cell_path
             .windows(2)
@@ -1088,6 +1215,12 @@ impl PathfindingService {
                 // still passable if it is the only way
                 if avoid.cells.contains(&link.to_cell) {
                     cost = cost.saturating_add(STALLED_CELL_COST_PENALTY);
+                }
+                // ...and the querying AI's body failed to get through this
+                // crossing once. Same bargain: prefer anything else, but
+                // walk it again rather than declare the goal unreachable.
+                if avoid.costly_links.contains(&(cell_id, link.to_cell)) {
+                    cost = cost.saturating_add(STALLED_LINK_COST_PENALTY);
                 }
                 (link.to_cell, cost)
             })
@@ -1876,6 +2009,14 @@ pub(crate) mod tests {
     /// Any other AI querying the same mesh
     const BYSTANDER: u64 = 22;
 
+    /// Two physical stalls on one crossing - what it takes to cut it
+    /// (`STALLS_BEFORE_CUT`).
+    fn stall_twice(service: &PathfindingService, entity: u64, from: u32, to: u32, at: f32) {
+        for _ in 0..STALLS_BEFORE_CUT {
+            service.report_blocked_link(entity, from, to, at);
+        }
+    }
+
     fn service(db: PathDatabase) -> PathfindingService {
         PathfindingService::new(Arc::new(db))
     }
@@ -2281,21 +2422,73 @@ pub(crate) mod tests {
         assert!(budget.try_acquire(), "reset must refill the budget");
     }
 
+    /// The first stall is one ambiguous failure - a neighbour passing
+    /// through, a door still swinging - so it makes the crossing expensive
+    /// for the AI that stalled and nothing more. Cutting on that evidence
+    /// severed crossings that were an AI's only way through.
     #[test]
-    fn reported_blocked_link_excludes_that_crossing_from_queries() {
+    fn a_first_stall_prices_a_crossing_without_cutting_it() {
+        let service = service(detour_db());
+        let start = vec3(1.0, 0.0, 1.0);
+        let goal = vec3(5.0, 0.0, 1.0);
+        let direct = service.find_path(start, goal, MovementBits::WALK).unwrap();
+        assert!(
+            !took_the_detour(&direct),
+            "baseline route must go straight through: {direct:?}"
+        );
+
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        let avoid = service.avoidance(STALLER, 1.0);
+        assert!(avoid.links.is_empty(), "one stall is not a cut: {avoid:?}");
+        assert!(avoid.costly_links.contains(&(0, 1)));
+        let rerouted = service
+            .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
+            .unwrap();
+        assert!(
+            took_the_detour(&rerouted),
+            "a stalled crossing must be worth a detour: {rerouted:?}"
+        );
+    }
+
+    /// ...and where there is no detour, the priced crossing is still walked.
+    /// A cost can never make a goal unreachable; that is the whole point of
+    /// paying it first.
+    #[test]
+    fn a_priced_crossing_stays_walkable_when_it_is_the_only_way() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        let avoid = service.avoidance(STALLER, 1.0);
+        assert!(
+            service
+                .find_path_avoiding(
+                    vec3(1.0, 0.0, 1.0),
+                    vec3(5.0, 0.0, 1.0),
+                    MovementBits::WALK,
+                    &avoid
+                )
+                .is_some(),
+            "the first stall is a cost, not a cut"
+        );
+    }
+
+    /// A second physical stall on the same crossing says the obstacle is
+    /// still there and the price was outbid. Now it goes out of that AI's
+    /// queries, so its re-path routes around instead of grinding on it
+    /// (issue #481) - and the partial fallback parks it rather than pushing
+    /// into the obstacle.
+    #[test]
+    fn a_second_physical_stall_cuts_the_crossing() {
         let service = service(three_cell_db(PathCellFlags::empty()));
         let start = vec3(1.0, 0.0, 1.0);
         let goal = vec3(5.0, 0.0, 1.0);
-        // Without a report the route crosses 0 -> 1 -> 2 normally
-        assert!(service.find_path(start, goal, MovementBits::WALK).is_some());
+        stall_twice(&service, STALLER, 0, 1, 0.0);
 
-        // A stall reported against the 0 -> 1 crossing severs the only
-        // route FOR THE AI THAT STALLED: the full search fails and the
-        // partial fallback reports no progress possible (it parks instead
-        // of grinding into the obstacle - issue #481).
-        service.report_blocked_link(STALLER, 0, 1, 0.0);
         let avoid = service.avoidance(STALLER, 1.0);
         assert!(avoid.links.contains(&(0, 1)));
+        assert!(
+            avoid.costly_links.is_empty(),
+            "a cut crossing is not also priced: {avoid:?}"
+        );
         assert!(
             service
                 .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
@@ -2307,7 +2500,7 @@ pub(crate) mod tests {
                 .is_none()
         );
 
-        // Only that DIRECTED crossing is excluded - a route already past it
+        // Only that DIRECTED crossing is cut - a route already past it
         // (start in cell 1) still enters cell 2
         assert!(
             service
@@ -2316,8 +2509,79 @@ pub(crate) mod tests {
         );
     }
 
-    /// One AI's stall must not disconnect the level for everybody else. The
-    /// exclusion is a hard cut in A*, so shared it fed back on itself: the
+    /// A re-query is not another attempt. When the search answers with the
+    /// route that already stalled, that is the same failure reported twice -
+    /// it refreshes the price and never escalates, or a cut would need no
+    /// second physical stall at all.
+    #[test]
+    fn a_reproduced_route_never_escalates_to_a_cut() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        for repeat in 1..5 {
+            service.refresh_link_penalty(STALLER, 0, 1, repeat as f32);
+        }
+        let avoid = service.avoidance(STALLER, 5.0);
+        assert!(
+            avoid.links.is_empty(),
+            "re-querying is not a physical attempt: {avoid:?}"
+        );
+        assert!(avoid.costly_links.contains(&(0, 1)));
+    }
+
+    /// Walking a leg of the route makes the next stall a fresh first
+    /// failure: two stalls only escalate when the body got nowhere between
+    /// them.
+    #[test]
+    fn route_progress_resets_the_stall_count() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        service.clear_link_stall_history(STALLER);
+        service.report_blocked_link(STALLER, 0, 1, 1.0);
+
+        let avoid = service.avoidance(STALLER, 2.0);
+        assert!(
+            avoid.links.is_empty(),
+            "the AI made progress between the two stalls: {avoid:?}"
+        );
+        assert!(
+            avoid.costly_links.contains(&(0, 1)),
+            "...but it still remembers what it cost: {avoid:?}"
+        );
+    }
+
+    /// The cut is short - one detour's worth of time - and lapses back into
+    /// a price the AI can pay long before it forgets it stalled there.
+    #[test]
+    fn a_cut_lapses_into_a_price_and_then_out_of_memory() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        let start = vec3(1.0, 0.0, 1.0);
+        let goal = vec3(5.0, 0.0, 1.0);
+        stall_twice(&service, STALLER, 0, 1, 100.0);
+        assert!(
+            service
+                .blocked_links(STALLER, 100.0 + BLOCKED_LINK_CUT_SECONDS - 1.0)
+                .contains(&(0, 1))
+        );
+
+        let lapsed = service.avoidance(STALLER, 100.0 + BLOCKED_LINK_CUT_SECONDS + 1.0);
+        assert!(lapsed.links.is_empty(), "the cut must lapse: {lapsed:?}");
+        assert!(lapsed.costly_links.contains(&(0, 1)));
+        assert!(
+            service
+                .find_path_avoiding(start, goal, MovementBits::WALK, &lapsed)
+                .is_some(),
+            "the route is walkable again once the cut lapses"
+        );
+
+        let forgotten = service.avoidance(STALLER, 100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
+        assert!(
+            forgotten.links.is_empty() && forgotten.costly_links.is_empty(),
+            "entries must expire: {forgotten:?}"
+        );
+    }
+
+    /// One AI's stalls must not disconnect the level for everybody else.
+    /// A cut is a hard cut in A*, so shared it fed back on itself: the
     /// blacklist only grew over an engagement, and where a crossing is the
     /// only way through, every other AI lost the route as well.
     #[test]
@@ -2325,12 +2589,12 @@ pub(crate) mod tests {
         let service = service(three_cell_db(PathCellFlags::empty()));
         let start = vec3(1.0, 0.0, 1.0);
         let goal = vec3(5.0, 0.0, 1.0);
-        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        stall_twice(&service, STALLER, 0, 1, 0.0);
 
         let bystander = service.avoidance(BYSTANDER, 1.0);
         assert!(
-            bystander.links.is_empty(),
-            "another AI's stall is not this AI's exclusion: {bystander:?}"
+            bystander.links.is_empty() && bystander.costly_links.is_empty(),
+            "another AI's stalls are not this AI's memory: {bystander:?}"
         );
         assert!(
             service
@@ -2342,30 +2606,6 @@ pub(crate) mod tests {
         // that is what warns the bystander off without cutting it off.
         service.report_blocked_cell(0, 0.0);
         assert!(service.avoidance(BYSTANDER, 1.0).cells.contains(&0));
-    }
-
-    #[test]
-    fn blocked_links_expire_after_their_ttl() {
-        let service = service(three_cell_db(PathCellFlags::empty()));
-        service.report_blocked_link(STALLER, 0, 1, 100.0);
-        assert!(
-            service
-                .blocked_links(STALLER, 100.0 + BLOCKED_LINK_TTL_SECONDS - 1.0)
-                .contains(&(0, 1))
-        );
-        let expired = service.avoidance(STALLER, 100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
-        assert!(expired.links.is_empty(), "entries must expire: {expired:?}");
-        // The route is usable again once the entry expired
-        assert!(
-            service
-                .find_path_avoiding(
-                    vec3(1.0, 0.0, 1.0),
-                    vec3(5.0, 0.0, 1.0),
-                    MovementBits::WALK,
-                    &expired
-                )
-                .is_some()
-        );
     }
 
     #[test]
@@ -2388,11 +2628,12 @@ pub(crate) mod tests {
                 stall_seconds: 0.0,
             },
         );
-        service.report_blocked_link(7, 0, 1, 0.0);
+        stall_twice(&service, 7, 0, 1, 0.0);
 
-        // Entity 7 died (or despawned): its records go with it, exclusions
-        // included - they were its memory of a route it could not walk
-        service.report_blocked_link(BYSTANDER, 1, 2, 0.0);
+        // Entity 7 died (or despawned): its records go with it, stall
+        // memories included - they were its memory of a route it could not
+        // walk
+        stall_twice(&service, BYSTANDER, 1, 2, 0.0);
         service.prune_ai_paths(|entity| entity != 7);
         assert!(service.ai_paths().is_empty());
         assert!(service.ai_steering(7).is_none());
@@ -2587,9 +2828,9 @@ pub(crate) mod tests {
         let service = service(island_db());
         let start = vec3(1.0, 0.0, 1.0);
         let island = vec3(21.0, 0.0, 1.0);
-        // The AI stalled on the other side of the level - nothing to do
-        // with this query's goal, which is on an island of its own
-        service.report_blocked_link(STALLER, 0, 1, 0.0);
+        // The AI stalled twice on the other side of the level - nothing to
+        // do with this query's goal, which is on an island of its own
+        stall_twice(&service, STALLER, 0, 1, 0.0);
         assert!(
             service
                 .find_path(start, island, MovementBits::WALK)
@@ -2618,9 +2859,9 @@ pub(crate) mod tests {
         // Both ways into the goal cell are blocked, the second one later -
         // and a stalled cell contributes nothing either way
         service.report_blocked_cell(1, 0.0);
-        service.report_blocked_link(STALLER, 1, 2, 0.0);
-        service.report_blocked_link(STALLER, 0, 1, 2.0);
-        service.report_blocked_link(STALLER, 3, 2, 5.0);
+        stall_twice(&service, STALLER, 1, 2, 0.0);
+        stall_twice(&service, STALLER, 0, 1, 2.0);
+        stall_twice(&service, STALLER, 3, 2, 5.0);
         let avoid = service.avoidance(STALLER, 0.0);
         assert!(
             service
@@ -2637,8 +2878,8 @@ pub(crate) mod tests {
                 &avoid,
                 0.0
             ),
-            Some(2.0 + BLOCKED_LINK_TTL_SECONDS),
-            "wait for the LAST exclusion on the route the goal is reachable by \
+            Some(2.0 + BLOCKED_LINK_CUT_SECONDS),
+            "wait for the LAST cut on the route the goal is reachable by \
              (0 -> 1 -> 2), neither the level's earliest (1 -> 2) nor its \
              latest (3 -> 2, on the detour the AI will not take)"
         );
@@ -2656,6 +2897,40 @@ pub(crate) mod tests {
                 0.0
             ),
             None
+        );
+    }
+
+    /// A price is not a reason to wait. However expensive a crossing has
+    /// become, the AI can still walk it, so a goal behind one is never
+    /// reported temporarily unreachable (#1353's deadline belongs to cuts).
+    #[test]
+    fn a_goal_behind_a_priced_crossing_is_never_something_to_wait_for() {
+        let service = service(detour_db());
+        let start = vec3(1.0, 0.0, 1.0);
+        let goal = vec3(5.0, 0.0, 1.0);
+        // One stall on each way into the goal cell: both expensive, neither
+        // cut
+        service.report_blocked_link(STALLER, 1, 2, 0.0);
+        service.report_blocked_link(STALLER, 3, 2, 0.0);
+        let avoid = service.avoidance(STALLER, 1.0);
+        assert_eq!(avoid.costly_links.len(), 2);
+        assert!(
+            service
+                .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
+                .is_some(),
+            "priced crossings must still get the AI there"
+        );
+        assert_eq!(
+            service.exclusion_expiry_for_unreached_goal(
+                STALLER,
+                start,
+                goal,
+                MovementBits::WALK,
+                &avoid,
+                1.0,
+            ),
+            None,
+            "a cost can never be why a goal is unreachable"
         );
     }
 
@@ -2683,10 +2958,10 @@ pub(crate) mod tests {
     #[test]
     fn an_ais_exclusions_outlive_only_their_ttl() {
         let service = service(three_cell_db(PathCellFlags::empty()));
-        service.report_blocked_link(STALLER, 0, 1, 0.0);
-        service.report_blocked_link(BYSTANDER, 0, 1, 0.0);
+        stall_twice(&service, STALLER, 0, 1, 0.0);
+        stall_twice(&service, BYSTANDER, 0, 1, 0.0);
         let later = BLOCKED_LINK_TTL_SECONDS + 1.0;
-        service.report_blocked_link(STALLER, 1, 2, later);
+        stall_twice(&service, STALLER, 1, 2, later);
 
         assert_eq!(
             service.blocked_links(STALLER, later),
@@ -2709,8 +2984,8 @@ pub(crate) mod tests {
         service.report_blocked_link(STALLER, 0, 1, 0.0);
         assert_eq!(service.stats().blocked_cells, 1);
         assert_eq!(service.stats().blocked_links, 1);
-        // The count is level-wide even though each exclusion applies to one
-        // AI: two AIs excluding the same crossing are two live entries.
+        // The count is level-wide even though each memory belongs to one
+        // AI: two AIs avoiding the same crossing are two live entries.
         service.report_blocked_link(BYSTANDER, 0, 1, 0.0);
         assert_eq!(service.stats().blocked_links, 2);
     }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -29,6 +29,16 @@ pub enum PathTarget {
     Point(Vector3<f32>),
 }
 
+/// What the no-progress clocks saw this frame (see `advance_stall_clocks`).
+#[derive(Debug, Clone, Copy, Default)]
+struct StallClocks {
+    /// The displacement watchdog fired: the body has been effectively still
+    /// for too long with a waypoint to walk to
+    stalled: bool,
+    /// The body covered real ground since the anchor was set
+    moved: bool,
+}
+
 /// A waypoint counts as reached within this XZ distance (2 Dark feet)
 const WAYPOINT_ADVANCE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
 /// ...and within this height difference (7 Dark feet). Waypoint heights are
@@ -232,7 +242,7 @@ impl PathFollowSteeringStrategy {
     }
 
     /// Advance - or freeze - the two no-progress clocks for this frame, and
-    /// answer whether the displacement watchdog has fired.
+    /// answer what they saw.
     ///
     /// A hold is a standstill the AI CHOSE (a door leaf still crossing the
     /// doorway, an authored pivot): it ends by itself, so neither clock moves
@@ -245,13 +255,13 @@ impl PathFollowSteeringStrategy {
         position: Vector3<f32>,
         distance: f32,
         elapsed: f32,
-    ) -> bool {
+    ) -> StallClocks {
         if hold.is_holding() {
             // Both clocks freeze where they are. A body with no anchor yet
             // takes one here, so the displacement watchdog resumes from where
             // it stood rather than from wherever it is first seen moving.
             self.displacement_anchor.get_or_insert((position, 0.0));
-            return false;
+            return StallClocks::default();
         }
         if self.next_waypoint != self.stall_waypoint
             || distance < self.stall_best - STALL_PROGRESS_EPSILON
@@ -272,16 +282,22 @@ impl PathFollowSteeringStrategy {
                 // not a continuation of a pinned body
                 self.last_stall_position = None;
                 self.stall_escalations = 0;
-                false
+                StallClocks {
+                    stalled: false,
+                    moved: true,
+                }
             }
             Some((anchor, age)) => {
                 let age = age + elapsed;
                 self.displacement_anchor = Some((anchor, age));
-                age >= DISPLACEMENT_STALL_SECONDS
+                StallClocks {
+                    stalled: age >= DISPLACEMENT_STALL_SECONDS,
+                    moved: false,
+                }
             }
             None => {
                 self.displacement_anchor = Some((position, 0.0));
-                false
+                StallClocks::default()
             }
         }
     }
@@ -526,15 +542,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
             }
         }
 
-        let was_heading_for = self.next_waypoint;
         self.next_waypoint = advance_waypoint(position, &self.path, self.next_waypoint);
-        if self.next_waypoint > was_heading_for {
-            // A whole leg of the route walked: whatever this AI stalled on
-            // before, its body is moving through the world now, so the next
-            // stall is a fresh first failure rather than the second one that
-            // cuts a crossing. The costs it remembers stay.
-            service.clear_link_stall_history(entity_id.inner());
-        }
 
         service.record_ai_steering(
             entity_id.inner(),
@@ -604,14 +612,23 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         // the path so the next re-path - or wander goal - starts fresh
         // instead of pushing into the obstacle forever.
         let distance = xz_distance(position, waypoint);
-        let displaced_stall = self.advance_stall_clocks(
+        let clocks = self.advance_stall_clocks(
             service.movement_hold(entity_id.inner()),
             position,
             distance,
             time.elapsed.as_secs_f32(),
         );
+        if clocks.moved {
+            // The body covered real ground, so the next stall on a crossing
+            // is a fresh first failure rather than the second one that cuts
+            // it. A body that cannot move keeps its count - which is the
+            // only case escalation is for. Waypoint arrival is NOT this
+            // signal: an adopted route drops waypoints already within reach,
+            // so a pinned body would "advance" one without moving.
+            service.clear_link_stall_history(entity_id.inner());
+        }
         {
-            if self.stall_seconds >= STALL_SECONDS || displaced_stall {
+            if self.stall_seconds >= STALL_SECONDS || clocks.stalled {
                 // Remember the crossing we could not traverse (TTL'd, per
                 // AI): the mesh says the link is walkable but something
                 // physical - a prop on the route, geometry the mesh doesn't
@@ -634,7 +651,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 tracing::debug!(
                     "ai {:?}: stall ({}) at {:.2},{:.2},{:.2} cell={:?} wp[{}]={:.2},{:.2},{:.2} d={:.2}",
                     entity_id,
-                    if displaced_stall {
+                    if clocks.stalled {
                         "displacement"
                     } else {
                         "no-progress"
@@ -1304,9 +1321,39 @@ mod tests {
     ) -> bool {
         let mut displaced = false;
         for _ in 0..(seconds / 0.1).round() as u32 {
-            displaced |= follower.advance_stall_clocks(hold, vec3(0.0, 0.0, 0.0), 5.0, 0.1);
+            displaced |= follower
+                .advance_stall_clocks(hold, vec3(0.0, 0.0, 0.0), 5.0, 0.1)
+                .stalled;
         }
         displaced
+    }
+
+    /// What resets an AI's stall count is ground covered, not a waypoint
+    /// index: an adopted route drops waypoints already within reach, so a
+    /// pinned body in tight geometry can "advance" one without moving - and
+    /// would clear the very count that escalates its second stall into a cut.
+    #[test]
+    fn only_a_body_that_covers_ground_reports_movement() {
+        let mut follower = PathFollowSteeringStrategy::chase_player();
+        for _ in 0..40 {
+            assert!(
+                !follower
+                    .advance_stall_clocks(MovementHold::None, vec3(0.0, 0.0, 0.0), 5.0, 0.1)
+                    .moved,
+                "a body standing in one spot has covered no ground"
+            );
+        }
+        assert!(
+            follower
+                .advance_stall_clocks(
+                    MovementHold::None,
+                    vec3(DISPLACEMENT_STALL_DISTANCE * 2.0, 0.0, 0.0),
+                    5.0,
+                    0.1
+                )
+                .moved,
+            "a body that walks off its anchor has"
+        );
     }
 
     /// The whole point of a hold: a door leaf the AI is standing off from is

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -111,9 +111,9 @@ const BLOCKED_PROBE_DISTANCE: f32 = 0.5 / SCALE_FACTOR;
 /// How many leading cells of the pre-stall route are remembered to check
 /// whether the re-path actually produced a different route
 const STALL_ROUTE_PREFIX: usize = 3;
-/// How many times one stall incident may escalate (blacklist more of the
-/// reproduced route) before falling through to the physical nudge. Bounded
-/// so a genuinely one-way corridor can't be sealed link by link.
+/// How many times one stall incident may re-ask after the route came back
+/// unchanged (pricing more of it each time) before falling through to the
+/// physical nudge. Bounded so a wedged AI can't spin the path worker.
 const MAX_STALL_ESCALATIONS: u32 = 3;
 /// Crowd separation: repel from living creatures within this radius (6 Dark
 /// feet - about two body widths)
@@ -404,8 +404,8 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         // A stall's re-path has to actually change the
                         // route. When it comes back starting exactly the
                         // way the stalled one did, walking it again just
-                        // grinds on the same obstacle - blacklist more of
-                        // it and ask once more (bounded, so a genuinely
+                        // grinds on the same obstacle - price more of it
+                        // and ask once more (bounded, so a genuinely
                         // one-way corridor still gets walked and the
                         // existing nudge remains the last resort).
                         if let Some(stalled) = self.stall_route_cells.take() {
@@ -425,18 +425,19 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                                     entity_id,
                                     self.stall_escalations + 1
                                 );
-                                // The cell penalty alone was outbid. Cut the
-                                // crossing this route opens with out of THIS
-                                // AI's queries, so its next one cannot answer
-                                // with it again - one per escalation, bounded
-                                // so a genuinely one-way corridor still gets
-                                // walked.
+                                // The penalties were outbid. Price the
+                                // crossing this route opens with, so the next
+                                // query weighs it too - but this is the same
+                                // failed attempt answered twice, not a second
+                                // one, so it never counts toward cutting the
+                                // crossing.
                                 self.stall_escalations += 1;
                                 report_stall(
                                     &service,
                                     entity_id.inner(),
                                     &fresh,
                                     time.total.as_secs_f32(),
+                                    StallReport::ReproducedRoute,
                                 );
                                 self.clear_path();
                                 self.repath_cooldown = REPATH_COOLDOWN_SECONDS
@@ -525,7 +526,15 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
             }
         }
 
+        let was_heading_for = self.next_waypoint;
         self.next_waypoint = advance_waypoint(position, &self.path, self.next_waypoint);
+        if self.next_waypoint > was_heading_for {
+            // A whole leg of the route walked: whatever this AI stalled on
+            // before, its body is moving through the world now, so the next
+            // stall is a fresh first failure rather than the second one that
+            // cuts a crossing. The costs it remembers stay.
+            service.clear_link_stall_history(entity_id.inner());
+        }
 
         service.record_ai_steering(
             entity_id.inner(),
@@ -673,7 +682,13 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     _ => route,
                 };
                 tracing::debug!("ai {:?}: blocked report cells={:?}", entity_id, route);
-                report_stall(&service, entity_id.inner(), &route, now_seconds);
+                report_stall(
+                    &service,
+                    entity_id.inner(),
+                    &route,
+                    now_seconds,
+                    StallReport::Physical,
+                );
                 // Remember how the route that failed began, so the re-path
                 // can be checked against it when it lands
                 self.stall_route_cells = Some(route);
@@ -1177,6 +1192,7 @@ fn report_stall(
     entity: u64,
     route: &[u32],
     now_seconds: f32,
+    kind: StallReport,
 ) {
     let Some(&from) = route.first() else {
         return;
@@ -1187,8 +1203,25 @@ fn report_stall(
         .map(|pair| (pair[0], pair[1]))
         .find(|&(from, to)| service.has_link(from, to))
     {
-        service.report_blocked_link(entity, from, to, now_seconds);
+        match kind {
+            StallReport::Physical => service.report_blocked_link(entity, from, to, now_seconds),
+            StallReport::ReproducedRoute => {
+                service.refresh_link_penalty(entity, from, to, now_seconds)
+            }
+        }
     }
+}
+
+/// What a stall report is evidence of. Only a body that tried and failed
+/// counts toward cutting a crossing; a re-query answering with the route
+/// that already stalled is the same evidence a second time, so it refreshes
+/// the penalty and nothing more.
+#[derive(Debug, Clone, Copy)]
+enum StallReport {
+    /// A stall fired: the body could not get through
+    Physical,
+    /// The re-path came back with the route that stalled
+    ReproducedRoute,
 }
 
 /// Whether a route actually arrives at the goal it was computed for. An
@@ -1897,20 +1930,47 @@ mod tests {
         let service = PathfindingService::new(Arc::new(crate::pathfinding::tests::three_cell_db(
             dark::mission::path_database::PathCellFlags::empty(),
         )));
-        report_stall(&service, 7, &[0, 2, 1], 0.0);
+        report_stall(&service, 7, &[0, 2, 1], 0.0, StallReport::Physical);
         let avoidance = service.avoidance(7, 1.0);
         assert!(avoidance.cells.contains(&0), "the stalled cell is reported");
         assert_eq!(
-            avoidance.links.into_iter().collect::<Vec<_>>(),
+            avoidance.costly_links.into_iter().collect::<Vec<_>>(),
             Vec::new(),
             "0 -> 2 is not a link, and 2 -> 1 is not a crossing this route makes first"
         );
 
-        report_stall(&service, 7, &[0, 1], 0.0);
-        assert!(service.avoidance(7, 1.0).links.contains(&(0, 1)));
+        report_stall(&service, 7, &[0, 1], 0.0, StallReport::Physical);
+        assert!(service.avoidance(7, 1.0).costly_links.contains(&(0, 1)));
         assert!(
-            service.avoidance(8, 1.0).links.is_empty(),
-            "the crossing is excluded for the AI that stalled on it, not the level"
+            service.avoidance(8, 1.0).costly_links.is_empty(),
+            "the crossing is priced for the AI that stalled on it, not the level"
+        );
+    }
+
+    /// The body failing twice is what cuts a crossing. A re-path answering
+    /// with the route that already stalled is the same failure reported
+    /// again - it must leave the crossing walkable, or the AI cuts its way
+    /// out of a pocket without ever trying it a second time.
+    #[test]
+    fn only_a_second_physical_stall_cuts_a_crossing() {
+        use crate::pathfinding::PathfindingService;
+        use std::sync::Arc;
+
+        let service = PathfindingService::new(Arc::new(crate::pathfinding::tests::three_cell_db(
+            dark::mission::path_database::PathCellFlags::empty(),
+        )));
+        report_stall(&service, 7, &[0, 1], 0.0, StallReport::Physical);
+        report_stall(&service, 7, &[0, 1], 1.0, StallReport::ReproducedRoute);
+        report_stall(&service, 7, &[0, 1], 2.0, StallReport::ReproducedRoute);
+        assert!(
+            service.avoidance(7, 3.0).links.is_empty(),
+            "a re-query is not a physical attempt"
+        );
+
+        report_stall(&service, 7, &[0, 1], 3.0, StallReport::Physical);
+        assert!(
+            service.avoidance(7, 3.0).links.contains(&(0, 1)),
+            "a second stall by the body cuts it"
         );
     }
 }


### PR DESCRIPTION
A stall mid-route used to **cut** the crossing out of the stalling AI's path queries for 30 seconds, on one failure. One failure is ambiguous - a neighbour walking through, a door still swinging, a body clipping a jamb - and on hydro2 about 20 of ~36 search shortfalls were an AI severed by its **own single** cut, on the only crossing it had (measured in #1367).

The first stall now makes the crossing **expensive** for that AI (`STALLED_LINK_COST_PENALTY`, the same weight as the stalled-cell penalty beside it), so its re-path prefers any other way round but still walks it when there is none. A **second physical stall** on the same directed crossing, with the body having covered no ground between them, escalates to a **5-second cut**. A re-query that answers with the route that already stalled is the same failure reported twice, not another attempt: it refreshes the price and never escalates.

## What it moves

Paired blocked-then-cleared traversal experiment, one binary, three arms behind a temporary switch (removed before this PR): **hard cut** (#1367 as-is), **pure cost** (never cut), **hybrid** (this PR). 120 s per run, 2 runs per arm per scenario, `DebugForceChase`, `--experimental nav_bridges` on hydro2. At t=60 s the blocker is cleared - the body that had not moved is killed via `/v1/entities/:id/message`. Counters: a *stall* is one steering stall event that named a crossing; a *crossing* is the body physically walking a crossing it had stalled on; *stuck* / *moving* are seconds an AI spent commanding movement (following a route, not deliberately holding - `movement_hold` excludes intentional holds) without / with displacing, summed over all AIs; *recovery* is mission seconds from the clear to that AI's first such crossing.

**hydro2** (17-18 unique AIs stalling in every arm; two runs shown as `a / b`):

| arm | stalls | distinct (AI, crossing) | crossings of a stalled crossing | AIs recovering after the clear (mean s) | stuck s | moving s | queries | `no_route` |
|---|---|---|---|---|---|---|---|---|
| hard cut (#1367) | 154 / 160 | 64 / 59 | **0 / 0** | 0 / 0 | 695 / 710 | 751 / 752 | 993 / 993 | **154 / 146** |
| pure cost | 184 / 184 | 52 / 56 | 2 / 5 | 0 / 3 (15.2) | 756 / 749 | 773 / 778 | 872 / 874 | 55 / 57 |
| hybrid (this PR) | 178 / 181 | 50 / 54 | **5 / 3** | 1 (34.6) / 2 (26.2) | 752 / 779 | 769 / 746 | 878 / 874 | **56 / 55** |

The movement outcome is the point: under the hard cut **no AI ever walked a crossing it had stalled on**, in either run, and the level answered `no_route` about 150 times. Priced instead, AIs cross - and cross again after the blocker is gone, within ~26-35 s of it clearing. Search load is *lower*, not higher (872-888 queries vs 993), because a failed search is the expensive one.

**medsci1**, the stationary-NPC pocket #481 chose parking for, is the safety case - does pricing grind there? It does not (10-11 unique AIs stalling per arm):

| arm | stalls | crossings of a stalled crossing | stuck s | moving s | queries |
|---|---|---|---|---|---|
| hard cut | 109 / 114 | 39 / 20 | 652 / 644 | 304 / 263 | 1069 / 1082 |
| pure cost | 112 / 115 | 15 / 16 | 669 / 662 | 228 / 230 | 897 / 920 |
| hybrid | 118 / 116 | 28 / 13 | 662 / 674 | 251 / 243 | 925 / 935 |

Seconds spent commanding movement without displacing are within 3% across all three arms, so the reviewer's objection in #1367 - that a fresh AI arriving at a real blocker would grind instead of parking - does not show up as grinding. The crossing counts here are not comparable between arms and should not be read as a win for the hard cut: the count is conditioned on the crossing being *remembered*, and the hard arm remembers nearly twice as many (58-67 vs 28-38), because every cut forces a new route that stalls somewhere new.

**medsci2's door jamb** produced 0-2 stalls in every arm - a forced chase from the spawn never reaches it - so it distinguishes nothing here and is reported for completeness rather than as evidence.

Nothing about this is visibly different frame to frame (the stuck seconds are flat across arms), so there is no before/after capture: the difference is where the routes go, which the table above measures and `GET /v1/ai/paths` shows live.

## Design

- `LinkStall { expiry, cut_until, stalls }` per (AI, directed crossing). The memory lasts `BLOCKED_LINK_TTL_SECONDS` (30 s, unchanged); a cut lasts `BLOCKED_LINK_CUT_SECONDS` (5 s) and lapses back into a price the AI can pay. Both are named constants, not knobs.
- `NavAvoidance` grew `costly_links` beside `links`: `get_successors` cuts the latter and prices the former. Cells stay shared and priced exactly as before - occupancy is a fact about the world, and #1367's per-AI scoping of crossings is unchanged.
- The steering distinguishes the two reports it makes. `StallReport::Physical` (the stall site) counts; `StallReport::ReproducedRoute` (the re-path arrived at the route that stalled) refreshes the price only. Reusing the existing escalation counter would have turned a price back into a cut with no second physical attempt.
- The count resets when the body **covers ground** - the displacement watchdog's own real-movement arm, which already declares "the next stall is a fresh incident, not a continuation of a pinned body". A cut already earned lives out its 5 s regardless.
- `exclusion_expiry_for_unreached_goal` (#1353) now reads `cut_until` only. A price can never be why a goal came back unreachable, so it never produces a deadline to wait out; the recovered-route proof is kept for cuts, which is now the only thing that exercises that path. Its tests were extended rather than relaxed.

`cargo bn path bench medsci2.mis --seed 424242` unchanged: 200/0 found, inflation 1.67, turn 944 deg, 45.8 waypoints - A* itself is untouched.

## Tests

Negative-first: with `STALLS_BEFORE_CUT` set to 1 (cut on the first stall, the behaviour this replaces), six tests fail - `a_first_stall_prices_a_crossing_without_cutting_it`, `a_priced_crossing_stays_walkable_when_it_is_the_only_way`, `a_goal_behind_a_priced_crossing_is_never_something_to_wait_for`, `route_progress_resets_the_stall_count`, `a_stall_reports_only_crossings_the_mesh_actually_has` and `only_a_second_physical_stall_cuts_a_crossing`. They pass with the change.

- `a_first_stall_prices_a_crossing_without_cutting_it` - one stall reroutes the query onto the detour without cutting; `a_priced_crossing_stays_walkable_when_it_is_the_only_way` - with no detour it is still walked.
- `a_second_physical_stall_cuts_the_crossing` - the cut, directed only: a route already past the crossing still uses it.
- `a_reproduced_route_never_escalates_to_a_cut` / `only_a_second_physical_stall_cuts_a_crossing` (steering level) - four re-queries in a row leave the crossing walkable; the body failing again cuts it.
- `route_progress_resets_the_stall_count` and `only_a_body_that_covers_ground_reports_movement` - progress makes the next stall a first stall, and a pinned body never reports progress.
- `a_cut_lapses_into_a_price_and_then_out_of_memory` - expiry and resumption: cut at +5 s, memory at +30 s, route walkable in between.
- `a_stalled_ais_exclusion_leaves_every_other_ais_route_intact` - per-AI isolation, now for both cuts and prices.
- Deadlines: `an_unreachable_goal_is_not_made_temporary_by_an_unrelated_exclusion` (a topologically disconnected goal gets none, now carrying a real cut so the path is genuinely exercised), `a_goal_cut_off_only_by_exclusions_reports_its_own_route_s_deadline` (an escalated cut does), `a_goal_behind_a_priced_crossing_is_never_something_to_wait_for` (a price does not).

`cargo test -p shock2vr` 1472 passed. `cargo fmt`, `RUSTFLAGS=\"-D warnings\" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` and `cargo check -p shock2vr --all-targets` clean. e2e: `medsci2-patrol-railing` 2/2, `patrol`, `medsci2-doorjamb-chase` - all green, re-run after the review fix below.

## Review

`/xreview`, both engines plus the de-dup pass.

- **Critical / High, [AGREED] by both engines** - the reset was gated on the waypoint *index* rising. An adopted route drops waypoints already within reach, so a body pinned in tight geometry (#481's pocket, medsci2's jamb slivers) could "advance" a waypoint without moving and clear the very count that escalates its second stall - a silent failure to escalate in exactly the case escalation exists for. The reset now hangs off the displacement watchdog's real-movement arm, which a pinned body never reaches, and `only_a_body_that_covers_ground_reports_movement` pins it.
- **Low, both engines + de-dup (S1-names, S4-read)** - `costly_links()` had no caller (`avoidance` populates the field) and was the third copy of the same "is it cut right now" predicate. Accessor deleted, predicate collapsed into `LinkStall::is_cut`.
- **Low** - the fresh-entry initializer set an expiry that the next line overwrote; it now initializes the real value. The re-arming of a cut on each further stall while the AI stays stuck is intended and now says so.

Noted, not taken: both engines observed that the pre-existing bounded re-ask loop (`MAX_STALL_ESCALATIONS`) does less now that the reproduced-route report only refreshes a price already applied, and costs a few query slots before the physical nudge. That loop predates this change and the second-physical-stall escalation largely supersedes it; removing it is a separate change with its own measurement, not a rider on this one. The de-dup pass also flagged the `StallReport` enum as a translation layer over `record_link_stall`'s flag - kept, because `StallReport::Physical` at the call site says what a bare `true` would not. Coverage: all four de-dup strategies ran (S1 15 queries / 8778 candidates, S2 650-line clone report with 1 pair intersecting the change, S3 4321-symbol index, S4 full diff read); nothing else actionable.
