### PR TITLE
feat(vr): add glove monitors with per-hand ammo readouts

### DIFF
--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -1,0 +1,29 @@
+# Astra MFD controls and dual weapons
+
+The unused regions have retail functions worth restoring. Keep their recognizable controls and reserve the weapon side for independently bound left/right weapon panels. The center is useful world-view space; filling it is not itself a goal.
+
+Retail behavior below is confirmed by the [System Shock 2 manual, PDF page 5](https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/238210/manuals/System%20Shock%202%20-%20Manual.pdf). Repository status is from the current implementation, not a claim of complete retail parity.
+
+| Control | Retail purpose | Existing foundation / missing work |
+| --- | --- | --- |
+| Research (test tube) | Current research status and completed reports | `ResearchState` tracks progress, chemical needs and completion; `ResearchGui` shows an item's status/report. Add a persistent research overview and entry button, including when the original object is no longer carried. Opening the overview must not start or restart research. |
+| Item information (?) | Select the button, then an item to read its description | The host already resolves hovered/lifted inventory items; `PropObjLookString` is parsed and used for research report fallback. Add a read-only inspection screen and explicit inspect interaction. No inventory Frob/use effects: inspecting a hypo must never consume it. |
+| Map | Open the current deck map | `Effect::ToggleMap` and the map MFD exist; expose the shared action through the matching button. |
+| PDA | Communications, logs and notes | Log collection/reader and media UI exist. Reuse them, then audit email/notes/help coverage separately; a last-unread action is not the full PDA browser. |
+| Access cards | List collected clearances | `QuestInfo` stores acquired key cards. Add a read-only clearance list; do not create physical duplicate cards. |
+| Character MFD | Statistics and abilities | `PlayerStats` and trainer/psi screens exist. Add a read-only character summary without exposing trainer purchase actions. |
+| Nanites / upgrade points | Persistent resource totals | Display actual player-state values beside the corresponding icons, including an explicit zero. |
+
+## Implementation order
+
+1. Complete the current wrist corrections: bracelet bio orientation and intact compact ammo art.
+2. Build the MFD composition around retail utility slots and two named weapon panels. Read authored BIN layout rectangles before placing controls; verify the same canvas in flat and VR.
+3. Resolve the held entity once per weapon panel. Bind reload, ammo cycling and settings to it, and revalidate that it is still held before activating. Support hands never create a duplicate weapon panel. Flat still has one wielded weapon.
+4. Wire Map and Research entry points, then item information. The research entry opens status without mutating research; the question-mark mode consumes only the inspection click and has an obvious cancel/exit.
+5. Add access-card and character summaries, then finish the PDA browser gaps.
+
+## Review cases
+
+Two different guns; gun plus psi amp; swapped hands; one support grip; no weapon; dropping/swapping a weapon between drawing and clicking its control. Research active, chemical-paused and completed after the item is gone. Inspect a hypo without consumption, a gun without firing, and an ordinary object without research data. Use the same rendered/hit-test rectangles in flat and VR, and retain press-edge protection when opening or switching panels.
+
+A weapon-pinned ammo display remains a separate optional grip-editor placement mode. The psi amp keeps its authored forearm and needs its own mount; glove-mounted wrist plates deliberately skip it.

--- a/projects/astra-vr-wrist-readouts.md
+++ b/projects/astra-vr-wrist-readouts.md
@@ -1,8 +1,8 @@
 # Astra VR wrist readouts
 
-Health and psi occupy the dorsal watch face on both gloves. Each underside shows the weapon actually held in that hand: clip count, ammo icon and ammo type, with a dedicated amp mount deferred because it retains its authored forearm. Empty hands, melee weapons and a supporting hand have no ammo plate. Dual wielding a pistol and shotgun therefore gives independent counters; a gun beside the amp keeps its own ammo display. Monitors share the glove visibility rule: the psi amp and unstripped legacy weapon hands have no glove plate.
+Health and psi occupy the dorsal watch face on both gloves, with its long edge running around the wrist like a bracelet. Each underside shows the weapon actually held in that hand: clip count, ammo icon and ammo type, with a dedicated amp mount deferred because it retains its authored forearm. Empty hands, melee weapons and a supporting hand have no ammo plate. Dual wielding a pistol and shotgun therefore gives independent counters; a gun beside the amp keeps its own ammo display. Monitors share the glove visibility rule: the psi amp and unstripped legacy weapon hands have no glove plate.
 
-The plates use the calibrated glove's wrist/palm basis and the final visible hand pose, including physical weapon displacement and two-hand support. Left-hand text uses a proper rotation rather than a mirrored text surface. Cropped shipped BIO/AMMO art and overlays share the existing flat/MFD layout. The watch has no clickable controls; entering the cyber interface suppresses these plates as before.
+The plates use the calibrated glove's wrist/palm basis and the final visible hand pose, including physical weapon displacement and two-hand support. Left-hand text uses a proper rotation rather than a mirrored text surface. The cropped BIO face and complete AMMOBACK compact ammo panel share the existing flat/MFD overlay layout. The ammo frame is preserved in full. The watch has no clickable controls; entering the cyber interface suppresses these plates as before.
 
 ## Next stack layer: dual weapons in the cyber interface
 

--- a/projects/astra-vr-wrist-readouts.md
+++ b/projects/astra-vr-wrist-readouts.md
@@ -1,0 +1,17 @@
+# Astra VR wrist readouts
+
+Health and psi occupy the dorsal watch face on both gloves. Each underside shows the weapon actually held in that hand: clip count, ammo icon and ammo type, with a dedicated amp mount deferred because it retains its authored forearm. Empty hands, melee weapons and a supporting hand have no ammo plate. Dual wielding a pistol and shotgun therefore gives independent counters; a gun beside the amp keeps its own ammo display. Monitors share the glove visibility rule: the psi amp and unstripped legacy weapon hands have no glove plate.
+
+The plates use the calibrated glove's wrist/palm basis and the final visible hand pose, including physical weapon displacement and two-hand support. Left-hand text uses a proper rotation rather than a mirrored text surface. Cropped shipped BIO/AMMO art and overlays share the existing flat/MFD layout. The watch has no clickable controls; entering the cyber interface suppresses these plates as before.
+
+## Next stack layer: dual weapons in the cyber interface
+
+The current interface still resolves its single weapon panel using the existing right-hand-first convention. Expand it to two labeled panels (Left weapon / Right weapon) when needed. Resolve a weapon entity once for each panel and bind reload, ammo cycling and settings to that same entity; revalidate ownership when activating a control. Do not merely duplicate the current global controls. Keep a single panel for flat presentation, where only one weapon is wielded.
+
+## Optional placement mode
+
+An editable weapon-pinned ammo plate can reuse the per-weapon readout. Store its position/XYZ rotation/uniform scale with the weapon grip metadata and expose it in Explorer. Attach it to the final weapon transform, so physical contact and two-hand rotation keep it aligned. This should be an alternative to underside ammo, not a second copy. Larger weapons and the psi amp's authored forearm are especially useful fit tests.
+
+## Verification
+
+Use debug_weapons in VR with pistol (template -17), shotgun (-19) and psi amp (-247), discovering concrete entity IDs each run. Check dorsal and palm views, independent 12/6 counts, gun plus amp, empty hand, and opening/closing the cyber interface. Unit tests cover per-weapon selection, hand swaps, mixed gun/amp readouts, crop parity and non-mirrored opposite faces. Headset review remains necessary for comfort and readability at arm's length.

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -86,6 +86,7 @@ pub struct GloveRenderer {
     open: Pose,
     fist: Pose,
     point: Pose,
+    wrist_frames: Option<[Matrix4<f32>; 2]>,
     materials: Vec<Vec<Rc<RefCell<Box<dyn Material>>>>>,
 }
 
@@ -150,6 +151,7 @@ impl GloveRenderer {
             fist: hand_pose::fist_right_hand(),
             point: hand_pose::point_right_hand(),
             materials,
+            wrist_frames: None,
         })
     }
 
@@ -205,6 +207,34 @@ impl GloveRenderer {
             palm,
             normal,
         }
+    }
+
+    /// A readable plate basis measured from this glove's wrist and palm, in
+    /// calibrated hand space. Keep text right-handed even on the mirrored glove.
+    pub(crate) fn wrist_frame(&mut self, hand: Handedness) -> Matrix4<f32> {
+        use cgmath::InnerSpace;
+        if self.wrist_frames.is_none() {
+            self.wrist_frames = Some([Handedness::Left, Handedness::Right].map(|side| {
+                let rig = self.grip_kinematics(side);
+                self.retarget.apply(&self.open, &mut self.model);
+                let node = self.model.skeleton().node_index_for_joint(1).unwrap();
+                let wrist = (crate::vr_grip::glove_to_hand(side)
+                    * self.model.get_global_transform(node).unwrap())
+                .w
+                .truncate();
+                let normal = -rig.normal;
+                let along = rig.palm - wrist;
+                let up = (along - normal * along.dot(normal)).normalize();
+                let right = up.cross(normal).normalize();
+                Matrix4::from_cols(
+                    right.extend(0.0),
+                    up.extend(0.0),
+                    normal.extend(0.0),
+                    wrist.extend(1.0),
+                )
+            }));
+        }
+        self.wrist_frames.unwrap()[if hand == Handedness::Left { 0 } else { 1 }]
     }
 
     /// Build the posed glove scene objects for one hand at its world transform.

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -27,7 +27,8 @@ use crate::ui::{HAlign, Rect, UiCanvas, VAlign};
 /// The AMMOFULL panel's authored pixel size.
 pub(crate) const PANEL_W: f32 = 260.0;
 pub(crate) const PANEL_H: f32 = 64.0;
-pub(crate) const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
+#[cfg(test)]
+const PANEL_SIZE: Vector2<f32> = vec2(PANEL_W, PANEL_H);
 
 /// Selected ammo type's object icon (P$ObjIcon), at the gauge well's left -
 /// right of the cycle arrow, which claims the well's leading 12 px.

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -229,14 +229,26 @@ impl AmmoReadout {
     /// Read the wielded weapon's readout from the world. `show_buttons` is the
     /// caller's (presentation's) call.
     pub(crate) fn from_world(world: &World, show_buttons: bool) -> Self {
-        let weapon = crate::wielded_weapon::wielded_weapon(world);
+        Self::for_weapon(
+            world,
+            crate::wielded_weapon::wielded_weapon(world),
+            show_buttons,
+        )
+    }
+
+    /// Resolve every field from the same weapon, including a gun beside a psi amp.
+    pub(crate) fn for_weapon(
+        world: &World,
+        weapon: Option<shipyard::EntityId>,
+        show_buttons: bool,
+    ) -> Self {
         Self {
-            psi_power: super::get_wielded_psi_power(world),
-            ammo: super::get_wielded_ammo(world),
-            ammo_icon: super::get_wielded_ammo_icon(world),
-            ammo_type: super::get_wielded_ammo_type(world),
             gun_condition: weapon.and_then(|w| wielded_gun_condition(world, w)),
-            gun_setting_header: super::get_wielded_gun_setting(world)
+            psi_power: super::get_weapon_psi_power(world, weapon),
+            ammo: super::get_weapon_ammo(world, weapon),
+            ammo_icon: super::get_weapon_ammo_icon(world, weapon),
+            ammo_type: super::get_weapon_ammo_type(world, weapon),
+            gun_setting_header: super::get_weapon_gun_setting(world, weapon)
                 .and_then(|(_, header)| header),
             can_cycle_ammo: weapon
                 .is_some_and(|w| crate::scripts::script_util::can_cycle_ammo(world, w)),
@@ -395,15 +407,165 @@ pub(crate) fn emit(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &AmmoRe
 /// panel *is* the canvas here, so the elements are emitted at panel origin
 /// (0,0) - flat emits the same ones at its own panel origin. Pure (no
 /// asset/GL access), so it is unit-testable like `build_flat_hud_canvas`.
-pub(crate) fn build_readout_canvas(readout: &AmmoReadout) -> UiCanvas {
+#[cfg(test)]
+fn build_readout_canvas(readout: &AmmoReadout) -> UiCanvas {
     let mut canvas = UiCanvas::new(PANEL_SIZE);
     emit(&mut canvas, vec2(0.0, 0.0), readout);
+    canvas
+}
+
+/// The gauge well with the bezel around it, cropped out of AMMOFULL.PCX - what
+/// each VR wrist wears. Outside this box the panel art is palette index 0
+/// (the cyan key colour ordinary UI art does not drop), so a wider crop would
+/// frame the readout in cyan.
+pub(crate) const WRIST_CROP: Rect = Rect::new(168.0, 14.0, 90.0, 44.0);
+
+/// The wrist canvas is exactly its crop.
+pub(crate) const WRIST_CROP_SIZE: Vector2<f32> = vec2(WRIST_CROP.w, WRIST_CROP.h);
+
+/// The readout as each VR wrist draws it: the cropped gauge well at canvas
+/// origin, with the readout placed over it by the shared [`emit`] off the panel
+/// corner the crop was taken from (hence the negative origin, exactly as the
+/// flat HUD anchors the same contents over the compact AMMOBACK crop).
+///
+/// Empty when nothing gun-like is wielded: flat drops the whole gauge then, and
+/// a bare plate strapped to the wrist would say less than nothing. Pure (no
+/// asset/GL access), so it is unit-testable like `build_flat_hud_canvas`.
+pub(crate) fn build_wrist_canvas(readout: &AmmoReadout) -> UiCanvas {
+    let mut canvas = UiCanvas::new(WRIST_CROP_SIZE);
+    if readout.is_empty() {
+        return canvas;
+    }
+    canvas.cropped_image(
+        Rect::new(0.0, 0.0, WRIST_CROP.w, WRIST_CROP.h),
+        "AMMOFULL.PCX",
+        WRIST_CROP,
+        PANEL_SIZE,
+    );
+    let passive = AmmoReadout {
+        show_buttons: false,
+        ..readout.clone()
+    };
+    emit(&mut canvas, vec2(-WRIST_CROP.x, -WRIST_CROP.y), &passive);
     canvas
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wrist_crop_preserves_the_shared_readout_layout_and_omits_controls() {
+        let readout = full_gun();
+        let wrist = build_wrist_canvas(&readout);
+        let passive = AmmoReadout {
+            show_buttons: false,
+            ..readout
+        };
+        let panel = build_readout_canvas(&passive);
+        assert_eq!(wrist.element_count(), panel.element_count() + 1);
+        for (cropped, full) in wrist.elements()[1..].iter().zip(panel.elements()) {
+            let (a, b) = (cropped.rect(), full.rect());
+            assert_eq!(
+                (a.x + WRIST_CROP.x, a.y + WRIST_CROP.y, a.w, a.h),
+                (b.x, b.y, b.w, b.h)
+            );
+        }
+        assert_eq!(
+            build_wrist_canvas(&AmmoReadout::default()).element_count(),
+            0
+        );
+    }
+
+    #[test]
+    fn each_wrist_reads_its_own_clip_and_empty_support_hand_has_no_counter() {
+        use crate::{mission::PlayerInfo, vr_config::Handedness, wielded_weapon::weapon_in_hand};
+        use dark::properties::PropGunState;
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let left = world.add_entity((PropGunState {
+            ammo: 6,
+            condition: 100.0,
+            setting: 0,
+            modification: 0,
+            silence_value: 0.0,
+        },));
+        let right = world.add_entity((PropGunState {
+            ammo: 12,
+            condition: 100.0,
+            setting: 1,
+            modification: 0,
+            silence_value: 0.0,
+        },));
+        let mut info = PlayerInfo {
+            pos: cgmath::vec3(0.0, 0.0, 0.0),
+            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            inventory_entity_id: player,
+            left_hand_entity_id: Some(left),
+            right_hand_entity_id: Some(right),
+        };
+        world.add_unique(info.clone());
+        let read = |world: &World, hand| {
+            AmmoReadout::for_weapon(world, weapon_in_hand(world, hand), false)
+        };
+        assert_eq!(read(&world, Handedness::Left).ammo, Some(6));
+        assert_eq!(read(&world, Handedness::Right).ammo, Some(12));
+        info.left_hand_entity_id = Some(right);
+        info.right_hand_entity_id = None;
+        *world
+            .borrow::<shipyard::UniqueViewMut<PlayerInfo>>()
+            .unwrap() = info;
+        assert_eq!(read(&world, Handedness::Left).ammo, Some(12));
+        assert!(read(&world, Handedness::Right).is_empty());
+    }
+
+    #[test]
+    fn psi_amp_beside_a_gun_does_not_steal_its_ammo_readout() {
+        use crate::{
+            mission::mission_core::GlobalTemplateClassTags,
+            psi::{GlobalPsiPowers, PsiPowerInfo, PsiPowerSelection},
+        };
+        use dark::properties::{PropGunState, PropPsiPower, PropTemplateId};
+        use std::collections::HashMap;
+        let mut world = World::new();
+        let gun = world.add_entity((PropGunState {
+            ammo: 12,
+            condition: 100.0,
+            setting: 0,
+            modification: 0,
+            silence_value: 0.0,
+        },));
+        let amp = world.add_entity((PropTemplateId { template_id: -247 },));
+        world.add_unique(GlobalTemplateClassTags(HashMap::from([(
+            -247,
+            HashMap::from([("weapontype".to_owned(), "psiamp".to_owned())]),
+        )])));
+        world.add_unique(GlobalPsiPowers(vec![PsiPowerInfo {
+            template_id: -100,
+            name: "Cryokinesis".to_owned(),
+            display_name: Some("Projected Cryokinesis".to_owned()),
+            power: PropPsiPower {
+                power_id: 1,
+                activation_type: 0,
+                psi_cost: 99,
+                data: [0.0; 4],
+            },
+            projectiles: vec![],
+            overloadable: false,
+            duration: None,
+        }]));
+        world.add_unique(PsiPowerSelection { index: 0 });
+        let gun_readout = AmmoReadout::for_weapon(&world, Some(gun), false);
+        let amp_readout = AmmoReadout::for_weapon(&world, Some(amp), false);
+        assert_eq!(gun_readout.ammo, Some(12));
+        assert_eq!(gun_readout.psi_power, None);
+        assert_eq!(amp_readout.ammo, None);
+        assert_eq!(
+            amp_readout.psi_power,
+            Some(("Projected Cryokinesis".to_owned(), 1))
+        );
+    }
 
     /// The gauge well the compact AMMOBACK crop shows, read off the art.
     const WELL: Rect = Rect::new(176.0, 13.0, 73.0, 42.0);

--- a/shock2vr/src/hud/ammo_panel.rs
+++ b/shock2vr/src/hud/ammo_panel.rs
@@ -414,33 +414,21 @@ fn build_readout_canvas(readout: &AmmoReadout) -> UiCanvas {
     canvas
 }
 
-/// The gauge well with the bezel around it, cropped out of AMMOFULL.PCX - what
-/// each VR wrist wears. Outside this box the panel art is palette index 0
-/// (the cyan key colour ordinary UI art does not drop), so a wider crop would
-/// frame the readout in cyan.
-pub(crate) const WRIST_CROP: Rect = Rect::new(168.0, 14.0, 90.0, 44.0);
-
-/// The wrist canvas is exactly its crop.
+/// The complete compact ammo UI, the rightmost 94x64 pixels of AMMOFULL.
+/// Preserve AMMOBACK's authored frame rather than cutting through its bezel.
+pub(crate) const WRIST_CROP: Rect = Rect::new(166.0, 0.0, 94.0, 64.0);
 pub(crate) const WRIST_CROP_SIZE: Vector2<f32> = vec2(WRIST_CROP.w, WRIST_CROP.h);
 
-/// The readout as each VR wrist draws it: the cropped gauge well at canvas
-/// origin, with the readout placed over it by the shared [`emit`] off the panel
-/// corner the crop was taken from (hence the negative origin, exactly as the
-/// flat HUD anchors the same contents over the compact AMMOBACK crop).
-///
-/// Empty when nothing gun-like is wielded: flat drops the whole gauge then, and
-/// a bare plate strapped to the wrist would say less than nothing. Pure (no
-/// asset/GL access), so it is unit-testable like `build_flat_hud_canvas`.
+/// The shipped compact ammo panel with the same overlay origin as the flat HUD.
+/// Empty hands have no panel; the wrist has no clickable controls.
 pub(crate) fn build_wrist_canvas(readout: &AmmoReadout) -> UiCanvas {
     let mut canvas = UiCanvas::new(WRIST_CROP_SIZE);
     if readout.is_empty() {
         return canvas;
     }
-    canvas.cropped_image(
+    canvas.image(
         Rect::new(0.0, 0.0, WRIST_CROP.w, WRIST_CROP.h),
-        "AMMOFULL.PCX",
-        WRIST_CROP,
-        PANEL_SIZE,
+        "AMMOBACK.PCX",
     );
     let passive = AmmoReadout {
         show_buttons: false,
@@ -455,9 +443,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn wrist_crop_preserves_the_shared_readout_layout_and_omits_controls() {
+    fn wrist_preserves_the_complete_compact_panel_and_shared_overlay_layout() {
         let readout = full_gun();
         let wrist = build_wrist_canvas(&readout);
+        assert_eq!(wrist.size(), vec2(94.0, 64.0));
+        assert!(
+            matches!(&wrist.elements()[0], crate::ui::UiElement::Image { texture, kind: crate::ui::ImageKind::Ui, .. } if texture == "AMMOBACK.PCX")
+        );
         let passive = AmmoReadout {
             show_buttons: false,
             ..readout

--- a/shock2vr/src/hud/readouts.rs
+++ b/shock2vr/src/hud/readouts.rs
@@ -134,12 +134,17 @@ fn emit_bio_overlays(canvas: &mut UiCanvas, origin: Vector2<f32>, readout: &BioR
         );
 }
 
-/// The bio overlays on a panel-sized canvas at panel origin (0,0), for a
-/// presentation that supplies its own BIOFULL backdrop - the VR left forearm.
-/// The counterpart of [`ammo_panel::build_readout_canvas`].
-pub(crate) fn build_bio_readout_canvas(readout: &BioReadout) -> UiCanvas {
-    let mut canvas = UiCanvas::new(BIO_FULL_SIZE);
-    emit_bio_overlays(&mut canvas, vec2(0.0, 0.0), readout);
+/// Both rows of the shipped bio monitor, cropped to a compact wrist face.
+pub(crate) const WATCH_CROP: Rect = Rect::new(0.0, 14.0, 128.0, 44.0);
+pub(crate) fn build_watch_canvas(readout: &BioReadout) -> UiCanvas {
+    let mut canvas = UiCanvas::new(vec2(WATCH_CROP.w, WATCH_CROP.h));
+    canvas.cropped_image(
+        Rect::new(0.0, 0.0, WATCH_CROP.w, WATCH_CROP.h),
+        "BIO.PCX",
+        WATCH_CROP,
+        BIO_SIZE,
+    );
+    emit_bio_overlays(&mut canvas, vec2(-WATCH_CROP.x, -WATCH_CROP.y), readout);
     canvas
 }
 
@@ -328,13 +333,10 @@ mod tests {
         }
     }
 
-    /// The VR left forearm and the interface canvas draw ONE bio layout: the
-    /// forearm's panel-local canvas carries exactly the elements `emit_bio`
-    /// places (minus the backdrop art the forearm wears as its own quad), at
-    /// the same rects relative to the panel origin. A forearm that re-derived
-    /// its bars would drift from the interface silently (issue #1268).
+    /// Cropping the wrist face translates the shared bio layout without
+    /// independently placing either row (issue #1268).
     #[test]
-    fn the_forearm_canvas_is_the_interface_bio_layout_at_panel_origin() {
+    fn the_watch_preserves_both_rows_of_the_interface_bio_layout() {
         let bio = BioReadout {
             health_fraction: 0.4,
             psi_fraction: 0.9,
@@ -349,15 +351,26 @@ mod tests {
             &bio,
         );
 
-        let forearm = build_bio_readout_canvas(&bio);
-        assert_eq!(forearm.size(), BIO_FULL_SIZE);
-        // The backdrop is the interface's first element and the forearm's quad.
-        assert_eq!(forearm.element_count(), interface.element_count() - 1);
+        let forearm = build_watch_canvas(&bio);
+        assert_eq!(forearm.size(), vec2(WATCH_CROP.w, WATCH_CROP.h));
+        // Each canvas has one backdrop followed by the same four overlays.
+        assert_eq!(forearm.element_count(), interface.element_count());
 
-        for (on_arm, on_panel) in forearm.elements().iter().zip(&interface.elements()[1..]) {
+        for (on_arm, on_panel) in forearm.elements()[1..]
+            .iter()
+            .zip(&interface.elements()[1..])
+        {
             let (arm, panel) = (on_arm.rect(), on_panel.rect());
-            assert_eq!(arm.x + BIO_ORIGIN.x, panel.x, "{arm:?} vs {panel:?}");
-            assert_eq!(arm.y + BIO_ORIGIN.y, panel.y, "{arm:?} vs {panel:?}");
+            assert_eq!(
+                arm.x + WATCH_CROP.x + BIO_ORIGIN.x,
+                panel.x,
+                "{arm:?} vs {panel:?}"
+            );
+            assert_eq!(
+                arm.y + WATCH_CROP.y + BIO_ORIGIN.y,
+                panel.y,
+                "{arm:?} vs {panel:?}"
+            );
             assert_eq!((arm.w, arm.h), (panel.w, panel.h));
         }
     }

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -74,11 +74,14 @@ fn wrist_panel_transform(
     hand: Handedness,
 ) -> Matrix4<f32> {
     const WIDTH: f32 = 0.085;
-    // Read across the body when turning either wrist toward the eyes.
-    let roll = if (hand == Handedness::Right) != under {
-        90.0
-    } else {
+    // The bio face runs around the wrist like a bracelet. Keep the ammo
+    // face oriented for an across-body underside glance.
+    let roll = if !under {
+        0.0
+    } else if hand == Handedness::Right {
         -90.0
+    } else {
+        90.0
     };
     root * Matrix4::from_translation(vec3(0.0, -0.015, if under { -0.06 } else { 0.04 }))
         * Matrix4::from_angle_y(Deg(if under { 180.0 } else { 0.0 }))

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -1,76 +1,89 @@
-use cgmath::{Deg, Euler, Matrix4, Quaternion, Rotation, Vector3, vec3};
-use dark::{
-    importers::TEXTURE_IMPORTER,
-    properties::{PropHitPoints, PropMaxHitPoints, PropPsiState},
-};
-use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
+use cgmath::{Deg, Matrix4, vec3};
+use dark::properties::{PropHitPoints, PropMaxHitPoints, PropPsiState};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use shipyard::{Get, UniqueView, View, World};
 
 use crate::{
     hud::{ammo_panel, readouts},
     mission::PlayerInfo,
-    ui::UiCanvas,
     vr_config::Handedness,
 };
 
-/// Offset from hand position to forearm HUD panel *centre*. The panel's width
-/// axis runs along the arm (hand-local +Z), so it spans
-/// `FOREARM_OFFSET.z +/- HUD_PANEL_WIDTH / 2` and its near edge - not this
-/// centre - is what the forearm geometry has to stop short of.
-pub(crate) const FOREARM_OFFSET: Vector3<f32> = vec3(0.0, 0.0, 0.25); // world units: 0.25 * 0.762 = 19 cm toward the elbow
-
-/// Size of the HUD panels (260x64 aspect ratio) - doubled in size. In world
-/// units, like every other length here; `crate::METERS_PER_WORLD_UNIT` converts.
-pub(crate) const HUD_PANEL_WIDTH: f32 = 0.26; // world units: 0.26 * 0.762 = 20 cm along the arm
-const HUD_PANEL_HEIGHT: f32 = 0.064; // 6.4cm tall (260:64 = 4.0625:1 ratio)
-
-/// Z-offset for overlay layers to ensure proper rendering order
-const OVERLAY_Z_OFFSET: f32 = 0.001;
-
-/// Create the forearm HUD panels: BIOFULL (health/psi) on the left arm,
-/// AMMOFULL (the live ammo readout) on the right.
-///
-/// `use_mode` silences both: the cyber interface carries the expanded BIOFULL
-/// and AMMOFULL readouts on its canvas while it is up (`hud::readouts`), so
-/// leaving the arms lit would show a VR player the same numbers twice, at two
-/// scales and orientations (issue #1268). Flat drops its compact overlay in
-/// use mode for the same reason (`hud::flat_hud`).
-pub fn create_arm_hud_panels(
+/// Compact readouts ride the calibrated visible glove, not the raw controller.
+/// Both wrists show health/psi dorsally; each underside shows only its own weapon.
+pub fn create_wrist_hud_panels(
     asset_cache: &mut AssetCache,
     world: &World,
     use_mode: bool,
-    left_hand_position: Vector3<f32>,
-    left_hand_rotation: Quaternion<f32>,
-    right_hand_position: Vector3<f32>,
-    right_hand_rotation: Quaternion<f32>,
+    poses: [crate::vr_support::GripPose; 2],
+    wrist_frames: [Matrix4<f32>; 2],
 ) -> Vec<SceneObject> {
     if use_mode {
         return Vec::new();
     }
+    let bio = readouts::BioReadout::from_world(world);
+    let mut objects = Vec::new();
+    for (i, hand) in [Handedness::Left, Handedness::Right]
+        .into_iter()
+        .enumerate()
+    {
+        if !poses[i].is_tracked()
+            || !crate::virtual_hand::shows_hand_visual(
+                world,
+                crate::wielded_weapon::held_by_hand(world, hand),
+            )
+        {
+            continue;
+        }
+        let root = Matrix4::from_translation(poses[i].position)
+            * Matrix4::from(poses[i].rotation)
+            * wrist_frames[i];
+        for (under, canvas) in [
+            (false, readouts::build_watch_canvas(&bio)),
+            (
+                true,
+                ammo_panel::build_wrist_canvas(&ammo_panel::AmmoReadout::for_weapon(
+                    world,
+                    crate::wielded_weapon::weapon_in_hand(world, hand),
+                    false,
+                )),
+            ),
+        ] {
+            if canvas.element_count() == 0 {
+                continue;
+            }
+            objects.extend(canvas.render_world_space(
+                asset_cache,
+                wrist_panel_transform(root, canvas.size(), under, hand),
+                None,
+                None,
+                0.001,
+            ));
+        }
+    }
+    crate::util::tag_render_source(&mut objects, crate::util::render_source::PLAYER_HANDS);
+    objects
+}
 
-    // The bio monitor on the left arm, the ammo gauge on the right - each the
-    // shared layout's own canvas, hung by the one compositor below.
-    let mut scene_objects = forearm_readout_panel(
-        asset_cache,
-        left_hand_position,
-        left_hand_rotation,
-        Handedness::Left,
-        readouts::build_bio_readout_canvas(&readouts::BioReadout::from_world(world)),
-    );
-    scene_objects.append(&mut forearm_readout_panel(
-        asset_cache,
-        right_hand_position,
-        right_hand_rotation,
-        Handedness::Right,
-        ammo_panel::build_readout_canvas(&ammo_panel::AmmoReadout::from_world(world, false)),
-    ));
-
-    // Part of the player's hand visuals: labelled here rather than at the call
-    // sites so the `debug_hud` scene, which emits these without an interaction
-    // controller, is covered by the pause menu's suppression too (issue #1018).
-    crate::util::tag_render_source(&mut scene_objects, crate::util::render_source::PLAYER_HANDS);
-
-    scene_objects
+/// Wrist-frame +Z points out of the glove's back; +Y points toward its fingers.
+/// The underside turns around +Y so glyphs remain readable, never mirrored.
+fn wrist_panel_transform(
+    root: Matrix4<f32>,
+    canvas_size: cgmath::Vector2<f32>,
+    under: bool,
+    hand: Handedness,
+) -> Matrix4<f32> {
+    const WIDTH: f32 = 0.085;
+    // Read across the body when turning either wrist toward the eyes.
+    let roll = if (hand == Handedness::Right) != under {
+        90.0
+    } else {
+        -90.0
+    };
+    root * Matrix4::from_translation(vec3(0.0, -0.015, if under { -0.06 } else { 0.04 }))
+        * Matrix4::from_angle_y(Deg(if under { 180.0 } else { 0.0 }))
+        * Matrix4::from_angle_z(Deg(roll))
+        * Matrix4::from_nonuniform_scale(WIDTH, WIDTH * canvas_size.y / canvas_size.x, 1.0)
 }
 
 /// Get player health percentage (0.0 to 1.0)
@@ -111,12 +124,17 @@ pub(crate) fn get_psi_percentage(world: &World) -> f32 {
 }
 
 /// The selected psi power to display in the HUD's weapon/ammo section:
-/// `(discipline name, tier)`. `Some` only while the wielded weapon is the
+/// `(discipline name, tier)`. `Some` only while the supplied weapon is the
 /// psi amp (class tag `weapontype psiamp`).
-pub(crate) fn get_wielded_psi_power(world: &World) -> Option<(String, i32)> {
+pub(crate) fn get_weapon_psi_power(
+    world: &World,
+    weapon: Option<shipyard::EntityId>,
+) -> Option<(String, i32)> {
     // The psi amp is resolved via its template's class tags, the same mechanism
-    // as `get_wielded_ammo_type`.
-    crate::wielded_weapon::wielded_psi_amp(world)?;
+    // as `get_weapon_ammo_type`.
+    if !crate::wielded_weapon::is_psi_amp(world, weapon?) {
+        return None;
+    }
 
     let powers = world
         .borrow::<UniqueView<crate::psi::GlobalPsiPowers>>()
@@ -145,23 +163,24 @@ pub(crate) fn get_wielded_psi_charge(
     v_charge.get(weapon).ok().copied()
 }
 
-/// Current clip ammo of the wielded weapon, or `None` when unarmed or the held
-/// item has no `PropGunState` (melee / unlimited debug weapons). Which held
-/// entity counts as "the wielded weapon" - in either presentation, in either
-/// hand - is decided by [`crate::wielded_weapon`].
-pub(crate) fn get_wielded_ammo(world: &World) -> Option<i32> {
-    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
+/// Current clip ammo of this weapon, or `None` for an empty hand or an item
+/// without `PropGunState` (melee / unlimited debug weapons).
+pub(crate) fn get_weapon_ammo(world: &World, weapon: Option<shipyard::EntityId>) -> Option<i32> {
+    let weapon = weapon?;
     let v_gun_state = world
         .borrow::<View<dark::properties::PropGunState>>()
         .ok()?;
     v_gun_state.get(weapon).ok().map(|g| g.ammo)
 }
 
-/// The template id of the wielded weapon's currently selected `Projectile` link
+/// The template id of this weapon's currently selected `Projectile` link
 /// (its ammo type), or `None` when unarmed or the weapon has no projectile links
 /// (melee). Honors `RuntimePropSelectedAmmo` (absent = the first link).
-pub(crate) fn wielded_selected_projectile_template(world: &World) -> Option<i32> {
-    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
+pub(crate) fn weapon_selected_projectile_template(
+    world: &World,
+    weapon: Option<shipyard::EntityId>,
+) -> Option<i32> {
+    let weapon = weapon?;
     let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
     if projectiles.is_empty() {
         return None;
@@ -176,21 +195,27 @@ pub(crate) fn wielded_selected_projectile_template(world: &World) -> Option<i32>
         .map(|(template_id, _)| *template_id)
 }
 
-/// The `ammotype` class-tag of the wielded weapon's selected ammo (e.g. "std",
+/// The `ammotype` class-tag of this weapon's selected ammo (e.g. "std",
 /// "he", "ap"), or `None`.
-pub(crate) fn get_wielded_ammo_type(world: &World) -> Option<String> {
-    let template_id = wielded_selected_projectile_template(world)?;
+pub(crate) fn get_weapon_ammo_type(
+    world: &World,
+    weapon: Option<shipyard::EntityId>,
+) -> Option<String> {
+    let template_id = weapon_selected_projectile_template(world, weapon)?;
     let class_tags = world
         .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateClassTags>>()
         .ok()?;
     class_tags.0.get(&template_id)?.get("ammotype").cloned()
 }
 
-/// The wielded gun's fire setting: its index (0 or 1) and the short header for
+/// This gun's fire setting: its index (0 or 1) and the short header for
 /// that setting ("NORM" / "BURST"), or `None` when nothing gun-like is wielded.
 /// The header is absent for a gun whose data names no header for the setting.
-pub(crate) fn get_wielded_gun_setting(world: &World) -> Option<(i32, Option<String>)> {
-    let weapon = crate::wielded_weapon::wielded_weapon(world)?;
+pub(crate) fn get_weapon_gun_setting(
+    world: &World,
+    weapon: Option<shipyard::EntityId>,
+) -> Option<(i32, Option<String>)> {
+    let weapon = weapon?;
     let setting = world
         .borrow::<View<dark::properties::PropGunState>>()
         .ok()
@@ -199,160 +224,54 @@ pub(crate) fn get_wielded_gun_setting(world: &World) -> Option<(i32, Option<Stri
     Some((setting, header))
 }
 
-/// The object-icon bitmap filename (e.g. "STD_I.pcx") of the wielded weapon's
+/// The object-icon bitmap filename (e.g. "STD_I.pcx") of this weapon's
 /// selected ammo type, or `None`. Resolved from the selected projectile
 /// template's `P$ObjIcon` (projectiles are templates, not instantiated entities,
 /// so this reads the precomputed [`GlobalTemplateObjIcons`] map rather than a
 /// `View`).
-pub(crate) fn get_wielded_ammo_icon(world: &World) -> Option<String> {
-    let template_id = wielded_selected_projectile_template(world)?;
+pub(crate) fn get_weapon_ammo_icon(
+    world: &World,
+    weapon: Option<shipyard::EntityId>,
+) -> Option<String> {
+    let template_id = weapon_selected_projectile_template(world, weapon)?;
     let icons = world
         .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateObjIcons>>()
         .ok()?;
     icons.0.get(&template_id).cloned()
 }
 
-/// One forearm panel: the backdrop art for `handedness` with `readout` - a
-/// panel-sized canvas drawn at panel origin (0,0) - composited one overlay step
-/// in front of it.
-///
-/// The backdrop stays a plain lit quad rather than a canvas element (the canvas
-/// presenter draws its elements fully emissive, which suits a readout but would
-/// make the panel glow), and `readout` is whatever the SHARED presentation-
-/// agnostic layout emitted, so an arm cannot drift from the interface canvas or
-/// the flat HUD (AGENTS.md section 3). Both arms composite identically here, so
-/// a change to how one is hung cannot miss the other.
-///
-/// No controls on either arm: the VR pointer only hits the cyber-interface
-/// panel, never these quads, so drawing a SETTING/RELOAD/cycle button nobody can
-/// press would be a lie. Only the interactive layer differs, and it differs by
-/// whether a pointer can reach it, not by presentation.
-fn forearm_readout_panel(
-    asset_cache: &mut AssetCache,
-    hand_position: Vector3<f32>,
-    hand_rotation: Quaternion<f32>,
-    handedness: Handedness,
-    readout: UiCanvas,
-) -> Vec<SceneObject> {
-    let mut objects = vec![create_forearm_hud_panel(
-        asset_cache,
-        hand_position,
-        hand_rotation,
-        handedness,
-    )];
-
-    objects.append(&mut readout.render_world_space(
-        asset_cache,
-        forearm_panel_transform(hand_position, hand_rotation, handedness)
-            * Matrix4::from_translation(vec3(0.0, 0.0, OVERLAY_Z_OFFSET)),
-        None,
-        None,
-        OVERLAY_Z_OFFSET,
-    ));
-
-    objects
+// Hand-agnostic snapshots preserve the existing dominant-weapon convention.
+pub(crate) fn get_wielded_ammo_type(world: &World) -> Option<String> {
+    get_weapon_ammo_type(world, crate::wielded_weapon::wielded_weapon(world))
 }
-
-/// Create a single forearm HUD panel
-fn create_forearm_hud_panel(
-    asset_cache: &mut AssetCache,
-    hand_position: Vector3<f32>,
-    hand_rotation: Quaternion<f32>,
-    handedness: Handedness,
-) -> SceneObject {
-    // Load appropriate texture based on handedness
-    let texture_options = TextureOptions {
-        wrap: false,
-        ..Default::default()
-    };
-    let texture = match handedness {
-        Handedness::Left => asset_cache.get_ext(&TEXTURE_IMPORTER, "BIOFULL.PCX", &texture_options),
-        Handedness::Right => {
-            asset_cache.get_ext(&TEXTURE_IMPORTER, "AMMOFULL.PCX", &texture_options)
-        }
-    };
-
-    // Create BasicMaterial with the loaded texture (casting to the expected trait object)
-    let material = engine::scene::basic_material::create(
-        texture.clone() as std::rc::Rc<dyn engine::texture::TextureTrait>,
-        0.0, // No emissivity
-        0.0, // No transparency
-    );
-
-    // Create quad geometry
-    let geometry = Box::new(engine::scene::quad::create());
-
-    // Create scene object, placed by the shared forearm pose
-    let mut scene_object = SceneObject::new(material, geometry);
-    scene_object.set_transform(forearm_panel_transform(
-        hand_position,
-        hand_rotation,
-        handedness,
-    ));
-
-    scene_object
-}
-
-/// Where a forearm panel hangs: offset from the hand toward the elbow, yawed
-/// toward the body and tilted flat against the arm like a wrist computer.
-/// The single source of forearm placement - the panel quad, its overlays and
-/// the ammo readout canvas all derive from this, so they cannot drift apart.
-fn forearm_pose(
-    hand_position: Vector3<f32>,
-    hand_rotation: Quaternion<f32>,
-    handedness: Handedness,
-) -> (Vector3<f32>, Quaternion<f32>) {
-    let forearm_position = hand_position + hand_rotation.rotate_vector(FOREARM_OFFSET);
-    let forearm_yaw_rotation = match handedness {
-        Handedness::Left => Quaternion::from(Euler::new(Deg(0.0), Deg(90.0), Deg(0.0))),
-        Handedness::Right => Quaternion::from(Euler::new(Deg(0.0), Deg(-90.0), Deg(0.0))),
-    };
-    let forearm_tilt_rotation = Quaternion::from(Euler::new(Deg(-90.0), Deg(0.0), Deg(180.0)));
-    (
-        forearm_position,
-        hand_rotation * forearm_yaw_rotation * forearm_tilt_rotation,
-    )
-}
-
-/// [`forearm_pose`] as a root transform for a panel-sized canvas, so canvas
-/// elements land exactly on the panel quad.
-fn forearm_panel_transform(
-    hand_position: Vector3<f32>,
-    hand_rotation: Quaternion<f32>,
-    handedness: Handedness,
-) -> Matrix4<f32> {
-    let (position, rotation) = forearm_pose(hand_position, hand_rotation, handedness);
-    Matrix4::from_translation(position)
-        * Matrix4::from(rotation)
-        * Matrix4::from_nonuniform_scale(HUD_PANEL_WIDTH, HUD_PANEL_HEIGHT, 1.0)
+pub(crate) fn get_wielded_gun_setting(world: &World) -> Option<(i32, Option<String>)> {
+    get_weapon_gun_setting(world, crate::wielded_weapon::wielded_weapon(world))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use engine::assets::asset_paths::AssetPath;
+    use cgmath::{InnerSpace, SquareMatrix};
 
-    /// With the cyber interface up, the forearms emit nothing at all - the
-    /// interface canvas is the single copy of both readouts (issue #1268).
-    ///
-    /// The gate short-circuits before the world or the asset cache is touched,
-    /// which is what makes an empty `World` (no `PlayerInfo`) and an asset path
-    /// that resolves nothing a sufficient fixture: an ungated build reaches
-    /// both and fails.
     #[test]
-    fn the_forearms_go_quiet_while_use_mode_is_up() {
-        // No mounts: every lookup misses, so touching the cache is the failure
-        // this test is looking for.
-        let mut assets = AssetCache::new(String::new(), AssetPath::combine(vec![]));
-        let objects = create_arm_hud_panels(
-            &mut assets,
-            &World::new(),
-            true,
-            vec3(0.0, 0.0, 0.0),
-            Quaternion::from(Euler::new(Deg(0.0), Deg(0.0), Deg(0.0))),
-            vec3(0.0, 0.0, 0.0),
-            Quaternion::from(Euler::new(Deg(0.0), Deg(0.0), Deg(0.0))),
-        );
-        assert!(objects.is_empty());
+    fn opposite_watch_faces_are_outward_and_text_is_never_mirrored() {
+        for (under, hand) in [
+            (false, Handedness::Left),
+            (true, Handedness::Left),
+            (false, Handedness::Right),
+            (true, Handedness::Right),
+        ] {
+            let transform =
+                wrist_panel_transform(Matrix4::identity(), cgmath::vec2(128.0, 44.0), under, hand);
+            let normal = transform.z.truncate();
+            assert!(normal.dot(transform.w.truncate()) > 0.0);
+            assert!(transform.determinant() > 0.0);
+            assert!(
+                (transform.x.truncate().magnitude() / transform.y.truncate().magnitude()
+                    - 128.0 / 44.0)
+                    .abs()
+                    < 0.0001
+            );
+        }
     }
 }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -22,7 +22,7 @@ use crate::{
     GameOptions,
     flat_player_controller::FlatPlayerController,
     hand_glove::GloveRenderer,
-    hud::create_arm_hud_panels,
+    hud::create_wrist_hud_panels,
     input_context::InputContext,
     physics::PhysicsWorld,
     virtual_hand::{VirtualHand, VirtualHandEffect, hand_world_position},
@@ -1228,7 +1228,7 @@ impl PlayerInteraction for VrInteraction {
         }
         // Labelled as the player's hands: that is what `Game` drops while the
         // pause menu is up (issue #1018), and what `/v1/scene` reports. The
-        // forearm panels carry their own label from `create_arm_hud_panels`,
+        // forearm panels carry their own label from `create_wrist_hud_panels`,
         // which the `debug_hud` scene emits without going through here.
         crate::util::tag_render_source(&mut objs, crate::util::render_source::PLAYER_HANDS);
         if crate::dev_params::get_bool(crate::dev_params::VR_SUPPORT_GRIPS) {
@@ -1293,15 +1293,21 @@ impl PlayerInteraction for VrInteraction {
                 objs.extend(overlay);
             }
         }
-        objs.append(&mut create_arm_hud_panels(
-            asset_cache,
-            world,
-            use_mode,
-            self.left_hand.get_position(),
-            self.left_hand.get_rotation(),
-            self.right_hand.get_position(),
-            self.right_hand.get_rotation(),
-        ));
+        if let Some(renderer) = glove_renderer.as_deref_mut() {
+            let frames = [
+                renderer.wrist_frame(Handedness::Left),
+                renderer.wrist_frame(Handedness::Right),
+            ];
+            let tracked = self.hand_poses();
+            let visible = std::array::from_fn(|i| self.visual_hands[i].unwrap_or(tracked[i]));
+            objs.append(&mut create_wrist_hud_panels(
+                asset_cache,
+                world,
+                use_mode,
+                visible,
+                frames,
+            ));
+        }
         objs
     }
 

--- a/shock2vr/src/scenes/debug_hud.rs
+++ b/shock2vr/src/scenes/debug_hud.rs
@@ -11,13 +11,16 @@ use shipyard::{UniqueViewMut, World};
 use crate::{
     GameOptions,
     game_scene::GameScene,
-    hud::create_arm_hud_panels,
+    hand_glove::GloveRenderer,
+    hud::create_wrist_hud_panels,
     input_context::InputContext,
     inventory::PlayerInventoryEntity,
     mission::{GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo},
     quest_info::QuestInfo,
     scripts::Effect,
     time::Time,
+    vr_config::Handedness,
+    vr_support::GripPose,
 };
 
 /// Debug HUD positioning constants
@@ -44,6 +47,7 @@ pub struct DebugHudScene {
     right_hand_position: Vector3<f32>,
     right_hand_rotation: Quaternion<f32>,
     scene_name: String,
+    wrist_frames: Option<[cgmath::Matrix4<f32>; 2]>,
 }
 
 impl DebugHudScene {
@@ -88,6 +92,7 @@ impl DebugHudScene {
             right_hand_position: vec3(0.0, 0.0, 0.0),
             right_hand_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
             scene_name: "debug_hud".to_owned(),
+            wrist_frames: None,
         }
     }
 
@@ -199,17 +204,28 @@ impl GameScene for DebugHudScene {
         asset_cache: &mut AssetCache,
         _options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
-        // Only render the virtual arms HUD panels
-        let hud_panels = create_arm_hud_panels(
+        let frames = *self.wrist_frames.get_or_insert_with(|| {
+            let mut gloves = GloveRenderer::new(asset_cache).expect("debug HUD requires VR gloves");
+            [
+                gloves.wrist_frame(Handedness::Left),
+                gloves.wrist_frame(Handedness::Right),
+            ]
+        });
+        let hud_panels = create_wrist_hud_panels(
             asset_cache,
             &self.world,
-            // The debug scene has no cyber interface, so the arms are never
-            // duplicating it.
             false,
-            self.left_hand_position,
-            self.left_hand_rotation,
-            self.right_hand_position,
-            self.right_hand_rotation,
+            [
+                GripPose {
+                    position: self.left_hand_position,
+                    rotation: self.left_hand_rotation,
+                },
+                GripPose {
+                    position: self.right_hand_position,
+                    rotation: self.right_hand_rotation,
+                },
+            ],
+            frames,
         );
 
         (hud_panels, self.player_position, self.player_rotation)

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -366,7 +366,7 @@ pub enum ButtonHoverBehavior {
 /// than their cell (the wrench is 22 wide) - and are blitted 1:1 into the
 /// slot, not stretched to it. They also key transparency on palette index 0,
 /// independent of that entry's RGB.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum ImageKind {
     /// Ordinary UI art: opaque, stretched to the element's rect.
     #[default]
@@ -385,6 +385,12 @@ pub enum ImageKind {
     /// `tiles_y` times across the element's rect, with its black dropped and
     /// its lines tinted (see [`HOLOGRAM_TINT`]). Sized like [`Self::Ui`].
     Hologram { tiles_x: u8, tiles_y: u8 },
+    /// One sub-rectangle of the art, stretched to the element's rect - the
+    /// corners in normalized texture coordinates, `v` measured from the top of
+    /// the bitmap. Built by [`UiCanvas::cropped_image`]; lets a panel wear a
+    /// region of a shipped bitmap (a single row of the bio monitor, the ammo
+    /// gauge's well) without a second, hand-cut copy of the art.
+    Crop { u0: f32, v0: f32, u1: f32, v1: f32 },
 }
 
 /// The grid tile every hologram panel is drawn from (`shodan/s45.pcx`): a black
@@ -426,6 +432,7 @@ impl ImageKind {
                     vec2(first + tiles_x as f32, first + tiles_y as f32),
                 ))
             }
+            Self::Crop { u0, v0, u1, v1 } => Some((vec2(u0, v0), vec2(u1, v1))),
             _ => None,
         }
     }
@@ -631,6 +638,30 @@ where
             texture: texture.to_owned(),
             alpha: 1.0,
             kind: ImageKind::Ui,
+        });
+        self
+    }
+
+    /// Draw the `source` region of `texture` - in the art's own texels, with
+    /// `art_size` its authored pixel size - stretched to `rect`.
+    pub fn cropped_image(
+        &mut self,
+        rect: Rect,
+        texture: &str,
+        source: Rect,
+        art_size: Vector2<f32>,
+    ) -> &mut Self {
+        self.elements.push(UiElement::Image {
+            position: vec2(rect.x, rect.y),
+            size: vec2(rect.w, rect.h),
+            texture: texture.to_owned(),
+            alpha: 1.0,
+            kind: ImageKind::Crop {
+                u0: source.x / art_size.x,
+                v0: source.y / art_size.y,
+                u1: (source.x + source.w) / art_size.x,
+                v1: (source.y + source.h) / art_size.y,
+            },
         });
         self
     }
@@ -1158,7 +1189,7 @@ pub(crate) fn drawn_rect(
     kind: ImageKind,
 ) -> (Vector2<f32>, Vector2<f32>) {
     match kind {
-        ImageKind::Ui | ImageKind::Hologram { .. } => (position, size),
+        ImageKind::Ui | ImageKind::Hologram { .. } | ImageKind::Crop { .. } => (position, size),
         ImageKind::ObjectIcon => (position + centered_offset(size, texture_px), texture_px),
         ImageKind::ObjectIconFit => {
             let scale = (size.x / texture_px.x).min(size.y / texture_px.y).min(1.0);
@@ -1212,6 +1243,37 @@ fn world_element_transform(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cropped_art_keeps_its_destination_rect_and_authored_texel_bounds() {
+        let mut canvas = UiCanvas::new(vec2(90.0, 44.0));
+        canvas.cropped_image(
+            Rect::new(0.0, 0.0, 90.0, 44.0),
+            "AMMOFULL.PCX",
+            Rect::new(168.0, 14.0, 90.0, 44.0),
+            vec2(260.0, 64.0),
+        );
+        let UiElement::Image {
+            position,
+            size,
+            kind,
+            ..
+        } = &canvas.elements()[0]
+        else {
+            panic!("expected image")
+        };
+        assert_eq!(
+            drawn_rect(*position, *size, vec2(260.0, 64.0), *kind),
+            (*position, *size)
+        );
+        assert_eq!(
+            kind.uv_rect(),
+            Some((
+                vec2(168.0 / 260.0, 14.0 / 64.0),
+                vec2(258.0 / 260.0, 58.0 / 64.0)
+            ))
+        );
+    }
 
     #[test]
     fn rect_contains() {

--- a/shock2vr/src/wielded_weapon.rs
+++ b/shock2vr/src/wielded_weapon.rs
@@ -11,10 +11,10 @@
 //!
 //! **Both-hands precedence.** When both hands hold a weapon, the RIGHT hand
 //! wins. It is the dominant/aiming hand for the default VR player, it is the
-//! hand the forearm ammo panel is worn beside, and - because flat never fills
-//! the right slot - preferring it leaves flatscreen behaviour exactly as it
-//! was. A future hand-specific affordance (e.g. a reload gesture that starts
-//! from one controller) should resolve its own hand with [`weapon_in_hand`]
+//! default for hand-agnostic controls. Because flat never fills the right
+//! slot, this leaves flatscreen behaviour as it was. Hand-specific affordances
+//! (the wrist ammo monitors and controller buttons) resolve their own hand
+//! with [`weapon_in_hand`]
 //! rather than going through [`wielded_weapon`].
 
 use dark::properties::PropGunState;


### PR DESCRIPTION
Replace the oversized forearm HUD with compact glove monitors: health and psi on the dorsal face of both wrists, oriented around the wrist like a bracelet, and each hand's own ammo readout underneath. Dual-wielding a pistol and shotgun shows independent 12/6 counters; a gun beside the psi amp retains its ammo. The amp retains its authored forearm, so its dedicated mount is deferred rather than drawing a glove plate inside that mesh. Empty/support hands have no ammo plate.

The readouts follow the final visible glove pose, including physical weapon displacement, and derive their orientation from the calibrated glove rig. Both faces preserve readable left-hand text. The complete AMMOBACK ammo frame and cropped bio face reuse shared flat/MFD overlay layout; cyber-interface suppression is retained.

Stacked on #1412. Adapts the compact-art idea from #1378 while preserving Astra's calibrated hands and resolving weapons per hand. The next layer is separate Left/Right weapon panels and entity-bound controls in the cyber interface; this PR preserves its existing single dominant-weapon panel. Editable weapon-pinned ammo is documented as an optional placement mode.

Validation: 68 HUD tests, 220 UI tests, and 9 existing debug-runtime E2E tests passed. Debug runtime and Quest APK build; Explorer checks. Codex correctness/simplicity review and dedicated duplication review found no actionable issues. Independent GPT-5.6-sol image review found no blocking visible defect; static monocular images do not establish stereo comfort or motion clearance. Claude review was unavailable because its usage credits were exhausted. The APK has not been installed; headset comfort/readability still needs in-device review.


![Original forearm HUD to current bracelet](https://gist.githubusercontent.com/tommy-xr/6b2a8e776ec4034f74b4469ab167572e/raw/astra-wrist-original-current.png)

![Previous wrist layout to requested bracelet revision](https://gist.githubusercontent.com/tommy-xr/6b2a8e776ec4034f74b4469ab167572e/raw/astra-wrist-revision.png)

![Matched bracelet and complete ammo-frame cycle](https://gist.githubusercontent.com/tommy-xr/6b2a8e776ec4034f74b4469ab167572e/raw/astra-wrist-revision.gif)

Same deterministic requests compare the previous wrist layout with the requested revision. Bio now runs around the cuff; its text is sideways in this unchanged across-body glance. Ammo keeps its orientation and now displays the complete shipped bezel. The loop cycles four viewpoints, not continuous motion. No clipping is visible in these poses; headset readability and comfort remain unverified.

![Independent counters with complete frames](https://gist.githubusercontent.com/tommy-xr/6b2a8e776ec4034f74b4469ab167572e/raw/astra-wrist-ammo-framed.png)

Right pistol: 12 STD; left shotgun: 6 ASLUG. Gun beside psi amp retains its counter. The authored amp forearm has no wrist plate; a dedicated mount remains deferred.

[Download current standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/6b2a8e776ec4034f74b4469ab167572e/raw/astra-wrist-bracelet-gallery.html). Includes current, previous wrist, original forearm, and unchanged flat readout references. Existing held-item fit is outside this HUD review.

MFD follow-up audit: [retail controls and implementation sequence](https://github.com/tommy-xr/shock2quest/blob/astra-vr-wrist-readouts/projects/astra-vr-mfd-controls.md) covers Research, item information, Map, PDA, access cards, stats and dual-weapon controls. These entry points are planning work in this PR, not newly implemented controls.
