### PR TITLE
fix(weapons): launch GunFlash casings independently

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -250,3 +250,25 @@ grenade-family clicks to `out_gren`, heavy/shotgun clicks to `out_sg`, and
 broken-gun feedback to `gunbrok1`. Existing skill, reload and cooldown gates
 retain their priority. A partial magazine below a mode's shot cost also uses
 OutofAmmo; no projectile, flash, wear or ammo debit accompanies that refusal.
+
+## GunFlash casing launch
+
+GunFlash flag 1 now creates a detached dynamic casing at its authored ejection
+point, preserving the full parsed PhysInitV vector in a normalized barrel frame.
+The left VR gun reflects lateral ejection; the right-handed flat viewmodel does
+not, even though it occupies the logical left inventory slot. Ordinary flashes
+remain attached. Cosmetic casings and impact-spang transients are omitted from
+saves so loading cannot relaunch stale effects through the bullet velocity path.
+
+Flat/right/left casing scenarios reproduce the frozen-shell regression on the
+parent, then verify upward launch, ejection side and lifetime after the fix.
+The flat case saves while a casing is alive and verifies it does not return;
+the normal projectile owner-save regression remains green. Matched VR footage
+shows the casing rise and fall independently of subsequent hand movement.
+Random-bank flag 2 and inherited player movement remain audit followups; this
+layer only establishes the distinct authored casing-launch path.
+
+User followup: the EMP footage reveals red splatter. EMP Shot explicitly authors
+`swingba2` with `NoRender`, but player projectile creation forces visibility.
+Respecting that hidden model and inspecting its legitimate particle riders is
+the next presentation fix, alongside the remaining muzzle-flash audit.

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -209,6 +209,7 @@ pub fn create_entity_with_position(
 
     if additional_options.transient_fx {
         world.add_component(entity_id, crate::runtime_props::RuntimePropTransientFx);
+        world.add_component(entity_id, crate::runtime_props::RuntimePropDoNotSerialize);
     }
 
     if let Some(origin) = additional_options.projectile_raycast_origin {
@@ -1678,7 +1679,8 @@ pub struct CreateEntityOptions {
     pub attach_to: Option<EntityId>,
     /// Mark the entity as a fire-and-forget effect (`RuntimePropTransientFx`):
     /// it is destroyed once its one-shot particle burst expires. Used for
-    /// impact spangs so they don't accumulate at every bullet hole.
+    /// impact spangs so they don't accumulate at every bullet hole. Cosmetic
+    /// transients are excluded from saves rather than replayed after loading.
     pub transient_fx: bool,
     /// Override the collision-ray origin when this entity resolves as a fast
     /// projectile. Flat firing supplies the camera origin while retaining the
@@ -1696,6 +1698,8 @@ pub struct CreateEntityOptions {
     /// Tweq emitter calls `launchProjectile`; this keeps frobbable emitted
     /// archetypes from being reduced to kinematic selection colliders.
     pub launch_projectile: bool,
+    /// Preserve the full authored velocity for GunFlash-launched casings.
+    pub authored_velocity_frame: Option<Matrix4<f32>>,
     /// The firing gun's per-shot multipliers, stamped on a launched projectile
     /// as `RuntimePropShotModifiers` so its damage and speed follow the fire
     /// mode that launched it. `None` for anything that is not a gun shot.
@@ -1718,6 +1722,7 @@ impl Default for CreateEntityOptions {
             projectile_weapon: None,
             player_fired_projectile: false,
             launch_projectile: false,
+            authored_velocity_frame: None,
             shot_modifiers: None,
             flinderize_debris: false,
         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2672,6 +2672,7 @@ impl MissionCore {
                 &mut script_world,
                 created_entity,
                 Matrix4::identity(),
+                None,
             );
         }
         engine::platform::service_events();
@@ -5845,6 +5846,7 @@ impl MissionCore {
         // brought along by a spang must not host a second spang).
         exclude_template: Option<i32>,
     ) -> EntityCreationInfo {
+        let authored_velocity_frame = additional_options.authored_velocity_frame;
         let transient_fx = additional_options.transient_fx;
         let has_spawn_clearance = additional_options.projectile_launch_origin.is_some();
         let created_entity = {
@@ -5874,6 +5876,7 @@ impl MissionCore {
             &mut self.script_world,
             created_entity,
             root_transform,
+            authored_velocity_frame,
         );
 
         // Spawn clearance may move the projectile before physics is built.
@@ -5997,6 +6000,7 @@ impl MissionCore {
         script_world: &mut ScriptWorld,
         created_entity: EntityCreationInfo,
         root_transform: Matrix4<f32>,
+        authored_velocity_frame: Option<Matrix4<f32>>,
     ) -> EntityCreationInfo {
         let ret = created_entity.clone();
 
@@ -6014,6 +6018,17 @@ impl MissionCore {
 
         let v_initial_velocity = world.borrow::<View<PropPhysInitialVelocity>>().unwrap();
         if let Some(rigid_body) = created_entity.rigid_body {
+            if let Some(velocity_frame) = authored_velocity_frame {
+                // The parser already converts Dark velocity to world units:
+                // (-forward, up, right). The launch frame uses +Z forward.
+                let velocity = v_initial_velocity
+                    .get(created_entity.entity_id)
+                    .map(|v| velocity_frame.transform_vector(vec3(v.0.z, v.0.y, -v.0.x)))
+                    .unwrap_or_else(|_| vec3(0.0, 0.0, 0.0));
+                id_to_physics.insert(created_entity.entity_id, rigid_body);
+                physics.set_velocity(created_entity.entity_id, velocity);
+                return ret;
+            }
             let initial_velocity = v_initial_velocity
                 .get(created_entity.entity_id)
                 // Not sure why the coordinate system is different for projectile launch?

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -700,6 +700,38 @@ pub(super) fn create_muzzle_flash(
 
     let transform = v_transform.get(entity_id).unwrap();
 
+    // GunFlash flag 1 means launch a physical object (e.g. an ejected casing),
+    // not an effect that remains attached to the gun. Dark CreateGunFlashes.
+    if options.flags & 1 != 0 {
+        let mut attachment = crate::weapon_muzzle::resolve(world, entity_id);
+        attachment.point = vhot_offset;
+        let frame = attachment.shot_frame(transform.0);
+        // Flat stores its right-handed viewmodel in the logical left slot.
+        let left = !world
+            .borrow::<View<RuntimePropFlatAim>>()
+            .unwrap()
+            .contains(entity_id)
+            && crate::wielded_weapon::weapon_in_hand(world, vr_config::Handedness::Left)
+                == Some(entity_id);
+        let velocity_frame =
+            frame * Matrix4::from_nonuniform_scale(if left { -1.0 } else { 1.0 }, 1.0, 1.0);
+        return Effect::CreateEntity {
+            template_id: muzzle_flash_template_id,
+            position: point3(0.0, 0.0, 0.0),
+            orientation: Quaternion::from_angle_y(Deg(90.0)),
+            root_transform: frame,
+            options: CreateEntityOptions {
+                launch_projectile: true,
+                authored_velocity_frame: Some(velocity_frame),
+                transient_fx: true,
+                player_fired_projectile: true,
+                projectile_weapon: Some(entity_id),
+                projectile_launch_origin: Some(transform.0.transform_point(point3(0.0, 0.0, 0.0))),
+                ..CreateEntityOptions::default()
+            },
+        };
+    }
+
     let adjustments = vr_config::get_vr_hand_model_adjustments_from_entity(
         entity_id,
         world,
@@ -778,20 +810,7 @@ pub(super) fn create_projectile(
 
     let transform = v_transform.get(entity_id).unwrap();
 
-    // Item size changes muzzle placement, never projectile size or speed.
-    let origin = transform.0.transform_point(muzzle.point);
-    let forward = transform.0.transform_vector(muzzle.axis).normalize();
-    let up = transform
-        .0
-        .transform_vector(cgmath::vec3(0.0, 1.0, 0.0))
-        .normalize();
-    let right = up.cross(forward).normalize();
-    let shot_frame = Matrix4::from_cols(
-        right.extend(0.0),
-        forward.cross(right).extend(0.0),
-        forward.extend(0.0),
-        origin.to_homogeneous(),
-    );
+    let shot_frame = muzzle.shot_frame(transform.0);
 
     Effect::CreateEntity {
         template_id: projectile_template_id,

--- a/shock2vr/src/weapon_muzzle.rs
+++ b/shock2vr/src/weapon_muzzle.rs
@@ -1,6 +1,6 @@
 //! Muzzle geometry in the rendered weapon's local frame. Authored ID 0 wins;
 //! missing points use the barrel end of the visible gun, excluding its arms.
-use cgmath::{EuclideanSpace, InnerSpace, Point3, Vector3, point3, vec3};
+use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Point3, Transform, Vector3, point3, vec3};
 use collision::{Aabb, Aabb3};
 use dark::{
     importers::{GLOVE_WEAPON_IMPORTER, GRIP_SURFACE_IMPORTER},
@@ -15,6 +15,23 @@ use crate::{physics::PhysicsWorld, runtime_props::RuntimePropVhots};
 pub(crate) struct MuzzleFallback {
     pub point: Point3<f32>,
     pub axis: Vector3<f32>,
+}
+
+impl MuzzleFallback {
+    /// Unit right/up/forward frame at this attachment. Item scaling affects the
+    /// attachment position, never launched projectile size or velocity.
+    pub(crate) fn shot_frame(self, transform: Matrix4<f32>) -> Matrix4<f32> {
+        let origin = transform.transform_point(self.point);
+        let forward = transform.transform_vector(self.axis).normalize();
+        let up = transform.transform_vector(vec3(0.0, 1.0, 0.0)).normalize();
+        let right = up.cross(forward).normalize();
+        Matrix4::from_cols(
+            right.extend(0.0),
+            forward.cross(right).extend(0.0),
+            forward.extend(0.0),
+            origin.to_homogeneous(),
+        )
+    }
 }
 
 /// These are authored weapon frames, not an inference from the longest mesh

--- a/tools/shock2-sdk/test/gunflash-casing.e2e.test.ts
+++ b/tools/shock2-sdk/test/gunflash-casing.e2e.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+import { aimVrHandAt, quatFromTo } from "./helpers/vr-hand.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+for (const presentation of ["flat", "left", "right"] as const) {
+  test(`AR15 casings launch independently in ${presentation}`,
+    { skip: enabled ? false : "set SHOCK2_E2E=1 to run" }, async () => {
+      const vr = presentation !== "flat";
+      const hand = presentation === "left" ? "left" : "right";
+      await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: vr ? ["--vr"] : [] });
+      await game.step({ frames: 10 });
+      const gun = await cycleToWeapon(game, e => e.name === "Assault Rifle", { settleFrames: 90 });
+      if (vr) {
+        await aimVrHandAt(game, gun.position as Vec3, 0.45, 1, 0, { hand });
+        await game.step({ frames: 8 });
+        const info = await game.info();
+        assert.equal(hand === "right" ? info.player.right_hand_entity_id : info.player.wielded_entity_id, gun.id);
+        await game.input.set(`${hand}_hand.position`, [0, 1, -2]);
+        await game.input.set(`${hand}_hand.rotation`, quatFromTo([0, 0, -1], [-1, 0, 0]));
+        await game.step({ frames: 3 });
+      }
+      const before = new Set((await game.entities.list()).entities.map(e => e.id));
+      await game.input.set(`${hand}_hand.trigger`, 1);
+      await game.step({ frames: 1 });
+      await game.input.set(`${hand}_hand.trigger`, 0);
+      const casing = (await game.entities.list()).entities.find(e => !before.has(e.id) && e.template_id === -2657);
+      assert.ok(casing, "the authored casing GunFlash link must spawn an object");
+      const initial = casing.position as Vec3;
+      await game.step({ frames: 8 });
+      const later = (await game.entities.detail(casing.id)).position as Vec3;
+      assert.ok(later[1] - initial[1] > 0.15,
+        `authored upward ejection must separate from the breech: ${JSON.stringify({initial, later})}`);
+      // With a level -X barrel, authored sideways speed is -0.2 world units/s;
+      // it reflects with the left-hand ejection port. Allow physics integration.
+      {
+        const sideways = later[2] - initial[2];
+        assert.ok(hand === "left" ? sideways > 0.01 : sideways < -0.01,
+          `casing must leave the ${hand} ejection side: ${sideways}`);
+      }
+      if (!vr) {
+        const save = `casing_fx_${Date.now()}`;
+        assert.equal((await game.save(save)).success, true);
+        assert.equal((await game.load(save)).success, true);
+        assert.ok(!(await game.entities.list()).entities.some(e => e.template_id === -2657),
+          "short-lived cosmetic casings must not be relaunched by save/load");
+        return;
+      }
+      await game.step({ frames: 60 });
+      assert.ok(!(await game.entities.list()).entities.some(e => e.id === casing.id),
+        "casing retains its authored effect lifetime");
+    });
+}


### PR DESCRIPTION
The AR15 casing GunFlash link was treated as an attached muzzle flash: shells stayed at the breech and followed hand motion. Honor the projectile flag by launching a detached dynamic casing with its full authored velocity. Normalize the launch frame so grip scale cannot change speed, and reflect lateral ejection only for an actual left VR hand.

Keep short-lived casings and impact-spang transients out of saves; loading must not relaunch cosmetic debris through the generic bullet path. Ordinary attached flashes retain their current behavior. Random-bank and inherited-player-velocity parity remain followups.

Validation: all three flat/left/right casing scenarios fail on parent956a107d and pass after; final four-case run includes casing save/load exclusion and the normal player-projectile save regression. Six existing muzzle/backstop cases and 80 focused Rust tests pass. Warnings-denied gameplay, desktop and debug package checks pass. Independent reviews caught flat-slot reflection and save lifecycle issues, fixed and retested.

Stacked on #1446. Full stack SDK and headset verification remain before landing.

![Casing launch before/after](https://gist.githubusercontent.com/tommy-xr/27d177a417045b3c97a5838f70548776/raw/casing-before-after.gif)

![Casing launch still](https://gist.githubusercontent.com/tommy-xr/27d177a417045b3c97a5838f70548776/raw/casing-before-after.png)
