### PR TITLE
test(sdk): restore native toxin self-offer coverage

### DIFF
--- a/tools/shock2-sdk/test/hydro2-vr-research-self-offer.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-vr-research-self-offer.e2e.test.ts
@@ -9,7 +9,16 @@ import type {
   Vec3,
 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
-import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+import {
+  GUI_PIXEL_TO_WORLD_SIZE,
+  LOOT_PANEL_SIZE_PX as PANEL_SIZE_PX,
+  add,
+  aimVrHandAt,
+  quatRotate,
+  normalize,
+  scale,
+  sub,
+} from "./helpers/vr-hand.js";
 
 // Regression for #1092. This follows the exact 25th Anniversary Hydro2 VR
 // production path that exposed the bug:
@@ -27,8 +36,6 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const SURVEY_LAB_DESK = 713;
 const TOXIN_A = 547;
-const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
-const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 
 function only(matches: EntitySummary[], label: string): EntitySummary {
   assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
@@ -151,7 +158,7 @@ test(
     assert.ok(toxinSlot, "Desk panel must render the authored Toxin-A slot");
 
     // Invert ProxyGuiScript's world -> normalized-canvas map for the rendered
-    // Toxin slot in the 188x296 container canvas.
+    // Toxin slot using the shared ContainerGui canvas dimensions.
     const panelSize: Vec3 = [
       PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
       PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
@@ -184,7 +191,7 @@ test(
     const productionSlotHit = await game.raycast({
       start: slotAim.start,
       end: slotAim.target,
-      collision_groups: ["world", "entity", "selectable", "ui"],
+      collision_groups: ["world", "entity", "selectable", "raycast", "ui"],
       max_distance: 1,
     });
     assert.equal(
@@ -200,6 +207,23 @@ test(
       "squeezing the real Desk slot must hold authored Toxin-A 547",
     );
     assert.equal(contains(await game.entities.detail(desk.id), toxin.id), false);
+
+    // Carry the real vial clear of its source desk before opening Research.
+    // Dropping while still aimed through the desk can legitimately offer it
+    // back to that container instead of exercising the self-offer path.
+    const pickupPosition = (await game.info()).player.position;
+    await game.input.set("right_hand.thumbstick", [0, -1]);
+    await game.step({ frames: 20 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 3 });
+    const carried = (await game.info()).player;
+    assert.equal(carried.right_hand_entity_id, toxin.id);
+    assert.ok(
+      Math.hypot(
+        ...carried.position.map((value, axis) => value - pickupPosition[axis]),
+      ) > 0.5,
+      "ordinary locomotion must carry the vial away from the source desk",
+    );
 
     // A held-item trigger uses ResearchableScript's real inventory action and
     // replaces the desk panel with the Toxin-A-bound Research GUI.
@@ -226,7 +250,7 @@ test(
     const panelHit = await game.raycast({
       start: panelAim.start,
       end: panelAim.target,
-      collision_groups: ["ui"],
+      collision_groups: ["world", "entity", "selectable", "raycast", "ui"],
       max_distance: 1,
     });
     assert.equal(
@@ -242,6 +266,52 @@ test(
     await game.step({ frames: 8 });
     assert.equal((await game.info()).player.right_hand_entity_id, null);
     await assertPhysicalWorldToxin(game, toxin.id);
+    await game.screenshot("hydro2-toxin-after-self-offer.png");
+
+    // The native drop can leave the vial falling or rotating. Let its real
+    // body settle before selecting a surface point that must remain under
+    // the hand ray while the aim helper advances simulation frames.
+    let settled = false;
+    let lastBody: PhysicsBodySummary | undefined;
+    for (let attempt = 0; attempt < 50; attempt++) {
+      await game.step({ frames: 6 });
+      const [body] = (await game.physics.bodies({ entityId: toxin.id })).bodies;
+      lastBody = body;
+      assert.ok(
+        body?.is_enabled,
+        `the dropped vial must keep its physical body while settling: ${JSON.stringify({ attempt, body })}`,
+      );
+      if (
+        Math.hypot(...body.velocity) < 0.02 &&
+        Math.hypot(...body.angular_velocity) < 0.05
+      ) {
+        settled = true;
+        break;
+      }
+    }
+    assert.ok(
+      settled,
+      `the dropped vial should settle before native re-grab: ${JSON.stringify(lastBody)}`,
+    );
+
+    // Walk out of the world panel's ordinary auto-close range, then return.
+    // Its own-host priority would otherwise select Research instead of the vial.
+    let retreatFrames = 0;
+    await game.input.set("right_hand.thumbstick", [0, -1]);
+    while ((await uiBodies(game)).length > 0 && retreatFrames < 80) {
+      await game.step({ frames: 10 });
+      retreatFrames += 10;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.equal(
+      (await uiBodies(game)).length,
+      0,
+      "walking away must dismiss the world panel before recovering its host",
+    );
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: retreatFrames });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 3 });
 
     // Player-observable recovery: select the dropped vial through the real
     // hand ray and squeeze it back into the same hand.
@@ -254,7 +324,22 @@ test(
       visibility: "required",
     });
     assert.equal(droppedAim.target_confirmed, true, JSON.stringify(droppedAim));
-    await aimVrHandAt(game, droppedAim.world_point, 0.35);
+    const regrabAim = await aimVrHandAt(game, droppedAim.world_point, 0.35);
+    const regrabHit = await game.raycast({
+      start: regrabAim.start,
+      // The actual hand ray continues beyond the selected surface.
+      end: add(
+        regrabAim.start,
+        scale(normalize(sub(regrabAim.target, regrabAim.start)), 1),
+      ),
+      collision_groups: ["world", "entity", "selectable", "raycast", "ui"],
+      max_distance: 1,
+    });
+    assert.equal(
+      regrabHit.entity_id,
+      toxin.id,
+      `the production ray must reach the settled vial before re-grabbing: ${JSON.stringify(regrabHit)}`,
+    );
     await game.input.set("right_hand.squeeze", 1);
     await game.step({ frames: 5 });
     assert.equal(


### PR DESCRIPTION
The Hydro2 VR Toxin-A regression stopped at its initial loot-slot ray because its copied 188×296 canvas no longer matched the shared 188×178 loot layout. Use the shared canvas constants so the test reaches the real pickup and Research interaction again.

Carry the physically collected vial clear of its source desk using ordinary locomotion, and require the combined production ray to hit its own Research proxy before release. The original UI-only probe could see that proxy through a desk that legitimately received the release offer. Preserve the immediate world-reference, containment, physics, and render assertions; then wait a bounded number of simulation frames for the dropped vial to settle before selecting it again. Extend the diagnostic ray beyond the exact selected surface, matching the controller ray, dismiss the host-prioritized Research quad by walking beyond its ordinary auto-close range and returning, and still require real squeeze to re-grab the vial.

Fixes #1420.

Validation:
- Negative-first main baseline reproduced the original slot-ray failure. Canvas-only correction exposed a wrong release recipient and stale moving/surface-endpoint targeting; the final fixture retains the actual native re-grab assertion.
- Corrected focused runtime test passed on immutable main c6ddb35b (46.0 s), ladder #1405 (46.5 s), replicator #1410 (47.1 s), and keypad #1411 (45.2 s).
- SDK fast tests: 60 passed / 432 skipped; TypeScript build, `git diff --check`, and pre-push workspace format check passed.
- CI: all five required checks passed.
- Independent review passed: all native pickup/self-offer/recovery assertions remain, with combined masks and ordinary auto-close traversal.


Visual assessment: test-only fixture correction; no game code or rendered behavior changes, so a before/after GIF would not show this change. Local runtime screenshots were captured for inspection.

Discovered during the full-game detailed play-through, 25th Anniversary assets, VR presentation, seed 1258205384. No debug grants or direct entity messages replace the native pickup, research, self-offer, or re-grab paths.
