### PR TITLE
fix(vr): preserve wrench support through physical contact

### DIFF
--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -218,6 +218,8 @@ struct SupportAttachment {
     blend: f32,
     correction: Quaternion<f32>,
     anchor: Vector3<f32>, // Scaled model-space contact, fixed until release.
+    primary_offset: Vector3<f32>, // Grab-time collision offset, in world space.
+    player_rotation: Quaternion<f32>, // Rebase the offset on locomotion turns, never wrist twists.
 }
 
 #[derive(Clone)]
@@ -226,6 +228,8 @@ struct SupportCandidate {
     primary: usize,
     profile: SupportProfile,
     primary_palm: Vector3<f32>,
+    visible_primary_palm: Vector3<f32>,
+    control_primary_palm: Vector3<f32>,
     primary_anchor: Vector3<f32>,
     tracked_axis: Vector3<f32>,
     anchor: Vector3<f32>,
@@ -393,6 +397,18 @@ impl VrInteraction {
                 primary,
                 profile: profile.clone(),
                 primary_palm,
+                visible_primary_palm: model_pose.point(primary_anchor),
+                // Calibrate the controller reference once when grabbing a blocked
+                // weapon. Later collision motion is feedback, not a release gesture.
+                control_primary_palm: self
+                    .support
+                    .as_ref()
+                    .filter(|s| {
+                        prefer_locked_anchor && s.entity == held.entity && s.primary == primary
+                    })
+                    .map_or(model_pose.point(primary_anchor), |s| {
+                        primary_palm + s.primary_offset
+                    }),
                 primary_anchor,
                 tracked_axis: base_rotation.rotate_vector(anchor - primary_anchor),
                 anchor,
@@ -410,6 +426,12 @@ impl VrInteraction {
 
     fn update_support(&mut self, ctx: &InteractionContext) {
         self.step_dt = ctx.step_dt.max(0.0);
+        if let Some(s) = self.support.as_mut() {
+            let player_rotation = ctx.player_rotation.normalize();
+            s.primary_offset =
+                (player_rotation * s.player_rotation.conjugate()).rotate_vector(s.primary_offset);
+            s.player_rotation = player_rotation;
+        }
         let inputs = [&ctx.input.left_hand, &ctx.input.right_hand];
         let poses = inputs.map(|input| GripPose {
             position: crate::virtual_hand::hand_world_position(
@@ -451,7 +473,8 @@ impl VrInteraction {
                 let Some(rig) = self.grip_kinematics.as_ref() else {
                     return false;
                 };
-                let separation = (poses[other].point(rig[other].palm) - c.primary_palm).magnitude();
+                let separation =
+                    (poses[other].point(rig[other].palm) - c.control_primary_palm).magnitude();
                 support.entity == c.entity
                     && support.primary == c.primary
                     && ctx.support_enabled
@@ -462,7 +485,7 @@ impl VrInteraction {
                     && separation > 0.06
                     && c.profile.allows_swing(
                         c.tracked_axis,
-                        poses[other].point(rig[other].palm) - c.primary_palm,
+                        poses[other].point(rig[other].palm) - c.control_primary_palm,
                     )
                     && (separation - (c.anchor - c.primary_anchor).magnitude()).abs()
                         <= c.profile.release_distance
@@ -485,9 +508,9 @@ impl VrInteraction {
                         && pressed[other]
                         && !self.support_pressed[other]
                         && !self.support_blocked[other]
-                        && (palm - c.primary_palm).magnitude() > 0.08
+                        && (palm - c.control_primary_palm).magnitude() > 0.08
                         && c.profile
-                            .allows_swing(c.tracked_axis, palm - c.primary_palm)
+                            .allows_swing(c.tracked_axis, palm - c.control_primary_palm)
                         && (palm - c.model_pose.point(c.anchor)).magnitude()
                             <= c.profile.grab_radius
                     {
@@ -503,6 +526,11 @@ impl VrInteraction {
                             blend,
                             correction,
                             anchor: c.anchor,
+                            // Lock this reference until release, including after a block
+                            // clears. Following the body would turn physics recovery into
+                            // a steering/release gesture with stationary controllers.
+                            primary_offset: c.visible_primary_palm - c.primary_palm,
+                            player_rotation: ctx.player_rotation.normalize(),
                         });
                         self.support_blocked[other] = true;
                     }
@@ -551,7 +579,10 @@ impl VrInteraction {
             let target = if s.active && poses[other].is_tracked() {
                 solve_two_hand_pose(
                     c.primary_palm,
-                    poses[other].point(rig[other].palm),
+                    // Use the grab-time calibrated controller reference for aim.
+                    // Collision motion must not steer the target back into itself.
+                    // Translation still follows the primary controller.
+                    c.primary_palm + (poses[other].point(rig[other].palm) - c.control_primary_palm),
                     base_rotation,
                     c.primary_anchor,
                     c.anchor,
@@ -932,6 +963,8 @@ impl PlayerInteraction for VrInteraction {
                     "controller_rotation": c.hand_pose.rotation,
                     "model_position": c.model_pose.position, "model_rotation": c.model_pose.rotation,
                     "primary_palm": c.primary_palm, "primary_anchor": c.primary_anchor,
+                    "visible_primary_palm": c.visible_primary_palm,
+                    "control_primary_palm": c.control_primary_palm,
                     "support_anchor": c.anchor, "grab_radius": c.profile.grab_radius,
                     "region_endpoints": c.region.map(|ends| ends.map(|p| c.model_pose.point(p))),
                     "visual_trigger": visual_triggers[1-i],
@@ -1419,8 +1452,7 @@ mod tests {
         physics.update(vec3(0.0, 0.0, 0.0), &mut player);
     }
 
-    #[test]
-    fn support_accepts_zero_dt_input_edges_and_requires_release_after_break() {
+    fn wrench_support_fixture() -> (World, EntityId, PhysicsWorld, VrInteraction, InputContext) {
         use crate::vr_grip::{GripKinematics, ResolvedGrip};
         let mut world = World::new();
         let entity = grabbable(&mut world);
@@ -1475,6 +1507,12 @@ mod tests {
         input.left_hand.position = vec3(0.0, 1.2, 0.0);
         input.left_hand.rotation = identity();
         input.left_hand.squeeze_value = 0.0;
+        (world, entity, physics, interaction, input)
+    }
+
+    #[test]
+    fn support_accepts_zero_dt_input_edges_and_requires_release_after_break() {
+        let (mut world, entity, physics, mut interaction, mut input) = wrench_support_fixture();
         interaction.update_support(&context(&world, &physics, &input));
         input.left_hand.squeeze_value = 1.0;
         let mut ctx = context(&world, &physics, &input);
@@ -1605,6 +1643,78 @@ mod tests {
         assert_eq!(
             interaction.held_entities(),
             (Some(other_item), Some(entity))
+        );
+    }
+
+    #[test]
+    fn physical_support_calibration_ignores_body_recovery_and_wrist_twists() {
+        use cgmath::{Deg, Rotation3};
+        let (mut world, entity, physics, mut interaction, mut input) = wrench_support_fixture();
+        world.add_component(
+            entity,
+            (
+                dark::properties::PropPosition {
+                    position: vec3(0.8, 1.0, 0.3),
+                    rotation: identity(),
+                    cell: 0,
+                },
+                crate::runtime_props::RuntimePropVrGripOffset(vec3(0.0, 0.0, 0.1)),
+            ),
+        );
+        input.left_hand.position = vec3(0.8, 1.2, 0.2);
+        interaction.update_support(&context(&world, &physics, &input));
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        let offset = vec3(0.8, 0.0, 0.2);
+        assert!(interaction.support.as_ref().unwrap().active);
+        assert!((interaction.support.as_ref().unwrap().primary_offset - offset).magnitude() < 1e-5);
+        // The collision clears all the way back to the primary controller.
+        world.add_component(
+            entity,
+            dark::properties::PropPosition {
+                position: vec3(0.0, 1.0, 0.1),
+                rotation: identity(),
+                cell: 0,
+            },
+        );
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(
+            interaction.support.as_ref().unwrap().active,
+            "body recovery cannot release unchanged controllers"
+        );
+        // Twist around the handle axis: the calibrated pivot must not orbit the wrist.
+        input.right_hand.rotation = Quaternion::from_angle_y(Deg(90.0));
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(interaction.support.as_ref().unwrap().active);
+        assert!((interaction.support.as_ref().unwrap().primary_offset - offset).magnitude() < 1e-5);
+        // A player turn, unlike a wrist twist, rotates both controller references.
+        let yaw = Quaternion::from_angle_y(Deg(90.0));
+        let mut ctx = context(&world, &physics, &input);
+        ctx.player_rotation = yaw;
+        interaction.update_support(&ctx);
+        assert!(interaction.support.as_ref().unwrap().active);
+        assert!(
+            (interaction.support.as_ref().unwrap().primary_offset - yaw.rotate_vector(offset))
+                .magnitude()
+                < 1e-5
+        );
+        // A new squeeze at the now-unblocked socket discards the old calibration.
+        input.right_hand.rotation = identity();
+        input.left_hand.position = vec3(0.0, 1.2, 0.0);
+        input.left_hand.squeeze_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(!interaction.support.as_ref().unwrap().active);
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert!(interaction.support.as_ref().unwrap().active);
+        assert!(
+            interaction
+                .support
+                .as_ref()
+                .unwrap()
+                .primary_offset
+                .magnitude()
+                < 1e-5
         );
     }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -1151,6 +1151,10 @@ export interface HandGrip {
     model_position: ResolvedGrip["offset"];
     model_rotation: ResolvedGrip["rotation"];
     primary_palm: ResolvedGrip["offset"];
+    /** Primary palm on the rendered, collision-resolved weapon. */
+    visible_primary_palm: ResolvedGrip["offset"];
+    /** Controller-driven pivot calibrated on support acquisition. */
+    control_primary_palm: ResolvedGrip["offset"];
     primary_anchor: ResolvedGrip["offset"];
     support_anchor: ResolvedGrip["offset"];
     /** World-space segment endpoints, or null for a fixed socket. */

--- a/tools/shock2-sdk/test/vr-wrench-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-wrench-support.e2e.test.ts
@@ -137,4 +137,35 @@ test("physical wrench glove stays attached during walking and wall contact", {
   const trackedModel = add(player.position,quatRotate(player.rotation,add([-3,1,0],vector(blocked.grip!.offset))));
   assert.ok(distance(trackedModel,vector(blocked.support!.model_position)) > .5,"wall actually blocks the weapon away from the tracked target");
   assert.ok(vector(blocked.support!.model_position)[0] > -13,"weapon remains on near side of wall");
+  // The controller is beyond the wall, but both visible glove and wrench stop
+  // on this side. A second hand on that visible socket must still attach.
+  await game.input.set("left_hand.squeeze",0);
+  const visiblePalm = add(vector(blocked.support!.model_position),quatRotate(quaternion(blocked.support!.model_rotation),vector(blocked.support!.primary_anchor)));
+  assert.ok(distance(visiblePalm,vector(blocked.support!.primary_palm))>.5,"visible primary palm is displaced from its controller");
+  const inverse = quatConjugate(player.rotation);
+  await game.input.set("left_hand.position",quatRotate(inverse,sub(vector(blocked.support!.controller_position),player.position)));
+  await game.input.set("left_hand.rotation",quatMultiply(inverse,quaternion(blocked.support!.controller_rotation)));
+  await game.step({frames:1});
+  await game.input.set("left_hand.squeeze",1);
+  await game.step({frames:10});
+  const supported = await check();
+  assert.equal(supported.support!.attached,true,"second hand can grab the visible wrench while its primary controller is blocked: "+JSON.stringify({before:blocked.support,after:supported.support}));
+  assert.equal((await game.info()).player.right_hand_entity_id,wrench.id);
+  assert.equal((await game.info()).player.hand_grips.length,1,"support retains one owner");
+  await game.input.set("left_hand.position",quatRotate(inverse,sub(add(vector(blocked.support!.controller_position),[.025,0,.025]),player.position)));
+  for (let frame=0;frame<8;frame++) {
+    await game.step({frames:1});
+    const moving = await check();
+    assert.equal(moving.support!.attached,true,"physical contact feedback is not a support-release gesture");
+  }
+  await game.input.set("right_hand.position",[-2.98,1,0]);
+  await game.step({frames:8});
+  const shifted = await check();
+  assert.equal(shifted.support!.attached,true);
+  const primaryMotion = sub(vector(shifted.support!.primary_palm),vector(supported.support!.primary_palm));
+  assert.ok(Math.hypot(...primaryMotion)>.01,"primary controller moved");
+  assert.ok(distance(vector(shifted.support!.control_primary_palm),add(vector(supported.support!.control_primary_palm),primaryMotion))<.0001,"control pivot follows the primary palm translation exactly, including player motion");
+  await game.input.set("left_hand.squeeze",0);
+  await game.step({frames:1});
+  assert.equal((await check()).support!.attached,false,"explicit release still ends support");
 });


### PR DESCRIPTION
A collision-blocked wrench could reject a second hand placed directly on its visible handle: support acquisition measured from the primary controller behind the wall instead of the primary glove on the physical weapon. Physics recovery could also break support after attachment.

Acquisition now uses the visible primary palm and calibrates a controller reference for that grab. Steering and separation checks follow controller motion against that reference, so collision response cannot masquerade as a release gesture. The calibration stays fixed until release, rotates with player locomotion, and does not orbit when the primary wrist twists. Regrabbing recalibrates it. The primary controller still owns translation; the physical body still positions both rendered gloves.

Stacked on #1400. No authored grip or scale changes.

Validation:

- The new blocked-wrench acquisition scenario fails on the frozen #1397 runtime and passes with this fix.
- All 11 headless VR scenarios pass: wrench in both hands, pistol/shotgun, and fusion/worm support regions. Wall coverage includes visible-socket acquisition, support motion, primary translation, glove/body agreement, and explicit release.
- A dedicated unit test covers complete collision recovery, wrist rotation, player turning, and release/regrab calibration.
- 1,527 Rust library tests pass (2 ignored). SDK TypeScript compilation and whitespace checks pass.
- Cross-engine correctness review and dedicated duplication review completed. `cargo fmt -p shock2vr -- --check` passes. Headset confirmation remains pending; no device was attached.

If acquired while the controller is substantially displaced by a wall, the calibrated aim reference persists after the obstruction clears; release and re-grab resets it. This prevents collision recovery from changing aim or releasing stationary hands, but that extreme case still needs headset feel validation.

![Wall-blocked wrench support: before and after](https://gist.githubusercontent.com/tommy-xr/a09672385302c49e9cd9da1050c627ad/raw/astra-visible-support-before-after.png)

![Squeeze, small support motion, and release](https://gist.githubusercontent.com/tommy-xr/a09672385302c49e9cd9da1050c627ad/raw/astra-visible-support-before-after.gif)

The free hand reaches the visible support socket while the primary controller is beyond the wall. The parent fails to attach; this fix attaches, remains attached through small support motion, and releases normally. Labels show recorded runtime state. Both captures use identical resources, camera and fixed-step controller requests; nearby debug enemies are disabled in both runs.

The acquisition offset stays fixed until release, rebases with player turning, and does not rotate with wrist twist. Wall contact occludes parts of the gloves during motion; no perfect collision-clearance or headset-verification claim.

[Download the standalone capture gallery and open locally](https://gist.githubusercontent.com/tommy-xr/a09672385302c49e9cd9da1050c627ad/raw/astra-visible-support-gallery.html).
