### PR TITLE
test(sdk): use ephemeral ports in gameplay fixtures

### DIFF
--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -166,9 +166,12 @@ const game = await GameServer.connect("http://127.0.0.1:8080");
 - The e2e suite runs **serially** (`--test-concurrency=1`): each test spawns its
   own heavy debug runtime, so one-at-a-time avoids resource contention. Ports
   no longer need hand-syncing across files - omit `port` and each runtime gets
-  its own ephemeral one. (Existing tests still pass a fixed port; that is now
-  an exact request, so a leftover runtime on it fails the launch loudly instead
-  of silently drifting to the next port.)
+  its own ephemeral one. Fixtures with a developer port override use
+  `test/helpers/e2e-port.ts`: unset or `0` requests an ephemeral port even for
+  offset cases; a positive override requests that exact base plus the case's
+  offset. An occupied explicit port fails loudly. Concurrent suites also need
+  separate asset roots with private `saves/` directories, since fixtures can
+  reuse save names.
 - Both `npm test` and `npm run test:e2e` end with a single verdict line,
   `shock2-sdk tests: PASS|FAIL ...`, and exit non-zero on any failure (a
   runner killed by a signal included). Gate on the exit code; when only a

--- a/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
+++ b/tools/shock2-sdk/test/always-collected-categories.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
@@ -45,7 +46,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8631),
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 5 });
@@ -100,7 +101,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8632),
+      port: e2ePort(),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/backpack-capacity.e2e.test.ts
+++ b/tools/shock2-sdk/test/backpack-capacity.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer, HttpError } from "../src/index.js";
 import type { UiElement } from "../src/types.js";
 import { earthWorldUse } from "./helpers/earth-world-use.js";
@@ -59,7 +60,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501),
+      port: e2ePort(),
     });
     await game.step({ frames: 2 });
 
@@ -103,7 +104,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 1,
+      port: e2ePort(1),
     });
     await game.step({ frames: 5 });
 
@@ -183,7 +184,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 2,
+      port: e2ePort(2),
     });
     await game.step({ frames: 30 });
 
@@ -217,7 +218,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 3,
+      port: e2ePort(3),
     });
     await game.step({ frames: 2 });
 
@@ -255,7 +256,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 4,
+      port: e2ePort(4),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -330,7 +331,7 @@ test(
     // the backpack, not in the world, not held.
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 9501) + 5,
+      port: e2ePort(5),
     });
     await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/e2e-port.test.ts
+++ b/tools/shock2-sdk/test/e2e-port.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { e2ePort } from "./helpers/e2e-port.js";
+
+test("fixture port defaults and explicit zero remain ephemeral at every offset", () => {
+  for (const offset of [0, 1, 5]) {
+    assert.equal(e2ePort(offset, "PORT", {}), 0);
+    assert.equal(e2ePort(offset, "PORT", { PORT: "0" }), 0);
+  }
+});
+
+test("fixture port preserves exact developer overrides and offsets", () => {
+  assert.equal(e2ePort(2, "PORT", { PORT: "9100" }), 9102);
+});
+
+test("fixture port rejects invalid explicit ports instead of drifting", () => {
+  for (const value of ["", "oops", "-1", "1.5", "65536"]) {
+    assert.throws(() => e2ePort(0, "PORT", { PORT: value }), /PORT/);
+  }
+  assert.throws(() => e2ePort(1, "PORT", { PORT: "65535" }), /PORT/);
+});

--- a/tools/shock2-sdk/test/earth-psi-cryo-self-hit.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psi-cryo-self-hit.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 
 // Regression test for the VR psi amp firing into the player's own capsule.
@@ -58,7 +59,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "earth.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8098),
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
 

--- a/tools/shock2-sdk/test/explosion-occlusion.e2e.test.ts
+++ b/tools/shock2-sdk/test/explosion-occlusion.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, Vec3 } from "../src/index.js";
 
@@ -67,14 +68,14 @@ test(
   async () => {
     const covered = await detonateBesidePlayer(
       "covered",
-      Number(process.env.SHOCK2_E2E_PORT ?? 8144),
+      e2ePort(),
     );
     assert.ok(covered.lineBlocked, "the covered control ray must hit the corridor wall");
     assert.equal(covered.damage, 0, "the wall must absorb the whole blast");
 
     const uncovered = await detonateBesidePlayer(
       "uncovered",
-      Number(process.env.SHOCK2_E2E_CONTROL_PORT ?? 8145),
+      e2ePort(0, "SHOCK2_E2E_CONTROL_PORT"),
     );
     assert.ok(!uncovered.lineBlocked, "the open-space control ray must stay clear");
     assert.ok(uncovered.damage > 0, "the unobstructed blast must still hurt the player");

--- a/tools/shock2-sdk/test/free-camera.e2e.test.ts
+++ b/tools/shock2-sdk/test/free-camera.e2e.test.ts
@@ -26,7 +26,6 @@ const skip = !e2eEnabled && "set SHOCK2_E2E=1 to run";
 test("the free camera is inert until the developer option enables it", { skip }, async () => {
   await using game = await GameServer.launch({
     mission: "medsci1.mis",
-    port: 8113,
   });
   await game.step({ frames: 30 });
 
@@ -58,7 +57,6 @@ test("the free camera is inert until the developer option enables it", { skip },
 test("flying the camera moves it and leaves the pawn standing", { skip }, async () => {
   await using game = await GameServer.launch({
     mission: "medsci1.mis",
-    port: 8114,
   });
   await game.step({ frames: 30 });
 
@@ -99,7 +97,6 @@ test("flying the camera moves it and leaves the pawn standing", { skip }, async 
 test("a level reload re-attaches the camera", { skip }, async () => {
   await using game = await GameServer.launch({
     mission: "medsci1.mis",
-    port: 8115,
   });
   await game.step({ frames: 30 });
 
@@ -139,7 +136,6 @@ test("a level reload re-attaches the camera", { skip }, async () => {
 test("a placed camera renders from where it was put", { skip }, async () => {
   await using game = await GameServer.launch({
     mission: "medsci1.mis",
-    port: 8700,
   });
   await game.step({ frames: 30 });
 
@@ -222,7 +218,6 @@ test("a placed camera renders from where it was put", { skip }, async () => {
 test("a nonsense camera placement is refused, not half-applied", { skip }, async () => {
   await using game = await GameServer.launch({
     mission: "medsci1.mis",
-    port: 8701,
   });
   await game.step({ frames: 30 });
 

--- a/tools/shock2-sdk/test/frob-range.e2e.test.ts
+++ b/tools/shock2-sdk/test/frob-range.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
@@ -22,7 +23,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8237),
+      port: e2ePort(),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/frobbable-physics.e2e.test.ts
+++ b/tools/shock2-sdk/test/frobbable-physics.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
@@ -16,7 +17,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "command1.mis",
-      port: Number(process.env.SHOCK2_E2E_FROBBABLE_PHYSICS_PORT ?? 8257),
+      port: e2ePort(0, "SHOCK2_E2E_FROBBABLE_PHYSICS_PORT"),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/helpers/e2e-port.ts
+++ b/tools/shock2-sdk/test/helpers/e2e-port.ts
@@ -1,0 +1,21 @@
+/** Optional exact developer port; ordinary fixtures let the OS choose. */
+export function e2ePort(
+  offset = 0,
+  variable = "SHOCK2_E2E_PORT",
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env[variable];
+  if (raw === undefined) return 0;
+  const base = Number(raw);
+  if (raw.trim() === "" || !Number.isInteger(base) || base < 0 || base > 65535) {
+    throw new Error(`${variable} must be an integer port from 0 to 65535`);
+  }
+  // Zero explicitly requests OS allocation; adding an offset would turn it
+  // into a fixed privileged port rather than another ephemeral launch.
+  if (base === 0) return 0;
+  const port = base + offset;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${variable} plus fixture offset is outside 1 to 65535`);
+  }
+  return port;
+}

--- a/tools/shock2-sdk/test/hitbox-coverage.e2e.test.ts
+++ b/tools/shock2-sdk/test/hitbox-coverage.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
@@ -23,7 +24,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_melee",
-      port: Number(process.env.SHOCK2_E2E_HITBOX_COVERAGE_PORT ?? 8393),
+      port: e2ePort(0, "SHOCK2_E2E_HITBOX_COVERAGE_PORT"),
     });
     // Hitbox proxies are built (and their bodies registered with the query
     // pipeline) on the first updates.

--- a/tools/shock2-sdk/test/hover-label-localization.e2e.test.ts
+++ b/tools/shock2-sdk/test/hover-label-localization.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
@@ -12,7 +13,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "eng1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8194),
+      port: e2ePort(),
     });
     await game.step({ frames: 5 });
 

--- a/tools/shock2-sdk/test/hydro2-vr-research-self-offer.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-vr-research-self-offer.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type {
   EntityDetailResult,
@@ -108,7 +109,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8592),
+      port: e2ePort(),
       debugFlags: ["--vr"],
       echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
     });

--- a/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
+++ b/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
@@ -150,7 +150,7 @@ test(
 
     let flatFailureObjects = 0;
     {
-      await using game = await GameServer.launch({ mission: "main_menu", port: 8124 });
+      await using game = await GameServer.launch({ mission: "main_menu" });
       await game.step({ frames: 5 });
       await click(game, LOAD_GAME_ENTRY);
       assert.equal((await game.info()).mission, "load_game");
@@ -206,7 +206,6 @@ test(
     {
       await using game = await GameServer.launch({
         mission: "main_menu",
-        port: 8125,
         debugFlags: ["--vr"],
       });
       await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/psi-powers-mfd.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-powers-mfd.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer, type UiElement, type Vec3 } from "../src/index.js";
 import { clickUiElement } from "./helpers/ui.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
@@ -24,7 +25,6 @@ import { aimVrHandAt } from "./helpers/vr-hand.js";
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PSI_PORT ?? 8711);
 
 /** The synthetic host entity's name, as `/v1/ui` reports it. */
 const PANEL_NAME = "Psi Powers";
@@ -97,7 +97,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: basePort,
+      port: e2ePort(0, "SHOCK2_E2E_PSI_PORT"),
     });
     await game.step({ frames: 30 });
     await game.input.trigger("ToggleUseMode");
@@ -191,7 +191,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: basePort + 1,
+      port: e2ePort(1, "SHOCK2_E2E_PSI_PORT"),
     });
     await game.step({ frames: 30 });
     await game.input.trigger("ToggleUseMode");
@@ -251,7 +251,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: basePort + 2,
+      port: e2ePort(2, "SHOCK2_E2E_PSI_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/rad-patch.e2e.test.ts
+++ b/tools/shock2-sdk/test/rad-patch.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import { teleportVerified } from "./helpers/teleport.js";
 
@@ -21,7 +22,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci2.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8737),
+      port: e2ePort(),
       repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
       debugFlags: ["--vr"],
     });

--- a/tools/shock2-sdk/test/vr-buttons-v2.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-buttons-v2.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { UiElement, UiState, Vec3 } from "../src/index.js";
 import { canvasCenter, clickCanvasWithRay, requirePanelPose } from "./helpers/ui.js";
@@ -25,7 +26,6 @@ import { cycleToWeapon } from "./helpers/weapon.js";
 // all, and the interface canvas carries no system button - so every assertion
 // below fails there.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_BUTTONS_V2_PORT ?? 8742);
 
 /** The debug pistol `DebugCycleWeapon` spawns first. */
 const PISTOL = -17;
@@ -95,7 +95,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(0, "SHOCK2_E2E_BUTTONS_V2_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 60 });
@@ -149,7 +149,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1, "SHOCK2_E2E_BUTTONS_V2_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -207,7 +207,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 2,
+      port: e2ePort(2, "SHOCK2_E2E_BUTTONS_V2_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -238,7 +238,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: basePort + 3,
+      port: e2ePort(3, "SHOCK2_E2E_BUTTONS_V2_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -262,7 +262,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 4,
+      port: e2ePort(4, "SHOCK2_E2E_BUTTONS_V2_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-clip-insert-reload.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, PlayedSound, Vec3 } from "../src/index.js";
 import {
@@ -24,7 +25,6 @@ import { fireOnce } from "./helpers/weapon.js";
 // nothing is consumed - VR had no reload at all except the Quest's face
 // button, which this change removes.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8636);
 
 /** The debug pistol and the ammo the scenarios carry to it. */
 const PISTOL = -17;
@@ -271,7 +271,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -396,7 +396,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -449,7 +449,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 2,
+      port: e2ePort(2),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-contextual-buttons.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
@@ -15,7 +16,6 @@ import { cycleToWeapon } from "./helpers/weapon.js";
 // The interface itself is reached from the Menu button now
 // (`vr-buttons-v2.e2e.test.ts`), which is what these tests use to open it.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8656);
 
 /** The debug pistol `DebugCycleWeapon` spawns first. */
 const PISTOL = -17;
@@ -52,7 +52,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -86,7 +86,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -119,7 +119,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 2,
+      port: e2ePort(2),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -159,7 +159,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 3,
+      port: e2ePort(3),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-cyber-interface-deposit.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary } from "../src/types.js";
 import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
@@ -15,7 +16,6 @@ import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
 // in the backpack" - the clip is a loose world prop on the floor instead, with
 // a physics body and no Contains link.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8619);
 
 /** Stable earth.mis mission object: the Weapons Training standard clip, a
  * loose grabbable world prop (see flat-world-pickup.e2e.test.ts). */
@@ -101,7 +101,7 @@ test(
   "releasing a held item over the VR inventory strip deposits it in the backpack",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
   async () => {
-    const { game, clip } = await launchWithHeldClip(basePort);
+    const { game, clip } = await launchWithHeldClip(e2ePort());
     await using _game = game;
 
     const pose = (await game.ui.state()).panel_pose!;
@@ -153,7 +153,7 @@ test(
   "releasing a held item away from the VR inventory strip still drops it into the world",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
   async () => {
-    const { game, clip } = await launchWithHeldClip(basePort + 1);
+    const { game, clip } = await launchWithHeldClip(e2ePort(1));
     await using _game = game;
 
     const pose = (await game.ui.state()).panel_pose!;
@@ -192,7 +192,7 @@ test(
   "releasing a held item on the cyber-interface canvas below the strip still drops it into the world",
   { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run", timeout: 600_000 },
   async () => {
-    const { game, clip } = await launchWithHeldClip(basePort + 2);
+    const { game, clip } = await launchWithHeldClip(e2ePort(2));
     await using _game = game;
 
     // The actual boundary the rule draws: the hand IS on the panel (it owns
@@ -236,7 +236,7 @@ test(
     //
     // A fresh earth character carries nothing, so deposit the clip first - the
     // scenario above, which is now the setup for the round trip.
-    const { game, clip } = await launchWithHeldClip(basePort + 3);
+    const { game, clip } = await launchWithHeldClip(e2ePort(3));
     await using _game = game;
     const item = clip.id;
 
@@ -291,7 +291,7 @@ test(
     // Retail drops a dragged item into the cell the player is pointing at.
     // Negative-first: on the parent this lands at the backpack's first free
     // cell (0, 0) regardless of where the release ray was aimed.
-    const { game, clip } = await launchWithHeldClip(basePort + 4);
+    const { game, clip } = await launchWithHeldClip(e2ePort(4));
     await using _game = game;
     // A middle cell, well clear of (0, 0) - a fresh earth character's
     // backpack is empty, so first-free would also land at (0, 0).

--- a/tools/shock2-sdk/test/vr-eject-clip.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-eject-clip.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
@@ -14,7 +15,6 @@ import { cycleToWeapon } from "./helpers/weapon.js";
 // itself is unchanged and still reachable from the flat key, HTTP and the SDK,
 // which is what these tests drive.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8676);
 
 /** The debug pistol, and the standard clip its rounds come back as. */
 const PISTOL = -17;
@@ -93,7 +93,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -179,7 +179,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-fire-mode-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-fire-mode-button.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
 import { describeSounds } from "./helpers/audio.js";
@@ -15,7 +16,6 @@ import { cycleToWeapon } from "./helpers/weapon.js";
 // (`vr-contextual-buttons` asserts it reaches no panel), so the mode never
 // leaves NORM and no `bset` sting plays.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8686);
 
 /** The debug pistol (NORM / BURST). */
 const PISTOL = -17;
@@ -57,7 +57,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -117,7 +117,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-forearm-readouts.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-forearm-readouts.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
@@ -18,7 +19,6 @@ import { aimVrHandAt } from "./helpers/vr-hand.js";
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_VR_FOREARM_PORT ?? 8741);
 
 /** The debug pistol: a magazine, two fire modes, and more than one ammo type. */
 const PISTOL = -17;
@@ -42,7 +42,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(0, "SHOCK2_E2E_VR_FOREARM_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -96,7 +96,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1, "SHOCK2_E2E_VR_FOREARM_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer, findRepoRoot } from "../src/index.js";
 import { cycleToWeapon } from "./helpers/weapon.js";
 
@@ -205,7 +206,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8108),
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
 

--- a/tools/shock2-sdk/test/vr-interface-readouts.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-interface-readouts.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { UiElement, UiState, Vec3 } from "../src/index.js";
 import {
@@ -24,7 +25,6 @@ import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_VR_READOUT_PORT ?? 8731);
 
 /** The debug pistol: a magazine, two fire modes, and more than one ammo type. */
 const PISTOL = -17;
@@ -88,7 +88,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(0, "SHOCK2_E2E_VR_READOUT_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -151,7 +151,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1, "SHOCK2_E2E_VR_READOUT_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -198,7 +198,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_psi",
-      port: basePort + 2,
+      port: e2ePort(2, "SHOCK2_E2E_VR_READOUT_PORT"),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });

--- a/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { e2ePort } from "./helpers/e2e-port.js";
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, PlayedSound, Vec3 } from "../src/index.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
@@ -22,7 +23,6 @@ import { fireOnce, cycleToWeapon } from "./helpers/weapon.js";
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
-const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8412);
 
 /** Pistol (first DebugCycleWeapon roster entry) and its standard clip. */
 const PISTOL = -17;
@@ -91,7 +91,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort,
+      port: e2ePort(),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });
@@ -164,7 +164,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "debug_weapons",
-      port: basePort + 1,
+      port: e2ePort(1),
       debugFlags: ["--vr"],
     });
     await game.step({ frames: 30 });


### PR DESCRIPTION
Concurrent SDK suites could fail at gameplay fixture startup because several tests still requested fixed ports such as 8631 and 8632. Ordinary fixtures now use OS-assigned ports. A shared test helper preserves supported developer overrides and case offsets; explicit zero remains ephemeral at every offset.

Fixes #1414.

The runtime’s exact-bind behavior and deliberate lifecycle collision tests remain intact. The SDK notes now also call out private save directories for concurrent suites.

Validation: reproduced both fixed-port failures with two concurrent copies of the affected fixture and independent asset/save roots; 63 SDK fast tests and typecheck pass, including default/zero/override/invalid-port coverage. All three existing runtime lifecycle tests pass, including occupied-port refusal. Two concurrent copies of the inventory/camera/VR-weapon fixtures pass all 18 cases. The ownership audit observed 18 distinct ports and instance IDs, matched every announced ID to its SDK launch, and found no owned runtime processes after cleanup. Independent code review passed. CI is green on macOS, Ubuntu, Windows, and Android, with formatting passing.

PR visuals assessment: no media needed. This changes test launch configuration and documentation; game rendering and interactions are unchanged.
