### PR TITLE
feat(vr): body anchors - a belt card and shoulders that stow

### DIFF
--- a/assets/vr_grips.json
+++ b/assets/vr_grips.json
@@ -216,6 +216,9 @@
       0.0
     ]
   },
+  "scipass": {
+    "scale": 0.28
+  },
   "sfg_h": {
     "rotation_deg": [
       0.0,

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -925,6 +925,9 @@ pub struct PlayerInfo {
     /// that lights the glove and pre-shapes its fingers. See
     /// `shock2vr::hand_affordance`.
     pub hand_affordance: shock2vr::game_scene::DebugHandAffordances,
+    /// The player's body anchors - belt and shoulders - and what hangs off
+    /// them. `null` outside VR. See `shock2vr::body_frame`.
+    pub body_frame: Option<shock2vr::game_scene::DebugBodyFrame>,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2449,6 +2449,9 @@ fn capture_frame_snapshot(
                     .debug_scene()
                     .and_then(|scene| scene.player_hand_affordances())
                     .unwrap_or_default(),
+                body_frame: game
+                    .debug_scene()
+                    .and_then(|scene| scene.player_body_frame()),
             }
         },
         entity_count,

--- a/shock2vr/src/belt_card.rs
+++ b/shock2vr/src/belt_card.rs
@@ -12,7 +12,7 @@
 //! script owns the refusal - so what it opens is exactly what the collected set
 //! opens.
 
-use cgmath::{Matrix4, Quaternion, Vector3};
+use cgmath::{Matrix4, Quaternion, Rotation3, Vector3};
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 
 use crate::{body_frame::BodyFrame, vr_config::Handedness};
@@ -36,10 +36,18 @@ pub enum CardPlacement {
     InHand(Handedness),
 }
 
-/// The card resting on the belt: upright on the left hip, facing the way the
-/// body does.
+/// The card resting on the belt: clipped edge-on to the left hip, standing up
+/// and facing the way the body does.
+///
+/// The model is authored lying flat (its long axis is +Z, its face normal +Y),
+/// so standing it up is a quarter turn about X. Its held size comes from the
+/// same `vr_grips` profile the hand uses, so belt and hand can never disagree
+/// about how big the card is.
 pub fn belt_transform(frame: &BodyFrame) -> Matrix4<f32> {
-    Matrix4::from_translation(frame.belt()) * Matrix4::from(frame.rotation())
+    Matrix4::from_translation(frame.belt())
+        * Matrix4::from(frame.rotation())
+        * Matrix4::from_angle_x(cgmath::Deg(-90.0))
+        * Matrix4::from_scale(crate::vr_config::held_geometry_scale(CARD_MODEL))
 }
 
 /// The card in a hand, seated the way any held pickup is - so it sits in the

--- a/shock2vr/src/belt_card.rs
+++ b/shock2vr/src/belt_card.rs
@@ -1,0 +1,73 @@
+//! The belt card: one persistent object on the left hip standing in for every
+//! credential the player has collected.
+//!
+//! Keycards are *collected*, not inventoried - frobbing one records it in
+//! `QuestInfo` and destroys the pickup, and doors consult the collected set.
+//! That leaves the player carrying an invisible key ring, which is fine on a
+//! flat screen where a locked door just opens, and unsatisfying in VR where
+//! there is a hand to put a card in. So the card here is **presentation**: it
+//! appears once any credential is held, never occupies an inventory slot, and
+//! is derived from `QuestInfo` every frame rather than saved. Held against a
+//! reader it runs the same credential check a frob does - the door's own
+//! script owns the refusal - so what it opens is exactly what the collected set
+//! opens.
+
+use cgmath::{Matrix4, Quaternion, Vector3};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+
+use crate::{body_frame::BodyFrame, vr_config::Handedness};
+
+/// The gamesys's own ID-card art (`ID Cards`, template -157, `P$ModelName`) -
+/// the model every collected card in the game already wears.
+const CARD_MODEL: &str = "scipass";
+
+/// How far in front of the card a reader counts as touched, world units
+/// (~15 cm). Short on purpose: the card is placed against the panel, not
+/// pointed at it from across the room.
+pub const READER_REACH: f32 = 0.2;
+
+/// Where the belt card is this frame. `None` at the call sites means the
+/// player has collected no credential yet, and there is no card to draw.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CardPlacement {
+    /// On the left hip, following the body frame.
+    Belt,
+    /// Taken off the belt into a hand.
+    InHand(Handedness),
+}
+
+/// The card resting on the belt: upright on the left hip, facing the way the
+/// body does.
+pub fn belt_transform(frame: &BodyFrame) -> Matrix4<f32> {
+    Matrix4::from_translation(frame.belt()) * Matrix4::from(frame.rotation())
+}
+
+/// The card in a hand, seated the way any held pickup is - so it sits in the
+/// glove's fingers rather than floating at the wrist.
+pub fn hand_transform(
+    position: Vector3<f32>,
+    rotation: Quaternion<f32>,
+    hand: Handedness,
+) -> Matrix4<f32> {
+    crate::hand_glove::hand_to_world(position, rotation, hand)
+        * crate::vr_config::held_model_hand_transform(CARD_MODEL, hand, 1.0)
+}
+
+/// The card's renderable geometry at `transform`, or nothing if the model is
+/// missing (a data set without it simply has no belt card).
+pub fn scene_objects(asset_cache: &mut AssetCache, transform: Matrix4<f32>) -> Vec<SceneObject> {
+    let Some(model) = asset_cache.get_opt::<_, dark::model::Model, _>(
+        &dark::importers::MODELS_IMPORTER,
+        &format!("{CARD_MODEL}.BIN"),
+    ) else {
+        return Vec::new();
+    };
+    model
+        .clone_scene_objects()
+        .into_iter()
+        .map(|mut object| {
+            object.set_transform(transform);
+            object
+        })
+        .collect()
+}

--- a/shock2vr/src/belt_card.rs
+++ b/shock2vr/src/belt_card.rs
@@ -12,7 +12,7 @@
 //! script owns the refusal - so what it opens is exactly what the collected set
 //! opens.
 
-use cgmath::{Matrix4, Quaternion, Rotation3, Vector3};
+use cgmath::{Matrix4, Quaternion, Vector3};
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 
 use crate::{body_frame::BodyFrame, vr_config::Handedness};
@@ -25,6 +25,44 @@ const CARD_MODEL: &str = "scipass";
 /// (~15 cm). Short on purpose: the card is placed against the panel, not
 /// pointed at it from across the room.
 pub const READER_REACH: f32 = 0.2;
+
+/// How long a touched reader stays claimed after the ray comes off it, in fixed
+/// 60 Hz frames (~0.4 s). A hand resting a card on a panel jitters across the
+/// collider edge, and re-arming on the first missed frame would send a second
+/// `Frob` - which on a door shuts what the first opened.
+pub const READER_RELEASE_FRAMES: u8 = 24;
+
+/// Whether an entity reads cards: it authors a key destination
+/// (`P$KeyDst`), which is what [`crate::scripts::script_util::is_entity_locked`]
+/// consults and what a card slot or a card-locked door carries.
+///
+/// The gate matters. Without it the card would be a 15 cm use-button that
+/// activates any switch, lever or item it brushes past - the hand's own trigger
+/// is what does that.
+pub fn is_reader(world: &shipyard::World, entity_id: shipyard::EntityId) -> bool {
+    use shipyard::Get;
+    world
+        .borrow::<shipyard::View<dark::properties::PropKeyDst>>()
+        .is_ok_and(|key_dst| key_dst.get(entity_id).is_ok())
+}
+
+/// Where the card actually is in a hand, and which way it is presented. The
+/// reach is measured from the card itself, not from the wrist that carries it.
+pub fn reader_ray(
+    position: Vector3<f32>,
+    rotation: Quaternion<f32>,
+    hand: Handedness,
+) -> (Vector3<f32>, Vector3<f32>) {
+    use cgmath::{Rotation, Transform};
+    let seated = hand_transform(position, rotation, hand);
+    let origin = seated.transform_point(cgmath::point3(0.0, 0.0, 0.0));
+    // The hand's own aim, the same direction its raycast uses - the card is
+    // presented where the hand points.
+    (
+        cgmath::vec3(origin.x, origin.y, origin.z),
+        rotation.rotate_vector(cgmath::vec3(0.0, 0.0, -1.0)),
+    )
+}
 
 /// Where the belt card is this frame. `None` at the call sites means the
 /// player has collected no credential yet, and there is no card to draw.

--- a/shock2vr/src/body_frame.rs
+++ b/shock2vr/src/body_frame.rs
@@ -176,6 +176,137 @@ impl BodyFrameTracker {
     }
 }
 
+/// How long a hand keeps the anchor it was over after losing it, in fixed
+/// 60 Hz frames (~200 ms). A hand reaching behind the shoulder is exactly where
+/// tracking is worst, and a pose that drops out for a frame must not read as
+/// "left the zone" - the release it is about to make would then land on the
+/// floor instead of in the backpack.
+const ANCHOR_HOLD_FRAMES: u8 = 12;
+
+/// What a hand's body-anchor gesture resolved to this frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AnchorGesture {
+    /// Opened over a shoulder holding something: it goes in the backpack.
+    Stow(Handedness),
+    /// Gripped at a shoulder with an empty hand: draw the last weapon stowed.
+    Draw(Handedness),
+    /// Gripped at the belt with an empty hand: take the card.
+    TakeCard(Handedness),
+    /// Opened while holding the card: it goes back on the belt, wherever the
+    /// hand is - the card is never dropped in the world.
+    ReturnCard(Handedness),
+}
+
+/// What one hand is doing this frame, for [`AnchorGestures::update`].
+#[derive(Clone, Copy, Debug)]
+pub struct HandAnchorInput {
+    pub hand: Handedness,
+    /// Raw grip value, thresholded here so the edge is defined in one place.
+    pub squeeze: f32,
+    /// The anchor the hand is inside right now, from [`BodyFrame::anchor_at`].
+    pub anchor: Option<BodyAnchor>,
+    /// Whether the hand holds a world pickup.
+    pub holding: bool,
+    /// Whether the hand holds the belt card.
+    pub holds_card: bool,
+    /// Whether the backpack could take what the hand holds.
+    pub can_stow: bool,
+    /// Whether there is a stowed weapon left to draw.
+    pub can_draw: bool,
+    /// Whether the player has collected any credential, i.e. whether the belt
+    /// card exists at all.
+    pub has_card: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct HandAnchorState {
+    squeezing: bool,
+    anchor: Option<BodyAnchor>,
+    hold_frames: u8,
+}
+
+/// The per-hand body-anchor gesture state machine: which anchor a hand is at
+/// (with hysteresis), and what its grip edges mean there.
+#[derive(Clone, Debug, Default)]
+pub struct AnchorGestures {
+    /// Indexed by [`crate::vr_config::hand_slot`].
+    hands: [HandAnchorState; 2],
+}
+
+impl AnchorGestures {
+    /// Advance one hand a frame. Returns the gesture its grip edge committed
+    /// to, if any, and leaves [`Self::affordance`] describing what the hand
+    /// could do next.
+    pub fn update(&mut self, input: &HandAnchorInput) -> Option<AnchorGesture> {
+        let state = &mut self.hands[crate::vr_config::hand_slot(input.hand)];
+        // Decide on this frame's anchor first, then expire: the frame the
+        // window runs out is still one the hand gets to act on.
+        let anchor = input.anchor.or(state.anchor);
+        match input.anchor {
+            Some(anchor) => {
+                state.anchor = Some(anchor);
+                state.hold_frames = ANCHOR_HOLD_FRAMES;
+            }
+            None if state.hold_frames > 0 => state.hold_frames -= 1,
+            None => state.anchor = None,
+        }
+
+        let squeezing = input.squeeze > crate::ui::VR_TRIGGER_THRESHOLD;
+        let was_squeezing = std::mem::replace(&mut state.squeezing, squeezing);
+
+        // Only a real grip edge commits. Losing the pose behind the shoulder
+        // changes nothing: the controller keeps reporting its grip.
+        if !was_squeezing && squeezing {
+            return match anchor {
+                Some(BodyAnchor::Shoulder(_)) if !input.holding && !input.holds_card => {
+                    input.can_draw.then_some(AnchorGesture::Draw(input.hand))
+                }
+                Some(BodyAnchor::Belt) if !input.holding && !input.holds_card => input
+                    .has_card
+                    .then_some(AnchorGesture::TakeCard(input.hand)),
+                _ => None,
+            };
+        }
+        if was_squeezing && !squeezing {
+            if input.holds_card {
+                return Some(AnchorGesture::ReturnCard(input.hand));
+            }
+            if input.holding && input.can_stow {
+                if let Some(BodyAnchor::Shoulder(_)) = anchor {
+                    return Some(AnchorGesture::Stow(input.hand));
+                }
+            }
+        }
+        None
+    }
+
+    /// What the hand's anchor offers right now: green when the gesture would
+    /// go through, amber when the anchor is recognised but the action is not
+    /// available (a full backpack, nothing stowed to draw). `None` leaves the
+    /// light to the hand's own raycast.
+    pub fn affordance(
+        &self,
+        input: &HandAnchorInput,
+    ) -> Option<crate::hand_affordance::HandAffordance> {
+        use crate::hand_affordance::HandAffordance;
+
+        let state = &self.hands[crate::vr_config::hand_slot(input.hand)];
+        let eligible = |yes: bool| {
+            Some(if yes {
+                HandAffordance::Grabbable
+            } else {
+                HandAffordance::Blocked
+            })
+        };
+        match state.anchor? {
+            BodyAnchor::Shoulder(_) if input.holding => eligible(input.can_stow),
+            BodyAnchor::Shoulder(_) if !input.holds_card => eligible(input.can_draw),
+            BodyAnchor::Belt if !input.holding && !input.holds_card => eligible(input.has_card),
+            _ => None,
+        }
+    }
+}
+
 /// The yaw a rotation faces, radians about +Y, or `None` for an untracked
 /// (zero-magnitude) pose.
 fn head_yaw(rotation: Quaternion<f32>) -> Option<f32> {
@@ -368,6 +499,187 @@ mod tests {
             None,
             "a hand held up in front of the face is not an anchor"
         );
+    }
+
+    fn at(anchor: Option<BodyAnchor>) -> HandAnchorInput {
+        HandAnchorInput {
+            hand: Handedness::Right,
+            squeeze: 0.0,
+            anchor,
+            holding: false,
+            holds_card: false,
+            can_stow: true,
+            can_draw: true,
+            has_card: true,
+        }
+    }
+
+    const SHOULDER: Option<BodyAnchor> = Some(BodyAnchor::Shoulder(Handedness::Right));
+
+    /// Opening a full hand over a shoulder stows; closing an empty one there
+    /// draws.
+    #[test]
+    fn a_shoulder_stows_what_you_hold_and_draws_what_you_stowed() {
+        let mut gestures = AnchorGestures::default();
+        let mut holding = HandAnchorInput {
+            holding: true,
+            squeeze: 1.0,
+            ..at(SHOULDER)
+        };
+        assert_eq!(gestures.update(&holding), None, "still gripping");
+        holding.squeeze = 0.0;
+        assert_eq!(
+            gestures.update(&holding),
+            Some(AnchorGesture::Stow(Handedness::Right))
+        );
+
+        let mut empty = at(SHOULDER);
+        assert_eq!(
+            gestures.update(&empty),
+            None,
+            "an open empty hand does not draw"
+        );
+        empty.squeeze = 1.0;
+        assert_eq!(
+            gestures.update(&empty),
+            Some(AnchorGesture::Draw(Handedness::Right))
+        );
+        assert_eq!(gestures.update(&empty), None, "a held grip fires once");
+    }
+
+    /// Tracking behind the shoulder is the worst tracking there is. A pose that
+    /// drops out for a few frames must not turn the release into a world drop.
+    #[test]
+    fn a_lost_pose_behind_the_shoulder_still_stows() {
+        let mut gestures = AnchorGestures::default();
+        let holding = |squeeze: f32, anchor| HandAnchorInput {
+            holding: true,
+            squeeze,
+            ..at(anchor)
+        };
+        gestures.update(&holding(1.0, SHOULDER));
+        for _ in 0..ANCHOR_HOLD_FRAMES {
+            assert_eq!(gestures.update(&holding(1.0, None)), None);
+        }
+        assert_eq!(
+            gestures.update(&holding(0.0, None)),
+            Some(AnchorGesture::Stow(Handedness::Right)),
+            "a release inside the hysteresis window still lands in the backpack"
+        );
+
+        // Past the window the hand really has left, and the release is an
+        // ordinary world drop again.
+        let mut gestures = AnchorGestures::default();
+        gestures.update(&holding(1.0, SHOULDER));
+        for _ in 0..=ANCHOR_HOLD_FRAMES {
+            gestures.update(&holding(1.0, None));
+        }
+        assert_eq!(gestures.update(&holding(0.0, None)), None);
+    }
+
+    /// Nothing stowed, or no room to stow: no gesture, and the light says so
+    /// before the player commits.
+    #[test]
+    fn an_unavailable_shoulder_refuses_and_pre_lights_amber() {
+        use crate::hand_affordance::HandAffordance;
+
+        let mut gestures = AnchorGestures::default();
+        let empty = HandAnchorInput {
+            can_draw: false,
+            ..at(SHOULDER)
+        };
+        gestures.update(&empty);
+        assert_eq!(gestures.affordance(&empty), Some(HandAffordance::Blocked));
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 1.0,
+                ..empty
+            }),
+            None
+        );
+
+        let mut gestures = AnchorGestures::default();
+        let full = HandAnchorInput {
+            holding: true,
+            can_stow: false,
+            squeeze: 1.0,
+            ..at(SHOULDER)
+        };
+        gestures.update(&full);
+        assert_eq!(gestures.affordance(&full), Some(HandAffordance::Blocked));
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 0.0,
+                ..full
+            }),
+            None,
+            "a full backpack leaves the release an ordinary world drop"
+        );
+    }
+
+    /// The belt yields the card to an empty hand, and the card comes back to
+    /// the belt wherever it is released - it is never dropped in the world.
+    #[test]
+    fn the_belt_lends_the_card_and_takes_it_back() {
+        let mut gestures = AnchorGestures::default();
+        let mut hand = at(Some(BodyAnchor::Belt));
+        gestures.update(&hand);
+        hand.squeeze = 1.0;
+        assert_eq!(
+            gestures.update(&hand),
+            Some(AnchorGesture::TakeCard(Handedness::Right))
+        );
+
+        let mut carrying = HandAnchorInput {
+            holds_card: true,
+            squeeze: 1.0,
+            anchor: None,
+            ..at(None)
+        };
+        assert_eq!(gestures.update(&carrying), None);
+        carrying.squeeze = 0.0;
+        assert_eq!(
+            gestures.update(&carrying),
+            Some(AnchorGesture::ReturnCard(Handedness::Right))
+        );
+    }
+
+    /// With no credential collected there is no card to take, and the belt
+    /// says so rather than silently doing nothing.
+    #[test]
+    fn an_empty_belt_offers_nothing() {
+        use crate::hand_affordance::HandAffordance;
+
+        let mut gestures = AnchorGestures::default();
+        let hand = HandAnchorInput {
+            has_card: false,
+            ..at(Some(BodyAnchor::Belt))
+        };
+        gestures.update(&hand);
+        assert_eq!(gestures.affordance(&hand), Some(HandAffordance::Blocked));
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 1.0,
+                ..hand
+            }),
+            None
+        );
+    }
+
+    /// Away from every anchor the hand is an ordinary hand, and the light is
+    /// left to its own raycast.
+    #[test]
+    fn away_from_the_body_nothing_is_claimed() {
+        let mut gestures = AnchorGestures::default();
+        let mut hand = HandAnchorInput {
+            holding: true,
+            squeeze: 1.0,
+            ..at(None)
+        };
+        assert_eq!(gestures.affordance(&hand), None);
+        gestures.update(&hand);
+        hand.squeeze = 0.0;
+        assert_eq!(gestures.update(&hand), None);
     }
 
     /// The belt is on the LEFT hip, and turns with the body rather than staying

--- a/shock2vr/src/body_frame.rs
+++ b/shock2vr/src/body_frame.rs
@@ -16,13 +16,7 @@
 
 use cgmath::{InnerSpace, Quaternion, Rad, Rotation, Rotation3, Vector3, vec3};
 
-use crate::{METERS_PER_WORLD_UNIT, vr_config::Handedness};
-
-/// Convert a real-world measurement (the units body dimensions are naturally
-/// written in) into world units.
-const fn meters(m: f32) -> f32 {
-    m / METERS_PER_WORLD_UNIT
-}
+use crate::{util::meters, vr_config::Handedness};
 
 /// Belt height as a fraction of the tracked eye height. ~0.55 puts it at the
 /// top of the hip on an average adult, which is where a real belt sits and
@@ -31,6 +25,12 @@ const BELT_HEIGHT_FRACTION: f32 = 0.55;
 
 /// How far the shoulder sockets sit below the eye.
 const SHOULDER_DROP: f32 = meters(0.2);
+
+/// How far the shoulder sockets sit BEHIND the eye. The head's floor
+/// projection is roughly the neck, not the shoulder joint - without this the
+/// zone sits beside the ear, and the "throw it over your shoulder" reach (which
+/// takes the hand back past the head) never enters it.
+const SHOULDER_BEHIND: f32 = meters(0.12);
 
 /// Half the shoulder/hip width: how far each anchor sits to the side of the
 /// body's midline.
@@ -112,8 +112,10 @@ pub struct BodyFrameInput {
     pub head_position: Vector3<f32>,
     pub head_rotation: Quaternion<f32>,
     /// How far the pawn origin sits above the floor, world units
-    /// (`physics::player_center_above_floor`). Crouching shrinks it, which is
-    /// what lowers the anchors with the player.
+    /// (`physics::player_center_above_floor`). Only the belt reads it - the
+    /// shoulders hang off the eye, where it cancels - so it must be the same
+    /// stance the tracked head was rebased with, or the belt moves out from
+    /// under the hand without the shoulders moving with it.
     pub pawn_above_floor: f32,
     /// The fixed simulation step this frame integrates, for the yaw low-pass.
     pub dt: f32,
@@ -141,22 +143,24 @@ impl BodyFrameTracker {
                 None => observed,
                 Some(current) => {
                     let alpha = 1.0 - (-input.dt / YAW_TIME_CONSTANT_SECS).exp();
-                    wrap_pi(current + wrap_pi(observed - current) * alpha)
+                    crate::util::wrap_pi(current + crate::util::wrap_pi(observed - current) * alpha)
                 }
             });
         }
         let rotation = input.pawn_rotation * Quaternion::from_angle_y(Rad(self.yaw.unwrap_or(0.0)));
         let right = rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
+        let back = rotation.rotate_vector(vec3(0.0, 0.0, 1.0));
 
         // Horizontal placement follows the head (lean out over a railing and
-        // your belt goes with you); heights come off the tracked eye.
+        // your belt goes with you); heights come off the tracked eye. The head
+        // is in the same pawn space the hands are, so it converts to world
+        // through the same function the hands tested against these anchors do.
         let floor_y = input.pawn_position.y - input.pawn_above_floor;
-        let ground = input.pawn_position
-            + input.pawn_rotation.rotate_vector(vec3(
-                input.head_position.x,
-                0.0,
-                input.head_position.z,
-            ));
+        let ground = crate::virtual_hand::hand_world_position(
+            input.pawn_position,
+            input.pawn_rotation,
+            vec3(input.head_position.x, 0.0, input.head_position.z),
+        );
         let eye_above_floor = input.head_position.y + input.pawn_above_floor;
 
         let shoulder_y = floor_y + eye_above_floor - SHOULDER_DROP;
@@ -164,12 +168,13 @@ impl BodyFrameTracker {
             (floor_y + eye_above_floor * BELT_HEIGHT_FRACTION).min(shoulder_y - ANCHOR_SEPARATION);
         let at = |y: f32| vec3(ground.x, y, ground.z);
 
+        let shoulder = at(shoulder_y) + back * SHOULDER_BEHIND;
         BodyFrame {
             // The card rides the left hip.
             belt: at(belt_y) - right * LATERAL_OFFSET,
             shoulders: [
-                at(shoulder_y) - right * LATERAL_OFFSET,
-                at(shoulder_y) + right * LATERAL_OFFSET,
+                shoulder - right * LATERAL_OFFSET,
+                shoulder + right * LATERAL_OFFSET,
             ],
             rotation,
         }
@@ -213,14 +218,19 @@ pub struct HandAnchorInput {
     pub can_stow: bool,
     /// Whether there is a stowed weapon left to draw.
     pub can_draw: bool,
-    /// Whether the player has collected any credential, i.e. whether the belt
-    /// card exists at all.
-    pub has_card: bool,
+    /// Whether the card is actually on the belt to be taken: the player has
+    /// collected a credential AND no hand is already carrying it. There is one
+    /// card, so a hand cannot take it out of the other hand's grip.
+    pub card_on_belt: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 struct HandAnchorState {
     squeezing: bool,
+    /// The anchor this hand is treated as being at - the live one, or the last
+    /// one for [`ANCHOR_HOLD_FRAMES`] after the pose is lost. One value, so the
+    /// gesture a grip commits to and the claim [`AnchorGestures::claim`] makes
+    /// on the hand can never disagree about where the hand is.
     anchor: Option<BodyAnchor>,
     hold_frames: u8,
 }
@@ -234,95 +244,107 @@ pub struct AnchorGestures {
 }
 
 impl AnchorGestures {
-    /// Advance one hand a frame. Returns the gesture its grip edge committed
-    /// to, if any, and leaves [`Self::affordance`] describing what the hand
-    /// could do next.
+    /// Advance one hand a frame, and return the gesture its grip edge committed
+    /// to. [`Self::claim`] must be read after this - both answers come from the
+    /// one intent this resolves.
     pub fn update(&mut self, input: &HandAnchorInput) -> Option<AnchorGesture> {
         let state = &mut self.hands[crate::vr_config::hand_slot(input.hand)];
-        // Decide on this frame's anchor first, then expire: the frame the
-        // window runs out is still one the hand gets to act on.
-        let anchor = input.anchor.or(state.anchor);
         match input.anchor {
             Some(anchor) => {
                 state.anchor = Some(anchor);
                 state.hold_frames = ANCHOR_HOLD_FRAMES;
             }
+            // The window is spent frame by frame; only when it runs out is the
+            // anchor really gone.
             None if state.hold_frames > 0 => state.hold_frames -= 1,
             None => state.anchor = None,
         }
 
-        let squeezing = input.squeeze > crate::ui::VR_TRIGGER_THRESHOLD;
+        // Thresholded to match `VirtualHand`'s own hold test exactly: a squeeze
+        // sitting on the threshold must not read as released here while the
+        // hand still holds the item, or a stow would claim a release the hand
+        // never made and the item would land on the floor a frame later.
+        let squeezing = input.squeeze >= crate::ui::VR_TRIGGER_THRESHOLD;
         let was_squeezing = std::mem::replace(&mut state.squeezing, squeezing);
 
         // Only a real grip edge commits. Losing the pose behind the shoulder
         // changes nothing: the controller keeps reporting its grip.
-        if !was_squeezing && squeezing {
-            return match anchor {
-                Some(BodyAnchor::Shoulder(_)) if !input.holding && !input.holds_card => {
-                    input.can_draw.then_some(AnchorGesture::Draw(input.hand))
-                }
-                Some(BodyAnchor::Belt) if !input.holding && !input.holds_card => input
-                    .has_card
-                    .then_some(AnchorGesture::TakeCard(input.hand)),
-                _ => None,
-            };
-        }
-        if was_squeezing && !squeezing {
-            if input.holds_card {
-                return Some(AnchorGesture::ReturnCard(input.hand));
-            }
-            if input.holding && input.can_stow {
-                if let Some(BodyAnchor::Shoulder(_)) = anchor {
-                    return Some(AnchorGesture::Stow(input.hand));
-                }
-            }
-        }
-        None
+        let (gesture, available) = self.intent(input)?;
+        let fires = match gesture {
+            // Letting go is what puts something away.
+            AnchorGesture::Stow(_) | AnchorGesture::ReturnCard(_) => was_squeezing && !squeezing,
+            // Closing on it is what takes something out.
+            AnchorGesture::Draw(_) | AnchorGesture::TakeCard(_) => !was_squeezing && squeezing,
+        };
+        (fires && available).then_some(gesture)
     }
 
-    /// What the hand's anchor offers right now: green when the gesture would
-    /// go through, amber when the anchor is recognised but the action is not
-    /// available (a full backpack, nothing stowed to draw). `None` leaves the
-    /// light to the hand's own raycast.
-    pub fn affordance(
-        &self,
-        input: &HandAnchorInput,
-    ) -> Option<crate::hand_affordance::HandAffordance> {
+    /// What owns this hand this frame, if anything. Must be read *after*
+    /// [`Self::update`], which resolves the anchor both answers come from.
+    pub fn claim(&self, input: &HandAnchorInput) -> Option<HandClaim> {
         use crate::hand_affordance::HandAffordance;
 
-        let state = &self.hands[crate::vr_config::hand_slot(input.hand)];
-        let eligible = |yes: bool| {
-            Some(if yes {
+        let (gesture, available) = self.intent(input)?;
+        Some(match gesture {
+            AnchorGesture::ReturnCard(_) => HandClaim::CarryingCard,
+            _ => HandClaim::Anchor(if available {
                 HandAffordance::Grabbable
             } else {
                 HandAffordance::Blocked
-            })
-        };
-        match state.anchor? {
-            BodyAnchor::Shoulder(_) if input.holding => eligible(input.can_stow),
-            BodyAnchor::Shoulder(_) if !input.holds_card => eligible(input.can_draw),
-            BodyAnchor::Belt if !input.holding && !input.holds_card => eligible(input.has_card),
-            _ => None,
+            }),
+        })
+    }
+
+    /// What this hand's next grip edge would do, and whether it could. The one
+    /// place the rules live: the light and the committed gesture both read it,
+    /// so the glove can never promise an action the grip would not perform.
+    fn intent(&self, input: &HandAnchorInput) -> Option<(AnchorGesture, bool)> {
+        // A hand carrying the belt card is full, wherever it is: it must not
+        // also grab a pickup or frob what its ray crosses, because the card's
+        // own touch already frobs (and a second Frob would shut the door the
+        // first opened). Opening it returns the card to the belt.
+        if input.holds_card {
+            return Some((AnchorGesture::ReturnCard(input.hand), true));
         }
+        Some(
+            match self.hands[crate::vr_config::hand_slot(input.hand)].anchor? {
+                BodyAnchor::Shoulder(_) if input.holding => {
+                    (AnchorGesture::Stow(input.hand), input.can_stow)
+                }
+                BodyAnchor::Shoulder(_) => (AnchorGesture::Draw(input.hand), input.can_draw),
+                BodyAnchor::Belt if !input.holding => {
+                    (AnchorGesture::TakeCard(input.hand), input.card_on_belt)
+                }
+                // A full hand at the belt has nowhere to put what it holds.
+                BodyAnchor::Belt => return None,
+            },
+        )
     }
 }
 
-/// The yaw a rotation faces, radians about +Y, or `None` for an untracked
-/// (zero-magnitude) pose.
+/// Why a hand is not an ordinary world-interacting hand this frame. Either way
+/// its grip belongs to the body, not to whatever its ray crossed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandClaim {
+    /// The hand is at a body anchor. The value is the anchor's eligibility -
+    /// green when the gesture would go through, amber when the anchor is
+    /// recognised but the action is not available (a full backpack, nothing
+    /// stowed to draw, an empty belt).
+    Anchor(crate::hand_affordance::HandAffordance),
+    /// The hand is carrying the belt card. Its light keeps reading its own
+    /// raycast, so a reader it is held against still shows locked or openable.
+    CarryingCard,
+}
+
+/// The yaw a tracked head faces, radians about +Y, or `None` for an untracked
+/// (zero-magnitude) pose - which is not a reading, and must not be smoothed
+/// toward. A head looking straight down at its own belt is exactly the pose
+/// whose horizontal forward vanishes, so the flattening is
+/// [`crate::util::horizontal_forward`]'s rather than a bare `atan2` on `xz`.
 fn head_yaw(rotation: Quaternion<f32>) -> Option<f32> {
-    if rotation.magnitude2() < 1e-6 {
-        return None;
-    }
+    let forward = crate::util::horizontal_forward(crate::util::tracked_rotation(rotation)?);
     // `Quaternion::from_angle_y(t) * (0, 0, -1)` is `(-sin t, 0, -cos t)`.
-    let forward = rotation.normalize().rotate_vector(vec3(0.0, 0.0, -1.0));
     Some((-forward.x).atan2(-forward.z))
-}
-
-/// Fold an angle into `[-pi, pi]`, so smoothing takes the short way round.
-fn wrap_pi(angle: f32) -> f32 {
-    let tau = std::f32::consts::TAU;
-    let wrapped = (angle + std::f32::consts::PI).rem_euclid(tau);
-    wrapped - std::f32::consts::PI
 }
 
 #[cfg(test)]
@@ -510,7 +532,7 @@ mod tests {
             holds_card: false,
             can_stow: true,
             can_draw: true,
-            has_card: true,
+            card_on_belt: true,
         }
     }
 
@@ -558,7 +580,9 @@ mod tests {
             ..at(anchor)
         };
         gestures.update(&holding(1.0, SHOULDER));
-        for _ in 0..ANCHOR_HOLD_FRAMES {
+        // The pose stays lost for the whole window; the release lands on its
+        // last frame and still stows.
+        for _ in 1..ANCHOR_HOLD_FRAMES {
             assert_eq!(gestures.update(&holding(1.0, None)), None);
         }
         assert_eq!(
@@ -589,7 +613,10 @@ mod tests {
             ..at(SHOULDER)
         };
         gestures.update(&empty);
-        assert_eq!(gestures.affordance(&empty), Some(HandAffordance::Blocked));
+        assert_eq!(
+            gestures.claim(&empty),
+            Some(HandClaim::Anchor(HandAffordance::Blocked))
+        );
         assert_eq!(
             gestures.update(&HandAnchorInput {
                 squeeze: 1.0,
@@ -606,7 +633,10 @@ mod tests {
             ..at(SHOULDER)
         };
         gestures.update(&full);
-        assert_eq!(gestures.affordance(&full), Some(HandAffordance::Blocked));
+        assert_eq!(
+            gestures.claim(&full),
+            Some(HandClaim::Anchor(HandAffordance::Blocked))
+        );
         assert_eq!(
             gestures.update(&HandAnchorInput {
                 squeeze: 0.0,
@@ -652,17 +682,116 @@ mod tests {
 
         let mut gestures = AnchorGestures::default();
         let hand = HandAnchorInput {
-            has_card: false,
+            card_on_belt: false,
             ..at(Some(BodyAnchor::Belt))
         };
         gestures.update(&hand);
-        assert_eq!(gestures.affordance(&hand), Some(HandAffordance::Blocked));
+        assert_eq!(
+            gestures.claim(&hand),
+            Some(HandClaim::Anchor(HandAffordance::Blocked))
+        );
         assert_eq!(
             gestures.update(&HandAnchorInput {
                 squeeze: 1.0,
                 ..hand
             }),
             None
+        );
+    }
+
+    /// A hand carrying the card is claimed wherever it is - it must not also
+    /// grab a pickup its ray crosses on the way to a reader, and the shoulder
+    /// must not promise a stow the release would not perform.
+    #[test]
+    fn a_hand_carrying_the_card_is_claimed_everywhere() {
+        let mut gestures = AnchorGestures::default();
+        for anchor in [None, SHOULDER, Some(BodyAnchor::Belt)] {
+            let hand = HandAnchorInput {
+                holds_card: true,
+                squeeze: 1.0,
+                ..at(anchor)
+            };
+            gestures.update(&hand);
+            assert_eq!(
+                gestures.claim(&hand),
+                Some(HandClaim::CarryingCard),
+                "the card fills the hand at {anchor:?}"
+            );
+            assert_eq!(
+                gestures.update(&HandAnchorInput {
+                    squeeze: 0.0,
+                    ..hand
+                }),
+                Some(AnchorGesture::ReturnCard(Handedness::Right)),
+                "and opening it returns the card rather than stowing"
+            );
+        }
+    }
+
+    /// There is one card. A hand at the belt while the other carries it finds
+    /// the hip empty rather than taking it out of that grip.
+    #[test]
+    fn the_belt_is_empty_while_the_other_hand_has_the_card() {
+        let mut gestures = AnchorGestures::default();
+        let hand = HandAnchorInput {
+            hand: Handedness::Left,
+            card_on_belt: false,
+            ..at(Some(BodyAnchor::Belt))
+        };
+        gestures.update(&hand);
+        assert_eq!(
+            gestures.claim(&hand),
+            Some(HandClaim::Anchor(
+                crate::hand_affordance::HandAffordance::Blocked
+            ))
+        );
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 1.0,
+                ..hand
+            }),
+            None,
+            "the second hand must not take the card out of the first"
+        );
+    }
+
+    /// The light and the gesture read one resolved anchor: a hand the
+    /// hysteresis has let go of neither commits nor claims.
+    #[test]
+    fn an_expired_anchor_neither_claims_nor_commits() {
+        let mut gestures = AnchorGestures::default();
+        let empty = |anchor| at(anchor);
+        gestures.update(&empty(SHOULDER));
+        for _ in 0..=ANCHOR_HOLD_FRAMES {
+            gestures.update(&empty(None));
+        }
+        assert_eq!(gestures.claim(&empty(None)), None);
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 1.0,
+                ..empty(None)
+            }),
+            None,
+            "an expired anchor must not draw into a hand it no longer owns"
+        );
+    }
+
+    /// The release edge is the same one `VirtualHand` drops on. A squeeze
+    /// resting exactly on the threshold is still a hold, so a stow cannot claim
+    /// a release the hand never made.
+    #[test]
+    fn the_release_edge_matches_the_hands_own_hold_test() {
+        let mut gestures = AnchorGestures::default();
+        let holding = |squeeze: f32| HandAnchorInput {
+            holding: true,
+            squeeze,
+            ..at(SHOULDER)
+        };
+        gestures.update(&holding(1.0));
+        assert_eq!(
+            gestures.update(&holding(crate::ui::VR_TRIGGER_THRESHOLD)),
+            None,
+            "a squeeze on the threshold still holds, so nothing is stowed"
         );
     }
 
@@ -676,7 +805,7 @@ mod tests {
             squeeze: 1.0,
             ..at(None)
         };
-        assert_eq!(gestures.affordance(&hand), None);
+        assert_eq!(gestures.claim(&hand), None);
         gestures.update(&hand);
         hand.squeeze = 0.0;
         assert_eq!(gestures.update(&hand), None);

--- a/shock2vr/src/body_frame.rs
+++ b/shock2vr/src/body_frame.rs
@@ -1,0 +1,395 @@
+//! Body-relative anchors: where the player's belt and shoulders are, so a hand
+//! can reach them.
+//!
+//! Every persistent VR interaction that is not attached to a world object hangs
+//! off one of these - the belt card, the shoulders that stand in for the
+//! backpack. They are plain world-space points the existing hand-proximity code
+//! already knows how to test, resolved once per frame from the tracked head.
+//!
+//! The head is the only tracked part of the body we have, so the frame is
+//! derived from it: horizontal position from the head's floor projection,
+//! heights from the tracked eye, facing from a **low-passed** head yaw. The
+//! low-pass is the whole point - a body whose belt swung with every glance
+//! would put the card somewhere new each time the player looked at it. Pitch
+//! and roll are ignored outright: leaning over does not move a real belt
+//! sideways.
+
+use cgmath::{InnerSpace, Quaternion, Rad, Rotation, Rotation3, Vector3, vec3};
+
+use crate::{METERS_PER_WORLD_UNIT, vr_config::Handedness};
+
+/// Convert a real-world measurement (the units body dimensions are naturally
+/// written in) into world units.
+const fn meters(m: f32) -> f32 {
+    m / METERS_PER_WORLD_UNIT
+}
+
+/// Belt height as a fraction of the tracked eye height. ~0.55 puts it at the
+/// top of the hip on an average adult, which is where a real belt sits and
+/// where the hand naturally falls when the arm hangs and the elbow bends.
+const BELT_HEIGHT_FRACTION: f32 = 0.55;
+
+/// How far the shoulder sockets sit below the eye.
+const SHOULDER_DROP: f32 = meters(0.2);
+
+/// Half the shoulder/hip width: how far each anchor sits to the side of the
+/// body's midline.
+const LATERAL_OFFSET: f32 = meters(0.18);
+
+/// Reach radius of each anchor. The belt card is a small object the hand has to
+/// find; a shoulder is a "throw it back there" gesture and is deliberately more
+/// forgiving.
+const BELT_RADIUS: f32 = meters(0.09);
+const SHOULDER_RADIUS: f32 = meters(0.15);
+
+/// Minimum vertical gap between the belt and the shoulders, so a deep crouch
+/// (which lowers the eye, and with it both anchors) can never bring the two
+/// zones into contact and make "which anchor is this" a matter of rounding.
+const ANCHOR_SEPARATION: f32 = BELT_RADIUS + SHOULDER_RADIUS + meters(0.05);
+
+/// Time constant of the yaw low-pass, in seconds. Long enough that a glance
+/// leaves the body where it was, short enough that turning to walk brings the
+/// belt round with you well before you reach for it.
+const YAW_TIME_CONSTANT_SECS: f32 = 0.5;
+
+/// A place on the player's body a hand can reach.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BodyAnchor {
+    /// Left hip: the belt card.
+    Belt,
+    /// Either shoulder: the backpack (stow what you hold, draw what you stowed).
+    Shoulder(Handedness),
+}
+
+/// This frame's resolved body anchors, in world space.
+#[derive(Clone, Copy, Debug)]
+pub struct BodyFrame {
+    belt: Vector3<f32>,
+    /// Indexed by [`crate::vr_config::hand_slot`].
+    shoulders: [Vector3<f32>; 2],
+    rotation: Quaternion<f32>,
+}
+
+impl BodyFrame {
+    /// Where the belt card sits.
+    pub fn belt(&self) -> Vector3<f32> {
+        self.belt
+    }
+
+    /// Where one shoulder socket sits.
+    pub fn shoulder(&self, hand: Handedness) -> Vector3<f32> {
+        self.shoulders[crate::vr_config::hand_slot(hand)]
+    }
+
+    /// The body's facing - yaw only, so anything parented to it stays upright.
+    pub fn rotation(&self) -> Quaternion<f32> {
+        self.rotation
+    }
+
+    /// Which anchor, if any, a hand at `position` is inside. The belt is tested
+    /// first: it is the smaller, more precisely-placed zone, and
+    /// [`ANCHOR_SEPARATION`] keeps the two from ever overlapping anyway.
+    pub fn anchor_at(&self, position: Vector3<f32>) -> Option<BodyAnchor> {
+        if (position - self.belt).magnitude2() <= BELT_RADIUS * BELT_RADIUS {
+            return Some(BodyAnchor::Belt);
+        }
+        for hand in [Handedness::Left, Handedness::Right] {
+            if (position - self.shoulder(hand)).magnitude2() <= SHOULDER_RADIUS * SHOULDER_RADIUS {
+                return Some(BodyAnchor::Shoulder(hand));
+            }
+        }
+        None
+    }
+}
+
+/// Per-frame inputs the frame is derived from.
+pub struct BodyFrameInput {
+    /// The pawn (player collider) origin and facing, in world space.
+    pub pawn_position: Vector3<f32>,
+    pub pawn_rotation: Quaternion<f32>,
+    /// The tracked head, in pawn space - the same space
+    /// [`crate::input_context::Hand::position`] uses.
+    pub head_position: Vector3<f32>,
+    pub head_rotation: Quaternion<f32>,
+    /// How far the pawn origin sits above the floor, world units
+    /// (`physics::player_center_above_floor`). Crouching shrinks it, which is
+    /// what lowers the anchors with the player.
+    pub pawn_above_floor: f32,
+    /// The fixed simulation step this frame integrates, for the yaw low-pass.
+    pub dt: f32,
+}
+
+/// Carries the low-passed yaw between frames. Runtime-only: the frame is
+/// re-derived from the live head pose, so a restored save simply starts from
+/// wherever the player is looking.
+#[derive(Clone, Debug, Default)]
+pub struct BodyFrameTracker {
+    /// Pawn-relative head yaw, radians. `None` until the first tracked frame,
+    /// so the body starts already facing the head instead of easing round to it.
+    yaw: Option<f32>,
+}
+
+impl BodyFrameTracker {
+    /// Advance the low-pass and resolve this frame's anchors.
+    pub fn update(&mut self, input: &BodyFrameInput) -> BodyFrame {
+        // An untracked head arrives as the zero quaternion, which cgmath
+        // rotates by silently (see the VR UI rules): treat it as "no new
+        // reading" and keep the yaw we had rather than snapping the body to
+        // pawn-forward.
+        if let Some(observed) = head_yaw(input.head_rotation) {
+            self.yaw = Some(match self.yaw {
+                None => observed,
+                Some(current) => {
+                    let alpha = 1.0 - (-input.dt / YAW_TIME_CONSTANT_SECS).exp();
+                    wrap_pi(current + wrap_pi(observed - current) * alpha)
+                }
+            });
+        }
+        let rotation = input.pawn_rotation * Quaternion::from_angle_y(Rad(self.yaw.unwrap_or(0.0)));
+        let right = rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
+
+        // Horizontal placement follows the head (lean out over a railing and
+        // your belt goes with you); heights come off the tracked eye.
+        let floor_y = input.pawn_position.y - input.pawn_above_floor;
+        let ground = input.pawn_position
+            + input.pawn_rotation.rotate_vector(vec3(
+                input.head_position.x,
+                0.0,
+                input.head_position.z,
+            ));
+        let eye_above_floor = input.head_position.y + input.pawn_above_floor;
+
+        let shoulder_y = floor_y + eye_above_floor - SHOULDER_DROP;
+        let belt_y =
+            (floor_y + eye_above_floor * BELT_HEIGHT_FRACTION).min(shoulder_y - ANCHOR_SEPARATION);
+        let at = |y: f32| vec3(ground.x, y, ground.z);
+
+        BodyFrame {
+            // The card rides the left hip.
+            belt: at(belt_y) - right * LATERAL_OFFSET,
+            shoulders: [
+                at(shoulder_y) - right * LATERAL_OFFSET,
+                at(shoulder_y) + right * LATERAL_OFFSET,
+            ],
+            rotation,
+        }
+    }
+}
+
+/// The yaw a rotation faces, radians about +Y, or `None` for an untracked
+/// (zero-magnitude) pose.
+fn head_yaw(rotation: Quaternion<f32>) -> Option<f32> {
+    if rotation.magnitude2() < 1e-6 {
+        return None;
+    }
+    // `Quaternion::from_angle_y(t) * (0, 0, -1)` is `(-sin t, 0, -cos t)`.
+    let forward = rotation.normalize().rotate_vector(vec3(0.0, 0.0, -1.0));
+    Some((-forward.x).atan2(-forward.z))
+}
+
+/// Fold an angle into `[-pi, pi]`, so smoothing takes the short way round.
+fn wrap_pi(angle: f32) -> f32 {
+    let tau = std::f32::consts::TAU;
+    let wrapped = (angle + std::f32::consts::PI).rem_euclid(tau);
+    wrapped - std::f32::consts::PI
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Deg, Zero};
+
+    use super::*;
+
+    const STEP: f32 = 1.0 / 60.0;
+
+    /// A standing player, facing pawn-forward, at the origin.
+    fn standing(head_rotation: Quaternion<f32>) -> BodyFrameInput {
+        BodyFrameInput {
+            pawn_position: Vector3::zero(),
+            pawn_rotation: Quaternion::from_angle_y(Deg(0.0)),
+            head_position: vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0),
+            head_rotation,
+            pawn_above_floor: crate::physics::player_center_above_floor(false),
+            dt: STEP,
+        }
+    }
+
+    /// The first tracked frame places the body where the head already is - no
+    /// easing in from pawn-forward.
+    #[test]
+    fn the_first_frame_adopts_the_head_yaw() {
+        let mut tracker = BodyFrameTracker::default();
+        let frame = tracker.update(&standing(Quaternion::from_angle_y(Deg(90.0))));
+
+        let forward = frame.rotation().rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(
+            forward.x < -0.99,
+            "a 90 deg head should face -X immediately, got {forward:?}"
+        );
+    }
+
+    /// The low-pass is the feature: a head that snaps 90 degrees leaves the
+    /// belt where it was for the frame, and takes about the time constant to
+    /// bring it most of the way round.
+    #[test]
+    fn a_head_turn_drags_the_body_round_over_the_time_constant() {
+        let mut tracker = BodyFrameTracker::default();
+        tracker.update(&standing(Quaternion::from_angle_y(Deg(0.0))));
+        let turned = || standing(Quaternion::from_angle_y(Deg(90.0)));
+
+        let after_one_frame = tracker.update(&turned());
+        let yaw = |frame: &BodyFrame| {
+            let f = frame.rotation().rotate_vector(vec3(0.0, 0.0, -1.0));
+            (-f.x).atan2(-f.z).to_degrees()
+        };
+        assert!(
+            yaw(&after_one_frame) < 5.0,
+            "one frame should barely move the body, got {}",
+            yaw(&after_one_frame)
+        );
+
+        let mut frame = after_one_frame;
+        for _ in 1..(YAW_TIME_CONSTANT_SECS / STEP) as usize {
+            frame = tracker.update(&turned());
+        }
+        // One time constant is 1 - 1/e of the way there.
+        assert!(
+            (55.0..75.0).contains(&yaw(&frame)),
+            "one time constant should be ~63% of the turn, got {}",
+            yaw(&frame)
+        );
+    }
+
+    /// Smoothing takes the short way round the wrap, rather than unwinding
+    /// almost a full turn the long way.
+    #[test]
+    fn yaw_smoothing_crosses_the_wrap_the_short_way() {
+        let mut tracker = BodyFrameTracker::default();
+        tracker.update(&standing(Quaternion::from_angle_y(Deg(175.0))));
+        let frame = tracker.update(&standing(Quaternion::from_angle_y(Deg(-175.0))));
+
+        let f = frame.rotation().rotate_vector(vec3(0.0, 0.0, -1.0));
+        let yaw = (-f.x).atan2(-f.z).to_degrees();
+        assert!(
+            yaw.abs() > 170.0,
+            "the body should stay near the wrap, not swing through 0, got {yaw}"
+        );
+    }
+
+    /// An untracked head (the zero quaternion) is not a reading. Without the
+    /// guard, cgmath returns the vector unrotated and the body snaps to
+    /// pawn-forward.
+    #[test]
+    fn an_untracked_head_holds_the_last_yaw() {
+        let mut tracker = BodyFrameTracker::default();
+        tracker.update(&standing(Quaternion::from_angle_y(Deg(90.0))));
+
+        let mut untracked = standing(Quaternion::from_angle_y(Deg(90.0)));
+        untracked.head_rotation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
+        let frame = tracker.update(&untracked);
+
+        let forward = frame.rotation().rotate_vector(vec3(0.0, 0.0, -1.0));
+        assert!(
+            forward.x < -0.99,
+            "an untracked frame must not swing the body, got {forward:?}"
+        );
+    }
+
+    /// Crouching lowers the tracked eye, and the belt and shoulders come down
+    /// with it.
+    #[test]
+    fn crouching_lowers_the_belt_and_the_shoulders() {
+        let mut standing_tracker = BodyFrameTracker::default();
+        let upright = standing_tracker.update(&standing(Quaternion::from_angle_y(Deg(0.0))));
+
+        let mut crouch = standing(Quaternion::from_angle_y(Deg(0.0)));
+        crouch.head_position.y = crate::PLAYER_CROUCH_EYE_HEIGHT / dark::SCALE_FACTOR;
+        crouch.pawn_above_floor = crate::physics::player_center_above_floor(true);
+        let crouched = BodyFrameTracker::default().update(&crouch);
+
+        assert!(
+            crouched.belt().y < upright.belt().y,
+            "crouched belt {} should be below standing {}",
+            crouched.belt().y,
+            upright.belt().y
+        );
+        assert!(
+            crouched.shoulder(Handedness::Left).y < upright.shoulder(Handedness::Left).y,
+            "crouched shoulders should be below standing ones"
+        );
+    }
+
+    /// The three zones never overlap, standing or crouched - a hand is only
+    /// ever in one of them, so the gesture it commits to is never a matter of
+    /// test order.
+    #[test]
+    fn the_anchor_zones_stay_disjoint_at_every_stance() {
+        for eye in [0.5, 1.04, 1.4] {
+            let mut input = standing(Quaternion::from_angle_y(Deg(0.0)));
+            input.head_position.y = eye;
+            let frame = BodyFrameTracker::default().update(&input);
+
+            let centers = [
+                (frame.belt(), BELT_RADIUS),
+                (frame.shoulder(Handedness::Left), SHOULDER_RADIUS),
+                (frame.shoulder(Handedness::Right), SHOULDER_RADIUS),
+            ];
+            for (i, (a, ra)) in centers.iter().enumerate() {
+                for (b, rb) in centers.iter().skip(i + 1) {
+                    assert!(
+                        (a - b).magnitude() > ra + rb,
+                        "zones at {a:?} and {b:?} overlap with an eye at {eye}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A hand in a zone reports it; a hand at the player's own eye - the rest
+    /// pose the wrist canvases live at - reports nothing, so reading the watch
+    /// can never arm a body-anchor gesture.
+    #[test]
+    fn anchors_answer_only_inside_their_own_zone() {
+        let mut tracker = BodyFrameTracker::default();
+        let frame = tracker.update(&standing(Quaternion::from_angle_y(Deg(0.0))));
+
+        assert_eq!(frame.anchor_at(frame.belt()), Some(BodyAnchor::Belt));
+        for hand in [Handedness::Left, Handedness::Right] {
+            assert_eq!(
+                frame.anchor_at(frame.shoulder(hand)),
+                Some(BodyAnchor::Shoulder(hand))
+            );
+        }
+
+        let eye = vec3(0.0, crate::input_context::DEFAULT_HEAD_HEIGHT, 0.0);
+        assert_eq!(frame.anchor_at(eye), None, "the eye is not an anchor");
+        assert_eq!(
+            frame.anchor_at(eye + vec3(0.0, 0.0, -meters(0.35))),
+            None,
+            "a hand held up in front of the face is not an anchor"
+        );
+    }
+
+    /// The belt is on the LEFT hip, and turns with the body rather than staying
+    /// in world space.
+    #[test]
+    fn the_belt_rides_the_left_hip() {
+        let mut tracker = BodyFrameTracker::default();
+        let frame = tracker.update(&standing(Quaternion::from_angle_y(Deg(0.0))));
+        // Facing -Z, the player's left is -X.
+        assert!(frame.belt().x < 0.0, "belt should be on the left hip");
+        assert!(frame.shoulder(Handedness::Left).x < 0.0);
+        assert!(frame.shoulder(Handedness::Right).x > 0.0);
+
+        // The pawn turned 90 deg with the head straight ahead: facing -X, so
+        // the player's left is +Z.
+        let mut turned = standing(Quaternion::from_angle_y(Deg(0.0)));
+        turned.pawn_rotation = Quaternion::from_angle_y(Deg(90.0));
+        let frame = BodyFrameTracker::default().update(&turned);
+        assert!(
+            frame.belt().z > 0.0,
+            "facing -X the left hip is at +Z, got {:?}",
+            frame.belt()
+        );
+    }
+}

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -400,6 +400,22 @@ pub struct DebugHandAffordances {
     pub right_model: Option<String>,
 }
 
+/// The player's body anchors, and what hangs off them: where a hand has to go
+/// to reach the belt or a shoulder, what a shoulder would draw, and where the
+/// belt card is.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugBodyFrame {
+    pub belt: [f32; 3],
+    pub left_shoulder: [f32; 3],
+    pub right_shoulder: [f32; 3],
+    /// The weapon an empty grip at a shoulder would draw right now, by name -
+    /// `null` when nothing was stowed, or it is gone/already in hand.
+    pub last_stowed_weapon: Option<String>,
+    /// Where the belt card is: "belt", "left", "right", or `null` while the
+    /// player has collected no credential.
+    pub belt_card: Option<&'static str>,
+}
+
 /// A hand's fitted grip: the family the fit solved in, and the curl it left
 /// each finger at (0 = open, 1 = closed fist), before the trigger adds its own.
 #[derive(Debug, Serialize, Clone, Copy)]
@@ -903,6 +919,12 @@ pub trait DebuggableScene {
     /// Each hand's affordance (see [`DebugHandAffordances`]). Scenes without a
     /// player report nothing.
     fn player_hand_affordances(&self) -> Option<DebugHandAffordances> {
+        None
+    }
+
+    /// The player's body anchors (see [`DebugBodyFrame`]). `None` outside VR,
+    /// and in scenes without a player.
+    fn player_body_frame(&self) -> Option<DebugBodyFrame> {
         None
     }
 

--- a/shock2vr/src/hand_fit.rs
+++ b/shock2vr/src/hand_fit.rs
@@ -19,6 +19,7 @@
 use cgmath::{EuclideanSpace, InnerSpace, Point3, Vector3};
 
 use crate::hand_pose::{Finger, FingerAmounts};
+use crate::util::meters;
 
 /// A capsule along one phalanx, in hand space (world units).
 #[derive(Debug, Clone, Copy)]
@@ -125,11 +126,6 @@ impl GripFamily {
             GripFamily::Trigger => "trigger",
         }
     }
-}
-
-/// Metres expressed in the world units the hand frame is measured in.
-const fn meters(m: f32) -> f32 {
-    m / crate::METERS_PER_WORLD_UNIT
 }
 
 /// Thinner than this in its smallest dimension and an item is pinched rather

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -40,6 +40,15 @@ pub struct InteractionContext<'a> {
     /// Eye height above `player_pos` in SS2 units - crouch-aware, so the flat
     /// controller's shot/viewmodel origin follows the actual camera.
     pub eye_height: f32,
+    /// This frame's body anchors (VR only). Resolved by `mission_core`, which
+    /// owns the gestures they drive; the hands only need it to draw the belt
+    /// card.
+    pub body_frame: Option<crate::body_frame::BodyFrame>,
+    /// What each hand's body anchor offers this frame, indexed by
+    /// `vr_config::hand_slot`. `Some` claims the hand: its light shows the
+    /// anchor's eligibility and its grip belongs to the anchor gesture rather
+    /// than to whatever its ray crossed.
+    pub anchor_affordance: [Option<crate::hand_affordance::HandAffordance>; 2],
 }
 
 /// Read-only per-frame inputs for the VR hand-climb resolve. Separate from
@@ -185,6 +194,9 @@ pub struct VrInteraction {
     glove_renderer: RefCell<Option<Option<GloveRenderer>>>,
     /// Which hands hold a climbing hold, and which one moves the body.
     hand_climb: crate::vr_climb::HandClimb,
+    /// This frame's body anchors, for drawing the belt card. Written by
+    /// `update`, read by `render` (which has no context of its own).
+    body_frame: std::cell::Cell<Option<crate::body_frame::BodyFrame>>,
     /// The grip each hand's last render fitted, indexed by
     /// `vr_config::hand_slot`. Written where the fit is solved (render, which
     /// owns the glove and the asset cache) and read by the debug readout.
@@ -198,6 +210,7 @@ impl VrInteraction {
             right_hand: VirtualHand::new(Handedness::Right),
             glove_renderer: RefCell::new(None),
             hand_climb: crate::vr_climb::HandClimb::default(),
+            body_frame: std::cell::Cell::new(None),
             fitted_grips: RefCell::new([None, None]),
         }
     }
@@ -258,6 +271,7 @@ impl PlayerInteraction for VrInteraction {
     }
 
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
+        self.body_frame.set(ctx.body_frame);
         let left_held_entity = self.left_hand.get_held_entity();
         let (right_hand, mut right_msgs) = VirtualHand::update(
             &self.right_hand,
@@ -267,6 +281,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.right_hand,
             left_held_entity,
+            ctx.anchor_affordance[crate::vr_config::hand_slot(Handedness::Right)],
         );
         self.right_hand = right_hand;
 
@@ -281,6 +296,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.left_hand,
             right_held_entity,
+            ctx.anchor_affordance[crate::vr_config::hand_slot(Handedness::Left)],
         );
         self.left_hand = left_hand;
 
@@ -569,6 +585,8 @@ mod tests {
             player_rotation: identity(),
             head_rotation: identity(),
             eye_height: 1.04,
+            body_frame: None,
+            anchor_affordance: [None, None],
         }
     }
 

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -44,6 +44,9 @@ pub struct InteractionContext<'a> {
     /// owns the gestures they drive; the hands only need it to draw the belt
     /// card.
     pub body_frame: Option<crate::body_frame::BodyFrame>,
+    /// Where the belt card is, or `None` while the player has collected no
+    /// credential and there is no card.
+    pub belt_card: Option<crate::belt_card::CardPlacement>,
     /// What each hand's body anchor offers this frame, indexed by
     /// `vr_config::hand_slot`. `Some` claims the hand: its light shows the
     /// anchor's eligibility and its grip belongs to the anchor gesture rather
@@ -164,6 +167,12 @@ pub trait PlayerInteraction {
         None
     }
 
+    /// Where a tracked hand is in the world. `None` for flat, which has no
+    /// hand to place anything at.
+    fn hand_pose(&self, _hand: Handedness) -> Option<(Vector3<f32>, Quaternion<f32>)> {
+        None
+    }
+
     fn hand_affordance(&self, _hand: Handedness) -> crate::hand_affordance::HandAffordance {
         crate::hand_affordance::HandAffordance::None
     }
@@ -197,6 +206,9 @@ pub struct VrInteraction {
     /// This frame's body anchors, for drawing the belt card. Written by
     /// `update`, read by `render` (which has no context of its own).
     body_frame: std::cell::Cell<Option<crate::body_frame::BodyFrame>>,
+    /// Where the belt card is, so `render` can place it - it is not an entity,
+    /// so nothing else in the scene would draw it.
+    belt_card: std::cell::Cell<Option<crate::belt_card::CardPlacement>>,
     /// The grip each hand's last render fitted, indexed by
     /// `vr_config::hand_slot`. Written where the fit is solved (render, which
     /// owns the glove and the asset cache) and read by the debug readout.
@@ -211,6 +223,7 @@ impl VrInteraction {
             glove_renderer: RefCell::new(None),
             hand_climb: crate::vr_climb::HandClimb::default(),
             body_frame: std::cell::Cell::new(None),
+            belt_card: std::cell::Cell::new(None),
             fitted_grips: RefCell::new([None, None]),
         }
     }
@@ -272,6 +285,7 @@ impl PlayerInteraction for VrInteraction {
 
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
         self.body_frame.set(ctx.body_frame);
+        self.belt_card.set(ctx.belt_card);
         let left_held_entity = self.left_hand.get_held_entity();
         let (right_hand, mut right_msgs) = VirtualHand::update(
             &self.right_hand,
@@ -328,6 +342,14 @@ impl PlayerInteraction for VrInteraction {
         }
     }
 
+    fn hand_pose(&self, hand: Handedness) -> Option<(Vector3<f32>, Quaternion<f32>)> {
+        let hand = match hand {
+            Handedness::Left => &self.left_hand,
+            Handedness::Right => &self.right_hand,
+        };
+        Some((hand.get_position(), hand.get_rotation()))
+    }
+
     fn hand_affordance(&self, hand: Handedness) -> crate::hand_affordance::HandAffordance {
         match hand {
             Handedness::Left => self.left_hand.affordance(),
@@ -364,6 +386,23 @@ impl PlayerInteraction for VrInteraction {
                 *self.fitted_grips.borrow_mut() = [None, None];
             }
         }
+        // The belt card: in the hand that took it, else on the hip, following
+        // the body frame. It is not an entity, so nothing else would draw it.
+        if let Some(transform) = match self.belt_card.get() {
+            Some(crate::belt_card::CardPlacement::InHand(hand)) => {
+                self.hand_pose(hand).map(|(position, rotation)| {
+                    crate::belt_card::hand_transform(position, rotation, hand)
+                })
+            }
+            Some(crate::belt_card::CardPlacement::Belt) => self
+                .body_frame
+                .get()
+                .map(|frame| crate::belt_card::belt_transform(&frame)),
+            None => None,
+        } {
+            objs.extend(crate::belt_card::scene_objects(asset_cache, transform));
+        }
+
         // Feedback comes from the resolved holds, never a second proximity
         // query: a blocked pull still shows a catch; release/break removes it.
         // Float just above the fist so the glove cannot hide the marker.
@@ -586,6 +625,7 @@ mod tests {
             head_rotation: identity(),
             eye_height: 1.04,
             body_frame: None,
+            belt_card: None,
             anchor_affordance: [None, None],
         }
     }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -47,11 +47,10 @@ pub struct InteractionContext<'a> {
     /// Where the belt card is, or `None` while the player has collected no
     /// credential and there is no card.
     pub belt_card: Option<crate::belt_card::CardPlacement>,
-    /// What each hand's body anchor offers this frame, indexed by
-    /// `vr_config::hand_slot`. `Some` claims the hand: its light shows the
-    /// anchor's eligibility and its grip belongs to the anchor gesture rather
-    /// than to whatever its ray crossed.
-    pub anchor_affordance: [Option<crate::hand_affordance::HandAffordance>; 2],
+    /// What owns each hand this frame (a body anchor, or the belt card it is
+    /// carrying), indexed by `vr_config::hand_slot`. `Some` claims the hand:
+    /// its grip belongs to the body rather than to whatever its ray crossed.
+    pub anchor_claim: [Option<crate::body_frame::HandClaim>; 2],
 }
 
 /// Read-only per-frame inputs for the VR hand-climb resolve. Separate from
@@ -295,7 +294,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.right_hand,
             left_held_entity,
-            ctx.anchor_affordance[crate::vr_config::hand_slot(Handedness::Right)],
+            ctx.anchor_claim[crate::vr_config::hand_slot(Handedness::Right)],
         );
         self.right_hand = right_hand;
 
@@ -310,7 +309,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             &ctx.input.left_hand,
             right_held_entity,
-            ctx.anchor_affordance[crate::vr_config::hand_slot(Handedness::Left)],
+            ctx.anchor_claim[crate::vr_config::hand_slot(Handedness::Left)],
         );
         self.left_hand = left_hand;
 
@@ -626,7 +625,7 @@ mod tests {
             eye_height: 1.04,
             body_frame: None,
             belt_card: None,
-            anchor_affordance: [None, None],
+            anchor_claim: [None, None],
         }
     }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_log;
+pub mod belt_card;
 pub mod body_frame;
 pub mod game_scene;
 pub mod hand_affordance;

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_log;
+pub mod body_frame;
 pub mod game_scene;
 pub mod hand_affordance;
 pub mod hand_buttons;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1677,9 +1677,11 @@ pub struct MissionCore {
     /// presentation - derived from `QuestInfo`'s collected credentials each
     /// frame - so nothing here needs saving: a reload puts it back on the belt.
     belt_card_hand: Option<crate::vr_config::Handedness>,
-    /// The reader the belt card is currently touching, so one touch sends one
-    /// frob rather than one every frame it rests there.
-    belt_card_reader: Option<EntityId>,
+    /// The reader the belt card is currently touching, and how many frames its
+    /// claim survives the ray coming off it - so one touch sends one frob
+    /// rather than one every frame it rests there, and a card jittering across
+    /// the panel edge does not re-frob (which on a door shuts it again).
+    belt_card_reader: Option<(EntityId, u8)>,
 
     /// The trigger-safe decision in flight for each hand (indexed by
     /// [`hand_slot`]), or `None` when that hand's trigger is released. The
@@ -3710,23 +3712,29 @@ impl MissionCore {
                     pawn_rotation: player_rot,
                     head_position: input_context.head.position,
                     head_rotation: input_context.head.rotation,
+                    // The stance the tracked head was rebased with (see
+                    // `rebase_input`), NOT the collider's - they disagree while
+                    // the player hangs from their hands, and the belt would
+                    // drop out from under the hand that reaches for it.
                     pawn_above_floor: crate::physics::player_center_above_floor(
-                        self.player_handle.is_crouched(),
+                        self.player_handle.tracking_is_crouched(),
                     ),
                     dt: time.elapsed.as_secs_f32(),
                 })
             });
         self.body_anchors = body_frame;
 
-        let mut anchor_affordance = [None, None];
+        let mut anchor_claim = [None, None];
         let mut anchor_gestures = Vec::new();
         if let Some(frame) = body_frame {
             let can_stow = backpack_accepts_deposit(&self.world);
             let can_draw = self.stowed_weapon_to_draw().is_some();
-            let has_card = self
-                .world
-                .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
-                .is_ok_and(|quests| quests.has_key_cards());
+            // One card: it is on the belt only while no hand is carrying it.
+            let card_on_belt = self.belt_card_hand.is_none()
+                && self
+                    .world
+                    .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+                    .is_ok_and(|quests| quests.has_key_cards());
             for hand in [
                 crate::vr_config::Handedness::Left,
                 crate::vr_config::Handedness::Right,
@@ -3748,10 +3756,10 @@ impl MissionCore {
                     holds_card: self.belt_card_hand == Some(hand),
                     can_stow,
                     can_draw,
-                    has_card,
+                    card_on_belt,
                 };
                 anchor_gestures.extend(self.anchor_gestures.update(&input));
-                anchor_affordance[slot] = self.anchor_gestures.affordance(&input);
+                anchor_claim[slot] = self.anchor_gestures.claim(&input);
             }
         }
         for gesture in &anchor_gestures {
@@ -3816,7 +3824,7 @@ impl MissionCore {
             eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
             body_frame,
             belt_card: belt_card_placement(&self.world, self.belt_card_hand),
-            anchor_affordance,
+            anchor_claim,
         });
         rewrite_strip_release(&mut interaction_msgs, &store, &collect);
         self.process_virtual_hand_effects(asset_cache, interaction_msgs);
@@ -9016,29 +9024,48 @@ impl MissionCore {
     fn update_belt_card_reader(&mut self) {
         let touched = self
             .belt_card_hand
-            .and_then(|hand| self.interaction.hand_pose(hand))
-            .and_then(|(position, rotation)| {
-                let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+            .and_then(|hand| {
+                self.interaction
+                    .hand_pose(hand)
+                    .map(|(position, rotation)| {
+                        crate::belt_card::reader_ray(position, rotation, hand)
+                    })
+            })
+            .and_then(|(origin, forward)| {
+                let start = vec3_to_point3(origin);
                 let hit = crate::virtual_hand::interaction_ray_cast(
                     &self.physics,
                     &self.world,
-                    vec3_to_point3(position),
+                    start,
                     forward,
                     None,
                 )?;
-                ((hit.hit_point - vec3_to_point3(position)).magnitude()
-                    <= crate::belt_card::READER_REACH)
-                    .then_some(hit.maybe_entity_id)
-                    .flatten()
+                let entity_id = hit.maybe_entity_id?;
+                ((hit.hit_point - start).magnitude() <= crate::belt_card::READER_REACH
+                    && crate::belt_card::is_reader(&self.world, entity_id))
+                .then_some(entity_id)
             });
-        if touched != self.belt_card_reader {
-            self.belt_card_reader = touched;
-            if let Some(entity_id) = touched {
+
+        match (touched, self.belt_card_reader) {
+            // Still on the same reader, or back on it inside the window: the
+            // touch it already made stands.
+            (Some(entity_id), Some((claimed, _))) if entity_id == claimed => {
+                self.belt_card_reader = Some((claimed, crate::belt_card::READER_RELEASE_FRAMES));
+            }
+            (Some(entity_id), _) => {
+                self.belt_card_reader = Some((entity_id, crate::belt_card::READER_RELEASE_FRAMES));
+                // The card is a credential, not a tool: the reader gets the same
+                // `Frob` a hand would send, and its own script runs the same key
+                // check - so a touch opens exactly what the collected set opens.
                 self.script_world.dispatch(Message {
                     payload: MessagePayload::Frob,
                     to: entity_id,
                 });
             }
+            (None, Some((claimed, frames))) => {
+                self.belt_card_reader = frames.checked_sub(1).map(|left| (claimed, left));
+            }
+            (None, None) => {}
         }
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -361,6 +361,22 @@ fn rewrite_strip_release(
     *effects = rewritten;
 }
 
+/// Where the belt card is this frame. It exists only once the player has
+/// collected a credential - it stands in for the whole set - and is derived
+/// here rather than stored, so nothing about it needs saving.
+fn belt_card_placement(
+    world: &World,
+    held_by: Option<crate::vr_config::Handedness>,
+) -> Option<crate::belt_card::CardPlacement> {
+    let has_card = world
+        .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+        .is_ok_and(|quests| quests.has_key_cards());
+    has_card.then(|| match held_by {
+        Some(hand) => crate::belt_card::CardPlacement::InHand(hand),
+        None => crate::belt_card::CardPlacement::Belt,
+    })
+}
+
 /// Whether the player's backpack can actually take a deposit right now.
 ///
 /// This is exactly [`move_live_entity_into_container`]'s success condition for
@@ -1661,6 +1677,9 @@ pub struct MissionCore {
     /// presentation - derived from `QuestInfo`'s collected credentials each
     /// frame - so nothing here needs saving: a reload puts it back on the belt.
     belt_card_hand: Option<crate::vr_config::Handedness>,
+    /// The reader the belt card is currently touching, so one touch sends one
+    /// frob rather than one every frame it rests there.
+    belt_card_reader: Option<EntityId>,
 
     /// The trigger-safe decision in flight for each hand (indexed by
     /// [`hand_slot`]), or `None` when that hand's trigger is released. The
@@ -2584,6 +2603,7 @@ impl MissionCore {
             anchor_gestures: crate::body_frame::AnchorGestures::default(),
             body_anchors: None,
             belt_card_hand: None,
+            belt_card_reader: None,
             vr_trigger_safe_latch: [None; 2],
             vr_clip_insert_engaged: [false; 2],
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
@@ -3795,6 +3815,7 @@ impl MissionCore {
             head_rotation: input_context.head.rotation,
             eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
             body_frame,
+            belt_card: belt_card_placement(&self.world, self.belt_card_hand),
             anchor_affordance,
         });
         rewrite_strip_release(&mut interaction_msgs, &store, &collect);
@@ -3806,6 +3827,7 @@ impl MissionCore {
         if game_options.presentation_mode == crate::PresentationMode::Vr {
             let cues = self.update_clip_insert_gesture(asset_cache);
             effects.extend(cues);
+            self.update_belt_card_reader();
         }
 
         // Tag the wielded weapon with the flat camera/crosshair fire ray so its
@@ -8984,6 +9006,42 @@ impl MissionCore {
         cues
     }
 
+    /// The belt card held against a reader. The card is a credential, not a
+    /// tool: it sends the target the same `Frob` a hand would, and the door's
+    /// own script runs the same key check - so a touch opens exactly what the
+    /// collected set opens, and refuses the rest.
+    ///
+    /// Latched on the target so resting the card against a panel frobs it once
+    /// (a door frobbed every frame would toggle open/shut).
+    fn update_belt_card_reader(&mut self) {
+        let touched = self
+            .belt_card_hand
+            .and_then(|hand| self.interaction.hand_pose(hand))
+            .and_then(|(position, rotation)| {
+                let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+                let hit = crate::virtual_hand::interaction_ray_cast(
+                    &self.physics,
+                    &self.world,
+                    vec3_to_point3(position),
+                    forward,
+                    None,
+                )?;
+                ((hit.hit_point - vec3_to_point3(position)).magnitude()
+                    <= crate::belt_card::READER_REACH)
+                    .then_some(hit.maybe_entity_id)
+                    .flatten()
+            });
+        if touched != self.belt_card_reader {
+            self.belt_card_reader = touched;
+            if let Some(entity_id) = touched {
+                self.script_world.dispatch(Message {
+                    payload: MessagePayload::Frob,
+                    to: entity_id,
+                });
+            }
+        }
+    }
+
     /// How many rounds `weapon`'s magazine holds, or `None` when it is not a
     /// gun that takes one.
     fn magazine_capacity(&self, weapon: EntityId) -> Option<i32> {
@@ -11887,6 +11945,30 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             right_grip: self.interaction.fitted_grip(Handedness::Right),
             left_model: model_of(left_held),
             right_model: model_of(right_held),
+        })
+    }
+
+    fn player_body_frame(&self) -> Option<crate::game_scene::DebugBodyFrame> {
+        use crate::vr_config::Handedness;
+        let frame = self.body_anchors?;
+        let xyz = |v: Vector3<f32>| [v.x, v.y, v.z];
+        Some(crate::game_scene::DebugBodyFrame {
+            belt: xyz(frame.belt()),
+            left_shoulder: xyz(frame.shoulder(Handedness::Left)),
+            right_shoulder: xyz(frame.shoulder(Handedness::Right)),
+            last_stowed_weapon: self.stowed_weapon_to_draw().and_then(|entity_id| {
+                self.world
+                    .borrow::<View<dark::properties::PropSymName>>()
+                    .ok()
+                    .and_then(|names| names.get(entity_id).ok().map(|name| name.0.clone()))
+            }),
+            belt_card: belt_card_placement(&self.world, self.belt_card_hand).map(|placement| {
+                match placement {
+                    crate::belt_card::CardPlacement::Belt => "belt",
+                    crate::belt_card::CardPlacement::InHand(Handedness::Left) => "left",
+                    crate::belt_card::CardPlacement::InHand(Handedness::Right) => "right",
+                }
+            }),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1650,6 +1650,18 @@ pub struct MissionCore {
     /// its own squeeze again, or the eventual release would not drop it.
     vr_squeeze_swallow: [bool; 2],
 
+    /// The player's body anchors (belt, shoulders) and the gestures the hands
+    /// make at them. Runtime state: the frame is re-derived from the live head
+    /// each tick, and what a stow *left behind* lives in `QuestInfo`.
+    body_frame: crate::body_frame::BodyFrameTracker,
+    anchor_gestures: crate::body_frame::AnchorGestures,
+    /// This frame's resolved anchors, for the belt card and the debug readout.
+    body_anchors: Option<crate::body_frame::BodyFrame>,
+    /// Which hand, if either, has the belt card off its hip. The card is
+    /// presentation - derived from `QuestInfo`'s collected credentials each
+    /// frame - so nothing here needs saving: a reload puts it back on the belt.
+    belt_card_hand: Option<crate::vr_config::Handedness>,
+
     /// The trigger-safe decision in flight for each hand (indexed by
     /// [`hand_slot`]), or `None` when that hand's trigger is released. The
     /// squeeze counterpart above latches because grabbing is *level*-triggered;
@@ -2568,6 +2580,10 @@ impl MissionCore {
             vr_trigger_swallow: false,
             vr_use_mode_pointer: None,
             vr_squeeze_swallow: [false; 2],
+            body_frame: crate::body_frame::BodyFrameTracker::default(),
+            anchor_gestures: crate::body_frame::AnchorGestures::default(),
+            body_anchors: None,
+            belt_card_hand: None,
             vr_trigger_safe_latch: [None; 2],
             vr_clip_insert_engaged: [false; 2],
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
@@ -3634,7 +3650,7 @@ impl MissionCore {
         let (collect, store): (Vec<_>, Vec<_>) = strip_deposits.iter().partition(|entity_id| {
             crate::scripts::script_util::is_always_collected(&self.world, **entity_id)
         });
-        let collect: Vec<_> = collect.into_iter().copied().collect();
+        let mut collect: Vec<_> = collect.into_iter().copied().collect();
         // The cell the depositing hand's ray was over, for a stored item -
         // whichever on-strip slot actually held it. `None` (a ray gone off
         // the strip between resolving `strip_cell` and here, or generally
@@ -3652,7 +3668,7 @@ impl MissionCore {
         // backpack can actually take it - a release is never suppressed into an
         // item that lands nowhere. A collected one never enters the pack (its
         // Frob awards and destroys it), so it is claimed either way.
-        let store: Vec<(EntityId, Option<(usize, usize)>)> =
+        let mut store: Vec<(EntityId, Option<(usize, usize)>)> =
             if backpack_accepts_deposit(&self.world) {
                 store
                     .into_iter()
@@ -3661,6 +3677,112 @@ impl MissionCore {
             } else {
                 Vec::new()
             };
+
+        // The player's own body: where the belt and shoulders are this frame,
+        // and what each hand's grip means there. VR only - flat has no tracked
+        // hand to reach with. Resolved BEFORE the hands update, like the strip
+        // deposit above and for the same reason: the release a gesture claims
+        // must be exactly the release `VirtualHand` is about to perform.
+        let body_frame =
+            (game_options.presentation_mode == crate::PresentationMode::Vr).then(|| {
+                self.body_frame.update(&crate::body_frame::BodyFrameInput {
+                    pawn_position: player_pos,
+                    pawn_rotation: player_rot,
+                    head_position: input_context.head.position,
+                    head_rotation: input_context.head.rotation,
+                    pawn_above_floor: crate::physics::player_center_above_floor(
+                        self.player_handle.is_crouched(),
+                    ),
+                    dt: time.elapsed.as_secs_f32(),
+                })
+            });
+        self.body_anchors = body_frame;
+
+        let mut anchor_affordance = [None, None];
+        let mut anchor_gestures = Vec::new();
+        if let Some(frame) = body_frame {
+            let can_stow = backpack_accepts_deposit(&self.world);
+            let can_draw = self.stowed_weapon_to_draw().is_some();
+            let has_card = self
+                .world
+                .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+                .is_ok_and(|quests| quests.has_key_cards());
+            for hand in [
+                crate::vr_config::Handedness::Left,
+                crate::vr_config::Handedness::Right,
+            ] {
+                let slot = hand_slot(hand);
+                let hand_input = match hand {
+                    crate::vr_config::Handedness::Left => &hands_input.left_hand,
+                    crate::vr_config::Handedness::Right => &hands_input.right_hand,
+                };
+                let input = crate::body_frame::HandAnchorInput {
+                    hand,
+                    squeeze: hand_input.squeeze_value,
+                    anchor: frame.anchor_at(crate::virtual_hand::hand_world_position(
+                        player_pos,
+                        player_rot,
+                        hand_input.position,
+                    )),
+                    holding: [left_hand_held, right_hand_held][slot].is_some(),
+                    holds_card: self.belt_card_hand == Some(hand),
+                    can_stow,
+                    can_draw,
+                    has_card,
+                };
+                anchor_gestures.extend(self.anchor_gestures.update(&input));
+                anchor_affordance[slot] = self.anchor_gestures.affordance(&input);
+            }
+        }
+        for gesture in &anchor_gestures {
+            match *gesture {
+                crate::body_frame::AnchorGesture::Stow(hand) => {
+                    // Over the shoulder is the backpack. Claimed exactly the
+                    // way a strip deposit is, so one rewrite covers both.
+                    if let Some(entity_id) = [left_hand_held, right_hand_held][hand_slot(hand)] {
+                        if crate::scripts::script_util::is_always_collected(&self.world, entity_id)
+                        {
+                            collect.push(entity_id);
+                        } else {
+                            store.push((entity_id, None));
+                            let stowed_class =
+                                crate::virtual_hand::is_wieldable_weapon(&self.world, entity_id)
+                                    .then(|| {
+                                        crate::scripts::script_util::entity_class_template_id(
+                                            &self.world,
+                                            entity_id,
+                                        )
+                                    })
+                                    .flatten();
+                            if let Some(class_template_id) = stowed_class {
+                                if let Ok(mut quests) = self
+                                    .world
+                                    .borrow::<shipyard::UniqueViewMut<crate::quest_info::QuestInfo>>(
+                                    )
+                                {
+                                    quests.set_last_stowed_weapon(Some(class_template_id));
+                                }
+                            }
+                        }
+                    }
+                }
+                crate::body_frame::AnchorGesture::Draw(hand) => {
+                    if let Some(entity_id) = self.stowed_weapon_to_draw() {
+                        effects.push(Effect::GrabEntity {
+                            entity_id,
+                            hand,
+                            current_parent_id: None,
+                        });
+                    }
+                }
+                crate::body_frame::AnchorGesture::TakeCard(hand) => {
+                    self.belt_card_hand = Some(hand);
+                }
+                crate::body_frame::AnchorGesture::ReturnCard(_) => {
+                    self.belt_card_hand = None;
+                }
+            }
+        }
 
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.
@@ -3672,6 +3794,8 @@ impl MissionCore {
             player_rotation: player_rot,
             head_rotation: input_context.head.rotation,
             eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
+            body_frame,
+            anchor_affordance,
         });
         rewrite_strip_release(&mut interaction_msgs, &store, &collect);
         self.process_virtual_hand_effects(asset_cache, interaction_msgs);
@@ -10390,6 +10514,20 @@ impl MissionCore {
 
     fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {
         is_vr_melee_weapon(&self.world, entity_id)
+    }
+
+    /// The weapon an empty grip at a shoulder would draw: the last one stowed
+    /// there, if the player still carries it and is not already holding it.
+    /// `None` (nothing stowed, spent, or dropped since) is what makes the
+    /// shoulder pre-light amber instead of green.
+    fn stowed_weapon_to_draw(&self) -> Option<EntityId> {
+        let class_template_id = self
+            .world
+            .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+            .ok()?
+            .last_stowed_weapon()?;
+        crate::virtual_hand::carried_weapon_by_class(&self.world, class_template_id)
+            .filter(|entity_id| !self.interaction.is_holding(*entity_id))
     }
 
     /// Undo a computed grip offset before a released item becomes a loose prop

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -379,6 +379,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.player_hand_affordances()
     }
 
+    fn player_body_frame(&self) -> Option<crate::game_scene::DebugBodyFrame> {
+        self.mission_core.player_body_frame()
+    }
+
     fn teleport_player(&mut self, position: Vector3<f32>) -> Result<(), String> {
         self.mission_core.teleport_player(position)
     }

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -53,6 +53,14 @@ pub struct QuestInfo {
     /// Campaign-wide research progress, keyed by stable gamesys archetype.
     #[serde(default)]
     research: ResearchState,
+    /// The gamesys weapon archetype of the last weapon the player stowed over
+    /// a shoulder, so an empty grip there draws it back
+    /// (`body_frame::AnchorGesture::Draw`). A canonical *class* template id
+    /// rather than an entity: the concrete weapon is re-found in the pack with
+    /// `carried_weapon_by_class`, which survives save/load and level
+    /// transitions where a runtime entity id would not.
+    #[serde(default)]
+    last_stowed_weapon: Option<i32>,
 }
 
 impl QuestInfo {
@@ -65,6 +73,7 @@ impl QuestInfo {
             collected_logs: Vec::new(),
             explored_maps: HashMap::new(),
             research: ResearchState::default(),
+            last_stowed_weapon: None,
         }
     }
 
@@ -172,6 +181,21 @@ impl QuestInfo {
 
     pub fn add_key_card(&mut self, key_card: KeyCard) {
         self.key_cards.push(key_card)
+    }
+
+    /// Whether the player carries any credential at all - what decides whether
+    /// the belt card exists (it stands in for the whole collected set).
+    pub fn has_key_cards(&self) -> bool {
+        !self.key_cards.is_empty()
+    }
+
+    /// The weapon archetype an empty grip at a shoulder draws back.
+    pub fn last_stowed_weapon(&self) -> Option<i32> {
+        self.last_stowed_weapon
+    }
+
+    pub fn set_last_stowed_weapon(&mut self, class_template_id: Option<i32>) {
+        self.last_stowed_weapon = class_template_id;
     }
 
     pub fn can_unlock(&self, key_dst: &KeyCard) -> bool {

--- a/shock2vr/src/ui/panel_anchor.rs
+++ b/shock2vr/src/ui/panel_anchor.rs
@@ -18,7 +18,7 @@
 
 use std::time::Duration;
 
-use cgmath::{Deg, InnerSpace, Quaternion, Rad, Rotation, Vector3, vec3};
+use cgmath::{Deg, InnerSpace, Quaternion, Rad, Vector3, vec3};
 
 use crate::ui::{FRONTEND_PANEL_SIZE, WorldPanel, frontend_panel_distance};
 
@@ -47,43 +47,6 @@ pub struct PanelPlacement {
     pub forward: Vector3<f32>,
 }
 
-/// The head's facing flattened onto the horizontal plane.
-///
-/// Yaw only, so a panel built from it is vertical however the head is pitched
-/// or rolled. Two degenerate inputs are handled:
-///
-/// - the **zero quaternion**, which is what a runtime reports for an untracked
-///   pose (rotating by it silently returns the input vector), is treated as
-///   identity;
-/// - a **vertical** forward (looking straight down or up), where the horizontal
-///   projection vanishes. There the head's own **up** axis carries the yaw -
-///   but only with the right sign: looking at the floor the top of your head
-///   points where you are facing, while looking at the ceiling it points
-///   *behind* you, so the up axis is negated in that case. (Getting this wrong
-///   spawns the panel behind a player who entered the menu looking up.)
-fn horizontal_forward(head_rotation: Quaternion<f32>) -> Vector3<f32> {
-    let rotation = if head_rotation.magnitude2() < 1e-6 {
-        Quaternion::new(1.0, 0.0, 0.0, 0.0)
-    } else {
-        head_rotation.normalize()
-    };
-
-    let flatten = |v: Vector3<f32>| {
-        let flat = vec3(v.x, 0.0, v.z);
-        (flat.magnitude2() > 1e-6).then(|| flat.normalize())
-    };
-
-    let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
-    flatten(forward)
-        .or_else(|| {
-            let up = rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
-            flatten(if forward.y > 0.0 { -up } else { up })
-        })
-        // Unreachable for a real rotation (forward and up cannot both be
-        // vertical), but a defined answer beats a NaN basis.
-        .unwrap_or_else(|| vec3(0.0, 0.0, -1.0))
-}
-
 /// The compass angle of a horizontal unit vector, and its inverse. Yaw is the
 /// only degree of freedom a placement has, so interpolating it directly is what
 /// makes a recenter turn the short way round at any angle - blending the
@@ -101,7 +64,7 @@ impl PanelPlacement {
     pub fn from_head(head_position: Vector3<f32>, head_rotation: Quaternion<f32>) -> Self {
         Self {
             head_position,
-            forward: horizontal_forward(head_rotation),
+            forward: crate::util::horizontal_forward(head_rotation),
         }
     }
 
@@ -123,7 +86,7 @@ impl PanelPlacement {
 
     /// Unsigned angle between this placement's yaw and a head facing.
     pub fn yaw_offset_degrees(&self, head_rotation: Quaternion<f32>) -> f32 {
-        let gaze = horizontal_forward(head_rotation);
+        let gaze = crate::util::horizontal_forward(head_rotation);
         let dot = self.forward.dot(gaze).clamp(-1.0, 1.0);
         Deg::from(Rad(dot.acos())).0
     }
@@ -149,8 +112,7 @@ fn lerp_placement(from: PanelPlacement, to: PanelPlacement, t: f32) -> PanelPlac
     // through the middle - exactly the teleport the ease exists to avoid.
     let from_yaw = yaw_of(from.forward);
     let mut delta = yaw_of(to.forward) - from_yaw;
-    let tau = std::f32::consts::TAU;
-    delta = delta - tau * (delta / tau).round();
+    delta = crate::util::wrap_pi(delta);
     PanelPlacement {
         head_position,
         forward: forward_of(from_yaw + delta * s),
@@ -265,6 +227,7 @@ impl FrontendPanelAnchor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::Rotation;
     use cgmath::{Rotation3, Zero};
 
     const FRAME: Duration = Duration::from_millis(1000 / 60);
@@ -313,7 +276,7 @@ mod tests {
         // and the fallback decides the answer. It must still be the yaw the
         // player is facing, not a fixed world axis.
         let straight_down = yaw(90.0) * Quaternion::from_angle_x(Deg(-90.0));
-        let forward = horizontal_forward(straight_down);
+        let forward = crate::util::horizontal_forward(straight_down);
         let expected = yaw(90.0).rotate_vector(vec3(0.0, 0.0, -1.0));
         assert!(
             (forward - expected).magnitude() < 1e-3,
@@ -328,7 +291,7 @@ mod tests {
         // fallback: looking up, the head's up axis points BEHIND the player,
         // so using it unsigned spawns the panel over their shoulder.
         let straight_up = yaw(90.0) * Quaternion::from_angle_x(Deg(90.0));
-        let forward = horizontal_forward(straight_up);
+        let forward = crate::util::horizontal_forward(straight_up);
         let expected = yaw(90.0).rotate_vector(vec3(0.0, 0.0, -1.0));
         assert!(
             (forward - expected).magnitude() < 1e-3,
@@ -338,7 +301,7 @@ mod tests {
 
     #[test]
     fn an_untracked_head_is_treated_as_identity() {
-        let forward = horizontal_forward(Quaternion::zero());
+        let forward = crate::util::horizontal_forward(Quaternion::zero());
         assert!((forward - vec3(0.0, 0.0, -1.0)).magnitude() < 1e-6);
     }
 

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -198,6 +198,53 @@ pub fn tracked_rotation(rotation: Quaternion<f32>) -> Option<Quaternion<f32>> {
     (rotation.magnitude2() >= 1e-6).then(|| rotation.normalize())
 }
 
+/// The horizontal direction a tracked head faces, as a unit vector. Handles
+/// the two poses that break a naive `forward.xz`:
+///
+/// - the **zero quaternion**, which is what a runtime reports for an untracked
+///   pose (rotating by it silently returns the input vector), is treated as
+///   identity - see [`tracked_rotation`];
+/// - a **vertical** forward (looking straight down or up), where the horizontal
+///   projection vanishes. There the head's own **up** axis carries the yaw -
+///   but only with the right sign: looking at the floor the top of your head
+///   points where you are facing, while looking at the ceiling it points
+///   *behind* you, so the up axis is negated in that case. (Getting this wrong
+///   spawned the frontend panel behind a player who entered the menu looking
+///   up, and swings the body frame's belt out from under a player looking down
+///   at it.)
+pub fn horizontal_forward(head_rotation: Quaternion<f32>) -> Vector3<f32> {
+    use cgmath::Rotation;
+    let rotation = tracked_rotation(head_rotation).unwrap_or(Quaternion::new(1.0, 0.0, 0.0, 0.0));
+
+    let flatten = |v: Vector3<f32>| {
+        let flat = vec3(v.x, 0.0, v.z);
+        (flat.magnitude2() > 1e-6).then(|| flat.normalize())
+    };
+
+    let forward = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+    flatten(forward)
+        .or_else(|| {
+            let up = rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+            flatten(if forward.y > 0.0 { -up } else { up })
+        })
+        // Unreachable for a real rotation (forward and up cannot both be
+        // vertical), but a defined answer beats a NaN basis.
+        .unwrap_or_else(|| vec3(0.0, 0.0, -1.0))
+}
+
+/// Fold an angle into `[-pi, pi]`, so interpolating or smoothing a yaw takes
+/// the short way round instead of unwinding almost a full turn.
+pub fn wrap_pi(angle: f32) -> f32 {
+    let tau = std::f32::consts::TAU;
+    angle - tau * (angle / tau).round()
+}
+
+/// Metres expressed in world units - the units every distance in the game is
+/// measured in, while body and hand dimensions are naturally written in metres.
+pub const fn meters(m: f32) -> f32 {
+    m / crate::METERS_PER_WORLD_UNIT
+}
+
 /// Smoothstep over `t`, clamped to `[0, 1]`: no velocity discontinuity at
 /// either end, which is what makes a timed ease read as a move rather than a
 /// jump. Shared by the UI panel re-placement ease and the death camera's fall.

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -241,7 +241,7 @@ impl VirtualHand {
         pawn_rot: Quaternion<f32>,
         input_hand: &Hand,
         held_by_other_hand: Option<EntityId>,
-        anchor_affordance: Option<HandAffordance>,
+        anchor_claim: Option<crate::body_frame::HandClaim>,
     ) -> (VirtualHand, Vec<VirtualHandEffect>) {
         let handedness = prev.handedness;
         let hand_position = hand_world_position(pawn_pos, pawn_rot, input_hand.position);
@@ -264,7 +264,7 @@ impl VirtualHand {
                 // anchor is the exception - a hand carried to the shoulder must
                 // show whether opening it there will stow, before it opens.
                 let mut affordance = AffordanceTracker::default();
-                if let Some(observed) = anchor_affordance {
+                if let Some(crate::body_frame::HandClaim::Anchor(observed)) = anchor_claim {
                     affordance.update(observed, 0.0, false);
                 }
 
@@ -367,7 +367,7 @@ impl VirtualHand {
                 physics,
                 input_hand,
                 held_by_other_hand,
-                anchor_affordance,
+                anchor_claim,
             ),
         };
 
@@ -490,7 +490,7 @@ fn handle_empty_hand_state(
     physics: &PhysicsWorld,
     input_hand: &Hand,
     held_by_other_hand: Option<EntityId>,
-    anchor_affordance: Option<HandAffordance>,
+    anchor_claim: Option<crate::body_frame::HandClaim>,
 ) -> (VirtualHand, Vec<VirtualHandEffect>) {
     let ray_start = point3(hand_position.x, hand_position.y, hand_position.z);
     let forward = hand_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
@@ -503,20 +503,26 @@ fn handle_empty_hand_state(
     //
     // A hand at one of the player's own body anchors is the exception: it is
     // reaching for the belt or a shoulder, not for whatever its ray happens to
-    // cross, so the anchor owns both the light and the input this frame
-    // (`mission_core` runs the gesture the grip commits to).
-    let (observed, preshape_weight) = match anchor_affordance {
-        Some(observed) => (observed, hand_affordance::preshape_weight(0.0)),
-        None => match result.as_ref().and_then(|hit| {
-            hit.maybe_entity_id
-                .map(|entity_id| (entity_id, (hit.hit_point - ray_start).magnitude()))
-        }) {
-            Some((entity_id, distance)) => (
-                hand_affordance::classify(world, entity_id),
-                hand_affordance::preshape_weight(distance),
-            ),
-            None => (HandAffordance::None, 0.0),
-        },
+    // cross, so the anchor owns the light as well as the input this frame
+    // (`mission_core` runs the gesture the grip commits to). A hand *carrying*
+    // the belt card is claimed too, but keeps its own light: what it needs to
+    // show is the reader it is being held against.
+    let (observed, preshape_weight) = match anchor_claim {
+        Some(crate::body_frame::HandClaim::Anchor(observed)) => {
+            (observed, hand_affordance::preshape_weight(0.0))
+        }
+        Some(crate::body_frame::HandClaim::CarryingCard) | None => {
+            match result.as_ref().and_then(|hit| {
+                hit.maybe_entity_id
+                    .map(|entity_id| (entity_id, (hit.hit_point - ray_start).magnitude()))
+            }) {
+                Some((entity_id, distance)) => (
+                    hand_affordance::classify(world, entity_id),
+                    hand_affordance::preshape_weight(distance),
+                ),
+                None => (HandAffordance::None, 0.0),
+            }
+        }
     };
     let mut attempt_failed = false;
     // A refusal is one press, not one per frame the player keeps holding.
@@ -527,7 +533,7 @@ fn handle_empty_hand_state(
     let mut next_hand_state = HandState::Empty;
     // A claimed hand reaches for the body, not through it: its grip belongs to
     // the anchor gesture, so it must not also grab or frob what the ray found.
-    let claimed_by_anchor = anchor_affordance.is_some();
+    let claimed_by_anchor = anchor_claim.is_some();
     if !claimed_by_anchor && (input_hand.trigger_value > 0.5 || input_hand.a_value > 0.5) {
         if let Some(RayCastResult {
             hit_point: _,

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -241,6 +241,7 @@ impl VirtualHand {
         pawn_rot: Quaternion<f32>,
         input_hand: &Hand,
         held_by_other_hand: Option<EntityId>,
+        anchor_affordance: Option<HandAffordance>,
     ) -> (VirtualHand, Vec<VirtualHandEffect>) {
         let handedness = prev.handedness;
         let hand_position = hand_world_position(pawn_pos, pawn_rot, input_hand.position);
@@ -259,8 +260,13 @@ impl VirtualHand {
 
                 // A full hand has nothing to reach for. Clear rather than decay:
                 // closing on an item is a hard transition, so the light must not
-                // keep advertising the grab for the hysteresis window.
-                let affordance = AffordanceTracker::default();
+                // keep advertising the grab for the hysteresis window. A body
+                // anchor is the exception - a hand carried to the shoulder must
+                // show whether opening it there will stow, before it opens.
+                let mut affordance = AffordanceTracker::default();
+                if let Some(observed) = anchor_affordance {
+                    affordance.update(observed, 0.0, false);
+                }
 
                 // If we're holding onto something, but not grabbing, we can drop it
                 if input_hand.squeeze_value < 0.5 {
@@ -361,6 +367,7 @@ impl VirtualHand {
                 physics,
                 input_hand,
                 held_by_other_hand,
+                anchor_affordance,
             ),
         };
 
@@ -483,6 +490,7 @@ fn handle_empty_hand_state(
     physics: &PhysicsWorld,
     input_hand: &Hand,
     held_by_other_hand: Option<EntityId>,
+    anchor_affordance: Option<HandAffordance>,
 ) -> (VirtualHand, Vec<VirtualHandEffect>) {
     let ray_start = point3(hand_position.x, hand_position.y, hand_position.z);
     let forward = hand_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
@@ -492,15 +500,23 @@ fn handle_empty_hand_state(
     // One resolved target per hand per frame: the glove's light and pre-shape
     // read the same hit the trigger and squeeze below act on, so the hand can
     // never advertise an action the input would refuse.
-    let (observed, preshape_weight) = match result.as_ref().and_then(|hit| {
-        hit.maybe_entity_id
-            .map(|entity_id| (entity_id, (hit.hit_point - ray_start).magnitude()))
-    }) {
-        Some((entity_id, distance)) => (
-            hand_affordance::classify(world, entity_id),
-            hand_affordance::preshape_weight(distance),
-        ),
-        None => (HandAffordance::None, 0.0),
+    //
+    // A hand at one of the player's own body anchors is the exception: it is
+    // reaching for the belt or a shoulder, not for whatever its ray happens to
+    // cross, so the anchor owns both the light and the input this frame
+    // (`mission_core` runs the gesture the grip commits to).
+    let (observed, preshape_weight) = match anchor_affordance {
+        Some(observed) => (observed, hand_affordance::preshape_weight(0.0)),
+        None => match result.as_ref().and_then(|hit| {
+            hit.maybe_entity_id
+                .map(|entity_id| (entity_id, (hit.hit_point - ray_start).magnitude()))
+        }) {
+            Some((entity_id, distance)) => (
+                hand_affordance::classify(world, entity_id),
+                hand_affordance::preshape_weight(distance),
+            ),
+            None => (HandAffordance::None, 0.0),
+        },
     };
     let mut attempt_failed = false;
     // A refusal is one press, not one per frame the player keeps holding.
@@ -509,7 +525,10 @@ fn handle_empty_hand_state(
     let mut msgs = Vec::new();
     let mut last_frobbed_entity = frobbed_entity;
     let mut next_hand_state = HandState::Empty;
-    if input_hand.trigger_value > 0.5 || input_hand.a_value > 0.5 {
+    // A claimed hand reaches for the body, not through it: its grip belongs to
+    // the anchor gesture, so it must not also grab or frob what the ray found.
+    let claimed_by_anchor = anchor_affordance.is_some();
+    if !claimed_by_anchor && (input_hand.trigger_value > 0.5 || input_hand.a_value > 0.5) {
         if let Some(RayCastResult {
             hit_point: _,
             hit_normal: _,
@@ -548,7 +567,7 @@ fn handle_empty_hand_state(
         last_frobbed_entity = None
     }
 
-    if input_hand.squeeze_value > 0.5 {
+    if !claimed_by_anchor && input_hand.squeeze_value > 0.5 {
         if let Some(RayCastResult {
             hit_point: _,
             hit_normal: _,
@@ -872,6 +891,7 @@ mod tests {
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             &input,
             None,
+            None,
         );
 
         effects
@@ -1175,6 +1195,7 @@ mod tests {
             &physics,
             &input,
             None,
+            None,
         );
         assert_eq!(frob_message_count(&effects), 1, "first frame should Frob");
 
@@ -1188,6 +1209,7 @@ mod tests {
             &world,
             &physics,
             &input,
+            None,
             None,
         );
         assert_eq!(
@@ -1222,6 +1244,7 @@ mod tests {
             &physics,
             &input,
             None,
+            None,
         );
         assert_eq!(
             frob_message_count(&effects),
@@ -1242,6 +1265,7 @@ mod tests {
             &world,
             &physics,
             &input,
+            None,
             None,
         );
         let frobbed_second = effects.iter().any(|effect| {
@@ -1310,6 +1334,7 @@ mod tests {
             identity,
             &input,
             None,
+            None,
         );
         assert_eq!(far_hand.get_raytraced_entity(), None);
         assert!(
@@ -1325,6 +1350,7 @@ mod tests {
             vec3(0.0, 0.0, 0.0),
             identity,
             &input,
+            None,
             None,
         );
         assert_eq!(near_hand.get_raytraced_entity(), Some(near_target));
@@ -1359,6 +1385,7 @@ mod tests {
                 identity,
                 &idle,
                 None,
+                None,
             )
             .0
             .affordance()
@@ -1385,6 +1412,7 @@ mod tests {
             identity,
             &Hand::default(),
             None,
+            None,
         );
         assert_eq!(hovering.affordance(), HandAffordance::Blocked);
 
@@ -1398,6 +1426,7 @@ mod tests {
                 trigger_value: 1.0,
                 ..Hand::default()
             },
+            None,
             None,
         );
         assert_eq!(frobbing.affordance(), HandAffordance::Failed);
@@ -1425,6 +1454,7 @@ mod tests {
                 identity,
                 &squeeze,
                 None,
+                None,
             )
             .0;
             assert_eq!(
@@ -1451,6 +1481,7 @@ mod tests {
             vec3(0.0, 0.0, 0.0),
             Quaternion::new(1.0, 0.0, 0.0, 0.0),
             &squeeze,
+            None,
             None,
         );
         assert_eq!(hand.affordance(), HandAffordance::Failed);

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -788,7 +788,7 @@ fn resolve_hit_proxy_entity(world: &World, ray_cast_result: RayCastResult) -> Ra
     }
 }
 
-fn interaction_ray_cast(
+pub(crate) fn interaction_ray_cast(
     physics: &PhysicsWorld,
     world: &World,
     ray_start: cgmath::Point3<f32>,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -671,6 +671,24 @@ export interface PlayerSnapshot {
   /** What each VR hand could do with whatever it is pointing at - the state
    * that lights the glove and pre-shapes its fingers. Flat reports "None". */
   hand_affordance: HandAffordances;
+
+  /** The player's body anchors (belt, shoulders) and what hangs off them.
+   * Null outside VR. */
+  body_frame: BodyFrame | null;
+}
+
+/** Where the player's belt and shoulders are, and what they hold
+ * (GET /v1/info -> player.body_frame). */
+export interface BodyFrame {
+  /** World position of the belt-card anchor on the left hip. */
+  belt: [number, number, number];
+  left_shoulder: [number, number, number];
+  right_shoulder: [number, number, number];
+  /** Name of the weapon an empty grip at a shoulder would draw, or null when
+   * nothing was stowed (or it is gone / already in hand). */
+  last_stowed_weapon: string | null;
+  /** Where the belt card is, or null while no credential has been collected. */
+  belt_card: "belt" | "left" | "right" | null;
 }
 
 /** Per-hand affordance names in the /v1/info readout. */

--- a/tools/shock2-sdk/test/vr-body-anchors.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-body-anchors.e2e.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary, Vec3 } from "../src/index.js";
+import { quatConjugate, quatRotate, sub, type Quat } from "./helpers/vr-hand.js";
+
+// The player's body anchors: shoulders that stand in for the backpack (release
+// what you hold there to stow it, grip an empty hand there to draw the last
+// weapon stowed) and a belt card that runs a reader's credential check.
+//
+// Everything here is driven through `player.body_frame`, which reports where
+// the anchors are this frame - so the tests place hands at the reported
+// anchors rather than at guessed offsets.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** A world point in the hand channel's pawn-local space. */
+function toPawnLocal(world: Vec3, pawnPosition: Vec3, pawnRotation: Quat): Vec3 {
+  return quatRotate(quatConjugate(pawnRotation), sub(world, pawnPosition));
+}
+
+function property(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+test(
+  "VR: a shoulder stows what the hand holds, and draws it back",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_melee",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    const before = await game.info();
+    const frame = before.player.body_frame;
+    assert.ok(frame, "VR should report the player's body anchors");
+    assert.ok(
+      frame.belt[1] < frame.left_shoulder[1],
+      `the belt (${frame.belt[1]}) should sit below the shoulders (${frame.left_shoulder[1]})`,
+    );
+    assert.equal(frame.last_stowed_weapon, null, "nothing is stowed at spawn");
+
+    const [wrench] = (await game.entities.list({ filter: "Wrench" })).entities;
+    assert.ok(wrench, "debug_melee racks a wrench");
+    // Counted with both hands empty: a held item already counts as carried, so
+    // measuring after the grab would see no growth when it is stowed.
+    const carried = (await game.player.inventory()).items.length;
+
+    // Reach for the wrench: the hand sits short of it and aims at it (45 deg
+    // about Y takes the hand's -Z forward onto the rack).
+    const pawn = before.player.position as Vec3;
+    await game.input.set("right_hand.position", [
+      wrench.position[0] - pawn[0] + 0.2,
+      wrench.position[1] - pawn[1],
+      wrench.position[2] - pawn[2] + 0.2,
+    ]);
+    await game.input.set("right_hand.rotation", [0, 0.38268, 0, 0.92388]);
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.info()).player.hand_affordance.right,
+      "Grabbable",
+      "the racked wrench should light the glove",
+    );
+
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.hand_affordance.right_model,
+      "wrench_h",
+      "the squeeze should take the wrench into the hand",
+    );
+
+    // Carry it to the shoulder. The zone pre-lights before the release.
+    const shoulder = toPawnLocal(
+      frame.right_shoulder as Vec3,
+      pawn,
+      before.player.rotation as Quat,
+    );
+    await game.input.set("right_hand.position", shoulder);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.hand_affordance.right,
+      "Grabbable",
+      "a full hand at the shoulder should show that opening it will stow",
+    );
+
+    // Open the hand: the wrench goes in the backpack, not on the floor.
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 5 });
+    const stowed = await game.info();
+    assert.equal(
+      stowed.player.hand_affordance.right_model,
+      null,
+      "the hand should be empty after the stow",
+    );
+    assert.equal(
+      stowed.player.body_frame?.last_stowed_weapon,
+      "Wrench",
+      "the shoulder should remember what it took",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.length,
+      carried + 1,
+      "the stowed wrench should be in the backpack",
+    );
+    assert.ok(
+      (await game.player.inventory()).items.some((item) => item.name === "Wrench"),
+      "and it should be the wrench that landed there",
+    );
+
+    // Grip the empty hand there: the same weapon comes back out.
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.hand_affordance.right_model,
+      "wrench_h",
+      "an empty grip at the shoulder should draw the last weapon stowed",
+    );
+  },
+);
+
+test(
+  "VR: the belt card opens a reader the collected credential opens",
+  { skip: !e2eEnabled, timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    // The Cryo Card's own reader: MedSci authors six card slots, and this is
+    // the one whose key destination the Cryo Card satisfies. Picked by
+    // authored position (stable mission data) - runtime entity ids are not.
+    const CRYO_SLOT: Vec3 = [-26.93811, 0.16234326, -5.46197];
+    const distance = (e: EntitySummary) =>
+      Math.hypot(...CRYO_SLOT.map((c: number, i: number) => c - e.position[i]));
+    const slots = (await game.entities.list({ filter: "Card slot" })).entities;
+    const slot = slots.reduce((a, b) => (distance(a) <= distance(b) ? a : b));
+    assert.ok(distance(slot) < 0.5, "the Cryo Card's own slot should be found");
+    const slotModel = async () =>
+      property(await game.entities.detail(slot.id), "Model");
+    assert.equal(await slotModel(), "cardslor", "the slot starts locked (red)");
+
+    assert.equal(
+      (await game.info()).player.body_frame?.belt_card,
+      null,
+      "no credential collected yet, so there is no belt card",
+    );
+
+    // Stand at the slot, hand held against it. With no card, nothing opens.
+    await game.player.teleport({
+      x: CRYO_SLOT[0],
+      y: CRYO_SLOT[1] + 0.5,
+      z: CRYO_SLOT[2] + 1.2,
+    });
+    await game.step({ frames: 10 });
+    const staged = await game.info();
+    const pawn = staged.player.position as Vec3;
+    const pawnRotation = staged.player.rotation as Quat;
+    const atSlot = toPawnLocal(
+      [CRYO_SLOT[0], CRYO_SLOT[1], CRYO_SLOT[2] + 0.15],
+      pawn,
+      pawnRotation,
+    );
+    await game.input.set("right_hand.position", atSlot);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.step({ frames: 30 });
+    assert.equal(
+      await slotModel(),
+      "cardslor",
+      "an empty hand at the reader must not open it",
+    );
+    assert.equal(
+      (await game.info()).player.hand_affordance.right,
+      "Blocked",
+      "a lock the player has no credential for should read blocked",
+    );
+
+    // Collect the credential the way frobbing the card does. The card itself
+    // is never inventoried - the belt card is what appears.
+    const [card] = (await game.entities.list({ filter: "Cryo Card" })).entities;
+    assert.ok(card, "medsci1 places the Cryo Card");
+    await game.entities.sendMessage(card.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.body_frame?.belt_card,
+      "belt",
+      "collecting a credential should put the card on the belt",
+    );
+
+    // Take it off the hip.
+    const onBelt = await game.info();
+    const belt = toPawnLocal(
+      onBelt.player.body_frame!.belt as Vec3,
+      onBelt.player.position as Vec3,
+      pawnRotation,
+    );
+    await game.input.set("right_hand.position", belt);
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.info()).player.hand_affordance.right,
+      "Grabbable",
+      "the belt should offer the card to an empty hand",
+    );
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 3 });
+    assert.equal((await game.info()).player.body_frame?.belt_card, "right");
+
+    // Hold it against the reader: the same credential check a frob runs.
+    await game.input.set("right_hand.position", atSlot);
+    await game.step({ frames: 10 });
+    assert.equal(
+      await slotModel(),
+      "cardslog",
+      "the card should unlock the reader it has the credential for",
+    );
+
+    // Opening the hand puts the card back on the belt - it is never dropped.
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.body_frame?.belt_card, "belt");
+  },
+);


### PR DESCRIPTION
Slice 7 of the VR interactions campaign: the player's body becomes somewhere the hands can reach.

**`body_frame.rs`** — belt and shoulder anchors from the tracked head. Horizontal position from the head's floor projection, heights from the tracked eye (belt ~0.55x eye height, shoulders 0.2 m below and 0.12 m behind it, ±0.18 m lateral), facing from a yaw low-pass with a 0.5 s time constant so a glance does not swing the belt out from under the hand. Zones are spheres (belt 9 cm, shoulders 15 cm), kept disjoint at every stance. Plus a per-hand gesture state machine: only a real grip edge commits, and an anchor survives 12 frames of lost pose — reaching behind the shoulder is exactly where tracking is worst, and a dropout must not turn a stow into a floor drop.

**Shoulder = backpack.** Releasing any held pickup in a shoulder zone stows it, reusing the cyber-interface strip-deposit rewrite rather than adding a second inventory path. An empty grip there draws the last weapon stowed, remembered in `QuestInfo` as a canonical gamesys archetype (so it survives save/load and level transitions) and re-found with `carried_weapon_by_class`. The zone pre-lights the glove before the player commits: green when the gesture will go through, amber when it will not (full pack, nothing stowed).

**Belt card.** One persistent card on the left hip standing in for every collected credential. Keycards are collected, not inventoried, so this is presentation — derived from `QuestInfo` every frame, never an inventory slot, nothing new to save. Grabbed off the hip and held against a reader it sends the same `Frob` a hand would, so the door's own key check decides what opens. Releasing it anywhere returns it to the belt.

**Readout.** `/v1/info` gains `player.body_frame` (anchor positions, `last_stowed_weapon`, where the card is), mirrored in the SDK types.

Yaw flattening, angle wrapping and the metre conversion moved to `util` and are now shared with `ui/panel_anchor` and `hand_fit` — which also fixes a real bug the split had: without the vertical-gaze fallback, a player looking straight down *at the belt* fed a garbage yaw into the low-pass.

**Tests.** 18 unit tests over the frame and the state machine (yaw smoothing and its wrap, untracked-head hold, crouch, zone disjointness, tracking-loss stow, the claim/gesture agreement). New e2e `vr-body-anchors.e2e.test.ts`: shoulder stow/draw in `debug_melee`, and the belt card against MedSci's Cryo Card reader including the negative case — an empty hand at that reader leaves it locked.

Known follow-up (queued from #1385): a held pickup is seated after the fingers close, so the card sits inside a fist rather than against an open palm.

![shoulder stow and draw](https://gist.githubusercontent.com/tommy-xr/2c636a37857ba2c294dc6fb3a1f540f4/raw/shoulder_stow.gif)

<sub>`debug_melee`, VR: the glove lights green at the rack, takes the wrench, carries it to the shoulder (still green - the stow will go through), opens, and the wrench is gone; an empty grip in the same zone brings it back. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| the card on the hip | the card at a reader |
| --- | --- |
| ![belt card](https://gist.githubusercontent.com/tommy-xr/2c636a37857ba2c294dc6fb3a1f540f4/raw/belt_card.png) | ![card at a reader](https://gist.githubusercontent.com/tommy-xr/2c636a37857ba2c294dc6fb3a1f540f4/raw/card_reader.png) |

<sub>MedSci deck 1, free camera. Left: the card standing on the left hip once the Cryo Card credential is collected. Right: the same card held against the slot that credential opens - the reader has gone from red to green.</sub>

Base: #1385.
