### PR TITLE
feat(vr): add thigh weapon holsters with a Pack Rat second slot

### DIFF
--- a/.claude/skills/vr-ui-design/SKILL.md
+++ b/.claude/skills/vr-ui-design/SKILL.md
@@ -135,3 +135,50 @@ remaining gap - PR/issue and open/closed state are marked where it matters.
     luminance) when correctness of *which* element reacted matters; and for
     timing-dependent device bugs, prefer deterministic fault injection over
     waiting for a natural repro (#1009's technique).
+
+## Held items and body inventory
+
+14. **One item, one owner, including within a frame.** A support hand steers
+    the primary hand's item; it never owns a second copy. Reserve a released
+    entity until its effects finish, because a release may become a backpack
+    deposit. The other hand must not acquire its still-present collider during
+    that frame. Test simultaneous grabs/releases, not only alternating input.
+15. **Attached gloves follow the final physical item.** Drive the weapon toward
+    the controller, then derive attached glove transforms from the synchronized,
+    collision-resolved weapon. Sampling the controller for one and the physics
+    body for the other separates them during locomotion and impacts. Verify the
+    relative grip transform every frame while walking and touching a wall.
+16. **Body storage needs an explicit grip edge and a clear refusal.** Reaching
+    through a slot while holding must not silently store an item. Deposit on a
+    deliberate release; retrieval requires a fresh squeeze. Define occupied/full
+    behavior before implementation. A refused shoulder deposit retains the item,
+    plays a refusal cue, and explains how to re-grip; leaving the zone must not
+    unexpectedly drop it behind the player. Enter disabled/recovered states
+    disarmed so stale input cannot create a gesture.
+17. **Tracking validity is separate from plausible pose values.** A finite pose
+    and nonzero quaternion can still be a stale runtime fallback. Body gestures
+    must honor live head/hand validity (`InputContext::pose_tracking`) as well as
+    numeric validation. Head-relative body targets use horizontal heading, not
+    head pitch/roll. Treat their offsets as estimates until tested seated and
+    standing in a headset; debug-runtime coordinates do not prove reach comfort.
+18. **Reuse ownership and inventory transitions.** Preserve the exact entity,
+    ammo, condition, and script state. Keep the normal `Drop`/`Hold` signals when
+    redirecting a release, and preserve deferred effects returned by shared
+    handlers. Check real capacity and reserve simultaneous destinations before
+    claiming releases. Carry additional body storage through save/load and level
+    transitions explicitly; hiding a world model is not storage.
+19. **Resolve readouts per hand and per weapon.** Dual wielding makes a global
+    “current weapon” ambiguous. Ammo, ammo type, condition, settings, and their
+    actions must all come from the same explicit entity. Exercise gun/gun and
+    gun/psi-amp combinations. Preserve the complete authored UI canvas when
+    mounting it on a glove; avoid arbitrary cropping to make it fit.
+
+## Evidence for physical interactions
+
+20. **Pair pictures with state assertions.** Before/after screenshots can show a
+    release, but cannot prove the stored item is the original instance. Assert
+    entity identity, ownership, containment, physics removal/restoration, and
+    retained weapon state. Include refusal, tracking recovery, and simultaneous
+    hand cases. Show the interaction's approach and release, not just an empty
+    hand afterward. Label debug zones as instrumentation; they do not establish
+    production discoverability or headset tracking reliability.

--- a/projects/astra-vr-thigh-holsters.md
+++ b/projects/astra-vr-thigh-holsters.md
@@ -1,0 +1,52 @@
+# VR thigh holsters
+
+The right thigh carries one weapon independently of backpack capacity. Pack Rat
+adds a left thigh slot as well as its existing backpack capacity bonus. Either
+hand can use either unlocked slot; the psi amp and ordinary pickups are excluded.
+
+Bring a weapon into the cyan marker, then release the grip to stow it. Reaching
+while still squeezing does not stow. A fresh squeeze with an empty hand draws
+the same weapon, preserving ammunition and condition. The marker turns green
+on approach. An occupied slot refuses with a red marker, message and sound,
+retaining the held weapon until the player deliberately squeezes again. The
+existing weapon is never swapped or discarded.
+
+The slot owns the actual entity, with no backpack duplicate or loose physics
+body. Ownership and the calibrated held size survive saves and level transitions.
+The world model is displayed barrel-down, matching the held weapon's longest
+extent, capped at 45 cm for large weapons. An occupied second slot remains
+retrievable if Pack Rat is removed. Loading the save in flatscreen returns
+holstered items to the backpack; overflow drops visibly in front of the player.
+
+## Calibration and verification
+
+Use `cargo dbgr --mission debug_interactions --vr`. Developer parameters:
+
+- `vr_holster_zones`: show the full 14 cm grab radius.
+- `vr_holster_drop`: vertical offset below the tracked head, default 0.78 m,
+  range 0.55–1.10 m. Reduce this when testing seated reach.
+- `vr_holster_side`: lateral offset, default 0.23 m, range 0.16–0.40 m.
+
+Targets use horizontal heading with gentle following and freeze that heading
+while a hand is in a slot. They are estimates from head/controller tracking,
+not tracked legs. Opening the cyber interface disables gestures but keeps worn
+weapons visible. Invalid tracking cannot invent a deposit or draw. A support or
+climbing hand cannot draw, and drawing with the trigger already held is safe
+until the trigger is released.
+
+`/v1/info` publishes `player.hand_feedback.holsters`: world centers, grab radius,
+enabled slots, nearby slot per hand, occupant IDs and refused-release latches.
+Hand arrays are left/right; slot arrays are right/left. Discover entity IDs each
+run rather than hardcoding them.
+
+The SDK `vr-holsters.e2e.test.ts` exercises both hands, occupied refusal, full
+backpack independence, trigger safety, condition/ammo preservation, real mission
+save/load, level transitions, and flat accessibility. Pure tests cover tracking,
+simultaneous hands and Pack Rat gating. Shoulder-backpack tests protect the
+shared heading/refusal logic.
+
+Headset acceptance still needs standing/seated reach, ordinary arm swings, and
+weapon visibility checks. Additional per-model holstered orientation, a preferred-leg
+selector, editor controls and haptics are follow-up refinements; the current
+increment adapts the shotgun/wrench axis corrections from #1399 and uses
+developer offsets.

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -193,6 +193,9 @@ dev_params! {
     MELEE_VOLUMES = float("melee_volumes", "Show hurtbox", 0.0, 0.0, 1.0, 1.0),
     /// Visualize shoulder backpack stow zones (cyan; green while reached).
     VR_BACKPACK_ZONES = bool("vr_backpack_zones", "Backpack zones", false),
+    VR_HOLSTER_ZONES = bool("vr_holster_zones", "Holster zones", false),
+    VR_HOLSTER_DROP = float("vr_holster_drop", "Holster below eyes (m)", 0.78, 0.55, 1.1, 0.02),
+    VR_HOLSTER_SIDE = float("vr_holster_side", "Holster side (m)", 0.23, 0.16, 0.40, 0.01),
     /// VR support target/radius (cyan; green when attached) and tracked palm (amber).
     VR_SUPPORT_GRIPS = bool("vr_support_grips", "Support grips", false),
     /// Draw a floating "-7 HP" at the point each blow lands, labeled with the

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -178,6 +178,11 @@ pub trait PlayerInteraction {
         self.holding_hand(entity_id).is_some()
     }
 
+    /// Body-slot retrieval cannot share a hand with support or climbing.
+    fn hand_available_for_body_slot(&self, _hand: Handedness) -> bool {
+        false
+    }
+
     /// Wield `entity_id` as the first-person weapon (flat); no-op for VR.
     fn wield(&mut self, _entity_id: EntityId) -> Vec<VirtualHandEffect> {
         Vec::new()
@@ -639,6 +644,17 @@ impl VrInteraction {
 }
 
 impl PlayerInteraction for VrInteraction {
+    fn hand_available_for_body_slot(&self, hand: Handedness) -> bool {
+        let i = crate::vr_config::hand_slot(hand);
+        let held = if i == 0 {
+            self.left_hand.get_held_entity()
+        } else {
+            self.right_hand.get_held_entity()
+        };
+        held.is_none()
+            && !self.support_blocked[i]
+            && !self.hand_climb.grips().any(|(h, _)| h == hand)
+    }
     fn fit_held_items(
         &mut self,
         world: &World,

--- a/shock2vr/src/mission/body_inventory.rs
+++ b/shock2vr/src/mission/body_inventory.rs
@@ -1,0 +1,33 @@
+//! Shared body-inventory heading and refused-release latch.
+use shipyard::EntityId;
+
+pub(super) fn followed_yaw(previous: Option<f32>, observed: f32, frozen: bool, dt: f32) -> f32 {
+    match previous {
+        Some(yaw) if frozen => yaw,
+        Some(yaw) => {
+            let delta = observed - yaw;
+            let delta = delta.sin().atan2(delta.cos());
+            yaw + delta * (1.0 - (-dt.clamp(0.0, 0.1) / 0.5).exp())
+        }
+        None => observed,
+    }
+}
+
+#[derive(Default)]
+pub(super) struct RetainedRelease(pub [Option<EntityId>; 2]);
+
+impl RetainedRelease {
+    pub fn update(&mut self, held: [Option<EntityId>; 2], squeezed: [f32; 2]) {
+        for i in 0..2 {
+            if self.0[i] != held[i] || squeezed[i] > 0.5 {
+                self.0[i] = None;
+            }
+        }
+    }
+    pub fn retain(&mut self, hand: usize, entity: EntityId) {
+        self.0[hand] = Some(entity);
+    }
+    pub fn keep_grip(&self, hand: usize) -> bool {
+        self.0[hand].is_some()
+    }
+}

--- a/shock2vr/src/mission/holsters.rs
+++ b/shock2vr/src/mission/holsters.rs
@@ -1,0 +1,501 @@
+//! Thigh slots own distinct weapon entities, independently of backpack capacity.
+use super::body_inventory::{RetainedRelease, followed_yaw};
+use crate::{
+    input_context::InputContext, runtime_props::RuntimePropHolstered, vr_support::GripPose,
+};
+use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, Vector3, vec3};
+use shipyard::{EntityId, IntoIter, IntoWithId, UniqueView, View, World};
+
+const SCALE: f32 = crate::METERS_PER_WORLD_UNIT;
+pub(super) const RADIUS: f32 = 0.14 / SCALE;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) enum Action {
+    Store { entity: EntityId, slot: usize },
+    Retrieve { entity: EntityId, slot: usize },
+    Refuse { entity: EntityId },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn setup() -> (Holsters, InputContext, [EntityId; 2]) {
+        let mut world = World::new();
+        let ids = [world.add_entity(()), world.add_entity(())];
+        let mut h = Holsters::default();
+        let input = InputContext::default();
+        h.update(
+            &input, [None; 2], [true; 2], [None; 2], 1, [false; 2], true, 0.016,
+        );
+        (h, input, ids)
+    }
+
+    #[test]
+    fn pack_rat_stat_unlocks_a_second_slot() {
+        let world = World::new();
+        world.add_unique(crate::quest_info::QuestInfo::new());
+        assert_eq!(slot_count(&world), 1);
+        world
+            .borrow::<shipyard::UniqueViewMut<crate::quest_info::QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .add_os_trait(crate::scripts::gui::TRAIT_PACK_RAT);
+        assert_eq!(slot_count(&world), 2);
+    }
+
+    #[test]
+    fn stow_is_a_release_and_draw_is_a_fresh_squeeze_for_either_hand() {
+        for hand in 0..2 {
+            let (mut h, mut input, ids) = setup();
+            let mut held = [None; 2];
+            held[hand] = Some(ids[0]);
+            let target = h.centers.unwrap()[0];
+            let controller = if hand == 0 {
+                &mut input.left_hand
+            } else {
+                &mut input.right_hand
+            };
+            controller.position = target;
+            controller.squeeze_value = 1.0;
+            assert_eq!(
+                h.update(
+                    &input, held, [false; 2], [None; 2], 1, [true; 2], true, 0.016
+                ),
+                [None; 2]
+            );
+            let controller = if hand == 0 {
+                &mut input.left_hand
+            } else {
+                &mut input.right_hand
+            };
+            controller.squeeze_value = 0.0;
+            assert_eq!(
+                h.update(
+                    &input, held, [false; 2], [None; 2], 1, [true; 2], true, 0.016
+                )[hand],
+                Some(Action::Store {
+                    entity: ids[0],
+                    slot: 0
+                })
+            );
+            let controller = if hand == 0 {
+                &mut input.left_hand
+            } else {
+                &mut input.right_hand
+            };
+            controller.squeeze_value = 1.0;
+            assert_eq!(
+                h.update(
+                    &input,
+                    [None; 2],
+                    [true; 2],
+                    [Some(ids[0]), None],
+                    1,
+                    [false; 2],
+                    true,
+                    0.016
+                )[hand],
+                Some(Action::Retrieve {
+                    entity: ids[0],
+                    slot: 0
+                })
+            );
+            assert_eq!(
+                h.update(
+                    &input,
+                    [None; 2],
+                    [true; 2],
+                    [Some(ids[0]), None],
+                    1,
+                    [false; 2],
+                    true,
+                    0.016
+                ),
+                [None; 2]
+            );
+        }
+    }
+
+    #[test]
+    fn simultaneous_hands_cannot_store_or_draw_the_same_slot_twice() {
+        let (mut h, mut input, ids) = setup();
+        for hand in [&mut input.left_hand, &mut input.right_hand] {
+            hand.position = h.centers.unwrap()[0];
+            hand.squeeze_value = 1.0;
+        }
+        let held = ids.map(Some);
+        h.update(
+            &input, held, [false; 2], [None; 2], 2, [true; 2], true, 0.016,
+        );
+        input.left_hand.squeeze_value = 0.0;
+        input.right_hand.squeeze_value = 0.0;
+        let actions = h.update(
+            &input, held, [false; 2], [None; 2], 2, [true; 2], true, 0.016,
+        );
+        assert_eq!(
+            actions,
+            [
+                Some(Action::Store {
+                    entity: ids[0],
+                    slot: 0
+                }),
+                Some(Action::Refuse { entity: ids[1] })
+            ]
+        );
+        assert!(h.retained.keep_grip(1));
+        input.left_hand.squeeze_value = 1.0;
+        input.right_hand.squeeze_value = 1.0;
+        let actions = h.update(
+            &input,
+            [None; 2],
+            [true; 2],
+            [Some(ids[0]), None],
+            2,
+            [false; 2],
+            true,
+            0.016,
+        );
+        assert_eq!(
+            actions,
+            [
+                Some(Action::Retrieve {
+                    entity: ids[0],
+                    slot: 0
+                }),
+                None
+            ]
+        );
+    }
+
+    #[test]
+    fn pack_rat_unlocks_left_slot_and_nonweapons_do_not_claim_releases() {
+        for count in [1, 2] {
+            let (mut h, mut input, ids) = setup();
+            input.right_hand.position = h.centers.unwrap()[1];
+            input.right_hand.squeeze_value = 1.0;
+            h.update(
+                &input,
+                [None, Some(ids[0])],
+                [false; 2],
+                [None; 2],
+                count,
+                [true; 2],
+                true,
+                0.016,
+            );
+            input.right_hand.squeeze_value = 0.0;
+            let action = h.update(
+                &input,
+                [None, Some(ids[0])],
+                [false; 2],
+                [None; 2],
+                count,
+                [true; 2],
+                true,
+                0.016,
+            )[1];
+            assert_eq!(action.is_some(), count == 2);
+            input.right_hand.position = h.centers.unwrap()[0];
+            input.right_hand.squeeze_value = 1.0;
+            h.update(
+                &input,
+                [None, Some(ids[0])],
+                [false; 2],
+                [None; 2],
+                count,
+                [false; 2],
+                true,
+                0.016,
+            );
+            input.right_hand.squeeze_value = 0.0;
+            assert_eq!(
+                h.update(
+                    &input,
+                    [None, Some(ids[0])],
+                    [false; 2],
+                    [None; 2],
+                    count,
+                    [false; 2],
+                    true,
+                    0.016
+                ),
+                [None; 2]
+            );
+        }
+    }
+
+    #[test]
+    fn tracking_recovery_and_disabled_input_cannot_invent_a_draw() {
+        let (mut h, mut input, ids) = setup();
+        input.right_hand.position = h.centers.unwrap()[0];
+        input.right_hand.squeeze_value = 1.0;
+        input.pose_tracking = Some(crate::input_context::PoseTracking {
+            head: true,
+            hands: [true, false],
+        });
+        assert_eq!(
+            h.update(
+                &input,
+                [None; 2],
+                [true; 2],
+                [Some(ids[0]), None],
+                1,
+                [false; 2],
+                true,
+                0.016
+            ),
+            [None; 2]
+        );
+        input.pose_tracking = None;
+        assert_eq!(
+            h.update(
+                &input,
+                [None; 2],
+                [true; 2],
+                [Some(ids[0]), None],
+                1,
+                [false; 2],
+                true,
+                0.016
+            ),
+            [None; 2]
+        );
+        h.update(
+            &input,
+            [None; 2],
+            [true; 2],
+            [Some(ids[0]), None],
+            1,
+            [false; 2],
+            false,
+            0.016,
+        );
+        assert!(
+            h.centers.is_some(),
+            "opening UI preserves the worn slot visuals"
+        );
+        assert_eq!(
+            h.update(
+                &input,
+                [None; 2],
+                [true; 2],
+                [Some(ids[0]), None],
+                1,
+                [false; 2],
+                true,
+                0.016
+            ),
+            [None; 2]
+        );
+    }
+}
+
+pub(super) struct Holsters {
+    yaw: Option<f32>,
+    pub centers: Option<[Vector3<f32>; 2]>,
+    pub near: [Option<usize>; 2],
+    pressed: [bool; 2],
+    pressed_item: [Option<EntityId>; 2],
+    pub retained: RetainedRelease,
+}
+
+impl Default for Holsters {
+    fn default() -> Self {
+        Self {
+            yaw: None,
+            centers: None,
+            near: [None; 2],
+            pressed: [true; 2],
+            pressed_item: [None; 2],
+            retained: RetainedRelease::default(),
+        }
+    }
+}
+
+/// Slots are right (default), then left (Pack Rat). Hand arrays are left/right.
+pub(super) fn occupants(world: &World) -> [Option<EntityId>; 2] {
+    let mut slots = [None; 2];
+    let holstered = world.borrow::<View<RuntimePropHolstered>>().unwrap();
+    for (id, slot) in holstered.iter().with_id() {
+        if let Some(cell) = slots.get_mut(slot.slot as usize) {
+            *cell = Some(id);
+        }
+    }
+    slots
+}
+
+pub(super) fn slot_count(world: &World) -> usize {
+    1 + usize::from(
+        world
+            .borrow::<UniqueView<crate::quest_info::QuestInfo>>()
+            .is_ok_and(|quests| {
+                quests
+                    .player_stats()
+                    .has_os_trait(crate::scripts::gui::TRAIT_PACK_RAT)
+            }),
+    )
+}
+
+impl Holsters {
+    pub fn update(
+        &mut self,
+        input: &InputContext,
+        held: [Option<EntityId>; 2],
+        available: [bool; 2],
+        mut slots: [Option<EntityId>; 2],
+        count: usize,
+        weapons: [bool; 2],
+        enabled: bool,
+        dt: f32,
+    ) -> [Option<Action>; 2] {
+        let hands = [&input.left_hand, &input.right_hand];
+        self.retained.update(held, hands.map(|h| h.squeeze_value));
+        let head = GripPose {
+            position: input.head.position,
+            rotation: input.head.rotation,
+        };
+        if !head.is_tracked() || input.pose_tracking.is_some_and(|p| !p.head) {
+            self.centers = None;
+            self.near = [None; 2];
+            self.pressed = [true; 2];
+            self.pressed_item = [None; 2];
+            self.yaw = None;
+            return [None; 2];
+        }
+        let direction = crate::ui::PanelPlacement::from_head(head.position, head.rotation).forward;
+        let yaw = followed_yaw(
+            self.yaw,
+            direction.x.atan2(-direction.z),
+            self.near.iter().any(Option::is_some),
+            dt,
+        );
+        self.yaw = Some(yaw);
+        let forward = vec3(yaw.sin(), 0.0, -yaw.cos());
+        let right = forward.cross(Vector3::unit_y());
+        let base = head.position
+            - Vector3::unit_y()
+                * (crate::dev_params::get(crate::dev_params::VR_HOLSTER_DROP) / SCALE)
+            + forward * (0.04 / SCALE);
+        let side = crate::dev_params::get(crate::dev_params::VR_HOLSTER_SIDE) / SCALE;
+        let centers = [base + right * side, base - right * side];
+        self.centers = Some(centers);
+        if !enabled {
+            self.near = [None; 2];
+            self.pressed = [true; 2];
+            self.pressed_item = [None; 2];
+            return [None; 2];
+        }
+        let mut actions = [None; 2];
+        let mut claimed = [false; 2];
+        // Reserve a slot/entity in this snapshot before considering the other
+        // hand, so two simultaneous deposits or draws cannot claim it twice.
+        for i in 0..2 {
+            let hand = hands[i];
+            let tracked = GripPose {
+                position: hand.position,
+                rotation: hand.rotation,
+            }
+            .is_tracked()
+                && hand.squeeze_value.is_finite()
+                && input.pose_tracking.is_none_or(|p| p.hands[i]);
+            let pressed = hand.squeeze_value >= 0.5;
+            self.near[i] = (tracked && (held[i].is_none() || weapons[i])).then(|| (0..2).find(|s|
+                // A stored item remains retrievable if its perk is removed.
+                (*s < count || slots[*s].is_some()) && (hand.position - centers[*s]).magnitude2() <= RADIUS * RADIUS
+            )).flatten();
+            if let Some(slot) = self.near[i] {
+                if let Some(entity) = held[i] {
+                    if !pressed && self.pressed_item[i] == Some(entity) {
+                        if weapons[i] && slot < count && slots[slot].is_none() && !claimed[slot] {
+                            claimed[slot] = true;
+                            slots[slot] = Some(entity);
+                            actions[i] = Some(Action::Store { entity, slot });
+                        } else {
+                            self.retained.retain(i, entity);
+                            actions[i] = Some(Action::Refuse { entity });
+                        }
+                    }
+                } else if available[i] && pressed && !self.pressed[i] && !claimed[slot] {
+                    if let Some(entity) = slots[slot].take() {
+                        claimed[slot] = true;
+                        actions[i] = Some(Action::Retrieve { entity, slot });
+                    }
+                }
+            }
+            self.pressed[i] = if tracked { pressed } else { true };
+            self.pressed_item[i] = if tracked && pressed { held[i] } else { None };
+        }
+        actions
+    }
+
+    pub fn world_rotation(&self, rotation: Quaternion<f32>) -> Matrix4<f32> {
+        // The heading convention is clockwise from -Z; cgmath yaw is opposite.
+        Matrix4::from(rotation) * Matrix4::from_angle_y(cgmath::Rad(-self.yaw.unwrap_or(0.0)))
+    }
+
+    pub fn world_centers(
+        &self,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+    ) -> Option<[Vector3<f32>; 2]> {
+        self.centers
+            .map(|cs| cs.map(|c| position + rotation.rotate_vector(c)))
+    }
+
+    pub fn diagnostics(
+        &self,
+        world: &World,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+    ) -> serde_json::Value {
+        serde_json::json!({"centers": self.world_centers(position, rotation).map(|cs| cs.map(|c| [c.x,c.y,c.z])),
+            "radius":RADIUS, "enabled_slots":slot_count(world), "near":self.near,
+            "items":occupants(world).map(|e| e.map(|id| id.inner() as i32)),
+            "retained":self.retained.0.map(|e| e.is_some())})
+    }
+
+    pub fn render(
+        &self,
+        world: &World,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+    ) -> Vec<engine::scene::SceneObject> {
+        use engine::scene::{SceneObject, color_material, lines_mesh};
+        let Some(centers) = self.world_centers(position, rotation) else {
+            return vec![];
+        };
+        let slots = occupants(world);
+        let count = slot_count(world);
+        let debug = crate::dev_params::get_bool(crate::dev_params::VR_HOLSTER_ZONES);
+        let mut objects = Vec::new();
+        for slot in 0..2 {
+            if slot >= count && slots[slot].is_none() {
+                continue;
+            }
+            let reached = self.near.contains(&Some(slot));
+            let refused = (0..2).any(|h| self.near[h] == Some(slot) && self.retained.keep_grip(h));
+            let color = if refused {
+                vec3(1.0, 0.2, 0.1)
+            } else if reached {
+                vec3(0.1, 1.0, 0.35)
+            } else {
+                vec3(0.1, 0.55, 0.7)
+            };
+            let radius = if debug { RADIUS } else { 0.04 / SCALE };
+            let mut points = Vec::new();
+            dark::hit_box::append_capsule_lines(
+                &mut points,
+                &Matrix4::from_scale(1.0),
+                centers[slot],
+                centers[slot],
+                radius,
+            );
+            objects.push(SceneObject::new(
+                color_material::create(color),
+                Box::new(lines_mesh::create(points)),
+            ));
+        }
+        crate::util::tag_render_source(&mut objects, crate::util::render_source::PLAYER_HANDS);
+        objects
+    }
+}

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -905,6 +905,7 @@ fn move_live_entity_into_container_at_slot(
         }
     }
     if was_able_to_drop {
+        world.remove::<crate::runtime_props::RuntimePropHolstered>(dropped_entity_id);
         world.add_component(dropped_entity_id, PropHasRefs(false));
     }
     was_able_to_drop
@@ -1037,6 +1038,7 @@ fn restore_live_entity_world_refs(world: &mut World, entity_id: EntityId) -> boo
             drop_contains_links_to(links, entity_id);
         }
     }
+    world.remove::<crate::runtime_props::RuntimePropHolstered>(entity_id);
     world.add_component(entity_id, PropHasRefs(true));
     true
 }
@@ -2102,6 +2104,7 @@ pub struct MissionCore {
     /// [`update_clip_insert_gesture`]: MissionCore::update_clip_insert_gesture
     vr_clip_insert_engaged: [bool; 2],
     shoulder_backpack: super::shoulder_backpack::ShoulderBackpack,
+    holsters: super::holsters::Holsters,
 
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
     /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
@@ -3029,6 +3032,7 @@ impl MissionCore {
             vr_trigger_safe_latch: [None; 2],
             vr_clip_insert_engaged: [false; 2],
             shoulder_backpack: Default::default(),
+            holsters: Default::default(),
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
@@ -4061,7 +4065,57 @@ impl MissionCore {
         });
         let hands_input = weapon_safe_input.as_ref().unwrap_or(input_context);
 
+        // VR body slots have no flat input surface. On a flat load, return
+        // their exact entities to the backpack, or visibly drop them if full.
+        if game_options.presentation_mode == crate::PresentationMode::Flat {
+            let stored = super::holsters::occupants(&self.world);
+            for entity in stored.into_iter().flatten() {
+                let inventory = self
+                    .world
+                    .borrow::<UniqueView<PlayerInfo>>()
+                    .unwrap()
+                    .inventory_entity_id;
+                if !self.drop_entity_into_container(inventory, entity) {
+                    let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+                    let position = player.pos
+                        + player
+                            .rotation
+                            .rotate_vector(input_context.head.position + vec3(0.0, 0.0, -0.5));
+                    let rotation = player.rotation;
+                    drop(player);
+                    self.set_entity_position_rotation(
+                        entity,
+                        position,
+                        rotation,
+                        vec3(1.0, 1.0, 1.0),
+                    );
+                    self.drop_held_item_into_world(entity);
+                }
+            }
+        }
+
         let held = [left_hand_held, right_hand_held];
+        let holster_actions = self.holsters.update(
+            hands_input,
+            held,
+            [
+                crate::vr_config::Handedness::Left,
+                crate::vr_config::Handedness::Right,
+            ]
+            .map(|hand| self.interaction.hand_available_for_body_slot(hand)),
+            super::holsters::occupants(&self.world),
+            super::holsters::slot_count(&self.world),
+            held.map(|entity| {
+                entity.is_some_and(|entity| {
+                    crate::virtual_hand::is_wieldable_weapon(&self.world, entity)
+                })
+            }),
+            game_options.presentation_mode == crate::PresentationMode::Vr
+                && !self.use_mode
+                && self.player_is_alive()
+                && self.player_controls_enabled,
+            time.elapsed.as_secs_f32(),
+        );
         let shoulder_releases = self.shoulder_backpack.update(
             hands_input,
             held,
@@ -4122,7 +4176,37 @@ impl MissionCore {
                 });
                 tracing::info!(hand = i, entity = ?held[i], accepted, "shoulder backpack release");
             }
-            if self.shoulder_backpack.keep_grip(i) {
+            if let Some(action) = holster_actions[i] {
+                use super::holsters::Action;
+                let refused = matches!(action, Action::Refuse { .. });
+                effects.push(Effect::ShowMessage {
+                    text: match action {
+                        Action::Store { .. } => "Weapon holstered",
+                        Action::Retrieve { .. } => "Weapon drawn",
+                        Action::Refuse { .. } => {
+                            "Holster unavailable — weapons only, one per slot. Squeeze to re-grip."
+                        }
+                    }
+                    .to_owned(),
+                });
+                effects.push(Effect::PlaySound {
+                    handle: AudioHandle::new(),
+                    name: if refused { "repfail" } else { "bset" }.to_owned(),
+                    source: held[i],
+                    spatial: false,
+                });
+                if matches!(action, Action::Retrieve { .. }) {
+                    let hand = if i == 0 {
+                        &mut shoulder_input.left_hand
+                    } else {
+                        &mut shoulder_input.right_hand
+                    };
+                    hand.squeeze_value = 0.0;
+                    hand.trigger_value = 0.0;
+                    self.vr_trigger_safe_latch[i] = Some(true);
+                }
+            }
+            if self.shoulder_backpack.keep_grip(i) || self.holsters.retained.keep_grip(i) {
                 match i {
                     0 => shoulder_input.left_hand.squeeze_value = 1.0,
                     _ => shoulder_input.right_hand.squeeze_value = 1.0,
@@ -4212,6 +4296,39 @@ impl MissionCore {
             game_options,
         );
         rewrite_inventory_release(&mut interaction_msgs, &store, &collect);
+        // Holstering claims only this release, including its consumption offer.
+        for (i, action) in holster_actions.into_iter().enumerate() {
+            let Some(action) = action else {
+                continue;
+            };
+            match action {
+                super::holsters::Action::Store { entity, slot } => {
+                    interaction_msgs.retain(|effect| !matches!(effect, VirtualHandEffect::OutMessage { message }
+                        if matches!(message.payload, MessagePayload::ProvideForConsumption { entity: offered } if offered == entity)));
+                    for effect in &mut interaction_msgs {
+                        if matches!(effect, VirtualHandEffect::DropItem { entity_id } if *entity_id == entity)
+                        {
+                            *effect = VirtualHandEffect::HolsterItem {
+                                entity_id: entity,
+                                slot,
+                            };
+                        }
+                    }
+                }
+                super::holsters::Action::Retrieve { entity, .. } => {
+                    effects.push(Effect::GrabEntity {
+                        entity_id: entity,
+                        hand: if i == 0 {
+                            crate::vr_config::Handedness::Left
+                        } else {
+                            crate::vr_config::Handedness::Right
+                        },
+                        current_parent_id: None,
+                    });
+                }
+                super::holsters::Action::Refuse { .. } => {}
+            }
+        }
         effects.extend(self.process_virtual_hand_effects(asset_cache, interaction_msgs));
 
         // The physical VR reload: a clip carried into the other hand's weapon
@@ -5819,6 +5936,8 @@ impl MissionCore {
     /// Remove every incoming `Contains` link to `entity_id` (take it out of
     /// whatever container holds it) without giving it world presence.
     fn detach_from_containers(&mut self, entity_id: EntityId) {
+        self.world
+            .remove::<crate::runtime_props::RuntimePropHolstered>(entity_id);
         let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
         for links in (&mut v_links).iter() {
             links.to_links.retain(|link| {
@@ -7809,6 +7928,8 @@ impl MissionCore {
                     effects.extend(self.process_virtual_hand_effects(asset_cache, grab_effects));
 
                     if self.interaction.is_holding(entity_id) {
+                        self.world
+                            .remove::<crate::runtime_props::RuntimePropHolstered>(entity_id);
                         // A grab routed through this effect (equip a carried
                         // weapon, a backpack double-click) never emits
                         // `HoldItem`, so establish the melee contact body here
@@ -10723,6 +10844,75 @@ impl MissionCore {
                 .render(asset_cache, &self.world, self.use_mode),
         );
 
+        if options.presentation_mode == crate::PresentationMode::Vr {
+            scene.extend(
+                self.holsters
+                    .render(&self.world, player.pos, player.rotation),
+            );
+            if let Some(centers) = self.holsters.world_centers(player.pos, player.rotation) {
+                for (slot, entity) in super::holsters::occupants(&self.world)
+                    .into_iter()
+                    .enumerate()
+                {
+                    let Some(model) = entity.and_then(|entity| self.id_to_model.get(&entity))
+                    else {
+                        continue;
+                    };
+                    let Some(bounds) = model.bounding_box() else {
+                        continue;
+                    };
+                    let extent = bounds.max - bounds.min;
+                    let longest = extent.x.max(extent.y).max(extent.z);
+                    if longest <= 0.0001 {
+                        continue;
+                    }
+                    let held_extent = entity
+                        .and_then(|id| {
+                            self.world
+                                .borrow::<View<crate::runtime_props::RuntimePropHolstered>>()
+                                .ok()
+                                .and_then(|slots| {
+                                    slots.get(id).ok().and_then(|slot| slot.held_extent)
+                                })
+                        })
+                        .unwrap_or(longest);
+                    let scale = held_extent.min(0.45 / crate::METERS_PER_WORLD_UNIT) / longest;
+                    let center = (bounds.min.to_vec() + bounds.max.to_vec()) * 0.5;
+                    // World meshes have different authored long axes. These
+                    // two corrections adapt the authored profiles from #1399.
+                    let name = entity
+                        .and_then(|id| {
+                            self.world
+                                .borrow::<View<PropModelName>>()
+                                .ok()
+                                .and_then(|names| {
+                                    names.get(id).ok().map(|name| name.0.to_ascii_lowercase())
+                                })
+                        })
+                        .unwrap_or_default();
+                    let orientation = match name.trim_end_matches(".bin") {
+                        "sg_w" => Matrix4::from_angle_x(cgmath::Deg(90.0)),
+                        "wrench_w" => Matrix4::from_angle_z(cgmath::Deg(-90.0)),
+                        _ => Matrix4::from_angle_x(cgmath::Deg(-90.0)),
+                    };
+                    let root = Matrix4::from_translation(centers[slot])
+                        * self.holsters.world_rotation(player.rotation)
+                        * orientation
+                        * Matrix4::from_scale(scale)
+                        * Matrix4::from_translation(-center);
+                    let mut objects = model.to_scene_objects().clone();
+                    for object in &mut objects {
+                        object.set_transform(root);
+                    }
+                    crate::util::tag_render_source(
+                        &mut objects,
+                        crate::util::render_source::PLAYER_HANDS,
+                    );
+                    scene.extend(objects);
+                }
+            }
+        }
+
         if options.presentation_mode == crate::PresentationMode::Vr
             && crate::dev_params::get_bool(crate::dev_params::VR_BACKPACK_ZONES)
         {
@@ -11145,6 +11335,8 @@ impl MissionCore {
                     );
                 }
                 VirtualHandEffect::HoldItem { entity_id } => {
+                    self.world
+                        .remove::<crate::runtime_props::RuntimePropHolstered>(entity_id);
                     if self.is_vr_melee_weapon(entity_id) {
                         // Held guns/items stay unphysical, but a VR melee
                         // weapon needs its authored collider to report genuine
@@ -11158,6 +11350,68 @@ impl MissionCore {
                     self.script_world.dispatch(Message {
                         payload: MessagePayload::Hold,
                         to: entity_id,
+                    });
+                }
+                VirtualHandEffect::HolsterItem { entity_id, slot } => {
+                    // Drop can swap the calibrated viewmodel for a differently
+                    // sized world mesh. Preserve its apparent size across that swap.
+                    let scale = self
+                        .world
+                        .borrow::<View<crate::runtime_props::RuntimePropGloveWeapon>>()
+                        .ok()
+                        .and_then(|v| v.get(entity_id).ok().map(|p| p.item_scale))
+                        .unwrap_or(1.0);
+                    let model_name = self
+                        .world
+                        .borrow::<View<PropModelName>>()
+                        .ok()
+                        .and_then(|names| names.get(entity_id).ok().map(|name| name.0.clone()));
+                    // Authored header bounds can still include the removed arms.
+                    // Measure only the same visible triangles used by grip fitting.
+                    let weapon_extent = model_name
+                        .filter(|name| crate::vr_weapon_grip::supports_model(name))
+                        .and_then(|name| {
+                            asset_cache.get_opt(
+                                &dark::importers::GLOVE_WEAPON_IMPORTER,
+                                &format!("{name}.bin"),
+                            )
+                        })
+                        .and_then(|source| {
+                            let source = source.as_ref().as_ref()?;
+                            let mut points = source.triangles.iter().flatten();
+                            let first = *points.next()?;
+                            let (min, max) = points.fold((first, first), |(min, max), p| {
+                                (
+                                    Point3::new(min.x.min(p.x), min.y.min(p.y), min.z.min(p.z)),
+                                    Point3::new(max.x.max(p.x), max.y.max(p.y), max.z.max(p.z)),
+                                )
+                            });
+                            Some(max - min)
+                        });
+                    let held_extent = weapon_extent
+                        .or_else(|| {
+                            self.id_to_model
+                                .get(&entity_id)
+                                .and_then(|model| model.bounding_box())
+                                .map(|bounds| bounds.max - bounds.min)
+                        })
+                        .map(|extent| extent.x.max(extent.y).max(extent.z) * scale)
+                        .filter(|extent| extent.is_finite() && *extent > 0.0001);
+                    self.detach_from_containers(entity_id);
+                    self.make_un_physical(entity_id);
+                    self.world.add_component(
+                        entity_id,
+                        (
+                            crate::runtime_props::RuntimePropHolstered {
+                                slot: slot as u8,
+                                held_extent,
+                            },
+                            PropHasRefs(false),
+                        ),
+                    );
+                    self.script_world.dispatch(Message {
+                        to: entity_id,
+                        payload: MessagePayload::Drop,
                     });
                 }
                 VirtualHandEffect::StoreItem { entity_id } => {
@@ -12609,6 +12863,11 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             feedback.as_object_mut(),
             self.world.borrow::<UniqueView<PlayerInfo>>(),
         ) {
+            object.insert(
+                "holsters".to_owned(),
+                self.holsters
+                    .diagnostics(&self.world, player.pos, player.rotation),
+            );
             object.insert(
                 "shoulder_backpack".to_owned(),
                 self.shoulder_backpack

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -1,7 +1,9 @@
 pub mod entity_creator;
 use tracing::info;
+mod body_inventory;
 pub mod entity_populator;
 pub mod flat_ui_host;
+mod holsters;
 pub mod mission_core;
 pub mod pathfinding_debug;
 pub mod pathfinding_test;

--- a/shock2vr/src/mission/shoulder_backpack.rs
+++ b/shock2vr/src/mission/shoulder_backpack.rs
@@ -15,7 +15,7 @@ pub(super) const RADIUS: f32 = 0.18 / SCALE;
 pub(super) struct ShoulderBackpack {
     yaw: Option<f32>,
     pressed_item: [Option<EntityId>; 2],
-    retained: [Option<EntityId>; 2],
+    retained: super::body_inventory::RetainedRelease,
     pub centers: Option<[Vector3<f32>; 2]>,
     pub near: [bool; 2],
 }
@@ -31,11 +31,7 @@ impl ShoulderBackpack {
         dt: f32,
     ) -> [bool; 2] {
         let hands = [&input.left_hand, &input.right_hand];
-        for i in 0..2 {
-            if self.retained[i] != held[i] || hands[i].squeeze_value > 0.5 {
-                self.retained[i] = None;
-            }
-        }
+        self.retained.update(held, hands.map(|h| h.squeeze_value));
         let head = GripPose {
             position: input.head.position,
             rotation: input.head.rotation,
@@ -49,16 +45,12 @@ impl ShoulderBackpack {
         }
         let forward = crate::ui::PanelPlacement::from_head(head.position, head.rotation).forward;
         let observed = forward.x.atan2(-forward.z);
-        let yaw = match self.yaw {
-            // Keep the shoulder target still while a hand is reaching into it.
-            Some(yaw) if self.near.iter().any(|near| *near) => yaw,
-            Some(yaw) => {
-                let delta = observed - yaw;
-                let delta = delta.sin().atan2(delta.cos());
-                yaw + delta * (1.0 - (-dt.max(0.0).min(0.1) / 0.5).exp())
-            }
-            None => observed,
-        };
+        let yaw = super::body_inventory::followed_yaw(
+            self.yaw,
+            observed,
+            self.near.iter().any(|near| *near),
+            dt,
+        );
         self.yaw = Some(yaw);
         let forward = vec3(yaw.sin(), 0.0, -yaw.cos());
         let right = forward.cross(Vector3::unit_y());
@@ -98,10 +90,10 @@ impl ShoulderBackpack {
     /// A rejected deposit stays held until a real re-grip, even if the hand
     /// leaves the zone or the cyber interface opens. No invisible floor drop.
     pub fn retain(&mut self, slot: usize, entity: EntityId) {
-        self.retained[slot] = Some(entity);
+        self.retained.retain(slot, entity);
     }
     pub fn keep_grip(&self, slot: usize) -> bool {
-        self.retained[slot].is_some()
+        self.retained.keep_grip(slot)
     }
 
     pub fn render(
@@ -118,7 +110,7 @@ impl ShoulderBackpack {
         for center in centers {
             dark::hit_box::append_capsule_lines(&mut vertices, &root, center, center, RADIUS);
         }
-        let color = if self.retained.iter().any(Option::is_some) {
+        let color = if self.retained.0.iter().any(Option::is_some) {
             vec3(1.0, 0.3, 0.1)
         } else if self.near.iter().any(|near| *near) {
             vec3(0.1, 1.0, 0.2)
@@ -141,7 +133,7 @@ impl ShoulderBackpack {
         serde_json::json!({
             "centers": self.centers.map(|cs| cs.map(|c| { let p = position + rotation.rotate_vector(c); [p.x,p.y,p.z] })),
             "radius": RADIUS, "near": self.near,
-            "retained": self.retained.map(|e| e.is_some()),
+            "retained": self.retained.0.map(|e| e.is_some()),
         })
     }
 }

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -412,3 +412,12 @@ pub struct RuntimePropVrGripOffset(pub Vector3<f32>);
 /// Diagnostic only: not saved and never consulted by firing logic.
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropLastFiredProjectile(pub i32);
+
+/// A weapon owned by a thigh holster: 0 right, 1 left. Saved and carried
+/// independently of backpack cells; not a world pickup while present.
+#[derive(Component, Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct RuntimePropHolstered {
+    pub slot: u8,
+    /// Longest extent of the calibrated held mesh, in world units.
+    pub held_extent: Option<f32>,
+}

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -30,6 +30,9 @@ pub struct EntitySaveData {
     /// the Dark property registry.
     #[serde(default)]
     pub selected_ammo: HashMap<u64 /* entity id */, usize>,
+    /// Exact weapon membership in right/left thigh slots.
+    #[serde(default)]
+    pub holstered: HashMap<u64, crate::runtime_props::RuntimePropHolstered>,
     /// Stable gamesys archetype for entities whose `PropTemplateId` is a
     /// positive, mission-local object ID.
     #[serde(default)]
@@ -59,6 +62,7 @@ impl EntitySaveData {
             links: HashMap::new(),
             death_poses: HashMap::new(),
             selected_ammo: HashMap::new(),
+            holstered: HashMap::new(),
             canonical_template_ids: HashMap::new(),
             launched_projectiles: Vec::new(),
             player_fired_projectiles: Vec::new(),
@@ -110,6 +114,13 @@ impl EntitySaveData {
             if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&entity_id) {
                 let links = Links::deserialize(link.clone(), &old_entity_id_to_new_entity_id);
                 world.add_component(*new_entity_id, links);
+            }
+        }
+        for (old, slot) in &self.holstered {
+            if let Some(new) =
+                EntityId::from_inner(*old).and_then(|id| old_entity_id_to_new_entity_id.get(&id))
+            {
+                world.add_component(*new, *slot);
             }
         }
         for (old_entity_id, selected_ammo) in &self.selected_ammo {
@@ -211,6 +222,46 @@ mod tests {
             }
             assert!(!remapped.contains_key(&excluded));
         }
+    }
+
+    #[test]
+    fn holster_membership_and_ammo_remap_to_the_same_saved_weapon() {
+        let mut source = World::new();
+        let weapon = source.add_entity(());
+        let mut data = EntitySaveData::empty();
+        data.all_entities.push(weapon.inner());
+        data.holstered.insert(
+            weapon.inner(),
+            crate::runtime_props::RuntimePropHolstered {
+                slot: 1,
+                held_extent: Some(0.3),
+            },
+        );
+        data.selected_ammo.insert(weapon.inner(), 2);
+        let data: EntitySaveData =
+            serde_json::from_str(&serde_json::to_string(&data).unwrap()).unwrap();
+        let mut restored = World::new();
+        restored.add_entity(());
+        let (_, map) = data.instantiate(&mut restored);
+        let id = map[&weapon];
+        assert_eq!(
+            restored
+                .borrow::<View<crate::runtime_props::RuntimePropHolstered>>()
+                .unwrap()
+                .get(id)
+                .unwrap()
+                .slot,
+            1
+        );
+        assert_eq!(
+            restored
+                .borrow::<View<RuntimePropSelectedAmmo>>()
+                .unwrap()
+                .get(id)
+                .unwrap()
+                .0,
+            2
+        );
     }
 
     #[test]

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -44,6 +44,16 @@ fn get_held_items(world: &World) -> HashSet<u64> {
         add_contained_entities(&mut out, world, 2, right_hand);
     }
 
+    for (entity, _) in world
+        .borrow::<View<crate::runtime_props::RuntimePropHolstered>>()
+        .unwrap()
+        .iter()
+        .with_id()
+    {
+        out.insert(entity.inner());
+        add_contained_entities(&mut out, world, 2, entity);
+    }
+
     out.insert(player.inventory_entity_id.inner());
     add_contained_entities(&mut out, world, 2, player.inventory_entity_id);
 
@@ -233,6 +243,17 @@ pub fn to_save_data_with_scripts(
         .map(|(entity_id, _)| entity_id.inner())
         .filter(|entity_id| !entities_to_filter.contains(entity_id))
         .partition(|entity_id| held_entities.contains(entity_id));
+
+    let raw_holstered: HashMap<u64, crate::runtime_props::RuntimePropHolstered> = world
+        .borrow::<View<crate::runtime_props::RuntimePropHolstered>>()
+        .unwrap()
+        .iter()
+        .with_id()
+        .filter(|(id, _)| !entities_to_filter.contains(&id.inner()))
+        .map(|(id, slot)| (id.inner(), *slot))
+        .collect();
+    let (held_holstered, world_holstered) =
+        partition_map(raw_holstered, |id| held_entities.contains(id));
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
         template_id_to_entity_id: template_id_to_entity_id.0.clone(),
@@ -240,6 +261,7 @@ pub fn to_save_data_with_scripts(
         all_entities: all_world_entities,
         death_poses: world_death_poses,
         selected_ammo: world_selected_ammo,
+        holstered: world_holstered,
         canonical_template_ids: world_canonical_templates,
         launched_projectiles: world_launched_projectiles,
         player_fired_projectiles: world_player_fired_projectiles,
@@ -253,6 +275,7 @@ pub fn to_save_data_with_scripts(
         properties: held_serialized_properties,
         death_poses: held_death_poses,
         selected_ammo: held_selected_ammo,
+        holstered: held_holstered,
         canonical_template_ids: held_canonical_templates,
         launched_projectiles: held_launched_projectiles,
         player_fired_projectiles: held_player_fired_projectiles,

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -133,6 +133,9 @@ impl TraitsContext {
     pub fn load(asset_cache: &mut AssetCache) -> TraitsContext {
         let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "traits.str");
         let descriptions = std::array::from_fn(|i| {
+            if (i + 1) as u8 == TRAIT_PACK_RAT {
+                return "Pack-Rat: +3 pack slots, +1 holster in VR.".to_owned();
+            }
             let key = format!("trait{}", i + 1);
             strings
                 .as_ref()
@@ -400,7 +403,7 @@ pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
     match trait_id {
         TRAIT_TANK => Some("+5 max hit points"),
         TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
-        TRAIT_PACK_RAT => Some("+3 backpack slots"),
+        TRAIT_PACK_RAT => Some("+3 pack slots, +1 VR holster"),
         TRAIT_PHARMO_FRIENDLY => Some("20% healing-item bonus"),
         TRAIT_REPLICATOR_EXPERT => Some("20% replicator discount"),
         _ => None,

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -120,6 +120,11 @@ pub enum VirtualHandEffect {
         entity_id: EntityId,
         cell: (usize, usize),
     },
+    /// A claimed body-slot release. Dispatches Drop but never creates a loose body.
+    HolsterItem {
+        entity_id: EntityId,
+        slot: usize,
+    },
     /// Eject an item into the world (it regains physics + its world model).
     /// This is an explicit drop only: VR opening its hand. Losing an item to a
     /// wield swap is a `StoreItem`, not a drop (#777).

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -661,6 +661,15 @@ export interface PlayerSnapshot {
     affordance: "None" | "Grabbable" | "Frobbable" | "Blocked";
     light: "Off" | "Green" | "Amber" | "Red";
   }> & {
+    /** Thigh slots are right then left; hand arrays remain left/right. */
+    holsters?: {
+      centers: [Vec3, Vec3] | null;
+      radius: number;
+      enabled_slots: number;
+      near: [number | null, number | null];
+      items: [number | null, number | null];
+      retained: [boolean, boolean];
+    };
     /** Shoulder stow targets in world space; absent on older runtimes. */
     shoulder_backpack?: {
       centers: [Vec3, Vec3] | null;

--- a/tools/shock2-sdk/test/vr-holsters.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-holsters.e2e.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import {
+  aimVrHandAt,
+  aimVrHandAtCanvas,
+  quatConjugate,
+  quatRotate,
+  sub,
+} from "./helpers/vr-hand.js";
+import { ammoOf } from "./helpers/weapon.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+const owner = (hand: "left" | "right") =>
+  hand === "left" ? "wielded_entity_id" : "right_hand_entity_id";
+async function reach(
+  game: GameServer,
+  hand: "left" | "right",
+  slot: number,
+) {
+  const player = (await game.info()).player;
+  const center = player.hand_feedback?.holsters?.centers?.[slot];
+  assert.ok(center, "tracked holster zones must be published");
+  await game.input.set(
+    `${hand}_hand.position`,
+    quatRotate(quatConjugate(player.rotation), sub(center, player.position)),
+  );
+  await game.input.set(`${hand}_hand.rotation`, [0, 0, 0, 1]);
+  await game.step({ frames: 5 });
+  assert.equal(
+    (await game.info()).player.hand_feedback?.holsters?.near[
+      hand === "left" ? 0 : 1
+    ],
+    slot,
+  );
+}
+
+for (const hand of ["left", "right"] as const) {
+  test(`${hand} holster preserves the exact weapon and ammunition`, { skip: !enabled, timeout: 180_000 }, async () => {
+    await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+    await game.step({ frames: 30 });
+    const item = (await game.entities.list()).entities.find(e => e.template_id === -17)!;
+    assert.ok(item);
+    await aimVrHandAt(game, item.position, 0.2, 1, 0, { hand });
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player[owner(hand)], item.id);
+    await game.entities.sendMessage(item.id, { type: "SetGunCondition", condition: 57 });
+    await game.step({ frames: 1 });
+    const ammo = ammoOf(await game.entities.detail(item.id));
+    if (hand === "right") {
+      // Holsters are dedicated capacity even when the largest backpack is full.
+      for (let i = 0; i < 45; i++) await game.player.spawnItem(-1221);
+    }
+    await reach(game, hand, 0);
+    assert.equal((await game.info()).player[owner(hand)], item.id, "reaching is not releasing");
+    await game.input.set(`${hand}_hand.squeeze`, 0);
+    await game.step({ frames: 8 });
+    assert.equal((await game.info()).player[owner(hand)], null);
+    assert.deepEqual((await game.info()).player.hand_feedback?.holsters?.items, [item.id, null]);
+    assert.equal((await game.player.inventory()).items.find(i => i.entity_id === item.id), undefined);
+    assert.equal((await game.physics.bodies({ entityId: item.id })).bodies.length, 0);
+    await game.input.set(`${hand}_hand.trigger`, 1);
+    await game.input.set(`${hand}_hand.squeeze`, 1);
+    await game.step({ frames: 90 });
+    assert.equal((await game.info()).player[owner(hand)], item.id);
+    assert.deepEqual((await game.info()).player.hand_feedback?.holsters?.items, [null, null]);
+    assert.equal(ammoOf(await game.entities.detail(item.id)), ammo, "drawing with trigger held must not fire");
+    assert.equal((await game.info()).player.wielded_gun_condition, 57);
+  });
+}
+
+test("occupied holster retains the refused weapon until a deliberate regrip", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+  await game.step({ frames: 30 });
+  const entities = (await game.entities.list()).entities;
+  const pistol = entities.find(e => e.template_id === -17)!;
+  const wrench = entities.find(e => e.template_id === -928)!;
+  assert.ok(pistol && wrench);
+  await aimVrHandAt(game, pistol.position, 0.2, 1);
+  await game.step({ frames: 5 });
+  await reach(game, "right", 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+  await aimVrHandAt(game, wrench.position, 0.2, 1);
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+  await reach(game, "right", 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+  assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+  assert.equal((await game.info()).player.hand_feedback?.holsters?.retained[1], true);
+  assert.deepEqual((await game.info()).player.hand_feedback?.holsters?.items, [pistol.id, null]);
+  await game.input.set("right_hand.position", [0.3, 1, -0.4]);
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.right_hand_entity_id, null);
+});
+
+test("holstered weapon survives real mission save, load, and transition", { skip: !enabled, timeout: 240_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "medsci1.mis", debugFlags: ["--vr"] });
+  await game.step({ frames: 5 });
+  const existing = new Set((await game.entities.list()).entities.map(e => e.id));
+  await game.player.spawnItem(-17);
+  const item = (await game.entities.list()).entities.find(e => e.template_id === -17 && !existing.has(e.id))!;
+  assert.ok(item);
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 5 });
+  const ui = await game.ui.state();
+  const cell = ui.strip?.elements.find(e => e.entity_id === item.id);
+  assert.ok(cell);
+  await aimVrHandAtCanvas(game, ui.panel_pose!, [cell.rect[0] + cell.rect[2] / 2, cell.rect[1] + cell.rect[3] / 2], { hand: "right", squeeze: 1 });
+  await game.step({ frames: 5 });
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.right_hand_entity_id, item.id);
+  const ammo = ammoOf(await game.entities.detail(item.id));
+  await reach(game, "right", 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+  const name = `holster-${Date.now()}`;
+  await game.save(name);
+  await game.load(name);
+  await game.step({ frames: 8 });
+  const saved = (await game.info()).player.hand_feedback?.holsters?.items[0];
+  assert.ok(saved != null);
+  assert.equal(ammoOf(await game.entities.detail(saved)), ammo);
+  assert.equal((await game.physics.bodies({ entityId: saved })).bodies.length, 0);
+  await reach(game, "left", 0);
+  await game.input.set("left_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal((await game.info()).player.wielded_entity_id, saved);
+  await game.input.set("left_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+  assert.equal((await game.info()).player.hand_feedback?.holsters?.items[0], saved);
+  await game.transitionLevel("medsci2.mis");
+  await game.step({ frames: 8 });
+  const moved = (await game.info()).player.hand_feedback?.holsters?.items[0];
+  assert.ok(moved != null);
+  assert.equal(ammoOf(await game.entities.detail(moved)), ammo);
+  await game.save(name);
+  await using flat = await GameServer.launch({ mission: "medsci1.mis" });
+  await flat.load(name);
+  await flat.step({ frames: 8 });
+  assert.ok((await flat.info()).player.hand_feedback == null, "flat presentation has no VR hand diagnostics");
+  const inventory = await flat.player.inventory();
+  assert.ok(inventory.items.length > 0, "flat load returns body storage to accessible backpack cells");
+  const carried = (await flat.entities.list()).entities.find(e => e.template_id === -17 && inventory.items.some(i => i.entity_id === e.id));
+  assert.ok(carried, "the stowed pistol must be in the backpack after flat load");
+  assert.equal(ammoOf(await flat.entities.detail(carried.id)), ammo);
+  let filled = 0;
+  for (let i = 0; i < 45; i++) {
+    try { await game.player.spawnItem(-1221); filled++; }
+    catch (error) {
+      // Real-mission spawn reports a failed capacity check as this legacy error.
+      assert.match(String(error), /could not add item to inventory/);
+      break;
+    }
+  }
+  assert.ok(filled > 0);
+  await game.save(name);
+  await flat.load(name);
+  await flat.step({ frames: 8 });
+  const packed = new Set((await flat.player.inventory()).items.map(i => i.entity_id));
+  const overflow = (await flat.entities.list()).entities.find(e => e.template_id === -17 && !packed.has(e.id));
+  assert.ok(overflow, "full backpack exposes the holstered pistol as a world pickup");
+  assert.equal(ammoOf(await flat.entities.detail(overflow.id)), ammo);
+  assert.ok((await flat.physics.bodies({ entityId: overflow.id })).bodies.length > 0);
+  assert.ok(Math.hypot(...sub(overflow.position, (await flat.info()).player.position)) < 3,
+    "overflow must drop beside the player, not at its saved old-world position");
+});
+
+
+test("drawing a holstered wrench restores its physical melee body", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+  await game.step({ frames: 30 });
+  const wrench = (await game.entities.list()).entities.find(e => e.template_id === -928)!;
+  assert.ok(wrench);
+  await aimVrHandAt(game, wrench.position, 0.2, 1);
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+  await reach(game, "right", 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+  assert.equal((await game.info()).player.hand_feedback?.holsters?.items[0], wrench.id);
+  assert.equal((await game.physics.bodies({ entityId: wrench.id })).bodies.length, 0);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+  assert.equal((await game.info()).player.hand_feedback?.holsters?.items[0], null);
+  assert.ok((await game.physics.bodies({ entityId: wrench.id })).bodies.length > 0);
+});


### PR DESCRIPTION
Weapons can now stay in dedicated thigh holsters: release a held weapon at the right thigh to stow it, then squeeze with an empty hand to draw that same instance. Pack Rat adds a left slot alongside its existing backpack bonus. Either hand can use either slot.

- Occupied slots refuse with visual/audio feedback and keep the rejected weapon in hand until a deliberate regrip. Drawing with an already-held trigger does not fire. Support/climbing hands cannot draw.
- Holsters preserve ammo, condition and entity identity across saves and level changes. They work with a full backpack. Flat loads return their contents to accessible storage, spilling beside the player when full.
- Worn models use the visible held weapon extent, excluding removed authored arms, with a 45 cm cap. Adapts the shotgun/wrench world-axis corrections from #1399. Shared heading follows horizontal head yaw and freezes while reaching.
- Adds `vr_holster_zones`, `vr_holster_drop`, `vr_holster_side` and SDK holster diagnostics. Updates Pack Rat's shared description and the VR interaction guidelines.

Built on #1438. Design and test instructions: `projects/astra-vr-thigh-holsters.md`.

Validation: 1,607 gameplay unit tests passed (2 ignored); focused holster/trait checks and four existing shoulder-backpack runtime regressions passed. Runtime evidence covers both hands, full-pack stow, trigger safety, condition/ammo, occupied refusal, physical wrench draw, real-mission save/load, transition and both flat-load capacity outcomes. Actual Pack Rat purchases in flat/VR unlock two slots. Gameplay library builds with warnings denied; release APK builds. Independent code, duplication and image reviews completed; Claude cross-engine review was unavailable because its credits were exhausted.

No Quest is attached: standing/seated reach and body clearance need headset acceptance. Leg selection, editor controls, haptics and further per-model worn poses remain follow-up refinements. The large wire spheres in instrumented captures are debug grab volumes; production uses smaller markers.

![Thigh holster stow and draw, both hands](https://gist.githubusercontent.com/tommy-xr/c15071ed0a0a70d7bd1120b4b78d3413/raw/astra-holster-stow-draw.gif)

Same deterministic pistol gesture: before releases into the world; after release stows in the right thigh slot and a fresh squeeze retrieves the exact same instance with either hand. Parked frames leave the stored weapon unobscured. Cyan/green spheres are developer zone overlays. No body mesh is rendered; these captures do not establish physical leg clearance or headset comfort.

![World drop versus parked holster](https://gist.githubusercontent.com/tommy-xr/c15071ed0a0a70d7bd1120b4b78d3413/raw/astra-holster-before-after.png)

![Occupied slot refusal](https://gist.githubusercontent.com/tommy-xr/c15071ed0a0a70d7bd1120b4b78d3413/raw/astra-holster-occupied.png)

The pistol remains holstered while the rejected shotgun remains held; diagnostics confirm retained=true. Parked shotgun and wrench orientation checks are included in the gallery. Haptics, leg selection, and editor controls remain future refinements.

[Download standalone gallery and open locally](https://gist.githubusercontent.com/tommy-xr/c15071ed0a0a70d7bd1120b4b78d3413/raw/astra-holster-gallery.html). Includes the corrected Pack Rat description in flat and VR. Actual perk purchases succeeded in both presentations; VR diagnostics report enabled_slots=2. Existing translucent machine art overlaps the VR panel, but its description fits without overflow.
