### PR TITLE
fix(weapons): preserve projectile shooter filtering across saves

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -124,9 +124,17 @@ has not yet been established as an insufficient-skill rejection. Existing
 
 ### 2. Correct firing and physical handling
 
-- [ ] Fix shooter filtering for fast rays and physical projectiles. Near-chest
+- [x] Fix shooter filtering for fast rays and physical projectiles. Near-chest
   shots must not hit the firing player's capsule or held items accidentally.
   Preserve enemy hits, point-blank world obstruction and explosive self-damage.
+  Baseline #1050 already supplies the ray/physical filters. The next stacked
+  slice, `fix/projectile-owner-save`, fixes their save/load lifetime: a live
+  player-fired laser bolt was transparent to the player before saving and solid
+  after loading. Ownership now round-trips separately from launch provenance,
+  including entity remapping and held/world partitions. Enemy shots are not
+  inferred to be player-owned. It leaves blast damage and muzzle placement
+  unchanged; source-filter unit tests and the close-body VR psi scenario cover
+  the existing firing paths alongside the new real save/load regression.
 - [ ] Audit muzzle/vhot lookup and missing-vhot fallbacks for all held models.
   Ensure no fallback or clearance moves a shot through a wall.
 - [ ] Reproduce flash/casing regressions with matched world/held models. Inspect

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -345,13 +345,10 @@ pub struct RuntimePropProjectileRayOrigin(pub Point3<f32>);
 /// (`player_movement_filter`), so the player can walk through their own grenade
 /// at rest - preferred over the alternative of being able to shoot yourself.
 ///
-/// Not serialized, like every other runtime prop, and - unlike
-/// `RuntimePropLaunchedProjectile` - deliberately not restored on load either,
-/// matching `RuntimePropProjectileRayOrigin`: in-flight projectile state is
-/// already lossy across a save. The residual case is a save taken during the
-/// frame or two a bolt still overlaps the capsule, which reloads solid to the
-/// player. If that ever proves reachable in practice, mirror the
-/// `launched_projectiles` round-trip in `EntitySaveData`.
+/// Round-tripped separately in `EntitySaveData::player_fired_projectiles`,
+/// before physics reconstruction, so a saved shot does not become solid to its
+/// shooter after load. Launch provenance alone cannot restore ownership because
+/// enemy projectiles also carry `RuntimePropLaunchedProjectile`.
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropPlayerFiredProjectile;
 

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -7,7 +7,7 @@ use shipyard::{EntityId, World};
 
 use crate::runtime_props::{
     RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropLaunchedProjectile,
-    RuntimePropSelectedAmmo,
+    RuntimePropPlayerFiredProjectile, RuntimePropSelectedAmmo,
 };
 use crate::scripts::SavedScriptState;
 
@@ -39,6 +39,10 @@ pub struct EntitySaveData {
     /// from taking velocity ownership after load.
     #[serde(default)]
     pub launched_projectiles: Vec<u64 /* entity id */>,
+    /// Player-owned shots retain their shooter collision filter after load.
+    /// This is separate from launch provenance: enemy shots are launched too.
+    #[serde(default)]
+    pub player_fired_projectiles: Vec<u64 /* entity id */>,
     /// Opt-in private state owned by scripts on these entities. Registered ECS
     /// properties and links remain in their existing fields above; this is only
     /// for runtime modes, timers, latches, and similar script internals.
@@ -57,6 +61,7 @@ impl EntitySaveData {
             selected_ammo: HashMap::new(),
             canonical_template_ids: HashMap::new(),
             launched_projectiles: Vec::new(),
+            player_fired_projectiles: Vec::new(),
             script_states: Vec::new(),
         }
     }
@@ -128,6 +133,12 @@ impl EntitySaveData {
                 world.add_component(*new_entity_id, RuntimePropLaunchedProjectile);
             }
         }
+        for old_entity_id in &self.player_fired_projectiles {
+            let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
+            if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
+                world.add_component(*new_entity_id, RuntimePropPlayerFiredProjectile);
+            }
+        }
         (template_to_entity_id, old_entity_id_to_new_entity_id)
     }
 }
@@ -138,6 +149,69 @@ mod tests {
     use crate::scripts::{SavedScriptState, ScriptState, ScriptStateIdentity};
     use dark::properties::{Link, ToLink};
     use shipyard::{Get, View};
+
+    #[test]
+    fn player_projectile_ownership_round_trips_without_marking_enemy_shots() {
+        use crate::mission::{GlobalTemplateIdMap, PlayerInfo};
+        use crate::runtime_props::{RuntimePropDoNotSerialize, RuntimePropPlayerFiredProjectile};
+        let mut world = World::new();
+        let player = world.add_entity(RuntimePropDoNotSerialize);
+        let inventory = world.add_entity(());
+        let shot = world.add_entity((
+            RuntimePropPlayerFiredProjectile,
+            RuntimePropLaunchedProjectile,
+        ));
+        let held_shot = world.add_entity((
+            RuntimePropPlayerFiredProjectile,
+            RuntimePropLaunchedProjectile,
+        ));
+        let enemy_shot = world.add_entity(RuntimePropLaunchedProjectile);
+        let excluded =
+            world.add_entity((RuntimePropPlayerFiredProjectile, RuntimePropDoNotSerialize));
+        world.add_unique(GlobalTemplateIdMap(HashMap::new()));
+        world.add_unique(PlayerInfo {
+            pos: cgmath::vec3(0.0, 0.0, 0.0),
+            rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            inventory_entity_id: inventory,
+            left_hand_entity_id: Some(held_shot),
+            right_hand_entity_id: None,
+        });
+        let (saved, held) = crate::save_load::to_save_data(&world);
+        assert!(!saved.all_entities.contains(&excluded.inner()));
+        assert!(!saved.all_entities.contains(&held_shot.inner()));
+        for (data, expected) in [(saved, shot), (held.held_entities, held_shot)] {
+            let encoded = serde_json::to_string(&data).unwrap();
+            let decoded: EntitySaveData = serde_json::from_str(&encoded).unwrap();
+            let mut restored = World::new();
+            for _ in 0..20 {
+                restored.add_entity(());
+            }
+            let (_, remapped) = decoded.instantiate(&mut restored);
+            let markers = restored
+                .borrow::<View<RuntimePropPlayerFiredProjectile>>()
+                .unwrap();
+            assert_ne!(remapped[&expected], expected);
+            assert!(
+                markers.contains(remapped[&expected]),
+                "saved ownership must reach the remapped shot"
+            );
+            if let Some(enemy) = remapped.get(&enemy_shot) {
+                assert!(
+                    !markers.contains(*enemy),
+                    "enemy projectiles must still hit the player"
+                );
+                assert!(
+                    restored
+                        .borrow::<View<RuntimePropLaunchedProjectile>>()
+                        .unwrap()
+                        .contains(*enemy),
+                    "launch provenance must survive without granting player ownership"
+                );
+            }
+            assert!(!remapped.contains_key(&excluded));
+        }
+    }
 
     #[test]
     fn legacy_save_without_death_poses_defaults_to_empty() {

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     mission::{GlobalTemplateIdMap, PlayerInfo},
     runtime_props::{
         RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropDoNotSerialize,
-        RuntimePropLaunchedProjectile, RuntimePropSelectedAmmo,
+        RuntimePropLaunchedProjectile, RuntimePropPlayerFiredProjectile, RuntimePropSelectedAmmo,
     },
     scripts::{ScriptWorld, script_util},
     util::partition_map,
@@ -225,6 +225,14 @@ pub fn to_save_data_with_scripts(
             world_launched_projectiles.push(entity_id.inner());
         }
     }
+    let (held_player_fired_projectiles, world_player_fired_projectiles): (Vec<_>, Vec<_>) = world
+        .borrow::<View<RuntimePropPlayerFiredProjectile>>()
+        .unwrap()
+        .iter()
+        .with_id()
+        .map(|(entity_id, _)| entity_id.inner())
+        .filter(|entity_id| !entities_to_filter.contains(entity_id))
+        .partition(|entity_id| held_entities.contains(entity_id));
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
         template_id_to_entity_id: template_id_to_entity_id.0.clone(),
@@ -234,6 +242,7 @@ pub fn to_save_data_with_scripts(
         selected_ammo: world_selected_ammo,
         canonical_template_ids: world_canonical_templates,
         launched_projectiles: world_launched_projectiles,
+        player_fired_projectiles: world_player_fired_projectiles,
         script_states: world_script_states,
     };
 
@@ -246,6 +255,7 @@ pub fn to_save_data_with_scripts(
         selected_ammo: held_selected_ammo,
         canonical_template_ids: held_canonical_templates,
         launched_projectiles: held_launched_projectiles,
+        player_fired_projectiles: held_player_fired_projectiles,
         script_states: held_script_states,
     };
 

--- a/tools/shock2-sdk/test/projectile-owner-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/projectile-owner-save.e2e.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+test("a saved player projectile keeps its shooter filter after entity remapping", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
+}, async () => {
+  await using game = await GameServer.launch({ mission: "earth.mis" });
+  await game.step({ frames: 30 });
+  await game.player.spawnItem("Laser Pistol");
+  await game.input.trigger("EquipLaserPistol");
+  await game.step({ frames: 5 });
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0);
+
+  const shotBody = async () => {
+    const shots = (await game.entities.list({ filter: "Laser Shot", limit: 50 })).entities;
+    assert.equal(shots.length, 1, "the fired bolt must remain alive for the save");
+    const bodies = (await game.physics.bodies({ entityId: shots[0].id })).bodies;
+    assert.equal(bodies.length, 1);
+    return bodies[0];
+  };
+  assert.equal((await shotBody()).blocks_player, false);
+  assert.equal((await shotBody()).blocks_actor, true);
+  const save = `projectile_owner_${Date.now()}`;
+  assert.equal((await game.save(save)).success, true);
+  assert.equal((await game.load(save)).success, true);
+  assert.equal((await shotBody()).blocks_player, false,
+    "loading must not turn the player's own projectile solid to its shooter");
+  assert.equal((await shotBody()).blocks_actor, true,
+    "the restored projectile must still collide with enemies");
+});


### PR DESCRIPTION
A player-fired laser bolt ignored the player before saving but became solid to its shooter after loading. Persist player-shot ownership separately from launch provenance and restore it onto remapped entities before physics reconstruction. World and held entities follow the existing save partition/filter rules; launched enemy shots keep their ordinary collision filter.

Stacked on #1441. This completes the save/load portion of the plan’s shooter-filtering item; the baseline already contains #1050’s fast-ray and physical-projectile filters. Muzzle placement, blast damage, and presentation are unchanged.

Validation:

- Negative-first unit round-trip and real Earth laser save/load scenario both reproduced the lost ownership on the parent.
- 29 save-related unit tests pass; strengthened round-trip coverage checks held/world partitions, excluded entities, remapped IDs, and launched enemy shots.
- Existing fast-ray and physical shooter-filter unit regressions pass.
- Warning-denied checks pass for shock2vr, desktop_runtime and debug_runtime; formatting/diff checks pass.
- 29 SDK runtime cases pass, including all 23 mission loads, close-body VR cryokinesis, the real save/load regression, close-range/wall projectile checks, and slow-projectile impacts.
- Independent correctness/duplication and Codex reviews completed; the launched-enemy fixture was strengthened from review. Claude CLI review remains unavailable in this session.

Visual assessment: save-state and collision-filter restoration only. The SDK inspects live physics before and after a real save/load; screenshots would not establish the ownership marker. Full SDK suite remains required before landing the stack (the parent records existing unrelated failures).
