### PR TITLE
feat(vr): stow held items by releasing over a shoulder

### DIFF
--- a/projects/astra-vr-shoulder-backpack.md
+++ b/projects/astra-vr-shoulder-backpack.md
@@ -1,0 +1,51 @@
+# Shoulder backpack
+
+Hold an item, move the controller behind either shoulder, and release grip to
+put it in the backpack. Either hand can use either shoulder. Moving through a
+zone while still squeezing does nothing. Retrieve stored items through the
+existing inventory interface.
+
+Successful stowing plays the inventory confirmation sound and displays “Stored
+in backpack.” The existing entity moves into a real inventory cell, preserving
+ammo and item state. Collectible credentials use the existing collection path.
+If no cell fits, the item stays held with a refusal sound and message: squeeze
+again to re-grip, then move it somewhere else and release normally.
+
+## Placement and diagnostics
+
+Each zone is a sphere of radius 18 cm, centered 18 cm to the side, 20 cm below,
+and 18 cm behind the tracked eyes. A release must also be at least 3 cm behind
+the eye plane. The zones follow head translation and a smoothed horizontal
+heading; pitch and roll do not tilt them. Heading stops following while a held
+hand is inside a zone. These are head-based estimates, not tracked shoulders.
+
+The gesture is VR-only and disabled while the cyber interface is open, the
+player is dead, or controls are disabled. It requires tracked head/hand poses
+and a prior squeeze holding the same item. Tracking recovery alone cannot
+cause a deposit.
+
+Enable **Backpack zones** (`vr_backpack_zones`) to draw cyan targets, green
+while reached, and red after a refused deposit. `/v1/info` exposes world-space
+centers, radius, per-hand proximity and retention under
+`player.hand_feedback.shoulder_backpack`. The arrays use left/right order.
+The debug overlay is off by default; it can be viewed from an external debug
+camera for automated captures.
+
+## Verification
+
+- Unit tests cover both hands and shoulders, release edges, invalid tracking,
+  disabled gestures, heading/height changes, retention and simultaneous cell
+  reservations.
+- `tools/shock2-sdk/test/vr-shoulder-backpack.e2e.test.ts` exercises real pickup,
+  stowing and retrieval with a mug and pistol, ammo preservation, full-pack
+  refusal/re-grip and ordinary world drops.
+- Existing cyber-interface deposit tests cover the shared release-to-inventory
+  rewrite used by both interactions.
+
+Before headset acceptance, check comfortable seated and standing reaches,
+looking sideways while reaching, real controller tracking behind the shoulder,
+and the refusal cue with a full backpack. Desktop VR emulation verifies the
+state transitions but cannot establish the physical comfort or tracking envelope.
+
+This increment adds depositing only. Shoulder retrieval, belt pouches, leg
+holsters and editable body anchors remain separate work.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -992,6 +992,21 @@ fn main() {
         input_context.head.rotation = head_rotation;
         input_context.head.position = tracking.stage_to_pawn(head_stage);
         input_context.tracking = Some(tracking);
+        let tracked_pose_flags = xr::SpaceLocationFlags::POSITION_VALID
+            | xr::SpaceLocationFlags::POSITION_TRACKED
+            | xr::SpaceLocationFlags::ORIENTATION_VALID
+            | xr::SpaceLocationFlags::ORIENTATION_TRACKED;
+        input_context.pose_tracking = Some(shock2vr::input_context::PoseTracking {
+            head: head_location.location_flags.contains(tracked_pose_flags),
+            hands: [
+                left_aim_location
+                    .location_flags
+                    .contains(tracked_pose_flags),
+                right_aim_location
+                    .location_flags
+                    .contains(tracked_pose_flags),
+            ],
+        });
         input_context.right_hand.rotation = aim_rotation;
         input_context.right_hand.position = right_hand_position;
         input_context.right_hand.trigger_value = right_trigger_value;

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -191,6 +191,8 @@ dev_params! {
     /// weapon is". Read out of Rapier at the collider's own isometry, so it
     /// shows what is actually simulated rather than what the wield intended.
     MELEE_VOLUMES = float("melee_volumes", "Show hurtbox", 0.0, 0.0, 1.0, 1.0),
+    /// Visualize shoulder backpack stow zones (cyan; green while reached).
+    VR_BACKPACK_ZONES = bool("vr_backpack_zones", "Backpack zones", false),
     /// VR support target/radius (cyan; green when attached) and tracked palm (amber).
     VR_SUPPORT_GRIPS = bool("vr_support_grips", "Support grips", false),
     /// Draw a floating "-7 HP" at the point each blow lands, labeled with the

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -31,6 +31,15 @@ pub struct InputContext {
 
     /// Conversion used by a tracked runtime; lets a stance change rebase all poses together.
     pub tracking: Option<crate::vr_tracking::TrackingTransform>,
+    /// Live runtime tracking validity, separate from fallback/stale pose values.
+    /// None means synthetic input (desktop/debug), whose poses are validated directly.
+    pub pose_tracking: Option<PoseTracking>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PoseTracking {
+    pub head: bool,
+    pub hands: [bool; 2],
 }
 
 impl InputContext {
@@ -44,6 +53,7 @@ impl InputContext {
             crouch: false,
             jump: false,
             tracking: None,
+            pose_tracking: None,
         }
     }
 }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -1059,6 +1059,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_rotation,
             ctx.input.right_hand.position,
         );
+        let right_held_before = self.right_hand.get_held_entity();
         let (right_hand, mut right_msgs) =
             if self.support_blocked[1] && self.right_hand.get_held_entity().is_none() {
                 (
@@ -1086,7 +1087,9 @@ impl PlayerInteraction for VrInteraction {
 
         // Right updates first, so a same-frame right-hand grab is visible to
         // the left hand and one physical item cannot enter both hand states.
-        let right_held_entity = self.right_hand.get_held_entity();
+        // A release is still owned until its effects run (it may be a backpack
+        // deposit), so the left hand must not acquire that same entity either.
+        let right_held_entity = self.right_hand.get_held_entity().or(right_held_before);
         let (left_hand, mut left_msgs) =
             if self.support_blocked[0] && self.left_hand.get_held_entity().is_none() {
                 (
@@ -1868,6 +1871,18 @@ mod tests {
             1,
             "one physical item must produce exactly one hold transition"
         );
+
+        // The release may be rewritten into a backpack deposit by the caller.
+        // Until effects remove its body, the left hand must not steal it.
+        input.right_hand.squeeze_value = 0.0;
+        let effects = interaction.update(&context(&world, &physics, &input));
+        assert_eq!(interaction.held_entities(), (None, None));
+        assert!(effects.iter().any(|effect| matches!(
+            effect, VirtualHandEffect::DropItem { entity_id } if *entity_id == item
+        )));
+        assert!(!effects.iter().any(|effect| matches!(
+            effect, VirtualHandEffect::HoldItem { entity_id } if *entity_id == item
+        )));
     }
 
     #[test]

--- a/shock2vr/src/inventory/mod.rs
+++ b/shock2vr/src/inventory/mod.rs
@@ -299,7 +299,7 @@ impl Inventory {
 
     /// The cell an ordinal names, or `None` if it is not a cell in this grid
     /// (an equip slot, or beyond the grid's bounds).
-    fn cell_of(&self, ordinal: u32) -> Option<(usize, usize)> {
+    pub(crate) fn cell_of(&self, ordinal: u32) -> Option<(usize, usize)> {
         if ordinal >= EQUIP_SLOT_BASE {
             return None;
         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -284,7 +284,7 @@ fn strip_deposit_entities(
         .collect()
 }
 
-/// Rewrite a release that [`strip_deposit_entities`] claimed, from the world
+/// Rewrite a release claimed by the inventory strip or shoulder backpack, from the world
 /// drop `VirtualHand` emitted into the backpack deposit the player meant.
 ///
 /// Each claimed item's `DropItem` - the world drop itself, which restores its
@@ -300,7 +300,7 @@ fn strip_deposit_entities(
 /// rather than stored, so the credential is recorded instead of an inert card
 /// being banked.
 ///
-/// `store` pairs each stored item with the strip cell its release was over,
+/// `store` pairs each stored item with its targeted or reserved inventory cell,
 /// when one resolved - the deposit becomes a [`VirtualHandEffect::StoreItemAtCell`]
 /// there, falling back to the first-free [`VirtualHandEffect::StoreItem`]
 /// only when no cell resolved.
@@ -310,7 +310,7 @@ fn strip_deposit_entities(
 /// that ray reaches straight through it - so a container standing behind the
 /// interface would otherwise take the item as well and the deposit would land
 /// twice. Everything else the hand emitted this frame is untouched.
-fn rewrite_strip_release(
+fn rewrite_inventory_release(
     effects: &mut Vec<VirtualHandEffect>,
     store: &[(EntityId, Option<(usize, usize)>)],
     collect: &[EntityId],
@@ -2101,6 +2101,7 @@ pub struct MissionCore {
     ///
     /// [`update_clip_insert_gesture`]: MissionCore::update_clip_insert_gesture
     vr_clip_insert_engaged: [bool; 2],
+    shoulder_backpack: super::shoulder_backpack::ShoulderBackpack,
 
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
     /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
@@ -3027,6 +3028,7 @@ impl MissionCore {
             vr_squeeze_swallow: [false; 2],
             vr_trigger_safe_latch: [None; 2],
             vr_clip_insert_engaged: [false; 2],
+            shoulder_backpack: Default::default(),
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
@@ -4059,6 +4061,76 @@ impl MissionCore {
         });
         let hands_input = weapon_safe_input.as_ref().unwrap_or(input_context);
 
+        let held = [left_hand_held, right_hand_held];
+        let shoulder_releases = self.shoulder_backpack.update(
+            hands_input,
+            held,
+            game_options.presentation_mode == crate::PresentationMode::Vr
+                && !self.use_mode
+                && self.player_is_alive()
+                && self.player_controls_enabled,
+            time.elapsed.as_secs_f32(),
+        );
+        let shoulder_collect = std::array::from_fn::<_, 2, _>(|i| {
+            shoulder_releases[i]
+                && held[i].is_some_and(|entity| {
+                    crate::scripts::script_util::is_always_collected(&self.world, entity)
+                })
+        });
+        let shoulder_cells = if (0..2).any(|i| {
+            shoulder_releases[i]
+                && held[i].is_some_and(|entity| backpack_accepts_deposit(&self.world, entity))
+        }) {
+            let inventory = self
+                .world
+                .borrow::<UniqueView<PlayerInfo>>()
+                .unwrap()
+                .inventory_entity_id;
+            super::shoulder_backpack::reserve_slots(
+                &self.world,
+                inventory,
+                std::array::from_fn(|i| {
+                    (shoulder_releases[i] && !shoulder_collect[i])
+                        .then_some(held[i])
+                        .flatten()
+                }),
+            )
+        } else {
+            [None; 2]
+        };
+        let mut shoulder_input = hands_input.clone();
+        for i in 0..2 {
+            if shoulder_releases[i] {
+                let accepted = shoulder_collect[i] || shoulder_cells[i].is_some();
+                if !accepted {
+                    self.shoulder_backpack.retain(i, held[i].unwrap());
+                }
+                effects.push(Effect::ShowMessage {
+                    text: if shoulder_collect[i] {
+                        "Collected".to_owned()
+                    } else if accepted {
+                        "Stored in backpack".to_owned()
+                    } else {
+                        "Backpack full — item kept in hand. Squeeze to re-grip.".to_owned()
+                    },
+                });
+                effects.push(Effect::PlaySound {
+                    handle: AudioHandle::new(),
+                    name: if accepted { "bset" } else { "repfail" }.to_owned(),
+                    source: held[i],
+                    spatial: false,
+                });
+                tracing::info!(hand = i, entity = ?held[i], accepted, "shoulder backpack release");
+            }
+            if self.shoulder_backpack.keep_grip(i) {
+                match i {
+                    0 => shoulder_input.left_hand.squeeze_value = 1.0,
+                    _ => shoulder_input.right_hand.squeeze_value = 1.0,
+                }
+            }
+        }
+        let hands_input = &shoulder_input;
+
         // Opening a hand over the inventory strip puts the item in the
         // backpack instead of on the floor. Decided from the input the hands
         // are about to see, so the release this claims is exactly the release
@@ -4084,7 +4156,12 @@ impl MissionCore {
         let (collect, store): (Vec<_>, Vec<_>) = strip_deposits.iter().partition(|entity_id| {
             crate::scripts::script_util::is_always_collected(&self.world, **entity_id)
         });
-        let collect: Vec<_> = collect.into_iter().copied().collect();
+        let mut collect: Vec<_> = collect.into_iter().copied().collect();
+        collect.extend(
+            (0..2)
+                .filter(|i| shoulder_collect[*i])
+                .filter_map(|i| held[i]),
+        );
         // The cell the depositing hand's ray was over, for a stored item -
         // whichever on-strip slot actually held it. `None` (a ray gone off
         // the strip between resolving `strip_cell` and here, or generally
@@ -4105,11 +4182,13 @@ impl MissionCore {
         // release can claim one item and leave the other to its ordinary
         // world drop. A collected one never enters the pack (its Frob awards
         // and destroys it), so it is claimed either way.
-        let store: Vec<(EntityId, Option<(usize, usize)>)> = store
+        let mut store: Vec<(EntityId, Option<(usize, usize)>)> = store
             .into_iter()
             .filter(|entity_id| backpack_accepts_deposit(&self.world, **entity_id))
             .map(|entity_id| (*entity_id, cell_for(*entity_id)))
             .collect();
+
+        store.extend((0..2).filter_map(|i| Some((held[i]?, Some(shoulder_cells[i]?)))));
 
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.
@@ -4132,7 +4211,7 @@ impl MissionCore {
             &mut interaction_msgs,
             game_options,
         );
-        rewrite_strip_release(&mut interaction_msgs, &store, &collect);
+        rewrite_inventory_release(&mut interaction_msgs, &store, &collect);
         effects.extend(self.process_virtual_hand_effects(asset_cache, interaction_msgs));
 
         // The physical VR reload: a clip carried into the other hand's weapon
@@ -10644,6 +10723,12 @@ impl MissionCore {
                 .render(asset_cache, &self.world, self.use_mode),
         );
 
+        if options.presentation_mode == crate::PresentationMode::Vr
+            && crate::dev_params::get_bool(crate::dev_params::VR_BACKPACK_ZONES)
+        {
+            scene.extend(self.shoulder_backpack.render(player.pos, player.rotation));
+        }
+
         // The old synthetic blue inventory cube remains a desktop diagnostic.
         // VR presents the authored INVBACK canvas through GuiManager instead.
         if options.presentation_mode == crate::PresentationMode::Flat {
@@ -12519,7 +12604,18 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn hand_feedback(&self) -> serde_json::Value {
-        self.interaction.hand_feedback_diagnostics()
+        let mut feedback = self.interaction.hand_feedback_diagnostics();
+        if let (Some(object), Ok(player)) = (
+            feedback.as_object_mut(),
+            self.world.borrow::<UniqueView<PlayerInfo>>(),
+        ) {
+            object.insert(
+                "shoulder_backpack".to_owned(),
+                self.shoulder_backpack
+                    .diagnostics(player.pos, player.rotation),
+            );
+        }
+        feedback
     }
 
     fn hand_grips(&self) -> serde_json::Value {
@@ -14159,7 +14255,7 @@ mod strip_deposit_tests {
             VirtualHandEffect::DropItem { entity_id: item },
             VirtualHandEffect::DropItem { entity_id: other },
         ];
-        rewrite_strip_release(&mut effects, &[(item, None)], &[]);
+        rewrite_inventory_release(&mut effects, &[(item, None)], &[]);
         assert!(
             matches!(
                 effects.as_slice(),
@@ -14186,7 +14282,7 @@ mod strip_deposit_tests {
     fn a_claimed_release_with_a_resolved_cell_targets_it() {
         let (_world, item, _other) = two_entities();
         let mut effects = vec![VirtualHandEffect::DropItem { entity_id: item }];
-        rewrite_strip_release(&mut effects, &[(item, Some((3, 1)))], &[]);
+        rewrite_inventory_release(&mut effects, &[(item, Some((3, 1)))], &[]);
         assert!(
             matches!(
                 effects.as_slice(),
@@ -14213,7 +14309,7 @@ mod strip_deposit_tests {
     fn a_claimed_key_source_is_frobbed_instead() {
         let (_world, card, _other) = two_entities();
         let mut effects = vec![VirtualHandEffect::DropItem { entity_id: card }];
-        rewrite_strip_release(&mut effects, &[], &[card]);
+        rewrite_inventory_release(&mut effects, &[], &[card]);
         assert!(
             matches!(
                 effects.as_slice(),
@@ -14248,7 +14344,7 @@ mod strip_deposit_tests {
                 payload: MessagePayload::ProvideForConsumption { entity: item },
             },
         }];
-        rewrite_strip_release(&mut effects, &[(item, None)], &[]);
+        rewrite_inventory_release(&mut effects, &[(item, None)], &[]);
         assert!(effects.is_empty(), "got {effects:?}");
     }
 
@@ -14267,7 +14363,7 @@ mod strip_deposit_tests {
             },
             VirtualHandEffect::HoldItem { entity_id: item },
         ];
-        rewrite_strip_release(&mut effects, &[(item, None)], &[]);
+        rewrite_inventory_release(&mut effects, &[(item, None)], &[]);
         assert!(
             matches!(
                 effects.as_slice(),
@@ -14290,7 +14386,7 @@ mod strip_deposit_tests {
     fn an_unclaimed_frame_is_untouched() {
         let (_world, item, _other) = two_entities();
         let mut effects = vec![VirtualHandEffect::DropItem { entity_id: item }];
-        rewrite_strip_release(&mut effects, &[], &[]);
+        rewrite_inventory_release(&mut effects, &[], &[]);
         assert!(
             matches!(effects.as_slice(), [VirtualHandEffect::DropItem { .. }]),
             "got {effects:?}"

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -7,6 +7,7 @@ pub mod pathfinding_debug;
 pub mod pathfinding_test;
 pub mod player_footsteps;
 pub(crate) mod reload;
+mod shoulder_backpack;
 pub mod spatial_query;
 mod spawn_location;
 pub mod stim_response;

--- a/shock2vr/src/mission/shoulder_backpack.rs
+++ b/shock2vr/src/mission/shoulder_backpack.rs
@@ -1,0 +1,375 @@
+//! Release-to-stow behind either shoulder. Coordinates are in tracked pawn space.
+//! Uses the head's slowly followed yaw, never its pitch/roll, for body direction.
+use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, Vector3, vec3};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::{input_context::InputContext, vr_support::GripPose};
+
+const SCALE: f32 = crate::METERS_PER_WORLD_UNIT;
+const SIDE: f32 = 0.18 / SCALE;
+const DROP: f32 = 0.20 / SCALE;
+const BEHIND: f32 = 0.18 / SCALE;
+pub(super) const RADIUS: f32 = 0.18 / SCALE;
+
+#[derive(Default)]
+pub(super) struct ShoulderBackpack {
+    yaw: Option<f32>,
+    pressed_item: [Option<EntityId>; 2],
+    retained: [Option<EntityId>; 2],
+    pub centers: Option<[Vector3<f32>; 2]>,
+    pub near: [bool; 2],
+}
+
+impl ShoulderBackpack {
+    /// A prior tracked squeeze with this same item is required. Crossing a zone
+    /// while still holding never stows; tracking recovery never invents a release.
+    pub fn update(
+        &mut self,
+        input: &InputContext,
+        held: [Option<EntityId>; 2],
+        enabled: bool,
+        dt: f32,
+    ) -> [bool; 2] {
+        let hands = [&input.left_hand, &input.right_hand];
+        for i in 0..2 {
+            if self.retained[i] != held[i] || hands[i].squeeze_value > 0.5 {
+                self.retained[i] = None;
+            }
+        }
+        let head = GripPose {
+            position: input.head.position,
+            rotation: input.head.rotation,
+        };
+        if !enabled || !head.is_tracked() || input.pose_tracking.is_some_and(|p| !p.head) {
+            self.centers = None;
+            self.near = [false; 2];
+            self.pressed_item = [None; 2];
+            self.yaw = None;
+            return [false; 2];
+        }
+        let forward = crate::ui::PanelPlacement::from_head(head.position, head.rotation).forward;
+        let observed = forward.x.atan2(-forward.z);
+        let yaw = match self.yaw {
+            // Keep the shoulder target still while a hand is reaching into it.
+            Some(yaw) if self.near.iter().any(|near| *near) => yaw,
+            Some(yaw) => {
+                let delta = observed - yaw;
+                let delta = delta.sin().atan2(delta.cos());
+                yaw + delta * (1.0 - (-dt.max(0.0).min(0.1) / 0.5).exp())
+            }
+            None => observed,
+        };
+        self.yaw = Some(yaw);
+        let forward = vec3(yaw.sin(), 0.0, -yaw.cos());
+        let right = forward.cross(Vector3::unit_y());
+        let center = head.position - forward * BEHIND - Vector3::unit_y() * DROP;
+        let centers = [center - right * SIDE, center + right * SIDE];
+        self.centers = Some(centers);
+        let mut released = [false; 2];
+        for i in 0..2 {
+            let hand = hands[i];
+            let tracked = GripPose {
+                position: hand.position,
+                rotation: hand.rotation,
+            }
+            .is_tracked()
+                && hand.squeeze_value.is_finite()
+                && input.pose_tracking.is_none_or(|p| p.hands[i]);
+            // Require the hand genuinely behind the head, not beside the face.
+            self.near[i] = tracked
+                && held[i].is_some()
+                && (hand.position - head.position).dot(forward) < -0.03 / SCALE
+                && centers
+                    .iter()
+                    .any(|c| (hand.position - c).magnitude2() <= RADIUS * RADIUS);
+            released[i] = self.near[i]
+                && hand.squeeze_value < 0.5
+                && held[i].is_some()
+                && self.pressed_item[i] == held[i];
+            self.pressed_item[i] = if tracked && hand.squeeze_value >= 0.5 {
+                held[i]
+            } else {
+                None
+            };
+        }
+        released
+    }
+
+    /// A rejected deposit stays held until a real re-grip, even if the hand
+    /// leaves the zone or the cyber interface opens. No invisible floor drop.
+    pub fn retain(&mut self, slot: usize, entity: EntityId) {
+        self.retained[slot] = Some(entity);
+    }
+    pub fn keep_grip(&self, slot: usize) -> bool {
+        self.retained[slot].is_some()
+    }
+
+    pub fn render(
+        &self,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+    ) -> Vec<engine::scene::SceneObject> {
+        use engine::scene::{SceneObject, color_material, lines_mesh};
+        let Some(centers) = self.centers else {
+            return Vec::new();
+        };
+        let root = Matrix4::from_translation(position) * Matrix4::from(rotation);
+        let mut vertices = Vec::new();
+        for center in centers {
+            dark::hit_box::append_capsule_lines(&mut vertices, &root, center, center, RADIUS);
+        }
+        let color = if self.retained.iter().any(Option::is_some) {
+            vec3(1.0, 0.3, 0.1)
+        } else if self.near.iter().any(|near| *near) {
+            vec3(0.1, 1.0, 0.2)
+        } else {
+            vec3(0.1, 0.8, 1.0)
+        };
+        let mut objects = vec![SceneObject::new(
+            color_material::create(color),
+            Box::new(lines_mesh::create(vertices)),
+        )];
+        crate::util::tag_render_source(&mut objects, crate::util::render_source::PLAYER_HANDS);
+        objects
+    }
+
+    pub fn diagnostics(
+        &self,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "centers": self.centers.map(|cs| cs.map(|c| { let p = position + rotation.rotate_vector(c); [p.x,p.y,p.z] })),
+            "radius": RADIUS, "near": self.near,
+            "retained": self.retained.map(|e| e.is_some()),
+        })
+    }
+}
+
+/// Reserve real grid cells for both simultaneous deposits. A full backpack
+/// refuses rather than creating a hidden overflow item. No world mutation here.
+pub(super) fn reserve_slots(
+    world: &World,
+    inventory: EntityId,
+    requests: [Option<EntityId>; 2],
+) -> [Option<(usize, usize)>; 2] {
+    if requests.iter().all(Option::is_none) {
+        return [None; 2];
+    }
+    let grid = crate::inventory::grid_for(world, inventory);
+    let mut occupied = crate::inventory::Inventory::from_container(world, inventory, grid);
+    let dimensions = world
+        .borrow::<View<dark::properties::PropInventoryDimensions>>()
+        .unwrap();
+    requests.map(|request| {
+        let entity = request?;
+        let (w, h) = dimensions
+            .get(entity)
+            .map(|d| (d.width as usize, d.height as usize))
+            .unwrap_or((1, 1));
+        if w == 0 || h == 0 {
+            return None;
+        }
+        let slot = occupied.first_free_slot(w, h)?;
+        let cell = occupied.cell_of(slot)?;
+        occupied
+            .insert_if_fits(entity, cell.0, cell.1, w, h)
+            .then_some(cell)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Deg, Rotation3, Zero};
+    use dark::properties::{Links, PropContainDimensions, PropInventoryDimensions};
+
+    fn fixture() -> (ShoulderBackpack, InputContext, EntityId) {
+        let mut world = World::new();
+        let item = world.add_entity(());
+        let mut input = InputContext::default();
+        input.left_hand.position = vec3(-0.3, 1.0, -0.4);
+        input.right_hand.position = vec3(0.3, 1.0, -0.4);
+        (ShoulderBackpack::default(), input, item)
+    }
+
+    #[test]
+    fn either_hand_can_release_at_either_shoulder_but_crossing_while_held_does_not_stow() {
+        for hand in 0..2 {
+            for shoulder in 0..2 {
+                let (mut tracker, mut input, item) = fixture();
+                let mut held = [None; 2];
+                held[hand] = Some(item);
+                tracker.update(&input, held, true, 0.016);
+                let center = tracker.centers.unwrap()[shoulder];
+                let h = if hand == 0 {
+                    &mut input.left_hand
+                } else {
+                    &mut input.right_hand
+                };
+                h.position = center;
+                h.squeeze_value = 1.0;
+                assert_eq!(tracker.update(&input, held, true, 0.016), [false; 2]);
+                let h = if hand == 0 {
+                    &mut input.left_hand
+                } else {
+                    &mut input.right_hand
+                };
+                h.squeeze_value = 0.0;
+                let result = tracker.update(&input, held, true, 0.016);
+                assert!(result[hand]);
+                assert!(!result[1 - hand]);
+                assert_eq!(tracker.update(&input, held, true, 0.016), [false; 2]);
+            }
+        }
+    }
+
+    #[test]
+    fn face_level_front_and_low_releases_stay_world_drops() {
+        for offset in [
+            vec3(0.0, 0.0, -0.2),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.18, -0.9, 0.18),
+        ] {
+            let (mut tracker, mut input, item) = fixture();
+            input.right_hand.position = input.head.position + offset / SCALE;
+            input.right_hand.squeeze_value = 1.0;
+            tracker.update(&input, [None, Some(item)], true, 0.016);
+            input.right_hand.squeeze_value = 0.0;
+            assert_eq!(
+                tracker.update(&input, [None, Some(item)], true, 0.016),
+                [false; 2]
+            );
+        }
+    }
+
+    #[test]
+    fn untracked_or_disabled_frames_disarm_the_release() {
+        for bad_head in [true, false] {
+            let (mut tracker, mut input, item) = fixture();
+            let held = [None, Some(item)];
+            tracker.update(&input, held, true, 0.016);
+            input.right_hand.position = tracker.centers.unwrap()[1];
+            input.right_hand.squeeze_value = 1.0;
+            tracker.update(&input, held, true, 0.016);
+            if bad_head {
+                input.head.rotation = Quaternion::zero();
+            } else {
+                input.right_hand.rotation = Quaternion::zero();
+            }
+            assert_eq!(tracker.update(&input, held, true, 0.016), [false; 2]);
+            input.head.rotation = Quaternion::from_angle_y(Deg(0.0));
+            input.right_hand.rotation = input.head.rotation;
+            input.right_hand.squeeze_value = 0.0;
+            assert_eq!(tracker.update(&input, held, true, 0.016), [false; 2]);
+            input.right_hand.squeeze_value = 1.0;
+            tracker.update(&input, held, true, 0.016);
+            tracker.update(&input, held, false, 0.016);
+            input.right_hand.squeeze_value = 0.0;
+            assert_eq!(tracker.update(&input, held, true, 0.016), [false; 2]);
+        }
+    }
+
+    #[test]
+    fn stale_valid_pose_values_do_not_override_runtime_tracking_loss() {
+        for lost in 0..3 {
+            let (mut tracker, mut input, item) = fixture();
+            let hand = if lost == 1 { 0 } else { 1 };
+            let mut held = [None; 2];
+            held[hand] = Some(item);
+            tracker.update(&input, held, true, 0.016);
+            let center = tracker.centers.unwrap()[hand];
+            for h in [&mut input.left_hand, &mut input.right_hand] {
+                h.position = center;
+                h.squeeze_value = 1.0;
+            }
+            tracker.update(&input, held, true, 0.016);
+            input.pose_tracking = Some(crate::input_context::PoseTracking {
+                head: lost != 0,
+                hands: [lost != 1, lost != 2],
+            });
+            input.left_hand.squeeze_value = 0.0;
+            input.right_hand.squeeze_value = 0.0;
+            assert_eq!(tracker.update(&input, held, true, 0.016), [false; 2]);
+            input.pose_tracking = None;
+            assert_eq!(tracker.update(&input, held, true, 0.016), [false; 2]);
+        }
+    }
+
+    #[test]
+    fn body_zones_follow_head_translation_and_yaw_but_ignore_pitch_and_roll() {
+        let (mut tracker, mut input, _) = fixture();
+        tracker.update(&input, [None; 2], true, 0.016);
+        let original = tracker.centers.unwrap();
+        input.head.position += vec3(2.0, -0.5, 1.0);
+        input.head.rotation =
+            Quaternion::from_angle_x(Deg(-40.0)) * Quaternion::from_angle_z(Deg(25.0));
+        tracker.update(&input, [None; 2], true, 0.016);
+        for i in 0..2 {
+            assert!(
+                (tracker.centers.unwrap()[i] - original[i] - vec3(2.0, -0.5, 1.0)).magnitude()
+                    < 0.0001
+            );
+        }
+        let mut turned = ShoulderBackpack::default();
+        input.head.rotation = Quaternion::from_angle_y(Deg(90.0));
+        turned.update(&input, [None; 2], true, 0.016);
+        for i in 0..2 {
+            let expected = input.head.position
+                + input
+                    .head
+                    .rotation
+                    .rotate_vector(original[i] - InputContext::default().head.position);
+            assert!((turned.centers.unwrap()[i] - expected).magnitude() < 0.0001);
+        }
+    }
+
+    #[test]
+    fn failed_deposit_retains_item_until_a_real_regrip() {
+        let (mut tracker, mut input, item) = fixture();
+        tracker.retain(1, item);
+        tracker.update(&input, [None, Some(item)], false, 0.016);
+        assert!(tracker.keep_grip(1));
+        input.right_hand.squeeze_value = 1.0;
+        tracker.update(&input, [None, Some(item)], true, 0.016);
+        assert!(!tracker.keep_grip(1));
+        tracker.retain(1, item);
+        tracker.update(&input, [None; 2], true, 0.016);
+        assert!(!tracker.keep_grip(1));
+    }
+
+    #[test]
+    fn simultaneous_deposits_reserve_different_cells_and_refuse_overflow() {
+        let mut world = World::new();
+        let inventory = world.add_entity((
+            Links { to_links: vec![] },
+            PropContainDimensions {
+                width: 2,
+                height: 1,
+            },
+        ));
+        let left = world.add_entity((PropInventoryDimensions {
+            width: 1,
+            height: 1,
+        },));
+        let right = world.add_entity((PropInventoryDimensions {
+            width: 2,
+            height: 1,
+        },));
+        assert_eq!(
+            reserve_slots(&world, inventory, [Some(left), Some(right)]),
+            [Some((0, 0)), None]
+        );
+        world.add_component(
+            right,
+            PropInventoryDimensions {
+                width: 1,
+                height: 1,
+            },
+        );
+        assert_eq!(
+            reserve_slots(&world, inventory, [Some(left), Some(right)]),
+            [Some((0, 0)), Some((1, 0))]
+        );
+    }
+}

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -660,7 +660,15 @@ export interface PlayerSnapshot {
     target: number | null;
     affordance: "None" | "Grabbable" | "Frobbable" | "Blocked";
     light: "Off" | "Green" | "Amber" | "Red";
-  }> | null;
+  }> & {
+    /** Shoulder stow targets in world space; absent on older runtimes. */
+    shoulder_backpack?: {
+      centers: [Vec3, Vec3] | null;
+      radius: number;
+      near: [boolean, boolean];
+      retained: [boolean, boolean];
+    };
+  } | null;
   /** Prepared VR pickup grips; empty for flat presentation or empty hands. */
   hand_grips: HandGrip[];
 }

--- a/tools/shock2-sdk/test/vr-shoulder-backpack.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-shoulder-backpack.e2e.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import {
+  aimVrHandAt,
+  aimVrHandAtCanvas,
+  quatConjugate,
+  quatRotate,
+  sub,
+} from "./helpers/vr-hand.js";
+import { ammoOf } from "./helpers/weapon.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+const owner = (hand: "left" | "right") =>
+  hand === "left" ? "wielded_entity_id" : "right_hand_entity_id";
+async function reach(
+  game: GameServer,
+  hand: "left" | "right",
+  shoulder: number,
+) {
+  const player = (await game.info()).player;
+  const center = player.hand_feedback?.shoulder_backpack?.centers?.[shoulder];
+  assert.ok(center, "tracked shoulder zones must be published");
+  await game.input.set(
+    `${hand}_hand.position`,
+    quatRotate(quatConjugate(player.rotation), sub(center, player.position)),
+  );
+  await game.input.set(`${hand}_hand.rotation`, [0, 0, 0, 1]);
+  await game.step({ frames: 5 });
+  assert.equal(
+    (await game.info()).player.hand_feedback?.shoulder_backpack?.near[
+      hand === "left" ? 0 : 1
+    ],
+    true,
+  );
+}
+
+for (const [hand, template] of [
+  ["left", -1221],
+  ["right", -17],
+] as const) {
+  test(
+    `${hand} shoulder release stores the exact held item and permits retrieval`,
+    { skip: !enabled, timeout: 180_000 },
+    async () => {
+      await using game = await GameServer.launch({
+        mission: "debug_interactions",
+        debugFlags: ["--vr"],
+      });
+      await game.step({ frames: 30 });
+      const item = (await game.entities.list()).entities.find(
+        (e) => e.template_id === template,
+      )!;
+      assert.ok(item);
+      await aimVrHandAt(game, item.position, 0.2, 1, 0, { hand });
+      await game.step({ frames: 5 });
+      assert.equal((await game.info()).player[owner(hand)], item.id);
+      const ammo =
+        template === -17 ? ammoOf(await game.entities.detail(item.id)) : null;
+      await reach(game, hand, hand === "left" ? 1 : 0); // either shoulder accepts either hand
+      assert.equal(
+        (await game.info()).player[owner(hand)],
+        item.id,
+        "reaching while squeezed must not stow",
+      );
+      await game.input.set(`${hand}_hand.squeeze`, 0);
+      await game.step({ frames: 8 });
+      assert.equal((await game.info()).player[owner(hand)], null);
+      assert.equal(
+        (await game.player.inventory()).items.find(
+          (i) => i.entity_id === item.id,
+        )?.location,
+        "inventory",
+      );
+      assert.equal(
+        (await game.physics.bodies({ entityId: item.id })).bodies.length,
+        0,
+        "stored item has no world body",
+      );
+      if (ammo !== null)
+        assert.equal(
+          ammoOf(await game.entities.detail(item.id)),
+          ammo,
+          "stowing preserves loaded ammo",
+        );
+      await game.input.trigger("ToggleUseMode");
+      await game.step({ frames: 5 });
+      const ui = await game.ui.state();
+      const slot = ui.strip?.elements.find((e) => e.entity_id === item.id);
+      assert.ok(slot, "stored item must occupy a visible backpack slot");
+      await aimVrHandAtCanvas(
+        game,
+        ui.panel_pose!,
+        [slot.rect[0] + slot.rect[2] / 2, slot.rect[1] + slot.rect[3] / 2],
+        { hand, squeeze: 1 },
+      );
+      await game.step({ frames: 5 });
+      assert.equal(
+        (await game.info()).player[owner(hand)],
+        item.id,
+        "retrieval returns the same instance",
+      );
+    },
+  );
+}
+
+test(
+  "a full backpack keeps the rejected item in hand until regripped",
+  { skip: !enabled, timeout: 180_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_interactions",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    const mug = (await game.entities.list()).entities.find(
+      (e) => e.template_id === -1221,
+    )!;
+    await aimVrHandAt(game, mug.position, 0.2, 1);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.right_hand_entity_id, mug.id);
+    // The maximum backpack is15x3; distinct non-stackable mugs occupy one cell each.
+    for (let i = 0; i < 45; i++) await game.player.spawnItem(-1221);
+    await reach(game, "right", 1);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.right_hand_entity_id, mug.id);
+    assert.equal(
+      (await game.info()).player.hand_feedback?.shoulder_backpack?.retained[1],
+      true,
+    );
+    await game.input.set("right_hand.position", [0.25, 1, -0.4]);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      mug.id,
+      "moving away must not silently drop the refused item",
+    );
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.ok(
+      (await game.physics.bodies({ entityId: mug.id })).bodies.length > 0,
+      "deliberate regrip/release still drops normally",
+    );
+  },
+);
+
+test(
+  "releasing in front of the head remains a world drop",
+  { skip: !enabled, timeout: 180_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_interactions",
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 30 });
+    const mug = (await game.entities.list()).entities.find(
+      (e) => e.template_id === -1221,
+    )!;
+    await aimVrHandAt(game, mug.position, 0.2, 1);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.position", [0.2, 1, -0.4]);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.ok(
+      (await game.physics.bodies({ entityId: mug.id })).bodies.length > 0,
+    );
+    assert.equal(
+      (await game.player.inventory()).items.find((i) => i.entity_id === mug.id)
+        ?.location,
+      undefined,
+    );
+  },
+);


### PR DESCRIPTION
Release a held item behind either shoulder to put it into the backpack. Crossing the zone while squeezing keeps it held. Either hand can use either shoulder; the exact item and loaded ammo survive storage and retrieval through the inventory interface.

A full backpack refuses the deposit with sound/text and keeps the item in hand until a deliberate re-grip. The gesture uses head-relative shoulder zones, requires live tracking, and is disabled while the cyber interface is open or gameplay controls are disabled. `vr_backpack_zones` shows the targets for fitting/debugging.

This layer builds on #1436. It reuses the existing inventory release/transfer path and prevents the other hand acquiring a physical weapon in the same frame it is stowed. Shoulder retrieval and belt/holster slots remain separate increments.

Validation: 7 shoulder unit tests, 12 inventory-release unit tests, 5 interaction tests, and 9 headless VR integration tests pass. SDK TypeScript build, warnings-denied gameplay library build, and Quest release APK build pass. Independent correctness review findings were fixed and re-reviewed; dedicated duplication and image reviews completed. Claude review was unavailable because its credits were exhausted.

No Quest was attached for this increment. Headset reach comfort and behind-shoulder tracking still need hands-on validation. The captures below use the deterministic debug runtime with `--vr`; optional wireframe zones are debug instrumentation, not the production appearance. API assertions establish entity identity and ammo preservation alongside the images.

![Shoulder reach and squeeze release, before and after](https://gist.githubusercontent.com/tommy-xr/d3b226dd8dc8a06692176d48eba02d2d/raw/astra-shoulder-reach.gif)

Same deterministic gesture in both hands: baseline releases the mug into the world; after releases it into the backpack. The spheres are optional developer zones (cyan available, green reached), not backpack art. Inventory diagnostics confirm the exact acquired entity is stored; `bset` sound and “Stored in backpack” status are recorded. No headset verification.

![World drop versus stored item](https://gist.githubusercontent.com/tommy-xr/d3b226dd8dc8a06692176d48eba02d2d/raw/astra-shoulder-before-after.png)

![Stored mug visible in inventory](https://gist.githubusercontent.com/tommy-xr/d3b226dd8dc8a06692176d48eba02d2d/raw/astra-shoulder-inventory.png)

![Full backpack retains the mug](https://gist.githubusercontent.com/tommy-xr/d3b226dd8dc8a06692176d48eba02d2d/raw/astra-shoulder-full.png)

A filled-inventory fixture shows red-orange refusal zones: after squeeze release the original mug stays in hand. Diagnostics report retained=true and the full-backpack message; ordinary re-grip/release behavior is covered separately by tests.

[Download standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/d3b226dd8dc8a06692176d48eba02d2d/raw/astra-shoulder-gallery.html).
