### PR TITLE
fix(weapons): deploy and detonate proximity grenades

### DIFF
--- a/projects/weapon-projectile-audit.md
+++ b/projects/weapon-projectile-audit.md
@@ -91,8 +91,9 @@ They are not skipped or counted as passing weapon behavior.
 
 ### Follow-up order
 
-1. Implement proximity-grenade arming, detection, detonation and cleanup,
-   including the contact-mode payload and save/load of deployed mines.
+1. **Implemented in the proximity-grenade stack layer below:** arming,
+   detection, detonation and cleanup, including the contact-mode payload and
+   save/load of deployed mines.
 2. Implement authored annelid homing and verify both target modes and secondary
    effects; remove the worm-launcher TODOs once firing and flight work.
 3. Route projectile contact stimuli through target receptrons, replacing fixed
@@ -116,3 +117,43 @@ From `tools/shock2-sdk`, run `npm run build`, then
 Set `WEAPON_AUDIT_PRESENTATION=flat` or `vr` to run one presentation.
 TODO cases execute and retain their crash output in the test report. No physical
 headset verification is claimed by this deterministic debug-runtime matrix.
+
+
+## Proximity-grenade implementation
+
+The next stack layer implements `ProxGrenade`, `ContactProxGrenade` and
+`ProxGrenadeTrigger`. Bounce mode arms at physics sleep and changes to its
+last authored model; contact mode arms the deployed `MissSpang` mine. An
+actual `Prox Grenade Trigger` owns the authored sensor dimensions and
+`Corpse -> HE Explosion`. Live AI collider overlap or damage to the armed
+mine detonates that trigger once. Player and scenery overlap do not trip it.
+The mine and sensor are removed together, including non-damage removal.
+
+The sensor follows any displacement of its mine before script damage and
+overlap checks. Kinematic sensor poses are updated immediately so sensing and
+the explosion cannot lag a moving mine by a physics step.
+
+The mine/sensor pair uses saved, remapped `ScriptParams` links. Arming zeros
+the mine's persisted initial-velocity property, preventing load reconstruction
+from launching it again. Contact mines are gameplay objects even though they
+arrive through an impact-spang link, so they are excluded from transient-FX
+save suppression.
+
+Source boundaries: the [allobjs script inventory](https://thiefmissions.com/telliamed/allscripts.html)
+identifies sleep-based bounce arming, contact activation and AI-triggered
+sensors. Local Dark sources `physics/phcore.cpp:4211` and
+`physics/phconst.h:73` define terrain reflection using object elasticity times
+`kTerrainBounce = 0.1`. This correction is scoped to proximity grenades here;
+other objects still use the existing port calibration. Rapier additionally
+uses angular damping 1.0 (linear damping 0) on bouncing mines to compensate
+for missing rolling resistance. That damping is a port approximation, not an
+assertion of exact Dark material or settling parity. The original script
+inventory does not provide the complete script implementation.
+
+Validation includes actual firing, deployment, live AI-triggered detonation,
+sensor physics and single-HE blast checks in flat and VR; both modes save/load in `earth.mis` without
+relaunching or duplicating sensors. Four proximity audit rows now pass and
+have no TODO. The original baseline above remains historical: its remaining
+known launch failures are the four worm-launcher presentation/mode cases.
+General projectile damage, pellet spread, homing and other effect lifecycles
+remain the follow-ups listed above.

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -57,6 +57,11 @@ fn needs_internal_simple_health(
     authored_scripts: &[String],
 ) -> bool {
     !is_creature
+        // Proximity scripts own the mine/sensor detonation as one transition.
+        && !authored_scripts.iter().any(|script| {
+            script.eq_ignore_ascii_case("ProxGrenade")
+                || script.eq_ignore_ascii_case("ContactProxGrenade")
+        })
         && (has_hit_points
             || authored_scripts
                 .iter()
@@ -207,7 +212,11 @@ pub fn create_entity_with_position(
         }
     }
 
-    if additional_options.transient_fx {
+    // A MissSpang can be a deployed gameplay object, not just disposable FX.
+    // Contact proximity mines must remain present in saves.
+    if additional_options.transient_fx
+        && !crate::scripts::script_util::entity_has_script(world, entity_id, "ContactProxGrenade")
+    {
         world.add_component(entity_id, crate::runtime_props::RuntimePropTransientFx);
         world.add_component(entity_id, crate::runtime_props::RuntimePropDoNotSerialize);
     }
@@ -1113,7 +1122,20 @@ fn create_physics_representation_with_options(
     let dynamics_options = if let Ok(phys_attr) = v_phys_attr.get(entity_id) {
         DynamicPhysicsOptions {
             gravity_scale: phys_attr.gravity_scale,
-            restitution: dark_elasticity_to_restitution(phys_attr.elasticity),
+            // Dark phcore::BounceObject multiplies object elasticity by
+            // phconst::kTerrainBounce (0.1). The legacy 0.7 calibration makes
+            // ProxGrenade's elasticity=3 perfectly elastic, preventing sleep
+            // and therefore arming. Keep this correction scoped to the mine;
+            // general material/contact parity is a separate physics change.
+            restitution: if crate::scripts::script_util::entity_has_script(
+                world,
+                entity_id,
+                "ProxGrenade",
+            ) {
+                (phys_attr.elasticity * 0.1).clamp(0.0, 1.0)
+            } else {
+                dark_elasticity_to_restitution(phys_attr.elasticity)
+            },
             friction: dark_friction(phys_attr.friction),
         }
     } else {
@@ -1435,7 +1457,12 @@ fn create_physics_representation_with_options(
         if let (Ok(pos), Ok(phys_type)) = (v_pos.get(entity_id), v_phys_type.get(entity_id)) {
             let qrotation = pos.rotation;
 
-            let mut is_sensor = false;
+            // Proximity triggers author PhysDims/PhysAttr without TripFlags.
+            let mut is_sensor = crate::scripts::script_util::entity_has_script(
+                world,
+                entity_id,
+                "ProxGrenadeTrigger",
+            );
             // Model scale belongs to the rendered model. An explicit
             // P$PhysDims is already the independently authored collision
             // volume and must not be scaled again (Shodan's window strips

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4276,6 +4276,37 @@ impl MissionCore {
         });
         self.flat_ui.set_name_strip(name_strip);
 
+        // A deployed mine may be displaced by a collision or moving support.
+        // Move its sensor before script damage/overlap checks, so sensing and
+        // the eventual Corpse explosion remain at the visible mine.
+        let proximity_poses: Vec<_> = {
+            let scripts = self.world.borrow::<View<PropScripts>>().unwrap();
+            let positions = self.world.borrow::<View<PropPosition>>().unwrap();
+            (&scripts)
+                .iter()
+                .with_id()
+                .filter_map(|(id, scripts)| {
+                    if !scripts
+                        .scripts
+                        .iter()
+                        .any(|s| s.eq_ignore_ascii_case("ProxGrenadeTrigger"))
+                    {
+                        return None;
+                    }
+                    let owner = crate::scripts::proximity_grenade::linked_peer(&self.world, id)?;
+                    let pose = positions.get(owner).ok()?;
+                    let current = positions.get(id).ok()?;
+                    (pose.position != current.position || pose.rotation != current.rotation)
+                        .then_some((id, pose.clone()))
+                })
+                .collect()
+        };
+        for (id, pose) in proximity_poses {
+            self.physics
+                .sync_sensor_position_rotation(id, pose.position, pose.rotation);
+            self.world.add_component(id, pose);
+        }
+
         // Update scripts
         let mut script_effects = profile!(
             scope: "game", level: DEBUG, "script_world.update",
@@ -6031,6 +6062,16 @@ impl MissionCore {
 
         let v_initial_velocity = world.borrow::<View<PropPhysInitialVelocity>>().unwrap();
         if let Some(rigid_body) = created_entity.rigid_body {
+            if crate::scripts::script_util::entity_has_script(
+                world,
+                created_entity.entity_id,
+                "ProxGrenade",
+            ) {
+                // Rapier has no rolling resistance: a spherical mine can roll
+                // forever after landing. Angular damping substitutes for that
+                // missing ground drag without damping its launch translation.
+                physics.set_body_damping(rigid_body, 0.0, 1.0);
+            }
             if let Some(velocity_frame) = authored_velocity_frame {
                 // The parser already converts Dark velocity to world units:
                 // (-forward, up, right). The launch frame uses +Z forward.
@@ -6115,6 +6156,24 @@ impl MissionCore {
         let mut visited: HashSet<EntityId> = HashSet::from([entity_id]);
         let mut frontier = vec![entity_id];
         while let Some(parent) = frontier.pop() {
+            // Mine and sensor are one deployed object, including when a mine
+            // is removed by a non-damage path. Reuse the visited set so their
+            // reciprocal, save-remapped ScriptParams links cannot cycle.
+            if ["ProxGrenade", "ContactProxGrenade", "ProxGrenadeTrigger"]
+                .iter()
+                .any(|script| {
+                    crate::scripts::script_util::entity_has_script(&self.world, parent, script)
+                })
+            {
+                if let Some(peer) =
+                    crate::scripts::proximity_grenade::linked_peer(&self.world, parent)
+                {
+                    if visited.insert(peer) {
+                        to_remove.push(peer);
+                        frontier.push(peer);
+                    }
+                }
+            }
             let children: Vec<(EntityId, bool)> = match self.world.borrow::<(
                 View<crate::runtime_props::RuntimePropAttachment>,
                 View<PropTweqDeleteConfig>,
@@ -7530,6 +7589,47 @@ impl MissionCore {
                     self.queue_flat_melee_swing(asset_cache, entity_id);
                 }
 
+                Effect::ArmProximityGrenade { entity_id } => {
+                    if crate::scripts::proximity_grenade::linked_peer(&self.world, entity_id)
+                        .is_none()
+                    {
+                        let pose = self
+                            .world
+                            .borrow::<View<PropPosition>>()
+                            .unwrap()
+                            .get(entity_id)
+                            .ok()
+                            .cloned();
+                        if let Some(pose) = pose {
+                            if let Some(trigger) = self.create_entity_by_template_name(
+                                asset_cache,
+                                "Prox Grenade Trigger",
+                                vec3_to_point3(pose.position),
+                                pose.rotation,
+                            ) {
+                                // Persist the deployed state in the authored property too:
+                                // physics reconstruction must not reapply launch velocity.
+                                self.world.add_component(
+                                    entity_id,
+                                    PropPhysInitialVelocity(vec3(0.0, 0.0, 0.0)),
+                                );
+                                let mut links = self.world.borrow::<ViewMut<Links>>().unwrap();
+                                for (from, to) in [
+                                    (entity_id, trigger.entity_id),
+                                    (trigger.entity_id, entity_id),
+                                ] {
+                                    if let Ok(from_links) = (&mut links).get(from) {
+                                        from_links.to_links.push(ToLink {
+                                            to_template_id: 0,
+                                            to_entity_id: Some(WrappedEntityId(to)),
+                                            link: Link::ScriptParams,
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 Effect::CreateEntityByTemplateName {
                     source_entity_id,
                     template_name,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -4037,6 +4037,80 @@ impl PhysicsWorld {
         maybe_rigid_body.map(|rigid_body| nvec_to_cgmath(*rigid_body.translation()))
     }
 
+    /// Move a kinematic sensor immediately without inventing a swept velocity.
+    /// The ordinary pose setter schedules a kinematic target for the next
+    /// step, which is too late for same-frame overlap and explosion queries.
+    pub fn sync_sensor_position_rotation(
+        &mut self,
+        entity_id: EntityId,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+    ) {
+        let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
+            return;
+        };
+        let is_sensor = self.rigid_body_set.get(handle).is_some_and(|body| {
+            body.is_kinematic()
+                && body
+                    .colliders()
+                    .iter()
+                    .all(|c| self.collider_set[*c].is_sensor())
+        });
+        if !is_sensor {
+            return;
+        }
+        self.set_position_rotation(handle, position, rotation);
+        if let Some(body) = self.rigid_body_set.get_mut(handle) {
+            let pose = *body.next_position();
+            body.set_position(pose, false);
+        }
+    }
+
+    /// A missing body is not a settled projectile.
+    pub fn is_entity_sleeping(&self, entity_id: EntityId) -> bool {
+        self.entity_id_to_body
+            .get(&entity_id)
+            .and_then(|handle| self.rigid_body_set.get(*handle))
+            .is_some_and(|body| body.is_sleeping())
+    }
+
+    /// Exact overlap of two entities' authored colliders, including sensors.
+    pub fn entities_overlap(&self, first: EntityId, second: EntityId) -> bool {
+        let bodies = self
+            .entity_id_to_body
+            .get(&first)
+            .and_then(|handle| self.rigid_body_set.get(*handle))
+            .zip(
+                self.entity_id_to_body
+                    .get(&second)
+                    .and_then(|handle| self.rigid_body_set.get(*handle)),
+            );
+        bodies.is_some_and(|(first, second)| {
+            first.colliders().iter().any(|a| {
+                let a = &self.collider_set[*a];
+                // Body poses may have been synchronized since the last physics
+                // step. Compose the local collider offset rather than reading its
+                // cached world pose (which updates in the next broad-phase pass).
+                let a_pose =
+                    first.position() * a.position_wrt_parent().copied().unwrap_or_default();
+                second.colliders().iter().any(|b| {
+                    let b = &self.collider_set[*b];
+                    let b_pose =
+                        second.position() * b.position_wrt_parent().copied().unwrap_or_default();
+                    a.is_enabled()
+                        && b.is_enabled()
+                        && rapier3d::parry::query::intersection_test(
+                            &a_pose,
+                            a.shape(),
+                            &b_pose,
+                            b.shape(),
+                        )
+                        .unwrap_or(false)
+                })
+            })
+        })
+    }
+
     pub fn get_velocity(&self, entity_id: EntityId) -> Option<Vector3<f32>> {
         if let Some(handle) = self.entity_id_to_body.get(&entity_id) {
             let maybe_rigid_body = self.rigid_body_set.get(*handle);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -569,6 +569,11 @@ pub enum Effect {
         initial_velocity: Vector3<f32>,
     },
 
+    /// Deploy the authored proximity sensor and link its lifetime to the mine.
+    ArmProximityGrenade {
+        entity_id: EntityId,
+    },
+
     CreateEntity {
         template_id: i32,
         position: Point3<f32>,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod effect;
+pub(crate) mod proximity_grenade;
 pub mod speech_registry;
 pub mod speech_util;
 
@@ -917,6 +918,9 @@ impl ScriptWorld {
         match script_name.to_ascii_lowercase().as_str() {
             // PROJECTILE stuff
             "lasershot" => Box::new(NoopScript::new()),
+            "proxgrenade" => Box::new(proximity_grenade::ProximityGrenade::new(false)),
+            "contactproxgrenade" => Box::new(proximity_grenade::ProximityGrenade::new(true)),
+            "proxgrenadetrigger" => Box::new(proximity_grenade::ProximityTrigger::default()),
             "timedgrenade" => Box::new(NoopScript::new()),
             "transluceinoutprop" => Box::new(NoopScript::new()),
 

--- a/shock2vr/src/scripts/proximity_grenade.rs
+++ b/shock2vr/src/scripts/proximity_grenade.rs
@@ -1,0 +1,293 @@
+//! Proximity grenades retain an authored sensor as a separate, saved object.
+//! Bounce mode arms at physics sleep; the contact spang is already deployed.
+//! The sensor's Corpse link supplies the blast, rather than a hardcoded radius
+//! or damage value. ScriptParams links persist/remap the mine/sensor pair.
+use dark::properties::{Link, PropAI, PropHitPoints};
+use shipyard::{EntitiesView, EntityId, IntoIter, IntoWithId, View, World};
+
+use super::{Effect, MessagePayload, Script, script_util};
+use crate::{physics::PhysicsWorld, time::Time};
+
+pub(crate) fn linked_peer(world: &World, entity: EntityId) -> Option<EntityId> {
+    script_util::get_first_link_of_type(world, entity, Link::ScriptParams)
+}
+
+pub struct ProximityGrenade {
+    contact: bool,
+    detonating: bool,
+}
+
+impl ProximityGrenade {
+    pub fn new(contact: bool) -> Self {
+        Self {
+            contact,
+            detonating: false,
+        }
+    }
+}
+
+impl Script for ProximityGrenade {
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        _time: &Time,
+    ) -> Effect {
+        if self.detonating || linked_peer(world, entity_id).is_some() {
+            return Effect::NoEffect;
+        }
+        if self.contact || physics.is_entity_sleeping(entity_id) {
+            Effect::Multiple(vec![
+                Effect::ArmProximityGrenade { entity_id },
+                script_util::change_to_last_model(world, entity_id),
+            ])
+        } else {
+            Effect::NoEffect
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if self.detonating || !matches!(msg, MessagePayload::Damage { amount, .. } if *amount > 0.0)
+        {
+            return Effect::NoEffect;
+        }
+        self.detonating = true;
+        match linked_peer(world, entity_id) {
+            Some(trigger) => Effect::Multiple(vec![
+                Effect::SlayEntity { entity_id: trigger },
+                Effect::DestroyEntity { entity_id },
+            ]),
+            None => Effect::SlayEntity { entity_id },
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ProximityTrigger {
+    detonating: bool,
+}
+
+impl Script for ProximityTrigger {
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        _time: &Time,
+    ) -> Effect {
+        if self.detonating {
+            return Effect::NoEffect;
+        }
+        let owner = linked_peer(world, entity_id);
+        if owner.is_some_and(|id| !world.borrow::<EntitiesView>().unwrap().is_alive(id)) {
+            return Effect::DestroyEntity { entity_id };
+        }
+        // General sensor enter events currently cover the player only. Query
+        // actual collider overlap for AI, including AI already inside at arm
+        // time or after a load. Scenery and the player cannot trip this sensor.
+        let ai = world.borrow::<View<PropAI>>().unwrap();
+        let hp = world.borrow::<View<PropHitPoints>>().unwrap();
+        let triggered = (&ai, &hp)
+            .iter()
+            .with_id()
+            .any(|(id, (_, hp))| hp.hit_points > 0 && physics.entities_overlap(entity_id, id));
+        if !triggered {
+            return Effect::NoEffect;
+        }
+        self.detonating = true;
+        let mut effects = vec![Effect::SlayEntity { entity_id }];
+        if let Some(entity_id) = owner {
+            effects.push(Effect::DestroyEntity { entity_id });
+        }
+        Effect::Multiple(effects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::{CollisionGroup, DynamicPhysicsOptions, PhysicsShape};
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Links, ToLink, WrappedEntityId};
+
+    fn link(world: &mut World, from: EntityId, to: EntityId) {
+        world.add_component(
+            from,
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(to)),
+                    link: Link::ScriptParams,
+                }],
+            },
+        );
+    }
+
+    fn body(physics: &mut PhysicsWorld, id: EntityId, x: f32, size: f32, sensor: bool) {
+        physics.add_kinematic(
+            id,
+            vec3(x, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(size, size, size),
+            CollisionGroup::actor(),
+            sensor,
+        );
+    }
+
+    #[test]
+    fn bounce_arms_only_when_the_body_sleeps() {
+        let mut world = World::new();
+        let mine = world.add_entity(Links { to_links: vec![] });
+        let mut physics = PhysicsWorld::new();
+        let handle = physics.add_dynamic(
+            mine,
+            vec3(0.0, 2.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Sphere(0.2),
+            CollisionGroup::actor(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        let mut script = ProximityGrenade::new(false);
+        assert!(matches!(
+            script.update(mine, &world, &physics, &Time::default()),
+            Effect::NoEffect
+        ));
+        physics.sleep_body(handle);
+        let Effect::Multiple(effects) = script.update(mine, &world, &physics, &Time::default())
+        else {
+            panic!("sleep must arm");
+        };
+        assert!(
+            effects.iter().any(
+                |e| matches!(e, Effect::ArmProximityGrenade {entity_id} if *entity_id == mine)
+            )
+        );
+        let trigger = world.add_entity(());
+        link(&mut world, mine, trigger);
+        assert!(matches!(
+            script.update(mine, &world, &physics, &Time::default()),
+            Effect::NoEffect
+        ));
+        // Arming lives in the persisted Links; a new script instance after load
+        // does not duplicate the trigger even though its physics starts awake.
+        assert!(matches!(
+            ProximityGrenade::new(false).update(mine, &world, &physics, &Time::default()),
+            Effect::NoEffect
+        ));
+    }
+
+    #[test]
+    fn contact_mine_arms_without_a_dynamic_body() {
+        let mut world = World::new();
+        let mine = world.add_entity(Links { to_links: vec![] });
+        assert!(matches!(
+            ProximityGrenade::new(true).update(
+                mine,
+                &world,
+                &PhysicsWorld::new(),
+                &Time::default()
+            ),
+            Effect::Multiple(_)
+        ));
+        assert!(matches!(
+            ProximityGrenade::new(false).update(
+                mine,
+                &world,
+                &PhysicsWorld::new(),
+                &Time::default()
+            ),
+            Effect::NoEffect
+        ));
+    }
+
+    #[test]
+    fn sensor_requires_live_ai_and_exact_overlap_then_fires_once() {
+        for (ai, hp, x, expected) in [
+            (false, 10, 0.0, false),
+            (true, 0, 0.0, false),
+            (true, 10, 5.0, false),
+            (true, 10, 2.7, true),
+        ] {
+            let mut world = World::new();
+            let owner = world.add_entity(());
+            let trigger = world.add_entity(());
+            link(&mut world, trigger, owner);
+            let target = world.add_entity(PropHitPoints { hit_points: hp });
+            if ai {
+                world.add_component(target, PropAI("Grunt".into()));
+            }
+            let mut physics = PhysicsWorld::new();
+            body(&mut physics, trigger, 0.0, 4.8, true);
+            body(&mut physics, target, x, 1.0, false);
+            let mut script = ProximityTrigger::default();
+            let effect = script.update(trigger, &world, &physics, &Time::default());
+            assert_eq!(matches!(effect, Effect::Multiple(_)), expected);
+            if expected {
+                let Effect::Multiple(effects) = effect else {
+                    unreachable!()
+                };
+                assert!(
+                    matches!(effects[0],Effect::SlayEntity {entity_id} if entity_id == trigger)
+                );
+                assert!(
+                    matches!(effects[1],Effect::DestroyEntity {entity_id} if entity_id == owner)
+                );
+                assert!(matches!(
+                    script.update(trigger, &world, &physics, &Time::default()),
+                    Effect::NoEffect
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn overlap_uses_moved_body_pose_before_the_next_physics_step() {
+        let mut world = World::new();
+        let trigger = world.add_entity(());
+        let target = world.add_entity(());
+        let mut physics = PhysicsWorld::new();
+        body(&mut physics, trigger, 0.0, 4.8, true);
+        body(&mut physics, target, 10.0, 1.0, false);
+        assert!(!physics.entities_overlap(trigger, target));
+        physics.sync_sensor_position_rotation(
+            trigger,
+            vec3(10.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        );
+        assert!(physics.entities_overlap(trigger, target));
+    }
+
+    #[test]
+    fn shot_armed_mine_slays_only_its_sensor() {
+        let mut world = World::new();
+        let mine = world.add_entity(());
+        let trigger = world.add_entity(());
+        link(&mut world, mine, trigger);
+        let mut script = ProximityGrenade::new(false);
+        let damage = MessagePayload::Damage {
+            amount: 1.0,
+            impact: None,
+        };
+        let Effect::Multiple(effects) =
+            script.handle_message(mine, &world, &PhysicsWorld::new(), &damage)
+        else {
+            panic!("must detonate");
+        };
+        assert!(matches!(effects[0],Effect::SlayEntity {entity_id} if entity_id == trigger));
+        assert!(matches!(effects[1],Effect::DestroyEntity {entity_id} if entity_id == mine));
+        assert!(matches!(
+            script.handle_message(mine, &world, &PhysicsWorld::new(), &damage),
+            Effect::NoEffect
+        ));
+    }
+}

--- a/tools/shock2-sdk/test/proximity-grenade.e2e.test.ts
+++ b/tools/shock2-sdk/test/proximity-grenade.e2e.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { cycleToWeapon, fireOnce } from "./helpers/weapon.js";
+import { aimVrHandAt, quatFromTo } from "./helpers/vr-hand.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+for (const vr of [false, true]) for (const setting of [0, 1]) {
+  test(`${vr ? "VR" : "flat"} proximity grenade setting ${setting} deploys one sensor and detonates once`,
+    { skip: !enabled, timeout: 180_000 }, async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: vr ? ["--vr"] : [] });
+    try {
+      await game.step({ frames: 5 });
+      await game.player.setStats({ skills: { heavy_weapons: 6 } });
+      const gun = await cycleToWeapon(game, e => e.template_id === -21, {settleFrames: vr ? 90 : 10});
+      if (vr) {
+        await aimVrHandAt(game, gun.position, 0.45, 1, 0, {hand:"right"});
+        await game.step({frames:8});
+        assert.equal((await game.info()).player.right_hand_entity_id,gun.id);
+        await game.input.set("right_hand.position",[0,1,-2]);
+        await game.input.set("right_hand.rotation",quatFromTo([0,0,-1],[-1,0,0]));
+        await game.step({frames:3});
+      }
+      if (setting) { await game.input.trigger("CycleGunSetting"); await game.step({ frames: 2 }); }
+      await game.input.trigger("EjectClip"); await game.step({ frames: 2 });
+      await game.input.trigger("CycleAmmo"); await game.step({ frames: 2 });
+      await game.player.spawnItem(-39);
+      await game.input.trigger("Reload"); await game.step({ frames: 180 });
+      await fireOnce(game);
+      let triggers = await game.entities.byTemplate(-1268);
+      for (let i = 0; i < 60 && !triggers.length; i++) {
+        await game.step({ frames: 30 });
+        triggers = await game.entities.byTemplate(-1268);
+      }
+      assert.equal(triggers.length, 1, "one authored sensor must arm");
+      const mineTemplate = setting ? -3444 : -3758;
+      const mines = await game.entities.byTemplate(mineTemplate);
+      assert.equal(mines.length, 1);
+      const bodies = (await game.physics.bodies({entityId: triggers[0]!.id})).bodies;
+      assert.equal(bodies.length, 1);
+      assert.equal(bodies[0]!.is_sensor, true);
+      await game.step({frames: 120});
+      assert.equal((await game.entities.byTemplate(-1268)).length, 1, "player and props do not trip the mine");
+      if (setting === 0) {
+        // The debug spawn is four units forward (-X in this scene). Put a
+        // live AI just inside the deployed mine's authored trigger volume.
+        const [x,y,z] = mines[0]!.position;
+        await game.player.teleport({x:x+5.5,y:y+0.5,z});
+        await game.input.set("head.look",[0,0]);
+        await game.input.trigger("SpawnDebugMonster");
+        await game.step({frames:1});
+        assert.equal((await game.entities.byTemplate(-397)).length,1);
+      } else {
+        await game.entities.sendMessage(mines[0]!.id, {type: "Damage", amount: 1});
+      }
+      await game.step({frames: 1});
+      assert.equal((await game.entities.byTemplate(mineTemplate)).length, 0);
+      assert.equal((await game.entities.byTemplate(-1268)).length, 0);
+      assert.equal((await game.entities.byTemplate(-3933)).length, 1, "one authored HE blast");
+      assert.equal((await game.entities.byTemplate(-2720)).length, 0, "no second standard blast");
+    } catch (error) { console.error(game.logs().slice(-30).join("\n")); throw error; }
+  });
+}
+
+for (const setting of [0, 1]) {
+  test(`deployed proximity setting ${setting} survives save/load at rest`,
+    {skip: !enabled, timeout: 180_000}, async () => {
+    await using game = await GameServer.launch({mission: "earth.mis"});
+    try {
+      await game.step({frames:30});
+      await game.player.setStats({skills:{heavy_weapons:6}});
+      await game.player.spawnItem("Gren Launcher");
+      await game.input.trigger("EquipGrenadeLauncher"); await game.step({frames:5});
+      if (setting) { await game.input.trigger("CycleGunSetting"); await game.step({frames:2}); }
+      await game.input.trigger("EjectClip"); await game.step({frames:2});
+      await game.input.trigger("CycleAmmo"); await game.step({frames:2});
+      await game.player.spawnItem(-39);
+      await game.input.trigger("Reload"); await game.step({frames:180});
+      await fireOnce(game);
+      let triggers = await game.entities.byTemplate(-1268);
+      for (let i=0;i<80&&!triggers.length;i++) {
+        await game.step({frames:30}); triggers = await game.entities.byTemplate(-1268);
+      }
+      assert.equal(triggers.length,1);
+      const mineTemplate = setting ? -3444 : -3758;
+      const [mine] = await game.entities.byTemplate(mineTemplate);
+      assert.ok(mine);
+      const save = `proximity_${setting}_${Date.now()}`;
+      assert.equal((await game.save(save)).success,true);
+      assert.equal((await game.load(save)).success,true);
+      await game.step({frames:120});
+      const [restored] = await game.entities.byTemplate(mineTemplate);
+      assert.ok(restored,"deployed mine survives save/load");
+      assert.equal((await game.entities.byTemplate(-1268)).length,1,"load must not duplicate sensor");
+      assert.ok(Math.hypot(...restored.position.map((v,i)=>v-mine.position[i]!))<0.15,"mine must not relaunch on load");
+      const [sensor] = await game.entities.byTemplate(-1268);
+      assert.ok(sensor);
+      assert.ok(Math.hypot(...sensor.position.map((v,i)=>v-triggers[0]!.position[i]!))<0.15);
+      await game.entities.sendMessage(restored.id,{type:"Damage",amount:1});
+      await game.step({frames:1});
+      assert.equal((await game.entities.byTemplate(mineTemplate)).length,0);
+      assert.equal((await game.entities.byTemplate(-1268)).length,0);
+      assert.equal((await game.entities.byTemplate(-3933)).length,1);
+    } catch(error) {console.error(game.logs().slice(-30).join("\n"));throw error;}
+  });
+}

--- a/tools/shock2-sdk/test/weapon-audit.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-audit.e2e.test.ts
@@ -15,8 +15,7 @@ const enabled = process.env.SHOCK2_E2E === "1";
 for (const vr of [false, true]) for (const row of cases) {
   test(`${vr ? "VR" : "flat"} audit: ${row.weapon} setting ${row.setting} ${row.projectileName}`,
     { skip: !enabled || (!!process.env.WEAPON_AUDIT_PRESENTATION && process.env.WEAPON_AUDIT_PRESENTATION !== (vr ? "vr" : "flat")), timeout: 180_000,
-      todo: row.projectile === -3444 ? "ProxGrenade script crashes on initialization"
-        : row.weaponTemplate === -27 ? "Homing script crashes on initialization" : undefined }, async () => {
+      todo: row.weaponTemplate === -27 ? "Homing script crashes on initialization" : undefined }, async () => {
     await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: vr ? ["--vr"] : [] });
     try {
     await game.step({ frames: 5 });


### PR DESCRIPTION
Firing a bounce-mode proximity grenade previously crashed on the missing `ProxGrenade` script; contact-mode impacts also reached missing mine/trigger scripts. Both modes now deploy a persistent mine with the authored proximity sensor. Live AI overlap or damage to an armed mine produces one authored HE explosion and removes the mine/sensor pair.

Bounce mines arm when their physics body sleeps and switch to the authored deployed model. Contact impact mines arm where they land and remain in saves. Saved ScriptParams links reconnect each pair after loading, and deployed mines retain zero initial velocity so they do not relaunch. Sensors follow displaced mines before overlap and damage checks, including immediate updates for kinematic sensor bodies.

Physics scope: proximity mines use Dark's terrain-bounce factor (0.1 × authored elasticity) instead of the legacy conversion that made them perfectly bouncy. Angular damping 1.0, with no linear damping, compensates for missing rolling resistance. This is a scoped port approximation; general material/settling parity remains separate. Source evidence and limits are documented in `projects/weapon-projectile-audit.md`.

Validation:
- Five focused Rust tests: sleep/contact arming, live-AI overlap filtering, single detonation and same-frame sensor displacement.
- Four proximity weapon-audit rows pass in flat/VR; removed their TODOs. Worm homing TODOs remain.
- Six SDK cases pass: actual flat/VR firing and deployment, live AI-triggered contact mines, damage-triggered bounce mines, plus both modes saved/loaded in earth.mis with stable positions, one sensor and one HE blast.
- All 23 mission-load checks passed.
- Warnings-denied Rust checks for shock2vr, desktop_runtime and debug_runtime; SDK TypeScript build passed.
- Code review findings on relaunch after load and stale sensor poses were fixed and revalidated.

Stacked on #1453. Headset verification and the broad gameplay suite remain outstanding. Damage, pellet spread, homing and other projectile effects are separate workstream items.


![Proximity mine deployment and AI-triggered detonation](https://gist.githubusercontent.com/tommy-xr/b2703217a8942b426469f6090240ff5f/raw/proximity-demo.gif)

Captured headlessly with deterministic stepping: contact-mode mine deploys, then a live hybrid enters its sensor and produces one HE blast. The mine and sensor are both removed. The [same sequence crashes on the parent build](https://gist.githubusercontent.com/tommy-xr/b2703217a8942b426469f6090240ff5f/raw/parent-crash.log), so there is no working before animation.

![Deployed contact mine](https://gist.githubusercontent.com/tommy-xr/b2703217a8942b426469f6090240ff5f/raw/proximity-deployed.png)

![HE blast beside the hybrid](https://gist.githubusercontent.com/tommy-xr/b2703217a8942b426469f6090240ff5f/raw/proximity-detonation.png)
