### PR TITLE
fix(weapons): resolve flash attachments by authored vhot ID

### DIFF
--- a/dark/examples/mesh_audit.rs
+++ b/dark/examples/mesh_audit.rs
@@ -50,7 +50,7 @@ fn main() {
         for v in &mesh.vhots {
             println!(
                 "  vhot {:?} ({:.3},{:.3},{:.3})",
-                v.vhot_type, v.point.x, v.point.y, v.point.z
+                v.id, v.point.x, v.point.y, v.point.z
             );
         }
         println!(

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -18,9 +18,7 @@ use engine::{
     },
     texture::{AnimatedTexture, TextureTrait},
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::FromPrimitive;
-use tracing::{trace, warn};
+use tracing::warn;
 
 use crate::{
     SCALE_FACTOR,
@@ -37,38 +35,19 @@ use crate::{
 // Dark LGMD polygons use clockwise front faces.
 const DARK_OBJECT_FRONT_FACE: FrontFaceWinding = FrontFaceWinding::Clockwise;
 
-#[derive(FromPrimitive, ToPrimitive, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum VhotType {
-    Unknown = 0,
-    LightSource = 1,
-    Anchor = 2,
-    Particle1 = 3,
-    Particle2 = 4,
-    Particle3 = 5,
-    Particle4 = 6,
-    Particle5 = 7,
-    LightSource2 = 8,
-}
-
 #[derive(Debug, Clone)]
 pub struct Vhot {
-    pub vhot_type: VhotType,
+    /// Authored attachment ID, not a type or an index into the file's table.
+    /// Dark's evaluated vhot table is keyed by this integer (`md_eval_vhots`).
+    pub id: u32,
     pub point: Point3<f32>,
 }
 
 impl Vhot {
     pub fn read<T: Read + Seek>(reader: &mut T) -> Vhot {
-        let vhot_type_num = read_u32(reader);
-        // Vhot ids outside the set we model are harmless - nothing reads the type
-        // today - so treat them as Unknown rather than refusing the whole model.
-        // (SCP's escpod.bin uses ids 10 and 11.)
-        let vhot_type = VhotType::from_u32(vhot_type_num).unwrap_or_else(|| {
-            trace!("unrecognized vhot type {vhot_type_num}, treating as Unknown");
-            VhotType::Unknown
-        });
-
+        let id = read_u32(reader);
         let point = read_point3(reader) / SCALE_FACTOR;
-        Vhot { vhot_type, point }
+        Vhot { id, point }
     }
 }
 
@@ -872,7 +851,8 @@ pub fn read_vhots<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Vec<
             vhots.push(Vhot::read(reader));
         }
     }
-    vhots.sort_by(|a, b| a.vhot_type.cmp(&b.vhot_type));
+    // Keep file order for consumers that explicitly need it. ID-based
+    // attachments must look up `Vhot::id`, including sparse/high identifiers.
     vhots
 }
 
@@ -1372,6 +1352,28 @@ mod tests {
             transparency: 0.0,
             emissivity: 0.0,
         }
+    }
+
+    #[test]
+    fn vhots_preserve_sparse_ids_and_authored_file_order() {
+        let mut header = header_with_mat_extra(8);
+        header.num_vhots = 4;
+        header.offset_vhots = 0;
+        let ids = [10_u32, 1, 0, u32::MAX];
+        let mut bytes = Vec::new();
+        for id in ids {
+            bytes.extend_from_slice(&id.to_le_bytes());
+            for coordinate in [1.0_f32, 2.0, 3.0] {
+                bytes.extend_from_slice(&(coordinate * SCALE_FACTOR).to_le_bytes());
+            }
+        }
+        let vhots = read_vhots(&header, &mut Cursor::new(bytes));
+        assert_eq!(vhots.iter().map(|vhot| vhot.id).collect::<Vec<_>>(), ids);
+        assert!(
+            vhots
+                .iter()
+                .all(|vhot| vhot.point == point3(-1.0, 3.0, 2.0))
+        );
     }
 
     /// Header with just the fields `read_extended_materials` reads.

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -84,7 +84,12 @@ and skill inaccuracy (#1406). Recheck earlier findings against this baseline.
   #1142. Uses blocking sweep contacts for held-gun impact audio without enabling
   projectile/solver collisions against the held gun.
 - [#1080](https://github.com/tommy-xr/shock2quest/pull/1080): open geometry-based
-  muzzle fallback fix; inspect before adding another implementation.
+  muzzle fallback fix. Reuse its bounds plumbing selectively: its claim that
+  `GunFlash.vhot` is a file index is incorrect. Dark's `gunflash.cpp` calls
+  `VHotGetLoc`, whose evaluated table is keyed by `v->id` in
+  `libsrc/md/render.c::md_eval_vhot_subobj`. `VHotGetRaw` is a distinct,
+  file-indexed helper. Preserve authored IDs and current scale-normalized shot
+  frames when adapting this reference.
 - [#1325](https://github.com/tommy-xr/shock2quest/pull/1325): open Sharpshooter
   damage work; coordinate rather than implement the trait twice.
 - [#140](https://github.com/tommy-xr/shock2quest/pull/140) is a query-name filter
@@ -137,6 +142,16 @@ has not yet been established as an insufficient-skill rejection. Existing
   the existing firing paths alongside the new real save/load regression.
 - [ ] Audit muzzle/vhot lookup and missing-vhot fallbacks for all held models.
   Ensure no fallback or clearance moves a shot through a wall.
+  The `fix/weapon-vhot-identities` layer preserves raw IDs (including sparse IDs
+  and values above 8) and file order, and resolves GunFlash attachments by ID.
+  It explicitly retains the current lowest-ID projectile muzzle choice for
+  existing weapon assets. Missing-muzzle geometry and obstruction are the next
+  separate layer; no unverified barrel-tip fallback is introduced here.
+  For sparse IDs, direct lookup intentionally avoids Dark's inconsistent
+  count-bound guard before its ID-keyed evaluated table. Inspected normal held
+  weapon models use dense IDs, so no visible change is claimed for those
+  assets. The existing VR muzzle regression now accounts for calibrated item
+  scale; its prior unscaled laser expectation failed on the parent as well.
 - [ ] Reproduce flash/casing regressions with matched world/held models. Inspect
   GunFlash flags, attachment point identity, orientation, visibility and lifetime.
   Muzzle flashes may follow the gun; ejected shells must detach correctly.

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -704,7 +704,8 @@ pub(super) fn create_muzzle_flash(
         .unwrap_or_default();
 
     let vhot_offset = vhots
-        .get(options.vhot as usize)
+        .iter()
+        .find(|vhot| vhot.id == options.vhot)
         .map(|v| v.point)
         .unwrap_or(point3(0.0, 0.0, 0.0));
 
@@ -789,7 +790,9 @@ pub(super) fn create_projectile(
         .get(entity_id)
         .map(|vhots| vhots.0.clone())
         .unwrap_or_default();
-    // The fire point is the model's first vhot, which the 25AE view models that
+    // Preserve the existing lowest-ID muzzle choice while removing the
+    // loader's implicit sort. Muzzle geometry/fallbacks are a separate layer.
+    // The fire point is the model's lowest-ID vhot, which the 25AE view models that
     // carry one author at the -X tip of the barrel (atek_h, ar15_h, sg_h,
     // lasehand, sfg_h, viro_h, amp_h).
     //
@@ -802,7 +805,8 @@ pub(super) fn create_projectile(
     // dying on the shooter, because a player-fired projectile's ray skips the
     // player's capsule (`player_fired_projectile` below).
     let muzzle = vhots
-        .first()
+        .iter()
+        .min_by_key(|vhot| vhot.id)
         .map(|v| v.point)
         .unwrap_or(point3(0.0, 0.0, 0.0));
 
@@ -846,6 +850,35 @@ pub(super) fn create_projectile(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn gun_flash_resolves_a_sparse_authored_vhot_id() {
+        let mut world = World::new();
+        let point = point3(-1.5, 0.2, 0.3);
+        let weapon = world.add_entity((
+            dark::properties::PropModelName("test_weapon".to_owned()),
+            RuntimePropTransform(Matrix4::from_scale(1.0)),
+            RuntimePropVhots(vec![
+                dark::ss2_bin_obj_loader::Vhot { id: 8, point },
+                muzzle_vhot(point3(-0.1, 0.0, 0.0)),
+            ]),
+        ));
+        for (id, expected) in [
+            (8, point),
+            (0, point3(-0.1, 0.0, 0.0)),
+            (1, point3(0.0, 0.0, 0.0)),
+        ] {
+            let Effect::CreateEntity { position, .. } =
+                create_muzzle_flash(&world, weapon, -1, &GunFlashOptions { vhot: id, flags: 0 })
+            else {
+                panic!("a GunFlash link must create an effect");
+            };
+            assert_eq!(
+                position, expected,
+                "GunFlash names an ID, not a vector index"
+            );
+        }
+    }
+
     #[test]
     fn an_untrained_trigger_returns_only_the_authored_requirement() {
         let (mut world, physics, weapon, _) = flat_melee_fixture();
@@ -1011,10 +1044,7 @@ mod tests {
     }
 
     fn muzzle_vhot(point: cgmath::Point3<f32>) -> dark::ss2_bin_obj_loader::Vhot {
-        dark::ss2_bin_obj_loader::Vhot {
-            vhot_type: dark::ss2_bin_obj_loader::VhotType::Unknown,
-            point,
-        }
+        dark::ss2_bin_obj_loader::Vhot { id: 0, point }
     }
 
     /// A VR shot leaves the model's muzzle vhot travelling down the barrel
@@ -1028,7 +1058,16 @@ mod tests {
         let transform = Matrix4::from_translation(translation) * Matrix4::from(rotation);
         let vhot = point3(-0.77, -0.03, 0.06);
 
-        let (origin, forward) = vr_fire_geometry(transform, vec![muzzle_vhot(vhot)]);
+        let (origin, forward) = vr_fire_geometry(
+            transform,
+            vec![
+                dark::ss2_bin_obj_loader::Vhot {
+                    id: 8,
+                    point: point3(0.0, 0.0, 0.0),
+                },
+                muzzle_vhot(vhot),
+            ],
+        );
 
         let expected_origin = translation + rotation * vhot.to_vec();
         let expected_forward = rotation * vec3(-1.0, 0.0, 0.0);

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -126,7 +126,13 @@ async function fireAndTrack(
   const weapon = await entityTransform(game, weaponId);
   const vhot = muzzleVhotFor(weapon.model, hand);
   assert.ok(vhot, `VR should wield a view model with a known muzzle vhot, got "${weapon.model}"`);
-  const muzzle = add(weapon.position, quatRotate(weapon.rotation, vhot));
+  // Grip calibration can scale the displayed item (the laser is 1.3x).
+  // The muzzle follows that rendered scale; projectile speed does not.
+  const grip = (await game.info()).player.hand_grips.find(g => g.hand === hand && g.entity_id === weaponId)?.grip;
+  // The psi amp retains its legacy hand mesh and has no glove item scaling.
+  const itemScale = grip?.item_scale ?? 1;
+  const scaledVhot: Vec3 = [vhot[0] * itemScale, vhot[1] * itemScale, vhot[2] * itemScale];
+  const muzzle = add(weapon.position, quatRotate(weapon.rotation, scaledVhot));
   // The 25AE view models are authored with the barrel along the model's -X.
   const barrel = quatRotate(weapon.rotation, [-1, 0, 0]);
 


### PR DESCRIPTION
GunFlash attachments treated an authored vhot ID as a vector index, so sparse IDs fell back to the gun origin or selected the wrong point. Preserve raw `u32` IDs and file order, then resolve attachments by ID. Existing weapon projectile origins retain the previous lowest-ID selection until the separate muzzle-geometry layer.

Stacked on #1442. This corrects a finding in reference #1080 before adapting its geometry changes: `gunflash.cpp` calls `VHotGetLoc`, and `md_eval_vhot_subobj` writes `mdd_vhot_tab[v->id]`. `VHotGetRaw` is a separate file-index helper. Direct lookup intentionally accepts valid sparse IDs instead of reproducing Dark’s inconsistent count-bound guard before its ID table.

Validation:

- Negative-first sparse-ID GunFlash test reproduced origin fallback; corrected lookup passes ID8, shuffled ID0, and missing-ID cases.
- Parser test covers shuffled/sparse/high IDs and coordinate conversion. Projectile test pins lowest-ID selection from an unsorted table. Four focused Rust tests pass.
- Warning-denied package checks and examples check pass; formatting/diff checks pass.
- Flat muzzle-flash and four two-hand support runtime cases pass. Both-hand laser tests exposed a preexisting expectation that ignored 1.3x grip scale, reproduced on an immutable parent binary; the fixture now follows calibrated item scale and retains the unscaled legacy amp path. All three corrected muzzle cases pass on both the immutable parent and this layer (8 focused runtime cases pass in total).
- Independent source/duplication and Codex reviews found no blockers; the unsorted-projectile fixture was strengthened from review.

Visual assessment: 13 installed KPF/CRF archives were inspected (151 vhot-bearing model records). Normal held gun models use dense IDs, so no player-visible delta is claimed or illustrated with unrelated captures. The sparse `sg_w` asset has ID1, but normal held shotgun uses dense `sg_h`; sparse behavior is demonstrated by focused effect assertions. GunFlash flags/casing detachment and missing-muzzle geometry remain subsequent layers. Full SDK validation remains required before landing the stack.
