### PR TITLE
fix(weapons): preserve sideways casing launch poses

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -322,3 +322,19 @@ adopts every authored first-person mesh through the existing ChangeModel path,
 matching its renderer and restoring the correct attachment positions and axes.
 The casing-side regression reproduced on the parent as well; this model fix
 addresses that underlying mismatch rather than changing its assertion.
+
+
+## Casing launch pose
+
+The shell's long axis is authored along Y in both classic and 25AE assets.
+The launch path's inherited bullet yaw left it upright. A quarter turn around
+launch-frame X now lays it along the barrel, independently of the existing
+velocity frame. Flat/right/left scenarios assert the actual spawned pose as
+well as upward/lateral motion and expiry; real-mission save/load remains
+covered. Matched side footage checks the visual pose while it rises and falls.
+
+Render verification caught the rotate Tweq replacing the entire launch pose
+with absolute world-time yaw every frame. Its existing 20 degrees/second spin
+now advances relative to the current orientation using elapsed time, preserving
+pitch/roll and resuming consistently after save/load. Authored rotate config
+rates/axes remain a separate parity audit; this does not claim to implement them.

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -716,7 +716,9 @@ pub(super) fn create_muzzle_flash(
         return Effect::CreateEntity {
             template_id: muzzle_flash_template_id,
             position: point3(0.0, 0.0, 0.0),
-            orientation: Quaternion::from_angle_y(Deg(90.0)),
+            // Casing meshes are long along +Y. Lay that axis along the
+            // barrel (+Z in this launch frame), not upright above the gun.
+            orientation: Quaternion::from_angle_x(Deg(90.0)),
             root_transform: frame,
             options: CreateEntityOptions {
                 launch_projectile: true,

--- a/shock2vr/src/systems/tweq.rs
+++ b/shock2vr/src/systems/tweq.rs
@@ -27,11 +27,14 @@ pub fn run_tweq(
     mut v_tweq_delete_config: ViewMut<PropTweqDeleteConfig>,
     mut effects: UniqueViewMut<EffectQueue>,
 ) {
-    for (id, tweq) in v_tweq_rotate_state.iter().with_id() {
+    for (id, (tweq, position)) in (&v_tweq_rotate_state, &v_prop_position).iter().with_id() {
         if tweq.animation_state.contains(TweqAnimationState::ON) {
             effects.push(Effect::SetRotation {
                 entity_id: id,
-                rotation: Quaternion::from_angle_y(Deg(u_time.total.as_secs_f32() * 20.0)),
+                // Advance from the current pose; absolute world-time yaw erased
+                // authored pitch/roll (including a sideways ejected casing).
+                rotation: Quaternion::from_angle_y(Deg(u_time.elapsed.as_secs_f32() * 20.0))
+                    * position.rotation,
             });
         }
     }
@@ -203,6 +206,39 @@ mod tests {
             },
         ));
         (world, emitter)
+    }
+
+    #[test]
+    fn rotate_tweq_preserves_launch_tilt_and_uses_elapsed_time() {
+        let tilt = Quaternion::from_angle_x(Deg(90.0));
+        let (mut world, emitter) = world_with_ops4_emitter(vec3(0.0, 0.0, 0.0), tilt, false, 0);
+        world.add_component(
+            emitter,
+            PropTweqRotateState {
+                animation_state: TweqAnimationState::ON,
+                axis1_animation_state: TweqAnimationState::ON,
+                axis2_animation_state: TweqAnimationState::empty(),
+                axis3_animation_state: TweqAnimationState::empty(),
+            },
+        );
+        world.borrow::<UniqueViewMut<Time>>().unwrap().total = std::time::Duration::from_secs(1000);
+        world.run(run_tweq);
+        let effects = world
+            .borrow::<UniqueViewMut<EffectQueue>>()
+            .unwrap()
+            .flush();
+        let rotation = effects
+            .iter()
+            .find_map(|effect| match effect {
+                Effect::SetRotation {
+                    entity_id,
+                    rotation,
+                } if *entity_id == emitter => Some(*rotation),
+                _ => None,
+            })
+            .unwrap();
+        let expected = Quaternion::from_angle_y(Deg(0.501 * 20.0)) * tilt;
+        assert!((rotation - expected).magnitude2() < 1.0e-6);
     }
 
     #[test]

--- a/tools/shock2-sdk/test/gunflash-casing.e2e.test.ts
+++ b/tools/shock2-sdk/test/gunflash-casing.e2e.test.ts
@@ -3,7 +3,9 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/index.js";
 import { cycleToWeapon } from "./helpers/weapon.js";
-import { aimVrHandAt, quatFromTo } from "./helpers/vr-hand.js";
+import { aimVrHandAt, quatFromTo, quatRotate } from "./helpers/vr-hand.js";
+
+import type { Quat } from "./helpers/vr-hand.js";
 
 const enabled = process.env.SHOCK2_E2E === "1";
 for (const presentation of ["flat", "left", "right"] as const) {
@@ -30,6 +32,12 @@ for (const presentation of ["flat", "left", "right"] as const) {
       const casing = (await game.entities.list()).entities.find(e => !before.has(e.id) && e.template_id === -2657);
       assert.ok(casing, "the authored casing GunFlash link must spawn an object");
       const initial = casing.position as Vec3;
+      // Both classic and 25AE shell meshes have their long axis along +Y.
+      // A level gun must launch that axis sideways, not standing upright.
+      const pose = (await game.entities.detail(casing.id)).rotation as Quat;
+      const longAxis = quatRotate(pose, [0, 1, 0]);
+      assert.ok(Math.abs(longAxis[1]) < 0.3,
+        `casing must lie along the barrel at launch: ${JSON.stringify(longAxis)}`);
       await game.step({ frames: 8 });
       const later = (await game.entities.detail(casing.id)).position as Vec3;
       assert.ok(later[1] - initial[1] > 0.15,


### PR DESCRIPTION
Ejected casings now start sideways along the barrel and retain that pose while spinning and falling. The previous launch yaw left the mesh's long Y axis upright, and the rotate Tweq overwrote any launch tilt with absolute world-time yaw on the first frame.

Lay the casing along the launch frame, and advance the existing Tweq spin from the current orientation using elapsed time. Ejection velocity is independent and unchanged. Authored Tweq rotation rates/axes and GunFlash random-bank parity remain followups.

Validation: all three pose assertions fail on the parent and pass in flat/left/right VR after the fix. Five focused SDK cases cover pose, launch motion, lifetime, real-mission save/load and muzzle-flash tracking. Five Tweq Rust tests pass, including tilted-pose/global-clock regression; warnings-denied gameplay/desktop/debug checks pass. Independent source review found no remaining blocker. Matched deterministic side captures verify horizontal brass above the breech and subsequent fall. Headset and full SDK verification remain outstanding before landing.


![Casing pose before/after](https://gist.githubusercontent.com/tommy-xr/2d16e0b280bb37e4f8d7d8a14947c203/raw/casing-pose-before-after.gif)
![Casing pose still](https://gist.githubusercontent.com/tommy-xr/2d16e0b280bb37e4f8d7d8a14947c203/raw/casing-pose-before-after.png)
![Later frame](https://gist.githubusercontent.com/tommy-xr/2d16e0b280bb37e4f8d7d8a14947c203/raw/casing-pose-later.png)
