### PR TITLE
fix(audio): repeat mission beds continuously and expose live loops

### DIFF
--- a/dark/src/importers/audio_importer.rs
+++ b/dark/src/importers/audio_importer.rs
@@ -8,7 +8,7 @@ pub static AUDIO_IMPORTER: Lazy<AssetImporter<AudioClip, AudioClip, ()>> =
     Lazy::new(|| AssetImporter::define(load_audio, |audio, _cache, _config| audio));
 
 fn load_audio(
-    _name: String,
+    name: String,
     reader: &mut Box<dyn engine::assets::asset_paths::ReadableAndSeekable>,
     _assets: &mut AssetCache,
     _config: &(),
@@ -16,5 +16,5 @@ fn load_audio(
     let mut buf = Vec::new();
     let _ = reader.read_to_end(&mut buf);
 
-    AudioClip::from_bytes(buf)
+    AudioClip::from_bytes(buf).with_sample_name(name)
 }

--- a/engine/src/audio/mod.rs
+++ b/engine/src/audio/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::io::Cursor;
 use std::rc::Rc;
+use std::time::Instant;
 
 use cgmath::{Vector3, vec3};
 use rodio::buffer::SamplesBuffer;
@@ -51,6 +52,41 @@ impl AudioHandle {
 
 pub struct AudioChannel {
     name: String,
+}
+
+/// A live, sink-owned loop. Elapsed time follows the audio wall clock.
+pub struct ActiveLoop<T> {
+    pub handle: u64,
+    pub sample: String,
+    pub owner: &'static str,
+    pub source: Option<T>,
+    pub elapsed_secs: f64,
+}
+
+struct LoopPlayback {
+    handle: u64,
+    sample: String,
+    started: Instant,
+}
+
+impl LoopPlayback {
+    fn new(handle: u64, clip: &AudioClip) -> Self {
+        Self {
+            handle,
+            sample: clip.sample.clone(),
+            started: Instant::now(),
+        }
+    }
+
+    fn snapshot<T>(&self, owner: &'static str, source: Option<T>) -> ActiveLoop<T> {
+        ActiveLoop {
+            handle: self.handle,
+            sample: self.sample.clone(),
+            owner,
+            source,
+            elapsed_secs: self.started.elapsed().as_secs_f64(),
+        }
+    }
 }
 
 /// Gain, stereo channel attenuation and repeat behavior for
@@ -197,20 +233,21 @@ where
     sinks: Vec<Sink>,
     channel_to_last_handle: HashMap<String, u64>,
     handle_to_sink: HashMap<u64, SinkAdapter<TAmbientKey>>,
+    handle_loops: HashMap<u64, LoopPlayback>,
     // Background music
     background_music: Option<Sink>,
     background_music_player: Option<Box<dyn BackgroundMusic<TCue>>>,
     next_music_cue: Option<TCue>,
 
     // Environmental sounds
-    environmental_sink: Option<(Sink, Rc<AudioClip>)>,
+    environmental_sink: Option<(Sink, LoopPlayback)>,
 
     // Position audio context
     last_left_ear_position: Vector3<f32>,
     last_right_ear_position: Vector3<f32>,
 
     // Ambient, positional sounds
-    ambient_sounds: HashMap<TAmbientKey, (SpatialSink, Rc<AudioClip>)>,
+    ambient_sounds: HashMap<TAmbientKey, (SpatialSink, LoopPlayback)>,
 }
 
 impl<TAmbientKey, TCue> Default for AudioContext<TAmbientKey, TCue>
@@ -236,6 +273,7 @@ where
             sinks: vec![],
             //spatial_sinks: vec![],
             handle_to_sink: HashMap::new(),
+            handle_loops: HashMap::new(),
             channel_to_last_handle: HashMap::new(),
             background_music: None,
             background_music_player: None,
@@ -268,11 +306,51 @@ where
     }
 
     pub fn set_environmental_sound(&mut self, clip: Rc<AudioClip>) {
+        self.stop_environmental_sound();
         let sink = rodio::Sink::try_new(&self.handle).unwrap();
-        clip.add_to_sink(&sink);
+        clip.add_to_sink_looping(&sink);
         sink.set_volume(0.2);
         sink.play();
-        self.environmental_sink = Some((sink, clip.clone()));
+        self.environmental_sink = Some((sink, LoopPlayback::new(AudioHandle::new().id(), &clip)));
+    }
+
+    pub fn stop_environmental_sound(&mut self) {
+        if let Some((sink, _)) = self.environmental_sink.take() {
+            sink.stop();
+        }
+    }
+
+    /// Mission beds belong to the outgoing scene, including silent loading/menu scenes.
+    pub fn stop_ambient_sounds(&mut self) {
+        self.stop_environmental_sound();
+        for (_, (sink, _)) in self.ambient_sounds.drain() {
+            sink.stop();
+        }
+    }
+
+    pub fn active_loops(&self) -> Vec<ActiveLoop<TAmbientKey>> {
+        let mut loops = Vec::new();
+        for (handle, playback) in &self.handle_loops {
+            if self
+                .handle_to_sink
+                .get(handle)
+                .is_some_and(|sink| !sink.empty())
+            {
+                loops.push(playback.snapshot("scene", None));
+            }
+        }
+        if let Some((sink, playback)) = &self.environmental_sink {
+            if !sink.empty() {
+                loops.push(playback.snapshot("environmental", None));
+            }
+        }
+        for (entity, (sink, playback)) in &self.ambient_sounds {
+            if !sink.empty() {
+                loops.push(playback.snapshot("ambient_emitter", Some(*entity)));
+            }
+        }
+        loops.sort_by_key(|entry| entry.handle);
+        loops
     }
 
     pub fn update<F>(
@@ -286,7 +364,6 @@ where
     {
         audio_log!(DEBUG, "Audio system update started");
         self.update_background_music();
-        self.update_environmental_sounds();
 
         trace!(
             "updating {} ambient sounds...",
@@ -308,6 +385,8 @@ where
         );
 
         self.handle_to_sink.retain(|_, sink| !sink.empty());
+        self.handle_loops
+            .retain(|handle, _| self.handle_to_sink.contains_key(handle));
         // Update positional sounds
         for sink in self.handle_to_sink.values_mut() {
             sink.update_spatial_position(
@@ -324,13 +403,9 @@ where
         }
 
         let mut sounds_to_remove = HashSet::new();
-        // First pass - check existing ambient sounds, update position, and see if they have completed
-        for (key, (sink, clip)) in &self.ambient_sounds {
+        // Refresh nearby emitters; explicitly stop those that left the active set.
+        for (key, (sink, _)) in &self.ambient_sounds {
             if let Some(current_sound) = current_sound_hash.get(key) {
-                if sink.len() == 0 {
-                    clip.add_to_spatial_sink(sink);
-                }
-
                 sink.set_emitter_position(to_audio_position(*current_sound.0));
 
                 // TODO
@@ -360,7 +435,12 @@ where
                 )
                 .unwrap();
 
-                self.ambient_sounds.insert(*key, (sink, clip.clone()));
+                clip.add_to_spatial_sink_looping(&sink);
+                sink.set_volume(0.5);
+                self.ambient_sounds.insert(
+                    *key,
+                    (sink, LoopPlayback::new(AudioHandle::new().id(), clip)),
+                );
             }
         }
     }
@@ -387,18 +467,6 @@ where
             }
         }
     }
-
-    fn update_environmental_sounds(&mut self) {
-        if let Some((current_sink, clip)) = &self.environmental_sink {
-            if current_sink.len() == 0 {
-                let sink = rodio::Sink::try_new(&self.handle).unwrap();
-                clip.add_to_sink(&sink);
-                sink.set_volume(0.2);
-                sink.play();
-                self.environmental_sink = Some((sink, clip.clone()));
-            }
-        }
-    }
 }
 
 #[derive(Clone)]
@@ -410,12 +478,31 @@ enum SourceType {
 #[derive(Clone)]
 pub struct AudioClip {
     source: SourceType,
+    sample: String,
     /// Total playback length, when the decoder can report it. Used by the
     /// audio log to tell how long a played clip occupies its channel.
     total_duration: Option<std::time::Duration>,
 }
 
 impl AudioClip {
+    pub fn with_sample_name(mut self, sample: String) -> Self {
+        self.sample = sample;
+        self
+    }
+
+    fn add_to_sink_looping(&self, sink: &Sink) {
+        match &self.source {
+            SourceType::Bytes(source) => sink.append(source.clone().repeat_infinite()),
+            SourceType::Raw(source) => sink.append(source.clone().repeat_infinite()),
+        }
+    }
+
+    fn add_to_spatial_sink_looping(&self, sink: &SpatialSink) {
+        match &self.source {
+            SourceType::Bytes(source) => sink.append(source.clone().repeat_infinite()),
+            SourceType::Raw(source) => sink.append(source.clone().repeat_infinite()),
+        }
+    }
     /// Playback length of the clip, if the underlying source knows it.
     pub fn total_duration(&self) -> Option<std::time::Duration> {
         self.total_duration
@@ -471,6 +558,7 @@ impl AudioClip {
         let source = decoder.buffered();
         AudioClip {
             source: SourceType::Bytes(source),
+            sample: String::new(),
             total_duration,
         }
     }
@@ -481,6 +569,7 @@ impl AudioClip {
         let source = samples.buffered();
         AudioClip {
             source: SourceType::Raw(source),
+            sample: String::new(),
             total_duration,
         }
     }
@@ -611,6 +700,7 @@ pub fn stop_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     handle: AudioHandle,
 ) {
     let maybe_sink = context.handle_to_sink.remove(&handle.id);
+    context.handle_loops.remove(&handle.id);
 
     if let Some(sink) = maybe_sink {
         sink.stop();
@@ -644,6 +734,11 @@ pub fn play_audio_with_settings<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     let preempted = prepare_audio_play(context, &handle, maybe_channel);
     let sink = rodio::Sink::try_new(&context.handle).unwrap();
     audio_clip.add_to_sink_with_settings(&sink, settings);
+    if settings.looping {
+        context
+            .handle_loops
+            .insert(id, LoopPlayback::new(id, &audio_clip));
+    }
 
     context.handle_to_sink.insert(id, SinkAdapter::fixed(sink));
     preempted
@@ -745,6 +840,7 @@ fn prepare_audio_play<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
         if let Some(audio) = maybe_previous_audio {
             let previous_id = *audio;
             let maybe_sink = context.handle_to_sink.remove(&previous_id);
+            context.handle_loops.remove(&previous_id);
 
             if let Some(sink) = maybe_sink {
                 if !sink.empty() {
@@ -759,6 +855,7 @@ fn prepare_audio_play<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
             .insert(channel.name, handle.id);
     }
 
+    context.handle_loops.remove(&handle.id);
     if let Some(current_channel) = context.handle_to_sink.get(&handle.id) {
         if !current_channel.empty() {
             current_channel.stop();
@@ -776,6 +873,17 @@ mod tests {
         wav_duration,
     };
     use cgmath::vec3;
+
+    #[test]
+    fn environmental_bed_repeats_without_game_updates() {
+        let clip = AudioClip::from_raw(1, 48_000, vec![8192; 64]);
+        let (sink, mut output) = rodio::Sink::new_idle();
+        clip.add_to_sink_looping(&sink);
+        let samples: Vec<_> = output.by_ref().take(1024).collect();
+        assert_eq!(samples.len(), 1024);
+        assert!(samples.iter().all(|sample| *sample > 0.2));
+        sink.stop();
+    }
 
     /// Chunk boundaries must be inaudible: the source is one continuous
     /// soundtrack, whatever sizes the decoder happened to hand over.

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -111,6 +111,7 @@ pub enum RuntimeCommand {
     /// Get the free (debug) camera's state: detached, and the pose it is
     /// rendering from when it is.
     GetCameraState(oneshot::Sender<CameraStateSnapshot>),
+    GetAudioLoops(oneshot::Sender<serde_json::Value>),
 
     /// Place the free (debug) camera, or re-attach it to the player. Replies
     /// with the resulting state, so a caller can read back what it set in the

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -429,6 +429,7 @@ async fn start_http_server(
         .route("/v1/dev-params", get(list_dev_params))
         .route("/v1/dev-params", axum::routing::post(set_dev_param))
         .route("/v1/audio/recent", get(get_recent_audio))
+        .route("/v1/audio/loops", get(get_audio_loops))
         .route("/v1/messages/recent", get(get_recent_messages))
         .route("/v1/screenshot", axum::routing::post(take_screenshot))
         .with_state(command_tx)
@@ -493,6 +494,9 @@ async fn start_http_server(
         "  POST /v1/dev-params       - Set a dev param {{key, value}} (clamped + snapped, live next frame)"
     );
     info!("  GET  /v1/audio/recent     - Recently played sounds (sample, tags, duration, source)");
+    info!(
+        "  GET  /v1/audio/loops      - Live looping sinks (sample, handle, owner, elapsed wall time)"
+    );
     info!("  GET  /v1/messages/recent  - Recently delivered script messages (to/payload/from)");
     info!("  POST /v1/screenshot       - Capture the current framebuffer");
     info!("");
@@ -1452,6 +1456,13 @@ fn process_command(
             if reply.send(camera_snapshot(game, current_input)).is_err() {
                 tracing::warn!("Failed to send camera state - receiver dropped");
             }
+        }
+        RuntimeCommand::GetAudioLoops(reply) => {
+            let loops: Vec<_> = game.active_audio_loops().into_iter().map(|entry| json!({
+                "handle": entry.handle, "sample": entry.sample, "owner": entry.owner,
+                "entity_id": entry.source.map(|id| id.inner()), "elapsed_secs": entry.elapsed_secs,
+            })).collect();
+            let _ = reply.send(json!({ "loops": loops }));
         }
         RuntimeCommand::SetCameraState { request, reply } => {
             let result = apply_camera_request(game, current_input, &request)
@@ -4307,6 +4318,19 @@ async fn list_input_actions() -> Json<Value> {
 /// schema. Reads a process-wide log, so no game-loop round-trip is needed.
 async fn get_recent_audio() -> Json<Value> {
     Json(serde_json::json!({ "sounds": shock2vr::audio_log::recent() }))
+}
+
+async fn get_audio_loops(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    command_tx
+        .send(RuntimeCommand::GetAudioLoops(reply_tx))
+        .map_err(|_| game_loop_unavailable())?;
+    reply_rx
+        .await
+        .map(Json)
+        .map_err(|_| game_loop_unavailable())
 }
 
 /// HTTP handler for the recently delivered script messages (receiver, payload

--- a/shock2vr/src/audio_log.rs
+++ b/shock2vr/src/audio_log.rs
@@ -17,7 +17,8 @@
 //! when the debug runtime steps frames faster (or slower) than real time.
 //! Entries whose duration is unknown report `still_playing: false`, and a
 //! looping sound's duration is one iteration, so it can read as finished while
-//! still audible. The buffer is process-global and never cleared, so it can
+//! still audible. Query `GET /v1/audio/loops` for actual live looping sinks.
+//! The buffer is process-global and never cleared, so it can
 //! span a level transition; `sim_time` stays monotonic across one.
 
 use std::collections::VecDeque;

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1550,6 +1550,9 @@ impl Game {
             if let Some(cue_schema) = state.environmental_cue {
                 let resolved = self.resolve_schema(&cue_schema);
                 self.update_env_sound_if_necessary(resolved);
+            } else {
+                self.audio_context.stop_environmental_sound();
+                self.last_env_sound = None;
             }
 
             state
@@ -1564,6 +1567,8 @@ impl Game {
                 })
                 .collect::<Vec<(EntityId, Vector3<f32>, Rc<AudioClip>)>>()
         } else {
+            self.audio_context.stop_environmental_sound();
+            self.last_env_sound = None;
             Vec::new()
         };
 
@@ -2074,6 +2079,8 @@ impl Game {
     /// scene swap goes through here so that hook cannot be forgotten.
     fn set_active_scene(&mut self, scene: Box<dyn GameScene>) {
         self.active_game_scene.on_exit(&mut self.audio_context);
+        self.audio_context.stop_ambient_sounds();
+        self.last_env_sound = None;
         // Only a cutscene standing in for a scene carries state on its behalf,
         // and `PlayCutscene` re-arms this straight after the swap. Clearing it
         // for every other swap means a chain that ends anywhere but a
@@ -2492,8 +2499,15 @@ impl Game {
         }
     }
 
+    /// Snapshot real live looping sinks; duration follows rodio's wall clock.
+    pub fn active_audio_loops(&self) -> Vec<engine::audio::ActiveLoop<EntityId>> {
+        self.audio_context.active_loops()
+    }
+
     fn update_env_sound_if_necessary(&mut self, new_cue: String) {
         if self.last_env_sound.is_none() || !self.last_env_sound.as_ref().unwrap().eq(&new_cue) {
+            self.audio_context.stop_environmental_sound();
+            self.last_env_sound = None;
             let maybe_audio_clip = self
                 .asset_cache
                 .get_opt(&AUDIO_IMPORTER, &format!("{new_cue}.wav"));

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -124,6 +124,11 @@ await game.raycast({
 // the headless way to assert audio, e.g. weapon impact sounds.
 const { sounds } = await game.audio.recent();
 
+// Live looping sinks: sample, handle, owner, ambient entity ID, elapsed wall time.
+// Unlike recent().still_playing (a simulation-time estimate for finite clips),
+// this reads actual sink ownership and can prove a bed stopped on scene exit.
+const { loops } = await game.audio.loops();
+
 // Live-tunable dev params (shock2vr::dev_params): list every knob with its
 // range/current/default, or set one - clamped + snapped, applied next frame.
 const { params } = await game.devParams.list();

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpError } from "./client.js";
 import type {
+  ActiveAudioLoopsResult,
   AnimationState,
   CommandResult,
   DebugEntityMessage,
@@ -782,6 +783,11 @@ export class UiApi {
 /** Played-sound introspection (there is no other headless way to observe audio). */
 export class AudioApi {
   constructor(private readonly client: HttpClient) {}
+
+  /** Live looping sinks, queried on the game thread (elapsed time is wall time). */
+  async loops(): Promise<ActiveAudioLoopsResult> {
+    return this.client.get<ActiveAudioLoopsResult>("/v1/audio/loops");
+  }
 
   /**
    * The most recently played sounds (oldest first): resolved schema sample,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -1015,6 +1015,19 @@ export interface SoundSourceEntity {
   template_id: number | null;
 }
 
+/** Real live repeating sinks, independent of the finite recent-play ring buffer. */
+export interface ActiveAudioLoopsResult {
+  loops: Array<{
+    handle: number;
+    sample: string;
+    owner: "scene" | "environmental" | "ambient_emitter";
+    /** Runtime entity ID for ambient emitters; discover again each launch. */
+    entity_id: number | null;
+    /** Wall-clock playback age; audio runs independently of simulation stepping. */
+    elapsed_secs: number;
+  }>;
+}
+
 /** One resolved-and-played sound (GET /v1/audio/recent). */
 export interface PlayedSound {
   /** Monotonically increasing id - diff against a snapshot to find new plays. */

--- a/tools/shock2-sdk/test/audio-loops.e2e.test.ts
+++ b/tools/shock2-sdk/test/audio-loops.e2e.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+test("live audio loops retire on scene changes and out-of-radius movement", {
+  skip: !enabled, timeout: 600_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "main_menu", port: 0 });
+  await game.step({ frames: 10 });
+  const menu = (await game.audio.loops()).loops;
+  assert.equal(menu.length, 1);
+  assert.match(menu[0].sample.toLowerCase(), /mloop1/);
+  assert.equal(menu[0].owner, "scene");
+  assert.equal(menu[0].entity_id, null);
+  assert.ok(menu[0].elapsed_secs >= 0);
+
+  await game.transitionLevel("medsci1.mis");
+  await game.step({ frames: 2 });
+  assert.ok(!(await game.audio.loops()).loops.some(loop => loop.handle === menu[0].handle));
+
+  // Discover the authored cryo hum by stable mission object ID, never runtime ID.
+  const [cryo] = await game.entities.byTemplate(349);
+  assert.ok(cryo);
+  await game.player.teleport({ x: -13.824831, y: -6.240317, z: -65.7749 });
+  await game.step({ frames: 2 });
+  const near = (await game.audio.loops()).loops;
+  const emitter = near.find(loop => loop.entity_id === cryo.id);
+  assert.ok(emitter, JSON.stringify(near));
+  assert.equal(emitter.owner, "ambient_emitter");
+  assert.ok(emitter.sample.length > 0);
+  await game.step({ frames: 120 });
+  assert.ok((await game.audio.loops()).loops.some(loop => loop.handle === emitter.handle));
+
+  await game.player.teleport({ x: 1000, y: 1000, z: 1000 });
+  await game.step({ frames: 2 });
+  assert.deepEqual((await game.audio.loops()).loops, [], "no beds outside every authored radius");
+
+  // Two non-overlapping parts of the authored environmental spheres (929/935).
+  await game.player.teleport({ x: -8, y: -0.244, z: -54.334 });
+  await game.step({ frames: 2 });
+  const first = (await game.audio.loops()).loops.find(loop => loop.owner === "environmental");
+  assert.ok(first, "ship hum region should have an environmental bed");
+  await game.player.teleport({ x: 11, y: -0.244, z: -54.334 });
+  await game.step({ frames: 2 });
+  const swapped = (await game.audio.loops()).loops.filter(loop => loop.owner === "environmental");
+  assert.equal(swapped.length, 1);
+  assert.notEqual(swapped[0].handle, first.handle);
+  assert.notEqual(swapped[0].sample, first.sample);
+
+  await game.player.teleport({ x: 1000, y: 1000, z: 1000 });
+  await game.step({ frames: 2 });
+  assert.deepEqual((await game.audio.loops()).loops, [], "leaving an environmental region stops its bed");
+  await game.player.teleport({ x: 11, y: -0.244, z: -54.334 });
+  await game.step({ frames: 2 });
+  assert.ok((await game.audio.loops()).loops.some(loop => loop.owner === "environmental"),
+    "re-entering the same cue restarts the stopped bed");
+  await game.input.trigger("TogglePauseMenu");
+  await game.step({ frames: 10 });
+  // SIMR.BIN row 4: Quit to Main Menu.
+  await game.input.set("pointer.position", [489.5 / 640, 426 / 480]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 10 });
+  assert.equal((await game.info()).mission, "main_menu");
+  const final = (await game.audio.loops()).loops;
+  assert.equal(final.length, 1, JSON.stringify(final));
+  assert.equal(final[0].owner, "scene", "scene replacement retires all mission beds");
+});


### PR DESCRIPTION
Mission ambient emitters and environmental beds waited for the game update to notice an empty sink before restarting a clip, producing silence between repeats. They now use rodio `repeat_infinite`, as the frontend bed already does. Leaving an emitter radius, leaving an environmental region, swapping its cue, or replacing the scene explicitly stops the owned beds; re-entering the same region starts a fresh loop.

`GET /v1/audio/loops` and `game.audio.loops()` expose actual live sink ownership, with sample, handle, owner, optional ambient emitter runtime ID, and elapsed wall time. This is separate from `audio.recent().still_playing`, which estimates finite playback from simulation time and cannot establish whether an infinite bed is alive.

Validation on base `c6ddb35b15eed14b415386e3cd8e3fa8cc86322e`:

- Negative source-buffer check: consuming 1024 samples from a 64-sample finite bed without game updates reached silence; the same assertion passes with source repetition. Engine audio tests: 7 passed.
- New focused SDK lifecycle scenario passed, then passed again in the full suite: menu→mission retirement, stable cryo emitter identity and handle, outside-all-radii silence, environmental sample/handle swap, silence→same-cue restart, and Quit→main-menu cleanup.
- Warning-free core/desktop/debug package checks, format check, SDK build and fast suite passed (60 passed, 433 E2E skipped).
- Full SDK E2E completed: 493 total, 475 passed, 10 failed, 8 skipped, 0 cancelled. All 23 missions loaded. All existing menu-audio, impact-audio and new loop lifecycle tests passed. Every failure matches the exact-base verification already recorded during the sweep: creature-loot reader host; Earth hacking nanite auto-collection; Hydro2 VR research self-offer; Korenchkin transcript spacing; saved VR wrench pickup; nondeterministic lethal-wrench ragdoll; PSI provisioning only raises; grav-lift refusal sound; forearm element count 5 versus 4; template -28 spawn refusal. No new failing assertion or port conflict.

Every runtime/E2E launch explicitly selected `DARK_ASSET_PATH=/Users/bryan/ss2-25th`, verified by `sshock2.kpf` and remaster `mods/{sshock2ee,400,scp,shtup,patch_ext}.kpf`. Full log retained locally at `/tmp/issue981-full-e2e.log`; source was frozen throughout the full run, followed only by formatting a help string. Main was fetched again and remained unchanged.

Visual proof assessment: `pr-visuals` applied; manager approved a non-renderable rationale. Continuous audio samples and read-only audio diagnostics do not alter game state or rendered frames. GIF/PNG cannot demonstrate audible gaps or leaked sinks; source-buffer assertions and live sink lifecycle tests provide the relevant evidence.

Fixes #981
