### PR TITLE
test(sdk): cast PSI 2 projectiles from a low-stat fixture

### DIFF
--- a/tools/shock2-sdk/test/psi.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi.e2e.test.ts
@@ -79,16 +79,26 @@ test(
   "the projectile tier follows the player's PSI stat",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    // The same cast from a sheet raised only to PSI 2 fires the PSI-2 bolt,
-    // not the capped one. (`/v1/player/stats` only raises, so the lower stat
-    // needs its own runtime.)
+    // debug_psi caps stats at 6. Start with the minimal scene's low-stat
+    // player instead: provisioning may raise PSI to 2, but never lower it.
+    // Debug scenes already train Cryokinesis; only the amp needs supplying.
     await using game = await GameServer.launch({
-      mission: "debug_psi",
+      mission: "debug_minimal",
     });
 
     await game.step({ frames: 10 });
     await game.player.setStats({ psionic_ability: 2 });
-    assert.equal((await game.info()).player.selected_psi_power, "Cryokinesis");
+    const amp = await game.player.spawnItem(-247); // Psi Amp
+    await game.input.trigger("EquipPsiAmp");
+    await game.step({ frames: 10 });
+    const player = (await game.info()).player;
+    assert.equal(player.stats?.psionic_ability, 2);
+    assert.equal(
+      player.wielded_entity_id,
+      amp.entity_id,
+      "the supplied amp should be wielded",
+    );
+    assert.equal(player.selected_psi_power, "Cryokinesis");
 
     await fireOnce(game);
     await game.step({ frames: 3 });


### PR DESCRIPTION
The PSI 2 projectile test started in `debug_psi`, which now grants PSI 6, then failed before casting because stat provisioning correctly refuses downgrades. Start this case in `debug_minimal`, raise PSI to 2, and supply one Psi Amp. Require that exact amp to be wielded, then retain the production trigger cast and exact `Cryo PSI 2` assertion. The PSI 6 case and production code are unchanged.

Validation: corrected focused test passes on the immutable main baseline and PR #1410 replicator build. SDK fast tests pass (60 passed, 432 skipped), including TypeScript compilation; `git diff --check` passes. Independent final review and all five CI checks are green. The original failure was independently reproduced on both binaries before this edit.

Visual assessment: test fixture only; no game rendering or player-visible behavior changes, so no GIF/PNG is required.

Found during the full-game, detailed, 25th Anniversary VR campaign (seed 1258205384); this isolated projectile fixture uses flatscreen presentation.

Fixes #1430
