### PR TITLE
feat(debug-runtime): simulate floor-relative VR tracking

### DIFF
--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -253,6 +253,12 @@ on-device automation - see the `vr-device-loop` skill. There it is applied as an
 override on top of the OpenXR-built `InputContext` (`InputOverrides`); here the
 runtime owns the context and patches it directly.
 
+Floor-relative VR tracking is available through `GET/POST /v1/control/tracking`
+when launched with `--vr`. It is opt-in; legacy pawn-local input channels keep
+their existing meaning. See the [SDK tracking guide](../tools/shock2-sdk/README.md#simulated-floor-relative-vr-tracking)
+for units, complete initial rig poses, calibration/reset, tracking loss, and
+resolved-camera diagnostics.
+
 ## Usage
 
 ### Starting the Debug Runtime

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -25,6 +25,11 @@ pub enum RuntimeCommand {
 
     /// Get current input state
     GetInput(oneshot::Sender<InputState>),
+    GetTracking(oneshot::Sender<crate::tracking::TrackingStatus>),
+    SetTracking(
+        crate::tracking::TrackingPatch,
+        oneshot::Sender<Result<(), String>>,
+    ),
 
     /// Set one or more input channel values. Replies `Ok(())` when every patch
     /// applied, or `Err(message)` describing the first invalid channel/value so
@@ -512,6 +517,7 @@ pub struct InputPointer {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InputHead {
+    pub position: [f32; 3],
     pub rotation: [f32; 4], // Quaternion [x, y, z, w]
 }
 
@@ -541,6 +547,7 @@ impl Default for InputState {
 impl Default for InputHead {
     fn default() -> Self {
         Self {
+            position: [0.0, shock2vr::input_context::DEFAULT_HEAD_HEIGHT, 0.0],
             rotation: [0.0, 0.0, 0.0, 1.0], // Identity quaternion
         }
     }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -27,6 +27,7 @@ use tracing::info;
 
 mod commands;
 mod lifecycle;
+mod tracking;
 use commands::*;
 use lifecycle::{DEFAULT_IDLE_TIMEOUT_SECS, IDLE_POLL_INTERVAL, IdleWatchdog};
 
@@ -412,6 +413,7 @@ async fn start_http_server(
         )
         .route("/v1/physics/colliders/validate", get(audit_colliders))
         .route("/v1/ragdoll/metrics", get(get_ragdoll_metrics))
+        .route("/v1/control/tracking", get(get_tracking).post(set_tracking))
         .route("/v1/control/input", get(get_input_state))
         .route("/v1/control/input", axum::routing::post(set_input_channel))
         .route(
@@ -629,6 +631,7 @@ fn run_game_blocking(
     // The head starts at the desktop default view; the SAME head rotation also
     // drives the render camera (below), so the flat viewmodel stays aligned with
     // what is rendered.
+    let mut tracking = tracking::TrackingSimulation::default();
     let mut current_input = InputContext::default();
     current_input.head.rotation = default_camera_head_rotation();
     // In VR mode, give the simulated hands a natural first-person rest pose
@@ -761,6 +764,8 @@ fn run_game_blocking(
                         frame_counter,
                         &mut action_state,
                         &mut current_input,
+                        &mut tracking,
+                        args.vr,
                         &last_scene,
                         last_scene_frame,
                         args.defer_transitions,
@@ -799,6 +804,9 @@ fn run_game_blocking(
             continue;
         }
 
+        tracking.update(game.player_is_gripping());
+        let effective_input = tracking_input(&game, &current_input, &tracking);
+
         // Only update the game if not paused or if step was requested
         let actual_game_time = if !is_paused || step_requested {
             // Deterministic stepping: while stepping (frame- or time-based) advance
@@ -818,7 +826,7 @@ fn run_game_blocking(
             };
             profile!(
                 "game.update",
-                game.update(&game_time, &current_input, &mut action_state)
+                game.update(&game_time, &effective_input, &mut action_state)
             );
             // An in-game transition (a frobbed bulkhead button, a trigger
             // volume) starts here; land it now for the same reason a warp does.
@@ -826,7 +834,7 @@ fn run_game_blocking(
                 complete_pending_transition(
                     &mut game,
                     &game_time,
-                    &current_input,
+                    &effective_input,
                     &mut action_state,
                 );
             }
@@ -912,13 +920,13 @@ fn run_game_blocking(
             // Still call update with zero time to maintain state consistency
             profile!(
                 "game.update",
-                game.update(&zero_time, &current_input, &mut action_state)
+                game.update(&zero_time, &effective_input, &mut action_state)
             );
             if !args.defer_transitions {
                 complete_pending_transition(
                     &mut game,
                     &zero_time,
-                    &current_input,
+                    &effective_input,
                     &mut action_state,
                 );
             }
@@ -938,7 +946,10 @@ fn run_game_blocking(
         // player is dying the game blends this tracked pose toward the fallen
         // death pose, once, for every runtime (see `shock2vr::death_camera`).
         // Alive, it hands back exactly what went in.
-        let render_context = resolved_camera(&game, pawn_offset, pawn_rotation, &current_input)
+        // Physics may have changed stance (or refused standing). Re-resolve
+        // the whole rig just as Quest does before drawing both eyes.
+        let rendered_input = tracking_input(&game, &current_input, &tracking);
+        let render_context = resolved_camera(&game, pawn_offset, pawn_rotation, &rendered_input)
             // Accumulated game time, not real time.
             .into_render_context(actual_game_time, projection_matrix, screen_size);
 
@@ -1066,13 +1077,16 @@ fn process_command(
     frame_counter: u64,
     action_state: &mut InputActionState,
     current_input: &mut InputContext,
+    tracking: &mut tracking::TrackingSimulation,
+    vr: bool,
     last_scene: &[commands::SceneObjectSummary],
     last_scene_frame: u64,
     defer_transitions: bool,
 ) {
+    let effective_input = tracking_input(game, current_input, tracking);
     match command {
         RuntimeCommand::GetInfo(reply) => {
-            let snapshot = capture_frame_snapshot(game, time, frame_counter, current_input);
+            let snapshot = capture_frame_snapshot(game, time, frame_counter, &effective_input);
             if let Err(_) = reply.send(snapshot) {
                 tracing::warn!("Failed to send frame snapshot - receiver dropped");
             }
@@ -1196,7 +1210,7 @@ fn process_command(
             // Land the warp before replying, so `success` and every later
             // request see the destination level (see `complete_pending_transition`).
             if !defer_transitions {
-                complete_pending_transition(game, time, current_input, action_state);
+                complete_pending_transition(game, time, &effective_input, action_state);
             }
             // Report the ACTUAL post-switch scene rather than assuming success.
             let mission = game.scene_name().to_string();
@@ -1449,13 +1463,13 @@ fn process_command(
             }
         }
         RuntimeCommand::GetCameraState(reply) => {
-            if reply.send(camera_snapshot(game, current_input)).is_err() {
+            if reply.send(camera_snapshot(game, &effective_input)).is_err() {
                 tracing::warn!("Failed to send camera state - receiver dropped");
             }
         }
         RuntimeCommand::SetCameraState { request, reply } => {
-            let result = apply_camera_request(game, current_input, &request)
-                .map(|()| camera_snapshot(game, current_input));
+            let result = apply_camera_request(game, &effective_input, &request)
+                .map(|()| camera_snapshot(game, &effective_input));
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send camera placement result - receiver dropped");
             }
@@ -2003,9 +2017,16 @@ fn process_command(
                 tracing::warn!("Failed to send impulse result - receiver dropped");
             }
         }
+        RuntimeCommand::GetTracking(reply) => {
+            let (head, _) = tracked_head(game, &effective_input);
+            let _ = reply.send(tracking.status(current_input, head));
+        }
+        RuntimeCommand::SetTracking(patch, reply) => {
+            let _ = reply.send(tracking.patch(patch, vr));
+        }
         RuntimeCommand::GetInput(reply) => {
             // Report the runtime-owned input state (what is fed to game.update).
-            let input_state = input_state_from_context(current_input);
+            let input_state = input_state_from_context(&effective_input);
             if let Err(_) = reply.send(input_state) {
                 tracing::warn!("Failed to send input state - receiver dropped");
             }
@@ -2059,6 +2080,11 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
             pressed: p.pressed,
         }),
         head: commands::InputHead {
+            position: [
+                input.head.position.x,
+                input.head.position.y,
+                input.head.position.z,
+            ],
             rotation: [
                 input.head.rotation.v.x,
                 input.head.rotation.v.y,
@@ -2109,7 +2135,22 @@ fn input_snapshot_from_context(input: &InputContext) -> InputSnapshot {
 /// drift from the one that matters.
 /// The *tracked* head this runtime reports: the crouch-aware eye height and
 /// whatever `/v1/control/input` last aimed the head at.
+fn tracking_input(
+    game: &Game,
+    raw: &InputContext,
+    tracking: &tracking::TrackingSimulation,
+) -> InputContext {
+    tracking.resolve(
+        raw,
+        game.player_center_above_floor(),
+        game.player_eye_cap_above_center(),
+    )
+}
+
 fn tracked_head(game: &Game, input: &InputContext) -> (Vector3<f32>, Quaternion<f32>) {
+    if input.tracking.is_some() {
+        return (input.head.position, input.head.rotation);
+    }
     (
         vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
         input.head.rotation,
@@ -3985,6 +4026,34 @@ fn parse_input_patches(body: &serde_json::Value) -> Result<Vec<commands::InputPa
         .into_iter()
         .map(|(channel, value)| commands::InputPatch { channel, value })
         .collect())
+}
+
+/// Explicit, opt-in floor-relative pose simulation; does not reinterpret the
+/// existing pawn-local /control/input position channels.
+async fn set_tracking(
+    State(tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(patch): LenientJson<tracking::TrackingPatch>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let (reply, response) = oneshot::channel();
+    tx.send(RuntimeCommand::SetTracking(patch, reply))
+        .map_err(|_| game_loop_unavailable())?;
+    match response.await {
+        Ok(Ok(())) => Ok(Json(serde_json::json!({"success": true}))),
+        Ok(Err(error)) => Err((StatusCode::BAD_REQUEST, error)),
+        Err(_) => Err(game_loop_unavailable()),
+    }
+}
+
+async fn get_tracking(
+    State(tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<tracking::TrackingStatus>, (StatusCode, String)> {
+    let (reply, response) = oneshot::channel();
+    tx.send(RuntimeCommand::GetTracking(reply))
+        .map_err(|_| game_loop_unavailable())?;
+    response
+        .await
+        .map(Json)
+        .map_err(|_| game_loop_unavailable())
 }
 
 /// HTTP endpoint handler: Set one or more input channel values.

--- a/runtimes/debug_runtime/src/tracking.rs
+++ b/runtimes/debug_runtime/src/tracking.rs
@@ -1,0 +1,259 @@
+//! Opt-in simulation of the Quest floor-relative tracking input.
+use cgmath::{Vector3, vec3};
+use serde::{Deserialize, Serialize};
+use shock2vr::{
+    input_context::InputContext, vr_crouch::VrCrouchDetector, vr_tracking::TrackingTransform,
+};
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TrackingPatch {
+    pub enabled: Option<bool>,
+    pub position_tracked: Option<bool>,
+    pub reset: bool,
+    pub head_position: Option<[f32; 3]>,
+    pub left_hand_position: Option<[f32; 3]>,
+    pub right_hand_position: Option<[f32; 3]>,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct TrackingStatus {
+    pub enabled: bool,
+    pub position_tracked: bool,
+    /// Requested floor-relative poses in meters, not pawn-local world units.
+    pub head_position: Option<[f32; 3]>,
+    pub left_hand_position: Option<[f32; 3]>,
+    pub right_hand_position: Option<[f32; 3]>,
+    pub physical_crouch: bool,
+    pub explicit_crouch: bool,
+    pub resolved_head_position: [f32; 3],
+}
+
+#[derive(Default)]
+pub struct TrackingSimulation {
+    status: TrackingStatus,
+    detector: VrCrouchDetector,
+    last_head: Option<[f32; 3]>,
+}
+
+impl TrackingSimulation {
+    pub fn patch(&mut self, patch: TrackingPatch, vr: bool) -> Result<(), String> {
+        if !vr {
+            return Err("Floor-relative tracking simulation requires --vr".into());
+        }
+        let mut next = self.status.clone();
+        if let Some(enabled) = patch.enabled {
+            next.enabled = enabled;
+        }
+        if let Some(tracked) = patch.position_tracked {
+            next.position_tracked = tracked;
+        }
+        for (target, pose) in [
+            (&mut next.head_position, patch.head_position),
+            (&mut next.left_hand_position, patch.left_hand_position),
+            (&mut next.right_hand_position, patch.right_hand_position),
+        ] {
+            if let Some(pose) = pose {
+                if !pose.iter().all(|x| x.is_finite()) {
+                    return Err("Tracking positions must be finite meters".into());
+                }
+                *target = Some(pose);
+            }
+        }
+        if next
+            .head_position
+            .is_some_and(|p| !(0.0..=3.0).contains(&p[1]))
+        {
+            return Err("Tracked head height must be between 0 and 3 meters".into());
+        }
+        if next.enabled
+            && (next.head_position.is_none()
+                || next.left_hand_position.is_none()
+                || next.right_hand_position.is_none())
+        {
+            return Err("Enabling tracking requires head_position and both hand positions in floor-relative meters".into());
+        }
+        if !self.status.enabled && next.enabled {
+            next.position_tracked = patch.position_tracked.unwrap_or(true);
+        }
+        if patch.reset || !next.enabled || !self.status.enabled {
+            self.detector.reset();
+            self.last_head = None;
+            next.physical_crouch = false;
+        }
+        self.status = next;
+        Ok(())
+    }
+
+    /// Same detector and climb-freeze policy as the Quest runtime. Invalid/lost
+    /// tracking holds the last pose and stance request until tracking returns.
+    pub fn update(&mut self, gripping: bool) {
+        if self.status.enabled {
+            if self.status.position_tracked {
+                self.last_head = self.status.head_position;
+            }
+            self.status.physical_crouch = self.detector.update(
+                self.status
+                    .position_tracked
+                    .then(|| self.status.head_position.unwrap()[1]),
+                gripping,
+            );
+        }
+    }
+
+    pub fn resolve(&self, raw: &InputContext, center: f32, cap: f32) -> InputContext {
+        let mut input = raw.clone();
+        if self.status.enabled {
+            let head = self.last_head.unwrap_or([
+                0.0,
+                (shock2vr::input_context::DEFAULT_HEAD_HEIGHT + center)
+                    * shock2vr::METERS_PER_WORLD_UNIT,
+                0.0,
+            ]);
+            let tracking = TrackingTransform::new(center, cap, head[1], 0.0);
+            let pose = |p: [f32; 3]| tracking.stage_to_pawn(vec3(p[0], p[1], p[2]));
+            input.head.position = pose(head);
+            input.left_hand.position = pose(self.status.left_hand_position.unwrap());
+            input.right_hand.position = pose(self.status.right_hand_position.unwrap());
+            input.tracking = Some(tracking);
+            input.crouch |= self.status.physical_crouch;
+        }
+        input
+    }
+
+    pub fn status(&self, raw: &InputContext, head: Vector3<f32>) -> TrackingStatus {
+        let mut status = self.status.clone();
+        status.explicit_crouch = raw.crouch;
+        status.resolved_head_position = [head.x, head.y, head.z];
+        status
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::InnerSpace;
+    fn enabled() -> TrackingSimulation {
+        let mut simulation = TrackingSimulation::default();
+        simulation
+            .patch(
+                TrackingPatch {
+                    enabled: Some(true),
+                    head_position: Some([0.0, 1.7, 0.0]),
+                    left_hand_position: Some([-0.2, 1.4, -0.3]),
+                    right_hand_position: Some([0.2, 1.4, -0.3]),
+                    ..Default::default()
+                },
+                true,
+            )
+            .unwrap();
+        simulation.update(false);
+        simulation
+    }
+    #[test]
+    fn opt_in_calibration_loss_reset_and_climb_freeze_use_shared_detector() {
+        let raw = InputContext::default();
+        let mut simulation = enabled();
+        simulation
+            .patch(
+                TrackingPatch {
+                    head_position: Some([0.0, 1.0, 0.0]),
+                    ..Default::default()
+                },
+                true,
+            )
+            .unwrap();
+        simulation.update(true);
+        assert!(!simulation.resolve(&raw, 1.2, 1.04).crouch);
+        simulation.update(false);
+        assert!(simulation.resolve(&raw, 1.2, 1.04).crouch);
+        simulation
+            .patch(
+                TrackingPatch {
+                    position_tracked: Some(false),
+                    ..Default::default()
+                },
+                true,
+            )
+            .unwrap();
+        simulation.update(false);
+        assert!(simulation.resolve(&raw, 1.2, 1.04).crouch);
+        simulation
+            .patch(
+                TrackingPatch {
+                    reset: true,
+                    position_tracked: Some(true),
+                    ..Default::default()
+                },
+                true,
+            )
+            .unwrap();
+        simulation.update(false);
+        assert!(!simulation.resolve(&raw, 1.2, 1.04).crouch);
+    }
+    #[test]
+    fn explicit_crouch_and_default_input_survive_without_stage_simulation() {
+        let simulation = TrackingSimulation::default();
+        let mut raw = InputContext::default();
+        raw.crouch = true;
+        raw.head.position = vec3(0.1, 0.2, 0.3);
+        let resolved = simulation.resolve(&raw, 1.2, 1.04);
+        assert!(resolved.crouch);
+        assert_eq!(resolved.head.position, raw.head.position);
+        assert!(resolved.tracking.is_none());
+        assert!(enabled().resolve(&raw, 1.2, 1.04).crouch);
+    }
+    #[test]
+    fn rejects_flat_incomplete_or_invalid_calibration_without_partial_application() {
+        let mut simulation = TrackingSimulation::default();
+        assert!(
+            simulation
+                .patch(
+                    TrackingPatch {
+                        enabled: Some(true),
+                        ..Default::default()
+                    },
+                    false
+                )
+                .is_err()
+        );
+        assert!(
+            simulation
+                .patch(
+                    TrackingPatch {
+                        enabled: Some(true),
+                        ..Default::default()
+                    },
+                    true
+                )
+                .is_err()
+        );
+        let mut simulation = enabled();
+        assert!(
+            simulation
+                .patch(
+                    TrackingPatch {
+                        head_position: Some([0.0, 5.0, 0.0]),
+                        ..Default::default()
+                    },
+                    true
+                )
+                .is_err()
+        );
+        assert_eq!(simulation.status.head_position, Some([0.0, 1.7, 0.0]));
+    }
+    #[test]
+    fn actual_stance_caps_eye_and_moves_whole_rig_together() {
+        let simulation = enabled();
+        let raw = InputContext::default();
+        let standing = simulation.resolve(&raw, 1.244, 1.04);
+        let blocked_stand = simulation.resolve(&raw, 0.604, 0.48);
+        assert!((blocked_stand.head.position.y - 0.48).abs() < 1e-5);
+        assert!(
+            ((standing.right_hand.position - standing.head.position)
+                - (blocked_stand.right_hand.position - blocked_stand.head.position))
+                .magnitude()
+                < 1e-5
+        );
+    }
+}

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -144,6 +144,54 @@ To attach to a runtime you started yourself (`cargo dbgr -- --mission ... --port
 const game = await GameServer.connect("http://127.0.0.1:8080");
 ```
 
+## Simulated floor-relative VR tracking
+
+Existing `head.position` and hand-position channels are pawn-local world units.
+They do not imply a calibrated physical headset. For physical crouch testing,
+launch with `debugFlags: ["--vr"]` and opt in with a complete tracked rig:
+
+```ts
+await game.input.setTracking({
+  enabled: true,
+  head_position: [0, 1.7, 0],
+  left_hand_position: [-0.2, 1.4, -0.3],
+  right_hand_position: [0.2, 1.4, -0.3],
+});
+await game.step({ frames: 3 }); // establish standing calibration
+await game.input.setTracking({ head_position: [0, 1.0, 0] });
+await game.step({ frames: 10 }); // physically crouch
+console.log(await game.input.tracking());
+```
+
+`GET/POST /v1/control/tracking` exposes the same operation over HTTP. All three
+requested positions are **floor-relative meters** in the tracking stage; +Y is
+up and -Z is forward before pawn rotation. Subsequent patches may update any
+subset. While enabled, these stage positions replace the legacy position
+channels; rotations, buttons, sticks, and the explicit `crouch` channel still
+come from `/v1/control/input`. Flat runtimes reject tracking patches.
+
+This uses Quest's shared `VrCrouchDetector` and `TrackingTransform`: tallest
+valid head height calibrates standing, 70%/85% thresholds provide hysteresis,
+and grip climbing freezes physical crouch detection. Explicit crouch is ORed
+with the physical request. Physics may refuse standing under a low ceiling;
+the post-physics head and hands use one transform based on the actual stance.
+`game.input.tracking()` separates requested stage poses, physical/explicit
+crouch requests, and resolved pawn-local head position. `/v1/control/input`
+reports the resolved input poses; `/v1/info` reports the rendered camera.
+
+The simulated stage offset is zero (Quest also supports a configurable eye-height
+offset). `position_tracked` governs the head position; supplied hand positions
+remain current, matching the shipping runtime’s separate controller poses.
+
+Set `position_tracked: false` to simulate head-position tracking loss: the last
+valid head pose and crouch request remain until tracking returns. Set
+`reset: true` after changing reference space to forget calibration and cached
+head pose; the next valid sample starts calibration anew. Resetting while low
+does not assume the player was standing. `enabled: false` disables simulation
+and resets its detector; existing explicit crouch and local inputs persist.
+This runtime tracking state is independent of mission saves and persists across
+level transitions, as a headset reference space does.
+
 ## Notes
 
 - `GameServer.launch` finds the cargo workspace by walking up from `cwd`;

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -1,6 +1,8 @@
 import { HttpClient, HttpError } from "./client.js";
 import type {
   AnimationState,
+  TrackingPatch,
+  TrackingStatus,
   CommandResult,
   DebugEntityMessage,
   DevParamSetResult,
@@ -411,6 +413,16 @@ export class EntitiesApi {
 /** Discrete input actions and continuous input channels. */
 export class InputApi {
   constructor(private readonly client: HttpClient) {}
+
+  /** Patch opt-in floor-relative head/hand positions in meters (--vr only). */
+  async setTracking(patch: TrackingPatch): Promise<void> {
+    await this.client.post("/v1/control/tracking", patch);
+  }
+
+  /** Requested stage poses and resolved pawn-local eye/crouch diagnostics. */
+  async tracking(): Promise<TrackingStatus> {
+    return this.client.get<TrackingStatus>("/v1/control/tracking");
+  }
 
   /** Trigger a discrete action (as if its bound key was pressed). Applies on the next update. */
   async trigger(action: InputAction): Promise<CommandResult> {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -1106,3 +1106,26 @@ export interface WaitForOptions {
   /** Description used in the timeout error message. */
   description?: string;
 }
+
+/** Opt-in debug VR floor-relative stage poses, in meters. Requires --vr. */
+export interface TrackingPatch {
+  enabled?: boolean;
+  position_tracked?: boolean;
+  /** Forget standing calibration after changing reference space. */
+  reset?: boolean;
+  head_position?: Vec3;
+  left_hand_position?: Vec3;
+  right_hand_position?: Vec3;
+}
+
+export interface TrackingStatus {
+  enabled: boolean;
+  position_tracked: boolean;
+  head_position: Vec3 | null;
+  left_hand_position: Vec3 | null;
+  right_hand_position: Vec3 | null;
+  physical_crouch: boolean;
+  explicit_crouch: boolean;
+  /** Actual post-stance pawn-local eye, in world units. */
+  resolved_head_position: Vec3;
+}

--- a/tools/shock2-sdk/test/vr-head-tracking.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-head-tracking.e2e.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+const skip = process.env.SHOCK2_E2E !== "1";
+const rig = {
+  enabled: true,
+  head_position: [0, 1.7, 0] as [number, number, number],
+  left_hand_position: [-0.2, 1.4, -0.3] as [number, number, number],
+  right_hand_position: [0.2, 1.4, -0.3] as [number, number, number],
+};
+
+test(
+  "VR stage tracking calibrates physical crouch and reports the rendered eye",
+  { skip, timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_minimal",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 3 });
+    const original = await game.info();
+    await game.input.set("head.position", [0, 0.2, 0]);
+    await game.step({ frames: 3 });
+    assert.deepEqual(
+      (await game.info()).player.camera_offset,
+      original.player.camera_offset,
+      "legacy pawn-local head patches do not imply tracked calibration",
+    );
+    await game.input.setTracking(rig);
+    await game.step({ frames: 3 });
+    const standing = await game.info();
+    assert.equal((await game.input.tracking()).physical_crouch, false);
+    await game.input.setTracking({ head_position: [0, 1, 0] });
+    await game.step({ frames: 10 });
+    const crouched = await game.info();
+    const tracking = await game.input.tracking();
+    assert.equal(tracking.physical_crouch, true);
+    assert.ok(
+      standing.player.position[1] - crouched.player.position[1] > 0.3,
+      "physical lowering shrinks the actual capsule",
+    );
+    assert.deepEqual(
+      crouched.player.camera_offset,
+      tracking.resolved_head_position,
+    );
+    const inputs = crouched.inputs as {
+      hands: { right: { position: [number, number, number] } };
+    };
+    const relativeHand = inputs.hands.right.position.map(
+      (value, axis) => value - crouched.player.camera_offset[axis],
+    );
+    for (const [axis, meters] of [0.2, 0.4, -0.3].entries()) {
+      assert.ok(
+        Math.abs(relativeHand[axis] - meters / 0.762) < 1e-4,
+        "crouch correction must translate head and hand together",
+      );
+    }
+    const eye = crouched.player.camera_offset[1];
+    await game.input.setTracking({
+      position_tracked: false,
+      head_position: [0, 1.7, 0],
+    });
+    await game.step({ frames: 3 });
+    assert.equal((await game.input.tracking()).physical_crouch, true);
+    assert.equal(
+      (await game.info()).player.camera_offset[1],
+      eye,
+      "tracking loss retains last valid head pose",
+    );
+    await game.input.setTracking({ position_tracked: true });
+    await game.step({ frames: 10 });
+    assert.equal((await game.input.tracking()).physical_crouch, false);
+    await game.input.setTracking({ head_position: [0, 1, 0] });
+    await game.step({ frames: 3 });
+    assert.equal((await game.input.tracking()).physical_crouch, true);
+    await game.input.setTracking({ reset: true });
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.input.tracking()).physical_crouch,
+      false,
+      "new reference space calibrates from its first valid pose",
+    );
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 3 });
+    assert.equal((await game.input.tracking()).explicit_crouch, true);
+    await game.input.setTracking({ enabled: false });
+    await game.step({ frames: 3 });
+    assert.equal((await game.input.tracking()).enabled, false);
+    assert.equal((await game.input.tracking()).explicit_crouch, true);
+  },
+);
+
+test(
+  "flat runtime rejects stage tracking and preserves its camera",
+  { skip, timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "debug_minimal" });
+    await game.step({ frames: 3 });
+    const before = (await game.info()).player.camera_offset;
+    await assert.rejects(game.input.setTracking(rig), /requires --vr/);
+    await game.input.set("head.position", [0, 0.2, 0]);
+    await game.step({ frames: 3 });
+    assert.deepEqual((await game.info()).player.camera_offset, before);
+  },
+);
+
+test(
+  "tracked stand-up remains headroom-gated and keeps the rendered rig below the ceiling",
+  { skip, timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 3 });
+    await game.input.setTracking(rig);
+    await game.step({ frames: 3 });
+    await game.input.setTracking({ head_position: [0, 1, 0] });
+    await game.step({ frames: 10 });
+    // Isolated physics fixture, not campaign progression: place the crouched
+    // capsule inside the authored five-foot Cryo passage (floor -1.6).
+    await teleportVerified(game, { x: -27, y: -0.996, z: -16.7 });
+    await game.step({ frames: 10 });
+    const before = await game.info();
+    const ceiling = await game.raycast({
+      start: [-27, -1.55, -16.7],
+      end: [-27, 2, -16.7],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceiling.hit_point && ceiling.hit_point[1] < 0.5,
+      "fixture must be under the authored ceiling",
+    );
+    await game.input.setTracking({ head_position: [0, 1.7, 0] });
+    await game.step({ frames: 15 });
+    const blocked = await game.info();
+    assert.equal(
+      (await game.input.tracking()).physical_crouch,
+      false,
+      "tracked head asks to stand",
+    );
+    assert.ok(
+      Math.abs(blocked.player.position[1] - before.player.position[1]) < 0.05,
+      "actual capsule must stay crouched",
+    );
+    assert.deepEqual(
+      blocked.player.camera_offset,
+      (await game.input.tracking()).resolved_head_position,
+    );
+    assert.ok(
+      blocked.player.position[1] + blocked.player.camera_offset[1] <
+        ceiling.hit_point![1],
+      "actual camera must remain below the ceiling",
+    );
+    await teleportVerified(game, { x: -23.2, y: -0.996, z: -16.1 });
+    await game.step({ frames: 15 });
+    assert.ok(
+      (await game.info()).player.position[1] - blocked.player.position[1] > 0.3,
+      "actual stand-up completes in clear headroom",
+    );
+  },
+);


### PR DESCRIPTION
The debug runtime accepted pawn-local head positions while rendering a fixed eye height, so VR playtests could not exercise physical headset crouching. Add opt-in `GET/POST /v1/control/tracking` and SDK `game.input.setTracking()` for floor-relative head and hand positions in meters. The existing Quest crouch detector and rig transform drive physical crouch and keep the rendered head/hands aligned with the actual collider stance, including refused stand-up under low ceilings.

Fixes #1419.

Existing flat and untracked callers retain their behavior. Tracking requires `--vr` and a complete initial rig; explicit crouch remains available. The API separates requested poses and physical/explicit crouch from the resolved eye, supports head-tracking loss and calibration reset, and documents its zero stage offset and existing rotation channels.

Validation: new opt-in scenarios fail on the baseline; 27 debug-runtime unit tests, 60 SDK fast tests/typecheck, warning-denying core/desktop/debug checks, and formatting pass. Three focused SDK cases pass: calibrated lowering/reset/loss, flat compatibility, and actual MedSci low-ceiling stand-up refusal followed by standing in clear headroom. An additional live assertion verifies that crouch translates the head and hand together. The isolated MedSci fixture uses no campaign save.

CI is green. Independent code and media review passed. Draft gate: the manager-owned full SDK suite remains in progress. No campaign save binaries will be uploaded.

Found during full-game detailed playthrough, 25th Anniversary assets, VR, seed1258205384. This fixes simulation tooling; it is not evidence of a physical-headset crouch failure.


Visual verification uses identical requests in `debug_ladder`: floor-relative headset samples descend from 1.70 m to 1.00 m and return. The baseline returns 404 for this previously unavailable API and retains its standing camera; fixed VR accepts the tracking samples. This comparison does not imply the old endpoint simulated physical tracking. Fixed flat rejects tracking, and all 11 paired flat frames are pixel-identical. GIF end frames are held for 500 ms for readability; intermediate frames span six simulation frames (100 ms).

![VR tracking before/after](https://gist.githubusercontent.com/tommy-xr/84b2343f0b6704a25ad172d9c699d372/raw/vr-tracking.gif)

![VR lowered headset before/after](https://gist.githubusercontent.com/tommy-xr/84b2343f0b6704a25ad172d9c699d372/raw/vr-before-after.png)

![Flat parity](https://gist.githubusercontent.com/tommy-xr/84b2343f0b6704a25ad172d9c699d372/raw/flat-parity.png)

