### PR TITLE
fix(psi): add Psi Sword to the amp in flat and VR

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -410,6 +410,12 @@ pub fn create_entity_core(
     if needs_internal_triggered_melee(v_limb_model.get(entity_id).is_ok()) {
         processed_scripts.push("internal_triggered_melee_weapon".to_owned());
     }
+    if v_limb_model
+        .get(entity_id)
+        .is_ok_and(|model| model.0.eq_ignore_ascii_case("psword_h"))
+    {
+        processed_scripts.push("internal_summoned_psi_sword".to_owned());
+    }
 
     // `MOVE` is an engine frob action, not an object script. Ordinary goodies
     // such as Med Patches and armor only inherit that flag, so give them the

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -7369,6 +7369,48 @@ impl MissionCore {
                     self.destroy_entity(entity_id);
                 }
 
+                Effect::SummonPsiSword { amp, duration_secs } => {
+                    // This power's flat weapon replacement uses the ordinary
+                    // wield slot; VR two-hand sword handling is separate.
+                    if game_options.presentation_mode != crate::PresentationMode::Flat {
+                        continue;
+                    }
+                    let (pos, rot) = {
+                        let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+                        (vec3_to_point3(player.pos), player.rotation)
+                    };
+                    let blade = self
+                        .create_entity_with_position(
+                            asset_cache,
+                            -2291,
+                            pos,
+                            rot,
+                            Matrix4::identity(),
+                            CreateEntityOptions::default(),
+                        )
+                        .entity_id;
+                    self.script_world.dispatch(Message {
+                        to: blade,
+                        payload: MessagePayload::BeginPsiSword { amp, duration_secs },
+                    });
+                    let msgs = self.interaction.wield(blade);
+                    effects.extend(self.process_virtual_hand_effects(asset_cache, msgs));
+                }
+                Effect::FinishPsiSword { blade, amp } => {
+                    let held = self.interaction.holding_hand(blade).is_some();
+                    self.world
+                        .borrow::<UniqueViewMut<crate::psi::ActivePsiPowers>>()
+                        .unwrap()
+                        .0
+                        .retain(|power| power.template_id != -1119);
+                    self.destroy_entity(blade);
+                    if let Some(amp) = amp.filter(|amp| {
+                        held && self.world.borrow::<EntitiesView>().unwrap().is_alive(*amp)
+                    }) {
+                        let msgs = self.interaction.wield(amp);
+                        effects.extend(self.process_virtual_hand_effects(asset_cache, msgs));
+                    }
+                }
                 Effect::ActivatePsiPower {
                     template_id,
                     name,

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -242,6 +242,10 @@ impl DebugScene {
 }
 
 impl GameScene for DebugScene {
+    fn script_world(&self) -> Option<&crate::scripts::ScriptWorld> {
+        Some(&self.core.script_world)
+    }
+
     fn is_pausable(&self) -> bool {
         true
     }
@@ -456,6 +460,10 @@ impl<H> HookedDebugScene<H> {
 }
 
 impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
+    fn script_world(&self) -> Option<&crate::scripts::ScriptWorld> {
+        Some(&self.core.script_world)
+    }
+
     fn is_pausable(&self) -> bool {
         true
     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -488,6 +488,14 @@ pub enum Effect {
         name: String,
         duration_secs: f32,
     },
+    SummonPsiSword {
+        amp: EntityId,
+        duration_secs: f32,
+    },
+    FinishPsiSword {
+        blade: EntityId,
+        amp: Option<EntityId>,
+    },
 
     /// Set the psi amp's hold-to-overload meter state
     /// (`RuntimePropPsiCharge`) on the amp entity - drives the HUD meter and

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -59,6 +59,7 @@ mod room_trigger;
 pub mod script_util;
 mod setup_initial_debrief;
 mod std_door;
+mod summoned_psi_sword;
 mod tool_consumable;
 mod transluce;
 mod trap_delay;
@@ -225,6 +226,10 @@ pub struct DamageImpact {
 
 #[derive(Clone, Debug)]
 pub enum MessagePayload {
+    BeginPsiSword {
+        amp: EntityId,
+        duration_secs: f32,
+    },
     Frob,
 
     /// This entity's MFD panel was opened. Frobbing used to be the only way in,
@@ -958,6 +963,9 @@ impl ScriptWorld {
                 Box::new(InternalSwitchHeldModelScript::new()),
             ])),
             "pistolmodify" => Box::new(NoopScript::new()),
+            "internal_summoned_psi_sword" => {
+                Box::new(summoned_psi_sword::SummonedPsiSword::default())
+            }
 
             // TODO: Necessary
             "changeinterface" => Box::new(NoopScript::new()),

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -434,6 +434,13 @@ fn cast_sustained_power(
     ];
     effects.extend(amp_cast_flashes(world, amp_entity));
 
+    if power.template_id == -1119 {
+        effects.push(Effect::SummonPsiSword {
+            amp: amp_entity,
+            duration_secs,
+        });
+    }
+
     game_log!(
         INFO,
         "Cast psi power: {} (tier {}, sustained {}s)",

--- a/shock2vr/src/scripts/summoned_psi_sword.rs
+++ b/shock2vr/src/scripts/summoned_psi_sword.rs
@@ -1,0 +1,182 @@
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, UniqueView, World};
+
+use super::{Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError};
+use crate::{mission::mission_core::PlayerInfo, physics::PhysicsWorld, time::Time};
+
+const KEY: &str = "shock2vr.summoned_psi_sword";
+
+#[derive(Serialize, Deserialize)]
+struct Summon {
+    amp: Option<u64>,
+    remaining_secs: f32,
+}
+
+/// The summoned blade owns its lifetime, including across saves and transitions.
+/// Ordinary PsiSword objects in debug scenes have no summon and never expire.
+#[derive(Default)]
+pub struct SummonedPsiSword {
+    summon: Option<Summon>,
+}
+
+impl Script for SummonedPsiSword {
+    fn handle_message(
+        &mut self,
+        _id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if let MessagePayload::BeginPsiSword { amp, duration_secs } = msg {
+            self.summon = Some(Summon {
+                amp: Some(amp.inner()),
+                remaining_secs: *duration_secs,
+            });
+        }
+        Effect::NoEffect
+    }
+
+    fn update(
+        &mut self,
+        id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        let Some(summon) = self.summon.as_mut() else {
+            return Effect::NoEffect;
+        };
+        summon.remaining_secs -= time.elapsed.as_secs_f32();
+        let player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+        let held =
+            player.left_hand_entity_id == Some(id) || player.right_hand_entity_id == Some(id);
+        // Putting the blade away cancels it without replacing the new weapon.
+        if summon.remaining_secs <= 0.0 || !held {
+            let amp = summon.amp.and_then(EntityId::from_inner);
+            self.summon = None;
+            return Effect::FinishPsiSword { blade: id, amp };
+        }
+        if !world
+            .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+            .unwrap()
+            .is_active(-1119)
+        {
+            // The generic active-power list is runtime-only; reconstruct this
+            // blade's entry from its saved timer after hydration.
+            return Effect::ActivatePsiPower {
+                template_id: -1119,
+                name: "Psi Sword".to_owned(),
+                duration_secs: summon.remaining_secs,
+            };
+        }
+        Effect::NoEffect
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(1, &self.summon, KEY)
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        self.summon = state.decode(1, KEY)?;
+        if let Some(summon) = self.summon.as_mut() {
+            summon.amp = match summon.amp.map(|id| context.remap_entity(id)).transpose() {
+                Ok(amp) => amp.map(EntityId::inner),
+                // A full backpack can leave the displaced amp in the previous
+                // level. Losing that reference must not prevent loading the
+                // carried blade, nor resurrect the abandoned amplifier.
+                Err(ScriptStateError::MissingEntityReference(_)) => None,
+                Err(error) => return Err(error),
+            };
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Quaternion, vec3};
+    use std::{collections::HashMap, time::Duration};
+
+    #[test]
+    fn save_restores_timer_and_remaps_amp_before_expiry() {
+        let mut world = World::new();
+        let old_amp = world.add_entity(());
+        let amp = world.add_entity(());
+        let blade = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: old_amp,
+            left_hand_entity_id: Some(blade),
+            right_hand_entity_id: None,
+            inventory_entity_id: old_amp,
+        });
+        world.add_unique(crate::psi::ActivePsiPowers::default());
+        let before = SummonedPsiSword {
+            summon: Some(Summon {
+                amp: Some(old_amp.inner()),
+                remaining_secs: 0.5,
+            }),
+        };
+        let mut after = SummonedPsiSword::default();
+        let map = HashMap::from([(old_amp, amp)]);
+        after
+            .restore_state(
+                &before.save_state().unwrap(),
+                &ScriptRestoreContext::new(&map),
+            )
+            .unwrap();
+        let physics = PhysicsWorld::new();
+        let time = Time {
+            elapsed: Duration::from_millis(250),
+            total: Duration::from_millis(250),
+        };
+        assert!(
+            matches!(after.update(blade, &world, &physics, &time), Effect::ActivatePsiPower { template_id: -1119, duration_secs, .. } if duration_secs == 0.25)
+        );
+        assert!(
+            matches!(after.update(blade, &world, &physics, &time), Effect::FinishPsiSword { blade: b, amp: a } if b == blade && a == Some(amp))
+        );
+        assert!(matches!(
+            after.update(blade, &world, &physics, &time),
+            Effect::NoEffect
+        ));
+    }
+
+    #[test]
+    fn an_amp_left_in_another_level_does_not_block_blade_hydration() {
+        let mut world = World::new();
+        let amp = world.add_entity(());
+        let before = SummonedPsiSword {
+            summon: Some(Summon {
+                amp: Some(amp.inner()),
+                remaining_secs: 12.0,
+            }),
+        };
+        let mut after = SummonedPsiSword::default();
+        after
+            .restore_state(
+                &before.save_state().unwrap(),
+                &ScriptRestoreContext::new(&HashMap::new()),
+            )
+            .unwrap();
+        let restored = after.summon.unwrap();
+        assert_eq!(
+            restored.amp, None,
+            "an absent amplifier must not be restored or duplicated"
+        );
+        assert_eq!(
+            restored.remaining_secs, 12.0,
+            "the carried blade keeps its remaining lifetime"
+        );
+    }
+}

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -407,7 +407,7 @@ impl Script for WeaponScript {
                 else {
                     return Effect::NoEffect;
                 };
-                flat_melee_hit(physics, aim, world)
+                flat_melee_hit(physics, aim, world, entity_id)
             }
             // The maintenance tool, offered to this weapon on the port's tool
             // channel: a VR hand releasing it onto the gun, or the flat
@@ -631,7 +631,12 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
 /// Resolve the authored hit event of a flat melee swing: raycast a short
 /// distance along the current crosshair ray and damage the hit entity (hitbox
 /// proxies resolve to their parent).
-fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World) -> Effect {
+fn flat_melee_hit(
+    physics: &PhysicsWorld,
+    aim: RuntimePropFlatAim,
+    world: &World,
+    weapon: EntityId,
+) -> Effect {
     let hit = physics.ray_cast(
         aim.origin,
         aim.forward.normalize() * MELEE_RANGE,
@@ -646,13 +651,18 @@ fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World
     }) = hit
     {
         let target = resolve_proxy_entity(world, target);
+        let damage = if super::script_util::entity_class_template_id(world, weapon) == Some(-2291) {
+            crate::mission::stim_response::contact_stim_damage(world, -2291, target)
+        } else {
+            MELEE_DAMAGE
+        };
         return Effect::Send {
             msg: Message {
                 to: target,
                 payload: MessagePayload::Damage {
                     // Adrenaline Overproduction scales the player's melee
                     // damage while it is active (1.0 otherwise).
-                    amount: MELEE_DAMAGE * crate::scripts::berserk::melee_damage_multiplier(world),
+                    amount: damage * crate::scripts::berserk::melee_damage_multiplier(world),
                     // Swing direction + contact point seed the victim's
                     // death-ragdoll reaction. No bone: melee resolves a hitbox
                     // proxy to its parent BEFORE sending (so HitBoxScript
@@ -862,6 +872,7 @@ mod tests {
                         forward: vec3(0.0, 0.0, 1.0),
                     },
                     &world,
+                    weapon,
                 ),
                 target,
             ),

--- a/tools/shock2-sdk/test/psi-sword.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sword.e2e.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { selectPsiPower } from "./helpers/psi.js";
+import { pullTrigger } from "./helpers/weapon.js";
+
+test("Psi Sword conjures a blade and restores the amp on expiry", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 600_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "debug_psi" });
+  await game.step({ frames: 10 });
+  await game.player.setStats({ psionic_ability: 6 });
+  const before = (await game.info()).player;
+  await selectPsiPower(game, "Psi Sword");
+  await pullTrigger(game);
+  await game.step({ frames: 10 });
+  const cast = (await game.info()).player;
+  assert.equal(cast.psi_points, before.psi_points! - 4);
+  assert.notEqual(cast.wielded_entity_id, before.wielded_entity_id,
+    "casting Psi Sword must replace the amp with its conjured blade");
+  const blade = cast.wielded_entity_id!;
+  assert.equal((await game.entities.detail(blade)).name, "PsiSword");
+  assert.deepEqual(cast.active_psi_powers, ["Psi Sword"]);
+  const [hybrid] = await game.entities.byTemplate(-397);
+  assert.ok(hybrid, "the psi pen has an authored hybrid target");
+  const target = await game.entities.detail(hybrid.id);
+  const hp = Number(target.properties.find((p) => p.name === "HitPoints")!.value);
+  assert.ok(hp > 6, "target must survive an ordinary six-point wrench hit");
+  const [x, y, z] = target.position;
+  await game.player.teleport({ x: x + 1, y: y + 0.5, z });
+  await game.step({ frames: 10 });
+  await game.player.aimAt(hybrid, { hitbox: "torso", visibility: "required" });
+  await pullTrigger(game);
+  await game.step({ frames: 65 });
+  const survivor = (await game.entities.byTemplate(-397)).find((e) => e.id === hybrid.id);
+  const afterHp = survivor
+    ? Number((await game.entities.detail(hybrid.id)).properties.find((p) => p.name === "HitPoints")!.value)
+    : 0;
+  assert.ok(hp - afterHp > 6, `psi blade should hit harder than a wrench: ${hp} -> ${afterHp}`);
+  await game.player.teleport({ x: 0, y: 2, z: 0 });
+  await game.step({ frames: 4260 });
+  assert.equal((await game.info()).player.wielded_entity_id, before.wielded_entity_id);
+  assert.deepEqual((await game.info()).player.active_psi_powers, []);
+  assert.ok(!(await game.entities.byTemplate(-2291)).some((e) => e.id === blade), "expired blade is destroyed");
+  await pullTrigger(game);
+  await game.step({ frames: 10 });
+  const secondBlade = (await game.info()).player.wielded_entity_id;
+  assert.notEqual(secondBlade, before.wielded_entity_id);
+  await game.input.trigger("EquipPsiAmp");
+  await game.step({ frames: 10 });
+  assert.equal((await game.info()).player.wielded_entity_id, before.wielded_entity_id);
+  assert.deepEqual((await game.info()).player.active_psi_powers, []);
+  assert.ok(!(await game.entities.byTemplate(-2291)).some((e) => e.id === secondBlade), "holstering cancels and destroys the summon");
+});
+
+test("summoned blade survives a mission transition and save/load without losing its expiry", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 600_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "debug_psi" });
+  await game.step({ frames: 10 });
+  await selectPsiPower(game, "Psi Sword");
+  await pullTrigger(game);
+  await game.step({ frames: 10 });
+  await game.transitionLevel("earth.mis");
+  await game.step({ frames: 10 });
+  const crossed = (await game.info()).player;
+  assert.deepEqual(crossed.active_psi_powers, ["Psi Sword"], JSON.stringify(crossed));
+  const saveName = `e2e_psi_sword_${Date.now()}`;
+  await game.save(saveName);
+  await game.load(saveName);
+  await game.step({ frames: 10 });
+  const loaded = (await game.info()).player;
+  assert.deepEqual(loaded.active_psi_powers, ["Psi Sword"]);
+  assert.equal((await game.entities.detail(loaded.wielded_entity_id!)).name, "PsiSword");
+  const amps = await game.entities.byTemplate(-247);
+  assert.equal(amps.length, 1, "transition and load preserve exactly one original amp");
+  for (let i = 0; i < 15; i++) await game.step({ frames: 300 });
+  const expired = (await game.info()).player;
+  assert.deepEqual(expired.active_psi_powers, []);
+  assert.equal(expired.wielded_entity_id, amps[0].id, "expiry restores the remapped amp");
+  assert.equal((await game.entities.byTemplate(-2291)).length, 0);
+});


### PR DESCRIPTION
Fixes Cerebro-Energetic Extension (`Psi Sword`) so the player keeps the psi amp and gains a blade mounted on top of it. Casting no longer replaces the amp with a separate sword item. The blade and amp move together during a flatscreen swing; in VR, a real hand sweep deals the authored sword contact damage without pulling the trigger.

The tier-4 cast costs four psi points. Duration uses real effective PSI and the corrected authored baseline, lasting 60 seconds at PSI 6. Expiry removes the blade while preserving the same amp. Character stats and overload use the shared PSI path; difficulty uses the shared player pools.

Renders cached weapon-only geometry extracted from the authored sword model in cyan. Reuses the existing classic/PMNM geometry split so classic assets also render correctly and the sword's original arm is not drawn over the retained amp. The same muzzle frame places the blade and defines its contact segment. World geometry blocks melee contact, and player translation alone is excluded from the VR swing-speed check. Zero-time updates preserve the previous motion sample so debug input updates cannot swallow a real swing.

Stacked on #1324. Stack order: #1595 → #1322 → #1326 → #1324 → this PR.

Validation: all four difficulty scenarios passed for cast cost, amp identity, authored melee damage, and expiry; save/load plus mission-transition/expiry coverage passed. The zero-time motion regression is covered by a focused test. The VR recording below repeats the previously failing tracked-hand sweep: with the trigger released, the nearby hybrid drops from 12 HP to 0 at the first blade contact.

### Flatscreen: amp plus blade, then swing

![Additive Psi Sword flatscreen](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-flat.gif)

![Psi amp before casting and with its blade during a swing](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-flat.png)

### VR: amp plus blade

![Additive Psi Sword VR](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-vr.gif)

![Psi amp before and after casting in VR](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-vr.png)

### VR contact: hand motion, trigger released

![Psi Sword VR contact damage](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-vr-contact.gif)

![Psi Sword VR contact still](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-vr-contact.png)

Stills compare before and after casting in the new build. Captured headlessly in `debug_psi`, at a fixed 60 Hz simulation timestep and 20 FPS screenshot cadence. GIFs loop.

Closes #1291.

Integration validation: all 16 difficulty scenarios for Major Heal, Soma Transference, Immolate, and Psi Sword passed together at the top of the stack. The durable VR physical-swing regression and both sword motion unit tests also passed.


<!-- capture-provenance -->
Visual capture provenance: current PR head [abff3f57](https://github.com/tommy-xr/shock2quest/commit/abff3f57abe38c1f214cb6b5fa6caf4a646e47b5). The VR captures use the authored `amp_h` model and its hand, with no duplicate glove. Inactive/active still pairs show states within this build. Source commit and binary SHA-256 are recorded with the media.
<!-- /capture-provenance -->


Source comparison: prior replacement implementation `4fe72081` versus current `abff3f57`, using the same deterministic flatscreen cast and swing requests. The old cast changes the wielded entity; the current cast preserves the amp and adds the blade.

![Old replacement versus additive amp and blade](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-source-comparison.gif)

![Old replacement versus additive amp and blade](https://gist.githubusercontent.com/tommy-xr/856d6a9cc75a7fdcf8d399eed9171349/raw/abff3f57-sword-source-comparison.png)

