### PR TITLE
feat(weapons): explain unmet skill requirements at the firing hand

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -11,6 +11,7 @@ mod prop_ambient_hacked;
 mod prop_anim_light;
 mod prop_anim_tex;
 mod prop_base_gun_desc;
+mod prop_base_weapon_desc;
 mod prop_bitmap_animation;
 mod prop_collision_type;
 mod prop_creature_pose;
@@ -57,6 +58,7 @@ pub use prop_ambient_hacked::*;
 pub use prop_anim_light::*;
 pub use prop_anim_tex::*;
 pub use prop_base_gun_desc::*;
+pub use prop_base_weapon_desc::*;
 pub use prop_bitmap_animation::*;
 pub use prop_collision_type::*;
 pub use prop_creature_pose::*;
@@ -1555,6 +1557,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$BaseTechD",
             PropBaseTechDesc::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$BaseWeapo",
+            PropBaseWeaponDesc::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_base_weapon_desc.rs
+++ b/dark/src/properties/prop_base_weapon_desc.rs
@@ -1,0 +1,35 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+
+use crate::ss2_common::read_i32;
+
+/// Dark's `sWeaponSkills`: Standard, Energy, Heavy, Exotic. On an object,
+/// `BaseWeaponDesc` is the skill requirement checked by CheckRequirements.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropBaseWeaponDesc(pub [i32; 4]);
+
+impl PropBaseWeaponDesc {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(len, 16, "a weapon-skill record contains four i32 values");
+        Self(std::array::from_fn(|_| read_i32(reader)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn weapon_requirements_preserve_all_four_classes() {
+        let mut bytes = Vec::new();
+        for value in [6_i32, 2, 3, 4] {
+            bytes.extend(value.to_le_bytes());
+        }
+        let mut reader = Cursor::new(bytes);
+        assert_eq!(PropBaseWeaponDesc::read(&mut reader, 16).0, [6, 2, 3, 4]);
+        assert_eq!(reader.position(), 16);
+    }
+}

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -1,0 +1,146 @@
+# Weapon correctness and VR feel
+
+Status: agreed direction, 2026-09-08. Implementation and runtime verification are
+tracked below; a source inspection is not a completed projectile audit.
+
+## Decisions
+
+- Establish original-game combat parity first, then layer deliberate VR
+  augmentations on top. Keep their tuning and rationale explicit.
+- **Strength improves VR recoil control.** This is an intentional augmentation,
+  not a claim about original System Shock 2. Preserve the original Agility,
+  Still Hand and aiming-implant behavior when establishing parity; tune how
+  Strength combines with it after that baseline is measurable.
+- Weapon skill governs authored inaccuracy. Preserve Sharpshooter's original
+  ranged-damage benefit; an accuracy bonus is not part of the accepted baseline.
+- Begin failed-fire feedback with a brief message above the firing glove, e.g.
+  `Requires Standard Weapons 6 · You have 4`. Do not force a vertical grip.
+  Derive the text and firing decision from the same requirement evaluation.
+- Adapt the existing physical-held work rather than restart by default. Retain
+  the recent calibrated grips, support grips, glove feedback and wrist readouts.
+- Recoil must affect the weapon pose used for aim and effects. Never recoil the
+  tracked head camera. A successful shot applies an impulse; failed attempts do
+  not consume ammo, spawn firing effects, or recoil.
+
+## Source baseline and dependencies
+
+Planning began on local `d693a5a4`; the implementation baseline is current main
+`c0ae0e54`. Main now includes glove monitors (#1436) and parsed authored gun kick
+and skill inaccuracy (#1406). Recheck earlier findings against this baseline.
+
+- [#1142](https://github.com/tommy-xr/shock2quest/pull/1142): open physical-held
+  ranged spike, default-off flag. Kinematic drive, world translation sweep,
+  inert gun collision groups. Rotation is not swept. Review actual code and
+  reproduce on the current interaction baseline before adopting it.
+- [#1153](https://github.com/tommy-xr/shock2quest/pull/1153): open, based on
+  #1142. Uses blocking sweep contacts for held-gun impact audio without enabling
+  projectile/solver collisions against the held gun.
+- [#1080](https://github.com/tommy-xr/shock2quest/pull/1080): open geometry-based
+  muzzle fallback fix; inspect before adding another implementation.
+- [#1325](https://github.com/tommy-xr/shock2quest/pull/1325): open Sharpshooter
+  damage work; coordinate rather than implement the trait twice.
+- [#140](https://github.com/tommy-xr/shock2quest/pull/140) is a query-name filter
+  fix, not a weapon implementation. The intended reference remains unresolved.
+- [Citadel recoil](https://github.com/tommy-xr/citadel-xr/blob/main/games/citadel/Citadel_Entities/Recoil.ml)
+  has pitch, yaw and kickback springs and computes the muzzle with recoil.
+  Its MachineGun uses reduced kick for two-hand support. Borrow the approach,
+  not its model-specific offsets or tuning constants.
+- Original-engine reference: `src/shock/shkplgun.cpp`, `CalcKickAngle`,
+  `CalcRandAngle`, and the launch-time Sharpshooter stim multiplier. The inspected
+  source scales angular kick by Agility and inaccuracy by weapon skill.
+
+## Ordered increments
+
+### 1. Requirement feedback and audit baseline
+
+Source inspection on `c0ae0e54` found no parser for `P$BaseWeapo` (the
+`BaseWeaponDesc` property's four weapon-skill integers) and no skill gate in
+`WeaponScript::handle_message`. The original `cShockPlayer::CheckRequirements`
+in `shkplayr.cpp` checks that property as well as required stats. Therefore the
+first slice includes an eligibility prerequisite; the reported silent trigger
+has not yet been established as an insufficient-skill rejection. Existing
+`script_util::player_skill_level` supplies the character-sheet lookup and
+`hud::message_line` supplies reusable status-text layout and expiry patterns.
+
+- [ ] Trace original requirement properties and current eligibility checks;
+  reproduce a failed trigger with insufficient skill. Do not assume every
+  silent trigger is an existing skill gate.
+- [ ] Return a structured rejection with required/current values and weapon
+  identity from shared gameplay code. VR presents it above the firing glove;
+  flat presents the same content through shared canvas layout.
+- [ ] Show feedback on an actual failed attempt, rate-limit repeated pulls,
+  and avoid restarting it every frame while the trigger stays held.
+- [ ] Verify left/right hands, dual wield, support hand, weapon changes,
+  untracked hands, use-mode suppression, and successful firing at the threshold.
+- [ ] Build the weapon audit matrix below from authored data and original code.
+
+### 2. Correct firing and physical handling
+
+- [ ] Fix shooter filtering for fast rays and physical projectiles. Near-chest
+  shots must not hit the firing player's capsule or held items accidentally.
+  Preserve enemy hits, point-blank world obstruction and explosive self-damage.
+- [ ] Audit muzzle/vhot lookup and missing-vhot fallbacks for all held models.
+  Ensure no fallback or clearance moves a shot through a wall.
+- [ ] Reproduce flash/casing regressions with matched world/held models. Inspect
+  GunFlash flags, attachment point identity, orientation, visibility and lifetime.
+  Muzzle flashes may follow the gun; ejected shells must detach correctly.
+- [ ] Resolve dry-fire sound end to end: event name, schema tags, selected clip
+  and playback. Distinguish empty, broken, reloading and insufficient-skill states.
+- [ ] Adapt #1142/#1153 to current main. Verify fitted gun-only colliders,
+  wall stops, material impact sounds, rotation into walls and lifecycle cleanup.
+
+### 3. Recoil, VR augmentation and audit completion
+
+- [ ] Implement authored accuracy/recoil behavior in shared gameplay code,
+  using #1406's parsed data and preserving original trait/psi/implant hooks.
+- [ ] Add bounded, timestep-stable pitch/yaw/kickback springs to the held drive:
+  tracked grip -> recoil offset -> collision-constrained weapon pose -> muzzle.
+  Rendering, projectile direction and attached effects read that resolved pose.
+- [ ] Define shot ordering explicitly: fire from the current resolved muzzle,
+  then apply the new impulse for recovery and subsequent shots. Document any
+  intentional departure from original pre-shot kick behavior.
+- [ ] Add and tune **Strength-based VR recoil control** after parity. Keep it
+  separate from weapon inaccuracy and projectile damage. Start with a monotonic,
+  bounded reduction in angular/backward kick; choose constants from headset
+  trials rather than commit guessed values as design requirements.
+- [ ] Evaluate additional two-hand stabilization using the existing support
+  grip. Losing support must not snap or reset accumulated recoil.
+- [ ] Tune pistol, assault rifle and a heavy weapon first. Check sustained fire,
+  return to rest, hand motion, cover, drop/regrab and different frame rates.
+- [ ] Complete remaining projectile/mode fixes by weapon family and rerun the
+  matrix. Include flat/VR verification and on-device feel review.
+
+## Weapon/projectile audit matrix
+
+One row per weapon x setting x ammo/projectile variant, including melee and psi
+entries explicitly classified as separate firing paths. Enumerate from data;
+do not assume the default setting exercises every projectile.
+
+Record:
+
+| Field | Evidence required |
+| --- | --- |
+| Identity | Stable template, weapon name, model, setting and ammo |
+| Eligibility | Required stats/skills/research; actual rejection and feedback |
+| Firing | Trigger semantics, cooldown/burst, projectile count and ammo/energy cost |
+| Geometry | Muzzle source, barrel axis, spread, spawn position and owner filtering |
+| Projectile | Speed/gravity, collision, damage/stim, resistances and special behavior |
+| Presentation | Flash, casing/spawns, shot/empty/impact sounds and effect lifetime |
+| Lifecycle | Reload, mode/ammo change, breakage, drop/store, current-build save/load |
+| Verification | Authored expectation, original-code reference, flat result, VR result, evidence |
+
+Cover ballistic, energy, heavy and exotic weapons, all grenade types and special
+effects (EMP, stasis, splash, biological effects), and any secondary spawns.
+Use stable template/name discovery, deterministic SDK scenarios and explicit
+observed outcomes. Existing fast-projectile fixed damage is an audit target,
+not evidence that projectile damage parity is complete.
+
+## Definition of done
+
+Each implementation increment is separately reviewable with focused regression
+tests. Gameplay scenarios demonstrate failure before the fix and success after
+it. Visual changes include inspected matched before/after PNG and looping GIF
+evidence; shared UI renders are checked in flat and VR. Run the repository's
+required build and SDK checks before landing. Headless geometry evidence does
+not establish headset comfort or recoil feel: record a Quest validation pass
+and human feel assessment separately from automated checks.

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -3,6 +3,54 @@
 Status: agreed direction, 2026-09-08. Implementation and runtime verification are
 tracked below; a source inspection is not a completed projectile audit.
 
+## First implementation slice
+
+Implemented on `feat/weapon-feedback-workstream`: authored `BaseWeaponDesc`
+weapon-skill parsing, a shared trigger-time skill check, and a three-second
+refusal bound to the attempted weapon. An existing burst stops if the weapon
+becomes ineligible. Repeated pulls while the same notice is active do not extend
+its lifetime or stack messages. Flat and VR read the same active notice and
+shared message layout; meeting the requirement clears it immediately. VR
+anchors the text above the firing hand, including when the weapon supplies its
+own hand mesh, and for a trigger-driven weapon with no ammo readout. The amp
+retains its separate psi eligibility path. VR melee contact eligibility remains
+part of the broader audit; this slice gates `WeaponScript` trigger pulls.
+
+The first text is `Requires Standard Weapons 6 - You have 4` (ASCII separator
+for the shipped bitmap font). This slice adds no denial sound, stat/research
+gate, grip change, recoil, or projectile behavior change beyond skill gating.
+Those remain separate increments. Headset readability is not yet verified.
+
+Earth's `PlayerFactory` marker authors Standard 1 / Energy 2. Dark's
+`sim/plyrloop.cpp::create_player_obj` clones that marker's properties onto the
+player, and `shkplayr.cpp::GetWeaponSkills` reads them. Mission construction now
+copies that weapon-skill allowance onto the nonserialized runtime player;
+`player_skill_level` takes the maximum of it and the persistent trained skill.
+This maximum is the port's adaptation to its split runtime/career state, not
+an original-engine formula. The allowance is reconstructed on same-mission
+load and rederived on transition, so tutorial Energy 2 never becomes a permanent
+career reward. Character-sheet/trainer displays still show persistent training.
+
+The SDK scenario `weapon-skill-feedback.e2e.test.ts` exercises a real mission
+with an under-skilled rifle, checks unchanged ammo and message expiry while
+holding the trigger, and raises the skill to the authored threshold to verify
+firing. It covers flat and both VR hands. The unit rejection assertion was run
+red before connecting the gate and green afterward.
+
+Verification: 14 focused runtime cases pass, including Earth firing/reload,
+save/load and removal of its allowance on transition; flat and left/right VR
+refusals; and the affected projectile-effect scenarios. Rust library tests pass
+(166 dark, 1600 shock2vr, 2 ignored), as do warning-denied runtime/package checks
+and 63 fast SDK tests. All 23 mission-load smoke cases passed during this slice.
+The full SDK run was stopped after failures and is not a complete green run;
+the unrelated Watts reader assertion is already tracked by #1415. Complete the
+full suite and headset review before landing.
+
+[Flat and both-hand captures](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/presentations.png)
+and [notice-expiry GIF](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/right.gif)
+show the first presentation; a headless capture establishes placement, not
+headset comfort.
+
 ## Decisions
 
 - Establish original-game combat parity first, then layer deliberate VR
@@ -62,13 +110,13 @@ has not yet been established as an insufficient-skill rejection. Existing
 `script_util::player_skill_level` supplies the character-sheet lookup and
 `hud::message_line` supplies reusable status-text layout and expiry patterns.
 
-- [ ] Trace original requirement properties and current eligibility checks;
+- [x] Trace original requirement properties and current eligibility checks;
   reproduce a failed trigger with insufficient skill. Do not assume every
   silent trigger is an existing skill gate.
-- [ ] Return a structured rejection with required/current values and weapon
+- [x] Return a structured rejection with required/current values and weapon
   identity from shared gameplay code. VR presents it above the firing glove;
   flat presents the same content through shared canvas layout.
-- [ ] Show feedback on an actual failed attempt, rate-limit repeated pulls,
+- [x] Show feedback on an actual failed attempt, rate-limit repeated pulls,
   and avoid restarting it every frame while the trigger stays held.
 - [ ] Verify left/right hands, dual wield, support hand, weapon changes,
   untracked hands, use-mode suppression, and successful firing at the threshold.

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -27,17 +27,36 @@ pub fn create_wrist_hud_panels(
         .into_iter()
         .enumerate()
     {
-        if !poses[i].is_tracked()
-            || !crate::virtual_hand::shows_hand_visual(
-                world,
-                crate::wielded_weapon::held_by_hand(world, hand),
-            )
-        {
+        if !poses[i].is_tracked() {
             continue;
         }
         let root = Matrix4::from_translation(poses[i].position)
             * Matrix4::from(poses[i].rotation)
             * wrist_frames[i];
+        if let Some(notice) = crate::wielded_weapon::held_by_hand(world, hand).and_then(|weapon| {
+            crate::weapon_requirements::active_weapon_skill_notice(world, weapon)
+        }) {
+            let canvas = crate::hud::message_line::build_message_canvas(&[notice.message()]);
+            // Same pixel layout as the flat status line. Only the panel's
+            // world placement differs: above this glove.
+            let width = 0.32;
+            let transform = root
+                * Matrix4::from_translation(vec3(0.0, 0.06, 0.10))
+                * Matrix4::from_nonuniform_scale(
+                    width,
+                    width * canvas.size().y / canvas.size().x,
+                    1.0,
+                );
+            objects.extend(canvas.render_world_space(asset_cache, transform, None, None, 0.001));
+        }
+        // The refusal is available even when a weapon carries its own hand
+        // mesh. Only the physical wrist plates require a visible glove.
+        if !crate::virtual_hand::shows_hand_visual(
+            world,
+            crate::wielded_weapon::held_by_hand(world, hand),
+        ) {
+            continue;
+        }
         for (under, canvas) in [
             (false, readouts::build_watch_canvas(&bio)),
             (

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -50,6 +50,7 @@ pub mod ui;
 mod util;
 mod virtual_hand;
 mod vr_config;
+mod weapon_requirements;
 pub use hand_glove::{GloveRenderer, HandLight};
 /// Re-exported (the module itself stays private) so the `melee_grip` example
 /// can re-measure the melee `_h` contact offsets off the shipped rigs with the

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2708,6 +2708,27 @@ impl MissionCore {
             &template_to_entity_id,
         );
 
+        // Dark clones the PlayerFactory marker onto its new player. Earth
+        // authors Standard 1 / Energy 2 there for training. Keep this allowance
+        // on the nonserialized runtime player, not the persistent career sheet;
+        // reconstruct it even when a saved position overrides the spawn pose.
+        // MapDefault uses the last instantiated factory for its spawn, too.
+        let factory_weapon_skills = abstract_mission
+            .entity_info
+            .link_playerfactories
+            .iter()
+            .rev()
+            .find_map(|link| template_to_entity_id.get(&link.src))
+            .and_then(|factory| {
+                world
+                    .borrow::<View<dark::properties::PropBaseWeaponDesc>>()
+                    .ok()
+                    .and_then(|skills| skills.get(factory.0).ok().copied())
+            });
+        if let Some(skills) = factory_weapon_skills {
+            world.add_component(player_entity, skills);
+        }
+
         let player_handle = physics.create_player(start_pos, player_entity);
 
         world.add_unique(PlayerInfo {
@@ -8588,6 +8609,33 @@ impl MissionCore {
                         .push(text, now);
                 }
 
+                Effect::ShowWeaponSkillRequirement {
+                    entity_id,
+                    requirement,
+                } => {
+                    use crate::weapon_requirements::WeaponSkillNotice;
+                    let now = self.world.borrow::<UniqueView<Time>>().unwrap().total;
+                    let repeated = self
+                        .world
+                        .borrow::<View<WeaponSkillNotice>>()
+                        .ok()
+                        .and_then(|notices| {
+                            notices.get(entity_id).ok().map(|notice| {
+                                notice.expires > now && notice.requirement == requirement
+                            })
+                        })
+                        .unwrap_or(false);
+                    if !repeated {
+                        self.world.add_component(
+                            entity_id,
+                            WeaponSkillNotice {
+                                requirement,
+                                expires: now + std::time::Duration::from_secs(3),
+                            },
+                        );
+                    }
+                }
+
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,
@@ -10065,10 +10113,31 @@ impl MissionCore {
             .borrow::<UniqueView<Time>>()
             .map(|time| time.total)
             .unwrap_or_default();
-        self.world
+        let mut messages = self
+            .world
             .borrow::<UniqueViewMut<crate::hud::HudMessages>>()
             .map(|mut messages| messages.active(now))
-            .unwrap_or_default()
+            .unwrap_or_default();
+        // The flat status line and glove share the same weapon-bound notice,
+        // including expiry and immediate removal after training/equipping.
+        if let Some(requirement) =
+            crate::wielded_weapon::held_by_hand(&self.world, crate::vr_config::Handedness::Left)
+                .filter(|weapon| {
+                    self.world
+                        .borrow::<View<crate::runtime_props::RuntimePropFlatAim>>()
+                        .ok()
+                        .is_some_and(|aims| aims.get(*weapon).is_ok())
+                })
+                .and_then(|weapon| {
+                    crate::weapon_requirements::active_weapon_skill_notice(&self.world, weapon)
+                })
+        {
+            messages.push(requirement.message());
+            if messages.len() > crate::hud::message_line::MAX_LINES {
+                messages.remove(0);
+            }
+        }
+        messages
     }
 
     /// The status-message block in VR: the same canvas flat draws into its HUD,
@@ -12129,6 +12198,14 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 }
 
                 // Add weapon ammo (current clip) and wear when present
+                if let Some(requirement) =
+                    crate::weapon_requirements::active_weapon_skill_notice(&self.world, id)
+                {
+                    properties.push(DebugPropertyInfo {
+                        name: "WeaponSkillNotice".to_string(),
+                        value: requirement.message(),
+                    });
+                }
                 if let Ok(gun_state) = v_gun_state.get(id) {
                     properties.push(DebugPropertyInfo {
                         name: "Ammo".to_string(),

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -940,6 +940,11 @@ pub enum Effect {
         text: String,
     },
 
+    ShowWeaponSkillRequirement {
+        entity_id: EntityId,
+        requirement: crate::weapon_requirements::WeaponSkillRequirement,
+    },
+
     Multiple(Vec<Effect>),
     // Deprecated:
     // Use Multiple instead

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -384,13 +384,39 @@ pub fn can_cycle_gun_setting(world: &World, weapon: EntityId) -> bool {
     has_second_fire_mode(second_header.as_deref(), &links)
 }
 
-/// The player's level in one skill, or 0 in a world with no character sheet
-/// (the unit-test worlds). Every skill gate reads it the same way.
+/// The player's effective skill. Authored factory skills are a mission-local
+/// floor (Earth's training guns), reconstructed on load without granting
+/// permanent career upgrades. Dark stores both in its player property; our
+/// split runtime/persistent sheet combines them here. Missing data means zero.
 pub(crate) fn player_skill_level(world: &World, skill: crate::player_stats::Skill) -> i32 {
-    world
+    let trained = world
         .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
         .map(|quests| quests.player_stats().skill_level(skill))
-        .unwrap_or(0)
+        .unwrap_or(0);
+    use crate::player_stats::Skill;
+    let index = match skill {
+        Skill::StandardWeapons => 0,
+        Skill::EnergyWeapons => 1,
+        Skill::HeavyWeapons => 2,
+        Skill::ExoticWeapons => 3,
+        _ => return trained,
+    };
+    let authored = world
+        .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
+        .ok()
+        .and_then(|player| {
+            world
+                .borrow::<View<dark::properties::PropBaseWeaponDesc>>()
+                .ok()
+                .and_then(|skills| {
+                    skills
+                        .get(player.entity_id)
+                        .ok()
+                        .map(|skills| skills.0[index])
+                })
+        })
+        .unwrap_or(0);
+    trained.max(authored)
 }
 
 /// A gun's condition (`PropGunState`, 0..100), or `None` for a weapon that

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -320,7 +320,9 @@ impl Script for WeaponScript {
         };
         // A burst belongs to the pull that started it: a reload, or the gun
         // leaving the player's hands, ends it.
-        if is_reloading(world, entity_id) || !crate::wielded_weapon::held_in_hand(world, entity_id)
+        if is_reloading(world, entity_id)
+            || !crate::wielded_weapon::held_in_hand(world, entity_id)
+            || crate::weapon_requirements::unmet_weapon_skill(world, entity_id).is_some()
         {
             self.burst = None;
             return Effect::NoEffect;
@@ -361,6 +363,15 @@ impl Script for WeaponScript {
     ) -> Effect {
         match msg {
             MessagePayload::TriggerPull => {
+                if let Some(requirement) =
+                    crate::weapon_requirements::unmet_weapon_skill(world, entity_id)
+                {
+                    self.burst = None;
+                    return Effect::ShowWeaponSkillRequirement {
+                        entity_id,
+                        requirement,
+                    };
+                }
                 // Firing is blocked while a reload is in progress.
                 if is_reloading(world, entity_id) {
                     return Effect::NoEffect;
@@ -835,6 +846,24 @@ pub(super) fn create_projectile(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn an_untrained_trigger_returns_only_the_authored_requirement() {
+        let (mut world, physics, weapon, _) = flat_melee_fixture();
+        world.add_component(weapon, dark::properties::PropBaseWeaponDesc([6, 0, 0, 0]));
+        let effect = WeaponScript::new().handle_message(
+            weapon,
+            &world,
+            &physics,
+            &MessagePayload::TriggerPull,
+        );
+        assert!(matches!(effect, Effect::ShowWeaponSkillRequirement {
+            entity_id,
+            requirement: crate::weapon_requirements::WeaponSkillRequirement {
+                required: 6, current: 0, ..
+            },
+        } if entity_id == weapon));
+    }
+
     use cgmath::{Quaternion, point3, vec3};
     use dark::{motion::MotionFlags, properties::Links};
 

--- a/shock2vr/src/weapon_requirements.rs
+++ b/shock2vr/src/weapon_requirements.rs
@@ -1,0 +1,189 @@
+//! Shared authored weapon-skill eligibility and the short-lived refusal shown
+//! at the firing hand. The renderer never decides whether a weapon can fire.
+
+use std::time::Duration;
+
+use dark::properties::PropBaseWeaponDesc;
+use shipyard::{Component, EntityId, Get, View, World};
+
+use crate::{player_stats::Skill, scripts::script_util::player_skill_level};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WeaponSkillRequirement {
+    pub skill: Skill,
+    pub required: i32,
+    pub current: i32,
+}
+
+impl WeaponSkillRequirement {
+    pub fn message(self) -> String {
+        let name = match self.skill {
+            Skill::StandardWeapons => "Standard Weapons",
+            Skill::EnergyWeapons => "Energy Weapons",
+            Skill::HeavyWeapons => "Heavy Weapons",
+            Skill::ExoticWeapons => "Exotic Weapons",
+            _ => unreachable!("only weapon skills have weapon requirements"),
+        };
+        format!(
+            "Requires {name} {} - You have {}",
+            self.required, self.current
+        )
+    }
+}
+
+/// First unmet requirement, in the same class order as Dark's CheckWeaponSkills.
+/// Unauthored requirements impose no gate (e.g. the psi amp's separate path).
+pub fn unmet_weapon_skill(world: &World, weapon: EntityId) -> Option<WeaponSkillRequirement> {
+    let requirements = world.borrow::<View<PropBaseWeaponDesc>>().ok()?;
+    let requirements = requirements.get(weapon).ok()?;
+    [
+        Skill::StandardWeapons,
+        Skill::EnergyWeapons,
+        Skill::HeavyWeapons,
+        Skill::ExoticWeapons,
+    ]
+    .into_iter()
+    .zip(requirements.0)
+    .find_map(|(skill, required)| {
+        let current = player_skill_level(world, skill);
+        (current < required).then_some(WeaponSkillRequirement {
+            skill,
+            required,
+            current,
+        })
+    })
+}
+
+/// Transient visual state on the rejected weapon; never serialized. Binding it
+/// to the weapon keeps one hand's refusal off the other hand's gun.
+#[derive(Clone, Debug, Component)]
+pub struct WeaponSkillNotice {
+    pub requirement: WeaponSkillRequirement,
+    pub expires: Duration,
+}
+
+pub fn active_weapon_skill_notice(
+    world: &World,
+    weapon: EntityId,
+) -> Option<WeaponSkillRequirement> {
+    let notices = world.borrow::<View<WeaponSkillNotice>>().ok()?;
+    let notice = notices.get(weapon).ok()?;
+    let now = world
+        .borrow::<shipyard::UniqueView<crate::time::Time>>()
+        .ok()?
+        .total;
+    (notice.expires > now && unmet_weapon_skill(world, weapon) == Some(notice.requirement))
+        .then_some(notice.requirement)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quest_info::QuestInfo;
+
+    #[test]
+    fn required_skill_threshold_is_inclusive_and_classes_are_independent() {
+        let mut world = World::new();
+        let weapon = world.add_entity(PropBaseWeaponDesc([6, 0, 0, 0]));
+        let mut quests = QuestInfo::new();
+        quests.player_stats_mut().skills.standard_weapons = 4;
+        quests.player_stats_mut().skills.energy_weapons = 6;
+        world.add_unique(quests);
+        let failure = unmet_weapon_skill(&world, weapon).unwrap();
+        assert_eq!(
+            failure.message(),
+            "Requires Standard Weapons 6 - You have 4"
+        );
+        world
+            .borrow::<shipyard::UniqueViewMut<QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .skills
+            .standard_weapons = 6;
+        assert!(unmet_weapon_skill(&world, weapon).is_none());
+    }
+
+    #[test]
+    fn no_authored_requirement_allows_use() {
+        let mut world = World::new();
+        let weapon = world.add_entity(());
+        assert!(unmet_weapon_skill(&world, weapon).is_none());
+    }
+
+    #[test]
+    fn factory_skills_allow_training_without_upgrading_the_persistent_sheet() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let player = world.add_entity(PropBaseWeaponDesc([1, 2, 0, 0]));
+        world.add_unique(crate::mission::PlayerInfo {
+            pos: cgmath::vec3(0.0, 0.0, 0.0),
+            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: player,
+        });
+        let pistol = world.add_entity(PropBaseWeaponDesc([1, 0, 0, 0]));
+        let laser = world.add_entity(PropBaseWeaponDesc([0, 2, 0, 0]));
+        assert!(unmet_weapon_skill(&world, pistol).is_none());
+        assert!(unmet_weapon_skill(&world, laser).is_none());
+        assert_eq!(
+            world
+                .borrow::<shipyard::UniqueView<QuestInfo>>()
+                .unwrap()
+                .player_stats()
+                .skills
+                .energy_weapons,
+            0
+        );
+        world
+            .borrow::<shipyard::UniqueViewMut<QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .skills
+            .standard_weapons = 4;
+        assert_eq!(player_skill_level(&world, Skill::StandardWeapons), 4);
+        // A new mission rederives the player component instead of carrying
+        // training allowances into the recruit's persistent career.
+        world.remove::<(PropBaseWeaponDesc,)>(player);
+        assert_eq!(player_skill_level(&world, Skill::EnergyWeapons), 0);
+    }
+
+    #[test]
+    fn notices_expire_and_disappear_when_the_requirement_is_met() {
+        let mut world = World::new();
+        world.add_unique(crate::time::Time::default());
+        world.add_unique(QuestInfo::new());
+        let weapon = world.add_entity(PropBaseWeaponDesc([6, 0, 0, 0]));
+        let other_weapon = world.add_entity(PropBaseWeaponDesc([6, 0, 0, 0]));
+        let requirement = unmet_weapon_skill(&world, weapon).unwrap();
+        world.add_component(
+            weapon,
+            WeaponSkillNotice {
+                requirement,
+                expires: Duration::from_secs(3),
+            },
+        );
+        assert_eq!(
+            active_weapon_skill_notice(&world, weapon),
+            Some(requirement)
+        );
+        assert!(active_weapon_skill_notice(&world, other_weapon).is_none());
+        world
+            .borrow::<shipyard::UniqueViewMut<crate::time::Time>>()
+            .unwrap()
+            .total = Duration::from_secs(3);
+        assert!(active_weapon_skill_notice(&world, weapon).is_none());
+        world
+            .borrow::<shipyard::UniqueViewMut<crate::time::Time>>()
+            .unwrap()
+            .total = Duration::ZERO;
+        world
+            .borrow::<shipyard::UniqueViewMut<QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .skills
+            .standard_weapons = 6;
+        assert!(active_weapon_skill_notice(&world, weapon).is_none());
+    }
+}

--- a/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
+++ b/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
@@ -114,6 +114,9 @@ test(
     // Provisioning only supplies the loadout; aiming, firing, projectile
     // raycasts, proxy resolution, melee reach, and damage all use production
     // paths. This independently guards the issue's weapon-immunity symptom.
+    // A fresh Hydro3 sheet is untrained: provision the pistol's authored
+    // Standard 1 requirement so this exercises damage, not skill rejection.
+    await game.player.setStats({ skills: { standard_weapons: 1 } });
     await game.input.trigger("SpawnDebugItem");
     await game.step({ frames: 5 });
     const pistolBefore = hitPoints(await game.entities.detail(north.id));

--- a/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
+++ b/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
@@ -40,6 +40,8 @@ test(
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
     });
+    // Exercise pistol behavior with its authored Standard 1 requirement met.
+    await game.player.setStats({ skills: { standard_weapons: 1 } });
     await game.step({ frames: 5 });
 
     const clickScreen = async (rect: [number, number, number, number]) => {

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -39,6 +39,8 @@ test(
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
     });
+    // Exercise pistol behavior with its authored Standard 1 requirement met.
+    await game.player.setStats({ skills: { standard_weapons: 1 } });
 
     // Wield the pistol (first DebugCycleWeapon roster entry).
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
+++ b/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
@@ -27,6 +27,8 @@ test(
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
     });
+    // Exercise pistol behavior with its authored Standard 1 requirement met.
+    await game.player.setStats({ skills: { standard_weapons: 1 } });
 
     const bulletHoles = async () =>
       (await game.entities.list({ filter: "Bullet Hit", limit: 50 })).entities.filter(

--- a/tools/shock2-sdk/test/weapon-skill-feedback.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-skill-feedback.e2e.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { ammoOf, pullTrigger, cycleToWeapon, fireOnce } from "./helpers/weapon.js";
+
+test("Earth weapon training survives save/load without granting permanent skills", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 240_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "earth.mis" });
+  await game.step({ frames: 30 });
+  await game.player.spawnItem("Pistol");
+  await game.input.trigger("EquipPistol");
+  await game.step({ frames: 5 });
+  const ammo = async () => {
+    const id = (await game.info()).player.wielded_entity_id;
+    assert.ok(id);
+    return ammoOf(await game.entities.detail(id));
+  };
+  const before = await ammo();
+  assert.ok(before > 1);
+  await fireOnce(game);
+  assert.equal(await ammo(), before - 1, "Earth's authored allowance permits firing");
+  const saveName = `weapon_training_${Date.now()}`;
+  assert.equal((await game.save(saveName)).success, true);
+  assert.equal((await game.load(saveName)).success, true);
+  await fireOnce(game);
+  assert.equal(await ammo(), before - 2, "saved-position loads reconstruct the allowance");
+  assert.equal((await game.info()).player.stats?.skills.standard_weapons, 0);
+  assert.equal((await game.info()).player.stats?.skills.energy_weapons, 0);
+  await game.transitionLevel("medsci1.mis");
+  await game.step({ frames: 5 });
+  const afterTransition = await ammo();
+  await fireOnce(game);
+  assert.equal(await ammo(), afterTransition, "tutorial allowance does not leave Earth");
+  assert.ok((await game.ui.state()).messages.includes(
+    "Requires Standard Weapons 1 - You have 0",
+  ));
+});
+
+test("an under-skilled rifle attempt explains its requirement and training unlocks firing", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
+}, async () => {
+  // A real mission retains its low character sheet; debug_weapons deliberately
+  // caps every skill, which would never exercise the rejection.
+  await using game = await GameServer.launch({ mission: "medsci1.mis" });
+  await game.step({ frames: 5 });
+  await game.player.setStats({ skills: { standard_weapons: 4 } });
+  const rifle = await game.player.spawnItem("Assault Rifle");
+  await game.input.trigger("EquipAssaultRifle");
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.wielded_entity_id, rifle.entity_id);
+  const ammo = async () => ammoOf(await game.entities.detail(rifle.entity_id));
+  const before = await ammo();
+  assert.ok(before > 0, "the rifle must have ammunition to test the skill gate");
+  const expected = "Requires Standard Weapons 6 - You have 4";
+  await pullTrigger(game);
+  assert.equal(await ammo(), before, "a rejected shot consumes no ammunition");
+  assert.ok((await game.ui.state()).messages.includes(expected));
+  assert.equal((await game.entities.detail(rifle.entity_id)).properties.find(
+    p => p.name === "WeaponSkillNotice",
+  )?.value, expected);
+
+  await pullTrigger(game);
+  assert.equal((await game.ui.state()).messages.filter(m => m === expected).length, 1,
+    "repeated attempts must not stack identical messages");
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 190 });
+  assert.equal(await ammo(), before, "holding trigger does not bypass the gate");
+  assert.ok(!(await game.entities.detail(rifle.entity_id)).properties.some(
+    p => p.name === "WeaponSkillNotice",
+  ), "the notice expires while trigger stays held");
+  assert.ok(!(await game.ui.state()).messages.includes(expected),
+    "flat text expires with the weapon notice, without stale duplicate lines");
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 1 });
+
+  await pullTrigger(game);
+  assert.equal((await game.ui.state()).messages.filter(m => m === expected).length, 1);
+
+  await game.player.setStats({ skills: { standard_weapons: 6 } });
+  assert.ok(!(await game.ui.state()).messages.includes(expected),
+    "training immediately removes the obsolete requirement");
+  await pullTrigger(game);
+  assert.equal(await ammo(), before - 1, "the authored threshold allows a real shot");
+});
+
+test("a trigger refusal is visible for a weapon with no ammo readout", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "medsci1.mis" });
+  await game.step({ frames: 5 });
+  const shard = await game.player.spawnItem("Crystal Shard");
+  await game.input.trigger("EquipCrystalShard");
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.wielded_entity_id, shard.entity_id);
+  await pullTrigger(game);
+  assert.ok((await game.ui.state()).messages.includes(
+    "Requires Exotic Weapons 1 - You have 0",
+  ));
+});
+
+for (const hand of ["left", "right"] as const) {
+  test(`VR ${hand} hand: rejected shots explain the requirement and expire without firing`, {
+    skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
+  }, async () => {
+    await using game = await GameServer.launch({ mission: "medsci1.mis", debugFlags: ["--vr"] });
+    await game.step({ frames: 10 });
+    await game.player.setStats({ skills: { standard_weapons: 4 } });
+    const rifle = await cycleToWeapon(game, e => e.name === "Assault Rifle", { settleFrames: 90 });
+    await aimVrHandAt(game, rifle.position, 0.45, 1, 0, { hand });
+    await game.step({ frames: 8 });
+    const player = (await game.info()).player;
+    assert.equal(hand === "right" ? player.right_hand_entity_id : player.wielded_entity_id, rifle.id);
+    assert.equal(hand === "right" ? player.wielded_entity_id : player.right_hand_entity_id, null);
+    const ammo = async () => ammoOf(await game.entities.detail(rifle.id));
+    const notice = async () => (await game.entities.detail(rifle.id)).properties.find(
+      p => p.name === "WeaponSkillNotice",
+    )?.value;
+    const before = await ammo();
+    assert.ok(before > 0);
+    await game.input.set(`${hand}_hand.trigger`, 1);
+    await game.step({ frames: 1 });
+    assert.equal(await ammo(), before);
+    assert.equal(await notice(), "Requires Standard Weapons 6 - You have 4");
+    await game.step({ frames: 190 });
+    assert.equal(await notice(), undefined, "a held trigger must let the notice expire");
+    assert.equal(await ammo(), before, "a held trigger must not bypass the skill gate");
+    await game.input.set(`${hand}_hand.trigger`, 0);
+    await game.step({ frames: 1 });
+    await game.player.setStats({ skills: { standard_weapons: 6 } });
+    await game.input.set(`${hand}_hand.trigger`, 1);
+    await game.step({ frames: 1 });
+    assert.equal(await ammo(), before - 1, "the authored threshold permits firing in either hand");
+    assert.equal(await notice(), undefined);
+  });
+}


### PR DESCRIPTION
A character below a weapon’s authored skill requirement could fire because `BaseWeaponDesc` was not parsed or enforced. This adds the shared skill check and a three-second refusal above the firing glove, with the same text and lifetime in the flat HUD: `Requires Standard Weapons 6 - You have 4`. Rejected attempts consume no ammo; training to the threshold immediately clears the notice and permits firing.

The notice belongs to the attempted weapon, supports either VR hand and ammo-less trigger weapons, and does not stack or extend on repeated pulls. Earth’s authored Standard 1 / Energy 2 training allowance is reconstructed on the runtime player, including saved-position loads, without granting permanent career skills. The runtime allowance is an explicitly documented adaptation to the port’s separate persistent character sheet.

`projects/weapon-feel-workstream.md` records the agreed sequence: original combat parity first, then spring-based physical recoil with Strength improving VR recoil control. Recoil, projectile/mode auditing, dry-fire audio, required stats/research, and VR melee-contact eligibility remain later increments.

Validation:

- Rust libraries: dark 166 passed; shock2vr 1600 passed, 2 ignored. Two existing test-only compiler warnings remain.
- Warning-denied checks passed for shock2vr, desktop_runtime and debug_runtime; formatting and diff checks passed.
- SDK TypeScript build and 63 fast tests passed (462 runtime cases intentionally skipped).
- All 23 mission-load smoke cases passed during this slice.
- 14 focused runtime tests passed: authored refusal and unlock, both VR hands, ammo-less weapon text, Earth save/load/transition, reloads, close-range projectiles and the affected effects/combat fixtures.
- Full SDK run was stopped after recorded failures; it is not a complete green run. Caused firing-fixture failures were addressed and rerun. The reader assertion `-1 !== 251` matches the existing failure addressed in #1415. The broad weapon-selection failure was reproduced on immutable base `c0ae0e54`: template -28 provisioning returns 400, “no inventory container.”
- Independent source/duplication and Codex reviews completed; findings about stale flat notices, legacy hand meshes and ammo-less weapons were fixed. The Claude CLI reviewer stalled, so no Claude review is claimed.

Matched visual evidence against base `c0ae0e54`, using the same inputs and Standard Weapons 4: before, the assault rifle fires (ammo 12 → 11) with no refusal; after, ammo remains 12 and the requirement appears. The animated VR comparison also shows notice expiry.

![VR before and after](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/vr-before-after.gif)

![Right hand before and after](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/right-before-after.png)

![Flat before and after](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/flat-before-after.png)

Additional hand/presentation coverage:

![Flat and both VR hands](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/presentations.png)

![Right-hand requirement appears and expires](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/right.gif)

![Left-hand requirement appears and expires](https://gist.githubusercontent.com/tommy-xr/ed550c7bd1ae1809da251e03f6a5793c/raw/left.gif)

Headless flat and both-hand captures establish placement and expiry; headset readability/comfort remains unverified.
