### PR TITLE
fix(weapons): play authored empty and broken gun sounds

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -239,3 +239,14 @@ evidence; shared UI renders are checked in flat and VR. Run the repository's
 required build and SDK checks before landing. Headless geometry evidence does
 not establish headset comfort or recoil feel: record a Quest validation pass
 and human feel assessment separately from automated checks.
+
+## Refused-shot sound parity
+
+Empty pulls now request authored `Event OutofAmmo`, replacing the unmatched
+`dryfire` tag. Broken/destroyed guns request `Event Broken` separately, matching
+`cPlayerGun::PullTrigger` in Dark `shkplgun.cpp` (original lines 1263/1269).
+The shipped environment schema resolves pistol empty clicks to `out_pist`,
+grenade-family clicks to `out_gren`, heavy/shotgun clicks to `out_sg`, and
+broken-gun feedback to `gunbrok1`. Existing skill, reload and cooldown gates
+retain their priority. A partial magazine below a mode's shot cost also uses
+OutofAmmo; no projectile, flash, wear or ammo debit accompanies that refusal.

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -377,8 +377,14 @@ impl Script for WeaponScript {
 
                 match fire_one_shot(world, entity_id, &setting) {
                     ShotOutcome::FlatMeleeSwing => Effect::FlatMeleeSwing { entity_id },
-                    // A broken gun clicks like an empty one: nothing leaves it.
-                    ShotOutcome::Empty | ShotOutcome::NotWorking => dry_fire(world, entity_id),
+                    ShotOutcome::Empty => dry_fire(world, entity_id),
+                    ShotOutcome::NotWorking => play_environmental_sound(
+                        world,
+                        entity_id,
+                        "broken",
+                        vec![],
+                        AudioHandle::new(),
+                    ),
                     ShotOutcome::Broke(effect) => effect,
                     ShotOutcome::Fired(effect) => {
                         // A burst setting owes more rounds than the one just
@@ -666,10 +672,10 @@ fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World
 }
 
 /// An empty-clip dry fire: no projectile or muzzle flash, just the weapon's
-/// "dryfire" click (best-effort - resolves via the gun's sound schema, like the
-/// "shoot" event). Reached when a `PropGunState` weapon has 0 rounds.
+/// authored "OutofAmmo" event (Dark cPlayerGun::PullTrigger). This also covers
+/// a mode whose per-shot cost exceeds the remaining ammo.
 fn dry_fire(world: &World, entity_id: EntityId) -> Effect {
-    play_environmental_sound(world, entity_id, "dryfire", vec![], AudioHandle::new())
+    play_environmental_sound(world, entity_id, "outofammo", vec![], AudioHandle::new())
 }
 
 pub(super) fn create_muzzle_flash(

--- a/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-reload.e2e.test.ts
@@ -106,6 +106,12 @@ test(
     const capacity = ammoOf(await game.entities.detail(pistol.id));
     assert.ok(capacity > 0, "the debug pistol starts loaded");
     await emptyTheMagazine(game, pistol);
+    const emptySequence = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await fireOnce(game);
+    const emptyCue = (await game.audio.recent()).sounds.find(sound =>
+      sound.sequence > emptySequence && tagValue(sound, "event") === "outofammo");
+    assert.equal(emptyCue?.sample, "out_pist", "an empty VR pull must play its authored click");
+
 
     // Reserve rounds are what a reload consumes. Two standard clips so the
     // reload has to drain the first and dip into the second.

--- a/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
@@ -59,8 +59,14 @@ test(
     // hit-spangs eventually despawn, so we only assert it does not grow below).
     const hitsAtEmpty = bulletHits((await game.entities.list({ limit: 120 })).entities);
 
+    const soundSequence = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+
     // Dry-fire: pulling on an empty clip must NOT spawn a projectile.
     for (let i = 0; i < 3; i++) await fireOnce(game);
+    const clicks = (await game.audio.recent()).sounds.filter(sound =>
+      sound.sequence > soundSequence && sound.sample === "out_pist" &&
+      sound.tags.some(([tag, value]) => tag === "event" && value === "outofammo"));
+    assert.equal(clicks.length, 3, "each empty pull must resolve the authored OutofAmmo sound");
     assert.equal(ammoOf(await game.entities.detail(pistolId)), 0, "ammo stays at 0");
     assert.ok(
       bulletHits((await game.entities.list({ limit: 120 })).entities) <= hitsAtEmpty,

--- a/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-condition.e2e.test.ts
@@ -156,7 +156,13 @@ test(
     const ammo = ammoOf(await game.entities.detail(gun));
     const condition = (await game.info()).player.wielded_gun_condition;
 
+    const soundSequence = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
     for (let i = 0; i < 3; i += 1) await fireOnce(game);
+    const brokenCues = (await game.audio.recent()).sounds.filter(sound =>
+      sound.sequence > soundSequence && sound.sample === "gunbrok1" &&
+      sound.tags.some(([tag, value]) => tag === "event" && value === "broken"));
+    assert.equal(brokenCues.length, 3, "broken pulls use Broken, not OutofAmmo");
+
 
     const detail = await game.entities.detail(gun);
     assert.equal(ammoOf(detail), ammo, "a broken gun spends no ammo");


### PR DESCRIPTION
Empty trigger pulls requested an unauthored `dryfire` event, so they produced no sound. Use the original `OutofAmmo` event and keep broken-gun refusal separate with `Broken`. Shipped schemas now resolve the pistol click to `out_pist` and broken-gun feedback to `gunbrok1`.

Matches Dark `cPlayerGun::PullTrigger` (`shkplgun.cpp`, OutofAmmo/Broken branches) and the shipped environment schema recorded in `references/env_sound.spew`. Existing skill, cooldown, reload, ammo and wear behavior is preserved.

Validation: three audio regressions fail before the fix; all 10 ammo, VR reload and condition SDK cases pass afterward. Assertions inspect newly resolved samples and event tags, including repeated empty pulls and VR. Warnings-denied gameplay/desktop/debug checks pass. Independent correctness/duplication review found no blocker. Audio-only change; visual capture is not applicable.

Stacked on #1445. Full SDK and headset verification remain part of stack landing checks.
