### PR TITLE
fix(vr): clear world panels from nearby wall trim

### DIFF
--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -253,6 +253,15 @@ impl GuiManager {
         offset: Vector3<f32>,
         components: Vec<GuiComponentRenderInfo>,
     ) {
+        let authored = get_position_from_transform(world, parent_entity, offset);
+        let facing = get_rotation_from_transform(world, parent_entity);
+        // World presentation boundary only: shared canvas pixels and widget
+        // layout stay unchanged. Resolve one full-panel pose for both drawing
+        // and its clickable proxy, using the same host exclusion as hand rays.
+        let is_not_host =
+            |entity| crate::util::resolve_proxy_entity(world, entity) != parent_entity;
+        let position =
+            physics.clear_world_panel_position(authored.to_vec(), facing, world_size, &is_not_host);
         if let std::collections::hash_map::Entry::Vacant(e) = self.handle_to_instance.entry(handle)
         {
             // Add proxy entity to world
@@ -264,12 +273,10 @@ impl GuiManager {
             self.entity_id_to_proxy_entity_id.insert(parent_entity, ent);
 
             log_entity(world, parent_entity);
-            let pos = get_position_from_transform(world, parent_entity, offset);
-            let facing = get_rotation_from_transform(world, parent_entity);
             // Create physics for this entity
             let physics_handle = physics.add_kinematic(
                 ent,
-                pos.to_vec(),
+                position,
                 facing,
                 vec3(0.0, 0.0, 0.0),
                 vec3(world_size.x, world_size.y, 0.0),
@@ -303,9 +310,7 @@ impl GuiManager {
                     vec3(world_size.x, world_size.y, 0.0),
                 );
             }
-            let pos = get_position_from_transform(world, parent_entity, offset);
-            let facing = get_rotation_from_transform(world, parent_entity);
-            physics.set_position_rotation(instance.physics_handle, pos.to_vec(), facing)
+            physics.set_position_rotation(instance.physics_handle, position, facing)
         }
     }
 
@@ -477,6 +482,84 @@ mod tests {
     use shipyard::{EntitiesView, Get};
 
     use super::*;
+
+    #[test]
+    fn world_panel_clears_trim_across_its_full_canvas() {
+        let mut world = World::new();
+        let parent = world.add_entity((RuntimePropTransform(Matrix4::from_scale(1.0)),));
+        let trim = world.add_entity(());
+        let player_entity = world.add_entity(());
+        let mut physics = PhysicsWorld::new();
+        let mut player = physics.create_player(vec3(10.0, 10.0, 10.0), player_entity);
+        physics.add_kinematic(
+            trim,
+            vec3(-0.32, 0.0, -0.12),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.12, 2.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        // A normal keypad's own mounting collider reaches the authored
+        // panel plane; it is excluded just like it is from controller rays.
+        physics.add_kinematic(
+            parent,
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.25, 0.5, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        let mut scripts = ScriptWorld::new();
+        let mut id_to_physics = HashMap::new();
+        let mut manager = GuiManager::new();
+        let handle = GuiHandle::new();
+        manager.update_ui(
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+            handle,
+            parent,
+            vec2(188.0, 296.0),
+            vec2(0.752, 1.184),
+            vec3(0.0, 0.0, -0.1),
+            Vec::new(),
+        );
+        let first = physics
+            .get_position(manager.handle_to_instance[&handle].physics_handle)
+            .unwrap();
+        // Later GUI updates see their own collider in the broad phase. It
+        // must not push the panel farther out on each frame.
+        for _ in 0..3 {
+            physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+            manager.update_ui(
+                &mut world,
+                &mut physics,
+                &mut scripts,
+                &mut id_to_physics,
+                handle,
+                parent,
+                vec2(188.0, 296.0),
+                vec2(0.752, 1.184),
+                vec3(0.0, 0.0, -0.1),
+                Vec::new(),
+            );
+        }
+        let instance = manager.handle_to_instance.get(&handle).unwrap();
+        let position = physics.get_position(instance.physics_handle).unwrap();
+        assert!(
+            position.z < -0.22,
+            "left controls must clear the trim: {position:?}"
+        );
+        assert_eq!(position, first, "own proxy must not cause placement drift");
+        assert_eq!(position.x, 0.0);
+        assert_eq!(position.y, 0.0);
+        assert_eq!(instance.canvas_size_px, vec2(188.0, 296.0));
+        assert_eq!(instance.world_size, vec2(0.752, 1.184));
+    }
 
     #[test]
     fn live_panel_resize_updates_render_input_and_collider_geometry() {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -6217,6 +6217,72 @@ impl PhysicsWorld {
         (collision_events, character_body)
     }
 
+    /// Move a host-bound panel just far enough outward to clear neighboring
+    /// geometry across its full footprint. The center must have a clear path
+    /// to the bounded search start, so this cannot relocate a panel through a
+    /// wall into another room. A blocked search leaves its authored pose alone.
+    pub fn clear_world_panel_position(
+        &self,
+        position: Vector3<f32>,
+        facing: Quaternion<f32>,
+        size: cgmath::Vector2<f32>,
+        entity_filter: &dyn Fn(EntityId) -> bool,
+    ) -> Vector3<f32> {
+        const MAX_OUTSET: f32 = 0.5;
+        const SKIN: f32 = 0.02;
+        if !size.x.is_finite() || !size.y.is_finite() || size.x <= 0.0 || size.y <= 0.0 {
+            return position;
+        }
+        let filter_entity = |_handle: ColliderHandle, collider: &Collider| {
+            EntityId::from_inner(collider.user_data as u64).is_none_or(entity_filter)
+        };
+        let groups = InternalCollisionGroups::ENTITIES
+            | InternalCollisionGroups::SELECTABLE
+            | InternalCollisionGroups::WORLD
+            | InternalCollisionGroups::RAYCAST;
+        let filter = QueryFilter::new()
+            .exclude_sensors()
+            .groups(InteractionGroups::new(
+                InternalCollisionGroups::ALL.bits.into(),
+                groups.bits.into(),
+                Default::default(),
+            ))
+            .predicate(&filter_entity);
+        let queries = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
+            &self.rigid_body_set,
+            &self.collider_set,
+            filter,
+        );
+        let rotation = quat_to_nquat(facing);
+        let outward = rotation * -Vector::z();
+        let center = vec_to_nvec(position);
+        let start = center + outward * MAX_OUTSET;
+        let shape = Cuboid::new(vector![size.x / 2.0, size.y / 2.0, SKIN]);
+        let start_pose = Isometry::from_parts(Translation::from(start), rotation);
+        if queries.intersect_shape(start_pose, &shape).next().is_some()
+            || queries
+                .cast_ray(&Ray::new(Point::from(center), outward), MAX_OUTSET, true)
+                .is_some()
+        {
+            return position;
+        }
+        let Some((_, hit)) = queries.cast_shape(
+            &start_pose,
+            &-outward,
+            &shape,
+            rapier3d::parry::query::ShapeCastOptions {
+                max_time_of_impact: MAX_OUTSET,
+                target_distance: SKIN,
+                stop_at_penetration: true,
+                compute_impact_geometry_on_penetration: true,
+            },
+        ) else {
+            return position;
+        };
+        nvec_to_cgmath(center + outward * (MAX_OUTSET - hit.time_of_impact).max(0.0))
+    }
+
     pub fn ray_cast2(
         &self,
         start_point: Point3<f32>,
@@ -8112,6 +8178,89 @@ mod tests {
             EntityId::from_inner(1001).unwrap(),
         );
         (world, player)
+    }
+
+    #[test]
+    fn world_panel_clearance_respects_host_orientation_and_keeps_clear_poses() {
+        use cgmath::{Rotation, Rotation3, vec2};
+        for yaw in [0.0, 90.0] {
+            let (mut world, mut player) = world_with_floor();
+            let facing = Quaternion::from_angle_y(cgmath::Deg(yaw));
+            let authored = facing.rotate_vector(vec3(0.0, 3.0, -0.1));
+            let size = vec2(0.752, 1.184);
+            step(&mut world, &mut player, 1);
+            assert_eq!(
+                world.clear_world_panel_position(authored, facing, size, &|_| true),
+                authored
+            );
+            world.add_kinematic(
+                EntityId::from_inner(2200).unwrap(),
+                facing.rotate_vector(vec3(-0.32, 3.0, -0.12)),
+                facing,
+                vec3(0.0, 0.0, 0.0),
+                vec3(0.12, 2.0, 0.2),
+                CollisionGroup::entity(),
+                false,
+            );
+            step(&mut world, &mut player, 1);
+            let placed = world.clear_world_panel_position(authored, facing, size, &|_| true);
+            let local = facing.conjugate().rotate_vector(placed);
+            assert!(
+                local.z < -0.22 && local.z > -0.3,
+                "minimal outward clearance: {local:?}"
+            );
+            assert!(local.x.abs() < 0.001 && (local.y - 3.0).abs() < 0.001);
+            // Left and right controls remain reachable by real world rays.
+            for x in [-0.32, 0.32] {
+                let start = facing.rotate_vector(vec3(0.0, 3.0, -1.0));
+                let target = placed + facing.rotate_vector(vec3(x, 0.0, 0.0));
+                assert!(
+                    world
+                        .ray_cast2(
+                            Point3::new(start.x, start.y, start.z),
+                            target - start,
+                            (target - start).magnitude(),
+                            InternalCollisionGroups::ENTITY,
+                            None,
+                            true
+                        )
+                        .is_none()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn world_panel_clearance_never_crosses_an_intervening_wall_or_exceeds_its_bound() {
+        use cgmath::vec2;
+        for (center, size) in [
+            (vec3(0.0, 3.0, -0.35), vec3(2.0, 2.0, 0.1)),
+            // Only the left edge covers the bounded search start; the center
+            // ray is clear but no full panel can fit within the allowed inset.
+            (vec3(-0.32, 3.0, -0.6), vec3(0.12, 2.0, 0.4)),
+        ] {
+            let (mut world, mut player) = world_with_floor();
+            world.add_kinematic(
+                EntityId::from_inner(2201).unwrap(),
+                center,
+                identity_quat(),
+                vec3(0.0, 0.0, 0.0),
+                size,
+                CollisionGroup::entity(),
+                false,
+            );
+            step(&mut world, &mut player, 1);
+            let authored = vec3(0.0, 3.0, -0.1);
+            assert_eq!(
+                world.clear_world_panel_position(
+                    authored,
+                    identity_quat(),
+                    vec2(0.752, 1.184),
+                    &|_| true
+                ),
+                authored
+            );
+        }
     }
 
     fn step(world: &mut PhysicsWorld, player: &mut PlayerHandle, frames: usize) {

--- a/tools/shock2-sdk/test/earth-vr-keypad-clearance.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-vr-keypad-clearance.e2e.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// #1408: the left column of Earth Technical's keypad HACK board extended
+// behind the surrounding wall trim despite its center being unobstructed.
+test("Earth VR keypad exposes the full board ahead of wall trim", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 120_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "earth.mis", debugFlags: ["--vr"] });
+  await game.step({ frames: 3 });
+  const [keypad] = await game.entities.byTemplate(266);
+  assert.ok(keypad, "authored Technical Training keypad must exist");
+  await teleportVerified(game, { x: 172.56207, y: 22.044, z: 175.5225 });
+  await aimVrHandAt(game, [172.38925, 22.8, 174.05382], 0.5);
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 2 });
+  const panels = (await game.physics.bodies()).bodies.filter(body => body.collision_groups.includes("ui"));
+  assert.equal(panels.length, 1, "real controller trigger opens the keypad board");
+  const panel = panels[0];
+  const target: Vec3 = [172.10925, 23.024, panel.position[2]];
+  const aim = await aimVrHandAt(game, target, 0.6);
+  const hit = await game.raycast({
+    start: aim.start, end: target,
+    collision_groups: ["ui", "world", "entity", "selectable", "raycast"],
+    ignore_sensors: true,
+  });
+  assert.equal(hit.entity_id, panel.entity_id, "left node must be in front of world trim on the ordinary controller ray");
+  await game.step({ frames: 30 });
+  const later = (await game.physics.bodies()).bodies.find(body => body.entity_id === panel.entity_id);
+  assert.deepEqual(later?.position, panel.position, "existing proxy must not push its own panel outward on later updates");
+});


### PR DESCRIPTION
Earth Technical Training’s keypad HACK board extends beyond the keypad mesh. Its left nodes sat behind nearby wall trim, so an ordinary VR controller ray hit the wall before reaching a visible node.

Resolve the full world-panel footprint against surrounding geometry and move its shared render/click pose only as far outward as necessary along the host normal. The search is bounded to 0.5 world units and refuses an intervening wall. If no bounded clear pose exists, the authored pose remains; world occlusion stays enforced. Flat canvas layout is unchanged.

Validation:
- Negative-first GUI regression, rotated-host/full-footprint and blocked-search tests; host/proxy stability across updates.
- Fresh Earth SDK controller regression fails on baseline (trim wins the combined ray), passes with the fix, and verifies 30-frame stability.
- Native checkpoint replay: real trigger opens HACK, START works, and the previously blocked left node responds to the trigger.
- Flat before/after screenshots and UI snapshots are identical; a second ordinary world panel (Earth replicator) stays stable.
- `cargo test -p shock2vr`: 1,562 passed, 2 ignored; all non-Android workspace checks, formatting, debug build, and SDK fast tests passed.
- All CI checks and independent code/visual reviews passed. The manager-owned full SDK suite remains in progress.

Campaign: full-game · detailed · 25th · VR · seed 1258205384. No game saves are published.

Fixes #1408

## Visual verification

Identical controller sequence at the Earth keypad. Before: the ray hits the surrounding trim and the left node ignores the trigger. After: the panel sits clear of the trim, receives the trigger, and the node responds. The pointer moves away at the end to expose the changed node. Captured with deterministic stepping; flat comparison is byte-identical.

![Keypad before and after](https://gist.githubusercontent.com/tommy-xr/d318606fb10cc31f9fc36a1d709664d1/raw/keypad-vr.gif)

![Keypad before and after](https://gist.githubusercontent.com/tommy-xr/d318606fb10cc31f9fc36a1d709664d1/raw/keypad-vr.png)

![Keypad before and after](https://gist.githubusercontent.com/tommy-xr/d318606fb10cc31f9fc36a1d709664d1/raw/keypad-flat.png)
