### PR TITLE
fix(vr): keep ladder-to-deck pulls supported through top-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ However, you can play with a keyboard and a mouse, using the following hard-code
   near the ladder's top edge, pull the held hand toward your chest to move
   your body beyond the edge, then raise that hand to lower yourself. Open
   the hand to release. When transferring onto a deck, keep its hand squeezed
-  while releasing the ladder and pulling yourself up. If the deck blocks your
+  while releasing the ladder. You can grip the deck with the second hand too,
+  then pull down or inward slowly with the newly placed hand to climb onto it.
+  Releasing that hand transfers support to the other held hand. No flick
+  or release is needed to finish the pull. If the deck blocks your
   pull, the held hand keeps supporting you until you open it; relax or adjust
   the pull to continue.
 - Quest VR: reload by hand. Pull a clip out of the cyber interface's inventory

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ However, you can play with a keyboard and a mouse, using the following hard-code
   above the fist confirms the hold. To descend from a deck, crouch and grab
   near the ladder's top edge, pull the held hand toward your chest to move
   your body beyond the edge, then raise that hand to lower yourself. Open
-  the hand to release.
+  the hand to release. When transferring onto a deck, keep its hand squeezed
+  while releasing the ladder and pulling yourself up. If the deck blocks your
+  pull, the held hand keeps supporting you until you open it; relax or adjust
+  the pull to continue.
 - Quest VR: reload by hand. Pull a clip out of the cyber interface's inventory
   strip with your free hand and bring it to the gun the other hand is holding -
   the clip goes in and the weapon is loaded. A clip of a different ammo type

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -76,6 +76,9 @@ pub trait PlayerInteraction {
         None
     }
 
+    /// Feed collision-resolved motion back into the held tracking reference.
+    fn resolve_hand_climb(&mut self, _requested: Vector3<f32>, _applied: Vector3<f32>) {}
+
     /// Drop every climb hold without throwing the body - the vault took over
     /// (see [`crate::vr_climb::HandClimb::release_all`]).
     fn release_climb_grips(&mut self) {}
@@ -233,6 +236,10 @@ impl PlayerInteraction for VrInteraction {
 
     fn hand_climb(&self) -> Option<&crate::vr_climb::HandClimb> {
         Some(&self.hand_climb)
+    }
+
+    fn resolve_hand_climb(&mut self, requested: Vector3<f32>, applied: Vector3<f32>) {
+        self.hand_climb.resolve_translation(requested, applied);
     }
 
     fn release_climb_grips(&mut self) {

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -214,9 +214,10 @@ impl PlayerInteraction for VrInteraction {
                 hand_input(&self.left_hand, &ctx.input.left_hand),
                 hand_input(&self.right_hand, &ctx.input.right_hand),
             ],
-            |point, from_ladder| {
-                if from_ladder {
-                    ctx.physics.climbable_grip_from_ladder_at(point, ctx.feet_y)
+            |point, transferring| {
+                if transferring {
+                    ctx.physics
+                        .climbable_grip_during_transfer_at(point, ctx.feet_y)
                 } else {
                     ctx.physics.climbable_grip_at(
                         point,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3662,11 +3662,16 @@ impl MissionCore {
                     push_to_climb: game_options.presentation_mode == crate::PresentationMode::Flat,
                 },
             };
-            profile!(
+            let moved = profile!(
                 "shock2.update.physics",
                 self.physics
                     .update_player_movement(request, &mut self.player_handle)
-            )
+            );
+            if let Some(requested) = hand_climb.translation {
+                self.interaction
+                    .resolve_hand_climb(requested, self.player_handle.self_translation());
+            }
+            moved
         };
 
         if !time.elapsed.is_zero() {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -10056,6 +10056,114 @@ mod tests {
     }
 
     #[test]
+    fn a_held_ledge_consumes_blocked_pull_without_falling_or_storing_motion() {
+        use crate::vr_climb::{ClimbHandInput, HandClimb};
+        let (mut world, mut player) = grip_world();
+        let block = EntityId::from_inner(2027).unwrap();
+        world.add_kinematic(
+            block,
+            vec3(0.0, 1.5, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 3.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        step(&mut world, &mut player, 1);
+        world.set_player_translation(vec3(2.4, 2.0, 0.0), &mut player);
+        world.set_player_crouch_hanging(true, &mut player);
+        let mut climb = HandClimb::default();
+        let mut hand = vec3(-0.38, 1.04, 0.0);
+        let input = |local_position, squeeze| ClimbHandInput {
+            local_position,
+            squeeze,
+            is_empty: true,
+        };
+        let mut frame = climb.update(
+            world.get_player_next_translation(&player),
+            identity_quat(),
+            world.player_step_dt(),
+            [input(vec3(0.0, 0.0, 0.0), 0.0), input(hand, 1.0)],
+            |p, _| world.climbable_grip_at(p, CLIMB_GRIP_RADIUS, 0.0),
+            |_| true,
+        );
+        assert!(climb.holds_a_ledge(), "must acquire the actual box's top");
+        let surface = climb.anchor_grip().unwrap().grip.point;
+        for _ in 0..8 {
+            let requested = frame.translation.expect("squeezed ledge retains support");
+            world.update_player_movement(
+                PlayerMoveRequest::HandClimb {
+                    translation: requested,
+                },
+                &mut player,
+            );
+            climb.resolve_translation(requested, player.self_translation());
+            let center = world.get_player_next_translation(&player);
+            assert!(
+                center.x >= 2.3,
+                "wall must stop the inward pull: {center:?}"
+            );
+            assert!(
+                (center.y - 2.0).abs() < 0.01,
+                "held hand must suppress gravity"
+            );
+            hand.x += 0.2;
+            frame = climb.update(
+                center,
+                identity_quat(),
+                world.player_step_dt(),
+                [input(vec3(0.0, 0.0, 0.0), 0.0), input(hand, 1.0)],
+                |_, _| None,
+                |_| true,
+            );
+        }
+        // Settle the last requested pull, then freeze the tracked hand. There
+        // must be no stored correction to snap the body inward on a later frame.
+        let requested = frame.translation.unwrap();
+        world.update_player_movement(
+            PlayerMoveRequest::HandClimb {
+                translation: requested,
+            },
+            &mut player,
+        );
+        climb.resolve_translation(requested, player.self_translation());
+        frame = climb.update(
+            world.get_player_next_translation(&player),
+            identity_quat(),
+            world.player_step_dt(),
+            [input(vec3(0.0, 0.0, 0.0), 0.0), input(hand, 1.0)],
+            |_, _| None,
+            |_| true,
+        );
+        assert!(frame.translation.unwrap().magnitude() < 0.001);
+        assert_eq!(climb.anchor_grip().unwrap().grip.point, surface);
+        // A small reverse motion takes effect immediately and only by the
+        // amount moved, instead of first paying back the blocked 1.6-unit pull.
+        hand.x -= 0.1;
+        frame = climb.update(
+            world.get_player_next_translation(&player),
+            identity_quat(),
+            world.player_step_dt(),
+            [input(vec3(0.0, 0.0, 0.0), 0.0), input(hand, 1.0)],
+            |_, _| None,
+            |_| true,
+        );
+        assert!((frame.translation.unwrap().x - 0.1).abs() < 0.001);
+        // Opening the hand still drops the body normally.
+        frame = climb.update(
+            world.get_player_next_translation(&player),
+            identity_quat(),
+            world.player_step_dt(),
+            [input(vec3(0.0, 0.0, 0.0), 0.0), input(hand, 0.0)],
+            |_, _| None,
+            |_| true,
+        );
+        assert!(frame.translation.is_none());
+        step(&mut world, &mut player, 30);
+        assert!(world.get_player_translation(&player).y < 1.5);
+    }
+
+    #[test]
     fn hand_top_out_tucks_past_the_wall_and_expands_only_at_the_landing() {
         for physically_crouched in [false, true] {
             let (mut world, mut player) = grip_world();

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -5490,9 +5490,10 @@ impl PhysicsWorld {
         self.climbable_grip_above(point, radius, feet_y + PLAYER_STEP_HEIGHT / SCALE_FACTOR)
     }
 
-    /// Near a held ladder, the deck can be less than a step above the feet.
+    /// Near an existing ladder or ledge hold, the deck can be less than a step
+    /// above the feet, including when bringing the second hand onto the deck.
     /// It must still be above them, so ordinary floor support is never a grip.
-    pub fn climbable_grip_from_ladder_at(
+    pub fn climbable_grip_during_transfer_at(
         &self,
         point: Vector3<f32>,
         feet_y: f32,
@@ -10432,13 +10433,13 @@ mod tests {
         );
         assert!(
             world
-                .climbable_grip_from_ladder_at(vec3(0.0, 3.05, 0.0), 2.5)
+                .climbable_grip_during_transfer_at(vec3(0.0, 3.05, 0.0), 2.5)
                 .is_some(),
             "a nearby deck within a step is available during ladder transfer"
         );
         assert!(
             world
-                .climbable_grip_from_ladder_at(vec3(0.0, 3.05, 0.0), 3.0)
+                .climbable_grip_during_transfer_at(vec3(0.0, 3.05, 0.0), 3.0)
                 .is_none(),
             "even a transfer must not grip the floor under the feet"
         );

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -790,6 +790,26 @@ struct ClimbTopOut {
     is_crouched: bool,
 }
 
+impl ClimbTopOut {
+    /// Hand vaults retain the tucked capsule that made the hold valid. A
+    /// sphere can classify a one-sided level mesh differently at that same
+    /// pose, aborting an otherwise clear climb the moment the shape changes.
+    /// Flat Dark jump-throughs retain their original compressed sphere.
+    fn movement_shape(&self) -> SharedShape {
+        if self.collide_terrain {
+            // Hand routes always tuck (is_crouched=true); the requested
+            // landing stance is tracked separately by stand_on_completion.
+            crouched_player_shared_shape()
+        } else {
+            SharedShape::ball(if self.is_crouched {
+                PLAYER_CROUCH_RADIUS / SCALE_FACTOR
+            } else {
+                CLIMB_TOP_OUT_RADIUS
+            })
+        }
+    }
+}
+
 struct PlayerMovement {
     movement: EffectiveCharacterMovement,
     /// `movement.translation` with the moving-platform carry removed, i.e.
@@ -1667,7 +1687,7 @@ fn plan_jump_mantle(
 /// before the capsule is expanded, and final standing fit is checked against
 /// every collider.
 /// Give the player the collider their top-out state calls for: the scripted
-/// mantle's compressed ball while it runs, their own capsule again once it
+/// route's tucked capsule or compressed ball while it runs, their own capsule once it
 /// ends. One place, because a top-out is entered both from the movement pass
 /// (flat, pushing into a ladder top) and outright (a VR hand vault - see
 /// [`PhysicsWorld::plan_hand_top_out`]).
@@ -1680,15 +1700,8 @@ fn sync_top_out_collider(
     let is_top_out = player_handle.top_out.is_some();
     let collider_handle = rigid_body_set[player_handle.character_handle].colliders()[0];
     if !was_top_out && is_top_out {
-        let compressed_radius = if player_handle
-            .top_out
-            .is_some_and(|top_out| top_out.is_crouched)
-        {
-            PLAYER_CROUCH_RADIUS / SCALE_FACTOR
-        } else {
-            CLIMB_TOP_OUT_RADIUS
-        };
-        collider_set[collider_handle].set_shape(SharedShape::ball(compressed_radius));
+        collider_set[collider_handle]
+            .set_shape(player_handle.top_out.as_ref().unwrap().movement_shape());
     } else if was_top_out && !is_top_out {
         let restored = if player_handle.is_crouched {
             crouched_player_shared_shape()
@@ -1768,24 +1781,22 @@ fn advance_climb_top_out(
             top_out.next_waypoint += 1;
         }
     };
-    let compressed_radius = if top_out.is_crouched {
-        PLAYER_CROUCH_RADIUS / SCALE_FACTOR
-    } else {
-        CLIMB_TOP_OUT_RADIUS
-    };
-    let compressed = Ball::new(compressed_radius);
-    // A live entity can move into the compressed sphere between frames. The
+    let compressed = top_out.movement_shape();
+    // A live entity can move into the movement shape between frames. The
     // forward route must stop, but refusing every cast from an overlapping
     // pose would pin the recovery forever. During reversal only, let Rapier's
     // character controller compute a collision-checked depenetrating step
     // toward the preceding validated waypoint.
-    let movement = (!shape_intersects(scripted_queries, pos.translation.vector, &compressed)
-        || top_out.reversing)
+    let movement = (!shape_intersects(
+        scripted_queries,
+        pos.translation.vector,
+        compressed.as_ref(),
+    ) || top_out.reversing)
         .then(|| {
             slide_toward(
                 controller,
                 scripted_queries,
-                &compressed,
+                compressed.as_ref(),
                 pos.translation.vector,
                 target,
                 dt,
@@ -5244,7 +5255,13 @@ impl PhysicsWorld {
         if player.top_out.is_some() || grip.kind != ClimbGripKind::Ledge {
             return false;
         }
-        let start = *self.rigid_body_set[player.character_handle].translation();
+        // The next physics step consumes the last hand pull before advancing
+        // this route. Planning from the old pose would first pull backwards to
+        // it; a tiny rejected step reverses the vault after its grips release.
+        let start = self.rigid_body_set[player.character_handle]
+            .next_position()
+            .translation
+            .vector;
         let toward = vec_to_nvec(grip.point) - start;
         let horizontal = vector![toward.x, 0.0, toward.z];
         if horizontal.norm() < 1e-4 {
@@ -5265,7 +5282,6 @@ impl PhysicsWorld {
             } else {
                 crouched_player_capsule()
             };
-            let compressed = Ball::new(PLAYER_CROUCH_RADIUS / SCALE_FACTOR);
             if shape_intersects(&route_queries, start, &crouched) {
                 return false;
             }
@@ -5301,9 +5317,9 @@ impl PhysicsWorld {
                 }
                 let raised = vector![start.x, start.y.max(landing.y), start.z];
                 let crossed = vector![landing.x, raised.y, landing.z];
-                if !shape_sweep_is_clear(&route_queries, start, raised, &compressed)
-                    || !shape_sweep_is_clear(&route_queries, raised, crossed, &compressed)
-                    || !shape_sweep_is_clear(&route_queries, crossed, landing, &compressed)
+                if !shape_sweep_is_clear(&route_queries, start, raised, &crouched)
+                    || !shape_sweep_is_clear(&route_queries, raised, crossed, &crouched)
+                    || !shape_sweep_is_clear(&route_queries, crossed, landing, &crouched)
                 {
                     continue;
                 }
@@ -5324,6 +5340,9 @@ impl PhysicsWorld {
             return false;
         };
         self.set_player_crouch_hanging(true, player);
+        // A stance change may reset the body's queued translation. Preserve
+        // the collision-resolved hand movement this route was planned from.
+        self.rigid_body_set[player.character_handle].set_next_kinematic_translation(start);
         player.top_out = Some(route);
         sync_top_out_collider(
             &mut self.collider_set,
@@ -10166,7 +10185,9 @@ mod tests {
 
     #[test]
     fn hand_top_out_tucks_past_the_wall_and_expands_only_at_the_landing() {
-        for physically_crouched in [false, true] {
+        for (physically_crouched, pending_rise) in
+            [(false, 0.0), (true, 0.0), (false, 0.01), (true, 0.01)]
+        {
             let (mut world, mut player) = grip_world();
             let block = EntityId::from_inner(2020).unwrap();
             world.add_kinematic(
@@ -10188,8 +10209,29 @@ mod tests {
                 normal: vec3(0.0, 1.0, 0.0),
             };
             assert!(!world.standing_player_pose_is_clear(vec3(2.4, 2.4, 0.0), &player));
+            // Real hand pulls are queued for the next physics step; a static
+            // teleport alone misses the hand-to-vault transition. The held
+            // ledge has already tucked the body without changing tracking.
+            if pending_rise > 0.0 {
+                world.set_player_crouch_hanging(true, &mut player);
+            }
+            world.rigid_body_set[player.character_handle].set_next_kinematic_translation(vector![
+                2.4,
+                2.4 + pending_rise,
+                0.0
+            ]);
             assert!(world.plan_hand_top_out(grip, &mut player));
             assert!(player.is_crouched());
+            assert_eq!(
+                world.get_player_next_translation(&player),
+                vec3(2.4, 2.4 + pending_rise, 0.0),
+                "committing a vault must retain the queued hand pull"
+            );
+            assert_eq!(
+                player.top_out.unwrap().save_pose,
+                vector![2.4, 2.4 + pending_rise, 0.0],
+                "the route must start where the queued pull will land"
+            );
             let mut previous = world.get_player_translation(&player);
             for _ in 0..180 {
                 step(&mut world, &mut player, 1);

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -165,7 +165,7 @@ impl HandClimb {
     /// demands, or `None` when no hand holds anything.
     ///
     /// `probe` answers "what could a hand at this world point grab?"; its bool
-    /// enables a nearby deck transfer from the other valid ladder hand (see
+    /// enables a nearby deck transfer from the other valid hold (see
     /// [`crate::physics::PhysicsWorld::climbable_grip_at`]) and `is_alive`
     /// whether a gripped entity still exists.
     pub fn update(
@@ -243,15 +243,16 @@ impl HandClimb {
             }
         }
         // Invalidate BOTH old holds before granting a contextual deck grab:
-        // a broken, deleted, released or newly occupied ladder hand cannot
+        // a broken, deleted, released or newly occupied hand cannot
         // authorize the free hand's transfer, regardless of hand iteration order.
         for index in 0..HANDS.len() {
             if self.grips[index].is_none() && self.grab_grace[index] > 0.0 {
-                let from_ladder = self.grips[1 - index].is_some_and(|other| {
-                    other.grip.kind == ClimbGripKind::Ladder
-                        && (hand_world[index] - other.grip.point).magnitude() <= 1.5
-                });
-                if let Some(grip) = probe(hand_world[index], from_ladder) {
+                // Keep the same deck within reach after releasing the ladder:
+                // the player can place the second hand beside the first and
+                // continue pulling hand over hand across the lip.
+                let transferring = self.grips[1 - index]
+                    .is_some_and(|other| (hand_world[index] - other.grip.point).magnitude() <= 1.5);
+                if let Some(grip) = probe(hand_world[index], transferring) {
                     self.grab_grace[index] = 0.0;
                     self.grips[index] = Some(GripAnchor {
                         grip,
@@ -481,6 +482,77 @@ mod tests {
         assert_eq!(released.translation, None);
         assert_eq!(climb.anchor(), None);
         assert_eq!(climb.grips().count(), 0);
+    }
+
+    #[test]
+    fn deck_transfer_requires_a_nearby_valid_hold_of_either_kind() {
+        for kind in [ClimbGripKind::Ladder, ClimbGripKind::Ledge] {
+            for (squeeze, empty, alive, distance, expected) in [
+                (1.0, true, true, 0.5, true),
+                (0.0, true, true, 0.5, false),
+                (1.0, false, true, 0.5, false),
+                (1.0, true, false, 0.5, false),
+                (1.0, true, true, 1.6, false),
+            ] {
+                for held in 0..2 {
+                    let mut climb = HandClimb::default();
+                    let pawn = Vector3::zero();
+                    let rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+                    let reach = vec3(0.0, 1.0, -1.0);
+                    let mut hands = [no_hand(), no_hand()];
+                    hands[held] = hand(reach, 1.0);
+                    climb.update(
+                        pawn,
+                        rotation,
+                        DT,
+                        hands,
+                        |p, _| {
+                            Some(ClimbGrip {
+                                kind,
+                                entity_id: Some(shipyard::EntityId::from_inner(123).unwrap()),
+                                ..ladder_grip(p)
+                            })
+                        },
+                        |_| true,
+                    );
+                    let mut hands = [
+                        hand(reach + vec3(distance, 0.0, 0.0), 1.0),
+                        hand(reach + vec3(distance, 0.0, 0.0), 1.0),
+                    ];
+                    hands[held] = ClimbHandInput {
+                        is_empty: empty,
+                        ..hand(reach, squeeze)
+                    };
+                    climb.update(
+                        pawn,
+                        rotation,
+                        DT,
+                        hands,
+                        |p, transfer| {
+                            assert_eq!(transfer, expected, "{kind:?}, hand {held}");
+                            transfer.then_some(ClimbGrip {
+                                kind: ClimbGripKind::Ledge,
+                                normal: vec3(0.0, 1.0, 0.0),
+                                ..ladder_grip(p)
+                            })
+                        },
+                        |_| alive,
+                    );
+                    assert_eq!(climb.grips[1 - held].is_some(), expected);
+                    if expected {
+                        assert_eq!(climb.grips().count(), 2);
+                        let mut hands = [
+                            hand(reach + vec3(distance, 0.0, 0.0), 1.0),
+                            hand(reach + vec3(distance, 0.0, 0.0), 1.0),
+                        ];
+                        hands[held] = no_hand();
+                        let frame = climb.update(pawn, rotation, DT, hands, |_, _| None, |_| true);
+                        assert_translation(frame, Vector3::zero());
+                        assert!(frame.launch.is_none());
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/shock2vr/src/vr_climb.rs
+++ b/shock2vr/src/vr_climb.rs
@@ -14,8 +14,8 @@ use crate::{
     vr_config::Handedness,
 };
 
-/// How far a gripping hand may drift from the point it grabbed before the grip
-/// breaks. The drift IS the body's failure to follow: the body is cast every
+/// How far a ladder hand or passive hold may drift before the grip breaks.
+/// An active ledge instead consumes collision-rejected travel and stays held. The drift IS the body's failure to follow: the body is cast every
 /// frame at exactly the offset the hand opened up, so a persistent gap means
 /// something blocked it. Roughly Dark's 2 ft climb-detach distance.
 pub const CLIMB_STRETCH_BREAK: f32 = 0.6;
@@ -101,6 +101,8 @@ pub struct ClimbFrame {
 #[derive(Clone, Copy, Debug)]
 pub struct GripAnchor {
     pub grip: ClimbGrip,
+    /// Tracking reference; an active ledge adjusts this by rejected movement
+    /// while `grip.point` continues to identify the actual held surface.
     pub hand_world_at_grab: Vector3<f32>,
     /// Where the body was when this hold was taken, so a vault can tell a pull
     /// from a grab (see [`vault_ready`]).
@@ -186,9 +188,15 @@ impl HandClimb {
             .each_ref()
             .map(|hand| hand_world_position(pawn_pos, pawn_rotation, hand.local_position));
 
-        // Sample the anchor's travel BEFORE the releases below, so the flick
-        // on the very frame the hand opens is part of what throws the body.
-        if let Some(hand) = previous_anchor {
+        // Ladder releases include the final tracking flick. Ledge throws use
+        // collision-resolved held motion only: the opening frame has no held
+        // movement to resolve, so its raw tracking delta cannot prove momentum.
+        if let Some(hand) = previous_anchor.filter(|hand| {
+            self.grips[slot(*hand)].is_none_or(|anchor| {
+                anchor.grip.kind != ClimbGripKind::Ledge
+                    || hands[slot(*hand)].squeeze > crate::ui::VR_TRIGGER_THRESHOLD
+            })
+        }) {
             let local = hands[slot(hand)].local_position;
             match self.last_anchor_local.replace(local) {
                 Some(previous) => {
@@ -212,9 +220,15 @@ impl HandClimb {
             }
             match self.grips[index] {
                 Some(anchor) => {
-                    let over_stretched = (hand_world[index] - anchor.hand_world_at_grab)
-                        .magnitude()
-                        > CLIMB_STRETCH_BREAK;
+                    // A deck can block the hips while its hand stays closed.
+                    // Keep that support until the player opens the hand; a
+                    // blocked pull must not silently abandon a ladder handoff.
+                    // Passive holds still break when the other hand carries
+                    // the body away: they no longer provide reachable support.
+                    let over_stretched = (anchor.grip.kind == ClimbGripKind::Ladder
+                        || previous_anchor != Some(HANDS[index]))
+                        && (hand_world[index] - anchor.hand_world_at_grab).magnitude()
+                            > CLIMB_STRETCH_BREAK;
                     let gone = anchor.grip.entity_id.is_some_and(|id| !is_alive(id));
                     // The hands update after this, so the same squeeze that
                     // took a hold can also close on an item; a full hand lets
@@ -296,6 +310,24 @@ impl HandClimb {
         ClimbFrame {
             translation,
             launch,
+        }
+    }
+
+    /// Consume only the part of a ledge pull that collision prevented. The
+    /// actual surface and acquisition pose stay fixed, but rejected tracking
+    /// travel must not accumulate into a sudden move when the obstruction
+    /// clears. Ladder holds retain their existing stretch-and-break behavior.
+    pub fn resolve_translation(&mut self, requested: Vector3<f32>, applied: Vector3<f32>) {
+        let Some(anchor) = self.anchor.and_then(|hand| self.grips[slot(hand)].as_mut()) else {
+            return;
+        };
+        if anchor.grip.kind == ClimbGripKind::Ledge {
+            anchor.hand_world_at_grab += applied - requested;
+            // A blocked pull made no body momentum. Do not turn that rejected
+            // travel into a throw when the hand is deliberately opened.
+            if let Some(travel) = self.recent_anchor_travel.back_mut() {
+                *travel = -applied;
+            }
         }
     }
 
@@ -650,6 +682,263 @@ mod tests {
                 .translation,
             None,
         );
+    }
+
+    #[test]
+    fn a_blocked_deck_pull_keeps_support_when_the_ladder_hand_opens() {
+        let mut climb = HandClimb::default();
+        let pawn = Vector3::zero();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let ladder = vec3(-0.3, 1.0, -0.5);
+        let deck = vec3(0.3, 1.2, -0.5);
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [hand(ladder, 1.0), no_hand()],
+            |p, _| Some(ladder_grip(p)),
+            |_| true,
+        );
+        climb.update(
+            pawn,
+            identity,
+            DT,
+            [hand(ladder, 1.0), hand(deck, 1.0)],
+            |p, _| {
+                Some(ClimbGrip {
+                    kind: ClimbGripKind::Ledge,
+                    ..ladder_grip(p)
+                })
+            },
+            |_| true,
+        );
+        // The wall prevents the pawn following this ordinary inward pull.
+        // A still-closed deck hand must not silently lose its hold underneath
+        // the ladder hand, leaving the next handoff unsupported.
+        for distance in [0.2, 0.4, 0.6, 0.8] {
+            let frame = climb.update(
+                pawn,
+                identity,
+                DT,
+                [
+                    hand(ladder, 1.0),
+                    hand(deck + vec3(0.0, 0.0, distance), 1.0),
+                ],
+                |_, _| None,
+                |_| true,
+            );
+            assert!(frame.translation.is_some());
+            assert!(frame.launch.is_none());
+        }
+        let pulled = deck + vec3(0.0, 0.0, 0.8);
+        let handoff = climb.update(
+            pawn,
+            identity,
+            DT,
+            [hand(ladder, 0.0), hand(pulled, 1.0)],
+            |_, _| None,
+            |_| true,
+        );
+        assert_eq!(climb.anchor(), Some(Handedness::Right));
+        assert!(climb.holds_a_ledge());
+        assert!(handoff.translation.is_some());
+        assert!(handoff.launch.is_none());
+        // Relaxing the pull recovers the same anchored hold; it never rebases
+        // the hand into space or ratchets the pawn through the obstruction.
+        let relaxed = climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(deck, 1.0)],
+            |_, _| None,
+            |_| true,
+        );
+        assert_translation(relaxed, Vector3::zero());
+        for _ in 0..RELEASE_SAMPLE_FRAMES {
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(deck, 1.0)],
+                |_, _| None,
+                |_| true,
+            );
+        }
+        let released = climb.update(
+            pawn,
+            identity,
+            DT,
+            [no_hand(), hand(deck, 0.0)],
+            |_, _| None,
+            |_| true,
+        );
+        assert!(released.translation.is_none());
+        assert!(released.launch.is_none());
+        assert!(!climb.holds_a_ledge());
+    }
+
+    #[test]
+    fn a_passive_ledge_cannot_support_a_handoff_after_the_body_moves_away() {
+        for active in 0..2 {
+            for active_kind in [ClimbGripKind::Ladder, ClimbGripKind::Ledge] {
+                let mut climb = HandClimb::default();
+                let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+                let positions = [vec3(-0.3, 1.0, -0.5), vec3(0.3, 1.0, -0.5)];
+                let inputs = |active_squeeze, travel| {
+                    std::array::from_fn(|i| {
+                        hand(
+                            positions[i] - if i == active { travel } else { Vector3::zero() },
+                            if i == active { active_squeeze } else { 1.0 },
+                        )
+                    })
+                };
+                climb.update(
+                    Vector3::zero(),
+                    identity,
+                    DT,
+                    inputs(0.0, Vector3::zero()),
+                    |p, _| {
+                        Some(ClimbGrip {
+                            kind: ClimbGripKind::Ledge,
+                            ..ladder_grip(p)
+                        })
+                    },
+                    |_| true,
+                );
+                climb.update(
+                    Vector3::zero(),
+                    identity,
+                    DT,
+                    inputs(1.0, Vector3::zero()),
+                    |p, _| {
+                        Some(ClimbGrip {
+                            kind: active_kind,
+                            ..ladder_grip(p)
+                        })
+                    },
+                    |_| true,
+                );
+                let travel = vec3(0.0, 0.8, 0.0);
+                climb.update(
+                    travel,
+                    identity,
+                    DT,
+                    inputs(1.0, travel),
+                    |_, _| None,
+                    |_| true,
+                );
+                assert_eq!(
+                    climb.grips().count(),
+                    1,
+                    "abandoned passive ledge must break"
+                );
+                let released = climb.update(
+                    travel,
+                    identity,
+                    DT,
+                    inputs(0.0, travel),
+                    |_, _| None,
+                    |_| true,
+                );
+                assert!(
+                    released.translation.is_none(),
+                    "cannot hang from a distant stale ledge"
+                );
+                assert!(climb.anchor().is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn only_applied_ledge_pull_motion_becomes_a_release_throw() {
+        for blocked in [false, true] {
+            let mut climb = HandClimb::default();
+            let mut pawn = Vector3::zero();
+            let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+            let mut at = vec3(0.3, 1.2, -0.5);
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(at, 1.0)],
+                |p, _| {
+                    Some(ClimbGrip {
+                        kind: ClimbGripKind::Ledge,
+                        ..ladder_grip(p)
+                    })
+                },
+                |_| true,
+            );
+            for _ in 0..RELEASE_SAMPLE_FRAMES {
+                at.y -= 0.1;
+                let frame = climb.update(
+                    pawn,
+                    identity,
+                    DT,
+                    [no_hand(), hand(at, 1.0)],
+                    |_, _| None,
+                    |_| true,
+                );
+                let requested = frame.translation.unwrap();
+                let applied = if blocked { Vector3::zero() } else { requested };
+                climb.resolve_translation(requested, applied);
+                pawn += applied;
+            }
+            // Opening can coincide with one more tracked pull. That frame
+            // never moved the body and must not resurrect blocked momentum.
+            at.y -= 0.2;
+            let released = climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(at, 0.0)],
+                |_, _| None,
+                |_| true,
+            );
+            assert!(released.translation.is_none());
+            assert_eq!(
+                released.launch.is_none(),
+                blocked,
+                "opening after a blocked pull drops; a real pull still throws"
+            );
+        }
+    }
+
+    #[test]
+    fn a_held_ledge_still_releases_if_occupied_or_removed() {
+        for occupied in [false, true] {
+            let mut climb = HandClimb::default();
+            let pawn = Vector3::zero();
+            let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+            let at = vec3(0.3, 1.2, -0.5);
+            climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), hand(at, 1.0)],
+                |p, _| {
+                    Some(ClimbGrip {
+                        kind: ClimbGripKind::Ledge,
+                        entity_id: Some(shipyard::EntityId::from_inner(123).unwrap()),
+                        ..ladder_grip(p)
+                    })
+                },
+                |_| true,
+            );
+            let mut holding = hand(at, 1.0);
+            holding.is_empty = !occupied;
+            let frame = climb.update(
+                pawn,
+                identity,
+                DT,
+                [no_hand(), holding],
+                |_, _| None,
+                |_| occupied,
+            );
+            assert!(frame.translation.is_none());
+            assert!(frame.launch.is_none());
+            assert!(!climb.holds_a_ledge());
+        }
     }
 
     #[test]

--- a/tools/shock2-sdk/test/medsci-deck-handoff.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-deck-handoff.e2e.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { vrHandLocal, vrHandLocalDelta } from "./helpers/vr-climb.js";
+
+test("medsci1 (VR): replace the ladder hand with a second low deck hold and pull slowly", {
+  skip: process.env.SHOCK2_E2E !== "1",
+  timeout: 600_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "medsci1.mis", debugFlags: ["--vr"] });
+  await game.step({ frames: 5 });
+  const rungs = (await game.entities.list({ filter: "Rick Ladder", limit: 100 })).entities;
+  // Mission-file identity, not a launch-dependent runtime entity ID.
+  const rung = rungs.find(entity => entity.template_id === 1481);
+  assert.ok(rung, "the cryo shaft's top rung exists");
+  const [x, , z] = rung.position;
+  const lipY = -1.6;
+  // Stage the reported top-of-ladder posture; all subsequent motion uses
+  // squeezed hands. The lip is above the feet but below the normal step gate.
+  await game.player.teleport({ x, y: -0.85, z: z + 0.596278 });
+  for (const hand of ["left", "right"] as const) {
+    await game.input.set(`${hand}_hand.squeeze`, 0);
+  }
+
+  const grab = async (hand: "left" | "right", world: Vec3) => {
+    const local = await vrHandLocal(game, world);
+    await game.input.set(`${hand}_hand.position`, local);
+    await game.input.set(`${hand}_hand.squeeze`, 0);
+    await game.step({ frames: 1 });
+    await game.input.set(`${hand}_hand.squeeze`, 1);
+    await game.step({ frames: 1 });
+    return local;
+  };
+
+  await grab("right", [x, -1.8, z + 0.146278]);
+  await grab("left", [x - 0.16, lipY + 0.05, z - 0.853722]);
+  const supported = (await game.info()).player;
+  assert.deepEqual(supported.climb.grips.map(grip => grip.kind).sort(), ["ladder", "ledge"]);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 30 });
+  const oneDeck = (await game.info()).player;
+  assert.equal(oneDeck.climb.grips[0]?.kind, "ledge");
+  assert.ok(Math.abs(oneDeck.position[1] - supported.position[1]) < 0.02, "the squeezed deck hand supports the player after releasing the ladder");
+
+  const secondDeck: Vec3 = [x + 0.14, lipY + 0.05, z - 0.653722];
+  assert.equal((await game.physics.grip(secondDeck)).grip, null,
+    "the normal grip probe rejects this near-feet deck; the held hand must authorize it");
+  const onTop = await grab("right", secondDeck);
+  assert.deepEqual((await game.info()).player.climb.grips.map(grip => grip.kind), ["ledge", "ledge"]);
+  await game.input.set("left_hand.squeeze", 0);
+  await game.step({ frames: 1 });
+  assert.equal((await game.info()).player.climb.anchor_hand, "right");
+
+  const down = await vrHandLocalDelta(game, [0, -0.8, 0]);
+  let vaulted = false;
+  for (let frame = 1; frame <= 120; frame++) {
+    await game.input.set("right_hand.position", onTop.map((value, axis) => value + down[axis] * frame / 120));
+    await game.step({ frames: 1 });
+    vaulted ||= (await game.info()).player.climb.vaulting;
+  }
+  assert.ok(vaulted, "a two-second held pull commits the top-out without a release flick");
+  await game.step({ frames: 90 });
+  const landed = (await game.info()).player;
+  assert.equal(landed.climb.vaulting, false);
+  assert.ok(Math.abs(landed.position[1] - (lipY + 1.244)) < 0.1,
+    `expected to stand on the deck, got ${landed.position}`);
+  assert.ok(landed.position[2] < z, "the body clears the ladder onto the landing");
+  await game.step({ frames: 60 });
+  assert.ok(Math.abs((await game.info()).player.position[1] - landed.position[1]) < 0.05,
+    "the completed top-out stays on the deck");
+});

--- a/tools/shock2-sdk/test/medsci-deck-handoff.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-deck-handoff.e2e.test.ts
@@ -4,6 +4,16 @@ import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { vrHandLocal, vrHandLocalDelta } from "./helpers/vr-climb.js";
 
+async function grab(game: GameServer, hand: "left" | "right", world: Vec3) {
+  const local = await vrHandLocal(game, world);
+  await game.input.set(`${hand}_hand.position`, local);
+  await game.input.set(`${hand}_hand.squeeze`, 0);
+  await game.step({ frames: 1 });
+  await game.input.set(`${hand}_hand.squeeze`, 1);
+  await game.step({ frames: 1 });
+  return local;
+}
+
 test("medsci1 (VR): replace the ladder hand with a second low deck hold and pull slowly", {
   skip: process.env.SHOCK2_E2E !== "1",
   timeout: 600_000,
@@ -23,18 +33,8 @@ test("medsci1 (VR): replace the ladder hand with a second low deck hold and pull
     await game.input.set(`${hand}_hand.squeeze`, 0);
   }
 
-  const grab = async (hand: "left" | "right", world: Vec3) => {
-    const local = await vrHandLocal(game, world);
-    await game.input.set(`${hand}_hand.position`, local);
-    await game.input.set(`${hand}_hand.squeeze`, 0);
-    await game.step({ frames: 1 });
-    await game.input.set(`${hand}_hand.squeeze`, 1);
-    await game.step({ frames: 1 });
-    return local;
-  };
-
-  await grab("right", [x, -1.8, z + 0.146278]);
-  await grab("left", [x - 0.16, lipY + 0.05, z - 0.853722]);
+  await grab(game, "right", [x, -1.8, z + 0.146278]);
+  await grab(game, "left", [x - 0.16, lipY + 0.05, z - 0.853722]);
   const supported = (await game.info()).player;
   assert.deepEqual(supported.climb.grips.map(grip => grip.kind).sort(), ["ladder", "ledge"]);
   await game.input.set("right_hand.squeeze", 0);
@@ -46,7 +46,7 @@ test("medsci1 (VR): replace the ladder hand with a second low deck hold and pull
   const secondDeck: Vec3 = [x + 0.14, lipY + 0.05, z - 0.653722];
   assert.equal((await game.physics.grip(secondDeck)).grip, null,
     "the normal grip probe rejects this near-feet deck; the held hand must authorize it");
-  const onTop = await grab("right", secondDeck);
+  const onTop = await grab(game, "right", secondDeck);
   assert.deepEqual((await game.info()).player.climb.grips.map(grip => grip.kind), ["ledge", "ledge"]);
   await game.input.set("left_hand.squeeze", 0);
   await game.step({ frames: 1 });
@@ -69,4 +69,52 @@ test("medsci1 (VR): replace the ladder hand with a second low deck hold and pull
   await game.step({ frames: 60 });
   assert.ok(Math.abs((await game.info()).player.position[1] - landed.position[1]) < 0.05,
     "the completed top-out stays on the deck");
+});
+
+test("medsci1 (VR): the cryo bay deck top-out keeps the latest held pull", {
+  skip: process.env.SHOCK2_E2E !== "1",
+  timeout: 600_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "medsci1.mis", debugFlags: ["--vr"] });
+  await game.step({ frames: 5 });
+  // This is the OTHER cryo ladder: the fallen duct must be broken before
+  // climbing it. Drive normal damage, discovering its runtime ID each launch.
+  const duct = (await game.entities.list({ filter: "Air Duct", limit: 100 })).entities
+    .find(entity => entity.template_id === 402);
+  assert.ok(duct, "the fallen cryo duct exists");
+  const damaged = await fetch(`${game.baseUrl}/v1/entities/${duct.id}/message`, {
+    method: "POST", body: JSON.stringify({ type: "Damage", amount: 100 }),
+  });
+  assert.ok(damaged.ok, "damage reaches the duct");
+  await game.step({ frames: 30 });
+  // Pose recorded on Quest when the player released the ladder hand and
+  // slowly pulled with the still-squeezed deck hand. Its 1.12 eye offset is
+  // essential: it permits the top-out before the body clears the lip.
+  await game.input.set("head.position", [0.031793468, 1.12, 0.17070708]);
+  await game.player.teleport({ x: -41.36099, y: -2.201106, z: 17.03226 });
+  await grab(game, "right", [-40.968594, -1.6741132, 16.597527]);
+  const left = await grab(game, "left", [-41.4958, -1.5342857, 16.272123]);
+  assert.deepEqual((await game.info()).player.climb.grips.map(grip => grip.kind).sort(), ["ladder", "ledge"]);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 1 });
+  const heldY = (await game.info()).player.position[1];
+  assert.equal((await game.info()).player.climb.anchor_hand, "left");
+
+  const down = await vrHandLocalDelta(game, [0.0289, -0.3, 0.05747]);
+  let vaulted = false;
+  for (let frame = 1; frame <= 180; frame++) {
+    await game.input.set("left_hand.position", left.map((value, axis) => value + down[axis] * Math.min(frame, 30) / 30));
+    await game.step({ frames: 1 });
+    const player = (await game.info()).player;
+    vaulted ||= player.climb.vaulting;
+    assert.ok(player.position[1] >= heldY - 0.05,
+      `the squeezed deck hold must not drop after top-out starts: ${player.position}`);
+  }
+  assert.ok(vaulted, "the slow held pull starts a top-out");
+  const landed = (await game.info()).player;
+  assert.equal(landed.climb.vaulting, false);
+  assert.ok(Math.abs(landed.position[1] - -0.356) < 0.1, `stand on the deck: ${landed.position}`);
+  assert.ok(landed.position[2] < 16.3, "the body clears the lip");
+  await game.step({ frames: 60 });
+  assert.ok(Math.abs((await game.info()).player.position[1] - landed.position[1]) < 0.05);
 });

--- a/tools/shock2-sdk/test/vr-vault.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-vault.e2e.test.ts
@@ -132,8 +132,9 @@ test(
 );
 
 for (const transferHeight of [4.5, 5.1]) {
+for (const twoDeckHands of [false, true]) {
 test(
-  `debug_ladder (VR): a deck grab at body height ${transferHeight} vaults off the ladder`,
+  `debug_ladder (VR): ${twoDeckHands ? "two deck hands" : "a deck grab"} at body height ${transferHeight} vaults off the ladder`,
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await launchVr();
@@ -186,8 +187,8 @@ test(
 
     // Reach onto the deck AFTER the head clears it: this used to permanently
     // fail the historical eye-at-grab gate. The new grip still waits for a pull.
-    const other: "left" | "right" = pulling === "right" ? "left" : "right";
-    const onTop = await grab(game, other, [-7.1, 6.05, LEDGE_Z]);
+    let other: "left" | "right" = pulling === "right" ? "left" : "right";
+    let onTop = await grab(game, other, [-7.1, 6.05, LEDGE_Z]);
     const held = (await game.info()).player.climb;
     assert.equal(held.anchor_hand, other);
     assert.equal(held.vaulting, false, "resting the hand on the deck is not a vault");
@@ -196,6 +197,28 @@ test(
       "ledge",
       "the block's top surface is a ledge hold",
     );
+
+    if (twoDeckHands) {
+      // Move the old ladder hand onto the same deck while the first deck
+      // hand supports us. Then release that first hand: either deck hand
+      // must support a slow pull, without a release flick.
+      await game.input.set(`${pulling}_hand.squeeze`, 0);
+      await game.step({ frames: 1 });
+      const second = await grab(game, pulling, [-7.1, 6.05, LEDGE_Z + 0.3]);
+      const atSecondGrip = (await game.info()).player;
+      const both = atSecondGrip.climb;
+      assert.equal(both.grips.length, 2);
+      assert.ok(both.grips.every((grip) => grip.kind === "ledge"));
+      await game.input.set(`${other}_hand.squeeze`, 0);
+      await game.step({ frames: 30 });
+      const supported = (await game.info()).player;
+      assert.equal(supported.climb.grips.length, 1);
+      assert.equal(supported.climb.anchor_hand, pulling);
+      assert.ok(Math.abs(supported.position[1] - atSecondGrip.position[1]) < 0.01,
+        `the second deck hand must prevent falling while resting: before=${atSecondGrip.position}, after=${supported.position}, climb=${JSON.stringify(supported.climb)}`);
+      other = pulling;
+      onTop = second;
+    }
 
     const topOut = await vrHandLocalDelta(game, [0, -0.8, 0]);
     const heights: number[] = [];
@@ -227,6 +250,7 @@ test(
   },
 );
 
+}
 }
 
 test(


### PR DESCRIPTION
Releasing the ladder hand on MedSci1 could still cause a fall while the deck hand remained squeezed. Quest logs showed the deck grip was acquired correctly: the automatic top-out cleared the grips, changed the hanging capsule into a sphere, then immediately rejected that sphere against the level mesh and reversed into a fall.

Hand top-outs now use the same tucked capsule for route planning, movement, and the active collider. They also plan from the queued hand-pull position and preserve that position through the stance transition. Flat top-outs keep their existing shape. This automatic collision-body tuck does not require the player to physically crouch.

The PR also keeps the active deck grip through blocked pulls and allows the second hand to take a nearby deck hold from an existing deck hold. Players can transfer hands and pull slowly onto the surface while keeping squeeze held; no flick or release is required.

Fixes #1403.

Validation: all 10 VR end-to-end scenarios pass (eight isolated ladder cases and two MedSci1 cases); 110 physics tests pass, two ignored; TypeScript build, formatting, and diff checks pass. The new campaign regression reconstructs the logged cryo-bay grip, body, and eye positions after breaking the fallen duct, then checks every frame of a slow held pull for a drop and verifies a stable deck landing. The prior build fails this replay. Independent code, duplication, and visual reviews completed.

Quest logs establish the original device failure; after-fix verification is in the debug runtime's VR presentation. A signed release APK is built, with installation queued for the disconnected test headset. Human device retesting remains pending. A newly moving obstruction can still trigger the existing route reversal; this change fixes the static-geometry rejection seen in the captured repro.

![Recorded MedSci1 deck pull before and after](https://gist.githubusercontent.com/tommy-xr/03701f4faa471fc0fd4169e1b41dd702/raw/quest-deck-pull.gif)

Same reconstructed Quest posture and slow squeezed pull: before (`30dbeeb5`) aborts the top-out and falls; after completes it. The debug-runtime replay and numerical assertions provide the motion/landing evidence, rather than a claim of after-fix headset capture.

![MedSci1 deck pull still](https://gist.githubusercontent.com/tommy-xr/03701f4faa471fc0fd4169e1b41dd702/raw/quest-deck-pull.png)

Second-deck-hand handoff comparison from the earlier increment:

![MedSci1 second deck hand before and after](https://gist.githubusercontent.com/tommy-xr/03701f4faa471fc0fd4169e1b41dd702/raw/medsci-deck-handoff.gif)

![Second deck grip before and after](https://gist.githubusercontent.com/tommy-xr/03701f4faa471fc0fd4169e1b41dd702/raw/medsci-two-deck-holds.png)

Original collision-blocked grip regression in the isolated ladder scene:

![Blocked grip before and after](https://gist.githubusercontent.com/tommy-xr/03701f4faa471fc0fd4169e1b41dd702/raw/handoff-before-after.gif)

![Blocked grip still](https://gist.githubusercontent.com/tommy-xr/03701f4faa471fc0fd4169e1b41dd702/raw/handoff-before-after.png)

Campaign verification: full-game · detailed · 25th · VR · seed 1258205384. Campaign build `dcb1b530` (PR commit `9d54c28c`) independently passes all 10 focused VR runtime cases and the warnings-as-errors non-Android workspace check. The new recorded-pose regression fails on the previous `30dbeeb5` build. The manager-owned full SDK suite remains in progress.
