### PR TITLE
fix(weapons): resolve particle sprites from the bitmap family

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -272,3 +272,24 @@ User followup: the EMP footage reveals red splatter. EMP Shot explicitly authors
 `swingba2` with `NoRender`, but player projectile creation forces visibility.
 Respecting that hidden model and inspecting its legitimate particle riders is
 the next presentation fix, alongside the remaining muzzle-flash audit.
+
+## EMP presentation correction
+
+The red splatter had a separate, confirmed resource collision: `blood.pcx` in
+`bitmap.crf` is a 32×32 blue glow; `obj.crf/txt16/BLOOD.PCX` is a 128×128 red
+splatter. The EMP Blue particle correctly authors the former. Bare texture
+lookup selected the latter because object resources precede bitmap resources.
+Particle sprites now use a `bitmap/`-qualified key, registered for classic and
+25AE base/mod mounts through the existing namespace mechanism. Unqualified
+object-texture precedence is unchanged.
+
+Player projectile creation also stops forcing `RenderType::Normal`: EMP Shot
+intentionally carries a hidden `swingba2` model. The render audit drops its four
+root draws to zero while retaining EMP Blue and EMP2. Matched before/after
+footage confirms the correct blue glow replaces the splatter. A fixture covers
+colliding bitmap/object basenames for all three archive layouts; flat and VR
+SDK checks verify hidden-root rendering and surviving particle riders.
+
+Remaining particle audit includes authored units, animation frames, tint/fade
+and additional jet attachments; this correction does not claim that every
+projectile's particle behavior now matches the original engine.

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -254,8 +254,8 @@ fn mod_layer_may_override(family: &str, archive: &str) -> bool {
 /// Mount one resource family, matching the options its `.crf` counterpart uses.
 ///
 /// `strings` must not collapse basenames (translated tables share them), and
-/// `iface` additionally registers an `iface/`-qualified key because it collides
-/// with `obj`/`bitmap` on seven names. Getting these wrong is silent: the wrong
+/// `iface` and `bitmap` register family-qualified keys because their basenames
+/// collide with object textures. Getting these wrong is silent: the wrong
 /// string table or the wrong texture simply resolves first.
 fn mount_family(
     archive: String,
@@ -264,7 +264,7 @@ fn mount_family(
 ) -> Box<dyn engine::assets::asset_paths::AbstractAssetPath> {
     match family {
         "strings" => ZipAssetPath::with_prefix_opts(archive, prefix, false, None),
-        "iface" => ZipAssetPath::with_prefix_opts(archive, prefix, true, Some("iface")),
+        "iface" | "bitmap" => ZipAssetPath::with_prefix_opts(archive, prefix, true, Some(family)),
         _ => ZipAssetPath::with_prefix(archive, prefix),
     }
 }
@@ -342,7 +342,7 @@ pub fn game_asset_mounts(
             AssetPath::folder(resource_path("res/obj")),
             // AssetPath::folder(resource_path("res/obj/txt16")),
             ZipAssetPath::new(resource_path("res/obj.crf")),
-            ZipAssetPath::new(resource_path("res/bitmap.crf")),
+            mount_family(resource_path("res/bitmap.crf"), "", "bitmap"),
             // Log/email sender portraits + deck icons (the reader panel art).
             ZipAssetPath::new(resource_path("res/book.crf")),
             ZipAssetPath::new(resource_path("res/fam.crf")),
@@ -2543,6 +2543,47 @@ mod tests {
     use super::*;
     use cgmath::{Deg, InnerSpace, Rotation3};
     use std::path::PathBuf;
+
+    #[test]
+    fn particle_bitmap_namespace_avoids_object_texture_collisions() {
+        for prefix in ["", "data/res/bitmap/", "bitmap/"] {
+            let root = crate::test_support::TempDir::new("particle-bitmap-family");
+            let object_archive = root.path().join("obj.zip");
+            let bitmap_archive = root.path().join("bitmap.zip");
+            let sprite = format!("{prefix}BLOOD.PCX");
+            crate::test_support::write_archive(
+                &object_archive,
+                &[("obj/txt16/BLOOD.PCX", b"red object blood")],
+            );
+            crate::test_support::write_archive(
+                &bitmap_archive,
+                &[(&sprite, b"blue particle glow")],
+            );
+            let mounts = AssetPath::combine(vec![
+                ZipAssetPath::with_prefix(object_archive.to_string_lossy().into_owned(), "obj/"),
+                mount_family(
+                    bitmap_archive.to_string_lossy().into_owned(),
+                    prefix,
+                    "bitmap",
+                ),
+            ]);
+            for (name, expected) in [
+                ("blood.pcx", "red object blood"),
+                ("bitmap/blood.pcx", "blue particle glow"),
+            ] {
+                let reader = mounts
+                    .get_reader(String::new(), name.to_owned())
+                    .expect("qualified bitmap must resolve");
+                let mut bytes = Vec::new();
+                reader.borrow_mut().read_to_end(&mut bytes).unwrap();
+                assert_eq!(
+                    bytes,
+                    expected.as_bytes(),
+                    "wrong family for {name} in {prefix}"
+                );
+            }
+        }
+    }
 
     fn features(list: &[&str]) -> HashSet<String> {
         list.iter().map(|s| s.to_string()).collect()

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4391,7 +4391,10 @@ impl MissionCore {
                             // so the palette tint is left white.
                             const PRT_SCALED_BITMAP: u32 = 5;
                             if pg.render_type == PRT_SCALED_BITMAP && !pg.model_name.is_empty() {
-                                let bitmap_name = format!("{}.PCX", pg.model_name);
+                                // A bare name can resolve an object texture first:
+                                // blood.pcx is a blue particle glow in bitmap/,
+                                // but red splatter in obj/txt16/.
+                                let bitmap_name = format!("bitmap/{}.PCX", pg.model_name);
                                 if let Some(texture) = asset_cache.get_ext_opt(
                                     &TEXTURE_IMPORTER,
                                     &bitmap_name,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -790,7 +790,6 @@ pub(super) fn create_projectile(
                 orientation: Quaternion::from_angle_y(Deg(90.0)),
                 root_transform: Matrix4::from_translation(origin.to_vec()) * rot,
                 options: CreateEntityOptions {
-                    force_visible: true,
                     projectile_raycast_origin: Some(aim.origin),
                     projectile_launch_origin: Some(aim.origin),
                     shot_modifiers: Some(modifiers),
@@ -822,7 +821,6 @@ pub(super) fn create_projectile(
         // the muzzle at the origin and aim +Z down the barrel.
         root_transform: shot_frame,
         options: CreateEntityOptions {
-            force_visible: true,
             shot_modifiers: Some(modifiers),
             player_fired_projectile: true,
             projectile_launch_origin: Some(transform.0.transform_point(point3(0.0, 0.0, 0.0))),

--- a/tools/shock2-sdk/test/emp-projectile-visibility.e2e.test.ts
+++ b/tools/shock2-sdk/test/emp-projectile-visibility.e2e.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+import { aimVrHandAt, quatFromTo } from "./helpers/vr-hand.js";
+
+for (const vr of [false, true]) {
+  test(`EMP keeps its hidden root model out of ${vr ? "VR" : "flat"} rendering`,
+    { skip: process.env.SHOCK2_E2E !== "1" }, async () => {
+      await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: vr ? ["--vr"] : [] });
+      await game.step({ frames: 10 });
+      const gun = await cycleToWeapon(game, e => e.name === "EMP Rifle", { settleFrames: 90 });
+      if (vr) {
+        await aimVrHandAt(game, gun.position as Vec3, 0.45, 1, 0);
+        await game.step({ frames: 8 });
+        assert.equal((await game.info()).player.right_hand_entity_id, gun.id);
+        await game.input.set("right_hand.position", [0, 1, -2]);
+        await game.input.set("right_hand.rotation", quatFromTo([0, 0, -1], [-1, 0, 0]));
+        await game.step({ frames: 3 });
+      }
+      await game.input.set("right_hand.trigger", 1);
+      await game.step({ frames: 1 });
+      await game.input.set("right_hand.trigger", 0);
+      const shot = (await game.entities.list()).entities.find(e => e.template_id === -235);
+      assert.ok(shot, "the normal firing path must create its live EMP projectile");
+      const p = shot.position;
+      await game.camera.set({ position: [p[0] + 1, p[1] + 0.5, p[2] + 2], lookAt: p });
+      await game.step({ frames: 1 });
+      assert.equal((await game.scene.objects({entityId: shot.id})).objects.length, 0,
+        "NoRender swingba2 must never be submitted as projectile geometry");
+      const entities = (await game.entities.list()).entities;
+      assert.ok(entities.some(e => e.name === "EMP Blue"), "the authored blue bitmap rider remains");
+      assert.ok(entities.some(e => e.name === "EMP2"), "the authored disk rider remains");
+    });
+}


### PR DESCRIPTION
The EMP bolt rendered red blood because its authored `blood.pcx` sprite resolved to the object texture instead of the particle bitmap. The files share a basename: bitmap.crf contains a blue glow, while obj.crf/txt16 contains red splatter. Qualify particle sprites with `bitmap/` and register that namespace for classic and 25AE base/mod archives.

Also preserve authored projectile visibility. EMP Shot marks its `swingba2` root model NoRender; forcing all player projectiles visible submitted four unwanted draws. It now submits none while EMP Blue and EMP2 remain alive and render the blue effect.

Validation: the namespace fixture and both flat/VR hidden-root tests fail before the fixes and pass after. All 11 focused EMP, muzzle-flash, muzzle-origin, blood-spang and slow-projectile-spang SDK cases pass. Inspected matched captures verify the rendered color, rather than only checking rider existence. Warnings-denied gameplay/desktop/debug checks pass; independent correctness/duplication and Codex reviews found no blocker. Remaining particle animation/units and GunFlash audit work stays separate.

Stacked on #1447; addresses the EMP splatter reported in #1445. Full SDK and headset validation remain before landing.

![EMP before/after](https://gist.githubusercontent.com/tommy-xr/e5d728fcd7854b65138ddc6dce9d304d/raw/emp-visibility-before-after.gif)

![EMP still](https://gist.githubusercontent.com/tommy-xr/e5d728fcd7854b65138ddc6dce9d304d/raw/emp-visibility-before-after.png)
