### PR TITLE
feat(vr): a hip pouch that hands you a clip for the gun you hold

### DIFF
--- a/shock2vr/src/ammo_pouch.rs
+++ b/shock2vr/src/ammo_pouch.rs
@@ -1,0 +1,32 @@
+//! The ammo pouch: the right hip hands out a clip for the gun you are holding.
+//!
+//! Like the belt card this is **presentation** - there is no pouch object and
+//! nothing extra to save. What is drawn is the top clip of the reserve stack
+//! the pouch would actually hand over, resolved from the inventory every frame,
+//! so the hip is occupied exactly when a grip there would produce something.
+//! An empty pouch simply is not drawn, and the glove's amber light is what says
+//! the gun is held but the reserve has nothing for it.
+
+use cgmath::Matrix4;
+
+use crate::body_frame::BodyFrame;
+
+/// The clip sitting in the pouch this frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PouchClip {
+    /// The clip archetype the withdrawal would hand over.
+    pub template_id: i32,
+    /// Its model, so the hip shows the ammo the player actually carries.
+    pub model: String,
+    /// Rounds in that clip.
+    pub rounds: i32,
+}
+
+/// The clip riding the right hip, upright and facing the way the body does. Its
+/// size comes from the same `vr_grips` profile the hand uses, so hip and hand
+/// can never disagree about how big a clip is.
+pub fn pouch_transform(frame: &BodyFrame, model: &str) -> Matrix4<f32> {
+    Matrix4::from_translation(frame.pouch())
+        * Matrix4::from(frame.rotation())
+        * Matrix4::from_scale(crate::vr_config::held_geometry_scale(model))
+}

--- a/shock2vr/src/belt_card.rs
+++ b/shock2vr/src/belt_card.rs
@@ -13,13 +13,12 @@
 //! opens.
 
 use cgmath::{Matrix4, Quaternion, Vector3};
-use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 
 use crate::{body_frame::BodyFrame, vr_config::Handedness};
 
 /// The gamesys's own ID-card art (`ID Cards`, template -157, `P$ModelName`) -
 /// the model every collected card in the game already wears.
-const CARD_MODEL: &str = "scipass";
+pub const CARD_MODEL: &str = "scipass";
 
 /// How far in front of the card a reader counts as touched, world units
 /// (~15 cm). Short on purpose: the card is placed against the panel, not
@@ -97,23 +96,4 @@ pub fn hand_transform(
 ) -> Matrix4<f32> {
     crate::hand_glove::hand_to_world(position, rotation, hand)
         * crate::vr_config::held_model_hand_transform(CARD_MODEL, hand, 1.0)
-}
-
-/// The card's renderable geometry at `transform`, or nothing if the model is
-/// missing (a data set without it simply has no belt card).
-pub fn scene_objects(asset_cache: &mut AssetCache, transform: Matrix4<f32>) -> Vec<SceneObject> {
-    let Some(model) = asset_cache.get_opt::<_, dark::model::Model, _>(
-        &dark::importers::MODELS_IMPORTER,
-        &format!("{CARD_MODEL}.BIN"),
-    ) else {
-        return Vec::new();
-    };
-    model
-        .clone_scene_objects()
-        .into_iter()
-        .map(|mut object| {
-            object.set_transform(transform);
-            object
-        })
-        .collect()
 }

--- a/shock2vr/src/body_frame.rs
+++ b/shock2vr/src/body_frame.rs
@@ -14,7 +14,8 @@
 //! and roll are ignored outright: leaning over does not move a real belt
 //! sideways.
 
-use cgmath::{InnerSpace, Quaternion, Rad, Rotation, Rotation3, Vector3, vec3};
+use cgmath::{InnerSpace, Matrix4, Quaternion, Rad, Rotation, Rotation3, Vector3, vec3};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 
 use crate::{util::meters, vr_config::Handedness};
 
@@ -36,10 +37,13 @@ const SHOULDER_BEHIND: f32 = meters(0.12);
 /// body's midline.
 const LATERAL_OFFSET: f32 = meters(0.18);
 
-/// Reach radius of each anchor. The belt card is a small object the hand has to
-/// find; a shoulder is a "throw it back there" gesture and is deliberately more
-/// forgiving.
+/// Reach radius of each anchor. The belt card and the ammo pouch are small
+/// objects the hand has to find; a shoulder is a "throw it back there" gesture
+/// and is deliberately more forgiving.
 const BELT_RADIUS: f32 = meters(0.09);
+/// The pouch rides the opposite hip and is the same size as the card, so the
+/// vertical clearance computed from [`BELT_RADIUS`] covers it too.
+const POUCH_RADIUS: f32 = BELT_RADIUS;
 const SHOULDER_RADIUS: f32 = meters(0.15);
 
 /// Minimum vertical gap between the belt and the shoulders, so a deep crouch
@@ -57,6 +61,8 @@ const YAW_TIME_CONSTANT_SECS: f32 = 0.5;
 pub enum BodyAnchor {
     /// Left hip: the belt card.
     Belt,
+    /// Right hip: the ammo pouch that hands out clips for the wielded gun.
+    Pouch,
     /// Either shoulder: the backpack (stow what you hold, draw what you stowed).
     Shoulder(Handedness),
 }
@@ -65,6 +71,7 @@ pub enum BodyAnchor {
 #[derive(Clone, Copy, Debug)]
 pub struct BodyFrame {
     belt: Vector3<f32>,
+    pouch: Vector3<f32>,
     /// Indexed by [`crate::vr_config::hand_slot`].
     shoulders: [Vector3<f32>; 2],
     rotation: Quaternion<f32>,
@@ -74,6 +81,11 @@ impl BodyFrame {
     /// Where the belt card sits.
     pub fn belt(&self) -> Vector3<f32> {
         self.belt
+    }
+
+    /// Where the ammo pouch sits.
+    pub fn pouch(&self) -> Vector3<f32> {
+        self.pouch
     }
 
     /// Where one shoulder socket sits.
@@ -86,12 +98,16 @@ impl BodyFrame {
         self.rotation
     }
 
-    /// Which anchor, if any, a hand at `position` is inside. The belt is tested
-    /// first: it is the smaller, more precisely-placed zone, and
-    /// [`ANCHOR_SEPARATION`] keeps the two from ever overlapping anyway.
+    /// Which anchor, if any, a hand at `position` is inside. The hips are
+    /// tested first: they are the smaller, more precisely-placed zones, and
+    /// [`ANCHOR_SEPARATION`] keeps them from ever overlapping the shoulders
+    /// anyway.
     pub fn anchor_at(&self, position: Vector3<f32>) -> Option<BodyAnchor> {
         if (position - self.belt).magnitude2() <= BELT_RADIUS * BELT_RADIUS {
             return Some(BodyAnchor::Belt);
+        }
+        if (position - self.pouch).magnitude2() <= POUCH_RADIUS * POUCH_RADIUS {
+            return Some(BodyAnchor::Pouch);
         }
         for hand in [Handedness::Left, Handedness::Right] {
             if (position - self.shoulder(hand)).magnitude2() <= SHOULDER_RADIUS * SHOULDER_RADIUS {
@@ -170,8 +186,9 @@ impl BodyFrameTracker {
 
         let shoulder = at(shoulder_y) + back * SHOULDER_BEHIND;
         BodyFrame {
-            // The card rides the left hip.
+            // The card rides the left hip, the ammo pouch the right.
             belt: at(belt_y) - right * LATERAL_OFFSET,
+            pouch: at(belt_y) + right * LATERAL_OFFSET,
             shoulders: [
                 shoulder - right * LATERAL_OFFSET,
                 shoulder + right * LATERAL_OFFSET,
@@ -179,6 +196,30 @@ impl BodyFrameTracker {
             rotation,
         }
     }
+}
+
+/// The renderable geometry of a model worn at a body anchor - the belt card,
+/// the pouch's clip - placed at `transform`. Nothing if the model is missing,
+/// so a data set without it simply wears nothing.
+pub fn worn_scene_objects(
+    asset_cache: &mut AssetCache,
+    model: &str,
+    transform: Matrix4<f32>,
+) -> Vec<SceneObject> {
+    let Some(model) = asset_cache.get_opt::<_, dark::model::Model, _>(
+        &dark::importers::MODELS_IMPORTER,
+        &format!("{model}.BIN"),
+    ) else {
+        return Vec::new();
+    };
+    model
+        .clone_scene_objects()
+        .into_iter()
+        .map(|mut object| {
+            object.set_transform(transform);
+            object
+        })
+        .collect()
 }
 
 /// How long a hand keeps the anchor it was over after losing it, in fixed
@@ -200,6 +241,11 @@ pub enum AnchorGesture {
     /// Opened while holding the card: it goes back on the belt, wherever the
     /// hand is - the card is never dropped in the world.
     ReturnCard(Handedness),
+    /// Gripped at the pouch with an empty hand: take out a clip for the gun the
+    /// OTHER hand wields.
+    TakeClip(Handedness),
+    /// Opened over the pouch holding a clip: its rounds go back to the reserve.
+    ReturnClip(Handedness),
 }
 
 /// What one hand is doing this frame, for [`AnchorGestures::update`].
@@ -214,6 +260,14 @@ pub struct HandAnchorInput {
     pub holding: bool,
     /// Whether the hand holds the belt card.
     pub holds_card: bool,
+    /// Whether the hand holds an ammo clip - the one thing the pouch takes back.
+    pub holds_clip: bool,
+    /// Whether the pouch has a gun to serve this hand: the OTHER hand wields
+    /// one. Without it the pouch is not drawn and claims nothing, so a hand at
+    /// an empty hip goes on interacting with the world.
+    pub pouch_serves: bool,
+    /// Whether that gun's selected ammo has a compatible clip left in reserve.
+    pub pouch_clip_available: bool,
     /// Whether the backpack could take what the hand holds.
     pub can_stow: bool,
     /// Whether there is a stowed weapon left to draw.
@@ -272,9 +326,13 @@ impl AnchorGestures {
         let (gesture, available) = self.intent(input)?;
         let fires = match gesture {
             // Letting go is what puts something away.
-            AnchorGesture::Stow(_) | AnchorGesture::ReturnCard(_) => was_squeezing && !squeezing,
+            AnchorGesture::Stow(_)
+            | AnchorGesture::ReturnCard(_)
+            | AnchorGesture::ReturnClip(_) => was_squeezing && !squeezing,
             // Closing on it is what takes something out.
-            AnchorGesture::Draw(_) | AnchorGesture::TakeCard(_) => !was_squeezing && squeezing,
+            AnchorGesture::Draw(_) | AnchorGesture::TakeCard(_) | AnchorGesture::TakeClip(_) => {
+                !was_squeezing && squeezing
+            }
         };
         (fires && available).then_some(gesture)
     }
@@ -317,6 +375,19 @@ impl AnchorGestures {
                 }
                 // A full hand at the belt has nowhere to put what it holds.
                 BodyAnchor::Belt => return None,
+                // The pouch takes clips back and hands them out. Anything else
+                // in the hand is recognised and refused rather than silently
+                // ignored - the light says the pouch will not take it.
+                BodyAnchor::Pouch if input.holding => {
+                    (AnchorGesture::ReturnClip(input.hand), input.holds_clip)
+                }
+                // No gun wielded means no pouch on the hip at all, so there is
+                // nothing to light up or grip.
+                BodyAnchor::Pouch if !input.pouch_serves => return None,
+                BodyAnchor::Pouch => (
+                    AnchorGesture::TakeClip(input.hand),
+                    input.pouch_clip_available,
+                ),
             },
         )
     }
@@ -472,7 +543,7 @@ mod tests {
         );
     }
 
-    /// The three zones never overlap, standing or crouched - a hand is only
+    /// The four zones never overlap, standing or crouched - a hand is only
     /// ever in one of them, so the gesture it commits to is never a matter of
     /// test order.
     #[test]
@@ -484,6 +555,7 @@ mod tests {
 
             let centers = [
                 (frame.belt(), BELT_RADIUS),
+                (frame.pouch(), POUCH_RADIUS),
                 (frame.shoulder(Handedness::Left), SHOULDER_RADIUS),
                 (frame.shoulder(Handedness::Right), SHOULDER_RADIUS),
             ];
@@ -507,6 +579,7 @@ mod tests {
         let frame = tracker.update(&standing(Quaternion::from_angle_y(Deg(0.0))));
 
         assert_eq!(frame.anchor_at(frame.belt()), Some(BodyAnchor::Belt));
+        assert_eq!(frame.anchor_at(frame.pouch()), Some(BodyAnchor::Pouch));
         for hand in [Handedness::Left, Handedness::Right] {
             assert_eq!(
                 frame.anchor_at(frame.shoulder(hand)),
@@ -530,6 +603,9 @@ mod tests {
             anchor,
             holding: false,
             holds_card: false,
+            holds_clip: false,
+            pouch_serves: true,
+            pouch_clip_available: true,
             can_stow: true,
             can_draw: true,
             card_on_belt: true,
@@ -819,6 +895,7 @@ mod tests {
         let frame = tracker.update(&standing(Quaternion::from_angle_y(Deg(0.0))));
         // Facing -Z, the player's left is -X.
         assert!(frame.belt().x < 0.0, "belt should be on the left hip");
+        assert!(frame.pouch().x > 0.0, "pouch should be on the right hip");
         assert!(frame.shoulder(Handedness::Left).x < 0.0);
         assert!(frame.shoulder(Handedness::Right).x > 0.0);
 
@@ -831,6 +908,112 @@ mod tests {
             frame.belt().z > 0.0,
             "facing -X the left hip is at +Z, got {:?}",
             frame.belt()
+        );
+        assert!(
+            frame.pouch().z < 0.0,
+            "facing -X the right hip is at -Z, got {:?}",
+            frame.pouch()
+        );
+    }
+
+    const POUCH: Option<BodyAnchor> = Some(BodyAnchor::Pouch);
+
+    /// The pouch lends a clip to an empty hand and takes one back when the hand
+    /// opens over it.
+    #[test]
+    fn the_pouch_lends_a_clip_and_takes_one_back() {
+        let mut gestures = AnchorGestures::default();
+        let mut hand = at(POUCH);
+        gestures.update(&hand);
+        hand.squeeze = 1.0;
+        assert_eq!(
+            gestures.update(&hand),
+            Some(AnchorGesture::TakeClip(Handedness::Right))
+        );
+
+        let mut carrying = HandAnchorInput {
+            holding: true,
+            holds_clip: true,
+            squeeze: 1.0,
+            ..at(POUCH)
+        };
+        assert_eq!(gestures.update(&carrying), None);
+        carrying.squeeze = 0.0;
+        assert_eq!(
+            gestures.update(&carrying),
+            Some(AnchorGesture::ReturnClip(Handedness::Right))
+        );
+    }
+
+    /// A gun with nothing compatible left in reserve pre-lights amber and
+    /// refuses the grip, rather than handing out rounds that do not exist.
+    #[test]
+    fn a_pouch_with_no_compatible_clip_refuses_and_pre_lights_amber() {
+        use crate::hand_affordance::HandAffordance;
+
+        let mut gestures = AnchorGestures::default();
+        let empty = HandAnchorInput {
+            pouch_clip_available: false,
+            ..at(POUCH)
+        };
+        gestures.update(&empty);
+        assert_eq!(
+            gestures.claim(&empty),
+            Some(HandClaim::Anchor(HandAffordance::Blocked))
+        );
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 1.0,
+                ..empty
+            }),
+            None
+        );
+    }
+
+    /// With no gun wielded there is no pouch on the hip, so the hand is left
+    /// to the world rather than claimed by an anchor that draws nothing.
+    #[test]
+    fn an_unserved_pouch_claims_nothing() {
+        let mut gestures = AnchorGestures::default();
+        let hand = HandAnchorInput {
+            pouch_serves: false,
+            ..at(POUCH)
+        };
+        gestures.update(&hand);
+        assert_eq!(gestures.claim(&hand), None);
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 1.0,
+                ..hand
+            }),
+            None
+        );
+    }
+
+    /// The pouch holds clips, not everything: a hand full of something else
+    /// says so and leaves the release an ordinary world drop.
+    #[test]
+    fn the_pouch_refuses_what_is_not_a_clip() {
+        use crate::hand_affordance::HandAffordance;
+
+        let mut gestures = AnchorGestures::default();
+        let full = HandAnchorInput {
+            holding: true,
+            holds_clip: false,
+            squeeze: 1.0,
+            ..at(POUCH)
+        };
+        gestures.update(&full);
+        assert_eq!(
+            gestures.claim(&full),
+            Some(HandClaim::Anchor(HandAffordance::Blocked))
+        );
+        assert_eq!(
+            gestures.update(&HandAnchorInput {
+                squeeze: 0.0,
+                ..full
+            }),
+            None
         );
     }
 }

--- a/shock2vr/src/body_frame.rs
+++ b/shock2vr/src/body_frame.rs
@@ -37,19 +37,16 @@ const SHOULDER_BEHIND: f32 = meters(0.12);
 /// body's midline.
 const LATERAL_OFFSET: f32 = meters(0.18);
 
-/// Reach radius of each anchor. The belt card and the ammo pouch are small
-/// objects the hand has to find; a shoulder is a "throw it back there" gesture
-/// and is deliberately more forgiving.
-const BELT_RADIUS: f32 = meters(0.09);
-/// The pouch rides the opposite hip and is the same size as the card, so the
-/// vertical clearance computed from [`BELT_RADIUS`] covers it too.
-const POUCH_RADIUS: f32 = BELT_RADIUS;
+/// Reach radius of each anchor. The hips carry small objects the hand has to
+/// find; a shoulder is a "throw it back there" gesture and is deliberately more
+/// forgiving.
+const HIP_RADIUS: f32 = meters(0.09);
 const SHOULDER_RADIUS: f32 = meters(0.15);
 
-/// Minimum vertical gap between the belt and the shoulders, so a deep crouch
+/// Minimum vertical gap between the hips and the shoulders, so a deep crouch
 /// (which lowers the eye, and with it both anchors) can never bring the two
 /// zones into contact and make "which anchor is this" a matter of rounding.
-const ANCHOR_SEPARATION: f32 = BELT_RADIUS + SHOULDER_RADIUS + meters(0.05);
+const ANCHOR_SEPARATION: f32 = HIP_RADIUS + SHOULDER_RADIUS + meters(0.05);
 
 /// Time constant of the yaw low-pass, in seconds. Long enough that a glance
 /// leaves the body where it was, short enough that turning to walk brings the
@@ -103,10 +100,10 @@ impl BodyFrame {
     /// [`ANCHOR_SEPARATION`] keeps them from ever overlapping the shoulders
     /// anyway.
     pub fn anchor_at(&self, position: Vector3<f32>) -> Option<BodyAnchor> {
-        if (position - self.belt).magnitude2() <= BELT_RADIUS * BELT_RADIUS {
+        if (position - self.belt).magnitude2() <= HIP_RADIUS * HIP_RADIUS {
             return Some(BodyAnchor::Belt);
         }
-        if (position - self.pouch).magnitude2() <= POUCH_RADIUS * POUCH_RADIUS {
+        if (position - self.pouch).magnitude2() <= HIP_RADIUS * HIP_RADIUS {
             return Some(BodyAnchor::Pouch);
         }
         for hand in [Handedness::Left, Handedness::Right] {
@@ -378,9 +375,10 @@ impl AnchorGestures {
                 // The pouch takes clips back and hands them out. Anything else
                 // in the hand is recognised and refused rather than silently
                 // ignored - the light says the pouch will not take it.
-                BodyAnchor::Pouch if input.holding => {
-                    (AnchorGesture::ReturnClip(input.hand), input.holds_clip)
-                }
+                BodyAnchor::Pouch if input.holding => (
+                    AnchorGesture::ReturnClip(input.hand),
+                    input.holds_clip && input.can_stow,
+                ),
                 // No gun wielded means no pouch on the hip at all, so there is
                 // nothing to light up or grip.
                 BodyAnchor::Pouch if !input.pouch_serves => return None,
@@ -554,8 +552,8 @@ mod tests {
             let frame = BodyFrameTracker::default().update(&input);
 
             let centers = [
-                (frame.belt(), BELT_RADIUS),
-                (frame.pouch(), POUCH_RADIUS),
+                (frame.belt(), HIP_RADIUS),
+                (frame.pouch(), HIP_RADIUS),
                 (frame.shoulder(Handedness::Left), SHOULDER_RADIUS),
                 (frame.shoulder(Handedness::Right), SHOULDER_RADIUS),
             ];

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -414,6 +414,21 @@ pub struct DebugBodyFrame {
     /// Where the belt card is: "belt", "left", "right", or `null` while the
     /// player has collected no credential.
     pub belt_card: Option<&'static str>,
+    /// The ammo pouch on the other hip.
+    pub pouch: DebugAmmoPouch,
+}
+
+/// The right-hip ammo pouch: where it is, and what a grip there would produce.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugAmmoPouch {
+    pub position: [f32; 3],
+    /// Whether a gun is wielded AND the reserve holds a clip for its selected
+    /// ammo - the pouch is drawn and the glove pre-lights green exactly then.
+    pub available: bool,
+    /// The clip archetype the pouch would hand over, `null` when empty.
+    pub clip_template: Option<i32>,
+    /// How many rounds that clip would carry.
+    pub clip_rounds: Option<i32>,
 }
 
 /// A hand's fitted grip: the family the fit solved in, and the curl it left

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -47,6 +47,9 @@ pub struct InteractionContext<'a> {
     /// Where the belt card is, or `None` while the player has collected no
     /// credential and there is no card.
     pub belt_card: Option<crate::belt_card::CardPlacement>,
+    /// The clip on the ammo pouch's hip, or `None` when the pouch is empty (no
+    /// gun wielded, or nothing compatible in reserve) and nothing is drawn.
+    pub ammo_pouch: Option<crate::ammo_pouch::PouchClip>,
     /// What owns each hand this frame (a body anchor, or the belt card it is
     /// carrying), indexed by `vr_config::hand_slot`. `Some` claims the hand:
     /// its grip belongs to the body rather than to whatever its ray crossed.
@@ -208,6 +211,7 @@ pub struct VrInteraction {
     /// Where the belt card is, so `render` can place it - it is not an entity,
     /// so nothing else in the scene would draw it.
     belt_card: std::cell::Cell<Option<crate::belt_card::CardPlacement>>,
+    ammo_pouch: std::cell::RefCell<Option<crate::ammo_pouch::PouchClip>>,
     /// The grip each hand's last render fitted, indexed by
     /// `vr_config::hand_slot`. Written where the fit is solved (render, which
     /// owns the glove and the asset cache) and read by the debug readout.
@@ -223,6 +227,7 @@ impl VrInteraction {
             hand_climb: crate::vr_climb::HandClimb::default(),
             body_frame: std::cell::Cell::new(None),
             belt_card: std::cell::Cell::new(None),
+            ammo_pouch: std::cell::RefCell::new(None),
             fitted_grips: RefCell::new([None, None]),
         }
     }
@@ -285,6 +290,7 @@ impl PlayerInteraction for VrInteraction {
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
         self.body_frame.set(ctx.body_frame);
         self.belt_card.set(ctx.belt_card);
+        *self.ammo_pouch.borrow_mut() = ctx.ammo_pouch.clone();
         let left_held_entity = self.left_hand.get_held_entity();
         let (right_hand, mut right_msgs) = VirtualHand::update(
             &self.right_hand,
@@ -399,7 +405,25 @@ impl PlayerInteraction for VrInteraction {
                 .map(|frame| crate::belt_card::belt_transform(&frame)),
             None => None,
         } {
-            objs.extend(crate::belt_card::scene_objects(asset_cache, transform));
+            objs.extend(crate::body_frame::worn_scene_objects(
+                asset_cache,
+                crate::belt_card::CARD_MODEL,
+                transform,
+            ));
+        }
+
+        // The ammo pouch: the top clip of the reserve stack a grip at the right
+        // hip would hand over. Drawn only when there is one, so the hip shows
+        // exactly what the gesture would produce.
+        if let (Some(clip), Some(frame)) = (
+            self.ammo_pouch.borrow().as_ref(),
+            self.body_frame.get().as_ref(),
+        ) {
+            objs.extend(crate::body_frame::worn_scene_objects(
+                asset_cache,
+                &clip.model,
+                crate::ammo_pouch::pouch_transform(frame, &clip.model),
+            ));
         }
 
         // Feedback comes from the resolved holds, never a second proximity
@@ -625,6 +649,7 @@ mod tests {
             eye_height: 1.04,
             body_frame: None,
             belt_card: None,
+            ammo_pouch: None,
             anchor_claim: [None, None],
         }
     }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ammo_pouch;
 pub mod audio_log;
 pub mod belt_card;
 pub mod body_frame;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3744,6 +3744,12 @@ impl MissionCore {
                     crate::vr_config::Handedness::Left => &hands_input.left_hand,
                     crate::vr_config::Handedness::Right => &hands_input.right_hand,
                 };
+                let held = [left_hand_held, right_hand_held][slot];
+                // The pouch serves the gun in the OTHER hand, so a clip comes
+                // out on the side that is free to carry it. Both hands full of
+                // guns leaves nobody to take one.
+                let other_gun = [left_hand_held, right_hand_held][1 - slot]
+                    .filter(|weapon| self.magazine_capacity(*weapon).is_some());
                 let input = crate::body_frame::HandAnchorInput {
                     hand,
                     squeeze: hand_input.squeeze_value,
@@ -3754,6 +3760,13 @@ impl MissionCore {
                     )),
                     holding: [left_hand_held, right_hand_held][slot].is_some(),
                     holds_card: self.belt_card_hand == Some(hand),
+                    holds_clip: held.is_some_and(|item| {
+                        crate::mission::reload::is_ammo_clip(&self.world, item)
+                    }),
+                    pouch_serves: other_gun.is_some(),
+                    pouch_clip_available: other_gun.is_some_and(|weapon| {
+                        crate::mission::reload::pouch_withdrawal(&self.world, weapon).is_some()
+                    }),
                     can_stow,
                     can_draw,
                     card_on_belt,
@@ -3809,6 +3822,23 @@ impl MissionCore {
                 crate::body_frame::AnchorGesture::ReturnCard(_) => {
                     self.belt_card_hand = None;
                 }
+                crate::body_frame::AnchorGesture::TakeClip(hand) => {
+                    if let Some(entity_id) = self.take_pouch_clip(asset_cache, hand) {
+                        effects.push(Effect::GrabEntity {
+                            entity_id,
+                            hand,
+                            current_parent_id: None,
+                        });
+                    }
+                }
+                crate::body_frame::AnchorGesture::ReturnClip(hand) => {
+                    // Back in the pouch is back in the backpack: claimed
+                    // exactly the way a shoulder stow is, so one deposit path
+                    // covers both and the rounds are never duplicated.
+                    if let Some(entity_id) = [left_hand_held, right_hand_held][hand_slot(hand)] {
+                        store.push((entity_id, None));
+                    }
+                }
             }
         }
 
@@ -3824,6 +3854,7 @@ impl MissionCore {
             eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
             body_frame,
             belt_card: belt_card_placement(&self.world, self.belt_card_hand),
+            ammo_pouch: body_frame.and_then(|_| self.ammo_pouch_clip()),
             anchor_claim,
         });
         rewrite_strip_release(&mut interaction_msgs, &store, &collect);
@@ -9014,6 +9045,93 @@ impl MissionCore {
         cues
     }
 
+    /// The gun in `hand`, if it is one that takes a magazine.
+    fn wielded_gun(&self, hand: crate::vr_config::Handedness) -> Option<EntityId> {
+        let (left, right) = self.interaction.held_entities();
+        let held = [left, right][hand_slot(hand)]?;
+        self.magazine_capacity(held).map(|_| held)
+    }
+
+    /// The clip sitting on the ammo pouch's hip: the one a grip there would
+    /// hand over, for whichever wielded gun the reserve can serve. `None` when
+    /// no gun is wielded or nothing compatible is left, which is exactly when
+    /// the hip is drawn empty and the glove pre-lights amber.
+    fn ammo_pouch_clip(&self) -> Option<crate::ammo_pouch::PouchClip> {
+        for hand in [
+            crate::vr_config::Handedness::Left,
+            crate::vr_config::Handedness::Right,
+        ] {
+            let Some(weapon) = self.wielded_gun(hand) else {
+                continue;
+            };
+            let Some(withdrawal) = crate::mission::reload::pouch_withdrawal(&self.world, weapon)
+            else {
+                continue;
+            };
+            // The pouch shows the ammo the player actually carries, so the
+            // model comes off the reserve stack rather than the archetype.
+            let Some(model) = self
+                .world
+                .borrow::<View<PropModelName>>()
+                .ok()
+                .and_then(|models| {
+                    models
+                        .get(withdrawal.item)
+                        .ok()
+                        .map(|model| model.0.clone())
+                })
+            else {
+                continue;
+            };
+            return Some(crate::ammo_pouch::PouchClip {
+                template_id: withdrawal.template_id,
+                model,
+                rounds: withdrawal.rounds,
+            });
+        }
+        None
+    }
+
+    /// Take one clip out of the reserve for the gun in `hand`'s other hand, and
+    /// return the entity to put in `hand`.
+    ///
+    /// A stack the clip empties is handed over as it stands - that is the strip
+    /// withdraw, unchanged. A larger stack is split: the clip carrying the
+    /// rounds is minted first and the reserve debited only once it exists, so
+    /// the rounds are in exactly one place at every instant and a failed mint
+    /// costs the player nothing.
+    fn take_pouch_clip(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        hand: crate::vr_config::Handedness,
+    ) -> Option<EntityId> {
+        let weapon = self.wielded_gun(crate::vr_config::other_hand(hand))?;
+        let withdrawal = crate::mission::reload::pouch_withdrawal(&self.world, weapon)?;
+        if withdrawal.takes_whole_stack {
+            return Some(withdrawal.item);
+        }
+        let entity_id = match self.spawn_into_backpack(asset_cache, withdrawal.template_id) {
+            Ok(entity_id) => entity_id,
+            Err(e) => {
+                game_log!(WARN, "Pouch clip could not be carried: {e}");
+                return None;
+            }
+        };
+        self.world.add_component(
+            entity_id,
+            dark::properties::PropStackCount(withdrawal.rounds),
+        );
+        if !crate::mission::reload::take_rounds_from_reserve(
+            &self.world,
+            withdrawal.item,
+            withdrawal.rounds,
+        ) {
+            self.destroy_entity(entity_id);
+            return None;
+        }
+        Some(entity_id)
+    }
+
     /// The belt card held against a reader. The card is a credential, not a
     /// tool: it sends the target the same `Frob` a hand would, and the door's
     /// own script runs the same key check - so a touch opens exactly what the
@@ -11989,6 +12107,15 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .ok()
                     .and_then(|names| names.get(entity_id).ok().map(|name| name.0.clone()))
             }),
+            pouch: {
+                let clip = self.ammo_pouch_clip();
+                crate::game_scene::DebugAmmoPouch {
+                    position: xyz(frame.pouch()),
+                    available: clip.is_some(),
+                    clip_template: clip.as_ref().map(|clip| clip.template_id),
+                    clip_rounds: clip.as_ref().map(|clip| clip.rounds),
+                }
+            },
             belt_card: belt_card_placement(&self.world, self.belt_card_hand).map(|placement| {
                 match placement {
                     crate::belt_card::CardPlacement::Belt => "belt",

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3748,8 +3748,8 @@ impl MissionCore {
                 // The pouch serves the gun in the OTHER hand, so a clip comes
                 // out on the side that is free to carry it. Both hands full of
                 // guns leaves nobody to take one.
-                let other_gun = [left_hand_held, right_hand_held][1 - slot]
-                    .filter(|weapon| self.magazine_capacity(*weapon).is_some());
+                let other_gun = self.wielded_gun(crate::vr_config::other_hand(hand));
+                let pouch_offer = self.pouch_withdrawal_for_hand(hand);
                 let input = crate::body_frame::HandAnchorInput {
                     hand,
                     squeeze: hand_input.squeeze_value,
@@ -3758,15 +3758,13 @@ impl MissionCore {
                         player_rot,
                         hand_input.position,
                     )),
-                    holding: [left_hand_held, right_hand_held][slot].is_some(),
+                    holding: held.is_some(),
                     holds_card: self.belt_card_hand == Some(hand),
                     holds_clip: held.is_some_and(|item| {
                         crate::mission::reload::is_ammo_clip(&self.world, item)
                     }),
                     pouch_serves: other_gun.is_some(),
-                    pouch_clip_available: other_gun.is_some_and(|weapon| {
-                        crate::mission::reload::pouch_withdrawal(&self.world, weapon).is_some()
-                    }),
+                    pouch_clip_available: pouch_offer.is_some(),
                     can_stow,
                     can_draw,
                     card_on_belt,
@@ -7234,7 +7232,19 @@ impl MissionCore {
                     // itself, via the `StoreItem` the controller returns. VR
                     // grabs into an occupied hand no-op, so nothing is
                     // displaced there.
-                    let grab_effects = self.interaction.grab(&self.world, entity_id, hand);
+                    // Effects are processed sequentially, so an earlier one in
+                    // the same batch may already have consumed the item (a
+                    // reload draining the very reserve stack the pouch handed
+                    // over). Grabbing a dead id would wedge the hand shut.
+                    let is_alive = self
+                        .world
+                        .borrow::<EntitiesView>()
+                        .is_ok_and(|entities| entities.is_alive(entity_id));
+                    let grab_effects = if is_alive {
+                        self.interaction.grab(&self.world, entity_id, hand)
+                    } else {
+                        Vec::new()
+                    };
                     self.process_virtual_hand_effects(asset_cache, grab_effects);
 
                     if self.interaction.is_holding(entity_id) {
@@ -9052,44 +9062,55 @@ impl MissionCore {
         self.magazine_capacity(held).map(|_| held)
     }
 
-    /// The clip sitting on the ammo pouch's hip: the one a grip there would
-    /// hand over, for whichever wielded gun the reserve can serve. `None` when
-    /// no gun is wielded or nothing compatible is left, which is exactly when
-    /// the hip is drawn empty and the glove pre-lights amber.
-    fn ammo_pouch_clip(&self) -> Option<crate::ammo_pouch::PouchClip> {
-        for hand in [
+    /// What a grip at the ammo pouch would hand to `hand`: `hand` must be empty
+    /// to carry a clip, and the OTHER hand must wield the gun the clip is for.
+    ///
+    /// The one rule the pre-light, the drawn clip and the committed gesture all
+    /// read, so the hip can never show a clip the grip would not produce.
+    fn pouch_withdrawal_for_hand(
+        &self,
+        hand: crate::vr_config::Handedness,
+    ) -> Option<crate::mission::reload::PouchWithdrawal> {
+        let (left, right) = self.interaction.held_entities();
+        if [left, right][hand_slot(hand)].is_some() {
+            return None;
+        }
+        let weapon = self.wielded_gun(crate::vr_config::other_hand(hand))?;
+        crate::mission::reload::pouch_withdrawal(&self.world, weapon)
+    }
+
+    /// The clip on the pouch's hip: whichever hand could take one, takes it.
+    fn ammo_pouch_offer(&self) -> Option<crate::mission::reload::PouchWithdrawal> {
+        [
             crate::vr_config::Handedness::Left,
             crate::vr_config::Handedness::Right,
-        ] {
-            let Some(weapon) = self.wielded_gun(hand) else {
-                continue;
-            };
-            let Some(withdrawal) = crate::mission::reload::pouch_withdrawal(&self.world, weapon)
-            else {
-                continue;
-            };
-            // The pouch shows the ammo the player actually carries, so the
-            // model comes off the reserve stack rather than the archetype.
-            let Some(model) = self
-                .world
-                .borrow::<View<PropModelName>>()
-                .ok()
-                .and_then(|models| {
-                    models
-                        .get(withdrawal.item)
-                        .ok()
-                        .map(|model| model.0.clone())
-                })
-            else {
-                continue;
-            };
-            return Some(crate::ammo_pouch::PouchClip {
-                template_id: withdrawal.template_id,
-                model,
-                rounds: withdrawal.rounds,
-            });
-        }
-        None
+        ]
+        .into_iter()
+        .find_map(|hand| self.pouch_withdrawal_for_hand(hand))
+    }
+
+    /// The pouch's clip as something to draw. `None` when the pouch is empty -
+    /// which is exactly when the hip shows nothing and the glove pre-lights
+    /// amber.
+    fn ammo_pouch_clip(&self) -> Option<crate::ammo_pouch::PouchClip> {
+        let withdrawal = self.ammo_pouch_offer()?;
+        // The pouch shows the ammo the player actually carries, so the model
+        // comes off the reserve stack rather than the archetype.
+        let model = self
+            .world
+            .borrow::<View<PropModelName>>()
+            .ok()
+            .and_then(|models| {
+                models
+                    .get(withdrawal.item)
+                    .ok()
+                    .map(|model| model.0.clone())
+            })?;
+        Some(crate::ammo_pouch::PouchClip {
+            template_id: withdrawal.template_id,
+            model,
+            rounds: withdrawal.rounds,
+        })
     }
 
     /// Take one clip out of the reserve for the gun in `hand`'s other hand, and
@@ -9105,22 +9126,11 @@ impl MissionCore {
         asset_cache: &mut AssetCache,
         hand: crate::vr_config::Handedness,
     ) -> Option<EntityId> {
-        let weapon = self.wielded_gun(crate::vr_config::other_hand(hand))?;
-        let withdrawal = crate::mission::reload::pouch_withdrawal(&self.world, weapon)?;
+        let withdrawal = self.pouch_withdrawal_for_hand(hand)?;
         if withdrawal.takes_whole_stack {
             return Some(withdrawal.item);
         }
-        let entity_id = match self.spawn_into_backpack(asset_cache, withdrawal.template_id) {
-            Ok(entity_id) => entity_id,
-            Err(e) => {
-                game_log!(WARN, "Pouch clip could not be carried: {e}");
-                return None;
-            }
-        };
-        self.world.add_component(
-            entity_id,
-            dark::properties::PropStackCount(withdrawal.rounds),
-        );
+        let entity_id = self.mint_clip(asset_cache, withdrawal.template_id, withdrawal.rounds)?;
         if !crate::mission::reload::take_rounds_from_reserve(
             &self.world,
             withdrawal.item,
@@ -9462,19 +9472,32 @@ impl MissionCore {
         clip_template: i32,
         rounds: i32,
     ) -> bool {
+        let Some(_) = self.mint_clip(asset_cache, clip_template, rounds) else {
+            return false;
+        };
+        crate::mission::reload::empty_magazine(&self.world, weapon);
+        true
+    }
+
+    /// Instantiate one clip of `clip_template` holding exactly `rounds` rounds
+    /// into the backpack. The archetype carries its own authored stack size, so
+    /// the count is overwritten with what this clip actually holds.
+    fn mint_clip(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        clip_template: i32,
+        rounds: i32,
+    ) -> Option<EntityId> {
         let entity_id = match self.spawn_into_backpack(asset_cache, clip_template) {
             Ok(entity_id) => entity_id,
             Err(e) => {
-                game_log!(WARN, "Ejected clip could not be carried: {e}");
-                return false;
+                game_log!(WARN, "Minted clip could not be carried: {e}");
+                return None;
             }
         };
-        // The archetype carries its authored stack size; this clip holds
-        // exactly what came out of the magazine.
         self.world
             .add_component(entity_id, dark::properties::PropStackCount(rounds));
-        crate::mission::reload::empty_magazine(&self.world, weapon);
-        true
+        Some(entity_id)
     }
 
     /// Instantiate `template_id` and route it through the ordinary pickup path
@@ -12108,12 +12131,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .and_then(|names| names.get(entity_id).ok().map(|name| name.0.clone()))
             }),
             pouch: {
-                let clip = self.ammo_pouch_clip();
+                let offer = self.ammo_pouch_offer();
                 crate::game_scene::DebugAmmoPouch {
                     position: xyz(frame.pouch()),
-                    available: clip.is_some(),
-                    clip_template: clip.as_ref().map(|clip| clip.template_id),
-                    clip_rounds: clip.as_ref().map(|clip| clip.rounds),
+                    available: offer.is_some(),
+                    clip_template: offer.map(|offer| offer.template_id),
+                    clip_rounds: offer.map(|offer| offer.rounds),
                 }
             },
             belt_card: belt_card_placement(&self.world, self.belt_card_hand).map(|placement| {

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -352,13 +352,12 @@ pub(crate) fn pouch_withdrawal(world: &World, weapon: EntityId) -> Option<PouchW
         .into_iter()
         .next()?;
     let template_id = crate::scripts::script_util::entity_class_template_id(world, item)?;
+    // `compatible_reserve_items` already rejected spent stacks, so this is the
+    // stack's real, positive size.
     let stack = world
         .borrow::<View<PropStackCount>>()
         .ok()
         .and_then(|stacks| stacks.get(item).ok().map(|stack| stack.0))?;
-    if stack <= 0 {
-        return None;
-    }
     // Reserve stacks are counted in ROUNDS, so a clip's worth is the
     // archetype's authored stack size. An archetype with no authored size has
     // no defined clip, and the whole remaining stack comes out in one go.
@@ -404,8 +403,8 @@ fn clip_size_of(
 }
 
 /// Take `rounds` out of a reserve stack, for a pouch withdrawal that splits it.
-/// The caller then mints the clip that carries them, so the rounds exist in
-/// exactly one place at every instant. `false` leaves the stack untouched.
+/// The caller debits only once the clip carrying the rounds exists, so they are
+/// in exactly one place at every instant. `false` leaves the stack untouched.
 pub(crate) fn take_rounds_from_reserve(world: &World, item: EntityId, rounds: i32) -> bool {
     let Ok(mut stacks) = world.borrow::<ViewMut<PropStackCount>>() else {
         return false;

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -392,10 +392,14 @@ fn clip_size_of(
     let hierarchy = world
         .borrow::<UniqueView<crate::mission::GlobalTemplateHierarchy>>()
         .ok()?;
-    clip_templates
-        .iter()
-        .find(|clip| hierarchy.is_or_descends_from(class_template_id, **clip))
-        .and_then(|clip| clips.clip_sizes.get(clip))
+    // `get_ancestors` is root-first, so the NEAREST clip archetype the item
+    // descends from is the last match: a mission's own small clip holds six
+    // rounds, not the twelve of the family archetype it ultimately inherits.
+    dark::ss2_entity_info::get_ancestors(&hierarchy.0, &class_template_id)
+        .into_iter()
+        .rev()
+        .find(|ancestor| clip_templates.contains(ancestor))
+        .and_then(|clip| clips.clip_sizes.get(&clip))
         .copied()
 }
 
@@ -774,6 +778,102 @@ mod tests {
                 .unwrap()
                 .0
         }
+    }
+
+    /// The pouch hands out one clip's worth - the archetype's authored stack
+    /// size - and leaves the rest of the stack behind.
+    #[test]
+    fn the_pouch_hands_out_one_clips_worth() {
+        let mut fixture = Fixture::new(0, 0);
+        let reserve = fixture.reserve(STD_CLIP, 30);
+
+        let withdrawal = pouch_withdrawal(&fixture.world, fixture.weapon).unwrap();
+        assert_eq!(
+            withdrawal,
+            PouchWithdrawal {
+                item: reserve,
+                template_id: STD_CLIP,
+                rounds: 12,
+                takes_whole_stack: false,
+            }
+        );
+        assert!(take_rounds_from_reserve(
+            &fixture.world,
+            withdrawal.item,
+            withdrawal.rounds
+        ));
+        assert_eq!(fixture.rounds(reserve), 18, "the rest stays in the pouch");
+    }
+
+    /// A stack smaller than a clip comes out whole, so the hand gets the stack
+    /// itself and nothing has to be minted.
+    #[test]
+    fn a_short_stack_comes_out_whole() {
+        let mut fixture = Fixture::new(0, 0);
+        let reserve = fixture.reserve(STD_CLIP, 5);
+
+        let withdrawal = pouch_withdrawal(&fixture.world, fixture.weapon).unwrap();
+        assert_eq!(withdrawal.item, reserve);
+        assert_eq!(withdrawal.rounds, 5);
+        assert!(withdrawal.takes_whole_stack);
+    }
+
+    /// The pouch hands out the clip the player actually carries, sized by the
+    /// archetype it descends from - not the family archetype the `Clip`
+    /// relation names.
+    #[test]
+    fn the_pouch_hands_out_the_carried_archetype() {
+        let mut fixture = Fixture::new(0, 0);
+        let reserve = fixture.reserve(EARTH_SMALL_STD_CLIP, 20);
+
+        let withdrawal = pouch_withdrawal(&fixture.world, fixture.weapon).unwrap();
+        assert_eq!(withdrawal.item, reserve);
+        assert_eq!(withdrawal.template_id, EARTH_SMALL_STD_CLIP);
+        assert_eq!(
+            withdrawal.rounds, 6,
+            "a small clip holds 6, however big the stack"
+        );
+    }
+
+    /// Nothing compatible in reserve is an EMPTY pouch, not a free clip.
+    #[test]
+    fn an_empty_pouch_hands_out_nothing() {
+        let mut fixture = Fixture::new(0, 0);
+        assert_eq!(pouch_withdrawal(&fixture.world, fixture.weapon), None);
+
+        // Ammo for the OTHER selected type is not this gun's ammo.
+        fixture.reserve(HE_CLIP, 12);
+        assert_eq!(pouch_withdrawal(&fixture.world, fixture.weapon), None);
+
+        // A spent stack is not a source either.
+        fixture.reserve(STD_CLIP, 0);
+        assert_eq!(pouch_withdrawal(&fixture.world, fixture.weapon), None);
+    }
+
+    /// The pouch follows the SELECTED ammo, so cycling ammo type changes what
+    /// the hip offers.
+    #[test]
+    fn the_pouch_follows_the_selected_ammo() {
+        let mut fixture = Fixture::new(0, 1);
+        let he = fixture.reserve(HE_CLIP, 12);
+        fixture.reserve(STD_CLIP, 12);
+
+        let withdrawal = pouch_withdrawal(&fixture.world, fixture.weapon).unwrap();
+        assert_eq!(withdrawal.item, he);
+        assert_eq!(withdrawal.template_id, HE_CLIP);
+    }
+
+    /// The debit never invents rounds: it refuses a take the stack cannot
+    /// cover, and leaves the stack alone.
+    #[test]
+    fn a_reserve_debit_never_goes_negative() {
+        let mut fixture = Fixture::new(0, 0);
+        let reserve = fixture.reserve(STD_CLIP, 5);
+
+        assert!(!take_rounds_from_reserve(&fixture.world, reserve, 12));
+        assert_eq!(fixture.rounds(reserve), 5);
+        assert!(!take_rounds_from_reserve(&fixture.world, reserve, 0));
+        assert_eq!(fixture.rounds(reserve), 5);
     }
 
     #[test]

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -91,7 +91,7 @@ pub(crate) struct ReloadOutcome {
 /// order the data's `Clip` relation authors them. `None` when the weapon has no
 /// projectile links at all, or the selected projectile has no clip archetype -
 /// which is also what makes its rounds unreturnable (see [`can_unload`]).
-fn selected_clip_templates(world: &World, weapon: EntityId) -> Option<Vec<i32>> {
+pub(crate) fn selected_clip_templates(world: &World, weapon: EntityId) -> Option<Vec<i32>> {
     let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
     if projectiles.is_empty() {
         return None;
@@ -277,7 +277,7 @@ pub(crate) fn clip_insert_zone_engaged(was_engaged: bool, distance: f32, scale: 
 
 /// The backpack's stackable items whose class descends from one of
 /// `clip_templates` - the reserve a reload draws from and an unload merges into.
-fn compatible_reserve_items(world: &World, clip_templates: &[i32]) -> Vec<EntityId> {
+pub(crate) fn compatible_reserve_items(world: &World, clip_templates: &[i32]) -> Vec<EntityId> {
     let Ok(inventory) = world
         .borrow::<UniqueView<crate::mission::PlayerInfo>>()
         .map(|player| player.inventory_entity_id)
@@ -322,6 +322,98 @@ fn compatible_reserve_items(world: &World, clip_templates: &[i32]) -> Vec<Entity
                 })
         })
         .collect()
+}
+
+/// One clip's worth of reserve ammo, ready to be handed out of the belt pouch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PouchWithdrawal {
+    /// The reserve stack the rounds come out of.
+    pub item: EntityId,
+    /// That stack's own archetype - the clip the player actually carries, so a
+    /// pouch full of small clips never hands out a large one.
+    pub template_id: i32,
+    /// Rounds in the withdrawn clip: the archetype's authored stack size, or
+    /// the whole remaining stack when it holds less.
+    pub rounds: i32,
+    /// Whether `rounds` empties `item`, so the stack itself can be handed over
+    /// rather than split. Splitting is what needs a fresh entity.
+    pub takes_whole_stack: bool,
+}
+
+/// The clip the ammo pouch would hand out for `weapon`'s CURRENTLY selected
+/// ammo, or `None` when nothing compatible is in reserve - which is exactly
+/// when the pouch is empty and the glove pre-lights amber.
+///
+/// Rounds are never fabricated: everything here is measured off a stack the
+/// player is already carrying.
+pub(crate) fn pouch_withdrawal(world: &World, weapon: EntityId) -> Option<PouchWithdrawal> {
+    let clip_templates = selected_clip_templates(world, weapon)?;
+    let item = compatible_reserve_items(world, &clip_templates)
+        .into_iter()
+        .next()?;
+    let template_id = crate::scripts::script_util::entity_class_template_id(world, item)?;
+    let stack = world
+        .borrow::<View<PropStackCount>>()
+        .ok()
+        .and_then(|stacks| stacks.get(item).ok().map(|stack| stack.0))?;
+    if stack <= 0 {
+        return None;
+    }
+    // Reserve stacks are counted in ROUNDS, so a clip's worth is the
+    // archetype's authored stack size. An archetype with no authored size has
+    // no defined clip, and the whole remaining stack comes out in one go.
+    let clip_size = world
+        .borrow::<UniqueView<GlobalProjectileClips>>()
+        .ok()
+        .and_then(|clips| clip_size_of(world, &clips, &clip_templates, template_id))
+        .unwrap_or(stack);
+    let rounds = stack.min(clip_size.max(1));
+    Some(PouchWithdrawal {
+        item,
+        template_id,
+        rounds,
+        takes_whole_stack: rounds >= stack,
+    })
+}
+
+/// The authored stack size for the clip archetype `class_template_id` descends
+/// from. A reserve item's own class may be a mission-local child of the
+/// archetype the `Clip` relation names, so the size is looked up through the
+/// hierarchy rather than on the class directly.
+fn clip_size_of(
+    world: &World,
+    clips: &GlobalProjectileClips,
+    clip_templates: &[i32],
+    class_template_id: i32,
+) -> Option<i32> {
+    if let Some(size) = clips.clip_sizes.get(&class_template_id) {
+        return Some(*size);
+    }
+    let hierarchy = world
+        .borrow::<UniqueView<crate::mission::GlobalTemplateHierarchy>>()
+        .ok()?;
+    clip_templates
+        .iter()
+        .find(|clip| hierarchy.is_or_descends_from(class_template_id, **clip))
+        .and_then(|clip| clips.clip_sizes.get(clip))
+        .copied()
+}
+
+/// Take `rounds` out of a reserve stack, for a pouch withdrawal that splits it.
+/// The caller then mints the clip that carries them, so the rounds exist in
+/// exactly one place at every instant. `false` leaves the stack untouched.
+pub(crate) fn take_rounds_from_reserve(world: &World, item: EntityId, rounds: i32) -> bool {
+    let Ok(mut stacks) = world.borrow::<ViewMut<PropStackCount>>() else {
+        return false;
+    };
+    let Ok(stack) = (&mut stacks).get(item) else {
+        return false;
+    };
+    if rounds <= 0 || stack.0 < rounds {
+        return false;
+    }
+    stack.0 -= rounds;
+    true
 }
 
 /// Move matching reserve rounds from the backpack into `weapon`.

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -83,6 +83,15 @@ pub fn hand_slot(hand: Handedness) -> usize {
     }
 }
 
+/// The other hand. The ammo pouch serves the gun in it, so the clip comes out
+/// on the side that is free to carry it.
+pub fn other_hand(hand: Handedness) -> Handedness {
+    match hand {
+        Handedness::Left => Handedness::Right,
+        Handedness::Right => Handedness::Left,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct VRHandModelPerHandAdjustments {
     pub offset: Vector3<f32>,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -689,6 +689,21 @@ export interface BodyFrame {
   last_stowed_weapon: string | null;
   /** Where the belt card is, or null while no credential has been collected. */
   belt_card: "belt" | "left" | "right" | null;
+  /** The ammo pouch on the right hip. */
+  pouch: AmmoPouch;
+}
+
+/** The right-hip ammo pouch: where it is, and what a grip there would produce
+ * (GET /v1/info -> player.body_frame.pouch). */
+export interface AmmoPouch {
+  position: [number, number, number];
+  /** True when a gun is wielded AND the reserve holds a clip for its selected
+   * ammo - the pouch is drawn and the glove pre-lights green exactly then. */
+  available: boolean;
+  /** The clip archetype the pouch would hand over, null when empty. */
+  clip_template: number | null;
+  /** How many rounds that clip would carry. */
+  clip_rounds: number | null;
 }
 
 /** Per-hand affordance names in the /v1/info readout. */

--- a/tools/shock2-sdk/test/helpers/vr-clip.ts
+++ b/tools/shock2-sdk/test/helpers/vr-clip.ts
@@ -22,7 +22,7 @@ export const STD_CLIP = -31;
  * the magazine zone. The live radius rides the gun's wield scale
  * (`reload::clip_insert_radii`), so it is read through
  * [`clipInsertExitRadius`] rather than used raw. */
-export const CLIP_INSERT_EXIT_RADIUS = 0.35;
+const CLIP_INSERT_EXIT_RADIUS = 0.35;
 
 /** The exit radius as a VR-wielded gun actually gets it: the constant above
  * times the live `gun_scale` dev param, so a test is not pinned to a

--- a/tools/shock2-sdk/test/helpers/vr-clip.ts
+++ b/tools/shock2-sdk/test/helpers/vr-clip.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+
+import type { EntitySummary, GameServer, Vec3 } from "../../src/index.js";
+import { ammoOf } from "./weapon.js";
+
+export { ammoOf };
+import {
+  aimVrHandAt,
+  add,
+  quatConjugate,
+  quatRotate,
+  sub,
+  type Quat,
+} from "./vr-hand.js";
+
+/** The debug pistol and the ammo the VR clip scenarios carry to it. */
+export const PISTOL = -17;
+export const STD_CLIP = -31;
+
+/** Mirrors `reload::CLIP_INSERT_EXIT_RADIUS` at the view model's authored size
+ * - what a clip must start OUTSIDE of for an insert to be a genuine entry into
+ * the magazine zone. The live radius rides the gun's wield scale
+ * (`reload::clip_insert_radii`), so it is read through
+ * [`clipInsertExitRadius`] rather than used raw. */
+export const CLIP_INSERT_EXIT_RADIUS = 0.35;
+
+/** The exit radius as a VR-wielded gun actually gets it: the constant above
+ * times the live `gun_scale` dev param, so a test is not pinned to a
+ * particular default. */
+export async function clipInsertExitRadius(game: GameServer): Promise<number> {
+  const params = await game.devParams.list();
+  const scale = params.params.find((p) => p.key === "gun_scale")?.value;
+  assert.ok(typeof scale === "number", "the runtime must expose the gun_scale dev param");
+  return scale * CLIP_INSERT_EXIT_RADIUS;
+}
+
+export function propOf(
+  detail: { properties: { name: string; value: string }[] },
+  name: string,
+): number | undefined {
+  const p = detail.properties.find((x) => x.name === name);
+  return p === undefined ? undefined : Number(p.value);
+}
+
+export function stackOf(detail: {
+  properties: { name: string; value: string }[];
+}): number {
+  const value = propOf(detail, "StackCount");
+  assert.ok(value !== undefined, "a clip should expose a StackCount property");
+  return value;
+}
+
+/**
+ * What the OFF hand is holding.
+ *
+ * `PlayerInfo` carries two hand slots and the snapshot spells the LEFT one
+ * `wielded_entity_id` - flatscreen wields into that slot, so the name is right
+ * there and merely unhelpful here (see `shock2vr::wielded_weapon`). These
+ * scenarios put the gun in the right hand and the clip in the left, so this is
+ * the clip hand.
+ */
+export function offHandEntityId(info: {
+  player: { wielded_entity_id: number | null };
+}): number | null {
+  return info.player.wielded_entity_id;
+}
+
+export const magnitude = (v: Vec3): number => Math.hypot(v[0], v[1], v[2]);
+
+export async function entityById(
+  game: GameServer,
+  id: number,
+): Promise<EntitySummary | undefined> {
+  return (await game.entities.list()).entities.find((e) => e.id === id);
+}
+
+/** Spawn the debug pistol and take hold of it with the VR RIGHT hand, then turn
+ * that hand off the cyber-interface panel so the free left hand owns the canvas
+ * pointer when the interface opens. */
+export async function grabPistol(game: GameServer): Promise<EntitySummary> {
+  await game.input.trigger("DebugCycleWeapon");
+  await game.step({ frames: 10 });
+  const pistol = (await game.entities.list()).entities.find(
+    (e) => e.template_id === PISTOL,
+  );
+  assert.ok(pistol, "DebugCycleWeapon must spawn the Pistol");
+
+  await aimVrHandAt(game, pistol.position as Vec3, 0.3);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal(
+    (await game.info()).player.right_hand_entity_id,
+    pistol.id,
+    "the VR right hand must hold the pistol",
+  );
+
+  // Point the gun hand down and away: a hand aimed at the head-anchored panel
+  // would compete for the canvas pointer the clip hand needs.
+  await game.input.set("right_hand.rotation", [0.5, 0, 0, 0.866]);
+  await game.step({ frames: 5 });
+  return pistol;
+}
+
+/**
+ * Move `hand` until the clip it holds sits at `target` (world space).
+ *
+ * Closed loop rather than an offset table: a held item hangs off its hand by a
+ * per-model grip offset the tests have no business knowing, so it reads where
+ * the clip actually IS and corrects the hand by that world delta (rotated into
+ * the pawn space `/v1/control/input` speaks). Returns the hand position it left
+ * the controller at, and whether the clip survived the trip.
+ */
+export async function steerHeldClip(
+  game: GameServer,
+  hand: "left" | "right",
+  handPosition: Vec3,
+  clipId: number,
+  target: () => Promise<Vec3>,
+): Promise<{ handPosition: Vec3; consumed: boolean }> {
+  let position = handPosition;
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const clip = await entityById(game, clipId);
+    if (!clip) return { handPosition: position, consumed: true };
+    const delta = sub(await target(), clip.position as Vec3);
+    if (magnitude(delta) <= 0.03) return { handPosition: position, consumed: false };
+    const pawnRotation = (await game.info()).player.rotation as Quat;
+    position = add(position, quatRotate(quatConjugate(pawnRotation), delta));
+    await game.input.set(`${hand}_hand.position`, position);
+    await game.step({ frames: 3 });
+  }
+  return { handPosition: position, consumed: false };
+}
+
+/** Where the weapon's magazine zone is centred: its per-model anchor, carried
+ * by the live transform, as the runtime reports it. Read live, since the gun
+ * rides the hand. */
+export async function magazineAnchor(
+  game: GameServer,
+  weaponId: number,
+): Promise<Vec3> {
+  const weapon = await game.entities.detail(weaponId);
+  assert.ok(weapon.magazine_anchor, "a held gun must report its magazine anchor");
+  return weapon.magazine_anchor;
+}
+
+/** Carry the parked clip into the weapon's magazine zone. */
+export async function insertClip(
+  game: GameServer,
+  handPosition: Vec3,
+  clipId: number,
+  weaponId: number,
+): Promise<void> {
+  await steerHeldClip(game, "left", handPosition, clipId, () =>
+    magazineAnchor(game, weaponId),
+  );
+  await game.step({ frames: 5 });
+}
+
+/** Spawn a clip archetype into the backpack and report its authored stack. */
+export async function spawnClip(
+  game: GameServer,
+  template: number,
+): Promise<{ id: number; rounds: number }> {
+  const spawned = await game.player.spawnItem(template);
+  const rounds = stackOf(await game.entities.detail(spawned.entity_id));
+  assert.ok(rounds > 0, "a spawned clip carries rounds");
+  return { id: spawned.entity_id, rounds };
+}
+
+/** Empty `weapon`'s magazine by firing it dry, and report the capacity it
+ * started at - the number a reload has to restore. */
+export async function fireDry(
+  game: GameServer,
+  weaponId: number,
+  fire: (game: GameServer) => Promise<void>,
+): Promise<number> {
+  const capacity = ammoOf(await game.entities.detail(weaponId));
+  assert.ok(capacity > 0, "the debug pistol starts loaded, and starts full");
+  for (let shot = 0; shot < 40; shot += 1) {
+    if (ammoOf(await game.entities.detail(weaponId)) === 0) break;
+    await fire(game);
+  }
+  assert.equal(ammoOf(await game.entities.detail(weaponId)), 0);
+  return capacity;
+}

--- a/tools/shock2-sdk/test/vr-ammo-pouch.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-ammo-pouch.e2e.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
-import { quatConjugate, quatRotate, sub, type Quat } from "./helpers/vr-hand.js";
+import { vrHandLocal } from "./helpers/vr-climb.js";
 import { fireOnce } from "./helpers/weapon.js";
 import {
   STD_CLIP,
@@ -28,23 +28,13 @@ import {
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8666);
 
-/** A world point in the hand channel's pawn-local space. */
-function toPawnLocal(world: Vec3, pawnPosition: Vec3, pawnRotation: Quat): Vec3 {
-  return quatRotate(quatConjugate(pawnRotation), sub(world, pawnPosition));
-}
-
 /** Put the LEFT hand exactly on the pouch the runtime reports this frame. */
 async function reachIntoPouch(game: GameServer): Promise<void> {
-  const info = await game.info();
-  const pouch = info.player.body_frame?.pouch;
+  const pouch = (await game.info()).player.body_frame?.pouch;
   assert.ok(pouch, "VR should report the ammo pouch on the body frame");
   await game.input.set(
     "left_hand.position",
-    toPawnLocal(
-      pouch.position as Vec3,
-      info.player.position as Vec3,
-      info.player.rotation as Quat,
-    ),
+    await vrHandLocal(game, pouch.position as Vec3),
   );
   await game.step({ frames: 4 });
 }
@@ -186,6 +176,38 @@ test(
       await reserveRounds(game, STD_CLIP),
       second.rounds,
       "and its rounds should be back in the reserve",
+    );
+
+    // A stack bigger than one clip is SPLIT, not emptied. Build one by ejecting
+    // the loaded magazine into the stack that is already there.
+    await game.input.trigger("EjectClip");
+    await game.step({ frames: 10 });
+    const pooled = await reserveRounds(game, STD_CLIP);
+    assert.equal(
+      pooled,
+      second.rounds + capacity,
+      "the ejected magazine should merge into the carried stack",
+    );
+
+    await reachIntoPouch(game);
+    assert.equal(
+      (await game.info()).player.body_frame?.pouch.clip_rounds,
+      second.rounds,
+      "the pouch offers ONE clip's worth out of the bigger stack",
+    );
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 6 });
+    const split = offHandEntityId(await game.info());
+    assert.ok(split, "the split withdraw should still fill the hand");
+    assert.equal(
+      stackOf(await game.entities.detail(split)),
+      second.rounds,
+      "the minted clip carries one clip's worth",
+    );
+    assert.equal(
+      await reserveRounds(game, STD_CLIP),
+      pooled - second.rounds,
+      "and exactly that many rounds left the reserve - no more, no fewer",
     );
   },
 );

--- a/tools/shock2-sdk/test/vr-ammo-pouch.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-ammo-pouch.e2e.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { quatConjugate, quatRotate, sub, type Quat } from "./helpers/vr-hand.js";
+import { fireOnce } from "./helpers/weapon.js";
+import {
+  STD_CLIP,
+  ammoOf,
+  entityById,
+  fireDry,
+  grabPistol,
+  insertClip,
+  offHandEntityId,
+  spawnClip,
+  stackOf,
+} from "./helpers/vr-clip.js";
+
+// The right-hip ammo pouch (slice 8): with a gun in one hand, an empty grip at
+// the other hip takes a clip for that gun's SELECTED ammo out of the real
+// reserve, and opening the hand there puts it back. The clip then loads the gun
+// through the existing insert gesture, unchanged.
+//
+// Negative-first: on the parent there is no pouch anchor at all, so
+// `player.body_frame.pouch` does not exist, the hip claims nothing, and a grip
+// there leaves the hand empty.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8666);
+
+/** A world point in the hand channel's pawn-local space. */
+function toPawnLocal(world: Vec3, pawnPosition: Vec3, pawnRotation: Quat): Vec3 {
+  return quatRotate(quatConjugate(pawnRotation), sub(world, pawnPosition));
+}
+
+/** Put the LEFT hand exactly on the pouch the runtime reports this frame. */
+async function reachIntoPouch(game: GameServer): Promise<void> {
+  const info = await game.info();
+  const pouch = info.player.body_frame?.pouch;
+  assert.ok(pouch, "VR should report the ammo pouch on the body frame");
+  await game.input.set(
+    "left_hand.position",
+    toPawnLocal(
+      pouch.position as Vec3,
+      info.player.position as Vec3,
+      info.player.rotation as Quat,
+    ),
+  );
+  await game.step({ frames: 4 });
+}
+
+/** Total reserve rounds the backpack carries in `template` stacks. */
+async function reserveRounds(game: GameServer, template: number): Promise<number> {
+  const items = (await game.player.inventory()).items;
+  let rounds = 0;
+  for (const item of items) {
+    const detail = await game.entities.detail(item.entity_id);
+    if (detail.template_id !== template) continue;
+    rounds += stackOf(detail);
+  }
+  return rounds;
+}
+
+test(
+  "VR: the hip pouch hands out a clip for the gun you hold, and takes it back",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+
+    const pistol = await grabPistol(game);
+
+    // An empty reserve is an empty pouch: nothing drawn, and the hip refuses.
+    const empty = (await game.info()).player.body_frame?.pouch;
+    assert.ok(empty, "the pouch should be reported even while empty");
+    assert.equal(empty.available, false, "no ammo carried means no clip on the hip");
+    assert.equal(empty.clip_template, null);
+
+    await reachIntoPouch(game);
+    assert.equal(
+      (await game.info()).player.hand_affordance.left,
+      "Blocked",
+      "a gun with nothing compatible in reserve should pre-light amber",
+    );
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      offHandEntityId(await game.info()),
+      null,
+      "an empty pouch must not fabricate a clip",
+    );
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+
+    // Empty the gun so the reload has somewhere to put rounds, then stock the
+    // reserve.
+    const capacity = await fireDry(game, pistol.id, fireOnce);
+    const clip = await spawnClip(game, STD_CLIP);
+    assert.ok(
+      clip.rounds >= capacity,
+      `this scenario needs a clip that can fill the magazine (${clip.rounds} vs ${capacity})`,
+    );
+    const stocked = await reserveRounds(game, STD_CLIP);
+    assert.equal(stocked, clip.rounds);
+
+    const pouch = (await game.info()).player.body_frame?.pouch;
+    assert.ok(pouch);
+    assert.equal(pouch.available, true, "a compatible clip fills the pouch");
+    assert.equal(pouch.clip_template, STD_CLIP);
+    assert.equal(pouch.clip_rounds, clip.rounds);
+
+    // Take it: an empty grip at the hip puts a clip in that hand.
+    await reachIntoPouch(game);
+    assert.equal(
+      (await game.info()).player.hand_affordance.left,
+      "Grabbable",
+      "a stocked pouch should pre-light green",
+    );
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 6 });
+    const taken = offHandEntityId(await game.info());
+    assert.ok(taken, "the grip should hand a clip to the free hand");
+    assert.equal(
+      await reserveRounds(game, STD_CLIP),
+      0,
+      "the clip comes out of the real reserve, not out of nowhere",
+    );
+    assert.equal(
+      stackOf(await game.entities.detail(taken)),
+      clip.rounds,
+      "and it carries exactly the rounds the stack held",
+    );
+    assert.equal(
+      (await game.info()).player.body_frame?.pouch.available,
+      false,
+      "the drained pouch should report itself empty",
+    );
+
+    // Carry it to the magazine: the existing insert gesture finishes the reload.
+    await insertClip(game, [0, 0, 0], taken, pistol.id);
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.id)),
+      capacity,
+      "the withdrawn clip should load the pistol",
+    );
+    assert.equal(
+      await entityById(game, taken),
+      undefined,
+      "the consumed clip should be gone",
+    );
+
+    // Put one back: a clip released in the pouch returns to the reserve rather
+    // than falling on the floor.
+    const second = await spawnClip(game, STD_CLIP);
+    await reachIntoPouch(game);
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 6 });
+    const carried = offHandEntityId(await game.info());
+    assert.ok(carried, "the restocked pouch should hand out another clip");
+    assert.equal(await reserveRounds(game, STD_CLIP), 0);
+
+    await reachIntoPouch(game);
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 6 });
+    assert.equal(
+      offHandEntityId(await game.info()),
+      null,
+      "opening the hand at the pouch should give the clip up",
+    );
+    assert.equal(
+      await reserveRounds(game, STD_CLIP),
+      second.rounds,
+      "and its rounds should be back in the reserve",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-ammo-pouch.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-ammo-pouch.e2e.test.ts
@@ -49,11 +49,14 @@ async function reachIntoPouch(game: GameServer): Promise<void> {
   await game.step({ frames: 4 });
 }
 
-/** Total reserve rounds the backpack carries in `template` stacks. */
+/** Total reserve rounds the BACKPACK carries in `template` stacks. A held clip
+ * is still a carried item, so the hands are excluded - the point of every
+ * assertion here is that rounds moved between the reserve and a hand. */
 async function reserveRounds(game: GameServer, template: number): Promise<number> {
   const items = (await game.player.inventory()).items;
   let rounds = 0;
   for (const item of items) {
+    if (item.location !== "inventory") continue;
     const detail = await game.entities.detail(item.entity_id);
     if (detail.template_id !== template) continue;
     rounds += stackOf(detail);
@@ -156,12 +159,20 @@ test(
     // Put one back: a clip released in the pouch returns to the reserve rather
     // than falling on the floor.
     const second = await spawnClip(game, STD_CLIP);
+    // Open the hand first: the withdraw is a grip EDGE, and the hand is still
+    // closed from carrying the last clip into the gun.
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 4 });
     await reachIntoPouch(game);
     await game.input.set("left_hand.squeeze", 1);
     await game.step({ frames: 6 });
     const carried = offHandEntityId(await game.info());
     assert.ok(carried, "the restocked pouch should hand out another clip");
-    assert.equal(await reserveRounds(game, STD_CLIP), 0);
+    assert.equal(
+      await reserveRounds(game, STD_CLIP),
+      0,
+      "the second clip should come out of the reserve too",
+    );
 
     await reachIntoPouch(game);
     await game.input.set("left_hand.squeeze", 0);

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -14,6 +14,22 @@ import {
   type Quat,
 } from "./helpers/vr-hand.js";
 import { fireOnce } from "./helpers/weapon.js";
+import {
+  PISTOL,
+  STD_CLIP,
+  ammoOf,
+  clipInsertExitRadius,
+  entityById,
+  grabPistol,
+  insertClip,
+  magazineAnchor,
+  magnitude,
+  offHandEntityId,
+  propOf,
+  spawnClip,
+  stackOf,
+  steerHeldClip,
+} from "./helpers/vr-clip.js";
 
 // The physical VR reload (R3a): a clip pulled out of the cyber-interface strip
 // with the free hand and carried to the gun the other hand holds loads it -
@@ -26,68 +42,10 @@ import { fireOnce } from "./helpers/weapon.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8636);
 
-/** The debug pistol and the ammo the scenarios carry to it. */
-const PISTOL = -17;
-const STD_CLIP = -31;
+/** High-explosive ammo, and shotgun shells: real ammo, but nothing the
+ * pistol's selected projectile links to. */
 const HE_CLIP = -32;
-/** Shotgun shells: real ammo, but nothing the pistol's projectiles link to. */
 const PELLET_SHOT_BOX = -42;
-
-/** Mirrors `reload::CLIP_INSERT_EXIT_RADIUS` at the view model's authored size
- * - what the clip must start OUTSIDE of for the insert to be a genuine entry
- * into the magazine zone. The live radius rides the gun's wield scale
- * (`reload::clip_insert_radii`), so it is read through `clipInsertExitRadius`
- * rather than used raw. */
-const CLIP_INSERT_EXIT_RADIUS = 0.35;
-
-/** The exit radius as a VR-wielded gun actually gets it: the constant above
- * times the live `gun_scale` dev param, so the test is not pinned to a
- * particular default. */
-async function clipInsertExitRadius(game: GameServer): Promise<number> {
-  const params = await game.devParams.list();
-  const scale = params.params.find((p) => p.key === "gun_scale")?.value;
-  assert.ok(typeof scale === "number", "the runtime must expose the gun_scale dev param");
-  return scale * CLIP_INSERT_EXIT_RADIUS;
-}
-
-function propOf(
-  detail: { properties: { name: string; value: string }[] },
-  name: string,
-): number | undefined {
-  const p = detail.properties.find((x) => x.name === name);
-  return p === undefined ? undefined : Number(p.value);
-}
-
-function ammoOf(detail: {
-  properties: { name: string; value: string }[];
-}): number {
-  const value = propOf(detail, "Ammo");
-  assert.ok(value !== undefined, "a weapon should expose an Ammo property");
-  return value;
-}
-
-function stackOf(detail: {
-  properties: { name: string; value: string }[];
-}): number {
-  const value = propOf(detail, "StackCount");
-  assert.ok(value !== undefined, "a clip should expose a StackCount property");
-  return value;
-}
-
-/**
- * What the OFF hand is holding.
- *
- * `PlayerInfo` carries two hand slots and the snapshot spells the LEFT one
- * `wielded_entity_id` - flatscreen wields into that slot, so the name is right
- * there and merely unhelpful here (see `shock2vr::wielded_weapon`). These
- * scenarios put the gun in the right hand and the clip in the left, so this is
- * the clip hand.
- */
-function offHandEntityId(info: {
-  player: { wielded_entity_id: number | null };
-}): number | null {
-  return info.player.wielded_entity_id;
-}
 
 function tagValue(sound: PlayedSound, tag: string): string | undefined {
   return sound.tags.find(([t]) => t === tag)?.[1];
@@ -106,72 +64,6 @@ async function eventsSince(
 
 async function lastSound(game: GameServer): Promise<number> {
   return (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
-}
-
-const magnitude = (v: Vec3): number => Math.hypot(v[0], v[1], v[2]);
-
-async function entityById(
-  game: GameServer,
-  id: number,
-): Promise<EntitySummary | undefined> {
-  return (await game.entities.list()).entities.find((e) => e.id === id);
-}
-
-/** Spawn the debug pistol and take hold of it with the VR RIGHT hand, then turn
- * that hand off the cyber-interface panel so the free left hand owns the canvas
- * pointer when the interface opens. */
-async function grabPistol(game: GameServer): Promise<EntitySummary> {
-  await game.input.trigger("DebugCycleWeapon");
-  await game.step({ frames: 10 });
-  const pistol = (await game.entities.list()).entities.find(
-    (e) => e.template_id === PISTOL,
-  );
-  assert.ok(pistol, "DebugCycleWeapon must spawn the Pistol");
-
-  await aimVrHandAt(game, pistol.position as Vec3, 0.3);
-  await game.input.set("right_hand.squeeze", 1);
-  await game.step({ frames: 8 });
-  assert.equal(
-    (await game.info()).player.right_hand_entity_id,
-    pistol.id,
-    "the VR right hand must hold the pistol",
-  );
-
-  // Point the gun hand down and away: a hand aimed at the head-anchored panel
-  // would compete for the canvas pointer the clip hand needs.
-  await game.input.set("right_hand.rotation", [0.5, 0, 0, 0.866]);
-  await game.step({ frames: 5 });
-  return pistol;
-}
-
-/**
- * Move `hand` until the clip it holds sits at `target` (world space).
- *
- * Closed loop rather than an offset table: a held item hangs off its hand by a
- * per-model grip offset this test has no business knowing, so it reads where
- * the clip actually IS and corrects the hand by that world delta (rotated into
- * the pawn space `/v1/control/input` speaks). Returns the hand position it left
- * the controller at, and whether the clip survived the trip.
- */
-async function steerHeldClip(
-  game: GameServer,
-  hand: "left" | "right",
-  handPosition: Vec3,
-  clipId: number,
-  target: () => Promise<Vec3>,
-): Promise<{ handPosition: Vec3; consumed: boolean }> {
-  let position = handPosition;
-  for (let attempt = 0; attempt < 6; attempt += 1) {
-    const clip = await entityById(game, clipId);
-    if (!clip) return { handPosition: position, consumed: true };
-    const delta = sub(await target(), clip.position as Vec3);
-    if (magnitude(delta) <= 0.03) return { handPosition: position, consumed: false };
-    const pawnRotation = (await game.info()).player.rotation as Quat;
-    position = add(position, quatRotate(quatConjugate(pawnRotation), delta));
-    await game.input.set(`${hand}_hand.position`, position);
-    await game.step({ frames: 3 });
-  }
-  return { handPosition: position, consumed: false };
 }
 
 /**
@@ -243,39 +135,6 @@ async function takeClipIntoOffHand(
     "the clip must start outside the magazine zone, or the insert proves nothing",
   );
   return parked.handPosition;
-}
-
-/** Where the weapon's magazine zone is centred: its per-model anchor, carried
- * by the live transform, as the runtime reports it. Read live, since the gun
- * rides the hand. */
-async function magazineAnchor(game: GameServer, weaponId: number): Promise<Vec3> {
-  const weapon = await game.entities.detail(weaponId);
-  assert.ok(weapon.magazine_anchor, "a held gun must report its magazine anchor");
-  return weapon.magazine_anchor;
-}
-
-/** Carry the parked clip into the weapon's magazine zone. */
-async function insertClip(
-  game: GameServer,
-  handPosition: Vec3,
-  clipId: number,
-  weaponId: number,
-): Promise<void> {
-  await steerHeldClip(game, "left", handPosition, clipId, () =>
-    magazineAnchor(game, weaponId),
-  );
-  await game.step({ frames: 5 });
-}
-
-/** Spawn a clip archetype into the backpack and report its authored stack. */
-async function spawnClip(
-  game: GameServer,
-  template: number,
-): Promise<{ id: number; rounds: number }> {
-  const spawned = await game.player.spawnItem(template);
-  const rounds = stackOf(await game.entities.detail(spawned.entity_id));
-  assert.ok(rounds > 0, "a spawned clip carries rounds");
-  return { id: spawned.entity_id, rounds };
 }
 
 test(


### PR DESCRIPTION
The right hip is now an ammo pouch. With a gun in one hand, an empty grip at the
other hip takes out a clip for that gun's **selected** ammo; carrying it to the
magazine loads the gun through the existing insert gesture, unchanged.

- `BodyAnchor::Pouch` mirrors the belt card on the opposite hip, same radius,
  disjoint from the belt and both shoulders at every stance (test extended).
- What the hip shows, what the glove pre-lights and what the grip commits to all
  read one rule: the taking hand must be empty and the **other** hand must wield
  a gun the reserve can serve. Green when a clip is there, amber when the gun is
  held but nothing compatible is left.
- The pouch draws the **top clip of the reserve stack itself**, so it is visible
  exactly when a grip would produce something; an empty pouch draws nothing and
  the amber light is what says so.
- Withdrawing never fabricates rounds. A stack a clip would empty is handed over
  as it stands (the strip withdraw, unchanged); a bigger one is split - the clip
  is minted first and the reserve debited only once it exists.
- Releasing a clip in the zone deposits it through the shoulder-stow path.
- Readout: `/v1/info` -> `player.body_frame.pouch` (position, `available`, clip
  template + rounds), plus the SDK type.

Left out, deliberately: a returned clip lands as its own backpack stack rather
than merging back into the one it came from - that is the existing stow deposit's
behaviour and rounds are conserved either way. A full hand carrying a non-clip
past the hip reads amber rather than being ignored, so the pouch says it will not
take it.

Tests: unit coverage for the zone, the availability rule and the withdrawal
accounting (a clip's worth, a short stack, a mission-local archetype's size, an
empty pouch, a debit that never goes negative); `vr-ammo-pouch.e2e.test.ts` walks
the refusal, the withdraw, the reload, the put-back and the stack-splitting
withdraw. Re-ran `vr-clip-insert-reload`, `vr-eject-clip`, `vr-body-anchors`,
`vr-hand-affordance`, `vr-grip-profiles` - all green.


![ammo pouch demo](https://gist.githubusercontent.com/tommy-xr/85070870043831ac9a5972314654f818/raw/demo.gif)

<sub>An empty hand at the right hip takes a clip out of the reserve and carries it into the gun: the hip's clip disappears, the glove lights green as it closes, and the pistol goes 0 -> 12 when the clip reaches the magazine. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep), framed with the free camera.</sub>

| the clip on the hip | taken into the hand |
| --- | --- |
| ![pouch on the hip](https://gist.githubusercontent.com/tommy-xr/85070870043831ac9a5972314654f818/raw/still-hip.png) | ![clip in hand](https://gist.githubusercontent.com/tommy-xr/85070870043831ac9a5972314654f818/raw/still-in-hand.png) |

<sub>Left: the pistol wielded in the right hand, the free glove out to the side, and the reserve's top clip riding the right hip. Right: after the grip - the hip is empty, the clip is in the fingers, and the glove reads green. The LEFT hip is bare in both because the belt card only exists once a credential has been collected, and `debug_weapons` has none.</sub>
