### PR TITLE
feat(vr): fingers curl until they touch what the hand holds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,6 +489,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_ragdoll`          | Test ragdoll physics                         |
    | `debug_hitbox`           | View fitted hitbox shapes vs ragdoll colliders across poses |
    | `debug_gloves`           | Test VR hand/glove rendering                 |
+   | `debug_grips`            | One held test item at a time in the VR glove, posed by the finger fit (`grip_item` dev param) |
    | `debug_hand_poses`       | 25AE authored hand poses, anchored at a common hand origin |
    | `debug_teleport`         | Test VR teleport locomotion                  |
    | `debug_joint_constraint` | Test physics joint constraints               |

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -371,6 +371,39 @@ pub static VR_HELD_GUN_MODELS_IMPORTER: Lazy<
     AssetImporter<SystemShockContentModel, VrHeldGunModel, ()>,
 > = Lazy::new(|| AssetImporter::define(load_model, process_vr_held_gun_model));
 
+/// The triangles of a held item's render mesh, in model space, with any baked
+/// first-person arm stripped.
+///
+/// The contact proxy the VR finger fit closes the glove against: every pickup
+/// template is `PhysType SPHERE`, so the physics collider says nothing about
+/// the shape of a mug, a magazine or a pistol grip - only the drawn surface
+/// does. Stripping the arm matches what a VR wield actually draws
+/// ([`VrHeldGunModel`]); leaving it in would stop the fingers on a hand that
+/// is not there.
+///
+/// Newtype for cache separation, as [`VrHeldGunModel`].
+pub struct VrContactMesh(pub Vec<[Point3<f32>; 3]>);
+
+fn process_vr_contact_mesh(
+    mesh: SystemShockContentModel,
+    _asset_cache: &mut AssetCache,
+    _config: &(),
+) -> VrContactMesh {
+    match mesh {
+        SystemShockContentModel::Obj(obj) => VrContactMesh(ss2_bin_obj_loader::to_triangles(
+            &ss2_bin_obj_loader::retain_materials(obj, |name| !is_first_person_arm_material(name)),
+        )),
+        // Skinned rigs (the melee `_h` set) draw their weapon from a posed
+        // skeleton, and their grip is computed from that pose rather than
+        // fitted - so there is nothing here for the fit to close against.
+        _ => VrContactMesh(Vec::new()),
+    }
+}
+
+pub static VR_CONTACT_MESH_IMPORTER: Lazy<
+    AssetImporter<SystemShockContentModel, VrContactMesh, ()>,
+> = Lazy::new(|| AssetImporter::define(load_model, process_vr_contact_mesh));
+
 /// Newtype so this importer gets its own [`AssetCache`] bucket.
 ///
 /// The cache keys by `importer.type_id()`, which is the *type* of the importer,

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -679,6 +679,48 @@ pub fn sub_object_bounds(
         .collect()
 }
 
+/// Every rendered triangle of `mesh`, in model space - the same fan
+/// triangulation and per-vertex sub-object placement [`to_vertices`] renders
+/// with, so a geometric test against these triangles tests the drawn surface.
+///
+/// The contact proxy for a held item: pickup physics is a sphere for every
+/// template, so nothing but the render mesh describes the shape a hand closes
+/// around.
+pub fn to_triangles(mesh: &SystemShock2ObjectMesh) -> Vec<[Point3<f32>; 3]> {
+    let placements = sub_object_transforms(mesh)
+        .into_iter()
+        .map(|(_, transform)| transform)
+        .collect::<Vec<_>>();
+
+    let mut triangles = Vec::new();
+    for polygon in &mesh.polygons {
+        let indices = &polygon.vertex_indices;
+        if indices.len() < 3 {
+            continue;
+        }
+        let place = |index: u16| -> Option<Point3<f32>> {
+            let vertex = mesh.vertices.get(index as usize)?;
+            let transform = placements
+                .get(get_bone_index_for_point(mesh, index) as usize)
+                .copied()
+                .unwrap_or_else(Matrix4::identity);
+            Some(transform.transform_point(point3(vertex.x, vertex.y, vertex.z)))
+        };
+        // Fan from corner 0, matching `to_vertices`.
+        for corner in 1..(indices.len() - 1) {
+            let (Some(a), Some(b), Some(c)) = (
+                place(indices[0]),
+                place(indices[corner]),
+                place(indices[corner + 1]),
+            ) else {
+                continue;
+            };
+            triangles.push([a, b, c]);
+        }
+    }
+    triangles
+}
+
 pub fn to_vertices(
     mesh: &SystemShock2ObjectMesh,
 ) -> HashMap<u16, Vec<VertexPositionTextureSkinnedNormal>> {

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -679,6 +679,14 @@ pub fn sub_object_bounds(
         .collect()
 }
 
+/// Whether the renderer builds geometry from this polygon at all: a corner
+/// needs a UV, so [`to_vertices`] silently drops any polygon short of them.
+/// The contact walk has to drop exactly the same ones - a face nobody can see
+/// must not stop a finger either.
+fn is_rendered(polygon: &SystemShock2ObjectPolygon) -> bool {
+    polygon.vertex_indices.len() >= 3 && polygon.uv_indices.len() >= polygon.vertex_indices.len()
+}
+
 /// Every rendered triangle of `mesh`, in model space - the same fan
 /// triangulation and per-vertex sub-object placement [`to_vertices`] renders
 /// with, so a geometric test against these triangles tests the drawn surface.
@@ -694,20 +702,21 @@ pub fn to_triangles(mesh: &SystemShock2ObjectMesh) -> Vec<[Point3<f32>; 3]> {
 
     let mut triangles = Vec::new();
     for polygon in &mesh.polygons {
-        let indices = &polygon.vertex_indices;
-        if indices.len() < 3 {
+        if !is_rendered(polygon) {
             continue;
         }
-        let place = |index: u16| -> Option<Point3<f32>> {
-            let vertex = mesh.vertices.get(index as usize)?;
+        let indices = &polygon.vertex_indices;
+        // Fan from corner 0, and - as `to_vertices` does - place the whole
+        // triangle by the fan corner's sub-object, not each vertex by its own.
+        for corner in 1..(indices.len() - 1) {
             let transform = placements
-                .get(get_bone_index_for_point(mesh, index) as usize)
+                .get(get_bone_index_for_point(mesh, indices[corner]) as usize)
                 .copied()
                 .unwrap_or_else(Matrix4::identity);
-            Some(transform.transform_point(point3(vertex.x, vertex.y, vertex.z)))
-        };
-        // Fan from corner 0, matching `to_vertices`.
-        for corner in 1..(indices.len() - 1) {
+            let place = |index: u16| -> Option<Point3<f32>> {
+                let vertex = mesh.vertices.get(index as usize)?;
+                Some(transform.transform_point(point3(vertex.x, vertex.y, vertex.z)))
+            };
             let (Some(a), Some(b), Some(c)) = (
                 place(indices[0]),
                 place(indices[corner]),
@@ -743,7 +752,6 @@ pub fn to_vertices(
         let verts = hash_map.get_mut(&slot).unwrap();
 
         let len = indices.len();
-        let uv_len = uv_indices.len();
 
         let normal_for_corner = |corner: usize| -> Vector3<f32> {
             normals
@@ -752,7 +760,7 @@ pub fn to_vertices(
                 .unwrap()
         };
 
-        if len >= 3 && uv_len >= len {
+        if is_rendered(poly) {
             for idx in 1..(len - 1) {
                 let bone_idx = get_bone_index_for_point(mesh, indices[idx]);
 

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -245,7 +245,7 @@ dev_params! {
     GUN_WIELD_SCALE = float("gun_scale", "Gun scale", 0.4, 0.1, 1.5, 0.05),
     /// Which of `debug_grips`' test items to show in the hand. Ignored
     /// everywhere else; the scene clamps it to its own list.
-    GRIP_ITEM = float("grip_item", "Grip test item", 0.0, 0.0, 15.0, 1.0),
+    GRIP_ITEM = float("grip_item", "Grip test item", 0.0, 0.0, 7.0, 1.0),
     /// Enables the detached debug ("free") camera. This is the *gate*, not
     /// the camera's own on/off: while it is false the toggle input is not
     /// even read, so a stray `Alt+V` (or controller chord) during normal play

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -243,6 +243,9 @@ dev_params! {
     /// into the model (and its muzzle vhots) once, so a change takes effect on
     /// the next grab.
     GUN_WIELD_SCALE = float("gun_scale", "Gun scale", 0.4, 0.1, 1.5, 0.05),
+    /// Which of `debug_grips`' test items to show in the hand. Ignored
+    /// everywhere else; the scene clamps it to its own list.
+    GRIP_ITEM = float("grip_item", "Grip test item", 0.0, 0.0, 15.0, 1.0),
     /// Enables the detached debug ("free") camera. This is the *gate*, not
     /// the camera's own on/off: while it is false the toggle input is not
     /// even read, so a stray `Alt+V` (or controller chord) during normal play

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -391,6 +391,22 @@ pub struct DebugClimbState {
 pub struct DebugHandAffordances {
     pub left: &'static str,
     pub right: &'static str,
+    /// The grip each hand fitted to whatever it holds, when it holds
+    /// something with a mesh to fit against.
+    pub left_grip: Option<DebugHandGrip>,
+    pub right_grip: Option<DebugHandGrip>,
+}
+
+/// A hand's fitted grip: the family the fit solved in, and the curl it left
+/// each finger at (0 = open, 1 = closed fist), before the trigger adds its own.
+#[derive(Debug, Serialize, Clone, Copy)]
+pub struct DebugHandGrip {
+    pub family: &'static str,
+    pub thumb: f32,
+    pub index: f32,
+    pub middle: f32,
+    pub ring: f32,
+    pub pinky: f32,
 }
 
 /// A scene with no hands reports the same name an idle hand does, so the field
@@ -401,6 +417,8 @@ impl Default for DebugHandAffordances {
         Self {
             left: idle,
             right: idle,
+            left_grip: None,
+            right_grip: None,
         }
     }
 }

--- a/shock2vr/src/hand_fit.rs
+++ b/shock2vr/src/hand_fit.rs
@@ -4,8 +4,11 @@
 //! `PhysType SPHERE` - so the fit runs against the item's **render mesh**
 //! ([`dark::importers::VrContactMesh`]), transformed into the hand's own
 //! space. For each finger the solver sweeps the open->fist blend the glove
-//! already poses with, takes the *largest* curl at which no phalanx capsule
-//! is inside the mesh, and bisects for the contact point. The result is a
+//! already poses with, stops at the first curl where a phalanx capsule
+//! reaches the surface, and bisects for the contact point. A finger already
+//! inside the item at the open pose gets no answer at all - the item is
+//! seated *through* the open hand, which is what a wield does deliberately -
+//! and keeps the resting wrap its caller passed in. The result is a
 //! [`FingerAmounts`] the renderer feeds straight to
 //! [`crate::hand_pose::Pose::blend_per_finger`].
 //!
@@ -15,57 +18,7 @@
 
 use cgmath::{EuclideanSpace, InnerSpace, Point3, Vector3};
 
-use crate::hand_pose::FingerAmounts;
-
-/// One finger of the hand.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Finger {
-    Thumb,
-    Index,
-    Middle,
-    Ring,
-    Pinky,
-}
-
-impl Finger {
-    pub const ALL: [Finger; 5] = [
-        Finger::Thumb,
-        Finger::Index,
-        Finger::Middle,
-        Finger::Ring,
-        Finger::Pinky,
-    ];
-
-    /// Where this finger's curl lands in a [`FingerAmounts`].
-    pub fn set(self, amounts: &mut FingerAmounts, curl: f32) {
-        match self {
-            Finger::Thumb => amounts.thumb = curl,
-            Finger::Index => amounts.index = curl,
-            Finger::Middle => amounts.middle = curl,
-            Finger::Ring => amounts.ring = curl,
-            Finger::Pinky => amounts.pinky = curl,
-        }
-    }
-
-    /// This finger's curl out of a [`FingerAmounts`].
-    pub fn curl_of(self, amounts: &FingerAmounts) -> f32 {
-        match self {
-            Finger::Thumb => amounts.thumb,
-            Finger::Index => amounts.index,
-            Finger::Middle => amounts.middle,
-            Finger::Ring => amounts.ring,
-            Finger::Pinky => amounts.pinky,
-        }
-    }
-
-    /// A blend that curls only this finger - what the solver poses the rig
-    /// with while it searches one finger at a time.
-    pub fn alone(self, curl: f32) -> FingerAmounts {
-        let mut amounts = FingerAmounts::default();
-        self.set(&mut amounts, curl);
-        amounts
-    }
-}
+use crate::hand_pose::{Finger, FingerAmounts};
 
 /// A capsule along one phalanx, in hand space (world units).
 #[derive(Debug, Clone, Copy)]
@@ -273,55 +226,72 @@ pub fn family_from_extents(extents: Vector3<f32>) -> GripFamily {
 
 /// Curl every finger until it reaches the item, within its family's envelope.
 ///
-/// An empty mesh (a model with no triangles, a skinned melee rig) fits nothing
-/// and every finger takes its cap - the same closed grip the glove posed
-/// before there was a fit at all.
-pub fn fit(rig: &mut impl HandRig, mesh: &ContactMesh, family: GripFamily) -> FingerAmounts {
+/// `resting` is what a finger keeps when the fit has nothing to say: the item
+/// is already through that finger at the open pose, which is exactly what a
+/// wield does on purpose (a gun's grip is seated inside the closed fist), so
+/// the authored wrap stands rather than being replaced by a guess. The
+/// family's envelope is applied either way - a trigger finger rests on the
+/// trigger whether or not anything was measured.
+pub fn fit(
+    rig: &mut impl HandRig,
+    mesh: &ContactMesh,
+    family: GripFamily,
+    resting: FingerAmounts,
+) -> FingerAmounts {
     let mut amounts = FingerAmounts::default();
     for finger in Finger::ALL {
-        finger.set(&mut amounts, fit_finger(rig, mesh, family, finger));
+        let Envelope { floor, cap } = family.envelope(finger);
+        let curl = fit_finger(rig, mesh, family, finger)
+            .unwrap_or_else(|| finger.curl_of(&resting))
+            .clamp(floor, cap);
+        finger.set(&mut amounts, curl);
     }
     amounts
 }
 
+/// The curl this finger stops at, or `None` when the mesh says nothing about
+/// it - nothing within reach, or the finger already inside the item at the
+/// open pose.
 fn fit_finger(
     rig: &mut impl HandRig,
     mesh: &ContactMesh,
     family: GripFamily,
     finger: Finger,
-) -> f32 {
+) -> Option<f32> {
     let Envelope { floor, cap } = family.envelope(finger);
     if cap <= floor || mesh.is_empty() {
-        return cap.max(floor);
+        return None;
     }
+
+    // Pose the coarse sweep once: the bounds pass and the scan below both
+    // want it, and posing the rig dominates the solve.
+    let curl_at = |step: usize| floor + (cap - floor) * (step as f32 / COARSE_STEPS as f32);
+    let sweep = (0..=COARSE_STEPS)
+        .map(|step| rig.phalanges(finger, curl_at(step)))
+        .collect::<Vec<_>>();
 
     // One prefilter per finger, over everything the finger sweeps through.
-    let (min, max) = swept_bounds(rig, finger, floor, cap);
+    let (min, max) = swept_bounds(&sweep);
     let candidates = mesh.near(min, max);
     if candidates.is_empty() {
-        return cap;
+        return Some(cap);
     }
 
-    let curl_at = |step: usize| floor + (cap - floor) * (step as f32 / COARSE_STEPS as f32);
-
-    // Scanned from the closed end down, not from the open end up. A held item
-    // is seated where the *closed* hand would be - a gun's grip lies right
-    // through the open hand's extended fingers - so "the first contact on the
-    // way in" is not the grip, it is the seat. The largest clear curl is.
-    let Some(step) = (0..=COARSE_STEPS)
-        .rev()
-        .find(|step| !mesh.touches(&rig.phalanges(finger, curl_at(*step)), &candidates))
+    // Scanned from the open end in, stopping at the first contact. A finger
+    // that is *already* in contact at the open pose has the item seated
+    // through it and yields nothing; scanning from the closed end instead
+    // would answer such a finger with whatever pose happens to be clear,
+    // including one buried inside a large closed mesh.
+    if mesh.touches(&sweep[0], &candidates) {
+        return None;
+    }
+    let Some(step) = (1..=COARSE_STEPS).find(|step| mesh.touches(&sweep[*step], &candidates))
     else {
-        // Nowhere clear: the item passes through the finger at every curl, so
-        // the only honest answer is the closed grip the wield authored.
-        return cap;
+        return Some(cap);
     };
-    if step == COARSE_STEPS {
-        return cap;
-    }
 
-    let mut clear = curl_at(step);
-    let mut blocked = curl_at(step + 1);
+    let mut clear = curl_at(step - 1);
+    let mut blocked = curl_at(step);
     for _ in 0..BISECT_ROUNDS {
         let middle = 0.5 * (clear + blocked);
         if mesh.touches(&rig.phalanges(finger, middle), &candidates) {
@@ -330,29 +300,20 @@ fn fit_finger(
             clear = middle;
         }
     }
-    clear
+    Some(clear)
 }
 
-/// Bounding box of everything one finger passes through between `floor` and
-/// `cap`, grown by the capsule radii.
-fn swept_bounds(
-    rig: &mut impl HandRig,
-    finger: Finger,
-    floor: f32,
-    cap: f32,
-) -> (Vector3<f32>, Vector3<f32>) {
+/// Bounding box of every capsule in a swept pose set, grown by their radii.
+fn swept_bounds(sweep: &[Vec<Capsule>]) -> (Vector3<f32>, Vector3<f32>) {
     let mut min = Vector3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY);
     let mut max = Vector3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
-    for step in 0..=COARSE_STEPS {
-        let curl = floor + (cap - floor) * (step as f32 / COARSE_STEPS as f32);
-        for capsule in rig.phalanges(finger, curl) {
-            let radius = Vector3::new(capsule.radius, capsule.radius, capsule.radius);
-            for point in [capsule.a.to_vec(), capsule.b.to_vec()] {
-                let lo = point - radius;
-                let hi = point + radius;
-                min = Vector3::new(min.x.min(lo.x), min.y.min(lo.y), min.z.min(lo.z));
-                max = Vector3::new(max.x.max(hi.x), max.y.max(hi.y), max.z.max(hi.z));
-            }
+    for capsule in sweep.iter().flatten() {
+        let radius = Vector3::new(capsule.radius, capsule.radius, capsule.radius);
+        for point in [capsule.a.to_vec(), capsule.b.to_vec()] {
+            let lo = point - radius;
+            let hi = point + radius;
+            min = Vector3::new(min.x.min(lo.x), min.y.min(lo.y), min.z.min(lo.z));
+            max = Vector3::new(max.x.max(hi.x), max.y.max(hi.y), max.z.max(hi.z));
         }
     }
     (min, max)
@@ -656,6 +617,18 @@ mod tests {
         }
     }
 
+    /// The wrap a finger keeps when the fit has nothing to say. Deliberately
+    /// short of a full fist so a test can tell "fitted" from "left alone".
+    fn resting() -> FingerAmounts {
+        FingerAmounts {
+            thumb: 0.85,
+            index: 0.5,
+            middle: 0.9,
+            ring: 0.9,
+            pinky: 0.9,
+        }
+    }
+
     /// The whole point of the fit, as a negative test and its fix in one: the
     /// ungoverned fist closes straight through a handle, and the fitted curl
     /// stops on its surface.
@@ -672,7 +645,7 @@ mod tests {
             "a full fist should close through a handle - otherwise this test proves nothing"
         );
 
-        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Cylindrical);
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Cylindrical, resting());
         assert!(
             !penetrates(&mesh, &fitted),
             "the fitted grip still penetrates: {fitted:?}"
@@ -684,17 +657,18 @@ mod tests {
         );
     }
 
-    /// Nothing in the hand means nothing to stop against: every finger takes
-    /// its family's cap.
+    /// Nothing in the hand means nothing measured: every finger keeps the
+    /// resting wrap its caller passed in.
     #[test]
-    fn an_empty_hand_closes_all_the_way() {
+    fn an_empty_hand_keeps_the_resting_wrap() {
         let fitted = fit(
             &mut FlatHand,
             &ContactMesh::new(Vec::new()),
             GripFamily::Cylindrical,
+            resting(),
         );
-        assert_eq!(fitted.middle, 1.0);
-        assert_eq!(fitted.thumb, 1.0);
+        assert_eq!(fitted.middle, resting().middle);
+        assert_eq!(fitted.thumb, resting().thumb);
     }
 
     /// A ball wider than the palm reads as broad, and the hand rests on its
@@ -710,7 +684,7 @@ mod tests {
 
         assert_eq!(family_from_extents(extents), GripFamily::Broad);
 
-        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Broad);
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Broad, resting());
         assert!(
             !penetrates(&mesh, &fitted),
             "hand inside the ball: {fitted:?}"
@@ -734,7 +708,7 @@ mod tests {
 
         assert_eq!(family_from_extents(extents), GripFamily::Pinch);
 
-        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Pinch);
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Pinch, resting());
         assert_eq!(fitted.middle, PINCH_REST);
         assert_eq!(fitted.ring, PINCH_REST);
         assert_eq!(fitted.pinky, PINCH_REST);
@@ -765,7 +739,7 @@ mod tests {
             meters(0.06),
         ));
 
-        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Trigger);
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Trigger, resting());
         assert!(fitted.index <= TRIGGER_INDEX_CAP);
         assert!(
             fitted.index < fitted.middle && fitted.index < fitted.ring,
@@ -774,6 +748,30 @@ mod tests {
             fitted.middle,
             fitted.ring
         );
+    }
+
+    /// An item seated *through* the open hand - a gun grip inside the fist -
+    /// tells the fit nothing, and the authored wrap stands. Scanning from the
+    /// closed end instead would answer with whatever pose happened to be
+    /// clear, which for a big closed mesh is one buried inside it.
+    #[test]
+    fn an_item_seated_through_the_open_hand_keeps_the_resting_wrap() {
+        // A slab straddling the fingers at every curl: it spans the whole
+        // sweep in Y and sits right on the open finger's line.
+        let mesh = ContactMesh::new(box_mesh(
+            vec3(0.0, meters(0.02), meters(-0.03)),
+            vec3(meters(0.2), meters(0.1), meters(0.005)),
+        ));
+        assert!(
+            mesh.touches(
+                &FlatHand.phalanges(Finger::Middle, 0.0),
+                &(0..mesh.triangle_count()).collect::<Vec<_>>()
+            ),
+            "the fixture must put the slab through the OPEN finger"
+        );
+
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Cylindrical, resting());
+        assert_eq!(fitted.middle, resting().middle);
     }
 
     /// A segment threading through a triangle is touching it, not a finger's

--- a/shock2vr/src/hand_fit.rs
+++ b/shock2vr/src/hand_fit.rs
@@ -1,0 +1,782 @@
+//! Curls the glove's fingers until they touch whatever the hand is holding.
+//!
+//! Pickup physics says nothing about shape - every pickup template is
+//! `PhysType SPHERE` - so the fit runs against the item's **render mesh**
+//! ([`dark::importers::VrContactMesh`]), transformed into the hand's own
+//! space. For each finger the solver sweeps the open->fist blend the glove
+//! already poses with, brackets the first curl at which a phalanx capsule
+//! reaches the surface, and bisects for the contact point. The result is a
+//! [`FingerAmounts`] the renderer feeds straight to
+//! [`crate::hand_pose::Pose::blend_per_finger`].
+//!
+//! Everything here is pure: the caller supplies a posed-hand [`HandRig`] and a
+//! [`ContactMesh`], so the solver is exercised in tests against synthetic
+//! meshes with no assets and no GPU.
+
+use cgmath::{EuclideanSpace, InnerSpace, Point3, Vector3};
+
+use crate::hand_pose::FingerAmounts;
+
+/// One finger of the hand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Finger {
+    Thumb,
+    Index,
+    Middle,
+    Ring,
+    Pinky,
+}
+
+impl Finger {
+    pub const ALL: [Finger; 5] = [
+        Finger::Thumb,
+        Finger::Index,
+        Finger::Middle,
+        Finger::Ring,
+        Finger::Pinky,
+    ];
+
+    /// Where this finger's curl lands in a [`FingerAmounts`].
+    fn set(self, amounts: &mut FingerAmounts, curl: f32) {
+        match self {
+            Finger::Thumb => amounts.thumb = curl,
+            Finger::Index => amounts.index = curl,
+            Finger::Middle => amounts.middle = curl,
+            Finger::Ring => amounts.ring = curl,
+            Finger::Pinky => amounts.pinky = curl,
+        }
+    }
+}
+
+/// A capsule along one phalanx, in hand space (world units).
+#[derive(Debug, Clone, Copy)]
+pub struct Capsule {
+    pub a: Point3<f32>,
+    pub b: Point3<f32>,
+    pub radius: f32,
+}
+
+/// A hand the fit can pose: the phalanx capsules of one finger at one curl,
+/// in hand space.
+///
+/// Whole phalanges rather than just the fingertip: a tip-only test lets a
+/// knuckle close straight through the item while the tip is still clear.
+pub trait HandRig {
+    fn phalanges(&mut self, finger: Finger, curl: f32) -> Vec<Capsule>;
+}
+
+/// The shape family of a grip: which curl envelope each finger searches in.
+///
+/// One blend space throughout - every amount is "how far from `open` toward
+/// `fist`" - so a family is a per-finger floor and cap on that blend rather
+/// than a second pose vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GripFamily {
+    /// Wrap a handle: every finger closes as far as the surface allows.
+    Cylindrical,
+    /// Thumb and index only; the rest hold a relaxed rest curl out of the way.
+    Pinch,
+    /// Something bigger than the palm: fingers splay on the surface rather
+    /// than wrapping, so the curl is capped shallow.
+    Broad,
+    /// A gun: the index rests on the trigger (and the player's own pull adds
+    /// the rest on top), the others wrap the grip.
+    Trigger,
+}
+
+/// How far the index may curl on a trigger before the player's own pull takes
+/// over - the resting finger, not a squeezed one.
+const TRIGGER_INDEX_CAP: f32 = 0.45;
+
+/// The relaxed curl a pinch leaves its idle fingers at: out of the way of the
+/// pinched item without reading as a fist.
+const PINCH_REST: f32 = 0.55;
+
+/// How far a hand closes on something too big to wrap.
+const BROAD_CAP: f32 = 0.4;
+
+/// The curl range one finger searches: `cap == floor` means the finger takes
+/// no part in this grip and simply holds that pose.
+#[derive(Debug, Clone, Copy)]
+struct Envelope {
+    floor: f32,
+    cap: f32,
+}
+
+impl GripFamily {
+    fn envelope(self, finger: Finger) -> Envelope {
+        let full = Envelope {
+            floor: 0.0,
+            cap: 1.0,
+        };
+        match (self, finger) {
+            (GripFamily::Cylindrical, _) => full,
+            (GripFamily::Broad, _) => Envelope {
+                floor: 0.0,
+                cap: BROAD_CAP,
+            },
+            (GripFamily::Pinch, Finger::Thumb | Finger::Index) => full,
+            (GripFamily::Pinch, _) => Envelope {
+                floor: PINCH_REST,
+                cap: PINCH_REST,
+            },
+            (GripFamily::Trigger, Finger::Index) => Envelope {
+                floor: 0.0,
+                cap: TRIGGER_INDEX_CAP,
+            },
+            (GripFamily::Trigger, _) => full,
+        }
+    }
+
+    /// Readable name, for the hand readout and the grip override table.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GripFamily::Cylindrical => "cylindrical",
+            GripFamily::Pinch => "pinch",
+            GripFamily::Broad => "broad",
+            GripFamily::Trigger => "trigger",
+        }
+    }
+}
+
+/// Metres expressed in the world units the hand frame is measured in.
+const fn meters(m: f32) -> f32 {
+    m / crate::METERS_PER_WORLD_UNIT
+}
+
+/// Thinner than this in its smallest dimension and an item is pinched rather
+/// than gripped - a magazine, a keycard.
+const PINCH_THICKNESS: f32 = meters(0.018);
+
+/// Wider than this across its two smaller dimensions and the hand cannot close
+/// round it at all - a basketball, a helmet.
+const BROAD_GIRTH: f32 = meters(0.10);
+
+/// How far a phalanx may sink into the surface before it counts as contact.
+/// Skin against a hard edge deforms a little; zero here would leave a visible
+/// air gap at every grip.
+const CONTACT_TOLERANCE: f32 = meters(0.0015);
+
+/// Curl samples the coarse sweep takes before bisecting. Fine enough that a
+/// fingertip cannot step clean through a wall of the mesh between samples.
+const COARSE_STEPS: usize = 16;
+
+/// Bisection rounds after the sweep brackets first contact; 6 rounds resolve
+/// the curl to under 1% of the envelope.
+const BISECT_ROUNDS: usize = 6;
+
+/// The triangles a hand can close against, in hand space.
+pub struct ContactMesh {
+    triangles: Vec<[Point3<f32>; 3]>,
+}
+
+impl ContactMesh {
+    pub fn new(triangles: Vec<[Point3<f32>; 3]>) -> Self {
+        Self { triangles }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.triangles.is_empty()
+    }
+
+    pub fn triangle_count(&self) -> usize {
+        self.triangles.len()
+    }
+
+    /// Axis-aligned extents of the mesh in hand space, or `None` when empty.
+    pub fn extents(&self) -> Option<Vector3<f32>> {
+        let mut min = Vector3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+        let mut max = Vector3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+        for triangle in &self.triangles {
+            for corner in triangle {
+                let p = corner.to_vec();
+                min = Vector3::new(min.x.min(p.x), min.y.min(p.y), min.z.min(p.z));
+                max = Vector3::new(max.x.max(p.x), max.y.max(p.y), max.z.max(p.z));
+            }
+        }
+        min.x.is_finite().then(|| max - min)
+    }
+
+    /// Indices of the triangles whose bounding box overlaps `[min, max]`. Run
+    /// once per finger over its whole curl sweep, so the inner loop only ever
+    /// sees triangles that finger could reach.
+    fn near(&self, min: Vector3<f32>, max: Vector3<f32>) -> Vec<usize> {
+        self.triangles
+            .iter()
+            .enumerate()
+            .filter(|(_, triangle)| {
+                let mut lo = triangle[0].to_vec();
+                let mut hi = lo;
+                for corner in &triangle[1..] {
+                    let p = corner.to_vec();
+                    lo = Vector3::new(lo.x.min(p.x), lo.y.min(p.y), lo.z.min(p.z));
+                    hi = Vector3::new(hi.x.max(p.x), hi.y.max(p.y), hi.z.max(p.z));
+                }
+                lo.x <= max.x
+                    && hi.x >= min.x
+                    && lo.y <= max.y
+                    && hi.y >= min.y
+                    && lo.z <= max.z
+                    && hi.z >= min.z
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// Whether any capsule has reached the surface.
+    fn touches(&self, capsules: &[Capsule], candidates: &[usize]) -> bool {
+        capsules.iter().any(|capsule| {
+            candidates.iter().any(|index| {
+                segment_triangle_distance(capsule.a, capsule.b, &self.triangles[*index])
+                    < capsule.radius - CONTACT_TOLERANCE
+            })
+        })
+    }
+}
+
+/// The family to use for an item of these hand-space extents, when nothing
+/// authored says otherwise. Guns are named, not measured - a pistol's box
+/// looks like any other handle - so [`GripFamily::Trigger`] only ever arrives
+/// as a hint.
+pub fn family_from_extents(extents: Vector3<f32>) -> GripFamily {
+    let mut sorted = [extents.x.abs(), extents.y.abs(), extents.z.abs()];
+    sorted.sort_by(f32::total_cmp);
+    if sorted[0] < PINCH_THICKNESS {
+        GripFamily::Pinch
+    } else if sorted[1] > BROAD_GIRTH {
+        GripFamily::Broad
+    } else {
+        GripFamily::Cylindrical
+    }
+}
+
+/// Curl every finger until it reaches the item, within its family's envelope.
+///
+/// An empty mesh (a model with no triangles, a skinned melee rig) fits nothing
+/// and every finger takes its cap - the same closed grip the glove posed
+/// before there was a fit at all.
+pub fn fit(rig: &mut impl HandRig, mesh: &ContactMesh, family: GripFamily) -> FingerAmounts {
+    let mut amounts = FingerAmounts::default();
+    for finger in Finger::ALL {
+        finger.set(&mut amounts, fit_finger(rig, mesh, family, finger));
+    }
+    amounts
+}
+
+fn fit_finger(
+    rig: &mut impl HandRig,
+    mesh: &ContactMesh,
+    family: GripFamily,
+    finger: Finger,
+) -> f32 {
+    let Envelope { floor, cap } = family.envelope(finger);
+    if cap <= floor || mesh.is_empty() {
+        return cap.max(floor);
+    }
+
+    // One prefilter per finger, over everything the finger sweeps through.
+    let (min, max) = swept_bounds(rig, finger, floor, cap);
+    let candidates = mesh.near(min, max);
+    if candidates.is_empty() {
+        return cap;
+    }
+
+    let curl_at = |step: usize| floor + (cap - floor) * (step as f32 / COARSE_STEPS as f32);
+
+    let mut clear = floor;
+    let mut first_contact = None;
+    for step in 1..=COARSE_STEPS {
+        let curl = curl_at(step);
+        if mesh.touches(&rig.phalanges(finger, curl), &candidates) {
+            first_contact = Some(curl);
+            break;
+        }
+        clear = curl;
+    }
+
+    let Some(mut blocked) = first_contact else {
+        return cap;
+    };
+
+    for _ in 0..BISECT_ROUNDS {
+        let middle = 0.5 * (clear + blocked);
+        if mesh.touches(&rig.phalanges(finger, middle), &candidates) {
+            blocked = middle;
+        } else {
+            clear = middle;
+        }
+    }
+    clear
+}
+
+/// Bounding box of everything one finger passes through between `floor` and
+/// `cap`, grown by the capsule radii.
+fn swept_bounds(
+    rig: &mut impl HandRig,
+    finger: Finger,
+    floor: f32,
+    cap: f32,
+) -> (Vector3<f32>, Vector3<f32>) {
+    let mut min = Vector3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut max = Vector3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+    for step in 0..=COARSE_STEPS {
+        let curl = floor + (cap - floor) * (step as f32 / COARSE_STEPS as f32);
+        for capsule in rig.phalanges(finger, curl) {
+            let radius = Vector3::new(capsule.radius, capsule.radius, capsule.radius);
+            for point in [capsule.a.to_vec(), capsule.b.to_vec()] {
+                let lo = point - radius;
+                let hi = point + radius;
+                min = Vector3::new(min.x.min(lo.x), min.y.min(lo.y), min.z.min(lo.z));
+                max = Vector3::new(max.x.max(hi.x), max.y.max(hi.y), max.z.max(hi.z));
+            }
+        }
+    }
+    (min, max)
+}
+
+// --- geometry -------------------------------------------------------------
+
+/// Distance from segment `pq` to a triangle; zero when they cross.
+fn segment_triangle_distance(p: Point3<f32>, q: Point3<f32>, tri: &[Point3<f32>; 3]) -> f32 {
+    if segment_crosses_triangle(p, q, tri) {
+        return 0.0;
+    }
+    let mut best = point_triangle_distance(p, tri).min(point_triangle_distance(q, tri));
+    for edge in 0..3 {
+        best = best.min(segment_segment_distance(
+            p,
+            q,
+            tri[edge],
+            tri[(edge + 1) % 3],
+        ));
+    }
+    best
+}
+
+/// Moller-Trumbore, restricted to the segment's own parameter range. Without
+/// it a segment threading clean through a triangle would report the distance
+/// to its nearest edge rather than zero.
+fn segment_crosses_triangle(p: Point3<f32>, q: Point3<f32>, tri: &[Point3<f32>; 3]) -> bool {
+    let direction = q - p;
+    let edge1 = tri[1] - tri[0];
+    let edge2 = tri[2] - tri[0];
+    let h = direction.cross(edge2);
+    let determinant = edge1.dot(h);
+    if determinant.abs() < 1e-12 {
+        return false;
+    }
+    let inverse = 1.0 / determinant;
+    let s = p - tri[0];
+    let u = inverse * s.dot(h);
+    if !(0.0..=1.0).contains(&u) {
+        return false;
+    }
+    let r = s.cross(edge1);
+    let v = inverse * direction.dot(r);
+    if v < 0.0 || u + v > 1.0 {
+        return false;
+    }
+    let t = inverse * edge2.dot(r);
+    (0.0..=1.0).contains(&t)
+}
+
+/// Distance from `p` to the closest point on a triangle (Ericson, *Real-Time
+/// Collision Detection*): test the vertex, edge and face regions in turn.
+fn point_triangle_distance(p: Point3<f32>, tri: &[Point3<f32>; 3]) -> f32 {
+    let (a, b, c) = (tri[0], tri[1], tri[2]);
+    let ab = b - a;
+    let ac = c - a;
+    let ap = p - a;
+
+    let d1 = ab.dot(ap);
+    let d2 = ac.dot(ap);
+    if d1 <= 0.0 && d2 <= 0.0 {
+        return ap.magnitude();
+    }
+
+    let bp = p - b;
+    let d3 = ab.dot(bp);
+    let d4 = ac.dot(bp);
+    if d3 >= 0.0 && d4 <= d3 {
+        return bp.magnitude();
+    }
+
+    let vc = d1 * d4 - d3 * d2;
+    if vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0 {
+        let v = d1 / (d1 - d3);
+        return (ap - ab * v).magnitude();
+    }
+
+    let cp = p - c;
+    let d5 = ab.dot(cp);
+    let d6 = ac.dot(cp);
+    if d6 >= 0.0 && d5 <= d6 {
+        return cp.magnitude();
+    }
+
+    let vb = d5 * d2 - d1 * d6;
+    if vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0 {
+        let w = d2 / (d2 - d6);
+        return (ap - ac * w).magnitude();
+    }
+
+    let va = d3 * d6 - d5 * d4;
+    if va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0 {
+        let w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        return (p - (b + (c - b) * w)).magnitude();
+    }
+
+    let denominator = 1.0 / (va + vb + vc);
+    let v = vb * denominator;
+    let w = vc * denominator;
+    (ap - (ab * v + ac * w)).magnitude()
+}
+
+/// Distance between two segments, clamped to both parameter ranges.
+fn segment_segment_distance(
+    p1: Point3<f32>,
+    q1: Point3<f32>,
+    p2: Point3<f32>,
+    q2: Point3<f32>,
+) -> f32 {
+    let d1 = q1 - p1;
+    let d2 = q2 - p2;
+    let r = p1 - p2;
+    let a = d1.dot(d1);
+    let e = d2.dot(d2);
+    let f = d2.dot(r);
+
+    const EPSILON: f32 = 1e-12;
+    let (s, t) = if a <= EPSILON && e <= EPSILON {
+        (0.0, 0.0)
+    } else if a <= EPSILON {
+        (0.0, (f / e).clamp(0.0, 1.0))
+    } else {
+        let c = d1.dot(r);
+        if e <= EPSILON {
+            ((-c / a).clamp(0.0, 1.0), 0.0)
+        } else {
+            let b = d1.dot(d2);
+            let denominator = a * e - b * b;
+            let s = if denominator > EPSILON {
+                ((b * f - c * e) / denominator).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            let t = (b * s + f) / e;
+            if t < 0.0 {
+                ((-c / a).clamp(0.0, 1.0), 0.0)
+            } else if t > 1.0 {
+                (((b - c) / a).clamp(0.0, 1.0), 1.0)
+            } else {
+                (s, t)
+            }
+        }
+    };
+
+    ((p1 + d1 * s) - (p2 + d2 * t)).magnitude()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Matrix3, Rad, point3, vec3};
+
+    /// Phalanx thickness the synthetic hand tests with.
+    const TEST_RADIUS: f32 = meters(0.008);
+    const PHALANX: f32 = meters(0.032);
+
+    /// A flat five-finger hand: every finger starts at the palm pointing down
+    /// -Z and curls toward +Y, one bend per phalanx. Enough geometry to
+    /// exercise the solver without loading the glove.
+    struct FlatHand;
+
+    impl HandRig for FlatHand {
+        fn phalanges(&mut self, finger: Finger, curl: f32) -> Vec<Capsule> {
+            let x = match finger {
+                Finger::Thumb => meters(0.035),
+                Finger::Index => meters(0.018),
+                Finger::Middle => 0.0,
+                Finger::Ring => meters(-0.018),
+                Finger::Pinky => meters(-0.035),
+            };
+            let mut origin = point3(x, 0.0, 0.0);
+            let mut direction = vec3(0.0, 0.0, -1.0);
+            // 60 degrees a joint: a full curl brings the finger through a
+            // half turn, which is what closes it round a handle.
+            let bend = Rad(curl * std::f32::consts::FRAC_PI_3);
+            (0..3)
+                .map(|_| {
+                    direction = Matrix3::from_angle_x(bend) * direction;
+                    let end = origin + direction * PHALANX;
+                    let capsule = Capsule {
+                        a: origin,
+                        b: end,
+                        radius: TEST_RADIUS,
+                    };
+                    origin = end;
+                    capsule
+                })
+                .collect()
+        }
+    }
+
+    fn quad(
+        a: Point3<f32>,
+        b: Point3<f32>,
+        c: Point3<f32>,
+        d: Point3<f32>,
+    ) -> Vec<[Point3<f32>; 3]> {
+        vec![[a, b, c], [a, c, d]]
+    }
+
+    /// An axis-aligned box, as 12 triangles.
+    fn box_mesh(center: Vector3<f32>, half: Vector3<f32>) -> Vec<[Point3<f32>; 3]> {
+        let corner = |sx: f32, sy: f32, sz: f32| {
+            point3(
+                center.x + sx * half.x,
+                center.y + sy * half.y,
+                center.z + sz * half.z,
+            )
+        };
+        let mut triangles = Vec::new();
+        for sign in [-1.0f32, 1.0] {
+            triangles.extend(quad(
+                corner(sign, -1.0, -1.0),
+                corner(sign, 1.0, -1.0),
+                corner(sign, 1.0, 1.0),
+                corner(sign, -1.0, 1.0),
+            ));
+            triangles.extend(quad(
+                corner(-1.0, sign, -1.0),
+                corner(1.0, sign, -1.0),
+                corner(1.0, sign, 1.0),
+                corner(-1.0, sign, 1.0),
+            ));
+            triangles.extend(quad(
+                corner(-1.0, -1.0, sign),
+                corner(1.0, -1.0, sign),
+                corner(1.0, 1.0, sign),
+                corner(-1.0, 1.0, sign),
+            ));
+        }
+        triangles
+    }
+
+    /// A tube whose axis runs along X - the handle the fingers wrap.
+    fn cylinder_mesh(center: Vector3<f32>, radius: f32, half_length: f32) -> Vec<[Point3<f32>; 3]> {
+        const SEGMENTS: usize = 48;
+        let ring = |step: usize| {
+            let angle = step as f32 / SEGMENTS as f32 * std::f32::consts::TAU;
+            (
+                center.y + radius * angle.cos(),
+                center.z + radius * angle.sin(),
+            )
+        };
+        (0..SEGMENTS)
+            .flat_map(|step| {
+                let (y0, z0) = ring(step);
+                let (y1, z1) = ring(step + 1);
+                quad(
+                    point3(center.x - half_length, y0, z0),
+                    point3(center.x + half_length, y0, z0),
+                    point3(center.x + half_length, y1, z1),
+                    point3(center.x - half_length, y1, z1),
+                )
+            })
+            .collect()
+    }
+
+    /// A UV sphere - something too big to wrap.
+    fn sphere_mesh(center: Vector3<f32>, radius: f32) -> Vec<[Point3<f32>; 3]> {
+        const RINGS: usize = 24;
+        const SEGMENTS: usize = 32;
+        let point = |ring: usize, segment: usize| {
+            let phi = ring as f32 / RINGS as f32 * std::f32::consts::PI;
+            let theta = segment as f32 / SEGMENTS as f32 * std::f32::consts::TAU;
+            point3(
+                center.x + radius * phi.sin() * theta.cos(),
+                center.y + radius * phi.cos(),
+                center.z + radius * phi.sin() * theta.sin(),
+            )
+        };
+        (0..RINGS)
+            .flat_map(|ring| {
+                (0..SEGMENTS).flat_map(move |segment| {
+                    quad(
+                        point(ring, segment),
+                        point(ring + 1, segment),
+                        point(ring + 1, segment + 1),
+                        point(ring, segment + 1),
+                    )
+                })
+            })
+            .collect()
+    }
+
+    /// Whether the hand, curled by `amounts`, is inside the mesh anywhere.
+    fn penetrates(mesh: &ContactMesh, amounts: &FingerAmounts) -> bool {
+        let all = (0..mesh.triangle_count()).collect::<Vec<_>>();
+        Finger::ALL.iter().any(|finger| {
+            let curl = match finger {
+                Finger::Thumb => amounts.thumb,
+                Finger::Index => amounts.index,
+                Finger::Middle => amounts.middle,
+                Finger::Ring => amounts.ring,
+                Finger::Pinky => amounts.pinky,
+            };
+            mesh.touches(&FlatHand.phalanges(*finger, curl), &all)
+        })
+    }
+
+    fn closed_fist() -> FingerAmounts {
+        FingerAmounts {
+            thumb: 1.0,
+            index: 1.0,
+            middle: 1.0,
+            ring: 1.0,
+            pinky: 1.0,
+        }
+    }
+
+    /// The whole point of the fit, as a negative test and its fix in one: the
+    /// ungoverned fist closes straight through a handle, and the fitted curl
+    /// stops on its surface.
+    #[test]
+    fn fingers_stop_on_a_handle_the_fist_would_close_through() {
+        let mesh = ContactMesh::new(cylinder_mesh(
+            vec3(0.0, meters(0.028), meters(-0.008)),
+            meters(0.015),
+            meters(0.06),
+        ));
+
+        assert!(
+            penetrates(&mesh, &closed_fist()),
+            "a full fist should close through a handle - otherwise this test proves nothing"
+        );
+
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Cylindrical);
+        assert!(
+            !penetrates(&mesh, &fitted),
+            "the fitted grip still penetrates: {fitted:?}"
+        );
+        assert!(
+            fitted.middle > 0.05 && fitted.middle < 1.0,
+            "the middle finger should curl partway onto the handle, got {}",
+            fitted.middle
+        );
+    }
+
+    /// Nothing in the hand means nothing to stop against: every finger takes
+    /// its family's cap.
+    #[test]
+    fn an_empty_hand_closes_all_the_way() {
+        let fitted = fit(
+            &mut FlatHand,
+            &ContactMesh::new(Vec::new()),
+            GripFamily::Cylindrical,
+        );
+        assert_eq!(fitted.middle, 1.0);
+        assert_eq!(fitted.thumb, 1.0);
+    }
+
+    /// A ball wider than the palm reads as broad, and the hand rests on its
+    /// surface rather than wrapping it.
+    #[test]
+    fn a_ball_is_broad_and_barely_curls() {
+        let radius = meters(0.12);
+        let mesh = ContactMesh::new(sphere_mesh(
+            vec3(0.0, radius + meters(0.02), meters(-0.03)),
+            radius,
+        ));
+        let extents = mesh.extents().expect("sphere has extents");
+
+        assert_eq!(family_from_extents(extents), GripFamily::Broad);
+
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Broad);
+        assert!(
+            !penetrates(&mesh, &fitted),
+            "hand inside the ball: {fitted:?}"
+        );
+        assert!(
+            fitted.middle <= BROAD_CAP,
+            "a broad grip must stay shallow, got {}",
+            fitted.middle
+        );
+    }
+
+    /// A slab thinner than a finger is pinched: thumb and index close on it,
+    /// the other three hold their rest curl.
+    #[test]
+    fn a_thin_slab_is_pinched() {
+        let mesh = ContactMesh::new(box_mesh(
+            vec3(0.0, meters(0.03), meters(-0.05)),
+            vec3(meters(0.06), meters(0.005), meters(0.04)),
+        ));
+        let extents = mesh.extents().expect("slab has extents");
+
+        assert_eq!(family_from_extents(extents), GripFamily::Pinch);
+
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Pinch);
+        assert_eq!(fitted.middle, PINCH_REST);
+        assert_eq!(fitted.ring, PINCH_REST);
+        assert_eq!(fitted.pinky, PINCH_REST);
+        assert!(
+            fitted.index < 1.0,
+            "the index should stop on the slab, got {}",
+            fitted.index
+        );
+    }
+
+    /// A handle-sized item is neither thin nor fat: the ordinary wrap.
+    #[test]
+    fn a_handle_sized_item_is_cylindrical() {
+        assert_eq!(
+            family_from_extents(vec3(meters(0.04), meters(0.09), meters(0.04))),
+            GripFamily::Cylindrical
+        );
+    }
+
+    /// The trigger family holds the index out on the trigger while the rest of
+    /// the hand closes on the grip - the shape that makes a held gun read as
+    /// held rather than squeezed.
+    #[test]
+    fn a_trigger_grip_leaves_the_index_out() {
+        let mesh = ContactMesh::new(cylinder_mesh(
+            vec3(0.0, meters(0.028), meters(-0.008)),
+            meters(0.008),
+            meters(0.06),
+        ));
+
+        let fitted = fit(&mut FlatHand, &mesh, GripFamily::Trigger);
+        assert!(fitted.index <= TRIGGER_INDEX_CAP);
+        assert!(
+            fitted.index < fitted.middle && fitted.index < fitted.ring,
+            "index {} should trail the wrapping fingers ({}, {})",
+            fitted.index,
+            fitted.middle,
+            fitted.ring
+        );
+    }
+
+    /// A segment threading through a triangle is touching it, not a finger's
+    /// width away from its nearest edge.
+    #[test]
+    fn a_segment_through_a_triangle_reads_as_contact() {
+        let triangle = [
+            point3(-1.0, 0.0, -1.0),
+            point3(1.0, 0.0, -1.0),
+            point3(0.0, 0.0, 1.0),
+        ];
+        assert_eq!(
+            segment_triangle_distance(point3(0.0, -1.0, 0.0), point3(0.0, 1.0, 0.0), &triangle),
+            0.0
+        );
+        assert!(
+            (segment_triangle_distance(point3(0.0, 0.5, 0.0), point3(0.0, 1.5, 0.0), &triangle)
+                - 0.5)
+                .abs()
+                < 1e-5
+        );
+    }
+}

--- a/shock2vr/src/hand_fit.rs
+++ b/shock2vr/src/hand_fit.rs
@@ -4,8 +4,8 @@
 //! `PhysType SPHERE` - so the fit runs against the item's **render mesh**
 //! ([`dark::importers::VrContactMesh`]), transformed into the hand's own
 //! space. For each finger the solver sweeps the open->fist blend the glove
-//! already poses with, brackets the first curl at which a phalanx capsule
-//! reaches the surface, and bisects for the contact point. The result is a
+//! already poses with, takes the *largest* curl at which no phalanx capsule
+//! is inside the mesh, and bisects for the contact point. The result is a
 //! [`FingerAmounts`] the renderer feeds straight to
 //! [`crate::hand_pose::Pose::blend_per_finger`].
 //!
@@ -164,8 +164,10 @@ const fn meters(m: f32) -> f32 {
 }
 
 /// Thinner than this in its smallest dimension and an item is pinched rather
-/// than gripped - a magazine, a keycard.
-const PINCH_THICKNESS: f32 = meters(0.018);
+/// than gripped. Measured off the art: a printed magazine (`magci`) is 21 mm
+/// through, the thinnest thing any of the test items presents to the hand,
+/// while the next thinnest - a pistol grip - is 34 mm.
+const PINCH_THICKNESS: f32 = meters(0.025);
 
 /// Wider than this across its two smaller dimensions and the hand cannot close
 /// round it at all - a basketball, a helmet.
@@ -302,21 +304,24 @@ fn fit_finger(
 
     let curl_at = |step: usize| floor + (cap - floor) * (step as f32 / COARSE_STEPS as f32);
 
-    let mut clear = floor;
-    let mut first_contact = None;
-    for step in 1..=COARSE_STEPS {
-        let curl = curl_at(step);
-        if mesh.touches(&rig.phalanges(finger, curl), &candidates) {
-            first_contact = Some(curl);
-            break;
-        }
-        clear = curl;
-    }
-
-    let Some(mut blocked) = first_contact else {
+    // Scanned from the closed end down, not from the open end up. A held item
+    // is seated where the *closed* hand would be - a gun's grip lies right
+    // through the open hand's extended fingers - so "the first contact on the
+    // way in" is not the grip, it is the seat. The largest clear curl is.
+    let Some(step) = (0..=COARSE_STEPS)
+        .rev()
+        .find(|step| !mesh.touches(&rig.phalanges(finger, curl_at(*step)), &candidates))
+    else {
+        // Nowhere clear: the item passes through the finger at every curl, so
+        // the only honest answer is the closed grip the wield authored.
         return cap;
     };
+    if step == COARSE_STEPS {
+        return cap;
+    }
 
+    let mut clear = curl_at(step);
+    let mut blocked = curl_at(step + 1);
     for _ in 0..BISECT_ROUNDS {
         let middle = 0.5 * (clear + blocked);
         if mesh.touches(&rig.phalanges(finger, middle), &candidates) {

--- a/shock2vr/src/hand_fit.rs
+++ b/shock2vr/src/hand_fit.rs
@@ -37,7 +37,7 @@ impl Finger {
     ];
 
     /// Where this finger's curl lands in a [`FingerAmounts`].
-    fn set(self, amounts: &mut FingerAmounts, curl: f32) {
+    pub fn set(self, amounts: &mut FingerAmounts, curl: f32) {
         match self {
             Finger::Thumb => amounts.thumb = curl,
             Finger::Index => amounts.index = curl,
@@ -45,6 +45,25 @@ impl Finger {
             Finger::Ring => amounts.ring = curl,
             Finger::Pinky => amounts.pinky = curl,
         }
+    }
+
+    /// This finger's curl out of a [`FingerAmounts`].
+    pub fn curl_of(self, amounts: &FingerAmounts) -> f32 {
+        match self {
+            Finger::Thumb => amounts.thumb,
+            Finger::Index => amounts.index,
+            Finger::Middle => amounts.middle,
+            Finger::Ring => amounts.ring,
+            Finger::Pinky => amounts.pinky,
+        }
+    }
+
+    /// A blend that curls only this finger - what the solver poses the rig
+    /// with while it searches one finger at a time.
+    pub fn alone(self, curl: f32) -> FingerAmounts {
+        let mut amounts = FingerAmounts::default();
+        self.set(&mut amounts, curl);
+        amounts
     }
 }
 
@@ -617,16 +636,9 @@ mod tests {
     /// Whether the hand, curled by `amounts`, is inside the mesh anywhere.
     fn penetrates(mesh: &ContactMesh, amounts: &FingerAmounts) -> bool {
         let all = (0..mesh.triangle_count()).collect::<Vec<_>>();
-        Finger::ALL.iter().any(|finger| {
-            let curl = match finger {
-                Finger::Thumb => amounts.thumb,
-                Finger::Index => amounts.index,
-                Finger::Middle => amounts.middle,
-                Finger::Ring => amounts.ring,
-                Finger::Pinky => amounts.pinky,
-            };
-            mesh.touches(&FlatHand.phalanges(*finger, curl), &all)
-        })
+        Finger::ALL
+            .iter()
+            .any(|finger| mesh.touches(&FlatHand.phalanges(*finger, finger.curl_of(amounts)), &all))
     }
 
     fn closed_fist() -> FingerAmounts {

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -9,12 +9,13 @@
 //! forearm mesh.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
-use cgmath::{Matrix4, Quaternion, Vector3};
+use cgmath::{EuclideanSpace, Matrix4, Point3, Quaternion, Transform, Vector3};
 use dark::{
     glb_model::GlbModel,
-    importers::{GLB_MODELS_IMPORTER, TEXTURE_IMPORTER},
+    importers::{GLB_MODELS_IMPORTER, TEXTURE_IMPORTER, VR_CONTACT_MESH_IMPORTER, VrContactMesh},
 };
 use engine::{
     assets::asset_cache::AssetCache,
@@ -22,8 +23,9 @@ use engine::{
 };
 
 use crate::{
+    hand_fit::{self, Capsule, ContactMesh, Finger, GripFamily, HandRig},
     hand_pose::{self, FingerAmounts, HandPoseRetarget, Pose},
-    vr_config::Handedness,
+    vr_config::{self, FingerOverrides, Handedness},
 };
 
 const GLOVE_MODEL: &str = "vr_glove_model.glb";
@@ -165,6 +167,9 @@ pub struct GloveRenderer {
     /// materials re-tinted per hand would give them both whichever colour was
     /// written last.
     materials: Vec<Vec<Rc<RefCell<Box<dyn Material>>>>>,
+    /// Solved grips, one per [`GripKey`]. The fit is a one-off per held model,
+    /// never a per-frame cost.
+    fits: HashMap<GripKey, FingerAmounts>,
 }
 
 /// An authored pose a hand can be shown in when nothing analog is driving it -
@@ -216,6 +221,7 @@ impl GloveRenderer {
             fist: hand_pose::fist_right_hand(),
             point: hand_pose::point_right_hand(),
             materials,
+            fits: HashMap::new(),
         })
     }
 
@@ -232,12 +238,12 @@ impl GloveRenderer {
         hand_to_world: Matrix4<f32>,
         trigger_value: f32,
         squeeze_value: f32,
-        holding: bool,
+        holding: Option<Option<FingerAmounts>>,
         light: HandLight,
         preshape: HandPreshape,
     ) -> Vec<SceneObject> {
-        let amounts = if holding {
-            grip_amounts(trigger_value)
+        let amounts = if let Some(fit) = holding {
+            grip_amounts(fit, trigger_value)
         } else {
             // Empty hand: index follows the trigger; the other fingers follow
             // the squeeze. A full squeeze also curls the index so a squeezed
@@ -252,7 +258,7 @@ impl GloveRenderer {
         };
         let pose = self.open.blend_per_finger(&self.fist, &amounts);
         // A full hand has nothing to reach for, so it is never prompted.
-        let pose = if holding {
+        let pose = if holding.is_some() {
             pose
         } else {
             prompted_pose(pose, &self.fist, &self.point, preshape)
@@ -264,6 +270,29 @@ impl GloveRenderer {
             &pose,
             hand_to_world,
         )
+    }
+
+    /// The fitted grip for a held item, solved once and remembered.
+    ///
+    /// Solved on the frame the item first appears in the hand rather than at
+    /// the grab itself: the answer depends only on the model, the hand and the
+    /// wield's scale, all of which the key carries, so one entry serves every
+    /// later pickup of the same thing.
+    pub fn fitted_grip(&mut self, key: GripKey, mesh: &ContactMesh) -> FingerAmounts {
+        if let Some(cached) = self.fits.get(&key) {
+            return *cached;
+        }
+        let family = key.family();
+        let mut rig = GloveRig {
+            model: &mut self.model,
+            retarget: &self.retarget,
+            open: &self.open,
+            fist: &self.fist,
+            to_hand: glove_model_to_hand(),
+        };
+        let fitted = hand_fit::fit(&mut rig, mesh, family);
+        self.fits.insert(key, fitted);
+        fitted
     }
 
     /// Build the glove in one of the authored [`StaticHandPose`]s.
@@ -316,8 +345,7 @@ impl GloveRenderer {
         // fingers up with where the hand points. Verified against the
         // raycast hit markers in-game; on-headset fine tuning would adjust
         // this rotation.
-        let grip = Matrix4::from_angle_y(cgmath::Deg(180.0));
-        let world = hand_to_world * grip * Matrix4::from_scale(GLOVE_SCALE);
+        let world = hand_to_world * glove_model_to_hand();
 
         let mut objects = model.to_scene_objects_with_skinning();
         for (object, material) in objects.iter_mut().zip(skin) {
@@ -327,6 +355,144 @@ impl GloveRenderer {
 
         objects
     }
+}
+
+/// Thickness of a finger's phalanx capsule, in world units - the flesh the
+/// fit stops on rather than the bone the rig gives it.
+const FINGER_RADIUS: f32 = 0.0075 / crate::METERS_PER_WORLD_UNIT;
+
+/// The thumb is thicker than the fingers, and lands flatter on an item.
+const THUMB_RADIUS: f32 = 0.0095 / crate::METERS_PER_WORLD_UNIT;
+
+/// SteamVR bones along one finger, knuckle to tip. The metacarpal (the first
+/// bone of each chain) is buried in the palm and cannot touch anything, so
+/// every chain starts one bone in.
+fn phalanx_bones(finger: Finger) -> &'static [usize] {
+    match finger {
+        Finger::Thumb => &[3, 4, 5],
+        Finger::Index => &[7, 8, 9, 10],
+        Finger::Middle => &[12, 13, 14, 15],
+        Finger::Ring => &[17, 18, 19, 20],
+        Finger::Pinky => &[22, 23, 24, 25],
+    }
+}
+
+/// Glove model space -> hand space: the same seat [`GloveRenderer::render_posed`]
+/// draws the glove at, so the fit measures the hand the player actually sees.
+fn glove_model_to_hand() -> Matrix4<f32> {
+    Matrix4::from_angle_y(cgmath::Deg(180.0)) * Matrix4::from_scale(GLOVE_SCALE)
+}
+
+/// The glove as the finger fit poses it: one finger curled from `open` toward
+/// `fist`, its phalanges read straight back out of the rig.
+struct GloveRig<'a> {
+    model: &'a mut GlbModel,
+    retarget: &'a HandPoseRetarget,
+    open: &'a Pose,
+    fist: &'a Pose,
+    to_hand: Matrix4<f32>,
+}
+
+impl HandRig for GloveRig<'_> {
+    fn phalanges(&mut self, finger: Finger, curl: f32) -> Vec<Capsule> {
+        let pose = self.open.blend_per_finger(self.fist, &finger.alone(curl));
+        self.retarget.apply(&pose, self.model);
+
+        let radius = if finger == Finger::Thumb {
+            THUMB_RADIUS
+        } else {
+            FINGER_RADIUS
+        };
+        let joints = phalanx_bones(finger)
+            .iter()
+            .filter_map(|joint| {
+                let node = self.model.skeleton().node_index_for_joint(*joint)?;
+                let global = self.model.get_global_transform(node)?;
+                Some(
+                    self.to_hand
+                        .transform_point(Point3::from_vec(global.w.truncate())),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        joints
+            .windows(2)
+            .map(|bone| Capsule {
+                a: bone[0],
+                b: bone[1],
+                radius,
+            })
+            .collect()
+    }
+}
+
+/// What a fitted grip is cached under. The solve depends on the item's
+/// geometry in hand space and nothing else, and those four values are what
+/// decide it: the model, which hand's reflection it is seen through, the
+/// family whose envelope it was solved in, and the scale the wield baked into
+/// the geometry.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GripKey {
+    model: String,
+    handedness: Handedness,
+    family: GripFamily,
+    /// `f32` has no `Hash`; the bit pattern is the exact-equality the cache
+    /// wants anyway - a different scale is a different solve.
+    scale_bits: u32,
+}
+
+impl GripKey {
+    pub fn new(model: &str, handedness: Handedness, family: GripFamily, scale: f32) -> Self {
+        Self {
+            model: model.to_ascii_lowercase(),
+            handedness,
+            family,
+            scale_bits: scale.to_bits(),
+        }
+    }
+
+    pub fn family(&self) -> GripFamily {
+        self.family
+    }
+}
+
+/// Everything the fit needs about one model held in one hand: the key to
+/// remember the solve under, its render mesh in hand space, and the per-finger
+/// corrections to write over the answer.
+///
+/// `None` when the model has no mesh to close against - a missing asset, or a
+/// skinned rig (the melee `_h` set, which draws its own arm anyway).
+pub fn grip_request(
+    model_name: &str,
+    handedness: Handedness,
+    gun_scale: f32,
+    asset_cache: &mut AssetCache,
+) -> Option<(GripKey, ContactMesh, FingerOverrides)> {
+    let triangles = asset_cache
+        .get_opt::<_, VrContactMesh, _>(&VR_CONTACT_MESH_IMPORTER, &format!("{model_name}.BIN"))?;
+
+    let to_hand = vr_config::held_model_hand_transform(model_name, handedness, gun_scale);
+    let mesh = ContactMesh::new(
+        triangles
+            .0
+            .iter()
+            .map(|triangle| triangle.map(|corner| to_hand.transform_point(corner)))
+            .collect(),
+    );
+    if mesh.is_empty() {
+        return None;
+    }
+
+    let hint = vr_config::grip_hint(model_name);
+    let family = hint
+        .family
+        .or_else(|| mesh.extents().map(hand_fit::family_from_extents))?;
+
+    Some((
+        GripKey::new(model_name, handedness, family, gun_scale),
+        mesh,
+        hint.fingers,
+    ))
 }
 
 /// Where a tracked hand's own space sits in the world.
@@ -343,19 +509,30 @@ pub fn hand_to_world(
     Matrix4::from_translation(position) * Matrix4::from(rotation) * handedness.mirror()
 }
 
-/// The curl of a hand closed around something it is holding: fingers wrapped on
-/// the handle, thumb locked, index resting on the trigger and curling with the
-/// pull (the squeeze is what holds the item, so it doesn't drive the pose here).
-/// Constants tuned visually against the held pistol.
-fn grip_amounts(trigger_value: f32) -> FingerAmounts {
+/// The curl of a hand closed around something it is holding: the grip fitted
+/// to that item's own mesh when there is one, else the generic wrap below.
+///
+/// The trigger always adds curl on top of the index, from wherever the fit
+/// left it: a real pull outranks a fitted rest position, the same way it
+/// outranks a pre-shape. The squeeze is what holds the item, so it does not
+/// drive the pose here.
+fn grip_amounts(fit: Option<FingerAmounts>, trigger_value: f32) -> FingerAmounts {
+    let base = fit.unwrap_or(GENERIC_GRIP);
     FingerAmounts {
-        thumb: 0.85,
-        index: 0.5 + 0.5 * trigger_value,
-        middle: 0.9,
-        ring: 0.9,
-        pinky: 0.9,
+        index: base.index + (1.0 - base.index) * trigger_value,
+        ..base
     }
 }
+
+/// The wrap a hand falls back on when the item has no mesh to fit against.
+/// Constants tuned visually against the held pistol.
+const GENERIC_GRIP: FingerAmounts = FingerAmounts {
+    thumb: 0.85,
+    index: 0.5,
+    middle: 0.9,
+    ring: 0.9,
+    pinky: 0.9,
+};
 
 /// One glove material, in a cell of its own. Shared with the `debug_gloves`
 /// harness so the two can't assemble the glove differently.
@@ -514,6 +691,54 @@ mod tests {
                 "the grip prompt moved bone {bone} of an already closed hand"
             );
         }
+    }
+
+    /// Everything the solve depends on is in the key, and nothing else is: the
+    /// same model in the other hand, at another scale, or under another family
+    /// is a different fit and must not be served the cached one - while the
+    /// same model spelled differently is the same fit.
+    #[test]
+    fn a_grip_is_cached_by_what_the_solve_depends_on() {
+        let base = GripKey::new("atek_h", Handedness::Right, GripFamily::Trigger, 0.4);
+
+        assert_eq!(
+            base,
+            GripKey::new("ATEK_H", Handedness::Right, GripFamily::Trigger, 0.4)
+        );
+        for other in [
+            GripKey::new("sg_h", Handedness::Right, GripFamily::Trigger, 0.4),
+            GripKey::new("atek_h", Handedness::Left, GripFamily::Trigger, 0.4),
+            GripKey::new("atek_h", Handedness::Right, GripFamily::Cylindrical, 0.4),
+            GripKey::new("atek_h", Handedness::Right, GripFamily::Trigger, 1.0),
+        ] {
+            assert_ne!(base, other, "{other:?} must not reuse {base:?}");
+        }
+    }
+
+    /// A trigger pull only ever adds curl to the index, from wherever the fit
+    /// left it - and touches nothing else.
+    #[test]
+    fn a_trigger_pull_closes_the_fitted_index_the_rest_of_the_way() {
+        let fitted = FingerAmounts {
+            thumb: 0.7,
+            index: 0.3,
+            middle: 0.6,
+            ring: 0.6,
+            pinky: 0.6,
+        };
+
+        let resting = grip_amounts(Some(fitted), 0.0);
+        assert_eq!(resting.index, fitted.index);
+        assert_eq!(resting.middle, fitted.middle);
+
+        let pulled = grip_amounts(Some(fitted), 1.0);
+        assert_eq!(pulled.index, 1.0);
+        assert_eq!(pulled.middle, fitted.middle);
+        assert_eq!(pulled.thumb, fitted.thumb);
+
+        // No fit: the generic wrap, still with the trigger on top.
+        assert_eq!(grip_amounts(None, 0.0).index, GENERIC_GRIP.index);
+        assert_eq!(grip_amounts(None, 1.0).index, 1.0);
     }
 
     /// The uncorrected glove is undersized, not oversized - a scale below 1.0

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -23,9 +23,9 @@ use engine::{
 };
 
 use crate::{
-    hand_fit::{self, Capsule, ContactMesh, Finger, GripFamily, HandRig},
-    hand_pose::{self, FingerAmounts, HandPoseRetarget, Pose},
-    vr_config::{self, FingerOverrides, Handedness},
+    hand_fit::{self, Capsule, ContactMesh, GripFamily, HandRig},
+    hand_pose::{self, Finger, FingerAmounts, HandPoseRetarget, Pose},
+    vr_config::{self, Handedness},
 };
 
 const GLOVE_MODEL: &str = "vr_glove_model.glb";
@@ -85,6 +85,15 @@ impl HandLight {
     fn index(self) -> usize {
         self as usize
     }
+}
+
+/// What a hand is holding, as far as its pose is concerned: nothing, or an
+/// item - with the grip fitted to that item's own mesh when there was one to
+/// fit against.
+#[derive(Debug, Clone, Copy)]
+pub enum Hold {
+    Empty,
+    Item(Option<FingerAmounts>),
 }
 
 /// A prompt the hand leans into before the player acts: the shape says what
@@ -167,9 +176,10 @@ pub struct GloveRenderer {
     /// materials re-tinted per hand would give them both whichever colour was
     /// written last.
     materials: Vec<Vec<Rc<RefCell<Box<dyn Material>>>>>,
-    /// Solved grips, one per [`GripKey`]. The fit is a one-off per held model,
-    /// never a per-frame cost.
-    fits: HashMap<GripKey, FingerAmounts>,
+    /// Solved grips, one per [`GripKey`] - `None` for a model with no mesh to
+    /// fit against. The fit is a one-off per held model, never a per-frame
+    /// cost.
+    fits: HashMap<GripKey, Option<FittedGrip>>,
 }
 
 /// An authored pose a hand can be shown in when nothing analog is driving it -
@@ -238,11 +248,11 @@ impl GloveRenderer {
         hand_to_world: Matrix4<f32>,
         trigger_value: f32,
         squeeze_value: f32,
-        holding: Option<Option<FingerAmounts>>,
+        hold: Hold,
         light: HandLight,
         preshape: HandPreshape,
     ) -> Vec<SceneObject> {
-        let amounts = if let Some(fit) = holding {
+        let amounts = if let Hold::Item(fit) = hold {
             grip_amounts(fit, trigger_value)
         } else {
             // Empty hand: index follows the trigger; the other fingers follow
@@ -258,7 +268,7 @@ impl GloveRenderer {
         };
         let pose = self.open.blend_per_finger(&self.fist, &amounts);
         // A full hand has nothing to reach for, so it is never prompted.
-        let pose = if holding.is_some() {
+        let pose = if matches!(hold, Hold::Item(_)) {
             pose
         } else {
             prompted_pose(pose, &self.fist, &self.point, preshape)
@@ -272,17 +282,45 @@ impl GloveRenderer {
         )
     }
 
-    /// The fitted grip for a held item, solved once and remembered.
+    /// The fitted grip for a model held in `handedness`, solved once and
+    /// remembered - the *miss* included, so a held model with no mesh does not
+    /// re-enter the asset cache's miss path on every frame it is held.
     ///
-    /// Solved on the frame the item first appears in the hand rather than at
-    /// the grab itself: the answer depends only on the model, the hand and the
-    /// wield's scale, all of which the key carries, so one entry serves every
-    /// later pickup of the same thing.
-    pub fn fitted_grip(&mut self, key: GripKey, mesh: &ContactMesh) -> FingerAmounts {
+    /// Solved on the frame the item first appears in a hand rather than at the
+    /// grab itself: the answer depends only on the key, so one entry serves
+    /// every later pickup of the same thing in the same hand.
+    pub fn fitted_grip(
+        &mut self,
+        model_name: &str,
+        handedness: Handedness,
+        gun_scale: f32,
+        asset_cache: &mut AssetCache,
+    ) -> Option<FittedGrip> {
+        let key = GripKey::new(model_name, handedness, gun_scale);
         if let Some(cached) = self.fits.get(&key) {
             return *cached;
         }
-        let family = key.family();
+        let fitted = self.solve(model_name, handedness, gun_scale, asset_cache);
+        self.fits.insert(key, fitted);
+        fitted
+    }
+
+    /// One grip fit, start to finish. Only ever reached on a cache miss.
+    fn solve(
+        &mut self,
+        model_name: &str,
+        handedness: Handedness,
+        gun_scale: f32,
+        asset_cache: &mut AssetCache,
+    ) -> Option<FittedGrip> {
+        if !vr_config::has_hand_seat(model_name) {
+            return None;
+        }
+        let mesh = contact_mesh(model_name, handedness, gun_scale, asset_cache)?;
+        let family = vr_config::grip_family(model_name)
+            .or_else(|| mesh.extents().map(hand_fit::family_from_extents))?;
+
+        let started = std::time::Instant::now();
         let mut rig = GloveRig {
             model: &mut self.model,
             retarget: &self.retarget,
@@ -290,9 +328,15 @@ impl GloveRenderer {
             fist: &self.fist,
             to_hand: glove_model_to_hand(),
         };
-        let fitted = hand_fit::fit(&mut rig, mesh, family);
-        self.fits.insert(key, fitted);
-        fitted
+        let amounts = hand_fit::fit(&mut rig, &mesh, family, GENERIC_GRIP);
+        let solve = started.elapsed();
+
+        tracing::debug!(
+            "grip fit: {model_name} {handedness:?} x{gun_scale} family {} {} tris solved in {solve:?} -> {amounts:?}",
+            family.as_str(),
+            mesh.triangle_count()
+        );
+        Some(FittedGrip { family, amounts })
     }
 
     /// Build the glove in one of the authored [`StaticHandPose`]s.
@@ -364,17 +408,11 @@ const FINGER_RADIUS: f32 = 0.0075 / crate::METERS_PER_WORLD_UNIT;
 /// The thumb is thicker than the fingers, and lands flatter on an item.
 const THUMB_RADIUS: f32 = 0.0095 / crate::METERS_PER_WORLD_UNIT;
 
-/// SteamVR bones along one finger, knuckle to tip. The metacarpal (the first
-/// bone of each chain) is buried in the palm and cannot touch anything, so
-/// every chain starts one bone in.
-fn phalanx_bones(finger: Finger) -> &'static [usize] {
-    match finger {
-        Finger::Thumb => &[3, 4, 5],
-        Finger::Index => &[7, 8, 9, 10],
-        Finger::Middle => &[12, 13, 14, 15],
-        Finger::Ring => &[17, 18, 19, 20],
-        Finger::Pinky => &[22, 23, 24, 25],
-    }
+/// The joints a finger's phalanx capsules run between, knuckle to tip. The
+/// metacarpal - the first bone of the chain - is buried in the palm and cannot
+/// touch anything, so every chain starts one bone in.
+fn phalanx_bones(finger: Finger) -> impl Iterator<Item = usize> {
+    finger.bones().skip(1)
 }
 
 /// Glove model space -> hand space: the same seat [`GloveRenderer::render_posed`]
@@ -404,9 +442,8 @@ impl HandRig for GloveRig<'_> {
             FINGER_RADIUS
         };
         let joints = phalanx_bones(finger)
-            .iter()
             .filter_map(|joint| {
-                let node = self.model.skeleton().node_index_for_joint(*joint)?;
+                let node = self.model.skeleton().node_index_for_joint(joint)?;
                 let global = self.model.get_global_transform(node)?;
                 Some(
                     self.to_hand
@@ -426,48 +463,47 @@ impl HandRig for GloveRig<'_> {
     }
 }
 
-/// What a fitted grip is cached under. The solve depends on the item's
-/// geometry in hand space and nothing else, and those four values are what
-/// decide it: the model, which hand's reflection it is seen through, the
-/// family whose envelope it was solved in, and the scale the wield baked into
-/// the geometry.
+/// What a fitted grip is cached under: the model, which hand's reflection it
+/// is seen through, and the scale the wield baked into its geometry. Those
+/// three decide everything else - the family included - so the key can be
+/// built without touching the mesh, which is what keeps a held item's every
+/// later frame off the solver.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct GripKey {
     model: String,
     handedness: Handedness,
-    family: GripFamily,
     /// `f32` has no `Hash`; the bit pattern is the exact-equality the cache
     /// wants anyway - a different scale is a different solve.
     scale_bits: u32,
 }
 
 impl GripKey {
-    pub fn new(model: &str, handedness: Handedness, family: GripFamily, scale: f32) -> Self {
+    pub fn new(model: &str, handedness: Handedness, scale: f32) -> Self {
         Self {
             model: model.to_ascii_lowercase(),
             handedness,
-            family,
             scale_bits: scale.to_bits(),
         }
     }
-
-    pub fn family(&self) -> GripFamily {
-        self.family
-    }
 }
 
-/// Everything the fit needs about one model held in one hand: the key to
-/// remember the solve under, its render mesh in hand space, and the per-finger
-/// corrections to write over the answer.
-///
-/// `None` when the model has no mesh to close against - a missing asset, or a
-/// skinned rig (the melee `_h` set, which draws its own arm anyway).
-pub fn grip_request(
+/// A hand's grip on one item: the family it was solved in, and how far each
+/// finger curled from `open` toward `fist` before it reached the surface.
+#[derive(Clone, Copy, Debug)]
+pub struct FittedGrip {
+    pub family: GripFamily,
+    pub amounts: FingerAmounts,
+}
+
+/// The item's render mesh in the glove's own hand space, or `None` when there
+/// is nothing to close against - a missing asset, or a skinned rig (the melee
+/// `_h` set, which draws its own arm anyway).
+fn contact_mesh(
     model_name: &str,
     handedness: Handedness,
     gun_scale: f32,
     asset_cache: &mut AssetCache,
-) -> Option<(GripKey, ContactMesh, FingerOverrides)> {
+) -> Option<ContactMesh> {
     let triangles = asset_cache
         .get_opt::<_, VrContactMesh, _>(&VR_CONTACT_MESH_IMPORTER, &format!("{model_name}.BIN"))?;
 
@@ -479,20 +515,7 @@ pub fn grip_request(
             .map(|triangle| triangle.map(|corner| to_hand.transform_point(corner)))
             .collect(),
     );
-    if mesh.is_empty() {
-        return None;
-    }
-
-    let hint = vr_config::grip_hint(model_name);
-    let family = hint
-        .family
-        .or_else(|| mesh.extents().map(hand_fit::family_from_extents))?;
-
-    Some((
-        GripKey::new(model_name, handedness, family, gun_scale),
-        mesh,
-        hint.fingers,
-    ))
+    (!mesh.is_empty()).then_some(mesh)
 }
 
 /// Where a tracked hand's own space sits in the world.
@@ -694,22 +717,18 @@ mod tests {
     }
 
     /// Everything the solve depends on is in the key, and nothing else is: the
-    /// same model in the other hand, at another scale, or under another family
-    /// is a different fit and must not be served the cached one - while the
-    /// same model spelled differently is the same fit.
+    /// same model in the other hand or at another scale is a different fit and
+    /// must not be served the cached one - while the same model spelled
+    /// differently is the same fit.
     #[test]
     fn a_grip_is_cached_by_what_the_solve_depends_on() {
-        let base = GripKey::new("atek_h", Handedness::Right, GripFamily::Trigger, 0.4);
+        let base = GripKey::new("atek_h", Handedness::Right, 0.4);
 
-        assert_eq!(
-            base,
-            GripKey::new("ATEK_H", Handedness::Right, GripFamily::Trigger, 0.4)
-        );
+        assert_eq!(base, GripKey::new("ATEK_H", Handedness::Right, 0.4));
         for other in [
-            GripKey::new("sg_h", Handedness::Right, GripFamily::Trigger, 0.4),
-            GripKey::new("atek_h", Handedness::Left, GripFamily::Trigger, 0.4),
-            GripKey::new("atek_h", Handedness::Right, GripFamily::Cylindrical, 0.4),
-            GripKey::new("atek_h", Handedness::Right, GripFamily::Trigger, 1.0),
+            GripKey::new("sg_h", Handedness::Right, 0.4),
+            GripKey::new("atek_h", Handedness::Left, 0.4),
+            GripKey::new("atek_h", Handedness::Right, 1.0),
         ] {
             assert_ne!(base, other, "{other:?} must not reuse {base:?}");
         }

--- a/shock2vr/src/hand_pose.rs
+++ b/shock2vr/src/hand_pose.rs
@@ -31,6 +31,76 @@ pub struct Pose {
     pub bone_positions: Vec<Vector3<f32>>,
 }
 
+/// One finger of the hand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Finger {
+    Thumb,
+    Index,
+    Middle,
+    Ring,
+    Pinky,
+}
+
+impl Finger {
+    pub const ALL: [Finger; 5] = [
+        Finger::Thumb,
+        Finger::Index,
+        Finger::Middle,
+        Finger::Ring,
+        Finger::Pinky,
+    ];
+
+    /// This finger's chain of SteamVR bones, metacarpal first. The one table:
+    /// everything that has to know which bones a finger owns - the blend, the
+    /// contact fit's phalanx capsules - derives it from here.
+    pub fn bones(self) -> std::ops::RangeInclusive<usize> {
+        match self {
+            Finger::Thumb => 2..=5,
+            Finger::Index => 6..=10,
+            Finger::Middle => 11..=15,
+            Finger::Ring => 16..=20,
+            Finger::Pinky => 21..=25,
+        }
+    }
+
+    /// The finger a SteamVR bone belongs to, if any.
+    fn of_bone(bone: usize) -> Option<Finger> {
+        Finger::ALL
+            .into_iter()
+            .find(|finger| finger.bones().contains(&bone))
+    }
+
+    /// Where this finger's curl lands in a [`FingerAmounts`].
+    pub fn set(self, amounts: &mut FingerAmounts, curl: f32) {
+        match self {
+            Finger::Thumb => amounts.thumb = curl,
+            Finger::Index => amounts.index = curl,
+            Finger::Middle => amounts.middle = curl,
+            Finger::Ring => amounts.ring = curl,
+            Finger::Pinky => amounts.pinky = curl,
+        }
+    }
+
+    /// This finger's curl out of a [`FingerAmounts`].
+    pub fn curl_of(self, amounts: &FingerAmounts) -> f32 {
+        match self {
+            Finger::Thumb => amounts.thumb,
+            Finger::Index => amounts.index,
+            Finger::Middle => amounts.middle,
+            Finger::Ring => amounts.ring,
+            Finger::Pinky => amounts.pinky,
+        }
+    }
+
+    /// A blend that curls only this finger - what the contact fit poses the
+    /// rig with while it searches one finger at a time.
+    pub fn alone(self, curl: f32) -> FingerAmounts {
+        let mut amounts = FingerAmounts::default();
+        self.set(&mut amounts, curl);
+        amounts
+    }
+}
+
 /// Per-finger blend amounts (0.0 = first pose, 1.0 = second pose) for
 /// [`Pose::blend_per_finger`]. `Default` leaves every finger at 0.0.
 #[derive(Debug, Clone, Copy, Default)]
@@ -45,14 +115,7 @@ pub struct FingerAmounts {
 impl FingerAmounts {
     /// The blend amount for a SteamVR bone index (0.0 for non-finger bones).
     fn for_bone(&self, bone: usize) -> f32 {
-        match bone {
-            2..=5 => self.thumb,
-            6..=10 => self.index,
-            11..=15 => self.middle,
-            16..=20 => self.ring,
-            21..=25 => self.pinky,
-            _ => 0.0,
-        }
+        Finger::of_bone(bone).map_or(0.0, |finger| finger.curl_of(self))
     }
 }
 

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -148,6 +148,13 @@ pub trait PlayerInteraction {
 
     /// What this hand could do with whatever it is pointing at. Flatscreen has
     /// no per-hand affordance to report.
+    /// The grip this hand's last render fitted to whatever it holds. `None`
+    /// for a hand holding nothing, holding something with no mesh to fit
+    /// against, or on a presentation with no glove at all.
+    fn fitted_grip(&self, _hand: Handedness) -> Option<crate::game_scene::DebugHandGrip> {
+        None
+    }
+
     fn hand_affordance(&self, _hand: Handedness) -> crate::hand_affordance::HandAffordance {
         crate::hand_affordance::HandAffordance::None
     }
@@ -178,6 +185,10 @@ pub struct VrInteraction {
     glove_renderer: RefCell<Option<Option<GloveRenderer>>>,
     /// Which hands hold a climbing hold, and which one moves the body.
     hand_climb: crate::vr_climb::HandClimb,
+    /// The grip each hand's last render fitted, indexed by
+    /// `vr_config::hand_slot`. Written where the fit is solved (render, which
+    /// owns the glove and the asset cache) and read by the debug readout.
+    fitted_grips: RefCell<[Option<crate::game_scene::DebugHandGrip>; 2]>,
 }
 
 impl VrInteraction {
@@ -187,6 +198,7 @@ impl VrInteraction {
             right_hand: VirtualHand::new(Handedness::Right),
             glove_renderer: RefCell::new(None),
             hand_climb: crate::vr_climb::HandClimb::default(),
+            fitted_grips: RefCell::new([None, None]),
         }
     }
 }
@@ -307,6 +319,10 @@ impl PlayerInteraction for VrInteraction {
         }
     }
 
+    fn fitted_grip(&self, hand: Handedness) -> Option<crate::game_scene::DebugHandGrip> {
+        self.fitted_grips.borrow()[crate::vr_config::hand_slot(hand)]
+    }
+
     fn render(
         &self,
         asset_cache: &mut AssetCache,
@@ -321,12 +337,15 @@ impl PlayerInteraction for VrInteraction {
         let mut objs = Vec::new();
         match glove_renderer {
             Some(renderer) => {
-                objs.append(&mut self.left_hand.render(world, Some(renderer)));
-                objs.append(&mut self.right_hand.render(world, Some(renderer)));
+                let mut grips = self.fitted_grips.borrow_mut();
+                for hand in [&self.left_hand, &self.right_hand] {
+                    let (mut hand_objects, grip) = hand.render(world, asset_cache, renderer);
+                    grips[crate::vr_config::hand_slot(hand.handedness())] = grip;
+                    objs.append(&mut hand_objects);
+                }
             }
             None => {
-                objs.append(&mut self.left_hand.render(world, None));
-                objs.append(&mut self.right_hand.render(world, None));
+                *self.fitted_grips.borrow_mut() = [None, None];
             }
         }
         // Feedback comes from the resolved holds, never a second proximity

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audio_log;
 pub mod game_scene;
 pub mod hand_affordance;
 pub mod hand_buttons;
+pub mod hand_fit;
 pub mod hand_pose;
 pub mod hand_pose_library;
 pub mod hit_feedback;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -11726,6 +11726,8 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         Some(crate::game_scene::DebugHandAffordances {
             left: self.interaction.hand_affordance(Handedness::Left).as_str(),
             right: self.interaction.hand_affordance(Handedness::Right).as_str(),
+            left_grip: self.interaction.fitted_grip(Handedness::Left),
+            right_grip: self.interaction.fitted_grip(Handedness::Right),
         })
     }
 

--- a/shock2vr/src/scenes/debug_grips.rs
+++ b/shock2vr/src/scenes/debug_grips.rs
@@ -3,8 +3,9 @@
 //!
 //! The item is drawn at the very transform the fit measured it in
 //! ([`vr_config::held_model_hand_transform`]) and the glove at the very grip
-//! the fit solved, so what the camera sees is what the solver decided - there
-//! is no second placement path that could flatter or slander it.
+//! the fit solved ([`GloveRenderer::fitted_grip`], the same call the wield
+//! makes), so what the camera sees is what the solver decided rather than a
+//! second, flattering placement.
 //!
 //! Cycle items with the `grip_item` dev param; frame them with `/v1/camera`.
 
@@ -88,27 +89,17 @@ impl DebugSceneHooks for GripHooks {
             Handedness::Right,
         );
 
-        let fit = hand_glove::grip_request(model_name, Handedness::Right, scale, asset_cache).map(
-            |(key, mesh, corrections)| {
-                let family = key.family();
-                // Timed around the solve alone - the mesh is already loaded and
-                // in hand space by here.
-                let started = std::time::Instant::now();
-                let mut fitted = glove.fitted_grip(key, &mesh);
-                let solve = started.elapsed();
-                corrections.apply(&mut fitted);
-                (family, mesh.triangle_count(), solve, mesh.extents(), fitted)
-            },
-        );
+        // The same cached entry point the wield uses; the mesh size and solve
+        // time are logged by the solve itself, at debug level.
+        let fit = glove.fitted_grip(model_name, Handedness::Right, scale, asset_cache);
 
         if self.shown != Some(index) {
             self.shown = Some(index);
             match &fit {
-                // The elapsed time is the *solve*: the fit is cached, so only
-                // the first frame showing an item pays it.
-                Some((family, triangles, solve, extents, fitted)) => info!(
-                    "debug_grips [{index}] {model_name}: family {} {triangles} tris solved in {solve:?} extents {extents:?} -> {fitted:?}",
-                    family.as_str()
+                Some(fit) => info!(
+                    "debug_grips [{index}] {model_name}: family {} -> {:?}",
+                    fit.family.as_str(),
+                    fit.amounts
                 ),
                 None => info!("debug_grips [{index}] {model_name}: no contact mesh"),
             }
@@ -118,7 +109,7 @@ impl DebugSceneHooks for GripHooks {
             hand,
             0.0,
             0.0,
-            Some(fit.map(|(_, _, _, _, fitted)| fitted)),
+            hand_glove::Hold::Item(fit.map(|fit| fit.amounts)),
             HandLight::Off,
             HandPreshape::None,
         ));

--- a/shock2vr/src/scenes/debug_grips.rs
+++ b/shock2vr/src/scenes/debug_grips.rs
@@ -1,0 +1,188 @@
+//! One held item at a time, in the right hand, at a fixed spot: the contact
+//! sheet for the finger fit ([`crate::hand_fit`]).
+//!
+//! The item is drawn at the very transform the fit measured it in
+//! ([`vr_config::held_model_hand_transform`]) and the glove at the very grip
+//! the fit solved, so what the camera sees is what the solver decided - there
+//! is no second placement path that could flatter or slander it.
+//!
+//! Cycle items with the `grip_item` dev param; frame them with `/v1/camera`.
+
+use cgmath::{Deg, Quaternion, Rotation3, Vector3, vec3};
+use dark::{
+    importers::{MODELS_IMPORTER, VR_HELD_GUN_MODELS_IMPORTER},
+    model::Model,
+};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext, scene::SceneObject};
+use shipyard::EntityId;
+use tracing::info;
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    hand_glove::{self, GloveRenderer, HandLight, HandPreshape},
+    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
+    scenes::debug_common::{
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    },
+    vr_config::{self, Handedness},
+};
+
+/// Where the held item hangs, in front of the scene's camera.
+const HAND_POSITION: Vector3<f32> = vec3(0.0, 2.6, 1.0);
+
+/// The owner's grip test cases: a mug (a handle its bounding box cannot see),
+/// a printed magazine (a slab), a clip (a small box), a basketball (bigger
+/// than the palm), and the four guns whose `_h` models range from an authored
+/// pistol grip to no grip at all.
+///
+/// `magci` is one of the six magazine covers the Magazines template picks
+/// from; they share a mesh, so any of them is the slab case.
+const GRIP_TEST_ITEMS: &[&str] = &[
+    "mug", "magci", "ammoss", "hamball", "atek_h", "sg_h", "fsn_h", "al_h",
+];
+
+struct GripHooks {
+    /// Which of [`GRIP_TEST_ITEMS`] was drawn last, so the log line is printed
+    /// on a change rather than every frame.
+    shown: Option<usize>,
+    glove: Option<GloveRenderer>,
+}
+
+/// The item the `grip_item` dev param selects, clamped to the list.
+fn selected_item() -> usize {
+    let index = crate::dev_params::get(crate::dev_params::GRIP_ITEM).round();
+    (index.max(0.0) as usize).min(GRIP_TEST_ITEMS.len() - 1)
+}
+
+impl DebugSceneHooks for GripHooks {
+    fn after_render(
+        &mut self,
+        _core: &mut MissionCore,
+        scene_objects: &mut Vec<SceneObject>,
+        _camera_position: &mut Vector3<f32>,
+        _camera_rotation: &mut Quaternion<f32>,
+        asset_cache: &mut AssetCache,
+        _options: &GameOptions,
+    ) {
+        let index = selected_item();
+        let model_name = GRIP_TEST_ITEMS[index];
+        let Some(glove) = self.glove.as_mut() else {
+            return;
+        };
+
+        // Guns are wielded shrunk to life size and stripped of their baked
+        // arm; everything else is held as authored.
+        let is_gun = vr_config::is_vr_gun_view_model(model_name);
+        let scale = if is_gun {
+            vr_config::gun_wield_scale()
+        } else {
+            1.0
+        };
+
+        // The right hand at a fixed spot, fingers along -X and rolled so the
+        // palm - the side the fit happens on - faces the -Z camera.
+        let hand = hand_glove::hand_to_world(
+            HAND_POSITION,
+            Quaternion::from_angle_y(Deg(90.0)) * Quaternion::from_angle_z(Deg(90.0)),
+            Handedness::Right,
+        );
+
+        let fit = hand_glove::grip_request(model_name, Handedness::Right, scale, asset_cache).map(
+            |(key, mesh, corrections)| {
+                let family = key.family();
+                // Timed around the solve alone - the mesh is already loaded and
+                // in hand space by here.
+                let started = std::time::Instant::now();
+                let mut fitted = glove.fitted_grip(key, &mesh);
+                let solve = started.elapsed();
+                corrections.apply(&mut fitted);
+                (family, mesh.triangle_count(), solve, mesh.extents(), fitted)
+            },
+        );
+
+        if self.shown != Some(index) {
+            self.shown = Some(index);
+            match &fit {
+                // The elapsed time is the *solve*: the fit is cached, so only
+                // the first frame showing an item pays it.
+                Some((family, triangles, solve, extents, fitted)) => info!(
+                    "debug_grips [{index}] {model_name}: family {} {triangles} tris solved in {solve:?} extents {extents:?} -> {fitted:?}",
+                    family.as_str()
+                ),
+                None => info!("debug_grips [{index}] {model_name}: no contact mesh"),
+            }
+        }
+
+        scene_objects.extend(glove.render_hand(
+            hand,
+            0.0,
+            0.0,
+            Some(fit.map(|(_, _, _, _, fitted)| fitted)),
+            HandLight::Off,
+            HandPreshape::None,
+        ));
+
+        if let Some(model) = held_model(model_name, is_gun, asset_cache) {
+            let world =
+                hand * vr_config::held_model_hand_transform(model_name, Handedness::Right, scale);
+            scene_objects.extend(model.clone_scene_objects().into_iter().map(|mut object| {
+                object.set_transform(world);
+                object
+            }));
+        }
+    }
+}
+
+/// The held item's model, drawn the way a VR wield would draw it - a gun
+/// through the arm-stripping importer, everything else as authored.
+fn held_model(model_name: &str, is_gun: bool, asset_cache: &mut AssetCache) -> Option<Model> {
+    let file = format!("{model_name}.BIN");
+    if is_gun {
+        asset_cache
+            .get_opt(&VR_HELD_GUN_MODELS_IMPORTER, &file)
+            .map(|held| held.0.clone())
+    } else {
+        asset_cache
+            .get_opt::<_, Model, _>(&MODELS_IMPORTER, &file)
+            .map(|model| model.as_ref().clone())
+    }
+}
+
+pub struct DebugGripsScene;
+
+impl DebugGripsScene {
+    pub fn new(
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Box<dyn GameScene> {
+        let builder = DebugSceneBuilder::new("debug_grips")
+            .with_default_floor()
+            .with_spawn_location(SpawnLocation::PositionRotation(
+                vec3(0.0, 2.6, 0.35),
+                Quaternion::from_angle_y(Deg(90.0)),
+            ));
+
+        let core = builder.build_core(DebugSceneBuildOptions {
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        });
+
+        info!(
+            "Created debug grips scene: {} items, select with the grip_item dev param",
+            GRIP_TEST_ITEMS.len()
+        );
+
+        Box::new(HookedDebugScene::new(
+            core,
+            GripHooks {
+                shown: None,
+                glove: GloveRenderer::new(asset_cache),
+            },
+        ))
+    }
+}

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -24,6 +24,7 @@ pub mod cutscene_skip;
 pub mod debug_camera;
 pub mod debug_common;
 pub mod debug_gloves;
+pub mod debug_grips;
 pub mod debug_hand_poses;
 pub mod debug_hitbox;
 pub mod debug_hud;
@@ -49,6 +50,7 @@ pub mod no_assets;
 pub use cutscene_player::CutscenePlayerScene;
 pub use debug_camera::DebugCameraScene;
 pub use debug_gloves::DebugGlovesScene;
+pub use debug_grips::DebugGripsScene;
 pub use debug_hand_poses::DebugHandPosesScene;
 pub use debug_hitbox::DebugHitboxScene;
 pub use debug_hud::DebugHudScene;
@@ -180,6 +182,7 @@ const DEBUG_SCENES: &[(&str, DebugSceneCtor)] = &[
         Box::new(DebugHudScene::new())
     }),
     ("debug_gloves", DebugGlovesScene::new),
+    ("debug_grips", DebugGripsScene::new),
     ("debug_hand_poses", DebugHandPosesScene::new),
     ("debug_joint_constraint", DebugJointConstraintScene::new),
     ("debug_map", |_global, _options, _assets, _audio| {

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -5,6 +5,7 @@ use dark::{
     SCALE_FACTOR,
     properties::{FrobFlag, PropFrobInfo, PropModelName},
 };
+use engine::assets::asset_cache::AssetCache;
 use engine::scene::SceneObject;
 use engine::script_log;
 
@@ -391,17 +392,21 @@ impl VirtualHand {
         self.affordance.state()
     }
 
-    /// Render the glove for this hand. The hand renderer is owned by the caller
-    /// (`VrInteraction`) so its cached state is shared between both hands.
+    /// Which hand this is.
+    pub fn handedness(&self) -> Handedness {
+        self.handedness
+    }
+
+    /// Render the glove for this hand, and report the grip it fitted to
+    /// whatever the hand holds. The hand renderer is owned by the caller
+    /// (`VrInteraction`) so its cached state - the fit cache included - is
+    /// shared between both hands.
     pub fn render(
         &self,
         world: &World,
-        glove_renderer: Option<&mut crate::hand_glove::GloveRenderer>,
-    ) -> Vec<SceneObject> {
-        let Some(renderer) = glove_renderer else {
-            return Vec::new();
-        };
-
+        asset_cache: &mut AssetCache,
+        renderer: &mut crate::hand_glove::GloveRenderer,
+    ) -> (Vec<SceneObject>, Option<crate::game_scene::DebugHandGrip>) {
         // A wielded gun draws the glove in place of the baked hand the wield
         // stripped off it; everything else draws it at the tracked hand, or not
         // at all when the held model draws a hand of its own. Either way the
@@ -410,19 +415,47 @@ impl VirtualHand {
         if !holds_gun_glove(world, self.get_held_entity())
             && !shows_hand_visual(world, self.get_held_entity())
         {
-            return Vec::new();
+            return (Vec::new(), None);
         }
         let hand = crate::hand_glove::hand_to_world(self.position, self.rotation, self.handedness);
 
-        renderer.render_hand(
+        // The fit is solved against the held item's own mesh and cached by the
+        // renderer, so a hand that keeps holding the same thing pays for it
+        // once; a held model with no mesh to close against reports `None` and
+        // falls back to the generic wrap.
+        let mut family = None;
+        let holding = self.get_held_entity().map(|entity_id| {
+            let (model_name, scale) = vr_config::held_model_and_scale(world, entity_id)?;
+            let (key, mesh, corrections) =
+                crate::hand_glove::grip_request(&model_name, self.handedness, scale, asset_cache)?;
+            family = Some(key.family());
+            let mut fitted = renderer.fitted_grip(key, &mesh);
+            corrections.apply(&mut fitted);
+            Some(fitted)
+        });
+
+        let objects = renderer.render_hand(
             hand,
             self.trigger_value,
             self.squeeze_value,
-            self.get_held_entity().is_some(),
+            holding,
             // Eligibility lights the glove; the action shapes it.
             self.affordance.state().light(),
             self.affordance.preshape(),
-        )
+        );
+
+        let grip = holding.flatten().zip(family).map(|(fitted, family)| {
+            crate::game_scene::DebugHandGrip {
+                family: family.as_str(),
+                thumb: fitted.thumb,
+                index: fitted.index,
+                middle: fitted.middle,
+                ring: fitted.ring,
+                pinky: fitted.pinky,
+            }
+        });
+
+        (objects, grip)
     }
 }
 

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -423,36 +423,32 @@ impl VirtualHand {
         // renderer, so a hand that keeps holding the same thing pays for it
         // once; a held model with no mesh to close against reports `None` and
         // falls back to the generic wrap.
-        let mut family = None;
-        let holding = self.get_held_entity().map(|entity_id| {
+        let fit = self.get_held_entity().and_then(|entity_id| {
             let (model_name, scale) = vr_config::held_model_and_scale(world, entity_id)?;
-            let (key, mesh, corrections) =
-                crate::hand_glove::grip_request(&model_name, self.handedness, scale, asset_cache)?;
-            family = Some(key.family());
-            let mut fitted = renderer.fitted_grip(key, &mesh);
-            corrections.apply(&mut fitted);
-            Some(fitted)
+            renderer.fitted_grip(&model_name, self.handedness, scale, asset_cache)
         });
+        let hold = match self.get_held_entity() {
+            Some(_) => crate::hand_glove::Hold::Item(fit.map(|fit| fit.amounts)),
+            None => crate::hand_glove::Hold::Empty,
+        };
 
         let objects = renderer.render_hand(
             hand,
             self.trigger_value,
             self.squeeze_value,
-            holding,
+            hold,
             // Eligibility lights the glove; the action shapes it.
             self.affordance.state().light(),
             self.affordance.preshape(),
         );
 
-        let grip = holding.flatten().zip(family).map(|(fitted, family)| {
-            crate::game_scene::DebugHandGrip {
-                family: family.as_str(),
-                thumb: fitted.thumb,
-                index: fitted.index,
-                middle: fitted.middle,
-                ring: fitted.ring,
-                pinky: fitted.pinky,
-            }
+        let grip = fit.map(|fit| crate::game_scene::DebugHandGrip {
+            family: fit.family.as_str(),
+            thumb: fit.amounts.thumb,
+            index: fit.amounts.index,
+            middle: fit.amounts.middle,
+            ring: fit.amounts.ring,
+            pinky: fit.amounts.pinky,
         });
 
         (objects, grip)

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -4,7 +4,6 @@ use cgmath::{Deg, Quaternion, Rotation3, Vector3, vec3};
 use dark::properties::PropModelName;
 
 use crate::hand_fit::GripFamily;
-use crate::hand_pose::FingerAmounts;
 use crate::runtime_props::{RuntimePropVrGripOffset, RuntimePropVrGunWield};
 use once_cell::sync::Lazy;
 use shipyard::{EntityId, Get, View, World};
@@ -693,70 +692,29 @@ pub fn get_vr_hand_model_adjustments_from_model(
     }
 }
 
-/// A per-model steer for the finger fit, keyed like [`HAND_MODEL_POSITIONING`].
-///
-/// Two levels of override only: the **family hint**, which picks the curl
-/// envelope the solve runs in, and a **finger correction**, which pins one
-/// finger the solve gets wrong. Everything else stays automatic - the grip's
-/// wrist placement is already the positioning table's job, and a fully
-/// authored per-finger grip waits for a tuner that can author it.
-#[derive(Clone, Default)]
-pub struct GripHint {
-    /// The family to solve in; `None` measures it off the item's own box.
-    pub family: Option<GripFamily>,
-    /// Curls written over the solved result, per finger.
-    pub fingers: FingerOverrides,
-}
-
-/// Per-finger curl corrections, `None` where the solve stands.
-#[derive(Clone, Copy, Default)]
-pub struct FingerOverrides {
-    pub thumb: Option<f32>,
-    pub index: Option<f32>,
-    pub middle: Option<f32>,
-    pub ring: Option<f32>,
-    pub pinky: Option<f32>,
-}
-
-impl FingerOverrides {
-    /// Write whatever is set over a solved grip.
-    pub fn apply(&self, amounts: &mut FingerAmounts) {
-        for (over, amount) in [
-            (self.thumb, &mut amounts.thumb),
-            (self.index, &mut amounts.index),
-            (self.middle, &mut amounts.middle),
-            (self.ring, &mut amounts.ring),
-            (self.pinky, &mut amounts.pinky),
-        ] {
-            if let Some(over) = over {
-                *amount = over;
-            }
-        }
-    }
-}
-
-/// The models whose measured box lies about how they are held.
-///
-/// Empty so far, deliberately. The gun `_h` set takes
-/// [`GripFamily::Trigger`] from [`is_vr_gun_view_model`] rather than an entry
-/// each, and the plain pickups have no authored hand seat yet - they are drawn
-/// centred on the wrist - so there is nothing to judge a correction against.
-/// The first entries belong with the seat data, not before it.
-static GRIP_HINTS: Lazy<HashMap<&str, GripHint>> = Lazy::new(HashMap::new);
-
-/// How `model_name` should be held, when the data says something the geometry
-/// does not.
-pub fn grip_hint(model_name: &str) -> GripHint {
+/// The grip family `model_name` is held in when its measured box would say
+/// something else, keyed like [`HAND_MODEL_POSITIONING`]. A gun is the one
+/// entry the code can derive: its grip measures like any other handle, but the
+/// index belongs on the trigger.
+pub fn grip_family(model_name: &str) -> Option<GripFamily> {
     let name = model_name.to_ascii_lowercase();
-    if let Some(hint) = GRIP_HINTS.get(name.as_str()) {
-        return hint.clone();
-    }
-    GripHint {
-        // A gun is held by name, not by measurement: its grip looks like any
-        // other handle, but the index belongs on the trigger.
-        family: is_vr_gun_view_model(&name).then_some(GripFamily::Trigger),
-        ..GripHint::default()
-    }
+    is_vr_gun_view_model(&name).then_some(GripFamily::Trigger)
+}
+
+/// Whether the wield puts `model_name` somewhere specific in the hand - an
+/// entry that actually *moves* the model, not merely one that turns it.
+///
+/// Only a seated model can be fitted: the contact fit measures where the
+/// item's surface falls against the fingers, and a model the wield leaves at
+/// the wrist origin is drawn straight through the hand, so anything measured
+/// off it describes the missing placement rather than the grip. Those keep the
+/// generic wrap until there is seat data for them.
+pub fn has_hand_seat(model_name: &str) -> bool {
+    use cgmath::InnerSpace;
+
+    HAND_MODEL_POSITIONING
+        .get(model_name.to_ascii_lowercase().as_str())
+        .is_some_and(|adjustments| adjustments.right_hand.offset.magnitude2() > 0.0)
 }
 
 /// Where a held model's geometry sits in the **glove's own hand space**, so
@@ -784,10 +742,9 @@ pub fn held_model_hand_transform(
         Matrix4::identity()
     };
 
-    handedness
-        .mirror()
-        .invert()
-        .unwrap_or_else(Matrix4::identity)
+    // `mirror` is a reflection, so it is its own inverse - this IS the
+    // division of the glove's own reflection out of the item's transform.
+    handedness.mirror()
         * Matrix4::from_translation(seat.offset)
         * Matrix4::from(seat.rotation)
         * bake
@@ -808,46 +765,35 @@ mod tests {
 
     /// A gun is held by name: its grip measures like any other handle, but the
     /// index belongs on the trigger, so every gun `_h` reports the trigger
-    /// family without an entry of its own - and nothing else does.
+    /// family - and nothing else does.
     #[test]
     fn every_gun_view_model_is_held_by_its_trigger() {
         for name in VR_25AE_GUN_MODELS {
             assert_eq!(
-                grip_hint(name).family,
+                grip_family(name),
                 Some(GripFamily::Trigger),
                 "{name} should be held on its trigger"
             );
         }
-        assert_eq!(grip_hint("mug").family, None);
-        assert_eq!(grip_hint("hamball").family, None);
+        assert_eq!(grip_family("mug"), None);
+        assert_eq!(grip_family("hamball"), None);
     }
 
-    /// Both levels of the override: the family a model is solved in, and a
-    /// finger the solve gets wrong - and a correction only touches the finger
-    /// it names.
+    /// Only a seated model can be fitted. Every wielded gun is seated (their
+    /// grips were fitted onto the pistol grips); a plain world pickup with no
+    /// entry is not, and must keep the generic wrap.
     #[test]
-    fn a_hint_can_steer_the_family_and_pin_one_finger() {
-        let hint = GripHint {
-            family: Some(GripFamily::Pinch),
-            fingers: FingerOverrides {
-                thumb: Some(0.25),
-                ..FingerOverrides::default()
-            },
-        };
-
-        let mut solved = FingerAmounts {
-            thumb: 1.0,
-            index: 0.8,
-            middle: 0.8,
-            ring: 0.8,
-            pinky: 0.8,
-        };
-        hint.fingers.apply(&mut solved);
-
-        assert_eq!(hint.family, Some(GripFamily::Pinch));
-        assert_eq!(solved.thumb, 0.25);
-        assert_eq!(solved.index, 0.8);
-        assert_eq!(solved.pinky, 0.8);
+    fn only_a_seated_model_can_be_fitted() {
+        for name in VR_25AE_GUN_MODELS {
+            assert!(has_hand_seat(name), "{name} should be seated");
+        }
+        assert!(has_hand_seat("ATEK_H"), "the lookup is case-insensitive");
+        // An entry that only turns the model leaves it on the wrist origin,
+        // which is not a seat.
+        assert!(!has_hand_seat("battery"));
+        assert!(!has_hand_seat("laser"));
+        assert!(!has_hand_seat("mug"));
+        assert!(!has_hand_seat("hamball"));
     }
 
     /// Every wielded view model is either a gun (glove on it, arm stripped), a

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -3,11 +3,13 @@ use std::collections::HashMap;
 use cgmath::{Deg, Quaternion, Rotation3, Vector3, vec3};
 use dark::properties::PropModelName;
 
+use crate::hand_fit::GripFamily;
+use crate::hand_pose::FingerAmounts;
 use crate::runtime_props::{RuntimePropVrGripOffset, RuntimePropVrGunWield};
 use once_cell::sync::Lazy;
 use shipyard::{EntityId, Get, View, World};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Handedness {
     Left,
     Right,
@@ -689,6 +691,124 @@ pub fn get_vr_hand_model_adjustments_from_model(
     } else {
         adjustments.right_hand.clone()
     }
+}
+
+/// A per-model steer for the finger fit, keyed like [`HAND_MODEL_POSITIONING`].
+///
+/// Two levels of override only: the **family hint**, which picks the curl
+/// envelope the solve runs in, and a **finger correction**, which pins one
+/// finger the solve gets wrong. Everything else stays automatic - the grip's
+/// wrist placement is already the positioning table's job, and a fully
+/// authored per-finger grip waits for a tuner that can author it.
+#[derive(Clone, Default)]
+pub struct GripHint {
+    /// The family to solve in; `None` measures it off the item's own box.
+    pub family: Option<GripFamily>,
+    /// Curls written over the solved result, per finger.
+    pub fingers: FingerOverrides,
+}
+
+/// Per-finger curl corrections, `None` where the solve stands.
+#[derive(Clone, Copy, Default)]
+pub struct FingerOverrides {
+    pub thumb: Option<f32>,
+    pub index: Option<f32>,
+    pub middle: Option<f32>,
+    pub ring: Option<f32>,
+    pub pinky: Option<f32>,
+}
+
+impl FingerOverrides {
+    /// Write whatever is set over a solved grip.
+    pub fn apply(&self, amounts: &mut FingerAmounts) {
+        for (over, amount) in [
+            (self.thumb, &mut amounts.thumb),
+            (self.index, &mut amounts.index),
+            (self.middle, &mut amounts.middle),
+            (self.ring, &mut amounts.ring),
+            (self.pinky, &mut amounts.pinky),
+        ] {
+            if let Some(over) = over {
+                *amount = over;
+            }
+        }
+    }
+}
+
+/// The models whose measured box lies about how they are held. Everything not
+/// listed is solved from its own geometry; the gun `_h` set gets
+/// [`GripFamily::Trigger`] from [`is_vr_gun_view_model`] rather than an entry
+/// each.
+static GRIP_HINTS: Lazy<HashMap<&str, GripHint>> = Lazy::new(|| {
+    HashMap::from([
+        // The mug's handle is a sub-feature its bounding box knows nothing
+        // about: measured, it is a fat cylinder and the hand would wrap the
+        // body. Pinch puts the thumb and index through the handle and holds
+        // the other three clear of the hot side.
+        (
+            "mug",
+            GripHint {
+                family: Some(GripFamily::Pinch),
+                ..GripHint::default()
+            },
+        ),
+    ])
+});
+
+/// How `model_name` should be held, when the data says something the geometry
+/// does not.
+pub fn grip_hint(model_name: &str) -> GripHint {
+    let name = model_name.to_ascii_lowercase();
+    if let Some(hint) = GRIP_HINTS.get(name.as_str()) {
+        return hint.clone();
+    }
+    GripHint {
+        // A gun is held by name, not by measurement: its grip looks like any
+        // other handle, but the index belongs on the trigger.
+        family: is_vr_gun_view_model(&name).then_some(GripFamily::Trigger),
+        ..GripHint::default()
+    }
+}
+
+/// Where a held model's geometry sits in the **glove's own hand space**, so
+/// the finger fit and the grip debug scene measure the item in the frame the
+/// fingers are posed in.
+///
+/// Three things compose. The wield seats the item in the hand's *rotation*
+/// frame ([`get_vr_hand_model_adjustments_from_model`], its offset scaled with
+/// the geometry). A gun's geometry additionally carries the wield's own bake -
+/// the life-size shrink and, for the left hand, [`Handedness::gun_mirror`] -
+/// which `Effect::ChangeModel` applies to the runtime model but not to the
+/// mesh an importer hands back. And the glove itself is drawn through
+/// [`Handedness::mirror`], which this divides back out.
+pub fn held_model_hand_transform(
+    model_name: &str,
+    handedness: Handedness,
+    gun_scale: f32,
+) -> cgmath::Matrix4<f32> {
+    use cgmath::{Matrix4, SquareMatrix};
+
+    let seat = gun_wield_adjustments(model_name, handedness, gun_scale);
+    let bake = if is_vr_gun_view_model(model_name) {
+        gun_wield_model_transform(handedness, gun_scale)
+    } else {
+        Matrix4::identity()
+    };
+
+    handedness
+        .mirror()
+        .invert()
+        .unwrap_or_else(Matrix4::identity)
+        * Matrix4::from_translation(seat.offset)
+        * Matrix4::from(seat.rotation)
+        * bake
+}
+
+/// The model a hand is holding and the scale its wield baked into it, for
+/// anything that has to measure the held geometry.
+pub fn held_model_and_scale(world: &World, entity_id: EntityId) -> Option<(String, f32)> {
+    let model_name = model_name_lower(world, entity_id)?;
+    Some((model_name, gun_wield_scale_of_entity(world, entity_id)))
 }
 
 #[cfg(test)]

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -735,25 +735,14 @@ impl FingerOverrides {
     }
 }
 
-/// The models whose measured box lies about how they are held. Everything not
-/// listed is solved from its own geometry; the gun `_h` set gets
+/// The models whose measured box lies about how they are held.
+///
+/// Empty so far, deliberately. The gun `_h` set takes
 /// [`GripFamily::Trigger`] from [`is_vr_gun_view_model`] rather than an entry
-/// each.
-static GRIP_HINTS: Lazy<HashMap<&str, GripHint>> = Lazy::new(|| {
-    HashMap::from([
-        // The mug's handle is a sub-feature its bounding box knows nothing
-        // about: measured, it is a fat cylinder and the hand would wrap the
-        // body. Pinch puts the thumb and index through the handle and holds
-        // the other three clear of the hot side.
-        (
-            "mug",
-            GripHint {
-                family: Some(GripFamily::Pinch),
-                ..GripHint::default()
-            },
-        ),
-    ])
-});
+/// each, and the plain pickups have no authored hand seat yet - they are drawn
+/// centred on the wrist - so there is nothing to judge a correction against.
+/// The first entries belong with the seat data, not before it.
+static GRIP_HINTS: Lazy<HashMap<&str, GripHint>> = Lazy::new(HashMap::new);
 
 /// How `model_name` should be held, when the data says something the geometry
 /// does not.
@@ -816,6 +805,50 @@ mod tests {
     use cgmath::InnerSpace;
 
     use super::*;
+
+    /// A gun is held by name: its grip measures like any other handle, but the
+    /// index belongs on the trigger, so every gun `_h` reports the trigger
+    /// family without an entry of its own - and nothing else does.
+    #[test]
+    fn every_gun_view_model_is_held_by_its_trigger() {
+        for name in VR_25AE_GUN_MODELS {
+            assert_eq!(
+                grip_hint(name).family,
+                Some(GripFamily::Trigger),
+                "{name} should be held on its trigger"
+            );
+        }
+        assert_eq!(grip_hint("mug").family, None);
+        assert_eq!(grip_hint("hamball").family, None);
+    }
+
+    /// Both levels of the override: the family a model is solved in, and a
+    /// finger the solve gets wrong - and a correction only touches the finger
+    /// it names.
+    #[test]
+    fn a_hint_can_steer_the_family_and_pin_one_finger() {
+        let hint = GripHint {
+            family: Some(GripFamily::Pinch),
+            fingers: FingerOverrides {
+                thumb: Some(0.25),
+                ..FingerOverrides::default()
+            },
+        };
+
+        let mut solved = FingerAmounts {
+            thumb: 1.0,
+            index: 0.8,
+            middle: 0.8,
+            ring: 0.8,
+            pinky: 0.8,
+        };
+        hint.fingers.apply(&mut solved);
+
+        assert_eq!(hint.family, Some(GripFamily::Pinch));
+        assert_eq!(solved.thumb, 0.25);
+        assert_eq!(solved.index, 0.8);
+        assert_eq!(solved.pinky, 0.8);
+    }
 
     /// Every wielded view model is either a gun (glove on it, arm stripped), a
     /// melee rig (posed skeleton, arm kept) or the amp (arm kept) - exactly

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -642,10 +642,28 @@ export type HandAffordance =
   | "Blocked"
   | "Failed";
 
-/** Both hands' affordances (GET /v1/info). */
+/** Both hands' affordances, and the grip each one fitted (GET /v1/info). */
 export interface HandAffordances {
   left: HandAffordance;
   right: HandAffordance;
+  /** The grip the left hand fitted to what it holds, or null. */
+  left_grip: HandGrip | null;
+  /** The grip the right hand fitted to what it holds, or null. */
+  right_grip: HandGrip | null;
+}
+
+/** The grip family a fit solved in. */
+export type GripFamily = "cylindrical" | "pinch" | "broad" | "trigger";
+
+/** A hand's fitted grip: how far each finger curled from open (0) toward a
+ * closed fist (1), before the trigger adds its own pull on the index. */
+export interface HandGrip {
+  family: GripFamily;
+  thumb: number;
+  index: number;
+  middle: number;
+  ring: number;
+  pinky: number;
 }
 
 /** One hand's hold in the /v1/info climb readout. */

--- a/tools/shock2-sdk/test/vr-finger-fit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-finger-fit.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// The finger fit (`shock2vr::hand_fit`) solves each finger's curl against the
+// held item's own render mesh at grab time. `/v1/info` reports the answer per
+// hand, which is the only observable the fit has - the pose itself lives in
+// skinning matrices no endpoint reports.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "VR: a held pistol fits a trigger grip, index trailing the wrapping fingers",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+    });
+
+    await game.step({ frames: 10 });
+
+    // An empty hand has nothing to fit.
+    assert.equal((await game.info()).player.hand_affordance.right_grip, null);
+
+    // DebugCycleWeapon spawns the pistol; the VR wield is a no-op so it drops
+    // to the floor in front of the player.
+    const pistol = await cycleToWeapon(game, (e) => e.name === "Pistol", {
+      settleFrames: 90,
+    });
+
+    // Grab it, the same way vr-held-model does: park the right hand on the
+    // pistol's forward raycast axis and squeeze.
+    const pawnY = (await game.info()).player.position[1];
+    const [px, py, pz] = pistol.position;
+    await game.input.set("right_hand.position", [px + 0.4, py - pawnY, pz]);
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      pistol.id,
+      "pistol should be grabbed by the right hand",
+    );
+
+    const grip = (await game.info()).player.hand_affordance.right_grip;
+    assert.ok(grip, "a held pistol should report a fitted grip");
+
+    // A gun is held by name, not by measurement: the index rests on the
+    // trigger while the rest of the hand wraps the grip. Without the fit every
+    // finger took one hardcoded curl and this ordering was an accident of
+    // those constants rather than a property of the weapon.
+    assert.equal(grip.family, "trigger");
+    for (const finger of ["middle", "ring", "pinky"] as const) {
+      assert.ok(
+        grip.index < grip[finger],
+        `index (${grip.index}) should trail ${finger} (${grip[finger]})`,
+      );
+    }
+    // Every curl is a blend amount, and the wrapping fingers really close.
+    for (const finger of ["thumb", "index", "middle", "ring", "pinky"] as const) {
+      assert.ok(
+        grip[finger] >= 0 && grip[finger] <= 1,
+        `${finger} curl out of range: ${grip[finger]}`,
+      );
+    }
+    assert.ok(grip.middle > 0.5, `middle should wrap the grip: ${grip.middle}`);
+
+    // Dropping it takes the fit away again.
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 10 });
+    assert.equal((await game.info()).player.hand_affordance.right_grip, null);
+  },
+);


### PR DESCRIPTION
Slice 5: the glove's fingers curl until they touch what the hand holds.

Every pickup template is `PhysType SPHERE`, so the contact proxy is the item's **render mesh** — a new `VrContactMesh` importer hands back its triangles with the baked first-person arm stripped, and `hand_glove` transforms them into the glove's own hand space. For each finger `hand_fit` sweeps the same open→fist blend the glove already poses with, stops at the first curl where a phalanx capsule (whole chain, not just the tip) reaches a triangle, and bisects for the contact point; a `GripFamily` gives each finger a floor/cap on that blend (guns take `Trigger` by name — index on the trigger, the rest wrap — everything else is measured off the mesh's hand-space box: thin → `Pinch`, wider than the palm → `Broad`, else `Cylindrical`). The answer is cached per (model, hand, wield scale) and read back at `/v1/info` as `player.hand_affordance.{left,right}_grip`; the trigger still adds curl on top of the index, so a real pull always wins.

**The fit only runs on a model the wield actually seats** (a `HAND_MODEL_POSITIONING` entry that *moves* it, not merely turns it), and a finger the item is already inside at the open pose keeps the authored wrap. Both matter: a plain world pickup is drawn centred on the wrist, so anything measured off it describes the missing placement rather than the grip — those keep today's generic wrap until the seat data lands (slice 6).

### Contact sheet

`debug_grips` (new): one test item at a time in the right hand, at the transform the fit measured it in and the grip it solved. `grip_item` dev param cycles; framed with `/v1/camera`.

![grips](https://gist.githubusercontent.com/tommy-xr/71a36b7d3bff89c260753594ef179162/raw/grips.gif)

![contact sheet](https://gist.githubusercontent.com/tommy-xr/71a36b7d3bff89c260753594ef179162/raw/grips_sheet.png)

| item | family | result |
| --- | --- | --- |
| pistol `atek_h` | trigger | **pass** — fist on the grip, index out on the trigger, ring fitted to 0.68 |
| shotgun `sg_h` | trigger | **pass** — thumb closes fully (nothing in its way), index 0.45 |
| fusion cannon `fsn_h` | trigger | **pass** — no fitted finger; the grip is inside the fist, so the wrap stands |
| worm launcher `al_h` | trigger | **pass** — pinky fitted to 0.60 on the organic body |
| coffee mug `mug` | — | **not fitted**: no seat, drawn centred on the wrist |
| magazine `magci` | — | **not fitted**: same; also renders as a wall-sized rack, not a held magazine |
| clip `ammoss` | — | **not fitted**: same (the world model is a half-metre ammo box) |
| basketball `hamball` | — | **not fitted**: same |

Honest summary: of the owner's test table only the guns are seated well enough to fit today, and three fingers across the four of them actually land on a surface — the rest of each gun's hand is the authored wrap, because a wield deliberately buries the grip inside the closed fist. The four plain pickups cannot be judged until they have a hand seat. The wrench is untouched (skinned melee rig, no glove).

### Perf

Release, `debug_grips`: **188–423 µs** per solve on 742–2106-triangle meshes. One-off per (model, hand, scale) — the cache stores the miss too, so a held item costs nothing per frame. Triangles are prefiltered by each finger's swept AABB and the coarse sweep is posed once.

### Tests

`hand_fit` unit tests on synthetic meshes (negative-first: the ungoverned fist closes through a handle, the fitted grip does not), family auto-pick from the box, the seated-through-the-hand case, cache key, trigger composition. `vr-finger-fit.e2e.test.ts` asserts a held pistol reports the trigger family with the index trailing the wrapping fingers. Ran `vr-finger-fit`, `vr-held-model`, `vr-hand-affordance`, `vr-muzzle-origin` (11 pass); full unit suite green; `RUSTFLAGS="-D warnings"` clean.

Follow-up, not done here: the geometry helpers duplicate what `parry` already does (`SharedShape::trimesh` + `query::contact`, as `debug_hitbox` uses for capsules) — worth replacing once the fit has settled.
