### PR TITLE
feat(weapons): parse the authored gun kick and the skill inaccuracy angle

### DIFF
--- a/dark/src/gamesys/params.rs
+++ b/dark/src/gamesys/params.rs
@@ -51,11 +51,16 @@ pub struct HrmParams {
     pub stat_break_chance: [f32; 8],
 }
 
+/// Angles are stored as 16-bit turns: `0x10000` units make a full circle.
+const DEGREES_PER_ANGLE_UNIT: f32 = 360.0 / 65536.0;
+
 /// Retail `SKILLPARAM` file-var (`sSkillParams`). Research scales authored
 /// progress by `1 + research_factor * (skill - 1)^2`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SkillParams {
-    pub weapon_break_angle: i16,
+    /// Shot deviation per level of weapon skill missing, in degrees. The
+    /// shipped gamesys authors 0, so retail shots never deviate.
+    pub inaccuracy_degrees: f32,
     pub weapon_break_factor: f32,
     pub research_factor: f32,
     pub damage_modifier: f32,
@@ -156,7 +161,8 @@ impl SkillParams {
 
     fn read_record<T: io::Read>(reader: &mut T) -> Option<Self> {
         Some(Self {
-            weapon_break_angle: reader.read_i16::<LittleEndian>().ok()?,
+            inaccuracy_degrees: reader.read_u16::<LittleEndian>().ok()? as f32
+                * DEGREES_PER_ANGLE_UNIT,
             weapon_break_factor: reader.read_f32::<LittleEndian>().ok()?,
             research_factor: reader.read_f32::<LittleEndian>().ok()?,
             damage_modifier: reader.read_f32::<LittleEndian>().ok()?,
@@ -173,17 +179,29 @@ mod tests {
 
     #[test]
     fn parses_packed_retail_skill_params_layout() {
-        let mut bytes = 0_i16.to_le_bytes().to_vec();
+        // The shipped gamesys record: inaccuracy 0, then the four floats.
+        let mut bytes = 0_u16.to_le_bytes().to_vec();
         for value in [0.0_f32, 1.0, 0.15, 1.25] {
             bytes.extend(value.to_le_bytes());
         }
         assert_eq!(bytes.len(), 18);
 
         let parsed = SkillParams::read_record(&mut Cursor::new(bytes)).unwrap();
-        assert_eq!(parsed.weapon_break_angle, 0);
+        assert_eq!(parsed.inaccuracy_degrees, 0.0);
         assert_eq!(parsed.weapon_break_factor, 0.0);
         assert_eq!(parsed.research_factor, 1.0);
         assert!((parsed.damage_modifier - 0.15).abs() < f32::EPSILON);
         assert_eq!(parsed.organ_damage, 1.25);
+    }
+
+    /// The leading field is a 16-bit turn, not a raw count of degrees.
+    #[test]
+    fn inaccuracy_converts_from_sixteen_bit_turns() {
+        let mut bytes = 2048_u16.to_le_bytes().to_vec();
+        bytes.extend([0u8; 16]);
+
+        let parsed = SkillParams::read_record(&mut Cursor::new(bytes)).unwrap();
+
+        assert_eq!(parsed.inaccuracy_degrees, 11.25);
     }
 }

--- a/dark/src/gamesys/params.rs
+++ b/dark/src/gamesys/params.rs
@@ -15,7 +15,7 @@ use std::io;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
-use crate::ss2_chunk_file_reader::ChunkFileTableOfContents;
+use crate::{ss2_chunk_file_reader::ChunkFileTableOfContents, ss2_common::DEGREES_PER_ANGLE_UNIT};
 
 /// The trainer upgrade cost tables (Normal difficulty), as authored in the
 /// gamesys. Each row is one stat/skill/tier; each column is the cost of buying
@@ -50,9 +50,6 @@ pub struct HrmParams {
     /// landing on a failed mine breaks a hack target unconditionally.
     pub stat_break_chance: [f32; 8],
 }
-
-/// Angles are stored as 16-bit turns: `0x10000` units make a full circle.
-const DEGREES_PER_ANGLE_UNIT: f32 = 360.0 / 65536.0;
 
 /// Retail `SKILLPARAM` file-var (`sSkillParams`). Research scales authored
 /// progress by `1 + research_factor * (skill - 1)^2`.

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -18,6 +18,7 @@ mod prop_ecology;
 mod prop_frame_anim_config;
 mod prop_frame_anim_state;
 mod prop_frob_info;
+mod prop_gun_kick;
 mod prop_gun_reliability;
 mod prop_gun_state;
 mod prop_hack_diff;
@@ -63,6 +64,7 @@ pub use prop_ecology::*;
 pub use prop_frame_anim_config::*;
 pub use prop_frame_anim_state::*;
 pub use prop_frob_info::*;
+pub use prop_gun_kick::*;
 pub use prop_gun_reliability::*;
 pub use prop_gun_state::*;
 pub use prop_hack_diff::*;
@@ -1559,6 +1561,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$GunState",
             PropGunState::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$GunKick",
+            PropGunKick::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_gun_kick.rs
+++ b/dark/src/properties/prop_gun_kick.rs
@@ -206,6 +206,62 @@ mod tests {
         assert_eq!(kick.settings[2], GunKickSetting::default());
     }
 
+    /// Pins the shipped assault rifle and shotgun: the rifle's single shot is
+    /// the gentlest kick of the three, its burst nearly doubles it, and the
+    /// shotgun's is the heaviest.
+    #[test]
+    fn parses_the_shipped_rifle_and_shotgun_records() {
+        let mut rifle = setting_bytes(
+            0.0,
+            [592, 592, 0, 1280],
+            [-0.25, -0.25, 1.25],
+            [1000, 800],
+            0.0,
+        );
+        rifle.extend(setting_bytes(
+            0.0,
+            [1280, 2048, 0, 2048],
+            [-0.5, -0.75, 1.5],
+            [500, 500],
+            1.0,
+        ));
+        rifle.extend(setting_bytes(0.0, [0; 4], [0.0; 3], [0; 2], 0.0));
+        let rifle = PropGunKick::read(&mut Cursor::new(rifle), 96);
+
+        assert_eq!(rifle.settings[0].kick_pitch_degrees, 3.251_953_1);
+        assert_eq!(rifle.settings[0].kick_angular_return_rate_degrees, 7.03125);
+        assert_eq!(rifle.settings[0].kick_back, -0.25);
+        assert_eq!(rifle.settings[0].kick_back_return_rate, 1.25);
+        assert_eq!(rifle.settings[0].jolt_back, 0.0);
+        assert_eq!(rifle.settings[1].kick_pitch_degrees, 7.03125);
+        assert_eq!(rifle.settings[1].kick_pitch_max_degrees, 11.25);
+        assert_eq!(rifle.settings[1].kick_back, -0.5);
+
+        let mut shotgun = setting_bytes(
+            0.0,
+            [2048, 4096, 0, 2048],
+            [-0.6, -0.75, 1.0],
+            [1500, 1500],
+            1.0,
+        );
+        shotgun.extend(setting_bytes(
+            0.0,
+            [4096, 4096, 0, 2048],
+            [-0.75, -0.75, 1.0],
+            [3000, 3000],
+            1.0,
+        ));
+        shotgun.extend(setting_bytes(0.0, [0; 4], [0.0; 3], [0; 2], 0.0));
+        let shotgun = PropGunKick::read(&mut Cursor::new(shotgun), 96);
+
+        assert_eq!(shotgun.settings[0].kick_pitch_degrees, 11.25);
+        assert_eq!(shotgun.settings[0].kick_pitch_max_degrees, 22.5);
+        assert_eq!(shotgun.settings[0].kick_back, -0.6);
+        assert_eq!(shotgun.settings[0].jolt_pitch_degrees, 8.239_746);
+        assert_eq!(shotgun.settings[1].kick_pitch_degrees, 22.5);
+        assert_eq!(shotgun.settings[1].jolt_pitch_degrees, 16.479_492);
+    }
+
     #[test]
     fn setting_selects_by_index_and_falls_back_to_the_first() {
         let kick = PropGunKick::read(&mut Cursor::new(pistol_chunk()), 96);

--- a/dark/src/properties/prop_gun_kick.rs
+++ b/dark/src/properties/prop_gun_kick.rs
@@ -4,38 +4,43 @@ use shipyard::Component;
 
 use crate::{
     properties::GUN_SETTING_COUNT,
-    ss2_common::{read_single, read_u16},
+    ss2_common::{read_single, read_u16_angle},
 };
 
 use serde::{Deserialize, Serialize};
-
-/// Angles are stored as 16-bit turns: `0x10000` units make a full circle.
-const DEGREES_PER_ANGLE_UNIT: f32 = 360.0 / 65536.0;
 
 /// On-disk size of one [`GunKickSetting`]: the eleven fields below, with the
 /// six 16-bit angles packed in pairs between the 32-bit floats.
 const SETTING_SIZE: u64 = 32;
 
-/// One fire setting's authored recoil. Angles are converted to degrees at
-/// parse time; the remaining fields are the raw authored scalars.
-#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+/// One fire setting's authored recoil.
+///
+/// Six fields are 16-bit turns, decoded here to degrees; the rest are the raw
+/// authored scalars. The *magnitudes* are what the data verifies - whether a
+/// field is applied per shot or per second is not settled by the data, and the
+/// shotgun's 22.5 deg kick / the 65.9 deg jolt on template -26 are too large to
+/// be instantaneous angles, so the first consumer must decide that, not these
+/// names. Angles are read unsigned: no shipped record exceeds 12000 units
+/// (65.9 deg), so whether the top half of the range is meant as negative is
+/// untested.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct GunKickSetting {
     /// Fraction of the kick applied before the shot leaves the barrel.
     pub pre_kick_pct: f32,
-    /// Pitch added to the gun per shot, in degrees.
+    /// Pitch the shot adds to the gun, in degrees.
     pub kick_pitch_degrees: f32,
     /// Ceiling on accumulated kick pitch, in degrees.
     pub kick_pitch_max_degrees: f32,
-    /// Heading added to the gun per shot, in degrees.
+    /// Heading the shot adds to the gun, in degrees.
     pub kick_heading_degrees: f32,
-    /// Rate the accumulated kick angles return to rest, in degrees.
+    /// How fast the accumulated kick angles return to rest, in degrees.
     pub kick_angular_return_rate_degrees: f32,
-    /// Displacement of the gun per shot (negative drives it towards the
+    /// Displacement the shot adds to the gun (negative drives it towards the
     /// player).
     pub kick_back: f32,
     /// Ceiling on accumulated kick back.
     pub kick_back_max: f32,
-    /// Rate the accumulated kick back returns to rest.
+    /// How fast the accumulated kick back returns to rest.
     pub kick_back_return_rate: f32,
     /// Pitch imparted to the player, in degrees.
     pub jolt_pitch_degrees: f32,
@@ -48,15 +53,15 @@ pub struct GunKickSetting {
 impl GunKickSetting {
     fn read<T: io::Read>(reader: &mut T) -> GunKickSetting {
         let pre_kick_pct = read_single(reader);
-        let kick_pitch_degrees = read_angle(reader);
-        let kick_pitch_max_degrees = read_angle(reader);
-        let kick_heading_degrees = read_angle(reader);
-        let kick_angular_return_rate_degrees = read_angle(reader);
+        let kick_pitch_degrees = read_u16_angle(reader).0;
+        let kick_pitch_max_degrees = read_u16_angle(reader).0;
+        let kick_heading_degrees = read_u16_angle(reader).0;
+        let kick_angular_return_rate_degrees = read_u16_angle(reader).0;
         let kick_back = read_single(reader);
         let kick_back_max = read_single(reader);
         let kick_back_return_rate = read_single(reader);
-        let jolt_pitch_degrees = read_angle(reader);
-        let jolt_heading_degrees = read_angle(reader);
+        let jolt_pitch_degrees = read_u16_angle(reader).0;
+        let jolt_heading_degrees = read_u16_angle(reader).0;
         let jolt_back = read_single(reader);
 
         GunKickSetting {
@@ -75,16 +80,14 @@ impl GunKickSetting {
     }
 }
 
-fn read_angle<T: io::Read>(reader: &mut T) -> f32 {
-    read_u16(reader) as f32 * DEGREES_PER_ANGLE_UNIT
-}
-
 /// `P$GunKick` - a gun archetype's authored recoil, one [`GunKickSetting`] per
 /// fire setting, selected by the same index as [`super::PropBaseGunDesc`].
 ///
 /// Every shipped record is exactly `GUN_SETTING_COUNT * SETTING_SIZE` bytes.
-/// Only the two selectable settings are authored; the third is zeroed.
-#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+/// Only the first two settings are selectable; the third still carries data on
+/// 24 of the 37 shipped records (usually a stale copy of setting 1), so it must
+/// not be read as "authored means used".
+#[derive(Debug, Component, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PropGunKick {
     pub settings: [GunKickSetting; GUN_SETTING_COUNT],
 }
@@ -148,7 +151,8 @@ mod tests {
     }
 
     /// The pistol as shipped: single shot, then a 3-round burst that drives the
-    /// gun back further. The third setting is zeroed.
+    /// gun back further. The pistol's unselectable third setting happens to be all
+    /// zeros - other guns carry data there.
     fn pistol_chunk() -> Vec<u8> {
         let mut bytes = setting_bytes(
             0.0,

--- a/dark/src/properties/prop_gun_kick.rs
+++ b/dark/src/properties/prop_gun_kick.rs
@@ -1,0 +1,231 @@
+use std::io::{self, SeekFrom};
+
+use shipyard::Component;
+
+use crate::{
+    properties::GUN_SETTING_COUNT,
+    ss2_common::{read_single, read_u16},
+};
+
+use serde::{Deserialize, Serialize};
+
+/// Angles are stored as 16-bit turns: `0x10000` units make a full circle.
+const DEGREES_PER_ANGLE_UNIT: f32 = 360.0 / 65536.0;
+
+/// On-disk size of one [`GunKickSetting`]: the eleven fields below, with the
+/// six 16-bit angles packed in pairs between the 32-bit floats.
+const SETTING_SIZE: u64 = 32;
+
+/// One fire setting's authored recoil. Angles are converted to degrees at
+/// parse time; the remaining fields are the raw authored scalars.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+pub struct GunKickSetting {
+    /// Fraction of the kick applied before the shot leaves the barrel.
+    pub pre_kick_pct: f32,
+    /// Pitch added to the gun per shot, in degrees.
+    pub kick_pitch_degrees: f32,
+    /// Ceiling on accumulated kick pitch, in degrees.
+    pub kick_pitch_max_degrees: f32,
+    /// Heading added to the gun per shot, in degrees.
+    pub kick_heading_degrees: f32,
+    /// Rate the accumulated kick angles return to rest, in degrees.
+    pub kick_angular_return_rate_degrees: f32,
+    /// Displacement of the gun per shot (negative drives it towards the
+    /// player).
+    pub kick_back: f32,
+    /// Ceiling on accumulated kick back.
+    pub kick_back_max: f32,
+    /// Rate the accumulated kick back returns to rest.
+    pub kick_back_return_rate: f32,
+    /// Pitch imparted to the player, in degrees.
+    pub jolt_pitch_degrees: f32,
+    /// Heading imparted to the player, in degrees.
+    pub jolt_heading_degrees: f32,
+    /// Backwards shove imparted to the player.
+    pub jolt_back: f32,
+}
+
+impl GunKickSetting {
+    fn read<T: io::Read>(reader: &mut T) -> GunKickSetting {
+        let pre_kick_pct = read_single(reader);
+        let kick_pitch_degrees = read_angle(reader);
+        let kick_pitch_max_degrees = read_angle(reader);
+        let kick_heading_degrees = read_angle(reader);
+        let kick_angular_return_rate_degrees = read_angle(reader);
+        let kick_back = read_single(reader);
+        let kick_back_max = read_single(reader);
+        let kick_back_return_rate = read_single(reader);
+        let jolt_pitch_degrees = read_angle(reader);
+        let jolt_heading_degrees = read_angle(reader);
+        let jolt_back = read_single(reader);
+
+        GunKickSetting {
+            pre_kick_pct,
+            kick_pitch_degrees,
+            kick_pitch_max_degrees,
+            kick_heading_degrees,
+            kick_angular_return_rate_degrees,
+            kick_back,
+            kick_back_max,
+            kick_back_return_rate,
+            jolt_pitch_degrees,
+            jolt_heading_degrees,
+            jolt_back,
+        }
+    }
+}
+
+fn read_angle<T: io::Read>(reader: &mut T) -> f32 {
+    read_u16(reader) as f32 * DEGREES_PER_ANGLE_UNIT
+}
+
+/// `P$GunKick` - a gun archetype's authored recoil, one [`GunKickSetting`] per
+/// fire setting, selected by the same index as [`super::PropBaseGunDesc`].
+///
+/// Every shipped record is exactly `GUN_SETTING_COUNT * SETTING_SIZE` bytes.
+/// Only the two selectable settings are authored; the third is zeroed.
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropGunKick {
+    pub settings: [GunKickSetting; GUN_SETTING_COUNT],
+}
+
+impl PropGunKick {
+    /// The kick for fire setting `index`, falling back to setting 0 for an
+    /// index the gun does not have.
+    pub fn setting(&self, index: i32) -> &GunKickSetting {
+        usize::try_from(index)
+            .ok()
+            .and_then(|index| self.settings.get(index))
+            .unwrap_or(&self.settings[0])
+    }
+
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropGunKick {
+        let start = reader.stream_position().unwrap();
+
+        // A short record (never seen in shipped data) defaults the settings it
+        // does not cover rather than reading past the chunk.
+        let settings = std::array::from_fn(|index| {
+            if (index as u64 + 1) * SETTING_SIZE <= len as u64 {
+                GunKickSetting::read(reader)
+            } else {
+                GunKickSetting::default()
+            }
+        });
+
+        reader.seek(SeekFrom::Start(start + len as u64)).unwrap();
+
+        PropGunKick { settings }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{GunKickSetting, PropGunKick, SETTING_SIZE};
+    use crate::properties::GUN_SETTING_COUNT;
+
+    fn setting_bytes(
+        pre_kick_pct: f32,
+        kick_angles: [u16; 4],
+        backs: [f32; 3],
+        jolt_angles: [u16; 2],
+        jolt_back: f32,
+    ) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend(pre_kick_pct.to_le_bytes());
+        for angle in kick_angles {
+            out.extend(angle.to_le_bytes());
+        }
+        for back in backs {
+            out.extend(back.to_le_bytes());
+        }
+        for angle in jolt_angles {
+            out.extend(angle.to_le_bytes());
+        }
+        out.extend(jolt_back.to_le_bytes());
+        out
+    }
+
+    /// The pistol as shipped: single shot, then a 3-round burst that drives the
+    /// gun back further. The third setting is zeroed.
+    fn pistol_chunk() -> Vec<u8> {
+        let mut bytes = setting_bytes(
+            0.0,
+            [1280, 1280, 0, 2048],
+            [-0.35, -0.35, 1.0],
+            [1200, 0],
+            1.0,
+        );
+        bytes.extend(setting_bytes(
+            0.0,
+            [1280, 1280, 0, 2048],
+            [-0.3, -0.6, 1.0],
+            [1200, 0],
+            1.0,
+        ));
+        bytes.extend(setting_bytes(0.0, [0; 4], [0.0; 3], [0; 2], 0.0));
+        bytes
+    }
+
+    #[test]
+    fn the_record_is_three_fixed_size_settings() {
+        assert_eq!(
+            pistol_chunk().len() as u64,
+            SETTING_SIZE * GUN_SETTING_COUNT as u64
+        );
+    }
+
+    /// Pins the shipped pistol values, in degrees.
+    #[test]
+    fn parses_every_setting_of_the_shipped_pistol_record() {
+        let chunk = pistol_chunk();
+        let len = chunk.len() as u32;
+        let mut cursor = Cursor::new(chunk);
+
+        let kick = PropGunKick::read(&mut cursor, len);
+
+        assert_eq!(cursor.position(), len as u64);
+        assert_eq!(kick.settings[0].pre_kick_pct, 0.0);
+        assert_eq!(kick.settings[0].kick_pitch_degrees, 7.03125);
+        assert_eq!(kick.settings[0].kick_pitch_max_degrees, 7.03125);
+        assert_eq!(kick.settings[0].kick_heading_degrees, 0.0);
+        assert_eq!(kick.settings[0].kick_angular_return_rate_degrees, 11.25);
+        assert_eq!(kick.settings[0].kick_back, -0.35);
+        assert_eq!(kick.settings[0].kick_back_max, -0.35);
+        assert_eq!(kick.settings[0].kick_back_return_rate, 1.0);
+        assert_eq!(kick.settings[0].jolt_pitch_degrees, 6.591_796_9);
+        assert_eq!(kick.settings[0].jolt_heading_degrees, 0.0);
+        assert_eq!(kick.settings[0].jolt_back, 1.0);
+
+        // The burst setting only differs in how far back it drives the gun.
+        assert_eq!(kick.settings[1].kick_pitch_degrees, 7.03125);
+        assert_eq!(kick.settings[1].kick_back, -0.3);
+        assert_eq!(kick.settings[1].kick_back_max, -0.6);
+
+        assert_eq!(kick.settings[2], GunKickSetting::default());
+    }
+
+    #[test]
+    fn setting_selects_by_index_and_falls_back_to_the_first() {
+        let kick = PropGunKick::read(&mut Cursor::new(pistol_chunk()), 96);
+
+        assert_eq!(kick.setting(1).kick_back, -0.3);
+        assert_eq!(kick.setting(3), kick.setting(0), "out of range");
+        assert_eq!(kick.setting(-1), kick.setting(0), "negative");
+    }
+
+    #[test]
+    fn a_short_record_defaults_the_settings_it_does_not_cover() {
+        let chunk = pistol_chunk()[..SETTING_SIZE as usize].to_vec();
+        let len = chunk.len() as u32;
+        let mut cursor = Cursor::new(chunk);
+
+        let kick = PropGunKick::read(&mut cursor, len);
+
+        assert_eq!(kick.settings[0].kick_back, -0.35);
+        assert_eq!(kick.settings[1], GunKickSetting::default());
+        assert_eq!(kick.settings[2], GunKickSetting::default());
+        assert_eq!(cursor.position(), len as u64, "never reads past the record");
+    }
+}

--- a/dark/src/ss2_common.rs
+++ b/dark/src/ss2_common.rs
@@ -25,10 +25,11 @@ pub struct LevelChunk {
     pub length: u32, // Length of chunk, in bytes
 }
 
+/// Angles are stored as 16-bit turns: `0x10000` units make a full circle.
+pub const DEGREES_PER_ANGLE_UNIT: f32 = 360.0 / 65536.0;
+
 pub fn read_u16_angle<T: io::Read>(reader: &mut T) -> Deg<f32> {
-    let denom = 0x8000 as f32;
-    let v = read_u16(reader) as f32;
-    Deg(v * 180.0 / denom)
+    Deg(read_u16(reader) as f32 * DEGREES_PER_ANGLE_UNIT)
 }
 
 pub fn read_u16_vec3<T: io::Read>(reader: &mut T) -> Vector3<Deg<f32>> {

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -208,6 +208,9 @@ pub struct PlayerStats {
 /// The player has four O/S trait slots (one per single-use machine in the game).
 pub const OS_TRAIT_SLOTS: usize = 4;
 
+/// The highest level a trainable skill reaches.
+pub const MAX_SKILL_LEVEL: i32 = 6;
+
 impl Default for PlayerStats {
     fn default() -> PlayerStats {
         // Baseline: every primary stat starts at the retail floor of 1, skills
@@ -306,6 +309,14 @@ impl PlayerStats {
             Skill::Maintenance => self.skills.maintenance,
             Skill::Research => self.skills.research,
         }
+    }
+
+    /// Per-shot deviation from the aim direction for a weapon fired at
+    /// `skill_level`, in degrees: the gamesys inaccuracy angle
+    /// (`SkillParams::inaccuracy_degrees`) scaled by how far the skill falls
+    /// short of [`MAX_SKILL_LEVEL`]. A maxed skill shoots dead straight.
+    pub fn shot_deviation_degrees(inaccuracy_degrees: f32, skill_level: i32) -> f32 {
+        inaccuracy_degrees * (MAX_SKILL_LEVEL - skill_level).max(0) as f32
     }
 
     /// Raise a primary stat by one level (a trainer purchase).
@@ -512,6 +523,23 @@ pub fn tour_reward(career: Career, year: u32, tour: u32) -> Option<&'static Tour
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shot_deviation_falls_to_zero_at_max_skill() {
+        // 11.25 degrees is one gamesys angle step (0x0800) - the shipped
+        // gamesys authors 0, so this uses a non-zero angle to pin the scaling.
+        assert_eq!(PlayerStats::shot_deviation_degrees(11.25, 1), 56.25);
+        assert_eq!(PlayerStats::shot_deviation_degrees(11.25, 5), 11.25);
+        assert_eq!(
+            PlayerStats::shot_deviation_degrees(11.25, MAX_SKILL_LEVEL),
+            0.0
+        );
+        assert_eq!(
+            PlayerStats::shot_deviation_degrees(11.25, 9),
+            0.0,
+            "over max"
+        );
+    }
 
     #[test]
     fn table_is_fully_populated_with_unique_text_keys() {

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -208,8 +208,10 @@ pub struct PlayerStats {
 /// The player has four O/S trait slots (one per single-use machine in the game).
 pub const OS_TRAIT_SLOTS: usize = 4;
 
-/// The highest level a trainable skill reaches.
-pub const MAX_SKILL_LEVEL: i32 = 6;
+/// Stats cap at 6 (start 1); skills cap at 6 (start 0); psi tiers cap at 5.
+pub const STAT_CAP: i32 = 6;
+pub const SKILL_CAP: i32 = 6;
+pub const PSI_TIER_CAP: i32 = 5;
 
 impl Default for PlayerStats {
     fn default() -> PlayerStats {
@@ -314,9 +316,9 @@ impl PlayerStats {
     /// Per-shot deviation from the aim direction for a weapon fired at
     /// `skill_level`, in degrees: the gamesys inaccuracy angle
     /// (`SkillParams::inaccuracy_degrees`) scaled by how far the skill falls
-    /// short of [`MAX_SKILL_LEVEL`]. A maxed skill shoots dead straight.
+    /// short of [`SKILL_CAP`]. A maxed skill shoots dead straight.
     pub fn shot_deviation_degrees(inaccuracy_degrees: f32, skill_level: i32) -> f32 {
-        inaccuracy_degrees * (MAX_SKILL_LEVEL - skill_level).max(0) as f32
+        inaccuracy_degrees * (SKILL_CAP - skill_level).max(0) as f32
     }
 
     /// Raise a primary stat by one level (a trainer purchase).
@@ -530,10 +532,7 @@ mod tests {
         // gamesys authors 0, so this uses a non-zero angle to pin the scaling.
         assert_eq!(PlayerStats::shot_deviation_degrees(11.25, 1), 56.25);
         assert_eq!(PlayerStats::shot_deviation_degrees(11.25, 5), 11.25);
-        assert_eq!(
-            PlayerStats::shot_deviation_degrees(11.25, MAX_SKILL_LEVEL),
-            0.0
-        );
+        assert_eq!(PlayerStats::shot_deviation_degrees(11.25, SKILL_CAP), 0.0);
         assert_eq!(
             PlayerStats::shot_deviation_degrees(11.25, 9),
             0.0,

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -13,6 +13,7 @@ mod trainer;
 mod traits;
 mod weapon_settings;
 
+pub use crate::player_stats::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP};
 pub use computer::*;
 pub use container::*;
 pub use elevator::*;

--- a/shock2vr/src/scripts/gui/trainer.rs
+++ b/shock2vr/src/scripts/gui/trainer.rs
@@ -32,7 +32,7 @@ use dark::gamesys::TrainerCostTables;
 use shipyard::{EntityId, UniqueView, World};
 
 use crate::gui::{Gui, GuiComponent, GuiConfig, GuiCursor};
-use crate::player_stats::{PlayerStats, Skill, Stat};
+use crate::player_stats::{PSI_TIER_CAP, PlayerStats, SKILL_CAP, STAT_CAP, Skill, Stat};
 use crate::quest_info::QuestInfo;
 use crate::scripts::Effect;
 
@@ -55,11 +55,6 @@ pub enum TrainerMode {
     Weapons,
     Psi,
 }
-
-/// Stats cap at 6 (start 1); skills cap at 6 (start 0); psi tiers cap at 5.
-pub const STAT_CAP: i32 = 6;
-pub const SKILL_CAP: i32 = 6;
-pub const PSI_TIER_CAP: i32 = 5;
 
 /// Normal difficulty grants five maximum hit points per Endurance level. The
 /// original manual documents the stat as raising maximum HP; the retail Normal


### PR DESCRIPTION
Parses the two pieces of authored data recoil and spread will need. No behaviour change, no callers.

**`P$GunKick`** — 96 bytes = 3 fixed 32-byte records, one per fire setting (same indexing as `PropBaseGunDesc`). One record, in order: `f32 pre_kick_pct`, four 16-bit turn angles (`kick_pitch`, `kick_pitch_max`, `kick_heading`, `kick_angular_return_rate`), `f32 kick_back / kick_back_max / kick_back_return_rate`, two 16-bit turns (`jolt_pitch`, `jolt_heading`), `f32 jolt_back`. Angles decode to degrees at parse time (`0x10000` units = a full circle). Every one of the 37 shipped records — 11 in `shock2.gam`, 26 across the 23 `.mis` files — is exactly 96 bytes.

Setting 0 / setting 1, in degrees:

| gun | kick pitch | pitch max | ang. return | kick back | back max | back return | jolt pitch | jolt hdg | jolt back |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Pistol (-17) | 7.03 / 7.03 | 7.03 / 7.03 | 11.25 | -0.35 / -0.30 | -0.35 / -0.60 | 1.0 | 6.59 | 0 | 1.0 |
| Assault Rifle (-18) | 3.25 / 7.03 | 3.25 / 11.25 | 7.03 / 11.25 | -0.25 / -0.50 | -0.25 / -0.75 | 1.25 / 1.5 | 5.49 / 2.75 | 4.39 / 2.75 | 0.0 / 1.0 |
| Shotgun (-19) | 11.25 / 22.5 | 22.5 / 22.5 | 11.25 | -0.60 / -0.75 | -0.75 / -0.75 | 1.0 | 8.24 / 16.48 | 8.24 / 16.48 | 1.0 |

`kick_heading` is 0 on every shipped gun. The unselectable third setting is *not* zeroed on 24 of the 37 records (usually a stale copy of setting 1) — the doc comment says so, so a consumer doesn't read "authored" as "used". Whether a field is per shot or per second is not settled by the data, and neither is the sign convention (no record exceeds 12000 units / 65.9°) — both are flagged in the struct docs rather than asserted.

**`SKILLPARAM.inaccuracy`** — the chunk's leading `i16`, previously misnamed `weapon_break_angle`, is the per-weapon-skill shot deviation. Same 16-bit turn unit, now `inaccuracy_degrees: f32`. **The shipped value is 0**, so a faithful port has zero spread; R2 will need a tuned value rather than the authored one.

`PlayerStats::shot_deviation_degrees(inaccuracy, skill) = inaccuracy * (SKILL_CAP - skill)` is pure and unit-tested, with no caller yet.

## Verification

- Negative test: with the property unregistered, `cargo dq templates 17` lists `P$GunKick (96 bytes)` under Unparsed Properties; with it registered, it prints the parsed struct.
- `cargo test -p dark -p shock2vr`; unit tests pin the pistol/rifle/shotgun values above and the record length.
- `missions.e2e.test.ts` (all 23 missions) plus `trainer` / `nanite-player-stat`: 25/25 pass.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

Review fallout, folded in: the angle constant now lives once in `ss2_common` (`read_u16_angle` uses it, so does `params.rs`), and the duplicate skill cap is gone — `SKILL_CAP`/`STAT_CAP`/`PSI_TIER_CAP` moved from `scripts::gui::trainer` to `player_stats` and are re-exported from `gui`.
