### PR TITLE
fix(weapons): render flashes at the displayed muzzle

### DIFF
--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -195,6 +195,8 @@ pub fn to_scene_objects(
                 transparency = 0.8
             }
 
+            let additive = !is_skinned && !debug_normals_enabled
+                && crate::util::object_material_is_additive_flash(asset_cache, &tex_path);
             let mat: Box<dyn engine::scene::Material> = if debug_normals_enabled {
                 if is_skinned {
                     engine::scene::debug_normal_material::create_skinned()
@@ -211,19 +213,22 @@ pub fn to_scene_objects(
                     transparency,
                 )
             } else {
-                engine::scene::basic_material::create(
+                engine::scene::basic_material::create_with_additive(
                     diffuse_texture
                         .as_ref()
                         .expect("diffuse texture should exist when debug normals disabled")
                         .clone(),
                     material.emissivity,
                     transparency,
+                    additive,
                 )
             };
 
             let material = RefCell::new(mat);
             let mut so = create_dark_object_scene_object(material, geometry);
 
+            so.additive_color = additive;
+            if additive { so.set_depth_write(false); }
             so.set_skinning_data(skeleton.get_transforms());
 
             Some(so)

--- a/dark/src/util/mod.rs
+++ b/dark/src/util/mod.rs
@@ -77,6 +77,13 @@ pub fn resolve_object_material_texture_name(
 }
 
 fn object_material_primary_texture(asset_cache: &AssetCache, requested: &str) -> Option<String> {
+    let script = object_material_script(asset_cache, requested)?;
+    let texture = primary_render_pass_texture(&script)?;
+    trace!("object material {requested} primary pass redirects to {texture}");
+    Some(texture)
+}
+
+fn object_material_script(asset_cache: &AssetCache, requested: &str) -> Option<String> {
     let stem = Path::new(requested).with_extension("");
     let stem = stem.to_str()?.to_ascii_lowercase();
     let candidates = [
@@ -90,9 +97,23 @@ fn object_material_primary_texture(asset_cache: &AssetCache, requested: &str) ->
     let reader = asset_cache.get_raw_reader(&script_name)?;
     let mut script = String::new();
     reader.borrow_mut().read_to_string(&mut script).ok()?;
-    let texture = primary_render_pass_texture(&script)?;
-    trace!("object material {requested} primary pass redirects to {texture}");
-    Some(texture)
+    Some(script)
+}
+
+/// A sole unlit, additive pass using the authored texture (25AE gun flashes).
+/// Do not apply overlay blending to ordinary multi-pass weapon materials.
+pub fn object_material_is_additive_flash(asset_cache: &AssetCache, requested: &str) -> bool {
+    object_material_script(asset_cache, requested)
+        .is_some_and(|script| is_additive_flash_script(&script))
+}
+
+fn is_additive_flash_script(script: &str) -> bool {
+    let passes = render_passes(script);
+    passes.len() == 1
+        && passes[0].keeps_authored_texture
+        && passes[0].additive_color
+        && passes[0].unlit
+        && passes[0].texture.is_none()
 }
 
 /// Find the texture a render-material script substitutes for the model's own
@@ -106,6 +127,21 @@ fn object_material_primary_texture(asset_cache: &AssetCache, requested: &str) ->
 /// skipped, and `$TEXTURE` in a base pass means the model keeps its authored
 /// texture.
 fn primary_render_pass_texture(script: &str) -> Option<String> {
+    for pass in render_passes(script) {
+        if pass.blend_is_base.unwrap_or(true) {
+            if pass.keeps_authored_texture {
+                return None;
+            }
+            if let Some(texture) = pass.texture.as_deref() {
+                return normalize_material_texture_reference(texture);
+            }
+        }
+    }
+    None
+}
+
+fn render_passes(script: &str) -> Vec<RenderPassFields> {
+    let mut passes = Vec::new();
     let mut pass: Option<RenderPassFields> = None;
     let mut brace_depth = 0_i32;
     let mut saw_open_brace = false;
@@ -148,6 +184,11 @@ fn primary_render_pass_texture(script: &str) -> Option<String> {
                 let source = fields.next();
                 let destination = fields.next();
                 fields_so_far.blend_is_base = Some(blend_is_base(source, destination));
+                fields_so_far.additive_color = source
+                    .is_some_and(|s| s.eq_ignore_ascii_case("SRC_COLOR"))
+                    && destination.is_some_and(|s| s.eq_ignore_ascii_case("ONE"));
+            } else if directive.eq_ignore_ascii_case("shaded") {
+                fields_so_far.unlit = fields.next() == Some("0");
             }
         }
 
@@ -159,22 +200,13 @@ fn primary_render_pass_texture(script: &str) -> Option<String> {
 
         if saw_open_brace && brace_depth <= 0 {
             if let Some(fields_so_far) = pass.take() {
-                // A pass with no `blend` directive draws normally.
-                if fields_so_far.blend_is_base.unwrap_or(true) {
-                    if fields_so_far.keeps_authored_texture {
-                        return None;
-                    }
-                    if let Some(texture) = fields_so_far.texture.as_deref() {
-                        return normalize_material_texture_reference(texture);
-                    }
-                }
-                // An overlay, or a base pass naming no texture: keep looking.
+                passes.push(fields_so_far);
             }
             saw_open_brace = false;
         }
     }
 
-    None
+    passes
 }
 
 /// The fields of one `render_pass` block that texture selection depends on.
@@ -186,6 +218,8 @@ struct RenderPassFields {
     keeps_authored_texture: bool,
     /// `None` when the pass carries no `blend` directive at all.
     blend_is_base: Option<bool>,
+    additive_color: bool,
+    unlit: bool,
 }
 
 /// Whether a `blend <source> <destination>` pair describes a base pass - one
@@ -603,5 +637,26 @@ render_pass
             resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
             Some("txt16/panel.dds".to_owned())
         );
+    }
+}
+
+#[cfg(test)]
+mod additive_tests {
+    use super::*;
+    #[test]
+    fn additive_flash_requires_one_authored_unlit_pass() {
+        let flash = "render_material_only 1\nrender_pass\n{\nblend SRC_COLOR ONE\ntexture $TEXTURE\nshaded 0\n}\n";
+        assert!(is_additive_flash_script(flash));
+        assert!(!is_additive_flash_script(
+            &flash.replace("shaded 0", "shaded 1")
+        ));
+        assert!(!is_additive_flash_script(
+            &flash.replace("SRC_COLOR ONE", "ONE ZERO")
+        ));
+        assert!(!is_additive_flash_script(
+            &flash.replace("$TEXTURE", "specular")
+        ));
+        assert!(!is_additive_flash_script(&format!("{flash}{flash}")));
+        assert!(!is_additive_flash_script(&flash.replace('}', "")));
     }
 }

--- a/engine/src/scene/basic_material.rs
+++ b/engine/src/scene/basic_material.rs
@@ -52,6 +52,7 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
         uniform sampler2D texture1;
         uniform float emissivity;
         uniform float transparency;
+        uniform bool additiveUnlit;
 
         // Spotlight array uniforms (up to 6 spotlights)
         uniform vec3 spotlightPos[6];
@@ -105,6 +106,12 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
 
         void main() {
             vec4 texColor = texture(texture1, texCoord);
+            if (additiveUnlit) {
+                // SRC_COLOR/ONE squares RGB. Scale by sqrt(opacity) so the
+                // accumulated light fades linearly with authored alpha.
+                fragColor = vec4(texColor.rgb * sqrt(texColor.a * (1.0 - transparency)), 1.0);
+                return;
+            }
             if (texColor.a < 0.1) discard;
 
             // Base material color (ambient)
@@ -132,6 +139,7 @@ struct UnifiedUniforms {
     // Material properties
     emissivity_loc: i32,
     transparency_loc: i32,
+    additive_unlit_loc: i32,
 
     // Spotlight array uniforms (6 spotlights)
     spotlight_pos_loc: [i32; 6],
@@ -153,6 +161,7 @@ where
     emissivity: f32,
     transparency: f32,
     base_transparency: f32,
+    additive_unlit: bool,
 }
 
 impl<T> BasicMaterial<T>
@@ -160,7 +169,7 @@ where
     T: Deref<Target = dyn TextureTrait>,
 {
     pub fn is_transparent(&self) -> bool {
-        self.transparency > 0.01
+        self.additive_unlit || self.transparency > 0.01
     }
 
     pub fn draw_unified(
@@ -185,6 +194,7 @@ where
             gl::UniformMatrix4fv(uniforms.projection_loc, 1, gl::FALSE, projection.as_ptr());
 
             // Set material properties
+            gl::Uniform1i(uniforms.additive_unlit_loc, i32::from(self.additive_unlit));
             gl::Uniform1f(uniforms.transparency_loc, self.transparency);
             gl::Uniform1f(uniforms.emissivity_loc, self.emissivity);
 
@@ -291,6 +301,10 @@ where
                     emissivity_loc: gl::GetUniformLocation(
                         shader.gl_id,
                         c_str!("emissivity").as_ptr(),
+                    ),
+                    additive_unlit_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("additiveUnlit").as_ptr(),
                     ),
                     transparency_loc: gl::GetUniformLocation(
                         shader.gl_id,
@@ -463,11 +477,24 @@ pub fn create<T>(diffuse_texture: T, emissivity: f32, transparency: f32) -> Box<
 where
     T: Deref<Target = dyn TextureTrait> + 'static,
 {
+    create_with_additive(diffuse_texture, emissivity, transparency, false)
+}
+
+pub fn create_with_additive<T>(
+    diffuse_texture: T,
+    emissivity: f32,
+    transparency: f32,
+    additive_unlit: bool,
+) -> Box<dyn Material>
+where
+    T: Deref<Target = dyn TextureTrait> + 'static,
+{
     Box::new(BasicMaterial {
         diffuse_texture,
         has_initialized: false,
         emissivity,
         transparency,
         base_transparency: transparency,
+        additive_unlit,
     })
 }

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -105,6 +105,8 @@ pub struct SceneObject {
     /// a lasting material-level override would bleed between entities; instead
     /// this is applied to the material only around this object's own draw.
     pub transparency_override: Option<f32>,
+    /// Authored SRC_COLOR/ONE light accumulation, scoped to this draw.
+    pub additive_color: bool,
     /// Front-face winding used to cull backfaces for this object. Most engine
     /// geometry remains double-sided; imported Dark models opt in explicitly.
     backface_culling: Option<FrontFaceWinding>,
@@ -337,6 +339,7 @@ impl SceneObject {
             depth_write: true,
             render_layer: RenderLayer::World,
             transparency_override: None,
+            additive_color: false,
             debug_tag: None,
             backface_culling: None,
             depth_bias: false,
@@ -464,6 +467,7 @@ impl SceneObject {
             depth_write: true,
             render_layer: RenderLayer::World,
             transparency_override: None,
+            additive_color: false,
             debug_tag: None,
             backface_culling: None,
             depth_bias: false,
@@ -480,6 +484,7 @@ impl SceneObject {
             depth_write: self.depth_write,
             render_layer: self.render_layer,
             transparency_override: self.transparency_override,
+            additive_color: self.additive_color,
             debug_tag: self.debug_tag.clone(),
             backface_culling: self.backface_culling,
             depth_bias: self.depth_bias,
@@ -554,7 +559,17 @@ impl SceneObject {
             }
         }
 
+        if self.additive_color {
+            unsafe {
+                gl::BlendFunc(gl::SRC_COLOR, gl::ONE);
+            }
+        }
         self.geometry.draw();
+        if self.additive_color {
+            unsafe {
+                gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+            }
+        }
 
         if self.backface_culling.is_some() {
             // Culling is an explicit per-object opt-in; restore the default for

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -293,3 +293,32 @@ SDK checks verify hidden-root rendering and surviving particle riders.
 Remaining particle audit includes authored units, animation frames, tint/fade
 and additional jet attachments; this correction does not claim that every
 projectile's particle behavior now matches the original engine.
+
+
+## Visible muzzle flashes
+
+The held-model grip correction rotated the one-sided flash cone 180 degrees,
+pointing it back into the weapon and culling its surface from the shooter.
+Flash orientation now maps its authored -X axis onto the weapon barrel frame;
+a unit regression covers held -X and classic world -Z models.
+
+25AE `ND-gunflash.mtl` also authors a sole unlit `SRC_COLOR ONE` pass using
+`$TEXTURE`. Ignoring it rendered a black polygon once orientation was fixed.
+The existing material-script parser now recognizes that narrow form, with an
+unlit additive shader and blend state scoped to the draw. Ordinary multi-pass
+weapon overlays retain existing behavior. Additive materials enter the
+transparent pass and scale accumulated light by authored opacity. Flat
+attachments now apply RenderAlpha as the VR world pass already does, and carry
+render-debug identity so SDK assertions inspect actual flash draws.
+
+The user's followup confirms casing motion improved in #1447 but its long
+axis remains upright. The casing asset is authored along Y; launch yaw alone
+does not lay it sideways. Correcting initial casing pose is the next layer;
+authored random bank and spin remain part of the weapon-effects audit.
+
+Flat AR15 verification also exposed a stale four-model wield whitelist: the
+renderer used `ar15_h`, but attachment data still came from `ar15_w`. Flat now
+adopts every authored first-person mesh through the existing ChangeModel path,
+matching its renderer and restoring the correct attachment positions and axes.
+The casing-side regression reproduced on the parent as well; this model fix
+addresses that underlying mismatch rather than changing its assertion.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -10056,6 +10056,12 @@ impl MissionCore {
                             .filter_map(|(id, _)| v_transform.get(id).ok().map(|t| (id, t.0)))
                             .collect()
                     };
+                    let render_alpha = self
+                        .world
+                        .borrow::<View<dark::properties::PropRenderAlpha>>()
+                        .unwrap();
+                    let names = self.world.borrow::<View<PropSymName>>().unwrap();
+                    let models = self.world.borrow::<View<PropModelName>>().unwrap();
                     for (attached_id, attached_xform) in attached {
                         if let Some(model) = self.id_to_model.get(&attached_id) {
                             let objs = match self.id_to_animation_player.get(&attached_id) {
@@ -10065,6 +10071,18 @@ impl MissionCore {
                             for obj in objs {
                                 let mut o = obj.clone();
                                 o.set_transform(squish * attached_xform);
+                                o.set_debug_tag(Some(Rc::new(
+                                    engine::scene::SceneObjectDebugTag {
+                                        entity_id: Some(attached_id.inner()),
+                                        name: names.get(attached_id).ok().map(|n| n.0.clone()),
+                                        model: models.get(attached_id).ok().map(|m| m.0.clone()),
+                                        source: Some("viewmodel_attachment".to_owned()),
+                                    },
+                                )));
+                                if let Ok(alpha) = render_alpha.get(attached_id) {
+                                    o.set_depth_write(false);
+                                    o.set_transparency(Some(1.0 - alpha.0.clamp(0.0, 1.0)));
+                                }
                                 ret.push(o);
                             }
                         }

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -69,7 +69,9 @@ impl Script for InternalSwitchHeldModelScript {
                     return Effect::Multiple(effects);
                 }
 
-                if let Some(view_model) = get_view_model(world, entity_id) {
+                // Flat renders every authored first-person model. Its attachment
+                // data must use that same mesh, without the old VR whitelist.
+                if let Some(view_model) = get_raw_view_model(world, entity_id) {
                     Effect::ChangeModel {
                         entity_id,
                         model_name: view_model,
@@ -116,10 +118,6 @@ fn get_raw_view_model(world: &World, entity_id: EntityId) -> Option<String> {
     } else {
         None
     }
-}
-
-fn get_view_model(world: &World, entity_id: EntityId) -> Option<String> {
-    get_raw_view_model(world, entity_id).filter(|str| vr_config::is_allowed_hand_model(str))
 }
 
 fn get_current_model(world: &World, entity_id: EntityId) -> Option<String> {

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -1,6 +1,4 @@
-use cgmath::{
-    Deg, EuclideanSpace, InnerSpace, Matrix4, Quaternion, Rotation, Rotation3, Transform, point3,
-};
+use cgmath::{Deg, EuclideanSpace, InnerSpace, Matrix4, Quaternion, Rotation3, Transform, point3};
 use dark::{
     SCALE_FACTOR,
     properties::{
@@ -732,12 +730,11 @@ pub(super) fn create_muzzle_flash(
         };
     }
 
-    let adjustments = vr_config::get_vr_hand_model_adjustments_from_entity(
-        entity_id,
-        world,
-        vr_config::Handedness::Left,
-    );
-    let orientation = adjustments.rotation.invert() * Quaternion::from_angle_y(Deg(90.0));
+    // Flash meshes are authored along -X, just like held gun barrels. The old
+    // inverse grip adjustment turned them 180 degrees, putting their one-sided
+    // faces away from the shooter and the cone back inside the gun.
+    let axis = crate::weapon_muzzle::resolve(world, entity_id).axis;
+    let orientation = Quaternion::from_arc(cgmath::vec3(-1.0, 0.0, 0.0), axis, None);
 
     Effect::CreateEntity {
         template_id: muzzle_flash_template_id,
@@ -832,6 +829,34 @@ pub(super) fn create_projectile(
 
 #[cfg(test)]
 mod tests {
+    use cgmath::Rotation;
+    #[test]
+    fn flash_cone_points_out_of_held_and_world_barrels() {
+        for (name, axis) in [
+            ("ar15_h", vec3(-1.0, 0.0, 0.0)),
+            ("ar15_w", vec3(0.0, 0.0, -1.0)),
+        ] {
+            let mut world = World::new();
+            let gun = world.add_entity((
+                dark::properties::PropModelName(name.to_owned()),
+                RuntimePropTransform(Matrix4::from_scale(0.55)),
+                RuntimePropVhots(vec![muzzle_vhot(point3(-1.0, 0.0, 0.0))]),
+            ));
+            let Effect::CreateEntity { orientation, .. } =
+                create_muzzle_flash(&world, gun, -2653, &GunFlashOptions { vhot: 0, flags: 0 })
+            else {
+                panic!("flash must spawn");
+            };
+            // The assflash cone extends down local -X. Flipping it points the
+            // visible CW front away from the shooter and buries it in the gun.
+            let forward = orientation.rotate_vector(vec3(-1.0, 0.0, 0.0));
+            assert!(
+                (forward - axis).magnitude() < 0.001,
+                "{name}: cone faces {forward:?}"
+            );
+        }
+    }
+
     #[test]
     fn gun_flash_resolves_a_sparse_authored_vhot_id() {
         let mut world = World::new();

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -301,16 +301,6 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     map
 });
 
-/// First-person models the flat wield swap may apply. Frozen to the set that
-/// was allowed before the VR `_h` route grew the grip table, so flat behavior
-/// (which models donate vhots via the swap) is unchanged by VR tuning entries.
-const FLAT_WIELD_SWAP_MODELS: &[&str] = &["atek_h", "amp_h", "lasehand", "wrench_h"];
-
-pub fn is_allowed_hand_model(model_name: &str) -> bool {
-    let name = model_name.to_ascii_lowercase();
-    FLAT_WIELD_SWAP_MODELS.contains(&name.as_str())
-}
-
 /// The 25th Anniversary Edition's remastered first-person gun models
 /// (`obj/*_h.bin`, LGMD), shipped in `mods/sshock2ee.kpf` which outranks every
 /// classic archive - so on a 25AE install these names always resolve to the
@@ -650,18 +640,6 @@ mod tests {
                 HAND_MODEL_POSITIONING.contains_key(name),
                 "missing HAND_MODEL_POSITIONING entry for {name}"
             );
-        }
-    }
-
-    /// Flat's wield swap is frozen: growing the VR grip table must not change
-    /// which models flat swaps to (and thereby its vhot donors).
-    #[test]
-    fn flat_wield_swap_set_is_frozen() {
-        for name in ["atek_h", "amp_h", "lasehand", "wrench_h"] {
-            assert!(is_allowed_hand_model(name));
-        }
-        for name in ["sg_h", "ar15_h", "empgun_h", "atek_w", "battery"] {
-            assert!(!is_allowed_hand_model(name), "{name} must not swap in flat");
         }
     }
 

--- a/tools/shock2-sdk/test/gunflash-casing.e2e.test.ts
+++ b/tools/shock2-sdk/test/gunflash-casing.e2e.test.ts
@@ -41,16 +41,30 @@ for (const presentation of ["flat", "left", "right"] as const) {
         assert.ok(hand === "left" ? sideways > 0.01 : sideways < -0.01,
           `casing must leave the ${hand} ejection side: ${sideways}`);
       }
-      if (!vr) {
-        const save = `casing_fx_${Date.now()}`;
-        assert.equal((await game.save(save)).success, true);
-        assert.equal((await game.load(save)).success, true);
-        assert.ok(!(await game.entities.list()).entities.some(e => e.template_id === -2657),
-          "short-lived cosmetic casings must not be relaunched by save/load");
-        return;
-      }
       await game.step({ frames: 60 });
       assert.ok(!(await game.entities.list()).entities.some(e => e.id === casing.id),
         "casing retains its authored effect lifetime");
     });
 }
+
+// Debug scenes have no mission file to reload; exercise saves in a real mission.
+test("flat AR15 casings stay transient across save/load", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "earth.mis" });
+  await game.step({ frames: 30 });
+  await game.player.setStats({ skills: { standard_weapons: 6 } });
+  await game.player.spawnItem("Assault Rifle");
+  await game.input.trigger("EquipAssaultRifle");
+  await game.step({ frames: 5 });
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0);
+  assert.ok((await game.entities.list()).entities.some(e => e.template_id === -2657));
+  const save = `casing_fx_${Date.now()}`;
+  assert.equal((await game.save(save)).success, true);
+  assert.equal((await game.load(save)).success, true);
+  assert.ok(!(await game.entities.list()).entities.some(e => e.template_id === -2657),
+    "short-lived casings must not return after loading");
+  const gun = (await game.info()).player.wielded_entity_id;
+  assert.ok(gun);
+  assert.ok((await game.entities.detail(gun)).properties.some(p => p.name === "Model" && p.value === "ar15_h"));
+});

--- a/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
+++ b/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
@@ -56,6 +56,13 @@ test(
     const flashA = posOf(listA, "Assault Flash");
     assert.ok(pistolA, "pistol present after firing");
     assert.ok(flashA, "muzzle flash should spawn on fire");
+    const flashEntity = listA.find((e) => e.name === "Assault Flash")!;
+    const draws = (await game.scene.objects({ entityId: flashEntity.id })).objects;
+    assert.ok(draws.length > 0, "flash reaches the viewmodel render pass");
+    for (const draw of draws) {
+      assert.equal(draw.depth_write, false);
+      assert.ok(Math.abs((draw.transparency ?? 0) - 0.2) < 0.001);
+    }
     const offsetA = dist(pistolA, flashA);
 
     // Turn the camera 30deg while the flash is still alive (it lives a couple of


### PR DESCRIPTION
Firing now produces a visible flash at the displayed muzzle in flat and VR. Held-model grip compensation had turned the one-sided cone away from the shooter; 25AE's unlit additive flash material was also ignored. Flat AR15 additionally used world-model attachment points despite drawing the first-person mesh.

Align the cone with the barrel, recognize the authored single additive material pass, and make flat wielded metadata follow the displayed first-person model. Flat attachments now honor RenderAlpha. This also corrects the AR15 casing's flat ejection direction; its upright mesh pose is a separate followup.

Validation: 15 material/parser and 19 weapon Rust tests; 13 focused SDK scenarios (flash draw/attachment tracking, flat/left/right casings, real-mission casing save/load, EMP flat/VR, six VR muzzle/backstop cases); warnings-denied checks for gameplay, desktop and debug runtime. Corrected the casing save test to reload a real mission, since debug scenes have no mission file. Independent source review addressed additive opacity, lighting and pass selection; Codex CLI review was unavailable due a missing installed dependency. Headset testing and the full SDK suite remain outstanding before landing.

Matched deterministic captures, pistol and AR15 (shot frames slowed 6x):

![Flat before/after](https://gist.githubusercontent.com/tommy-xr/4d26ba791f40f17c2c6f42b14d3ffb4d/raw/flat-flash-before-after.gif)
![Flat still](https://gist.githubusercontent.com/tommy-xr/4d26ba791f40f17c2c6f42b14d3ffb4d/raw/flat-flash-before-after.png)
![VR before/after](https://gist.githubusercontent.com/tommy-xr/4d26ba791f40f17c2c6f42b14d3ffb4d/raw/vr-flash-before-after.gif)
![VR still](https://gist.githubusercontent.com/tommy-xr/4d26ba791f40f17c2c6f42b14d3ffb4d/raw/vr-flash-before-after.png)
