### PR TITLE
test: verify Earth hacking payments from nanite balance

### DIFF
--- a/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
@@ -50,21 +50,19 @@ test(
 
     // Acquire the actual training nanites through the rendered world
     // interaction path (crosshair ray + right-hand squeeze), not debug give.
+    const naniteBalance = async () => {
+      const stats = (await game.info()).player.stats;
+      assert.ok(stats, "Earth should expose the player nanite balance");
+      return stats.nanites;
+    };
+    const balanceBeforePickup = await naniteBalance();
     await earthWorldUse(game, nanites);
-    const inventoryBefore = await game.player.inventory();
-    const carriedNanites = inventoryBefore.items.find(
-      (item) => item.name === "Big Nanite Pile",
+    const balanceBefore = await naniteBalance();
+    assert.equal(
+      balanceBefore - balanceBeforePickup,
+      250,
+      "physical pickup should credit the authored 250 nanites to the player balance",
     );
-    assert.ok(
-      carriedNanites,
-      `physical pickup should put Big Nanite Pile in the backpack (got ${JSON.stringify(inventoryBefore.items)})`,
-    );
-    const stackBefore = Number(
-      (await game.entities.detail(carriedNanites.entity_id)).properties.find(
-        (property) => property.name === "StackCount",
-      )?.value,
-    );
-    assert.equal(stackBefore, 250, "the physical Earth pile should carry 250 nanites");
 
     const doorBefore = await game.entities.detail(door.id);
 
@@ -137,14 +135,9 @@ test(
     };
 
     await clickElement(start);
-    const stackAfterPayment = Number(
-      (await game.entities.detail(carriedNanites.entity_id)).properties.find(
-        (property) => property.name === "StackCount",
-      )?.value,
-    );
     assert.equal(
-      stackAfterPayment,
-      stackBefore - cost,
+      await naniteBalance(),
+      balanceBefore - cost,
       "starting the board should deduct exactly the authored cost",
     );
 
@@ -206,5 +199,6 @@ test(
       `HRM success should TurnOn linked door 265 (moved ${doorMovement.toFixed(2)}; ` +
         `before=${doorBefore.position})`,
     );
+    await game.screenshot("earth-hack-success.png");
   },
 );


### PR DESCRIPTION
The Earth hacking regression stopped after its real nanite pickup because it expected a backpack pile and later charged its `StackCount`. Pickups now credit the persistent player nanite balance directly.

Verify that the authored physical pickup credits exactly 250 nanites and starting the HRM board deducts its displayed authored cost from that balance. Preserve the ordinary keypad interaction, linked-door identity, no movement after payment or only one/two nodes, connected three-node success art, visible cost, and final door displacement. No currency grants or game-code changes are introduced.

Validation:
- Negative baseline on unchanged main `c6ddb35b`: physical pickup succeeded but the stale backpack assertion failed with `got []`.
- Balance-corrected focused test passes on the same immutable baseline through HRM success and door movement (18.2 seconds).
- Corrected focused test passes sequentially against immutable PR #1405, #1410, and #1411 binaries (18.4, 18.8, and 18.1 seconds), with private assets and isolated SDK output.
- SDK `npm test`: TypeScript compilation and 60 fast tests pass; 432 runtime tests skipped as intended.
- Inspected `earth-hack-success.png`: three connected lit nodes, SUCCESS artwork, and visible COST 3.

Visual assessment: test-only assertion update with no rendered game changes; no before/after GIF is required.

Found during campaign validation: full-game · detailed · 25th Anniversary assets · VR · seed 1258205384. This regression uses flat pointer controls and focused setup; it is not campaign traversal evidence.

Fixes #1417

