### PR TITLE
feat(vr): the glove's light and pose read one resolved affordance

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -921,6 +921,10 @@ pub struct PlayerInfo {
     /// Climb state: whether the player is on a ladder/hand hold at all, and
     /// (VR) which hands hold what. See `shock2vr::vr_climb`.
     pub climb: shock2vr::game_scene::DebugClimbState,
+    /// What each VR hand could do with whatever it is pointing at - the state
+    /// that lights the glove and pre-shapes its fingers. See
+    /// `shock2vr::hand_affordance`.
+    pub hand_affordance: shock2vr::game_scene::DebugHandAffordances,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2442,6 +2442,10 @@ fn capture_frame_snapshot(
                     .debug_scene()
                     .and_then(|scene| scene.player_climb())
                     .unwrap_or_default(),
+                hand_affordance: game
+                    .debug_scene()
+                    .and_then(|scene| scene.player_hand_affordances())
+                    .unwrap_or_default(),
             }
         },
         entity_count,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -387,10 +387,22 @@ pub struct DebugClimbState {
 /// What each VR hand could do with whatever it is pointing at, by
 /// [`crate::hand_affordance::HandAffordance`] name ("None" / "Grabbable" /
 /// "Frobbable" / "Blocked" / "Failed").
-#[derive(Debug, Serialize, Clone, Default)]
+#[derive(Debug, Serialize, Clone)]
 pub struct DebugHandAffordances {
-    pub left: String,
-    pub right: String,
+    pub left: &'static str,
+    pub right: &'static str,
+}
+
+/// A scene with no hands reports the same name an idle hand does, so the field
+/// is always a valid state name rather than an empty string.
+impl Default for DebugHandAffordances {
+    fn default() -> Self {
+        let idle = crate::hand_affordance::HandAffordance::None.as_str();
+        Self {
+            left: idle,
+            right: idle,
+        }
+    }
 }
 
 /// Raycast mask for collision group filtering

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -384,6 +384,15 @@ pub struct DebugClimbState {
     pub grips: Vec<DebugClimbHold>,
 }
 
+/// What each VR hand could do with whatever it is pointing at, by
+/// [`crate::hand_affordance::HandAffordance`] name ("None" / "Grabbable" /
+/// "Frobbable" / "Blocked" / "Failed").
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct DebugHandAffordances {
+    pub left: String,
+    pub right: String,
+}
+
 /// Raycast mask for collision group filtering
 #[derive(Debug, Clone)]
 pub struct RaycastMask {
@@ -853,6 +862,12 @@ pub trait DebuggableScene {
     /// The player's climb state (see [`DebugClimbState`]). Scenes without a
     /// player report nothing.
     fn player_climb(&self) -> Option<DebugClimbState> {
+        None
+    }
+
+    /// Each hand's affordance (see [`DebugHandAffordances`]). Scenes without a
+    /// player report nothing.
+    fn player_hand_affordances(&self) -> Option<DebugHandAffordances> {
         None
     }
 

--- a/shock2vr/src/hand_affordance.rs
+++ b/shock2vr/src/hand_affordance.rs
@@ -68,9 +68,9 @@ impl HandAffordance {
     }
 
     /// Action: which shape the hand leans into to prompt it. Only the states
-    /// the hand can actually act on prompt - a blocked or failed target has no
-    /// action to offer.
-    pub fn preshape(self, weight: f32) -> HandPreshape {
+    /// the hand can actually act on prompt - a blocked target has no action to
+    /// offer.
+    fn preshape(self, weight: f32) -> HandPreshape {
         match self {
             HandAffordance::Grabbable => HandPreshape::Grip(weight),
             HandAffordance::Frobbable => HandPreshape::Point(weight),
@@ -123,9 +123,11 @@ impl AffordanceTracker {
         }
     }
 
-    /// How hard to pre-shape toward the hover's action.
+    /// How hard to pre-shape toward the hover's action. Read off the hover, not
+    /// [`Self::state`]: the two channels are independent, so a failure pulse
+    /// recolours the light without dropping the hand out of its shape.
     pub fn preshape(&self) -> HandPreshape {
-        self.state().preshape(self.hover_weight)
+        self.hover.preshape(self.hover_weight)
     }
 }
 
@@ -139,16 +141,16 @@ pub fn preshape_weight(distance: f32) -> f32 {
 /// Classify what a hand's ray hit, using the same predicates the hand's own
 /// trigger/squeeze consult - never a second opinion about the target.
 ///
-/// Order matters: a locked target is blocked whatever else it is, and a pickup
-/// the squeeze would take reads as a grab even though the trigger would also
-/// frob it.
+/// Order matters, and follows the input: the squeeze does not consult locks, so
+/// a pickup it would take reads as a grab even if the object is somehow locked;
+/// only a frob target's lock blocks it.
 pub fn classify(world: &World, entity_id: EntityId) -> HandAffordance {
-    if is_blocked(world, entity_id) {
-        return HandAffordance::Blocked;
-    }
     let scripted = crate::virtual_hand::uses_scripted_world_frob(world, entity_id);
     if !scripted && crate::virtual_hand::can_grab_item(world, entity_id) {
         return HandAffordance::Grabbable;
+    }
+    if is_blocked(world, entity_id) {
+        return HandAffordance::Blocked;
     }
     if scripted || is_frob_responsive(world, entity_id) {
         return HandAffordance::Frobbable;
@@ -156,31 +158,29 @@ pub fn classify(world: &World, entity_id: EntityId) -> HandAffordance {
     HandAffordance::None
 }
 
-/// Whether the entity is locked against the player. Guarded rather than
-/// delegating outright because a hand can raycast in a scene with no
-/// `QuestInfo` (unit fixtures): an unlocked prop is the honest answer there,
-/// and a locked one with no credential state to consult stays blocked.
+/// Whether the entity is locked against the player - the one lock predicate,
+/// shared with buttons and door-opening AIs.
 fn is_blocked(world: &World, entity_id: EntityId) -> bool {
-    let locked = world
-        .borrow::<View<dark::properties::PropLocked>>()
-        .map(|v| v.get(entity_id).is_ok_and(|locked| locked.0))
-        .unwrap_or(false);
-    if !locked {
-        return false;
-    }
-    if world
-        .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
-        .is_err()
-    {
-        return true;
-    }
     crate::scripts::script_util::is_entity_locked(world, entity_id)
 }
 
-/// Whether frobbing this entity does anything: it authors a world frob action,
-/// or it is a door (whose script opens on Frob without authoring one).
+/// Whether frobbing this entity plausibly does something: it hosts a world
+/// panel's widget, authors a world frob action, or is a door (whose script
+/// opens on Frob without authoring one).
+///
+/// A heuristic, deliberately: the trigger itself Frobs *whatever* the ray hit,
+/// so the light cannot promise less than the input will attempt without
+/// narrowing somewhere. This narrows it to what a frob can plausibly move, which
+/// is stricter than flatscreen's highlight filter
+/// (`flat_player_controller::is_frobbable`, any `PropFrobInfo` at all) - a wall
+/// with an `IGNORE` action should not glow.
 fn is_frob_responsive(world: &World, entity_id: EntityId) -> bool {
     use dark::properties::{FrobFlag, PropFrobInfo, PropTranslatingDoor};
+
+    let is_panel_widget = world
+        .borrow::<View<crate::gui::GuiPropProxyEntity>>()
+        .map(|v| v.get(entity_id).is_ok())
+        .unwrap_or(false);
 
     let authored = world
         .borrow::<View<PropFrobInfo>>()
@@ -192,7 +192,8 @@ fn is_frob_responsive(world: &World, entity_id: EntityId) -> bool {
         })
         .unwrap_or(false);
 
-    authored
+    is_panel_widget
+        || authored
         || world
             .borrow::<View<PropTranslatingDoor>>()
             .map(|v| v.get(entity_id).is_ok())
@@ -239,6 +240,17 @@ mod tests {
 
         tracker.update(HandAffordance::Frobbable, 0.3, false);
         assert_eq!(tracker.state(), HandAffordance::Frobbable);
+    }
+
+    /// The failure pulse recolours the light without dropping the hand out of
+    /// its shape - the two channels are independent.
+    #[test]
+    fn a_failure_pulse_keeps_the_hand_prompting() {
+        let mut tracker = AffordanceTracker::default();
+        tracker.update(HandAffordance::Grabbable, 0.3, true);
+
+        assert_eq!(tracker.state(), HandAffordance::Failed);
+        assert!(matches!(tracker.preshape(), HandPreshape::Grip(_)));
     }
 
     /// The two channels stay independent: eligibility colours the light, the

--- a/shock2vr/src/hand_affordance.rs
+++ b/shock2vr/src/hand_affordance.rs
@@ -1,0 +1,281 @@
+//! What a VR hand could do with whatever it is pointing at, resolved once per
+//! hand per frame from the same raycast the trigger and squeeze act on.
+//!
+//! The light says *whether* the hand can act (green: yes, amber: recognised but
+//! refused, red: an attempt just failed); the pre-shape pose says *what* the
+//! action is (curl toward a grip, or extend the index toward a press). Two
+//! channels, one target - a light that promised an action the input would
+//! refuse is exactly the drift AGENTS.md section 3 warns about, so both read
+//! this one resolved state.
+
+use shipyard::{EntityId, Get, View, World};
+
+use crate::hand_glove::{HandLight, HandPreshape};
+
+/// How long a hover survives losing its target, in fixed 60 Hz frames. A hand
+/// held at the edge of a small collider dips in and out of the ray for a frame
+/// at a time; without this the light strobes.
+const HOVER_HOLD_FRAMES: u8 = 6;
+
+/// How long a refused attempt shows red, in fixed 60 Hz frames (~250 ms).
+const FAILED_PULSE_FRAMES: u8 = 15;
+
+/// Pre-shape weight with the target at arm's length, and with it under the
+/// fingertips. The hand prompts harder as it closes in (the UEVR-style
+/// distance ramp), but never so hard that an idle hand looks like it is
+/// already gripping.
+const PRESHAPE_WEIGHT_FAR: f32 = 0.15;
+const PRESHAPE_WEIGHT_NEAR: f32 = 0.45;
+
+/// What the hand could do with its current target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HandAffordance {
+    /// Nothing actionable in reach.
+    #[default]
+    None,
+    /// A pickup the squeeze would take into the hand.
+    Grabbable,
+    /// A button, switch, door or scripted pickup the trigger would frob.
+    Frobbable,
+    /// Recognised, but the hand cannot act on it: locked, or needing a
+    /// credential the player has not collected.
+    Blocked,
+    /// An attempt was refused this frame. Transient - it decays back to the
+    /// hover state.
+    Failed,
+}
+
+impl HandAffordance {
+    /// The name reported over HTTP (`/v1/info` -> `player.hand_affordance`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HandAffordance::None => "None",
+            HandAffordance::Grabbable => "Grabbable",
+            HandAffordance::Frobbable => "Frobbable",
+            HandAffordance::Blocked => "Blocked",
+            HandAffordance::Failed => "Failed",
+        }
+    }
+
+    /// Eligibility: can the hand act, yes / not here / not that.
+    pub fn light(self) -> HandLight {
+        match self {
+            HandAffordance::None => HandLight::Off,
+            HandAffordance::Grabbable | HandAffordance::Frobbable => HandLight::Green,
+            HandAffordance::Blocked => HandLight::Amber,
+            HandAffordance::Failed => HandLight::Red,
+        }
+    }
+
+    /// Action: which shape the hand leans into to prompt it. Only the states
+    /// the hand can actually act on prompt - a blocked or failed target has no
+    /// action to offer.
+    pub fn preshape(self, weight: f32) -> HandPreshape {
+        match self {
+            HandAffordance::Grabbable => HandPreshape::Grip(weight),
+            HandAffordance::Frobbable => HandPreshape::Point(weight),
+            _ => HandPreshape::None,
+        }
+    }
+}
+
+/// The per-hand affordance state machine: hysteresis on the hover, and a fixed
+/// pulse for a refused attempt.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AffordanceTracker {
+    hover: HandAffordance,
+    hover_weight: f32,
+    hold_frames: u8,
+    failed_frames: u8,
+}
+
+impl AffordanceTracker {
+    /// Advance one simulation frame. `observed` is this frame's raw
+    /// classification ([`HandAffordance::None`] when the ray hit nothing
+    /// actionable) and `weight` its pre-shape strength;
+    /// `attempt_failed` marks an input the world refused this frame.
+    pub fn update(&mut self, observed: HandAffordance, weight: f32, attempt_failed: bool) {
+        if attempt_failed {
+            self.failed_frames = FAILED_PULSE_FRAMES;
+        } else {
+            self.failed_frames = self.failed_frames.saturating_sub(1);
+        }
+
+        if observed != HandAffordance::None {
+            self.hover = observed;
+            self.hover_weight = weight;
+            self.hold_frames = HOVER_HOLD_FRAMES;
+        } else if self.hold_frames > 0 {
+            self.hold_frames -= 1;
+        } else {
+            self.hover = HandAffordance::None;
+            self.hover_weight = 0.0;
+        }
+    }
+
+    /// The resolved state: a refused attempt outranks the hover for its pulse,
+    /// then the hover shows through again.
+    pub fn state(&self) -> HandAffordance {
+        if self.failed_frames > 0 {
+            HandAffordance::Failed
+        } else {
+            self.hover
+        }
+    }
+
+    /// How hard to pre-shape toward the hover's action.
+    pub fn preshape(&self) -> HandPreshape {
+        self.state().preshape(self.hover_weight)
+    }
+}
+
+/// The pre-shape strength for a target `distance` away, ramped between the
+/// edge of reach and the fingertips.
+pub fn preshape_weight(distance: f32) -> f32 {
+    let t = (distance / crate::virtual_hand::FROB_REACH).clamp(0.0, 1.0);
+    PRESHAPE_WEIGHT_NEAR + (PRESHAPE_WEIGHT_FAR - PRESHAPE_WEIGHT_NEAR) * t
+}
+
+/// Classify what a hand's ray hit, using the same predicates the hand's own
+/// trigger/squeeze consult - never a second opinion about the target.
+///
+/// Order matters: a locked target is blocked whatever else it is, and a pickup
+/// the squeeze would take reads as a grab even though the trigger would also
+/// frob it.
+pub fn classify(world: &World, entity_id: EntityId) -> HandAffordance {
+    if is_blocked(world, entity_id) {
+        return HandAffordance::Blocked;
+    }
+    let scripted = crate::virtual_hand::uses_scripted_world_frob(world, entity_id);
+    if !scripted && crate::virtual_hand::can_grab_item(world, entity_id) {
+        return HandAffordance::Grabbable;
+    }
+    if scripted || is_frob_responsive(world, entity_id) {
+        return HandAffordance::Frobbable;
+    }
+    HandAffordance::None
+}
+
+/// Whether the entity is locked against the player. Guarded rather than
+/// delegating outright because a hand can raycast in a scene with no
+/// `QuestInfo` (unit fixtures): an unlocked prop is the honest answer there,
+/// and a locked one with no credential state to consult stays blocked.
+fn is_blocked(world: &World, entity_id: EntityId) -> bool {
+    let locked = world
+        .borrow::<View<dark::properties::PropLocked>>()
+        .map(|v| v.get(entity_id).is_ok_and(|locked| locked.0))
+        .unwrap_or(false);
+    if !locked {
+        return false;
+    }
+    if world
+        .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
+        .is_err()
+    {
+        return true;
+    }
+    crate::scripts::script_util::is_entity_locked(world, entity_id)
+}
+
+/// Whether frobbing this entity does anything: it authors a world frob action,
+/// or it is a door (whose script opens on Frob without authoring one).
+fn is_frob_responsive(world: &World, entity_id: EntityId) -> bool {
+    use dark::properties::{FrobFlag, PropFrobInfo, PropTranslatingDoor};
+
+    let authored = world
+        .borrow::<View<PropFrobInfo>>()
+        .map(|v| {
+            v.get(entity_id).is_ok_and(|frob_info| {
+                !frob_info.world_action.is_empty()
+                    && !frob_info.world_action.contains(FrobFlag::IGNORE)
+            })
+        })
+        .unwrap_or(false);
+
+    authored
+        || world
+            .borrow::<View<PropTranslatingDoor>>()
+            .map(|v| v.get(entity_id).is_ok())
+            .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A hover that blinks out for a frame or two must not blink the light out
+    /// with it - but a hover that is really gone must eventually drop to Off.
+    #[test]
+    fn hover_survives_a_short_dropout_then_expires() {
+        let mut tracker = AffordanceTracker::default();
+        tracker.update(HandAffordance::Grabbable, 0.3, false);
+        assert_eq!(tracker.state(), HandAffordance::Grabbable);
+
+        for _ in 0..HOVER_HOLD_FRAMES {
+            tracker.update(HandAffordance::None, 0.0, false);
+            assert_eq!(
+                tracker.state(),
+                HandAffordance::Grabbable,
+                "hover should survive the hysteresis window"
+            );
+        }
+
+        tracker.update(HandAffordance::None, 0.0, false);
+        assert_eq!(tracker.state(), HandAffordance::None);
+    }
+
+    /// A refused attempt shows red for its pulse and then hands the light back
+    /// to whatever the hand is still hovering.
+    #[test]
+    fn failed_pulse_lasts_its_window_then_restores_the_hover() {
+        let mut tracker = AffordanceTracker::default();
+        tracker.update(HandAffordance::Frobbable, 0.3, true);
+        assert_eq!(tracker.state(), HandAffordance::Failed);
+
+        for _ in 1..FAILED_PULSE_FRAMES {
+            tracker.update(HandAffordance::Frobbable, 0.3, false);
+            assert_eq!(tracker.state(), HandAffordance::Failed);
+        }
+
+        tracker.update(HandAffordance::Frobbable, 0.3, false);
+        assert_eq!(tracker.state(), HandAffordance::Frobbable);
+    }
+
+    /// The two channels stay independent: eligibility colours the light, the
+    /// action shapes the hand, and a state with no action prompts nothing.
+    #[test]
+    fn light_reads_eligibility_and_preshape_reads_the_action() {
+        assert_eq!(HandAffordance::None.light(), HandLight::Off);
+        assert_eq!(HandAffordance::Grabbable.light(), HandLight::Green);
+        assert_eq!(HandAffordance::Frobbable.light(), HandLight::Green);
+        assert_eq!(HandAffordance::Blocked.light(), HandLight::Amber);
+        assert_eq!(HandAffordance::Failed.light(), HandLight::Red);
+
+        assert!(matches!(
+            HandAffordance::Grabbable.preshape(0.3),
+            HandPreshape::Grip(_)
+        ));
+        assert!(matches!(
+            HandAffordance::Frobbable.preshape(0.3),
+            HandPreshape::Point(_)
+        ));
+        for state in [
+            HandAffordance::None,
+            HandAffordance::Blocked,
+            HandAffordance::Failed,
+        ] {
+            assert_eq!(state.preshape(0.3), HandPreshape::None);
+        }
+    }
+
+    /// The prompt ramps up as the hand closes in, and never reaches a full
+    /// curl - the player's own trigger has to stay visible on top of it.
+    #[test]
+    fn preshape_weight_ramps_toward_the_target() {
+        let far = preshape_weight(crate::virtual_hand::FROB_REACH);
+        let near = preshape_weight(0.0);
+        assert!(far < near, "{far} should prompt less than {near}");
+        assert!((0.0..0.6).contains(&near), "{near} is too strong a prompt");
+        assert!(preshape_weight(f32::MAX) >= PRESHAPE_WEIGHT_FAR);
+    }
+}

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -98,22 +98,30 @@ pub enum HandPreshape {
     Point(f32),
 }
 
-impl HandPreshape {
-    /// Lean the analog curl toward this shape. Never overrides: a finger the
-    /// player is already curling further stays where they put it.
-    fn apply(self, amounts: &mut FingerAmounts) {
-        let (weight, index_too) = match self {
-            HandPreshape::None => return,
-            HandPreshape::Grip(weight) => (weight, true),
-            HandPreshape::Point(weight) => (weight, false),
-        };
-        let weight = weight.clamp(0.0, 1.0);
-        amounts.thumb = amounts.thumb.max(weight);
-        amounts.middle = amounts.middle.max(weight);
-        amounts.ring = amounts.ring.max(weight);
-        amounts.pinky = amounts.pinky.max(weight);
-        if index_too {
-            amounts.index = amounts.index.max(weight);
+/// Lean an analog-posed hand toward the prompt's authored shape - the same
+/// `fist` and `point` poses the rest of the glove uses, so there is one
+/// vocabulary of hand shapes rather than a second, synthetic one.
+///
+/// Trigger authority: `fist` is the maximal curl the analog blend already runs
+/// toward, so leaning into it only ever adds curl; `point` is applied to every
+/// finger *but* the index, which is what makes it a point and what leaves the
+/// trigger's own finger exactly where the player put it.
+fn prompted_pose(posed: Pose, fist: &Pose, point: &Pose, preshape: HandPreshape) -> Pose {
+    match preshape {
+        HandPreshape::None => posed,
+        HandPreshape::Grip(weight) => posed.blend(fist, weight.clamp(0.0, 1.0)),
+        HandPreshape::Point(weight) => {
+            let weight = weight.clamp(0.0, 1.0);
+            posed.blend_per_finger(
+                point,
+                &FingerAmounts {
+                    thumb: weight,
+                    index: 0.0,
+                    middle: weight,
+                    ring: weight,
+                    pinky: weight,
+                },
+            )
         }
     }
 }
@@ -223,7 +231,7 @@ impl GloveRenderer {
         light: HandLight,
         preshape: HandPreshape,
     ) -> Vec<SceneObject> {
-        let mut amounts = if holding {
+        let amounts = if holding {
             // Gripping a held item: fingers wrapped on the handle, thumb
             // locked, index resting on the trigger and curling with the pull
             // (the squeeze is what holds the item, so it doesn't drive the
@@ -247,12 +255,13 @@ impl GloveRenderer {
                 pinky: squeeze_value,
             }
         };
-        // The prompt is a floor under the analog curl, so a real pull always
-        // shows through it. A full hand has nothing to reach for.
-        if !holding {
-            preshape.apply(&mut amounts);
-        }
         let pose = self.open.blend_per_finger(&self.fist, &amounts);
+        // A full hand has nothing to reach for, so it is never prompted.
+        let pose = if holding {
+            pose
+        } else {
+            prompted_pose(pose, &self.fist, &self.point, preshape)
+        };
         Self::render_posed(
             &mut self.model,
             &self.retarget,
@@ -437,30 +446,63 @@ mod tests {
         }
     }
 
-    /// The prompt only ever adds curl, and the player's own pull outranks it:
-    /// a full trigger stays full whatever the hand is hovering.
+    /// Slerping a pose onto itself is exact only up to float round-off.
+    fn same_rotation(a: cgmath::Quaternion<f32>, b: cgmath::Quaternion<f32>) -> bool {
+        use cgmath::InnerSpace;
+        (a - b).magnitude() < 1e-4
+    }
+
+    /// A trigger pull owns the index finger: the point prompt curls the other
+    /// four toward the authored pointing pose and leaves the index exactly
+    /// where the player put it, and no prompt at all changes nothing.
     #[test]
-    fn preshape_floors_the_curl_without_overriding_a_real_pull() {
-        let pulled = FingerAmounts {
-            index: 1.0,
-            ..FingerAmounts::default()
-        };
+    fn the_point_prompt_leaves_the_pulled_index_alone() {
+        let open = hand_pose::open_right_hand();
+        let fist = hand_pose::fist_right_hand();
+        let point = hand_pose::point_right_hand();
+        let pulled = open.blend_per_finger(
+            &fist,
+            &FingerAmounts {
+                index: 1.0,
+                ..FingerAmounts::default()
+            },
+        );
 
-        let mut grip = pulled;
-        HandPreshape::Grip(0.3).apply(&mut grip);
-        assert_eq!(grip.index, 1.0, "a real trigger pull must win");
-        assert_eq!(grip.thumb, 0.3);
-        assert_eq!(grip.pinky, 0.3);
+        let prompted = prompted_pose(pulled.clone(), &fist, &point, HandPreshape::Point(0.4));
+        // SteamVR bones 6..=10 are the index chain.
+        for bone in 6..=10 {
+            assert!(
+                same_rotation(prompted.bone_rotations[bone], pulled.bone_rotations[bone]),
+                "the point prompt must not move index bone {bone}"
+            );
+        }
+        let moved = (11..=15)
+            .any(|bone| !same_rotation(prompted.bone_rotations[bone], pulled.bone_rotations[bone]));
+        assert!(moved, "the point prompt should curl the middle finger");
 
-        // Point leaves the index extended - that is what makes it a point.
-        let mut point = FingerAmounts::default();
-        HandPreshape::Point(0.3).apply(&mut point);
-        assert_eq!(point.index, 0.0);
-        assert_eq!(point.middle, 0.3);
+        let unprompted = prompted_pose(pulled.clone(), &fist, &point, HandPreshape::None);
+        assert_eq!(unprompted.bone_rotations, pulled.bone_rotations);
+    }
 
-        let mut none = pulled;
-        HandPreshape::None.apply(&mut none);
-        assert_eq!(none.thumb, 0.0);
+    /// The grip prompt only ever adds curl - it leans toward the same fist the
+    /// analog blend already runs toward, so a fully squeezed hand is unmoved.
+    #[test]
+    fn the_grip_prompt_never_uncurls_a_closed_hand() {
+        let fist = hand_pose::fist_right_hand();
+        let point = hand_pose::point_right_hand();
+
+        let prompted = prompted_pose(fist.clone(), &fist, &point, HandPreshape::Grip(0.4));
+        for (bone, (prompted, closed)) in prompted
+            .bone_rotations
+            .iter()
+            .zip(&fist.bone_rotations)
+            .enumerate()
+        {
+            assert!(
+                same_rotation(*prompted, *closed),
+                "the grip prompt moved bone {bone} of an already closed hand"
+            );
+        }
     }
 
     /// The uncorrected glove is undersized, not oversized - a scale below 1.0

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -85,6 +85,39 @@ impl HandLight {
     }
 }
 
+/// A prompt the hand leans into before the player acts: the shape says what
+/// the action would be, the weight (0..1) how far to lean. Applied as a *floor*
+/// on the analog curl, so a real trigger or squeeze always outranks it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum HandPreshape {
+    /// Nothing to prompt.
+    None,
+    /// Curl toward a grip - something to pick up.
+    Grip(f32),
+    /// Curl the rest, leave the index extended - something to press.
+    Point(f32),
+}
+
+impl HandPreshape {
+    /// Lean the analog curl toward this shape. Never overrides: a finger the
+    /// player is already curling further stays where they put it.
+    fn apply(self, amounts: &mut FingerAmounts) {
+        let (weight, index_too) = match self {
+            HandPreshape::None => return,
+            HandPreshape::Grip(weight) => (weight, true),
+            HandPreshape::Point(weight) => (weight, false),
+        };
+        let weight = weight.clamp(0.0, 1.0);
+        amounts.thumb = amounts.thumb.max(weight);
+        amounts.middle = amounts.middle.max(weight);
+        amounts.ring = amounts.ring.max(weight);
+        amounts.pinky = amounts.pinky.max(weight);
+        if index_too {
+            amounts.index = amounts.index.max(weight);
+        }
+    }
+}
+
 /// Wrist-to-fingertip length the glove model is authored at, in world units -
 /// the +Z span of its bind-pose bounding box (fingers point along +Z).
 pub const AUTHORED_HAND_LENGTH_WORLD: f32 = 0.2049;
@@ -188,8 +221,9 @@ impl GloveRenderer {
         squeeze_value: f32,
         holding: bool,
         light: HandLight,
+        preshape: HandPreshape,
     ) -> Vec<SceneObject> {
-        let amounts = if holding {
+        let mut amounts = if holding {
             // Gripping a held item: fingers wrapped on the handle, thumb
             // locked, index resting on the trigger and curling with the pull
             // (the squeeze is what holds the item, so it doesn't drive the
@@ -213,6 +247,11 @@ impl GloveRenderer {
                 pinky: squeeze_value,
             }
         };
+        // The prompt is a floor under the analog curl, so a real pull always
+        // shows through it. A full hand has nothing to reach for.
+        if !holding {
+            preshape.apply(&mut amounts);
+        }
         let pose = self.open.blend_per_finger(&self.fist, &amounts);
         Self::render_posed(
             &mut self.model,
@@ -396,6 +435,32 @@ mod tests {
         for (expected, light) in HandLight::ALL.iter().enumerate() {
             assert_eq!(light.index(), expected);
         }
+    }
+
+    /// The prompt only ever adds curl, and the player's own pull outranks it:
+    /// a full trigger stays full whatever the hand is hovering.
+    #[test]
+    fn preshape_floors_the_curl_without_overriding_a_real_pull() {
+        let pulled = FingerAmounts {
+            index: 1.0,
+            ..FingerAmounts::default()
+        };
+
+        let mut grip = pulled;
+        HandPreshape::Grip(0.3).apply(&mut grip);
+        assert_eq!(grip.index, 1.0, "a real trigger pull must win");
+        assert_eq!(grip.thumb, 0.3);
+        assert_eq!(grip.pinky, 0.3);
+
+        // Point leaves the index extended - that is what makes it a point.
+        let mut point = FingerAmounts::default();
+        HandPreshape::Point(0.3).apply(&mut point);
+        assert_eq!(point.index, 0.0);
+        assert_eq!(point.middle, 0.3);
+
+        let mut none = pulled;
+        HandPreshape::None.apply(&mut none);
+        assert_eq!(none.thumb, 0.0);
     }
 
     /// The uncorrected glove is undersized, not oversized - a scale below 1.0

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -146,13 +146,13 @@ pub trait PlayerInteraction {
         self.holding_hand(entity_id).is_some()
     }
 
-    /// Wield `entity_id` as the first-person weapon (flat); no-op for VR.
     /// What this hand could do with whatever it is pointing at. Flatscreen has
     /// no per-hand affordance to report.
     fn hand_affordance(&self, _hand: Handedness) -> crate::hand_affordance::HandAffordance {
         crate::hand_affordance::HandAffordance::None
     }
 
+    /// Wield `entity_id` as the first-person weapon (flat); no-op for VR.
     fn wield(&mut self, _entity_id: EntityId) -> Vec<VirtualHandEffect> {
         Vec::new()
     }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -147,6 +147,12 @@ pub trait PlayerInteraction {
     }
 
     /// Wield `entity_id` as the first-person weapon (flat); no-op for VR.
+    /// What this hand could do with whatever it is pointing at. Flatscreen has
+    /// no per-hand affordance to report.
+    fn hand_affordance(&self, _hand: Handedness) -> crate::hand_affordance::HandAffordance {
+        crate::hand_affordance::HandAffordance::None
+    }
+
     fn wield(&mut self, _entity_id: EntityId) -> Vec<VirtualHandEffect> {
         Vec::new()
     }
@@ -291,6 +297,13 @@ impl PlayerInteraction for VrInteraction {
         match hand {
             Handedness::Left => self.left_hand.get_raytraced_entity(),
             Handedness::Right => self.right_hand.get_raytraced_entity(),
+        }
+    }
+
+    fn hand_affordance(&self, hand: Handedness) -> crate::hand_affordance::HandAffordance {
+        match hand {
+            Handedness::Left => self.left_hand.affordance(),
+            Handedness::Right => self.right_hand.affordance(),
         }
     }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audio_log;
 pub mod game_scene;
+pub mod hand_affordance;
 pub mod hand_buttons;
 pub mod hand_pose;
 pub mod hand_pose_library;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -11665,16 +11665,8 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     fn player_hand_affordances(&self) -> Option<crate::game_scene::DebugHandAffordances> {
         use crate::vr_config::Handedness;
         Some(crate::game_scene::DebugHandAffordances {
-            left: self
-                .interaction
-                .hand_affordance(Handedness::Left)
-                .as_str()
-                .to_string(),
-            right: self
-                .interaction
-                .hand_affordance(Handedness::Right)
-                .as_str()
-                .to_string(),
+            left: self.interaction.hand_affordance(Handedness::Left).as_str(),
+            right: self.interaction.hand_affordance(Handedness::Right).as_str(),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -11662,6 +11662,22 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         })
     }
 
+    fn player_hand_affordances(&self) -> Option<crate::game_scene::DebugHandAffordances> {
+        use crate::vr_config::Handedness;
+        Some(crate::game_scene::DebugHandAffordances {
+            left: self
+                .interaction
+                .hand_affordance(Handedness::Left)
+                .as_str()
+                .to_string(),
+            right: self
+                .interaction
+                .hand_affordance(Handedness::Right)
+                .as_str()
+                .to_string(),
+        })
+    }
+
     fn raycast(
         &self,
         start: cgmath::Point3<f32>,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -375,6 +375,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.player_climb()
     }
 
+    fn player_hand_affordances(&self) -> Option<crate::game_scene::DebugHandAffordances> {
+        self.mission_core.player_hand_affordances()
+    }
+
     fn teleport_player(&mut self, position: Vector3<f32>) -> Result<(), String> {
         self.mission_core.teleport_player(position)
     }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -144,28 +144,31 @@ pub fn is_message_turnon_or_turnoff(msg: &MessagePayload) -> bool {
 /// Whether an entity is currently locked against the player: it carries
 /// `PropLocked(true)` and either has no key destination or a key/quest gate
 /// the player hasn't satisfied. Shared by buttons and (door-opening) AIs.
+/// Borrows are tolerated rather than unwrapped: a hand raycasts in scenes and
+/// fixtures that carry no `QuestInfo`, and "locked with no credential state to
+/// consult" is still locked.
 pub fn is_entity_locked(world: &World, entity_id: EntityId) -> bool {
-    let v_locked = world
-        .borrow::<View<dark::properties::PropLocked>>()
-        .unwrap();
+    let Ok(v_locked) = world.borrow::<View<dark::properties::PropLocked>>() else {
+        return false;
+    };
     let Ok(locked) = v_locked.get(entity_id) else {
         return false;
     };
     if !locked.0 {
         return false;
     }
-    let v_key_dst = world
-        .borrow::<View<dark::properties::PropKeyDst>>()
-        .unwrap();
-    let quest = world
+    // Locked with no key destination - nothing can unlock it.
+    let Ok(v_key_dst) = world.borrow::<View<dark::properties::PropKeyDst>>() else {
+        return true;
+    };
+    let Ok(key_dst) = v_key_dst.get(entity_id) else {
+        return true;
+    };
+    // Locked behind a credential: open only if the player has collected it.
+    world
         .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
-        .unwrap();
-    match v_key_dst.get(entity_id) {
-        // Locked, and the player lacks the key/quest state to open it
-        Ok(key_dst) => !quest.can_unlock(&key_dst.0),
-        // Locked with no key destination - nothing can unlock it
-        Err(_) => true,
-    }
+        .map(|quest| !quest.can_unlock(&key_dst.0))
+        .unwrap_or(true)
 }
 
 /// Set the lock state of one live entity, writing Dark's own `P$Locked`

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -1,6 +1,6 @@
 // Helper to convert the input context to a form more useful for gameplay / interacting with the world
 
-use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, Vector3, Zero, point3, vec3};
+use cgmath::{InnerSpace, Quaternion, Rotation, Vector3, Zero, point3, vec3};
 use dark::{
     SCALE_FACTOR,
     properties::{FrobFlag, PropFrobInfo, PropModelName},
@@ -14,6 +14,7 @@ use tracing::{self, trace};
 
 use crate::{
     gui::GuiPropProxyEntity,
+    hand_affordance::{self, AffordanceTracker, HandAffordance},
     input_context::Hand,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     scripts::{Message, MessagePayload},
@@ -52,6 +53,10 @@ pub struct VirtualHand {
     last_frobbed_entity: Option<EntityId>,
 
     hand_state: HandState,
+
+    /// What this hand could do with whatever it is pointing at - the light on
+    /// the glove and the pre-shape it leans into.
+    affordance: AffordanceTracker,
 
     handedness: Handedness,
 }
@@ -139,6 +144,7 @@ impl VirtualHand {
             raytrace_hit: None,
             last_frobbed_entity: None,
             hand_state: HandState::Empty,
+            affordance: Default::default(),
             handedness,
         }
     }
@@ -249,6 +255,10 @@ impl VirtualHand {
                 // See what we're hitting
                 let mut msgs = Vec::new();
 
+                // A full hand has nothing to reach for, so its light decays.
+                let mut affordance = prev.affordance;
+                affordance.update(HandAffordance::None, 0.0, false);
+
                 // If we're holding onto something, but not grabbing, we can drop it
                 if input_hand.squeeze_value < 0.5 {
                     let mut msgs = vec![VirtualHandEffect::DropItem { entity_id }];
@@ -275,6 +285,7 @@ impl VirtualHand {
                         raytrace_hit: None,
                         last_frobbed_entity: None,
                         hand_state: HandState::Empty,
+                        affordance,
                         handedness,
                     };
                     (updated_hand, msgs)
@@ -326,6 +337,7 @@ impl VirtualHand {
                         raytrace_hit: None,
                         last_frobbed_entity: None,
                         hand_state: next_hand_state,
+                        affordance,
                         handedness,
                     };
                     (updated_hand, msgs)
@@ -336,6 +348,7 @@ impl VirtualHand {
                 hand_position,
                 hand_rotation,
                 prev.last_frobbed_entity,
+                prev.affordance,
                 world,
                 physics,
                 input_hand,
@@ -368,9 +381,15 @@ impl VirtualHand {
         (hand, effs)
     }
 
-    /// Render the glove for this hand, plus the raycast-hit debug cube. The
-    /// hand renderer is owned by the caller (`VrInteraction`) so its cached
-    /// state is shared between both hands.
+    /// What this hand could do with whatever it is pointing at, after
+    /// hysteresis and any failure pulse. Drives the glove's light and its
+    /// pre-shape, and is reported over HTTP for tests.
+    pub fn affordance(&self) -> HandAffordance {
+        self.affordance.state()
+    }
+
+    /// Render the glove for this hand. The hand renderer is owned by the caller
+    /// (`VrInteraction`) so its cached state is shared between both hands.
     pub fn render(
         &self,
         world: &World,
@@ -378,7 +397,7 @@ impl VirtualHand {
     ) -> Vec<SceneObject> {
         // The hand itself: the skinned hand model, posed from the analog
         // inputs - unless a wielded weapon's model stands in for it.
-        let mut scene_objects = glove_renderer
+        glove_renderer
             .filter(|_| shows_hand_visual(world, self.get_held_entity()))
             .map(|renderer| {
                 renderer.render_hand(
@@ -388,40 +407,12 @@ impl VirtualHand {
                     self.trigger_value,
                     self.squeeze_value,
                     self.get_held_entity().is_some(),
-                    // The state machine that lights the glove is a later slice;
-                    // the affordance still reads off the hit cube below.
-                    crate::hand_glove::HandLight::Off,
+                    // Eligibility lights the glove; the action shapes it.
+                    self.affordance.state().light(),
+                    self.affordance.preshape(),
                 )
             })
-            .unwrap_or_default();
-
-        let hit_color = self.color_from_state();
-
-        // Show ray trace hit
-        if let Some(rayhit) = &self.raytrace_hit {
-            let cm = engine::scene::color_material::create(hit_color);
-            let transform = Matrix4::from_translation(vec3(
-                rayhit.hit_point.x,
-                rayhit.hit_point.y,
-                rayhit.hit_point.z,
-            )) * Matrix4::from_scale(0.05);
-            let mut new_obj = SceneObject::new(cm, Box::new(engine::scene::cube::create()));
-            new_obj.set_transform(transform);
-            scene_objects.push(new_obj);
-        }
-
-        scene_objects
-    }
-
-    fn color_from_state(&self) -> Vector3<f32> {
-        if self.trigger_value < 0.1 && self.squeeze_value < 0.1 {
-            vec3(1.0, 1.0, 1.0)
-        } else {
-            let r = self.trigger_value;
-            let b = self.squeeze_value;
-            let g = 0.0;
-            vec3(r, g, b)
-        }
+            .unwrap_or_default()
     }
 }
 
@@ -430,6 +421,7 @@ fn handle_empty_hand_state(
     hand_position: Vector3<f32>,
     hand_rotation: Quaternion<f32>,
     frobbed_entity: Option<EntityId>,
+    mut affordance: AffordanceTracker,
     world: &World,
     physics: &PhysicsWorld,
     input_hand: &Hand,
@@ -439,6 +431,22 @@ fn handle_empty_hand_state(
     let forward = hand_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
     let result = interaction_ray_cast(physics, world, ray_start, forward, held_by_other_hand);
     trace!("ray cast result: {:?}", &result);
+
+    // One resolved target per hand per frame: the glove's light and pre-shape
+    // read the same hit the trigger and squeeze below act on, so the hand can
+    // never advertise an action the input would refuse.
+    let (observed, preshape_weight) = match result.as_ref().and_then(|hit| {
+        hit.maybe_entity_id
+            .map(|entity_id| (entity_id, (hit.hit_point - ray_start).magnitude()))
+    }) {
+        Some((entity_id, distance)) => (
+            hand_affordance::classify(world, entity_id),
+            hand_affordance::preshape_weight(distance),
+        ),
+        None => (HandAffordance::None, 0.0),
+    };
+    let mut attempt_failed = false;
+
     let mut msgs = Vec::new();
     let mut last_frobbed_entity = frobbed_entity;
     let mut next_hand_state = HandState::Empty;
@@ -466,6 +474,9 @@ fn handle_empty_hand_state(
                     },
                 });
                 last_frobbed_entity = Some(entity);
+                // The frob still goes out - the script owns the refusal - but a
+                // locked target is one the hand knew it could not open.
+                attempt_failed = observed == HandAffordance::Blocked;
 
                 // Also, frob any items that may be nearby...
             }
@@ -512,9 +523,15 @@ fn handle_empty_hand_state(
                     },
                 });
                 last_frobbed_entity = Some(entity_id);
+            } else {
+                // Squeezing something the hand cannot take: the other hand's
+                // item, or scenery with no `MOVE`.
+                attempt_failed = true;
             }
         }
     }
+
+    affordance.update(observed, preshape_weight, attempt_failed);
 
     let updated_hand = VirtualHand {
         position: hand_position,
@@ -524,6 +541,7 @@ fn handle_empty_hand_state(
         raytrace_hit: result,
         last_frobbed_entity,
         hand_state: next_hand_state,
+        affordance,
         handedness,
     };
     (updated_hand, msgs)
@@ -1089,6 +1107,7 @@ mod tests {
             Vector3::zero(),
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             None,
+            AffordanceTracker::default(),
             &world,
             &physics,
             &input,
@@ -1101,6 +1120,7 @@ mod tests {
             Vector3::zero(),
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             hand.last_frobbed_entity,
+            AffordanceTracker::default(),
             &world,
             &physics,
             &input,
@@ -1132,6 +1152,7 @@ mod tests {
             Vector3::zero(),
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             None,
+            AffordanceTracker::default(),
             &world,
             &physics,
             &input,
@@ -1151,6 +1172,7 @@ mod tests {
             vec3(1.0, 0.0, 0.0),
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             hand.last_frobbed_entity,
+            AffordanceTracker::default(),
             &world,
             &physics,
             &input,
@@ -1174,9 +1196,13 @@ mod tests {
     }
 
     fn frob_fixture(distance: f32) -> (World, PhysicsWorld, EntityId) {
+        frob_fixture_with(distance, FrobFlag::SCRIPT)
+    }
+
+    fn frob_fixture_with(distance: f32, world_action: FrobFlag) -> (World, PhysicsWorld, EntityId) {
         let mut world = World::new();
         let target = world.add_entity(PropFrobInfo {
-            world_action: FrobFlag::SCRIPT,
+            world_action,
             inventory_action: FrobFlag::empty(),
             tool_action: FrobFlag::empty(),
         });
@@ -1248,5 +1274,53 @@ mod tests {
             )),
             "an in-reach VR trigger should preserve frob behavior, got {near_effects:?}"
         );
+    }
+
+    /// The light and the pre-shape must resolve off the same target the input
+    /// acts on: an authored pickup in reach reads as a grab, a scripted-frob
+    /// target as a press, and an empty ray as nothing.
+    #[test]
+    fn hovering_resolves_one_affordance_per_hand() {
+        let idle = Hand::default();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let hover = |distance: f32, world_action: FrobFlag| {
+            let (world, physics, _) = frob_fixture_with(distance, world_action);
+            VirtualHand::update(
+                &VirtualHand::new(Handedness::Right),
+                &physics,
+                &world,
+                vec3(0.0, 0.0, 0.0),
+                identity,
+                &idle,
+                None,
+            )
+            .0
+            .affordance()
+        };
+
+        assert_eq!(hover(2.5, FrobFlag::MOVE), HandAffordance::Grabbable);
+        assert_eq!(hover(2.5, FrobFlag::SCRIPT), HandAffordance::Frobbable);
+        assert_eq!(hover(4.0, FrobFlag::MOVE), HandAffordance::None);
+    }
+
+    /// A squeeze on something the hand cannot take is a refused attempt, and
+    /// reads red rather than staying green on a grab that never happens.
+    #[test]
+    fn a_refused_grab_reads_as_a_failed_attempt() {
+        let (world, physics, _) = frob_fixture_with(2.5, FrobFlag::empty());
+        let squeeze = Hand {
+            squeeze_value: 1.0,
+            ..Hand::default()
+        };
+        let (hand, _) = VirtualHand::update(
+            &VirtualHand::new(Handedness::Right),
+            &physics,
+            &world,
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            &squeeze,
+            None,
+        );
+        assert_eq!(hand.affordance(), HandAffordance::Failed);
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -255,9 +255,10 @@ impl VirtualHand {
                 // See what we're hitting
                 let mut msgs = Vec::new();
 
-                // A full hand has nothing to reach for, so its light decays.
-                let mut affordance = prev.affordance;
-                affordance.update(HandAffordance::None, 0.0, false);
+                // A full hand has nothing to reach for. Clear rather than decay:
+                // closing on an item is a hard transition, so the light must not
+                // keep advertising the grab for the hysteresis window.
+                let affordance = AffordanceTracker::default();
 
                 // If we're holding onto something, but not grabbing, we can drop it
                 if input_hand.squeeze_value < 0.5 {
@@ -349,6 +350,7 @@ impl VirtualHand {
                 hand_rotation,
                 prev.last_frobbed_entity,
                 prev.affordance,
+                prev.squeeze_value,
                 world,
                 physics,
                 input_hand,
@@ -422,6 +424,7 @@ fn handle_empty_hand_state(
     hand_rotation: Quaternion<f32>,
     frobbed_entity: Option<EntityId>,
     mut affordance: AffordanceTracker,
+    prev_squeeze: f32,
     world: &World,
     physics: &PhysicsWorld,
     input_hand: &Hand,
@@ -446,6 +449,8 @@ fn handle_empty_hand_state(
         None => (HandAffordance::None, 0.0),
     };
     let mut attempt_failed = false;
+    // A refusal is one press, not one per frame the player keeps holding.
+    let squeeze_pressed = prev_squeeze <= 0.5 && input_hand.squeeze_value > 0.5;
 
     let mut msgs = Vec::new();
     let mut last_frobbed_entity = frobbed_entity;
@@ -523,9 +528,10 @@ fn handle_empty_hand_state(
                     },
                 });
                 last_frobbed_entity = Some(entity_id);
-            } else {
-                // Squeezing something the hand cannot take: the other hand's
-                // item, or scenery with no `MOVE`.
+            } else if squeeze_pressed && !needs_scripted_frob {
+                // Squeezing scenery with no `MOVE` and no script to take it.
+                // A scripted target already Frobbed by this same press is not a
+                // refusal - it is the press still being held.
                 attempt_failed = true;
             }
         }
@@ -1108,6 +1114,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             None,
             AffordanceTracker::default(),
+            0.0,
             &world,
             &physics,
             &input,
@@ -1121,6 +1128,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             hand.last_frobbed_entity,
             AffordanceTracker::default(),
+            0.0,
             &world,
             &physics,
             &input,
@@ -1153,6 +1161,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             None,
             AffordanceTracker::default(),
+            0.0,
             &world,
             &physics,
             &input,
@@ -1173,6 +1182,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             hand.last_frobbed_entity,
             AffordanceTracker::default(),
+            0.0,
             &world,
             &physics,
             &input,
@@ -1335,6 +1345,38 @@ mod tests {
             None,
         );
         assert_eq!(frobbing.affordance(), HandAffordance::Failed);
+    }
+
+    /// A squeeze the world *accepted* must never read as a refusal, however
+    /// long it is held: a scripted pickup is Frobbed once and the latch then
+    /// suppresses further frobs, which is the same press, not a rejection.
+    #[test]
+    fn holding_a_squeeze_on_a_scripted_pickup_never_reads_as_failed() {
+        let (world, physics, _) = frob_fixture_with(2.5, FrobFlag::SCRIPT);
+        let squeeze = Hand {
+            squeeze_value: 1.0,
+            ..Hand::default()
+        };
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+
+        let mut hand = VirtualHand::new(Handedness::Right);
+        for frame in 0..5 {
+            hand = VirtualHand::update(
+                &hand,
+                &physics,
+                &world,
+                vec3(0.0, 0.0, 0.0),
+                identity,
+                &squeeze,
+                None,
+            )
+            .0;
+            assert_eq!(
+                hand.affordance(),
+                HandAffordance::Frobbable,
+                "frame {frame} of an accepted squeeze must not flash a refusal"
+            );
+        }
     }
 
     /// A squeeze on something the hand cannot take is a refused attempt, and

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -1303,6 +1303,40 @@ mod tests {
         assert_eq!(hover(4.0, FrobFlag::MOVE), HandAffordance::None);
     }
 
+    /// A locked target is recognised but refused: amber, not green, and a frob
+    /// against it reads as a failed attempt.
+    #[test]
+    fn a_locked_target_reads_as_blocked_then_failed() {
+        let (mut world, physics, target) = frob_fixture_with(2.5, FrobFlag::SCRIPT);
+        world.add_component(target, dark::properties::PropLocked(true));
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+
+        let (hovering, _) = VirtualHand::update(
+            &VirtualHand::new(Handedness::Right),
+            &physics,
+            &world,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            &Hand::default(),
+            None,
+        );
+        assert_eq!(hovering.affordance(), HandAffordance::Blocked);
+
+        let (frobbing, _) = VirtualHand::update(
+            &hovering,
+            &physics,
+            &world,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            &Hand {
+                trigger_value: 1.0,
+                ..Hand::default()
+            },
+            None,
+        );
+        assert_eq!(frobbing.affordance(), HandAffordance::Failed);
+    }
+
     /// A squeeze on something the hand cannot take is a refused attempt, and
     /// reads red rather than staying green on a grab that never happens.
     #[test]

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -628,6 +628,24 @@ export interface PlayerSnapshot {
   explored_map_locations: number[];
   /** Climb state: ladder/hand climbing, and (VR) the hands holding on. */
   climb: ClimbState;
+
+  /** What each VR hand could do with whatever it is pointing at - the state
+   * that lights the glove and pre-shapes its fingers. Flat reports "None". */
+  hand_affordance: HandAffordances;
+}
+
+/** Per-hand affordance names in the /v1/info readout. */
+export type HandAffordance =
+  | "None"
+  | "Grabbable"
+  | "Frobbable"
+  | "Blocked"
+  | "Failed";
+
+/** Both hands' affordances (GET /v1/info). */
+export interface HandAffordances {
+  left: HandAffordance;
+  right: HandAffordance;
 }
 
 /** One hand's hold in the /v1/info climb readout. */

--- a/tools/shock2-sdk/test/vr-hand-affordance.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-hand-affordance.e2e.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// The VR glove's light and finger pre-shape are driven by one resolved
+// affordance per hand, read off the same raycast the trigger and squeeze act
+// on. This checks the readout that state reports (`player.hand_affordance`):
+// a pickup under the hand's ray is grabbable, and a hand pointing at nothing
+// eventually goes dark.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "VR: a hand aimed at a pickup reads Grabbable, and at nothing reads None",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+
+    // DebugCycleWeapon spawns the pistol; VR wield is a no-op so it drops to
+    // the floor in front of the player.
+    await game.step({ frames: 10 });
+    const pistol = await cycleToWeapon(game, (e) => e.name === "Pistol", {
+      settleFrames: 90,
+    });
+
+    // Park the right hand on the pistol's forward raycast axis (debug_weapons
+    // spawns the pawn at the origin with identity rotation, so pawn-local ==
+    // world minus the pawn position). No squeeze: the point is the hover.
+    const pawnY = (await game.info()).player.position[1];
+    const [px, py, pz] = pistol.position;
+    await game.input.set("right_hand.position", [px + 0.4, py - pawnY, pz]);
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      (await game.info()).player.hand_affordance.right,
+      "Grabbable",
+      "a pickup under the hand's ray should light the glove for a grab",
+    );
+
+    // Aim the same hand straight up ([x,y,z,w] for +90 degrees about X takes
+    // the hand's -Z forward to +Y), at open air. The hover survives a few
+    // frames of hysteresis, so step well past it.
+    await game.input.set("right_hand.rotation", [0.7071068, 0, 0, 0.7071068]);
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.info()).player.hand_affordance.right,
+      "None",
+      "a hand pointing at nothing should go dark",
+    );
+  },
+);


### PR DESCRIPTION
Slice 2 of the VR hands round-2 campaign. Stacks on #1373.

The hand's ray already decides what the trigger and squeeze act on. That same hit now resolves one affordance per hand per frame — `None` / `Grabbable` / `Frobbable` / `Blocked` / `Failed` — and drives two channels:

- **light = eligibility**: Off / Green / Amber, plus a ~250 ms Red pulse when an attempt is refused. Hysteresis holds a hover 6 frames so the light can't strobe at a collider edge.
- **pose = action**: the hand leans toward the authored `fist` (grab) or `point` (press) pose, weighted by how close the target is. Applied so a real pull always shows through — `fist` only ever adds curl, and the point prompt leaves the index finger exactly where the trigger put it.

The coloured raycast-hit cube and `color_from_state` are gone; the light replaces them.

Each hand's state is reported at `/v1/info` → `player.hand_affordance.{left,right}`, with an e2e test that aims a hand at a pickup and at nothing.

Left: nothing in reach. Middle: a wrench in reach (green, grip). Right: a hybrid in reach (green, index extended to frob).

![states](https://gist.githubusercontent.com/tommy-xr/4c450a0c89d5d4ce0deb79be2571bc0a/raw/affordance.png)

Approach, in `debug_melee`: the light comes up and the fingers close as the hand enters reach.

![approach](https://gist.githubusercontent.com/tommy-xr/4c450a0c89d5d4ce0deb79be2571bc0a/raw/affordance.gif)

Not captured on screen: Amber (`Blocked`) and Red (`Failed`) — no debug scene has a locked target within reach, and neither state is reachable in one without staging a mission. Both are covered by unit tests, and #1373's `debug_gloves` row already renders all four light colours.

No haptics: the codebase has no haptic path to pulse.
