### PR TITLE
feat(vr): a second hand grips the held weapon, and two hands aim it

### DIFF
--- a/assets/vr_grips.json
+++ b/assets/vr_grips.json
@@ -53,7 +53,17 @@
       0.123,
       -0.469
     ],
-    "mirror": "flip_x"
+    "mirror": "flip_x",
+    "support": [
+      {
+        "offset": [
+          -0.299,
+          0.025,
+          -0.008
+        ],
+        "family": "cylindrical"
+      }
+    ]
   },
   "ar15_w": {
     "rotation_deg": [
@@ -124,7 +134,17 @@
       0.083,
       -0.473
     ],
-    "mirror": "flip_x"
+    "mirror": "flip_x",
+    "support": [
+      {
+        "offset": [
+          -0.386,
+          0.019,
+          -0.035
+        ],
+        "family": "cylindrical"
+      }
+    ]
   },
   "fsn_h": {
     "rotation_deg": [
@@ -250,7 +270,17 @@
       -0.025,
       -0.693
     ],
-    "mirror": "flip_x"
+    "mirror": "flip_x",
+    "support": [
+      {
+        "offset": [
+          -0.382,
+          0.014,
+          -0.052
+        ],
+        "family": "cylindrical"
+      }
+    ]
   },
   "sg_w": {
     "rotation_deg": [

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -928,6 +928,12 @@ pub struct PlayerInfo {
     /// The player's body anchors - belt and shoulders - and what hangs off
     /// them. `null` outside VR. See `shock2vr::body_frame`.
     pub body_frame: Option<shock2vr::game_scene::DebugBodyFrame>,
+    /// Whether a second hand has hold of what the first is holding - the
+    /// weapon is then aimed down the line between the hands, not down the
+    /// primary wrist. See `shock2vr::two_hand_grip`.
+    pub two_handed: bool,
+    /// Where that second hand took hold.
+    pub two_hand: shock2vr::game_scene::DebugTwoHandGrip,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2370,6 +2370,10 @@ fn capture_frame_snapshot(
             // Real player state from the active world (position, look, and the
             // held/wielded entities), or zeros when the scene has no player.
             let state = game.player_state();
+            let two_hand = game
+                .debug_scene()
+                .map(|scene| scene.player_two_hand())
+                .unwrap_or_default();
             PlayerInfo {
                 entity_id: state.as_ref().map(|s| s.entity_id),
                 inventory_entity_id: state.as_ref().map(|s| s.inventory_entity_id),
@@ -2452,6 +2456,8 @@ fn capture_frame_snapshot(
                 body_frame: game
                     .debug_scene()
                     .and_then(|scene| scene.player_body_frame()),
+                two_handed: two_hand.two_handed,
+                two_hand,
             }
         },
         entity_count,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2456,7 +2456,7 @@ fn capture_frame_snapshot(
                 body_frame: game
                     .debug_scene()
                     .and_then(|scene| scene.player_body_frame()),
-                two_handed: two_hand.two_handed,
+                two_handed: two_hand.support_hand.is_some(),
                 two_hand,
             }
         },

--- a/shock2vr/src/body_frame.rs
+++ b/shock2vr/src/body_frame.rs
@@ -224,7 +224,7 @@ pub fn worn_scene_objects(
 /// tracking is worst, and a pose that drops out for a frame must not read as
 /// "left the zone" - the release it is about to make would then land on the
 /// floor instead of in the backpack.
-const ANCHOR_HOLD_FRAMES: u8 = 12;
+pub(crate) const ANCHOR_HOLD_FRAMES: u8 = 12;
 
 /// What a hand's body-anchor gesture resolved to this frame.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -400,6 +400,23 @@ pub struct DebugHandAffordances {
     pub right_model: Option<String>,
 }
 
+/// The second hand's grip on whatever the first hand holds: what makes a
+/// weapon two-handed, and where the off-hand took hold of it.
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct DebugTwoHandGrip {
+    /// Whether a support grip is attached right now.
+    pub two_handed: bool,
+    /// Which hand is supporting ("left"/"right"), or `null`.
+    pub support_hand: Option<&'static str>,
+    /// The entity the support hand has hold of, or `null`.
+    pub support_of: Option<u64>,
+    /// Where it took hold, in the holding hand's own space.
+    pub support_point: Option<[f32; 3]>,
+    /// Whether an authored support seat claimed the grip rather than the palm
+    /// latching wherever it met the surface.
+    pub snapped: bool,
+}
+
 /// The player's body anchors, and what hangs off them: where a hand has to go
 /// to reach the belt or a shoulder, what a shoulder would draw, and where the
 /// belt card is.
@@ -941,6 +958,12 @@ pub trait DebuggableScene {
     /// and in scenes without a player.
     fn player_body_frame(&self) -> Option<DebugBodyFrame> {
         None
+    }
+
+    /// The second hand's grip (see [`DebugTwoHandGrip`]). Scenes without a
+    /// player report the idle state.
+    fn player_two_hand(&self) -> DebugTwoHandGrip {
+        DebugTwoHandGrip::default()
     }
 
     /// Teleport the player to a specific position

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -404,13 +404,12 @@ pub struct DebugHandAffordances {
 /// weapon two-handed, and where the off-hand took hold of it.
 #[derive(Debug, Serialize, Clone, Default)]
 pub struct DebugTwoHandGrip {
-    /// Whether a support grip is attached right now.
-    pub two_handed: bool,
-    /// Which hand is supporting ("left"/"right"), or `null`.
+    /// Which hand is supporting ("left"/"right"), or `null`. `null` is also
+    /// what "not two-handed" reads as - `player.two_handed` is the flag.
     pub support_hand: Option<&'static str>,
     /// The entity the support hand has hold of, or `null`.
     pub support_of: Option<u64>,
-    /// Where it took hold, in the holding hand's own space.
+    /// Where it took hold, in the item's own model space.
     pub support_point: Option<[f32; 3]>,
     /// Whether an authored support seat claimed the grip rather than the palm
     /// latching wherever it met the surface.

--- a/shock2vr/src/hand_fit.rs
+++ b/shock2vr/src/hand_fit.rs
@@ -154,11 +154,17 @@ const BISECT_ROUNDS: usize = 6;
 /// The triangles a hand can close against, in hand space.
 pub struct ContactMesh {
     triangles: Vec<[Point3<f32>; 3]>,
+    /// The whole soup's bounds, measured once. The support-grab test runs every
+    /// frame one hand holds something and the other is free, and a palm outside
+    /// these bounds cannot be near any triangle - that reject is the difference
+    /// between six float compares and a walk of the mesh.
+    bounds: Option<(Vector3<f32>, Vector3<f32>)>,
 }
 
 impl ContactMesh {
     pub fn new(triangles: Vec<[Point3<f32>; 3]>) -> Self {
-        Self { triangles }
+        let bounds = triangle_bounds(&triangles);
+        Self { triangles, bounds }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -171,7 +177,7 @@ impl ContactMesh {
 
     /// Axis-aligned extents of the mesh in hand space, or `None` when empty.
     pub fn extents(&self) -> Option<Vector3<f32>> {
-        triangle_bounds(&self.triangles).map(|(min, max)| max - min)
+        self.bounds.map(|(min, max)| max - min)
     }
 
     /// Whether any triangle comes within `radius` of `point`.
@@ -180,25 +186,20 @@ impl ContactMesh {
     /// hold wherever its palm meets the item's own surface, so the question is
     /// proximity to the mesh rather than to an authored point.
     pub fn within(&self, point: Point3<f32>, radius: f32) -> bool {
+        let reach = Vector3::new(radius, radius, radius);
         let p = point.to_vec();
-        self.triangles.iter().any(|triangle| {
-            // Reject on the triangle's own box before paying for the exact
-            // distance: at a few thousand triangles that is most of the cost.
-            let mut lo = triangle[0].to_vec();
-            let mut hi = lo;
-            for corner in &triangle[1..] {
-                let c = corner.to_vec();
-                lo = Vector3::new(lo.x.min(c.x), lo.y.min(c.y), lo.z.min(c.z));
-                hi = Vector3::new(hi.x.max(c.x), hi.y.max(c.y), hi.z.max(c.z));
-            }
-            lo.x - radius <= p.x
-                && hi.x + radius >= p.x
-                && lo.y - radius <= p.y
-                && hi.y + radius >= p.y
-                && lo.z - radius <= p.z
-                && hi.z + radius >= p.z
-                && point_triangle_distance(point, triangle) <= radius
-        })
+        let Some((lo, hi)) = self.bounds else {
+            return false;
+        };
+        if (p.x - radius > hi.x || p.x + radius < lo.x)
+            || (p.y - radius > hi.y || p.y + radius < lo.y)
+            || (p.z - radius > hi.z || p.z + radius < lo.z)
+        {
+            return false;
+        }
+        self.near(p - reach, p + reach)
+            .into_iter()
+            .any(|index| point_triangle_distance(point, &self.triangles[index]) <= radius)
     }
 
     /// Indices of the triangles whose bounding box overlaps `[min, max]`. Run

--- a/shock2vr/src/hand_fit.rs
+++ b/shock2vr/src/hand_fit.rs
@@ -174,6 +174,33 @@ impl ContactMesh {
         triangle_bounds(&self.triangles).map(|(min, max)| max - min)
     }
 
+    /// Whether any triangle comes within `radius` of `point`.
+    ///
+    /// The support-grab test ([`crate::two_hand_grip`]): a second hand takes
+    /// hold wherever its palm meets the item's own surface, so the question is
+    /// proximity to the mesh rather than to an authored point.
+    pub fn within(&self, point: Point3<f32>, radius: f32) -> bool {
+        let p = point.to_vec();
+        self.triangles.iter().any(|triangle| {
+            // Reject on the triangle's own box before paying for the exact
+            // distance: at a few thousand triangles that is most of the cost.
+            let mut lo = triangle[0].to_vec();
+            let mut hi = lo;
+            for corner in &triangle[1..] {
+                let c = corner.to_vec();
+                lo = Vector3::new(lo.x.min(c.x), lo.y.min(c.y), lo.z.min(c.z));
+                hi = Vector3::new(hi.x.max(c.x), hi.y.max(c.y), hi.z.max(c.z));
+            }
+            lo.x - radius <= p.x
+                && hi.x + radius >= p.x
+                && lo.y - radius <= p.y
+                && hi.y + radius >= p.y
+                && lo.z - radius <= p.z
+                && hi.z + radius >= p.z
+                && point_triangle_distance(point, triangle) <= radius
+        })
+    }
+
     /// Indices of the triangles whose bounding box overlaps `[min, max]`. Run
     /// once per finger over its whole curl sweep, so the inner loop only ever
     /// sees triangles that finger could reach.

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -189,6 +189,11 @@ pub struct GloveRenderer {
     support_fits: HashMap<(GripKey, [i32; 3]), Option<FittedGrip>>,
 }
 
+/// How many support grips are remembered before the map is dropped wholesale.
+/// A session realistically takes a handful; the cap is only there so a player
+/// re-gripping a rifle all afternoon cannot grow it without bound.
+const SUPPORT_FIT_BUDGET: usize = 64;
+
 /// An authored pose a hand can be shown in when nothing analog is driving it -
 /// the VR frontend pointer, where there is no world to grab and the trigger is
 /// just a button.
@@ -305,13 +310,7 @@ impl GloveRenderer {
         gun_scale: f32,
         asset_cache: &mut AssetCache,
     ) -> Option<FittedGrip> {
-        // A tuner edit re-seats the item, so everything solved against the old
-        // seat is stale. Cheaper to drop the lot than to track what moved.
-        let generation = crate::vr_grips::generation();
-        if self.fits_generation != generation {
-            self.fits.clear();
-            self.fits_generation = generation;
-        }
+        self.drop_stale_fits();
         let key = GripKey::new(model_name, handedness, gun_scale);
         if let Some(cached) = self.fits.get(&key) {
             return *cached;
@@ -319,6 +318,18 @@ impl GloveRenderer {
         let fitted = self.solve(model_name, handedness, gun_scale, asset_cache);
         self.fits.insert(key, fitted);
         fitted
+    }
+
+    /// A tuner edit re-seats every item, so everything solved against the old
+    /// seat is stale. Both fit maps go together - dropping only one leaves a
+    /// support grip fitted against a seat the held item no longer uses.
+    fn drop_stale_fits(&mut self) {
+        let generation = crate::vr_grips::generation();
+        if self.fits_generation != generation {
+            self.fits.clear();
+            self.support_fits.clear();
+            self.fits_generation = generation;
+        }
     }
 
     /// The grip a *support* hand closes in on an item the other hand holds.
@@ -335,14 +346,10 @@ impl GloveRenderer {
         handedness: Handedness,
         gun_scale: f32,
         latch: Vector3<f32>,
+        seated: Option<GripFamily>,
         asset_cache: &mut AssetCache,
     ) -> Option<FittedGrip> {
-        let generation = crate::vr_grips::generation();
-        if self.fits_generation != generation {
-            self.fits.clear();
-            self.support_fits.clear();
-            self.fits_generation = generation;
-        }
+        self.drop_stale_fits();
         let key = (
             GripKey::new(model_name, handedness, gun_scale),
             crate::two_hand_grip::quantise_latch(latch),
@@ -350,7 +357,21 @@ impl GloveRenderer {
         if let Some(cached) = self.support_fits.get(&key) {
             return *cached;
         }
-        let fitted = self.solve_support(model_name, handedness, gun_scale, latch, asset_cache);
+        // A free latch is a distinct key per centimetre of surface, so this map
+        // could otherwise grow for as long as the player keeps re-gripping.
+        // Nothing here is expensive to rebuild - drop the lot rather than carry
+        // eviction machinery for a handful of entries.
+        if self.support_fits.len() >= SUPPORT_FIT_BUDGET {
+            self.support_fits.clear();
+        }
+        let fitted = self.solve_support(
+            model_name,
+            handedness,
+            gun_scale,
+            latch,
+            seated,
+            asset_cache,
+        );
         self.support_fits.insert(key, fitted);
         fitted
     }
@@ -361,6 +382,7 @@ impl GloveRenderer {
         handedness: Handedness,
         gun_scale: f32,
         latch: Vector3<f32>,
+        seated: Option<GripFamily>,
         asset_cache: &mut AssetCache,
     ) -> Option<FittedGrip> {
         use cgmath::{EuclideanSpace, Point3};
@@ -375,12 +397,12 @@ impl GloveRenderer {
         let mesh = placed_contact_mesh(model_name, handedness, gun_scale, slide, asset_cache)?;
 
         // The support hand has no trigger to rest on, so a gun's authored
-        // Trigger family is not its family. An authored support seat may name
-        // one; otherwise the item's own girth decides, which is what makes a
-        // basketball Broad and a rifle handguard Cylindrical.
-        let family = crate::vr_grips::support_seats(model_name)
-            .first()
-            .and_then(|seat| seat.family())
+        // Trigger family is not its family. The family of the seat that actually
+        // claimed this grip wins - `seated` is `None` for a free latch, which
+        // must not inherit a seat it did not land on - and otherwise the item's
+        // own girth decides, which is what makes a basketball Broad and a rifle
+        // handguard Cylindrical.
+        let family = seated
             .or_else(|| mesh.extents().map(hand_fit::family_from_extents))
             .unwrap_or(GripFamily::Cylindrical);
         let mut rig = GloveRig {

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -363,29 +363,16 @@ impl GloveRenderer {
         latch: Vector3<f32>,
         asset_cache: &mut AssetCache,
     ) -> Option<FittedGrip> {
-        use cgmath::{EuclideanSpace, Point3, Transform};
+        use cgmath::{EuclideanSpace, Point3};
 
-        let triangles = asset_cache.get_opt::<_, VrContactMesh, _>(
-            &VR_CONTACT_MESH_IMPORTER,
-            &format!("{model_name}.BIN"),
-        )?;
         // Slide the item along until the latched point sits on the palm; its
         // turn in the hand is the one the model's own grip already gives, which
         // is close enough at a support grip and keeps the answer cacheable.
         let seat = vr_config::held_model_hand_transform(model_name, handedness, gun_scale);
-        let place = Matrix4::from_translation(
+        let slide = Matrix4::from_translation(
             crate::hand_seat::PALM_CENTRE - seat.transform_point(Point3::from_vec(latch)).to_vec(),
-        ) * seat;
-        let mesh = ContactMesh::new(
-            triangles
-                .0
-                .iter()
-                .map(|triangle| triangle.map(|corner| place.transform_point(corner)))
-                .collect(),
         );
-        if mesh.is_empty() {
-            return None;
-        }
+        let mesh = placed_contact_mesh(model_name, handedness, gun_scale, slide, asset_cache)?;
 
         // The support hand has no trigger to rest on, so a gun's authored
         // Trigger family is not its family. An authored support seat may name
@@ -641,16 +628,36 @@ pub fn warm_held_seat(model_name: &str, asset_cache: &mut AssetCache) {
 /// The item's render mesh in the glove's own hand space, or `None` when there
 /// is nothing to close against - a missing asset, or a skinned rig (the melee
 /// `_h` set, which draws its own arm anyway).
-fn contact_mesh(
+pub(crate) fn contact_mesh(
     model_name: &str,
     handedness: Handedness,
     gun_scale: f32,
     asset_cache: &mut AssetCache,
 ) -> Option<ContactMesh> {
+    placed_contact_mesh(
+        model_name,
+        handedness,
+        gun_scale,
+        <Matrix4<f32> as cgmath::SquareMatrix>::identity(),
+        asset_cache,
+    )
+}
+
+/// [`contact_mesh`], with `slide` applied on top of the item's own seat: the
+/// support grip slides the item along until the point that hand latched sits on
+/// the palm, because that hand did not pick the item up, it took hold of it
+/// somewhere.
+fn placed_contact_mesh(
+    model_name: &str,
+    handedness: Handedness,
+    gun_scale: f32,
+    slide: Matrix4<f32>,
+    asset_cache: &mut AssetCache,
+) -> Option<ContactMesh> {
     let triangles = asset_cache
         .get_opt::<_, VrContactMesh, _>(&VR_CONTACT_MESH_IMPORTER, &format!("{model_name}.BIN"))?;
 
-    let to_hand = vr_config::held_model_hand_transform(model_name, handedness, gun_scale);
+    let to_hand = slide * vr_config::held_model_hand_transform(model_name, handedness, gun_scale);
     let mesh = ContactMesh::new(
         triangles
             .0

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -182,6 +182,11 @@ pub struct GloveRenderer {
     fits: HashMap<GripKey, Option<FittedGrip>>,
     /// The [`crate::vr_grips::generation`] `fits` was solved against.
     fits_generation: u64,
+    /// Grips a *support* hand solved, keyed by the item and where on it the
+    /// hand latched (see [`crate::two_hand_grip`]). Separate from `fits`
+    /// because the same model gives a different answer at every grip point:
+    /// a shotgun's pump closes the hand, its receiver barely does.
+    support_fits: HashMap<(GripKey, [i32; 3]), Option<FittedGrip>>,
 }
 
 /// An authored pose a hand can be shown in when nothing analog is driving it -
@@ -234,6 +239,7 @@ impl GloveRenderer {
             point: hand_pose::point_right_hand(),
             materials,
             fits: HashMap::new(),
+            support_fits: HashMap::new(),
             fits_generation: crate::vr_grips::generation(),
         })
     }
@@ -313,6 +319,92 @@ impl GloveRenderer {
         let fitted = self.solve(model_name, handedness, gun_scale, asset_cache);
         self.fits.insert(key, fitted);
         fitted
+    }
+
+    /// The grip a *support* hand closes in on an item the other hand holds.
+    ///
+    /// Same contact fit as a held item's, but the item is placed at the point
+    /// this hand latched rather than at its own authored seat - the support
+    /// hand did not pick the item up, it took hold of it somewhere.
+    ///
+    /// Cached per grip point rounded to the centimetre: finer is below what a
+    /// tracked hand resolves, and would re-solve every frame.
+    pub fn support_grip(
+        &mut self,
+        model_name: &str,
+        handedness: Handedness,
+        gun_scale: f32,
+        latch: Vector3<f32>,
+        asset_cache: &mut AssetCache,
+    ) -> Option<FittedGrip> {
+        let generation = crate::vr_grips::generation();
+        if self.fits_generation != generation {
+            self.fits.clear();
+            self.support_fits.clear();
+            self.fits_generation = generation;
+        }
+        let key = (
+            GripKey::new(model_name, handedness, gun_scale),
+            crate::two_hand_grip::quantise_latch(latch),
+        );
+        if let Some(cached) = self.support_fits.get(&key) {
+            return *cached;
+        }
+        let fitted = self.solve_support(model_name, handedness, gun_scale, latch, asset_cache);
+        self.support_fits.insert(key, fitted);
+        fitted
+    }
+
+    fn solve_support(
+        &mut self,
+        model_name: &str,
+        handedness: Handedness,
+        gun_scale: f32,
+        latch: Vector3<f32>,
+        asset_cache: &mut AssetCache,
+    ) -> Option<FittedGrip> {
+        use cgmath::{EuclideanSpace, Point3, Transform};
+
+        let triangles = asset_cache.get_opt::<_, VrContactMesh, _>(
+            &VR_CONTACT_MESH_IMPORTER,
+            &format!("{model_name}.BIN"),
+        )?;
+        // Slide the item along until the latched point sits on the palm; its
+        // turn in the hand is the one the model's own grip already gives, which
+        // is close enough at a support grip and keeps the answer cacheable.
+        let seat = vr_config::held_model_hand_transform(model_name, handedness, gun_scale);
+        let place = Matrix4::from_translation(
+            crate::hand_seat::PALM_CENTRE - seat.transform_point(Point3::from_vec(latch)).to_vec(),
+        ) * seat;
+        let mesh = ContactMesh::new(
+            triangles
+                .0
+                .iter()
+                .map(|triangle| triangle.map(|corner| place.transform_point(corner)))
+                .collect(),
+        );
+        if mesh.is_empty() {
+            return None;
+        }
+
+        // The support hand has no trigger to rest on, so a gun's authored
+        // Trigger family is not its family. An authored support seat may name
+        // one; otherwise the item's own girth decides, which is what makes a
+        // basketball Broad and a rifle handguard Cylindrical.
+        let family = crate::vr_grips::support_seats(model_name)
+            .first()
+            .and_then(|seat| seat.family())
+            .or_else(|| mesh.extents().map(hand_fit::family_from_extents))
+            .unwrap_or(GripFamily::Cylindrical);
+        let mut rig = GloveRig {
+            model: &mut self.model,
+            retarget: &self.retarget,
+            open: &self.open,
+            fist: &self.fist,
+            to_hand: glove_model_to_hand(),
+        };
+        let amounts = hand_fit::fit(&mut rig, &mesh, family, unmeasured_wrap(family));
+        Some(FittedGrip { family, amounts })
     }
 
     /// One grip fit, start to finish. Only ever reached on a cache miss.

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -446,8 +446,14 @@ impl PlayerInteraction for VrInteraction {
         match glove_renderer {
             Some(renderer) => {
                 let mut grips = self.fitted_grips.borrow_mut();
+                let support = self.two_hand.latch();
                 for hand in [&self.left_hand, &self.right_hand] {
-                    let (mut hand_objects, grip) = hand.render(world, asset_cache, renderer);
+                    let (mut hand_objects, grip) = hand.render(
+                        world,
+                        asset_cache,
+                        renderer,
+                        support.filter(|latch| latch.hand == hand.handedness()),
+                    );
                     grips[crate::vr_config::hand_slot(hand.handedness())] = grip;
                     objs.append(&mut hand_objects);
                 }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -285,12 +285,16 @@ impl PlayerInteraction for VrInteraction {
     fn update_hand_climb(&mut self, ctx: &ClimbContext) -> crate::vr_climb::ClimbFrame {
         use shipyard::EntitiesView;
 
+        // A hand supporting the other's weapon is not free either, even though
+        // it holds no entity of its own - without this it could take a ladder
+        // hold with the same closed grip that is already on the weapon.
+        let supporting = self.two_hand.latch().map(|latch| latch.hand);
         let hand_input = |hand: &VirtualHand, input: &crate::input_context::Hand| {
             crate::vr_climb::ClimbHandInput {
                 local_position: input.position,
                 squeeze: input.squeeze_value,
                 // A hand that is carrying something cannot also hold a ladder.
-                is_empty: hand.get_held_entity().is_none(),
+                is_empty: hand.get_held_entity().is_none() && supporting != Some(hand.handedness()),
             }
         };
         self.hand_climb.update(

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -175,6 +175,12 @@ pub trait PlayerInteraction {
         None
     }
 
+    /// The second hand's grip on whatever the first hand holds, when there is
+    /// one. Flat has no second hand, so it never has one.
+    fn support_latch(&self) -> Option<crate::two_hand_grip::SupportLatch> {
+        None
+    }
+
     fn hand_affordance(&self, _hand: Handedness) -> crate::hand_affordance::HandAffordance {
         crate::hand_affordance::HandAffordance::None
     }
@@ -216,6 +222,9 @@ pub struct VrInteraction {
     /// `vr_config::hand_slot`. Written where the fit is solved (render, which
     /// owns the glove and the asset cache) and read by the debug readout.
     fitted_grips: RefCell<[Option<crate::game_scene::DebugHandGrip>; 2]>,
+    /// The second hand's grip on whatever the first hand holds. Owned here
+    /// because this is the only place that sees both hands at once.
+    two_hand: crate::two_hand_grip::TwoHandGrip,
 }
 
 impl VrInteraction {
@@ -229,6 +238,39 @@ impl VrInteraction {
             belt_card: std::cell::Cell::new(None),
             ammo_pouch: std::cell::RefCell::new(None),
             fitted_grips: RefCell::new([None, None]),
+            two_hand: crate::two_hand_grip::TwoHandGrip::default(),
+        }
+    }
+}
+
+impl VrInteraction {
+    /// One hand's inputs to the two-hand resolve, in the same world frame
+    /// `VirtualHand` places itself in.
+    fn two_hand_input(
+        &self,
+        ctx: &InteractionContext,
+        hand: Handedness,
+    ) -> crate::two_hand_grip::HandInput {
+        let (state, input) = match hand {
+            Handedness::Left => (&self.left_hand, &ctx.input.left_hand),
+            Handedness::Right => (&self.right_hand, &ctx.input.right_hand),
+        };
+        crate::two_hand_grip::HandInput {
+            hand,
+            position: crate::virtual_hand::hand_world_position(
+                ctx.player_pos,
+                ctx.player_rotation,
+                input.position,
+            ),
+            rotation: ctx.player_rotation * input.rotation,
+            squeeze: input.squeeze_value,
+            held: state.get_held_entity(),
+            // A hand at a body anchor or on a climbing hold is already busy.
+            claimed: ctx.anchor_claim[crate::vr_config::hand_slot(hand)].is_some()
+                || self
+                    .hand_climb
+                    .grips()
+                    .any(|(gripping, _)| gripping == hand),
         }
     }
 }
@@ -291,6 +333,23 @@ impl PlayerInteraction for VrInteraction {
         self.body_frame.set(ctx.body_frame);
         self.belt_card.set(ctx.belt_card);
         *self.ammo_pouch.borrow_mut() = ctx.ammo_pouch.clone();
+
+        // The two-hand resolve runs BEFORE either hand updates, because both
+        // hands need its answer on the same frame: the support hand to know its
+        // grip is spoken for, the primary to place the item down the hand line.
+        // It reads this frame's tracked poses with the previous frame's hold,
+        // which is the same one-frame lag the body anchors run on.
+        let two_hand = self
+            .two_hand
+            .resolve(&crate::two_hand_grip::ResolveContext {
+                world: ctx.world,
+                physics: ctx.physics,
+                hands: [
+                    self.two_hand_input(ctx, Handedness::Left),
+                    self.two_hand_input(ctx, Handedness::Right),
+                ],
+            });
+
         let left_held_entity = self.left_hand.get_held_entity();
         let (right_hand, mut right_msgs) = VirtualHand::update(
             &self.right_hand,
@@ -301,6 +360,7 @@ impl PlayerInteraction for VrInteraction {
             &ctx.input.right_hand,
             left_held_entity,
             ctx.anchor_claim[crate::vr_config::hand_slot(Handedness::Right)],
+            two_hand[crate::vr_config::hand_slot(Handedness::Right)],
         );
         self.right_hand = right_hand;
 
@@ -316,6 +376,7 @@ impl PlayerInteraction for VrInteraction {
             &ctx.input.left_hand,
             right_held_entity,
             ctx.anchor_claim[crate::vr_config::hand_slot(Handedness::Left)],
+            two_hand[crate::vr_config::hand_slot(Handedness::Left)],
         );
         self.left_hand = left_hand;
 
@@ -364,6 +425,10 @@ impl PlayerInteraction for VrInteraction {
 
     fn fitted_grip(&self, hand: Handedness) -> Option<crate::game_scene::DebugHandGrip> {
         self.fitted_grips.borrow()[crate::vr_config::hand_slot(hand)]
+    }
+
+    fn support_latch(&self) -> Option<crate::two_hand_grip::SupportLatch> {
+        self.two_hand.latch()
     }
 
     fn render(

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -18,6 +18,7 @@ pub mod save_load;
 pub mod scenes;
 pub mod teleport;
 pub mod time;
+pub mod two_hand_grip;
 
 pub mod career;
 pub mod creature;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -12132,7 +12132,6 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             return Default::default();
         };
         crate::game_scene::DebugTwoHandGrip {
-            two_handed: true,
             support_hand: Some(match latch.hand {
                 Handedness::Left => "left",
                 Handedness::Right => "right",

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2895,10 +2895,20 @@ impl MissionCore {
         crate::vr_grips::ensure_loaded(asset_cache);
         let (left_held, right_held) = self.interaction.held_entities();
         for entity_id in [left_held, right_held].into_iter().flatten() {
-            if let Some((model_name, _)) =
+            if let Some((model_name, gun_scale)) =
                 crate::vr_config::held_model_and_scale(&self.world, entity_id)
             {
                 crate::hand_glove::warm_held_seat(&model_name, asset_cache);
+                // The same split for the item's contact triangles, which the
+                // second hand's grab test needs and cannot load itself.
+                if let Some(hand) = self.interaction.holding_hand(entity_id) {
+                    crate::two_hand_grip::warm_contact_mesh(
+                        &model_name,
+                        hand,
+                        gun_scale,
+                        asset_cache,
+                    );
+                }
             }
         }
 
@@ -12114,6 +12124,23 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             left_model: model_of(left_held),
             right_model: model_of(right_held),
         })
+    }
+
+    fn player_two_hand(&self) -> crate::game_scene::DebugTwoHandGrip {
+        use crate::vr_config::Handedness;
+        let Some(latch) = self.interaction.support_latch() else {
+            return Default::default();
+        };
+        crate::game_scene::DebugTwoHandGrip {
+            two_handed: true,
+            support_hand: Some(match latch.hand {
+                Handedness::Left => "left",
+                Handedness::Right => "right",
+            }),
+            support_of: Some(latch.entity_id.inner()),
+            support_point: Some([latch.point.x, latch.point.y, latch.point.z]),
+            snapped: latch.snapped,
+        }
     }
 
     fn player_body_frame(&self) -> Option<crate::game_scene::DebugBodyFrame> {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -383,6 +383,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.player_body_frame()
     }
 
+    fn player_two_hand(&self) -> crate::game_scene::DebugTwoHandGrip {
+        self.mission_core.player_two_hand()
+    }
+
     fn teleport_player(&mut self, position: Vector3<f32>) -> Result<(), String> {
         self.mission_core.teleport_player(position)
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3169,6 +3169,33 @@ impl PhysicsWorld {
         }
     }
 
+    /// The fitted contact cuboid of a held melee weapon, in world space:
+    /// `(centre, rotation, half extents)`. `None` for anything that is not a
+    /// driven melee wield, or whose collider is not a cuboid.
+    ///
+    /// This is the volume the weapon's damage is billed through and the volume
+    /// the player sees, so it is also what a second hand may take hold of - a
+    /// melee `_h` rig is skinned and reports no render triangles to test
+    /// against (see [`crate::two_hand_grip`]).
+    pub fn held_melee_contact_box(
+        &self,
+        entity_id: EntityId,
+    ) -> Option<(Vector3<f32>, Quaternion<f32>, Vector3<f32>)> {
+        let handle = *self.entity_id_to_body.get(&entity_id)?;
+        if !self.held_melee_drives.contains_key(&handle) {
+            return None;
+        }
+        let body = self.rigid_body_set.get(handle)?;
+        let collider = self.collider_set.get(*body.colliders().first()?)?;
+        let cuboid = collider.shape().as_cuboid()?;
+        let position = collider.position();
+        Some((
+            nvec_to_cgmath(position.translation.vector),
+            nquat_to_quat(position.rotation),
+            nvec_to_cgmath(cuboid.half_extents),
+        ))
+    }
+
     /// Turn an existing loose-prop body into a swept kinematic contact shape
     /// while a melee weapon is held in VR.
     ///

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3177,6 +3177,12 @@ impl PhysicsWorld {
     /// the player sees, so it is also what a second hand may take hold of - a
     /// melee `_h` rig is skinned and reports no render triangles to test
     /// against (see [`crate::two_hand_grip`]).
+    ///
+    /// The *body's* pose, deliberately, not the drive target's: the sweep stops
+    /// the body on world geometry, and the render transform is read back off
+    /// that same body (`mission_core::synchronize_physics_positions`). So a
+    /// weapon held against a wall offers its grip where it is drawn, not where
+    /// the controller is asking for it.
     pub fn held_melee_contact_box(
         &self,
         entity_id: EntityId,

--- a/shock2vr/src/two_hand_grip.rs
+++ b/shock2vr/src/two_hand_grip.rs
@@ -1,0 +1,457 @@
+//! A second hand on an item the first hand already holds.
+//!
+//! The primary hand keeps everything it owns - the item's position, its trigger,
+//! its magazine anchors. What the support hand adds is an **aim**: while it is
+//! attached, the item's forward runs down the line from the primary hand to the
+//! support hand instead of down the primary wrist. Every consumer of the held
+//! transform (muzzle, mag zone, the melee drive's kinematic target) follows for
+//! free, because there is still exactly one transform.
+//!
+//! Where the off-hand may take hold is deliberately unrestricted: any point on
+//! the item's own surface. An authored anchor ([`crate::vr_grips::SupportSeat`],
+//! the pump on `sg_h`, the foregrip on `empgun_h`, the magwell on `ar15_h`) is a
+//! *snap preference* when the palm comes near it, not a requirement - the
+//! oversized weapons bake no support hand at all, and a basketball has no
+//! authored anything.
+//!
+//! The latch is taken **once**, at the grip edge, in the primary hand's own
+//! space. Re-picking the nearest surface point every frame would let the item
+//! crawl through the off-hand as the aim swung it.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use cgmath::{
+    EuclideanSpace, InnerSpace, Matrix3, Point3, Quaternion, Rotation, SquareMatrix, Transform,
+    Vector3, vec3,
+};
+use engine::assets::asset_cache::AssetCache;
+use once_cell::sync::Lazy;
+use shipyard::EntityId;
+
+use dark::importers::{VR_CONTACT_MESH_IMPORTER, VrContactMesh};
+
+use crate::hand_fit::ContactMesh;
+use crate::physics::PhysicsWorld;
+use crate::util::meters;
+use crate::vr_config::{self, Handedness};
+
+/// How far the off-hand's palm may sit from the item's surface and still take
+/// hold. Generous on purpose: the point is that a second hand lands on a rifle
+/// wherever the player puts it, not that they hunt for a sweet spot.
+const CONTACT_RADIUS: f32 = meters(0.10);
+
+/// An authored support seat this close to the palm wins over a free latch, so
+/// a hand brought to a shotgun's pump lands *on* the pump.
+const ANCHOR_SNAP_RADIUS: f32 = meters(0.08);
+
+/// Closer than this the hand line carries no direction, so the last valid one
+/// stands - hands do cross, and a weapon must not spin when they do.
+const MIN_HAND_SEPARATION: f32 = meters(0.10);
+
+/// Frames the aim takes to ramp in on attach and out on release. Without it the
+/// weapon snaps to the new axis in one frame, which reads as a glitch.
+const BLEND_FRAMES: f32 = 6.0;
+
+/// How long a lost support pose is held before the grip is dropped. Same window
+/// as the body anchors' (`body_frame::ANCHOR_HOLD_FRAMES`): a controller that
+/// blinks out for a few frames has not let go.
+const TRACKING_HOLD_FRAMES: u8 = 12;
+
+/// Latch points are cached per centimetre; finer than that is below what a
+/// tracked hand resolves and would only thrash the cache.
+const LATCH_QUANTUM: f32 = meters(0.01);
+
+/// Where the off-hand took hold of the other hand's item.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SupportLatch {
+    pub entity_id: EntityId,
+    /// The hand doing the supporting.
+    pub hand: Handedness,
+    /// The grip point, in the **primary** hand's own space - rigid with the
+    /// item, so it survives the aim swinging the item about.
+    pub point: Vector3<f32>,
+    /// Whether an authored support seat claimed it, rather than a free latch.
+    pub snapped: bool,
+}
+
+/// What the two-hand resolve says about one hand this frame.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TwoHandFrame {
+    /// The rotation the held item is placed with, replacing the tracked wrist
+    /// while a support is attached. `None` is ordinary one-hand placement.
+    ///
+    /// This is a *placement* rotation only: the glove still draws at the
+    /// tracked pose, because that is where the player's hand really is.
+    pub aim_rotation: Option<Quaternion<f32>>,
+    /// This hand holds a support grip on the other hand's item, so it must not
+    /// also grab or frob whatever its ray crosses.
+    pub supporting: bool,
+    /// This hand is empty and on (or already holding) the other hand's item:
+    /// the glove lights green for the grip it could take.
+    pub offered: bool,
+}
+
+/// One hand's inputs to the resolve.
+#[derive(Clone, Copy, Debug)]
+pub struct HandInput {
+    pub hand: Handedness,
+    /// World pose of the tracked hand, as `VirtualHand` sees it.
+    pub position: Vector3<f32>,
+    pub rotation: Quaternion<f32>,
+    pub squeeze: f32,
+    /// What this hand holds, from the *previous* frame's hand state.
+    pub held: Option<EntityId>,
+    /// The hand is already spoken for (a body anchor, a climbing hold): it
+    /// cannot also take a support grip.
+    pub claimed: bool,
+}
+
+/// Everything the resolve reads that is not per-hand.
+pub struct ResolveContext<'a> {
+    pub world: &'a shipyard::World,
+    pub physics: &'a PhysicsWorld,
+    pub hands: [HandInput; 2],
+}
+
+/// The two-hand grip state, owned by the VR interaction (it is the only thing
+/// that sees both hands).
+#[derive(Clone, Debug, Default)]
+pub struct TwoHandGrip {
+    latch: Option<SupportLatch>,
+    /// The last valid world aim axis (primary -> support). Kept through a
+    /// degenerate frame and through the whole release ramp, which is what lets
+    /// the weapon ease back to the wrist instead of snapping.
+    axis: Option<Vector3<f32>>,
+    /// 0 = one-handed, 1 = fully aimed down the hand line.
+    blend: f32,
+    lost_frames: u8,
+}
+
+impl TwoHandGrip {
+    /// Whether a support grip is attached right now.
+    pub fn is_two_handed(&self) -> bool {
+        self.latch.is_some()
+    }
+
+    pub fn latch(&self) -> Option<SupportLatch> {
+        self.latch
+    }
+
+    /// Advance a frame: take, keep or drop the support grip, then hand each
+    /// hand what it needs to place and light itself.
+    pub fn resolve(&mut self, ctx: &ResolveContext) -> [TwoHandFrame; 2] {
+        self.step_latch(ctx);
+
+        // Ramp toward the state the latch just settled on, so attach and
+        // release share one ease.
+        let target = if self.latch.is_some() { 1.0 } else { 0.0 };
+        let step = 1.0 / BLEND_FRAMES;
+        self.blend = if self.blend < target {
+            (self.blend + step).min(target)
+        } else {
+            (self.blend - step).max(target)
+        };
+        if self.blend <= 0.0 {
+            self.axis = None;
+        }
+
+        let mut frames = [TwoHandFrame::default(); 2];
+        let Some(latch) = self.latch else {
+            // Still easing back to the wrist after a release: the primary hand
+            // keeps an aim until the ramp reaches zero.
+            if self.blend > 0.0 {
+                if let Some(primary) = ctx
+                    .hands
+                    .iter()
+                    .find(|hand| hand.held.is_some() && !hand.claimed)
+                {
+                    frames[vr_config::hand_slot(primary.hand)].aim_rotation =
+                        self.aim_for(primary.rotation);
+                }
+            }
+            // An empty hand resting on the other's item still lights green.
+            if let Some(offered) = self.offer(ctx) {
+                frames[vr_config::hand_slot(offered)].offered = true;
+            }
+            return frames;
+        };
+
+        let support = ctx.hands[vr_config::hand_slot(latch.hand)];
+        let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(latch.hand))];
+
+        // The axis is re-read from the live hands every frame the pose is
+        // good; a lost or degenerate one keeps the last.
+        let delta = support.position - primary.position;
+        if delta.magnitude() >= MIN_HAND_SEPARATION {
+            self.axis = Some(delta.normalize());
+        }
+
+        frames[vr_config::hand_slot(support.hand)].supporting = true;
+        frames[vr_config::hand_slot(support.hand)].offered = true;
+        frames[vr_config::hand_slot(primary.hand)].aim_rotation = self.aim_for(primary.rotation);
+        frames
+    }
+
+    /// The placement rotation for a primary wrist at `wrist`, blended over the
+    /// attach/release ramp. `None` once the ramp is fully out.
+    fn aim_for(&self, wrist: Quaternion<f32>) -> Option<Quaternion<f32>> {
+        if self.blend <= 0.0 {
+            return None;
+        }
+        let axis = self.axis?;
+        Some(wrist.slerp(aim_rotation(wrist, axis), self.blend.min(1.0)))
+    }
+
+    /// Take, keep, or drop the support grip.
+    fn step_latch(&mut self, ctx: &ResolveContext) {
+        if let Some(latch) = self.latch {
+            let support = ctx.hands[vr_config::hand_slot(latch.hand)];
+            let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(latch.hand))];
+
+            // The primary letting go takes the support with it - the item is
+            // dropped, and this slice does not hand it over.
+            if primary.held != Some(latch.entity_id) {
+                self.latch = None;
+                return;
+            }
+            // A pose that blinks out is not a release: the controller keeps
+            // reporting its grip, so only a real open hand detaches. The hold
+            // window covers the pose, not the button.
+            if crate::util::tracked_rotation(support.rotation).is_none() {
+                if self.lost_frames >= TRACKING_HOLD_FRAMES {
+                    self.latch = None;
+                } else {
+                    self.lost_frames += 1;
+                }
+                return;
+            }
+            self.lost_frames = 0;
+            if support.squeeze < crate::ui::VR_TRIGGER_THRESHOLD {
+                self.latch = None;
+            }
+            return;
+        }
+
+        self.lost_frames = 0;
+        let Some(hand) = self.offer(ctx) else {
+            return;
+        };
+        let support = ctx.hands[vr_config::hand_slot(hand)];
+        // Closing on it is what takes hold, the same edge the world grab uses.
+        if support.squeeze < crate::ui::VR_TRIGGER_THRESHOLD {
+            return;
+        }
+        let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(hand))];
+        let Some(entity_id) = primary.held else {
+            return;
+        };
+        let Some((point, snapped)) = latch_point(ctx, primary, support) else {
+            return;
+        };
+        self.latch = Some(SupportLatch {
+            entity_id,
+            hand,
+            point,
+            snapped,
+        });
+    }
+
+    /// The hand that could take a support grip on the other's item this frame,
+    /// if any: empty, unclaimed, and on the item's surface.
+    fn offer(&self, ctx: &ResolveContext) -> Option<Handedness> {
+        for support in ctx.hands {
+            if support.held.is_some() || support.claimed {
+                continue;
+            }
+            let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(support.hand))];
+            if primary.held.is_none() || primary.claimed {
+                continue;
+            }
+            if latch_point(ctx, primary, support).is_some() {
+                return Some(support.hand);
+            }
+        }
+        None
+    }
+}
+
+/// The hand rotation that aims a held item down `axis`.
+///
+/// A VR hand points along its own -Z (the same forward the interaction ray
+/// uses), so aiming the item at the support hand means turning the placement
+/// frame until -Z lies along the hand line. Roll comes from the primary wrist's
+/// own up, projected off the axis: the player still decides which way the
+/// sights face, they just no longer decide where the barrel points.
+pub fn aim_rotation(wrist: Quaternion<f32>, axis: Vector3<f32>) -> Quaternion<f32> {
+    let z = -axis.normalize();
+    let up = wrist.rotate_vector(vec3(0.0, 1.0, 0.0));
+    // Hands stacked straight along the wrist's own up leave no roll reference;
+    // fall back to the wrist's right, which cannot also be parallel to z.
+    let mut x = up.cross(z);
+    if x.magnitude2() < 1e-6 {
+        x = wrist.rotate_vector(vec3(1.0, 0.0, 0.0));
+        x = x - z * x.dot(z);
+    }
+    if x.magnitude2() < 1e-6 {
+        return wrist;
+    }
+    let x = x.normalize();
+    let y = z.cross(x);
+    Quaternion::from(Matrix3::from_cols(x, y, z))
+}
+
+/// Where the off-hand's palm takes hold of the primary hand's item, in the
+/// primary hand's own space, and whether an authored seat claimed it.
+fn latch_point(
+    ctx: &ResolveContext,
+    primary: HandInput,
+    support: HandInput,
+) -> Option<(Vector3<f32>, bool)> {
+    let entity_id = primary.held?;
+    let (model_name, gun_scale) = vr_config::held_model_and_scale(ctx.world, entity_id)?;
+
+    let to_world =
+        crate::hand_glove::hand_to_world(primary.position, primary.rotation, primary.hand);
+    let to_hand = to_world.invert()?;
+    let palm_world =
+        crate::hand_glove::hand_to_world(support.position, support.rotation, support.hand)
+            .transform_point(Point3::from_vec(crate::hand_seat::PALM_CENTRE));
+    let palm = to_hand.transform_point(palm_world);
+
+    let to_model = vr_config::held_model_hand_transform(&model_name, primary.hand, gun_scale);
+
+    // An authored seat within reach wins: a hand brought to a shotgun's pump
+    // lands on the pump rather than a centimetre off it.
+    let snap = crate::vr_grips::support_seats(&model_name)
+        .into_iter()
+        .map(|seat| to_model.transform_point(Point3::from_vec(seat.offset())))
+        .map(|seat| (seat, (seat - palm).magnitude()))
+        .filter(|(_, distance)| *distance <= ANCHOR_SNAP_RADIUS)
+        .min_by(|a, b| a.1.total_cmp(&b.1));
+    if let Some((seat, _)) = snap {
+        return Some((seat.to_vec(), true));
+    }
+
+    on_surface(
+        ctx,
+        entity_id,
+        &model_name,
+        primary,
+        gun_scale,
+        palm,
+        palm_world,
+    )
+    .then_some((palm.to_vec(), false))
+}
+
+/// Whether the palm is on the held item's own surface.
+///
+/// Two volumes, because the two kinds of held item report different geometry:
+/// a melee wield is a *skinned* rig with no triangle soup to test, but it does
+/// carry the fitted contact cuboid its damage is billed through - which is
+/// exactly the volume the player sees. Everything else (the rigid gun `_h` set,
+/// world pickups) tests against its own render triangles.
+fn on_surface(
+    ctx: &ResolveContext,
+    entity_id: EntityId,
+    model_name: &str,
+    primary: HandInput,
+    gun_scale: f32,
+    palm_in_hand: Point3<f32>,
+    palm_world: Point3<f32>,
+) -> bool {
+    if let Some((centre, rotation, half_extents)) = ctx.physics.held_melee_contact_box(entity_id) {
+        let local = rotation
+            .invert()
+            .rotate_vector(palm_world.to_vec() - centre);
+        return box_distance(local, half_extents) <= CONTACT_RADIUS;
+    }
+
+    match contact_mesh(model_name, primary.hand, gun_scale) {
+        Some(mesh) => mesh.within(palm_in_hand, CONTACT_RADIUS),
+        None => false,
+    }
+}
+
+/// Distance from a point to an axis-aligned box centred on the origin.
+fn box_distance(point: Vector3<f32>, half_extents: Vector3<f32>) -> f32 {
+    let outside = vec3(
+        (point.x.abs() - half_extents.x).max(0.0),
+        (point.y.abs() - half_extents.y).max(0.0),
+        (point.z.abs() - half_extents.z).max(0.0),
+    );
+    outside.magnitude()
+}
+
+/// Held items' contact meshes, in the holding hand's own space, keyed the same
+/// way the finger fit keys its cache.
+///
+/// Filled by [`warm_contact_mesh`], where an asset cache is in reach, and read
+/// by the resolve, which runs in the hand update and has none - the same split
+/// [`crate::vr_grips`] uses for measured seats.
+type ContactKey = (String, Handedness, u32);
+static CONTACT: Lazy<RwLock<HashMap<ContactKey, Option<Arc<ContactMesh>>>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+fn contact_key(model_name: &str, handedness: Handedness, gun_scale: f32) -> ContactKey {
+    (
+        model_name.to_ascii_lowercase(),
+        handedness,
+        gun_scale.to_bits(),
+    )
+}
+
+/// Load and place `model_name`'s render triangles for a hand that holds it, if
+/// that has not happened yet. The miss is remembered too: a skinned melee rig
+/// has no triangles, and re-walking every asset mount for it each frame is what
+/// remembering avoids.
+pub fn warm_contact_mesh(
+    model_name: &str,
+    handedness: Handedness,
+    gun_scale: f32,
+    asset_cache: &mut AssetCache,
+) {
+    let key = contact_key(model_name, handedness, gun_scale);
+    if CONTACT.read().unwrap().contains_key(&key) {
+        return;
+    }
+    let to_hand = vr_config::held_model_hand_transform(model_name, handedness, gun_scale);
+    let mesh = asset_cache
+        .get_opt::<_, VrContactMesh, _>(&VR_CONTACT_MESH_IMPORTER, &format!("{model_name}.BIN"))
+        .map(|triangles| {
+            ContactMesh::new(
+                triangles
+                    .0
+                    .iter()
+                    .map(|triangle| triangle.map(|corner| to_hand.transform_point(corner)))
+                    .collect(),
+            )
+        })
+        .filter(|mesh| !mesh.is_empty())
+        .map(Arc::new);
+    CONTACT.write().unwrap().insert(key, mesh);
+}
+
+fn contact_mesh(
+    model_name: &str,
+    handedness: Handedness,
+    gun_scale: f32,
+) -> Option<Arc<ContactMesh>> {
+    CONTACT
+        .read()
+        .unwrap()
+        .get(&contact_key(model_name, handedness, gun_scale))
+        .cloned()
+        .flatten()
+}
+
+/// The support hand's own fit key: the item, and where on it the hand latched,
+/// rounded to the centimetre so a tracked hand's jitter does not re-solve it.
+pub fn quantise_latch(point: Vector3<f32>) -> [i32; 3] {
+    [
+        (point.x / LATCH_QUANTUM).round() as i32,
+        (point.y / LATCH_QUANTUM).round() as i32,
+        (point.z / LATCH_QUANTUM).round() as i32,
+    ]
+}

--- a/shock2vr/src/two_hand_grip.rs
+++ b/shock2vr/src/two_hand_grip.rs
@@ -19,17 +19,19 @@
 //! crawl through the off-hand as the aim swung it.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use cgmath::{
-    EuclideanSpace, InnerSpace, Matrix3, Point3, Quaternion, Rotation, SquareMatrix, Transform,
-    Vector3, vec3,
+    EuclideanSpace, InnerSpace, Point3, Quaternion, Rotation, SquareMatrix, Transform, Vector3,
+    vec3,
 };
 use engine::assets::asset_cache::AssetCache;
 use once_cell::sync::Lazy;
 use shipyard::EntityId;
 
-use crate::hand_fit::ContactMesh;
+use crate::hand_fit::{ContactMesh, GripFamily};
+use crate::hand_glove::GripKey;
 use crate::physics::PhysicsWorld;
 use crate::util::meters;
 use crate::vr_config::{self, Handedness};
@@ -51,10 +53,10 @@ const MIN_HAND_SEPARATION: f32 = meters(0.10);
 /// weapon snaps to the new axis in one frame, which reads as a glitch.
 const BLEND_FRAMES: f32 = 6.0;
 
-/// How long a lost support pose is held before the grip is dropped. Same window
-/// as the body anchors' (`body_frame::ANCHOR_HOLD_FRAMES`): a controller that
-/// blinks out for a few frames has not let go.
-const TRACKING_HOLD_FRAMES: u8 = 12;
+/// How long a lost support pose is held before the grip is dropped: the body
+/// anchors' own window, shared rather than re-declared so the two cannot drift.
+/// A controller that blinks out for a few frames has not let go.
+use crate::body_frame::ANCHOR_HOLD_FRAMES as TRACKING_HOLD_FRAMES;
 
 /// Latch points are cached per centimetre; finer than that is below what a
 /// tracked hand resolves and would only thrash the cache.
@@ -72,6 +74,20 @@ pub struct SupportLatch {
     pub point: Vector3<f32>,
     /// Whether an authored support seat claimed it, rather than a free latch.
     pub snapped: bool,
+    /// The grip family the claiming seat named, if one did. A free latch has
+    /// none - the seat's family describes the seat, so a hand that landed
+    /// somewhere else must not inherit it.
+    pub family: Option<GripFamily>,
+    /// The grip -> latch direction, in the frame the item is *placed* in (the
+    /// tracked hand, before the glove's own reflection). This is the axis the
+    /// two hands aim: the part of the item the second hand has hold of is what
+    /// must end up at the second hand.
+    ///
+    /// Item-relative on purpose. Aiming a fixed hand-local forward would be
+    /// right only for a gun, whose barrel happens to run down the wrist; a
+    /// wrench's shaft does not, and forcing its forward onto the hand line
+    /// swings the handle out of both hands.
+    pub direction: Vector3<f32>,
 }
 
 /// What the two-hand resolve says about one hand this frame.
@@ -122,9 +138,21 @@ pub struct TwoHandGrip {
     /// degenerate frame and through the whole release ramp, which is what lets
     /// the weapon ease back to the wrist instead of snapping.
     axis: Option<Vector3<f32>>,
+    /// The latched item's grip -> latch direction, kept beside the axis so the
+    /// release ramp still has both halves of the solve after the latch is gone.
+    direction: Option<Vector3<f32>>,
     /// 0 = one-handed, 1 = fully aimed down the hand line.
     blend: f32,
     lost_frames: u8,
+    /// Last frame's squeeze per hand, indexed by [`vr_config::hand_slot`]. A
+    /// support grip is taken on the closing EDGE, so a hand closed in empty
+    /// space that then sweeps onto the weapon does not silently attach.
+    squeezing: [bool; 2],
+    /// The hand and item the aim belongs to while the ramp runs out after a
+    /// release. Without it a release would hand the fading aim to whichever
+    /// hand happens to hold something - including the off-hand, if it grabbed
+    /// something of its own on the way out.
+    fading: Option<(Handedness, EntityId)>,
 }
 
 impl TwoHandGrip {
@@ -140,38 +168,52 @@ impl TwoHandGrip {
     /// Advance a frame: take, keep or drop the support grip, then hand each
     /// hand what it needs to place and light itself.
     pub fn resolve(&mut self, ctx: &ResolveContext) -> [TwoHandFrame; 2] {
-        self.step_latch(ctx);
+        let offered = self.step_latch(ctx);
         self.ramp(self.latch.is_some());
 
         let mut frames = [TwoHandFrame::default(); 2];
+        // An empty hand on the other's item lights green whether or not it has
+        // closed on it yet.
+        if let Some(hand) = offered {
+            frames[vr_config::hand_slot(hand)].offered = true;
+        }
+
         let Some(latch) = self.latch else {
-            // Still easing back to the wrist after a release: the primary hand
-            // keeps an aim until the ramp reaches zero.
-            if self.blend > 0.0 {
-                if let Some(primary) = ctx
-                    .hands
-                    .iter()
-                    .find(|hand| hand.held.is_some() && !hand.claimed)
-                {
-                    frames[vr_config::hand_slot(primary.hand)].aim_rotation =
-                        self.aim_for(primary.rotation);
+            // Easing back to the wrist after a release. The aim goes to the
+            // hand that had it, and only while that hand still holds the same
+            // item - anything else and there is nothing left to ease.
+            match self.fading.filter(|(hand, entity_id)| {
+                self.blend > 0.0 && ctx.hands[vr_config::hand_slot(*hand)].held == Some(*entity_id)
+            }) {
+                Some((hand, _)) => {
+                    frames[vr_config::hand_slot(hand)].aim_rotation =
+                        self.aim_for(ctx.hands[vr_config::hand_slot(hand)].rotation);
                 }
-            }
-            // An empty hand resting on the other's item still lights green.
-            if let Some(offered) = self.offer(ctx) {
-                frames[vr_config::hand_slot(offered)].offered = true;
+                None => {
+                    self.blend = 0.0;
+                    self.axis = None;
+                    self.direction = None;
+                    self.fading = None;
+                }
             }
             return frames;
         };
 
         let support = ctx.hands[vr_config::hand_slot(latch.hand)];
-        let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(latch.hand))];
+        let primary_hand = vr_config::other_hand(latch.hand);
+        let primary = ctx.hands[vr_config::hand_slot(primary_hand)];
 
-        self.track_axis(primary.position, support.position);
+        // A held pose is not a tracked one: reading the axis off an untracked
+        // position would swing the weapon for the whole hold window.
+        if crate::util::tracked_rotation(support.rotation).is_some() {
+            self.track_axis(primary.position, support.position);
+        }
+        self.direction = Some(latch.direction);
+        self.fading = Some((primary_hand, latch.entity_id));
 
         frames[vr_config::hand_slot(support.hand)].supporting = true;
         frames[vr_config::hand_slot(support.hand)].offered = true;
-        frames[vr_config::hand_slot(primary.hand)].aim_rotation = self.aim_for(primary.rotation);
+        frames[vr_config::hand_slot(primary_hand)].aim_rotation = self.aim_for(primary.rotation);
         frames
     }
 
@@ -188,6 +230,7 @@ impl TwoHandGrip {
         };
         if self.blend <= 0.0 {
             self.axis = None;
+            self.direction = None;
         }
     }
 
@@ -207,67 +250,86 @@ impl TwoHandGrip {
         if self.blend <= 0.0 {
             return None;
         }
-        let axis = self.axis?;
-        Some(wrist.slerp(aim_rotation(wrist, axis), self.blend.min(1.0)))
+        let (axis, direction) = (self.axis?, self.direction?);
+        Some(wrist.slerp(aim_rotation(wrist, direction, axis), self.blend))
     }
 
-    /// Take, keep, or drop the support grip.
-    fn step_latch(&mut self, ctx: &ResolveContext) {
+    /// Take, keep, or drop the support grip, and report the hand that is on the
+    /// other's item this frame (the one that lights green) - resolved once,
+    /// because the surface test it runs is the expensive part of the frame.
+    fn step_latch(&mut self, ctx: &ResolveContext) -> Option<Handedness> {
+        let closed = |hand: &HandInput| hand.squeeze >= crate::ui::VR_TRIGGER_THRESHOLD;
+        let mut now_closed = [false; 2];
+        for hand in ctx.hands {
+            now_closed[vr_config::hand_slot(hand.hand)] = closed(&hand);
+        }
+        let was_closed = std::mem::replace(&mut self.squeezing, now_closed);
+
         if let Some(latch) = self.latch {
             let support = ctx.hands[vr_config::hand_slot(latch.hand)];
             let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(latch.hand))];
 
             // The primary letting go takes the support with it - the item is
             // dropped, and this slice does not hand it over.
-            if primary.held != Some(latch.entity_id) {
+            //
+            // The support hand is re-checked too: the two-hand grip only claims
+            // it for as long as the grip stands, so a hand that has since taken
+            // a climbing hold, reached a body anchor or picked something up has
+            // left.
+            if primary.held != Some(latch.entity_id)
+                || primary.claimed
+                || support.held.is_some()
+                || support.claimed
+            {
                 self.latch = None;
-                return;
+                return None;
             }
-            // A pose that blinks out is not a release: the controller keeps
-            // reporting its grip, so only a real open hand detaches. The hold
-            // window covers the pose, not the button.
+            // Opening the hand releases, tracked or not: the controller reports
+            // its grip through a lost pose, so the button is the reliable half
+            // and is read first. The hold window below covers the pose alone.
+            if !closed(&support) {
+                self.latch = None;
+                return None;
+            }
             if crate::util::tracked_rotation(support.rotation).is_none() {
                 if self.lost_frames >= TRACKING_HOLD_FRAMES {
                     self.latch = None;
-                } else {
-                    self.lost_frames += 1;
+                    return None;
                 }
-                return;
+                self.lost_frames += 1;
+                return Some(latch.hand);
             }
             self.lost_frames = 0;
-            if support.squeeze < crate::ui::VR_TRIGGER_THRESHOLD {
-                self.latch = None;
-            }
-            return;
+            return Some(latch.hand);
         }
 
         self.lost_frames = 0;
-        let Some(hand) = self.offer(ctx) else {
-            return;
-        };
+        let (hand, taken) = self.offer(ctx)?;
         let support = ctx.hands[vr_config::hand_slot(hand)];
-        // Closing on it is what takes hold, the same edge the world grab uses.
-        if support.squeeze < crate::ui::VR_TRIGGER_THRESHOLD {
-            return;
+        // Closing ON the item is what takes hold - the same rising edge the
+        // body anchors commit on. A hand already closed when it arrives has to
+        // open and close again, so sweeping a fist across a held weapon does
+        // not grab it.
+        if !closed(&support) || was_closed[vr_config::hand_slot(hand)] {
+            return Some(hand);
         }
+        // An untracked hand has no palm to latch at.
+        crate::util::tracked_rotation(support.rotation)?;
         let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(hand))];
-        let Some(entity_id) = primary.held else {
-            return;
-        };
-        let Some((point, snapped)) = latch_point(ctx, primary, support) else {
-            return;
-        };
         self.latch = Some(SupportLatch {
-            entity_id,
+            entity_id: primary.held?,
             hand,
-            point,
-            snapped,
+            point: taken.point,
+            snapped: taken.snapped,
+            family: taken.family,
+            direction: taken.direction,
         });
+        Some(hand)
     }
 
     /// The hand that could take a support grip on the other's item this frame,
     /// if any: empty, unclaimed, and on the item's surface.
-    fn offer(&self, ctx: &ResolveContext) -> Option<Handedness> {
+    fn offer(&self, ctx: &ResolveContext) -> Option<(Handedness, TakenGrip)> {
         for support in ctx.hands {
             if support.held.is_some() || support.claimed {
                 continue;
@@ -276,46 +338,64 @@ impl TwoHandGrip {
             if primary.held.is_none() || primary.claimed {
                 continue;
             }
-            if latch_point(ctx, primary, support).is_some() {
-                return Some(support.hand);
+            // Resolved once and carried out: the surface test is the expensive
+            // part of the frame, and it runs whenever one hand holds something
+            // and the other is free - which is most of normal play.
+            if let Some(taken) = latch_point(ctx, primary, support) {
+                return Some((support.hand, taken));
             }
         }
         None
     }
 }
 
-/// The hand rotation that aims a held item down `axis`.
+/// The placement rotation that puts the part of the item the support hand has
+/// hold of onto the support hand.
 ///
-/// A VR hand points along its own -Z (the same forward the interaction ray
-/// uses), so aiming the item at the support hand means turning the placement
-/// frame until -Z lies along the hand line. Roll comes from the primary wrist's
-/// own up, projected off the axis: the player still decides which way the
-/// sights face, they just no longer decide where the barrel points.
-pub fn aim_rotation(wrist: Quaternion<f32>, axis: Vector3<f32>) -> Quaternion<f32> {
-    let z = -axis.normalize();
-    let up = wrist.rotate_vector(vec3(0.0, 1.0, 0.0));
-    // Hands stacked straight along the wrist's own up leave no roll reference;
-    // fall back to the wrist's right, which cannot also be parallel to z.
-    let mut x = up.cross(z);
-    if x.magnitude2() < 1e-6 {
-        x = wrist.rotate_vector(vec3(1.0, 0.0, 0.0));
-        x = x - z * x.dot(z);
-    }
-    if x.magnitude2() < 1e-6 {
+/// `direction` is the grip -> latch direction in the item's own placement frame
+/// and `axis` is where that has to point in the world (primary hand -> support
+/// hand). The answer is the wrist turned by the **shortest arc** between the two
+/// - which adds no twist about the axis, so the primary wrist keeps the roll,
+/// and which is exactly the identity while the hands are still where the
+/// one-hand pose put them. That last property is what makes attaching seamless:
+/// the ease starts from no correction at all and only grows as the hands move.
+pub fn aim_rotation(
+    wrist: Quaternion<f32>,
+    direction: Vector3<f32>,
+    axis: Vector3<f32>,
+) -> Quaternion<f32> {
+    let from = wrist.rotate_vector(direction);
+    if from.magnitude2() < 1e-12 || axis.magnitude2() < 1e-12 {
         return wrist;
     }
-    let x = x.normalize();
-    let y = z.cross(x);
-    Quaternion::from(Matrix3::from_cols(x, y, z))
+    let from = from.normalize();
+    let axis = axis.normalize();
+    // Hands folded back through the grip leave the arc ambiguous (any plane
+    // through the pair turns one onto the other); hold the pose rather than
+    // pick one at random.
+    if from.dot(axis) < -0.999_9 {
+        return wrist;
+    }
+    Quaternion::between_vectors(from, axis) * wrist
 }
 
-/// Where the off-hand's palm takes hold of the primary hand's item, in the
-/// primary hand's own space, and whether an authored seat claimed it.
-fn latch_point(
-    ctx: &ResolveContext,
-    primary: HandInput,
-    support: HandInput,
-) -> Option<(Vector3<f32>, bool)> {
+/// What the off-hand took hold of.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TakenGrip {
+    /// The grip point in the item's own model space.
+    point: Vector3<f32>,
+    snapped: bool,
+    family: Option<GripFamily>,
+    /// Grip -> latch, in the placement frame (see [`SupportLatch::direction`]).
+    direction: Vector3<f32>,
+}
+
+/// Where the off-hand's palm takes hold of the primary hand's item, and how.
+///
+/// The surface test comes first because it is the one that says *no* on almost
+/// every frame: the authored seats are only read once the palm is known to be
+/// on the item at all.
+fn latch_point(ctx: &ResolveContext, primary: HandInput, support: HandInput) -> Option<TakenGrip> {
     let entity_id = primary.held?;
     let (model_name, gun_scale) = vr_config::held_model_and_scale(ctx.world, entity_id)?;
 
@@ -326,19 +406,6 @@ fn latch_point(
         crate::hand_glove::hand_to_world(support.position, support.rotation, support.hand)
             .transform_point(Point3::from_vec(crate::hand_seat::PALM_CENTRE));
     let palm = to_hand.transform_point(palm_world);
-
-    let to_model = vr_config::held_model_hand_transform(&model_name, primary.hand, gun_scale);
-
-    let seats: Vec<SupportSeatPoint> = crate::vr_grips::support_seats(&model_name)
-        .into_iter()
-        .map(|seat| SupportSeatPoint {
-            model: seat.offset(),
-            hand: to_model.transform_point(Point3::from_vec(seat.offset())),
-        })
-        .collect();
-    if let Some(seat) = nearest_seat(palm, &seats) {
-        return Some((seat.model, true));
-    }
 
     if !on_surface(
         ctx,
@@ -351,9 +418,36 @@ fn latch_point(
     ) {
         return None;
     }
-    // Back into the item's own space, which is where the latch has to live to
-    // stay put while the aim swings the item about.
-    Some((to_model.invert()?.transform_point(palm).to_vec(), false))
+
+    let to_model = vr_config::held_model_hand_transform(&model_name, primary.hand, gun_scale);
+    // An authored seat within reach claims the grip; otherwise the palm latches
+    // where it landed. Either way the point goes back into the item's own space,
+    // which is where it has to live to stay put while the aim swings the item.
+    let seats: Vec<SupportSeatPoint> = crate::vr_grips::support_seats(&model_name)
+        .into_iter()
+        .map(|seat| SupportSeatPoint {
+            model: seat.offset(),
+            family: seat.family(),
+            hand: to_model.transform_point(Point3::from_vec(seat.offset())),
+        })
+        .collect();
+    let (point, hand_point, snapped, family) = match nearest_seat(palm, &seats) {
+        Some(seat) => (seat.model, seat.hand, true, seat.family),
+        None => (
+            to_model.invert()?.transform_point(palm).to_vec(),
+            palm,
+            false,
+            None,
+        ),
+    };
+    Some(TakenGrip {
+        point,
+        snapped,
+        family,
+        // The placement frame is the tracked hand BEFORE the glove's own
+        // reflection, so the grip's hand-space position reflects back out of it.
+        direction: primary.hand.mirror_point(hand_point.to_vec()),
+    })
 }
 
 /// The authored seat the palm should snap to, if one is within reach.
@@ -378,6 +472,7 @@ fn nearest_seat(palm: Point3<f32>, seats: &[SupportSeatPoint]) -> Option<Support
 struct SupportSeatPoint {
     model: Vector3<f32>,
     hand: Point3<f32>,
+    family: Option<GripFamily>,
 }
 
 /// Whether the palm is on the held item's own surface.
@@ -419,22 +514,26 @@ fn box_distance(point: Vector3<f32>, half_extents: Vector3<f32>) -> f32 {
     outside.magnitude()
 }
 
-/// Held items' contact meshes, in the holding hand's own space, keyed the same
-/// way the finger fit keys its cache.
+/// Held items' contact meshes, in the holding hand's own space, under the same
+/// key the finger fit uses - the model, the hand's reflection, and the scale the
+/// wield baked in decide the placement, so one key serves both.
 ///
 /// Filled by [`warm_contact_mesh`], where an asset cache is in reach, and read
 /// by the resolve, which runs in the hand update and has none - the same split
 /// [`crate::vr_grips`] uses for measured seats.
-type ContactKey = (String, Handedness, u32);
-static CONTACT: Lazy<RwLock<HashMap<ContactKey, Option<Arc<ContactMesh>>>>> =
+static CONTACT: Lazy<RwLock<HashMap<GripKey, Option<Arc<ContactMesh>>>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
 
-fn contact_key(model_name: &str, handedness: Handedness, gun_scale: f32) -> ContactKey {
-    (
-        model_name.to_ascii_lowercase(),
-        handedness,
-        gun_scale.to_bits(),
-    )
+/// The [`crate::vr_grips::generation`] the cache was filled at. A tuner edit
+/// re-seats every held item, so meshes placed against the old seat are stale -
+/// the same invalidation the finger fit's own cache runs.
+static CONTACT_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+fn drop_stale_contact_meshes() {
+    let generation = crate::vr_grips::generation();
+    if CONTACT_GENERATION.swap(generation, Ordering::Relaxed) != generation {
+        CONTACT.write().unwrap().clear();
+    }
 }
 
 /// Load and place `model_name`'s render triangles for a hand that holds it, if
@@ -447,7 +546,8 @@ pub fn warm_contact_mesh(
     gun_scale: f32,
     asset_cache: &mut AssetCache,
 ) {
-    let key = contact_key(model_name, handedness, gun_scale);
+    drop_stale_contact_meshes();
+    let key = GripKey::new(model_name, handedness, gun_scale);
     if CONTACT.read().unwrap().contains_key(&key) {
         return;
     }
@@ -463,7 +563,7 @@ fn contact_mesh(
     CONTACT
         .read()
         .unwrap()
-        .get(&contact_key(model_name, handedness, gun_scale))
+        .get(&GripKey::new(model_name, handedness, gun_scale))
         .cloned()
         .flatten()
 }
@@ -494,6 +594,7 @@ mod tests {
         SupportSeatPoint {
             model: vec3(x, 0.0, 0.0),
             hand: Point3::new(x, 0.0, 0.0),
+            family: None,
         }
     }
 
@@ -506,6 +607,10 @@ mod tests {
         rotation.rotate_vector(vec3(0.0, 1.0, 0.0))
     }
 
+    /// A gun-shaped latch: the second hand has hold of a point out along the
+    /// hand's own forward (a foregrip ahead of the pistol grip).
+    const ALONG_BARREL: Vector3<f32> = vec3(0.0, 0.0, -1.0);
+
     fn degrees_between(a: Vector3<f32>, b: Vector3<f32>) -> f32 {
         a.dot(b).clamp(-1.0, 1.0).acos().to_degrees()
     }
@@ -517,7 +622,7 @@ mod tests {
         // A wrist pointing straight ahead, with the support hand out to the
         // side: the aim has to leave the wrist's own forward entirely.
         let axis = vec3(1.0, 0.0, 0.0);
-        let aimed = aim_rotation(identity(), axis);
+        let aimed = aim_rotation(identity(), ALONG_BARREL, axis);
         assert_relative_eq!(forward(aimed), axis, epsilon = 1e-5);
     }
 
@@ -526,10 +631,10 @@ mod tests {
     #[test]
     fn the_primary_wrist_still_owns_the_roll() {
         let axis = vec3(1.0, 0.0, 0.0);
-        let upright = aim_rotation(identity(), axis);
+        let upright = aim_rotation(identity(), ALONG_BARREL, axis);
         // Rolling about the wrist's own forward is the gesture that must reach
         // the sights.
-        let rolled = aim_rotation(Quaternion::from_angle_z(Deg(90.0)), axis);
+        let rolled = aim_rotation(Quaternion::from_angle_z(Deg(90.0)), ALONG_BARREL, axis);
 
         assert_relative_eq!(forward(rolled), axis, epsilon = 1e-5);
         let turn = degrees_between(up(upright), up(rolled));
@@ -544,7 +649,7 @@ mod tests {
     #[test]
     fn an_axis_along_the_wrists_own_up_still_solves() {
         let axis = vec3(0.0, 1.0, 0.0);
-        let aimed = aim_rotation(identity(), axis);
+        let aimed = aim_rotation(identity(), ALONG_BARREL, axis);
         assert_relative_eq!(forward(aimed), axis, epsilon = 1e-5);
         assert_relative_eq!(up(aimed).magnitude(), 1.0, epsilon = 1e-4);
         assert_relative_eq!(up(aimed).dot(axis), 0.0, epsilon = 1e-4);
@@ -573,6 +678,7 @@ mod tests {
     #[test]
     fn the_aim_eases_in_and_back_out() {
         let mut grip = TwoHandGrip::default();
+        grip.direction = Some(ALONG_BARREL);
         grip.track_axis(Vector3::zero(), vec3(1.0, 0.0, 0.0));
 
         grip.ramp(true);
@@ -651,6 +757,205 @@ mod tests {
         assert!(
             crate::vr_grips::support_seats("fsn_h").is_empty(),
             "an oversized weapon bakes no support hand and authors no seat"
+        );
+    }
+
+    /// A support grip already taken, so the retention path can be driven with
+    /// no assets: `latch_point` is only consulted when taking a new one.
+    fn attached(hand: Handedness, entity_id: EntityId) -> TwoHandGrip {
+        TwoHandGrip {
+            latch: Some(SupportLatch {
+                entity_id,
+                hand,
+                point: Vector3::zero(),
+                snapped: false,
+                family: None,
+                direction: ALONG_BARREL,
+            }),
+            squeezing: [true, true],
+            ..Default::default()
+        }
+    }
+
+    /// Two closed, tracked hands a stride apart, with `entity_id` in `hand`.
+    fn held_by(hand: Handedness, entity_id: EntityId) -> [HandInput; 2] {
+        let mut hands = [
+            HandInput {
+                hand: Handedness::Left,
+                position: Vector3::zero(),
+                rotation: identity(),
+                squeeze: 1.0,
+                held: None,
+                claimed: false,
+            },
+            HandInput {
+                hand: Handedness::Right,
+                position: vec3(0.0, meters(0.4), 0.0),
+                rotation: identity(),
+                squeeze: 1.0,
+                held: None,
+                claimed: false,
+            },
+        ];
+        hands[vr_config::hand_slot(hand)].held = Some(entity_id);
+        hands
+    }
+
+    /// Drive one frame of the retention path.
+    fn step(grip: &mut TwoHandGrip, hands: [HandInput; 2]) {
+        let world = shipyard::World::new();
+        let physics = crate::physics::PhysicsWorld::new();
+        grip.resolve(&ResolveContext {
+            world: &world,
+            physics: &physics,
+            hands,
+        });
+    }
+
+    /// A controller that blinks out behind the player has not let go: the grip
+    /// survives the hold window, then gives up.
+    #[test]
+    fn a_lost_support_pose_is_held_then_dropped() {
+        let item = EntityId::from_inner(9).unwrap();
+        let mut grip = attached(Handedness::Left, item);
+        let mut hands = held_by(Handedness::Right, item);
+        // The zero quaternion is what a runtime reports for an untracked pose.
+        hands[vr_config::hand_slot(Handedness::Left)].rotation =
+            Quaternion::new(0.0, 0.0, 0.0, 0.0);
+
+        for frame in 0..TRACKING_HOLD_FRAMES {
+            step(&mut grip, hands);
+            assert!(
+                grip.is_two_handed(),
+                "frame {frame} inside the window let go"
+            );
+        }
+        step(&mut grip, hands);
+        assert!(!grip.is_two_handed(), "the window should eventually expire");
+    }
+
+    /// The controller keeps reporting its grip through a lost pose, so opening
+    /// the hand must release whether or not the pose came back.
+    #[test]
+    fn opening_an_untracked_support_hand_still_releases() {
+        let item = EntityId::from_inner(9).unwrap();
+        let mut grip = attached(Handedness::Left, item);
+        let mut hands = held_by(Handedness::Right, item);
+        hands[vr_config::hand_slot(Handedness::Left)].rotation =
+            Quaternion::new(0.0, 0.0, 0.0, 0.0);
+        hands[vr_config::hand_slot(Handedness::Left)].squeeze = 0.0;
+
+        step(&mut grip, hands);
+        assert!(
+            !grip.is_two_handed(),
+            "an open hand is a release, tracked or not"
+        );
+    }
+
+    /// An untracked support pose must not drag the aim about: the axis is held
+    /// with the grip, not re-read off a position the runtime is not reporting.
+    #[test]
+    fn a_lost_support_pose_freezes_the_aim_axis() {
+        let item = EntityId::from_inner(9).unwrap();
+        let mut grip = attached(Handedness::Left, item);
+        let hands = held_by(Handedness::Right, item);
+        step(&mut grip, hands);
+        let tracked = grip.axis.expect("a tracked frame reads the axis");
+
+        // The pose drops out and the reported position lurches somewhere else.
+        let mut lost = hands;
+        lost[vr_config::hand_slot(Handedness::Left)].rotation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
+        lost[vr_config::hand_slot(Handedness::Left)].position = vec3(meters(0.9), 0.0, 0.0);
+        step(&mut grip, lost);
+        assert_relative_eq!(grip.axis.unwrap(), tracked, epsilon = 1e-5);
+    }
+
+    /// The support hand is only claimed for as long as the grip stands, so a
+    /// hand that has since been claimed by the body or a climb has left.
+    #[test]
+    fn a_support_hand_claimed_elsewhere_lets_go() {
+        let item = EntityId::from_inner(9).unwrap();
+        let mut grip = attached(Handedness::Left, item);
+        let mut hands = held_by(Handedness::Right, item);
+        hands[vr_config::hand_slot(Handedness::Left)].claimed = true;
+
+        step(&mut grip, hands);
+        assert!(
+            !grip.is_two_handed(),
+            "a hand claimed elsewhere is not supporting"
+        );
+    }
+
+    /// The primary letting go takes the support with it - and the fading aim
+    /// must not follow the ramp onto whatever either hand grabs next.
+    #[test]
+    fn the_primary_releasing_drops_the_support_and_its_aim() {
+        let item = EntityId::from_inner(9).unwrap();
+        let mut grip = attached(Handedness::Left, item);
+        let mut hands = held_by(Handedness::Right, item);
+        hands[vr_config::hand_slot(Handedness::Right)].held = None;
+
+        step(&mut grip, hands);
+        assert!(!grip.is_two_handed());
+
+        // A different item, in the other hand, one frame later.
+        step(
+            &mut grip,
+            held_by(Handedness::Left, EntityId::from_inner(11).unwrap()),
+        );
+        assert!(
+            grip.aim_for(identity()).is_none(),
+            "no aim survives the item it was solved for"
+        );
+    }
+
+    /// The aim points the part of the item the second hand HAS HOLD OF at the
+    /// second hand - not a fixed hand-local forward. A wrench's shaft does not
+    /// run down the wrist, and aiming the wrist's forward would swing its
+    /// handle out of both hands.
+    #[test]
+    fn the_aim_points_the_grip_the_second_hand_holds_at_that_hand() {
+        // A shaft running up out of the fist, as the melee wield seats it.
+        let shaft = vec3(0.0, 1.0, 0.0);
+        // ... and a support hand out to the right instead.
+        let axis = vec3(1.0, 0.0, 0.0);
+        let aimed = aim_rotation(identity(), shaft, axis);
+
+        assert_relative_eq!(aimed.rotate_vector(shaft), axis, epsilon = 1e-5);
+        // Aiming the hand's forward instead would have left the shaft pointing
+        // somewhere else entirely.
+        let wrong = aim_rotation(identity(), ALONG_BARREL, axis);
+        assert!(
+            degrees_between(wrong.rotate_vector(shaft), axis) > 45.0,
+            "the fixed-forward solve is what this test exists to rule out"
+        );
+    }
+
+    /// The solve is the identity while the hands are still where the one-hand
+    /// pose put them, which is what makes the attach ease start from nothing.
+    #[test]
+    fn an_attach_with_the_hands_already_in_place_changes_nothing() {
+        let wrist = Quaternion::from_angle_y(Deg(35.0));
+        let grip = vec3(0.2, 0.9, -0.3);
+        let aimed = aim_rotation(wrist, grip, wrist.rotate_vector(grip));
+        assert_relative_eq!(
+            aimed.rotate_vector(vec3(1.0, 2.0, 3.0)),
+            wrist.rotate_vector(vec3(1.0, 2.0, 3.0)),
+            epsilon = 1e-4
+        );
+    }
+
+    /// Hands folded back through the grip leave the arc ambiguous; hold the
+    /// pose rather than pick a plane at random.
+    #[test]
+    fn an_antiparallel_axis_holds_the_wrist_pose() {
+        let wrist = Quaternion::from_angle_y(Deg(20.0));
+        let grip = vec3(0.0, 0.0, -1.0);
+        let aimed = aim_rotation(wrist, grip, -wrist.rotate_vector(grip));
+        assert_relative_eq!(
+            aimed.rotate_vector(vec3(1.0, 2.0, 3.0)),
+            wrist.rotate_vector(vec3(1.0, 2.0, 3.0)),
+            epsilon = 1e-4
         );
     }
 }

--- a/shock2vr/src/two_hand_grip.rs
+++ b/shock2vr/src/two_hand_grip.rs
@@ -29,8 +29,6 @@ use engine::assets::asset_cache::AssetCache;
 use once_cell::sync::Lazy;
 use shipyard::EntityId;
 
-use dark::importers::{VR_CONTACT_MESH_IMPORTER, VrContactMesh};
-
 use crate::hand_fit::ContactMesh;
 use crate::physics::PhysicsWorld;
 use crate::util::meters;
@@ -453,21 +451,8 @@ pub fn warm_contact_mesh(
     if CONTACT.read().unwrap().contains_key(&key) {
         return;
     }
-    let to_hand = vr_config::held_model_hand_transform(model_name, handedness, gun_scale);
-    let mesh = asset_cache
-        .get_opt::<_, VrContactMesh, _>(&VR_CONTACT_MESH_IMPORTER, &format!("{model_name}.BIN"))
-        .map(|triangles| {
-            ContactMesh::new(
-                triangles
-                    .0
-                    .iter()
-                    .map(|triangle| triangle.map(|corner| to_hand.transform_point(corner)))
-                    .collect(),
-            )
-        })
-        .filter(|mesh| !mesh.is_empty())
-        .map(Arc::new);
-    CONTACT.write().unwrap().insert(key, mesh);
+    let mesh = crate::hand_glove::contact_mesh(model_name, handedness, gun_scale, asset_cache);
+    CONTACT.write().unwrap().insert(key, mesh.map(Arc::new));
 }
 
 fn contact_mesh(

--- a/shock2vr/src/two_hand_grip.rs
+++ b/shock2vr/src/two_hand_grip.rs
@@ -68,8 +68,9 @@ pub struct SupportLatch {
     pub entity_id: EntityId,
     /// The hand doing the supporting.
     pub hand: Handedness,
-    /// The grip point, in the **primary** hand's own space - rigid with the
-    /// item, so it survives the aim swinging the item about.
+    /// The grip point in the item's own **model** space - rigid with the item,
+    /// so it survives the aim swinging the item about, and the space the
+    /// authored seats and the render triangles are already written in.
     pub point: Vector3<f32>,
     /// Whether an authored support seat claimed it, rather than a free latch.
     pub snapped: bool,
@@ -142,19 +143,7 @@ impl TwoHandGrip {
     /// hand what it needs to place and light itself.
     pub fn resolve(&mut self, ctx: &ResolveContext) -> [TwoHandFrame; 2] {
         self.step_latch(ctx);
-
-        // Ramp toward the state the latch just settled on, so attach and
-        // release share one ease.
-        let target = if self.latch.is_some() { 1.0 } else { 0.0 };
-        let step = 1.0 / BLEND_FRAMES;
-        self.blend = if self.blend < target {
-            (self.blend + step).min(target)
-        } else {
-            (self.blend - step).max(target)
-        };
-        if self.blend <= 0.0 {
-            self.axis = None;
-        }
+        self.ramp(self.latch.is_some());
 
         let mut frames = [TwoHandFrame::default(); 2];
         let Some(latch) = self.latch else {
@@ -180,17 +169,38 @@ impl TwoHandGrip {
         let support = ctx.hands[vr_config::hand_slot(latch.hand)];
         let primary = ctx.hands[vr_config::hand_slot(vr_config::other_hand(latch.hand))];
 
-        // The axis is re-read from the live hands every frame the pose is
-        // good; a lost or degenerate one keeps the last.
-        let delta = support.position - primary.position;
-        if delta.magnitude() >= MIN_HAND_SEPARATION {
-            self.axis = Some(delta.normalize());
-        }
+        self.track_axis(primary.position, support.position);
 
         frames[vr_config::hand_slot(support.hand)].supporting = true;
         frames[vr_config::hand_slot(support.hand)].offered = true;
         frames[vr_config::hand_slot(primary.hand)].aim_rotation = self.aim_for(primary.rotation);
         frames
+    }
+
+    /// Advance the attach/release ease one frame toward `attached`. One ramp
+    /// in both directions, so a weapon eases back to the wrist exactly as it
+    /// eased onto the hand line.
+    fn ramp(&mut self, attached: bool) {
+        let target = if attached { 1.0 } else { 0.0 };
+        let step = 1.0 / BLEND_FRAMES;
+        self.blend = if self.blend < target {
+            (self.blend + step).min(target)
+        } else {
+            (self.blend - step).max(target)
+        };
+        if self.blend <= 0.0 {
+            self.axis = None;
+        }
+    }
+
+    /// Re-read the aim axis from the live hands. Hands closer together than
+    /// [`MIN_HAND_SEPARATION`] carry no direction, so the last good one stands
+    /// - hands do cross, and the weapon must not spin when they do.
+    fn track_axis(&mut self, primary: Vector3<f32>, support: Vector3<f32>) {
+        let delta = support - primary;
+        if delta.magnitude() >= MIN_HAND_SEPARATION {
+            self.axis = Some(delta.normalize());
+        }
     }
 
     /// The placement rotation for a primary wrist at `wrist`, blended over the
@@ -321,19 +331,18 @@ fn latch_point(
 
     let to_model = vr_config::held_model_hand_transform(&model_name, primary.hand, gun_scale);
 
-    // An authored seat within reach wins: a hand brought to a shotgun's pump
-    // lands on the pump rather than a centimetre off it.
-    let snap = crate::vr_grips::support_seats(&model_name)
+    let seats: Vec<SupportSeatPoint> = crate::vr_grips::support_seats(&model_name)
         .into_iter()
-        .map(|seat| to_model.transform_point(Point3::from_vec(seat.offset())))
-        .map(|seat| (seat, (seat - palm).magnitude()))
-        .filter(|(_, distance)| *distance <= ANCHOR_SNAP_RADIUS)
-        .min_by(|a, b| a.1.total_cmp(&b.1));
-    if let Some((seat, _)) = snap {
-        return Some((seat.to_vec(), true));
+        .map(|seat| SupportSeatPoint {
+            model: seat.offset(),
+            hand: to_model.transform_point(Point3::from_vec(seat.offset())),
+        })
+        .collect();
+    if let Some(seat) = nearest_seat(palm, &seats) {
+        return Some((seat.model, true));
     }
 
-    on_surface(
+    if !on_surface(
         ctx,
         entity_id,
         &model_name,
@@ -341,8 +350,36 @@ fn latch_point(
         gun_scale,
         palm,
         palm_world,
-    )
-    .then_some((palm.to_vec(), false))
+    ) {
+        return None;
+    }
+    // Back into the item's own space, which is where the latch has to live to
+    // stay put while the aim swings the item about.
+    Some((to_model.invert()?.transform_point(palm).to_vec(), false))
+}
+
+/// The authored seat the palm should snap to, if one is within reach.
+///
+/// The snap is a *preference*: away from every seat - and on a model that
+/// authors none at all, which the oversized weapons do not - the palm latches
+/// wherever it is. That is what makes "take hold anywhere" the rule and the
+/// authored seats the exception.
+fn nearest_seat(palm: Point3<f32>, seats: &[SupportSeatPoint]) -> Option<SupportSeatPoint> {
+    seats
+        .iter()
+        .copied()
+        .map(|seat| (seat, (seat.hand - palm).magnitude()))
+        .filter(|(_, distance)| *distance <= ANCHOR_SNAP_RADIUS)
+        .min_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(seat, _)| seat)
+}
+
+/// One authored seat, in both the spaces the choice needs: the hand space the
+/// palm is measured in, and the model space the latch is recorded in.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct SupportSeatPoint {
+    model: Vector3<f32>,
+    hand: Point3<f32>,
 }
 
 /// Whether the palm is on the held item's own surface.
@@ -454,4 +491,181 @@ pub fn quantise_latch(point: Vector3<f32>) -> [i32; 3] {
         (point.y / LATCH_QUANTUM).round() as i32,
         (point.z / LATCH_QUANTUM).round() as i32,
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Deg, Rotation3, Zero, assert_relative_eq};
+
+    use super::*;
+
+    fn identity() -> Quaternion<f32> {
+        Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    /// A seat on the hand-space x axis; the model-space half is irrelevant to
+    /// the choice, so it just mirrors it.
+    fn seat_at(x: f32) -> SupportSeatPoint {
+        SupportSeatPoint {
+            model: vec3(x, 0.0, 0.0),
+            hand: Point3::new(x, 0.0, 0.0),
+        }
+    }
+
+    /// The placement's own forward is the interaction ray's: hand-local -Z.
+    fn forward(rotation: Quaternion<f32>) -> Vector3<f32> {
+        rotation.rotate_vector(vec3(0.0, 0.0, -1.0))
+    }
+
+    fn up(rotation: Quaternion<f32>) -> Vector3<f32> {
+        rotation.rotate_vector(vec3(0.0, 1.0, 0.0))
+    }
+
+    fn degrees_between(a: Vector3<f32>, b: Vector3<f32>) -> f32 {
+        a.dot(b).clamp(-1.0, 1.0).acos().to_degrees()
+    }
+
+    /// The whole point of the solve: the weapon points at the second hand, not
+    /// where the first wrist happens to be turned.
+    #[test]
+    fn the_item_aims_down_the_line_between_the_hands() {
+        // A wrist pointing straight ahead, with the support hand out to the
+        // side: the aim has to leave the wrist's own forward entirely.
+        let axis = vec3(1.0, 0.0, 0.0);
+        let aimed = aim_rotation(identity(), axis);
+        assert_relative_eq!(forward(aimed), axis, epsilon = 1e-5);
+    }
+
+    /// Roll is the half the player keeps: rolling the primary wrist rolls the
+    /// sights, without moving the barrel off the hand line.
+    #[test]
+    fn the_primary_wrist_still_owns_the_roll() {
+        let axis = vec3(1.0, 0.0, 0.0);
+        let upright = aim_rotation(identity(), axis);
+        // Rolling about the wrist's own forward is the gesture that must reach
+        // the sights.
+        let rolled = aim_rotation(Quaternion::from_angle_z(Deg(90.0)), axis);
+
+        assert_relative_eq!(forward(rolled), axis, epsilon = 1e-5);
+        let turn = degrees_between(up(upright), up(rolled));
+        assert!(
+            (turn - 90.0).abs() < 1.0,
+            "a 90 degree wrist roll should roll the sights 90 degrees, got {turn}"
+        );
+    }
+
+    /// Hands stacked along the wrist's own up leave `up x axis` degenerate; the
+    /// solve must still produce an orthonormal frame aimed down the line.
+    #[test]
+    fn an_axis_along_the_wrists_own_up_still_solves() {
+        let axis = vec3(0.0, 1.0, 0.0);
+        let aimed = aim_rotation(identity(), axis);
+        assert_relative_eq!(forward(aimed), axis, epsilon = 1e-5);
+        assert_relative_eq!(up(aimed).magnitude(), 1.0, epsilon = 1e-4);
+        assert_relative_eq!(up(aimed).dot(axis), 0.0, epsilon = 1e-4);
+    }
+
+    /// Hands crossing over each other must not spin the weapon: inside the
+    /// separation floor the last good axis stands.
+    #[test]
+    fn hands_too_close_together_keep_the_last_axis() {
+        let mut grip = TwoHandGrip::default();
+        grip.track_axis(Vector3::zero(), vec3(1.0, 0.0, 0.0));
+        assert_relative_eq!(grip.axis.unwrap(), vec3(1.0, 0.0, 0.0), epsilon = 1e-5);
+
+        // The support hand slides in to well under 10 cm, on a wholly different
+        // bearing. Without the guard this would swing the weapon 90 degrees.
+        grip.track_axis(Vector3::zero(), vec3(0.0, 0.0, meters(0.02)));
+        assert_relative_eq!(grip.axis.unwrap(), vec3(1.0, 0.0, 0.0), epsilon = 1e-5);
+
+        // Past the floor it tracks again.
+        grip.track_axis(Vector3::zero(), vec3(0.0, 0.0, meters(0.3)));
+        assert_relative_eq!(grip.axis.unwrap(), vec3(0.0, 0.0, 1.0), epsilon = 1e-5);
+    }
+
+    /// Attach and release both ease: neither may land in one frame, and both
+    /// must actually arrive.
+    #[test]
+    fn the_aim_eases_in_and_back_out() {
+        let mut grip = TwoHandGrip::default();
+        grip.track_axis(Vector3::zero(), vec3(1.0, 0.0, 0.0));
+
+        grip.ramp(true);
+        let first = grip.aim_for(identity()).expect("attaching aims already");
+        let turn = degrees_between(forward(first), vec3(0.0, 0.0, -1.0));
+        assert!(
+            turn > 0.0 && turn < 89.0,
+            "the first frame should be partway onto the hand line, got {turn} degrees"
+        );
+
+        for _ in 1..BLEND_FRAMES as usize {
+            grip.ramp(true);
+        }
+        assert_relative_eq!(
+            forward(grip.aim_for(identity()).unwrap()),
+            vec3(1.0, 0.0, 0.0),
+            epsilon = 1e-4
+        );
+
+        // Releasing runs the same ease back, and ends by handing placement to
+        // the wrist outright rather than leaving a stale aim behind.
+        for _ in 0..BLEND_FRAMES as usize {
+            assert!(grip.aim_for(identity()).is_some());
+            grip.ramp(false);
+        }
+        assert!(grip.aim_for(identity()).is_none());
+        assert!(grip.axis.is_none());
+    }
+
+    /// An authored seat is a preference, not a gate: only a palm that arrives
+    /// near one snaps to it.
+    #[test]
+    fn a_seat_only_claims_a_palm_that_arrives_near_it() {
+        let seat = seat_at(0.0);
+        let near = Point3::new(meters(0.04), 0.0, 0.0);
+        let far = Point3::new(meters(0.3), 0.0, 0.0);
+
+        assert_eq!(nearest_seat(near, &[seat]), Some(seat));
+        assert_eq!(
+            nearest_seat(far, &[seat]),
+            None,
+            "a palm well off the seat latches where it is"
+        );
+        assert_eq!(
+            nearest_seat(near, &[]),
+            None,
+            "a model with no authored seat always latches free"
+        );
+    }
+
+    /// With more than one seat the palm takes the one it is actually on.
+    #[test]
+    fn the_nearest_seat_wins() {
+        let pump = seat_at(0.0);
+        let magwell = seat_at(meters(0.07));
+        let palm = Point3::new(meters(0.06), 0.0, 0.0);
+        assert_eq!(nearest_seat(palm, &[pump, magwell]), Some(magwell));
+    }
+
+    /// The three authored gun seats must survive the shipped profile file's
+    /// round trip, or a support hand silently stops snapping.
+    #[test]
+    fn the_shipped_profiles_author_the_support_seats() {
+        let _guard = crate::vr_grips::test_guard();
+        crate::vr_grips::load_shipped_for_test();
+
+        for model in ["sg_h", "empgun_h", "ar15_h"] {
+            let seats = crate::vr_grips::support_seats(model);
+            assert_eq!(seats.len(), 1, "{model} should author one support seat");
+            assert_eq!(
+                seats[0].family(),
+                Some(crate::hand_fit::GripFamily::Cylindrical),
+                "{model}'s support seat should name a family the fit understands"
+            );
+        }
+        assert!(
+            crate::vr_grips::support_seats("fsn_h").is_empty(),
+            "an oversized weapon bakes no support hand and authors no seat"
+        );
+    }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -242,6 +242,7 @@ impl VirtualHand {
         input_hand: &Hand,
         held_by_other_hand: Option<EntityId>,
         anchor_claim: Option<crate::body_frame::HandClaim>,
+        two_hand: crate::two_hand_grip::TwoHandFrame,
     ) -> (VirtualHand, Vec<VirtualHandEffect>) {
         let handedness = prev.handedness;
         let hand_position = hand_world_position(pawn_pos, pawn_rot, input_hand.position);
@@ -329,12 +330,17 @@ impl VirtualHand {
                         });
                     }
 
+                    // A second hand on the item re-aims it down the line
+                    // between the hands; the tracked wrist still owns where it
+                    // is. One transform either way, so the muzzle, the magazine
+                    // anchors and the melee drive's kinematic target all follow.
+                    let placement = two_hand.aim_rotation.unwrap_or(hand_rotation);
                     msgs.push(VirtualHandEffect::SetPositionRotation {
                         entity_id,
                         // The offset is hand-local (e.g. seating a weapon's
                         // grip in the palm), so it must rotate with the hand
-                        position: hand_position + hand_rotation.rotate_vector(vr_offsets.offset),
-                        rotation: hand_rotation * vr_offsets.rotation,
+                        position: hand_position + placement.rotate_vector(vr_offsets.offset),
+                        rotation: placement * vr_offsets.rotation,
                         // A pickup's authored held scale (`vr_grips`): the
                         // world models run well over life size and the glove
                         // holding them is life size. Guns report 1.0 - their
@@ -368,6 +374,7 @@ impl VirtualHand {
                 input_hand,
                 held_by_other_hand,
                 anchor_claim,
+                two_hand,
             ),
         };
 
@@ -491,6 +498,7 @@ fn handle_empty_hand_state(
     input_hand: &Hand,
     held_by_other_hand: Option<EntityId>,
     anchor_claim: Option<crate::body_frame::HandClaim>,
+    two_hand: crate::two_hand_grip::TwoHandFrame,
 ) -> (VirtualHand, Vec<VirtualHandEffect>) {
     let ray_start = point3(hand_position.x, hand_position.y, hand_position.z);
     let forward = hand_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
@@ -524,6 +532,16 @@ fn handle_empty_hand_state(
             }
         }
     };
+    // A hand on the other hand's item advertises the support grip it could
+    // take, whatever its ray happens to cross past the item.
+    let (observed, preshape_weight) = if two_hand.offered {
+        (
+            HandAffordance::Grabbable,
+            hand_affordance::preshape_weight(0.0),
+        )
+    } else {
+        (observed, preshape_weight)
+    };
     let mut attempt_failed = false;
     // A refusal is one press, not one per frame the player keeps holding.
     let squeeze_pressed = prev_squeeze <= 0.5 && input_hand.squeeze_value > 0.5;
@@ -533,7 +551,10 @@ fn handle_empty_hand_state(
     let mut next_hand_state = HandState::Empty;
     // A claimed hand reaches for the body, not through it: its grip belongs to
     // the anchor gesture, so it must not also grab or frob what the ray found.
-    let claimed_by_anchor = anchor_claim.is_some();
+    // A supporting hand holds the other hand's weapon: like a hand at a body
+    // anchor, its grip is spoken for and must not also grab or frob whatever
+    // its ray found past the weapon.
+    let claimed_by_anchor = anchor_claim.is_some() || two_hand.supporting;
     if !claimed_by_anchor && (input_hand.trigger_value > 0.5 || input_hand.a_value > 0.5) {
         if let Some(RayCastResult {
             hit_point: _,
@@ -898,6 +919,7 @@ mod tests {
             &input,
             None,
             None,
+            Default::default(),
         );
 
         effects
@@ -1341,6 +1363,7 @@ mod tests {
             &input,
             None,
             None,
+            Default::default(),
         );
         assert_eq!(far_hand.get_raytraced_entity(), None);
         assert!(
@@ -1358,6 +1381,7 @@ mod tests {
             &input,
             None,
             None,
+            Default::default(),
         );
         assert_eq!(near_hand.get_raytraced_entity(), Some(near_target));
         assert!(
@@ -1392,6 +1416,7 @@ mod tests {
                 &idle,
                 None,
                 None,
+                Default::default(),
             )
             .0
             .affordance()
@@ -1419,6 +1444,7 @@ mod tests {
             &Hand::default(),
             None,
             None,
+            Default::default(),
         );
         assert_eq!(hovering.affordance(), HandAffordance::Blocked);
 
@@ -1434,6 +1460,7 @@ mod tests {
             },
             None,
             None,
+            Default::default(),
         );
         assert_eq!(frobbing.affordance(), HandAffordance::Failed);
     }
@@ -1461,6 +1488,7 @@ mod tests {
                 &squeeze,
                 None,
                 None,
+                Default::default(),
             )
             .0;
             assert_eq!(
@@ -1489,6 +1517,7 @@ mod tests {
             &squeeze,
             None,
             None,
+            Default::default(),
         );
         assert_eq!(hand.affordance(), HandAffordance::Failed);
     }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -424,13 +424,17 @@ impl VirtualHand {
         world: &World,
         asset_cache: &mut AssetCache,
         renderer: &mut crate::hand_glove::GloveRenderer,
+        support: Option<crate::two_hand_grip::SupportLatch>,
     ) -> (Vec<SceneObject>, Option<crate::game_scene::DebugHandGrip>) {
         // A wielded gun draws the glove in place of the baked hand the wield
         // stripped off it; everything else draws it at the tracked hand, or not
         // at all when the held model draws a hand of its own. Either way the
         // glove is the tracked pose at life size - the gun is the thing scaled
         // to meet it (`vr_config::gun_wield_scale`).
-        if !holds_gun_glove(world, self.get_held_entity())
+        // A hand supporting the other's weapon is an empty hand as far as its
+        // own visual goes: it always draws.
+        if support.is_none()
+            && !holds_gun_glove(world, self.get_held_entity())
             && !shows_hand_visual(world, self.get_held_entity())
         {
             return (Vec::new(), None);
@@ -441,13 +445,30 @@ impl VirtualHand {
         // renderer, so a hand that keeps holding the same thing pays for it
         // once; a held model with no mesh to close against reports `None` and
         // falls back to the generic wrap.
-        let fit = self.get_held_entity().and_then(|entity_id| {
-            let (model_name, scale) = vr_config::held_model_and_scale(world, entity_id)?;
-            renderer.fitted_grip(&model_name, self.handedness, scale, asset_cache)
-        });
-        let hold = match self.get_held_entity() {
-            Some(_) => crate::hand_glove::Hold::Item(fit.map(|fit| fit.amounts)),
-            None => crate::hand_glove::Hold::Empty,
+        // A support hand closes on the item at the point it latched, not at the
+        // item's own grip, so it fits against the same mesh placed there.
+        let fit = match support {
+            Some(latch) => vr_config::held_model_and_scale(world, latch.entity_id).and_then(
+                |(model_name, scale)| {
+                    renderer.support_grip(
+                        &model_name,
+                        self.handedness,
+                        scale,
+                        latch.point,
+                        asset_cache,
+                    )
+                },
+            ),
+            None => self.get_held_entity().and_then(|entity_id| {
+                let (model_name, scale) = vr_config::held_model_and_scale(world, entity_id)?;
+                renderer.fitted_grip(&model_name, self.handedness, scale, asset_cache)
+            }),
+        };
+        let hold = match (support, self.get_held_entity()) {
+            (Some(_), _) | (_, Some(_)) => {
+                crate::hand_glove::Hold::Item(fit.map(|fit| fit.amounts))
+            }
+            _ => crate::hand_glove::Hold::Empty,
         };
 
         let objects = renderer.render_hand(
@@ -1224,6 +1245,7 @@ mod tests {
             &input,
             None,
             None,
+            Default::default(),
         );
         assert_eq!(frob_message_count(&effects), 1, "first frame should Frob");
 
@@ -1239,6 +1261,7 @@ mod tests {
             &input,
             None,
             None,
+            Default::default(),
         );
         assert_eq!(
             frob_message_count(&effects),
@@ -1273,6 +1296,7 @@ mod tests {
             &input,
             None,
             None,
+            Default::default(),
         );
         assert_eq!(
             frob_message_count(&effects),
@@ -1295,6 +1319,7 @@ mod tests {
             &input,
             None,
             None,
+            Default::default(),
         );
         let frobbed_second = effects.iter().any(|effect| {
             matches!(

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -455,6 +455,7 @@ impl VirtualHand {
                         self.handedness,
                         scale,
                         latch.point,
+                        latch.family,
                         asset_cache,
                     )
                 },

--- a/shock2vr/src/vr_grips.rs
+++ b/shock2vr/src/vr_grips.rs
@@ -69,8 +69,45 @@ pub struct GripProfile {
     /// A uniform scale applied to the held geometry (not to the dropped item).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scale: Option<f32>,
+    /// Where a *second* hand prefers to take hold, in the model's own space -
+    /// the shotgun's pump, the assault rifle's magwell. A preference, not a
+    /// requirement: the off-hand may latch anywhere on the item's surface
+    /// (see [`crate::two_hand_grip`]), and a seat only wins when the palm
+    /// comes within snapping distance of it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub support: Vec<SupportSeat>,
     #[serde(default, skip_serializing_if = "is_default_mirror")]
     pub mirror: Mirror,
+}
+
+/// One authored support-hand seat on a model.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct SupportSeat {
+    /// The grip point in the model's own (unscaled) space, the same space the
+    /// render triangles are read in - so the wield's life-size shrink applies
+    /// to the seat exactly as it applies to the geometry.
+    pub offset: [f32; 3],
+    /// The grip family the support hand closes in, overriding what the item's
+    /// box measures. Omitted leaves it to the fit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+}
+
+impl SupportSeat {
+    pub fn offset(&self) -> Vector3<f32> {
+        to_vec(self.offset)
+    }
+
+    pub fn family(&self) -> Option<GripFamily> {
+        self.family.as_deref().and_then(GripFamily::from_str)
+    }
+}
+
+/// Every authored support seat on `model_name`, empty when it has none.
+pub fn support_seats(model_name: &str) -> Vec<SupportSeat> {
+    profile(model_name)
+        .map(|profile| profile.support)
+        .unwrap_or_default()
 }
 
 fn is_default_mirror(mirror: &Mirror) -> bool {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -686,8 +686,8 @@ export interface PlayerSnapshot {
 /** The second hand's grip on what the first hand holds
  * (GET /v1/info -> player.two_hand). */
 export interface TwoHandGrip {
-  two_handed: boolean;
-  /** Which hand is supporting, or null. */
+  /** Which hand is supporting, or null - which is also what "not two-handed"
+   * reads as; `player.two_handed` is the flag. */
   support_hand: "left" | "right" | null;
   /** The entity the support hand has hold of, or null. */
   support_of: number | null;

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -675,6 +675,27 @@ export interface PlayerSnapshot {
   /** The player's body anchors (belt, shoulders) and what hangs off them.
    * Null outside VR. */
   body_frame: BodyFrame | null;
+
+  /** Whether a second hand has hold of what the first is holding - the weapon
+   * is then aimed down the line between the hands. */
+  two_handed: boolean;
+  /** Where that second hand took hold. */
+  two_hand: TwoHandGrip;
+}
+
+/** The second hand's grip on what the first hand holds
+ * (GET /v1/info -> player.two_hand). */
+export interface TwoHandGrip {
+  two_handed: boolean;
+  /** Which hand is supporting, or null. */
+  support_hand: "left" | "right" | null;
+  /** The entity the support hand has hold of, or null. */
+  support_of: number | null;
+  /** Where it took hold, in the item's own model space. */
+  support_point: [number, number, number] | null;
+  /** True when an authored support seat claimed the grip (the shotgun's pump,
+   * the rifle's magwell) rather than the palm latching where it landed. */
+  snapped: boolean;
 }
 
 /** Where the player's belt and shoulders are, and what they hold

--- a/tools/shock2-sdk/test/vr-two-hand-grip.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-two-hand-grip.e2e.test.ts
@@ -124,21 +124,45 @@ test(
       "the supporting hand lights for the grip it holds",
     );
 
-    // The weapon now points at the support hand rather than down the wrist.
-    const aimed = await aimAxis(game, wrench.id);
-    const turn = degreesBetween(aimed, oneHanded);
-    assert.ok(
-      turn > 60,
-      `two hands should re-aim the weapon down the hand line, turned only ${turn.toFixed(1)} degrees`,
+    // A hand that closed in empty space and then swept onto the weapon must not
+    // silently attach: taking hold is a rising edge, like every other grip.
+    await releaseSupport(game);
+    await game.input.set("left_hand.position", [
+      onWrench[0] + 2.0,
+      onWrench[1],
+      onWrench[2],
+    ]);
+    await game.input.set("left_hand.squeeze", 1.0);
+    await game.step({ frames: 6 });
+    await game.input.set("left_hand.position", [
+      onWrench[0],
+      onWrench[1] + 0.6,
+      onWrench[2],
+    ]);
+    await game.step({ frames: 20 });
+    assert.equal(
+      (await game.info()).player.two_handed,
+      false,
+      "a fist swept onto the weapon should not grab it without a fresh grip",
     );
-    // The support hand is straight up from the primary, so that is where the
-    // weapon points.
-    assert.ok(
-      aimed[1] > 0.9,
-      `the weapon should aim at the support hand, got ${JSON.stringify(aimed)}`,
+    // Opening and closing again on the same spot does take hold.
+    await supportAt(game, [onWrench[0], onWrench[1] + 0.6, onWrench[2]]);
+    assert.equal(
+      (await game.info()).player.two_handed,
+      true,
+      "a fresh grip on the same spot takes hold",
     );
 
-    // Moving the support hand moves the aim with it.
+    // Taking hold where the hands already are changes nothing - the solve is
+    // the identity there, which is what makes the attach ease start from zero.
+    const attached = await aimAxis(game, wrench.id);
+    assert.ok(
+      degreesBetween(attached, oneHanded) < 5,
+      "attaching with the hands already in place should not move the weapon",
+    );
+
+    // MOVING the support hand is what turns it: the weapon swings so the point
+    // that hand has hold of follows it round.
     await game.input.set("left_hand.position", [
       onWrench[0],
       onWrench[1],
@@ -146,9 +170,10 @@ test(
     ]);
     await game.step({ frames: 20 });
     const moved = await aimAxis(game, wrench.id);
+    const turn = degreesBetween(moved, oneHanded);
     assert.ok(
-      moved[2] < -0.8,
-      `the aim should follow the support hand forward, got ${JSON.stringify(moved)}`,
+      turn > 45,
+      `the weapon should follow the support hand round, turned only ${turn.toFixed(1)} degrees`,
     );
 
     // Releasing the support hand hands the aim back to the wrist.
@@ -210,19 +235,20 @@ test(
 
     // Well back down the receiver, away from the pump: a free latch.
     await supportAt(game, gripAt(0.0));
-    const free = (await game.info()).player.two_hand;
+    const free = (await game.info()).player;
     assert.equal(free.two_handed, true, "the receiver is still grabbable");
     assert.equal(
-      free.snapped,
+      free.two_hand.snapped,
       false,
-      `a palm off the pump latches where it is, got ${JSON.stringify(free.support_point)}`,
+      `a palm off the pump latches where it is, got ${JSON.stringify(free.two_hand.support_point)}`,
     );
     await releaseSupport(game);
 
     // Out on the pump: the authored seat claims it.
     await supportAt(game, gripAt(-0.45));
-    const snapped = (await game.info()).player.two_hand;
-    assert.equal(snapped.two_handed, true, "the pump should take a support grip");
+    const withPump = (await game.info()).player;
+    assert.equal(withPump.two_handed, true, "the pump should take a support grip");
+    const snapped = withPump.two_hand;
     assert.equal(snapped.snapped, true, "the palm should snap to the authored pump");
     assert.ok(snapped.support_point, "a snapped grip reports where it landed");
     for (const [axis, want] of PUMP.entries()) {
@@ -238,9 +264,10 @@ test(
     // --- the fusion cannon: no authored seat anywhere on it ---
     const [fusion, fusionHand] = await grab("Fusion Cannon");
     await supportAt(game, [fusionHand[0], fusionHand[1], fusionHand[2] - 0.4]);
-    const oversized = (await game.info()).player.two_hand;
+    const held = (await game.info()).player;
+    const oversized = held.two_hand;
     assert.equal(
-      oversized.two_handed,
+      held.two_handed,
       true,
       "an oversized weapon must still take a second hand anywhere on its body",
     );

--- a/tools/shock2-sdk/test/vr-two-hand-grip.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-two-hand-grip.e2e.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// A second hand takes hold of what the first is holding, anywhere on it, and
+// the item is then aimed down the line between the hands.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   SHOCK2_E2E=1 npm run test:e2e
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** The direction a placed item faces, from its body rotation `[x, y, z, w]`.
+ * Hand-local -Z is the aim axis the placement solves for. */
+function forward(q: [number, number, number, number]): Vec3 {
+  const [x, y, z, w] = q;
+  const v: Vec3 = [0, 0, -1];
+  const t: Vec3 = [
+    2 * (y * v[2] - z * v[1]),
+    2 * (z * v[0] - x * v[2]),
+    2 * (x * v[1] - y * v[0]),
+  ];
+  return [
+    v[0] + w * t[0] + (y * t[2] - z * t[1]),
+    v[1] + w * t[1] + (z * t[0] - x * t[2]),
+    v[2] + w * t[2] + (x * t[1] - y * t[0]),
+  ];
+}
+
+function degreesBetween(a: Vec3, b: Vec3): number {
+  const dot = a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+  return (Math.acos(Math.max(-1, Math.min(1, dot))) * 180) / Math.PI;
+}
+
+async function aimAxis(game: GameServer, entityId: number): Promise<Vec3> {
+  const body = (await game.physics.bodies({ entityId })).bodies[0];
+  assert.ok(body, `entity ${entityId} should have a physics body to read`);
+  return forward(body.rotation);
+}
+
+/** Close the off-hand at `at` (pawn-local) and let the attach ramp finish. */
+async function supportAt(game: GameServer, at: Vec3): Promise<void> {
+  await game.input.set("left_hand.position", at);
+  await game.input.set("left_hand.squeeze", 0.0);
+  await game.step({ frames: 4 });
+  await game.input.set("left_hand.squeeze", 1.0);
+  await game.step({ frames: 20 });
+}
+
+async function releaseSupport(game: GameServer): Promise<void> {
+  await game.input.set("left_hand.squeeze", 0.0);
+  await game.step({ frames: 20 });
+}
+
+test(
+  "VR: a second hand supports the melee weapon the first holds, and aims it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_melee",
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 30 });
+
+    const wrench = (await game.entities.list({ filter: "Wrench", limit: 20 }))
+      .entities[0];
+    assert.ok(wrench, "debug_melee should stock a Wrench");
+
+    // Grab it with the right hand through the production selection ray. The
+    // rack stocks several melee weapons, so the hand goes ON the wrench rather
+    // than pointing across the rack at whatever is nearest.
+    const pawn = (await game.info()).player.position;
+    const onWrench: Vec3 = [
+      wrench.position[0] - pawn[0],
+      wrench.position[1] - pawn[1],
+      wrench.position[2] - pawn[2],
+    ];
+    await game.input.set("right_hand.position", onWrench);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0.0);
+    // Park the off-hand well clear, so nothing is offered before it is moved.
+    await game.input.set("left_hand.position", [
+      onWrench[0] + 2.0,
+      onWrench[1],
+      onWrench[2],
+    ]);
+    await game.input.set("left_hand.squeeze", 0.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 8 });
+
+    const held = (await game.info()).player.right_hand_entity_id;
+    assert.equal(held, wrench.id, "the right hand should hold the Wrench");
+    assert.equal(
+      (await game.info()).player.two_handed,
+      false,
+      "one hand on the weapon is not two-handed",
+    );
+    const oneHanded = await aimAxis(game, wrench.id);
+
+    // The melee wield's fitted contact volume runs up out of the tracked hand
+    // (`vr_config::melee_contact_offset` parks the body on the weapon head), so
+    // the shaft is above the grip.
+    await supportAt(game, [onWrench[0], onWrench[1] + 0.6, onWrench[2]]);
+    const withSupport = (await game.info()).player;
+    assert.equal(withSupport.two_handed, true, "the off-hand should take hold");
+    assert.equal(withSupport.two_hand.support_hand, "left");
+    assert.equal(
+      withSupport.two_hand.support_of,
+      wrench.id,
+      "the support grip should be on the wrench the other hand holds",
+    );
+    assert.equal(
+      withSupport.two_hand.snapped,
+      false,
+      "a melee weapon authors no support seat, so the palm latches free",
+    );
+    assert.equal(
+      (await game.info()).player.hand_affordance.left,
+      "Grabbable",
+      "the supporting hand lights for the grip it holds",
+    );
+
+    // The weapon now points at the support hand rather than down the wrist.
+    const aimed = await aimAxis(game, wrench.id);
+    const turn = degreesBetween(aimed, oneHanded);
+    assert.ok(
+      turn > 60,
+      `two hands should re-aim the weapon down the hand line, turned only ${turn.toFixed(1)} degrees`,
+    );
+    // The support hand is straight up from the primary, so that is where the
+    // weapon points.
+    assert.ok(
+      aimed[1] > 0.9,
+      `the weapon should aim at the support hand, got ${JSON.stringify(aimed)}`,
+    );
+
+    // Moving the support hand moves the aim with it.
+    await game.input.set("left_hand.position", [
+      onWrench[0],
+      onWrench[1],
+      onWrench[2] - 0.6,
+    ]);
+    await game.step({ frames: 20 });
+    const moved = await aimAxis(game, wrench.id);
+    assert.ok(
+      moved[2] < -0.8,
+      `the aim should follow the support hand forward, got ${JSON.stringify(moved)}`,
+    );
+
+    // Releasing the support hand hands the aim back to the wrist.
+    await releaseSupport(game);
+    const released = (await game.info()).player;
+    assert.equal(released.two_handed, false, "opening the off-hand detaches");
+    assert.equal(released.two_hand.support_of, null);
+    assert.ok(
+      degreesBetween(await aimAxis(game, wrench.id), oneHanded) < 5,
+      "the weapon should return to its one-hand aim",
+    );
+  },
+);
+
+test(
+  "VR: the off-hand snaps to a shotgun's authored pump, and latches free on a fusion cannon",
+  { skip: !e2eEnabled, timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 10 });
+
+    // `sg_h`'s authored support seat, read off the model's own baked arm island
+    // (assets/vr_grips.json).
+    const PUMP: Vec3 = [-0.382, 0.014, -0.052];
+
+    // Grab `name` off the floor and return its id plus the pawn-local hand
+    // position it is now held at - the frame every support probe below is
+    // expressed in, since the weapon itself has moved into the hand by then.
+    const grab = async (name: string): Promise<[number, Vec3]> => {
+      const weapon = await cycleToWeapon(game, (e) => e.name === name, {
+        settleFrames: 90,
+      });
+      const pawnY = (await game.info()).player.position[1];
+      const [px, py, pz] = weapon.position;
+      const hand: Vec3 = [px + 0.4, py - pawnY, pz];
+      await game.input.set("right_hand.position", hand);
+      await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+      await game.input.set("right_hand.squeeze", 1.0);
+      // Off-hand parked clear of the weapon until the probe moves it.
+      await game.input.set("left_hand.position", [hand[0], hand[1] + 3.0, hand[2]]);
+      await game.input.set("left_hand.squeeze", 0.0);
+      await game.step({ frames: 10 });
+      const held = (await game.info()).player.right_hand_entity_id;
+      assert.equal(held, weapon.id, `the right hand should hold the ${name}`);
+      return [weapon.id, hand];
+    };
+
+    // --- the shotgun's pump ---
+    const [shotgun, shotgunHand] = await grab("Shotgun");
+    const gripAt = (dz: number): Vec3 => [
+      shotgunHand[0],
+      shotgunHand[1],
+      shotgunHand[2] + dz,
+    ];
+
+    // Well back down the receiver, away from the pump: a free latch.
+    await supportAt(game, gripAt(0.0));
+    const free = (await game.info()).player.two_hand;
+    assert.equal(free.two_handed, true, "the receiver is still grabbable");
+    assert.equal(
+      free.snapped,
+      false,
+      `a palm off the pump latches where it is, got ${JSON.stringify(free.support_point)}`,
+    );
+    await releaseSupport(game);
+
+    // Out on the pump: the authored seat claims it.
+    await supportAt(game, gripAt(-0.45));
+    const snapped = (await game.info()).player.two_hand;
+    assert.equal(snapped.two_handed, true, "the pump should take a support grip");
+    assert.equal(snapped.snapped, true, "the palm should snap to the authored pump");
+    assert.ok(snapped.support_point, "a snapped grip reports where it landed");
+    for (const [axis, want] of PUMP.entries()) {
+      assert.ok(
+        Math.abs(snapped.support_point![axis] - want) < 1e-3,
+        `the snap should land on the authored pump ${JSON.stringify(PUMP)}, got ${JSON.stringify(snapped.support_point)}`,
+      );
+    }
+    await releaseSupport(game);
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 10 });
+
+    // --- the fusion cannon: no authored seat anywhere on it ---
+    const [fusion, fusionHand] = await grab("Fusion Cannon");
+    await supportAt(game, [fusionHand[0], fusionHand[1], fusionHand[2] - 0.4]);
+    const oversized = (await game.info()).player.two_hand;
+    assert.equal(
+      oversized.two_handed,
+      true,
+      "an oversized weapon must still take a second hand anywhere on its body",
+    );
+    assert.equal(
+      oversized.support_of,
+      fusion,
+      "the support grip should be on the fusion cannon",
+    );
+    assert.equal(
+      oversized.snapped,
+      false,
+      "the fusion cannon bakes no support hand, so every grip is a free latch",
+    );
+  },
+);


### PR DESCRIPTION
A second hand can take hold of the weapon the first is holding - anywhere on
it - and the two together aim it.

- **Support grab.** An empty hand whose palm meets the other hand's held item
  latches onto it on a fresh grip edge. The test is the item's own surface: its
  render triangles for a gun or pickup, its fitted contact cuboid for a melee
  wield (the `_h` melee rigs are skinned and report no triangles). The latch is
  taken once, in the item's model space - re-picking the nearest point each
  frame would let the item crawl through the hand as the aim swung it.
- **Authored seats are a preference, not a gate.** `sg_h`'s pump, `empgun_h`'s
  foregrip and `ar15_h`'s magwell are authored in `assets/vr_grips.json`, read
  off each model's own baked arm island; a palm within 8 cm snaps to one, and
  takes that seat's grip family. The oversized weapons bake no support hand, so
  every grip on them is a free latch.
- **Two-hand aim.** The primary hand keeps position and the trigger. The
  placement rotation is the wrist turned by the shortest arc that puts *the
  point the support hand has hold of* onto that hand - so it is the identity
  while the hands are still where the one-hand pose put them, and moving the
  support hand swings the item to follow it. Aiming a fixed hand-local forward
  instead would only be right for a gun, whose barrel happens to run down the
  wrist; a wrench's shaft does not. One transform either way, so the muzzle, the
  magazine anchors and the melee drive's kinematic target all follow. Hands
  closer than 10 cm keep the last axis; attach and release ease over six frames.
- **Support pose.** The glove closes on the item placed at the point it latched,
  cached per model and grip point rounded to the centimetre.
- **What ends the grip:** opening the off-hand (tracked or not - the controller
  reports its grip through a lost pose, so the button is the reliable half), the
  primary dropping the item, or either hand being claimed elsewhere. A lost
  *pose* alone is held for the body anchors' own 12-frame window, with the aim
  axis frozen meanwhile.
- Readout: `/v1/info` `player.two_handed` and `player.two_hand`, plus SDK types.

The primary releasing still drops the item - no hand transfer in this slice.

Known, and left for the melee/aim slice that reads this state: the glove's
finger fit for the *primary* hand is solved against the item at its own seat, so
a large aim excursion turns the item under fingers that were fitted to it
upright. The item-relative solve above makes that zero at attach and only as
large as the hands make it.

## Visuals

![two-hand grip demo](https://gist.githubusercontent.com/tommy-xr/297dab8774a795f7c76f58d3dc53aa38/raw/two-hand-grip.gif)

<sub>`debug_melee --vr`: the wrench held in one hand; the second hand grips it (the weapon does not jump - attaching in place is the identity); then the support hand travels and the weapon swings so the gripped point follows it; finally both hands swing it together.</sub>

![shotgun support hand snapped to the pump](https://gist.githubusercontent.com/tommy-xr/297dab8774a795f7c76f58d3dc53aa38/raw/shotgun-pump-snap.png)

<sub>`debug_weapons --vr`: the support hand snaps to the shotgun's authored pump - `two_hand.snapped = true`, `support_point = [-0.382, 0.014, -0.052]`.</sub>

![fusion cannon held two-handed](https://gist.githubusercontent.com/tommy-xr/297dab8774a795f7c76f58d3dc53aa38/raw/fusion-cannon-two-hand.png)

<sub>`debug_weapons --vr`: with no authored anchor the support hand latches wherever it touched the body - `two_handed = true`, `snapped = false`.</sub>

<sub>Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep), framed with the free camera.</sub>


