### PR TITLE
feat(explorer): add editable VR pickup grip previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,8 +1162,10 @@ dependencies = [
  "engine",
  "gl",
  "image 0.24.7",
+ "serde_json",
  "shipyard",
  "shock2vr",
+ "tempfile",
  "zip",
 ]
 
@@ -1704,6 +1706,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -5579,6 +5587,19 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys 0.8.4",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/projects/astra-debug-interactions.md
+++ b/projects/astra-debug-interactions.md
@@ -65,3 +65,10 @@ loads image-review notes keyed by negative template ID, with `status` (`reviewed
 existing capture manifest after updating those notes, without launching a game.
 The default gallery includes the psi amp as an authored-forearm reference. Other
 authored weapon grips remain a separate pass.
+
+## Editing pickup grips
+
+Use Explorer’s [VR Grips editor](astra-vr-grip-editor.md) to adjust position,
+rotation and finger amounts, then save the prepared resource directly. The
+gallery remains useful for sharing reviews; `_h` weapons will extend both tools
+in the next workstream.

--- a/projects/astra-vr-grip-editor.md
+++ b/projects/astra-vr-grip-editor.md
@@ -16,23 +16,39 @@ and right poses are independent. Drafts stay in memory when switching models.
 - **Front / back / top / oblique** frame the glove and item. **Palm** is a
   contact close-up: large objects may extend outside it. Drag to orbit; scroll
   to zoom.
-- Drag or type **item position** in centimeters in the calibrated hand frame.
-- Set a rotation step, then use **X− / X+**, **Y− / Y+**, or **Z− / Z+** to rotate
-  the item about its origin along hand-local axes.
-- **Open / point / closed** provide starting finger amounts. Each finger can
-  be adjusted independently from 0 (open) to 1 (closed).
+- **Position**, **XYZ rotation**, **finger curls**, and **uniform item scale**
+  have sliders and **− / +** nudge buttons. Click any displayed number for an
+  exact final adjustment; typing is optional. Rotation values are XYZ Euler
+  angles in degrees; the separately labeled nudge step controls button size.
+- **Open / point / closed / ball** provide starting finger amounts. Ball cups
+  the fingers; tune it to the actual object's size. Each curl runs from 0
+  (open) to 1 (closed).
+- Uniform item scale affects the held model, preserving glove calibration.
+  Dropping the item restores its normal world size before loose physics resumes.
 - **Save all edits** writes `assets/astra-vr-grips.json` atomically. Restart the
   game/debug runtime process to load the saved resource (scene reloads can retain
   cached assets). Closing Explorer with unsaved drafts offers save, discard, or keep editing.
-- **Revert this hand to saved** discards just that hand's draft.
+- **Save As…** writes a separate JSON file and makes it the active save target.
+  It refuses to overwrite an existing file. Use a new filename; the original
+  stays untouched. Reopen the copy with `--grip-library /path/to/file.json`.
+- **Revert this hand to saved** discards just that hand's draft, if a saved
+  baseline exists.
 - **Automatic fitting → Replace draft with auto fit** explicitly replaces this
   hand's draft using the model's existing region/orientation hints. An optional
   family choice (cylindrical, pinch, broad grasp, trigger) guides the fit. This
   must still be reviewed and saved. Model defaults remove the manual override.
 
-Manual poses carry `authored: true`. The bulk baker preserves them if the mesh,
-rig, hints, and solver revision still match; otherwise it stops without writing
-and asks for review. Manual edits clear old solver contact diagnostics, since
+In the **Files** model picker, select a model and choose **Edit VR Grip**.
+Existing entries open directly. Missing hands are fitted into new unsaved
+entries using a background worker, keeping the preview responsive. Review and
+save the pair with Save or Save As. `--grip <model>` also prepares missing
+entries, so the same path is available for automated captures.
+
+Manual poses carry `authored: true`. For rack models the bulk baker preserves
+them if mesh, rig, hints and solver revision still match; otherwise it stops
+without writing and asks for review. Entries for additional models outside the
+rack are kept verbatim with their original fingerprints; gameplay still rejects
+stale geometry/rig/hints. A solver revision change requires their review. Manual edits clear old solver contact diagnostics, since
 those samples no longer describe the edited pose. A successful load is not a
 visual approval. The scene regression still verifies holding, motion and
 release, but does not assert old automatic contact counts for authored poses.
@@ -53,4 +69,5 @@ The native Explorer capture is used here because the debug runtime does not host
 the desktop egui tool. The standalone gallery remains available for sharing and
 multi-item review. The `_h` weapon workstream will expand both tools after
 stripping authored weapon hands and fitting the gloves; psi amp keeps its
-integrated forearm. This first editor lists models with prepared pickup grips.
+integrated forearm. This editor supports pickup model entries. Authored weapon hands are not
+stripped here; their special handling remains in the `_h` workstream.

--- a/projects/astra-vr-grip-editor.md
+++ b/projects/astra-vr-grip-editor.md
@@ -1,0 +1,56 @@
+# Astra VR grip editor
+
+Explorer's **VR Grips** tab edits the prepared pickup grips used by the game.
+It uses the game renderer, calibrated glove, and model importers directly.
+
+From the repository root:
+
+```sh
+cargo run -p dark_explorer -- ui --grip mug
+```
+
+Select a model on the left and a hand above the preview. Shared implant models
+list every fixture using them. Edits apply to all items using that model; left
+and right poses are independent. Drafts stay in memory when switching models.
+
+- **Front / back / top / oblique** frame the glove and item. **Palm** is a
+  contact close-up: large objects may extend outside it. Drag to orbit; scroll
+  to zoom.
+- Drag or type **item position** in centimeters in the calibrated hand frame.
+- Set a rotation step, then use **X− / X+**, **Y− / Y+**, or **Z− / Z+** to rotate
+  the item about its origin along hand-local axes.
+- **Open / point / closed** provide starting finger amounts. Each finger can
+  be adjusted independently from 0 (open) to 1 (closed).
+- **Save all edits** writes `assets/astra-vr-grips.json` atomically. Restart the
+  game/debug runtime process to load the saved resource (scene reloads can retain
+  cached assets). Closing Explorer with unsaved drafts offers save, discard, or keep editing.
+- **Revert this hand to saved** discards just that hand's draft.
+- **Automatic fitting → Replace draft with auto fit** explicitly replaces this
+  hand's draft using the model's existing region/orientation hints. An optional
+  family choice (cylindrical, pinch, broad grasp, trigger) guides the fit. This
+  must still be reviewed and saved. Model defaults remove the manual override.
+
+Manual poses carry `authored: true`. The bulk baker preserves them if the mesh,
+rig, hints, and solver revision still match; otherwise it stops without writing
+and asks for review. Manual edits clear old solver contact diagnostics, since
+those samples no longer describe the edited pose. A successful load is not a
+visual approval. The scene regression still verifies holding, motion and
+release, but does not assert old automatic contact counts for authored poses.
+
+The editor rejects malformed resources and detects concurrent changes to the
+resource before saving. Stale selected poses are visible for diagnosis but must
+be refitted before editing/saving. Use `--grip-library /path/to/grips.json` to
+work on a copy; automatic fitting still uses this checkout's model hints.
+
+For repeatable screenshots:
+
+```sh
+cargo run -p dark_explorer -- ui --grip icepick --grip-hand left \
+  --grip-view oblique --screenshot /tmp/astra-ice-editor.png
+```
+
+The native Explorer capture is used here because the debug runtime does not host
+the desktop egui tool. The standalone gallery remains available for sharing and
+multi-item review. The `_h` weapon workstream will expand both tools after
+stripping authored weapon hands and fitting the gloves; psi amp keeps its
+integrated forearm. This first editor lists models with prepared pickup grips.

--- a/projects/astra-vr-grip-fitting.md
+++ b/projects/astra-vr-grip-fitting.md
@@ -97,8 +97,9 @@ that model's hint fingerprint and requires rebaking.
 
 Pronged implants constrain contact to the housing; GamePig constrains it to the
 middle of a side. These are model-space region hints rather than changes to glove
-calibration or asset scale. The current gallery remains a review tool. A usable
-override editor is the next prerequisite before moving to `_h` weapon fitting.
+calibration or asset scale. The gallery remains a review tool. The
+[Explorer override editor](astra-vr-grip-editor.md) now supports direct pickup
+pose editing and saves; `_h` weapon fitting is the next workstream.
 
 The output resource has a versioned schema and one entry per model and hand.
 Mesh, glove-kinematics, and hints fingerprints plus a solver revision prevent a

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -319,6 +319,8 @@ pub struct SceneObjectSummary {
     /// geometry (world, HUD, debug overlays).
     pub source: Option<String>,
     pub position: [f32; 3],
+    /// Magnitudes of the rendered world-transform axes (mesh-local transform excluded).
+    pub scale: [f32; 3],
     /// Transparency in effect for this draw (0.0 = opaque, 1.0 = invisible).
     pub transparency: Option<f32>,
     pub depth_write: bool,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1012,7 +1012,8 @@ fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneO
         .iter()
         .map(|obj| {
             let tag = obj.debug_tag();
-            let translation = obj.get_transform().w;
+            let transform = obj.get_transform();
+            let translation = transform.w;
             let render_layer = obj.render_layer();
             let first_in_layer = seen_layers.insert(render_layer);
             commands::SceneObjectSummary {
@@ -1021,6 +1022,11 @@ fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneO
                 model: tag.and_then(|t| t.model.clone()),
                 source: tag.and_then(|t| t.source.clone()),
                 position: [translation.x, translation.y, translation.z],
+                scale: [
+                    transform.x.truncate().magnitude(),
+                    transform.y.truncate().magnitude(),
+                    transform.z.truncate().magnitude(),
+                ],
                 transparency: obj.effective_transparency(),
                 depth_write: obj.depth_write,
                 depth_bias: obj.depth_bias(),
@@ -1809,6 +1815,7 @@ fn process_command(
                     model: o.model.clone(),
                     source: o.source.clone(),
                     position: o.position,
+                    scale: o.scale,
                     transparency: o.transparency,
                     depth_write: o.depth_write,
                     depth_bias: o.depth_bias,

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -397,7 +397,7 @@ impl PlayerInteraction for VrInteraction {
                     entity_id: entity,
                     position: hand.get_position() + hand.get_rotation().rotate_vector(grip.offset),
                     rotation: hand.get_rotation() * grip.rotation,
-                    scale: cgmath::vec3(1.0, 1.0, 1.0),
+                    scale: cgmath::vec3(grip.item_scale, grip.item_scale, grip.item_scale),
                 });
             }
         }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -209,6 +209,7 @@ struct HeldGrip {
     kinematics_hash: String,
     hints_hash: String,
     source: &'static str,
+    authored: bool,
 }
 
 impl VrInteraction {
@@ -363,6 +364,15 @@ impl PlayerInteraction for VrInteraction {
                 println!(
                     "SHOCK2QUEST_VR_GRIP model={model} hand={hand_name} source={source} elapsed_ms={solve_ms:.3}"
                 );
+                let authored = !bake
+                    && resolved.is_some()
+                    && self
+                        .grip_library
+                        .as_ref()
+                        .unwrap()
+                        .entries
+                        .iter()
+                        .any(|e| e.model == model && e.hand == hand_name && e.authored);
                 self.fitted_grips[index] = Some(HeldGrip {
                     entity,
                     model,
@@ -372,6 +382,7 @@ impl PlayerInteraction for VrInteraction {
                     kinematics_hash,
                     hints_hash,
                     source,
+                    authored,
                 });
             }
             if let Some(grip) = self.fitted_grips[index]
@@ -397,7 +408,7 @@ impl PlayerInteraction for VrInteraction {
             let grip=grip.as_ref()?;
             Some(serde_json::json!({"hand": if i == 0 {"left"} else {"right"}, "entity_id": grip.entity.inner() as i32,
                 "model": grip.model, "solve_ms": grip.solve_ms, "grip": grip.resolved,
-                "surface_hash": grip.surface_hash, "kinematics_hash": grip.kinematics_hash, "hints_hash": grip.hints_hash, "solver_revision": crate::vr_grip::SOLVER_REVISION, "source": grip.source,
+                "surface_hash": grip.surface_hash, "kinematics_hash": grip.kinematics_hash, "hints_hash": grip.hints_hash, "solver_revision": crate::vr_grip::SOLVER_REVISION, "source": grip.source, "authored": grip.authored,
                 "palm": self.grip_kinematics.as_ref().map(|k| k[i].palm), "palm_normal": self.grip_kinematics.as_ref().map(|k| k[i].normal)}))
         }).collect())
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -10280,14 +10280,12 @@ impl MissionCore {
     fn return_held_entity_to_the_hand(&mut self, entity_id: EntityId) {
         use cgmath::Rotation;
 
-        let Some(grip) = self
+        let grip = self
             .world
             .borrow::<View<RuntimePropVrGripOffset>>()
             .ok()
             .and_then(|view| view.get(entity_id).ok().map(|grip| grip.0))
-        else {
-            return;
-        };
+            .unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
 
         let Some((position, rotation)) =
             self.world
@@ -10301,6 +10299,8 @@ impl MissionCore {
         else {
             return;
         };
+        // Pickups without a melee grip keep their position and restore unit
+        // held-item scale before rebuilding their loose-object physics.
         // The grip is hand-local and the entity carries the hand's rotation
         // (a computed grip contributes none of its own).
         let hand = position - rotation.rotate_vector(grip);

--- a/shock2vr/src/vr_grip.rs
+++ b/shock2vr/src/vr_grip.rs
@@ -24,6 +24,9 @@ pub struct GripKinematics {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ResolvedGrip {
+    /// Uniform held-item scale; the glove calibration is unchanged.
+    #[serde(default = "default_item_scale")]
+    pub item_scale: f32,
     pub pose_family: String,
     /// Item origin and rotation in tracked-hand space (world units).
     pub offset: Vector3<f32>,
@@ -33,6 +36,10 @@ pub struct ResolvedGrip {
     pub contacts: [Option<[f32; 3]>; 5],
     pub anchor: [f32; 3],
     pub score: f32,
+}
+
+fn default_item_scale() -> f32 {
+    1.0
 }
 
 impl ResolvedGrip {
@@ -49,6 +56,9 @@ impl ResolvedGrip {
         ]
         .into_iter()
         .all(f32::is_finite)
+            && self.item_scale.is_finite()
+            && self.item_scale > 0.0
+            && self.item_scale <= 10.0
             && (self.rotation.magnitude2() - 1.0).abs() < 0.001
             && self
                 .curls
@@ -409,6 +419,7 @@ impl GripSurface {
             score = f32::NEG_INFINITY;
         }
         ResolvedGrip {
+            item_scale: 1.0,
             pose_family: "broad".to_owned(),
             offset,
             rotation,
@@ -833,5 +844,24 @@ mod tests {
             }
             .is_valid()
         );
+    }
+    #[test]
+    fn uniform_item_scale_defaults_to_one_and_rejects_invalid_values() {
+        let mut grip =
+            plane(0.05).fit_at(&straight_fingers(), vec3(0.0, 0.0, 0.0), Quaternion::one());
+        let mut json = serde_json::to_value(&grip).unwrap();
+        json.as_object_mut().unwrap().remove("item_scale");
+        assert_eq!(
+            serde_json::from_value::<ResolvedGrip>(json)
+                .unwrap()
+                .item_scale,
+            1.0
+        );
+        for scale in [0.0, -1.0, f32::NAN, f32::INFINITY, 11.0] {
+            grip.item_scale = scale;
+            assert!(!grip.is_valid());
+        }
+        grip.item_scale = 0.8;
+        assert!(grip.is_valid());
     }
 }

--- a/shock2vr/src/vr_grip.rs
+++ b/shock2vr/src/vr_grip.rs
@@ -22,7 +22,7 @@ pub struct GripKinematics {
     pub normal: Vector3<f32>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ResolvedGrip {
     pub pose_family: String,
     /// Item origin and rotation in tracked-hand space (world units).
@@ -429,7 +429,7 @@ pub fn glove_to_hand(hand: Handedness) -> Matrix4<f32> {
 
 /// Authoring hints are inputs to the offline baker. Numbers are stable:
 /// 0 cylindrical, 1 pinch, 2 broad grasp, 3 trigger. Omission stays automatic.
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Clone, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GripHints {
     pub pose_family: Option<u8>,
@@ -446,8 +446,11 @@ pub struct GripHints {
     pub curls: [Option<f32>; 5],
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct BakedGripEntry {
+    /// Edited in Explorer; bulk baking must preserve this pose.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub authored: bool,
     pub model: String,
     pub hand: String,
     pub surface_hash: String,
@@ -456,7 +459,7 @@ pub struct BakedGripEntry {
     pub grip: ResolvedGrip,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct GripLibrary {
     pub version: u32,
     pub solver_revision: u32,
@@ -695,6 +698,7 @@ mod tests {
             version: 1,
             solver_revision: SOLVER_REVISION,
             entries: vec![BakedGripEntry {
+                authored: false,
                 model: "mug".into(),
                 hand: "right".into(),
                 surface_hash: "mesh1".into(),

--- a/tools/dark_explorer/Cargo.toml
+++ b/tools/dark_explorer/Cargo.toml
@@ -21,3 +21,5 @@ clap = { version = "4.5.4", features = ["derive"] }
 eframe = { version = "=0.36.1", default-features = false, features = ["glow", "default_fonts", "wayland", "x11"] }
 # Same version the engine uses, so the workspace builds one copy.
 image = { version = "0.24.3", default-features = false, features = ["png"] }
+serde_json = "1.0"
+tempfile = "3"

--- a/tools/dark_explorer/src/grip_editor.rs
+++ b/tools/dark_explorer/src/grip_editor.rs
@@ -1,0 +1,519 @@
+//! Local authoring of prepared grips. The preview and runtime share geometry,
+//! glove poses, transforms, and fingerprint validation.
+use crate::model_preview::{ModelPreview, PreviewScene};
+use cgmath::{Deg, InnerSpace, Quaternion, Rotation3, Vector3};
+use eframe::egui;
+use shock2vr::{
+    Handedness,
+    scenes::debug_interactions::INTERACTION_FIXTURES,
+    vr_grip::{GripHints, GripLibrary, SOLVER_REVISION},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io::Write,
+    path::PathBuf,
+};
+
+pub fn default_library_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/astra-vr-grips.json")
+}
+
+pub struct GripDocument {
+    pub library: GripLibrary,
+    path: PathBuf,
+    saved_bytes: Vec<u8>,
+    saved: GripLibrary,
+}
+
+impl GripDocument {
+    pub fn load(path: PathBuf) -> Result<Self, String> {
+        let saved_bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
+        let library: GripLibrary =
+            serde_json::from_slice(&saved_bytes).map_err(|e| e.to_string())?;
+        if library.version != 1 || library.solver_revision != SOLVER_REVISION {
+            return Err("Unsupported grip resource revision; rebake with this build first".into());
+        }
+        let mut keys = BTreeSet::new();
+        for e in &library.entries {
+            if !matches!(e.hand.as_str(), "left" | "right")
+                || !e.grip.is_valid()
+                || !keys.insert((e.model.clone(), e.hand.clone()))
+            {
+                return Err("Invalid or duplicate prepared grip entry".into());
+            }
+        }
+        Ok(Self {
+            saved: library.clone(),
+            library,
+            path,
+            saved_bytes,
+        })
+    }
+
+    pub fn dirty(&self) -> bool {
+        serde_json::to_vec(&self.library).unwrap() != serde_json::to_vec(&self.saved).unwrap()
+    }
+
+    pub fn save(&mut self) -> Result<(), String> {
+        if self.library.entries.iter().any(|e| !e.grip.is_valid()) {
+            return Err("Cannot save an invalid pose".into());
+        }
+        if std::fs::read(&self.path).map_err(|e| e.to_string())? != self.saved_bytes {
+            return Err(
+                "Resource changed on disk. Reopen the editor to load it before saving.".into(),
+            );
+        }
+        let mut bytes = serde_json::to_vec_pretty(&self.library).map_err(|e| e.to_string())?;
+        bytes.push(b'\n');
+        let mut temp = tempfile::NamedTempFile::new_in(self.path.parent().unwrap())
+            .map_err(|e| e.to_string())?;
+        temp.write_all(&bytes)
+            .and_then(|_| temp.as_file().sync_all())
+            .map_err(|e| e.to_string())?;
+        temp.persist(&self.path).map_err(|e| e.to_string())?;
+        self.saved_bytes = bytes;
+        self.saved = self.library.clone();
+        Ok(())
+    }
+
+    fn restore(&mut self, index: usize) {
+        self.library.entries[index] = self.saved.entries[index].clone();
+    }
+}
+
+pub struct GripEditor {
+    document: Result<GripDocument, String>,
+    hints: Result<BTreeMap<String, GripHints>, String>,
+    model: String,
+    hand: String,
+    search: String,
+    view: String,
+    camera_pending: bool,
+    validated: Option<(String, String)>,
+    hashes: Option<(String, String)>,
+    stale: bool,
+    message: String,
+    family: Option<u8>,
+    rotation_step: f32,
+    confirm_close: bool,
+    allow_close: bool,
+}
+
+impl GripEditor {
+    pub fn new(path: Option<PathBuf>, model: Option<String>, hand: String, view: String) -> Self {
+        // Hints are the same authoring inputs used by gameplay and the baker.
+        let hints_path = default_library_path().with_file_name("astra-vr-grip-hints.json");
+        let hints = std::fs::read(hints_path)
+            .map_err(|e| e.to_string())
+            .and_then(|bytes| serde_json::from_slice(&bytes).map_err(|e| e.to_string()));
+        Self {
+            document: GripDocument::load(path.unwrap_or_else(default_library_path)),
+            hints,
+            model: model.unwrap_or_else(|| "mug".into()),
+            hand,
+            search: String::new(),
+            view,
+            camera_pending: true,
+            validated: None,
+            hashes: None,
+            stale: false,
+            message: String::new(),
+            family: None,
+            rotation_step: 5.0,
+            confirm_close: false,
+            allow_close: false,
+        }
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        match (&self.document, &self.hints) {
+            (Err(e), _) | (_, Err(e)) => Some(e),
+            (Ok(doc), _)
+                if !doc
+                    .library
+                    .entries
+                    .iter()
+                    .any(|e| e.model == self.model && e.hand == self.hand) =>
+            {
+                Some("No prepared grip for the selected model and hand")
+            }
+            _ => None,
+        }
+    }
+
+    pub fn guard_close(&mut self, ctx: &egui::Context) {
+        let Ok(doc) = &mut self.document else {
+            return;
+        };
+        if !self.allow_close && doc.dirty() && ctx.input(|i| i.viewport().close_requested()) {
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+            self.confirm_close = true;
+        }
+        if self.confirm_close {
+            egui::Modal::new(egui::Id::new("unsaved_grips")).show(ctx, |ui| {
+                ui.heading("Unsaved grip edits");
+                ui.label("Save your drafts before closing?");
+                ui.horizontal(|ui| {
+                    if ui.button("Keep editing").clicked() {
+                        self.confirm_close = false;
+                    }
+                    if ui
+                        .add_enabled(!self.stale, egui::Button::new("Save and close"))
+                        .clicked()
+                    {
+                        match doc.save() {
+                            Ok(()) => self.allow_close = true,
+                            Err(e) => self.message = e,
+                        }
+                    }
+                    if ui.button("Discard and close").clicked() {
+                        self.allow_close = true;
+                    }
+                });
+                if !self.message.is_empty() {
+                    ui.label(&self.message);
+                }
+            });
+            if self.allow_close {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+        }
+    }
+
+    pub fn show_list(&mut self, ui: &mut egui::Ui) {
+        ui.heading("VR Grips");
+        ui.label("Pickup overrides · shared glove rig");
+        ui.text_edit_singleline(&mut self.search);
+        let Ok(doc) = &self.document else {
+            return;
+        };
+        let models: BTreeSet<_> = doc.library.entries.iter().map(|e| &e.model).collect();
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            for model in models {
+                let labels = INTERACTION_FIXTURES
+                    .iter()
+                    .filter(|f| f.model == model)
+                    .map(|f| f.label)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let text = format!("{model}  {labels}");
+                if !text.to_lowercase().contains(&self.search.to_lowercase()) {
+                    continue;
+                }
+                if ui.selectable_label(self.model == *model, text).clicked() {
+                    self.model = model.clone();
+                    self.validated = None;
+                    self.camera_pending = true;
+                    self.message.clear();
+                    self.family = None;
+                }
+            }
+        });
+        ui.separator();
+        ui.label(
+            "Edits affect every item using this model. Left and right hands save independently.",
+        );
+        ui.label("Authored weapon hands and psi-amp editing arrive in the weapon workstream.");
+    }
+
+    pub fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        frame: &mut eframe::Frame,
+        preview: &mut ModelPreview,
+    ) {
+        if let (Err(error), _) | (_, Err(error)) = (&self.document, &self.hints) {
+            ui.colored_label(egui::Color32::LIGHT_RED, error);
+            return;
+        }
+        let doc = self.document.as_mut().unwrap();
+        let hints = self
+            .hints
+            .as_ref()
+            .unwrap()
+            .get(&self.model)
+            .cloned()
+            .unwrap_or_default();
+        ui.heading(format!("{} — grip override", self.model));
+        ui.horizontal(|ui| {
+            for hand in ["left", "right"] {
+                if ui
+                    .selectable_value(&mut self.hand, hand.to_string(), hand)
+                    .changed()
+                {
+                    self.validated = None;
+                    self.camera_pending = true;
+                    self.message.clear();
+                }
+            }
+            ui.separator();
+            for view in ["front", "back", "top", "oblique", "palm"] {
+                if ui
+                    .selectable_value(&mut self.view, view.to_string(), view)
+                    .clicked()
+                {
+                    self.camera_pending = true;
+                }
+            }
+        });
+        let Some(index) = doc
+            .library
+            .entries
+            .iter()
+            .position(|e| e.model == self.model && e.hand == self.hand)
+        else {
+            ui.label("No prepared grip for this hand. Select the other hand above.");
+            return;
+        };
+        let hand = if self.hand == "left" {
+            Handedness::Left
+        } else {
+            Handedness::Right
+        };
+        let key = format!("{}.bin", self.model);
+        let identity = (self.model.clone(), self.hand.clone());
+        if self.validated.as_ref() != Some(&identity) {
+            self.hashes = match preview.grip_inputs(&key, hand) {
+                Ok((_, rig, surface)) => Some((surface, rig.fingerprint())),
+                Err(e) => {
+                    self.message = e;
+                    None
+                }
+            };
+            self.validated = Some(identity);
+        }
+        let entry = &doc.library.entries[index];
+        self.stale = self.hashes.as_ref().is_none_or(|(surface, rig)| {
+            entry.surface_hash != *surface
+                || entry.kinematics_hash != *rig
+                || entry.hints_hash != hints.fingerprint()
+        });
+        if self.stale {
+            ui.colored_label(
+                egui::Color32::YELLOW,
+                "Inputs changed: replace with an automatic fit before editing or saving this pose.",
+            );
+        }
+        ui.horizontal(|ui| {
+            let label = if doc.dirty() {
+                "Save all edits *"
+            } else {
+                "Saved"
+            };
+            if ui
+                .add_enabled(doc.dirty() && !self.stale, egui::Button::new(label))
+                .clicked()
+            {
+                self.message = match doc.save() {
+                    Ok(()) => "Saved. Restart the game runtime to load the resource.".into(),
+                    Err(e) => e,
+                };
+            }
+            if ui.button("Revert this hand to saved").clicked() {
+                doc.restore(index);
+            }
+            ui.label(if doc.library.entries[index].authored {
+                "Manual override"
+            } else {
+                "Automatic fit"
+            });
+        });
+        egui::CollapsingHeader::new("Automatic fitting").show(ui, |ui| {
+            ui.horizontal(|ui| {
+                egui::ComboBox::from_id_salt("grip_family")
+                    .selected_text(match self.family {
+                        Some(0) => "Cylindrical",
+                        Some(1) => "Pinch",
+                        Some(2) => "Broad grasp",
+                        Some(3) => "Trigger",
+                        _ => "Model defaults",
+                    })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.family, None, "Model defaults");
+                        for (i, name) in ["Cylindrical", "Pinch", "Broad grasp", "Trigger"]
+                            .iter()
+                            .enumerate()
+                        {
+                            ui.selectable_value(&mut self.family, Some(i as u8), *name);
+                        }
+                    });
+                if ui
+                    .add_enabled(
+                        self.hashes.is_some(),
+                        egui::Button::new("Replace draft with auto fit"),
+                    )
+                    .clicked()
+                {
+                    let mut fit_hints = hints.clone();
+                    if self.family.is_some() {
+                        fit_hints.pose_family = self.family;
+                    }
+                    match preview.fit_grip(&key, hand, &fit_hints) {
+                        Ok(grip) => {
+                            let e = &mut doc.library.entries[index];
+                            e.grip = grip;
+                            e.authored = self.family.is_some();
+                            let (surface, rig) = self.hashes.as_ref().unwrap();
+                            e.surface_hash = surface.clone();
+                            e.kinematics_hash = rig.clone();
+                            e.hints_hash = hints.fingerprint();
+                            self.stale = false;
+                            self.message = "Automatic fit ready for review; save to apply.".into();
+                        }
+                        Err(e) => self.message = e,
+                    }
+                }
+            });
+        });
+        let entry = &mut doc.library.entries[index];
+        let before = entry.grip.clone();
+        ui.add_enabled_ui(!self.stale, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Item position (cm)");
+                for (axis, value) in ["X", "Y", "Z"].into_iter().zip([
+                    &mut entry.grip.offset.x,
+                    &mut entry.grip.offset.y,
+                    &mut entry.grip.offset.z,
+                ]) {
+                    let mut cm = *value * shock2vr::METERS_PER_WORLD_UNIT * 100.0;
+                    if ui
+                        .add(
+                            egui::DragValue::new(&mut cm)
+                                .speed(0.1)
+                                .prefix(format!("{axis} "))
+                                .range(-500.0..=500.0),
+                        )
+                        .changed()
+                    {
+                        *value = cm / (shock2vr::METERS_PER_WORLD_UNIT * 100.0);
+                    }
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Rotate item about hand axis");
+                ui.add(
+                    egui::DragValue::new(&mut self.rotation_step)
+                        .speed(0.1)
+                        .range(0.1..=90.0)
+                        .suffix("°"),
+                );
+                for (name, axis) in [
+                    ("X", Vector3::unit_x()),
+                    ("Y", Vector3::unit_y()),
+                    ("Z", Vector3::unit_z()),
+                ] {
+                    for sign in [-1.0, 1.0] {
+                        if ui
+                            .button(format!("{name}{}", if sign < 0.0 { "−" } else { "+" }))
+                            .clicked()
+                        {
+                            entry.grip.rotation =
+                                (Quaternion::from_axis_angle(axis, Deg(self.rotation_step * sign))
+                                    * entry.grip.rotation)
+                                    .normalize();
+                        }
+                    }
+                }
+            });
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Fingers");
+                if ui.button("Open").clicked() {
+                    entry.grip.curls = [0.0; 5];
+                }
+                if ui.button("Point").clicked() {
+                    entry.grip.curls = [0.85, 0.0, 0.9, 0.9, 0.9];
+                }
+                if ui.button("Closed").clicked() {
+                    entry.grip.curls = [1.0; 5];
+                }
+                for (name, value) in ["Thumb", "Index", "Middle", "Ring", "Pinky"]
+                    .into_iter()
+                    .zip(&mut entry.grip.curls)
+                {
+                    ui.add(
+                        egui::DragValue::new(value)
+                            .speed(0.01)
+                            .range(0.0..=1.0)
+                            .prefix(format!("{name} ")),
+                    );
+                }
+            });
+        });
+        if before != entry.grip {
+            entry.authored = true;
+            // Contact diagnostics describe the old solver pose, not this edit.
+            entry.grip.contacts = [None; 5];
+            entry.grip.score = 0.0;
+        }
+        if !self.message.is_empty() {
+            ui.label(&self.message);
+        }
+        ui.small("Drag values to adjust; click a value to type. Unsaved drafts stay when switching models. Orbit to inspect hidden contacts.");
+        // Build first, then select the requested camera so the initial model
+        // framing cannot overwrite it. show() keeps the same camera on edits.
+        let scene = PreviewScene::Grip(hand, entry.grip.clone());
+        preview.prepare(&key, &scene);
+        if self.camera_pending {
+            preview.grip_camera(&self.view, hand);
+            self.camera_pending = false;
+        }
+        preview.show(ui, frame, &key, &scene);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn document() -> (tempfile::TempDir, GripDocument) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grips.json");
+        std::fs::write(&path, include_bytes!("../../../assets/astra-vr-grips.json")).unwrap();
+        let doc = GripDocument::load(path).unwrap();
+        (dir, doc)
+    }
+
+    #[test]
+    fn saved_manual_pose_round_trips_through_runtime_lookup_without_changing_other_hands() {
+        let (_dir, mut doc) = document();
+        let untouched = serde_json::to_vec(&doc.library.entries[1..]).unwrap();
+        let entry = &mut doc.library.entries[0];
+        entry.authored = true;
+        entry.grip.offset.y += 0.01;
+        entry.grip.curls[0] = 0.3;
+        let expected = entry.grip.clone();
+        assert!(doc.dirty());
+        doc.save().unwrap();
+        assert!(!doc.dirty());
+        let loaded = GripDocument::load(doc.path.clone()).unwrap();
+        let entry = &loaded.library.entries[0];
+        assert!(entry.authored);
+        assert_eq!(
+            loaded.library.lookup(
+                &entry.model,
+                &entry.hand,
+                &entry.surface_hash,
+                &entry.kinematics_hash,
+                &entry.hints_hash
+            ),
+            Some(&expected)
+        );
+        assert_eq!(
+            serde_json::to_vec(&loaded.library.entries[1..]).unwrap(),
+            untouched
+        );
+    }
+
+    #[test]
+    fn external_edits_and_invalid_drafts_cannot_overwrite_the_resource() {
+        let (_dir, mut doc) = document();
+        doc.library.entries[0].grip.rotation.s = f32::NAN;
+        assert!(doc.save().is_err());
+        assert_eq!(std::fs::read(&doc.path).unwrap(), doc.saved_bytes);
+        doc.restore(0);
+        assert!(!doc.dirty());
+        let external = b"external edit";
+        std::fs::write(&doc.path, external).unwrap();
+        assert!(doc.save().unwrap_err().contains("changed on disk"));
+        assert_eq!(std::fs::read(&doc.path).unwrap(), external);
+    }
+}

--- a/tools/dark_explorer/src/grip_editor.rs
+++ b/tools/dark_explorer/src/grip_editor.rs
@@ -1,12 +1,12 @@
 //! Local authoring of prepared grips. The preview and runtime share geometry,
 //! glove poses, transforms, and fingerprint validation.
 use crate::model_preview::{ModelPreview, PreviewScene};
-use cgmath::{Deg, InnerSpace, Quaternion, Rotation3, Vector3};
+use cgmath::{Deg, Euler, InnerSpace, Quaternion, Rad};
 use eframe::egui;
 use shock2vr::{
     Handedness,
     scenes::debug_interactions::INTERACTION_FIXTURES,
-    vr_grip::{GripHints, GripLibrary, SOLVER_REVISION},
+    vr_grip::{BakedGripEntry, GripHints, GripLibrary, SOLVER_REVISION},
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -27,6 +27,13 @@ pub struct GripDocument {
 
 impl GripDocument {
     pub fn load(path: PathBuf) -> Result<Self, String> {
+        let path = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir()
+                .map_err(|e| e.to_string())?
+                .join(path)
+        };
         let saved_bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
         let library: GripLibrary =
             serde_json::from_slice(&saved_bytes).map_err(|e| e.to_string())?;
@@ -55,29 +62,61 @@ impl GripDocument {
     }
 
     pub fn save(&mut self) -> Result<(), String> {
+        if std::fs::read(&self.path).map_err(|e| e.to_string())? != self.saved_bytes {
+            return Err(
+                "Resource changed on disk. Use Save As to keep your drafts, or reopen to load it."
+                    .into(),
+            );
+        }
+        self.write(self.path.clone(), false)
+    }
+
+    /// Save As never replaces an existing file, including the current file.
+    /// Future Save commands target the successfully written new path.
+    pub fn save_as(&mut self, path: PathBuf) -> Result<(), String> {
+        let path = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir()
+                .map_err(|e| e.to_string())?
+                .join(path)
+        };
+        self.write(path, true)
+    }
+
+    fn write(&mut self, path: PathBuf, new_file: bool) -> Result<(), String> {
         if self.library.entries.iter().any(|e| !e.grip.is_valid()) {
             return Err("Cannot save an invalid pose".into());
         }
-        if std::fs::read(&self.path).map_err(|e| e.to_string())? != self.saved_bytes {
-            return Err(
-                "Resource changed on disk. Reopen the editor to load it before saving.".into(),
-            );
-        }
         let mut bytes = serde_json::to_vec_pretty(&self.library).map_err(|e| e.to_string())?;
         bytes.push(b'\n');
-        let mut temp = tempfile::NamedTempFile::new_in(self.path.parent().unwrap())
-            .map_err(|e| e.to_string())?;
+        let mut temp =
+            tempfile::NamedTempFile::new_in(path.parent().unwrap()).map_err(|e| e.to_string())?;
         temp.write_all(&bytes)
             .and_then(|_| temp.as_file().sync_all())
             .map_err(|e| e.to_string())?;
-        temp.persist(&self.path).map_err(|e| e.to_string())?;
+        if new_file {
+            temp.persist_noclobber(&path)
+        } else {
+            temp.persist(&path)
+        }
+        .map_err(|e| e.to_string())?;
+        self.path = path;
         self.saved_bytes = bytes;
         self.saved = self.library.clone();
         Ok(())
     }
 
     fn restore(&mut self, index: usize) {
-        self.library.entries[index] = self.saved.entries[index].clone();
+        let current = &self.library.entries[index];
+        if let Some(saved) = self
+            .saved
+            .entries
+            .iter()
+            .find(|e| e.model == current.model && e.hand == current.hand)
+        {
+            self.library.entries[index] = saved.clone();
+        }
     }
 }
 
@@ -94,9 +133,14 @@ pub struct GripEditor {
     stale: bool,
     message: String,
     family: Option<u8>,
+    rotation_edit: Option<(Quaternion<f32>, [f32; 3])>,
     rotation_step: f32,
+    save_as_path: Option<String>,
     confirm_close: bool,
     allow_close: bool,
+    prepare_missing: bool,
+    fitting: Option<std::sync::mpsc::Receiver<Result<Vec<BakedGripEntry>, String>>>,
+    fitting_model: String,
 }
 
 impl GripEditor {
@@ -119,9 +163,133 @@ impl GripEditor {
             stale: false,
             message: String::new(),
             family: None,
+            rotation_edit: None,
             rotation_step: 5.0,
+            save_as_path: None,
             confirm_close: false,
             allow_close: false,
+            prepare_missing: true,
+            fitting: None,
+            fitting_model: String::new(),
+        }
+    }
+
+    pub fn open_model(&mut self, key: &str) {
+        self.model = std::path::Path::new(key)
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_lowercase();
+        self.prepare_missing = true;
+        self.validated = None;
+        self.camera_pending = true;
+        self.rotation_edit = None;
+        self.message.clear();
+    }
+
+    pub fn is_busy(&self) -> bool {
+        self.fitting.is_some()
+    }
+
+    fn start_fit(
+        &mut self,
+        preview: &mut ModelPreview,
+        hands: Vec<String>,
+        family: Option<u8>,
+        authored: bool,
+    ) {
+        if self.is_busy() || hands.is_empty() {
+            return;
+        }
+        let Ok(hints) = &self.hints else {
+            return;
+        };
+        let mut hints = hints.get(&self.model).cloned().unwrap_or_default();
+        let hints_hash = hints.fingerprint();
+        if family.is_some() {
+            hints.pose_family = family;
+        }
+        let key = format!("{}.bin", self.model);
+        let mut inputs = Vec::new();
+        for name in hands {
+            let hand = if name == "left" {
+                Handedness::Left
+            } else {
+                Handedness::Right
+            };
+            match preview.grip_inputs(&key, hand) {
+                Ok((surface, rig, hash)) => inputs.push((name, surface, rig, hash)),
+                Err(e) => {
+                    self.message = e;
+                    return;
+                }
+            }
+        }
+        let model = self.model.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.fitting = Some(rx);
+        self.fitting_model = model.clone();
+        self.message = format!("Fitting {model}… You can continue inspecting the preview.");
+        std::thread::spawn(move || {
+            let result = inputs
+                .into_iter()
+                .map(|(hand, surface, rig, surface_hash)| {
+                    let grip = surface.resolve(&rig, &hints).ok_or_else(|| {
+                        format!("No valid {hand} fit for {model}; existing drafts kept")
+                    })?;
+                    Ok(BakedGripEntry {
+                        model: model.clone(),
+                        hand,
+                        surface_hash,
+                        kinematics_hash: rig.fingerprint(),
+                        hints_hash: hints_hash.clone(),
+                        grip,
+                        authored,
+                    })
+                })
+                .collect::<Result<Vec<_>, String>>();
+            let _ = tx.send(result);
+        });
+    }
+
+    fn poll_fit(&mut self, ctx: &egui::Context) {
+        let Some(receiver) = &self.fitting else {
+            return;
+        };
+        let result = match receiver.try_recv() {
+            Ok(result) => result,
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                ctx.request_repaint_after(std::time::Duration::from_millis(50));
+                return;
+            }
+            Err(_) => Err("Fitting worker stopped; existing drafts kept".into()),
+        };
+        self.fitting = None;
+        match result {
+            Ok(entries) => {
+                if let Ok(doc) = &mut self.document {
+                    for entry in entries {
+                        if let Some(old) = doc
+                            .library
+                            .entries
+                            .iter_mut()
+                            .find(|e| e.model == entry.model && e.hand == entry.hand)
+                        {
+                            *old = entry;
+                        } else {
+                            doc.library.entries.push(entry);
+                        }
+                    }
+                }
+                self.validated = None;
+                self.rotation_edit = None;
+                self.camera_pending = true;
+                self.message = format!(
+                    "{} drafts ready. Review, then Save or Save As.",
+                    self.fitting_model
+                );
+            }
+            Err(e) => self.message = e,
         }
     }
 
@@ -142,23 +310,32 @@ impl GripEditor {
     }
 
     pub fn guard_close(&mut self, ctx: &egui::Context) {
+        self.poll_fit(ctx);
+        let busy = self.is_busy();
         let Ok(doc) = &mut self.document else {
             return;
         };
-        if !self.allow_close && doc.dirty() && ctx.input(|i| i.viewport().close_requested()) {
+        if !self.allow_close
+            && (doc.dirty() || busy)
+            && ctx.input(|i| i.viewport().close_requested())
+        {
             ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
             self.confirm_close = true;
         }
         if self.confirm_close {
             egui::Modal::new(egui::Id::new("unsaved_grips")).show(ctx, |ui| {
                 ui.heading("Unsaved grip edits");
-                ui.label("Save your drafts before closing?");
+                ui.label(if busy {
+                    "Fitting is still running. Keep editing to wait, or discard and close."
+                } else {
+                    "Save your drafts before closing?"
+                });
                 ui.horizontal(|ui| {
                     if ui.button("Keep editing").clicked() {
                         self.confirm_close = false;
                     }
                     if ui
-                        .add_enabled(!self.stale, egui::Button::new("Save and close"))
+                        .add_enabled(!self.stale && !busy, egui::Button::new("Save and close"))
                         .clicked()
                     {
                         match doc.save() {
@@ -226,6 +403,28 @@ impl GripEditor {
             ui.colored_label(egui::Color32::LIGHT_RED, error);
             return;
         }
+        self.poll_fit(ui.ctx());
+        if self.prepare_missing && !self.is_busy() {
+            self.prepare_missing = false;
+            let doc = self.document.as_ref().unwrap();
+            let missing = ["left", "right"]
+                .into_iter()
+                .filter(|hand| {
+                    !doc.library
+                        .entries
+                        .iter()
+                        .any(|e| e.model == self.model && e.hand == *hand)
+                })
+                .map(str::to_string)
+                .collect();
+            self.start_fit(preview, missing, None, true);
+        }
+        let busy = self.is_busy();
+        if busy {
+            ui.ctx()
+                .request_repaint_after(std::time::Duration::from_millis(50));
+        }
+        let mut request_fit = false;
         let doc = self.document.as_mut().unwrap();
         let hints = self
             .hints
@@ -262,7 +461,19 @@ impl GripEditor {
             .iter()
             .position(|e| e.model == self.model && e.hand == self.hand)
         else {
-            ui.label("No prepared grip for this hand. Select the other hand above.");
+            if !self.message.is_empty() {
+                ui.label(&self.message);
+            }
+            ui.label("No prepared grip for this hand yet.");
+            if !busy && ui.button("Prepare left and right drafts").clicked() {
+                self.prepare_missing = true;
+            }
+            preview.show(
+                ui,
+                frame,
+                &format!("{}.bin", self.model),
+                &PreviewScene::Model,
+            );
             return;
         };
         let hand = if self.hand == "left" {
@@ -301,7 +512,10 @@ impl GripEditor {
                 "Saved"
             };
             if ui
-                .add_enabled(doc.dirty() && !self.stale, egui::Button::new(label))
+                .add_enabled(
+                    doc.dirty() && !self.stale && !busy,
+                    egui::Button::new(label),
+                )
                 .clicked()
             {
                 self.message = match doc.save() {
@@ -309,7 +523,29 @@ impl GripEditor {
                     Err(e) => e,
                 };
             }
-            if ui.button("Revert this hand to saved").clicked() {
+            if ui
+                .add_enabled(!busy, egui::Button::new("Save As…"))
+                .clicked()
+            {
+                self.save_as_path = Some(
+                    doc.path
+                        .with_file_name("astra-vr-grips.custom.json")
+                        .display()
+                        .to_string(),
+                );
+            }
+            let has_saved = doc
+                .saved
+                .entries
+                .iter()
+                .any(|e| e.model == self.model && e.hand == self.hand);
+            if ui
+                .add_enabled(
+                    has_saved && !busy,
+                    egui::Button::new("Revert this hand to saved"),
+                )
+                .clicked()
+            {
                 doc.restore(index);
             }
             ui.label(if doc.library.entries[index].authored {
@@ -339,103 +575,95 @@ impl GripEditor {
                     });
                 if ui
                     .add_enabled(
-                        self.hashes.is_some(),
+                        self.hashes.is_some() && !busy,
                         egui::Button::new("Replace draft with auto fit"),
                     )
                     .clicked()
                 {
-                    let mut fit_hints = hints.clone();
-                    if self.family.is_some() {
-                        fit_hints.pose_family = self.family;
-                    }
-                    match preview.fit_grip(&key, hand, &fit_hints) {
-                        Ok(grip) => {
-                            let e = &mut doc.library.entries[index];
-                            e.grip = grip;
-                            e.authored = self.family.is_some();
-                            let (surface, rig) = self.hashes.as_ref().unwrap();
-                            e.surface_hash = surface.clone();
-                            e.kinematics_hash = rig.clone();
-                            e.hints_hash = hints.fingerprint();
-                            self.stale = false;
-                            self.message = "Automatic fit ready for review; save to apply.".into();
-                        }
-                        Err(e) => self.message = e,
-                    }
+                    request_fit = true;
                 }
             });
         });
         let entry = &mut doc.library.entries[index];
         let before = entry.grip.clone();
-        ui.add_enabled_ui(!self.stale, |ui| {
-            ui.horizontal(|ui| {
-                ui.label("Item position (cm)");
+        // Keep entered Euler angles stable while dragging across a singularity;
+        // only re-project when the pose changes outside these sliders.
+        if self
+            .rotation_edit
+            .as_ref()
+            .is_none_or(|(q, _)| *q != entry.grip.rotation)
+        {
+            let angles: Euler<Rad<f32>> = entry.grip.rotation.into();
+            self.rotation_edit = Some((
+                entry.grip.rotation,
+                [
+                    angles.x.0.to_degrees(),
+                    angles.y.0.to_degrees(),
+                    angles.z.0.to_degrees(),
+                ],
+            ));
+        }
+        ui.add_enabled_ui(!self.stale && !busy, |ui| {
+            ui.columns(3, |columns| {
+                columns[0].strong("Position (cm)");
                 for (axis, value) in ["X", "Y", "Z"].into_iter().zip([
                     &mut entry.grip.offset.x,
                     &mut entry.grip.offset.y,
                     &mut entry.grip.offset.z,
                 ]) {
                     let mut cm = *value * shock2vr::METERS_PER_WORLD_UNIT * 100.0;
-                    if ui
-                        .add(
-                            egui::DragValue::new(&mut cm)
-                                .speed(0.1)
-                                .prefix(format!("{axis} "))
-                                .range(-500.0..=500.0),
-                        )
-                        .changed()
-                    {
+                    if tweak_slider(&mut columns[0], axis, &mut cm, -50.0..=50.0, 0.1, 2) {
                         *value = cm / (shock2vr::METERS_PER_WORLD_UNIT * 100.0);
                     }
                 }
-            });
-            ui.horizontal(|ui| {
-                ui.label("Rotate item about hand axis");
-                ui.add(
-                    egui::DragValue::new(&mut self.rotation_step)
-                        .speed(0.1)
-                        .range(0.1..=90.0)
-                        .suffix("°"),
-                );
-                for (name, axis) in [
-                    ("X", Vector3::unit_x()),
-                    ("Y", Vector3::unit_y()),
-                    ("Z", Vector3::unit_z()),
-                ] {
-                    for sign in [-1.0, 1.0] {
-                        if ui
-                            .button(format!("{name}{}", if sign < 0.0 { "−" } else { "+" }))
-                            .clicked()
-                        {
-                            entry.grip.rotation =
-                                (Quaternion::from_axis_angle(axis, Deg(self.rotation_step * sign))
-                                    * entry.grip.rotation)
-                                    .normalize();
-                        }
-                    }
+                columns[1].strong("Rotation (degrees)");
+                let (last, angles) = self.rotation_edit.as_mut().unwrap();
+                let mut changed = false;
+                for (axis, angle) in ["X", "Y", "Z"].into_iter().zip(angles.iter_mut()) {
+                    changed |= tweak_slider(
+                        &mut columns[1],
+                        axis,
+                        angle,
+                        -180.0..=180.0,
+                        self.rotation_step,
+                        1,
+                    );
                 }
-            });
-            ui.horizontal_wrapped(|ui| {
-                ui.label("Fingers");
-                if ui.button("Open").clicked() {
-                    entry.grip.curls = [0.0; 5];
+                if changed {
+                    entry.grip.rotation = Quaternion::from(Euler::new(
+                        Deg(angles[0]),
+                        Deg(angles[1]),
+                        Deg(angles[2]),
+                    ))
+                    .normalize();
+                    *last = entry.grip.rotation;
                 }
-                if ui.button("Point").clicked() {
-                    entry.grip.curls = [0.85, 0.0, 0.9, 0.9, 0.9];
-                }
-                if ui.button("Closed").clicked() {
-                    entry.grip.curls = [1.0; 5];
-                }
+                columns[2].strong("Finger curls");
                 for (name, value) in ["Thumb", "Index", "Middle", "Ring", "Pinky"]
                     .into_iter()
                     .zip(&mut entry.grip.curls)
                 {
-                    ui.add(
-                        egui::DragValue::new(value)
-                            .speed(0.01)
-                            .range(0.0..=1.0)
-                            .prefix(format!("{name} ")),
-                    );
+                    tweak_slider(&mut columns[2], name, value, 0.0..=1.0, 0.02, 2);
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Rotation nudge step");
+                ui.add(egui::Slider::new(&mut self.rotation_step, 0.1..=15.0).suffix("°"));
+                ui.separator();
+                ui.label("Uniform item scale");
+                tweak_slider(ui, "×", &mut entry.grip.item_scale, 0.1..=3.0, 0.02, 2);
+            });
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Pose presets");
+                for (name, amounts) in [
+                    ("Open", [0.0; 5]),
+                    ("Point", [0.85, 0.0, 0.9, 0.9, 0.9]),
+                    ("Closed", [1.0; 5]),
+                    ("Ball", [0.35, 0.25, 0.3, 0.35, 0.4]),
+                ] {
+                    if ui.button(name).clicked() {
+                        entry.grip.curls = amounts;
+                    }
                 }
             });
         });
@@ -448,7 +676,7 @@ impl GripEditor {
         if !self.message.is_empty() {
             ui.label(&self.message);
         }
-        ui.small("Drag values to adjust; click a value to type. Unsaved drafts stay when switching models. Orbit to inspect hidden contacts.");
+        ui.small("Drag sliders or click values to type. Ball is a cupped starting pose; adjust curls to the item. Unsaved drafts stay when switching models.");
         // Build first, then select the requested camera so the initial model
         // framing cannot overwrite it. show() keeps the same camera on edits.
         let scene = PreviewScene::Grip(hand, entry.grip.clone());
@@ -458,7 +686,77 @@ impl GripEditor {
             self.camera_pending = false;
         }
         preview.show(ui, frame, &key, &scene);
+        if let Some(path) = &mut self.save_as_path {
+            let mut close = false;
+            egui::Modal::new(egui::Id::new("save_grips_as")).show(ui.ctx(), |ui| {
+                ui.heading("Save grips as JSON");
+                ui.label("Write a new file. The original stays untouched.");
+                ui.add(egui::TextEdit::singleline(path).desired_width(520.0));
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                    if ui.button("Save new file").clicked() {
+                        self.message = match doc.save_as(PathBuf::from(path.trim())) {
+                            Ok(()) => {
+                                close = true;
+                                format!("Saving to {}", doc.path.display())
+                            }
+                            Err(e) => format!("Could not save: {e}. Choose a new filename."),
+                        };
+                    }
+                });
+                if !self.message.is_empty() {
+                    ui.label(&self.message);
+                }
+            });
+            if close {
+                self.save_as_path = None;
+            }
+        }
+        if request_fit {
+            self.start_fit(
+                preview,
+                vec![self.hand.clone()],
+                self.family,
+                self.family.is_some(),
+            );
+        }
     }
+}
+
+/// Each value offers a coarse slider, small nudges, and optional exact entry.
+fn tweak_slider(
+    ui: &mut egui::Ui,
+    label: &str,
+    value: &mut f32,
+    range: std::ops::RangeInclusive<f32>,
+    step: f32,
+    decimals: usize,
+) -> bool {
+    let mut changed = false;
+    ui.push_id(label, |ui| {
+        ui.horizontal(|ui| {
+            ui.label(label);
+            if ui.small_button("−").clicked() {
+                *value = (*value - step).max(*range.start());
+                changed = true;
+            }
+            ui.spacing_mut().slider_width = 80.0;
+            changed |= ui
+                .add(
+                    egui::Slider::new(value, range.clone())
+                        .clamping(egui::SliderClamping::Edits)
+                        .fixed_decimals(decimals),
+                )
+                .changed();
+            if ui.small_button("+").clicked() {
+                *value = (*value + step).min(*range.end());
+                changed = true;
+            }
+        })
+    });
+    changed
 }
 
 #[cfg(test)]
@@ -515,5 +813,47 @@ mod tests {
         std::fs::write(&doc.path, external).unwrap();
         assert!(doc.save().unwrap_err().contains("changed on disk"));
         assert_eq!(std::fs::read(&doc.path).unwrap(), external);
+    }
+    #[test]
+    fn save_as_preserves_original_and_refuses_to_replace_an_existing_file() {
+        let (dir, mut doc) = document();
+        let original = std::fs::read(&doc.path).unwrap();
+        let original_path = doc.path.clone();
+        doc.library.entries[0].grip.item_scale = 0.8;
+        doc.library.entries[0].authored = true;
+        assert!(doc.save_as(original_path.clone()).is_err());
+        assert_eq!(doc.path, original_path);
+        let copy = dir.path().join("my-overrides.json");
+        doc.save_as(copy.clone()).unwrap();
+        assert_eq!(std::fs::read(&original_path).unwrap(), original);
+        let loaded = GripDocument::load(copy.clone()).unwrap();
+        assert_eq!(loaded.library.entries[0].grip.item_scale, 0.8);
+        doc.library.entries[0].grip.item_scale = 0.9;
+        doc.save().unwrap();
+        assert_eq!(
+            GripDocument::load(copy).unwrap().library.entries[0]
+                .grip
+                .item_scale,
+            0.9
+        );
+        assert_eq!(std::fs::read(&original_path).unwrap(), original);
+    }
+
+    #[test]
+    fn added_entries_can_be_saved_without_a_saved_baseline_hand() {
+        let (_dir, mut doc) = document();
+        let mut added = doc.library.entries[0].clone();
+        added.model = "new-model".into();
+        doc.library.entries.push(added);
+        doc.restore(doc.library.entries.len() - 1); // no saved hand to revert
+        doc.save().unwrap();
+        let loaded = GripDocument::load(doc.path).unwrap();
+        assert!(
+            loaded
+                .library
+                .entries
+                .iter()
+                .any(|e| e.model == "new-model")
+        );
     }
 }

--- a/tools/dark_explorer/src/main.rs
+++ b/tools/dark_explorer/src/main.rs
@@ -4,6 +4,7 @@ use engine::assets::asset_paths::AssetEntry;
 mod archetypes;
 mod archives;
 mod explorer;
+mod grip_editor;
 mod model_preview;
 mod ui;
 
@@ -44,6 +45,18 @@ enum Commands {
     },
     /// Open a windowed asset browser (tree + search + preview)
     Ui {
+        /// Open VR Grips with this prepared pickup model selected (e.g. mug)
+        #[arg(long)]
+        grip: Option<String>,
+        /// Hand to inspect in VR Grips
+        #[arg(long, default_value = "right", value_parser = ["left", "right"])]
+        grip_hand: String,
+        /// Initial grip camera
+        #[arg(long, default_value = "oblique", value_parser = ["front", "back", "top", "oblique", "palm"])]
+        grip_view: String,
+        /// Prepared grip resource to edit (defaults to this checkout's assets)
+        #[arg(long)]
+        grip_library: Option<std::path::PathBuf>,
         /// Write a PNG of the first rendered frame to this path and exit
         #[arg(long)]
         screenshot: Option<std::path::PathBuf>,
@@ -220,6 +233,10 @@ fn main() {
         } => ls(family, filter, limit),
         Commands::Find { pattern, limit } => find(pattern, limit),
         Commands::Ui {
+            grip,
+            grip_hand,
+            grip_view,
+            grip_library,
             screenshot,
             select,
             search,
@@ -233,6 +250,10 @@ fn main() {
             archives,
             select_entry,
         } => ui::run(ui::UiOptions {
+            grip,
+            grip_hand,
+            grip_view,
+            grip_library,
             screenshot,
             select,
             search,

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -12,13 +12,17 @@
 
 use std::ffi::CString;
 
-use cgmath::{Quaternion, Rad, Rotation3, vec2, vec3};
+use cgmath::{InnerSpace, Matrix4, One, Quaternion, Rad, Rotation3, vec2, vec3};
 use dark::importers::MODELS_IMPORTER;
 use dark::model::Model;
 use dark_viewer::scenes::{BinAiViewerScene, BinObjViewerScene, SkeletonViewerScene, ToolScene};
 use eframe::{egui, glow};
 use engine::Engine;
 use engine::assets::asset_cache::AssetCache;
+use shock2vr::{
+    GloveRenderer, Handedness,
+    vr_grip::{GripHints, GripKinematics, GripSurface, ResolvedGrip, surface_fingerprint},
+};
 
 use crate::ui::quiet_catch;
 
@@ -41,6 +45,7 @@ pub fn init_raw_gl(cc: &eframe::CreationContext<'_>) {
 pub enum PreviewScene {
     /// The `.bin` model alone.
     Model,
+    Grip(Handedness, ResolvedGrip),
     /// The `.bin` model animated by a motion clip (`<name>_.mc`).
     Clip(String),
     /// Bone lines only: the `.bin`'s skeleton posed by a motion clip.
@@ -50,7 +55,7 @@ pub enum PreviewScene {
 impl PreviewScene {
     fn clip(&self) -> Option<&str> {
         match self {
-            PreviewScene::Model => None,
+            PreviewScene::Model | PreviewScene::Grip(..) => None,
             PreviewScene::Clip(clip) | PreviewScene::Skeleton(clip) => Some(clip),
         }
     }
@@ -69,6 +74,8 @@ struct OffscreenTarget {
 
 pub struct ModelPreview {
     engine: Box<dyn Engine>,
+    glove: Option<GloveRenderer>,
+    grip_bounds: Option<(cgmath::Vector3<f32>, f32)>,
     asset_cache: AssetCache,
     /// What the current scene (or error) was built for: (key, scene, skeletons,
     /// hitboxes, articulation). Guards against rebuilding — or re-panicking —
@@ -111,6 +118,8 @@ impl ModelPreview {
         let asset_cache = AssetCache::new(base_path, mounts);
         ModelPreview {
             engine,
+            glove: None,
+            grip_bounds: None,
             asset_cache,
             built_for: None,
             scene: None,
@@ -155,7 +164,7 @@ impl ModelPreview {
         // itself triggers that repaint). The overlays mean nothing in
         // skeleton-only mode, which draws bones and nothing else.
         ui.horizontal(|ui| {
-            if !matches!(scene, PreviewScene::Skeleton(_)) {
+            if !matches!(scene, PreviewScene::Skeleton(_) | PreviewScene::Grip(..)) {
                 ui.checkbox(&mut self.debug_skeletons, "Skeleton");
                 ui.checkbox(&mut self.debug_hit_boxes, "Hitboxes");
             }
@@ -207,6 +216,10 @@ impl ModelPreview {
         }
     }
 
+    pub fn prepare(&mut self, key: &str, scene: &PreviewScene) {
+        self.ensure_scene(key, scene);
+    }
+
     /// (Re)build the scene when the key, clip, or a debug toggle changed,
     /// framing the camera from the model's bounds where they are known.
     fn ensure_scene(&mut self, key: &str, scene: &PreviewScene) {
@@ -242,6 +255,55 @@ impl ModelPreview {
         // bounding box for `frame_camera` to use.
         let mut pose_bounds = None;
         let built: Result<Box<dyn ToolScene>, String> = match scene {
+            PreviewScene::Grip(hand, grip) => quiet_catch(|| {
+                let mut objects = Model::transform(
+                    &model,
+                    Matrix4::from_translation(grip.offset) * Matrix4::from(grip.rotation),
+                )
+                .clone_scene_objects();
+                if self.glove.is_none() {
+                    self.glove = GloveRenderer::new(&mut self.asset_cache);
+                }
+                let glove = self.glove.as_mut().ok_or("Glove model unavailable")?;
+                objects.extend(glove.render_hand(
+                    vec3(0.0, 0.0, 0.0),
+                    Quaternion::one(),
+                    *hand,
+                    0.0,
+                    0.0,
+                    true,
+                    Some(grip.finger_amounts()),
+                ));
+                let triangles = self
+                    .asset_cache
+                    .get(&dark::importers::GRIP_SURFACE_IMPORTER, key);
+                let transform =
+                    Matrix4::from_translation(grip.offset) * Matrix4::from(grip.rotation);
+                // Include the actual sampled glove arcs as well as the item, so
+                // a small prop cannot crop the wrist or a large one its far end.
+                let kinematics = glove.grip_kinematics(*hand);
+                let points = triangles
+                    .iter()
+                    .flatten()
+                    .map(|p| (transform * p.to_homogeneous()).truncate())
+                    .chain(kinematics.fingers.iter().flatten().flatten().copied());
+                let mut min = vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+                let mut max = -min;
+                for p in points {
+                    for i in 0..3 {
+                        min[i] = min[i].min(p[i]);
+                        max[i] = max[i].max(p[i]);
+                    }
+                }
+                pose_bounds = Some(((min + max) * 0.5, (max - min).magnitude() * 0.5));
+                self.grip_bounds = pose_bounds;
+                Ok(
+                    Box::new(GripPreviewScene(engine::scene::Scene::from_objects(
+                        objects,
+                    ))) as Box<dyn ToolScene>,
+                )
+            })
+            .and_then(|r: Result<_, &str>| r.map_err(str::to_string)),
             PreviewScene::Model => BinObjViewerScene::from_model(
                 key.to_string(),
                 &self.asset_cache,
@@ -301,13 +363,83 @@ impl ModelPreview {
                 self.needs_render = true;
                 if reframe {
                     match pose_bounds {
-                        Some((center, radius)) => self.frame_bounds(center, radius, 1.0),
+                        Some((center, radius)) => self.frame_bounds(
+                            center,
+                            radius,
+                            if matches!(scene, PreviewScene::Grip(..)) {
+                                0.25
+                            } else {
+                                1.0
+                            },
+                        ),
                         None => self.frame_camera(&model),
                     }
                 }
             }
             Err(err) => self.error = Some(err),
         }
+    }
+
+    /// Shared game geometry and rig samples for validation and explicit auto-fit.
+    pub fn grip_inputs(
+        &mut self,
+        key: &str,
+        hand: Handedness,
+    ) -> Result<(GripSurface, GripKinematics, String), String> {
+        quiet_catch(|| {
+            let triangles = self
+                .asset_cache
+                .get(&dark::importers::GRIP_SURFACE_IMPORTER, key);
+            let surface = GripSurface::new(&triangles).ok_or("No usable pickup surface")?;
+            if self.glove.is_none() {
+                self.glove = GloveRenderer::new(&mut self.asset_cache);
+            }
+            let rig = self
+                .glove
+                .as_mut()
+                .ok_or("Glove model unavailable")?
+                .grip_kinematics(hand);
+            Ok((surface, rig, surface_fingerprint(&triangles)))
+        })
+        .and_then(|r: Result<_, &str>| r.map_err(str::to_string))
+    }
+
+    pub fn fit_grip(
+        &mut self,
+        key: &str,
+        hand: Handedness,
+        hints: &GripHints,
+    ) -> Result<ResolvedGrip, String> {
+        let (surface, rig, _) = self.grip_inputs(key, hand)?;
+        surface
+            .resolve(&rig, hints)
+            .ok_or_else(|| "No valid automatic fit; existing draft kept".to_string())
+    }
+
+    /// Camera presets share the gallery's hand-local axes. Orbit remains free.
+    pub fn grip_camera(&mut self, view: &str, hand: Handedness) {
+        if let Some((center, radius)) = self.grip_bounds {
+            self.frame_bounds(center, radius, 0.25);
+        }
+        (self.yaw, self.pitch) = match view {
+            "front" => (90.0, 90.0),
+            "back" => (-90.0, 90.0),
+            "top" => (90.0, 0.1),
+            "palm" => (
+                if hand == Handedness::Right {
+                    63.4
+                } else {
+                    -63.4
+                },
+                65.9,
+            ),
+            _ => (-45.0, 66.2),
+        };
+        if view == "palm" {
+            self.target = vec3(0.0, 0.0, -0.12);
+            self.distance = 0.5;
+        }
+        self.needs_render = true;
     }
 
     /// Step the playing scene forward by `seconds` of simulation time (in
@@ -383,7 +515,16 @@ impl ModelPreview {
         if response.hovered() {
             let scroll = ui.input(|i| i.smooth_scroll_delta.y);
             if scroll != 0.0 {
-                self.distance = (self.distance * (-scroll * 0.003).exp()).clamp(0.5, 300.0);
+                let minimum = if self
+                    .built_for
+                    .as_ref()
+                    .is_some_and(|(_, s, ..)| matches!(s, PreviewScene::Grip(..)))
+                {
+                    0.15
+                } else {
+                    0.5
+                };
+                self.distance = (self.distance * (-scroll * 0.003).exp()).clamp(minimum, 300.0);
                 moved = true;
             }
         }
@@ -522,7 +663,15 @@ impl ModelPreview {
             projection_matrix: cgmath::perspective(
                 cgmath::Deg(45.0),
                 size[0] as f32 / size[1] as f32,
-                0.1,
+                if self
+                    .built_for
+                    .as_ref()
+                    .is_some_and(|(_, s, ..)| matches!(s, PreviewScene::Grip(..)))
+                {
+                    0.01
+                } else {
+                    0.1
+                },
                 1000.0,
             ),
             screen_size: vec2(size[0] as f32, size[1] as f32),
@@ -548,5 +697,13 @@ impl ModelPreview {
                 prev_viewport[3],
             );
         }
+    }
+}
+
+struct GripPreviewScene(engine::scene::Scene);
+impl ToolScene for GripPreviewScene {
+    fn update(&mut self, _delta_time: f32) {}
+    fn render(&self, _asset_cache: &mut AssetCache) -> engine::scene::Scene {
+        self.0.clone()
     }
 }

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -21,7 +21,7 @@ use engine::Engine;
 use engine::assets::asset_cache::AssetCache;
 use shock2vr::{
     GloveRenderer, Handedness,
-    vr_grip::{GripHints, GripKinematics, GripSurface, ResolvedGrip, surface_fingerprint},
+    vr_grip::{GripKinematics, GripSurface, ResolvedGrip, surface_fingerprint},
 };
 
 use crate::ui::quiet_catch;
@@ -258,7 +258,9 @@ impl ModelPreview {
             PreviewScene::Grip(hand, grip) => quiet_catch(|| {
                 let mut objects = Model::transform(
                     &model,
-                    Matrix4::from_translation(grip.offset) * Matrix4::from(grip.rotation),
+                    Matrix4::from_translation(grip.offset)
+                        * Matrix4::from(grip.rotation)
+                        * Matrix4::from_scale(grip.item_scale),
                 )
                 .clone_scene_objects();
                 if self.glove.is_none() {
@@ -277,8 +279,9 @@ impl ModelPreview {
                 let triangles = self
                     .asset_cache
                     .get(&dark::importers::GRIP_SURFACE_IMPORTER, key);
-                let transform =
-                    Matrix4::from_translation(grip.offset) * Matrix4::from(grip.rotation);
+                let transform = Matrix4::from_translation(grip.offset)
+                    * Matrix4::from(grip.rotation)
+                    * Matrix4::from_scale(grip.item_scale);
                 // Include the actual sampled glove arcs as well as the item, so
                 // a small prop cannot crop the wrist or a large one its far end.
                 let kinematics = glove.grip_kinematics(*hand);
@@ -402,18 +405,6 @@ impl ModelPreview {
             Ok((surface, rig, surface_fingerprint(&triangles)))
         })
         .and_then(|r: Result<_, &str>| r.map_err(str::to_string))
-    }
-
-    pub fn fit_grip(
-        &mut self,
-        key: &str,
-        hand: Handedness,
-        hints: &GripHints,
-    ) -> Result<ResolvedGrip, String> {
-        let (surface, rig, _) = self.grip_inputs(key, hand)?;
-        surface
-            .resolve(&rig, hints)
-            .ok_or_else(|| "No valid automatic fit; existing draft kept".to_string())
     }
 
     /// Camera presets share the gallery's hand-local axes. Orbit remains free.

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -28,6 +28,10 @@ const GRID_TILE_CAP: usize = 400;
 const THUMBS_PER_FRAME: usize = 6;
 
 pub struct UiOptions {
+    pub grip: Option<String>,
+    pub grip_hand: String,
+    pub grip_view: String,
+    pub grip_library: Option<PathBuf>,
     pub screenshot: Option<PathBuf>,
     pub select: Option<String>,
     pub search: Option<String>,
@@ -244,12 +248,14 @@ struct Preview {
 
 #[derive(Clone, Copy, PartialEq)]
 enum Tab {
+    Grips,
     Files,
     Archetypes,
     Archives,
 }
 
 pub struct ExplorerApp {
+    grip_editor: crate::grip_editor::GripEditor,
     tab: Tab,
     family_names: Vec<&'static str>,
     families: BTreeMap<String, LoadedFamily>,
@@ -342,8 +348,15 @@ struct MountIndex {
 
 impl ExplorerApp {
     fn new(options: UiOptions) -> ExplorerApp {
+        let grip_tab = options.grip.is_some();
         let mut app = ExplorerApp {
-            tab: Tab::Files,
+            grip_editor: crate::grip_editor::GripEditor::new(
+                options.grip_library,
+                options.grip,
+                options.grip_hand,
+                options.grip_view,
+            ),
+            tab: if grip_tab { Tab::Grips } else { Tab::Files },
             family_names: explorer::family_names(),
             families: BTreeMap::new(),
             search: options.search.unwrap_or_default(),
@@ -1013,6 +1026,7 @@ impl eframe::App for ExplorerApp {
                     ui.selectable_value(&mut self.tab, Tab::Files, "Files");
                     ui.selectable_value(&mut self.tab, Tab::Archetypes, "Archetypes");
                     ui.selectable_value(&mut self.tab, Tab::Archives, "Archives");
+                    ui.selectable_value(&mut self.tab, Tab::Grips, "VR Grips");
                 });
                 // The preview belongs to the tab that selected it; a Files
                 // asset must not keep showing under the Archives tab.
@@ -1021,6 +1035,7 @@ impl eframe::App for ExplorerApp {
                 }
                 ui.separator();
                 match self.tab {
+                    Tab::Grips => self.grip_editor.show_list(ui),
                     Tab::Files => {
                         ui.horizontal(|ui| {
                             ui.selectable_value(&mut self.grid_view, false, "List");
@@ -1051,7 +1066,10 @@ impl eframe::App for ExplorerApp {
             });
 
         egui::CentralPanel::default_margins().show(ui, |ui| {
-            if self.tab == Tab::Archetypes {
+            if self.tab == Tab::Grips {
+                let host = self.model_preview.get_or_insert_with(ModelPreview::new);
+                self.grip_editor.show(ui, frame, host);
+            } else if self.tab == Tab::Archetypes {
                 self.show_archetype_preview(ui, frame);
             } else if self.tab == Tab::Archives {
                 self.show_preview(ui, frame);
@@ -1080,6 +1098,7 @@ impl eframe::App for ExplorerApp {
             self.select_archive_entry(archive, entry);
         }
 
+        self.grip_editor.guard_close(&ctx);
         self.drive_screenshot(&ctx);
     }
 }
@@ -1826,6 +1845,12 @@ impl ExplorerApp {
         let thumbs_ready =
             !self.grid_view || self.thumbs_pending == 0 || self.frames_rendered >= 250;
         if self.frames_rendered >= 3 && thumbs_ready && !self.screenshot_sent {
+            if self.tab == Tab::Grips {
+                if let Some(error) = self.grip_editor.error() {
+                    eprintln!("cannot render grip: {error}");
+                    std::process::exit(2);
+                }
+            }
             // A selection that failed to load would capture only its error
             // label; fail loudly instead so automation can trust exit 0.
             if let Some(error) = self.model_preview.as_ref().and_then(|p| p.error()) {

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -1731,6 +1731,10 @@ impl ExplorerApp {
                     self.initial_overlays,
                     self.screenshot.is_some(),
                 );
+                if ui.button("Edit VR Grip").clicked() {
+                    self.grip_editor.open_model(&key);
+                    self.tab = Tab::Grips;
+                }
                 host.show(ui, frame, &key, &PreviewScene::Model);
             }
             PreviewKind::Motion { clip } => {
@@ -1831,6 +1835,10 @@ impl ExplorerApp {
         let Some(path) = self.screenshot.clone() else {
             return;
         };
+        if self.tab == Tab::Grips && self.grip_editor.is_busy() {
+            ctx.request_repaint_after(std::time::Duration::from_millis(50));
+            return;
+        }
         self.frames_rendered += 1;
         ctx.request_repaint();
         // The scene exists after the first frame's show; step it before the

--- a/tools/shock2-sdk/scripts/bake-vr-grips.mjs
+++ b/tools/shock2-sdk/scripts/bake-vr-grips.mjs
@@ -1,12 +1,21 @@
 // Run after npm run build, with Node 22+. This intentionally runs the expensive
 // search headlessly; gameplay only reads the prepared resource it writes.
 import assert from 'node:assert/strict';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile, rename, rm } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { GameServer } from '../dist/src/index.js';
+import {preserveAuthoredGrips} from './prepared-grips.mjs';
 import { aimVrHandAt } from '../dist/test/helpers/vr-hand.js';
 
-const output = process.argv[2] ?? fileURLToPath(new URL('../../../assets/astra-vr-grips.json', import.meta.url));
+const source = fileURLToPath(new URL('../../../assets/astra-vr-grips.json', import.meta.url));
+const output = process.argv[2] ?? source;
+const sourceBytes = await readFile(source, 'utf8');
+const readOutput = () => readFile(output, 'utf8').catch(error => {
+  if (error.code === 'ENOENT') return null;
+  throw error;
+});
+const outputBytes = await readOutput();
+const previous = JSON.parse(outputBytes ?? sourceBytes);
 const entries = [];
 let solverRevision;
 const game = await GameServer.launch({mission: 'debug_interactions', debugFlags: ['--vr', '--experimental', 'astra-bake-vr-grips']});
@@ -37,5 +46,14 @@ try {
 } finally {
   await game.shutdown();
 }
-await writeFile(output,JSON.stringify({version:1,solver_revision:solverRevision,entries},null,2)+'\n');
+const library = preserveAuthoredGrips(previous, {version:1,solver_revision:solverRevision,entries});
+assert.equal(await readFile(source, 'utf8'), sourceBytes, 'Source grips changed during baking; no output written');
+assert.equal(await readOutput(), outputBytes, 'Output grips changed during baking; no output written');
+const temporary = `${output}.${process.pid}.tmp`;
+try {
+  await writeFile(temporary,JSON.stringify(library,null,2)+'\n', {flag:'wx'});
+  await rename(temporary,output);
+} finally {
+  await rm(temporary,{force:true});
+}
 console.log(`Wrote ${entries.length} prepared grips to ${output}`);

--- a/tools/shock2-sdk/scripts/prepared-grips.mjs
+++ b/tools/shock2-sdk/scripts/prepared-grips.mjs
@@ -3,10 +3,19 @@
 import assert from 'node:assert/strict';
 export function preserveAuthoredGrips(previous, fresh) {
   const entries = [...fresh.entries];
-  for (const entry of previous.entries.filter(e => e.authored)) {
+  for (const entry of previous.entries) {
     const index = entries.findIndex(e => e.model === entry.model && e.hand === entry.hand);
     const replacement = entries[index];
-    assert.ok(replacement && previous.version === fresh.version && previous.solver_revision === fresh.solver_revision &&
+    if (!replacement) {
+      assert.ok(previous.version === fresh.version && previous.solver_revision === fresh.solver_revision,
+        `Additional model ${entry.model} ${entry.hand} needs review after a solver revision change`);
+      // Explorer can add models that have no rack fixture. Keep their exact
+      // entries; runtime fingerprint checks still reject stale geometry/rig/hints.
+      entries.push(entry);
+      continue;
+    }
+    if (!entry.authored) continue;
+    assert.ok(previous.version === fresh.version && previous.solver_revision === fresh.solver_revision &&
       ['surface_hash', 'kinematics_hash', 'hints_hash'].every(key => entry[key] === replacement[key]),
       `Manual override ${entry.model} ${entry.hand} needs review in Explorer before rebaking; no output written`);
     entries[index] = entry;

--- a/tools/shock2-sdk/scripts/prepared-grips.mjs
+++ b/tools/shock2-sdk/scripts/prepared-grips.mjs
@@ -1,0 +1,15 @@
+// A manual pose is authoring data. Bulk baking may refresh automatic entries,
+// but cannot erase an override or carry it across changed geometry/rig/hints.
+import assert from 'node:assert/strict';
+export function preserveAuthoredGrips(previous, fresh) {
+  const entries = [...fresh.entries];
+  for (const entry of previous.entries.filter(e => e.authored)) {
+    const index = entries.findIndex(e => e.model === entry.model && e.hand === entry.hand);
+    const replacement = entries[index];
+    assert.ok(replacement && previous.version === fresh.version && previous.solver_revision === fresh.solver_revision &&
+      ['surface_hash', 'kinematics_hash', 'hints_hash'].every(key => entry[key] === replacement[key]),
+      `Manual override ${entry.model} ${entry.hand} needs review in Explorer before rebaking; no output written`);
+    entries[index] = entry;
+  }
+  return {...fresh, entries};
+}

--- a/tools/shock2-sdk/scripts/prepared-grips.test.mjs
+++ b/tools/shock2-sdk/scripts/prepared-grips.test.mjs
@@ -11,11 +11,12 @@ test('bulk baking preserves authored hands and updates automatic hands', () => {
   assert.deepEqual(result.entries,[manual,fresh.entries[1]]);
   assert.equal(fresh.entries[0].grip.offset,2);
 });
-test('changed inputs or missing fixtures cannot silently erase an override', () => {
+test('changed inputs cannot silently erase an override', () => {
   const previous=library([{...entry,authored:true}]);
   for (const key of ['surface_hash','kinematics_hash','hints_hash']) {
     assert.throws(() => preserveAuthoredGrips(previous,library([{...entry,[key]:'changed'}])),/needs review/);
   }
-  assert.throws(() => preserveAuthoredGrips(previous,library([])),/needs review/);
+  assert.deepEqual(preserveAuthoredGrips(previous,library([])).entries,previous.entries);
+  assert.deepEqual(preserveAuthoredGrips(library([entry]),library([])).entries,[entry]);
   assert.throws(() => preserveAuthoredGrips(previous,{...library([entry]),solver_revision:3}),/needs review/);
 });

--- a/tools/shock2-sdk/scripts/prepared-grips.test.mjs
+++ b/tools/shock2-sdk/scripts/prepared-grips.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {preserveAuthoredGrips} from './prepared-grips.mjs';
+const entry = {model:'mug', hand:'left',surface_hash:'mesh',kinematics_hash:'rig',hints_hash:'hints',grip:{offset:1}};
+const library = entries => ({version:1,solver_revision:2,entries});
+test('bulk baking preserves authored hands and updates automatic hands', () => {
+  const manual = {...entry,authored:true};
+  const right = {...entry,hand:'right'};
+  const fresh = library([{...entry,grip:{offset:2}}, {...right,grip:{offset:3}}]);
+  const result = preserveAuthoredGrips(library([manual,right]),fresh);
+  assert.deepEqual(result.entries,[manual,fresh.entries[1]]);
+  assert.equal(fresh.entries[0].grip.offset,2);
+});
+test('changed inputs or missing fixtures cannot silently erase an override', () => {
+  const previous=library([{...entry,authored:true}]);
+  for (const key of ['surface_hash','kinematics_hash','hints_hash']) {
+    assert.throws(() => preserveAuthoredGrips(previous,library([{...entry,[key]:'changed'}])),/needs review/);
+  }
+  assert.throws(() => preserveAuthoredGrips(previous,library([])),/needs review/);
+  assert.throws(() => preserveAuthoredGrips(previous,{...library([entry]),solver_revision:3}),/needs review/);
+});

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -1083,6 +1083,8 @@ export interface WaitForOptions {
 
 /** Diagnostics from the same resolved pose used by gameplay and rendering. */
 export interface HandGrip {
+  /** Manual Explorer override; solver contact samples do not validate this pose. */
+  authored: boolean;
   hand: "left" | "right";
   entity_id: number;
   model: string;

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -418,6 +418,8 @@ export interface SceneObjectSummary {
    */
   source: string | null;
   position: Vec3;
+  /** Rendered world-transform axis magnitudes, excluding mesh-local transforms. */
+  scale: Vec3;
   /** Transparency in effect for this draw (0 = opaque, 1 = invisible). */
   transparency: number | null;
   depth_write: boolean;
@@ -1100,6 +1102,7 @@ export interface HandGrip {
 }
 
 export interface ResolvedGrip {
+  item_scale: number;
   pose_family: string;
   offset: {x:number;y:number;z:number};
   rotation: {s:number;v:{x:number;y:number;z:number}};

--- a/tools/shock2-sdk/test/debug-interactions.e2e.test.ts
+++ b/tools/shock2-sdk/test/debug-interactions.e2e.test.ts
@@ -58,6 +58,11 @@ test(
           assert.ok(before.grip);
           if (!before.authored) assert.ok(before.grip.contacts.filter(Boolean).length >= 3, "at least three fingers support each automatic fixture fit");
           assert.ok(before.grip.curls.every(c => Number.isFinite(c) && c >= 0 && c <= 1));
+          const heldDraws = (await game.scene.objects({entityId:item.id})).objects;
+          assert.ok(heldDraws.length > 0);
+          for (const draw of heldDraws) for (const scale of draw.scale) {
+            assert.ok(Math.abs(scale - before.grip.item_scale) < 1e-5, "rendered item uses uniform grip scale");
+          }
           await game.input.set(`${hand}_hand.position`, [0, 3, 0]);
           await game.input.set(`${hand}_hand.rotation`, [0, Math.sin(0.3), 0, Math.cos(0.3)]);
           await game.step({frames: 30});
@@ -79,6 +84,11 @@ test(
           `${hand} releases ${item.name}`,
         );
         assert.ok(!(await game.info()).player.hand_grips.some(g => g.hand === hand), "release clears the fitted grip");
+        if (![-928, -17, -19, -26, -27, -247].includes(template)) {
+          for (const draw of (await game.scene.objects({entityId:item.id})).objects) {
+            for (const scale of draw.scale) assert.ok(Math.abs(scale - 1) < 1e-5, "release restores world size");
+          }
+        }
       }
     }
     await game.input.trigger("DebugReloadLevel");

--- a/tools/shock2-sdk/test/debug-interactions.e2e.test.ts
+++ b/tools/shock2-sdk/test/debug-interactions.e2e.test.ts
@@ -56,7 +56,7 @@ test(
           const before = (await game.info()).player.hand_grips.find(g => g.hand === hand)!;
           assert.equal(before.source, "prepared", "gameplay reads a bake instead of running the search");
           assert.ok(before.grip);
-          assert.ok(before.grip.contacts.filter(Boolean).length >= 3, "at least three fingers support each fixture");
+          if (!before.authored) assert.ok(before.grip.contacts.filter(Boolean).length >= 3, "at least three fingers support each automatic fixture fit");
           assert.ok(before.grip.curls.every(c => Number.isFinite(c) && c >= 0 && c <= 1));
           await game.input.set(`${hand}_hand.position`, [0, 3, 0]);
           await game.input.set(`${hand}_hand.rotation`, [0, Math.sin(0.3), 0, Math.cos(0.3)]);


### PR DESCRIPTION
Add a **VR Grips** tab to Explorer for authoring pickup grip overrides without editing JSON. The shared game model/glove preview offers orbiting and five camera presets. Position, separate XYZ rotation angles, finger curls, and uniform item scale have sliders, nudge buttons, and editable numbers for precise final tweaks. Open, Point, Closed, and Ball provide starting poses; rotation nudge size is separately labeled.

The Files model picker has **Edit VR Grip**. Existing entries open directly; missing hands are fitted into new drafts on a background worker, keeping the preview responsive. Save persists all drafts; Save As writes a separate JSON and makes it the future save target without overwriting an existing file. Revert applies to saved hands, and closing with drafts or fitting work offers keep editing/save/discard. Custom-file support is also available through `--grip-library`.

Manual edits are marked in the prepared resource and clear obsolete solver contact diagnostics. Bulk baking preserves matching manual entries; additional models outside the rack keep their original entries and fingerprints. Runtime checks still reject stale meshes/rigs/hints. Uniform scaling affects the held item, preserving glove calibration, and restores normal world size on drop. The debug runtime's scene inspection exposes rendered world-transform scale for verification.

Run from the repository root:

```sh
cargo run -p dark_explorer -- ui --grip mug
```

Restart the game/debug runtime process to load saved resource changes. The gallery remains a sharing/review tool. `_h` weapons will extend both editor and gallery in the next workstream; the psi amp retains its integrated forearm. Existing pickup placement concerns remain for visual adjustment. User-edited pose assets are excluded from this code change.

Validation: Explorer/debug runtime builds, SDK compile, 12 grip unit tests, 4 editor persistence/Save As/conflict tests, 2 baker preservation tests, and the full 35-station both-hand regression with rendered-scale assertions. A separate copied-resource runtime scenario verified scale 0.8 on all rendered axes while held and 1.0 after release. Native screenshots verify controls, scale changes, the Files entry point, and a newly prepared ammo-model draft. Earlier full 46-entry rebaking also preserved an authored custom-file pose exactly. UI save behavior is exercised through its persistence methods in tests; automated UI clicking is not claimed.

Independent Codex review and duplication review completed without remaining findings. Claude feedback review timed out without completing. Based on #1377. [Editor documentation](https://github.com/tommy-xr/shock2quest/blob/astra-vr-grip-editor/projects/astra-vr-grip-editor.md).

![Previous controls and new sliders, nudges and XYZ angles](https://gist.githubusercontent.com/tommy-xr/d244a9e3ecfdeb0634c6ed80b40a19ee/raw/astra-editor-before-after.png)

Before/after uses the same copied mug override, hand and camera view.

![Editor controls, item scaling, Files entry and new-model draft](https://gist.githubusercontent.com/tommy-xr/d244a9e3ecfdeb0634c6ed80b40a19ee/raw/astra-editor-feedback.gif)

The loop shows new controls, scale 1.0 versus 0.8 at the same position/curls, the Files Edit VR Grip entry point, and a new unsaved ammo-model draft. Native Explorer captures use copied resources; canonical user-edited assets were untouched. Save As modal interaction was not automated.
