### PR TITLE
feat(vr): edit support regions for oversized weapons

### DIFF
--- a/assets/vr-support-grips.json
+++ b/assets/vr-support-grips.json
@@ -64,5 +64,73 @@
     "grab_radius": 0.07,
     "release_distance": 0.12,
     "max_swing_degrees": 75.0
+  },
+  "fsn_h": {
+    "palm_anchor": [
+      -0.7,
+      -0.38,
+      0.0
+    ],
+    "region": {
+      "start": [
+        -0.55,
+        -0.38,
+        0.0
+      ],
+      "end": [
+        -0.85,
+        -0.38,
+        0.0
+      ]
+    },
+    "rotation_degrees": [
+      0,
+      0,
+      90
+    ],
+    "curls": [
+      0.3,
+      0.3,
+      0.35,
+      0.4,
+      0.45
+    ],
+    "grab_radius": 0.07,
+    "release_distance": 0.12,
+    "max_swing_degrees": 75.0
+  },
+  "al_h": {
+    "palm_anchor": [
+      -0.175,
+      -0.04,
+      0.1
+    ],
+    "region": {
+      "start": [
+        -0.1,
+        -0.04,
+        0.1
+      ],
+      "end": [
+        -0.25,
+        -0.04,
+        0.1
+      ]
+    },
+    "rotation_degrees": [
+      90,
+      0,
+      0
+    ],
+    "curls": [
+      0.4,
+      0.45,
+      0.5,
+      0.55,
+      0.6
+    ],
+    "grab_radius": 0.07,
+    "release_distance": 0.12,
+    "max_swing_degrees": 75.0
   }
 }

--- a/dark/src/hit_box.rs
+++ b/dark/src/hit_box.rs
@@ -309,7 +309,7 @@ fn append_box_lines(
 
 /// Capsule wireframe (joint-local) between `a` and `b`: end rings, longitudinal
 /// lines, and two great-circle arcs over each hemispherical cap.
-fn append_capsule_lines(
+pub fn append_capsule_lines(
     verts: &mut Vec<VertexPosition>,
     xform: &Matrix4<f32>,
     a: Vector3<f32>,
@@ -318,10 +318,12 @@ fn append_capsule_lines(
 ) {
     let axis_vec = b - a;
     let len = axis_vec.magnitude();
-    if len < 1e-5 {
-        return;
-    }
-    let axis = axis_vec / len;
+    // A zero-length support region is a spherical socket.
+    let axis = if len < 1e-5 {
+        Vector3::unit_y()
+    } else {
+        axis_vec / len
+    };
     // Two unit vectors perpendicular to the axis.
     let mut helper = Vector3::new(0.0, 1.0, 0.0);
     if axis.dot(helper).abs() > 0.99 {
@@ -375,6 +377,17 @@ mod tests {
         for vertex in &verts {
             let r = (vertex.position - center).magnitude();
             assert!((r - 0.25).abs() < 1e-5, "vertex off the sphere: r = {r}");
+        }
+    }
+
+    #[test]
+    fn zero_length_capsule_draws_a_finite_sphere_at_the_requested_radius() {
+        let mut points = Vec::new();
+        let center = Vector3::new(1.0, 2.0, 3.0);
+        append_capsule_lines(&mut points, &Matrix4::from_scale(1.0), center, center, 0.07);
+        assert!(!points.is_empty());
+        for point in points {
+            assert!(((point.position - center).magnitude() - 0.07).abs() < 1e-5);
         }
     }
 }

--- a/projects/astra-vr-grip-editor.md
+++ b/projects/astra-vr-grip-editor.md
@@ -105,3 +105,26 @@ Gameplay blends using analog controller trigger input. Fire/use thresholds are
 unchanged, and the supporting hand can animate without firing or using an item.
 The debug runtime's hand-grip diagnostics report `visual_trigger` and
 `finger_curls` for the primary hand and its support hand.
+
+## Support regions for large weapons
+
+In **Support hand**, choose **Fixed socket** or **Support region**. A region has
+editable XYZ start/end points in the displayed hand's frame, plus a grab radius
+in centimeters. The cyan wire capsule shows the eligible area. **Position along
+region** previews the support glove along it without editing the saved pose.
+Wrist rotation and both finger poses apply everywhere on that region.
+
+The fusion cannon (`fsn_h`) and worm launcher (`al_h`) use regions; the wrench,
+pistol, and shotgun retain fixed sockets by default. Their existing primary
+poses and uniform scales are preserved. A support squeeze selects the closest
+point on the region and locks that contact until release. Moving the second
+hand steers the weapon; it does not slide the contact or resize the model.
+Releasing and squeezing again selects a new nearest point. The primary hand
+retains ownership, and releasing it drops the weapon.
+
+Regions save as optional `region: {start: [x,y,z], end: [x,y,z]}` in
+`vr-support-grips.json`, in normalized right-primary model coordinates before
+item scale. The editor mirrors them through the same model frame as gameplay.
+Omitting the region uses `palm_anchor` as a fixed socket. A zero-length region
+also behaves as a socket. Runtime diagnostics expose world-space
+`support.region_endpoints` and the locked scaled-model-space `support_anchor`.

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -217,6 +217,7 @@ struct SupportAttachment {
     active: bool,
     blend: f32,
     correction: Quaternion<f32>,
+    anchor: Vector3<f32>, // Scaled model-space contact, fixed until release.
 }
 
 #[derive(Clone)]
@@ -228,6 +229,7 @@ struct SupportCandidate {
     primary_anchor: Vector3<f32>,
     tracked_axis: Vector3<f32>,
     anchor: Vector3<f32>,
+    region: Option<[Vector3<f32>; 2]>,
     model_pose: GripPose,
     hand_pose: GripPose,
 }
@@ -313,7 +315,12 @@ impl VrInteraction {
         })
     }
 
-    fn support_candidate(&self, world: &World, poses: [GripPose; 2]) -> Option<SupportCandidate> {
+    fn support_candidate(
+        &self,
+        world: &World,
+        poses: [GripPose; 2],
+        prefer_locked_anchor: bool,
+    ) -> Option<SupportCandidate> {
         let rig = self.grip_kinematics.as_ref()?;
         for (primary, hand) in [&self.left_hand, &self.right_hand].into_iter().enumerate() {
             let Some(held) = self.fitted_grips[primary].as_ref() else {
@@ -346,7 +353,6 @@ impl VrInteraction {
             let Some(model_mirror) = held.model_mirror else {
                 continue;
             };
-            let anchor = profile.anchor_in_frame(handedness, model_mirror) * grip.item_scale;
             let correction = self
                 .support
                 .as_ref()
@@ -360,6 +366,26 @@ impl VrInteraction {
             // Melee physics may stop short of its target at a wall. Acquisition
             // and visible gloves belong on that actual weapon, not an unseen target.
             let model_pose = held.physical_model_pose(world).unwrap_or(target_pose);
+            let anchor = self
+                .support
+                .as_ref()
+                .filter(|s| prefer_locked_anchor && s.entity == held.entity && s.primary == primary)
+                .map_or_else(
+                    || {
+                        if !poses[1 - primary].is_tracked() {
+                            return profile.region_in_frame(handedness, model_mirror)[0]
+                                * grip.item_scale;
+                        }
+                        profile.closest_anchor(
+                            handedness,
+                            model_mirror,
+                            grip.item_scale,
+                            model_pose,
+                            poses[1 - primary].point(rig[1 - primary].palm),
+                        )
+                    },
+                    |s| s.anchor,
+                );
             let hand_pose =
                 profile.glove_pose(handedness, model_pose, grip, &rig[1 - primary], anchor);
             return Some(SupportCandidate {
@@ -370,6 +396,11 @@ impl VrInteraction {
                 primary_anchor,
                 tracked_axis: base_rotation.rotate_vector(anchor - primary_anchor),
                 anchor,
+                region: profile.region.as_ref().map(|_| {
+                    profile
+                        .region_in_frame(handedness, model_mirror)
+                        .map(|p| p * grip.item_scale)
+                }),
                 model_pose,
                 hand_pose,
             });
@@ -394,7 +425,10 @@ impl VrInteraction {
                 self.support_blocked[i] = false;
             }
         }
-        let candidate = self.support_candidate(ctx.world, poses);
+        let candidate = self
+            .support
+            .as_ref()
+            .and_then(|_| self.support_candidate(ctx.world, poses, true));
         let available = |primary: usize| {
             let other = 1 - primary;
             let hand = if other == 0 {
@@ -440,6 +474,7 @@ impl VrInteraction {
         // Hand input still updates on render-only (zero-dt) frames, just like
         // VirtualHand. Consume the squeeze edge there too; only blending needs dt.
         if ctx.support_enabled && self.support.as_ref().is_none_or(|s| !s.active) {
+            let candidate = self.support_candidate(ctx.world, poses, false);
             if let Some(c) = candidate.as_ref() {
                 let other = 1 - c.primary;
                 if let Some(rig) = self.grip_kinematics.as_ref() {
@@ -467,6 +502,7 @@ impl VrInteraction {
                             active: true,
                             blend,
                             correction,
+                            anchor: c.anchor,
                         });
                         self.support_blocked[other] = true;
                     }
@@ -480,7 +516,7 @@ impl VrInteraction {
         use shipyard::{Get, View};
         self.visual_hands = [None, None];
         let poses = self.hand_poses();
-        let candidate = self.support_candidate(world, poses);
+        let candidate = self.support_candidate(world, poses, true);
         let valid = self
             .support
             .as_ref()
@@ -832,7 +868,7 @@ impl PlayerInteraction for VrInteraction {
 
     fn synchronize_held_visuals(&mut self, world: &World) {
         let poses = self.hand_poses();
-        self.support_preview = self.support_candidate(world, poses);
+        self.support_preview = self.support_candidate(world, poses, true);
         self.visual_hands = [None, None];
         // Physical melee follows its synchronized body even with one hand.
         // Supported guns follow their solved pose so both gloves stay seated.
@@ -897,6 +933,7 @@ impl PlayerInteraction for VrInteraction {
                     "model_position": c.model_pose.position, "model_rotation": c.model_pose.rotation,
                     "primary_palm": c.primary_palm, "primary_anchor": c.primary_anchor,
                     "support_anchor": c.anchor, "grab_radius": c.profile.grab_radius,
+                    "region_endpoints": c.region.map(|ends| ends.map(|p| c.model_pose.point(p))),
                     "visual_trigger": visual_triggers[1-i],
                     "finger_curls": crate::vr_grip::blended_curls(c.profile.curls, c.profile.trigger_curls, visual_triggers[1-i]),
                     "release_distance": c.profile.release_distance, "max_swing_degrees": c.profile.max_swing_degrees
@@ -1399,6 +1436,7 @@ mod tests {
             "wrench_h".into(),
             SupportProfile {
                 palm_anchor: [0.0, 0.2, 0.0],
+                region: None,
                 rotation_degrees: [0.0; 3],
                 curls: [0.5; 5],
                 trigger_curls: None,
@@ -1517,6 +1555,43 @@ mod tests {
         input.left_hand.squeeze_value = 1.0;
         interaction.update_support(&context(&world, &physics, &input));
         assert!(interaction.support.as_ref().unwrap().active);
+        // A broad region chooses a fresh nearest point only on a new squeeze.
+        interaction.support = None;
+        interaction
+            .support_profiles
+            .get_mut("wrench_h")
+            .unwrap()
+            .region = Some(crate::vr_support::SupportRegion {
+            start: [0.0, 0.2, 0.0],
+            end: [0.0, 0.35, 0.0],
+        });
+        input.left_hand.squeeze_value = 0.0;
+        let mut untracked = interaction.hand_poses();
+        untracked[0].position.x = f32::NAN;
+        let preview = interaction
+            .support_candidate(&world, untracked, false)
+            .unwrap();
+        assert_eq!(preview.anchor, vec3(0.0, 0.2, 0.0));
+        assert!(
+            preview.hand_pose.is_tracked(),
+            "untracked support input keeps a finite region preview"
+        );
+        input.left_hand.position.y = 1.22;
+        interaction.update_support(&context(&world, &physics, &input));
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        let locked = interaction.support.as_ref().unwrap().anchor;
+        assert!((locked.y - 0.22).abs() < 1e-5);
+        input.left_hand.position.y = 1.28;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(interaction.support.as_ref().unwrap().active);
+        assert_eq!(interaction.support.as_ref().unwrap().anchor, locked);
+        input.left_hand.squeeze_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!((interaction.support.as_ref().unwrap().anchor.y - 0.28).abs() < 1e-5);
+        interaction.support.as_mut().unwrap().blend = 1.0;
         let mut ctx = context(&world, &physics, &input);
         ctx.support_enabled = false;
         interaction.update_support(&ctx);

--- a/shock2vr/src/vr_support.rs
+++ b/shock2vr/src/vr_support.rs
@@ -2,10 +2,10 @@
 use cgmath::{Deg, Euler, InnerSpace, Matrix4, Point3, Quaternion, Rotation, Transform, Vector3};
 use serde::{Deserialize, Serialize};
 
-/// Fixed authored support sockets currently enabled in gameplay.
+/// Authored support sockets and regions currently enabled in gameplay.
 /// Keep the Explorer eligibility notice and runtime policy together.
 pub fn supports_model(model: &str) -> bool {
-    matches!(model, "wrench_h" | "atek_h" | "sg_h")
+    matches!(model, "wrench_h" | "atek_h" | "sg_h" | "fsn_h" | "al_h")
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -35,11 +35,20 @@ impl GripPose {
     }
 }
 
+/// A model-local segment swept by the profile's grab radius.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SupportRegion {
+    pub start: [f32; 3],
+    pub end: [f32; 3],
+}
+
 /// Anchor in the normalized weapon mesh used by prepared grips (before item scale).
 /// Stored in the right-primary model frame; the renderer supplies the opposite frame.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SupportProfile {
     pub palm_anchor: [f32; 3],
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<SupportRegion>,
     /// Support wrist rotation relative to the primary wrist; authored right-primary.
     #[serde(default)]
     pub rotation_degrees: [f32; 3],
@@ -54,6 +63,10 @@ pub struct SupportProfile {
 impl SupportProfile {
     pub fn is_valid(&self) -> bool {
         self.palm_anchor.iter().all(|v| v.is_finite())
+            && self
+                .region
+                .as_ref()
+                .is_none_or(|r| r.start.iter().chain(&r.end).all(|v| v.is_finite()))
             && self
                 .rotation_degrees
                 .iter()
@@ -104,6 +117,49 @@ impl SupportProfile {
             && from.normalize().dot(to.normalize()) >= self.max_swing_degrees.to_radians().cos()
     }
 
+    pub fn region_in_frame(
+        &self,
+        primary: crate::Handedness,
+        mirror: Matrix4<f32>,
+    ) -> [Vector3<f32>; 2] {
+        let points = self
+            .region
+            .as_ref()
+            .map_or([self.palm_anchor; 2], |r| [r.start, r.end]);
+        points.map(|p| Self::point_in_frame(p, primary, mirror))
+    }
+
+    /// Query in scaled model space. The chosen anchor is locked by the attachment.
+    pub fn closest_anchor(
+        &self,
+        primary: crate::Handedness,
+        mirror: Matrix4<f32>,
+        scale: f32,
+        model: GripPose,
+        palm: Vector3<f32>,
+    ) -> Vector3<f32> {
+        use rapier3d::{
+            na,
+            parry::{query::PointQuery, shape::Segment},
+        };
+        let [a, b] = self.region_in_frame(primary, mirror).map(|p| p * scale);
+        if (b - a).magnitude2() < 1e-8 {
+            return a;
+        }
+        let local = model
+            .rotation
+            .conjugate()
+            .rotate_vector(palm - model.position);
+        let segment = Segment::new(
+            na::Point3::new(a.x, a.y, a.z),
+            na::Point3::new(b.x, b.y, b.z),
+        );
+        let point = segment
+            .project_local_point(&na::Point3::new(local.x, local.y, local.z), false)
+            .point;
+        Vector3::new(point.x, point.y, point.z)
+    }
+
     /// Use the same reflection as the rendered item: gun Z and posed melee X
     /// are different model frames even though both gloves mirror hand X.
     pub fn anchor_in_frame(
@@ -111,7 +167,15 @@ impl SupportProfile {
         primary: crate::Handedness,
         model_mirror: Matrix4<f32>,
     ) -> Vector3<f32> {
-        let point = Point3::from(self.palm_anchor);
+        Self::point_in_frame(self.palm_anchor, primary, model_mirror)
+    }
+
+    pub fn point_in_frame(
+        point: [f32; 3],
+        primary: crate::Handedness,
+        model_mirror: Matrix4<f32>,
+    ) -> Vector3<f32> {
+        let point = Point3::from(point);
         let point = if primary == crate::Handedness::Left {
             model_mirror.transform_point(point)
         } else {
@@ -158,9 +222,55 @@ mod tests {
     use cgmath::{Deg, One, Rotation3, vec3};
 
     #[test]
+    fn support_region_projects_in_scaled_rotated_and_mirrored_model_frames() {
+        let mut profile: SupportProfile = serde_json::from_value(serde_json::json!({
+            "palm_anchor": [0.0,0.2,0.0], "curls":[0.5,0.5,0.5,0.5,0.5],
+            "grab_radius":0.07,"release_distance":0.12,"max_swing_degrees":75.0
+        }))
+        .unwrap();
+        profile.region = Some(SupportRegion {
+            start: [0.1, 0.2, 0.1],
+            end: [0.1, 0.6, 0.1],
+        });
+        let model = GripPose {
+            position: vec3(2.0, 3.0, 4.0),
+            rotation: Quaternion::from_angle_z(Deg(47.0)),
+        };
+        for hand in [crate::Handedness::Left, crate::Handedness::Right] {
+            let mirror = Matrix4::from_translation(vec3(0.0, 0.0, 0.15))
+                * crate::Handedness::Left.gun_mirror();
+            let [a, b] = profile.region_in_frame(hand, mirror).map(|p| p * 0.55);
+            for t in [-0.5_f32, 0.0, 0.3, 1.0, 1.5] {
+                let palm = model.point(a + (b - a) * t + vec3(0.02, 0.0, 0.0));
+                let anchor = profile.closest_anchor(hand, mirror, 0.55, model, palm);
+                assert!((anchor - (a + (b - a) * t.clamp(0.0, 1.0))).magnitude() < 1e-5);
+            }
+        }
+        profile.region.as_mut().unwrap().end = profile.region.as_ref().unwrap().start;
+        assert!(profile.is_valid(), "zero-length region behaves as a socket");
+        let expected = Vector3::from(profile.region.as_ref().unwrap().start);
+        assert_eq!(
+            profile.closest_anchor(
+                crate::Handedness::Right,
+                Matrix4::one(),
+                1.0,
+                model,
+                model.position
+            ),
+            expected
+        );
+        let restored: SupportProfile =
+            serde_json::from_str(&serde_json::to_string(&profile).unwrap()).unwrap();
+        assert_eq!(restored, profile);
+        profile.region.as_mut().unwrap().start[0] = f32::NAN;
+        assert!(!profile.is_valid());
+    }
+
+    #[test]
     fn rotated_support_pose_preserves_the_mirrored_palm_in_runtime_and_editor() {
         let profile = SupportProfile {
             palm_anchor: [-0.09, 0.354, 0.02],
+            region: None,
             rotation_degrees: [20.0, 15.0, -30.0],
             curls: [0.4; 5],
             trigger_curls: None,
@@ -232,6 +342,7 @@ mod tests {
         );
         let mut profile = SupportProfile {
             palm_anchor: [0.02, 0.2, 0.0],
+            region: None,
             rotation_degrees: [0.0; 3],
             curls: [0.5; 5],
             trigger_curls: None,

--- a/tools/dark_explorer/src/grip_editor.rs
+++ b/tools/dark_explorer/src/grip_editor.rs
@@ -1154,6 +1154,7 @@ mod tests {
             }
             let support = shock2vr::vr_support::SupportProfile {
                 palm_anchor: [0.13, -0.21, 0.34],
+                region: None,
                 rotation_degrees: [15.0, -20.0, 30.0],
                 curls: [0.4; 5],
                 trigger_curls: None,

--- a/tools/dark_explorer/src/model_preview.rs
+++ b/tools/dark_explorer/src/model_preview.rs
@@ -339,6 +339,16 @@ impl ModelPreview {
                 ));
                 let mut support_points = Vec::new();
                 if let Some(support) = support {
+                    if support.region.is_some() {
+                        let [a, b] = support
+                            .region_in_frame(*hand, model_mirror)
+                            .map(|p| grip.offset + grip.rotation * (p * grip.item_scale));
+                        objects.push(support_region_overlay(a, b, support.grab_radius));
+                        for p in [a, b] {
+                            support_points.push(p - vec3(1.0, 1.0, 1.0) * support.grab_radius);
+                            support_points.push(p + vec3(1.0, 1.0, 1.0) * support.grab_radius);
+                        }
+                    }
                     let other = if *hand == Handedness::Left {
                         Handedness::Right
                     } else {
@@ -839,4 +849,22 @@ impl ToolScene for GripPreviewScene {
     fn render(&self, _asset_cache: &mut AssetCache) -> engine::scene::Scene {
         self.0.clone()
     }
+}
+
+/// Wire capsule in preview coordinates: the same world-unit radius used to grab.
+fn support_region_overlay(
+    a: cgmath::Vector3<f32>,
+    b: cgmath::Vector3<f32>,
+    radius: f32,
+) -> engine::scene::SceneObject {
+    use engine::scene::{SceneObject, VertexPosition, color_material, lines_mesh};
+    let mut vertices = vec![
+        VertexPosition { position: a },
+        VertexPosition { position: b },
+    ];
+    dark::hit_box::append_capsule_lines(&mut vertices, &Matrix4::one(), a, b, radius);
+    SceneObject::new(
+        color_material::create(vec3(0.1, 0.9, 0.8)),
+        Box::new(lines_mesh::create(vertices)),
+    )
 }

--- a/tools/dark_explorer/src/support_grip_editor.rs
+++ b/tools/dark_explorer/src/support_grip_editor.rs
@@ -1,7 +1,10 @@
 //! Support-hand authoring uses the same resource and placement as gameplay.
 use crate::grip_editor::{CurlPoseEditor, default_library_path, persist_json, tweak_slider};
 use eframe::egui;
-use shock2vr::{Handedness, vr_support::SupportProfile};
+use shock2vr::{
+    Handedness,
+    vr_support::{SupportProfile, SupportRegion},
+};
 use std::{collections::BTreeMap, path::PathBuf};
 
 struct SupportDocument {
@@ -68,12 +71,44 @@ impl SupportDocument {
     }
 }
 
+/// Edit model-local points in the displayed hand frame and physical centimeters.
+fn tweak_anchor(
+    ui: &mut egui::Ui,
+    point: &mut [f32; 3],
+    primary: Handedness,
+    mirror: cgmath::Matrix4<f32>,
+    item_scale: f32,
+) {
+    use cgmath::{SquareMatrix, Transform};
+    let factor = item_scale * shock2vr::METERS_PER_WORLD_UNIT * 100.0;
+    let mut anchor: [f32; 3] = SupportProfile::point_in_frame(*point, primary, mirror).into();
+    let mut changed = false;
+    for (i, axis) in ["X", "Y", "Z"].into_iter().enumerate() {
+        let mut cm = anchor[i] * factor;
+        if tweak_slider(ui, axis, &mut cm, -100.0..=100.0, 0.1, 2) {
+            anchor[i] = cm / factor;
+            changed = true;
+        }
+    }
+    if changed {
+        *point = if primary == Handedness::Left {
+            mirror
+                .invert()
+                .map(|inverse| inverse.transform_point(cgmath::Point3::from(anchor)).into())
+                .unwrap_or(*point)
+        } else {
+            anchor
+        };
+    }
+}
+
 pub struct SupportEditor {
     document: Result<SupportDocument, String>,
     save_as: Option<String>,
     message: String,
     rotation_step: f32,
     curl_editor: CurlPoseEditor,
+    region_preview: f32,
 }
 impl SupportEditor {
     pub fn new(path: Option<PathBuf>) -> Self {
@@ -87,6 +122,7 @@ impl SupportEditor {
             message: String::new(),
             rotation_step: 5.0,
             curl_editor: CurlPoseEditor::default(),
+            region_preview: 0.5,
         }
     }
     pub fn dirty(&self) -> bool {
@@ -104,6 +140,11 @@ impl SupportEditor {
 
     pub fn preview_profile(&self, model: &str) -> Option<SupportProfile> {
         let mut profile = self.profile(model)?.clone();
+        if let Some(region) = &profile.region {
+            profile.palm_anchor = std::array::from_fn(|i| {
+                region.start[i] + (region.end[i] - region.start[i]) * self.region_preview
+            });
+        }
         profile.curls = shock2vr::vr_grip::blended_curls(
             profile.curls,
             profile.trigger_curls,
@@ -179,6 +220,7 @@ impl SupportEditor {
                     model.into(),
                     SupportProfile {
                         palm_anchor: [-0.09, 0.35, 0.02],
+                        region: None,
                         rotation_degrees: [0.0; 3],
                         curls: [0.4; 5],
                         trigger_curls: None,
@@ -193,31 +235,27 @@ impl SupportEditor {
             ui.add_enabled_ui(
                 enabled && item_scale.is_finite() && item_scale > 0.0,
                 |ui| {
-                    ui.columns(3, |columns| {
-                        columns[0].strong("Palm position on item (cm)");
-                        use cgmath::{SquareMatrix, Transform};
-                        let factor = item_scale * shock2vr::METERS_PER_WORLD_UNIT * 100.0;
-                        let mut anchor: [f32; 3] =
-                            profile.anchor_in_frame(primary, model_mirror).into();
-                        let mut changed = false;
-                        for (i, axis) in ["X", "Y", "Z"].into_iter().enumerate() {
-                            let mut cm = anchor[i] * factor;
-                            if tweak_slider(&mut columns[0], axis, &mut cm, -100.0..=100.0, 0.1, 2)
-                            {
-                                anchor[i] = cm / factor;
-                                changed = true;
+                    ui.horizontal(|ui| {
+                        if ui.selectable_label(profile.region.is_none(), "Fixed socket").clicked() {
+                            if let Some(region) = profile.region.take() {
+                                profile.palm_anchor = std::array::from_fn(|i| region.start[i] + (region.end[i] - region.start[i]) * self.region_preview);
                             }
                         }
-                        if changed {
-                            let anchor = cgmath::Point3::from(anchor);
-                            profile.palm_anchor = if primary == Handedness::Left {
-                                model_mirror
-                                    .invert()
-                                    .map(|inverse| inverse.transform_point(anchor).into())
-                                    .unwrap_or(profile.palm_anchor)
-                            } else {
-                                anchor.into()
-                            };
+                        if ui.selectable_label(profile.region.is_some(), "Support region").clicked() && profile.region.is_none() {
+                            let mut end = profile.palm_anchor;
+                            end[0] -= 0.2 / item_scale;
+                            profile.region = Some(SupportRegion { start: profile.palm_anchor, end });
+                        }
+                    });
+                    ui.columns(3, |columns| {
+                        columns[0].strong("Palm position on item (cm)");
+                        if let Some(region) = &mut profile.region {
+                            columns[0].small("Region start");
+                            tweak_anchor(&mut columns[0], &mut region.start, primary, model_mirror, item_scale);
+                            columns[0].small("Region end");
+                            tweak_anchor(&mut columns[0], &mut region.end, primary, model_mirror, item_scale);
+                        } else {
+                            tweak_anchor(&mut columns[0], &mut profile.palm_anchor, primary, model_mirror, item_scale);
                         }
                         columns[1].strong("Support wrist rotation (degrees)");
                         for (i, axis) in ["X", "Y", "Z"].into_iter().enumerate() {
@@ -246,6 +284,16 @@ impl SupportEditor {
                             "Support trigger preview",
                         );
                     });
+                    if profile.region.is_some() {
+                        ui.add(egui::Slider::new(&mut self.region_preview, 0.0..=1.0).text("Position along region"));
+                        ui.small("Squeeze selects the nearest point; the contact stays fixed until release.");
+                    }
+                    let units = shock2vr::METERS_PER_WORLD_UNIT * 100.0;
+                    let mut radius = profile.grab_radius * units;
+                    if tweak_slider(ui, "Grab radius (cm)", &mut radius, 0.01*units..=0.15*units, 0.1, 2) {
+                        profile.grab_radius = (radius / units).clamp(0.01,0.15);
+                        profile.release_distance = profile.release_distance.max(profile.grab_radius);
+                    }
                     ui.horizontal_wrapped(|ui| {
                         ui.label("Rotation nudge");
                         ui.add(egui::Slider::new(&mut self.rotation_step, 0.1..=15.0).suffix("°"));
@@ -325,6 +373,10 @@ mod tests {
         assert!(!doc.profiles.contains_key("nanocan"));
         doc.profiles.get_mut("wrench_h").unwrap().rotation_degrees = [20.0, -15.0, 30.0];
         doc.profiles.get_mut("wrench_h").unwrap().palm_anchor[2] = 0.04;
+        doc.profiles.get_mut("wrench_h").unwrap().region = Some(SupportRegion {
+            start: [0.0, 0.2, 0.0],
+            end: [0.0, 0.4, 0.0],
+        });
         doc.profiles.get_mut("wrench_h").unwrap().trigger_curls = Some([0.7; 5]);
         doc.save().unwrap();
         assert_eq!(

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -1153,6 +1153,8 @@ export interface HandGrip {
     primary_palm: ResolvedGrip["offset"];
     primary_anchor: ResolvedGrip["offset"];
     support_anchor: ResolvedGrip["offset"];
+    /** World-space segment endpoints, or null for a fixed socket. */
+    region_endpoints: [ResolvedGrip["offset"], ResolvedGrip["offset"]] | null;
     grab_radius: number;
     release_distance: number;
     max_swing_degrees: number;

--- a/tools/shock2-sdk/test/vr-support-region.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-support-region.e2e.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import type { HandGrip, ResolvedGrip, Vec3 } from "../src/types.js";
+import { add, sub, aimVrHandAt, quatConjugate, quatMultiply, quatRotate, type Quat } from "./helpers/vr-hand.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+const vector = (v: ResolvedGrip["offset"]): Vec3 => [v.x,v.y,v.z];
+const quaternion = (q: ResolvedGrip["rotation"]): Quat => [...vector(q.v),q.s];
+const distance = (a: Vec3,b: Vec3) => Math.hypot(...sub(a,b));
+for (const [model,template] of [["fsn_h",-26],["al_h",-27]] as const) {
+  for (const primary of ["left","right"] as const) {
+    test(`${model} ${primary}: broad support locks a contact until release`, {
+      skip: process.env.SHOCK2_E2E !== "1", timeout:180_000,
+    }, async () => {
+      await using game = await GameServer.launch({mission:"debug_weapons",debugFlags:["--vr"]});
+      await game.step({frames:30});
+      const weapon = await cycleToWeapon(game,e=>e.template_id === template);
+      await aimVrHandAt(game,weapon.position,.2,1,0,{hand:primary});
+      const other = primary === "left" ? "right" : "left";
+      await game.input.set(`${primary}_hand.position`,[0,1,-.5]);
+      await game.input.set(`${primary}_hand.rotation`,[0,0,0,1]);
+      await game.input.set(`${other}_hand.squeeze`,0);
+      await game.step({frames:30});
+      const grip = async (): Promise<HandGrip> => (await game.info()).player.hand_grips.find(g=>g.hand === primary)!;
+      const placeAt = async (fraction:number) => {
+        const current = await grip();
+        const support = current.support!;
+        assert.ok(support.region_endpoints,`${model} exposes its region`);
+        const [a,b] = support.region_endpoints.map(vector);
+        const palm = a!.map((v,i)=>v+(b![i]!-v)*fraction) as Vec3;
+        const wrist = add(vector(support.controller_position),sub(palm,vector(support.socket_position)));
+        const player = (await game.info()).player;
+        const inverse = quatConjugate(player.rotation);
+        await game.input.set(`${other}_hand.position`,quatRotate(inverse,sub(wrist,player.position)));
+        await game.input.set(`${other}_hand.rotation`,quatMultiply(inverse,quaternion(support.controller_rotation)));
+      };
+      await placeAt(.2);
+      await game.input.set(`${other}_hand.squeeze`,1);
+      await game.step({frames:20});
+      const attached = await grip();
+      assert.equal(attached.support!.attached,true);
+      const contact = vector(attached.support!.support_anchor);
+      const length = distance(...attached.support!.region_endpoints!.map(vector) as [Vec3,Vec3]);
+      await placeAt(.4);
+      await game.step({frames:10});
+      const moved = await grip();
+      assert.equal(moved.support!.attached,true);
+      assert.ok(distance(vector(moved.support!.tracked_palm),vector(attached.support!.tracked_palm))>length*.1,"support palm actually moves along the region");
+      assert.deepEqual(vector(moved.support!.support_anchor),contact,"contact cannot slide while squeezed");
+      for (const draw of (await game.scene.objects({entityId:weapon.id})).objects) {
+        for (const scale of draw.scale) assert.ok(Math.abs(scale-attached.grip!.item_scale)<1e-5);
+      }
+      await game.input.set(`${other}_hand.squeeze`,0);
+      await game.step({frames:1});
+      assert.equal((await grip()).support!.attached,false);
+      // Re-grab during release blend, before the prior attachment disappears.
+      await placeAt(.75);
+      await game.input.set(`${other}_hand.squeeze`,1);
+      await game.step({frames:1});
+      const again = await grip();
+      assert.equal(again.support!.attached,true);
+      assert.ok(distance(vector(again.support!.support_anchor),contact)>length*.25,"fresh squeeze chooses a fresh contact");
+      await game.input.set(`${primary}_hand.squeeze`,0);
+      await game.step({frames:5});
+      const player = (await game.info()).player;
+      assert.equal(player.wielded_entity_id,null);
+      assert.equal(player.right_hand_entity_id,null);
+      assert.ok(!player.hand_grips.some(g=>g.entity_id === weapon.id),"released weapon is fitted to neither hand");
+    });
+  }
+}


### PR DESCRIPTION
Large weapons can now expose a support region instead of one fixed socket. A squeeze selects the nearest point, locks that contact until release, and steers the weapon without stretching or transferring ownership. Fusion cannon and worm launcher get initial support regions; their primary fits and scales are preserved.

Explorer edits mirrored XYZ endpoints and grab radius, draws the eligible capsule, and previews the support glove along the region. Regions persist with support poses in `vr-support-grips.json`; missing or zero-length regions act as fixed sockets.

Stacked on #1397 (`astra-vr-trigger-poses`). Validation: 1,526 Rust tests (2 ignored), 8 Explorer tests, shared capsule geometry test, TypeScript build, four large-weapon E2E scenarios including re-grab during release blend, and pistol/shotgun/wrench regression scenarios. Cross-engine review completed; fixed untracked-hand preview handling, reused existing capsule geometry, and strengthened movement/drop assertions. Final authored region endpoints tested in both hands. Headset comfort remains to be checked.

### Visual evidence

Matching parent/current controller and camera sequences: acquire a point, keep that contact while moving, steer, release, and choose another point. Both hands and both region endpoints were inspected.

![Fusion cannon before / after region support](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-fsn_h-before-after.png)

![Fusion cannon before / after region support](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-fsn_h-before-after.gif)

![Worm launcher before / after region support](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-al_h-before-after.png)

![Worm launcher before / after region support](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-al_h-before-after.gif)

![Support-region editor](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-support-region-editor.png)

[Both-hand contact stills: fusion](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-fsn_h-contact.png) · [worm](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-al_h-contact.png) · [Editor cycle](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-support-region-editor.gif) · [Download standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/78a9638c3590ac680ceea24a697b13e7/raw/astra-support-region-gallery.html)

Visual review: fusion palms face the housing in both hands (high confidence); worm neck sits in the finger pocket without visible piercing (medium confidence). Initial editable poses are suitable for first headset assessment. Inner finger seams remain occluded; no headset verification or final contact approval is claimed. Native screenshots use the normal Explorer screenshot path; no automated slider interaction is claimed.
