### PR TITLE
fix(ui): resolve replicator catalog names and stack formats

### DIFF
--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -46,7 +46,7 @@ const LABEL_HEIGHT: f32 = 10.0;
 /// of text drawn above it.
 const LABEL_MARGIN: f32 = BRACKET_SIZE + LABEL_HEIGHT;
 
-fn format_stack_aware_item_name(item_name: &str, stack_count: Option<i32>) -> String {
+pub(crate) fn format_stack_aware_item_name(item_name: &str, stack_count: Option<i32>) -> String {
     match stack_count {
         Some(count) => item_name.replace("%d", &count.to_string()),
         None => item_name.to_owned(),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1764,6 +1764,7 @@ pub struct DebugLine {
 pub struct EntityMetadata {
     pub template_id: i32,
     pub obj_icon: Option<String>,
+    /// Localized catalog label, with the purchase template's stack quantity.
     pub obj_short_name: Option<String>,
     #[allow(dead_code)]
     pub obj_name: Option<String>,
@@ -2282,8 +2283,12 @@ impl MissionCore {
 
         // Create a map of template name (ie 'HE Explosion' to the template id).
         // This is important for creating entities based on template name
+        let short_name_strings = asset_cache
+            .get_opt(&dark::importers::STRINGS_IMPORTER, "objshort.str")
+            .map(|strings| (*strings).clone())
+            .unwrap_or_default();
         let (template_name_to_template_id, unique_gamesys_template_names) =
-            create_template_name_map(game_entity_info);
+            create_template_name_map(game_entity_info, &short_name_strings);
         let mission_object_name_to_id = create_mission_object_name_map(&entity_info_rc);
 
         world.add_unique(GlobalEntityMetadata(template_name_to_template_id.clone()));
@@ -10934,6 +10939,7 @@ impl MissionCore {
 
 fn create_template_name_map(
     game_entity_info: &Gamesys,
+    short_name_strings: &HashMap<String, String>,
 ) -> (HashMap<String, EntityMetadata>, HashMap<String, i32>) {
     let mut gamesys_world = World::new();
     game_entity_info.entity_info.initialize_world_with_entities(
@@ -10942,6 +10948,13 @@ fn create_template_name_map(
         |_id| true,
     );
 
+    template_name_map_from_world(&gamesys_world, short_name_strings)
+}
+
+fn template_name_map_from_world(
+    gamesys_world: &World,
+    short_name_strings: &HashMap<String, String>,
+) -> (HashMap<String, EntityMetadata>, HashMap<String, i32>) {
     let mut name_to_template_id = HashMap::new();
     let mut template_ids_by_exact_name: HashMap<String, Vec<i32>> = HashMap::new();
 
@@ -10950,6 +10963,7 @@ fn create_template_name_map(
          v_obj_icon: View<dark::properties::PropObjIcon>,
          v_obj_short_name: View<dark::properties::PropObjShortName>,
          v_obj_name: View<dark::properties::PropObjName>,
+         v_stack_count: View<dark::properties::PropStackCount>,
          v_template_id: View<dark::properties::PropTemplateId>| {
             for (entity_id, (sym_name, template_id)) in
                 (&v_sym_name, &v_template_id).iter().with_id()
@@ -10963,7 +10977,22 @@ fn create_template_name_map(
                             .map(|p| format!("{}.pcx", p.0))
                             .ok(),
                         obj_name: v_obj_name.get(entity_id).map(|p| p.0.clone()).ok(),
-                        obj_short_name: v_obj_short_name.get(entity_id).map(|p| p.0.clone()).ok(),
+                        obj_short_name: v_obj_short_name.get(entity_id).ok().map(|p| {
+                            let name = dark::importers::resolve_localized_property_string(
+                                &p.0,
+                                short_name_strings,
+                            );
+                            // This world is hydrated through the full hierarchy:
+                            // Small Standard Clip's six overrides its parent's twelve.
+                            let quantity = v_stack_count.get(entity_id).ok().map(|p| p.0);
+                            if name.contains("%d") && quantity.is_none() {
+                                // Do not show a format token or promise an invented
+                                // quantity when an incomplete template lacks one.
+                                sym_name.0.clone()
+                            } else {
+                                crate::hud::format_stack_aware_item_name(&name, quantity)
+                            }
+                        }),
                     },
                 );
                 if template_id.template_id < 0 {
@@ -13300,6 +13329,116 @@ mod held_item_restore_tests {
                 VirtualHandEffect::StoreItem { entity_id } if *entity_id == left
             )),
             "the displaced left-hand item must be returned to the backpack, got {effects:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod template_catalog_name_tests {
+    use super::*;
+    use crate::gui::{Gui, GuiComponent};
+    use crate::scripts::gui::{ReplicatorGui, ReplicatorState};
+    use dark::properties::{
+        ObjectState, PropObjIcon, PropObjShortName, PropObjState, PropReplicatorContents,
+        PropReplicatorHackedContents, PropStackCount, PropSymName, PropTemplateId,
+    };
+
+    #[test]
+    fn replicator_catalog_resolves_names_and_effective_quantities_in_both_inventories() {
+        // Template hydration applies inherited properties before the child's
+        // overrides. Standard Clip supplies twelve; Small Standard Clip six.
+        let mut templates = World::new();
+        let clip = templates.add_entity((
+            PropTemplateId { template_id: -1358 },
+            PropSymName("Small Standard Clip".to_owned()),
+            PropObjIcon("clip".to_owned()),
+            PropObjShortName("Standard_Clip: \"%d standard bullets\"".to_owned()),
+            PropStackCount(12),
+        ));
+        templates.add_component(clip, PropStackCount(6));
+        templates.add_entity((
+            PropTemplateId { template_id: -100 },
+            PropSymName("Chips".to_owned()),
+            PropObjIcon("chips".to_owned()),
+            PropObjShortName("Chips: \"Bag of chips\"".to_owned()),
+        ));
+        let strings = HashMap::from([
+            (
+                "standard_clip".to_owned(),
+                "%d translated bullets".to_owned(),
+            ),
+            ("chips".to_owned(), "Translated chips".to_owned()),
+        ]);
+        let (metadata, _) = template_name_map_from_world(&templates, &strings);
+        let mut world = World::new();
+        world.add_unique(GlobalEntityMetadata(metadata));
+        let names = |first: &str, second: &str| {
+            [
+                first.to_owned(),
+                second.to_owned(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ]
+        };
+        let replicator = world.add_entity((
+            PropReplicatorContents {
+                costs: [3, 40, 0, 0, 0, 0],
+                object_names: names("chips", "small standard clip"),
+            },
+            PropReplicatorHackedContents {
+                costs: [25, 2, 0, 0, 0, 0],
+                object_names: names("small standard clip", "chips"),
+            },
+        ));
+        for state in [ObjectState::Normal, ObjectState::Hacked] {
+            world.add_component(replicator, PropObjState(state));
+            let texts: Vec<_> = ReplicatorGui
+                .get_components(&None, replicator, &world, &ReplicatorState::default())
+                .into_iter()
+                .filter_map(|component| match component {
+                    GuiComponent::Text { text, .. } => Some(text),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                texts.iter().any(|text| text == "Translated chips"),
+                "{texts:?}"
+            );
+            assert!(
+                texts.iter().any(|text| text == "6 translated bullets"),
+                "{texts:?}"
+            );
+            assert!(
+                texts
+                    .iter()
+                    .all(|text| !text.contains("%d") && !text.contains('"'))
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_names_use_authored_fallback_and_do_not_invent_missing_quantities() {
+        let mut templates = World::new();
+        templates.add_entity((
+            PropTemplateId { template_id: -1 },
+            PropSymName("Juice bottle".to_owned()),
+            PropObjShortName("Juice_bottle: \"Bottle of juice\"".to_owned()),
+        ));
+        templates.add_entity((
+            PropTemplateId { template_id: -2 },
+            PropSymName("Unknown clip".to_owned()),
+            PropObjShortName("Clip: \"%d bullets\"".to_owned()),
+        ));
+        let (metadata, _) = template_name_map_from_world(&templates, &HashMap::new());
+        assert_eq!(
+            metadata["juice bottle"].obj_short_name.as_deref(),
+            Some("Bottle of juice")
+        );
+        assert_eq!(
+            metadata["unknown clip"].obj_short_name.as_deref(),
+            Some("Unknown clip")
         );
     }
 }

--- a/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
@@ -88,7 +88,12 @@ test(
     const text = opened.elements
       .filter((element) => element.kind === "text")
       .map((element) => element.text ?? "");
-    for (const expected of ["003", "004", "040", "0270"]) {
+    // Honor the active localized catalog wording (which may omit a count).
+    // The actual purchase below still verifies the child's six-round stack.
+    for (const expected of [
+      "003", "004", "040", "0270",
+      "Bag of chips", "Bottle of juice", "Standard bullets",
+    ]) {
       assert.ok(
         text.includes(expected),
         `replicator should visibly render ${expected}; got ${JSON.stringify(text)}`,
@@ -153,7 +158,21 @@ test(
         (element) => element.label === "buy:small standard clip",
       );
       assert.ok(clip, "Standard Clip row should remain available");
+      const beforeClips = new Set(
+        (await game.entities.byTemplate(-1358)).map((entity) => entity.id),
+      );
       await clickUiElement(game, clip);
+      const purchasedClip = (await game.entities.byTemplate(-1358)).find(
+        (entity) => !beforeClips.has(entity.id),
+      );
+      assert.ok(purchasedClip, "purchase should create Small Standard Clip");
+      assert.equal(
+        Number((await game.entities.detail(purchasedClip.id)).properties.find(
+          (property) => property.name === "StackCount",
+        )?.value),
+        6,
+        "Small Standard Clip must override its parent's twelve-round stack",
+      );
     }
     for (let purchase = 0; purchase < 2; purchase++) {
       const panel = (await game.ui.state()).active_panel;

--- a/tools/shock2-sdk/test/earth-replicator-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-hacking.e2e.test.ts
@@ -137,6 +137,14 @@ test(
     await clickUiElement(game, button(won, "close"));
     await physicallyOpenEarthReplicator(game, replicator);
     const hacked = await activePanel(game);
+    assert.ok(
+      texts(hacked).includes("Standard bullets"),
+      "hacked catalog must use the active localized Small Standard Clip name",
+    );
+    assert.ok(
+      texts(hacked).every((text) => !text.includes("%d") && !text.includes('"')),
+      "hacked catalog must not expose raw property strings or quantity tokens",
+    );
     for (const label of [
       "buy:small he clip",
       "buy:small standard clip",


### PR DESCRIPTION
Opening a replicator exposed raw object keys, quoted fallback text, and `%d` tokens. Resolve catalog labels through the active `objshort.str` table, then format requested quantities using the purchased template’s effective stack count. Normal and hacked stock share the same metadata; templates missing a requested quantity fall back to their symbolic name.

The installed SCP table calls Earth’s small clip “Standard bullets”, so that localized wording is preserved. When a table requests `%d`, Small Standard Clip uses its child override of six, rather than its parent’s twelve.

Fixes #1409.

Validation: both new catalog tests failed against the raw-label baseline and pass with the fix; all 1,561 core tests pass (two ignored), SDK unit/typecheck passes, warning-denying checks pass for core/desktop/debug, and formatting passes. Actual Earth economy and hacking/save-load scenarios pass, including purchases with stack count six. All 23 mission-load smoke tests pass.

Independent code and flat/VR visual reviews passed; all CI checks are green. The manager-owned full SDK e2e suite remains in progress, so the PR stays draft until its result is recorded. No save binaries are uploaded.

Campaign: full-game · detailed · 25th · VR · seed 1258205384.

## Visual verification

Same Earth replicator and deterministic inputs before/after. The VR panel is opened with an actual controller trigger. Labels retain their positions inside the shared rows; active localized names are Bag of chips, Bottle of juice, and Standard bullets.

![flat before and after](https://gist.githubusercontent.com/tommy-xr/99bee3ba413fa769ec72e2f381611031/raw/replicator-flat.gif)

![flat before and after](https://gist.githubusercontent.com/tommy-xr/99bee3ba413fa769ec72e2f381611031/raw/replicator-flat.png)

![vr before and after](https://gist.githubusercontent.com/tommy-xr/99bee3ba413fa769ec72e2f381611031/raw/replicator-vr.gif)

![vr before and after](https://gist.githubusercontent.com/tommy-xr/99bee3ba413fa769ec72e2f381611031/raw/replicator-vr.png)
