### PR TITLE
feat(vr): support two-handed wrench grips and keep melee gloves attached

### DIFF
--- a/assets/astra-vr-support-grips.json
+++ b/assets/astra-vr-support-grips.json
@@ -1,0 +1,19 @@
+{
+  "wrench_h": {
+    "palm_anchor": [
+      -0.09,
+      0.354,
+      0.02
+    ],
+    "curls": [
+      0.08,
+      0.375,
+      0.4,
+      0.45,
+      0.6
+    ],
+    "grab_radius": 0.07,
+    "release_distance": 0.12,
+    "max_swing_degrees": 75.0
+  }
+}

--- a/projects/astra-vr-hands-round-2.md
+++ b/projects/astra-vr-hands-round-2.md
@@ -439,3 +439,61 @@ into/out of holding, and repeated pouch/stow operations without loss or duplicat
 Record grab success, accidental actions, correction effort, visible penetration,
 and device timing against the baseline. Set final reach distances and blend times
 from these trials rather than hard-coding guesses into the design.
+
+### Wrench support increment
+
+The first support implementation opts in `wrench_h` only. Hold it in either
+hand, bring the free palm to the upper shaft, and squeeze. The primary hand
+owns the item and fixes its palm anchor; the support hand steers the vector
+between the two anchors. Primary wrist rotation supplies twist. The solver supplies the physics target;
+visible attached gloves and grab sockets follow the collision-resolved weapon. Weapon scale
+stays at the prepared primary grip's scale regardless of controller separation.
+
+Release support to blend back to the primary pose. Release the primary to drop
+once; the supporting hand never becomes a second owner. Support input is
+reserved until squeeze and trigger are both released, including after an excessive-separation break, so
+returning to the handle while still squeezed cannot reacquire or grab through
+it. Support cannot share a hand with climbing or another held item. Invalid
+pose data cancels support; headset tracking-loss behavior still needs device
+validation because this does not add OpenXR tracking-validity channels.
+
+`assets/astra-vr-support-grips.json` holds the fixed support palm anchor and
+finger curls. Anchors use normalized weapon coordinates before uniform item
+scale; X is mirrored for a left-primary hold. `grab_radius` and
+`release_distance` use runtime world units. The latter is allowed deviation
+from the fixed anchor separation. Initial capture uses a 0.07 grab radius,
+0.12 separation allowance, a 75-degree maximum support swing from the primary
+orientation, 80 ms glove/finger attachment blend, and 60 ms orientation
+smoothing. These are starting values for headset review. Missing or invalid
+profiles leave ordinary one-hand behavior available.
+
+The debug runtime exposes `hand_grips[].support` on the primary grip, including
+attachment state, desired support controller pose, tracked palm, both anchors,
+and solved model transform. Run the SDK's `vr-wrench-support.e2e.test.ts` with
+`SHOCK2_E2E=1` to exercise either hand, fresh-press acquisition, steering, constant
+scale, support release, separation break, and primary release. Rust tests cover
+degenerate geometry, invalid pose data, disabled support, and zero-dt input
+edges. The existing grip gallery remains the primary-fit inspection tool;
+this increment adds motion capture for the support behavior.
+
+Sliding/broad support regions, other weapons, and melee damage/perk changes
+remain separate increments. Headset comfort and collision contact under a
+real swing are still required checks before expanding the support policy.
+
+Single-hand fitted melee gloves also follow the synchronized physical weapon.
+The runtime walking/wall-contact regression checks their relative pose every
+frame, including a controller target past the debug melee wall. Weapon scale
+was accepted in headset; pickup scales (including ammo) remain individual
+Explorer overrides. No weapon scales changed in this increment.
+
+Capture a local gallery after building the SDK:
+`node scripts/capture-wrench-support.mjs --output /tmp/astra-wrench-support/gallery`
+(from `tools/shock2-sdk`). `--reference <data.json>` replays the saved sequence
+for comparable before/after captures.
+
+Physical guns are a subsequent integration: PR #1142 extends the existing
+swept held-item drive to inert ranged weapons, and #1153 adds impact sounds.
+They need collider fitting from our stripped/scaled weapon geometry and the
+same post-physics glove placement, not a second motion solver. A merge trial
+against the committed parent found conflicts in `ss2_bin_obj_loader.rs`,
+`physics/mod.rs`, and `scripts/melee_weapon.rs`; neither PR was merged here.

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -179,11 +179,9 @@ impl GloveRenderer {
         trigger_value: f32,
         squeeze_value: f32,
         holding: bool,
-        fitted: Option<FingerAmounts>,
+        fitted: Option<(FingerAmounts, f32)>,
     ) -> Vec<SceneObject> {
-        let amounts = if let Some(fitted) = fitted {
-            fitted
-        } else if holding {
+        let mut amounts = if holding {
             // Gripping a held item: fingers wrapped on the handle, thumb
             // locked, index resting on the trigger and curling with the pull
             // (the squeeze is what holds the item, so it doesn't drive the
@@ -207,6 +205,16 @@ impl GloveRenderer {
                 pinky: squeeze_value,
             }
         };
+        if let Some((fitted, blend)) = fitted {
+            let t = blend.clamp(0.0, 1.0);
+            amounts = FingerAmounts {
+                thumb: amounts.thumb * (1.0 - t) + fitted.thumb * t,
+                index: amounts.index * (1.0 - t) + fitted.index * t,
+                middle: amounts.middle * (1.0 - t) + fitted.middle * t,
+                ring: amounts.ring * (1.0 - t) + fitted.ring * t,
+                pinky: amounts.pinky * (1.0 - t) + fitted.pinky * t,
+            };
+        }
         let pose = self.open.blend_per_finger(&self.fist, &amounts);
         Self::render_posed(
             &mut self.model,

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -10,7 +10,7 @@
 
 use std::{cell::RefCell, collections::HashMap};
 
-use cgmath::{InnerSpace, Point3, Quaternion, Vector3, Vector4};
+use cgmath::{InnerSpace, One, Point3, Quaternion, Rotation, Vector3, Vector4};
 use engine::{
     assets::asset_cache::AssetCache,
     scene::{SceneObject, light::SpotLight},
@@ -27,6 +27,7 @@ use crate::{
     physics::PhysicsWorld,
     virtual_hand::{VirtualHand, VirtualHandEffect, hand_world_position},
     vr_config::Handedness,
+    vr_support::{GripPose, SupportProfile, solve_two_hand_pose},
 };
 
 /// Read-only per-frame inputs an interaction controller needs to update.
@@ -40,6 +41,8 @@ pub struct InteractionContext<'a> {
     /// Eye height above `player_pos` in SS2 units - crouch-aware, so the flat
     /// controller's shot/viewmodel origin follows the actual camera.
     pub eye_height: f32,
+    pub step_dt: f32,
+    pub support_enabled: bool,
 }
 
 /// Read-only per-frame inputs for the VR hand-climb resolve. Separate from
@@ -73,6 +76,9 @@ pub trait PlayerInteraction {
         _options: &GameOptions,
     ) {
     }
+
+    /// Refresh glove attachment from the collision-resolved item transform.
+    fn synchronize_held_visuals(&mut self, _world: &World) {}
 
     fn grip_diagnostics(&self) -> serde_json::Value {
         serde_json::json!([])
@@ -196,6 +202,34 @@ pub struct VrInteraction {
     grip_hints: HashMap<String, crate::vr_grip::GripHints>,
     grip_overlay: bool,
     fitted_grips: [Option<HeldGrip>; 2],
+    support_profiles: HashMap<String, SupportProfile>,
+    support: Option<SupportAttachment>,
+    support_preview: Option<SupportCandidate>,
+    support_pressed: [bool; 2],
+    support_blocked: [bool; 2],
+    visual_hands: [Option<GripPose>; 2],
+    step_dt: f32,
+}
+
+struct SupportAttachment {
+    entity: EntityId,
+    primary: usize,
+    active: bool,
+    blend: f32,
+    correction: Quaternion<f32>,
+}
+
+#[derive(Clone)]
+struct SupportCandidate {
+    entity: EntityId,
+    primary: usize,
+    profile: SupportProfile,
+    primary_palm: Vector3<f32>,
+    primary_anchor: Vector3<f32>,
+    tracked_axis: Vector3<f32>,
+    anchor: Vector3<f32>,
+    model_pose: GripPose,
+    hand_pose: GripPose,
 }
 
 struct GripGeometry {
@@ -217,6 +251,28 @@ struct HeldGrip {
     item_bounds: Option<[[f32; 3]; 2]>,
 }
 
+impl HeldGrip {
+    /// Undo the contact-origin split on the collision-resolved melee body.
+    fn physical_model_pose(&self, world: &World) -> Option<GripPose> {
+        use shipyard::{Get, View};
+        let grip = self.resolved.as_ref()?;
+        let (positions, offsets) = world
+            .borrow::<(
+                View<dark::properties::PropPosition>,
+                View<crate::runtime_props::RuntimePropVrGripOffset>,
+            )>()
+            .ok()?;
+        let position = positions.get(self.entity).ok()?;
+        let contact = offsets.get(self.entity).ok()?.0;
+        let pose = GripPose {
+            position: position.position
+                - position.rotation.rotate_vector(contact * grip.item_scale),
+            rotation: position.rotation,
+        };
+        pose.is_tracked().then_some(pose)
+    }
+}
+
 impl VrInteraction {
     pub fn new() -> Self {
         Self {
@@ -231,6 +287,13 @@ impl VrInteraction {
             grip_hints: HashMap::new(),
             grip_overlay: false,
             fitted_grips: [None, None],
+            support_profiles: HashMap::new(),
+            support: None,
+            support_preview: None,
+            support_pressed: [true; 2],
+            support_blocked: [false; 2],
+            visual_hands: [None, None],
+            step_dt: 0.0,
         }
     }
 }
@@ -238,6 +301,259 @@ impl VrInteraction {
 impl Default for VrInteraction {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl VrInteraction {
+    fn hand_poses(&self) -> [GripPose; 2] {
+        [&self.left_hand, &self.right_hand].map(|hand| GripPose {
+            position: hand.get_position(),
+            rotation: hand.get_rotation(),
+        })
+    }
+
+    fn support_candidate(&self, world: &World, poses: [GripPose; 2]) -> Option<SupportCandidate> {
+        let rig = self.grip_kinematics.as_ref()?;
+        for (primary, hand) in [&self.left_hand, &self.right_hand].into_iter().enumerate() {
+            let Some(held) = self.fitted_grips[primary].as_ref() else {
+                continue;
+            };
+            if held.model != "wrench_h"
+                || hand.get_held_entity() != Some(held.entity)
+                || !poses[primary].is_tracked()
+            {
+                continue;
+            }
+            let Some(grip) = held.resolved.as_ref() else {
+                continue;
+            };
+            let Some(profile) = self.support_profiles.get(&held.model) else {
+                continue;
+            };
+            let base_rotation = poses[primary].rotation.normalize() * grip.rotation;
+            let primary_palm = poses[primary].point(rig[primary].palm);
+            // Scaled model-space anchors, independent of the melee contact-origin split.
+            let primary_anchor = grip
+                .rotation
+                .conjugate()
+                .rotate_vector(rig[primary].palm - grip.offset);
+            let anchor = profile.anchor(primary) * grip.item_scale;
+            let correction = self
+                .support
+                .as_ref()
+                .filter(|s| s.entity == held.entity && s.primary == primary)
+                .map_or(Quaternion::one(), |s| s.correction);
+            let rotation = base_rotation * correction;
+            let target_pose = GripPose {
+                position: primary_palm - rotation.rotate_vector(primary_anchor),
+                rotation,
+            };
+            // Melee physics may stop short of its target at a wall. Acquisition
+            // and visible gloves belong on that actual weapon, not an unseen target.
+            let model_pose = held.physical_model_pose(world).unwrap_or(target_pose);
+            let hand_rotation = model_pose.rotation * grip.rotation.conjugate();
+            let hand_pose = GripPose {
+                position: model_pose.point(anchor)
+                    - hand_rotation.rotate_vector(rig[1 - primary].palm),
+                rotation: hand_rotation,
+            };
+            return Some(SupportCandidate {
+                entity: held.entity,
+                primary,
+                profile: profile.clone(),
+                primary_palm,
+                primary_anchor,
+                tracked_axis: base_rotation.rotate_vector(anchor - primary_anchor),
+                anchor,
+                model_pose,
+                hand_pose,
+            });
+        }
+        None
+    }
+
+    fn update_support(&mut self, ctx: &InteractionContext) {
+        self.step_dt = ctx.step_dt.max(0.0);
+        let inputs = [&ctx.input.left_hand, &ctx.input.right_hand];
+        let poses = inputs.map(|input| GripPose {
+            position: crate::virtual_hand::hand_world_position(
+                ctx.player_pos,
+                ctx.player_rotation,
+                input.position,
+            ),
+            rotation: ctx.player_rotation * input.rotation,
+        });
+        let pressed = inputs.map(|input| input.squeeze_value >= 0.5);
+        for i in 0..2 {
+            if !pressed[i] && inputs[i].trigger_value < 0.5 {
+                self.support_blocked[i] = false;
+            }
+        }
+        let candidate = self.support_candidate(ctx.world, poses);
+        let available = |primary: usize| {
+            let other = 1 - primary;
+            let hand = if other == 0 {
+                &self.left_hand
+            } else {
+                &self.right_hand
+            };
+            hand.get_held_entity().is_none()
+                && !self.hand_climb.grips().any(|(h, _)| {
+                    h == if other == 0 {
+                        Handedness::Left
+                    } else {
+                        Handedness::Right
+                    }
+                })
+        };
+        if let Some(support) = self.support.as_mut() {
+            let valid = candidate.as_ref().is_some_and(|c| {
+                let other = 1 - c.primary;
+                let Some(rig) = self.grip_kinematics.as_ref() else {
+                    return false;
+                };
+                let separation = (poses[other].point(rig[other].palm) - c.primary_palm).magnitude();
+                support.entity == c.entity
+                    && support.primary == c.primary
+                    && ctx.support_enabled
+                    && available(c.primary)
+                    && poses.iter().all(|p| p.is_tracked())
+                    && pressed[c.primary]
+                    && pressed[other]
+                    && separation > 0.06
+                    && c.profile.allows_swing(
+                        c.tracked_axis,
+                        poses[other].point(rig[other].palm) - c.primary_palm,
+                    )
+                    && (separation - (c.anchor - c.primary_anchor).magnitude()).abs()
+                        <= c.profile.release_distance
+            });
+            if !valid {
+                support.active = false;
+            }
+        }
+        // Hand input still updates on render-only (zero-dt) frames, just like
+        // VirtualHand. Consume the squeeze edge there too; only blending needs dt.
+        if ctx.support_enabled && self.support.as_ref().is_none_or(|s| !s.active) {
+            if let Some(c) = candidate.as_ref() {
+                let other = 1 - c.primary;
+                if let Some(rig) = self.grip_kinematics.as_ref() {
+                    let palm = poses[other].point(rig[other].palm);
+                    if available(c.primary)
+                        && poses.iter().all(|p| p.is_tracked())
+                        && pressed[c.primary]
+                        && pressed[other]
+                        && !self.support_pressed[other]
+                        && !self.support_blocked[other]
+                        && (palm - c.primary_palm).magnitude() > 0.08
+                        && c.profile
+                            .allows_swing(c.tracked_axis, palm - c.primary_palm)
+                        && (palm - c.model_pose.point(c.anchor)).magnitude()
+                            <= c.profile.grab_radius
+                    {
+                        let (blend, correction) = self
+                            .support
+                            .as_ref()
+                            .filter(|s| s.entity == c.entity && s.primary == c.primary)
+                            .map_or((0.0, Quaternion::one()), |s| (s.blend, s.correction));
+                        self.support = Some(SupportAttachment {
+                            entity: c.entity,
+                            primary: c.primary,
+                            active: true,
+                            blend,
+                            correction,
+                        });
+                        self.support_blocked[other] = true;
+                    }
+                }
+            }
+        }
+        self.support_pressed = pressed;
+    }
+
+    fn apply_support(&mut self, world: &World, effects: &mut Vec<VirtualHandEffect>) {
+        use shipyard::{Get, View};
+        self.visual_hands = [None, None];
+        let poses = self.hand_poses();
+        let candidate = self.support_candidate(world, poses);
+        let valid = self
+            .support
+            .as_ref()
+            .zip(candidate.as_ref())
+            .is_some_and(|(s, c)| {
+                s.entity == c.entity
+                    && s.primary == c.primary
+                    && (!s.active
+                        || [
+                            self.left_hand.get_held_entity(),
+                            self.right_hand.get_held_entity(),
+                        ][1 - s.primary]
+                            .is_none())
+            });
+        if !valid {
+            self.support = None;
+        }
+        if let (Some(s), Some(c), Some(rig)) = (
+            &mut self.support,
+            candidate.as_ref(),
+            self.grip_kinematics.as_ref(),
+        ) {
+            let primary = s.primary;
+            let other = 1 - primary;
+            let grip = self.fitted_grips[primary]
+                .as_ref()
+                .unwrap()
+                .resolved
+                .as_ref()
+                .unwrap();
+            let base_rotation = poses[primary].rotation.normalize() * grip.rotation;
+            let target = if s.active && poses[other].is_tracked() {
+                solve_two_hand_pose(
+                    c.primary_palm,
+                    poses[other].point(rig[other].palm),
+                    base_rotation,
+                    c.primary_anchor,
+                    c.anchor,
+                    base_rotation * s.correction,
+                )
+                .rotation
+            } else {
+                base_rotation
+            };
+            let alpha = 1.0 - (-self.step_dt / 0.06).exp();
+            s.correction = s
+                .correction
+                .slerp(base_rotation.conjugate() * target, alpha)
+                .normalize();
+            s.blend = (s.blend
+                + if s.active {
+                    self.step_dt / 0.08
+                } else {
+                    -self.step_dt / 0.08
+                })
+            .clamp(0.0, 1.0);
+            let rotation = base_rotation * s.correction;
+            let model_pose = GripPose {
+                position: c.primary_palm - rotation.rotate_vector(c.primary_anchor),
+                rotation,
+            };
+            let contact = world
+                .borrow::<View<crate::runtime_props::RuntimePropVrGripOffset>>()
+                .ok()
+                .and_then(|v| v.get(c.entity).ok().map(|p| p.0))
+                .unwrap_or(Vector3::new(0.0, 0.0, 0.0));
+            effects.retain(|e| !matches!(e, VirtualHandEffect::SetPositionRotation { entity_id, .. } if *entity_id == c.entity));
+            effects.push(VirtualHandEffect::SetPositionRotation {
+                entity_id: c.entity,
+                position: model_pose.point(contact * grip.item_scale),
+                rotation,
+                scale: Vector3::new(grip.item_scale, grip.item_scale, grip.item_scale),
+            });
+            if !s.active && s.blend == 0.0 && s.correction.s.abs() > 0.99999 {
+                self.support = None;
+                self.visual_hands = [None, None];
+            }
+        }
     }
 }
 
@@ -257,6 +573,14 @@ impl PlayerInteraction for VrInteraction {
         use engine::assets::text_importer::TEXT_IMPORTER;
         use shipyard::{Get, View};
         if self.grip_library.is_none() {
+            self.support_profiles = assets
+                .get_opt(&TEXT_IMPORTER, "astra-vr-support-grips.json")
+                .and_then(|text| {
+                    serde_json::from_str::<HashMap<String, SupportProfile>>(&text).ok()
+                })
+                .unwrap_or_default();
+            self.support_profiles
+                .retain(|model, profile| model == "wrench_h" && profile.is_valid());
             self.grip_library = Some(
                 assets
                     .get_opt(&TEXT_IMPORTER, "astra-vr-grips.json")
@@ -490,12 +814,71 @@ impl PlayerInteraction for VrInteraction {
                 });
             }
         }
+        drop(slot);
+        self.apply_support(world, effects);
+    }
+
+    fn synchronize_held_visuals(&mut self, world: &World) {
+        let poses = self.hand_poses();
+        self.support_preview = self.support_candidate(world, poses);
+        self.visual_hands = [None, None];
+        // All fitted physical melee gloves follow the synchronized body, even
+        // with one hand: locomotion and impacts must not separate mesh and grip.
+        for (index, held) in self.fitted_grips.iter().enumerate() {
+            let Some(held) = held else { continue };
+            let (Some(grip), Some(model)) = (&held.resolved, held.physical_model_pose(world))
+            else {
+                continue;
+            };
+            let rotation = model.rotation * grip.rotation.conjugate();
+            self.visual_hands[index] = Some(GripPose {
+                position: model.position - rotation.rotate_vector(grip.offset),
+                rotation,
+            });
+        }
+        let (Some(support), Some(candidate)) = (&self.support, &self.support_preview) else {
+            return;
+        };
+        let other = 1 - support.primary;
+        if poses[other].is_tracked()
+            && [
+                self.left_hand.get_held_entity(),
+                self.right_hand.get_held_entity(),
+            ][other]
+                .is_none()
+        {
+            self.visual_hands[other] = Some(GripPose {
+                position: poses[other].position * (1.0 - support.blend)
+                    + candidate.hand_pose.position * support.blend,
+                rotation: poses[other]
+                    .rotation
+                    .normalize()
+                    .slerp(candidate.hand_pose.rotation, support.blend),
+            });
+        }
     }
 
     fn grip_diagnostics(&self) -> serde_json::Value {
         serde_json::Value::Array(self.fitted_grips.iter().enumerate().filter_map(|(i, grip)| {
             let grip=grip.as_ref()?;
-            Some(serde_json::json!({"hand": if i == 0 {"left"} else {"right"}, "entity_id": grip.entity.inner() as i32,
+            let support = self.support_preview.as_ref().filter(|c| c.primary == i && c.entity == grip.entity).map(|c| {
+                let attachment = self.support.as_ref().filter(|s| s.primary == i && s.entity == grip.entity);
+                serde_json::json!({
+                    "hand": if i == 0 { "right" } else { "left" },
+                    "attached": attachment.is_some_and(|s| s.active),
+                    "blend": attachment.map_or(0.0, |s| s.blend),
+                    "tracked_palm": self.grip_kinematics.as_ref().map(|rig| self.hand_poses()[1-i].point(rig[1-i].palm)),
+                    "pressed": self.support_pressed, "blocked": self.support_blocked, "step_dt": self.step_dt,
+                    "socket_position": c.model_pose.point(c.anchor),
+                    "controller_position": c.hand_pose.position,
+                    "controller_rotation": c.hand_pose.rotation,
+                    "model_position": c.model_pose.position, "model_rotation": c.model_pose.rotation,
+                    "primary_palm": c.primary_palm, "primary_anchor": c.primary_anchor,
+                    "support_anchor": c.anchor, "grab_radius": c.profile.grab_radius,
+                    "release_distance": c.profile.release_distance, "max_swing_degrees": c.profile.max_swing_degrees
+                })
+            });
+            Some(serde_json::json!({"glove_pose": self.visual_hands[i], "support": support, "hand": if i == 0 {"left"} else {"right"}, "entity_id": grip.entity.inner() as i32,
                 "model": grip.model, "item_bounds": grip.item_bounds, "solve_ms": grip.solve_ms, "grip": grip.resolved,
                 "surface_hash": grip.surface_hash, "kinematics_hash": grip.kinematics_hash, "hints_hash": grip.hints_hash, "solver_revision": crate::vr_grip::SOLVER_REVISION, "source": grip.source, "authored": grip.authored,
                 "palm": self.grip_kinematics.as_ref().map(|k| k[i].palm), "palm_normal": self.grip_kinematics.as_ref().map(|k| k[i].normal)}))
@@ -505,12 +888,12 @@ impl PlayerInteraction for VrInteraction {
     fn update_hand_climb(&mut self, ctx: &ClimbContext) -> crate::vr_climb::ClimbFrame {
         use shipyard::EntitiesView;
 
-        let hand_input = |hand: &VirtualHand, input: &crate::input_context::Hand| {
+        let hand_input = |index: usize, hand: &VirtualHand, input: &crate::input_context::Hand| {
             crate::vr_climb::ClimbHandInput {
                 local_position: input.position,
                 squeeze: input.squeeze_value,
                 // A hand that is carrying something cannot also hold a ladder.
-                is_empty: hand.get_held_entity().is_none(),
+                is_empty: hand.get_held_entity().is_none() && !self.support_blocked[index],
             }
         };
         self.hand_climb.update(
@@ -518,8 +901,8 @@ impl PlayerInteraction for VrInteraction {
             ctx.pawn_rotation,
             ctx.step_dt,
             [
-                hand_input(&self.left_hand, &ctx.input.left_hand),
-                hand_input(&self.right_hand, &ctx.input.right_hand),
+                hand_input(0, &self.left_hand, &ctx.input.left_hand),
+                hand_input(1, &self.right_hand, &ctx.input.right_hand),
             ],
             |point, transferring| {
                 if transferring {
@@ -555,40 +938,69 @@ impl PlayerInteraction for VrInteraction {
     }
 
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
+        self.update_support(ctx);
         let left_held_entity = self.left_hand.get_held_entity();
-        // Both hands' positions come from this frame's input, before either
-        // update: the two-hand gesture must read the same distance whichever
-        // hand releases.
-        let hand_position = |hand: &crate::input_context::Hand| {
-            hand_world_position(ctx.player_pos, ctx.player_rotation, hand.position)
-        };
-        let left_position = hand_position(&ctx.input.left_hand);
-        let right_position = hand_position(&ctx.input.right_hand);
-        let (right_hand, mut right_msgs) = VirtualHand::update(
-            &self.right_hand,
-            ctx.physics,
-            ctx.world,
+        // Read both positions from this frame before either hand updates, so
+        // native-toxin self-use has the same distance in either hand.
+        let left_position = hand_world_position(
             ctx.player_pos,
             ctx.player_rotation,
-            &ctx.input.right_hand,
-            left_held_entity,
-            left_position,
+            ctx.input.left_hand.position,
         );
+        let right_position = hand_world_position(
+            ctx.player_pos,
+            ctx.player_rotation,
+            ctx.input.right_hand.position,
+        );
+        let (right_hand, mut right_msgs) =
+            if self.support_blocked[1] && self.right_hand.get_held_entity().is_none() {
+                (
+                    self.right_hand.update_suppressed(
+                        ctx.player_pos,
+                        ctx.player_rotation,
+                        &ctx.input.right_hand,
+                    ),
+                    Vec::new(),
+                )
+            } else {
+                VirtualHand::update(
+                    &self.right_hand,
+                    ctx.physics,
+                    ctx.world,
+                    ctx.player_pos,
+                    ctx.player_rotation,
+                    &ctx.input.right_hand,
+                    left_held_entity,
+                    left_position,
+                )
+            };
         self.right_hand = right_hand;
 
         // Right updates first, so a same-frame right-hand grab is visible to
         // the left hand and one physical item cannot enter both hand states.
         let right_held_entity = self.right_hand.get_held_entity();
-        let (left_hand, mut left_msgs) = VirtualHand::update(
-            &self.left_hand,
-            ctx.physics,
-            ctx.world,
-            ctx.player_pos,
-            ctx.player_rotation,
-            &ctx.input.left_hand,
-            right_held_entity,
-            right_position,
-        );
+        let (left_hand, mut left_msgs) =
+            if self.support_blocked[0] && self.left_hand.get_held_entity().is_none() {
+                (
+                    self.left_hand.update_suppressed(
+                        ctx.player_pos,
+                        ctx.player_rotation,
+                        &ctx.input.left_hand,
+                    ),
+                    Vec::new(),
+                )
+            } else {
+                VirtualHand::update(
+                    &self.left_hand,
+                    ctx.physics,
+                    ctx.world,
+                    ctx.player_pos,
+                    ctx.player_rotation,
+                    &ctx.input.left_hand,
+                    right_held_entity,
+                    right_position,
+                )
+            };
         self.left_hand = left_hand;
 
         left_msgs.append(&mut right_msgs);
@@ -626,36 +1038,43 @@ impl PlayerInteraction for VrInteraction {
         use_mode: bool,
     ) -> Vec<SceneObject> {
         let mut glove_slot = self.glove_renderer.borrow_mut();
-        let glove_renderer = glove_slot
+        let mut glove_renderer = glove_slot
             .get_or_insert_with(|| GloveRenderer::new(asset_cache))
             .as_mut();
 
         let mut objs = Vec::new();
-        match glove_renderer {
-            Some(renderer) => {
-                objs.append(
-                    &mut self.left_hand.render(
-                        world,
-                        Some(renderer),
-                        self.fitted_grips[0]
+        let support_grip = self.support.as_ref().and_then(|support| {
+            let mut grip = self.fitted_grips[support.primary]
+                .as_ref()?
+                .resolved
+                .clone()?;
+            grip.curls = self.support_preview.as_ref()?.profile.curls;
+            Some((1 - support.primary, grip))
+        });
+        for (index, hand) in [&self.left_hand, &self.right_hand].into_iter().enumerate() {
+            let grip = self.fitted_grips[index]
+                .as_ref()
+                .and_then(|g| g.resolved.as_ref())
+                .or_else(|| {
+                    support_grip
+                        .as_ref()
+                        .filter(|(i, _)| *i == index)
+                        .map(|(_, g)| g)
+                });
+            objs.extend(hand.render(
+                world,
+                glove_renderer.as_deref_mut(),
+                grip.map(|grip| {
+                    (
+                        grip,
+                        self.support
                             .as_ref()
-                            .and_then(|g| g.resolved.as_ref()),
-                    ),
-                );
-                objs.append(
-                    &mut self.right_hand.render(
-                        world,
-                        Some(renderer),
-                        self.fitted_grips[1]
-                            .as_ref()
-                            .and_then(|g| g.resolved.as_ref()),
-                    ),
-                );
-            }
-            None => {
-                objs.append(&mut self.left_hand.render(world, None, None));
-                objs.append(&mut self.right_hand.render(world, None, None));
-            }
+                            .filter(|s| 1 - s.primary == index && hand.get_held_entity().is_none())
+                            .map_or(1.0, |s| s.blend),
+                    )
+                }),
+                self.visual_hands[index],
+            ));
         }
         if self.grip_overlay {
             use cgmath::{Matrix4, Rotation, vec3};
@@ -749,6 +1168,18 @@ impl PlayerInteraction for VrInteraction {
         if self.left_hand.is_holding(entity_id) || self.right_hand.is_holding(entity_id) {
             return Vec::new();
         }
+        let index = if hand == Handedness::Left { 0 } else { 1 };
+        if let Some(support) = self.support.as_mut() {
+            if support.primary == index {
+                self.support = None;
+            } else {
+                // A new offhand item must not snap the primary out of its decay.
+                support.active = false;
+            }
+        }
+        // Consumed squeeze/trigger input remains blocked until both release.
+        self.support_preview = None;
+        self.visual_hands = [None, None];
         if hand == Handedness::Left {
             self.left_hand = self.left_hand.grab_entity(world, entity_id);
         } else {
@@ -758,11 +1189,21 @@ impl PlayerInteraction for VrInteraction {
     }
 
     fn replace_entity(&mut self, old: EntityId, new: EntityId, rigid_body: RigidBodyHandle) {
+        if self.support.as_ref().is_some_and(|s| s.entity == old) {
+            self.support = None;
+            self.support_preview = None;
+            self.visual_hands = [None, None];
+        }
         self.left_hand = self.left_hand.replace_entity(old, new, rigid_body);
         self.right_hand = self.right_hand.replace_entity(old, new, rigid_body);
     }
 
     fn on_entity_destroyed(&mut self, entity_id: EntityId) {
+        if self.support.as_ref().is_some_and(|s| s.entity == entity_id) {
+            self.support = None;
+            self.support_preview = None;
+            self.visual_hands = [None, None];
+        }
         self.left_hand = self.left_hand.destroy_entity(entity_id);
         self.right_hand = self.right_hand.destroy_entity(entity_id);
     }
@@ -904,6 +1345,8 @@ mod tests {
             player_rotation: identity(),
             head_rotation: identity(),
             eye_height: 1.04,
+            step_dt: 1.0 / 60.0,
+            support_enabled: true,
         }
     }
 
@@ -911,6 +1354,153 @@ mod tests {
         let player = EntityId::from_inner(10_000).unwrap();
         let mut player = physics.create_player(vec3(10.0, 10.0, 10.0), player);
         physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+    }
+
+    #[test]
+    fn support_accepts_zero_dt_input_edges_and_requires_release_after_break() {
+        use crate::vr_grip::{GripKinematics, ResolvedGrip};
+        let mut world = World::new();
+        let entity = grabbable(&mut world);
+        let physics = PhysicsWorld::new();
+        let mut interaction = VrInteraction::new();
+        interaction.grab(&world, entity, Handedness::Right);
+        interaction.grip_kinematics = Some(std::array::from_fn(|_| GripKinematics {
+            fingers: std::array::from_fn(|_| Vec::new()),
+            palm: vec3(0.0, 0.0, 0.0),
+            normal: Vector3::unit_x(),
+        }));
+        interaction.support_profiles.insert(
+            "wrench_h".into(),
+            SupportProfile {
+                palm_anchor: [0.0, 0.2, 0.0],
+                curls: [0.5; 5],
+                grab_radius: 0.07,
+                release_distance: 0.12,
+                max_swing_degrees: 75.0,
+            },
+        );
+        interaction.fitted_grips[1] = Some(HeldGrip {
+            entity,
+            model: "wrench_h".into(),
+            resolved: Some(ResolvedGrip {
+                item_scale: 1.0,
+                pose_family: "cylindrical".into(),
+                offset: vec3(0.0, 0.0, 0.0),
+                rotation: identity(),
+                curls: [0.5; 5],
+                contacts: [None; 5],
+                anchor: [0.0; 3],
+                score: 0.0,
+            }),
+            solve_ms: 0.0,
+            surface_hash: String::new(),
+            kinematics_hash: String::new(),
+            hints_hash: String::new(),
+            source: "prepared",
+            authored: false,
+            item_bounds: None,
+        });
+        let mut input = InputContext::default();
+        input.right_hand.position = vec3(0.0, 1.0, 0.0);
+        input.right_hand.rotation = identity();
+        input.right_hand.squeeze_value = 1.0;
+        input.left_hand.position = vec3(0.0, 1.2, 0.0);
+        input.left_hand.rotation = identity();
+        input.left_hand.squeeze_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        input.left_hand.squeeze_value = 1.0;
+        let mut ctx = context(&world, &physics, &input);
+        ctx.step_dt = 0.0;
+        interaction.update_support(&ctx);
+        assert!(interaction.support.as_ref().unwrap().active);
+        // Supporting hand input is swallowed even on render-only frames.
+        let effects = interaction.update(&ctx);
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, VirtualHandEffect::HoldItem { .. }))
+        );
+        assert_eq!(interaction.held_entities(), (None, Some(entity)));
+        // Simulate collision blocking the physical wrench away from its target.
+        world.add_component(
+            entity,
+            (
+                dark::properties::PropPosition {
+                    position: vec3(0.0, 1.0, 0.3),
+                    rotation: identity(),
+                    cell: 0,
+                },
+                crate::runtime_props::RuntimePropVrGripOffset(vec3(0.0, 0.0, 0.1)),
+            ),
+        );
+        interaction.support.as_mut().unwrap().blend = 1.0;
+        interaction.synchronize_held_visuals(&world);
+        let actual = interaction.support_preview.as_ref().unwrap();
+        assert!((actual.model_pose.position - vec3(0.0, 1.0, 0.2)).magnitude() < 1e-5);
+        assert!(
+            (interaction.visual_hands[0].unwrap().position - vec3(0.0, 1.2, 0.2)).magnitude()
+                < 1e-5
+        );
+        assert!(
+            (interaction.visual_hands[1].unwrap().position - vec3(0.0, 1.0, 0.2)).magnitude()
+                < 1e-5
+        );
+        let attachment = interaction.support.take();
+        interaction.synchronize_held_visuals(&world);
+        assert!(
+            (interaction.visual_hands[1].unwrap().position - vec3(0.0, 1.0, 0.2)).magnitude()
+                < 1e-5,
+            "single-hand melee also follows the physical body"
+        );
+        interaction.support = attachment;
+        world.remove::<crate::runtime_props::RuntimePropVrGripOffset>(entity);
+        // A trigger consumed while supporting must not leak on squeeze release.
+        input.left_hand.trigger_value = 1.0;
+        input.left_hand.squeeze_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(interaction.support_blocked[0]);
+        input.left_hand.trigger_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(!interaction.support_blocked[0]);
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(interaction.support.as_ref().unwrap().active);
+        input.left_hand.position.y = 2.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(!interaction.support.as_ref().unwrap().active);
+        input.left_hand.position.y = 1.2;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(!interaction.support.as_ref().unwrap().active);
+        input.left_hand.squeeze_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(interaction.support.as_ref().unwrap().active);
+        input.left_hand.rotation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(!interaction.support.as_ref().unwrap().active);
+        input.left_hand.rotation = identity();
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(!interaction.support.as_ref().unwrap().active);
+        input.left_hand.squeeze_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(interaction.support.as_ref().unwrap().active);
+        let mut ctx = context(&world, &physics, &input);
+        ctx.support_enabled = false;
+        interaction.update_support(&ctx);
+        assert!(!interaction.support.as_ref().unwrap().active);
+        let other_item = grabbable(&mut world);
+        interaction.grab(&world, other_item, Handedness::Left);
+        interaction.apply_support(&world, &mut Vec::new());
+        // The owning wrench keeps its release blend while the new item gets
+        // its own grip; there is no support-hand visual attached to the wrench.
+        assert!(interaction.support.as_ref().is_some_and(|s| !s.active));
+        assert_eq!(
+            interaction.held_entities(),
+            (Some(other_item), Some(entity))
+        );
     }
 
     #[test]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -57,6 +57,7 @@ pub use vr_config::{Handedness, MeleePosedArm, melee_contact_offset};
 pub mod vr_climb;
 pub mod vr_crouch;
 pub mod vr_grip;
+pub mod vr_support;
 pub mod vr_tracking;
 pub mod vr_weapon_grip;
 mod wielded_weapon;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4095,6 +4095,10 @@ impl MissionCore {
             physics: &self.physics,
             world: &self.world,
             input: hands_input,
+            step_dt: time.elapsed.as_secs_f32(),
+            support_enabled: !self.use_mode
+                && self.player_is_alive()
+                && self.player_controls_enabled,
             player_pos,
             player_rotation: player_rot,
             head_rotation: input_context.head.rotation,
@@ -4142,6 +4146,7 @@ impl MissionCore {
         // The timing of this is important - things like the GUI rendering depend on an up-to-date position
         // from physics
         self.synchronize_physics_positions();
+        self.interaction.synchronize_held_visuals(&self.world);
 
         // Re-anchor attached entities (e.g. a muzzle flash) to their parent's
         // now-current transform, so they track a moving parent rather than their

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -197,6 +197,24 @@ impl VirtualHand {
         self.rotation
     }
 
+    /// A supporting hand tracks its controller but cannot also ray-grab/frob.
+    pub(crate) fn update_suppressed(
+        &self,
+        pawn_pos: Vector3<f32>,
+        pawn_rot: Quaternion<f32>,
+        input: &Hand,
+    ) -> Self {
+        debug_assert!(self.get_held_entity().is_none());
+        let mut hand = self.clone();
+        hand.position = hand_world_position(pawn_pos, pawn_rot, input.position);
+        hand.rotation = pawn_rot * input.rotation;
+        hand.squeeze_value = input.squeeze_value;
+        hand.trigger_value = input.trigger_value;
+        hand.raytrace_hit = None;
+        hand.last_frobbed_entity = None;
+        hand
+    }
+
     pub fn grab_entity(
         &self,
         _world: &World,
@@ -404,21 +422,30 @@ impl VirtualHand {
         &self,
         world: &World,
         glove_renderer: Option<&mut crate::hand_glove::GloveRenderer>,
-        grip: Option<&crate::vr_grip::ResolvedGrip>,
+        grip: Option<(&crate::vr_grip::ResolvedGrip, f32)>,
+        visual_pose: Option<crate::vr_support::GripPose>,
     ) -> Vec<SceneObject> {
+        let hand_pose = visual_pose.unwrap_or(crate::vr_support::GripPose {
+            position: self.position,
+            rotation: self.rotation,
+        });
+        // Invalid controller tracking must not send a non-finite transform to GL.
+        if !hand_pose.is_tracked() {
+            return Vec::new();
+        }
         // The hand itself: the skinned hand model, posed from the analog
         // inputs - unless a wielded weapon's model stands in for it.
         let mut scene_objects = glove_renderer
             .filter(|_| shows_hand_visual(world, self.get_held_entity()))
             .map(|renderer| {
                 renderer.render_hand(
-                    self.position,
-                    self.rotation,
+                    hand_pose.position,
+                    hand_pose.rotation,
                     self.handedness,
                     self.trigger_value,
                     self.squeeze_value,
                     self.get_held_entity().is_some(),
-                    grip.map(|grip| grip.finger_amounts()),
+                    grip.map(|(grip, blend)| (grip.finger_amounts(), blend)),
                 )
             })
             .unwrap_or_default();

--- a/shock2vr/src/vr_support.rs
+++ b/shock2vr/src/vr_support.rs
@@ -1,0 +1,181 @@
+//! Rigid two-anchor posing. Geometry, scale and ownership stay with the primary hand.
+use cgmath::{InnerSpace, Quaternion, Rotation, Vector3};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct GripPose {
+    pub position: Vector3<f32>,
+    pub rotation: Quaternion<f32>,
+}
+
+impl GripPose {
+    pub fn point(self, local: Vector3<f32>) -> Vector3<f32> {
+        self.position + self.rotation.rotate_vector(local)
+    }
+
+    pub fn is_tracked(self) -> bool {
+        [
+            self.position.x,
+            self.position.y,
+            self.position.z,
+            self.rotation.s,
+            self.rotation.v.x,
+            self.rotation.v.y,
+            self.rotation.v.z,
+        ]
+        .into_iter()
+        .all(f32::is_finite)
+            && crate::util::tracked_rotation(self.rotation).is_some()
+    }
+}
+
+/// Anchor in the normalized weapon mesh used by prepared grips (before item scale).
+/// The left-primary variant mirrors X. This first slice opts in only the wrench.
+#[derive(Clone, Debug, Deserialize)]
+pub struct SupportProfile {
+    pub palm_anchor: [f32; 3],
+    pub curls: [f32; 5],
+    pub grab_radius: f32,
+    pub release_distance: f32,
+    pub max_swing_degrees: f32,
+}
+
+impl SupportProfile {
+    pub fn is_valid(&self) -> bool {
+        self.palm_anchor.iter().all(|v| v.is_finite())
+            && self
+                .curls
+                .iter()
+                .all(|v| v.is_finite() && (0.0..=1.0).contains(v))
+            && self.grab_radius.is_finite()
+            && (0.01..=0.15).contains(&self.grab_radius)
+            && self.release_distance.is_finite()
+            && (self.grab_radius..=0.3).contains(&self.release_distance)
+            && (20.0..=120.0).contains(&self.max_swing_degrees)
+    }
+
+    pub fn allows_swing(&self, from: Vector3<f32>, to: Vector3<f32>) -> bool {
+        from.magnitude2() > 1e-8
+            && to.magnitude2() > 1e-8
+            && from.normalize().dot(to.normalize()) >= self.max_swing_degrees.to_radians().cos()
+    }
+
+    pub fn anchor(&self, primary: usize) -> Vector3<f32> {
+        let [x, y, z] = self.palm_anchor;
+        let hand = if primary == 0 {
+            crate::vr_config::Handedness::Left
+        } else {
+            crate::vr_config::Handedness::Right
+        };
+        hand.mirror_point(Vector3::new(x, y, z))
+    }
+}
+
+/// Keep the primary anchor exact, align the anchor vector, and inherit twist
+/// from the primary orientation. Coincident hands keep the previous rotation.
+/// Anchors are already scaled: there is no scale solve or hand-distance stretch.
+pub fn solve_two_hand_pose(
+    primary_palm: Vector3<f32>,
+    support_palm: Vector3<f32>,
+    primary_rotation: Quaternion<f32>,
+    primary_anchor: Vector3<f32>,
+    support_anchor: Vector3<f32>,
+    previous_rotation: Quaternion<f32>,
+) -> GripPose {
+    let source = primary_rotation.rotate_vector(support_anchor - primary_anchor);
+    let target = support_palm - primary_palm;
+    let rotation = if source.magnitude2() < 1e-8 || target.magnitude2() < 1e-8 {
+        previous_rotation
+    } else {
+        let from = source.normalize();
+        // The antiparallel case needs a deterministic primary-hand twist axis.
+        let mut axis = primary_rotation.rotate_vector(Vector3::unit_x());
+        if axis.dot(from).abs() > 0.9 {
+            axis = primary_rotation.rotate_vector(Vector3::unit_z());
+        }
+        let axis = (axis - from * axis.dot(from)).normalize();
+        (Quaternion::from_arc(from, target.normalize(), Some(axis)) * primary_rotation).normalize()
+    };
+    GripPose {
+        position: primary_palm - rotation.rotate_vector(primary_anchor),
+        rotation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Deg, One, Rotation3, vec3};
+
+    #[test]
+    fn primary_twist_survives_and_invalid_profiles_do_not_opt_in() {
+        let a = vec3(0.0, 0.0, 0.0);
+        let b = vec3(0.0, 0.2, 0.0);
+        let q = Quaternion::from_angle_y(Deg(73.0));
+        let pose = solve_two_hand_pose(a, b, q, a, b, Quaternion::one());
+        assert!(
+            (pose.rotation.rotate_vector(Vector3::unit_x()) - q.rotate_vector(Vector3::unit_x()))
+                .magnitude()
+                < 1e-5
+        );
+        let mut profile = SupportProfile {
+            palm_anchor: [0.02, 0.2, 0.0],
+            curls: [0.5; 5],
+            grab_radius: 0.07,
+            release_distance: 0.12,
+            max_swing_degrees: 75.0,
+        };
+        assert!(profile.is_valid());
+        assert!(profile.allows_swing(Vector3::unit_y(), Vector3::unit_y()));
+        assert!(!profile.allows_swing(Vector3::unit_y(), Vector3::unit_x()));
+        assert_eq!(profile.anchor(0).x, -profile.anchor(1).x);
+        profile.release_distance = 0.02;
+        assert!(!profile.is_valid());
+        profile.release_distance = 0.12;
+        profile.curls[0] = f32::NAN;
+        assert!(!profile.is_valid());
+    }
+
+    #[test]
+    fn off_axis_anchors_preserve_primary_and_align_without_stretching() {
+        let a = vec3(0.04, 0.1, -0.06);
+        let b = vec3(-0.03, 0.35, -0.02);
+        let p = vec3(2.0, 3.0, 4.0);
+        let target = vec3(0.5, 0.3, -0.2);
+        let q = Quaternion::from_angle_z(Deg(27.0));
+        let pose = solve_two_hand_pose(p, p + target, q, a, b, q);
+        assert!((pose.point(a) - p).magnitude() < 1e-5);
+        assert!(((pose.point(b) - p).normalize() - target.normalize()).magnitude() < 1e-5);
+        assert!(((pose.point(b) - p).magnitude() - (b - a).magnitude()).abs() < 1e-5);
+        assert!((pose.rotation.magnitude() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn antiparallel_and_coincident_hands_are_finite_and_stable() {
+        let a = Vector3::new(0.03, 0.02, -0.01);
+        let b = a + Vector3::unit_y() * 0.2;
+        let q = Quaternion::from_angle_y(Deg(41.0));
+        let p = Vector3::new(1.0, 2.0, 3.0);
+        let pose = solve_two_hand_pose(p, p - Vector3::unit_y(), q, a, b, q);
+        assert!(pose.is_tracked());
+        assert!((pose.point(a) - p).magnitude() < 1e-5);
+        assert!(((pose.point(b) - p).normalize() + Vector3::unit_y()).magnitude() < 1e-5);
+        let still = solve_two_hand_pose(p, p, q, a, b, pose.rotation);
+        assert_eq!(still.rotation, pose.rotation);
+        assert!((still.point(a) - p).magnitude() < 1e-5);
+        assert!(
+            !GripPose {
+                position: p,
+                rotation: Quaternion::new(0.0, 0.0, 0.0, 0.0)
+            }
+            .is_tracked()
+        );
+        assert!(
+            GripPose {
+                position: p,
+                rotation: Quaternion::one()
+            }
+            .is_tracked()
+        );
+    }
+}

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -312,7 +312,7 @@ impl ModelPreview {
                     0.0,
                     0.0,
                     true,
-                    Some(grip.finger_amounts()),
+                    Some((grip.finger_amounts(), 1.0)),
                 ));
                 let triangles = if shock2vr::vr_weapon_grip::supports_model(key) {
                     shock2vr::vr_weapon_grip::inputs(&mut self.asset_cache, key, *hand)

--- a/tools/shock2-sdk/scripts/capture-wrench-support.mjs
+++ b/tools/shock2-sdk/scripts/capture-wrench-support.mjs
@@ -1,0 +1,199 @@
+// Node 22+, built SDK. Run from tools/shock2-sdk:
+// node scripts/capture-wrench-support.mjs --output /tmp/astra-wrench-support/after
+// --reference <prior data.json> replays exactly the saved camera and secondary inputs.
+// Use a baseline checkout/runtime to produce matching before evidence. Runtime lifecycle
+// remains SDK-owned. No grip resources are changed. Gallery statuses are diagnostic.
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { GameServer } from "../dist/src/index.js";
+import { aimVrHandAt } from "../dist/test/helpers/vr-hand.js";
+import { parseArgs } from "node:util";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+const { values } = parseArgs({
+  options: {
+    output: { type: "string", default: "/tmp/astra-wrench-support" },
+    reference: { type: "string" },
+  },
+});
+const out = resolve(values.output),
+  reference = values.reference
+    ? JSON.parse(await readFile(resolve(values.reference), "utf8"))
+    : null;
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+await mkdir(out, { recursive: true });
+const game = await GameServer.launch({
+  mission: "debug_interactions",
+  debugFlags: ["--vr"],
+  repoRoot,
+});
+const data = { hands: {} };
+try {
+  for (const primary of ["right", "left"]) {
+    const secondary = primary === "right" ? "left" : "right";
+    await game.input.set("left_hand.squeeze", 0);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.camera.attach();
+    await game.input.trigger("DebugReloadLevel");
+    await game.step({ frames: 90 });
+    const item = (await game.entities.list({ limit: 100 })).entities.find(
+      (e) => e.template_id === -928,
+    );
+    assert.ok(item);
+    await game.player.teleport({ x: item.position[0], y: 1, z: 0 });
+    await aimVrHandAt(game, item.position, 0.2, 0, 0, { hand: primary });
+    await game.input.set(`${primary}_hand.squeeze`, 1);
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.info()).player[
+        primary === "left" ? "wielded_entity_id" : "right_hand_entity_id"
+      ],
+      item.id,
+    );
+    await game.player.teleport({ x: 4, y: 1.25, z: 5 });
+    await game.input.set(`${primary}_hand.position`, [0, 1, 0]);
+    await game.input.set(`${primary}_hand.rotation`, [
+      0,
+      Math.SQRT1_2,
+      0,
+      Math.SQRT1_2,
+    ]);
+    await game.input.set(`${secondary}_hand.position`, [0, -100, 0]);
+    await game.step({ frames: 3 });
+    const info = await game.info(),
+      g = info.player.hand_grips.find((g) => g.hand === primary),
+      s = g.support,
+      pawn = info.player.position;
+    const vec = (v) => (Array.isArray(v) ? v : [v.x, v.y, v.z]);
+    const pos =
+      reference?.hands[primary].basePosition ??
+      vec(s.controller_position).map((v, i) => v - pawn[i]);
+    const rot = reference?.hands[primary].baseRotation ?? [
+      s.controller_rotation.v.x,
+      s.controller_rotation.v.y,
+      s.controller_rotation.v.z,
+      s.controller_rotation.s,
+    ];
+    const camera = reference?.hands[primary].camera ?? {
+      position: [4.8, pawn[1] + 1.3, 5.7],
+      lookAt: [3.96, pawn[1] + 1.16, 5],
+    };
+    await game.camera.set(camera);
+    const record = {
+      basePosition: pos,
+      baseRotation: rot,
+      camera,
+      initialDiagnostic: g,
+      initialPlayerPosition: pawn,
+      steps: [],
+    };
+    data.hands[primary] = record;
+    const steps = reference?.hands[primary].steps ?? [
+      {
+        name: "approach",
+        position: pos.map((v, i) => v + (i === 0 ? 0.16 : 0)),
+        squeeze: 0,
+        frames: 6,
+      },
+      { name: "at-socket", position: pos, squeeze: 0, frames: 6 },
+      ...Array.from({ length: 5 }, (_, i) => ({
+        name: "attach-" + i,
+        position: pos,
+        squeeze: 1,
+        frames: 3,
+      })),
+      ...Array.from({ length: 9 }, (_, i) => ({
+        name: "steer-" + i,
+        position: pos.map(
+          (v, j) =>
+            v +
+            (j === 0
+              ? 0.16 * Math.sin((i * Math.PI) / 4)
+              : j === 2
+                ? 0.07 * Math.sin((i * Math.PI) / 4)
+                : 0),
+        ),
+        squeeze: 1,
+        frames: 3,
+      })),
+      ...Array.from({ length: 6 }, (_, i) => ({
+        name: "release-" + i,
+        position: pos.map((v, j) => v + (j === 0 ? 0.16 : 0)),
+        squeeze: 0,
+        frames: 3,
+      })),
+    ];
+    for (const step of steps) {
+      await game.input.set(`${secondary}_hand.position`, step.position);
+      await game.input.set(`${secondary}_hand.rotation`, rot);
+      await game.input.set(`${secondary}_hand.squeeze`, step.squeeze);
+      await game.step({ frames: step.frames });
+      const state = await game.info();
+      const file = `${primary}-${step.name}.png`;
+      await game.screenshot(`${out}/${file}`, 1600);
+      if (step.name === "attach-4") {
+        const support = state.player.hand_grips.find(
+          (g) => g.hand === primary,
+        )?.support;
+        const priorViews = reference?.hands[primary].closeViews;
+        record.closeViews = {};
+        for (const [view, delta] of Object.entries({
+          front: [0.35, 0.08, 0.35],
+          back: [-0.35, 0.08, -0.35],
+          top: [0, 0.45, 0.01],
+        })) {
+          if (!support && !priorViews?.[view]) continue;
+          const target = support
+            ? vec(support.socket_position)
+            : priorViews[view].lookAt;
+          const pose = priorViews?.[view] ?? {
+            position: target.map((v, i) => v + delta[i]),
+            lookAt: target,
+          };
+          await game.camera.set(pose);
+          await game.step({ frames: 1 });
+          const closeFile = `${primary}-contact-${view}.png`;
+          await game.screenshot(`${out}/${closeFile}`, 1600);
+          record.closeViews[view] = { ...pose, file: closeFile };
+        }
+        await game.camera.set(camera);
+      }
+      record.steps.push({
+        ...step,
+        file,
+        diagnostic: state.player.hand_grips,
+        playerPosition: state.player.position,
+      });
+    }
+    await writeFile(`${out}/data.json`, JSON.stringify(data, null, 2));
+  }
+} finally {
+  await game.shutdown();
+  await writeFile(`${out}/runtime.log`, game.logs().join("\n"));
+}
+
+const sections = [];
+for (const [hand, record] of Object.entries(data.hands)) {
+  for (const [view, shot] of Object.entries(record.closeViews ?? {})) {
+    const image = await readFile(`${out}/${shot.file}`);
+    sections.push(
+      `<section><h2>${hand} primary / contact ${view}</h2><img alt="${hand} primary contact ${view}" src="data:image/png;base64,${image.toString("base64")}"></section>`,
+    );
+  }
+
+  for (const step of record.steps) {
+    const image = await readFile(`${out}/${step.file}`);
+    const support = step.diagnostic.find((g) => g.hand === hand)?.support;
+    const status = support
+      ? `attached=${support.attached}, blend=${Number(support.blend).toFixed(3)}`
+      : "baseline: no support diagnostics";
+    sections.push(
+      `<section><h2>${hand} primary / ${step.name}</h2><p>${status}</p><img alt="${hand} primary ${step.name}" src="data:image/png;base64,${image.toString("base64")}"></section>`,
+    );
+  }
+}
+await writeFile(
+  `${out}/index.html`,
+  `<!doctype html><meta charset="utf-8"><title>Astra wrench support</title><style>body{background:#18202a;color:white;font:16px system-ui;margin:24px}img{max-width:100%;max-height:80vh}section{margin-bottom:32px}</style><h1>Wrench support diagnostic capture</h1><p>Primary controller fixed; secondary approaches, acquires, steers and releases. Rendered images and state transitions are evidence, not automatic fit or headset approval.</p>${sections.join("")}`,
+);
+console.log(`${out}/index.html`);

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -1129,6 +1129,29 @@ export interface HandGrip {
   palm: {x:number;y:number;z:number};
   palm_normal: {x:number;y:number;z:number};
   grip: ResolvedGrip | null;
+  /** Glove pose following a physical melee body; null uses raw tracked pose. */
+  glove_pose: { position: ResolvedGrip["offset"]; rotation: ResolvedGrip["rotation"] } | null;
+  /** Optional support socket on this owned item; the support hand owns no entity. */
+  support: {
+    hand: "left" | "right";
+    attached: boolean;
+    blend: number;
+    tracked_palm: ResolvedGrip["offset"];
+    pressed: [boolean, boolean];
+    blocked: [boolean, boolean];
+    step_dt: number;
+    socket_position: ResolvedGrip["offset"];
+    controller_position: ResolvedGrip["offset"];
+    controller_rotation: ResolvedGrip["rotation"];
+    model_position: ResolvedGrip["offset"];
+    model_rotation: ResolvedGrip["rotation"];
+    primary_palm: ResolvedGrip["offset"];
+    primary_anchor: ResolvedGrip["offset"];
+    support_anchor: ResolvedGrip["offset"];
+    grab_radius: number;
+    release_distance: number;
+    max_swing_degrees: number;
+  } | null;
 }
 
 export interface ResolvedGrip {

--- a/tools/shock2-sdk/test/vr-wrench-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-wrench-support.e2e.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import type { HandGrip, ResolvedGrip, Vec3 } from "../src/types.js";
+import { add, sub, aimVrHandAt, quatConjugate, quatMultiply, quatRotate, type Quat } from "./helpers/vr-hand.js";
+
+const vector = (v: ResolvedGrip["offset"]): Vec3 => [v.x, v.y, v.z];
+const quaternion = (q: ResolvedGrip["rotation"]): Quat => [...vector(q.v), q.s];
+const distance = (a: Vec3, b: Vec3) => Math.hypot(...sub(a,b));
+
+for (const primary of ["right", "left"] as const) {
+  test(`wrench support (${primary} primary): near grab, rigid steering, release and separation break`,
+    { skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000 }, async () => {
+      await using game = await GameServer.launch({mission:"debug_interactions", debugFlags:["--vr"]});
+      await game.step({frames:90});
+      const wrench = (await game.entities.list()).entities.find(e => e.template_id === -928)!;
+      const other = primary === "right" ? "left" : "right";
+      const owned = primary === "right" ? "right_hand_entity_id" : "wielded_entity_id";
+      const empty = primary === "right" ? "wielded_entity_id" : "right_hand_entity_id";
+      await game.player.teleport({x:wrench.position[0],y:1,z:0});
+      await aimVrHandAt(game, wrench.position, .2, 1, 0, {hand:primary});
+      await game.input.set(`${primary}_hand.position`, [0,1,-.5]);
+      await game.input.set(`${primary}_hand.rotation`, [0,0,0,1]);
+      await game.input.set(`${other}_hand.squeeze`, 0);
+      await game.step({frames:90});
+      const grip = async (): Promise<HandGrip> => (await game.info()).player.hand_grips.find(g => g.hand === primary)!;
+      const before = await grip();
+      assert.ok(before?.support, "wrench publishes its prepared support socket");
+      const itemScale = before.grip!.item_scale;
+      const place = async (position: Vec3, rotation = quaternion(before.support!.controller_rotation)) => {
+        const player = (await game.info()).player;
+        const inverse = quatConjugate(player.rotation);
+        await game.input.set(`${other}_hand.position`, quatRotate(inverse, sub(position, player.position)));
+        await game.input.set(`${other}_hand.rotation`, quatMultiply(inverse, rotation));
+      };
+      const socketHand = vector(before.support.controller_position);
+      // A squeeze begun away from the handle cannot attach by drifting into it.
+      await place(add(socketHand,[0,0,.6]));
+      await game.input.set(`${other}_hand.squeeze`, 1);
+      await game.step({frames:3});
+      await place(socketHand);
+      await game.step({frames:3});
+      assert.equal((await grip()).support!.attached,false);
+      await game.input.set(`${other}_hand.squeeze`, 0);
+      await game.step({frames:2});
+      await game.input.set(`${other}_hand.squeeze`, 1);
+      await game.step({frames:15});
+      assert.equal((await grip()).support!.attached,true, JSON.stringify({before:before.support, support:(await grip()).support}));
+      const state = (await game.info()).player;
+      assert.equal(state[owned],wrench.id);
+      assert.equal(state[empty],null,"support does not own a second entity");
+      assert.equal(state.hand_grips.length,1);
+      // Move only the supporting controller sideways; scale and the primary palm stay fixed.
+      await place(add(socketHand,[.09,0,0]));
+      await game.input.set(`${other}_hand.trigger`,1);
+      await game.step({frames:45});
+      const steered = await grip();
+      assert.equal(steered.support!.attached,true);
+      assert.equal((await game.info()).player[empty],null,"support trigger cannot acquire another item");
+      assert.ok(distance(vector(steered.support!.primary_palm),vector(before.support.primary_palm)) < .0001);
+      assert.ok(distance(vector(steered.support!.socket_position),vector(before.support.socket_position)) > .04);
+      const q = quaternion(steered.support!.model_rotation);
+      const root = vector(steered.support!.model_position);
+      const palm = add(root,quatRotate(q,vector(steered.support!.primary_anchor)));
+      assert.ok(distance(palm,vector(before.support.primary_palm)) < .0001,"model keeps primary anchor exact");
+      for (const draw of (await game.scene.objects({entityId:wrench.id})).objects) {
+        for (const scale of draw.scale) assert.ok(Math.abs(scale-itemScale) < 1e-5,"weapon never stretches");
+      }
+      await game.input.set(`${other}_hand.trigger`,0);
+      await game.input.set(`${other}_hand.squeeze`,0);
+      await game.step({frames:1});
+      const releasing = await grip();
+      assert.equal(releasing.support!.attached,false);
+      assert.ok(releasing.support!.blend > 0,"support release blends instead of snapping");
+      assert.equal((await game.info()).player[owned],wrench.id);
+      await game.step({frames:60});
+      assert.ok(distance(vector((await grip()).support!.model_position),vector(before.support.model_position)) < .001);
+      // Over-separation ends support; moving back while squeezed does not reattach.
+      await place(socketHand);
+      await game.input.set(`${other}_hand.squeeze`,1);
+      await game.step({frames:10});
+      assert.equal((await grip()).support!.attached,true);
+      await place(add(socketHand,[0,.5,0]));
+      await game.step({frames:1});
+      assert.equal((await grip()).support!.attached,false);
+      await place(socketHand);
+      await game.step({frames:10});
+      assert.equal((await grip()).support!.attached,false);
+      await game.input.set(`${other}_hand.squeeze`,0);
+      await game.step({frames:60});
+      await place(socketHand);
+      await game.input.set(`${other}_hand.squeeze`,1);
+      await game.step({frames:10});
+      assert.equal((await grip()).support!.attached,true);
+      await game.input.set(`${primary}_hand.squeeze`,0);
+      await game.step({frames:5});
+      const released = (await game.info()).player;
+      assert.equal(released[owned],null);
+      assert.equal(released[empty],null,"primary release never hands the wrench to the supporting hand");
+      assert.equal(released.hand_grips.length,0);
+    });
+}
+
+
+test("physical wrench glove stays attached during walking and wall contact", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
+}, async () => {
+  await using game = await GameServer.launch({mission:"debug_melee",debugFlags:["--vr"]});
+  await game.step({frames:90});
+  const wrench = (await game.entities.list()).entities.find(e => e.template_id === -928)!;
+  await aimVrHandAt(game,wrench.position,.2,1);
+  await game.player.teleport({x:-11,y:1,z:0});
+  await game.input.set("right_hand.position",[0,1,0]);
+  await game.input.set("right_hand.rotation",[0,0,0,1]);
+  await game.step({frames:90});
+  const check = async () => {
+    const g = (await game.info()).player.hand_grips.find(g=>g.hand === "right")!;
+    assert.ok(g.glove_pose && g.support && g.grip);
+    const modelFromGlove = add(vector(g.glove_pose.position),quatRotate(quaternion(g.glove_pose.rotation),vector(g.grip.offset)));
+    assert.ok(distance(modelFromGlove,vector(g.support.model_position)) < .0001,"glove and rendered physical weapon agree every frame");
+    return g;
+  };
+  await game.input.set("right_hand.thumbstick",[.7,0]);
+  for (let frame=0;frame<20;frame++) { await game.step({frames:1}); await check(); }
+  await game.input.set("right_hand.thumbstick",[0,0]);
+  await game.player.teleport({x:-11,y:1,z:0});
+  await game.step({frames:30});
+  // The debug_melee back wall is x=-13. Sweep the held controller through it.
+  for (let frame=0;frame<30;frame++) {
+    await game.input.set("right_hand.position",[-3*frame/29,1,0]);
+    await game.step({frames:1});
+    await check();
+  }
+  await game.step({frames:30});
+  const blocked = await check();
+  const player = (await game.info()).player;
+  const trackedModel = add(player.position,quatRotate(player.rotation,add([-3,1,0],vector(blocked.grip!.offset))));
+  assert.ok(distance(trackedModel,vector(blocked.support!.model_position)) > .5,"wall actually blocks the weapon away from the tracked target");
+  assert.ok(vector(blocked.support!.model_position)[0] > -13,"weapon remains on near side of wall");
+});


### PR DESCRIPTION
Holding the wrench with the free hand now steers it from two palm anchors while the primary hand retains ownership and weapon scale. Release blends back; support input stays reserved until squeeze and trigger are released. The support socket/curls live in `assets/astra-vr-support-grips.json`.

Fixes the reported melee glove separation during walking and impacts: every fitted physical melee glove now follows the collision-resolved weapon after physics synchronization. Includes per-frame walking/wall assertions and a local gallery capture script. Weapon scales are unchanged.

Validation: 1,522 Rust tests passed (2 ignored); all 44 rack fixtures passed in both hands; support acquisition/steering/release and single-hand wall regression passed; four existing production melee contact/save-load tests passed. Formatting and SDK TypeScript build pass. Claude, Codex, and duplication review completed; corrected trigger leakage, physical glove anchoring, angular limits, and finger blending. Close-up visual review cleared the gross wrist-side fit issue.

Stacked on #1382. Headset review remains for support reach, exact thumb clearance, and live tracking recovery. Other two-handed weapons, damage/perk changes, and physical-gun PRs #1142/#1153 are follow-on work.

## Visual evidence

![Wrench support before and after](https://gist.githubusercontent.com/tommy-xr/a75147cc72c49bd544f23bb7d849b0d6/raw/astra-wrench-support.gif)

Identical controller inputs on the preserved base runtime and current runtime: both primary hands, secondary acquisition, steering, and release.

![Support grip comparison](https://gist.githubusercontent.com/tommy-xr/a75147cc72c49bd544f23bb7d849b0d6/raw/astra-wrench-support-comparison.png)

![Single-hand movement and wall contact](https://gist.githubusercontent.com/tommy-xr/a75147cc72c49bd544f23bb7d849b0d6/raw/astra-single-hand.gif)

![Glove alignment at a blocked wall](https://gist.githubusercontent.com/tommy-xr/a75147cc72c49bd544f23bb7d849b0d6/raw/astra-single-wall-held.png)

The isolated wall sequence disables calibration overlays and lethally damages the scene creatures before pickup. Before, the glove passes behind the wall while the wrench stops; after, the glove stays on the physical handle. This is not a dedicated enemy-strike test.

[Download the standalone diagnostic gallery and open locally](https://gist.githubusercontent.com/tommy-xr/a75147cc72c49bd544f23bb7d849b0d6/raw/astra-wrench-support-gallery.html) for both-hand contact closeups and still comparisons. The initial support fit is improved; tight thumb/shaft clearance still needs headset assessment. Captured through the VR debug runtime with fixed simulation steps; no headset verification in this slice.
