### PR TITLE
test(sdk): accept mounted Korenchkin transcript variants

### DIFF
--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -280,16 +280,16 @@ test(
   },
 );
 
-// Hydro 3's Korenchkin entry is authored as `LogText12:  "..."` in
-// LEVEL03.STR, with two spaces between the colon and opening quote. It follows
-// the same Dark string-table grammar as the compact `Key:"..."` form and must
-// remain available after the disc has been consumed into the PDA.
+// The mounted transcript can use either the original ellipses or SCP's
+// punctuation. String-table colon whitespace is covered independently by
+// strings_importer::tests::accepts_whitespace_between_colon_and_opening_quote.
 test(
-  "hydro3: collected Korenchkin log opens its double-spaced transcript",
+  "hydro3: collected Korenchkin log opens its mounted transcript",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
       mission: "hydro3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 0),
     });
     await game.step({ frames: 5 });
 
@@ -309,14 +309,27 @@ test(
 
     const panel = (await game.ui.state()).active_panel;
     assert.ok(panel, "the collected Hydro 3 log should open in the reader");
+    assert.notEqual(
+      panel.entity_id,
+      korenchkin.id,
+      "the collected log must open in the player-owned reader, not its source disc",
+    );
     const transcript = panel.elements
       .filter((element) => element.kind === "text" && element.text)
       .map((element) => element.text)
       .join(" ");
     assert.ok(
-      transcript.includes("Glory... to the Many"),
+      [
+        "Glory... to the Many... I am a voice in their choir.",
+        "Glory to the Many. I am a voice in their choir.",
+      ].some((opening) => transcript.includes(opening)),
       `the reader should render Korenchkin's transcript (got: ${transcript.slice(0, 160)})`,
     );
+    assert.ok(
+      transcript.toUpperCase().includes("KORENCHKIN"),
+      "the reader should identify Korenchkin as the sender",
+    );
+    await game.screenshot("hydro3-korenchkin-mounted-transcript.png");
     assert.deepEqual(
       (await game.info()).player.collected_logs,
       [{ deck: 3, log: 12, read: true }],


### PR DESCRIPTION
The Hydro3 collected-log fixture rejected the active SCP transcript because it required the original ellipses. Both supported string tables contain the same Korenchkin sentence with different punctuation. Accept those two exact authored openings, require Korenchkin's sender text and a reader host separate from the source disc, and retain exact deck 3/log 12 unread→read checks.

Rename the scenario to describe mounted-transcript coverage. The deterministic `strings_importer::tests::accepts_whitespace_between_colon_and_opening_quote` test already covers the original double-space grammar and remains unchanged. No localization or game code changes are needed.

Fixes #1423. Related: #1262.

Validation:
- Negative-first main baseline reproduced the stale ellipsis assertion against the correctly mounted SCP text.
- Corrected targeted test passed on immutable main c6ddb35b (16.0 s), #1405 (16.0 s), #1410 (14.6 s), #1411 (14.4 s), and #1421 (14.1 s).
- SDK fast tests: 60 passed / 432 skipped; TypeScript build, `git diff --check`, and pre-push workspace format check passed.
- Independent review passed (committed diff and actual reader PNG). All five CI checks passed; the campaign manager verified the final result.


Visual assessment: test-only assertions and fixture naming; no game-rendered behavior changes, so a before/after GIF would not show this change. A local actual-reader PNG is captured for review.

Campaign: full-game, detailed, 25th Anniversary assets, VR, seed 1258205384. This existing reader scenario uses its original flat presentation; the campaign discovery does not imply headset validation. No public saves or synthetic localization overrides.
