### PR TITLE
feat(vr): author rest and trigger-pressed finger poses

### DIFF
--- a/projects/astra-vr-grip-editor.md
+++ b/projects/astra-vr-grip-editor.md
@@ -86,3 +86,22 @@ active document when missing. This also permits a custom weapon override in the
 pickup resource: a valid matching entry there takes precedence over the shipped
 weapon default. A separate Save As file must be copied to a runtime resource path
 to be loaded by gameplay.
+
+## Rest and Trigger pressed poses
+
+The finger controls offer **Rest** and **Trigger pressed** for primary and support
+hands. Select Trigger pressed, then **Customize pressed pose** to start with a
+copy of Rest. Adjust any finger: a gun can curl its index while a hypo can press
+with its thumb. **Use Rest for both** removes the pressed override.
+
+The **Trigger preview** slider blends the two poses without changing the saved
+values. Item position, wrist rotation, and item scale are shared by both poses.
+Copy/paste and mirroring carry both finger poses. Primary poses save optional
+`trigger_curls` in the pickup/weapon library; support poses save it in
+`vr-support-grips.json`. If absent, the resting pose remains unchanged at any
+trigger value. Existing resources therefore keep their authored fit.
+
+Gameplay blends using analog controller trigger input. Fire/use thresholds are
+unchanged, and the supporting hand can animate without firing or using an item.
+The debug runtime's hand-grip diagnostics report `visual_trigger` and
+`finger_curls` for the primary hand and its support hand.

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -877,6 +877,10 @@ impl PlayerInteraction for VrInteraction {
     }
 
     fn grip_diagnostics(&self) -> serde_json::Value {
+        let visual_triggers = [
+            self.left_hand.get_trigger_value(),
+            self.right_hand.get_trigger_value(),
+        ];
         serde_json::Value::Array(self.fitted_grips.iter().enumerate().filter_map(|(i, grip)| {
             let grip=grip.as_ref()?;
             let support = self.support_preview.as_ref().filter(|c| c.primary == i && c.entity == grip.entity).map(|c| {
@@ -893,10 +897,13 @@ impl PlayerInteraction for VrInteraction {
                     "model_position": c.model_pose.position, "model_rotation": c.model_pose.rotation,
                     "primary_palm": c.primary_palm, "primary_anchor": c.primary_anchor,
                     "support_anchor": c.anchor, "grab_radius": c.profile.grab_radius,
+                    "visual_trigger": visual_triggers[1-i],
+                    "finger_curls": crate::vr_grip::blended_curls(c.profile.curls, c.profile.trigger_curls, visual_triggers[1-i]),
                     "release_distance": c.profile.release_distance, "max_swing_degrees": c.profile.max_swing_degrees
                 })
             });
             Some(serde_json::json!({"glove_pose": self.visual_hands[i], "support": support, "hand": if i == 0 {"left"} else {"right"}, "entity_id": grip.entity.inner() as i32,
+                "visual_trigger": visual_triggers[i], "finger_curls": grip.resolved.as_ref().map(|g| g.curls_at(visual_triggers[i])),
                 "model": grip.model, "item_bounds": grip.item_bounds, "solve_ms": grip.solve_ms, "grip": grip.resolved,
                 "surface_hash": grip.surface_hash, "kinematics_hash": grip.kinematics_hash, "hints_hash": grip.hints_hash, "solver_revision": crate::vr_grip::SOLVER_REVISION, "source": grip.source, "authored": grip.authored,
                 "palm": self.grip_kinematics.as_ref().map(|k| k[i].palm), "palm_normal": self.grip_kinematics.as_ref().map(|k| k[i].normal)}))
@@ -1067,6 +1074,7 @@ impl PlayerInteraction for VrInteraction {
                 .resolved
                 .clone()?;
             grip.curls = self.support_preview.as_ref()?.profile.curls;
+            grip.trigger_curls = self.support_preview.as_ref()?.profile.trigger_curls;
             Some((1 - support.primary, grip))
         });
         for (index, hand) in [&self.left_hand, &self.right_hand].into_iter().enumerate() {
@@ -1393,6 +1401,7 @@ mod tests {
                 palm_anchor: [0.0, 0.2, 0.0],
                 rotation_degrees: [0.0; 3],
                 curls: [0.5; 5],
+                trigger_curls: None,
                 grab_radius: 0.07,
                 release_distance: 0.12,
                 max_swing_degrees: 75.0,
@@ -1408,6 +1417,7 @@ mod tests {
                 offset: vec3(0.0, 0.0, 0.0),
                 rotation: identity(),
                 curls: [0.5; 5],
+                trigger_curls: None,
                 contacts: [None; 5],
                 anchor: [0.0; 3],
                 score: 0.0,

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -197,6 +197,10 @@ impl VirtualHand {
         self.rotation
     }
 
+    pub(crate) fn get_trigger_value(&self) -> f32 {
+        self.trigger_value
+    }
+
     /// A supporting hand tracks its controller but cannot also ray-grab/frob.
     pub(crate) fn update_suppressed(
         &self,
@@ -445,7 +449,7 @@ impl VirtualHand {
                     self.trigger_value,
                     self.squeeze_value,
                     self.get_held_entity().is_some(),
-                    grip.map(|(grip, blend)| (grip.finger_amounts(), blend)),
+                    grip.map(|(grip, blend)| (grip.finger_amounts_at(self.trigger_value), blend)),
                 )
             })
             .unwrap_or_default();

--- a/shock2vr/src/vr_grip.rs
+++ b/shock2vr/src/vr_grip.rs
@@ -34,6 +34,8 @@ pub struct ResolvedGrip {
     pub offset: Vector3<f32>,
     pub rotation: Quaternion<f32>,
     pub curls: [f32; 5],
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_curls: Option<[f32; 5]>,
     /// Contact samples in item-local space; null means no contact was found.
     pub contacts: [Option<[f32; 3]>; 5],
     pub anchor: [f32; 3],
@@ -66,6 +68,11 @@ impl ResolvedGrip {
                 .curls
                 .iter()
                 .all(|c| c.is_finite() && (0.0..=1.0).contains(c))
+            && self.trigger_curls.is_none_or(|curls| {
+                curls
+                    .into_iter()
+                    .all(|v| v.is_finite() && (0.0..=1.0).contains(&v))
+            })
             && self
                 .anchor
                 .iter()
@@ -90,8 +97,16 @@ impl ResolvedGrip {
         ])
     }
 
+    pub fn curls_at(&self, trigger: f32) -> [f32; 5] {
+        blended_curls(self.curls, self.trigger_curls, trigger)
+    }
+
     pub fn finger_amounts(&self) -> FingerAmounts {
-        let [thumb, index, middle, ring, pinky] = self.curls;
+        self.finger_amounts_at(0.0)
+    }
+
+    pub fn finger_amounts_at(&self, trigger: f32) -> FingerAmounts {
+        let [thumb, index, middle, ring, pinky] = self.curls_at(trigger);
         FingerAmounts {
             thumb,
             index,
@@ -100,6 +115,17 @@ impl ResolvedGrip {
             pinky,
         }
     }
+}
+
+/// Analog visual blend, independent of the fire/use action threshold.
+pub fn blended_curls(rest: [f32; 5], pressed: Option<[f32; 5]>, trigger: f32) -> [f32; 5] {
+    let amount = if trigger.is_finite() {
+        trigger.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let pressed = pressed.unwrap_or(rest);
+    std::array::from_fn(|i| rest[i] + (pressed[i] - rest[i]) * amount)
 }
 
 pub struct GripSurface {
@@ -488,6 +514,7 @@ impl GripSurface {
             offset,
             rotation,
             curls,
+            trigger_curls: None,
             contacts,
             anchor: [0.0; 3],
             score,
@@ -766,6 +793,38 @@ mod tests {
         restored.rotation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
         assert!(!restored.is_valid());
     }
+    #[test]
+    fn trigger_curls_blend_independently_and_round_trip() {
+        let mut grip =
+            plane(0.05).fit_at(&straight_fingers(), vec3(0.0, 0.0, 0.0), Quaternion::one());
+        grip.curls = [0.2, 0.4, 0.6, 0.8, 1.0];
+        assert_eq!(grip.curls_at(1.0), grip.curls);
+        let legacy = serde_json::to_value(&grip).unwrap();
+        assert!(legacy.get("trigger_curls").is_none());
+        assert_eq!(
+            serde_json::from_value::<ResolvedGrip>(legacy)
+                .unwrap()
+                .trigger_curls,
+            None
+        );
+        grip.trigger_curls = Some([0.8, 0.8, 0.6, 0.8, 1.0]);
+        assert_eq!(grip.curls_at(-1.0), grip.curls);
+        assert_eq!(grip.curls_at(f32::NAN), grip.curls);
+        assert_eq!(grip.curls_at(2.0), grip.trigger_curls.unwrap());
+        let halfway = grip.curls_at(0.5);
+        assert!((halfway[0] - 0.5).abs() < 1e-6);
+        assert!((halfway[1] - 0.6).abs() < 1e-6);
+        assert_eq!(&halfway[2..], &grip.curls[2..]);
+        let restored: ResolvedGrip =
+            serde_json::from_str(&serde_json::to_string(&grip).unwrap()).unwrap();
+        assert_eq!(restored, grip);
+        assert!(restored.is_valid());
+        grip.trigger_curls = Some([1.1; 5]);
+        assert!(!grip.is_valid());
+        grip.trigger_curls = Some([f32::NAN; 5]);
+        assert!(!grip.is_valid());
+    }
+
     #[test]
     fn prepared_lookup_rejects_wrong_hand_stale_mesh_and_stale_rig() {
         let grip = plane(0.05).fit_at(&straight_fingers(), vec3(0.0, 0.0, 0.0), Quaternion::one());

--- a/shock2vr/src/vr_support.rs
+++ b/shock2vr/src/vr_support.rs
@@ -44,6 +44,8 @@ pub struct SupportProfile {
     #[serde(default)]
     pub rotation_degrees: [f32; 3],
     pub curls: [f32; 5],
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_curls: Option<[f32; 5]>,
     pub grab_radius: f32,
     pub release_distance: f32,
     pub max_swing_degrees: f32,
@@ -60,6 +62,11 @@ impl SupportProfile {
                 .curls
                 .iter()
                 .all(|v| v.is_finite() && (0.0..=1.0).contains(v))
+            && self.trigger_curls.is_none_or(|curls| {
+                curls
+                    .into_iter()
+                    .all(|v| v.is_finite() && (0.0..=1.0).contains(&v))
+            })
             && self.grab_radius.is_finite()
             && (0.01..=0.15).contains(&self.grab_radius)
             && self.release_distance.is_finite()
@@ -156,6 +163,7 @@ mod tests {
             palm_anchor: [-0.09, 0.354, 0.02],
             rotation_degrees: [20.0, 15.0, -30.0],
             curls: [0.4; 5],
+            trigger_curls: None,
             grab_radius: 0.07,
             release_distance: 0.12,
             max_swing_degrees: 75.0,
@@ -166,6 +174,7 @@ mod tests {
             offset: vec3(-0.05, -0.1, 0.02),
             rotation: Quaternion::from_angle_x(Deg(20.0)),
             curls: [0.4; 5],
+            trigger_curls: None,
             contacts: [None; 5],
             anchor: [0.0; 3],
             score: 0.0,
@@ -225,6 +234,7 @@ mod tests {
             palm_anchor: [0.02, 0.2, 0.0],
             rotation_degrees: [0.0; 3],
             curls: [0.5; 5],
+            trigger_curls: None,
             grab_radius: 0.07,
             release_distance: 0.12,
             max_swing_degrees: 75.0,

--- a/tools/dark_explorer/src/grip_editor.rs
+++ b/tools/dark_explorer/src/grip_editor.rs
@@ -81,7 +81,8 @@ impl CurlPoseEditor {
                 }
             });
         });
-        ui.add(egui::Slider::new(&mut self.preview, 0.0..=1.0).text(preview_label));
+        ui.label(preview_label);
+        ui.add(egui::Slider::new(&mut self.preview, 0.0..=1.0));
     }
 }
 

--- a/tools/dark_explorer/src/grip_editor.rs
+++ b/tools/dark_explorer/src/grip_editor.rs
@@ -22,6 +22,69 @@ pub(crate) const POSE_PRESETS: [(&str, [f32; 5]); 5] = [
     ("Ball", [0.35, 0.25, 0.3, 0.35, 0.4]),
 ];
 
+/// Shared Rest/pressed authoring for primary and support finger poses.
+#[derive(Default)]
+pub(crate) struct CurlPoseEditor {
+    pressed: bool,
+    pub preview: f32,
+}
+impl CurlPoseEditor {
+    pub fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        rest: &mut [f32; 5],
+        pressed: &mut Option<[f32; 5]>,
+        preview_label: &str,
+    ) {
+        ui.horizontal_wrapped(|ui| {
+            if ui
+                .selectable_value(&mut self.pressed, false, "Rest")
+                .clicked()
+            {
+                self.preview = 0.0;
+            }
+            if ui
+                .selectable_value(&mut self.pressed, true, "Trigger pressed")
+                .clicked()
+            {
+                self.preview = 1.0;
+            }
+        });
+        if self.pressed {
+            if pressed.is_none() {
+                ui.small("Pressed uses Rest until customized.");
+                if ui.button("Customize pressed pose").clicked() {
+                    *pressed = Some(*rest);
+                }
+            } else if ui.button("Use Rest for both").clicked() {
+                *pressed = None;
+            }
+        }
+        let editable = !self.pressed || pressed.is_some();
+        let curls = if self.pressed {
+            pressed.as_mut().unwrap_or(rest)
+        } else {
+            rest
+        };
+        ui.add_enabled_ui(editable, |ui| {
+            for (name, value) in ["Thumb", "Index", "Middle", "Ring", "Pinky"]
+                .into_iter()
+                .zip(curls.iter_mut())
+            {
+                tweak_slider(ui, name, value, 0.0..=1.0, 0.02, 2);
+            }
+            ui.horizontal_wrapped(|ui| {
+                for (name, values) in POSE_PRESETS {
+                    if ui.button(name).clicked() {
+                        *curls = values;
+                    }
+                }
+            });
+        });
+        ui.add(egui::Slider::new(&mut self.preview, 0.0..=1.0).text(preview_label));
+    }
+}
+
 pub fn default_library_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/vr-grips.json")
 }
@@ -179,6 +242,7 @@ fn transfer_grip(
 pub struct GripEditor {
     support_editor: crate::support_grip_editor::SupportEditor,
     support_mode: bool,
+    curl_editor: CurlPoseEditor,
     clipboard: Option<(String, String, ResolvedGrip)>,
     document: Result<GripDocument, String>,
     hints: Result<BTreeMap<String, GripHints>, String>,
@@ -227,6 +291,7 @@ impl GripEditor {
         Self {
             support_editor: crate::support_grip_editor::SupportEditor::new(support_path),
             support_mode,
+            curl_editor: CurlPoseEditor::default(),
             clipboard: None,
             document: GripDocument::load(path.unwrap_or(default_path)),
             hints,
@@ -681,10 +746,12 @@ impl GripEditor {
                 model_mirror,
                 !self.stale && !busy,
             );
+            let mut visual_grip = entry.grip.clone();
+            visual_grip.curls = entry.grip.curls_at(self.curl_editor.preview);
             let scene = PreviewScene::Grip(
                 hand,
-                entry.grip.clone(),
-                self.support_editor.profile(&self.model).cloned(),
+                visual_grip,
+                self.support_editor.preview_profile(&self.model),
             );
             preview.show_grip(
                 ui,
@@ -880,12 +947,12 @@ impl GripEditor {
                     *last = entry.grip.rotation;
                 }
                 columns[2].strong("Finger curls");
-                for (name, value) in ["Thumb", "Index", "Middle", "Ring", "Pinky"]
-                    .into_iter()
-                    .zip(&mut entry.grip.curls)
-                {
-                    tweak_slider(&mut columns[2], name, value, 0.0..=1.0, 0.02, 2);
-                }
+                self.curl_editor.show(
+                    &mut columns[2],
+                    &mut entry.grip.curls,
+                    &mut entry.grip.trigger_curls,
+                    "Primary trigger preview",
+                );
             });
             ui.horizontal(|ui| {
                 ui.label("Rotation nudge step");
@@ -893,14 +960,6 @@ impl GripEditor {
                 ui.separator();
                 ui.label("Uniform item scale");
                 tweak_slider(ui, "×", &mut entry.grip.item_scale, 0.1..=3.0, 0.02, 2);
-            });
-            ui.horizontal_wrapped(|ui| {
-                ui.label("Pose presets");
-                for (name, amounts) in POSE_PRESETS {
-                    if ui.button(name).clicked() {
-                        entry.grip.curls = amounts;
-                    }
-                }
             });
         });
         if before != entry.grip {
@@ -915,10 +974,12 @@ impl GripEditor {
         ui.small("Drag sliders or click values to type. Ball is a cupped starting pose; adjust curls to the item. Unsaved drafts stay when switching models.");
         // Build first, then select the requested camera so the initial model
         // framing cannot overwrite it. show() keeps the same camera on edits.
+        let mut visual_grip = entry.grip.clone();
+        visual_grip.curls = entry.grip.curls_at(self.curl_editor.preview);
         let scene = PreviewScene::Grip(
             hand,
-            entry.grip.clone(),
-            self.support_editor.profile(&self.model).cloned(),
+            visual_grip,
+            self.support_editor.preview_profile(&self.model),
         );
         preview.show_grip(
             ui,
@@ -1018,6 +1079,7 @@ mod tests {
         let mut source = doc.library.entries[0].grip.clone();
         source.item_scale = 0.63;
         source.curls = [0.1, 0.2, 0.3, 0.4, 0.5];
+        source.trigger_curls = Some([0.6, 0.7, 0.3, 0.4, 0.5]);
         let identity = doc.library.entries[1].clone();
         transfer_grip(&source, &mut doc.library.entries[1], None).unwrap();
         let target = &doc.library.entries[1];
@@ -1038,6 +1100,7 @@ mod tests {
             )
         );
         assert_eq!(target.grip.curls, source.curls);
+        assert_eq!(target.grip.trigger_curls, source.trigger_curls);
         assert_eq!(target.grip.item_scale, 0.63);
         assert_eq!(target.grip.contacts, [None; 5]);
         assert!(target.authored);
@@ -1064,6 +1127,7 @@ mod tests {
         source.offset = cgmath::vec3(0.12, -0.08, 0.03);
         source.rotation = Quaternion::from(Euler::new(Deg(23.0), Deg(-37.0), Deg(11.0)));
         source.item_scale = 0.7;
+        source.trigger_curls = Some([0.2, 0.8, 0.3, 0.4, 0.5]);
         // Guns reflect Z; posed melee reflects X around its contact origin.
         let contact = cgmath::vec3(0.15, 0.2, -0.1);
         for mirror in [
@@ -1074,6 +1138,7 @@ mod tests {
         ] {
             transfer_grip(&source, &mut target, Some(mirror)).unwrap();
             assert!(target.grip.is_valid());
+            assert_eq!(target.grip.trigger_curls, source.trigger_curls);
             for point in [
                 cgmath::Point3::new(0.2, 0.1, 0.4),
                 cgmath::Point3::new(-0.1, 0.4, -0.3),
@@ -1090,6 +1155,7 @@ mod tests {
                 palm_anchor: [0.13, -0.21, 0.34],
                 rotation_degrees: [15.0, -20.0, 30.0],
                 curls: [0.4; 5],
+                trigger_curls: None,
                 grab_radius: 0.07,
                 release_distance: 0.12,
                 max_swing_degrees: 75.0,
@@ -1129,6 +1195,7 @@ mod tests {
             assert!((target.grip.offset - source.offset).magnitude() < 1e-5);
             assert!((target.grip.rotation.dot(source.rotation).abs() - 1.0).abs() < 1e-5);
             assert_eq!(target.grip.curls, source.curls);
+            assert_eq!(target.grip.trigger_curls, source.trigger_curls);
             assert!(
                 (cgmath::Vector3::from(target.grip.anchor) - cgmath::Vector3::from(source.anchor))
                     .magnitude()

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -357,6 +357,7 @@ impl ModelPreview {
                     );
                     let mut support_grip = grip.clone();
                     support_grip.curls = support.curls;
+                    support_grip.trigger_curls = None; // Preview curls are already blended.
                     objects.extend(glove.render_hand(
                         pose.position,
                         pose.rotation,

--- a/tools/dark_explorer/src/support_grip_editor.rs
+++ b/tools/dark_explorer/src/support_grip_editor.rs
@@ -1,5 +1,5 @@
 //! Support-hand authoring uses the same resource and placement as gameplay.
-use crate::grip_editor::{POSE_PRESETS, default_library_path, persist_json, tweak_slider};
+use crate::grip_editor::{CurlPoseEditor, default_library_path, persist_json, tweak_slider};
 use eframe::egui;
 use shock2vr::{Handedness, vr_support::SupportProfile};
 use std::{collections::BTreeMap, path::PathBuf};
@@ -73,6 +73,7 @@ pub struct SupportEditor {
     save_as: Option<String>,
     message: String,
     rotation_step: f32,
+    curl_editor: CurlPoseEditor,
 }
 impl SupportEditor {
     pub fn new(path: Option<PathBuf>) -> Self {
@@ -85,6 +86,7 @@ impl SupportEditor {
             save_as: None,
             message: String::new(),
             rotation_step: 5.0,
+            curl_editor: CurlPoseEditor::default(),
         }
     }
     pub fn dirty(&self) -> bool {
@@ -98,6 +100,16 @@ impl SupportEditor {
     }
     pub fn profile(&self, model: &str) -> Option<&SupportProfile> {
         self.document.as_ref().ok()?.profiles.get(model)
+    }
+
+    pub fn preview_profile(&self, model: &str) -> Option<SupportProfile> {
+        let mut profile = self.profile(model)?.clone();
+        profile.curls = shock2vr::vr_grip::blended_curls(
+            profile.curls,
+            profile.trigger_curls,
+            self.curl_editor.preview,
+        );
+        Some(profile)
     }
 
     pub fn show(
@@ -169,6 +181,7 @@ impl SupportEditor {
                         palm_anchor: [-0.09, 0.35, 0.02],
                         rotation_degrees: [0.0; 3],
                         curls: [0.4; 5],
+                        trigger_curls: None,
                         grab_radius: 0.07,
                         release_distance: 0.12,
                         max_swing_degrees: 75.0,
@@ -226,20 +239,14 @@ impl SupportEditor {
                             }
                         }
                         columns[2].strong("Support finger curls");
-                        for (name, value) in ["Thumb", "Index", "Middle", "Ring", "Pinky"]
-                            .into_iter()
-                            .zip(&mut profile.curls)
-                        {
-                            tweak_slider(&mut columns[2], name, value, 0.0..=1.0, 0.02, 2);
-                        }
+                        self.curl_editor.show(
+                            &mut columns[2],
+                            &mut profile.curls,
+                            &mut profile.trigger_curls,
+                            "Support trigger preview",
+                        );
                     });
                     ui.horizontal_wrapped(|ui| {
-                        ui.label("Support pose presets");
-                        for (name, curls) in POSE_PRESETS {
-                            if ui.button(name).clicked() {
-                                profile.curls = curls;
-                            }
-                        }
                         ui.label("Rotation nudge");
                         ui.add(egui::Slider::new(&mut self.rotation_step, 0.1..=15.0).suffix("°"));
                     });
@@ -285,6 +292,21 @@ impl SupportEditor {
 mod tests {
     use super::*;
     #[test]
+    fn trigger_preview_does_not_change_saved_support_curls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("support.json");
+        let bytes = br#"{"atek_h":{"palm_anchor":[-0.2,0.0,0.0],"curls":[0.2,0.2,0.2,0.2,0.2],"trigger_curls":[0.8,0.8,0.8,0.8,0.8],"grab_radius":0.07,"release_distance":0.12,"max_swing_degrees":75.0}}"#;
+        std::fs::write(&path, bytes).unwrap();
+        let mut editor = SupportEditor::new(Some(path.clone()));
+        editor.curl_editor.preview = 0.5;
+        assert_eq!(editor.preview_profile("atek_h").unwrap().curls, [0.5; 5]);
+        assert_eq!(editor.profile("atek_h").unwrap().curls, [0.2; 5]);
+        assert!(!editor.dirty());
+        editor.save().unwrap();
+        assert_eq!(std::fs::read(path).unwrap(), bytes);
+    }
+
+    #[test]
     fn support_edits_round_trip_and_preserve_external_files() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("support.json");
@@ -303,6 +325,7 @@ mod tests {
         assert!(!doc.profiles.contains_key("nanocan"));
         doc.profiles.get_mut("wrench_h").unwrap().rotation_degrees = [20.0, -15.0, 30.0];
         doc.profiles.get_mut("wrench_h").unwrap().palm_anchor[2] = 0.04;
+        doc.profiles.get_mut("wrench_h").unwrap().trigger_curls = Some([0.7; 5]);
         doc.save().unwrap();
         assert_eq!(
             SupportDocument::load(path.clone()).unwrap().profiles,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -1129,6 +1129,9 @@ export interface HandGrip {
   palm: {x:number;y:number;z:number};
   palm_normal: {x:number;y:number;z:number};
   grip: ResolvedGrip | null;
+  /** Raw analog input used for held finger animation, independent of action reservation. */
+  visual_trigger: number;
+  finger_curls: ResolvedGrip["curls"] | null;
   /** Glove pose following a physical melee body; null uses raw tracked pose. */
   glove_pose: { position: ResolvedGrip["offset"]; rotation: ResolvedGrip["rotation"] } | null;
   /** Optional support socket on this owned item; the support hand owns no entity. */
@@ -1140,6 +1143,8 @@ export interface HandGrip {
     pressed: [boolean, boolean];
     blocked: [boolean, boolean];
     step_dt: number;
+    visual_trigger: number;
+    finger_curls: ResolvedGrip["curls"];
     socket_position: ResolvedGrip["offset"];
     controller_position: ResolvedGrip["offset"];
     controller_rotation: ResolvedGrip["rotation"];
@@ -1160,6 +1165,8 @@ export interface ResolvedGrip {
   offset: {x:number;y:number;z:number};
   rotation: {s:number;v:{x:number;y:number;z:number}};
   curls: [number,number,number,number,number];
+  /** Optional pressed pose; omission preserves resting curls at any trigger value. */
+  trigger_curls?: [number,number,number,number,number];
   contacts: (Vec3 | null)[];
   anchor: Vec3;
   score: number;

--- a/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
@@ -56,12 +56,16 @@ for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
       await game.input.set(`${other}_hand.trigger`,1);
       await game.step({frames:2});
       assert.equal(ammoOf(await game.entities.detail(weapon.id)),ammo,"support trigger cannot fire");
+      assert.equal((await grip()).support!.visual_trigger,1,"reserved support input remains available to finger animation");
       assert.equal((await game.info()).player[empty],null);
       // Pistol/shotgun rounds are fast raycast projectiles, not Rapier bodies.
       // Barrel geometry is checked by the weapon-script solver integration test.
       await game.input.set(`${primary}_hand.trigger`,1);
       await game.step({frames:1});
       assert.equal(ammoOf(await game.entities.detail(weapon.id)),ammo-1,"primary trigger fires while supported");
+      const fired = await grip();
+      assert.equal(fired.visual_trigger,1);
+      assert.deepEqual(fired.finger_curls,fired.grip!.trigger_curls ?? fired.grip!.curls);
       await game.input.set(`${primary}_hand.trigger`,0);
       await game.input.set(`${other}_hand.squeeze`,0);
       await game.step({frames:1});


### PR DESCRIPTION
Add independently editable Rest and Trigger pressed finger poses to primary and support grips. The editor previews analog blending; gameplay uses the same curls while preserving existing fire/use thresholds and support-hand input reservation. Missing pressed poses retain Rest, and existing authored resources are unchanged.

Stacked on #1396 (`astra-vr-gun-support`).

Validation: 1,525 Rust tests passed (2 ignored), 8 Explorer tests, TypeScript build, and 4 headless VR pistol/shotgun scenarios covering both hands, firing, support input, scale, release, and ownership. Cross-engine review completed; redundant input state removed and preview label clipping fixed. Visual review confirms progressive motion and return; demo contact poses still require item-specific calibration.

### Visual evidence

Temporary copied pose fixtures opt in to analog finger blending; shipped resources are unchanged. Pistol index .35 → .60, hypo thumb 0 → .40. Matching parent/current runtime sequences include release back to rest. These demonstrate animation, not calibrated trigger contact or headset approval.

![atek_h fixture before / after](https://gist.githubusercontent.com/tommy-xr/eb467a7c72f765aefc8d30f548c008a3/raw/astra-atek_h-before-after.png)

![atek_h fixture before / after](https://gist.githubusercontent.com/tommy-xr/eb467a7c72f765aefc8d30f548c008a3/raw/astra-atek_h-before-after.gif)

![medpatch fixture before / after](https://gist.githubusercontent.com/tommy-xr/eb467a7c72f765aefc8d30f548c008a3/raw/astra-medpatch-before-after.png)

![medpatch fixture before / after](https://gist.githubusercontent.com/tommy-xr/eb467a7c72f765aefc8d30f548c008a3/raw/astra-medpatch-before-after.gif)

![Native Explorer trigger authoring](https://gist.githubusercontent.com/tommy-xr/eb467a7c72f765aefc8d30f548c008a3/raw/astra-trigger-editor.png)

[Native editor preview cycle](https://gist.githubusercontent.com/tommy-xr/eb467a7c72f765aefc8d30f548c008a3/raw/astra-trigger-editor.gif) · [Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/eb467a7c72f765aefc8d30f548c008a3/raw/astra-trigger-gallery.html)

Native preview states were selected with isolated capture-only instrumentation, using the normal renderer and copied JSON libraries. This does not claim automated mouse interaction. Support preview uses a separately authored pinky curl. Pistol contact remains a demonstration pose; hypo contact is partly occluded.
