### PR TITLE
fix(loot): expose cyber-module pickups in containers

### DIFF
--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -266,12 +266,6 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
 
             let obj_icon = &maybe_obj_icon.unwrap().0;
 
-            // TODO: Fix this issue:
-            // thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidInput, error: "pcx::Reader::next_row_paletted called on non-paletted image" }', engine/src/texture_format.rs:81:45
-            if obj_icon.contains("upgrade") {
-                continue;
-            }
-
             let on_click = if self.take_on_click {
                 ContainerGuiMsg::Take(ent)
             } else {
@@ -878,6 +872,29 @@ mod tests {
                 kinds.iter().all(|k| *k == ImageKind::ObjectIcon),
                 "every item icon should be object-icon art, got {:?}",
                 kinds
+            );
+        }
+    }
+
+    #[test]
+    fn cyber_module_icons_remain_collectible_in_both_container_layouts() {
+        let (mut world, container, item, _inventory) = loot_world();
+        world.add_component(item, PropObjIcon("upgrade".to_owned()));
+
+        for gui in [
+            ContainerGui::loot_container(),
+            ContainerGui::inv_container(),
+        ] {
+            let components = gui.get_components(&None, container, &world, &ContainerGuiState {});
+            assert!(
+                components.iter().any(|component| matches!(
+                    component,
+                    GuiComponent::Button { texture, entity: Some(entity), kind, .. }
+                        if texture == "upgrade.pcx"
+                            && *entity == item
+                            && *kind == crate::ui::ImageKind::ObjectIcon
+                )),
+                "a contained cyber-module pile must emit its collectible object-icon button"
             );
         }
     }

--- a/tools/shock2-sdk/test/cyber-module-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/cyber-module-loot.e2e.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+import {
+  GUI_PIXEL_TO_WORLD_SIZE,
+  LOOT_PANEL_SIZE_PX,
+  add,
+  aimVrHandAt,
+  quatRotate,
+} from "./helpers/vr-hand.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+// MedSci1 corpse 490 authors cookie 1398 with StackCount 4. Exercise the
+// shared visible slot and each native collection gesture, without granting
+// modules or injecting Frob messages into either entity.
+for (const mode of ["flat", "vr-trigger", "vr-grip"] as const) {
+  test(`MedSci1 cyber-module corpse loot: ${mode}`, {
+    skip: !enabled,
+    timeout: 600_000,
+  }, async () => {
+    const vr = mode !== "flat";
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 0),
+      debugFlags: vr ? ["--vr"] : [],
+    });
+    await game.step({ frames: 5 });
+    const [corpse] = await game.entities.byTemplate(490);
+    const [cookie] = await game.entities.byTemplate(1398);
+    assert.ok(corpse && cookie, "the authored corpse and module pile must exist");
+    const detail = await game.entities.detail(cookie.id);
+    assert.equal(
+      Number(detail.properties.find((p) => p.name === "StackCount")?.value),
+      4,
+    );
+    assert.ok((await game.entities.detail(corpse.id)).outgoing_links.some(
+      (link) => link.link_type.startsWith("Contains") && link.target_id === cookie.id,
+    ));
+    const before = (await game.info()).player.stats?.cyber_modules;
+    assert.equal(typeof before, "number");
+
+    // Isolate the real corpse interaction at a supported nearby approach.
+    await teleportVerified(game, { x: -23, y: -6.755, z: -56.5 });
+    await game.step({ frames: 3 });
+    const aim = await game.player.aimAt(corpse.id, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+    if (vr) await aimVrHandAt(game, aim.world_point, 0.35);
+    const openInput = vr ? "right_hand.trigger" : "right_hand.squeeze";
+    await game.input.set(openInput, 1);
+    await game.step({ frames: 2 });
+    await game.input.set(openInput, 0);
+    await game.step({ frames: 4 });
+    const panel = (await game.ui.state()).active_panel;
+    assert.equal(
+      panel?.entity_id,
+      corpse.id,
+      "native use must open the corpse loot panel",
+    );
+    await game.screenshot(`cyber-module-loot-${mode}-before.png`);
+    const slot = panel.elements.find(
+      (element) => element.kind === "button" && element.entity_id === cookie.id,
+    );
+    assert.ok(slot, "the real four-module pile must have a visible collectible slot");
+    assert.ok(
+      slot.texture?.toLowerCase().includes("upgrade"),
+      "the slot must use the authored module icon",
+    );
+
+    if (vr) {
+      const proxies = (await game.physics.bodies()).bodies.filter(
+        (body) => body.collision_groups.includes("ui"),
+      );
+      assert.equal(proxies.length, 1);
+      const [proxy] = proxies;
+      const u = (slot.rect[0] + slot.rect[2] / 2) / LOOT_PANEL_SIZE_PX[0];
+      const v = (slot.rect[1] + slot.rect[3] / 2) / LOOT_PANEL_SIZE_PX[1];
+      const target = add(proxy.position, quatRotate(proxy.rotation, [
+        LOOT_PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE * (0.5 - u),
+        LOOT_PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE * (0.5 - v),
+        0,
+      ]));
+      const hand = await aimVrHandAt(game, target, 0.35);
+      const hit = await game.raycast({
+        start: hand.start,
+        end: hand.target,
+        collision_groups: ["world", "entity", "selectable", "raycast", "ui"],
+      });
+      assert.equal(
+        hit.entity_id,
+        proxy.entity_id,
+        "the native controller ray must reach the module slot",
+      );
+      const input = mode === "vr-trigger"
+        ? "right_hand.trigger"
+        : "right_hand.squeeze";
+      await game.input.set(input, 1);
+      await game.step({ frames: 6 });
+      await game.input.set(input, 0);
+      await game.step({ frames: 3 });
+    } else {
+      await clickUiElement(game, slot);
+    }
+
+    const after = (await game.info()).player;
+    assert.equal(
+      after.stats?.cyber_modules,
+      before! + 4,
+      "native collection must award exactly the authored four modules",
+    );
+    assert.equal(
+      after.right_hand_entity_id,
+      null,
+      "modules are collected rather than held",
+    );
+    assert.deepEqual(
+      await game.entities.byTemplate(1398), [], "the module pile must be consumed",
+    );
+    assert.equal((await game.entities.detail(corpse.id)).outgoing_links.some(
+      (link) => link.link_type.startsWith("Contains") && link.target_id === cookie.id,
+    ), false, "consumption must remove corpse containment");
+    await game.step({ frames: 30 });
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      before! + 4,
+      "collection must not award the pile twice after settling",
+    );
+    await game.screenshot(`cyber-module-loot-${mode}-after.png`);
+    const save = `cyber_module_loot_${mode}_${Date.now()}`;
+    await game.save(save);
+    await game.load(save);
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      before! + 4,
+      "the exact module balance must round-trip",
+    );
+    assert.deepEqual(
+      await game.entities.byTemplate(1398),
+      [],
+      "the consumed pile must stay consumed after reload",
+    );
+  });
+}


### PR DESCRIPTION
Opening MedSci1 corpse 490 showed an empty loot grid even though it contained a four-module pickup. A legacy `upgrade` icon filter suppressed the button entirely. Remove that filter so flat clicks and VR trigger/grip gestures can use the existing instant-consumable path to award the authored four modules and consume the pile.

The filter guarded an obsolete non-paletted-PCX panic. Current `PcxFormat::load_indexed` already decodes RGB PCX through `next_row_rgb` and applies the color key. Inspected both mounted 32×29 UPGRADE assets: `iface/UPGRADE.PCX` is RGB and `objicon/UPGRADE.PCX` is paletted; both contain the module icon. The shared ObjectIcon layout and existing module award logic are unchanged.

Fixes #1425.

Validation: core suite 1,560 passed / 2 ignored; SDK fast suite 60 passed / 435 skipped; TypeScript build and workspace format checks passed. All three native fixed scenarios pass, including save/load. All-host workspace check, all five CI checks, and independent code/media review passed; only the full SDK suite remains pending under the campaign manager. Negative-first: fresh native flat/VR-trigger/VR-grip corpse scenarios and the shared-layout unit regression all fail at the missing collectible icon before the guard removal. The new runtime test requires an exact four-module award once, no held item, removal of the real item/containment, and save/load persistence.

Visual before/after captures are embedded below (flat and VR).

Campaign: full-game, detailed, 25th Anniversary assets, VR, seed 1258205384. No module-grant shim or direct entity Frob messages. Private prerepro campaign save `pt-vr-full-20260907-repro-004-exp-cookie` SHA256 `58b61dfc4390f9d09c9c283e8da88a8f343f1042516b3d35601ab9c68c0c51e5` remains local; no save upload.

## Visual verification

Fresh MedSci1 corpse 490, identical deterministic native input sequences before and after. The empty grid gains its real module icon; flat click and VR controller trigger collect exactly four modules. Border counters are recorded player stats, not added game HUD. Crops improve icon legibility; uncropped frames preserve actual placement and scene context. Separate native tests also verify VR grip and save/load persistence.

![FLAT cyber-module loot before and after](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-flat.gif)

![FLAT cyber-module loot before and after](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-flat.png)

[Uncropped FLAT frames](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-flat-full.png) · [Collected state](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-flat-collected.png)

![VR cyber-module loot before and after](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-vr.gif)

![VR cyber-module loot before and after](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-vr.png)

[Uncropped VR frames](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-vr-full.png) · [Collected state](https://gist.githubusercontent.com/tommy-xr/8d8c688317dccb50799bffab914a03b4/raw/cyber-module-vr-collected.png)
