### PR TITLE
feat(vr): calibrate belt distance and holster placement live

### DIFF
--- a/projects/astra-vr-thigh-holsters.md
+++ b/projects/astra-vr-thigh-holsters.md
@@ -28,6 +28,15 @@ Use `cargo dbgr --mission debug_interactions --vr`. Developer parameters:
 - `vr_holster_drop`: vertical offset below the tracked head, default 0.78 m,
   range 0.55–1.10 m. Reduce this when testing seated reach.
 - `vr_holster_side`: lateral offset, default 0.23 m, range 0.16–0.40 m.
+- `vr_holster_forward`: forward/back offset, default 0.04 m, range −0.20–0.30 m.
+- `vr_belt_distance`: distance to the front of the belt, default 0.20 m,
+  range 0.10–0.45 m. The ammo pouch and its target follow the belt, 5 cm farther
+  forward. This compensates for the belt mesh's authored 30 cm offset.
+
+All placement settings take effect live, in metres, without changing hand poses
+or holstered weapon scale. Belt distance and thigh placement are independent.
+If calibration overlaps the pouch and a holster, an empty hand with a gun in the
+opposite hand uses the pouch there; one squeeze cannot draw both objects.
 
 Targets use horizontal heading with gentle following and freeze that heading
 while a hand is in a slot. They are estimates from head/controller tracking,

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -195,8 +195,12 @@ dev_params! {
     VR_BACKPACK_ZONES = bool("vr_backpack_zones", "Backpack zones", false),
     VR_AMMO_POUCH_ZONES = bool("vr_ammo_pouch_zones", "Ammo pouch zone", false),
     VR_HOLSTER_ZONES = bool("vr_holster_zones", "Holster zones", false),
+    /// Actual front of the curved belt, including the asset's authored offset.
+    /// The ammo pouch follows this setting so its mesh and grab target stay together.
+    VR_BELT_DISTANCE = float("vr_belt_distance", "Belt forward (m)", 0.20, 0.10, 0.45, 0.01),
     VR_HOLSTER_DROP = float("vr_holster_drop", "Holster below eyes (m)", 0.78, 0.55, 1.1, 0.02),
     VR_HOLSTER_SIDE = float("vr_holster_side", "Holster side (m)", 0.23, 0.16, 0.40, 0.01),
+    VR_HOLSTER_FORWARD = float("vr_holster_forward", "Holster forward (m)", 0.04, -0.20, 0.30, 0.01),
     /// VR support target/radius (cyan; green when attached) and tracked palm (amber).
     VR_SUPPORT_GRIPS = bool("vr_support_grips", "Support grips", false),
     /// Draw a floating "-7 HP" at the point each blow lands, labeled with the

--- a/shock2vr/src/mission/ammo_pouch.rs
+++ b/shock2vr/src/mission/ammo_pouch.rs
@@ -6,7 +6,14 @@ use shipyard::EntityId;
 
 pub(super) const RADIUS: f32 = 0.10 / crate::METERS_PER_WORLD_UNIT;
 const BELOW: f32 = 0.55;
-const FORWARD: f32 = 0.35;
+const POUCH_OFFSET: f32 = 0.05;
+
+pub(super) fn center_for(body: BodyPose) -> Vector3<f32> {
+    body.front(
+        BELOW,
+        crate::dev_params::get(crate::dev_params::VR_BELT_DISTANCE) + POUCH_OFFSET,
+    )
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum Action {
@@ -56,7 +63,7 @@ impl AmmoPouch {
         enabled: bool,
     ) -> [Option<Action>; 2] {
         self.enabled = enabled && body.is_some();
-        self.center = body.map(|body| body.front(BELOW, FORWARD));
+        self.center = body.map(center_for);
         self.offers = offers;
         self.near = [false; 2];
         self.blocks_grab = [false; 2];
@@ -187,7 +194,7 @@ mod tests {
             head: input.head.position,
             yaw: 0.0,
         };
-        input.left_hand.position = body.front(BELOW, FORWARD);
+        input.left_hand.position = center_for(body);
         let mut pouch = AmmoPouch::default();
         let update = |pouch: &mut AmmoPouch, input: &InputContext, available: bool, enabled| {
             pouch.update(
@@ -232,7 +239,7 @@ mod tests {
             head: input.head.position,
             yaw: 0.0,
         };
-        input.left_hand.position = body.front(BELOW, FORWARD);
+        input.left_hand.position = center_for(body);
         let mut pouch = AmmoPouch::default();
         for squeeze in [1.0, 0.5] {
             input.left_hand.squeeze_value = squeeze;
@@ -322,18 +329,16 @@ mod tests {
     }
 
     #[test]
-    fn pouch_is_separate_from_thighs_across_all_calibration_extremes() {
+    fn default_pouch_is_separate_from_thighs_and_shoulders() {
         let body = BodyPose {
             head: cgmath::vec3(0.0, 2.0, 0.0),
             yaw: 0.0,
         };
-        let center = body.front(BELOW, FORWARD);
-        for drop in [0.55, 1.10] {
-            for side in [-0.40, -0.16, 0.16, 0.40] {
-                let thigh = body.front(drop, 0.04)
-                    + cgmath::vec3(side / crate::METERS_PER_WORLD_UNIT, 0.0, 0.0);
-                assert!((thigh - center).magnitude() > RADIUS + super::super::holsters::RADIUS);
-            }
+        let center = center_for(body);
+        for side in [-0.23, 0.23] {
+            let thigh = body.front(0.78, 0.04)
+                + cgmath::vec3(side / crate::METERS_PER_WORLD_UNIT, 0.0, 0.0);
+            assert!((thigh - center).magnitude() > RADIUS + super::super::holsters::RADIUS);
         }
         assert!(
             (BELOW - 0.20) / crate::METERS_PER_WORLD_UNIT

--- a/shock2vr/src/mission/holsters.rs
+++ b/shock2vr/src/mission/holsters.rs
@@ -334,6 +334,7 @@ mod tests {
 pub(super) struct Holsters {
     pub body_pose: Option<super::body_inventory::BodyPose>,
     pub freeze_heading: bool,
+    pub pouch_priority: [bool; 2],
     yaw: Option<f32>,
     pub centers: Option<[Vector3<f32>; 2]>,
     pub near: [Option<usize>; 2],
@@ -347,6 +348,7 @@ impl Default for Holsters {
         Self {
             body_pose: None,
             freeze_heading: false,
+            pouch_priority: [false; 2],
             yaw: None,
             centers: None,
             near: [None; 2],
@@ -441,7 +443,7 @@ impl Holsters {
         let base = head.position
             - Vector3::unit_y()
                 * (crate::dev_params::get(crate::dev_params::VR_HOLSTER_DROP) / SCALE)
-            + forward * (0.04 / SCALE);
+            + forward * (crate::dev_params::get(crate::dev_params::VR_HOLSTER_FORWARD) / SCALE);
         let side = crate::dev_params::get(crate::dev_params::VR_HOLSTER_SIDE) / SCALE;
         let centers = [base + right * side, base - right * side];
         self.centers = Some(centers);
@@ -465,7 +467,14 @@ impl Holsters {
                 && hand.squeeze_value.is_finite()
                 && input.pose_tracking.is_none_or(|p| p.hands[i]);
             let pressed = hand.squeeze_value >= 0.5;
-            self.near[i] = (tracked && (held[i].is_none() || weapons[i])).then(|| (0..2).find(|s|
+            // Calibration can put a thigh target over the ammo pouch. An empty
+            // hand with an opposite gun uses the pouch there, never both slots.
+            let at_pouch = self.pouch_priority[i]
+                && held[i].is_none()
+                && (hand.position - super::ammo_pouch::center_for(self.body_pose.unwrap()))
+                    .magnitude2()
+                    <= super::ammo_pouch::RADIUS.powi(2);
+            self.near[i] = (tracked && !at_pouch && (held[i].is_none() || weapons[i])).then(|| (0..2).find(|s|
                 // A stored item remains retrievable if its perk is removed.
                 (*s < count || slots[*s].is_some()) && (hand.position - centers[*s]).magnitude2() <= RADIUS * RADIUS
             )).flatten();

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4137,6 +4137,10 @@ impl MissionCore {
         }
 
         let held = [left_hand_held, right_hand_held];
+        let pouch_weapons = std::array::from_fn(|i| {
+            held[1 - i].filter(|gun| self.magazine_capacity(*gun).is_some())
+        });
+        self.holsters.pouch_priority = pouch_weapons.map(|weapon| weapon.is_some());
         self.holsters.freeze_heading = self.ammo_pouch.near.iter().any(|near| *near);
         let holster_actions = self.holsters.update(
             hands_input,
@@ -4164,9 +4168,6 @@ impl MissionCore {
         );
         let pouch_available = [crate::Handedness::Left, crate::Handedness::Right]
             .map(|hand| self.interaction.hand_available_for_body_slot(hand));
-        let pouch_weapons = std::array::from_fn(|i| {
-            held[1 - i].filter(|gun| self.magazine_capacity(*gun).is_some())
-        });
         let pouch_offers = std::array::from_fn(|i| {
             pouch_available[i]
                 .then_some(pouch_weapons[i])
@@ -11034,7 +11035,13 @@ impl MissionCore {
             // origins. Gameplay zones and visuals use the same body frame.
             if let Some(body) = self.holsters.body_pose {
                 let root_rotation = self.holsters.world_rotation(player.rotation);
-                let belt_center = player.pos + player.rotation.rotate_vector(body.front(0.55, 0.0));
+                // The belt mesh already places its front 30 cm forward of its
+                // origin. Expose the actual belt distance, not that asset origin.
+                let belt_center = player.pos
+                    + player.rotation.rotate_vector(body.front(
+                        0.55,
+                        crate::dev_params::get(crate::dev_params::VR_BELT_DISTANCE) - 0.30,
+                    ));
                 let pouch_center = self.ammo_pouch.world_center(player.pos, player.rotation);
                 let mut parts = vec![("astra-vr-belt.glb", belt_center, Matrix4::from_scale(1.0))];
                 if let Some(center) = pouch_center {

--- a/tools/shock2-sdk/test/vr-body-calibration.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-body-calibration.e2e.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { aimVrHandAt, quatConjugate, quatRotate, sub } from "./helpers/vr-hand.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+test("belt and holster calibration moves live targets independently and resolves pouch overlap", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+  await game.step({ frames: 30 });
+  const before = (await game.info()).player.hand_feedback!;
+  await game.devParams.set("vr_belt_distance", 0.30);
+  await game.step({ frames: 3 });
+  const movedBelt = (await game.info()).player.hand_feedback!;
+  assert.deepEqual(movedBelt.holsters!.centers, before.holsters!.centers, "belt must not move thighs");
+  const delta = sub(movedBelt.ammo_pouch!.center!, before.ammo_pouch!.center!);
+  assert.ok(Math.abs(Math.hypot(...delta) * 0.762 - 0.10) < 0.001, "pouch moves by ten centimetres with belt");
+  await game.devParams.set("vr_holster_forward", -0.10);
+  await game.step({ frames: 3 });
+  const movedThighs = (await game.info()).player.hand_feedback!;
+  assert.deepEqual(movedThighs.ammo_pouch!.center, movedBelt.ammo_pouch!.center, "thighs must not move pouch");
+  assert.ok(Math.abs(Math.hypot(...sub(movedThighs.holsters!.centers![0], movedBelt.holsters!.centers![0])) * 0.762 - 0.14) < 0.001);
+
+  const rack = (await game.entities.list()).entities;
+  const wrench = rack.find(e => e.template_id === -928)!;
+  const pistol = rack.find(e => e.template_id === -17)!;
+  await aimVrHandAt(game, wrench.position, 0.2, 1);
+  await game.step({ frames: 5 });
+  let player = (await game.info()).player;
+  assert.equal(player.right_hand_entity_id, wrench.id);
+  await game.input.set("right_hand.position", quatRotate(quatConjugate(player.rotation), sub(player.hand_feedback!.holsters!.centers![0], player.position)));
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.items[0], wrench.id);
+  await aimVrHandAt(game, pistol.position, 0.2, 1);
+  await game.step({ frames: 5 });
+  const reserve = await game.player.spawnItem(-31);
+  // Put the right holster beside the pouch, with intersecting grab volumes.
+  await game.devParams.set("vr_holster_drop", 0.55);
+  await game.devParams.set("vr_holster_side", 0.16);
+  await game.devParams.set("vr_holster_forward", 0.25);
+  await game.devParams.set("vr_belt_distance", 0.20);
+  await game.step({ frames: 5 });
+  player = (await game.info()).player;
+  const pouch = player.hand_feedback!.ammo_pouch!.center!;
+  const thigh = player.hand_feedback!.holsters!.centers![0];
+  const overlap = pouch.map((v, i) => (v + thigh[i]) / 2) as [number, number, number];
+  await game.input.set("left_hand.position", quatRotate(quatConjugate(player.rotation), sub(overlap, player.position)));
+  await game.input.set("left_hand.squeeze", 0);
+  await game.step({ frames: 3 });
+  assert.equal((await game.info()).player.hand_feedback!.ammo_pouch!.near[0], true);
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.near[0], null);
+  await game.input.set("left_hand.squeeze", 1);
+  await game.step({ frames: 8 });
+  assert.equal((await game.info()).player.wielded_entity_id, reserve.entity_id, "one squeeze draws only ammunition");
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.items[0], wrench.id);
+});


### PR DESCRIPTION
The waist belt sat too far forward in VR. Add live `vr_belt_distance` calibration, defaulting to 20 cm instead of the mesh’s authored 30 cm, and move the ammo pouch and its grab target with it. Add `vr_holster_forward` alongside the existing side/drop controls; holster placement and weapon scale keep their defaults.

Calibration can make a holster overlap the pouch. When an empty hand reaches for the opposite gun’s ammunition, the pouch takes priority so one squeeze cannot draw two items.

Developer controls (metres):
- `vr_belt_distance`: 0.20 default, 0.10–0.45.
- `vr_holster_forward`: 0.04 default, −0.20–0.30.
- Existing `vr_holster_drop` and `vr_holster_side` still adjust height and spread independently.

![Live body calibration](https://gist.githubusercontent.com/tommy-xr/1e1b702206c65e0b6d8bda0a37c06948/raw/body-calibration.gif)

![Before and after](https://gist.githubusercontent.com/tommy-xr/1e1b702206c65e0b6d8bda0a37c06948/raw/body-calibration-before-after.png)

Matched deterministic debug-runtime VR camera orbit. The belt/pouch moves closer while the holster stays fixed. Local self-contained gallery: `/tmp/astra-body-reach/index.html`, including an independent live-tuning example.

Validation: 239 mission Rust tests; TypeScript, formatting, warning-denied library build; headless calibration/pouch/holster integration checks; Android release build. Code and duplication reviews found no actionable issues. Sol image review confirmed independent movement; headset reach comfort remains a human check. Claude cross-engine review was unavailable because CLI credits were exhausted.

This increment covers placement calibration. Enlarged reach regions, shoulder haptics, and script-controlled cyber-interface gating remain separate follow-ups.
