### PR TITLE
feat(explorer): edit support-hand grip poses

### DIFF
--- a/projects/astra-vr-hands-round-2.md
+++ b/projects/astra-vr-hands-round-2.md
@@ -497,3 +497,31 @@ They need collider fitting from our stripped/scaled weapon geometry and the
 same post-physics glove placement, not a second motion solver. A merge trial
 against the committed parent found conflicts in `ss2_bin_obj_loader.rs`,
 `physics/mod.rs`, and `scripts/melee_weapon.rs`; neither PR was merged here.
+
+### Editing the supporting hand
+
+Explorer's VR Grips view now has **Primary grip** and **Support grip** modes.
+The left/right selector identifies the primary hand; the support pose mirrors
+for the other configuration. Both gloves remain visible in either mode.
+Support controls include palm XYZ position, wrist XYZ rotation, finger curls,
+Open/Point/Closed/Ball presets, sliders, nudge buttons, and exact value entry.
+Preview and runtime call the same palm-placement function, including item scale.
+
+Support edits save separately to `astra-vr-support-grips.json`. **Save As** writes
+a new JSON file without replacing an existing one. Reopen a custom support file
+with `--support-grip-library <path>`; gameplay reads the normal asset filename
+on startup. Closing prompts for unsaved primary or support edits, and external
+file changes are detected before overwriting. **Save all edits** in Primary grip
+mode saves both resources; **Save support edits** saves only the support file.
+
+To open directly:
+`cargo run -p dark_explorer -- ui --grip wrench_h --grip-support`
+Add `--grip-hand left` to inspect the mirrored configuration. Other models can
+have support drafts authored, but runtime two-hand grabbing currently opts in
+only the wrench; the tool labels those other support drafts as preview-only.
+
+To add a new primary model, use **Files → select the .bin model → Edit VR Grip**.
+The tool prepares left/right drafts (or offers **Prepare left and right drafts**),
+which enter the override map when saved. Nanites use `nanocan.bin`; nanite
+pickups still collect immediately in gameplay, so authoring their grip does not
+change their collection behavior.

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -351,12 +351,16 @@ impl VrInteraction {
             // Melee physics may stop short of its target at a wall. Acquisition
             // and visible gloves belong on that actual weapon, not an unseen target.
             let model_pose = held.physical_model_pose(world).unwrap_or(target_pose);
-            let hand_rotation = model_pose.rotation * grip.rotation.conjugate();
-            let hand_pose = GripPose {
-                position: model_pose.point(anchor)
-                    - hand_rotation.rotate_vector(rig[1 - primary].palm),
-                rotation: hand_rotation,
-            };
+            let hand_pose = profile.glove_pose(
+                if primary == 0 {
+                    Handedness::Left
+                } else {
+                    Handedness::Right
+                },
+                model_pose,
+                grip,
+                &rig[1 - primary],
+            );
             return Some(SupportCandidate {
                 entity: held.entity,
                 primary,
@@ -1373,6 +1377,7 @@ mod tests {
             "wrench_h".into(),
             SupportProfile {
                 palm_anchor: [0.0, 0.2, 0.0],
+                rotation_degrees: [0.0; 3],
                 curls: [0.5; 5],
                 grab_radius: 0.07,
                 release_distance: 0.12,

--- a/shock2vr/src/vr_support.rs
+++ b/shock2vr/src/vr_support.rs
@@ -1,5 +1,5 @@
 //! Rigid two-anchor posing. Geometry, scale and ownership stay with the primary hand.
-use cgmath::{InnerSpace, Quaternion, Rotation, Vector3};
+use cgmath::{Deg, Euler, InnerSpace, Quaternion, Rotation, Vector3};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -31,9 +31,12 @@ impl GripPose {
 
 /// Anchor in the normalized weapon mesh used by prepared grips (before item scale).
 /// The left-primary variant mirrors X. This first slice opts in only the wrench.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SupportProfile {
     pub palm_anchor: [f32; 3],
+    /// Support wrist rotation relative to the primary wrist; authored right-primary.
+    #[serde(default)]
+    pub rotation_degrees: [f32; 3],
     pub curls: [f32; 5],
     pub grab_radius: f32,
     pub release_distance: f32,
@@ -44,6 +47,10 @@ impl SupportProfile {
     pub fn is_valid(&self) -> bool {
         self.palm_anchor.iter().all(|v| v.is_finite())
             && self
+                .rotation_degrees
+                .iter()
+                .all(|v| v.is_finite() && v.abs() <= 360.0)
+            && self
                 .curls
                 .iter()
                 .all(|v| v.is_finite() && (0.0..=1.0).contains(v))
@@ -52,6 +59,34 @@ impl SupportProfile {
             && self.release_distance.is_finite()
             && (self.grab_radius..=0.3).contains(&self.release_distance)
             && (20.0..=120.0).contains(&self.max_swing_degrees)
+    }
+
+    /// Shared runtime/editor support glove placement from the same palm anchor.
+    pub fn glove_pose(
+        &self,
+        primary: crate::Handedness,
+        model: GripPose,
+        grip: &crate::vr_grip::ResolvedGrip,
+        support_rig: &crate::vr_grip::GripKinematics,
+    ) -> GripPose {
+        let [x, y, z] = self.rotation_degrees;
+        let q = Quaternion::from(Euler::new(Deg(x), Deg(y), Deg(z)));
+        // Reflect the authored rotation along with the palm's X mirror.
+        let q = if primary == crate::Handedness::Left {
+            Quaternion::new(q.s, q.v.x, -q.v.y, -q.v.z)
+        } else {
+            q
+        };
+        let rotation = model.rotation * grip.rotation.conjugate() * q;
+        let anchor = self.anchor(if primary == crate::Handedness::Left {
+            0
+        } else {
+            1
+        }) * grip.item_scale;
+        GripPose {
+            position: model.point(anchor) - rotation.rotate_vector(support_rig.palm),
+            rotation,
+        }
     }
 
     pub fn allows_swing(&self, from: Vector3<f32>, to: Vector3<f32>) -> bool {
@@ -108,6 +143,59 @@ mod tests {
     use cgmath::{Deg, One, Rotation3, vec3};
 
     #[test]
+    fn rotated_support_pose_preserves_the_mirrored_palm_in_runtime_and_editor() {
+        let profile = SupportProfile {
+            palm_anchor: [-0.09, 0.354, 0.02],
+            rotation_degrees: [20.0, 15.0, -30.0],
+            curls: [0.4; 5],
+            grab_radius: 0.07,
+            release_distance: 0.12,
+            max_swing_degrees: 75.0,
+        };
+        let grip = crate::vr_grip::ResolvedGrip {
+            item_scale: 0.7,
+            pose_family: "cylindrical".into(),
+            offset: vec3(-0.05, -0.1, 0.02),
+            rotation: Quaternion::from_angle_x(Deg(20.0)),
+            curls: [0.4; 5],
+            contacts: [None; 5],
+            anchor: [0.0; 3],
+            score: 0.0,
+        };
+        let model = GripPose {
+            position: vec3(2.0, 3.0, 4.0),
+            rotation: Quaternion::from_angle_y(Deg(35.0)),
+        };
+        for primary in [crate::Handedness::Left, crate::Handedness::Right] {
+            let rig = crate::vr_grip::GripKinematics {
+                fingers: std::array::from_fn(|_| Vec::new()),
+                palm: vec3(0.01, -0.001, -0.079),
+                normal: Vector3::unit_x(),
+            };
+            let pose = profile.glove_pose(primary, model, &grip, &rig);
+            let expected =
+                model.point(primary.mirror_point(vec3(-0.09, 0.354, 0.02)) * grip.item_scale);
+            assert!((pose.point(rig.palm) - expected).magnitude() < 1e-5);
+            assert!((pose.rotation.magnitude() - 1.0).abs() < 1e-5);
+            let sign = if primary == crate::Handedness::Left {
+                -1.0
+            } else {
+                1.0
+            };
+            let editor_rotation = Quaternion::from(cgmath::Euler::new(
+                Deg(20.0),
+                Deg(15.0 * sign),
+                Deg(-30.0 * sign),
+            ));
+            let expected_rotation = model.rotation * grip.rotation.conjugate() * editor_rotation;
+            for axis in [Vector3::unit_x(), Vector3::unit_y(), Vector3::unit_z()] {
+                assert!((pose.rotation * axis - expected_rotation * axis).magnitude() < 1e-5);
+            }
+            assert!(pose.is_tracked());
+        }
+    }
+
+    #[test]
     fn primary_twist_survives_and_invalid_profiles_do_not_opt_in() {
         let a = vec3(0.0, 0.0, 0.0);
         let b = vec3(0.0, 0.2, 0.0);
@@ -120,6 +208,7 @@ mod tests {
         );
         let mut profile = SupportProfile {
             palm_anchor: [0.02, 0.2, 0.0],
+            rotation_degrees: [0.0; 3],
             curls: [0.5; 5],
             grab_radius: 0.07,
             release_distance: 0.12,

--- a/tools/dark_explorer/src/grip_editor.rs
+++ b/tools/dark_explorer/src/grip_editor.rs
@@ -14,6 +14,13 @@ use std::{
     path::PathBuf,
 };
 
+pub(crate) const POSE_PRESETS: [(&str, [f32; 5]); 4] = [
+    ("Open", [0.0; 5]),
+    ("Point", [0.85, 0.0, 0.9, 0.9, 0.9]),
+    ("Closed", [1.0; 5]),
+    ("Ball", [0.35, 0.25, 0.3, 0.35, 0.4]),
+];
+
 pub fn default_library_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/astra-vr-grips.json")
 }
@@ -90,17 +97,7 @@ impl GripDocument {
         }
         let mut bytes = serde_json::to_vec_pretty(&self.library).map_err(|e| e.to_string())?;
         bytes.push(b'\n');
-        let mut temp =
-            tempfile::NamedTempFile::new_in(path.parent().unwrap()).map_err(|e| e.to_string())?;
-        temp.write_all(&bytes)
-            .and_then(|_| temp.as_file().sync_all())
-            .map_err(|e| e.to_string())?;
-        if new_file {
-            temp.persist_noclobber(&path)
-        } else {
-            temp.persist(&path)
-        }
-        .map_err(|e| e.to_string())?;
+        persist_json(&path, &bytes, new_file)?;
         self.path = path;
         self.saved_bytes = bytes;
         self.saved = self.library.clone();
@@ -120,7 +117,29 @@ impl GripDocument {
     }
 }
 
+pub(crate) fn persist_json(
+    path: &std::path::Path,
+    bytes: &[u8],
+    new_file: bool,
+) -> Result<(), String> {
+    let mut temp =
+        tempfile::NamedTempFile::new_in(path.parent().ok_or("Missing parent directory")?)
+            .map_err(|e| e.to_string())?;
+    temp.write_all(bytes)
+        .and_then(|_| temp.as_file().sync_all())
+        .map_err(|e| e.to_string())?;
+    if new_file {
+        temp.persist_noclobber(path)
+    } else {
+        temp.persist(path)
+    }
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 pub struct GripEditor {
+    support_editor: crate::support_grip_editor::SupportEditor,
+    support_mode: bool,
     document: Result<GripDocument, String>,
     hints: Result<BTreeMap<String, GripHints>, String>,
     model: String,
@@ -144,7 +163,14 @@ pub struct GripEditor {
 }
 
 impl GripEditor {
-    pub fn new(path: Option<PathBuf>, model: Option<String>, hand: String, view: String) -> Self {
+    pub fn new(
+        path: Option<PathBuf>,
+        model: Option<String>,
+        hand: String,
+        view: String,
+        support_mode: bool,
+        support_path: Option<PathBuf>,
+    ) -> Self {
         // Hints are the same authoring inputs used by gameplay and the baker.
         let hints_path = default_library_path().with_file_name("astra-vr-grip-hints.json");
         let hints = std::fs::read(hints_path)
@@ -159,6 +185,8 @@ impl GripEditor {
             default_library_path()
         };
         Self {
+            support_editor: crate::support_grip_editor::SupportEditor::new(support_path),
+            support_mode,
             document: GripDocument::load(path.unwrap_or(default_path)),
             hints,
             model: model.unwrap_or_else(|| "mug".into()),
@@ -357,11 +385,9 @@ impl GripEditor {
     pub fn guard_close(&mut self, ctx: &egui::Context) {
         self.poll_fit(ctx);
         let busy = self.is_busy();
-        let Ok(doc) = &mut self.document else {
-            return;
-        };
+        let primary_dirty = self.document.as_ref().is_ok_and(|doc| doc.dirty());
         if !self.allow_close
-            && (doc.dirty() || busy)
+            && (primary_dirty || self.support_editor.dirty() || busy)
             && ctx.input(|i| i.viewport().close_requested())
         {
             ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
@@ -383,7 +409,11 @@ impl GripEditor {
                         .add_enabled(!self.stale && !busy, egui::Button::new("Save and close"))
                         .clicked()
                     {
-                        match doc.save() {
+                        let primary_saved = match &mut self.document {
+                            Ok(doc) if doc.dirty() => doc.save(),
+                            _ => Ok(()),
+                        };
+                        match primary_saved.and_then(|_| self.support_editor.save()) {
                             Ok(()) => self.allow_close = true,
                             Err(e) => self.message = e,
                         }
@@ -422,8 +452,15 @@ impl GripEditor {
             }
         });
         if let Some((file, model)) = switch {
-            self.document = GripDocument::load(default_library_path().with_file_name(file));
-            self.open_model(model);
+            match GripDocument::load(default_library_path().with_file_name(file)) {
+                Ok(doc) => {
+                    self.document = Ok(doc);
+                    self.open_model(model);
+                }
+                Err(error) => {
+                    self.message = format!("Could not switch library: {error}");
+                }
+            }
         }
         ui.text_edit_singleline(&mut self.search);
         let Ok(doc) = &self.document else {
@@ -453,10 +490,10 @@ impl GripEditor {
         });
         ui.separator();
         ui.label(
-            "Edits affect every item using this model. Left and right hands save independently.",
+            "Primary grips affect every item using this model. Left and right primary hands save independently.",
         );
         ui.label("Weapon grips replace authored hands with the glove. Psi amp retains its integrated forearm.");
-        ui.small(format!("Saving to {}", doc.path.display()));
+        ui.small(format!("Primary grip resource: {}", doc.path.display()));
         if !can_switch {
             ui.small("Save or revert drafts before switching libraries.");
         }
@@ -510,6 +547,11 @@ impl GripEditor {
             .unwrap_or_default();
         ui.heading(format!("{} — grip override", self.model));
         ui.horizontal(|ui| {
+            ui.selectable_value(&mut self.support_mode, false, "Primary grip");
+            ui.selectable_value(&mut self.support_mode, true, "Support grip");
+        });
+        ui.horizontal(|ui| {
+            ui.label("Primary hand");
             for hand in ["left", "right"] {
                 if ui
                     .selectable_value(&mut self.hand, hand.to_string(), hand)
@@ -580,20 +622,49 @@ impl GripEditor {
                 "Inputs changed: replace with an automatic fit before editing or saving this pose.",
             );
         }
+        if self.support_mode {
+            if doc.dirty() {
+                ui.label("Primary grip also has unsaved edits. Primary grip → Save all edits saves both resources.");
+            }
+            let entry = &doc.library.entries[index];
+            self.support_editor.show(
+                ui,
+                &self.model,
+                hand,
+                entry.grip.item_scale,
+                !self.stale && !busy,
+            );
+            let scene = PreviewScene::Grip(
+                hand,
+                entry.grip.clone(),
+                self.support_editor.profile(&self.model).cloned(),
+            );
+            preview.show_grip(
+                ui,
+                frame,
+                &key,
+                &scene,
+                self.camera_pending.then_some((&self.view, hand)),
+            );
+            self.camera_pending = false;
+            return;
+        }
         ui.horizontal(|ui| {
-            let label = if doc.dirty() {
+            let label = if doc.dirty() || self.support_editor.dirty() {
                 "Save all edits *"
             } else {
                 "Saved"
             };
             if ui
                 .add_enabled(
-                    doc.dirty() && !self.stale && !busy,
+                    (doc.dirty() || self.support_editor.dirty()) && !self.stale && !busy,
                     egui::Button::new(label),
                 )
                 .clicked()
             {
-                self.message = match doc.save() {
+                self.message = match (if doc.dirty() { doc.save() } else { Ok(()) })
+                    .and_then(|_| self.support_editor.save())
+                {
                     Ok(()) => "Saved. Restart the game runtime to load the resource.".into(),
                     Err(e) => e,
                 };
@@ -734,12 +805,7 @@ impl GripEditor {
             });
             ui.horizontal_wrapped(|ui| {
                 ui.label("Pose presets");
-                for (name, amounts) in [
-                    ("Open", [0.0; 5]),
-                    ("Point", [0.85, 0.0, 0.9, 0.9, 0.9]),
-                    ("Closed", [1.0; 5]),
-                    ("Ball", [0.35, 0.25, 0.3, 0.35, 0.4]),
-                ] {
+                for (name, amounts) in POSE_PRESETS {
                     if ui.button(name).clicked() {
                         entry.grip.curls = amounts;
                     }
@@ -758,13 +824,19 @@ impl GripEditor {
         ui.small("Drag sliders or click values to type. Ball is a cupped starting pose; adjust curls to the item. Unsaved drafts stay when switching models.");
         // Build first, then select the requested camera so the initial model
         // framing cannot overwrite it. show() keeps the same camera on edits.
-        let scene = PreviewScene::Grip(hand, entry.grip.clone());
-        preview.prepare(&key, &scene);
-        if self.camera_pending {
-            preview.grip_camera(&self.view, hand);
-            self.camera_pending = false;
-        }
-        preview.show(ui, frame, &key, &scene);
+        let scene = PreviewScene::Grip(
+            hand,
+            entry.grip.clone(),
+            self.support_editor.profile(&self.model).cloned(),
+        );
+        preview.show_grip(
+            ui,
+            frame,
+            &key,
+            &scene,
+            self.camera_pending.then_some((&self.view, hand)),
+        );
+        self.camera_pending = false;
         if let Some(path) = &mut self.save_as_path {
             let mut close = false;
             egui::Modal::new(egui::Id::new("save_grips_as")).show(ui.ctx(), |ui| {
@@ -805,7 +877,7 @@ impl GripEditor {
 }
 
 /// Each value offers a coarse slider, small nudges, and optional exact entry.
-fn tweak_slider(
+pub(crate) fn tweak_slider(
     ui: &mut egui::Ui,
     label: &str,
     value: &mut f32,

--- a/tools/dark_explorer/src/main.rs
+++ b/tools/dark_explorer/src/main.rs
@@ -6,6 +6,7 @@ mod archives;
 mod explorer;
 mod grip_editor;
 mod model_preview;
+mod support_grip_editor;
 mod ui;
 
 use explorer::{family_entries, family_names, print_coverage_caveat, short_source};
@@ -48,6 +49,12 @@ enum Commands {
         /// Open VR Grips with this prepared pickup model selected (e.g. mug)
         #[arg(long)]
         grip: Option<String>,
+        /// Edit the supporting hand while previewing both gloves
+        #[arg(long)]
+        grip_support: bool,
+        /// Support-pose JSON to edit (defaults to assets/astra-vr-support-grips.json)
+        #[arg(long)]
+        support_grip_library: Option<std::path::PathBuf>,
         /// Hand to inspect in VR Grips
         #[arg(long, default_value = "right", value_parser = ["left", "right"])]
         grip_hand: String,
@@ -235,6 +242,8 @@ fn main() {
         Commands::Ui {
             grip,
             grip_hand,
+            grip_support,
+            support_grip_library,
             grip_view,
             grip_library,
             screenshot,
@@ -252,6 +261,8 @@ fn main() {
         } => ui::run(ui::UiOptions {
             grip,
             grip_hand,
+            grip_support,
+            support_grip_library,
             grip_view,
             grip_library,
             screenshot,

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -47,7 +47,11 @@ pub enum PreviewScene {
     Model,
     /// Authored VR weapon reference, retaining its integrated hand.
     VrReference,
-    Grip(Handedness, ResolvedGrip),
+    Grip(
+        Handedness,
+        ResolvedGrip,
+        Option<shock2vr::vr_support::SupportProfile>,
+    ),
     /// The `.bin` model animated by a motion clip (`<name>_.mc`).
     Clip(String),
     /// Bone lines only: the `.bin`'s skeleton posed by a motion clip.
@@ -221,6 +225,22 @@ impl ModelPreview {
         }
     }
 
+    /// Both grip editing modes share model preparation and camera ordering.
+    pub fn show_grip(
+        &mut self,
+        ui: &mut egui::Ui,
+        frame: &mut eframe::Frame,
+        key: &str,
+        scene: &PreviewScene,
+        camera: Option<(&str, Handedness)>,
+    ) {
+        self.prepare(key, scene);
+        if let Some((view, hand)) = camera {
+            self.grip_camera(view, hand);
+        }
+        self.show(ui, frame, key, scene);
+    }
+
     pub fn prepare(&mut self, key: &str, scene: &PreviewScene) {
         self.ensure_scene(key, scene);
     }
@@ -283,7 +303,7 @@ impl ModelPreview {
             PreviewScene::VrReference => Ok(Box::new(GripPreviewScene(
                 engine::scene::Scene::from_objects(model.clone_scene_objects()),
             ))),
-            PreviewScene::Grip(hand, grip) => quiet_catch(|| {
+            PreviewScene::Grip(hand, grip, support) => quiet_catch(|| {
                 let mut model = model.as_ref().clone();
                 if shock2vr::vr_weapon_grip::supports_model(key) {
                     let source = self
@@ -314,6 +334,42 @@ impl ModelPreview {
                     true,
                     Some((grip.finger_amounts(), 1.0)),
                 ));
+                let mut support_points = Vec::new();
+                if let Some(support) = support {
+                    let other = if *hand == Handedness::Left {
+                        Handedness::Right
+                    } else {
+                        Handedness::Left
+                    };
+                    let rig = glove.grip_kinematics(other);
+                    let pose = support.glove_pose(
+                        *hand,
+                        shock2vr::vr_support::GripPose {
+                            position: grip.offset,
+                            rotation: grip.rotation,
+                        },
+                        grip,
+                        &rig,
+                    );
+                    let mut support_grip = grip.clone();
+                    support_grip.curls = support.curls;
+                    objects.extend(glove.render_hand(
+                        pose.position,
+                        pose.rotation,
+                        other,
+                        0.0,
+                        0.0,
+                        false,
+                        Some((support_grip.finger_amounts(), 1.0)),
+                    ));
+                    support_points.extend(
+                        rig.fingers
+                            .iter()
+                            .flatten()
+                            .flatten()
+                            .map(|p| pose.point(*p)),
+                    );
+                }
                 let triangles = if shock2vr::vr_weapon_grip::supports_model(key) {
                     shock2vr::vr_weapon_grip::inputs(&mut self.asset_cache, key, *hand)
                         .ok_or("Weapon grip geometry unavailable")?
@@ -334,7 +390,8 @@ impl ModelPreview {
                     .iter()
                     .flatten()
                     .map(|p| (transform * p.to_homogeneous()).truncate())
-                    .chain(kinematics.fingers.iter().flatten().flatten().copied());
+                    .chain(kinematics.fingers.iter().flatten().flatten().copied())
+                    .chain(support_points);
                 let mut min = vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
                 let mut max = -min;
                 for p in points {

--- a/tools/dark_explorer/src/support_grip_editor.rs
+++ b/tools/dark_explorer/src/support_grip_editor.rs
@@ -1,0 +1,313 @@
+//! Support-hand authoring uses the same resource and placement as gameplay.
+use crate::grip_editor::{POSE_PRESETS, default_library_path, persist_json, tweak_slider};
+use eframe::egui;
+use shock2vr::{Handedness, vr_support::SupportProfile};
+use std::{collections::BTreeMap, path::PathBuf};
+
+struct SupportDocument {
+    profiles: BTreeMap<String, SupportProfile>,
+    saved: BTreeMap<String, SupportProfile>,
+    path: PathBuf,
+    saved_bytes: Vec<u8>,
+}
+impl SupportDocument {
+    fn load(path: PathBuf) -> Result<Self, String> {
+        let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
+        let profiles: BTreeMap<String, SupportProfile> =
+            serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+        if profiles.values().any(|p| !p.is_valid()) {
+            return Err("Invalid support pose resource".into());
+        }
+        Ok(Self {
+            saved: profiles.clone(),
+            profiles,
+            path,
+            saved_bytes: bytes,
+        })
+    }
+    fn dirty(&self) -> bool {
+        self.profiles != self.saved
+    }
+    fn restore(&mut self, model: &str) {
+        if let Some(saved) = self.saved.get(model) {
+            self.profiles.insert(model.into(), saved.clone());
+        } else {
+            self.profiles.remove(model);
+        }
+    }
+    fn save(&mut self) -> Result<(), String> {
+        if !self.dirty() {
+            return Ok(());
+        }
+        if std::fs::read(&self.path).map_err(|e| e.to_string())? != self.saved_bytes {
+            return Err(
+                "Support resource changed on disk. Save As a new file to preserve your draft."
+                    .into(),
+            );
+        }
+        self.write(self.path.clone(), false)
+    }
+    fn write(&mut self, path: PathBuf, new_file: bool) -> Result<(), String> {
+        if self.profiles.values().any(|p| !p.is_valid()) {
+            return Err("Cannot save an invalid support pose".into());
+        }
+        let path = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir()
+                .map_err(|e| e.to_string())?
+                .join(path)
+        };
+        let mut bytes = serde_json::to_vec_pretty(&self.profiles).map_err(|e| e.to_string())?;
+        bytes.push(b'\n');
+        persist_json(&path, &bytes, new_file)?;
+        self.path = path;
+        self.saved = self.profiles.clone();
+        self.saved_bytes = bytes;
+        Ok(())
+    }
+}
+
+pub struct SupportEditor {
+    document: Result<SupportDocument, String>,
+    save_as: Option<String>,
+    message: String,
+    rotation_step: f32,
+}
+impl SupportEditor {
+    pub fn new(path: Option<PathBuf>) -> Self {
+        Self {
+            document: SupportDocument::load(path.unwrap_or_else(|| {
+                default_library_path().with_file_name("astra-vr-support-grips.json")
+            })),
+            save_as: None,
+            message: String::new(),
+            rotation_step: 5.0,
+        }
+    }
+    pub fn dirty(&self) -> bool {
+        self.document.as_ref().is_ok_and(|d| d.dirty())
+    }
+    pub fn save(&mut self) -> Result<(), String> {
+        if !self.dirty() {
+            return Ok(());
+        }
+        self.document.as_mut().map_err(|e| e.clone())?.save()
+    }
+    pub fn profile(&self, model: &str) -> Option<&SupportProfile> {
+        self.document.as_ref().ok()?.profiles.get(model)
+    }
+
+    pub fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        model: &str,
+        primary: Handedness,
+        item_scale: f32,
+        enabled: bool,
+    ) {
+        let doc = match &mut self.document {
+            Ok(doc) => doc,
+            Err(e) => {
+                ui.colored_label(egui::Color32::LIGHT_RED, e.as_str());
+                return;
+            }
+        };
+        ui.label("Adjust the free hand while the primary grip stays visible. One support pose mirrors for either primary hand.");
+        if model != "wrench_h" {
+            ui.colored_label(
+                egui::Color32::YELLOW,
+                "Preview only: this model does not yet support two-hand grabbing in game.",
+            );
+        }
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(
+                    enabled && doc.dirty(),
+                    egui::Button::new("Save support edits *"),
+                )
+                .clicked()
+            {
+                self.message = match doc.save() {
+                    Ok(()) => "Saved support poses to the displayed resource.".into(),
+                    Err(e) => e,
+                };
+            }
+            if ui
+                .add_enabled(enabled, egui::Button::new("Save As…"))
+                .clicked()
+            {
+                self.message.clear();
+                self.save_as = Some(
+                    doc.path
+                        .with_file_name("astra-vr-support-grips.custom.json")
+                        .display()
+                        .to_string(),
+                );
+            }
+            if ui
+                .add_enabled(
+                    enabled && doc.profiles.contains_key(model),
+                    egui::Button::new("Revert support pose"),
+                )
+                .clicked()
+            {
+                doc.restore(model);
+            }
+        });
+        if !doc.profiles.contains_key(model) {
+            if ui
+                .add_enabled(enabled, egui::Button::new("Add support pose"))
+                .clicked()
+            {
+                doc.profiles.insert(
+                    model.into(),
+                    SupportProfile {
+                        palm_anchor: [-0.09, 0.35, 0.02],
+                        rotation_degrees: [0.0; 3],
+                        curls: [0.4; 5],
+                        grab_radius: 0.07,
+                        release_distance: 0.12,
+                        max_swing_degrees: 75.0,
+                    },
+                );
+            }
+        }
+        if let Some(profile) = doc.profiles.get_mut(model) {
+            ui.add_enabled_ui(
+                enabled && item_scale.is_finite() && item_scale > 0.0,
+                |ui| {
+                    ui.columns(3, |columns| {
+                        columns[0].strong("Palm position on item (cm)");
+                        for (i, axis) in ["X", "Y", "Z"].into_iter().enumerate() {
+                            let mirror = if primary == Handedness::Left && i == 0 {
+                                -1.0
+                            } else {
+                                1.0
+                            };
+                            let factor =
+                                item_scale * shock2vr::METERS_PER_WORLD_UNIT * 100.0 * mirror;
+                            let mut cm = profile.palm_anchor[i] * factor;
+                            if tweak_slider(&mut columns[0], axis, &mut cm, -100.0..=100.0, 0.1, 2)
+                            {
+                                profile.palm_anchor[i] = cm / factor;
+                            }
+                        }
+                        columns[1].strong("Support wrist rotation (degrees)");
+                        for (i, axis) in ["X", "Y", "Z"].into_iter().enumerate() {
+                            let mirror = if primary == Handedness::Left && i > 0 {
+                                -1.0
+                            } else {
+                                1.0
+                            };
+                            let mut angle = profile.rotation_degrees[i] * mirror;
+                            if tweak_slider(
+                                &mut columns[1],
+                                axis,
+                                &mut angle,
+                                -180.0..=180.0,
+                                self.rotation_step,
+                                1,
+                            ) {
+                                profile.rotation_degrees[i] = angle * mirror;
+                            }
+                        }
+                        columns[2].strong("Support finger curls");
+                        for (name, value) in ["Thumb", "Index", "Middle", "Ring", "Pinky"]
+                            .into_iter()
+                            .zip(&mut profile.curls)
+                        {
+                            tweak_slider(&mut columns[2], name, value, 0.0..=1.0, 0.02, 2);
+                        }
+                    });
+                    ui.horizontal_wrapped(|ui| {
+                        ui.label("Support pose presets");
+                        for (name, curls) in POSE_PRESETS {
+                            if ui.button(name).clicked() {
+                                profile.curls = curls;
+                            }
+                        }
+                        ui.label("Rotation nudge");
+                        ui.add(egui::Slider::new(&mut self.rotation_step, 0.1..=15.0).suffix("°"));
+                    });
+                },
+            );
+        }
+        if !self.message.is_empty() {
+            ui.label(&self.message);
+        }
+        ui.small(format!(
+            "Support poses save separately: {}",
+            doc.path.display()
+        ));
+        if let Some(path) = &mut self.save_as {
+            let mut close = false;
+            egui::Modal::new(egui::Id::new("save_support_as")).show(ui.ctx(), |ui| {
+                ui.heading("Save support poses as JSON");
+                ui.text_edit_singleline(path);
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                    if ui.button("Save new file").clicked() {
+                        self.message = match doc.write(PathBuf::from(path.trim()), true) {
+                            Ok(()) => {
+                                close = true;
+                                "Saved support resource".into()
+                            }
+                            Err(e) => e,
+                        };
+                    }
+                });
+                ui.label(&self.message);
+            });
+            if close {
+                self.save_as = None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn support_edits_round_trip_and_preserve_external_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("support.json");
+        let original = br#"{"wrench_h":{"palm_anchor":[-0.09,0.354,0.02],"curls":[0.08,0.375,0.4,0.45,0.6],"grab_radius":0.07,"release_distance":0.12,"max_swing_degrees":75.0}}"#;
+        std::fs::write(&path, original).unwrap();
+        let mut doc = SupportDocument::load(path.clone()).unwrap();
+        assert_eq!(doc.profiles["wrench_h"].rotation_degrees, [0.0; 3]);
+        doc.profiles
+            .insert("nanocan".into(), doc.profiles["wrench_h"].clone());
+        assert!(doc.dirty());
+        doc.restore("nanocan");
+        assert!(
+            !doc.dirty(),
+            "reverting a new draft removes it without saving it"
+        );
+        assert!(!doc.profiles.contains_key("nanocan"));
+        doc.profiles.get_mut("wrench_h").unwrap().rotation_degrees = [20.0, -15.0, 30.0];
+        doc.profiles.get_mut("wrench_h").unwrap().palm_anchor[2] = 0.04;
+        doc.save().unwrap();
+        assert_eq!(
+            SupportDocument::load(path.clone()).unwrap().profiles,
+            doc.profiles
+        );
+        let saved = std::fs::read(&path).unwrap();
+        doc.profiles.get_mut("wrench_h").unwrap().curls[0] = 0.7;
+        std::fs::write(&path, b"external edit").unwrap();
+        assert!(doc.save().is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), b"external edit");
+        let copy = dir.path().join("support-custom.json");
+        doc.write(copy.clone(), true).unwrap();
+        assert!(doc.write(copy.clone(), true).is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), b"external edit");
+        assert_ne!(std::fs::read(&copy).unwrap(), saved);
+        let before = std::fs::read(&copy).unwrap();
+        doc.profiles.get_mut("wrench_h").unwrap().curls[1] = 2.0;
+        assert!(doc.save().is_err());
+        assert_eq!(std::fs::read(&copy).unwrap(), before);
+    }
+}

--- a/tools/dark_explorer/src/ui.rs
+++ b/tools/dark_explorer/src/ui.rs
@@ -30,6 +30,8 @@ const THUMBS_PER_FRAME: usize = 6;
 pub struct UiOptions {
     pub grip: Option<String>,
     pub grip_hand: String,
+    pub grip_support: bool,
+    pub support_grip_library: Option<PathBuf>,
     pub grip_view: String,
     pub grip_library: Option<PathBuf>,
     pub screenshot: Option<PathBuf>,
@@ -348,13 +350,15 @@ struct MountIndex {
 
 impl ExplorerApp {
     fn new(options: UiOptions) -> ExplorerApp {
-        let grip_tab = options.grip.is_some();
+        let grip_tab = options.grip.is_some() || options.grip_support;
         let mut app = ExplorerApp {
             grip_editor: crate::grip_editor::GripEditor::new(
                 options.grip_library,
                 options.grip,
                 options.grip_hand,
                 options.grip_view,
+                options.grip_support,
+                options.support_grip_library,
             ),
             tab: if grip_tab { Tab::Grips } else { Tab::Files },
             family_names: explorer::family_names(),


### PR DESCRIPTION
Support-hand poses can now be adjusted in VR Grips while both gloves remain visible. Select Support grip to tweak palm XYZ position, wrist XYZ rotation, and each finger curl using sliders, nudges, or exact values; Open, Point, Closed, and Ball presets provide starting points.

Support poses save separately to `assets/astra-vr-support-grips.json`, with Save As, revert, unsaved-close protection, and external-edit detection. Editor and gameplay share the same scaled, mirrored placement calculation. Existing weapon scales are unchanged. Other models can be previewed, but runtime two-hand grabbing remains wrench-only.

Stacked on #1384. Launch with `cargo dx ui --grip wrench_h --grip-support`. To add a missing primary grip, select the model in Files and choose Edit VR Grip (nanites use `nanocan.bin`).

Validation: 5 Explorer unit tests, 4 support solver/placement tests, and 3 headless VR support/physical-melee scenarios passed; Explorer build and formatting checks passed. Claude, Codex, and duplication reviews completed. Headset fit review remains pending.

## Visual evidence

![Native support grip editor](https://gist.githubusercontent.com/tommy-xr/a0bdd9e0bbdff971b8f8728a48c1ad37/raw/astra-support-editor.gif)

Native Explorer screenshots cycle primary/support modes, both primary hands, and front/back/oblique views. Both gloves remain visible while editing the support pose; editor and runtime use the shared `SupportProfile::glove_pose`.

![Support editor controls](https://gist.githubusercontent.com/tommy-xr/a0bdd9e0bbdff971b8f8728a48c1ad37/raw/astra-support-editor.png)

![Primary preview before and after](https://gist.githubusercontent.com/tommy-xr/a0bdd9e0bbdff971b8f8728a48c1ad37/raw/astra-support-editor-before-after.png)

Parent `9fb5c546` and current primary preview use the same wrench grip resource, right hand, and oblique view.

![Temporary support JSON override](https://gist.githubusercontent.com/tommy-xr/a0bdd9e0bbdff971b8f8728a48c1ad37/raw/astra-support-editor-variant.png)

The copied JSON changes wrist rotation to `[15, 0, 10]` degrees, thumb curl to `0.4`, and normalized model Z by `+0.02` (1.067 cm at wrench scale 0.7). This demonstrates loading an override, not automated interaction with Save or Save As. Capture did not modify canonical resources.

[Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/a0bdd9e0bbdff971b8f8728a48c1ad37/raw/astra-support-editor-gallery.html). Captured with native `dark_explorer ui --screenshot`; no HTTP UI or headset verification. Tight support thumb clearance remains a headset review caveat.
