### PR TITLE
feat(vr): grab along the wrench handle and visualize support targets

### DIFF
--- a/assets/vr-support-grips.json
+++ b/assets/vr-support-grips.json
@@ -41,7 +41,19 @@
     ],
     "grab_radius": 0.07,
     "release_distance": 0.12,
-    "max_swing_degrees": 75.0
+    "max_swing_degrees": 75.0,
+    "region": {
+      "start": [
+        -0.05624297,
+        0.14,
+        0.02
+      ],
+      "end": [
+        -0.05624297,
+        0.43,
+        0.02
+      ]
+    }
   },
   "sg_h": {
     "palm_anchor": [

--- a/projects/astra-vr-grip-editor.md
+++ b/projects/astra-vr-grip-editor.md
@@ -106,7 +106,7 @@ unchanged, and the supporting hand can animate without firing or using an item.
 The debug runtime's hand-grip diagnostics report `visual_trigger` and
 `finger_curls` for the primary hand and its support hand.
 
-## Support regions for large weapons
+## Support regions
 
 In **Support hand**, choose **Fixed socket** or **Support region**. A region has
 editable XYZ start/end points in the displayed hand's frame, plus a grab radius
@@ -114,8 +114,8 @@ in centimeters. The cyan wire capsule shows the eligible area. **Position along
 region** previews the support glove along it without editing the saved pose.
 Wrist rotation and both finger poses apply everywhere on that region.
 
-The fusion cannon (`fsn_h`) and worm launcher (`al_h`) use regions; the wrench,
-pistol, and shotgun retain fixed sockets by default. Their existing primary
+The wrench (`wrench_h`), fusion cannon (`fsn_h`), and worm launcher (`al_h`) use
+regions; the pistol and shotgun retain fixed sockets by default. Their existing primary
 poses and uniform scales are preserved. A support squeeze selects the closest
 point on the region and locks that contact until release. Moving the second
 hand steers the weapon; it does not slide the contact or resize the model.
@@ -128,3 +128,31 @@ item scale. The editor mirrors them through the same model frame as gameplay.
 Omitting the region uses `palm_anchor` as a fixed socket. A zero-length region
 also behaves as a socket. Runtime diagnostics expose world-space
 `support.region_endpoints` and the locked scaled-model-space `support_anchor`.
+
+### In-game support target overlay
+
+Enable **Support grips** in the pause menu's **Developer** screen (dev parameter
+`vr_support_grips`). It defaults off and can be toggled while running. While
+holding a supported weapon in VR, cyan wire geometry shows the support region
+and its grab radius; the small target marks the nearest point, or the locked
+contact while attached. Amber shows the tracked offhand palm and a line to that
+target. Green means support is attached; cyan alone does not promise the input
+is eligible. A fixed socket displays as a sphere.
+
+Move the amber palm into the region, then squeeze the offhand grip. Acquisition
+requires a fresh squeeze, the primary grip held, an empty tracked offhand, and
+a valid two-hand separation/angle. If squeeze was already held while approaching,
+release it first. After a blocked gesture, release both offhand squeeze and
+trigger before trying again. The wrench region follows the usable handle while
+leaving space for the primary hand and the head. Edit its endpoints in Explorer
+under **Support hand → Support region**.
+
+The same toggle is available to automation:
+
+```sh
+curl -X POST http://127.0.0.1:8080/v1/dev-params \
+  -d '{"key":"vr_support_grips","value":1}'
+```
+
+The overlay uses the rendered weapon's mirrored/scaled support geometry, and
+`/v1/scene` labels its objects `vr_support_grip`. It does not change grab rules.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -191,6 +191,8 @@ dev_params! {
     /// weapon is". Read out of Rapier at the collider's own isometry, so it
     /// shows what is actually simulated rather than what the wield intended.
     MELEE_VOLUMES = float("melee_volumes", "Show hurtbox", 0.0, 0.0, 1.0, 1.0),
+    /// VR support target/radius (cyan; green when attached) and tracked palm (amber).
+    VR_SUPPORT_GRIPS = bool("vr_support_grips", "Support grips", false),
     /// Draw a floating "-7 HP" at the point each blow lands, labeled with the
     /// hitbox it struck.
     ///

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -1222,6 +1222,68 @@ impl PlayerInteraction for VrInteraction {
         // forearm panels carry their own label from `create_arm_hud_panels`,
         // which the `debug_hud` scene emits without going through here.
         crate::util::tag_render_source(&mut objs, crate::util::render_source::PLAYER_HANDS);
+        if crate::dev_params::get_bool(crate::dev_params::VR_SUPPORT_GRIPS) {
+            // Draw the same candidate geometry used for acquisition, including
+            // model mirroring, scale and collision-resolved weapon transforms.
+            if let Some(c) = &self.support_preview {
+                use cgmath::{Matrix4, vec3};
+                use engine::scene::{VertexPosition, color_material, lines_mesh};
+                let socket = c.model_pose.point(c.anchor);
+                let [a, b] = c
+                    .region
+                    .map_or([socket; 2], |ends| ends.map(|p| c.model_pose.point(p)));
+                let mut vertices = Vec::new();
+                dark::hit_box::append_capsule_lines(
+                    &mut vertices,
+                    &Matrix4::one(),
+                    a,
+                    b,
+                    c.profile.grab_radius,
+                );
+                dark::hit_box::append_capsule_lines(
+                    &mut vertices,
+                    &Matrix4::one(),
+                    socket,
+                    socket,
+                    0.008,
+                );
+                let attached = self
+                    .support
+                    .as_ref()
+                    .is_some_and(|s| s.active && s.entity == c.entity && s.primary == c.primary);
+                let mut overlay = vec![SceneObject::new(
+                    color_material::create(if attached {
+                        vec3(0.1, 1.0, 0.2)
+                    } else {
+                        vec3(0.1, 0.9, 1.0)
+                    }),
+                    Box::new(lines_mesh::create(vertices)),
+                )];
+                if let Some(rig) = &self.grip_kinematics {
+                    let pose = self.hand_poses()[1 - c.primary];
+                    if pose.is_tracked() {
+                        let palm = pose.point(rig[1 - c.primary].palm);
+                        let mut vertices = vec![
+                            VertexPosition { position: palm },
+                            VertexPosition { position: socket },
+                        ];
+                        dark::hit_box::append_capsule_lines(
+                            &mut vertices,
+                            &Matrix4::one(),
+                            palm,
+                            palm,
+                            0.012,
+                        );
+                        overlay.push(SceneObject::new(
+                            color_material::create(vec3(1.0, 0.65, 0.1)),
+                            Box::new(lines_mesh::create(vertices)),
+                        ));
+                    }
+                }
+                crate::util::tag_render_source(&mut overlay, "vr_support_grip");
+                objs.extend(overlay);
+            }
+        }
         objs.append(&mut create_arm_hud_panels(
             asset_cache,
             world,

--- a/tools/shock2-sdk/test/vr-support-region.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-support-region.e2e.test.ts
@@ -8,14 +8,16 @@ import { cycleToWeapon } from "./helpers/weapon.js";
 const vector = (v: ResolvedGrip["offset"]): Vec3 => [v.x,v.y,v.z];
 const quaternion = (q: ResolvedGrip["rotation"]): Quat => [...vector(q.v),q.s];
 const distance = (a: Vec3,b: Vec3) => Math.hypot(...sub(a,b));
-for (const [model,template] of [["fsn_h",-26],["al_h",-27]] as const) {
+for (const [model,template] of [["fsn_h",-26],["al_h",-27],["wrench_h",-928]] as const) {
   for (const primary of ["left","right"] as const) {
     test(`${model} ${primary}: broad support locks a contact until release`, {
       skip: process.env.SHOCK2_E2E !== "1", timeout:180_000,
     }, async () => {
-      await using game = await GameServer.launch({mission:"debug_weapons",debugFlags:["--vr"]});
+      await using game = await GameServer.launch({mission:model === "wrench_h" ? "debug_interactions" : "debug_weapons",debugFlags:["--vr"]});
       await game.step({frames:30});
-      const weapon = await cycleToWeapon(game,e=>e.template_id === template);
+      const weapon = model === "wrench_h"
+        ? (await game.entities.list()).entities.find(e=>e.template_id === template)!
+        : await cycleToWeapon(game,e=>e.template_id === template);
       await aimVrHandAt(game,weapon.position,.2,1,0,{hand:primary});
       const other = primary === "left" ? "right" : "left";
       await game.input.set(`${primary}_hand.position`,[0,1,-.5]);
@@ -35,6 +37,10 @@ for (const [model,template] of [["fsn_h",-26],["al_h",-27]] as const) {
         await game.input.set(`${other}_hand.position`,quatRotate(inverse,sub(wrist,player.position)));
         await game.input.set(`${other}_hand.rotation`,quatMultiply(inverse,quaternion(support.controller_rotation)));
       };
+      assert.equal((await game.scene.fromSource("vr_support_grip")).length,0,"overlay defaults off");
+      await game.devParams.set("vr_support_grips",1);
+      await game.step({frames:1});
+      assert.equal((await game.scene.fromSource("vr_support_grip")).length,2,"target and tracked-palm overlays render");
       await placeAt(.2);
       await game.input.set(`${other}_hand.squeeze`,1);
       await game.step({frames:20});
@@ -61,6 +67,9 @@ for (const [model,template] of [["fsn_h",-26],["al_h",-27]] as const) {
       const again = await grip();
       assert.equal(again.support!.attached,true);
       assert.ok(distance(vector(again.support!.support_anchor),contact)>length*.25,"fresh squeeze chooses a fresh contact");
+      await game.devParams.set("vr_support_grips",0);
+      await game.step({frames:1});
+      assert.equal((await game.scene.fromSource("vr_support_grip")).length,0,"overlay can be hidden while still holding");
       await game.input.set(`${primary}_hand.squeeze`,0);
       await game.step({frames:5});
       const player = (await game.info()).player;


### PR DESCRIPTION
The wrench previously required a second-hand squeeze near one fixed, invisible support point. It now accepts a fresh squeeze anywhere along an authored handle region, choosing the nearest contact and locking it until release. The region preserves the existing wrist pose, finger curls, and weapon scale; its endpoints remain editable in Explorer’s Support hand controls.

Enable **Pause → Developer → Support grips** (`vr_support_grips`) to see support geometry on held weapons. Cyan shows the region/socket and grab radius, amber shows the tracked offhand palm and its line to the target, and green means attached. The overlay defaults off and reads the same mirrored, scaled, collision-resolved candidate used by interactions. Cyan indicates target geometry, not that every input/angle guard is satisfied.

A fresh offhand squeeze is still required near the handle; holding squeeze while approaching will not attach. The primary grip must remain held and the offhand must be free. This addresses target discoverability independently of the wall-contact failure fixed in parent #1402.

Validation:

- 13 headless VR support scenarios pass, including wrench region grabs in both hands and pistol/shotgun/fusion/worm regressions.
- 22 support-related Rust tests and 24 developer parameter/panel tests pass.
- Capture probes attach at 0%, 20%, 75%, and 100% of the wrench region with either primary hand; moving while squeezed keeps the selected contact locked.
- All 6 region scenarios also pass with overlay default-off/on/off assertions. TypeScript compilation and formatting pass.


Independent image review found no gross endpoint placement issue. The lowest contact is close to the primary glove; headset feel will determine whether to shorten that end. Finger clearance inside the grasp is partly occluded in the images.

Cross-engine code review and dedicated duplication review found no actionable issues.

![Optional support-grip overlay off and on](https://gist.githubusercontent.com/tommy-xr/4593e9102d890a1dc8707b2b379c21e2/raw/astra-wrench-region-off-on.png)

![Both hands: region acquisition, locked movement, and release](https://gist.githubusercontent.com/tommy-xr/4593e9102d890a1dc8707b2b379c21e2/raw/astra-wrench-region.gif)

Cyan shows the available handle region and acquisition radius, amber connects the tracked free palm to its nearest contact, and green indicates attachment. Captured in open space in `debug_interactions --vr`, with fresh squeezes at 0%, 20%, 75%, and 100% for both primary hands. Moving while squeezed preserves the selected contact until release. Overlay off/on uses the same build.

![Attached at 20 percent with either primary hand](https://gist.githubusercontent.com/tommy-xr/4593e9102d890a1dc8707b2b379c21e2/raw/astra-wrench-region-attached.png)

The lower endpoint is close to the primary glove; the upper endpoint stays below the wrench head. No endpoint adjustment was indicated by these views. Hidden finger seams and headset comfort remain unverified.

[Download the standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/4593e9102d890a1dc8707b2b379c21e2/raw/astra-wrench-support-region-gallery.html).
