### PR TITLE
feat(vr): hold a gun at life size, by its pistol grip

### DIFF
--- a/shock2vr/examples/gun_hand_islands.rs
+++ b/shock2vr/examples/gun_hand_islands.rs
@@ -27,21 +27,47 @@ const GUNS: &[&str] = &[
     "viro_h", "amp_h",
 ];
 
-/// The longest axis of the geometry a mesh's polygons actually reference, in
-/// world units - the one number that says how big a model is drawn.
-fn longest_span(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) -> f32 {
+/// Bounds and centroid of the geometry a mesh's polygons actually reference -
+/// the one pass every readout below is derived from. `None` for a mesh whose
+/// polygons reference nothing.
+struct MeshBounds {
+    lo: [f32; 3],
+    hi: [f32; 3],
+    centroid: [f32; 3],
+}
+
+fn mesh_bounds(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) -> Option<MeshBounds> {
     let mut lo = [f32::INFINITY; 3];
     let mut hi = [f32::NEG_INFINITY; 3];
+    let mut sum = [0.0f32; 3];
+    let mut count = 0.0f32;
     for polygon in &mesh.polygons {
         for index in &polygon.vertex_indices {
             let vertex = mesh.vertices[*index as usize];
             for (axis, value) in [vertex.x, vertex.y, vertex.z].into_iter().enumerate() {
                 lo[axis] = lo[axis].min(value);
                 hi[axis] = hi[axis].max(value);
+                sum[axis] += value;
             }
+            count += 1.0;
         }
     }
-    (0..3).map(|axis| hi[axis] - lo[axis]).fold(0.0, f32::max)
+    (count > 0.0).then(|| MeshBounds {
+        lo,
+        hi,
+        centroid: [sum[0] / count, sum[1] / count, sum[2] / count],
+    })
+}
+
+/// The longest axis of a mesh, in world units - the one number that says how
+/// big a model is drawn.
+fn longest_span(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) -> f32 {
+    let Some(bounds) = mesh_bounds(mesh) else {
+        return 0.0;
+    };
+    (0..3)
+        .map(|axis| bounds.hi[axis] - bounds.lo[axis])
+        .fold(0.0, f32::max)
 }
 
 /// The mesh's XY silhouette (barrel along -X, +Y up) on a coarse grid, with the
@@ -53,8 +79,9 @@ fn print_silhouette(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) {
     const COLS: usize = 78;
     const ROWS: usize = 24;
 
-    let mut lo = [f32::INFINITY; 2];
-    let mut hi = [f32::NEG_INFINITY; 2];
+    let Some(MeshBounds { lo, hi, .. }) = mesh_bounds(mesh) else {
+        return;
+    };
     let mut edges = Vec::new();
     for polygon in &mesh.polygons {
         let corners = polygon
@@ -63,15 +90,8 @@ fn print_silhouette(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) {
             .map(|index| mesh.vertices[*index as usize])
             .collect::<Vec<_>>();
         for (index, corner) in corners.iter().enumerate() {
-            lo[0] = lo[0].min(corner.x);
-            hi[0] = hi[0].max(corner.x);
-            lo[1] = lo[1].min(corner.y);
-            hi[1] = hi[1].max(corner.y);
             edges.push((*corner, corners[(index + 1) % corners.len()]));
         }
-    }
-    if edges.is_empty() {
-        return;
     }
     // Square cells, so the picture is not stretched: one span drives both axes.
     let span = (hi[0] - lo[0]).max((hi[1] - lo[1]) * COLS as f32 / ROWS as f32);
@@ -115,35 +135,12 @@ fn print_silhouette(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) {
 
 /// A mesh's centroid and bounds - for an arm island, where the baked hand is.
 fn print_bounds(label: &str, mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) {
-    let mut lo = [f32::INFINITY; 3];
-    let mut hi = [f32::NEG_INFINITY; 3];
-    let mut sum = [0.0f32; 3];
-    let mut count = 0.0f32;
-    for polygon in &mesh.polygons {
-        for index in &polygon.vertex_indices {
-            let vertex = mesh.vertices[*index as usize];
-            for (axis, value) in [vertex.x, vertex.y, vertex.z].into_iter().enumerate() {
-                lo[axis] = lo[axis].min(value);
-                hi[axis] = hi[axis].max(value);
-                sum[axis] += value;
-            }
-            count += 1.0;
-        }
-    }
-    if count == 0.0 {
+    let Some(MeshBounds { lo, hi, centroid }) = mesh_bounds(mesh) else {
         return;
-    }
+    };
     println!(
         "   {label}: centroid ({:+.3},{:+.3},{:+.3}) bounds x[{:+.3},{:+.3}] y[{:+.3},{:+.3}] z[{:+.3},{:+.3}]",
-        sum[0] / count,
-        sum[1] / count,
-        sum[2] / count,
-        lo[0],
-        hi[0],
-        lo[1],
-        hi[1],
-        lo[2],
-        hi[2],
+        centroid[0], centroid[1], centroid[2], lo[0], hi[0], lo[1], hi[1], lo[2], hi[2],
     );
 }
 

--- a/shock2vr/examples/gun_hand_islands.rs
+++ b/shock2vr/examples/gun_hand_islands.rs
@@ -1,11 +1,17 @@
-//! Scratch tool: report the material table and the baked-hand islands of the
-//! static first-person gun models (`obj/*_h.bin`).
+//! Scratch tool: report the material table, the baked-hand islands and the
+//! side-on silhouette of the static first-person gun models (`obj/*_h.bin`).
 //!
 //! VR draws the glove on a wielded gun and strips the baked hand/arm, and both
 //! halves are decided by *material*: which slots the arm uses, and which arm
 //! island is the trigger hand. This prints exactly that, so the classifier in
 //! `dark::importers::is_first_person_arm_material` and the trigger-hand pick
 //! are reviewable against the art instead of asserted.
+//!
+//! The silhouette is how `vr_config::HAND_MODEL_POSITIONING`'s grips are
+//! placed: it draws the weapon-only geometry in its own authored frame (barrel
+//! along -X, +Y up) on a labelled grid, so the pistol grip can be read off in
+//! model units instead of guessed from a screenshot. `o` marks the model
+//! origin, which the grip offset is measured from.
 //!
 //! ```bash
 //! cargo run -p shock2vr --example gun_hand_islands
@@ -36,6 +42,109 @@ fn longest_span(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) -> f32 {
         }
     }
     (0..3).map(|axis| hi[axis] - lo[axis]).fold(0.0, f32::max)
+}
+
+/// The mesh's XY silhouette (barrel along -X, +Y up) on a coarse grid, with the
+/// model origin marked - a readable map of where a gun's grip, trigger guard
+/// and magazine actually are in the frame the wield's grip offset is expressed
+/// in. Polygon edges are rasterized, not just their vertices, so a thin part
+/// like a trigger guard still draws.
+fn print_silhouette(mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) {
+    const COLS: usize = 78;
+    const ROWS: usize = 24;
+
+    let mut lo = [f32::INFINITY; 2];
+    let mut hi = [f32::NEG_INFINITY; 2];
+    let mut edges = Vec::new();
+    for polygon in &mesh.polygons {
+        let corners = polygon
+            .vertex_indices
+            .iter()
+            .map(|index| mesh.vertices[*index as usize])
+            .collect::<Vec<_>>();
+        for (index, corner) in corners.iter().enumerate() {
+            lo[0] = lo[0].min(corner.x);
+            hi[0] = hi[0].max(corner.x);
+            lo[1] = lo[1].min(corner.y);
+            hi[1] = hi[1].max(corner.y);
+            edges.push((*corner, corners[(index + 1) % corners.len()]));
+        }
+    }
+    if edges.is_empty() {
+        return;
+    }
+    // Square cells, so the picture is not stretched: one span drives both axes.
+    let span = (hi[0] - lo[0]).max((hi[1] - lo[1]) * COLS as f32 / ROWS as f32);
+    let cell = span / COLS as f32;
+    let x0 = (lo[0] + hi[0]) / 2.0 - span / 2.0;
+    let y_top = (lo[1] + hi[1]) / 2.0 + (ROWS as f32 / 2.0) * cell;
+
+    let mut grid = vec![vec![b' '; COLS]; ROWS];
+    let mut plot = |x: f32, y: f32, mark: u8| {
+        let c = ((x - x0) / cell).floor() as isize;
+        let r = ((y_top - y) / cell).floor() as isize;
+        if (0..COLS as isize).contains(&c) && (0..ROWS as isize).contains(&r) {
+            grid[r as usize][c as usize] = mark;
+        }
+    };
+    for (a, b) in &edges {
+        let steps = (((b.x - a.x).abs().max((b.y - a.y).abs())) / cell).ceil() as usize + 1;
+        for step in 0..=steps {
+            let t = step as f32 / steps as f32;
+            plot(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, b'#');
+        }
+    }
+    plot(0.0, 0.0, b'o');
+
+    println!("   silhouette: col 0 = x {x0:+.3}, row 0 = y {y_top:+.3}, cell {cell:.4} units");
+    for (r, row) in grid.iter().enumerate() {
+        let y = y_top - (r as f32 + 0.5) * cell;
+        println!("   {y:+6.3} |{}|", String::from_utf8_lossy(row));
+    }
+    let tens: String = (0..COLS)
+        .map(|c| {
+            if c % 10 == 0 {
+                char::from(b'0' + (c / 10) as u8)
+            } else {
+                ' '
+            }
+        })
+        .collect();
+    println!("           {tens}   (x = {x0:+.3} + col * {cell:.4})");
+}
+
+/// A mesh's centroid and bounds - for an arm island, where the baked hand is.
+fn print_bounds(label: &str, mesh: &ss2_bin_obj_loader::SystemShock2ObjectMesh) {
+    let mut lo = [f32::INFINITY; 3];
+    let mut hi = [f32::NEG_INFINITY; 3];
+    let mut sum = [0.0f32; 3];
+    let mut count = 0.0f32;
+    for polygon in &mesh.polygons {
+        for index in &polygon.vertex_indices {
+            let vertex = mesh.vertices[*index as usize];
+            for (axis, value) in [vertex.x, vertex.y, vertex.z].into_iter().enumerate() {
+                lo[axis] = lo[axis].min(value);
+                hi[axis] = hi[axis].max(value);
+                sum[axis] += value;
+            }
+            count += 1.0;
+        }
+    }
+    if count == 0.0 {
+        return;
+    }
+    println!(
+        "   {label}: centroid ({:+.3},{:+.3},{:+.3}) bounds x[{:+.3},{:+.3}] y[{:+.3},{:+.3}] z[{:+.3},{:+.3}]",
+        sum[0] / count,
+        sum[1] / count,
+        sum[2] / count,
+        lo[0],
+        hi[0],
+        lo[1],
+        hi[1],
+        lo[2],
+        hi[2],
+    );
 }
 
 fn main() {
@@ -107,6 +216,14 @@ fn main() {
             }
         }
 
+        {
+            let weapon = ss2_bin_obj_loader::retain_materials(mesh.clone(), |name| {
+                !dark::importers::is_first_person_arm_material(name)
+            });
+            print_bounds("weapon", &weapon);
+            print_silhouette(&weapon);
+        }
+
         let islands = ss2_bin_obj_loader::split_connected(
             &mesh,
             dark::importers::is_first_person_arm_material,
@@ -128,6 +245,7 @@ fn main() {
             // The island's own longest axis, to size the baked hand against a
             // real one (`HAND_LENGTH_WORLD`, 0.2493 units ~ 19 cm).
             println!("   island {index}: span {:.3} units", longest_span(island));
+            print_bounds(&format!("island {index}"), island);
             match ss2_bin_obj_loader::hand_frame(
                 island,
                 dark::importers::is_first_person_arm_material,

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -227,6 +227,22 @@ dev_params! {
     /// making the arm exactly life-size (0.79) would leave the Wrench at 52,
     /// and making the Wrench right (~0.5) would leave a child's arm.
     MELEE_WIELD_SCALE = float("melee_scale", "Melee scale", 0.7, 0.25, 1.5, 0.05),
+    /// Uniform scale applied to a wielded rigid gun `_h` view model, about
+    /// the grip so the weapon stays seated in the hand as the value moves.
+    ///
+    /// Same problem as [`MELEE_WIELD_SCALE`] and the same knob, but the guns
+    /// admit an exact answer where the melee rigs do not: only the weapon is
+    /// drawn (the baked arm is stripped for the glove), so there is no second
+    /// exaggerated thing to compromise with. `atek_h`'s weapon geometry spans
+    /// 0.663 world units - 0.51 m against a real pistol's 0.20 - and the rest
+    /// of the set is exaggerated by about the same factor, so one scale serves
+    /// all of them: at 0.4 the pistol is 20 cm, the assault rifle 72 cm and
+    /// the shotgun 74 cm.
+    ///
+    /// Read at *wield* time, like the melee scale: the correction is baked
+    /// into the model (and its muzzle vhots) once, so a change takes effect on
+    /// the next grab.
+    GUN_WIELD_SCALE = float("gun_scale", "Gun scale", 0.4, 0.1, 1.5, 0.05),
     /// Enables the detached debug ("free") camera. This is the *gate*, not
     /// the camera's own on/off: while it is false the toggle input is not
     /// even read, so a stray `Alt+V` (or controller chord) during normal play

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7429,7 +7429,14 @@ impl MissionCore {
                         // (`vr_config`), which together makes it a uniform
                         // scale about the grip. The amp keeps its own baked arm
                         // and therefore its authored size.
-                        let gun_scale = if vr_held_gun {
+                        //
+                        // ONE condition decides both the bake and the record,
+                        // so a gun that also reports as melee (an authored
+                        // `PropLimbModel` on a gun template) cannot get a
+                        // scaled grip against unscaled geometry.
+                        let rigid_gun_wield =
+                            vr_held_gun && !is_melee_weapon(&self.world, entity_id);
+                        let gun_scale = if rigid_gun_wield {
                             crate::vr_config::gun_wield_scale()
                         } else {
                             1.0
@@ -7448,7 +7455,7 @@ impl MissionCore {
                         // model, whose glove has to survive with it, and a
                         // drop must not leave the restored world model wearing
                         // one.
-                        if vr_held_gun {
+                        if rigid_gun_wield {
                             self.world
                                 .add_component(entity_id, RuntimePropVrGunWield(gun_scale));
                         } else {
@@ -8826,6 +8833,7 @@ impl MissionCore {
                     Some(crate::mission::reload::clip_insert_zone_engaged(
                         self.vr_clip_insert_engaged[slot],
                         (clip_position - magazine).magnitude(),
+                        crate::vr_config::gun_wield_scale_of_entity(&self.world, weapon),
                     ))
                 })
                 .unwrap_or(false);
@@ -9980,14 +9988,17 @@ impl MissionCore {
                 } else {
                     vec3(0.2, 1.0, 0.3)
                 };
+                let (enter, exit) = crate::mission::reload::clip_insert_radii(
+                    crate::vr_config::gun_wield_scale_of_entity(&self.world, weapon),
+                );
                 scene.push(dark::hit_box::draw_debug_wire_sphere(
                     anchor,
-                    crate::mission::reload::CLIP_INSERT_ENTER_RADIUS,
+                    enter,
                     enter_color,
                 ));
                 scene.push(dark::hit_box::draw_debug_wire_sphere(
                     anchor,
-                    crate::mission::reload::CLIP_INSERT_EXIT_RADIUS,
+                    exit,
                     vec3(0.35, 0.35, 0.2),
                 ));
                 if let Some(origin) = self.entity_world_position(weapon) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -94,7 +94,7 @@ use crate::{
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
         RuntimePropLaunchedProjectile, RuntimePropReloading, RuntimePropSelectedAmmo,
         RuntimePropShotCooldown, RuntimePropShotModifiers, RuntimePropTransform, RuntimePropVhots,
-        RuntimePropVrGripOffset, RuntimePropVrGunGlove,
+        RuntimePropVrGripOffset, RuntimePropVrGunWield,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -7421,11 +7421,24 @@ impl MissionCore {
                         // Melee rigs mirror in their own frame below. The
                         // model's authored bounding box is left as-is: a held
                         // gun is unphysical, and nothing frames it by that box.
+                        // The gun set is authored several times life size for
+                        // a fixed flat camera; VR draws it at true world scale
+                        // beside a life-size glove, so it is shrunk here, once,
+                        // with the muzzle vhots. The grip offset and magazine
+                        // anchor are scaled to match where they are read
+                        // (`vr_config`), which together makes it a uniform
+                        // scale about the grip. The amp keeps its own baked arm
+                        // and therefore its authored size.
+                        let gun_scale = if vr_held_gun {
+                            crate::vr_config::gun_wield_scale()
+                        } else {
+                            1.0
+                        };
                         if vr_held && !is_melee_weapon(&self.world, entity_id) {
-                            let mirror = hand.gun_mirror();
-                            new_model.apply_local_transform(mirror);
+                            let seat = crate::vr_config::gun_wield_model_transform(hand, gun_scale);
+                            new_model.apply_local_transform(seat);
                             for vhot in vhots.iter_mut() {
-                                vhot.point = mirror.transform_point(vhot.point);
+                                vhot.point = seat.transform_point(vhot.point);
                             }
                         }
                         // Whether there is a glove to draw over the weapon at
@@ -7436,9 +7449,10 @@ impl MissionCore {
                         // drop must not leave the restored world model wearing
                         // one.
                         if vr_held_gun {
-                            self.world.add_component(entity_id, RuntimePropVrGunGlove);
+                            self.world
+                                .add_component(entity_id, RuntimePropVrGunWield(gun_scale));
                         } else {
-                            self.world.remove::<RuntimePropVrGunGlove>(entity_id);
+                            self.world.remove::<RuntimePropVrGunWield>(entity_id);
                         }
                         // An articulated VR-wielded first-person model (hand +
                         // arm + gun as skeleton sub-objects) renders unposed
@@ -7599,7 +7613,7 @@ impl MissionCore {
                     // from - an entity with no model has neither a grip nor a
                     // glove.
                     self.world
-                        .remove::<(RuntimePropVrGripOffset, RuntimePropVrGunGlove)>(entity_id);
+                        .remove::<(RuntimePropVrGripOffset, RuntimePropVrGunWield)>(entity_id);
                 }
                 Effect::SetVhotsFromModel {
                     entity_id,

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -240,23 +240,38 @@ pub(crate) fn load_from_held_clip(
     outcome
 }
 
-/// Enter/exit radii (world units) of a weapon's magazine zone - the volume a
-/// held clip is inserted by entering. One world unit is ~0.76 m, so this is a
-/// generous ~19 cm sphere around the weapon's magazine anchor
-/// (`vr_config::magazine_anchor_from_entity`), entered deliberately but not
-/// requiring the player to thread a needle in mid-air.
+/// Enter/exit radii of a weapon's magazine zone at the view model's authored
+/// size - the volume a held clip is inserted by entering, around the weapon's
+/// magazine anchor (`vr_config::magazine_anchor_from_entity`).
+///
+/// Expressed against the model, not against the room: they scale with the gun
+/// (`clip_insert_radii`). At the authored size one world unit is ~0.76 m, so
+/// the enter radius is a generous ~19 cm; a gun drawn at life size shrinks the
+/// zone with it (~7.6 cm at `gun_scale` 0.4), which is what keeps the zone
+/// meaning "the magwell" rather than "somewhere near the gun" - a life-size
+/// pistol is only ~0.26 units long, so an unscaled zone would swallow the whole
+/// weapon and the per-model anchors with it.
 pub(crate) const CLIP_INSERT_ENTER_RADIUS: f32 = 0.25;
 pub(crate) const CLIP_INSERT_EXIT_RADIUS: f32 = 0.35;
+
+/// The zone's (enter, exit) radii for a weapon drawn at `scale`.
+pub(crate) fn clip_insert_radii(scale: f32) -> (f32, f32) {
+    (
+        scale * CLIP_INSERT_ENTER_RADIUS,
+        scale * CLIP_INSERT_EXIT_RADIUS,
+    )
+}
 
 /// Whether the magazine zone is engaged this frame, given whether it was
 /// engaged last frame. The two radii are deliberately different: a single
 /// threshold flickers on hand jitter right at the boundary, and every flicker
 /// is another insert attempt.
-pub(crate) fn clip_insert_zone_engaged(was_engaged: bool, distance: f32) -> bool {
+pub(crate) fn clip_insert_zone_engaged(was_engaged: bool, distance: f32, scale: f32) -> bool {
+    let (enter, exit) = clip_insert_radii(scale);
     if was_engaged {
-        distance <= CLIP_INSERT_EXIT_RADIUS
+        distance <= exit
     } else {
-        distance <= CLIP_INSERT_ENTER_RADIUS
+        distance <= enter
     }
 }
 
@@ -1172,18 +1187,17 @@ mod tests {
     fn the_magazine_zone_needs_a_closer_approach_than_it_needs_to_hold() {
         // Hysteresis: without it, hand jitter right at the boundary re-enters
         // the zone every few frames, and every entry is another insert.
-        let between = (CLIP_INSERT_ENTER_RADIUS + CLIP_INSERT_EXIT_RADIUS) / 2.0;
+        // At both the authored size and a life-size wield, so the hysteresis
+        // survives the scaling rather than only holding at 1.0.
+        for scale in [1.0f32, 0.4] {
+            let (enter, exit) = clip_insert_radii(scale);
+            let between = (enter + exit) / 2.0;
 
-        assert!(!clip_insert_zone_engaged(false, between));
-        assert!(clip_insert_zone_engaged(true, between));
-        assert!(clip_insert_zone_engaged(
-            false,
-            CLIP_INSERT_ENTER_RADIUS - 0.01
-        ));
-        assert!(!clip_insert_zone_engaged(
-            true,
-            CLIP_INSERT_EXIT_RADIUS + 0.01
-        ));
+            assert!(!clip_insert_zone_engaged(false, between, scale));
+            assert!(clip_insert_zone_engaged(true, between, scale));
+            assert!(clip_insert_zone_engaged(false, enter - 0.01 * scale, scale));
+            assert!(!clip_insert_zone_engaged(true, exit + 0.01 * scale, scale));
+        }
     }
 
     #[test]

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -373,22 +373,24 @@ pub struct RuntimePropLogData {
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropVrGripOffset(pub Vector3<f32>);
 
-// RuntimePropVrGunGlove - marks a VR-wielded gun as one the player's own glove
-// is drawn holding.
+// RuntimePropVrGunWield - marks a VR-wielded rigid gun `_h` model, and carries
+// the uniform scale its geometry was baked at.
 //
 // VR strips the baked hand off the rigid gun view models
-// (`dark::importers::VrHeldGunModel`) and draws the tracked glove in its place;
-// the melee rigs and the psi amp keep the hand their model draws. Which of
-// those a wield is depends on the model, and is settled once - when
-// `Effect::ChangeModel` applies the wield - so it is recorded here rather than
-// re-derived from the model name every frame in the render path.
+// (`dark::importers::VrHeldGunModel`) and draws the tracked glove in its place,
+// at life size - which means the gun itself has to be drawn at life size, and
+// the `_h` set is authored several times that (see
+// `dev_params::GUN_WIELD_SCALE`). Both facts are settled once, when
+// `Effect::ChangeModel` applies the wield: it bakes the scale into the model
+// and its muzzle vhots, and records it here.
 //
-// A marker, not a transform: the placement itself
-// (`vr_config::held_gun_glove_scale`) is hand-agnostic and composes onto the
-// tracked pose the renderer already has, so there is nothing per-entity to
-// store and no way for a stored handedness to go stale.
+// The scale is stored rather than re-read per frame because the placement has
+// two halves that must agree - the baked geometry, and the hand-local grip
+// offset (`vr_config::get_vr_hand_model_adjustments_from_entity`) and magazine
+// anchor that are scaled to match. Re-reading a live dev param on only one of
+// them would slide the gun out of the hand as the knob moved.
 //
 // Not serialized: the wield's `Effect::ChangeModel` re-applies it whenever the
 // first-person model is (re)applied, including on load.
 #[derive(Component, Clone, Copy, Debug)]
-pub struct RuntimePropVrGunGlove;
+pub struct RuntimePropVrGunWield(pub f32);

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -1,8 +1,6 @@
 // Helper to convert the input context to a form more useful for gameplay / interacting with the world
 
-use cgmath::{
-    InnerSpace, Matrix4, Quaternion, Rotation, SquareMatrix, Vector3, Zero, point3, vec3,
-};
+use cgmath::{InnerSpace, Quaternion, Rotation, Vector3, Zero, point3, vec3};
 use dark::{
     SCALE_FACTOR,
     properties::{FrobFlag, PropFrobInfo, PropModelName},
@@ -19,7 +17,7 @@ use crate::{
     hand_affordance::{self, AffordanceTracker, HandAffordance},
     input_context::Hand,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
-    runtime_props::RuntimePropVrGunGlove,
+    runtime_props::RuntimePropVrGunWield,
     scripts::{Message, MessagePayload},
     util::{self, point3_to_vec3},
     vr_config::{self, Handedness},
@@ -405,25 +403,19 @@ impl VirtualHand {
         };
 
         // A wielded gun draws the glove in place of the baked hand the wield
-        // stripped off it, at the weapon's own scale; everything else draws it
-        // at the tracked hand, or not at all when the held model draws a hand
-        // of its own. The `MELEE_GLOVE_OVERLAY` calibration override wants the
-        // unscaled tracked pose - that is the whole point of it - so it takes
-        // the ordinary path even for a gun.
-        let holds_gun_glove = holds_gun_glove(world, self.get_held_entity())
-            && crate::dev_params::get(crate::dev_params::MELEE_GLOVE_OVERLAY) <= 0.5;
-        if !holds_gun_glove && !shows_hand_visual(world, self.get_held_entity()) {
+        // stripped off it; everything else draws it at the tracked hand, or not
+        // at all when the held model draws a hand of its own. Either way the
+        // glove is the tracked pose at life size - the gun is the thing scaled
+        // to meet it (`vr_config::gun_wield_scale`).
+        if !holds_gun_glove(world, self.get_held_entity())
+            && !shows_hand_visual(world, self.get_held_entity())
+        {
             return Vec::new();
         }
         let hand = crate::hand_glove::hand_to_world(self.position, self.rotation, self.handedness);
-        let seat = if holds_gun_glove {
-            crate::vr_config::held_gun_glove_scale()
-        } else {
-            Matrix4::identity()
-        };
 
         renderer.render_hand(
-            hand * seat,
+            hand,
             self.trigger_value,
             self.squeeze_value,
             self.get_held_entity().is_some(),
@@ -436,13 +428,13 @@ impl VirtualHand {
 
 /// Whether the held entity is a wield that draws the glove over the weapon -
 /// the arm-stripped gun `_h` set, marked by the wield itself (see
-/// [`crate::runtime_props::RuntimePropVrGunGlove`]).
+/// [`crate::runtime_props::RuntimePropVrGunWield`]).
 fn holds_gun_glove(world: &World, held_entity: Option<EntityId>) -> bool {
     let Some(entity_id) = held_entity else {
         return false;
     };
     world
-        .borrow::<View<RuntimePropVrGunGlove>>()
+        .borrow::<View<RuntimePropVrGunWield>>()
         .map(|marked| marked.get(entity_id).is_ok())
         .unwrap_or(false)
 }

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -180,30 +180,60 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // Weapons - first-person hand models (_h). Used by flat's wield swap
         // (FLAT_WIELD_SWAP_MODELS) and, on a 25AE install, wielded directly in
         // VR (VR_25AE_VIEW_MODELS). The whole 25AE set is authored barrel
-        // along -X, so one -90 yaw seats every gun; offsets are hand-fitted
-        // per model to land the grip in the palm.
+        // along -X, so one -90 yaw seats every gun.
+        //
+        // The offsets put the model's own PISTOL GRIP in the glove's fist,
+        // read off the side-on silhouette `cargo run -p shock2vr --example
+        // gun_hand_islands` prints and then corrected against `debug_weapons`
+        // captures. They were previously fitted to where each model's *baked*
+        // hand sat, which for `ar15_h` is a rest hand on the receiver and for
+        // `sg_h` one on the pump - invisible while that hand was the one
+        // drawn, wrong the moment the player's own glove replaced it.
+        //
+        // Hand-local metres at the wield's own scale: they are multiplied by
+        // `gun_wield_scale` alongside the geometry (see
+        // `gun_wield_adjustments`), so the pair is one uniform scale about the
+        // grip. The oversized weapons (`sfg_h`, `fsn_h`, `gren_h`, `al_h`,
+        // `viro_h`) have no authored grip to find; their offsets put the fist
+        // on the nearest thing a hand could hold and leave the far end alone.
         (
             "atek_h",
-            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.10))),
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.073, 0.020)),
+            ),
         ),
         (
             "ar15_h",
-            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.01, 0.17))),
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.123, -0.469)),
+            ),
         ),
         (
             "sg_h",
-            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.04, 0.28))),
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, -0.025, -0.693)),
+            ),
         ),
         (
             "empgun_h",
-            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.01, 0.29))),
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.083, -0.473)),
+            ),
         ),
         (
             "gren_h",
             symmetric(
                 held_weapon_right
                     .clone()
-                    .with_offset(vec3(0.0, 0.11, -0.56)),
+                    .with_offset(vec3(0.0, 0.111, -0.960)),
             ),
         ),
         (
@@ -211,7 +241,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
             symmetric(
                 held_weapon_right
                     .clone()
-                    .with_offset(vec3(0.0, 0.27, -0.21)),
+                    .with_offset(vec3(0.0, 0.466, -0.553)),
             ),
         ),
         (
@@ -219,19 +249,23 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
             symmetric(
                 held_weapon_right
                     .clone()
-                    .with_offset(vec3(0.0, 0.27, -0.63)),
+                    .with_offset(vec3(0.0, 0.310, -0.516)),
             ),
         ),
         (
             "al_h",
-            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.09, 0.0))),
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.206, -0.442)),
+            ),
         ),
         (
             "viro_h",
             symmetric(
                 held_weapon_right
                     .clone()
-                    .with_offset(vec3(0.0, 0.22, -0.90)),
+                    .with_offset(vec3(0.0, 0.111, -0.710)),
             ),
         ),
         (
@@ -240,7 +274,11 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ),
         (
             "lasehand",
-            symmetric(held_weapon_right.clone().with_offset(vec3(0.0, 0.12, 0.27))),
+            symmetric(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.0, 0.096, 0.190)),
+            ),
         ),
         // Melee first-person models (_h) deliberately have NO entry: their
         // grip is not a constant. The held body is the melee contact collider

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -117,7 +117,8 @@ impl VRHandModelPerHandAdjustments {
         }
     }
 
-    /// Hand-local translation (meters): +X toward the thumb side of the right
+    /// Hand-local translation (world units, 1 unit ~ 0.762 m - the space
+    /// `hand_position` itself is in): +X toward the thumb side of the right
     /// hand, +Y up out of the back of the hand, -Z along the fingers.
     pub fn with_offset(self, offset: Vector3<f32>) -> VRHandModelPerHandAdjustments {
         VRHandModelPerHandAdjustments { offset, ..self }
@@ -190,7 +191,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // `sg_h` one on the pump - invisible while that hand was the one
         // drawn, wrong the moment the player's own glove replaced it.
         //
-        // Hand-local metres at the wield's own scale: they are multiplied by
+        // Hand-local world units at the wield's own scale: multiplied by
         // `gun_wield_scale` alongside the geometry (see
         // `gun_wield_adjustments`), so the pair is one uniform scale about the
         // grip. The oversized weapons (`sfg_h`, `fsn_h`, `gren_h`, `al_h`,
@@ -629,7 +630,11 @@ fn gun_wield_adjustments(
 
 /// The scale `entity_id`'s wield baked into its gun model, or 1.0 for anything
 /// that is not a scaled gun wield (world models, melee rigs, the psi amp).
-fn gun_wield_scale_of_entity(world: &World, entity_id: EntityId) -> f32 {
+///
+/// Everything measured against the gun's own geometry reads it: the grip offset
+/// and magazine anchor below, and the clip-insert zone's radii
+/// (`crate::mission::reload::clip_insert_radii`).
+pub fn gun_wield_scale_of_entity(world: &World, entity_id: EntityId) -> f32 {
     world
         .borrow::<View<RuntimePropVrGunWield>>()
         .ok()

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use cgmath::{Deg, Quaternion, Rotation3, Vector3, vec3};
 use dark::properties::PropModelName;
 
-use crate::runtime_props::RuntimePropVrGripOffset;
+use crate::runtime_props::{RuntimePropVrGripOffset, RuntimePropVrGunWield};
 use once_cell::sync::Lazy;
 use shipyard::{EntityId, Get, View, World};
 
@@ -330,7 +330,7 @@ const VR_25AE_VIEW_MODELS: &[&str] = &[
 
 /// The subset of [`VR_25AE_VIEW_MODELS`] VR wields as a rigid gun: the static
 /// LGMD meshes whose baked hand is stripped so the player's own glove can hold
-/// them ([`dark::importers::VrHeldGunModel`], [`held_gun_glove_scale`]).
+/// them ([`dark::importers::VrHeldGunModel`], [`gun_wield_scale`]).
 ///
 /// Keyed on the model name, like every other per-model table here, rather than
 /// on gamesys metadata: the strip and the glove have to agree about which
@@ -379,8 +379,12 @@ static MAGAZINE_ANCHORS: Lazy<HashMap<&str, Vector3<f32>>> = Lazy::new(|| {
 /// Where `entity_id`'s magazine is, in its model's local frame - the origin
 /// for a model with no entry.
 pub fn magazine_anchor_from_entity(world: &World, entity_id: EntityId) -> Vector3<f32> {
+    // The anchor is authored against the model as shipped, and a VR wield draws
+    // the gun shrunk to life size - so the anchor rides the same scale, or the
+    // clip zone would sit off in space beside a 40%-size gun.
+    let scale = gun_wield_scale_of_entity(world, entity_id);
     model_name_lower(world, entity_id)
-        .map(|name| magazine_anchor_from_model(&name))
+        .map(|name| scale * magazine_anchor_from_model(&name))
         .unwrap_or(vec3(0.0, 0.0, 0.0))
 }
 
@@ -547,51 +551,52 @@ fn melee_wield_pose_correction_scaled(
         * Matrix4::from_translation(-arm.fist)
 }
 
-/// How much larger than life a 25AE first-person view model is drawn, and
-/// therefore how much larger than life the glove holding one has to be.
+/// Live tuning for how large a wielded rigid gun `_h` view model is drawn -
+/// see [`crate::dev_params::GUN_WIELD_SCALE`]. Every half of the placement is
+/// scaled by the value the wield recorded on
+/// [`crate::runtime_props::RuntimePropVrGunWield`] - the geometry and its
+/// muzzle vhots when the model is applied, the hand-local grip offset and the
+/// magazine anchor when they are read - so the gun shrinks about the grip
+/// point and stays seated, aimed and reloadable at any scale.
 ///
-/// The set is authored for a fixed flat camera, where an exaggerated weapon
-/// reads better, and VR draws it at true world scale: `atek_h`'s weapon
-/// geometry spans 0.66 world units - 0.51 m against a real pistol's 0.20 - and
-/// its baked hand is exaggerated to match, which is why the wield read
-/// coherently while that hand was the one drawn. A life-size glove on the same
-/// gun reads as a doll's hand next to it, so the glove joins the weapon at the
-/// weapon's own scale. Measured off `debug_weapons` captures against the baked
-/// hand it replaces; it is not [`dark::SCALE_FACTOR`], which happens to have
-/// the same value for unrelated reasons.
-///
-/// This is a presentation correction for the glove only. Drawing the view
-/// models at life size is the real fix and a change of its own: it moves every
-/// grip offset, muzzle vhot and magazine anchor with it.
-const VIEW_MODEL_GLOVE_SCALE: f32 = 2.5;
+/// The player's glove is drawn on it at life size, unscaled: that is the whole
+/// point of shrinking the gun.
+pub fn gun_wield_scale() -> f32 {
+    crate::dev_params::get(crate::dev_params::GUN_WIELD_SCALE)
+}
 
-/// The glove's placement on a VR-wielded gun, in the tracked hand's own frame.
-///
-/// VR strips the baked hand off a gun view model
-/// ([`dark::importers::VrHeldGunModel`]) and draws the tracked glove in its
-/// place - so the hand the player sees is the hand they are moving. The
-/// placement is the tracked hand's own pose, unaltered but for the size
-/// correction above: [`HAND_MODEL_POSITIONING`] already carries a hand-fitted
-/// grip per model, tuned in PR #1023 with the baked hand drawn, which is
-/// exactly the alignment the glove wants. A gun that needs a nudge records it
-/// there, in its own grip entry, rather than in a second per-model table.
-///
-/// Inheriting the placement from the *art* instead - each baked hand carries a
-/// geometric frame ([`dark::ss2_bin_obj_loader::HandFrame`]), so the glove's
-/// wrist could go on the baked wrist with no authoring at all - was measured
-/// and rejected. `ar15_h` bakes exactly one hand, a rest hand laid over the
-/// receiver; `sg_h`'s rides the pump; only `atek_h` bakes one on the grip, and
-/// it bakes three islands (a sleeve, the firing hand, and a spare parked 0.6 m
-/// behind the gun for the reload animation). The meshes are not life size
-/// either, and `HandFrame`'s wrist is only estimated - stepped back a hand's
-/// length from the far end of the point cloud. See `cargo run -p shock2vr
-/// --example gun_hand_islands` for the measurements.
-///
-/// Deliberately hand-agnostic: it is composed onto the tracked pose *inside*
-/// [`Handedness::mirror`], so the left hand's glove reflects exactly as an
-/// empty left hand's does and no second definition of "the other hand" exists.
-pub fn held_gun_glove_scale() -> cgmath::Matrix4<f32> {
-    cgmath::Matrix4::from_scale(VIEW_MODEL_GLOVE_SCALE)
+/// The local transform a VR wield bakes into a first-person gun model: the
+/// left hand's reflection, and the life-size shrink. One of the two halves of
+/// a uniform scale about the grip point; [`gun_wield_adjustments`] is the
+/// other. Applied to the geometry AND its muzzle vhots, so the shot still
+/// leaves the drawn barrel.
+pub fn gun_wield_model_transform(handedness: Handedness, scale: f32) -> cgmath::Matrix4<f32> {
+    cgmath::Matrix4::from_scale(scale) * handedness.gun_mirror()
+}
+
+/// The hand-local seat of a gun wielded at `scale`: the model's authored grip
+/// entry, its offset scaled with the geometry so the grip point itself does
+/// not move off the hand.
+fn gun_wield_adjustments(
+    model_name: &str,
+    handedness: Handedness,
+    scale: f32,
+) -> VRHandModelPerHandAdjustments {
+    let adjustments = get_vr_hand_model_adjustments_from_model(model_name, handedness);
+    VRHandModelPerHandAdjustments {
+        offset: scale * adjustments.offset,
+        ..adjustments
+    }
+}
+
+/// The scale `entity_id`'s wield baked into its gun model, or 1.0 for anything
+/// that is not a scaled gun wield (world models, melee rigs, the psi amp).
+fn gun_wield_scale_of_entity(world: &World, entity_id: EntityId) -> f32 {
+    world
+        .borrow::<View<RuntimePropVrGunWield>>()
+        .ok()
+        .and_then(|wields| wields.get(entity_id).ok().map(|wield| wield.0))
+        .unwrap_or(1.0)
 }
 
 pub fn get_vr_hand_model_adjustments_from_entity(
@@ -613,8 +618,13 @@ pub fn get_vr_hand_model_adjustments_from_entity(
         return VRHandModelPerHandAdjustments::new().with_offset(grip);
     }
 
+    // A scaled gun wield seats the same authored grip on a shrunk model, so the
+    // hand-local offset shrinks with the geometry: together they are one
+    // uniform scale about the grip point, which is what keeps the gun in the
+    // fist at any [`gun_wield_scale`].
+    let scale = gun_wield_scale_of_entity(world, entity_id);
     match model_name_lower(world, entity_id) {
-        Some(model_name) => get_vr_hand_model_adjustments_from_model(&model_name, handedness),
+        Some(model_name) => gun_wield_adjustments(&model_name, handedness, scale),
         None => VRHandModelPerHandAdjustments::new(),
     }
 }
@@ -640,7 +650,7 @@ pub fn get_vr_hand_model_adjustments_from_model(
 
 #[cfg(test)]
 mod tests {
-    use cgmath::{InnerSpace, SquareMatrix, assert_relative_eq};
+    use cgmath::InnerSpace;
 
     use super::*;
 
@@ -676,25 +686,61 @@ mod tests {
         assert!(is_vr_gun_view_model("ATEK_H"));
     }
 
-    /// The gun glove's placement is a pure scale, so it puts the glove's wrist
-    /// on the tracked hand and leaves the direction its fingers point alone -
-    /// which is what lets it compose inside `Handedness::mirror` and reuse the
-    /// one definition of "the other hand".
+    /// The gun wield's two halves are one uniform scale about the grip point:
+    /// the model (and its muzzle vhots) shrink about the model origin, and the
+    /// hand-local grip offset shrinks with them. So at any scale the authored
+    /// grip point stays exactly on the tracked hand, and the muzzle stays down
+    /// the barrel it was authored on - the shot still leaves the drawn gun.
+    ///
+    /// Exercised through the scale-explicit composition rather than the
+    /// dev-param registry, so it neither mutates process-global state nor
+    /// depends on the default staying 0.4 - the same shape as
+    /// `melee_wield_scale_keeps_the_fist_and_the_collider_honest`.
     #[test]
-    fn the_gun_glove_sits_on_the_tracked_hand_facing_the_same_way() {
-        use cgmath::{Transform, point3};
+    fn the_gun_wield_scale_keeps_the_grip_in_the_hand_and_the_muzzle_on_the_barrel() {
+        use cgmath::{EuclideanSpace, Matrix4, Point3, Rotation, Transform, point3};
 
-        let scale = held_gun_glove_scale();
+        for name in VR_25AE_GUN_MODELS {
+            for handedness in [Handedness::Right, Handedness::Left] {
+                // Two points in the model's own authored frame - the space
+                // vhots live in, and the space the wield transform consumes.
+                // The grip: the authored seat says where the model origin goes
+                // relative to the hand, so read back through the rotation (and
+                // the mirror, which is part of the seat) for the point that
+                // lands ON the hand.
+                let authored = gun_wield_adjustments(name, handedness, 1.0);
+                let grip_model = handedness
+                    .gun_mirror()
+                    .transform_vector(authored.rotation.invert().rotate_vector(-authored.offset));
+                // The muzzle: somewhere down the authored barrel (-X).
+                let muzzle_model = point3(-0.6, 0.0, 0.0);
+                let unscaled = |scale: f32| {
+                    let seat = gun_wield_adjustments(name, handedness, scale);
+                    Matrix4::from_translation(seat.offset)
+                        * Matrix4::from(seat.rotation)
+                        * gun_wield_model_transform(handedness, scale)
+                };
+                let unscaled_muzzle = unscaled(1.0).transform_point(muzzle_model);
 
-        assert!(scale.determinant() > 0.0, "the scale must not reflect");
-        assert_relative_eq!(
-            scale.transform_point(point3(0.0, 0.0, 0.0)),
-            point3(0.0, 0.0, 0.0)
-        );
-        assert_relative_eq!(
-            scale.transform_vector(vec3(0.0, 0.0, -1.0)).normalize(),
-            vec3(0.0, 0.0, -1.0)
-        );
+                for scale in [0.4f32, 1.0, 1.25] {
+                    // Exactly what the wield composes: the seat this scale
+                    // resolves to, carrying the model transform it bakes.
+                    let seated = unscaled(scale);
+
+                    let grip = seated.transform_point(Point3::from_vec(grip_model));
+                    assert!(
+                        grip.to_vec().magnitude() < 1e-4,
+                        "{name} ({handedness:?}) at {scale}: grip {grip:?} left the tracked hand"
+                    );
+
+                    let muzzle = seated.transform_point(muzzle_model);
+                    assert!(
+                        (muzzle.to_vec() - scale * unscaled_muzzle.to_vec()).magnitude() < 1e-4,
+                        "{name} ({handedness:?}) at {scale}: muzzle {muzzle:?} is not {scale}x the authored {unscaled_muzzle:?}"
+                    );
+                }
+            }
+        }
     }
 
     /// The melee subset of [`VR_25AE_VIEW_MODELS`]: skinned arm rigs, seated

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -7,7 +7,6 @@ import {
   aimVrHandAt,
   aimVrHandAtCanvas,
   add,
-  normalize,
   quatConjugate,
   quatRotate,
   scale,
@@ -34,9 +33,22 @@ const HE_CLIP = -32;
 /** Shotgun shells: real ammo, but nothing the pistol's projectiles link to. */
 const PELLET_SHOT_BOX = -42;
 
-/** Mirrors `reload::CLIP_INSERT_EXIT_RADIUS` - what the clip must start
- * OUTSIDE of for the insert to be a genuine entry into the magazine zone. */
+/** Mirrors `reload::CLIP_INSERT_EXIT_RADIUS` at the view model's authored size
+ * - what the clip must start OUTSIDE of for the insert to be a genuine entry
+ * into the magazine zone. The live radius rides the gun's wield scale
+ * (`reload::clip_insert_radii`), so it is read through `clipInsertExitRadius`
+ * rather than used raw. */
 const CLIP_INSERT_EXIT_RADIUS = 0.35;
+
+/** The exit radius as a VR-wielded gun actually gets it: the constant above
+ * times the live `gun_scale` dev param, so the test is not pinned to a
+ * particular default. */
+async function clipInsertExitRadius(game: GameServer): Promise<number> {
+  const params = await game.devParams.list();
+  const scale = params.params.find((p) => p.key === "gun_scale")?.value;
+  assert.ok(typeof scale === "number", "the runtime must expose the gun_scale dev param");
+  return scale * CLIP_INSERT_EXIT_RADIUS;
+}
 
 function propOf(
   detail: { properties: { name: string; value: string }[] },
@@ -227,7 +239,7 @@ async function takeClipIntoOffHand(
   assert.ok(clip);
   assert.ok(
     magnitude(sub(clip.position as Vec3, await magazineAnchor(game, weaponId))) >
-      CLIP_INSERT_EXIT_RADIUS,
+      (await clipInsertExitRadius(game)),
     "the clip must start outside the magazine zone, or the insert proves nothing",
   );
   return parked.handPosition;
@@ -284,8 +296,10 @@ test(
       await magazineAnchor(game, pistol.id),
       (await entityById(game, pistol.id))!.position as Vec3,
     );
+    // The zone rides the gun's wield scale, so it stays smaller than the gun:
+    // the anchor is still meaningfully outside it even at life size.
     assert.ok(
-      magnitude(anchorOffset) > 0.05,
+      2 * magnitude(anchorOffset) > (await clipInsertExitRadius(game)),
       `the pistol's magazine anchor must sit off its origin (offset ${JSON.stringify(anchorOffset)})`,
     );
     // The debug pistol spawns with a FULL magazine, so what it holds now is its
@@ -310,31 +324,25 @@ test(
     let parked = await takeClipIntoOffHand(game, clip.id, pistol.id);
     const before = await lastSound(game);
 
-    // The zone belongs to the anchor, not to the gun's origin: a clip brought
-    // just OUTSIDE the exit radius, on the ray running out of the anchor past
-    // the origin, must not load. Approached from well beyond, so the clip never
-    // strays inside the zone on the way.
-    //
-    // Measured in radii rather than in multiples of the anchor offset: a
-    // life-size gun is smaller than the gesture's tolerance (the pistol's whole
-    // magazine offset is ~0.1 units against a 0.35 exit radius), so "the far
-    // side of the origin" is now inside the zone and is no longer a miss.
-    const outward = normalize(anchorOffset);
-    const alongAnchorRay = async (radii: number): Promise<Vec3> =>
-      sub(await magazineAnchor(game, pistol.id), scale(outward, radii * CLIP_INSERT_EXIT_RADIUS));
+    // The zone moved with the anchor: the point mirrored across the model
+    // origin is twice the anchor's offset from it - reaching it must NOT
+    // load. Approached along the ray out of the anchor (from well beyond the
+    // mirror point), so the clip never strays inside the zone on the way.
+    const alongAnchorRay = async (steps: number): Promise<Vec3> =>
+      sub(await magazineAnchor(game, pistol.id), scale(anchorOffset, steps));
     const far = await steerHeldClip(game, "left", parked, clip.id, () =>
-      alongAnchorRay(3),
+      alongAnchorRay(8),
     );
-    const justOutside = await steerHeldClip(game, "left", far.handPosition, clip.id, () =>
-      alongAnchorRay(1.3),
+    const mirrored = await steerHeldClip(game, "left", far.handPosition, clip.id, () =>
+      alongAnchorRay(2),
     );
     await game.step({ frames: 5 });
     assert.equal(
       ammoOf(await game.entities.detail(pistol.id)),
       0,
-      "a clip held just outside the exit radius must miss the magazine",
+      "a clip carried to the far side of the gun's origin must miss the magazine",
     );
-    parked = justOutside.handPosition;
+    parked = mirrored.handPosition;
 
     await insertClip(game, parked, clip.id, pistol.id);
 

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   aimVrHandAt,
   aimVrHandAtCanvas,
   add,
+  normalize,
   quatConjugate,
   quatRotate,
   scale,
@@ -284,7 +285,7 @@ test(
       (await entityById(game, pistol.id))!.position as Vec3,
     );
     assert.ok(
-      2 * magnitude(anchorOffset) > CLIP_INSERT_EXIT_RADIUS,
+      magnitude(anchorOffset) > 0.05,
       `the pistol's magazine anchor must sit off its origin (offset ${JSON.stringify(anchorOffset)})`,
     );
     // The debug pistol spawns with a FULL magazine, so what it holds now is its
@@ -309,25 +310,31 @@ test(
     let parked = await takeClipIntoOffHand(game, clip.id, pistol.id);
     const before = await lastSound(game);
 
-    // The zone moved with the anchor: the point mirrored across the model
-    // origin is twice the anchor's offset from it - reaching it must NOT
-    // load. Approached along the ray out of the anchor (from well beyond the
-    // mirror point), so the clip never strays inside the zone on the way.
-    const alongAnchorRay = async (steps: number): Promise<Vec3> =>
-      sub(await magazineAnchor(game, pistol.id), scale(anchorOffset, steps));
+    // The zone belongs to the anchor, not to the gun's origin: a clip brought
+    // just OUTSIDE the exit radius, on the ray running out of the anchor past
+    // the origin, must not load. Approached from well beyond, so the clip never
+    // strays inside the zone on the way.
+    //
+    // Measured in radii rather than in multiples of the anchor offset: a
+    // life-size gun is smaller than the gesture's tolerance (the pistol's whole
+    // magazine offset is ~0.1 units against a 0.35 exit radius), so "the far
+    // side of the origin" is now inside the zone and is no longer a miss.
+    const outward = normalize(anchorOffset);
+    const alongAnchorRay = async (radii: number): Promise<Vec3> =>
+      sub(await magazineAnchor(game, pistol.id), scale(outward, radii * CLIP_INSERT_EXIT_RADIUS));
     const far = await steerHeldClip(game, "left", parked, clip.id, () =>
-      alongAnchorRay(8),
+      alongAnchorRay(3),
     );
-    const mirrored = await steerHeldClip(game, "left", far.handPosition, clip.id, () =>
-      alongAnchorRay(2),
+    const justOutside = await steerHeldClip(game, "left", far.handPosition, clip.id, () =>
+      alongAnchorRay(1.3),
     );
     await game.step({ frames: 5 });
     assert.equal(
       ammoOf(await game.entities.detail(pistol.id)),
       0,
-      "a clip carried to the far side of the gun's origin must miss the magazine",
+      "a clip held just outside the exit radius must miss the magazine",
     );
-    parked = mirrored.handPosition;
+    parked = justOutside.handPosition;
 
     await insertClip(game, parked, clip.id, pistol.id);
 

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -54,7 +54,13 @@ const MUZZLE_VHOT: Record<string, Vec3> = {
   amp_h: [-1.1072 / SCALE_FACTOR, 0.2719 / SCALE_FACTOR, -0.1199 / SCALE_FACTOR],
 };
 
-/** The models the wield shrinks - `vr_config::VR_25AE_GUN_MODELS`. */
+/**
+ * The models the wield shrinks. A hand-listed subset of Rust's
+ * `vr_config::VR_25AE_GUN_MODELS` covering only what this file wields, so it
+ * cannot go stale for a model no test here touches - and the psi amp's absence
+ * from it is the assertion that the partition still holds. Add a model here
+ * only alongside adding it to `MUZZLE_VHOT`.
+ */
 const SCALED_GUN_MODELS = new Set(["lasehand"]);
 
 /** The live `gun_scale` dev param, so the test is not pinned to its default. */

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -42,11 +42,28 @@ const SCALE_FACTOR = 2.5;
  * The muzzle vhot of each model, in world units (the model's vhot 0, read from
  * the 25AE `obj/*.bin` and divided by SCALE_FACTOR). Both sit at the model's
  * -X extreme, which is the authored barrel direction for these models.
+ *
+ * A VR wield draws the rigid gun set shrunk to life size and shrinks its vhots
+ * with it (`vr_config::gun_wield_scale`), so the laser's live muzzle is
+ * `gun_scale` times the authored point. The psi amp is NOT in that set - it
+ * keeps its own baked arm and its authored size - which is why it is compared
+ * unscaled here, and why this test would notice if the partition moved.
  */
 const MUZZLE_VHOT: Record<string, Vec3> = {
   lasehand: [-1.913 / SCALE_FACTOR, -0.0688 / SCALE_FACTOR, 0.16 / SCALE_FACTOR],
   amp_h: [-1.1072 / SCALE_FACTOR, 0.2719 / SCALE_FACTOR, -0.1199 / SCALE_FACTOR],
 };
+
+/** The models the wield shrinks - `vr_config::VR_25AE_GUN_MODELS`. */
+const SCALED_GUN_MODELS = new Set(["lasehand"]);
+
+/** The live `gun_scale` dev param, so the test is not pinned to its default. */
+async function gunWieldScale(game: GameServer): Promise<number> {
+  const params = await game.devParams.list();
+  const scale = params.params.find((p) => p.key === "gun_scale")?.value;
+  assert.ok(typeof scale === "number", "the runtime must expose the gun_scale dev param");
+  return scale;
+}
 
 const len = (v: Vec3): number => Math.sqrt(dot(v, v));
 
@@ -87,10 +104,12 @@ async function grabWith(game: GameServer, hand: Hand, target: Vec3): Promise<voi
 /** The model's muzzle vhot as the wielding hand renders it: the left hand
  * draws the right-handed model reflected across the gun (its Z), muzzle
  * included, so a left-hand shot must leave the reflected point. */
-function muzzleVhotFor(model: string, hand: Hand): Vec3 | undefined {
+function muzzleVhotFor(model: string, hand: Hand, gunScale: number): Vec3 | undefined {
   const authored = MUZZLE_VHOT[model];
   if (!authored) return undefined;
-  return hand === "left" ? [authored[0], authored[1], -authored[2]] : authored;
+  const mirrored: Vec3 =
+    hand === "left" ? [authored[0], authored[1], -authored[2]] : authored;
+  return SCALED_GUN_MODELS.has(model) ? scale(mirrored, gunScale) : mirrored;
 }
 
 /**
@@ -124,7 +143,7 @@ async function fireAndTrack(
   await game.step({ frames: 5 });
 
   const weapon = await entityTransform(game, weaponId);
-  const vhot = muzzleVhotFor(weapon.model, hand);
+  const vhot = muzzleVhotFor(weapon.model, hand, await gunWieldScale(game));
   assert.ok(vhot, `VR should wield a view model with a known muzzle vhot, got "${weapon.model}"`);
   const muzzle = add(weapon.position, quatRotate(weapon.rotation, vhot));
   // The 25AE view models are authored with the barrel along the model's -X.
@@ -225,9 +244,9 @@ test(
 
 // A gun wielded in the LEFT hand draws the mirror image of its right-handed
 // model (the baked hand becomes a left hand), and the muzzle reflects with it.
-// Negative-first: unmirrored, the laser's muzzle sits 0.064 units the other
-// side of the barrel plane, so the shot misses the reflected point by 0.128 -
-// past the 0.05 tolerance below.
+// Negative-first: unmirrored, the laser's muzzle sits off the barrel plane, so
+// the shot misses the reflected point by twice that - past the 0.05 tolerance
+// below.
 test(
   "a laser pistol wielded in the LEFT hand fires from its mirrored muzzle",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" },


### PR DESCRIPTION
Slice 4b of the VR interaction pass, stacked on #1380.

A VR-wielded gun is drawn at **life size**, and the glove goes back to life size with it. #1380 stripped the baked arm and put the player's own glove on the gun, but scaled the glove up 2.5x to meet a view model authored several times life size — a doll's hand on a cannon, from the wrong end. This shrinks the gun instead, and refits every grip onto the model's actual pistol grip.

![one full orbit of a life-size pistol held in the glove](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/demo.gif)

<sub>One turn around a VR-wielded pistol, trigger pulled through the middle. Every side shows the same thing: the grip inside the fist, the barrel out of the hand, the gun no longer than the hand holding it. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![still](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/hero.png)

## Before → after

![pistol: a 51 cm gun and a giant glove become a 20 cm gun in a real hand](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/ba_pistol.png)

Same camera, same distance. Before, the glove and the gun together overflow the frame; after, the whole pistol sits in a life-size hand. The glove is the scale reference in every capture here — it is drawn at 1.0 and is ~19 cm.

![assault rifle: and the grip moves from the receiver to the pistol grip](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/ba_ar15.png)

## The scale — 0.4, from the pistol

`gun_scale` (`dev_params::GUN_WIELD_SCALE`, default **0.4**) is a uniform scale on the wielded gun. It is set from `atek_h`: its weapon geometry spans 0.663 world units — 0.51 m against a real pistol's 0.20 — so 0.4 draws it at 0.20 m. One value serves the whole set, because the set is exaggerated by about one factor (`cargo run -p shock2vr --example gun_hand_islands` prints the spans; nine of eleven view models match their own world model to within 3%):

| model | span (units) | at 0.4 | real class |
| --- | --- | --- | --- |
| `atek_h` | 0.663 | **0.20 m** | pistol |
| `lasehand` | 0.744 | 0.23 m | pistol |
| `al_h` | 1.042 | 0.32 m | — |
| `viro_h` | 2.028 | 0.62 m | — |
| `gren_h` | 2.330 | 0.71 m | grenade launcher |
| `ar15_h` | 2.360 | 0.72 m | carbine (M4 ~0.76) |
| `sg_h` | 2.419 | 0.74 m | short shotgun |
| `fsn_h` | 2.506 | 0.76 m | — |
| `empgun_h` | 2.780 | 0.85 m | rifle |
| `sfg_h` | 7.840 | — | a stray part 5 m off the model; the body is ~1.1 units |

Not 0.5 to split the difference with melee, and melee is left alone here: `melee_scale` 0.7 is a compromise between two *differently* exaggerated things (the baked arm and the weapon), which the guns no longer have — their arm is stripped. If 0.7 melee now reads oversized beside life-size guns, that is a follow-up on `melee_scale`, not a reason to fudge this one.

## How it composes — one scale about the grip

The scale has two halves and they are read from one recorded value:

- `Effect::ChangeModel` bakes `gun_wield_model_transform` (mirror × scale) into the geometry **and its muzzle vhots**, then records the scale on `RuntimePropVrGunWield`.
- `gun_wield_adjustments`, `magazine_anchor_from_entity` and `reload::clip_insert_radii` multiply the authored hand-local grip offset, the clip anchor and the clip-insert zone's radii by that same recorded scale.

Together that is a uniform scale **about the grip point**: the grip stays on the tracked hand and the muzzle stays where the barrel is, at any scale. Storing the value (rather than re-reading the dev param on each half) is what keeps them from disagreeing while the knob moves; like `melee_scale`, a change lands on the next grab.

The scale deliberately does *not* go into the entity transform: projectile velocity is `root_transform * (0,0,magnitude)`, so a scale there would slow every shot by 60%.

The zone scales for the same reason the anchor does. A life-size pistol is only ~0.26 units long; an unscaled 0.25-unit enter radius would swallow the whole weapon and every per-model anchor with it, degrading "bring the clip to the magwell" into "bring the clip near the gun". Scaled, the gesture keeps exactly the tolerance it had relative to the gun (~7.6 cm at 0.4).

## Grips — refit onto the pistol grip

#1380's grips were #1023's, fitted to where each model's *baked* hand sat. That hand is a rest hand on `ar15_h`'s receiver and rides `sg_h`'s pump — invisible while it was the hand being drawn, wrong the moment the player's glove replaced it. Each grip is now placed from the model's own side-on silhouette (added to the `gun_hand_islands` probe) and corrected against `debug_weapons` captures.

| model | grip the fist is on |
| --- | --- |
| `atek_h` | pistol grip, magazine hanging below the fist |
| `lasehand` | grip below the body |
| `ar15_h` | pistol grip, behind the magwell (was: the receiver) |
| `sg_h` | small of the stock, behind the trigger guard (was: the pump) |
| `empgun_h` | pistol grip below the receiver |
| `gren_h` | the stock behind the drum (was: inside the drum) |
| `fsn_h` | the trigger handle under the body |
| `sfg_h` | lower-rear corner of the housing — no authored grip exists |
| `al_h` | the body lump — no authored grip exists |
| `viro_h` | the stalk behind the head — no authored grip exists |

The last three (plus `gren_h`'s far end) are the oversized/organic cases: the primary hold is placed and the far end is left alone, as agreed.

## Contact sheet

Every gun `debug_weapons` stocks, right hand:

![contact sheet, right hand](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/sheet_right.png)

Left hand — the model mirrors and the grip mirrors with it:

![contact sheet, left hand](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/sheet_left.png)

<sub>Green/blue wireframes are the `clip_zone` dev overlay (the clip-insert zone and the model origin), turned on so the placement is measurable rather than guessed.</sub>

The sheet's `ar15_h` tile hides its own evidence — the fist covers the pistol grip and the magwell in front of it reads like an empty grip. Close up, with the same wield:

![ar15_h close up: the pistol grip is inside the fist, the magazine is the box in front of it](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/ar15_grip.png)

Aim is unchanged by the shrink — four rounds down `debug_weapons`' 12-unit lane land on the wall, on the lane's centre line:

![bullet holes on the test wall](https://gist.githubusercontent.com/tommy-xr/995cffee33a7ba06d615b3544c252d6a/raw/wall.png)

## Tests

- `vr_config::the_gun_wield_scale_keeps_the_grip_in_the_hand_and_the_muzzle_on_the_barrel`: over every gun model and both hands, at 0.4 / 1.0 / 1.25, the authored grip point lands exactly on the tracked hand and the muzzle stays proportionally down the barrel. Verified to fail when the offset stops being scaled with the geometry.
- `reload::the_magazine_zone_needs_a_closer_approach_than_it_needs_to_hold`: now runs at both the authored size and a life-size wield, so the hysteresis survives the scaling.
- `vr-muzzle-origin.e2e`: the laser's muzzle vhot scales with the wield (read from the live `gun_scale`, not the default); the psi amp stays unscaled, which is what pins the gun/amp partition end to end.
- `vr-clip-insert-reload.e2e`: keeps its original negative — a clip carried to the mirror of the anchor across the model origin must still miss — because the zone shrank with the gun. Its radius is now read through the live `gun_scale` rather than hardcoded.
- Run green: `vr-held-model`, `vr-muzzle-origin`, `vr-clip-insert-reload`, `vr-eject-clip`, `vr-fire-mode-button`, `vr-weapon-reload`, `vr-contextual-buttons`, `vr-hand-affordance`, `vr-wrist-readouts`, plus `vr-melee-contact` as an untouched-path check.

## Known follow-up

FX spawned in the weapon's own frame — the `GunFlash`-linked muzzle flash and ejected casing (`weapon_script::create_muzzle_flash`) — are *placed* at the scaled vhot but drawn at their own authored size, so they now read relatively larger against a life-size gun. Ten consecutive single-frame captures of a VR pistol shot show no flash on screen at all, so there is nothing to see yet; scaling attached FX means plumbing a scale through `CreateEntityOptions`, which also feeds the created entity's physics, and is left as its own change.
