### PR TITLE
feat(gameplay): enable Agility movement upgrades

### DIFF
--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use crate::{
     EnvMap, EnvSoundQuery, ResolvedSoundSchema, SoundSchema, SpeechDB, TagDatabase,
-    gamesys::params::{HrmParams, SkillParams, TrainerCostTables},
+    gamesys::params::{GameParams, HrmParams, SkillParams, TrainerCostTables},
     properties::{LinkDefinition, LinkDefinitionWithData, PropertyDefinition},
     ss2_chunk_file_reader::{self},
     ss2_entity_info::{self, SystemShock2EntityInfo},
@@ -20,6 +20,8 @@ pub struct Gamesys {
     hrm_params: Option<HrmParams>,
     /// Skill-system tuning (`SKILLPARAM` file-var chunk).
     skill_params: Option<SkillParams>,
+    /// General gameplay tuning, including the authored Agility speed table.
+    game_params: Option<GameParams>,
 }
 
 impl Gamesys {
@@ -69,6 +71,10 @@ impl Gamesys {
         self.hrm_params.as_ref()
     }
 
+    pub fn game_params(&self) -> Option<&GameParams> {
+        self.game_params.as_ref()
+    }
+
     pub fn skill_params(&self) -> Option<&SkillParams> {
         self.skill_params.as_ref()
     }
@@ -97,6 +103,7 @@ pub fn read<T: io::Read + io::Seek>(
     let trainer_costs = TrainerCostTables::read(&table_of_contents, reader);
     let hrm_params = HrmParams::read(&table_of_contents, reader);
     let skill_params = SkillParams::read(&table_of_contents, reader);
+    let game_params = GameParams::read(&table_of_contents, reader);
 
     // Uncomment to output debug info for voices:
     // debug_print_voices(&sound_schema, &speech_db);
@@ -110,5 +117,6 @@ pub fn read<T: io::Read + io::Seek>(
         trainer_costs,
         hrm_params,
         skill_params,
+        game_params,
     }
 }

--- a/dark/src/gamesys/params.rs
+++ b/dark/src/gamesys/params.rs
@@ -62,6 +62,47 @@ pub struct SkillParams {
     pub organ_damage: f32,
 }
 
+/// Retail `GAMEPARAM` (`sGameParams`): 19 packed little-endian floats.
+/// Agility consumes `speed[AGI-1]`; the other authored fields remain data only.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GameParams {
+    pub throw_power: f32,
+    pub bash: [f32; 8],
+    pub speed: [f32; 8],
+    pub overlay_distance: f32,
+    pub frob_distance: f32,
+}
+
+impl GameParams {
+    pub fn read<T: io::Read + io::Seek>(
+        table_of_contents: &ChunkFileTableOfContents,
+        reader: &mut T,
+    ) -> Option<Self> {
+        let chunk = table_of_contents.get_chunk("GAMEPARAM".to_owned())?;
+        if chunk.length < 76 {
+            return None;
+        }
+        reader.seek(io::SeekFrom::Start(chunk.offset)).ok()?;
+        Self::read_record(reader)
+    }
+
+    fn read_record<T: io::Read>(reader: &mut T) -> Option<Self> {
+        let throw_power = reader.read_f32::<LittleEndian>().ok()?;
+        let mut bash = [0.0; 8];
+        let mut speed = [0.0; 8];
+        for value in bash.iter_mut().chain(speed.iter_mut()) {
+            *value = reader.read_f32::<LittleEndian>().ok()?;
+        }
+        Some(Self {
+            throw_power,
+            bash,
+            speed,
+            overlay_distance: reader.read_f32::<LittleEndian>().ok()?,
+            frob_distance: reader.read_f32::<LittleEndian>().ok()?,
+        })
+    }
+}
+
 fn read_table<T: io::Read + io::Seek, const COLS: usize, const ROWS: usize>(
     table_of_contents: &ChunkFileTableOfContents,
     reader: &mut T,
@@ -169,7 +210,23 @@ impl SkillParams {
 mod tests {
     use std::io::Cursor;
 
-    use super::SkillParams;
+    use super::{GameParams, SkillParams};
+
+    #[test]
+    fn parses_game_params_speed_after_throw_and_bash_fields() {
+        let values = [
+            10.0_f32, 0.005, 0.0045, 0.004, 0.0035, 0.003, 0.0025, 0.002, 0.0015, 1.2, 1.3, 1.4,
+            1.5, 1.6, 1.7, 1.85, 2.0, 175.0, 50.0,
+        ];
+        let bytes: Vec<u8> = values.into_iter().flat_map(f32::to_le_bytes).collect();
+        let params = GameParams::read_record(&mut Cursor::new(&bytes)).unwrap();
+        assert_eq!(params.speed, [1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.85, 2.0]);
+        assert_eq!(params.bash[7], 0.0015);
+        assert_eq!(params.frob_distance, 50.0);
+        for length in 0..bytes.len() {
+            assert!(GameParams::read_record(&mut Cursor::new(&bytes[..length])).is_none());
+        }
+    }
 
     #[test]
     fn parses_packed_retail_skill_params_layout() {

--- a/projects/agility-movement.md
+++ b/projects/agility-movement.md
@@ -1,0 +1,21 @@
+# Base Agility movement
+
+The native Stats Trainer can sell Agility because shared player locomotion now consumes the saved base stat. It charges the existing Normal-difficulty `STATCOST` row; no new currency, save field, or runtime-specific movement path is involved. This addresses #1422, not the broader #1310 modifier work.
+
+## Authored data and integration
+
+The original [`ShockPlayer` recalculation](https://github.com/dima424658/darkengine/blob/main/src/shock/shkplayr.cpp#L919) selects `GAMEPARAM.speed[agility - 1]`, substitutes 1 for a zero entry, and installs a translation-only speed scale. The [`sGameParams` layout](https://github.com/dima424658/darkengine/blob/main/src/shock/shkparam.h#L82) is 19 floats: throw power, eight bash coefficients, eight speed scales, overlay distance, and frob distance. The speed table begins at byte 36 of the 76-byte chunk.
+
+The shipped 25th Anniversary `sshock2.kpf/data/shock2.gam` table is `[1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.85, 2.0]`. Valid custom gamesys tables take precedence. Missing/truncated tables, or tables with negative/nonfinite entries, use this documented retail fallback. Authored zero values retain the original zero-to-one substitution. A normalized ratio that overflows or underflows uses the corresponding retail ratio. Base stat lookup clamps to the table's 1–8 range; native training still caps at 6.
+
+The port has an established Agility-1 input rate of 25 Dark units/s (10 world units/s after `SCALE_FACTOR = 2.5`). It predates stat consumption: commit `f1e2a899` merely extracted the existing literal into `PLAYER_MOVE_SPEED`. That is not asserted to be the original game's exact absolute speed. One named boundary, `agility_movement_scale`, divides the selected authored entry by the level-1 entry. Consequently Agility 1 remains 10 world units/s, Agility 2 becomes 10 × 1.3/1.2 ≈ 10.833, and Agility 6 becomes 10 × 1.7/1.2 ≈ 14.167. This preserves established starting movement while matching authored relative progression.
+
+The multiplier applies once to ordinary right-stick translation in the shared mission update. Direction, analog magnitude, collision and stance resolution retain their existing behavior. Flat push-to-climb redirects that scaled input as before; physical VR hand pulls and mantle trajectories are not amplified. Turning, jump launch, gravity, developer vertical input, and detached camera flight keep their own existing rates. The table and stat are read each update, so a native purchase or current-build load takes effect without a cached movement field.
+
+## Deferred work
+
+This change does not implement Agility fall vulnerability, weapon kickback/handling, temporary implant/psi/hypo modifiers, Speedy, or a general movement modifier stack. It does not introduce retail run/walk direction factors or a crouched movement penalty. Their absence remains separate from the supported base-stat movement consumer.
+
+## Validation
+
+`agility-movement.e2e.test.ts` measures ordinary flat and VR input at controlled stats, including unchanged level-1 pace, authored ratios, partial reverse input and crouched strafe. It checks turn and detached-camera independence, real hand-pull distance and flat ladder redirection. A fresh MedSci trainer fixture purchases Agility with the native button, measures movement, and saves/loads within the same build. Parser/unit tests cover packed field order, every truncated record length, custom tables, zero semantics, invalid data and bounded indexing. No campaign save is used or published.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -241,9 +241,9 @@ dev_params! {
     /// something. Inert while the camera is attached (the two poses are the
     /// same pose).
     FREE_CAMERA_CULL_FROM_CAMERA = bool("free_camera_cull", "Cull from cam", false),
-    /// How fast the free camera flies, in the player's own speed units - the
-    /// default IS [`PLAYER_MOVE_SPEED`], so "walking pace" cannot drift from
-    /// what walking actually is. These are pre-scale SS2 units, not world
+    /// How fast the free camera flies, in the player's own speed units. Its
+    /// default is the established Agility-1 rate [`PLAYER_MOVE_SPEED`]; stat
+    /// upgrades do not change developer flight. These are SS2 units, not world
     /// units per second: the consumer divides by `dark::SCALE_FACTOR` (2.5)
     /// exactly as the player's locomotion does, so the default 25 travels 10
     /// world units a second, not 25. The range spans a crawl to a fast survey of a

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1864,6 +1864,10 @@ pub struct GlobalHrmParams(pub Option<dark::gamesys::HrmParams>);
 #[derive(Unique, Clone)]
 pub struct GlobalSkillParams(pub Option<dark::gamesys::SkillParams>);
 
+/// Authored Agility movement table, shared by flat and VR locomotion.
+#[derive(Unique)]
+pub struct GlobalGameParams(pub Option<dark::gamesys::GameParams>);
+
 /// Whether `template_id` is `class_template_id` or inherits from it, given a
 /// template-inheritance hierarchy (MetaProp parent map). A free function
 /// (rather than only the `GlobalTemplateHierarchy` method below) so callers
@@ -1912,10 +1916,10 @@ struct FailedAnimationGuard {
 /// both, rather than the two silently drifting apart.
 pub const PLAYER_TURN_RATE: f32 = 2.0;
 
-/// How fast the player walks, in SS2 units per second at full deflection
-/// (divided by `dark::SCALE_FACTOR` at the point of use). Shared with the
-/// free camera, whose speed dev param defaults to it so "walking pace" stays
-/// the same pace.
+/// Established Agility-1 movement rate, in SS2 units/second at full
+/// deflection (divided by `dark::SCALE_FACTOR` at the point of use). Ordinary
+/// locomotion applies authored Agility ratios here; the free camera keeps
+/// this unmodified rate as its developer speed default.
 pub const PLAYER_MOVE_SPEED: f32 = 25.0;
 
 pub struct MissionCore {
@@ -2316,6 +2320,7 @@ impl MissionCore {
         ));
         world.add_unique(GlobalHrmParams(game_entity_info.hrm_params().cloned()));
         world.add_unique(GlobalSkillParams(game_entity_info.skill_params().cloned()));
+        world.add_unique(GlobalGameParams(game_entity_info.game_params().cloned()));
         let (mut psi_powers, psi_selection) = crate::psi::build_psi_power_registry(&entity_info_rc);
         // Player-facing discipline names come from the psihelp string table;
         // a data install without it just keeps the gamesys symbolic names.
@@ -3530,10 +3535,22 @@ impl MissionCore {
         let dir = new_rotation * input_context.head.rotation;
         let facing = dir.rotate_vector(cgmath::vec3(0.0, 0.0, -1.0));
         let move_thumbstick_value = input_context.right_hand.thumbstick;
+        let movement_scale = {
+            let quests = self.world.borrow::<UniqueView<QuestInfo>>().unwrap();
+            let params = self.world.borrow::<UniqueView<GlobalGameParams>>().unwrap();
+            crate::player_stats::agility_movement_scale(
+                quests.player_stats().agility,
+                params.0.as_ref(),
+            )
+        };
+        // Apply once to ordinary stick movement, before collision/flat ladder
+        // redirection. Hand pulls, turn, jump launch and free-camera flight
+        // have their own paths and do not gain an Agility multiplier.
+        let move_speed = PLAYER_MOVE_SPEED * movement_scale;
         let forward = dir.rotate_vector(cgmath::vec3(
-            -delta_time * move_thumbstick_value.x * PLAYER_MOVE_SPEED / dark::SCALE_FACTOR,
+            -delta_time * move_thumbstick_value.x * move_speed / dark::SCALE_FACTOR,
             0.0,
-            -delta_time * move_thumbstick_value.y * PLAYER_MOVE_SPEED / dark::SCALE_FACTOR,
+            -delta_time * move_thumbstick_value.y * move_speed / dark::SCALE_FACTOR,
         ));
 
         let up_value = input_context.left_hand.thumbstick.y / dark::SCALE_FACTOR;

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -231,6 +231,32 @@ impl Default for PlayerStats {
     }
 }
 
+/// Normalize the retail Agility speed table at the port's existing level-1
+/// locomotion boundary. This preserves the established starting pace while
+/// applying authored relative progression; it is not retail absolute speed.
+///
+/// `ShockPlayer::RecalcData` selects GAMEPARAM.speed[AGI-1], replacing zero
+/// with 1. A missing table or negative/nonfinite entries use the shipped
+/// table; valid custom tables (including equal levels and zero entries) win.
+/// Temporary stat modifiers, fall vulnerability and weapon handling are not
+/// implemented here. The caller supplies the saved base Agility stat.
+pub fn agility_movement_scale(agility: i32, params: Option<&dark::gamesys::GameParams>) -> f32 {
+    const RETAIL_SPEED: [f32; 8] = [1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.85, 2.0];
+    let authored = params
+        .map(|params| &params.speed)
+        .filter(|speed| speed.iter().all(|value| value.is_finite() && *value >= 0.0))
+        .unwrap_or(&RETAIL_SPEED);
+    let retail_zero = |value: f32| if value == 0.0 { 1.0 } else { value };
+    let index = (agility.clamp(1, 8) - 1) as usize;
+    let scale = retail_zero(authored[index]) / retail_zero(authored[0]);
+    // A finite but tiny custom baseline can overflow the ratio.
+    if scale.is_finite() && scale > 0.0 {
+        scale
+    } else {
+        RETAIL_SPEED[index] / RETAIL_SPEED[0]
+    }
+}
+
 impl PlayerStats {
     pub fn new() -> PlayerStats {
         PlayerStats::default()
@@ -738,5 +764,51 @@ mod tests {
                 "Psychogenic Agility".to_string()
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod agility_tests {
+    use super::agility_movement_scale;
+    use dark::gamesys::GameParams;
+    fn params(speed: [f32; 8]) -> GameParams {
+        GameParams {
+            throw_power: 10.0,
+            bash: [0.0; 8],
+            speed,
+            overlay_distance: 175.0,
+            frob_distance: 50.0,
+        }
+    }
+    #[test]
+    fn agility_normalizes_at_level_one_and_uses_every_authored_entry() {
+        let authored = params([2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+        for level in 1..=8 {
+            assert_eq!(
+                agility_movement_scale(level, Some(&authored)),
+                (level + 1) as f32 / 2.0
+            );
+        }
+        assert_eq!(agility_movement_scale(i32::MIN, Some(&authored)), 1.0);
+        assert_eq!(agility_movement_scale(i32::MAX, Some(&authored)), 4.5);
+    }
+    #[test]
+    fn agility_keeps_retail_zero_semantics_and_falls_back_only_for_unusable_tables() {
+        let mut authored = params([0.0; 8]);
+        authored.speed[1] = 2.0;
+        assert_eq!(agility_movement_scale(1, Some(&authored)), 1.0);
+        assert_eq!(agility_movement_scale(2, Some(&authored)), 2.0);
+        authored.speed = [2.0; 8];
+        authored.speed[1] = 0.0;
+        assert_eq!(agility_movement_scale(2, Some(&authored)), 0.5);
+        for invalid in [-1.0, f32::NAN, f32::INFINITY] {
+            authored.speed[7] = invalid;
+            assert_eq!(agility_movement_scale(2, Some(&authored)), 1.3 / 1.2);
+        }
+        assert_eq!(agility_movement_scale(6, None), 1.7 / 1.2);
+        authored.speed = [1.0; 8];
+        authored.speed[0] = f32::MIN_POSITIVE;
+        authored.speed[1] = f32::MAX;
+        assert_eq!(agility_movement_scale(2, Some(&authored)), 1.3 / 1.2);
     }
 }

--- a/shock2vr/src/scripts/gui/trainer.rs
+++ b/shock2vr/src/scripts/gui/trainer.rs
@@ -22,10 +22,9 @@
 //! difficulty (no difficulty setting exists yet).
 //!
 //! A stat is only sold when it has a live gameplay consumer. Strength expands
-//! the backpack, Endurance raises maximum HP, and Cyber Affinity feeds hacking
-//! odds; Psionics and Agility stay visible but unavailable until their
-//! advertised systems exist. This prevents a stored-only stat bump from
-//! consuming irreplaceable modules.
+//! the backpack, Endurance raises maximum HP, Cyber Affinity feeds hacking,
+//! Psionics scales casts, and Agility scales shared movement. Other retail
+//! Agility effects (fall vulnerability and weapon handling) remain deferred.
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::gamesys::TrainerCostTables;
@@ -73,7 +72,11 @@ pub const ENDURANCE_HP_PER_LEVEL: u32 = 5;
 pub fn stat_upgrade_available(stat: Stat) -> bool {
     matches!(
         stat,
-        Stat::Strength | Stat::Endurance | Stat::CyberAffinity | Stat::PsionicAbility
+        Stat::Strength
+            | Stat::Endurance
+            | Stat::CyberAffinity
+            | Stat::PsionicAbility
+            | Stat::Agility
     )
 }
 
@@ -563,8 +566,8 @@ mod tests {
         );
         assert_eq!(
             upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Agility)),
-            None,
-            "Agility must not be sold until it has a gameplay effect"
+            Some(3),
+            "Agility is purchasable now that shared movement consumes it"
         );
     }
 }

--- a/tools/shock2-sdk/test/agility-movement.e2e.test.ts
+++ b/tools/shock2-sdk/test/agility-movement.e2e.test.ts
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { vrClimbPull } from "./helpers/vr-climb.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+const planar = (a: Vec3, b: Vec3) => Math.hypot(a[0] - b[0], a[2] - b[2]);
+const close = (actual: number, expected: number, description: string) =>
+  assert.ok(
+    Math.abs(actual - expected) < 0.04,
+    `${description}: ${actual} != ${expected}`,
+  );
+
+// The shipped GAMEPARAM speed table is [1.2,1.3,1.4,1.5,1.6,1.7,1.85,2].
+// The port's Agility 1 input pace is 25 Dark units/s = 10 world units/s.
+// Negative-first: the baseline moves 10 world units at both Agility 1 and 6.
+for (const vr of [false, true]) {
+  test(
+    `Agility changes shared ${vr ? "VR" : "flat"} movement, without scaling turn or developer flight`,
+    { skip: !enabled, timeout: 600_000 },
+    async () => {
+      await using game = await GameServer.launch({
+        mission: "debug_minimal",
+        debugFlags: vr ? ["--vr"] : [],
+      });
+      await game.step({ frames: 30 });
+      const travel = async (
+        agility: number,
+        crouch: boolean,
+        stick: [number, number],
+      ) => {
+        await game.input.set("right_hand.thumbstick", [0, 0]);
+        await game.input.set("crouch", crouch ? 1 : 0);
+        await game.player.setStats({ agility });
+        await teleportVerified(game, { x: 0, y: 1.5, z: 0 });
+        await game.input.set("head.look", [0, 0]);
+        await game.step({ frames: 30 });
+        await game.input.set("right_hand.thumbstick", stick);
+        // Prime the queued kinematic target before measuring 60 full steps.
+        await game.step({ frames: 1 });
+        const before = (await game.info()).player.position;
+        await game.step({ frames: 60 });
+        await game.input.set("right_hand.thumbstick", [0, 0]);
+        const after = (await game.info()).player.position;
+        return planar(before, after);
+      };
+      const independentMotion = async () => {
+        const before = (await game.info()).player.rotation;
+        await game.input.set("left_hand.thumbstick", [1, 0]);
+        await game.step({ frames: 15 });
+        await game.input.set("left_hand.thumbstick", [0, 0]);
+        const after = (await game.info()).player.rotation;
+        const dot = Math.abs(
+          before.reduce((sum, value, i) => sum + value * after[i], 0),
+        );
+        const turn = 2 * Math.acos(Math.min(1, dot));
+        await game.camera.set({ position: [0, 5, 0], lookAt: [-10, 5, 0] });
+        const pawn = (await game.info()).player.position;
+        const start = (await game.camera.state()).eye_position!;
+        await game.input.set("right_hand.thumbstick", [0, 1]);
+        await game.step({ frames: 60 });
+        await game.input.set("right_hand.thumbstick", [0, 0]);
+        const flight = planar(start, (await game.camera.state()).eye_position!);
+        close(
+          planar(pawn, (await game.info()).player.position),
+          0,
+          "free camera keeps pawn still",
+        );
+        await game.camera.attach();
+        return { turn, flight };
+      };
+      const low = await travel(1, false, [0, 1]);
+      const initial = await independentMotion();
+      const middle = await travel(2, false, [0, 1]);
+      close(
+        await travel(2, true, [1, 0]),
+        (10 * 1.3) / 1.2,
+        "crouched strafe keeps Agility scaling",
+      );
+      close(
+        await travel(2, false, [0, -0.5]),
+        (5 * 1.3) / 1.2,
+        "partial reverse stays proportional",
+      );
+      const high = await travel(6, false, [0, 1]);
+      const upgraded = await independentMotion();
+      console.info("Measured Agility movement", {
+        vr,
+        level1: low,
+        level2: middle,
+        level6: high,
+      });
+      close(low, 10, "established Agility1 pace");
+      close(middle / low, 1.3 / 1.2, "Agility2 authored ratio");
+      close(high, (10 * 1.7) / 1.2, "Agility6 pace");
+      close(initial.turn, 0.5, "ordinary turn rate");
+      close(upgraded.turn, initial.turn, "Agility leaves turn unchanged");
+      close(initial.flight, 10, "developer flight retains its pace");
+      close(
+        upgraded.flight,
+        initial.flight,
+        "Agility leaves developer flight unchanged",
+      );
+    },
+  );
+}
+
+test(
+  "native Agility upgrade charges authored cost, changes movement, and survives current-build save/load",
+  { skip: !enabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis" });
+    await game.step({ frames: 5 });
+    await game.player.setStats({ cyber_modules: 3, agility: 1 });
+    const trainer = (
+      await game.entities.list({ filter: "Trainer" })
+    ).entities.find((e) => e.template_id === 1352);
+    assert.ok(trainer);
+    const [x, y, z] = (await game.entities.detail(trainer.id)).position;
+    // A short unobstructed path in the same trainer room avoids replacing the
+    // purchased character with a debug scene. No campaign save is involved.
+    const measure = async () => {
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      await teleportVerified(game, { x, y: y + 0.5, z: z + 1.2 });
+      await game.step({ frames: 30 });
+      const player = (await game.info()).player;
+      await game.input.lookAtWorldPoint([
+        player.position[0],
+        player.position[1] + player.camera_offset[1],
+        player.position[2] + 10,
+      ]);
+      await game.input.set("right_hand.thumbstick", [0, 0.1]);
+      await game.step({ frames: 1 });
+      const before = (await game.info()).player.position;
+      await game.step({ frames: 12 });
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      return planar(before, (await game.info()).player.position);
+    };
+    const baseMoved = await measure();
+    close(baseMoved, 0.2, "level-1 movement before the native purchase");
+    await teleportVerified(game, { x, y: y + 0.5, z: z + 1.2 });
+    await game.step({ frames: 30 });
+    await game.entities.sendMessage(trainer.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel);
+    const button = panel.elements.find(
+      (e) => e.kind === "button" && e.label === "Agility",
+    );
+    assert.ok(button);
+    await clickUiElement(game, button);
+    assert.equal(
+      (await game.info()).player.stats?.agility,
+      2,
+      "native purchase must apply Agility",
+    );
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      0,
+      "1→2 costs three authored modules",
+    );
+    const moved = await measure();
+    assert.ok(
+      Math.abs(moved / baseMoved - 1.3 / 1.2) < 0.005,
+      `native purchase must increase movement by the authored ratio: ${baseMoved}→${moved}`,
+    );
+    close(
+      moved,
+      (0.2 * 1.3) / 1.2,
+      "purchased Agility changes actual movement",
+    );
+    await game.step({ frames: 10 });
+    const name = `agility_e2e_${Date.now()}`;
+    await game.save(name);
+    await game.player.setStats({ agility: 6 });
+    await game.load(name);
+    assert.equal((await game.info()).player.stats?.agility, 2);
+    assert.equal((await game.info()).player.stats?.cyber_modules, 0);
+    const loadedMoved = await measure();
+    assert.ok(
+      Math.abs(loadedMoved / moved - 1) < 0.005,
+      `loaded Agility keeps actual movement effect: ${moved}→${loadedMoved}`,
+    );
+  },
+);
+
+test(
+  "Agility preserves physical VR hand pull distance and ordinary flat ladder redirection",
+  { skip: !enabled, timeout: 600_000 },
+  async () => {
+    for (const vr of [true, false]) {
+      await using game = await GameServer.launch({
+        mission: "debug_ladder",
+        debugFlags: vr ? ["--vr"] : [],
+      });
+      for (const agility of [1, 6]) {
+        await game.input.set("right_hand.squeeze", 0);
+        await game.input.set("right_hand.thumbstick", [0, 0]);
+        await game.step({ frames: 1 });
+        await game.player.setStats({ agility });
+        await teleportVerified(game, { x: -5.5, y: 1.5, z: 0 });
+        await game.step({ frames: 30 });
+        if (vr) {
+          const result = await vrClimbPull(game, {
+            grabAt: [-6.8, 2.6, 0],
+            pull: [0, -1, 0],
+            frames: 30,
+          });
+          close(
+            result.after[1] - result.before[1],
+            1,
+            "Agility cannot amplify a physical hand pull",
+          );
+          assert.equal(
+            (await game.info()).player.climb.grips[0]?.kind,
+            "ladder",
+          );
+        } else {
+          const before = (await game.info()).player.position;
+          const eye = (await game.info()).player.camera_offset[1];
+          await game.input.lookAtWorldPoint([-7, before[1] + eye, 0]);
+          await game.input.set("right_hand.thumbstick", [0, 1]);
+          await game.step({ frames: 30 });
+          await game.input.set("right_hand.thumbstick", [0, 0]);
+          const after = (await game.info()).player.position;
+          assert.ok(
+            after[1] - before[1] > 0.7,
+            "flat input still redirects up the authored ladder",
+          );
+          assert.ok(after[0] > -7, "ladder backing remains solid");
+        }
+      }
+    }
+  },
+);

--- a/tools/shock2-sdk/test/trainer.e2e.test.ts
+++ b/tools/shock2-sdk/test/trainer.e2e.test.ts
@@ -12,7 +12,7 @@ import { teleportVerified } from "./helpers/teleport.js";
 // the current level and the cost of the next level from the gamesys cost
 // tables (STATCOST 3/8/15/30/50 etc.). Only stats with live effects may be
 // bought: Strength expands the backpack, Endurance raises maximum HP,
-// Cybernetics feeds the hacking path, and storage-only stats refuse without
+// Cybernetics feeds the hacking path, and capped stats refuse without
 // spending modules.
 //
 // Negative-first: on the C1 base, frobbing the Stats Trainer hits the
@@ -38,7 +38,7 @@ test(
 
     // Provision only currency/items; purchases still go through the real MFD,
     // button messages, effect queue, cost table, and live player properties.
-    const funded = await game.player.setStats({ cyber_modules: 29 });
+    const funded = await game.player.setStats({ cyber_modules: 29, agility: 6 });
     assert.equal(funded.cyber_modules, 29);
     assert.equal(funded.endurance, 1, "the regression starts at Endurance 1");
     await Promise.all([
@@ -86,8 +86,8 @@ test(
     await game.screenshot("trainer-panel-open.png");
 
     // --- The panel lists labeled rows with current level + cost from the
-    // gamesys STATCOST table (Endurance 1 -> 2 costs 3). Unsupported stats
-    // remain listed but clearly unavailable instead of quoting a price. ---
+    // gamesys STATCOST table (Endurance 1 -> 2 costs 3). Capped stats
+    // remain listed at MAX instead of quoting another price. ---
     const textEl = (needle: string, els: UiElement[]) =>
       els.find((e) => e.kind === "text" && e.text?.includes(needle));
     const els = opened.active_panel.elements;
@@ -101,10 +101,10 @@ test(
         els.filter((e) => e.kind === "text").map((e) => e.text),
       )}`,
     );
-    assert.ok(textEl("unavailable", els), "storage-only stats are marked unavailable");
+    assert.ok(textEl("lvl 6 (MAX)", els), "capped Agility is marked MAX");
     assert.ok(textEl("modules: 29", els), "panel shows the module pool");
 
-    // --- A storage-only stat refuses without taking currency. The same
+    // --- A capped stat refuses without taking currency. The same
     // machine then remains usable for a supported purchase. ---
     const rowButton = (label: string, from: UiElement[]) => {
       const el = from.find((e) => e.kind === "button" && e.label === label);
@@ -130,7 +130,7 @@ test(
     );
     let refreshed = await game.ui.state();
     assert.ok(
-      textEl("Upgrade unavailable", refreshed.active_panel!.elements),
+      textEl("Already at maximum", refreshed.active_panel!.elements),
       "the panel explains the refusal",
     );
 


### PR DESCRIPTION
The Stats Trainer refused Agility because it had no gameplay effect. Agility now scales ordinary movement in the shared flat/VR mission path, and the native trainer charges the authored upgrade cost. Level 1 keeps the established pace; level 2 moves about 8.3% faster. The purchased stat and movement effect survive current-build save/load.

Fixes #1422. The broader modifier work in #1310 remains open.

Read the eight speed values from the gamesys `GAMEPARAM` chunk, using the [original layout](https://github.com/dima424658/darkengine/blob/main/src/shock/shkparam.h#L82) and [Agility lookup](https://github.com/dima424658/darkengine/blob/main/src/shock/shkplayr.cpp#L919). The shipped 25AE table is `[1.2,1.3,1.4,1.5,1.6,1.7,1.85,2.0]`. One shared boundary normalizes against its level-1 entry, preserving the port's existing 25 Dark units/s (10 world units/s); this reproduces relative progression, not retail absolute speed. Valid custom tables and retail zero-to-one semantics are retained; missing/unusable tables use the documented retail fallback.

Collision and stance still resolve through the existing physics controller. Flat ladder redirection inherits the scaled stick input; physical VR hand pulls, mantle paths, turning, jump launch and detached developer-camera flight retain their existing behavior. Fall vulnerability, weapon handling, temporary implant/psi/hypo modifiers, Speedy and broader movement mode tuning remain deferred.

Validation: the baseline moves equally at Agility 1 and 6 and refuses the native purchase. Fixed flat/VR measurements for one primed second are approximately 10.000, 10.833 and 14.167 world units at levels 1, 2 and 6. Five focused SDK cases pass (trainer opening and currency are fixture setup; purchases use native pointer/controller input): shared movement/crouch/reverse/turn/free-camera behavior in both presentations, native purchase/cost/save-load, VR hand pull/flat ladder behavior, and existing trainer regression. Parser and Agility unit tests, SDK 60 fast tests/typecheck, and formatting pass. Native VR trigger capture also confirms the purchase changes Agility 1→2 and modules 3→0.

Full core tests pass (1,561 passed, 2 ignored); all CI checks are green. Independent code and media review passed. The all non-Android workspace check passed without warnings. Draft gate: the manager-owned full SDK suite remains in progress. No campaign save is used or uploaded.

Found during full-game detailed playthrough, 25th Anniversary assets, VR, seed1258205384.


The captures use the same deterministic setup and inputs on both builds. Trainer opening and three modules are fixture setup; the purchase uses a real VR trigger or flat pointer edge. Panel crops enlarge the same shared layout. The movement comparison provisions Agility 6 in a fresh `debug_ladder` scene and advances 24 simulation frames (0.4 s); GIF endpoint holds aid reading. All nine paired Agility-1 movement frames are pixel-identical in **both** presentations.

![VR trainer before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/trainer-vr.gif)

![VR trainer before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/trainer-vr.png)

![VR movement before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/movement-vr.gif)

![VR movement before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/movement-vr.png)

<details>
<summary>Flat render and movement verification</summary>

![Flat trainer before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/trainer-flat.gif)

![Flat trainer before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/trainer-flat.png)

![Flat movement before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/movement-flat.gif)

![Flat movement before/after](https://gist.githubusercontent.com/tommy-xr/cbc34a7b81dc462616b72aaeba6b4c91/raw/movement-flat.png)

</details>
