### PR TITLE
fix(vr): launch missing-vhot shots from the visible barrel

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -160,6 +160,30 @@ has not yet been established as an insufficient-skill rejection. Existing
 - [ ] Adapt #1142/#1153 to current main. Verify fitted gun-only colliders,
   wall stops, material impact sounds, rotation into walls and lifecycle cleanup.
 
+### Muzzle geometry implementation
+
+The next stacked layer selects authored muzzle ID 0 first. Known weapon models
+without that point use the center of their frontmost gun-only polygon cap;
+arm materials are excluded through the existing glove geometry importer.
+Explicit barrel-frame profiles distinguish world -Z guns from held -X guns.
+Unknown models retain their prior lowest-ID/origin behavior. Model swaps and
+current-build loads regenerate the fallback, and left-hand reflection applies
+to both the authored point and fallback. Projectile frames remain normalized,
+so grip scaling changes muzzle placement without changing speed.
+
+Spawn clearance begins at the tracked firing palm (the camera in flatscreen),
+not the calibrated model origin. It sweeps an enclosing sphere for authored
+projectile radii/offsets and a tiny sphere for point projectiles, excluding the
+player and held objects while retaining anonymous level geometry. Spawn
+translation also applies to projectile trails. This prevents forward muzzle
+placement across a wall; a controller already pushed into the wall still needs
+the later physical-held collision work.
+
+Matched EMP footage demonstrates the former inside-gun origin and corrected
+barrel-tip origin. Independent archive polygon decoding supplies regression
+coordinates for both hands. This layer does not implement GunFlash launch/
+random-bank flags or physical recoil; those remain separate increments.
+
 ### 3. Recoil, VR augmentation and audit completion
 
 - [ ] Implement authored accuracy/recoil behavior in shared gameplay code,

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -166,6 +166,11 @@ pub trait PlayerInteraction {
     /// right, matching the right-hand trigger it fires with.
     fn holding_hand(&self, entity_id: EntityId) -> Option<Handedness>;
 
+    /// Tracked palm on the firing side of a held weapon's muzzle offset.
+    fn held_launch_origin(&self, _entity_id: EntityId) -> Option<Point3<f32>> {
+        None
+    }
+
     /// Whether `entity_id` is currently held. Answered from
     /// [`Self::holding_hand`] so "is it held" and "which hand holds it" cannot
     /// give different answers.
@@ -1381,6 +1386,19 @@ impl PlayerInteraction for VrInteraction {
         self.right_hand = self.right_hand.destroy_entity(entity_id);
     }
 
+    fn held_launch_origin(&self, entity_id: EntityId) -> Option<Point3<f32>> {
+        let index = [&self.left_hand, &self.right_hand]
+            .iter()
+            .position(|hand| hand.get_held_entity() == Some(entity_id))?;
+        let pose = self.hand_poses()[index];
+        let palm = self
+            .grip_kinematics
+            .as_ref()
+            .map_or(Vector3::new(0.0, 0.0, 0.0), |rig| rig[index].palm);
+        let point = pose.point(palm);
+        Some(Point3::new(point.x, point.y, point.z))
+    }
+
     fn holding_hand(&self, entity_id: EntityId) -> Option<Handedness> {
         if self.left_hand.is_holding(entity_id) {
             Some(Handedness::Left)
@@ -1585,6 +1603,25 @@ mod tests {
         input.left_hand.rotation = identity();
         input.left_hand.squeeze_value = 0.0;
         (world, entity, physics, interaction, input)
+    }
+
+    #[test]
+    fn weapon_clearance_starts_at_palm_despite_model_anchor_offset() {
+        let (world, entity, physics, mut interaction, input) = wrench_support_fixture();
+        interaction.grip_kinematics.as_mut().unwrap()[1].palm = vec3(0.0, 0.0, 0.1);
+        interaction.fitted_grips[1]
+            .as_mut()
+            .unwrap()
+            .resolved
+            .as_mut()
+            .unwrap()
+            .offset = vec3(0.0, 0.0, 0.5);
+        interaction.update(&context(&world, &physics, &input));
+        let start = interaction.held_launch_origin(entity).unwrap();
+        assert!(
+            (start.z - 0.1).abs() < 0.001,
+            "must start at the palm, not the offset model: {start:?}"
+        );
     }
 
     #[test]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -50,6 +50,7 @@ pub mod ui;
 mod util;
 mod virtual_hand;
 mod vr_config;
+mod weapon_muzzle;
 mod weapon_requirements;
 pub use hand_glove::{GloveRenderer, HandLight};
 /// Re-exported (the module itself stays private) so the `melee_grip` example

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1,3 +1,4 @@
+use cgmath::InnerSpace;
 use std::{collections::HashMap, rc::Rc};
 
 use crate::{
@@ -138,6 +139,27 @@ pub fn create_entity_with_position(
     let _time_in_seconds = {
         let u_time = world.borrow::<UniqueView<Time>>().unwrap();
         u_time.total.as_secs_f32()
+    };
+
+    let root_transform = if let Some(origin) = additional_options.projectile_launch_origin {
+        // Enclose the authored projectile sphere, including its local offset.
+        let radius = world
+            .borrow::<View<PropPhysDimensions>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|dims| dims.radius0.abs().max(dims.radius1.abs()) + dims.offset0.magnitude())
+            .unwrap_or(0.0);
+        let requested = root_transform.transform_point(position);
+        let clamped = crate::weapon_muzzle::clamp_projectile_spawn(
+            physics,
+            origin,
+            requested,
+            radius,
+            &|entity| !crate::wielded_weapon::held_in_hand(world, entity),
+        );
+        Matrix4::from_translation(clamped - requested) * root_transform
+    } else {
+        root_transform
     };
 
     let transformed_position = root_transform.transform_point(position);
@@ -656,6 +678,7 @@ fn create_model(
         _v_rendertype,
         v_scale,
         mut rv_vhots,
+        mut rv_muzzle,
     ) = world
         .borrow::<(
             EntitiesView,
@@ -667,6 +690,7 @@ fn create_model(
             View<PropRenderType>,
             View<PropScale>,
             ViewMut<RuntimePropVhots>,
+            ViewMut<crate::weapon_muzzle::MuzzleFallback>,
         )>()
         .unwrap();
 
@@ -681,6 +705,9 @@ fn create_model(
 
         let vhots = model.vhots();
         entities.add_component(entity_id, &mut rv_vhots, RuntimePropVhots(vhots));
+        if let Some(muzzle) = crate::weapon_muzzle::load_fallback(asset_cache, &model_name) {
+            entities.add_component(entity_id, &mut rv_muzzle, muzzle);
+        }
 
         let qrotation = pos.rotation;
         let rotation = Matrix4::<f32>::from(qrotation);
@@ -1657,6 +1684,11 @@ pub struct CreateEntityOptions {
     /// projectile. Flat firing supplies the camera origin while retaining the
     /// forward spawn clearance needed by slow physics projectiles.
     pub projectile_raycast_origin: Option<Point3<f32>>,
+    /// Starting side of a player-shot spawn offset (camera or held gun grip).
+    /// Checked against world geometry before applying the requested muzzle pose.
+    pub projectile_launch_origin: Option<Point3<f32>>,
+    /// VR weapon whose tracked palm supplies the launch clearance start.
+    pub projectile_weapon: Option<EntityId>,
     /// The player fired this projectile, so its collision ray must skip the
     /// player's own capsule (see `RuntimePropPlayerFiredProjectile`).
     pub player_fired_projectile: bool,
@@ -1682,6 +1714,8 @@ impl Default for CreateEntityOptions {
             attach_to: None,
             transient_fx: false,
             projectile_raycast_origin: None,
+            projectile_launch_origin: None,
+            projectile_weapon: None,
             player_fired_projectile: false,
             launch_projectile: false,
             shot_modifiers: None,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5811,6 +5811,11 @@ impl MissionCore {
         root_transform: Matrix4<f32>,
         additional_options: CreateEntityOptions,
     ) -> EntityCreationInfo {
+        let mut additional_options = additional_options;
+        additional_options.projectile_launch_origin = additional_options
+            .projectile_weapon
+            .and_then(|weapon| self.interaction.held_launch_origin(weapon))
+            .or(additional_options.projectile_launch_origin);
         self.create_entity_with_position_and_rider_depth(
             asset_cache,
             template_id,
@@ -5841,6 +5846,7 @@ impl MissionCore {
         exclude_template: Option<i32>,
     ) -> EntityCreationInfo {
         let transient_fx = additional_options.transient_fx;
+        let has_spawn_clearance = additional_options.projectile_launch_origin.is_some();
         let created_entity = {
             entity_creator::create_entity_with_position(
                 template_id,
@@ -5869,6 +5875,17 @@ impl MissionCore {
             created_entity,
             root_transform,
         );
+
+        // Spawn clearance may move the projectile before physics is built.
+        // Apply that same translation to trails instantiated below.
+        let root_transform = if has_spawn_clearance {
+            let positions = self.world.borrow::<View<PropPosition>>().unwrap();
+            let actual = positions.get(info.entity_id).unwrap().position;
+            Matrix4::from_translation(actual - root_transform.transform_point(position).to_vec())
+                * root_transform
+        } else {
+            root_transform
+        };
 
         // Instantiate the particle groups authored to ride this archetype
         // (`ParticleAttachement` links from particle archetypes to this
@@ -7967,6 +7984,8 @@ impl MissionCore {
                             );
                         }
                         let mut vhots = new_model.vhots();
+                        let mut muzzle =
+                            crate::weapon_muzzle::load_fallback(asset_cache, &model_name);
                         // Which hand a VR wield renders for. The `_h` models
                         // are all authored right-handed, so a left-hand wield
                         // draws the mirror image. A model applied while
@@ -7989,6 +8008,10 @@ impl MissionCore {
                             new_model.apply_local_transform(mirror);
                             for vhot in vhots.iter_mut() {
                                 vhot.point = mirror.transform_point(vhot.point);
+                            }
+                            if let Some(muzzle) = muzzle.as_mut() {
+                                muzzle.point = mirror.transform_point(muzzle.point);
+                                muzzle.axis = mirror.transform_vector(muzzle.axis);
                             }
                         }
                         // An articulated VR-wielded first-person model (hand +
@@ -8144,6 +8167,11 @@ impl MissionCore {
                             .add_component(entity_id, PropModelName(model_name));
 
                         self.world.add_component(entity_id, RuntimePropVhots(vhots));
+                        self.world
+                            .remove::<crate::weapon_muzzle::MuzzleFallback>(entity_id);
+                        if let Some(muzzle) = muzzle {
+                            self.world.add_component(entity_id, muzzle);
+                        }
                     }
                 }
                 Effect::ClearModel { entity_id } => {
@@ -8153,29 +8181,10 @@ impl MissionCore {
                     self.world.remove::<(
                         PropModelName,
                         RuntimePropVhots,
+                        crate::weapon_muzzle::MuzzleFallback,
                         crate::runtime_props::RuntimePropGloveWeapon,
                     )>(entity_id);
                     self.world.remove::<RuntimePropVrGripOffset>(entity_id);
-                }
-                Effect::SetVhotsFromModel {
-                    entity_id,
-                    model_name,
-                } => {
-                    if let Some(model) = self.id_to_model.get(&entity_id) {
-                        let xform = model.get_transform();
-                        // Same hazard as ChangeModel above: a missing donor
-                        // model must not panic the frame.
-                        let Some(donor_model) =
-                            asset_cache.get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
-                        else {
-                            tracing::error!(
-                                "SetVhotsFromModel: model '{model_name}.BIN' could not be loaded for entity {entity_id:?} - keeping current vhots"
-                            );
-                            continue;
-                        };
-                        let vhots = Model::transform(donor_model.as_ref(), xform).vhots();
-                        self.world.add_component(entity_id, RuntimePropVhots(vhots));
-                    }
                 }
                 Effect::PlayEmail { deck, email, force } => {
                     let email_file = get_email_sound_file(deck, email);

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -6317,6 +6317,50 @@ impl PhysicsWorld {
     /// Ownerless world geometry is always retained. This is intentionally the
     /// same all-membership query as [`Self::ray_cast2`]; callers use it only
     /// when a semantic relationship makes one entity transparent to the ray.
+    /// Sweep a projectile's enclosing sphere through its forward spawn offset.
+    pub(crate) fn projectile_spawn_distance(
+        &self,
+        origin: Point3<f32>,
+        direction: Vector3<f32>,
+        distance: f32,
+        radius: f32,
+        can_hit: &dyn Fn(EntityId) -> bool,
+    ) -> f32 {
+        let predicate = |_: ColliderHandle, collider: &Collider| {
+            EntityId::from_inner(collider.user_data as u64).is_none_or(can_hit)
+        };
+        let groups = InternalCollisionGroups::ALL_COLLIDABLE & !InternalCollisionGroups::PLAYER;
+        let filter = QueryFilter::default()
+            .exclude_sensors()
+            .predicate(&predicate)
+            .groups(InteractionGroups::new(
+                InternalCollisionGroups::ALL.bits.into(),
+                groups.bits.into(),
+                Default::default(),
+            ));
+        let queries = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
+            &self.rigid_body_set,
+            &self.collider_set,
+            filter,
+        );
+        queries
+            .cast_shape(
+                &Isometry::translation(origin.x, origin.y, origin.z),
+                &vector![direction.x, direction.y, direction.z],
+                &Ball::new(radius),
+                rapier3d::parry::query::ShapeCastOptions {
+                    max_time_of_impact: distance,
+                    target_distance: 0.01,
+                    // A palm close to a wall may start the enclosing sphere
+                    // overlapping it; permit a shot moving back into clear space.
+                    stop_at_penetration: false,
+                    compute_impact_geometry_on_penetration: true,
+                },
+            )
+            .map_or(distance, |(_, hit)| hit.time_of_impact)
+    }
+
     pub fn ray_cast2_with_entity_filter(
         &self,
         start_point: Point3<f32>,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -561,14 +561,6 @@ pub enum Effect {
     ClearModel {
         entity_id: EntityId,
     },
-    /// Replace the entity's fire-point vhots with those of `model_name`
-    /// without changing the rendered model. Used by the VR held-weapon path:
-    /// the world model stays rendered (#352), but its mesh has no vhots -
-    /// the muzzle points live in the _h viewmodel.
-    SetVhotsFromModel {
-        entity_id: EntityId,
-        model_name: String,
-    },
     CreateEntityByTemplateName {
         source_entity_id: EntityId,
         template_name: String,

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -63,15 +63,8 @@ impl Script for InternalSwitchHeldModelScript {
                         }
                     }
 
-                    // The world model stays rendered, but its mesh has no
-                    // vhots - take the fire points (muzzle) from the hand
-                    // model so projectiles/flash don't spawn at the grip.
-                    if let Some(view_model) = get_view_model(world, entity_id) {
-                        effects.push(Effect::SetVhotsFromModel {
-                            entity_id,
-                            model_name: view_model,
-                        });
-                    }
+                    // Keep the world model's own attachment IDs and barrel
+                    // geometry. A hand-model donor can have different axes.
 
                     return Effect::Multiple(effects);
                 }

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -40,23 +40,6 @@ const MELEE_DAMAGE: f32 = 6.0;
 /// guns for now; per-weapon loudness is a follow-up.
 const GUNSHOT_NOISE_RADIUS: f32 = 50.0 / SCALE_FACTOR;
 
-/// Rotation taking the projectile's +Z travel axis onto the barrel of a 25AE
-/// first-person gun model, which is authored along the model's **-X** - that is
-/// where each of those meshes puts its muzzle vhot, and pointing that axis out
-/// of the hand is the whole job of every gun's -90 degree yaw in the
-/// `vr_config` grip table (pinned by its
-/// `gun_grips_aim_the_barrel_out_of_the_hand` test). So this one rotation aims
-/// every VR weapon - ballistic, energy and psi alike - down its own rendered
-/// barrel, with no per-weapon correction.
-///
-/// Caveat, pre-existing and unchanged by this: several *classic-install* world
-/// models (`atek_w`, `ar15_w`, `sg_w`, `gren_w`, `viro_w`, `al_w`) are authored
-/// barrel-along-Z instead, so VR mis-aims them by 90 degrees when the 25AE view
-/// models are unavailable. Tracked in #1034.
-fn barrel_axis_from_forward() -> Quaternion<f32> {
-    Quaternion::from_angle_y(Deg(-90.0))
-}
-
 /// The weapon entity's current world position (from its live transform).
 fn weapon_world_position(world: &World, entity_id: EntityId) -> Option<cgmath::Vector3<f32>> {
     let v_transform = world.borrow::<View<RuntimePropTransform>>().ok()?;
@@ -707,7 +690,7 @@ pub(super) fn create_muzzle_flash(
         .iter()
         .find(|vhot| vhot.id == options.vhot)
         .map(|v| v.point)
-        .unwrap_or(point3(0.0, 0.0, 0.0));
+        .unwrap_or_else(|| crate::weapon_muzzle::resolve(world, entity_id).point);
 
     let transform = v_transform.get(entity_id).unwrap();
 
@@ -771,6 +754,7 @@ pub(super) fn create_projectile(
                 options: CreateEntityOptions {
                     force_visible: true,
                     projectile_raycast_origin: Some(aim.origin),
+                    projectile_launch_origin: Some(aim.origin),
                     shot_modifiers: Some(modifiers),
                     player_fired_projectile: true,
                     ..CreateEntityOptions::default()
@@ -784,40 +768,13 @@ pub(super) fn create_projectile(
     // travelling down the model's barrel. Both are read from the weapon's own
     // live transform, so no per-weapon aim correction is involved.
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
-    let v_vhots = world.borrow::<View<RuntimePropVhots>>().unwrap();
-
-    let vhots = v_vhots
-        .get(entity_id)
-        .map(|vhots| vhots.0.clone())
-        .unwrap_or_default();
-    // Preserve the existing lowest-ID muzzle choice while removing the
-    // loader's implicit sort. Muzzle geometry/fallbacks are a separate layer.
-    // The fire point is the model's lowest-ID vhot, which the 25AE view models that
-    // carry one author at the -X tip of the barrel (atek_h, ar15_h, sg_h,
-    // lasehand, sfg_h, viro_h, amp_h).
-    //
-    // Documented fallback for a model with no vhot at all: the model origin,
-    // i.e. the grip. The shot still leaves along the barrel, just from the
-    // hand. This is not rare - `empgun_h`, `gren_h`, `fsn_h` and `al_h` ship
-    // with zero vhots, as do most classic-install world models. Where the shot
-    // *starts* is still only as good as the model, and #1034 tracks giving the
-    // vhotless ones a better fire point; what is no longer at stake is the shot
-    // dying on the shooter, because a player-fired projectile's ray skips the
-    // player's capsule (`player_fired_projectile` below).
-    let muzzle = vhots
-        .iter()
-        .min_by_key(|vhot| vhot.id)
-        .map(|v| v.point)
-        .unwrap_or(point3(0.0, 0.0, 0.0));
+    let muzzle = crate::weapon_muzzle::resolve(world, entity_id);
 
     let transform = v_transform.get(entity_id).unwrap();
 
     // Item size changes muzzle placement, never projectile size or speed.
-    let origin = transform.0.transform_point(muzzle);
-    let forward = transform
-        .0
-        .transform_vector(barrel_axis_from_forward() * cgmath::Vector3::unit_z())
-        .normalize();
+    let origin = transform.0.transform_point(muzzle.point);
+    let forward = transform.0.transform_vector(muzzle.axis).normalize();
     let up = transform
         .0
         .transform_vector(cgmath::vec3(0.0, 1.0, 0.0))
@@ -843,6 +800,8 @@ pub(super) fn create_projectile(
             force_visible: true,
             shot_modifiers: Some(modifiers),
             player_fired_projectile: true,
+            projectile_launch_origin: Some(transform.0.transform_point(point3(0.0, 0.0, 0.0))),
+            projectile_weapon: Some(entity_id),
             ..CreateEntityOptions::default()
         },
     }
@@ -865,7 +824,7 @@ mod tests {
         for (id, expected) in [
             (8, point),
             (0, point3(-0.1, 0.0, 0.0)),
-            (1, point3(0.0, 0.0, 0.0)),
+            (1, point3(-0.1, 0.0, 0.0)),
         ] {
             let Effect::CreateEntity { position, .. } =
                 create_muzzle_flash(&world, weapon, -1, &GunFlashOptions { vhot: id, flags: 0 })

--- a/shock2vr/src/weapon_muzzle.rs
+++ b/shock2vr/src/weapon_muzzle.rs
@@ -1,0 +1,227 @@
+//! Muzzle geometry in the rendered weapon's local frame. Authored ID 0 wins;
+//! missing points use the barrel end of the visible gun, excluding its arms.
+use cgmath::{EuclideanSpace, InnerSpace, Point3, Vector3, point3, vec3};
+use collision::{Aabb, Aabb3};
+use dark::{
+    importers::{GLOVE_WEAPON_IMPORTER, GRIP_SURFACE_IMPORTER},
+    properties::PropModelName,
+};
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{Component, EntityId, Get, View, World};
+
+use crate::{physics::PhysicsWorld, runtime_props::RuntimePropVhots};
+
+#[derive(Component, Clone, Copy, Debug)]
+pub(crate) struct MuzzleFallback {
+    pub point: Point3<f32>,
+    pub axis: Vector3<f32>,
+}
+
+/// These are authored weapon frames, not an inference from the longest mesh
+/// extent (which can instead measure an arm). Unknown assets retain old aim.
+fn barrel_axis(name: &str) -> Option<Vector3<f32>> {
+    match name.to_ascii_lowercase().trim_end_matches(".bin") {
+        "atek_w" | "ar15_w" | "sg_w" | "gren_w" | "viro_w" | "al_w" => Some(vec3(0.0, 0.0, -1.0)),
+        "atek_h" | "ar15_h" | "sg_h" | "lasehand" | "empgun_h" | "gren_h" | "fsn_h" | "al_h"
+        | "sfg_h" | "viro_h" | "amp_h" | "laser" | "empgun" | "fsn_w" | "sfg_w" | "amp_w" => {
+            Some(vec3(-1.0, 0.0, 0.0))
+        }
+        _ => None,
+    }
+}
+
+fn barrel_end(triangles: &[[Point3<f32>; 3]], axis: Vector3<f32>) -> Option<Point3<f32>> {
+    let points = triangles
+        .iter()
+        .flatten()
+        .copied()
+        .filter(|p| p.x.is_finite() && p.y.is_finite() && p.z.is_finite());
+    let (near, far) = points
+        .clone()
+        .map(|p| p.to_vec().dot(axis))
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(near, far), p| {
+            (near.min(p), far.max(p))
+        });
+    if !far.is_finite() {
+        return None;
+    }
+    // Bound only the front cap, not the entire gun's cross-section: a stock,
+    // magazine or grip below the barrel must not pull its muzzle downward.
+    let cap = points
+        .filter(|p| p.to_vec().dot(axis) >= far - (far - near).max(0.01) * 0.001)
+        .fold(None, |bounds: Option<Aabb3<f32>>, p| {
+            Some(bounds.map_or_else(|| Aabb3::new(p, p), |b| b.grow(p)))
+        })?;
+    let center = cap.min + (cap.max - cap.min) * 0.5;
+    Some(center + axis * (far - center.to_vec().dot(axis)))
+}
+
+/// Cached by the normal asset importers; called on model load/swap, not per shot.
+pub(crate) fn load_fallback(cache: &mut AssetCache, name: &str) -> Option<MuzzleFallback> {
+    let name = name.to_ascii_lowercase();
+    let name = name.trim_end_matches(".bin");
+    let axis = barrel_axis(name)?;
+    let filename = format!("{name}.bin");
+    let glove = cache.get_opt(&GLOVE_WEAPON_IMPORTER, &filename);
+    let point = if let Some(source) = glove.as_ref().and_then(|s| s.as_ref().as_ref()) {
+        barrel_end(&source.triangles, axis)
+    } else {
+        let surface = cache.get_opt(&GRIP_SURFACE_IMPORTER, &filename)?;
+        barrel_end(surface.as_ref(), axis)
+    }?;
+    Some(MuzzleFallback { point, axis })
+}
+
+pub(crate) fn resolve(world: &World, weapon: EntityId) -> MuzzleFallback {
+    let fallback = world
+        .borrow::<View<MuzzleFallback>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().copied());
+    let authored = world.borrow::<View<RuntimePropVhots>>().ok().and_then(|v| {
+        v.get(weapon).ok().and_then(|vhots| {
+            vhots
+                .0
+                .iter()
+                .min_by_key(|vhot| vhot.id)
+                .map(|vhot| (vhot.id, vhot.point))
+        })
+    });
+    let axis = fallback
+        .map(|f| f.axis)
+        .or_else(|| {
+            world
+                .borrow::<View<PropModelName>>()
+                .ok()
+                .and_then(|v| v.get(weapon).ok().and_then(|name| barrel_axis(&name.0)))
+        })
+        .unwrap_or_else(|| vec3(-1.0, 0.0, 0.0));
+    MuzzleFallback {
+        point: authored
+            .filter(|(id, _)| *id == 0)
+            .map(|(_, point)| point)
+            .or(fallback.map(|f| f.point))
+            // Unprofiled assets retain their previous lowest-ID fallback.
+            .or(authored.map(|(_, point)| point))
+            .unwrap_or_else(|| point3(0.0, 0.0, 0.0)),
+        axis,
+    }
+}
+
+/// Keep a forward spawn offset on the firing side of any intervening surface.
+/// The caller filters held items; the player's own capsule is always excluded.
+pub(crate) fn clamp_projectile_spawn(
+    physics: &PhysicsWorld,
+    origin: Point3<f32>,
+    requested: Point3<f32>,
+    radius: f32,
+    can_hit: &dyn Fn(EntityId) -> bool,
+) -> Point3<f32> {
+    let delta = requested - origin;
+    let distance = delta.magnitude();
+    if distance <= 1.0e-6 || !distance.is_finite() {
+        return origin;
+    }
+    let direction = delta / distance;
+    // A tiny sphere also covers point projectiles without dropping anonymous
+    // level colliders from the query's entity predicate.
+    origin
+        + direction
+            * physics.projectile_spawn_distance(
+                origin,
+                direction,
+                distance,
+                radius.max(0.0001),
+                can_hit,
+            )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::CollisionGroup;
+    use cgmath::Quaternion;
+
+    #[test]
+    fn fallback_uses_front_cap_not_stock_or_arm_extents() {
+        let triangles = [
+            [
+                point3(-2.0, 3.0, -1.0),
+                point3(-2.0, 3.0, 1.0),
+                point3(-2.0, 5.0, 0.0),
+            ],
+            [
+                point3(0.0, -10.0, -5.0),
+                point3(0.0, -10.0, 5.0),
+                point3(0.0, 0.0, 0.0),
+            ],
+        ];
+        assert_eq!(
+            barrel_end(&triangles, vec3(-1.0, 0.0, 0.0)),
+            Some(point3(-2.0, 4.0, 0.0))
+        );
+        assert_eq!(barrel_end(&[], vec3(-1.0, 0.0, 0.0)), None);
+    }
+
+    #[test]
+    fn authored_muzzle_id_wins_over_geometry_and_other_attachments() {
+        let mut world = World::new();
+        let point = point3(-1.0, 0.2, 0.1);
+        let weapon = world.add_entity((
+            MuzzleFallback {
+                point: point3(-2.0, 0.0, 0.0),
+                axis: vec3(-1.0, 0.0, 0.0),
+            },
+            RuntimePropVhots(vec![
+                dark::ss2_bin_obj_loader::Vhot {
+                    id: 1,
+                    point: point3(-3.0, 0.0, 0.0),
+                },
+                dark::ss2_bin_obj_loader::Vhot { id: 0, point },
+            ]),
+        ));
+        assert_eq!(resolve(&world, weapon).point, point);
+    }
+
+    #[test]
+    fn forward_spawn_offset_cannot_cross_a_thin_obstacle() {
+        let mut physics = PhysicsWorld::new();
+        let wall = EntityId::from_inner(20).unwrap();
+        physics.add_kinematic(
+            wall,
+            vec3(0.0, 0.0, 1.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(4.0, 4.0, 0.02),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            physics.create_player(vec3(10.0, 0.0, 0.0), EntityId::from_inner(21).unwrap());
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        let start = point3(0.0, 0.0, 0.0);
+        let muzzle = point3(0.0, 0.0, 2.0);
+        let clamped = clamp_projectile_spawn(&physics, start, muzzle, 0.0, &|_| true);
+        assert!(
+            clamped.z > 0.9 && clamped.z < 0.99,
+            "must stay before wall: {clamped:?}"
+        );
+        assert_eq!(
+            clamp_projectile_spawn(&physics, point3(0.0, 0.0, 0.9), start, 0.2, &|_| true),
+            start,
+            "a shot directed away from an initially overlapping wall must clear it",
+        );
+        let grenade = clamp_projectile_spawn(&physics, start, muzzle, 0.2, &|_| true);
+        assert!(
+            grenade.z + 0.2 < 0.99,
+            "grenade must fit before the wall: {grenade:?}"
+        );
+        assert_eq!(
+            clamp_projectile_spawn(&physics, start, muzzle, 0.0, &|id| id != wall),
+            muzzle
+        );
+        assert_eq!(
+            clamp_projectile_spawn(&physics, start, start, 0.0, &|_| true),
+            start
+        );
+    }
+}

--- a/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-muzzle-origin.e2e.test.ts
@@ -46,6 +46,11 @@ const SCALE_FACTOR = 2.5;
 const MUZZLE_VHOT: Record<string, Vec3> = {
   lasehand: [-1.913 / SCALE_FACTOR, -0.0688 / SCALE_FACTOR, 0.16 / SCALE_FACTOR],
   amp_h: [-1.1072 / SCALE_FACTOR, 0.2719 / SCALE_FACTOR, -0.1199 / SCALE_FACTOR],
+  // No authored vhots: independently decoded front-cap vertices from 25AE
+  // object polygons, with ND-arm material removed and bind translations applied.
+  empgun_h: [-1.614333725, 0.100172064, -0.000514221],
+  gren_h: [-1.105836868, 0.020605141, -0.000560760],
+  fsn_h: [-1.244823456, 0.002128685, -0.003411102],
 };
 
 const len = (v: Vec3): number => Math.sqrt(dot(v, v));
@@ -292,3 +297,47 @@ test(
     assertLeftTheMuzzle(shot, "cryo bolt");
   },
 );
+
+for (const hand of ["left", "right"] as const) {
+  test(`a ${hand}-held EMP rifle without vhots fires from the visible barrel cap`,
+    { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" }, async () => {
+      await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: ["--vr"] });
+      await game.step({ frames: 30 });
+      const gun = await cycleToWeapon(game, e => e.name === "EMP Rifle", { settleFrames: 90 });
+      await aimVrHandAt(game, gun.position as Vec3, 0.45, 1, 0, { hand });
+      await game.step({ frames: 8 });
+      const info = await game.info();
+      assert.equal(hand === "right" ? info.player.right_hand_entity_id : info.player.wielded_entity_id, gun.id);
+      const shot = await fireAndTrack(game, gun.id, [0, 1, -2], [-1, 0, 0], e => e.name === "EMP Shot", hand);
+      assertLeftTheMuzzle(shot, `${hand} EMP bolt`);
+    });
+}
+
+test("an EMP muzzle extending through the backstop cannot shoot through it",
+  { skip: e2eEnabled ? false : "set SHOCK2_E2E=1 to run" }, async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: ["--vr"] });
+    await game.step({ frames: 30 });
+    const gun = await cycleToWeapon(game, e => e.name === "EMP Rifle", { settleFrames: 90 });
+    await aimVrHandAt(game, gun.position as Vec3, 0.45, 1, 0);
+    await game.step({ frames: 8 });
+    assert.equal((await game.info()).player.right_hand_entity_id, gun.id);
+    // Backstop front is x=-11.5; the palm is in front and the barrel crosses it.
+    await game.input.set("right_hand.position", [-10.5, 1, -2]);
+    await game.input.set("right_hand.rotation", quatFromTo([0, 0, -1], [-1, 0, 0]));
+    await game.step({ frames: 5 });
+    const weapon = await entityTransform(game, gun.id);
+    assert.ok(weapon.position[0] > -11.5 && weapon.position[0] < -10.6);
+    const before = new Set((await game.entities.list()).entities.map(e => e.id));
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
+    let remaining = 0;
+    for (let frame = 0; frame < 8; frame++) {
+      const shots = (await game.entities.list()).entities.filter(e => !before.has(e.id) && e.name === "EMP Shot");
+      // The sampled frame already integrated physics; allow its contact skin.
+      for (const shot of shots) assert.ok(shot.position[0] >= -11.55, `bolt must not appear beyond the backstop: ${JSON.stringify(shot.position)}, weapon ${JSON.stringify(weapon.position)}, frame ${frame}`);
+      remaining = shots.length;
+      await game.step({ frames: 1 });
+    }
+    assert.equal(remaining, 0, "nearby backstop must absorb the bolt");
+  });


### PR DESCRIPTION
VR guns without muzzle vhots, including the EMP rifle, currently spawn shots inside the gun. Resolve authored ID 0 first, then use the visible gun-only barrel cap in an explicit model frame. Mirror the fallback with the held weapon and preserve normalized projectile speed under grip scaling.

Check the forward spawn offset from the tracked palm/camera against level geometry and entities. Enclosing-sphere clearance accounts for physical projectile radius and offset; projectile trails receive the same spawn translation. Unknown models retain their existing lowest-ID/origin fallback.

Validation: 80 focused Rust tests, including nonzero grip anchors, thin obstacles, projectile radius and firing away from an initially overlapping wall; warnings-denied gameplay/desktop/debug checks. Both EMP origin regressions fail on immutable parent3594c6ba. Matched runtime footage below shows the corrected barrel origin in both hands. SDK: all 23 missions load; all 9 final muzzle/backstop and weapon-mode cases pass.

Independent code/duplication and Codex reviews caught palm/radius/initial-overlap issues, now fixed and retested. Full SDK and headset feel validation remain required before landing. A controller already inside level geometry needs the later physical-held work; GunFlash casing flags and recoil remain separate stack layers.

![EMP muzzle before/after, 3× slow motion](https://gist.githubusercontent.com/tommy-xr/744d985578b2a70d88b7bb8b944f35fe/raw/emp-before-after.gif)

![EMP muzzle before/after](https://gist.githubusercontent.com/tommy-xr/744d985578b2a70d88b7bb8b944f35fe/raw/emp-before-after.png)

![Left-hand muzzle](https://gist.githubusercontent.com/tommy-xr/744d985578b2a70d88b7bb8b944f35fe/raw/emp-left-after.png)
