### PR TITLE
fix(sdk): typecheck the arachnid hitbox classes as literals

### DIFF
--- a/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/selection-bounds.e2e.test.ts
@@ -105,7 +105,7 @@ test(
       "the arachnid definition maps every skinned joint: body, mandibles, eight legs",
     );
     const parts = new Set(points.map((point) => point.classification));
-    for (const part of ["torso", "head", "limb", "extremity"]) {
+    for (const part of ["torso", "head", "limb", "extremity"] as const) {
       assert.ok(parts.has(part), `expected a ${part} hitbox on the arachnid`);
     }
 


### PR DESCRIPTION
`npx tsc` on main fails at `test/selection-bounds.e2e.test.ts:109`: `Set<Classification>.has(string)`. One `as const` on the literal array. `npm test` now runs on main again.

Fixes #1369

`npx tsc` clean; `npm test` green.