### PR TITLE
fix(vr): pickups sit against the open palm, then the fingers close on them

### DIFF
--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -245,7 +245,7 @@ dev_params! {
     GUN_WIELD_SCALE = float("gun_scale", "Gun scale", 0.4, 0.1, 1.5, 0.05),
     /// Which of `debug_grips`' test items to show in the hand. Ignored
     /// everywhere else; the scene clamps it to its own list.
-    GRIP_ITEM = float("grip_item", "Grip test item", 0.0, 0.0, 7.0, 1.0),
+    GRIP_ITEM = float("grip_item", "Grip test item", 0.0, 0.0, 8.0, 1.0),
     /// Enables the detached debug ("free") camera. This is the *gate*, not
     /// the camera's own on/off: while it is false the toggle input is not
     /// even read, so a stray `Alt+V` (or controller chord) during normal play

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -347,7 +347,18 @@ impl GloveRenderer {
             fist: &self.fist,
             to_hand: glove_model_to_hand(),
         };
-        let amounts = hand_fit::fit(&mut rig, &mesh, family, GENERIC_GRIP);
+        // What a finger the fit can't measure falls back to, which depends on
+        // *why* it can't. An authored seat puts the item inside the closed hand
+        // on purpose (a gun's grip lives in the fist), so a finger already
+        // touching at the open pose keeps the generic wrap. A measured seat
+        // puts the item against the *open* palm on purpose, so a finger already
+        // touching it - the thumb lies on anything the palm is carrying - has
+        // finished closing, and curling it further would drive it through.
+        let resting = match grip.source {
+            crate::vr_grips::GripSource::Heuristic => FingerAmounts::default(),
+            _ => GENERIC_GRIP,
+        };
+        let amounts = hand_fit::fit(&mut rig, &mesh, family, resting);
         let solve = started.elapsed();
 
         tracing::debug!(
@@ -636,37 +647,60 @@ pub fn glove_material(
     })))
 }
 
-/// Where the palm faces the world, in the glove's own hand space: the midpoint
-/// of the index and pinky knuckles at the open pose - the line an item resting
-/// in the hand touches.
+/// The palm frame of the open glove, in the glove's own hand space: where the
+/// palm's centre is, which way it faces, which way the fingers curl about, and
+/// where thumb and index meet.
 ///
-/// [`crate::hand_seat`] seats unprofiled items against it. It is a constant of
-/// the rig rather than something a seat can afford to pose a glove for, so that
-/// module writes the number down and `the_palm_anchor_matches_the_glove_rig`
-/// holds it to this measurement.
+/// [`crate::hand_seat`] seats unprofiled items against this. It is a constant
+/// of the rig rather than something a seat can afford to pose a glove for, so
+/// that module writes the numbers down and
+/// `the_palm_frame_matches_the_glove_rig` holds them to this measurement.
 #[cfg(test)]
-fn palm_anchor_of(
+fn palm_frame_of(
     model: &mut GlbModel,
     retarget: &HandPoseRetarget,
     open: &Pose,
-    fist: &Pose,
-) -> Vector3<f32> {
-    use cgmath::Zero;
+) -> (Vector3<f32>, Vector3<f32>, Vector3<f32>, Vector3<f32>) {
+    use cgmath::{InnerSpace, Zero};
 
-    let mut rig = GloveRig {
-        model,
-        retarget,
-        open,
-        fist,
-        to_hand: glove_model_to_hand(),
-    };
-    let mut knuckle = |finger| {
-        rig.phalanges(finger, 0.0)
-            .first()
-            .map(|capsule: &Capsule| capsule.a.to_vec())
+    retarget.apply(open, model);
+    let to_hand = glove_model_to_hand();
+    let joint = |model: &mut GlbModel, index: usize| {
+        model
+            .skeleton()
+            .node_index_for_joint(index)
+            .and_then(|node| model.get_global_transform(node))
+            .map(|global| {
+                to_hand
+                    .transform_point(Point3::from_vec(global.w.truncate()))
+                    .to_vec()
+            })
             .unwrap_or_else(Vector3::zero)
     };
-    (knuckle(Finger::Index) + knuckle(Finger::Pinky)) * 0.5
+    // The palm's flat is the quad of the four fingers' metacarpals: base and
+    // knuckle of each. The thumb is left out - it swings out of that plane.
+    let fingers = [Finger::Index, Finger::Middle, Finger::Ring, Finger::Pinky];
+    let mut bases = Vector3::zero();
+    let mut knuckles = Vector3::zero();
+    for finger in fingers {
+        let mut bones = finger.bones();
+        bases += joint(model, *bones.start());
+        knuckles += joint(model, bones.nth(1).expect("a finger has a knuckle"));
+    }
+    let (bases, knuckles) = (bases * 0.25, knuckles * 0.25);
+
+    let centre = (bases + knuckles) * 0.5;
+    let curl = (joint(model, *Finger::Pinky.bones().nth(1).as_ref().unwrap())
+        - joint(model, *Finger::Index.bones().nth(1).as_ref().unwrap()))
+    .normalize();
+    // Out of the palm is what the fingers curl toward, which the wrist-to-
+    // knuckle run and the across-the-palm run bracket in this order.
+    let normal = (knuckles - bases).cross(curl).normalize();
+    // Thumb and index tips - the last joint of each chain.
+    let pinch = (joint(model, *Finger::Thumb.bones().end())
+        + joint(model, *Finger::Index.bones().end()))
+        * 0.5;
+    (centre, normal, curl, pinch)
 }
 
 /// The glove's colour map. One loader, shared with the `debug_gloves` harness,
@@ -696,6 +730,7 @@ fn load_texture(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::meters;
 
     /// Guards the two constants against drifting apart: the scale exists to put
     /// the authored glove at a real hand's length once the world's true scale
@@ -711,13 +746,9 @@ mod tests {
         );
     }
 
-    /// `hand_seat` writes the palm anchor down rather than posing a glove to
-    /// find it, so re-measure it off the shipped rig here: an unprofiled item
-    /// is seated against this line, and a glove that moved under it would seat
-    /// every one of them somewhere the fingers are not.
-    #[test]
-    fn the_palm_anchor_matches_the_glove_rig() {
-        use cgmath::{InnerSpace, Point3};
+    /// The glove built for a fit, from the shipped rig and nothing else.
+    #[cfg(test)]
+    fn test_glove() -> (GlbModel, HandPoseRetarget) {
         use collision::Aabb3;
         use dark::importers::skeleton_from_glb_bytes;
 
@@ -729,21 +760,141 @@ mod tests {
         let bytes = std::fs::read(path).expect("read the glove GLB");
         let skeleton = skeleton_from_glb_bytes(&bytes).expect("the glove GLB has a skeleton");
         let unit = Aabb3::new(Point3::new(0.0, 0.0, 0.0), Point3::new(0.0, 0.0, 0.0));
-        let mut model = GlbModel::new(Vec::new(), unit, skeleton);
+        let model = GlbModel::new(Vec::new(), unit, skeleton);
         let retarget = HandPoseRetarget::for_right_glove(model.skeleton());
+        (model, retarget)
+    }
 
-        let measured = palm_anchor_of(
-            &mut model,
-            &retarget,
-            &hand_pose::open_right_hand(),
-            &hand_pose::fist_right_hand(),
-        );
+    /// `hand_seat` writes the palm frame down rather than posing a glove to
+    /// find it, so re-measure it off the shipped rig here: an unprofiled item
+    /// is seated against this frame, and a glove that moved under it would seat
+    /// every one of them somewhere the fingers are not.
+    #[test]
+    fn the_palm_frame_matches_the_glove_rig() {
+        use cgmath::InnerSpace;
 
+        let (mut model, retarget) = test_glove();
+
+        let (centre, normal, curl, pinch) =
+            palm_frame_of(&mut model, &retarget, &hand_pose::open_right_hand());
+
+        for (name, measured, written) in [
+            ("centre", centre, crate::hand_seat::PALM_CENTRE),
+            ("normal", normal, crate::hand_seat::PALM_NORMAL),
+            ("curl axis", curl, crate::hand_seat::PALM_CURL_AXIS),
+            ("pinch point", pinch, crate::hand_seat::PINCH_POINT),
+        ] {
+            assert!(
+                (measured - written).magnitude() < 2e-3,
+                "glove rig palm {name} is {measured:?}, hand_seat says {written:?}"
+            );
+        }
+    }
+
+    /// The whole point of the seat: a handle put against the open palm is
+    /// somewhere the fingers can *reach and stop on*, so the fit measures a
+    /// real wrap instead of falling back on a canned one.
+    ///
+    /// Negative test: seat the same cylinder the way #1385 did - dropped along
+    /// hand -Y, which runs across the knuckles rather than out of the palm, so
+    /// the item lands beside the hand - and every finger runs to its cap
+    /// without ever meeting it.
+    ///
+    /// The thumb is the deliberate exception: it lies *on* whatever the open
+    /// palm carries, so it is at contact before it curls at all. `solve` gives
+    /// a measured seat the open hand as its fallback for exactly that reason,
+    /// which is what this asserts for the thumb.
+    #[test]
+    fn a_seated_handle_is_somewhere_every_finger_can_close_onto_it() {
+        use crate::hand_fit::{ContactMesh, GripFamily};
+        use crate::hand_pose::Finger;
+
+        // A 40 mm handle, 150 mm long, drawn centred on the model origin the
+        // way a world pickup is.
+        let radius = meters(0.02);
+        let half_length = meters(0.075);
+        let half = Vector3::new(half_length, radius, radius);
+        let (seat, family) = crate::hand_seat::seat(-half, half, None);
+        assert_eq!(family, GripFamily::Cylindrical);
+
+        let mesh = ContactMesh::new(seated_cylinder(radius, half_length, seat));
+        let (mut model, retarget) = test_glove();
+        let open = hand_pose::open_right_hand();
+        let fist = hand_pose::fist_right_hand();
+        let mut rig = GloveRig {
+            model: &mut model,
+            retarget: &retarget,
+            open: &open,
+            fist: &fist,
+            to_hand: glove_model_to_hand(),
+        };
+
+        // Fitted twice against opposite fallbacks: a finger that answers the
+        // same either way measured the item, and one that just echoes the
+        // fallback did not.
+        let amounts = hand_fit::fit(&mut rig, &mesh, family, all_fingers(0.0));
+        let against_a_fist = hand_fit::fit(&mut rig, &mesh, family, all_fingers(1.0));
+
+        for finger in [Finger::Index, Finger::Middle, Finger::Ring, Finger::Pinky] {
+            let curl = finger.curl_of(&amounts);
+            assert!(
+                (curl - finger.curl_of(&against_a_fist)).abs() < 1e-6,
+                "{finger:?} answered the fallback, not the item"
+            );
+            assert!(
+                curl > 0.0 && curl < 1.0,
+                "{finger:?} closed to {curl} without stopping on the handle"
+            );
+        }
         assert!(
-            (measured - crate::hand_seat::PALM_ANCHOR).magnitude() < 1e-3,
-            "glove rig palm anchor is {measured:?}, hand_seat says {:?}",
-            crate::hand_seat::PALM_ANCHOR
+            Finger::Thumb.curl_of(&amounts) == 0.0 && Finger::Thumb.curl_of(&against_a_fist) == 1.0,
+            "the thumb should be reading its fallback - it starts resting on the handle"
         );
+    }
+
+    #[cfg(test)]
+    fn all_fingers(curl: f32) -> FingerAmounts {
+        FingerAmounts {
+            thumb: curl,
+            index: curl,
+            middle: curl,
+            ring: curl,
+            pinky: curl,
+        }
+    }
+
+    /// The cylinder of `a_seated_cylinder_gives_every_finger_something_to_close_on`,
+    /// in hand space: model-space triangles put through the seat.
+    #[cfg(test)]
+    fn seated_cylinder(
+        radius: f32,
+        half_length: f32,
+        seat: crate::hand_seat::Seat,
+    ) -> Vec<[Point3<f32>; 3]> {
+        use cgmath::Rotation;
+
+        const SEGMENTS: usize = 48;
+        let place =
+            |v: Vector3<f32>| Point3::from_vec(seat.rotation.rotate_vector(v) + seat.offset);
+        let ring = |i: usize| {
+            let angle = std::f32::consts::TAU * (i as f32) / (SEGMENTS as f32);
+            (radius * angle.cos(), radius * angle.sin())
+        };
+        let mut triangles = Vec::new();
+        for i in 0..SEGMENTS {
+            let (y0, z0) = ring(i);
+            let (y1, z1) = ring(i + 1);
+            let quad = [
+                Vector3::new(-half_length, y0, z0),
+                Vector3::new(half_length, y0, z0),
+                Vector3::new(half_length, y1, z1),
+                Vector3::new(-half_length, y1, z1),
+            ]
+            .map(place);
+            triangles.push([quad[0], quad[1], quad[2]]);
+            triangles.push([quad[0], quad[2], quad[3]]);
+        }
+        triangles
     }
 
     /// Only `Off` is dark, and no two lit states share a colour - a light the

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -660,6 +660,7 @@ fn palm_frame_of(
     model: &mut GlbModel,
     retarget: &HandPoseRetarget,
     open: &Pose,
+    fist: &Pose,
 ) -> (Vector3<f32>, Vector3<f32>, Vector3<f32>, Vector3<f32>) {
     use cgmath::{InnerSpace, Zero};
 
@@ -696,11 +697,36 @@ fn palm_frame_of(
     // Out of the palm is what the fingers curl toward, which the wrist-to-
     // knuckle run and the across-the-palm run bracket in this order.
     let normal = (knuckles - bases).cross(curl).normalize();
-    // Thumb and index tips - the last joint of each chain.
-    let pinch = (joint(model, *Finger::Thumb.bones().end())
-        + joint(model, *Finger::Index.bones().end()))
-        * 0.5;
-    (centre, normal, curl, pinch)
+    // Where thumb and index pads converge. Searched over the pair's curl
+    // range, not read off the open pose: open, the two are 7 cm apart and one
+    // behind the other, and their tips only come face to face part way closed.
+    let mut rig = GloveRig {
+        model,
+        retarget,
+        open,
+        fist,
+        to_hand,
+    };
+    let tip = |rig: &mut GloveRig, finger, curl| {
+        rig.phalanges(finger, curl)
+            .last()
+            .map(|capsule: &Capsule| capsule.b.to_vec())
+            .unwrap_or_else(Vector3::zero)
+    };
+    const PINCH_STEPS: usize = 20;
+    let step = |i: usize| i as f32 / PINCH_STEPS as f32;
+    let mut pinch = (f32::INFINITY, Vector3::zero());
+    for t in 0..=PINCH_STEPS {
+        let thumb = tip(&mut rig, Finger::Thumb, step(t));
+        for i in 0..=PINCH_STEPS {
+            let index = tip(&mut rig, Finger::Index, step(i));
+            let gap = (thumb - index).magnitude();
+            if gap < pinch.0 {
+                pinch = (gap, (thumb + index) * 0.5);
+            }
+        }
+    }
+    (centre, normal, curl, pinch.1)
 }
 
 /// The glove's colour map. One loader, shared with the `debug_gloves` harness,
@@ -775,8 +801,12 @@ mod tests {
 
         let (mut model, retarget) = test_glove();
 
-        let (centre, normal, curl, pinch) =
-            palm_frame_of(&mut model, &retarget, &hand_pose::open_right_hand());
+        let (centre, normal, curl, pinch) = palm_frame_of(
+            &mut model,
+            &retarget,
+            &hand_pose::open_right_hand(),
+            &hand_pose::fist_right_hand(),
+        );
 
         for (name, measured, written) in [
             ("centre", centre, crate::hand_seat::PALM_CENTRE),

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -347,18 +347,7 @@ impl GloveRenderer {
             fist: &self.fist,
             to_hand: glove_model_to_hand(),
         };
-        // What a finger the fit can't measure falls back to, which depends on
-        // *why* it can't. An authored seat puts the item inside the closed hand
-        // on purpose (a gun's grip lives in the fist), so a finger already
-        // touching at the open pose keeps the generic wrap. A measured seat
-        // puts the item against the *open* palm on purpose, so a finger already
-        // touching it - the thumb lies on anything the palm is carrying - has
-        // finished closing, and curling it further would drive it through.
-        let resting = match grip.source {
-            crate::vr_grips::GripSource::Heuristic => FingerAmounts::default(),
-            _ => GENERIC_GRIP,
-        };
-        let amounts = hand_fit::fit(&mut rig, &mesh, family, resting);
+        let amounts = hand_fit::fit(&mut rig, &mesh, family, unmeasured_wrap(family));
         let solve = started.elapsed();
 
         tracing::debug!(
@@ -619,6 +608,26 @@ const GENERIC_GRIP: FingerAmounts = FingerAmounts {
     pinky: 0.9,
 };
 
+/// Where a finger the contact fit could not measure is left.
+///
+/// The fit yields nothing for a finger already touching the item at the open
+/// pose, and what that *means* depends on what the hand is holding. A gun's
+/// grip is seated inside the closed hand on purpose, so its fingers start
+/// inside the mesh and the generic wrap is the answer. Everything else is
+/// seated against the **open** palm on purpose ([`crate::hand_seat`]), so a
+/// finger already touching has finished closing - the thumb lies on anything
+/// the palm carries - and curling it on would drive it through.
+///
+/// Keyed on the family, not on where the seat came from: `Trigger` is the one
+/// family nothing measures its way into, and authoring a pickup's offset in
+/// the tuner must not silently change how its fingers land.
+fn unmeasured_wrap(family: GripFamily) -> FingerAmounts {
+    match family {
+        GripFamily::Trigger => GENERIC_GRIP,
+        _ => FingerAmounts::default(),
+    }
+}
+
 /// One glove material, in a cell of its own. Shared with the `debug_gloves`
 /// harness so the two can't assemble the glove differently.
 ///
@@ -676,7 +685,7 @@ fn palm_frame_of(
                     .transform_point(Point3::from_vec(global.w.truncate()))
                     .to_vec()
             })
-            .unwrap_or_else(Vector3::zero)
+            .unwrap_or_else(|| panic!("the glove rig has no joint {index}"))
     };
     // The palm's flat is the quad of the four fingers' metacarpals: base and
     // knuckle of each. The thumb is left out - it swings out of that plane.
@@ -707,19 +716,25 @@ fn palm_frame_of(
         fist,
         to_hand,
     };
-    let tip = |rig: &mut GloveRig, finger, curl| {
-        rig.phalanges(finger, curl)
-            .last()
-            .map(|capsule: &Capsule| capsule.b.to_vec())
-            .unwrap_or_else(Vector3::zero)
+    let mut tip = |rig: &mut GloveRig, finger| {
+        // Posed once per curl per finger, not once per pair: the index's tip
+        // does not depend on where the thumb is, and posing the rig is what
+        // this costs.
+        (0..=PINCH_STEPS)
+            .map(|i| {
+                rig.phalanges(finger, i as f32 / PINCH_STEPS as f32)
+                    .last()
+                    .map(|capsule: &Capsule| capsule.b.to_vec())
+                    .expect("a finger has phalanges")
+            })
+            .collect::<Vec<_>>()
     };
     const PINCH_STEPS: usize = 20;
-    let step = |i: usize| i as f32 / PINCH_STEPS as f32;
+    let thumb_tips = tip(&mut rig, Finger::Thumb);
+    let index_tips = tip(&mut rig, Finger::Index);
     let mut pinch = (f32::INFINITY, Vector3::zero());
-    for t in 0..=PINCH_STEPS {
-        let thumb = tip(&mut rig, Finger::Thumb, step(t));
-        for i in 0..=PINCH_STEPS {
-            let index = tip(&mut rig, Finger::Index, step(i));
+    for &thumb in &thumb_tips {
+        for &index in &index_tips {
             let gap = (thumb - index).magnitude();
             if gap < pinch.0 {
                 pinch = (gap, (thumb + index) * 0.5);
@@ -821,6 +836,27 @@ mod tests {
         }
     }
 
+    /// Only a gun keeps the canned wrap. Everything else is seated against the
+    /// open palm, so an unmeasurable finger stays where it is - and because
+    /// this reads the family rather than the seat's provenance, authoring a
+    /// pickup's offset in the tuner cannot change how its fingers land.
+    #[test]
+    fn only_a_trigger_grip_falls_back_on_the_canned_wrap() {
+        for family in GripFamily::ALL {
+            let wrap = unmeasured_wrap(family);
+            if family == GripFamily::Trigger {
+                assert_eq!(wrap.thumb, GENERIC_GRIP.thumb);
+            } else {
+                assert_eq!(
+                    (wrap.thumb, wrap.index, wrap.middle, wrap.ring, wrap.pinky),
+                    (0.0, 0.0, 0.0, 0.0, 0.0),
+                    "{} should leave an unmeasured finger open",
+                    family.as_str()
+                );
+            }
+        }
+    }
+
     /// The whole point of the seat: a handle put against the open palm is
     /// somewhere the fingers can *reach and stop on*, so the fit measures a
     /// real wrap instead of falling back on a canned one.
@@ -893,7 +929,7 @@ mod tests {
         }
     }
 
-    /// The cylinder of `a_seated_cylinder_gives_every_finger_something_to_close_on`,
+    /// The cylinder of `a_seated_handle_is_somewhere_every_finger_can_close_onto_it`,
     /// in hand space: model-space triangles put through the seat.
     #[cfg(test)]
     fn seated_cylinder(

--- a/shock2vr/src/hand_seat.rs
+++ b/shock2vr/src/hand_seat.rs
@@ -81,16 +81,23 @@ pub struct Seat {
 /// The family is read off the box first, because it decides both how the box
 /// is turned and where against the hand it goes:
 ///
-/// - wrapped or splayed on (cylindrical, broad, and an unprofiled trigger):
-///   the longest axis lies across the palm, the shortest faces it, and the
-///   nearest face rests on the palm skin at [`PALM_CENTRE`] - out of the open
-///   fingers' way, so every one of them has room to close;
-/// - pinched: the slab stands on edge between the open thumb and index pads,
-///   its thin axis along the palm normal and its long axis running out past
-///   the fingertips, with its near edge at [`PINCH_POINT`].
+/// - **pinched** (a slab): it stands on edge at the thumb and index pads, thin
+///   axis along the palm normal and long axis running out past the fingertips,
+///   near edge at [`PINCH_POINT`];
+/// - **wrapped or splayed on** (everything else): the longest axis lies across
+///   the palm, the shortest faces it, and the nearest face rests on the palm
+///   skin at [`PALM_CENTRE`] - clear of the open fingers, so every one of them
+///   has room to close.
+///
+/// Only [`hand_fit::family_from_extents`] decides here, so `Trigger` never
+/// arrives: a gun's family is attached by name later, in
+/// [`crate::vr_grips::resolve`], and a gun's seat is authored anyway.
 ///
 /// `authored_rotation` is the turn a grip profile already specifies; it is kept
-/// exactly, and only the placement is solved.
+/// exactly, and only the placement is solved. Note the placement then anchors
+/// the turned box's *support* along one frame axis, which is its near face only
+/// while the box is square to the frame - true of every measured turn, and
+/// approximate for an authored one.
 pub fn seat(
     min: Vector3<f32>,
     max: Vector3<f32>,
@@ -113,17 +120,15 @@ pub fn seat(
 
     let (_, out, along) = palm_frame();
     let target = match family {
+        // Straddling the pinch line, running away from the hand: the pads meet
+        // its near edge and close onto its faces.
+        GripFamily::Pinch => PINCH_POINT + along * support(along),
         // The near face on the palm skin, the rest of the item out in front of
         // it. Centred on the palm and no further toward the knuckles: the open
         // fingers' first phalanges run *below* the palm plane there, so a nudge
         // that way seats the item into the fingers rather than in front of
         // them, and they read as already closed before they move.
-        GripFamily::Cylindrical | GripFamily::Broad | GripFamily::Trigger => {
-            PALM_CENTRE + out * (PALM_DEPTH + support(out))
-        }
-        // Straddling the pinch line, running away from the hand: the pads meet
-        // its near edge and close onto its faces.
-        GripFamily::Pinch => PINCH_POINT + along * support(along),
+        _ => PALM_CENTRE + out * (PALM_DEPTH + support(out)),
     };
 
     let centre = rotation.rotate_vector((min + max) * 0.5);
@@ -145,13 +150,11 @@ fn seating_turn(extents: Vector3<f32>, family: GripFamily) -> Quaternion<f32> {
     let (across, out, along) = palm_frame();
     // Where the box's longest / shortest / middle axes are sent.
     let frame = match family {
-        // Long axis across the palm (a rod through the fist), flat side down.
-        GripFamily::Cylindrical | GripFamily::Broad | GripFamily::Trigger => {
-            Matrix3::from_cols(across, out, along)
-        }
         // Long axis out past the fingertips, thin axis facing the palm, so the
         // pads land on the faces. `-across` keeps the triple right-handed.
         GripFamily::Pinch => Matrix3::from_cols(along, out, -across),
+        // Long axis across the palm (a rod through the fist), flat side down.
+        _ => Matrix3::from_cols(across, out, along),
     };
     Quaternion::from(frame * axis_order(extents))
 }
@@ -180,10 +183,7 @@ mod tests {
     use super::*;
     use cgmath::{Deg, Rotation3};
 
-    /// Metres in the world units the hand frame is measured in.
-    fn meters(m: f32) -> f32 {
-        m / crate::METERS_PER_WORLD_UNIT
-    }
+    use crate::util::meters;
 
     fn box_of(half: Vector3<f32>) -> (Vector3<f32>, Vector3<f32>) {
         (-half, half)

--- a/shock2vr/src/hand_seat.rs
+++ b/shock2vr/src/hand_seat.rs
@@ -36,9 +36,14 @@ pub const PALM_NORMAL: Vector3<f32> = vec3(-0.97836, 0.15474, -0.13728);
 /// about, so the axis a rod lies along when the fist closes on it.
 pub const PALM_CURL_AXIS: Vector3<f32> = vec3(-0.17354, -0.97693, 0.13556);
 
-/// Where thumb and index meet when the open hand closes on something thin: the
-/// midpoint of their tips at the open pose. A pinched item straddles this.
-pub const PINCH_POINT: Vector3<f32> = vec3(-0.05139, 0.055755, -0.168875);
+/// Where thumb and index meet when the hand closes on something thin: the
+/// point their pads converge on, searched over the pair's whole curl range
+/// rather than read off the open pose - at the open pose they are 7 cm apart
+/// and one behind the other, and only closing brings them face to face. A
+/// pinched item straddles this, and the direction between the pads there is
+/// (to within a few degrees) the palm normal, which is why a pinched slab
+/// faces the palm with its thin side.
+pub const PINCH_POINT: Vector3<f32> = vec3(-0.07385, 0.041375, -0.13198);
 
 /// How far the palm's skin is from the joints the frame is measured through,
 /// in world units - roughly half the thickness of a hand.
@@ -48,15 +53,6 @@ pub const PINCH_POINT: Vector3<f32> = vec3(-0.05139, 0.055755, -0.168875);
 /// the fit already inside it (which the fit reads as "leave the authored wrap
 /// alone"). Items sit on the skin instead.
 const PALM_DEPTH: f32 = 0.012 / crate::METERS_PER_WORLD_UNIT;
-
-/// How far toward the knuckles a wrapped item sits from the palm's centre, in
-/// world units.
-///
-/// A grip is not held in the middle of the palm: it sits under the base of the
-/// fingers, which is the only stretch of palm both the fingers and the *thumb*
-/// close over. Centred on the palm proper, a handle falls behind the thumb's
-/// whole swing and the thumb closes past it into a fist.
-const GRIP_SEAT_ALONG: f32 = 0.015 / crate::METERS_PER_WORLD_UNIT;
 
 /// The palm frame as the seat uses it: `(across, out, along)` - across the palm
 /// (the curl axis), out of the palm, and along the fingers wrist-to-tips.
@@ -118,10 +114,12 @@ pub fn seat(
     let (_, out, along) = palm_frame();
     let target = match family {
         // The near face on the palm skin, the rest of the item out in front of
-        // it - and pushed toward the knuckles, which is the stretch of palm the
-        // fingers *and* the thumb can both reach round.
+        // it. Centred on the palm and no further toward the knuckles: the open
+        // fingers' first phalanges run *below* the palm plane there, so a nudge
+        // that way seats the item into the fingers rather than in front of
+        // them, and they read as already closed before they move.
         GripFamily::Cylindrical | GripFamily::Broad | GripFamily::Trigger => {
-            PALM_CENTRE + out * (PALM_DEPTH + support(out)) + along * GRIP_SEAT_ALONG
+            PALM_CENTRE + out * (PALM_DEPTH + support(out))
         }
         // Straddling the pinch line, running away from the hand: the pads meet
         // its near edge and close onto its faces.

--- a/shock2vr/src/hand_seat.rs
+++ b/shock2vr/src/hand_seat.rs
@@ -2,41 +2,73 @@
 //!
 //! The finger fit ([`crate::hand_fit`]) measures how far each finger closes on
 //! the item's surface, which only says anything once the item is somewhere a
-//! hand could hold it. A world pickup is drawn centred on the wrist, so this
-//! module puts it in the palm first, from the one thing every model has: the
-//! box its geometry occupies.
+//! hand could hold it - and specifically somewhere the **open** hand is not
+//! already touching, because a finger that starts in contact yields nothing and
+//! keeps its authored wrap. A world pickup is drawn centred on the wrist, so
+//! this module puts it against the open palm first, from the one thing every
+//! model has: the box its geometry occupies.
 //!
-//! Hand space is the glove's own: **+X toward the thumb side** of the right
-//! hand, **+Y out of the back of the hand** (so the palm faces -Y), **-Z along
-//! the fingers**. Units are world units (1 ~ 0.762 m), the space the seat
-//! offsets in [`crate::vr_grips`] are written in.
+//! Hand space is the glove's own, and it is not axis-aligned to the palm: the
+//! rig's palm plane runs obliquely through it. So the seat works in a **palm
+//! frame** measured off the open glove ([`PALM_CENTRE`], [`PALM_NORMAL`],
+//! [`PALM_CURL_AXIS`]) rather than in hand X/Y/Z. Units are world units
+//! (1 ~ 0.762 m), the space the seat offsets in [`crate::vr_grips`] are
+//! written in.
 
-use cgmath::{Matrix3, Quaternion, SquareMatrix, Vector3, vec3};
+use cgmath::{InnerSpace, Matrix3, Quaternion, Rotation, SquareMatrix, Vector3, vec3};
 
 use crate::hand_fit::{self, GripFamily};
 
-/// Where the palm's surface is, in hand space: the midpoint of the index and
-/// pinky knuckles at the glove's open pose - the line an item resting in the
-/// hand touches.
+/// Centre of the palm, in hand space: the mean of the four fingers'
+/// metacarpal bases and knuckles at the open pose - the middle of the flat
+/// the palm presents, roughly halfway between wrist and knuckles.
 ///
 /// Measured off the shipped rig; `hand_glove`'s
-/// `the_palm_anchor_matches_the_glove_rig` re-measures it and fails if the
-/// glove ever moves under it.
-pub const PALM_ANCHOR: Vector3<f32> = vec3(0.0055, -0.0002, -0.0971);
+/// `the_palm_frame_matches_the_glove_rig` re-measures the whole frame and
+/// fails if the glove ever moves under it.
+pub const PALM_CENTRE: Vector3<f32> = vec3(0.005287, -0.000243, -0.058655);
 
-/// How far the palm's skin is from that knuckle line, in world units - roughly
-/// half the thickness of a hand.
+/// Out of the palm, in hand space - the side the fingers curl toward, so the
+/// side a held item sits on.
+pub const PALM_NORMAL: Vector3<f32> = vec3(-0.97836, 0.15474, -0.13728);
+
+/// Across the palm, index knuckle to pinky knuckle: the axis the fingers curl
+/// about, so the axis a rod lies along when the fist closes on it.
+pub const PALM_CURL_AXIS: Vector3<f32> = vec3(-0.17354, -0.97693, 0.13556);
+
+/// Where thumb and index meet when the open hand closes on something thin: the
+/// midpoint of their tips at the open pose. A pinched item straddles this.
+pub const PINCH_POINT: Vector3<f32> = vec3(-0.05139, 0.055755, -0.168875);
+
+/// How far the palm's skin is from the joints the frame is measured through,
+/// in world units - roughly half the thickness of a hand.
 ///
-/// The anchor is a line of *joints*, which sit inside the flesh; an item rested
-/// on it would be buried in the palm and the fingers would start the fit
-/// already inside it (which the fit reads as "leave the authored wrap alone").
-/// Items sit on the skin instead.
+/// The frame runs through a plane of *joints*, which sit inside the flesh; an
+/// item rested on it would be buried in the palm and the fingers would start
+/// the fit already inside it (which the fit reads as "leave the authored wrap
+/// alone"). Items sit on the skin instead.
 const PALM_DEPTH: f32 = 0.012 / crate::METERS_PER_WORLD_UNIT;
 
-/// Where an item's surface rests: the palm's skin, on the -Y side of the
-/// knuckle line.
-pub fn palm_surface() -> Vector3<f32> {
-    PALM_ANCHOR - vec3(0.0, PALM_DEPTH, 0.0)
+/// How far toward the knuckles a wrapped item sits from the palm's centre, in
+/// world units.
+///
+/// A grip is not held in the middle of the palm: it sits under the base of the
+/// fingers, which is the only stretch of palm both the fingers and the *thumb*
+/// close over. Centred on the palm proper, a handle falls behind the thumb's
+/// whole swing and the thumb closes past it into a fist.
+const GRIP_SEAT_ALONG: f32 = 0.015 / crate::METERS_PER_WORLD_UNIT;
+
+/// The palm frame as the seat uses it: `(across, out, along)` - across the palm
+/// (the curl axis), out of the palm, and along the fingers wrist-to-tips.
+///
+/// The written-down axes are transcribed measurements and so are only unit and
+/// perpendicular to within a thousandth; everything here is a projection onto
+/// them, which needs them exact. Orthonormalized about the normal, and the
+/// third derived rather than written down so the three can never disagree.
+pub fn palm_frame() -> (Vector3<f32>, Vector3<f32>, Vector3<f32>) {
+    let out = PALM_NORMAL.normalize();
+    let across = (PALM_CURL_AXIS - out * PALM_CURL_AXIS.dot(out)).normalize();
+    (across, out, across.cross(out))
 }
 
 /// A held item's placement in hand space: where its model origin goes, and how
@@ -47,53 +79,93 @@ pub struct Seat {
     pub rotation: Quaternion<f32>,
 }
 
-/// Seat a model-space box in the hand.
+/// Seat a model-space box against the **open** hand, for the finger fit to
+/// close on.
 ///
-/// `authored_rotation` is the turn a grip profile already specifies; with none,
-/// the box is turned so its **longest** axis runs across the palm (hand X, the
-/// axis the fingers curl about - a rod lies through the fist), its **shortest**
-/// faces the palm (hand Y), and the remaining one runs along the fingers. Either
-/// way the box is then dropped onto the palm: its surface against
-/// [`palm_surface`], which is half its palm-facing extent below it.
+/// The family is read off the box first, because it decides both how the box
+/// is turned and where against the hand it goes:
 ///
-/// The family follows the seated box, so what the fingers are allowed to do
-/// matches what they are closing on: thin is pinched, wider than the palm is
-/// splayed on, anything else is wrapped.
+/// - wrapped or splayed on (cylindrical, broad, and an unprofiled trigger):
+///   the longest axis lies across the palm, the shortest faces it, and the
+///   nearest face rests on the palm skin at [`PALM_CENTRE`] - out of the open
+///   fingers' way, so every one of them has room to close;
+/// - pinched: the slab stands on edge between the open thumb and index pads,
+///   its thin axis along the palm normal and its long axis running out past
+///   the fingertips, with its near edge at [`PINCH_POINT`].
+///
+/// `authored_rotation` is the turn a grip profile already specifies; it is kept
+/// exactly, and only the placement is solved.
 pub fn seat(
     min: Vector3<f32>,
     max: Vector3<f32>,
     authored_rotation: Option<Quaternion<f32>>,
 ) -> (Seat, GripFamily) {
-    let rotation = authored_rotation.unwrap_or_else(|| across_the_palm(max - min));
+    let half = (max - min) * 0.5;
+    let family = hand_fit::family_from_extents(max - min);
+    let rotation = authored_rotation.unwrap_or_else(|| seating_turn(max - min, family));
 
-    // The box turned into hand space. A rotation of an axis-aligned box is not
-    // axis-aligned, so re-bound the eight corners rather than permuting extents.
-    let (hand_min, hand_max) = rotated_bounds(min, max, rotation);
-    let extents = hand_max - hand_min;
-    let centre = (hand_min + hand_max) * 0.5;
+    // Support of the turned box along `axis`: how far its surface reaches from
+    // its own centre that way. A rotated box is not axis-aligned in hand
+    // space, and the palm frame is oblique to it either way, so this is
+    // measured against the axis rather than read off a re-bound AABB.
+    let support = |axis: Vector3<f32>| {
+        let along = |unit: Vector3<f32>| axis.dot(rotation.rotate_vector(unit)).abs();
+        along(Vector3::unit_x()) * half.x
+            + along(Vector3::unit_y()) * half.y
+            + along(Vector3::unit_z()) * half.z
+    };
 
-    // The palm faces -Y, so the item hangs below the skin by half its depth.
-    let target = palm_surface() - vec3(0.0, extents.y * 0.5, 0.0);
+    let (_, out, along) = palm_frame();
+    let target = match family {
+        // The near face on the palm skin, the rest of the item out in front of
+        // it - and pushed toward the knuckles, which is the stretch of palm the
+        // fingers *and* the thumb can both reach round.
+        GripFamily::Cylindrical | GripFamily::Broad | GripFamily::Trigger => {
+            PALM_CENTRE + out * (PALM_DEPTH + support(out)) + along * GRIP_SEAT_ALONG
+        }
+        // Straddling the pinch line, running away from the hand: the pads meet
+        // its near edge and close onto its faces.
+        GripFamily::Pinch => PINCH_POINT + along * support(along),
+    };
+
+    let centre = rotation.rotate_vector((min + max) * 0.5);
     (
         Seat {
             offset: target - centre,
             rotation,
         },
-        hand_fit::family_from_extents(extents),
+        family,
     )
 }
 
-/// The turn that lays a box's longest axis across the palm and its shortest
-/// against it. A signed permutation of the model axes, kept a proper rotation
-/// (determinant +1) so it never reflects the geometry.
-fn across_the_palm(extents: Vector3<f32>) -> Quaternion<f32> {
+/// The turn that lays a box into the palm frame for its family.
+///
+/// A signed permutation of the model axes onto the frame's own axes, composed
+/// with the frame. Kept a proper rotation (determinant +1) throughout, so it
+/// never reflects the geometry.
+fn seating_turn(extents: Vector3<f32>, family: GripFamily) -> Quaternion<f32> {
+    let (across, out, along) = palm_frame();
+    // Where the box's longest / shortest / middle axes are sent.
+    let frame = match family {
+        // Long axis across the palm (a rod through the fist), flat side down.
+        GripFamily::Cylindrical | GripFamily::Broad | GripFamily::Trigger => {
+            Matrix3::from_cols(across, out, along)
+        }
+        // Long axis out past the fingertips, thin axis facing the palm, so the
+        // pads land on the faces. `-across` keeps the triple right-handed.
+        GripFamily::Pinch => Matrix3::from_cols(along, out, -across),
+    };
+    Quaternion::from(frame * axis_order(extents))
+}
+
+/// The signed permutation that sends a box's longest model axis to local X,
+/// its shortest to local Y and the remaining one to local Z.
+fn axis_order(extents: Vector3<f32>) -> Matrix3<f32> {
     let mut order = [0usize, 1, 2];
     let size = [extents.x.abs(), extents.y.abs(), extents.z.abs()];
     order.sort_by(|a, b| size[*b].total_cmp(&size[*a]));
     let [longest, middle, shortest] = order;
 
-    // Column j is where model axis j lands: longest across the palm, shortest
-    // through it, the remainder along the fingers.
     let mut columns = [Vector3::unit_x(); 3];
     columns[longest] = Vector3::unit_x();
     columns[middle] = Vector3::unit_z();
@@ -102,36 +174,13 @@ fn across_the_palm(extents: Vector3<f32>) -> Quaternion<f32> {
     if matrix.determinant() < 0.0 {
         matrix.z = -matrix.z;
     }
-    Quaternion::from(matrix)
-}
-
-/// The axis-aligned bounds of `[min, max]` after `rotation` - the same
-/// transform-the-corners-and-re-bound `dark::model` does for a posed hitbox.
-fn rotated_bounds(
-    min: Vector3<f32>,
-    max: Vector3<f32>,
-    rotation: Quaternion<f32>,
-) -> (Vector3<f32>, Vector3<f32>) {
-    use cgmath::{EuclideanSpace, Point3, Rotation};
-    use collision::{Aabb, Aabb3};
-
-    let box_of = Aabb3::new(Point3::from_vec(min), Point3::from_vec(max));
-    let turned = box_of
-        .to_corners()
-        .map(|corner| Point3::from_vec(rotation.rotate_vector(corner.to_vec())));
-    let bounds = turned
-        .iter()
-        .skip(1)
-        .fold(Aabb3::new(turned[0], turned[0]), |bounds, point| {
-            bounds.grow(*point)
-        });
-    (bounds.min.to_vec(), bounds.max.to_vec())
+    matrix
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::{Deg, InnerSpace, Rotation, Rotation3};
+    use cgmath::{Deg, Rotation3};
 
     /// Metres in the world units the hand frame is measured in.
     fn meters(m: f32) -> f32 {
@@ -142,16 +191,49 @@ mod tests {
         (-half, half)
     }
 
-    /// The seated box's own hand-space bounds - what the fingers see.
-    fn seated_bounds(
-        min: Vector3<f32>,
-        max: Vector3<f32>,
-        seat: Seat,
-    ) -> (Vector3<f32>, Vector3<f32>) {
-        let (lo, hi) = rotated_bounds(min, max, seat.rotation);
-        (lo + seat.offset, hi + seat.offset)
+    /// Where a seated box's corners land in the palm frame: `(normal, curl,
+    /// fingerward)` components of each of the eight.
+    fn seated_in_frame(min: Vector3<f32>, max: Vector3<f32>, seat: Seat) -> Vec<(f32, f32, f32)> {
+        let (across, out, along) = palm_frame();
+        let mut corners = Vec::new();
+        for i in 0..8 {
+            let corner = vec3(
+                if i & 1 == 0 { min.x } else { max.x },
+                if i & 2 == 0 { min.y } else { max.y },
+                if i & 4 == 0 { min.z } else { max.z },
+            );
+            let p = seat.rotation.rotate_vector(corner) + seat.offset - PALM_CENTRE;
+            corners.push((p.dot(out), p.dot(across), p.dot(along)));
+        }
+        corners
     }
 
+    /// The palm frame is orthonormal and right-handed - every projection the
+    /// seat takes assumes it, and the axes it is built from are transcribed
+    /// measurements rather than exact numbers.
+    #[test]
+    fn the_palm_frame_is_an_orthonormal_right_handed_basis() {
+        let (across, out, along) = palm_frame();
+        for axis in [across, out, along] {
+            assert!(
+                (axis.magnitude() - 1.0).abs() < 1e-5,
+                "{axis:?} is not unit"
+            );
+        }
+        assert!(out.dot(across).abs() < 1e-5);
+        assert!(out.dot(along).abs() < 1e-5);
+        assert!(across.dot(along).abs() < 1e-5);
+        assert!(
+            (across.cross(out) - along).magnitude() < 1e-5,
+            "the frame is left-handed"
+        );
+        // Orthonormalizing must not have turned the axes into different ones.
+        assert!(out.dot(PALM_NORMAL.normalize()) > 0.999);
+        assert!(across.dot(PALM_CURL_AXIS.normalize()) > 0.999);
+    }
+
+    /// A rod lies across the palm - along the axis the fingers curl about -
+    /// with its near face on the palm skin.
     #[test]
     fn a_rod_lies_across_the_palm() {
         let (min, max) = box_of(vec3(
@@ -162,34 +244,28 @@ mod tests {
 
         let (seat, family) = seat(min, max, None);
 
-        let (lo, hi) = seated_bounds(min, max, seat);
-        let extents = hi - lo;
+        let corners = seated_in_frame(min, max, seat);
+        let span = |pick: fn(&(f32, f32, f32)) -> f32| {
+            let lo = corners.iter().map(pick).fold(f32::INFINITY, f32::min);
+            let hi = corners.iter().map(pick).fold(f32::NEG_INFINITY, f32::max);
+            (lo, hi - lo)
+        };
+        let (near, depth) = span(|c| c.0);
+        let (_, across) = span(|c| c.1);
+        let (_, along) = span(|c| c.2);
         assert!(
-            extents.x > extents.y && extents.x > extents.z,
-            "the long axis should run across the palm, got {extents:?}"
+            across > along && across > depth,
+            "the long axis should run across the palm, got across {across} along {along} depth {depth}"
+        );
+        assert!(
+            (near - PALM_DEPTH).abs() < 1e-5,
+            "the rod's near face should rest on the palm skin, got {near}"
         );
         assert_eq!(family, GripFamily::Cylindrical);
     }
 
-    #[test]
-    fn a_slab_is_pinched_flat_against_the_palm() {
-        let (min, max) = box_of(vec3(
-            meters(0.35) * 0.5,
-            meters(0.02) * 0.5,
-            meters(0.48) * 0.5,
-        ));
-
-        let (seat, family) = seat(min, max, None);
-
-        let (lo, hi) = seated_bounds(min, max, seat);
-        let extents = hi - lo;
-        assert!(
-            extents.y < extents.x && extents.y < extents.z,
-            "the thin axis should face the palm, got {extents:?}"
-        );
-        assert_eq!(family, GripFamily::Pinch);
-    }
-
+    /// A ball's surface touches the palm skin too - the seat drops the surface,
+    /// not the origin, so shape does not change where contact happens.
     #[test]
     fn a_ball_rests_on_the_palm() {
         let radius = meters(0.35) * 0.5;
@@ -197,47 +273,82 @@ mod tests {
 
         let (seat, family) = seat(min, max, None);
 
-        let (_, hi) = seated_bounds(min, max, seat);
+        let near = seated_in_frame(min, max, seat)
+            .iter()
+            .map(|c| c.0)
+            .fold(f32::INFINITY, f32::min);
         assert!(
-            (hi.y - palm_surface().y).abs() < 1e-5,
-            "the ball's top should touch the palm, got {}",
-            hi.y
+            (near - PALM_DEPTH).abs() < 1e-5,
+            "the ball should touch the palm, got {near}"
         );
         assert_eq!(family, GripFamily::Broad);
     }
 
-    /// Everything sits against the palm, whatever its shape: the surface the
-    /// fingers close onto is the anchor, not the model origin.
+    /// A slab stands on edge at the pinch line: thin side facing the palm, near
+    /// edge at the pads, the rest of it out past the fingertips.
     #[test]
-    fn every_seat_puts_the_surface_on_the_palm() {
-        for half in [
-            vec3(meters(0.08), meters(0.01), meters(0.02)),
-            vec3(meters(0.02), meters(0.02), meters(0.02)),
-            vec3(meters(0.3), meters(0.05), meters(0.1)),
-        ] {
-            let (min, max) = box_of(half);
-            let (seat, _) = seat(min, max, None);
-            let (_, hi) = seated_bounds(min, max, seat);
-            assert!(
-                (hi.y - palm_surface().y).abs() < 1e-5,
-                "half {half:?} seated with its top at {}",
-                hi.y
-            );
-        }
+    fn a_slab_stands_on_edge_at_the_pinch_line() {
+        let (min, max) = box_of(vec3(
+            meters(0.35) * 0.5,
+            meters(0.02) * 0.5,
+            meters(0.48) * 0.5,
+        ));
+
+        let (seat, family) = seat(min, max, None);
+        assert_eq!(family, GripFamily::Pinch);
+
+        let corners = seated_in_frame(min, max, seat);
+        let pinch = PINCH_POINT - PALM_CENTRE;
+        let (_, out, fingerward) = palm_frame();
+        let (pinch_n, pinch_f) = (pinch.dot(out), pinch.dot(fingerward));
+
+        let depth = corners
+            .iter()
+            .map(|c| c.0)
+            .fold(f32::NEG_INFINITY, f32::max)
+            - corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
+        let along_lo = corners.iter().map(|c| c.2).fold(f32::INFINITY, f32::min);
+        let along_hi = corners
+            .iter()
+            .map(|c| c.2)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let across = corners
+            .iter()
+            .map(|c| c.1)
+            .fold(f32::NEG_INFINITY, f32::max)
+            - corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
+
+        assert!(
+            depth < across && depth < (along_hi - along_lo),
+            "the thin axis should face the palm, got depth {depth}"
+        );
+        assert!(
+            (along_lo - pinch_f).abs() < 1e-5,
+            "the near edge should sit at the pinch point, got {along_lo} vs {pinch_f}"
+        );
+        let mid_n = 0.5
+            * (corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min)
+                + corners
+                    .iter()
+                    .map(|c| c.0)
+                    .fold(f32::NEG_INFINITY, f32::max));
+        assert!(
+            (mid_n - pinch_n).abs() < 1e-5,
+            "the slab's mid-plane should be on the pinch line, got {mid_n} vs {pinch_n}"
+        );
     }
 
     /// An authored turn is kept as authored - the profile decides which way the
-    /// item faces - and only the drop onto the palm is computed.
+    /// item faces - and only the placement is solved.
     #[test]
-    fn an_authored_rotation_is_kept_and_only_the_drop_is_solved() {
+    fn an_authored_rotation_is_kept_and_only_the_placement_is_solved() {
         let (min, max) = box_of(vec3(meters(0.1), meters(0.02), meters(0.03)));
         let authored = Quaternion::from_angle_y(Deg(-90.0));
 
         let (seat, _) = seat(min, max, Some(authored));
 
         assert!((seat.rotation.s - authored.s).abs() < 1e-6);
-        let (_, hi) = seated_bounds(min, max, seat);
-        assert!((hi.y - palm_surface().y).abs() < 1e-5);
+        assert_eq!(seat.rotation, authored);
     }
 
     /// A permutation with an odd number of swaps must not sneak in as a
@@ -252,14 +363,17 @@ mod tests {
             vec3(3.0, 1.0, 2.0),
             vec3(2.0, 1.0, 3.0),
         ] {
-            let rotation = across_the_palm(extents);
-            let cross = rotation
-                .rotate_vector(Vector3::unit_x())
-                .cross(rotation.rotate_vector(Vector3::unit_y()));
-            assert!(
-                (cross - rotation.rotate_vector(Vector3::unit_z())).magnitude() < 1e-5,
-                "{extents:?} produced a reflection"
-            );
+            for family in GripFamily::ALL {
+                let rotation = seating_turn(extents, family);
+                let cross = rotation
+                    .rotate_vector(Vector3::unit_x())
+                    .cross(rotation.rotate_vector(Vector3::unit_y()));
+                assert!(
+                    (cross - rotation.rotate_vector(Vector3::unit_z())).magnitude() < 1e-3,
+                    "{extents:?} produced a reflection for {}",
+                    family.as_str()
+                );
+            }
         }
     }
 }

--- a/shock2vr/src/scenes/debug_grips.rs
+++ b/shock2vr/src/scenes/debug_grips.rs
@@ -34,13 +34,14 @@ const HAND_POSITION: Vector3<f32> = vec3(0.0, 2.6, 1.0);
 
 /// The owner's grip test cases: a mug (a handle its bounding box cannot see),
 /// a printed magazine (a slab), a clip (a small box), a basketball (bigger
-/// than the palm), and the four guns whose `_h` models range from an authored
-/// pistol grip to no grip at all.
+/// than the palm), the belt card (the thinnest slab there is, and what the
+/// body frame hangs on the hip), and the four guns whose `_h` models range
+/// from an authored pistol grip to no grip at all.
 ///
 /// `magci` is one of the six magazine covers the Magazines template picks
 /// from; they share a mesh, so any of them is the slab case.
 const GRIP_TEST_ITEMS: &[&str] = &[
-    "mug", "magci", "ammoss", "hamball", "atek_h", "sg_h", "fsn_h", "al_h",
+    "mug", "magci", "ammoss", "hamball", "scipass", "atek_h", "sg_h", "fsn_h", "al_h",
 ];
 
 struct GripHooks {

--- a/shock2vr/src/scenes/debug_grips.rs
+++ b/shock2vr/src/scenes/debug_grips.rs
@@ -9,7 +9,7 @@
 //!
 //! Cycle items with the `grip_item` dev param; frame them with `/v1/camera`.
 
-use cgmath::{Deg, Quaternion, Rotation3, Vector3, vec3};
+use cgmath::{Deg, Matrix, Matrix3, Quaternion, Rotation3, Vector3, vec3};
 use dark::{
     importers::{MODELS_IMPORTER, VR_HELD_GUN_MODELS_IMPORTER},
     model::Model,
@@ -22,6 +22,7 @@ use crate::{
     GameOptions,
     game_scene::GameScene,
     hand_glove::{self, GloveRenderer, HandLight, HandPreshape},
+    hand_seat,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
         DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
@@ -49,6 +50,24 @@ struct GripHooks {
     /// on a change rather than every frame.
     shown: Option<usize>,
     glove: Option<GloveRenderer>,
+}
+
+/// The turn that presents the palm to the scene's camera, with the fingers
+/// running to the left across frame.
+///
+/// Derived from [`hand_seat::palm_frame`] rather than written as a pair of
+/// Euler angles: the palm plane is oblique to every hand axis, so a hand-picked
+/// roll that once looked right shows the *edge* of the hand as soon as the
+/// measured frame moves - which is exactly what a fixed `Ry(90)·Rz(90)` did
+/// once the frame was measured properly. This is the harness the fit is
+/// eyeballed in, so it has to follow the frame it is checking.
+fn palm_to_camera() -> Quaternion<f32> {
+    let (across, out, along) = hand_seat::palm_frame();
+    // Out of the palm toward the camera (-Z), fingers to the left (-X); the
+    // third axis follows, keeping the turn a proper rotation.
+    let hand = Matrix3::from_cols(across, out, along);
+    let world = Matrix3::from_cols(Vector3::unit_y(), -Vector3::unit_z(), -Vector3::unit_x());
+    Quaternion::from(world * hand.transpose())
 }
 
 /// The item the `grip_item` dev param selects, clamped to the list.
@@ -82,13 +101,9 @@ impl DebugSceneHooks for GripHooks {
             1.0
         };
 
-        // The right hand at a fixed spot, fingers along -X and rolled so the
-        // palm - the side the fit happens on - faces the -Z camera.
-        let hand = hand_glove::hand_to_world(
-            HAND_POSITION,
-            Quaternion::from_angle_y(Deg(90.0)) * Quaternion::from_angle_z(Deg(90.0)),
-            Handedness::Right,
-        );
+        // The right hand at a fixed spot, turned to show the camera the side
+        // the fit happens on.
+        let hand = hand_glove::hand_to_world(HAND_POSITION, palm_to_camera(), Handedness::Right);
 
         // The scene's own `MissionCore::update` already loaded the profiles;
         // what it cannot do is measure this item, which no entity is holding.

--- a/tools/shock2-sdk/test/vr-finger-fit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-finger-fit.e2e.test.ts
@@ -76,62 +76,66 @@ test(
   },
 );
 
+/**
+ * The per-finger curls `debug_grips` logs for the item it is showing, e.g.
+ * `debug_grips [0] mug: family cylindrical -> FingerAmounts { thumb: 0.0, ... }`.
+ *
+ * The scene solves the very grip a wield would (`GloveRenderer::fitted_grip`)
+ * and prints the answer; nothing is "held" there, so `/v1/info` has no hand
+ * affordance to report and the log line is the observable.
+ */
+function fittedGrip(
+  logs: string[],
+  model: string,
+): { family: string; fingers: Record<string, number> } {
+  const line = logs.findLast((l) => l.includes(`] ${model}: family `));
+  assert.ok(line, `debug_grips should have logged a fit for ${model}`);
+  const family = /family (\w+)/.exec(line)?.[1];
+  assert.ok(family, `no family in: ${line}`);
+  const fingers: Record<string, number> = {};
+  for (const [, name, value] of line.matchAll(/(thumb|index|middle|ring|pinky): ([\d.]+)/g)) {
+    fingers[name] = Number(value);
+  }
+  assert.equal(Object.keys(fingers).length, 5, `no finger curls in: ${line}`);
+  return { family, fingers };
+}
+
 test(
-  "VR: a held mug is wrapped by the fingers, not answered with a canned grip",
+  "VR: a plain pickup is wrapped by the fingers, not answered with a canned grip",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    await using game = await GameServer.launch({
-      mission: "medsci1.mis",
-      debugFlags: ["--vr"],
-    });
+    await using game = await GameServer.launch({ mission: "debug_grips" });
     await game.step({ frames: 10 });
 
-    // A plain pickup: no authored grip profile, so its seat and its whole
-    // finger wrap are measured off its own geometry.
-    const { entities } = await game.entities.list({ filter: "Mug" });
-    const mug = entities[0];
-    assert.ok(mug, "medsci1 should have a mug");
+    // The mug and the clip: two unprofiled pickups whose whole placement and
+    // wrap are measured off their own geometry.
+    for (const [index, model] of [
+      [0, "mug"],
+      [2, "ammoss"],
+    ] as const) {
+      await game.devParams.set("grip_item", index);
+      await game.step({ frames: 10 });
 
-    // Stand next to it and put the hand on it. `right_hand.position` is
-    // pawn-local, and the pawn is placed with identity rotation by teleport.
-    const [mx, my, mz] = mug.position;
-    await game.player.teleport({ x: mx - 1.2, y: my, z: mz });
-    await game.step({ frames: 30 });
-    const pawn = (await game.info()).player.position;
-    await game.input.set("right_hand.position", [
-      mx - pawn[0],
-      my - pawn[1],
-      mz - pawn[2],
-    ]);
-    await game.input.set("right_hand.squeeze", 1.0);
-    await game.step({ frames: 10 });
-    assert.equal(
-      (await game.info()).player.right_hand_entity_id,
-      mug.id,
-      "the mug should be grabbed by the right hand",
-    );
+      const { family, fingers } = fittedGrip(game.logs(), model);
+      assert.equal(family, "cylindrical", `${model} should be wrapped`);
 
-    const grip = (await game.info()).player.hand_affordance.right_grip;
-    assert.ok(grip, "a held mug should report a fitted grip");
-    assert.equal(grip.family, "cylindrical");
-
-    // The point of the open-palm seat: the four wrapping fingers each stop on
-    // the mug's own surface. A curl pinned at either end means the fit
-    // measured nothing and handed back a fallback - which is what #1385
-    // shipped, a closed fist beside the mug.
-    for (const finger of ["index", "middle", "ring", "pinky"] as const) {
+      // The point of the open-palm seat: each wrapping finger stops somewhere
+      // on the item's own surface. Pinned at either end means the fit measured
+      // nothing and echoed a fallback - which is what a seat beside the hand
+      // produces, and what #1385 shipped: a closed fist next to the mug.
+      for (const finger of ["index", "middle", "ring", "pinky"] as const) {
+        assert.ok(
+          fingers[finger] > 0 && fingers[finger] < 1,
+          `${model}'s ${finger} closed to ${fingers[finger]} without stopping on it`,
+        );
+      }
+      // The thumb is the deliberate exception: it lies on whatever the open
+      // palm carries, so it is at contact before it curls at all, and a
+      // measured seat's fallback leaves it open rather than closing it through.
       assert.ok(
-        grip[finger] > 0 && grip[finger] < 1,
-        `${finger} should stop on the mug, got ${grip[finger]}`,
+        fingers.thumb >= 0 && fingers.thumb < 1,
+        `${model}'s thumb closed to ${fingers.thumb}`,
       );
     }
-    // The thumb is the exception, and deliberately so: it lies on whatever the
-    // open palm carries, so it is at contact before it curls at all and the
-    // measured seat's fallback leaves it open rather than closing it through
-    // the mug.
-    assert.ok(
-      grip.thumb >= 0 && grip.thumb <= 1,
-      `thumb curl out of range: ${grip.thumb}`,
-    );
   },
 );

--- a/tools/shock2-sdk/test/vr-finger-fit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-finger-fit.e2e.test.ts
@@ -75,3 +75,63 @@ test(
     assert.equal((await game.info()).player.hand_affordance.right_grip, null);
   },
 );
+
+test(
+  "VR: a held mug is wrapped by the fingers, not answered with a canned grip",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    // A plain pickup: no authored grip profile, so its seat and its whole
+    // finger wrap are measured off its own geometry.
+    const { entities } = await game.entities.list({ filter: "Mug" });
+    const mug = entities[0];
+    assert.ok(mug, "medsci1 should have a mug");
+
+    // Stand next to it and put the hand on it. `right_hand.position` is
+    // pawn-local, and the pawn is placed with identity rotation by teleport.
+    const [mx, my, mz] = mug.position;
+    await game.player.teleport({ x: mx - 1.2, y: my, z: mz });
+    await game.step({ frames: 30 });
+    const pawn = (await game.info()).player.position;
+    await game.input.set("right_hand.position", [
+      mx - pawn[0],
+      my - pawn[1],
+      mz - pawn[2],
+    ]);
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      mug.id,
+      "the mug should be grabbed by the right hand",
+    );
+
+    const grip = (await game.info()).player.hand_affordance.right_grip;
+    assert.ok(grip, "a held mug should report a fitted grip");
+    assert.equal(grip.family, "cylindrical");
+
+    // The point of the open-palm seat: the four wrapping fingers each stop on
+    // the mug's own surface. A curl pinned at either end means the fit
+    // measured nothing and handed back a fallback - which is what #1385
+    // shipped, a closed fist beside the mug.
+    for (const finger of ["index", "middle", "ring", "pinky"] as const) {
+      assert.ok(
+        grip[finger] > 0 && grip[finger] < 1,
+        `${finger} should stop on the mug, got ${grip[finger]}`,
+      );
+    }
+    // The thumb is the exception, and deliberately so: it lies on whatever the
+    // open palm carries, so it is at contact before it curls at all and the
+    // measured seat's fallback leaves it open rather than closing it through
+    // the mug.
+    assert.ok(
+      grip.thumb >= 0 && grip.thumb <= 1,
+      `thumb curl out of range: ${grip.thumb}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-grip-profiles.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-grip-profiles.e2e.test.ts
@@ -16,6 +16,16 @@ import { cycleToWeapon } from "./helpers/weapon.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
+/**
+ * Out of the palm, in the glove's hand space (`shock2vr::hand_seat`'s
+ * `PALM_NORMAL`). The palm plane is oblique to every hand axis - the palm faces
+ * roughly -X, not -Y - so "the seat put it against the palm" is a projection
+ * onto this, not a sign test on one coordinate.
+ */
+const PALM_NORMAL = [-0.97836, 0.15474, -0.13728];
+
+const dot = (a: number[], b: number[]) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+
 /** Offsets round-trip through `f32`, so compare them with a tolerance. */
 function assertVecClose(actual: number[] | undefined, expected: number[], what: string) {
   assert.ok(actual, `${what} should be present`);
@@ -49,8 +59,8 @@ test(
     assert.ok(Math.abs(mug.scale - 0.65) < 1e-5, `held at ${mug.scale}, expected 0.65`);
     assert.equal(mug.family, "cylindrical", "a mug-sized box is gripped");
     assert.ok(
-      mug.offset[1] < 0,
-      `a measured seat hangs below the palm, got ${mug.offset[1]}`,
+      dot(mug.offset, PALM_NORMAL) > 0,
+      `a measured seat should sit out of the palm, got ${mug.offset}`,
     );
 
     // Nudge it: the readout moves, and the change is merged rather than

--- a/tools/shock2-sdk/test/vr-grip-profiles.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-grip-profiles.e2e.test.ts
@@ -6,6 +6,8 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import { cycleToWeapon } from "./helpers/weapon.js";
+import { dot, sub } from "./helpers/vr-hand.js";
+import type { Vec3 } from "../src/types.js";
 
 // Where a model sits in a VR hand is authored in `assets/vr_grips.json`, with
 // anything it leaves out measured off the model's own box. `/v1/vr/grip` reads
@@ -17,14 +19,19 @@ import { cycleToWeapon } from "./helpers/weapon.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 /**
- * Out of the palm, in the glove's hand space (`shock2vr::hand_seat`'s
- * `PALM_NORMAL`). The palm plane is oblique to every hand axis - the palm faces
- * roughly -X, not -Y - so "the seat put it against the palm" is a projection
- * onto this, not a sign test on one coordinate.
+ * The palm frame, copied from `shock2vr::hand_seat`: the palm's centre, the way
+ * it faces, and how far its skin is from the joints the frame runs through
+ * (`PALM_DEPTH`, 12 mm in world units).
+ *
+ * The palm plane is oblique to every hand axis - the palm faces roughly -X, not
+ * -Y - so "the seat put it against the palm" is a projection onto the normal,
+ * not a sign test on one coordinate. Transcribed rather than served over HTTP,
+ * so `the_palm_frame_matches_the_glove_rig` is what actually guards the numbers;
+ * this checks the *seat* built on them.
  */
-const PALM_NORMAL = [-0.97836, 0.15474, -0.13728];
-
-const dot = (a: number[], b: number[]) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const PALM_CENTRE: Vec3 = [0.005287, -0.000243, -0.058655];
+const PALM_NORMAL: Vec3 = [-0.97836, 0.15474, -0.13728];
+const PALM_DEPTH = 0.012 / 0.762;
 
 /** Offsets round-trip through `f32`, so compare them with a tolerance. */
 function assertVecClose(actual: number[] | undefined, expected: number[], what: string) {
@@ -58,9 +65,15 @@ test(
     assert.equal(mug.source, "heuristic", "an unauthored seat is measured");
     assert.ok(Math.abs(mug.scale - 0.65) < 1e-5, `held at ${mug.scale}, expected 0.65`);
     assert.equal(mug.family, "cylindrical", "a mug-sized box is gripped");
+    // A measured seat puts the item's near face on the palm skin, so its origin
+    // clears the palm plane by at least that skin depth - and by rather more,
+    // since half the mug's own depth is added on top. The seat this replaced
+    // dropped it along hand -Y, which is *across* the knuckles: that lands the
+    // mug 0.014 on the wrong side of the palm and fails here.
+    const outOfPalm = dot(sub(mug.offset as Vec3, PALM_CENTRE), PALM_NORMAL);
     assert.ok(
-      dot(mug.offset, PALM_NORMAL) > 0,
-      `a measured seat should sit out of the palm, got ${mug.offset}`,
+      outOfPalm > PALM_DEPTH,
+      `a measured seat should clear the palm skin (${PALM_DEPTH}), got ${outOfPalm}`,
     );
 
     // Nudge it: the readout moves, and the change is merged rather than


### PR DESCRIPTION
Slice 6b: a pickup sits against the **open** palm, and then the fingers close on it.

#1385 put plain pickups at the right size, but its sheet showed a closed fist *beside* the item. The seat was not off by a nudge — it was on the wrong axis. `hand_seat` documented hand space as "+Y out of the back of the hand, palm faces -Y" and dropped every item along -Y. Measured off the shipped glove rig, -Y runs **across the knuckles**: the palm faces roughly -X and its plane is oblique to every hand axis. So an item landed off the pinky side, the open fingers were already through it, and `hand_fit` — which by design yields nothing for a finger already in contact — handed all five back the canned wrap.

The numbers, off `debug_grips`, before and after:

| item | before | after |
| --- | --- | --- |
| `mug` | thumb 1.0 index 1.0 middle 1.0 ring 0.9 pinky 0.9 | 0.0 / 0.15 / 0.18 / 0.25 / 0.28 |
| `ammoss` | 1.0 / 1.0 / 1.0 / 0.9 / 0.9 | 0.0 / 0.29 / 0.56 / 0.57 / 0.23 |
| `magci` | 0.55 / 1.0 / 0.55 / 0.55 / 0.55 | 0.0 / 0.02 / 0.55 / 0.55 / 0.55 |
| `hamball` | 0.4 / 0.4 / 0.4 / 0.4 / 0.10 | 0.4 / 0.01 / 0.04 / 0.02 / 0.04 |

Every `1.0`/`0.9` above is `GENERIC_GRIP` echoed back — the fist in the old sheet.

### The palm frame

`PALM_ANCHOR` (one point) becomes a frame measured off the open glove's own metacarpals: `PALM_CENTRE`, `PALM_NORMAL`, `PALM_CURL_AXIS`, and `PINCH_POINT`. `hand_glove`'s `the_palm_frame_matches_the_glove_rig` re-derives all four from the shipped GLB and fails if the rig moves under them.

Two things the frame settled that guessing had got backwards:

- **No nudge toward the knuckles.** A grip "sits under the base of the fingers" — but on this rig the open fingers' first phalanges run *below* the palm plane there, so seating that way puts the item into the fingers. Centred on the palm, the mug and the clip go from a 0.01–0.2 curl to a real wrap.
- **The pinch point is not at the open pose.** Open, the thumb and index are 7 cm apart and one behind the other, so a slab landed against the index while the thumb swung past. Searched over the pair's curl range they converge to 1.3 cm at thumb 0.15 / index 0.25 — and the direction between the pads *there* is the palm normal to within a few degrees, which is what makes "thin side to the palm" the right turn rather than a guess.

A measured seat also gets the **open** hand as its fit fallback, not `GENERIC_GRIP`: the seat deliberately puts the item against the open palm, so a finger already touching has finished closing. The thumb is always that finger — it lies on whatever the palm carries — and answering it with a 0.85 curl is what put a closed thumb next to an open hand. Keyed on the family (`Trigger` is the one family nothing measures its way into), so authoring a pickup's offset in the tuner cannot silently change how its fingers land.

### Before / after

Same camera, same scene, only the seat differs.

![before/after](https://gist.githubusercontent.com/tommy-xr/9a7ccba1816950c6947066339fefe928/raw/grips_before_after.png)

### Contact sheet

`debug_grips`, palm-on and from the thumb. The harness itself was part of the bug: it rolled the hand by a hardcoded `Ry(90)·Rz(90)` chosen under the old assumption, which against the measured frame points the palm at the floor — so the one place this work is eyeballed was framing the back of the hand. The roll now comes from `hand_seat::palm_frame`.

![grips](https://gist.githubusercontent.com/tommy-xr/9a7ccba1816950c6947066339fefe928/raw/grips.gif)

![contact sheet](https://gist.githubusercontent.com/tommy-xr/9a7ccba1816950c6947066339fefe928/raw/grips_sheet.png)

| item | family | verdict |
| --- | --- | --- |
| coffee mug `mug` | cylindrical | **pass** — in the palm, fingers curled onto the body, nothing through it. Held by the body, not the handle: see below. |
| clip `ammoss` | cylindrical | **pass** — the clearest win. Was a fist with the clip behind it; now the fingers wrap it. |
| magazine `magci` | pinch | **pass** — a real edge pinch now, held at its near corner and standing away from the hand, which is what #1385 called honest-partial. |
| basketball `hamball` | broad | **pass** — the palm on the ball, fingers splayed almost open. A hand cannot wrap a basketball and no longer pretends to. |
| belt card `scipass` | pinch | **pass** — at the fingertips, face outward, readable. #1387's "same look as the mug at the reader" is gone. |
| the four guns | trigger | **unchanged** — their seats are authored, and `the_profile_file_reproduces_the_grips_it_replaced` still pins all 28 migrated entries. |

### Not done

**The mug's handle.** The brief asked for a handle-aware seat, with an authored profile as the fallback. Neither shipped, and the reason is that `mug.bin` is a *single* sub-object and a single connected island — the handle is welded to the body, so `split_connected` returns one component and there is no sub-feature to find. Authoring it instead means inferring the handle's axis from bounding-box asymmetry alone, which is a guess I could not check cheaply. The mug is meanwhile no longer a fist beside a mug: it is cradled in the palm with the fingers on it and the handle outboard. Left as follow-up, and it needs the mesh rather than its box.

**The thumb reads open on anything the palm carries.** Geometrically it is at contact before it curls, and the sheet shows it lying along the item rather than sticking out — but it is a visible change for every unprofiled pickup and every rotation-only profile, so it is called out rather than buried.

### Tests

Unit: the palm frame is orthonormal and right-handed; a rod lies across the palm with its near face on the skin; a ball's surface lands on the palm; a slab stands on edge with its mid-plane on the pinch line; the seating turn never reflects, per family; only `Trigger` falls back on the canned wrap. Plus `a_seated_handle_is_somewhere_every_finger_can_close_onto_it`, which fits a seated cylinder against the *real* glove rig twice with opposite fallbacks — a finger that answers the same either way measured the item — and fails on the old seat with "Index closed to 1 without stopping on the handle". 1575 pass.

e2e: `vr-finger-fit` gains a `debug_grips` case asserting the mug's and the clip's wrapping fingers each stop on their own surface (both answer 1.0/0.9 on the base ref). `vr-grip-profiles` asserted a measured seat by the sign of its hand Y, which was the bug written into a test; it now projects onto the palm normal and checks the origin clears the palm skin. Ran `vr-finger-fit`, `vr-grip-profiles`, `vr-held-model`, `vr-body-anchors`, `vr-hand-affordance`: 13 pass.

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

### Review

`/xreview` (Claude + Codex). Both engines independently caught that `grip_item`'s range still stopped at the 8th item, so adding the belt card pushed `al_h` out of reach — fixed. Also applied: the harness roll above; the fallback re-keyed from the seat's provenance to the family (Codex: authoring an unchanged offset would otherwise change the pose); the rig tripwire no longer reads a missing joint as the origin; the pinch search no longer re-poses the index once per thumb sample; dead `Trigger` arms in the seat removed; the e2e's near-unfalsifiable sign test strengthened. Duplication pass found no re-implementation of the new geometry; its test-helper extraction notes span modules this PR does not otherwise touch and are left alone.
