### PR TITLE
feat(vr): add palm contact spheres and shoulder reach haptics

### DIFF
--- a/projects/astra-vr-thigh-holsters.md
+++ b/projects/astra-vr-thigh-holsters.md
@@ -24,7 +24,9 @@ holstered items to the backpack; overflow drops visibly in front of the player.
 
 Use `cargo dbgr --mission debug_interactions --vr`. Developer parameters:
 
-- `vr_holster_zones`: show the full 14 cm grab radius.
+- `vr_holster_zones`: show the full grab radius.
+- `vr_holster_radius`: reach radius, default 0.35 m (previously 0.14 m),
+  range 0.14–0.45 m. It enlarges the target without enlarging the holster mesh.
 - `vr_holster_drop`: vertical offset below the tracked head, default 0.78 m,
   range 0.55–1.10 m. Reduce this when testing seated reach.
 - `vr_holster_side`: lateral offset, default 0.23 m, range 0.16–0.40 m.
@@ -37,6 +39,19 @@ All placement settings take effect live, in metres, without changing hand poses
 or holstered weapon scale. Belt distance and thigh placement are independent.
 If calibration overlaps the pouch and a holster, an empty hand with a gun in the
 opposite hand uses the pouch there; one squeeze cannot draw both objects.
+Where both leg regions overlap, the nearest unlocked/occupied slot wins. A
+shoulder region takes priority over holsters and the pouch, including when seated calibration
+brings their enlarged volumes together.
+
+Body targets test sphere-to-sphere contact against the calibrated tracked palm,
+using the glove kinematics already used for held-item fitting and support hands.
+They no longer test the controller aim origin at the back of the glove. The
+palm center can remain outside a region while the glove surface touches it.
+`vr_glove_radius` adjusts the hand sphere (default 5 cm, range 2–9 cm), and
+`vr_glove_spheres` draws the exact sampled spheres: amber outside, green while
+touching a body target. `hand_feedback.glove_contacts` exposes their world
+centers and radius. The scope is body inventory; ordinary world-object pickup
+and weapon-support contacts retain their existing policies.
 
 Targets use horizontal heading with gentle following and freeze that heading
 while a hand is in a slot. They are estimates from head/controller tracking,
@@ -66,7 +81,7 @@ developer offsets.
 
 The backpack remembers the last weapon successfully stored at each shoulder:
 left and right independently, regardless of which hand deposited it. Reach
-behind that shoulder with an empty hand and squeeze freshly to retrieve the
+beside or behind that shoulder with an empty hand and squeeze freshly to retrieve the
 actual weapon. Holding squeeze while entering the zone never retrieves it.
 
 Weapons still occupy normal backpack cells. A full backpack refuses the deposit
@@ -84,3 +99,50 @@ inventory through save/load and level transitions. Only current backpack members
 can be recalled. The debug snapshot exposes `hand_feedback.body_gear.shoulder_weapons`
 in left/right order. `vr-shoulder-weapon-recall.e2e.test.ts` exercises the complete
 loop, replacement, independent sides, cross-hand recall and persistence.
+
+## Shoulder reach and feedback
+
+The shoulder centers are 24 cm to either side, 10 cm below the tracked head and
+6 cm behind it. `vr_backpack_radius` defaults to 28 cm (range 18–35 cm).
+This allows an approach beside/above the shoulder while the controller remains
+in view of the headset cameras. The face is excluded: a hand must be more than
+10 cm to the side and no more than 8 cm forward of the head. The debug wire
+spheres show the reach radius; these face-safety limits still apply inside them.
+
+Entering with an item, or with an empty hand at a remembered weapon, requests
+one 60 ms controller pulse. This signals the target, not a successful deposit:
+a full backpack still retains the item and plays its existing refusal sound.
+Lingering or brief boundary jitter does not repeat the pulse; a tracked exit
+of at least 150 ms rearms it. Tracking loss does not rearm feedback. The MFD,
+pause and invalid tracking cannot emit pulses, and unfocused XR sessions discard
+them. Headless `hand_feedback.haptics.sequence` counts requests per hand;
+Quest logs `SHOCK2QUEST_HAPTIC` report submission or an OpenXR error.
+
+`vr-reach-haptics.e2e.test.ts` verifies both hands' approach/stow/recall cues,
+disabled input, and a wrench stow 30 cm below the holster mesh. Pure tests cover
+nearest-slot arbitration, shoulder priority and tracking/boundary hysteresis.
+
+## Extending haptics
+
+Gameplay emits `Effect::HandHaptic { hand, pulse }`, with hardware-independent
+amplitude and duration. Only the central effect handler updates the transient
+per-hand output state. The Quest runtime consumes that state once and performs
+the OpenXR call; pause/loading discard unconsumed output. Same-frame requests
+resolve to the strongest pulse, then longest duration for equal strength.
+The request counters remain available to headless assertions.
+
+Next increments can translate semantic weapon events into named pulse profiles:
+
+- Successful shot: short firing-hand recoil; a weaker optional support-hand
+  pulse, with weapon-specific strength/duration. Do not cue a dry fire as a shot.
+- Melee enemy hit: contact pulse in the primary hand and, when attached, the
+  support hand. Use real impact/damage events, not overlap every physics frame.
+- Melee wall block: a distinct, lighter profile, with per-contact cooldown so
+  resting a weapon against a surface never produces continuous buzzing.
+- Inventory refusal: distinguish it from the light shoulder-ready tick.
+
+Before multiple sources ship, add arbitration over the lifetime of an active
+pulse as well as within a frame, so a weaker later ready tick cannot interrupt a
+strong impact. Keep profiles and cooldown policy in shared gameplay, leaving
+only haptic submission in platform runtimes. These weapon cues are planned;
+this increment emits shoulder-ready feedback only.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -304,6 +304,12 @@ fn main() {
     let left_grip = action_set
         .create_action::<xr::Posef>("left_grip", "Left Hand Grip", &[])
         .unwrap();
+    let left_haptic = action_set
+        .create_action::<xr::Haptic>("left_haptic", "Left Hand Haptic", &[])
+        .unwrap();
+    let right_haptic = action_set
+        .create_action::<xr::Haptic>("right_haptic", "Right Hand Haptic", &[])
+        .unwrap();
 
     let right_grip = action_set
         .create_action::<xr::Posef>("right_grip", "Right Hand Grip", &[])
@@ -396,6 +402,18 @@ fn main() {
                     &left_aim,
                     xr_instance
                         .string_to_path("/user/hand/left/input/aim/pose")
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &left_haptic,
+                    xr_instance
+                        .string_to_path("/user/hand/left/output/haptic")
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &right_haptic,
+                    xr_instance
+                        .string_to_path("/user/hand/right/output/haptic")
                         .unwrap(),
                 ),
                 xr::Binding::new(
@@ -1033,6 +1051,28 @@ fn main() {
         }
         let update_started = Instant::now();
         game.update(&time_context, &input_context, &mut action_state);
+        let pulses = game.take_haptics();
+        if session_focused {
+            for (hand, action) in [&left_haptic, &right_haptic].into_iter().enumerate() {
+                if let Some(request) = pulses[hand] {
+                    let pulse = xr::HapticVibration::new()
+                        .amplitude(request.amplitude)
+                        .frequency(xr::FREQUENCY_UNSPECIFIED)
+                        .duration(xr::Duration::from_nanos(
+                            i64::from(request.duration_ms) * 1_000_000,
+                        ));
+                    match action.apply_feedback(&session, xr::Path::NULL, &pulse) {
+                        Ok(()) => println!(
+                            "SHOCK2QUEST_HAPTIC hand={} amplitude={} duration_ms={} status=submitted",
+                            hand, request.amplitude, request.duration_ms
+                        ),
+                        Err(error) => {
+                            println!("SHOCK2QUEST_HAPTIC hand={} error={:?}", hand, error)
+                        }
+                    }
+                }
+            }
+        }
         let update_elapsed = update_started.elapsed();
 
         // Must be called before any rendering is done!

--- a/shock2vr/src/dev_params.rs
+++ b/shock2vr/src/dev_params.rs
@@ -193,6 +193,10 @@ dev_params! {
     MELEE_VOLUMES = float("melee_volumes", "Show hurtbox", 0.0, 0.0, 1.0, 1.0),
     /// Visualize shoulder backpack stow zones (cyan; green while reached).
     VR_BACKPACK_ZONES = bool("vr_backpack_zones", "Backpack zones", false),
+    VR_BACKPACK_RADIUS = float("vr_backpack_radius", "Backpack reach radius (m)", 0.28, 0.18, 0.35, 0.01),
+    VR_HOLSTER_RADIUS = float("vr_holster_radius", "Holster reach radius (m)", 0.35, 0.14, 0.45, 0.01),
+    VR_GLOVE_SPHERES = bool("vr_glove_spheres", "Glove contact spheres", false),
+    VR_GLOVE_RADIUS = float("vr_glove_radius", "Glove contact radius (m)", 0.05, 0.02, 0.09, 0.005),
     VR_AMMO_POUCH_ZONES = bool("vr_ammo_pouch_zones", "Ammo pouch zone", false),
     VR_HOLSTER_ZONES = bool("vr_holster_zones", "Holster zones", false),
     /// Actual front of the curved belt, including the asset's authored offset.

--- a/shock2vr/src/haptics.rs
+++ b/shock2vr/src/haptics.rs
@@ -1,0 +1,100 @@
+//! Transient controller output, separate from input and persistent game state.
+use shipyard::{Unique, UniqueViewMut, World};
+
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize)]
+pub struct HapticPulse {
+    pub amplitude: f32,
+    pub duration_ms: u32,
+}
+
+pub const SHOULDER_READY: HapticPulse = HapticPulse {
+    amplitude: 0.45,
+    duration_ms: 60,
+};
+
+#[derive(Default, Unique, serde::Serialize)]
+pub struct HapticFeedback {
+    pub pending: [Option<HapticPulse>; 2],
+    /// Monotonic request counters for headless/device diagnostics, left/right.
+    pub sequence: [u64; 2],
+}
+
+impl HapticFeedback {
+    pub fn request(&mut self, hand: crate::Handedness, pulse: HapticPulse) {
+        let hand = crate::vr_config::hand_slot(hand);
+        if !pulse.amplitude.is_finite() || pulse.amplitude <= 0.0 || pulse.duration_ms == 0 {
+            return;
+        }
+        let pulse = HapticPulse {
+            amplitude: pulse.amplitude.min(1.0),
+            duration_ms: pulse.duration_ms,
+        };
+        // Same-frame effects resolve deterministically: the stronger pulse
+        // wins, then the longer one. A ready tick cannot overwrite an impact.
+        if self.pending[hand].is_none_or(|current| {
+            pulse.amplitude > current.amplitude
+                || (pulse.amplitude == current.amplitude && pulse.duration_ms > current.duration_ms)
+        }) {
+            self.pending[hand] = Some(pulse);
+        }
+        self.sequence[hand] += 1;
+    }
+}
+
+/// Consume once. A menu/transition world without gameplay output is silent.
+pub fn take(world: &World) -> [Option<HapticPulse>; 2] {
+    world
+        .borrow::<UniqueViewMut<HapticFeedback>>()
+        .map(|mut feedback| std::mem::take(&mut feedback.pending))
+        .unwrap_or([None; 2])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_is_consumed_once_and_absent_worlds_are_silent() {
+        let world = World::new();
+        assert_eq!(take(&world), [None; 2]);
+        world.add_unique(HapticFeedback::default());
+        world
+            .borrow::<UniqueViewMut<HapticFeedback>>()
+            .unwrap()
+            .request(crate::Handedness::Right, SHOULDER_READY);
+        assert_eq!(take(&world), [None, Some(SHOULDER_READY)]);
+        assert_eq!(take(&world), [None; 2]);
+        assert_eq!(
+            world
+                .borrow::<shipyard::UniqueView<HapticFeedback>>()
+                .unwrap()
+                .sequence,
+            [0, 1]
+        );
+    }
+
+    #[test]
+    fn strongest_same_frame_pulse_wins_in_either_order_and_hands_are_independent() {
+        let impact = HapticPulse {
+            amplitude: 0.8,
+            duration_ms: 35,
+        };
+        for pulses in [[SHOULDER_READY, impact], [impact, SHOULDER_READY]] {
+            let mut feedback = HapticFeedback::default();
+            for pulse in pulses {
+                feedback.request(crate::Handedness::Right, pulse);
+            }
+            feedback.request(crate::Handedness::Left, SHOULDER_READY);
+            assert_eq!(feedback.pending, [Some(SHOULDER_READY), Some(impact)]);
+            feedback.request(
+                crate::Handedness::Right,
+                HapticPulse {
+                    amplitude: f32::NAN,
+                    duration_ms: 60,
+                },
+            );
+            assert_eq!(feedback.pending[1], Some(impact));
+            assert_eq!(feedback.sequence, [1, 2]);
+        }
+    }
+}

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -183,6 +183,12 @@ pub trait PlayerInteraction {
         false
     }
 
+    /// Current tracked palms in pawn space, using the same calibrated glove
+    /// kinematics as fitted items and support grips. Missing rigs are disarmed.
+    fn body_palm_positions(&self, _input: &InputContext) -> [Option<Vector3<f32>>; 2] {
+        [None; 2]
+    }
+
     /// Wield `entity_id` as the first-person weapon (flat); no-op for VR.
     fn wield(&mut self, _entity_id: EntityId) -> Vec<VirtualHandEffect> {
         Vec::new()
@@ -644,6 +650,21 @@ impl VrInteraction {
 }
 
 impl PlayerInteraction for VrInteraction {
+    fn body_palm_positions(&self, input: &InputContext) -> [Option<Vector3<f32>>; 2] {
+        let Some(rig) = &self.grip_kinematics else {
+            return [None; 2];
+        };
+        let hands = [&input.left_hand, &input.right_hand];
+        std::array::from_fn(|i| {
+            let pose = GripPose {
+                position: hands[i].position,
+                rotation: hands[i].rotation,
+            };
+            (pose.is_tracked() && input.pose_tracking.is_none_or(|p| p.head && p.hands[i]))
+                .then(|| pose.point(rig[i].palm))
+        })
+    }
+
     fn hand_available_for_body_slot(&self, hand: Handedness) -> bool {
         let i = crate::vr_config::hand_slot(hand);
         let held = if i == 0 {
@@ -1521,6 +1542,32 @@ mod tests {
     use dark::properties::{FrobFlag, PropFrobInfo, PropModelName};
 
     use super::*;
+    #[test]
+    fn body_contacts_rotate_the_calibrated_palm_and_reject_missing_tracking() {
+        use cgmath::{Deg, Rotation3};
+        let mut interaction = VrInteraction::new();
+        let mut input = InputContext::default();
+        assert_eq!(interaction.body_palm_positions(&input), [None; 2]);
+        interaction.grip_kinematics =
+            Some(std::array::from_fn(|_| crate::vr_grip::GripKinematics {
+                fingers: std::array::from_fn(|_| Vec::new()),
+                palm: vec3(0.0, 0.0, -0.08),
+                normal: Vector3::unit_x(),
+            }));
+        input.right_hand.position = vec3(1.0, 2.0, 3.0);
+        input.right_hand.rotation = Quaternion::from_angle_y(Deg(90.0));
+        let palm = interaction.body_palm_positions(&input)[1].unwrap();
+        assert!((palm - vec3(0.92, 2.0, 3.0)).magnitude() < 0.0001);
+        input.pose_tracking = Some(crate::input_context::PoseTracking {
+            head: true,
+            hands: [true, false],
+        });
+        assert!(interaction.body_palm_positions(&input)[1].is_none());
+        input.pose_tracking = None;
+        input.right_hand.rotation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
+        assert!(interaction.body_palm_positions(&input)[1].is_none());
+    }
+
     use crate::{
         input_context::InputContext,
         physics::{CollisionGroup, DynamicPhysicsOptions, PhysicsShape},

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -3,6 +3,7 @@ pub mod game_scene;
 pub mod hand_buttons;
 pub mod hand_pose;
 pub mod hand_pose_library;
+pub mod haptics;
 pub mod hit_feedback;
 pub mod input;
 pub mod input_context;
@@ -1404,6 +1405,9 @@ impl Game {
         let span = span!(Level::INFO, "update");
         let _enter = span.enter();
         let delta_time = time.elapsed.as_secs_f32();
+        // Discard unconsumed output before every early return (pause/loading).
+        // A short feedback pulse belongs only to the frame that requested it.
+        haptics::take(self.world());
         trace!("delta_time: {}", delta_time);
 
         // Publish the simulation clock for the diagnostics ring buffers
@@ -2712,6 +2716,13 @@ pub enum App {
 }
 
 impl App {
+    pub fn take_haptics(&self) -> [Option<haptics::HapticPulse>; 2] {
+        match self {
+            App::Ready(game) => haptics::take(game.world()),
+            App::MissingAssets(_) => [None; 2],
+        }
+    }
+
     /// Probe the data root, then build whichever of the two is appropriate.
     pub fn init(options: GameOptions, bundle_storage: Arc<dyn Storage>) -> App {
         let install = install::probe_data_root();

--- a/shock2vr/src/mission/ammo_pouch.rs
+++ b/shock2vr/src/mission/ammo_pouch.rs
@@ -29,6 +29,7 @@ pub(super) struct AmmoPouch {
     pub blocks_grab: [bool; 2],
     pub offers: [Option<PouchClip>; 2],
     pub refused: [bool; 2],
+    pub shoulder_priority: [bool; 2],
     consumed: [bool; 2],
     pressed: [bool; 2],
     pressed_item: [Option<EntityId>; 2],
@@ -43,6 +44,7 @@ impl Default for AmmoPouch {
             blocks_grab: [false; 2],
             offers: [None; 2],
             refused: [false; 2],
+            shoulder_priority: [false; 2],
             consumed: [false; 2],
             pressed: [true; 2],
             pressed_item: [None; 2],
@@ -82,8 +84,11 @@ impl AmmoPouch {
                 && input.pose_tracking.is_none_or(|p| p.hands[i]);
             let pressed = hand.squeeze_value >= 0.5;
             self.near[i] = tracked
-                && active_center
-                    .is_some_and(|center| (hand.position - center).magnitude2() <= RADIUS * RADIUS);
+                && !self.shoulder_priority[i]
+                && active_center.is_some_and(|center| {
+                    (hand.position - center).magnitude2()
+                        <= (RADIUS + super::body_inventory::hand_radius()).powi(2)
+                });
             if tracked && !pressed {
                 self.consumed[i] = false;
             }
@@ -326,23 +331,5 @@ mod tests {
             true,
         );
         assert!(!pouch.blocks_grab[0]);
-    }
-
-    #[test]
-    fn default_pouch_is_separate_from_thighs_and_shoulders() {
-        let body = BodyPose {
-            head: cgmath::vec3(0.0, 2.0, 0.0),
-            yaw: 0.0,
-        };
-        let center = center_for(body);
-        for side in [-0.23, 0.23] {
-            let thigh = body.front(0.78, 0.04)
-                + cgmath::vec3(side / crate::METERS_PER_WORLD_UNIT, 0.0, 0.0);
-            assert!((thigh - center).magnitude() > RADIUS + super::super::holsters::RADIUS);
-        }
-        assert!(
-            (BELOW - 0.20) / crate::METERS_PER_WORLD_UNIT
-                > RADIUS + super::super::shoulder_backpack::RADIUS
-        );
     }
 }

--- a/shock2vr/src/mission/body_inventory.rs
+++ b/shock2vr/src/mission/body_inventory.rs
@@ -1,6 +1,10 @@
 //! Shared body-inventory heading and refused-release latch.
 use shipyard::EntityId;
 
+pub(super) fn hand_radius() -> f32 {
+    crate::dev_params::get(crate::dev_params::VR_GLOVE_RADIUS) / crate::METERS_PER_WORLD_UNIT
+}
+
 pub(super) fn followed_yaw(previous: Option<f32>, observed: f32, frozen: bool, dt: f32) -> f32 {
     match previous {
         Some(yaw) if frozen => yaw,

--- a/shock2vr/src/mission/holsters.rs
+++ b/shock2vr/src/mission/holsters.rs
@@ -7,7 +7,9 @@ use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, Vector3, vec3};
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, View, World};
 
 const SCALE: f32 = crate::METERS_PER_WORLD_UNIT;
-pub(super) const RADIUS: f32 = 0.14 / SCALE;
+fn radius() -> f32 {
+    crate::dev_params::get(crate::dev_params::VR_HOLSTER_RADIUS) / SCALE
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum Action {
@@ -28,6 +30,62 @@ mod tests {
             &input, [None; 2], [true; 2], [None; 2], 1, [false; 2], [false; 2], true, 0.016,
         );
         (h, input, ids)
+    }
+
+    #[test]
+    fn enlarged_overlapping_slots_choose_nearest_and_yield_to_shoulders() {
+        let (mut tracker, mut input, ids) = setup();
+        let centers = tracker.centers.unwrap();
+        // Both 35 cm volumes include this point; the left slot is closer.
+        input.left_hand.position = (centers[0] + centers[1]) * 0.5 - vec3(0.02 / SCALE, 0.0, 0.0);
+        let update = |tracker: &mut Holsters, input: &InputContext| {
+            tracker.update(
+                input,
+                [None; 2],
+                [true; 2],
+                [Some(ids[0]), Some(ids[1])],
+                2,
+                [false; 2],
+                [false; 2],
+                true,
+                0.016,
+            )
+        };
+        input.left_hand.squeeze_value = 0.0;
+        update(&mut tracker, &input);
+        assert_eq!(tracker.near[0], Some(1));
+        input.left_hand.squeeze_value = 1.0;
+        assert_eq!(
+            update(&mut tracker, &input)[0],
+            Some(Action::Retrieve {
+                entity: ids[1],
+                slot: 1
+            })
+        );
+        tracker.shoulder_priority[0] = true;
+        input.left_hand.squeeze_value = 0.0;
+        update(&mut tracker, &input);
+        input.left_hand.squeeze_value = 1.0;
+        assert_eq!(update(&mut tracker, &input)[0], None);
+        assert_eq!(tracker.near[0], None);
+        tracker.shoulder_priority[0] = false;
+        input.left_hand.position = centers[0] + vec3(0.0, -0.30 / SCALE, 0.0);
+        update(&mut tracker, &input);
+        assert_eq!(
+            tracker.near[0],
+            Some(0),
+            "30 cm below the slot is reachable"
+        );
+        input.left_hand.position = centers[0] + vec3(0.0, -0.38 / SCALE, 0.0);
+        update(&mut tracker, &input);
+        assert_eq!(
+            tracker.near[0],
+            Some(0),
+            "palm center stays outside while the glove sphere touches"
+        );
+        input.left_hand.position = centers[0] + vec3(0.0, -0.41 / SCALE, 0.0);
+        update(&mut tracker, &input);
+        assert_eq!(tracker.near[0], None, "separated spheres do not touch");
     }
 
     #[test]
@@ -335,6 +393,7 @@ pub(super) struct Holsters {
     pub body_pose: Option<super::body_inventory::BodyPose>,
     pub freeze_heading: bool,
     pub pouch_priority: [bool; 2],
+    pub shoulder_priority: [bool; 2],
     yaw: Option<f32>,
     pub centers: Option<[Vector3<f32>; 2]>,
     pub near: [Option<usize>; 2],
@@ -349,6 +408,7 @@ impl Default for Holsters {
             body_pose: None,
             freeze_heading: false,
             pouch_priority: [false; 2],
+            shoulder_priority: [false; 2],
             yaw: None,
             centers: None,
             near: [None; 2],
@@ -473,11 +533,26 @@ impl Holsters {
                 && held[i].is_none()
                 && (hand.position - super::ammo_pouch::center_for(self.body_pose.unwrap()))
                     .magnitude2()
-                    <= super::ammo_pouch::RADIUS.powi(2);
-            self.near[i] = (tracked && !at_pouch && (held[i].is_none() || weapons[i])).then(|| (0..2).find(|s|
-                // A stored item remains retrievable if its perk is removed.
-                (*s < count || slots[*s].is_some()) && (hand.position - centers[*s]).magnitude2() <= RADIUS * RADIUS
-            )).flatten();
+                    <= (super::ammo_pouch::RADIUS + super::body_inventory::hand_radius()).powi(2);
+            self.near[i] = (tracked
+                && !at_pouch
+                && !self.shoulder_priority[i]
+                && (held[i].is_none() || weapons[i]))
+                .then(|| {
+                    (0..2)
+                        // Stored items remain retrievable if their perk is removed.
+                        .filter(|s| {
+                            (*s < count || slots[*s].is_some())
+                                && (hand.position - centers[*s]).magnitude2()
+                                    <= (radius() + super::body_inventory::hand_radius()).powi(2)
+                        })
+                        .min_by(|a, b| {
+                            (hand.position - centers[*a])
+                                .magnitude2()
+                                .total_cmp(&(hand.position - centers[*b]).magnitude2())
+                        })
+                })
+                .flatten();
             if let Some(slot) = self.near[i] {
                 if let Some(entity) = held[i] {
                     if !pressed && self.pressed_item[i] == Some(entity) {
@@ -524,7 +599,7 @@ impl Holsters {
         rotation: Quaternion<f32>,
     ) -> serde_json::Value {
         serde_json::json!({"centers": self.world_centers(position, rotation).map(|cs| cs.map(|c| [c.x,c.y,c.z])),
-            "radius":RADIUS, "enabled_slots":slot_count(world), "near":self.near,
+            "radius":radius(), "enabled_slots":slot_count(world), "near":self.near,
             "items":occupants(world).map(|e| e.map(|id| id.inner() as i32)),
             "retained":self.retained.0.map(|e| e.is_some())})
     }
@@ -556,7 +631,7 @@ impl Holsters {
             } else {
                 vec3(0.1, 0.55, 0.7)
             };
-            let radius = if debug { RADIUS } else { 0.04 / SCALE };
+            let radius = if debug { radius() } else { 0.04 / SCALE };
             let mut points = Vec::new();
             dark::hit_box::append_capsule_lines(
                 &mut points,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2146,6 +2146,7 @@ pub struct MissionCore {
     shoulder_backpack: super::shoulder_backpack::ShoulderBackpack,
     holsters: super::holsters::Holsters,
     ammo_pouch: super::ammo_pouch::AmmoPouch,
+    body_hand_contacts: [Option<Vector3<f32>>; 2],
 
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
     /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
@@ -2788,6 +2789,7 @@ impl MissionCore {
         world.add_unique(PlayerLifeState::Alive);
 
         world.add_unique(quest_info);
+        world.add_unique(crate::haptics::HapticFeedback::default());
 
         // Current saves record the width that encoded their backpack link
         // ordinals. Pre-#948 saves omit it and used the former fixed width 15;
@@ -3073,6 +3075,7 @@ impl MissionCore {
             vr_trigger_safe_latch: [None; 2],
             vr_clip_insert_engaged: [false; 2],
             shoulder_backpack: Default::default(),
+            body_hand_contacts: [None; 2],
             holsters: Default::default(),
             ammo_pouch: Default::default(),
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
@@ -4137,13 +4140,38 @@ impl MissionCore {
         }
 
         let held = [left_hand_held, right_hand_held];
+        // Body contacts use a calibrated palm sphere, not the aim origin at
+        // the back of the glove. Keep the original input for weapon controls.
+        let mut body_input = hands_input.clone();
+        self.body_hand_contacts = self.interaction.body_palm_positions(hands_input);
+        for (i, hand) in [&mut body_input.left_hand, &mut body_input.right_hand]
+            .into_iter()
+            .enumerate()
+        {
+            if let Some(palm) = self.body_hand_contacts[i] {
+                hand.position = palm;
+            } else {
+                hand.rotation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
+            }
+        }
+        let mut shoulder_releases = self.shoulder_backpack.update(
+            &body_input,
+            held,
+            game_options.presentation_mode == crate::PresentationMode::Vr
+                && !self.use_mode
+                && self.player_is_alive()
+                && self.player_controls_enabled,
+            time.elapsed.as_secs_f32(),
+        );
+        self.holsters.shoulder_priority = self.shoulder_backpack.near;
+        self.ammo_pouch.shoulder_priority = self.shoulder_backpack.near;
         let pouch_weapons = std::array::from_fn(|i| {
             held[1 - i].filter(|gun| self.magazine_capacity(*gun).is_some())
         });
         self.holsters.pouch_priority = pouch_weapons.map(|weapon| weapon.is_some());
         self.holsters.freeze_heading = self.ammo_pouch.near.iter().any(|near| *near);
         let holster_actions = self.holsters.update(
-            hands_input,
+            &body_input,
             held,
             [
                 crate::vr_config::Handedness::Left,
@@ -4175,7 +4203,7 @@ impl MissionCore {
                 .and_then(|gun| super::reload::reserve_clip_for_pouch(&self.world, gun))
         });
         let pouch_actions = self.ammo_pouch.update(
-            hands_input,
+            &body_input,
             self.holsters.body_pose,
             held,
             pouch_available,
@@ -4189,26 +4217,35 @@ impl MissionCore {
                 && self.player_is_alive()
                 && self.player_controls_enabled,
         );
-        let mut shoulder_releases = self.shoulder_backpack.update(
-            hands_input,
-            held,
-            game_options.presentation_mode == crate::PresentationMode::Vr
-                && !self.use_mode
-                && self.player_is_alive()
-                && self.player_controls_enabled,
-            time.elapsed.as_secs_f32(),
-        );
         let shoulder_slots = self.shoulder_backpack.near_slot;
         let inventory = self
             .world
             .borrow::<UniqueView<PlayerInfo>>()
             .unwrap()
             .inventory_entity_id;
-        let mut recalls = if self.shoulder_backpack.draws.iter().any(Option::is_some) {
+        let needs_recall = self.shoulder_backpack.draws.iter().any(Option::is_some)
+            || (0..2).any(|i| self.shoulder_backpack.entered[i] && held[i].is_none());
+        let mut recalls = if needs_recall {
             super::shoulder_backpack::weapons(&self.world, inventory)
         } else {
             [None; 2]
         };
+        for i in 0..2 {
+            if self.shoulder_backpack.entered[i]
+                && (held[i].is_some()
+                    || (pouch_available[i]
+                        && shoulder_slots[i].is_some_and(|slot| recalls[slot].is_some())))
+            {
+                effects.push(Effect::HandHaptic {
+                    hand: if i == 0 {
+                        crate::Handedness::Left
+                    } else {
+                        crate::Handedness::Right
+                    },
+                    pulse: crate::haptics::SHOULDER_READY,
+                });
+            }
+        }
         for i in 0..2 {
             if !pouch_available[i] {
                 continue;
@@ -8723,6 +8760,12 @@ impl MissionCore {
                     }
                     drop(quests);
                 }
+                Effect::HandHaptic { hand, pulse } => {
+                    self.world
+                        .borrow::<UniqueViewMut<crate::haptics::HapticFeedback>>()
+                        .unwrap()
+                        .request(hand, pulse);
+                }
                 Effect::PlaySound {
                     handle,
                     name,
@@ -11180,6 +11223,33 @@ impl MissionCore {
             scene.extend(self.shoulder_backpack.render(player.pos, player.rotation));
         }
 
+        if options.presentation_mode == crate::PresentationMode::Vr
+            && crate::dev_params::get_bool(crate::dev_params::VR_GLOVE_SPHERES)
+        {
+            for (i, center) in self.body_hand_contacts.into_iter().enumerate() {
+                let Some(center) = center else {
+                    continue;
+                };
+                let touching = self.shoulder_backpack.near[i]
+                    || self.holsters.near[i].is_some()
+                    || self.ammo_pouch.near[i];
+                let mut objects = vec![dark::hit_box::draw_debug_wire_sphere(
+                    player.pos + player.rotation.rotate_vector(center),
+                    super::body_inventory::hand_radius(),
+                    if touching {
+                        vec3(0.1, 1.0, 0.2)
+                    } else {
+                        vec3(1.0, 0.65, 0.1)
+                    },
+                )];
+                crate::util::tag_render_source(
+                    &mut objects,
+                    crate::util::render_source::PLAYER_HANDS,
+                );
+                scene.extend(objects);
+            }
+        }
+
         // The old synthetic blue inventory cube remains a desktop diagnostic.
         // VR presents the authored INVBACK canvas through GuiManager instead.
         if options.presentation_mode == crate::PresentationMode::Flat {
@@ -13257,6 +13327,26 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 "holsters".to_owned(),
                 self.holsters
                     .diagnostics(&self.world, player.pos, player.rotation),
+            );
+            object.insert(
+                "haptics".to_owned(),
+                serde_json::to_value(
+                    &*self
+                        .world
+                        .borrow::<UniqueView<crate::haptics::HapticFeedback>>()
+                        .unwrap(),
+                )
+                .unwrap(),
+            );
+            object.insert(
+                "glove_contacts".to_owned(),
+                serde_json::json!({
+                    "centers": self.body_hand_contacts.map(|c| c.map(|c| {
+                        let p = player.pos + player.rotation.rotate_vector(c);
+                        [p.x, p.y, p.z]
+                    })),
+                    "radius": super::body_inventory::hand_radius(),
+                }),
             );
             object.insert(
                 "shoulder_backpack".to_owned(),

--- a/shock2vr/src/mission/shoulder_backpack.rs
+++ b/shock2vr/src/mission/shoulder_backpack.rs
@@ -6,10 +6,13 @@ use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
 use crate::{input_context::InputContext, vr_support::GripPose};
 
 const SCALE: f32 = crate::METERS_PER_WORLD_UNIT;
-const SIDE: f32 = 0.18 / SCALE;
-const DROP: f32 = 0.20 / SCALE;
-const BEHIND: f32 = 0.18 / SCALE;
-pub(super) const RADIUS: f32 = 0.18 / SCALE;
+const SIDE: f32 = 0.24 / SCALE;
+const DROP: f32 = 0.10 / SCALE;
+const BEHIND: f32 = 0.06 / SCALE;
+
+fn radius() -> f32 {
+    crate::dev_params::get(crate::dev_params::VR_BACKPACK_RADIUS) / SCALE
+}
 
 pub(super) struct ShoulderBackpack {
     yaw: Option<f32>,
@@ -22,6 +25,9 @@ pub(super) struct ShoulderBackpack {
     pub blocks_grab: [bool; 2],
     draw_pressed: [bool; 2],
     consumed: [bool; 2],
+    pub entered: [bool; 2],
+    feedback_slot: [Option<usize>; 2],
+    outside_time: [f32; 2],
 }
 
 impl Default for ShoulderBackpack {
@@ -37,6 +43,9 @@ impl Default for ShoulderBackpack {
             blocks_grab: [false; 2],
             draw_pressed: [true; 2],
             consumed: [false; 2],
+            entered: [false; 2],
+            feedback_slot: [None; 2],
+            outside_time: [0.0; 2],
         }
     }
 }
@@ -94,6 +103,7 @@ impl ShoulderBackpack {
         let hands = [&input.left_hand, &input.right_hand];
         self.retained.update(held, hands.map(|h| h.squeeze_value));
         self.draws = [None; 2];
+        self.entered = [false; 2];
         self.near_slot = [None; 2];
         let tracked = std::array::from_fn::<_, 2, _>(|i| {
             let hand = hands[i];
@@ -141,14 +151,20 @@ impl ShoulderBackpack {
         for i in 0..2 {
             let hand = hands[i];
             let tracked = tracked[i];
-            // Require the hand genuinely behind the head, not beside the face.
+            // Reach beside/over the shoulder while optical tracking still sees
+            // the controller. Exclude the face and ordinary forward gestures.
+            let offset = hand.position - head.position;
             self.near_slot[i] = (tracked
-                && (hand.position - head.position).dot(forward) < -0.03 / SCALE)
+                && offset.dot(forward) < 0.08 / SCALE
+                && offset.dot(right).abs() > 0.10 / SCALE)
                 .then(|| {
                     centers
                         .iter()
                         .enumerate()
-                        .filter(|(_, c)| (hand.position - **c).magnitude2() <= RADIUS * RADIUS)
+                        .filter(|(_, c)| {
+                            (hand.position - **c).magnitude2()
+                                <= (radius() + super::body_inventory::hand_radius()).powi(2)
+                        })
                         .min_by(|(_, a), (_, b)| {
                             (hand.position - **a)
                                 .magnitude2()
@@ -158,6 +174,17 @@ impl ShoulderBackpack {
                 })
                 .flatten();
             self.near[i] = self.near_slot[i].is_some();
+            if let Some(slot) = self.near_slot[i] {
+                self.outside_time[i] = 0.0;
+                self.entered[i] = self.feedback_slot[i] != Some(slot);
+                self.feedback_slot[i] = Some(slot);
+            } else if tracked {
+                // A brief boundary jitter or tracking loss must not buzz again.
+                self.outside_time[i] += dt.clamp(0.0, 0.1);
+                if self.outside_time[i] >= 0.15 {
+                    self.feedback_slot[i] = None;
+                }
+            }
             let pressed = hand.squeeze_value >= 0.5;
             if held[i].is_none() && self.near[i] {
                 self.blocks_grab[i] = true;
@@ -203,7 +230,7 @@ impl ShoulderBackpack {
         let root = Matrix4::from_translation(position) * Matrix4::from(rotation);
         let mut vertices = Vec::new();
         for center in centers {
-            dark::hit_box::append_capsule_lines(&mut vertices, &root, center, center, RADIUS);
+            dark::hit_box::append_capsule_lines(&mut vertices, &root, center, center, radius());
         }
         let color = if self.retained.0.iter().any(Option::is_some) {
             vec3(1.0, 0.3, 0.1)
@@ -227,7 +254,8 @@ impl ShoulderBackpack {
     ) -> serde_json::Value {
         serde_json::json!({
             "centers": self.centers.map(|cs| cs.map(|c| { let p = position + rotation.rotate_vector(c); [p.x,p.y,p.z] })),
-            "radius": RADIUS, "near": self.near, "near_slot": self.near_slot,
+            "radius": radius(), "near": self.near, "near_slot": self.near_slot,
+            "entered": self.entered,
             "retained": self.retained.0.map(|e| e.is_some()),
         })
     }
@@ -278,6 +306,55 @@ mod tests {
         input.left_hand.position = vec3(-0.3, 1.0, -0.4);
         input.right_hand.position = vec3(0.3, 1.0, -0.4);
         (ShoulderBackpack::default(), input, item)
+    }
+
+    #[test]
+    fn beside_head_reach_cues_once_and_rearms_only_after_a_tracked_exit() {
+        let (mut tracker, mut input, item) = fixture();
+        let held = [Some(item), None];
+        input.left_hand.position = input.head.position + vec3(-0.26, 0.05, -0.03) / SCALE;
+        input.left_hand.squeeze_value = 1.0;
+        tracker.update(&input, held, true, 0.016);
+        assert_eq!(tracker.near_slot[0], Some(0));
+        assert!(tracker.entered[0]);
+        for _ in 0..60 {
+            tracker.update(&input, held, true, 0.016);
+            assert!(!tracker.entered[0]);
+        }
+        let target = input.left_hand.position;
+        input.left_hand.position = input.head.position;
+        tracker.update(&input, held, true, 0.016);
+        input.left_hand.position = target;
+        tracker.update(&input, held, true, 0.016);
+        assert!(
+            !tracker.entered[0],
+            "short boundary jitter does not repeat the cue"
+        );
+        input.pose_tracking = Some(crate::input_context::PoseTracking {
+            head: true,
+            hands: [false, true],
+        });
+        for _ in 0..20 {
+            tracker.update(&input, held, true, 0.016);
+            assert!(!tracker.entered[0]);
+        }
+        input.pose_tracking = None;
+        tracker.update(&input, held, true, 0.016);
+        assert!(
+            !tracker.entered[0],
+            "tracking recovery is not a fresh entry"
+        );
+        input.left_hand.position = input.head.position;
+        for _ in 0..10 {
+            tracker.update(&input, held, true, 0.016);
+        }
+        input.left_hand.position = target;
+        tracker.update(&input, held, true, 0.016);
+        assert!(tracker.entered[0]);
+        input.left_hand.squeeze_value = 0.0;
+        assert!(tracker.update(&input, held, true, 0.016)[0]);
+        tracker.update(&input, held, false, 0.016);
+        assert!(!tracker.entered[0]);
     }
 
     #[test]

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -683,6 +683,12 @@ pub enum Effect {
         email: u32,
         force: bool,
     },
+    /// One-shot controller feedback. Gameplay describes it; only the runtime
+    /// talks to hardware. Transient output is never serialized into saves.
+    HandHaptic {
+        hand: crate::Handedness,
+        pulse: crate::haptics::HapticPulse,
+    },
     PlaySound {
         handle: AudioHandle,
         name: String,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -684,11 +684,16 @@ export interface PlayerSnapshot {
       items: [number | null, number | null];
       retained: [boolean, boolean];
     };
+    /** Per-hand transient haptic requests and monotonic diagnostic counters. */
+    haptics?: { pending: [{ amplitude: number; duration_ms: number } | null, { amplitude: number; duration_ms: number } | null]; sequence: [number, number] };
+    glove_contacts?: { centers: [Vec3 | null, Vec3 | null]; radius: number };
     /** Shoulder stow targets in world space; absent on older runtimes. */
     shoulder_backpack?: {
       centers: [Vec3, Vec3] | null;
       radius: number;
       near: [boolean, boolean];
+      near_slot?: [number | null, number | null];
+      entered?: [boolean, boolean];
       retained: [boolean, boolean];
     };
   } | null;

--- a/tools/shock2-sdk/test/vr-reach-haptics.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-reach-haptics.e2e.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { aimVrHandAt, quatConjugate, quatRotate, sub } from "./helpers/vr-hand.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+for (const hand of ["left", "right"] as const) {
+  test(`${hand} shoulder cues once on approach, stows beside head, and cues recall`, { skip: !enabled, timeout: 180_000 }, async () => {
+    await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+    await game.step({ frames: 30 });
+    const i = hand === "left" ? 0 : 1;
+    const owner = hand === "left" ? "wielded_entity_id" : "right_hand_entity_id";
+    const pulses = async () => (await game.info()).player.hand_feedback!.haptics!.sequence;
+    const item = (await game.entities.list()).entities.find(e => e.template_id === -19)!;
+    const grab = await aimVrHandAt(game, item.position, 0.2, 1, 0, { hand });
+    await game.step({ frames: 5 });
+    let player = (await game.info()).player;
+    assert.equal(player[owner], item.id);
+    const palmTarget = quatRotate(quatConjugate(player.rotation), sub(player.hand_feedback!.shoulder_backpack!.centers![i], player.position));
+    // Above and slightly forward of the new center: reachable beside the head,
+    // but outside the old low/behind shoulder sphere.
+    palmTarget[1] += 0.15 / 0.762;
+    palmTarget[2] -= 0.08 / 0.762;
+    const palmNow = quatRotate(quatConjugate(player.rotation), sub(player.hand_feedback!.glove_contacts!.centers[i]!, player.position));
+    const target = grab.local.map((v, j) => v + palmTarget[j] - palmNow[j]);
+    const before = await pulses();
+    await game.input.set(`${hand}_hand.position`, target);
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.hand_feedback!.shoulder_backpack!.near[i], true);
+    assert.equal((await pulses())[i], before[i] + 1);
+    assert.equal((await pulses())[1 - i], before[1 - i]);
+    await game.step({ frames: 60 });
+    assert.equal((await pulses())[i], before[i] + 1, "lingering does not keep buzzing");
+    await game.input.set(`${hand}_hand.squeeze`, 0);
+    await game.step({ frames: 8 });
+    assert.equal((await game.info()).player[owner], null);
+    assert.equal((await game.info()).player.hand_feedback!.body_gear!.shoulder_weapons![i], item.id);
+    await game.input.set(`${hand}_hand.position`, [i === 0 ? -0.8 : 0.8, 0.8, -0.8]);
+    await game.step({ frames: 15 });
+    await game.input.set(`${hand}_hand.position`, target);
+    await game.step({ frames: 3 });
+    assert.equal((await pulses())[i], before[i] + 2, "a remembered weapon cues empty-hand recall");
+    await game.input.set(`${hand}_hand.squeeze`, 1);
+    await game.step({ frames: 8 });
+    assert.equal((await game.info()).player[owner], item.id);
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 10 });
+    assert.equal((await pulses())[i], before[i] + 2, "disabled body gestures cannot cue");
+    assert.deepEqual((await game.info()).player.hand_feedback!.haptics!.pending, [null, null]);
+  });
+}
+
+test("enlarged holster accepts a release thirty centimetres below its mesh", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+  await game.step({ frames: 30 });
+  const item = (await game.entities.list()).entities.find(e => e.template_id === -928)!;
+  const grab = await aimVrHandAt(game, item.position, 0.2, 1);
+  await game.step({ frames: 5 });
+  const player = (await game.info()).player;
+  const palmTarget = quatRotate(quatConjugate(player.rotation), sub(player.hand_feedback!.holsters!.centers![0], player.position));
+  palmTarget[1] -= 0.30 / 0.762;
+  const palmNow = quatRotate(quatConjugate(player.rotation), sub(player.hand_feedback!.glove_contacts!.centers[1]!, player.position));
+  const target = grab.local.map((v, j) => v + palmTarget[j] - palmNow[j]);
+  await game.input.set("right_hand.position", target);
+  await game.step({ frames: 3 });
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.near[1], 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 8 });
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.items[0], item.id);
+  assert.equal((await game.info()).player.right_hand_entity_id, null);
+  // Radius can be tuned live without moving the mesh or its center.
+  await game.devParams.set("vr_holster_radius", 0.14);
+  await game.step({ frames: 3 });
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.near[1], null);
+});
+
+test("glove sphere contacts a holster while its calibrated palm is still outside", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+  const start: [number, number, number] = [0.8, 1, -0.4];
+  await game.input.set("right_hand.position", start);
+  await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+  await game.step({ frames: 30 });
+  let player = (await game.info()).player;
+  const contacts = player.hand_feedback!.glove_contacts!;
+  const holster = player.hand_feedback!.holsters!;
+  assert.ok(contacts.centers[1]);
+  const target: [number, number, number] = [...holster.centers![0]];
+  target[1] -= holster.radius + contacts.radius * 0.5;
+  const shift = quatRotate(quatConjugate(player.rotation), sub(target, contacts.centers[1]));
+  await game.input.set("right_hand.position", start.map((v, i) => v + shift[i]));
+  await game.step({ frames: 3 });
+  player = (await game.info()).player;
+  const distance = Math.hypot(...sub(player.hand_feedback!.glove_contacts!.centers[1]!, player.hand_feedback!.holsters!.centers![0]));
+  assert.ok(distance > holster.radius, "palm center has not entered the holster region");
+  assert.ok(distance < holster.radius + contacts.radius, "the two sphere surfaces overlap");
+  assert.equal(player.hand_feedback!.holsters!.near[1], 0);
+  await game.devParams.set("vr_glove_spheres", 1);
+  await game.step({ frames: 3 });
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.near[1], 0, "visualization does not change contact");
+  await game.devParams.set("vr_glove_radius", 0.02);
+  await game.step({ frames: 3 });
+  assert.equal((await game.info()).player.hand_feedback!.holsters!.near[1], null, "radius is live and uses surface contact");
+});

--- a/tools/shock2-sdk/test/vr-shoulder-backpack.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-shoulder-backpack.e2e.test.ts
@@ -7,12 +7,31 @@ import {
   quatConjugate,
   quatRotate,
   sub,
+  add,
+  scale,
+  normalize,
+  cross,
 } from "./helpers/vr-hand.js";
 import { ammoOf } from "./helpers/weapon.js";
 
 const enabled = process.env.SHOCK2_E2E === "1";
 const owner = (hand: "left" | "right") =>
   hand === "left" ? "wielded_entity_id" : "right_hand_entity_id";
+
+async function reachInFront(game: GameServer) {
+  const player = (await game.info()).player;
+  const centers = player.hand_feedback?.shoulder_backpack?.centers;
+  assert.ok(centers);
+  // aimVrHandAt turns the head toward the rack. Pawn-local -Z is therefore
+  // not necessarily in front of the body; derive its actual horizontal frame.
+  const right = normalize(sub(centers[1], centers[0]));
+  const forward = cross([0, 1, 0], right);
+  const target = add(scale(add(centers[0], centers[1]), 0.5), scale(forward, 0.8));
+  await game.input.set("right_hand.position", quatRotate(quatConjugate(player.rotation), sub(target, player.position)));
+  await game.step({ frames: 5 });
+  assert.equal((await game.info()).player.hand_feedback!.shoulder_backpack!.near[1], false);
+}
+
 async function reach(
   game: GameServer,
   hand: "left" | "right",
@@ -129,8 +148,7 @@ test(
       (await game.info()).player.hand_feedback?.shoulder_backpack?.retained[1],
       true,
     );
-    await game.input.set("right_hand.position", [0.25, 1, -0.4]);
-    await game.step({ frames: 5 });
+    await reachInFront(game);
     assert.equal(
       (await game.info()).player.right_hand_entity_id,
       mug.id,
@@ -162,8 +180,7 @@ test(
     )!;
     await aimVrHandAt(game, mug.position, 0.2, 1);
     await game.step({ frames: 5 });
-    await game.input.set("right_hand.position", [0.2, 1, -0.4]);
-    await game.step({ frames: 5 });
+    await reachInFront(game);
     await game.input.set("right_hand.squeeze", 0);
     await game.step({ frames: 5 });
     assert.equal((await game.info()).player.right_hand_entity_id, null);


### PR DESCRIPTION
Body-inventory grabs now use a calibrated 5 cm palm sphere, so touching a reach region registers before the hand center enters it. Holster regions grow from 14 to 35 cm; shoulder regions grow from 18 to 28 cm and sit closer to a natural beside-head reach.

An actionable shoulder entry returns `Effect::HandHaptic`; the central applier queues transient per-hand output for OpenXR. Remaining inside does not repeat the cue. Tracking loss does not rearm it, and pause/focus guards prevent stale output. Shooting/melee feedback extensions are documented for a later increment.

- Developer controls: `vr_glove_spheres`, `vr_glove_radius`, `vr_holster_radius`, `vr_backpack_radius`.
- Overlapping body targets use shoulder priority and nearest holster selection.
- Scope: body inventory contact; general world pickup and support grips retain their existing behavior.

Validation: 1,641 Rust library tests passed after restacking (2 ignored), formatting and diff checks passed. Before restacking, 19 SDK body-inventory scenarios passed, including calibrated palm contact, shoulder storage/recall and haptic rearming; Android release build and TypeScript compilation passed. Headset validation is explicitly deferred, so physical vibration and comfort remain unverified. Captures were made before the restack; the feature commit is unchanged by it.

Review: Codex correctness review and duplication review completed; GPT-5.6-sol inspected the final visual captures without blocking findings. The Claude CLI review was unavailable because its credits were exhausted.

### Visual evidence

![Reach zones before and after](https://gist.githubusercontent.com/tommy-xr/24344d0aeb7b1b765cec7da889af9607/raw/astra-reach-before-after.gif)

![Matched reach-zone still](https://gist.githubusercontent.com/tommy-xr/24344d0aeb7b1b765cec7da889af9607/raw/astra-reach-before-after.png)

Same detached-camera orbit, debug zones enabled: holster radius 0.14→0.35 m, shoulder radius 0.18→0.28 m, with updated shoulder placement. Playback is slowed and loops back across the orbit.

![Glove contact and disengagement](https://gist.githubusercontent.com/tommy-xr/24344d0aeb7b1b765cec7da889af9607/raw/astra-glove-contact.gif)

![Glove surface contact](https://gist.githubusercontent.com/tommy-xr/24344d0aeb7b1b765cec7da889af9607/raw/astra-glove-contact.png)

Three captured states demonstrate the calibrated 5 cm glove sphere contacting the holster zone before its center enters. Empty-slot contact has no actionable pulse. The gallery separately includes shotgun shoulder approach/storage and diagnostics recording one entry pulse; images do not verify physical vibration. Headset validation is deferred.

[Download the self-contained gallery and open locally](https://gist.githubusercontent.com/tommy-xr/24344d0aeb7b1b765cec7da889af9607/raw/astra-reach-haptics-gallery.html).
