### PR TITLE
feat(explorer): copy and mirror VR grips across hands and models

### DIFF
--- a/projects/astra-vr-hands-round-2.md
+++ b/projects/astra-vr-hands-round-2.md
@@ -525,3 +525,11 @@ The tool prepares left/right drafts (or offers **Prepare left and right drafts**
 which enter the override map when saved. Nanites use `nanocan.bin`; nanite
 pickups still collect immediately in gameplay, so authoring their grip does not
 change their collection behavior.
+
+### Reusing a primary pose
+
+- **Copy pose**, select another model, then **Paste pose** copies position, rotation, finger curls, pose family, and uniform item scale into that hand's draft. The clipboard stays available while switching models/libraries. Target model identity and validation hashes stay intact. Review size and fit before saving.
+- **Mirror to left/right hand** replaces the opposite primary hand's draft using the current pose. It does not save automatically. Weapons use their actual rendered reflection (including the melee contact origin); asymmetric pickups receive an approximate opposite-side starting pose. The two hands remain independently editable.
+- **Cylindrical** is now a finger-curl preset for handles, distinct from the more open, cupped **Ball** preset. Neither preset runs automatic fitting or changes item alignment.
+
+Support anchors and their position sliders use the weapon model reflection too: `atek_h` reflects model Z, while posed melee uses its own contact-origin frame. Support wrist rotation continues to mirror in glove space. This keeps the supporting palm aligned when mirroring the primary grip.

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -360,6 +360,7 @@ impl VrInteraction {
                 model_pose,
                 grip,
                 &rig[1 - primary],
+                anchor,
             );
             return Some(SupportCandidate {
                 entity: held.entity,

--- a/shock2vr/src/vr_support.rs
+++ b/shock2vr/src/vr_support.rs
@@ -1,5 +1,5 @@
 //! Rigid two-anchor posing. Geometry, scale and ownership stay with the primary hand.
-use cgmath::{Deg, Euler, InnerSpace, Quaternion, Rotation, Vector3};
+use cgmath::{Deg, Euler, InnerSpace, Matrix4, Point3, Quaternion, Rotation, Transform, Vector3};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -30,7 +30,7 @@ impl GripPose {
 }
 
 /// Anchor in the normalized weapon mesh used by prepared grips (before item scale).
-/// The left-primary variant mirrors X. This first slice opts in only the wrench.
+/// Stored in the right-primary model frame; the renderer supplies the opposite frame.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SupportProfile {
     pub palm_anchor: [f32; 3],
@@ -68,23 +68,19 @@ impl SupportProfile {
         model: GripPose,
         grip: &crate::vr_grip::ResolvedGrip,
         support_rig: &crate::vr_grip::GripKinematics,
+        scaled_anchor: Vector3<f32>,
     ) -> GripPose {
         let [x, y, z] = self.rotation_degrees;
         let q = Quaternion::from(Euler::new(Deg(x), Deg(y), Deg(z)));
-        // Reflect the authored rotation along with the palm's X mirror.
+        // Glove rotation mirrors hand X independently of the item's model axes.
         let q = if primary == crate::Handedness::Left {
             Quaternion::new(q.s, q.v.x, -q.v.y, -q.v.z)
         } else {
             q
         };
         let rotation = model.rotation * grip.rotation.conjugate() * q;
-        let anchor = self.anchor(if primary == crate::Handedness::Left {
-            0
-        } else {
-            1
-        }) * grip.item_scale;
         GripPose {
-            position: model.point(anchor) - rotation.rotate_vector(support_rig.palm),
+            position: model.point(scaled_anchor) - rotation.rotate_vector(support_rig.palm),
             rotation,
         }
     }
@@ -96,13 +92,27 @@ impl SupportProfile {
     }
 
     pub fn anchor(&self, primary: usize) -> Vector3<f32> {
-        let [x, y, z] = self.palm_anchor;
         let hand = if primary == 0 {
             crate::vr_config::Handedness::Left
         } else {
             crate::vr_config::Handedness::Right
         };
-        hand.mirror_point(Vector3::new(x, y, z))
+        self.anchor_in_frame(hand, crate::Handedness::Left.mirror())
+    }
+    /// Use the same reflection as the rendered item: gun Z and posed melee X
+    /// are different model frames even though both gloves mirror hand X.
+    pub fn anchor_in_frame(
+        &self,
+        primary: crate::Handedness,
+        model_mirror: Matrix4<f32>,
+    ) -> Vector3<f32> {
+        let point = Point3::from(self.palm_anchor);
+        let point = if primary == crate::Handedness::Left {
+            model_mirror.transform_point(point)
+        } else {
+            point
+        };
+        point.to_homogeneous().truncate()
     }
 }
 
@@ -172,7 +182,14 @@ mod tests {
                 palm: vec3(0.01, -0.001, -0.079),
                 normal: Vector3::unit_x(),
             };
-            let pose = profile.glove_pose(primary, model, &grip, &rig);
+            let pose = profile.glove_pose(
+                primary,
+                model,
+                &grip,
+                &rig,
+                profile.anchor_in_frame(primary, crate::Handedness::Left.mirror())
+                    * grip.item_scale,
+            );
             let expected =
                 model.point(primary.mirror_point(vec3(-0.09, 0.354, 0.02)) * grip.item_scale);
             assert!((pose.point(rig.palm) - expected).magnitude() < 1e-5);

--- a/tools/dark_explorer/src/grip_editor.rs
+++ b/tools/dark_explorer/src/grip_editor.rs
@@ -1,12 +1,12 @@
 //! Local authoring of prepared grips. The preview and runtime share geometry,
 //! glove poses, transforms, and fingerprint validation.
 use crate::model_preview::{ModelPreview, PreviewScene};
-use cgmath::{Deg, Euler, InnerSpace, Quaternion, Rad};
+use cgmath::{Deg, Euler, InnerSpace, Matrix3, Matrix4, Quaternion, Rad, SquareMatrix, Transform};
 use eframe::egui;
 use shock2vr::{
     Handedness,
     scenes::debug_interactions::INTERACTION_FIXTURES,
-    vr_grip::{BakedGripEntry, GripHints, GripLibrary, SOLVER_REVISION},
+    vr_grip::{BakedGripEntry, GripHints, GripLibrary, ResolvedGrip, SOLVER_REVISION},
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -14,10 +14,11 @@ use std::{
     path::PathBuf,
 };
 
-pub(crate) const POSE_PRESETS: [(&str, [f32; 5]); 4] = [
+pub(crate) const POSE_PRESETS: [(&str, [f32; 5]); 5] = [
     ("Open", [0.0; 5]),
     ("Point", [0.85, 0.0, 0.9, 0.9, 0.9]),
     ("Closed", [1.0; 5]),
+    ("Cylindrical", [0.65, 0.65, 0.7, 0.7, 0.7]),
     ("Ball", [0.35, 0.25, 0.3, 0.35, 0.4]),
 ];
 
@@ -137,9 +138,48 @@ pub(crate) fn persist_json(
     Ok(())
 }
 
+/// Copies authoring values only; destination identity and validation hashes stay intact.
+fn transfer_grip(
+    source: &ResolvedGrip,
+    target: &mut BakedGripEntry,
+    mirror: Option<Matrix4<f32>>,
+) -> Result<(), String> {
+    let mut grip = source.clone();
+    if let Some(model_mirror) = mirror {
+        // The glove reflects across hand X. Guns and posed melee geometry use
+        // their own model reflection, including the melee contact-origin offset.
+        let scale = Matrix4::from_scale(grip.item_scale);
+        let pose = Handedness::Left.mirror()
+            * Matrix4::from_translation(grip.offset)
+            * Matrix4::from(grip.rotation)
+            * scale
+            * model_mirror.invert().ok_or("Invalid model reflection")?
+            * Matrix4::from_scale(1.0 / grip.item_scale);
+        grip.offset = pose.w.truncate();
+        grip.rotation = Quaternion::from(Matrix3::from_cols(
+            pose.x.truncate(),
+            pose.y.truncate(),
+            pose.z.truncate(),
+        ))
+        .normalize();
+        grip.anchor = model_mirror
+            .transform_point(cgmath::Point3::from(grip.anchor))
+            .into();
+    }
+    grip.contacts = [None; 5];
+    grip.score = 0.0;
+    if !grip.is_valid() {
+        return Err("Cannot transfer an invalid pose".into());
+    }
+    target.grip = grip;
+    target.authored = true;
+    Ok(())
+}
+
 pub struct GripEditor {
     support_editor: crate::support_grip_editor::SupportEditor,
     support_mode: bool,
+    clipboard: Option<(String, String, ResolvedGrip)>,
     document: Result<GripDocument, String>,
     hints: Result<BTreeMap<String, GripHints>, String>,
     model: String,
@@ -187,6 +227,7 @@ impl GripEditor {
         Self {
             support_editor: crate::support_grip_editor::SupportEditor::new(support_path),
             support_mode,
+            clipboard: None,
             document: GripDocument::load(path.unwrap_or(default_path)),
             hints,
             model: model.unwrap_or_else(|| "mug".into()),
@@ -627,11 +668,19 @@ impl GripEditor {
                 ui.label("Primary grip also has unsaved edits. Primary grip → Save all edits saves both resources.");
             }
             let entry = &doc.library.entries[index];
+            let model_mirror = match preview.grip_model_mirror(&key) {
+                Ok(mirror) => mirror,
+                Err(error) => {
+                    ui.label(error);
+                    return;
+                }
+            };
             self.support_editor.show(
                 ui,
                 &self.model,
                 hand,
                 entry.grip.item_scale,
+                model_mirror,
                 !self.stale && !busy,
             );
             let scene = PreviewScene::Grip(
@@ -699,6 +748,50 @@ impl GripEditor {
             } else {
                 "Automatic fit"
             });
+        });
+        ui.horizontal_wrapped(|ui| {
+            if ui.add_enabled(!self.stale && !busy, egui::Button::new("Copy pose")).clicked() {
+                self.clipboard = Some((self.model.clone(), self.hand.clone(), doc.library.entries[index].grip.clone()));
+                self.message = format!("Copied {} {} pose", self.model, self.hand);
+            }
+            if ui.add_enabled(!self.stale && !busy && self.clipboard.is_some(), egui::Button::new("Paste pose")).clicked() {
+                let (model, source_hand, grip) = self.clipboard.as_ref().unwrap();
+                let mirror = if source_hand != &self.hand { preview.grip_model_mirror(&key).map(Some) } else { Ok(None) };
+                match mirror {
+                    Ok(mirror) => {
+                        self.message = match transfer_grip(grip, &mut doc.library.entries[index], mirror) {
+                            Ok(()) => format!("Pasted {model} {source_hand} pose. Review the fit, then save."),
+                            Err(e) => e,
+                        };
+                    }
+                    Err(e) => self.message = e,
+                }
+            }
+            let opposite = if self.hand == "right" { "left" } else { "right" };
+            if ui.add_enabled(!self.stale && !busy, egui::Button::new(format!("Mirror to {opposite} hand"))).clicked() {
+                let other = if hand == Handedness::Right { Handedness::Left } else { Handedness::Right };
+                let result = preview.grip_inputs(&key, other).and_then(|(_, rig, surface, _)| {
+                    let mirror = preview.grip_model_mirror(&key)?;
+                    let mut target = doc.library.entries[index].clone();
+                    target.hand = opposite.into();
+                    target.surface_hash = surface;
+                    target.kinematics_hash = rig.fingerprint();
+                    transfer_grip(&doc.library.entries[index].grip, &mut target, Some(mirror))?;
+                    Ok(target)
+                });
+                match result {
+                    Ok(target) => {
+                        if let Some(existing) = doc.library.entries.iter_mut().find(|e| e.model == self.model && e.hand == opposite) {
+                            *existing = target;
+                        } else {
+                            doc.library.entries.push(target);
+                        }
+                        self.message = format!("Mirrored to {opposite} hand. Switch hands to review; Save all edits keeps both.");
+                    }
+                    Err(e) => self.message = e,
+                }
+            }
+            if let Some((model, hand, _)) = &self.clipboard { ui.small(format!("Copied: {model} · {hand}")); }
         });
         egui::CollapsingHeader::new("Automatic fitting").show(ui, |ui| {
             ui.horizontal(|ui| {
@@ -919,6 +1012,131 @@ mod tests {
         std::fs::write(&path, include_bytes!("../../../assets/astra-vr-grips.json")).unwrap();
         let doc = GripDocument::load(path).unwrap();
         (dir, doc)
+    }
+
+    #[test]
+    fn copied_pose_preserves_destination_identity_and_round_trips() {
+        let (_dir, mut doc) = document();
+        let mut source = doc.library.entries[0].grip.clone();
+        source.item_scale = 0.63;
+        source.curls = [0.1, 0.2, 0.3, 0.4, 0.5];
+        let identity = doc.library.entries[1].clone();
+        transfer_grip(&source, &mut doc.library.entries[1], None).unwrap();
+        let target = &doc.library.entries[1];
+        assert_eq!(
+            (
+                &target.model,
+                &target.hand,
+                &target.surface_hash,
+                &target.kinematics_hash,
+                &target.hints_hash
+            ),
+            (
+                &identity.model,
+                &identity.hand,
+                &identity.surface_hash,
+                &identity.kinematics_hash,
+                &identity.hints_hash
+            )
+        );
+        assert_eq!(target.grip.curls, source.curls);
+        assert_eq!(target.grip.item_scale, 0.63);
+        assert_eq!(target.grip.contacts, [None; 5]);
+        assert!(target.authored);
+        let before_invalid = doc.library.entries[1].grip.clone();
+        assert!(
+            transfer_grip(
+                &source,
+                &mut doc.library.entries[1],
+                Some(Matrix4::from_scale(0.0))
+            )
+            .is_err()
+        );
+        assert_eq!(doc.library.entries[1].grip, before_invalid);
+        doc.save().unwrap();
+        let loaded = GripDocument::load(doc.path.clone()).unwrap();
+        assert_eq!(loaded.library.entries[1].grip, doc.library.entries[1].grip);
+    }
+
+    #[test]
+    fn mirrored_pose_reflects_rendered_points_and_round_trips_for_weapon_frames() {
+        let (_dir, doc) = document();
+        let mut target = doc.library.entries[0].clone();
+        let mut source = target.grip.clone();
+        source.offset = cgmath::vec3(0.12, -0.08, 0.03);
+        source.rotation = Quaternion::from(Euler::new(Deg(23.0), Deg(-37.0), Deg(11.0)));
+        source.item_scale = 0.7;
+        // Guns reflect Z; posed melee reflects X around its contact origin.
+        let contact = cgmath::vec3(0.15, 0.2, -0.1);
+        for mirror in [
+            Handedness::Left.gun_mirror(),
+            Matrix4::from_translation(contact)
+                * Handedness::Left.mirror()
+                * Matrix4::from_translation(-contact),
+        ] {
+            transfer_grip(&source, &mut target, Some(mirror)).unwrap();
+            assert!(target.grip.is_valid());
+            for point in [
+                cgmath::Point3::new(0.2, 0.1, 0.4),
+                cgmath::Point3::new(-0.1, 0.4, -0.3),
+            ] {
+                let original = source.offset
+                    + source.rotation * (point.to_homogeneous().truncate() * source.item_scale);
+                let reflected = target.grip.offset
+                    + target.grip.rotation
+                        * (mirror.transform_point(point).to_homogeneous().truncate()
+                            * target.grip.item_scale);
+                assert!((reflected - Handedness::Left.mirror_point(original)).magnitude() < 1e-5);
+            }
+            let support = shock2vr::vr_support::SupportProfile {
+                palm_anchor: [0.13, -0.21, 0.34],
+                rotation_degrees: [15.0, -20.0, 30.0],
+                curls: [0.4; 5],
+                grab_radius: 0.07,
+                release_distance: 0.12,
+                max_swing_degrees: 75.0,
+            };
+            let mut rig = shock2vr::vr_grip::GripKinematics {
+                fingers: std::array::from_fn(|_| Vec::new()),
+                palm: cgmath::vec3(0.02, -0.01, -0.08),
+                normal: cgmath::Vector3::unit_x(),
+            };
+            let right = support.glove_pose(
+                Handedness::Right,
+                shock2vr::vr_support::GripPose {
+                    position: source.offset,
+                    rotation: source.rotation,
+                },
+                &source,
+                &rig,
+                support.anchor_in_frame(Handedness::Right, mirror) * source.item_scale,
+            );
+            rig.palm = Handedness::Left.mirror_point(rig.palm);
+            let left = support.glove_pose(
+                Handedness::Left,
+                shock2vr::vr_support::GripPose {
+                    position: target.grip.offset,
+                    rotation: target.grip.rotation,
+                },
+                &target.grip,
+                &rig,
+                support.anchor_in_frame(Handedness::Left, mirror) * target.grip.item_scale,
+            );
+            assert!(
+                (left.position - Handedness::Left.mirror_point(right.position)).magnitude() < 1e-5,
+                "support glove must use the gun/offset-melee model reflection too"
+            );
+            let mirrored = target.grip.clone();
+            transfer_grip(&mirrored, &mut target, Some(mirror)).unwrap();
+            assert!((target.grip.offset - source.offset).magnitude() < 1e-5);
+            assert!((target.grip.rotation.dot(source.rotation).abs() - 1.0).abs() < 1e-5);
+            assert_eq!(target.grip.curls, source.curls);
+            assert!(
+                (cgmath::Vector3::from(target.grip.anchor) - cgmath::Vector3::from(source.anchor))
+                    .magnitude()
+                    < 1e-5
+            );
+        }
     }
 
     #[test]

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -12,7 +12,7 @@
 
 use std::ffi::CString;
 
-use cgmath::{InnerSpace, Matrix4, One, Quaternion, Rad, Rotation3, vec2, vec3};
+use cgmath::{InnerSpace, Matrix4, One, Quaternion, Rad, Rotation3, SquareMatrix, vec2, vec3};
 use dark::importers::MODELS_IMPORTER;
 use dark::model::Model;
 use dark_viewer::scenes::{BinAiViewerScene, BinObjViewerScene, SkeletonViewerScene, ToolScene};
@@ -304,6 +304,9 @@ impl ModelPreview {
                 engine::scene::Scene::from_objects(model.clone_scene_objects()),
             ))),
             PreviewScene::Grip(hand, grip, support) => quiet_catch(|| {
+                let model_mirror = self
+                    .grip_model_mirror(key)
+                    .map_err(|_| "Weapon mirror unavailable")?;
                 let mut model = model.as_ref().clone();
                 if shock2vr::vr_weapon_grip::supports_model(key) {
                     let source = self
@@ -350,6 +353,7 @@ impl ModelPreview {
                         },
                         grip,
                         &rig,
+                        support.anchor_in_frame(*hand, model_mirror) * grip.item_scale,
                     );
                     let mut support_grip = grip.clone();
                     support_grip.curls = support.curls;
@@ -483,6 +487,25 @@ impl ModelPreview {
             }
             Err(err) => self.error = Some(err),
         }
+    }
+
+    /// Reflection between the two rendered weapon frames. Ordinary pickups
+    /// retain their mesh, so X reflection supplies an approximate opposite-side fit.
+    pub fn grip_model_mirror(&mut self, key: &str) -> Result<Matrix4<f32>, String> {
+        if !shock2vr::vr_weapon_grip::supports_model(key) {
+            return Ok(Handedness::Left.mirror());
+        }
+        let source = self
+            .asset_cache
+            .get_opt(&dark::importers::GLOVE_WEAPON_IMPORTER, key)
+            .ok_or("Weapon grip geometry unavailable")?;
+        let source = source
+            .as_ref()
+            .as_ref()
+            .ok_or("Weapon grip geometry unavailable")?;
+        let right = shock2vr::vr_weapon_grip::model_frame(source, Handedness::Right);
+        let left = shock2vr::vr_weapon_grip::model_frame(source, Handedness::Left);
+        Ok(left * right.invert().ok_or("Invalid weapon frame")?)
     }
 
     /// Shared game geometry and rig samples for validation and explicit auto-fit.

--- a/tools/dark_explorer/src/support_grip_editor.rs
+++ b/tools/dark_explorer/src/support_grip_editor.rs
@@ -104,6 +104,7 @@ impl SupportEditor {
         model: &str,
         primary: Handedness,
         item_scale: f32,
+        model_mirror: cgmath::Matrix4<f32>,
         enabled: bool,
     ) {
         let doc = match &mut self.document {
@@ -179,19 +180,29 @@ impl SupportEditor {
                 |ui| {
                     ui.columns(3, |columns| {
                         columns[0].strong("Palm position on item (cm)");
+                        use cgmath::{SquareMatrix, Transform};
+                        let factor = item_scale * shock2vr::METERS_PER_WORLD_UNIT * 100.0;
+                        let mut anchor: [f32; 3] =
+                            profile.anchor_in_frame(primary, model_mirror).into();
+                        let mut changed = false;
                         for (i, axis) in ["X", "Y", "Z"].into_iter().enumerate() {
-                            let mirror = if primary == Handedness::Left && i == 0 {
-                                -1.0
-                            } else {
-                                1.0
-                            };
-                            let factor =
-                                item_scale * shock2vr::METERS_PER_WORLD_UNIT * 100.0 * mirror;
-                            let mut cm = profile.palm_anchor[i] * factor;
+                            let mut cm = anchor[i] * factor;
                             if tweak_slider(&mut columns[0], axis, &mut cm, -100.0..=100.0, 0.1, 2)
                             {
-                                profile.palm_anchor[i] = cm / factor;
+                                anchor[i] = cm / factor;
+                                changed = true;
                             }
+                        }
+                        if changed {
+                            let anchor = cgmath::Point3::from(anchor);
+                            profile.palm_anchor = if primary == Handedness::Left {
+                                model_mirror
+                                    .invert()
+                                    .map(|inverse| inverse.transform_point(anchor).into())
+                                    .unwrap_or(profile.palm_anchor)
+                            } else {
+                                anchor.into()
+                            };
                         }
                         columns[1].strong("Support wrist rotation (degrees)");
                         for (i, axis) in ["X", "Y", "Z"].into_iter().enumerate() {


### PR DESCRIPTION
VR Grips now supports reusing a fitted pose across models and applying it to the opposite primary hand. For example, copy one hypo spray, select another, and paste; after tuning the right-hand wrench, use **Mirror to left hand** and save both drafts.

- Copy/paste transfers position, rotation, curls, pose family, and uniform item scale while retaining the destination model identity and validation hashes. The clipboard survives switching models and libraries.
- Mirroring uses each weapon’s actual rendered model frame, including the melee contact origin. Ordinary unmirrored pickups get an approximate opposite-side starting pose. Hands remain independently editable; transfers create unsaved drafts.
- Corrects `atek_h` support-hand mirroring: support anchors and position sliders now follow the rendered weapon’s reflection, while wrist orientation mirrors in glove space. A mirrored primary pistol pose now keeps the supporting palm at its corresponding grip position. In-game two-hand grabbing remains wrench-only.
- Adds a **Cylindrical** finger-curl preset alongside the more open **Ball** preset, in primary and support modes.

Stacked on #1386. User-edited grip resources are excluded from this change.

Validation: 7 Explorer tests passed, including copied-pose save/reload, preserved target fingerprints, reflected rendered points at scale 0.7, and mirror round trips for gun and offset melee frames. 4 runtime support tests and 3 headless VR wrench scenarios also passed, covering both primary hands and glove attachment during walking/wall contact. Explorer build and formatting checks passed. Headset fit remains for user review.

## Visual evidence

![Grip copy and mirror editor](https://gist.githubusercontent.com/tommy-xr/bd524f7833e27e85f466025069065534/raw/astra-grip-copy-mirror.gif)

Native Explorer screenshots show the new controls and a temporary mirrored wrench fixture across both hands and multiple views.

![New controls](https://gist.githubusercontent.com/tommy-xr/bd524f7833e27e85f466025069065534/raw/astra-grip-copy-mirror.png)

![Parent controls versus current controls](https://gist.githubusercontent.com/tommy-xr/bd524f7833e27e85f466025069065534/raw/astra-copy-controls-before-after.png)

Parent `f006f405` and current editor use identical temporary resource snapshots, right hand, and oblique view.

![Existing left pose versus mirrored fixture](https://gist.githubusercontent.com/tommy-xr/bd524f7833e27e85f466025069065534/raw/astra-mirror-fixture.png)

The fixture was generated in an isolated instrumented build using the same `grip_model_mirror` and `transfer_grip` helpers as the UI, then loaded into the uninstrumented editor. Only the left wrench entry changed; destination identity and hashes, and every other entry, were preserved. These captures demonstrate helper output and fixture loading, not automated Copy/Paste/Mirror button interaction. Cylindrical is shown as an available preset.

[Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/bd524f7833e27e85f466025069065534/raw/astra-grip-copy-mirror-gallery.html). Captured with native `dark_explorer ui --screenshot`. User-edited resources were copied, never modified; this is editor evidence, not headset fit approval.

### Pistol support mirror correction

![Pistol support mirror comparison](https://gist.githubusercontent.com/tommy-xr/bd524f7833e27e85f466025069065534/raw/astra-pistol-support-mirror.gif)

![Left pistol support before and after](https://gist.githubusercontent.com/tommy-xr/bd524f7833e27e85f466025069065534/raw/astra-pistol-support-left-oblique.png)

Identical refreshed resource snapshots in the preserved and corrected editors. Left support now follows the pistol model reflection and remains beneath the grip. The primary pistol poses already matched the helper-generated mirror. Pistol two-hand support is editor preview only; runtime support remains wrench-only.
