### PR TITLE
fix(weapons): implement authored annelid homing

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -24,6 +24,7 @@ mod prop_gun_reliability;
 mod prop_gun_state;
 mod prop_hack_diff;
 mod prop_hit_points;
+mod prop_homing;
 mod prop_key;
 mod prop_log;
 mod prop_obj_state;
@@ -71,6 +72,7 @@ pub use prop_gun_reliability::*;
 pub use prop_gun_state::*;
 pub use prop_hack_diff::*;
 pub use prop_hit_points::*;
+pub use prop_homing::*;
 pub use prop_key::*;
 pub use prop_log::*;
 pub use prop_obj_state::*;
@@ -1898,6 +1900,13 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$PhysInitV",
             PropPhysInitialVelocity::read,
             identity,
+            accumulator::latest,
+        ),
+        define_prop("P$Homing", PropHoming::read, identity, accumulator::latest),
+        define_prop(
+            "P$TargetTyp",
+            |reader, _len| read_u32(reader),
+            PropTargetType,
             accumulator::latest,
         ),
         define_prop(

--- a/dark/src/properties/prop_homing.rs
+++ b/dark/src/properties/prop_homing.rs
@@ -1,0 +1,58 @@
+use std::{io, time::Duration};
+
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+
+use crate::{
+    SCALE_FACTOR,
+    ss2_common::{read_single, read_u32},
+};
+
+/// Dark's `sHoming` (shkhome.h): two fix-angle limits and a millisecond pulse.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropHoming {
+    pub target_types: u32,
+    pub distance: f32,
+    pub heading_limit: f32,
+    pub max_turn: f32,
+    pub update_interval: Duration,
+}
+
+impl PropHoming {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        Self {
+            target_types: read_u32(reader),
+            distance: read_single(reader) / SCALE_FACTOR,
+            heading_limit: read_u32(reader) as f32 * std::f32::consts::TAU / 65536.0,
+            max_turn: read_u32(reader) as f32 * std::f32::consts::TAU / 65536.0,
+            update_interval: Duration::from_millis(read_u32(reader) as u64),
+        }
+    }
+}
+
+/// Authored target-category bits; a target may belong to both categories.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropTargetType(pub u32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_shipped_annelid_homing_record() {
+        let mut bytes = Vec::new();
+        bytes.extend(2u32.to_le_bytes());
+        bytes.extend(50f32.to_le_bytes());
+        bytes.extend(4944u32.to_le_bytes());
+        bytes.extend(2048u32.to_le_bytes());
+        bytes.extend(200u32.to_le_bytes());
+        let mut reader = io::Cursor::new(bytes);
+        let prop = PropHoming::read(&mut reader, 20);
+        assert_eq!(reader.position(), 20);
+        assert_eq!(prop.target_types, 2);
+        assert_eq!(prop.distance, 50.0 / SCALE_FACTOR);
+        assert!((prop.heading_limit.to_degrees() - 27.158203).abs() < 0.001);
+        assert!((prop.max_turn.to_degrees() - 11.25).abs() < 0.001);
+        assert_eq!(prop.update_interval, Duration::from_millis(200));
+    }
+}

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -369,3 +369,37 @@ setting and ammo combinations and the current verification boundaries.
 including setting-filtered link inputs and unparsed-property gaps. The SDK
 matrix exercises both flat and right VR; diagnostic last-projectile identity
 keeps instantaneous ray shots observable without changing their lifetime.
+
+
+## Annelid homing
+
+The new stack starts from merged main `69cffd92`. Both Worm Launcher settings
+now execute the authored `Homing` script instead of panicking. `P$Homing` supplies
+target mask, range, heading filter, per-pulse turn limit and pulse interval;
+`P$TargetTyp` supplies target flags. Shipped AH/AA rockets use masks 1/2, range
+50 Dark units, a 27.158-degree yaw/pitch window, an 11.25-degree turn limit and
+200 ms pulses. Hybrids carry mask 3 and are eligible for both modes.
+
+The source baseline is Dark `shock/shkhome.h` / `shkhome.cpp`, with the one-time
+scan and recurring `HomingPulse` checked against the shipped 25AE script binary
+and [Telliamed's script reference](https://thiefmissions.com/telliamed/allscripts.html).
+Targets must be alive, referenced, in range and angular bounds, with
+terrain line of sight. A lost/dead target is not reacquired. Deliberate port
+adaptations are scanning from the actual projectile launch pose for VR hands,
+using symmetric distance bounds instead of the source's signed-axis comparison,
+and preserving actual launch speed (including modifiers) while steering.
+
+Save/load preserves target identity through remapping, pulse remainder and
+world-space projectile velocity. The shared velocity snapshot also prevents
+ordinary player-fired projectiles from restarting toward world +Z on load.
+
+Both modes have flat/VR firing coverage and visible off-axis steering/impact
+captures. Impact kills the fixture hybrid and visible blast particles expire;
+the explosion root and two particle child entities still exist after 26 seconds.
+That secondary-effect entity cleanup remains an audit gap. These checks do not
+establish full damage/stim parity.
+
+The next separate layer addresses Quest's explicit `render_particles: false`
+override. It explains the missing particle orbs despite smaller mesh effects
+(the user's four-dot EMP observation); headset before/after verification remains
+required before calling that presentation gap fixed.

--- a/projects/weapon-projectile-audit.md
+++ b/projects/weapon-projectile-audit.md
@@ -157,3 +157,16 @@ have no TODO. The original baseline above remains historical: its remaining
 known launch failures are the four worm-launcher presentation/mode cases.
 General projectile damage, pellet spread, homing and other effect lifecycles
 remain the follow-ups listed above.
+
+
+## Annelid homing followup
+
+Both worm-launcher modes now fire without the unimplemented-script panic.
+All four affected flat/VR matrix rows pass and their TODO annotations are
+removed; the historical 76-case baseline above is not a new full-matrix rerun.
+Authored homing masks, angular limits, pulse timing and target remapping are
+covered by focused tests. Both modes visibly steer toward a hybrid (target
+mask 3), hit it, and remove the rocket and its flight riders. Visible impact
+particles expire, but three secondary effect entities persist after 26 seconds;
+cleanup remains open. See [the workstream](weapon-feel-workstream.md#annelid-homing)
+for source references and intentional VR adaptations.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4979,12 +4979,33 @@ impl MissionCore {
                 .borrow::<ViewMut<RuntimePropTransform>>()
                 .unwrap();
             let mut v_prop_position = self.world.borrow::<ViewMut<PropPosition>>().unwrap();
+            let launched = self
+                .world
+                .borrow::<View<crate::runtime_props::RuntimePropLaunchedProjectile>>()
+                .unwrap();
+            let player_fired = self
+                .world
+                .borrow::<View<crate::runtime_props::RuntimePropPlayerFiredProjectile>>()
+                .unwrap();
+            let mut velocities = self
+                .world
+                .borrow::<ViewMut<crate::runtime_props::RuntimePropProjectileVelocity>>()
+                .unwrap();
             let v_entities = self.world.borrow::<EntitiesView>().unwrap();
             let v_glove_weapon = self
                 .world
                 .borrow::<View<crate::runtime_props::RuntimePropGloveWeapon>>()
                 .unwrap();
             for (entity_id, handle) in &self.id_to_physics {
+                if launched.contains(*entity_id) || player_fired.contains(*entity_id) {
+                    if let Some(velocity) = self.physics.get_velocity(*entity_id) {
+                        v_entities.add_component(
+                            *entity_id,
+                            &mut velocities,
+                            crate::runtime_props::RuntimePropProjectileVelocity(velocity),
+                        );
+                    }
+                }
                 let scale = v_glove_weapon
                     .get(*entity_id)
                     .ok()
@@ -6649,6 +6670,34 @@ impl MissionCore {
             }
         };
 
+        // Saved world-space flight velocity takes precedence over launch-time
+        // defaults before the first physics step of a restored mission.
+        drop(v_initial_velocity);
+        if world
+            .borrow::<View<crate::runtime_props::RuntimePropLaunchedProjectile>>()
+            .unwrap()
+            .contains(created_entity.entity_id)
+            || world
+                .borrow::<View<crate::runtime_props::RuntimePropPlayerFiredProjectile>>()
+                .unwrap()
+                .contains(created_entity.entity_id)
+        {
+            let restored = world
+                .borrow::<View<crate::runtime_props::RuntimePropProjectileVelocity>>()
+                .unwrap()
+                .get(created_entity.entity_id)
+                .ok()
+                .map(|v| v.0);
+            if let Some(velocity) =
+                restored.or_else(|| physics.get_velocity(created_entity.entity_id))
+            {
+                physics.set_velocity(created_entity.entity_id, velocity);
+                world.add_component(
+                    created_entity.entity_id,
+                    crate::runtime_props::RuntimePropProjectileVelocity(velocity),
+                );
+            }
+        }
         ret
     }
 
@@ -9188,6 +9237,18 @@ impl MissionCore {
                             v_teleported.remove(entity_id);
                         },
                     );
+                }
+                Effect::SetLinearVelocity {
+                    entity_id,
+                    velocity,
+                } => {
+                    self.physics.set_velocity(entity_id, velocity);
+                    if self.physics.get_velocity(entity_id).is_some() {
+                        self.world.add_component(
+                            entity_id,
+                            crate::runtime_props::RuntimePropProjectileVelocity(velocity),
+                        );
+                    }
                 }
                 Effect::SetRenderType {
                     entity_id,

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -358,6 +358,11 @@ pub struct RuntimePropPlayerFiredProjectile;
 #[derive(Component, Clone, Copy)]
 pub struct RuntimePropLaunchedProjectile;
 
+/// Current world-space projectile velocity, synchronized from physics and saved
+/// so a steered or ricocheting shot resumes its flight instead of relaunching.
+#[derive(Component, Clone, Copy)]
+pub struct RuntimePropProjectileVelocity(pub Vector3<f32>);
+
 // RuntimePropMapData - the automap page data for the current mission, attached
 // to the synthetic map-panel entity at mission init: the mission's level file
 // name (for the per-level `intrface/<LEVEL>/english/` art paths), its authored

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -48,6 +48,8 @@ pub struct EntitySaveData {
     /// This is separate from launch provenance: enemy shots are launched too.
     #[serde(default)]
     pub player_fired_projectiles: Vec<u64 /* entity id */>,
+    #[serde(default)]
+    pub projectile_velocities: HashMap<u64, cgmath::Vector3<f32>>,
     /// Opt-in private state owned by scripts on these entities. Registered ECS
     /// properties and links remain in their existing fields above; this is only
     /// for runtime modes, timers, latches, and similar script internals.
@@ -69,6 +71,7 @@ impl EntitySaveData {
             canonical_template_ids: HashMap::new(),
             launched_projectiles: Vec::new(),
             player_fired_projectiles: Vec::new(),
+            projectile_velocities: HashMap::new(),
             script_states: Vec::new(),
         }
     }
@@ -94,6 +97,17 @@ impl EntitySaveData {
         }
 
         let (all_properties, _, _) = dark::properties::get::<File>();
+
+        for (old, velocity) in &self.projectile_velocities {
+            if let Some(new) =
+                EntityId::from_inner(*old).and_then(|id| old_entity_id_to_new_entity_id.get(&id))
+            {
+                world.add_component(
+                    *new,
+                    crate::runtime_props::RuntimePropProjectileVelocity(*velocity),
+                );
+            }
+        }
 
         for prop in all_properties {
             let name = prop.name();

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -264,6 +264,14 @@ pub fn to_save_data_with_scripts(
         .collect();
     let (held_shoulders, world_shoulders) =
         partition_map(raw_shoulders, |id| held_entities.contains(id));
+    let (held_velocities, world_velocities): (Vec<_>, Vec<_>) = world
+        .borrow::<View<crate::runtime_props::RuntimePropProjectileVelocity>>()
+        .unwrap()
+        .iter()
+        .with_id()
+        .map(|(id, velocity)| (id.inner(), velocity.0))
+        .filter(|(id, _)| !entities_to_filter.contains(id))
+        .partition(|(id, _)| held_entities.contains(id));
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
         template_id_to_entity_id: template_id_to_entity_id.0.clone(),
@@ -276,6 +284,7 @@ pub fn to_save_data_with_scripts(
         canonical_template_ids: world_canonical_templates,
         launched_projectiles: world_launched_projectiles,
         player_fired_projectiles: world_player_fired_projectiles,
+        projectile_velocities: world_velocities.into_iter().collect(),
         script_states: world_script_states,
     };
 
@@ -291,6 +300,7 @@ pub fn to_save_data_with_scripts(
         canonical_template_ids: held_canonical_templates,
         launched_projectiles: held_launched_projectiles,
         player_fired_projectiles: held_player_fired_projectiles,
+        projectile_velocities: held_velocities.into_iter().collect(),
         script_states: held_script_states,
     };
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -741,6 +741,11 @@ pub enum Effect {
         entity_id: EntityId,
         rotation: Quaternion<f32>,
     },
+    /// Change a live projectile's flight velocity without changing its pose.
+    SetLinearVelocity {
+        entity_id: EntityId,
+        velocity: Vector3<f32>,
+    },
     SetPositionRotation {
         entity_id: EntityId,
         position: Vector3<f32>,

--- a/shock2vr/src/scripts/homing.rs
+++ b/shock2vr/src/scripts/homing.rs
@@ -1,0 +1,329 @@
+//! Annelid lock-on and fixed-cadence steering (Dark `shkhome.cpp`).
+use cgmath::{EuclideanSpace, InnerSpace, Point3, Vector3, vec3};
+use dark::properties::{PropHasRefs, PropHitPoints, PropHoming, PropPosition, PropTargetType};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, World};
+
+use super::{Effect, Script, ScriptRestoreContext, ScriptState, ScriptStateError};
+use crate::{
+    physics::{InternalCollisionGroups, PhysicsWorld},
+    time::Time,
+};
+
+const STATE_KEY: &str = "shock2vr.homing";
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct Homing {
+    initialized: bool,
+    target: Option<u64>,
+    remaining_seconds: f32,
+}
+
+impl Script for Homing {
+    fn update(
+        &mut self,
+        entity: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        let (homing, positions, health) = world
+            .borrow::<(View<PropHoming>, View<PropPosition>, View<PropHitPoints>)>()
+            .unwrap();
+        let (Ok(config), Ok(position), Some(velocity)) = (
+            homing.get(entity),
+            positions.get(entity),
+            physics.get_velocity(entity),
+        ) else {
+            return Effect::NoEffect;
+        };
+        if !self.initialized {
+            self.initialized = true;
+            // Use the actual launch aim in both presentations: in VR the hand
+            // can aim independently of the head. The original scans player aim.
+            self.target =
+                acquire_target(world, physics, entity, position.position, velocity, config)
+                    .map(EntityId::inner);
+            self.remaining_seconds = config.update_interval.as_secs_f32().max(0.001);
+            return Effect::NoEffect;
+        }
+        let Some(target) = self.target.and_then(EntityId::from_inner) else {
+            return Effect::NoEffect;
+        };
+        let Ok(target_position) = positions.get(target) else {
+            self.target = None;
+            return Effect::NoEffect;
+        };
+        if !health.get(target).is_ok_and(|hp| hp.hit_points > 0) {
+            self.target = None;
+            return Effect::NoEffect;
+        }
+        self.remaining_seconds -= time.elapsed.as_secs_f32();
+        if self.remaining_seconds > 0.0 {
+            return Effect::NoEffect;
+        }
+        let interval = config.update_interval.as_secs_f32().max(0.001);
+        let pulses = 1.0 + (-self.remaining_seconds / interval).floor();
+        self.remaining_seconds += pulses * interval;
+        Effect::SetLinearVelocity {
+            entity_id: entity,
+            velocity: homing_velocity(
+                velocity,
+                target_position.position - position.position,
+                config.max_turn * pulses,
+            ),
+        }
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(STATE_KEY)
+    }
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(1, self, STATE_KEY)
+    }
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let mut restored: Self = state.decode(1, STATE_KEY)?;
+        restored.target = match restored.target {
+            Some(target) => match context.remap_entity(target) {
+                Ok(target) => Some(target.inner()),
+                // A target deleted before the save no longer has a live link.
+                Err(ScriptStateError::MissingEntityReference(_)) => None,
+                Err(error) => return Err(error),
+            },
+            None => None,
+        };
+        *self = restored;
+        Ok(())
+    }
+}
+
+fn acquire_target(
+    world: &World,
+    physics: &PhysicsWorld,
+    projectile: EntityId,
+    origin: Vector3<f32>,
+    forward: Vector3<f32>,
+    config: &PropHoming,
+) -> Option<EntityId> {
+    if forward.magnitude2() < 1e-8 {
+        return None;
+    }
+    let (types, positions, health, refs) = world
+        .borrow::<(
+            View<PropTargetType>,
+            View<PropPosition>,
+            View<PropHitPoints>,
+            View<PropHasRefs>,
+        )>()
+        .unwrap();
+    let (yaw, pitch) = direction_angles(forward);
+    let mut best = None;
+    let mut best_angle = f32::INFINITY;
+    for (target, (kind, position, hp)) in (&types, &positions, &health).iter().with_id() {
+        if target == projectile
+            || kind.0 & config.target_types == 0
+            || hp.hit_points <= 0
+            || refs.get(target).is_ok_and(|r| !r.0)
+        {
+            continue;
+        }
+        let delta = position.position - origin;
+        // Symmetric axis-distance prefilter; avoid the original signed-delta
+        // typo that admits arbitrarily distant targets on negative axes.
+        if delta.x.abs() >= config.distance
+            || delta.y.abs() >= config.distance
+            || delta.z.abs() >= config.distance
+            || delta.magnitude2() < 1e-8
+        {
+            continue;
+        }
+        let (target_yaw, target_pitch) = direction_angles(delta);
+        let dy = angle_delta(yaw, target_yaw).abs();
+        let dp = angle_delta(pitch, target_pitch).abs();
+        if dy >= config.heading_limit || dp >= config.heading_limit || dy + dp >= best_angle {
+            continue;
+        }
+        // Dark PortalRaycast tests level geometry, not other target bodies.
+        if physics
+            .ray_cast2(
+                Point3::from_vec(origin),
+                delta.normalize(),
+                delta.magnitude(),
+                InternalCollisionGroups::WORLD,
+                Some(projectile),
+                true,
+            )
+            .is_some()
+        {
+            continue;
+        }
+        best = Some(target);
+        best_angle = dy + dp;
+    }
+    best
+}
+
+fn direction_angles(direction: Vector3<f32>) -> (f32, f32) {
+    (
+        direction.z.atan2(direction.x),
+        direction.y.atan2(direction.x.hypot(direction.z)),
+    )
+}
+
+fn angle_delta(from: f32, to: f32) -> f32 {
+    (to - from + std::f32::consts::PI).rem_euclid(std::f32::consts::TAU) - std::f32::consts::PI
+}
+
+fn homing_velocity(
+    velocity: Vector3<f32>,
+    target_delta: Vector3<f32>,
+    max_turn: f32,
+) -> Vector3<f32> {
+    if velocity.magnitude2() < 1e-8 || target_delta.magnitude2() < 1e-8 {
+        return velocity;
+    }
+    let (yaw, pitch) = direction_angles(velocity);
+    let (target_yaw, target_pitch) = direction_angles(target_delta);
+    let max_turn = max_turn.max(0.0);
+    let yaw = yaw + angle_delta(yaw, target_yaw).clamp(-max_turn, max_turn);
+    let pitch = pitch + angle_delta(pitch, target_pitch).clamp(-max_turn, max_turn);
+    vec3(
+        yaw.cos() * pitch.cos(),
+        pitch.sin(),
+        yaw.sin() * pitch.cos(),
+    ) * velocity.magnitude()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{One, Quaternion};
+    use std::{collections::HashMap, time::Duration};
+
+    fn config(mask: u32) -> PropHoming {
+        PropHoming {
+            target_types: mask,
+            distance: 30.0,
+            heading_limit: 30f32.to_radians(),
+            max_turn: 11.25f32.to_radians(),
+            update_interval: Duration::from_millis(200),
+        }
+    }
+
+    fn target(
+        world: &mut World,
+        mask: u32,
+        position: Vector3<f32>,
+        hp: i32,
+        visible: bool,
+    ) -> EntityId {
+        world.add_entity((
+            PropTargetType(mask),
+            PropHitPoints { hit_points: hp },
+            PropHasRefs(visible),
+            PropPosition {
+                position,
+                rotation: Quaternion::one(),
+                cell: 0,
+            },
+        ))
+    }
+
+    #[test]
+    fn target_masks_health_visibility_range_and_angular_priority() {
+        let mut world = World::new();
+        let shot = world.add_entity(());
+        let human = target(&mut world, 1, vec3(10.0, 0.0, 2.0), 10, true);
+        let annelid = target(&mut world, 2, vec3(10.0, 0.0, 1.0), 10, true);
+        target(&mut world, 3, vec3(10.0, 0.0, 0.0), 0, true);
+        target(&mut world, 3, vec3(10.0, 0.0, 0.0), 10, false);
+        target(&mut world, 3, vec3(100.0, 0.0, 0.0), 10, true);
+        target(&mut world, 3, vec3(-100.0, 0.0, 0.0), 10, true);
+        target(&mut world, 3, vec3(1.0, 0.0, 10.0), 10, true);
+        let physics = PhysicsWorld::new();
+        assert_eq!(
+            acquire_target(
+                &world,
+                &physics,
+                shot,
+                vec3(0.0, 0.0, 0.0),
+                vec3(1.0, 0.0, 0.0),
+                &config(1)
+            ),
+            Some(human)
+        );
+        assert_eq!(
+            acquire_target(
+                &world,
+                &physics,
+                shot,
+                vec3(0.0, 0.0, 0.0),
+                vec3(1.0, 0.0, 0.0),
+                &config(2)
+            ),
+            Some(annelid)
+        );
+        let aligned = target(&mut world, 3, vec3(20.0, 0.0, 0.0), 10, true);
+        assert_eq!(
+            acquire_target(
+                &world,
+                &physics,
+                shot,
+                vec3(0.0, 0.0, 0.0),
+                vec3(1.0, 0.0, 0.0),
+                &config(1)
+            ),
+            Some(aligned)
+        );
+    }
+
+    #[test]
+    fn steering_caps_both_axes_preserves_speed_and_wraps_heading() {
+        let velocity = vec3(10.0, 0.0, 0.0);
+        let turned = homing_velocity(velocity, vec3(1.0, 1.0, 1.0), 11.25f32.to_radians());
+        let (yaw, pitch) = direction_angles(turned);
+        assert!((yaw.to_degrees() - 11.25).abs() < 0.001);
+        assert!((pitch.to_degrees() - 11.25).abs() < 0.001);
+        assert!((turned.magnitude() - 10.0).abs() < 0.001);
+        let from = vec3(
+            (-179f32).to_radians().cos(),
+            0.0,
+            (-179f32).to_radians().sin(),
+        );
+        let to = vec3(179f32.to_radians().cos(), 0.0, 179f32.to_radians().sin());
+        assert!((homing_velocity(from, to, 3f32.to_radians()) - to).magnitude() < 0.001);
+        assert_eq!(
+            homing_velocity(velocity, vec3(0.0, 0.0, 0.0), 1.0),
+            velocity
+        );
+    }
+
+    #[test]
+    fn save_remaps_lock_and_preserves_pulse_remainder() {
+        let mut world = World::new();
+        let old = world.add_entity(());
+        let new = world.add_entity(());
+        let script = Homing {
+            initialized: true,
+            target: Some(old.inner()),
+            remaining_seconds: 0.125,
+        };
+        let state = script.save_state().unwrap();
+        let map = HashMap::from([(old, new)]);
+        let mut restored = Homing::default();
+        restored
+            .restore_state(&state, &ScriptRestoreContext::new(&map))
+            .unwrap();
+        assert!(restored.initialized);
+        assert_eq!(restored.target, Some(new.inner()));
+        assert_eq!(restored.remaining_seconds, 0.125);
+        restored
+            .restore_state(&state, &ScriptRestoreContext::new(&HashMap::new()))
+            .unwrap();
+        assert_eq!(restored.target, None);
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -30,6 +30,7 @@ mod exp_cookie;
 mod frob_qb;
 pub mod gui;
 pub mod healing_item;
+mod homing;
 mod internal_collision_type;
 mod internal_explosion;
 pub mod internal_fast_projectile;
@@ -919,6 +920,7 @@ impl ScriptWorld {
         match script_name.to_ascii_lowercase().as_str() {
             // PROJECTILE stuff
             "lasershot" => Box::new(laser_shot::LaserShot::new()),
+            "homing" => Box::new(homing::Homing::default()),
             "proxgrenade" => Box::new(proximity_grenade::ProximityGrenade::new(false)),
             "contactproxgrenade" => Box::new(proximity_grenade::ProximityGrenade::new(true)),
             "proxgrenadetrigger" => Box::new(proximity_grenade::ProximityTrigger::default()),

--- a/tools/shock2-sdk/test/annelid-homing.e2e.test.ts
+++ b/tools/shock2-sdk/test/annelid-homing.e2e.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+for (const setting of [0, 1]) {
+  test(
+    `annelid mode ${setting} homes toward a hybrid with both target flags`,
+    {
+      skip: process.env.SHOCK2_E2E !== "1",
+      timeout: 180_000,
+    },
+    async () => {
+      await using game = await GameServer.launch({ mission: "debug_weapons" });
+      try {
+        await game.step({ frames: 10 });
+        await game.player.setStats({ skills: { exotic_weapons: 6 } });
+        await cycleToWeapon(game, (e) => e.template_id === -27, {
+          settleFrames: 10,
+        });
+        await game.player.spawnItem(-1264);
+        await game.input.trigger("Reload");
+        await game.step({ frames: 180 });
+        for (let i = 0; (await game.info()).player.reloading && i < 20; i++)
+          await game.step({ frames: 60 });
+        assert.equal((await game.info()).player.reloading, false);
+        if (setting) {
+          await game.input.trigger("CycleGunSetting");
+          await game.step({ frames: 2 });
+        }
+        await game.player.teleport({ x: -2, y: 0, z: 1.5 });
+        await game.input.set("head.look", [0, 0]);
+        await game.input.trigger("SpawnDebugMonster");
+        await game.step({ frames: 1 });
+        const [target] = await game.entities.byTemplate(-397);
+        assert.ok(target);
+        await game.player.teleport({ x: 0, y: 0, z: 0 });
+        await game.step({ frames: 2 });
+        await game.input.set("right_hand.trigger", 1);
+        await game.step({ frames: 1 });
+        await game.input.set("right_hand.trigger", 0);
+        const [shot] = await game.entities.byTemplate(setting ? -3502 : -1356);
+        assert.ok(shot);
+        const [body] = (await game.physics.bodies({ entityId: shot.id }))
+          .bodies;
+        assert.ok(body);
+        await game.step({ frames: 16 });
+        const [turned] = (await game.physics.bodies({ entityId: shot.id }))
+          .bodies;
+        assert.ok(
+          turned,
+          "projectile remains in flight beyond first homing pulse",
+        );
+        const change = Math.hypot(
+          ...turned.velocity.map((v, i) => v - body.velocity[i]!),
+        );
+        assert.ok(
+          change > 0.1,
+          `both modes must steer toward the off-axis hybrid; velocity delta=${change}`,
+        );
+        assert.ok(
+          Math.abs(
+            Math.hypot(...turned.velocity) - Math.hypot(...body.velocity),
+          ) < 0.01,
+          "homing preserves launch speed",
+        );
+        assert.ok(
+          (await game.scene.objects({ entityId: shot.id })).objects.length > 0,
+          "the annelid rocket model is actually submitted to the renderer",
+        );
+        // Authored lifetime is five seconds even when no compatible target exists.
+        await game.step({ frames: 360 });
+        assert.equal(
+          (await game.entities.byTemplate(setting ? -3502 : -1356)).length,
+          0,
+        );
+      } catch (error) {
+        console.error(game.logs().slice(-30).join("\n"));
+        throw error;
+      }
+    },
+  );
+}
+
+test(
+  "a turning annelid missile preserves velocity and lock through a mission save",
+  {
+    skip: process.env.SHOCK2_E2E !== "1",
+    timeout: 180_000,
+  },
+  async () => {
+    await using game = await GameServer.launch({ mission: "earth.mis" });
+    await game.step({ frames: 30 });
+    await game.player.setStats({ skills: { exotic_weapons: 6 } });
+    await game.player.spawnItem("Worm Launcher");
+    await game.input.trigger("EquipWormLauncher");
+    await game.step({ frames: 5 });
+    await game.player.spawnItem(-1264);
+    await game.input.trigger("Reload");
+    await game.step({ frames: 180 });
+    for (let i = 0; (await game.info()).player.reloading && i < 20; i++)
+      await game.step({ frames: 60 });
+    await game.input.set("head.look", [0, 0]);
+    const home = (await game.info()).player.position;
+    // Spawn far enough beyond the muzzle that the target fits the pitch cone.
+    await game.player.teleport({ x: home[0], y: home[1], z: home[2] + 4 });
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 1 });
+    await game.player.teleport({ x: home[0], y: home[1], z: home[2] });
+    await game.input.set("head.look", [15, 0]);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
+    const [shot] = await game.entities.byTemplate(-1356);
+    assert.ok(shot);
+    const [initial] = (await game.physics.bodies({ entityId: shot.id })).bodies;
+    await game.step({ frames: 16 });
+    const [turned] = (await game.physics.bodies({ entityId: shot.id })).bodies;
+    assert.ok(initial && turned);
+    assert.ok(
+      Math.hypot(...turned.velocity.map((v, i) => v - initial.velocity[i]!)) >
+        0.1,
+      "fixture saves after a real homing turn",
+    );
+    const slot = `homing_${Date.now()}`;
+    assert.equal((await game.save(slot)).success, true);
+    assert.equal((await game.load(slot)).success, true);
+    const [restored] = await game.entities.byTemplate(-1356);
+    assert.ok(restored);
+    const [body] = (await game.physics.bodies({ entityId: restored.id }))
+      .bodies;
+    assert.ok(body);
+    assert.ok(
+      Math.hypot(...body.velocity.map((v, i) => v - turned.velocity[i]!)) <
+        0.001,
+      "saved world-space direction and speed survive reconstruction before the next physics step",
+    );
+    await game.step({ frames: 13 });
+    const [later] = (await game.physics.bodies({ entityId: restored.id }))
+      .bodies;
+    assert.ok(later);
+    assert.ok(
+      Math.hypot(...later.velocity.map((v, i) => v - body.velocity[i]!)) > 0.1,
+      "the remapped target remains locked and drives the next steering pulse",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/projectile-owner-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/projectile-owner-save.e2e.test.ts
@@ -3,32 +3,59 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 
-test("a saved player projectile keeps its shooter filter after entity remapping", {
-  skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
-}, async () => {
-  await using game = await GameServer.launch({ mission: "earth.mis" });
-  await game.step({ frames: 30 });
-  await game.player.spawnItem("Laser Pistol");
-  await game.input.trigger("EquipLaserPistol");
-  await game.step({ frames: 5 });
-  await game.input.set("right_hand.trigger", 1);
-  await game.step({ frames: 1 });
-  await game.input.set("right_hand.trigger", 0);
+test(
+  "a saved player projectile keeps its shooter filter after entity remapping",
+  {
+    skip: process.env.SHOCK2_E2E !== "1",
+    timeout: 180_000,
+  },
+  async () => {
+    await using game = await GameServer.launch({ mission: "earth.mis" });
+    await game.step({ frames: 30 });
+    await game.player.spawnItem("Laser Pistol");
+    await game.input.trigger("EquipLaserPistol");
+    await game.step({ frames: 5 });
+    await game.input.set("head.look", [15, 0]);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
 
-  const shotBody = async () => {
-    const shots = (await game.entities.list({ filter: "Laser Shot", limit: 50 })).entities;
-    assert.equal(shots.length, 1, "the fired bolt must remain alive for the save");
-    const bodies = (await game.physics.bodies({ entityId: shots[0].id })).bodies;
-    assert.equal(bodies.length, 1);
-    return bodies[0];
-  };
-  assert.equal((await shotBody()).blocks_player, false);
-  assert.equal((await shotBody()).blocks_actor, true);
-  const save = `projectile_owner_${Date.now()}`;
-  assert.equal((await game.save(save)).success, true);
-  assert.equal((await game.load(save)).success, true);
-  assert.equal((await shotBody()).blocks_player, false,
-    "loading must not turn the player's own projectile solid to its shooter");
-  assert.equal((await shotBody()).blocks_actor, true,
-    "the restored projectile must still collide with enemies");
-});
+    const shotBody = async () => {
+      const shots = (
+        await game.entities.list({ filter: "Laser Shot", limit: 50 })
+      ).entities;
+      assert.equal(
+        shots.length,
+        1,
+        "the fired bolt must remain alive for the save",
+      );
+      const bodies = (await game.physics.bodies({ entityId: shots[0].id }))
+        .bodies;
+      assert.equal(bodies.length, 1);
+      return bodies[0];
+    };
+    assert.equal((await shotBody()).blocks_player, false);
+    assert.equal((await shotBody()).blocks_actor, true);
+    const velocityBefore = (await shotBody()).velocity;
+    const save = `projectile_owner_${Date.now()}`;
+    assert.equal((await game.save(save)).success, true);
+    assert.equal((await game.load(save)).success, true);
+    const velocityAfter = (await shotBody()).velocity;
+    assert.ok(
+      Math.hypot(...velocityAfter.map((v, i) => v - velocityBefore[i]!)) <
+        0.001,
+      "loading preserves world-space flight velocity",
+    );
+    assert.equal(
+      (await shotBody()).blocks_player,
+      false,
+      "loading must not turn the player's own projectile solid to its shooter",
+    );
+    assert.equal(
+      (await shotBody()).blocks_actor,
+      true,
+      "the restored projectile must still collide with enemies",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/weapon-audit.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-audit.e2e.test.ts
@@ -14,8 +14,7 @@ const cases: Case[] = JSON.parse(readFileSync(new URL("../../test/fixtures/weapo
 const enabled = process.env.SHOCK2_E2E === "1";
 for (const vr of [false, true]) for (const row of cases) {
   test(`${vr ? "VR" : "flat"} audit: ${row.weapon} setting ${row.setting} ${row.projectileName}`,
-    { skip: !enabled || (!!process.env.WEAPON_AUDIT_PRESENTATION && process.env.WEAPON_AUDIT_PRESENTATION !== (vr ? "vr" : "flat")), timeout: 180_000,
-      todo: row.weaponTemplate === -27 ? "Homing script crashes on initialization" : undefined }, async () => {
+    { skip: !enabled || (!!process.env.WEAPON_AUDIT_PRESENTATION && process.env.WEAPON_AUDIT_PRESENTATION !== (vr ? "vr" : "flat")), timeout: 180_000 }, async () => {
     await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: vr ? ["--vr"] : [] });
     try {
     await game.step({ frames: 5 });


### PR DESCRIPTION
Firing either annelid-launcher mode previously reached an unimplemented `Homing` script and crashed. Both modes now acquire an eligible target once and steer at the authored interval and angular limits, preserving launch speed. Target flags distinguish modes; hybrids carry both flags.

The implementation parses `Homing` and `TargetTyp`, returns velocity changes through the shared effect handler, and saves the target lock, pulse remainder and world-space projectile velocity. A real save/load regression caught player shots restarting toward world +Z; both player-fired and other launched projectiles now retain their flight velocity.

Source: Dark `shkhome.h` / `shkhome.cpp`, plus the shipped 25AE `HomingPulse` script and [Telliamed](https://thiefmissions.com/telliamed/allscripts.html). Intentional adaptations: scan actual launch aim for independent VR hands, use symmetric distance bounds, and retain modified launch speed. See `projects/weapon-feel-workstream.md` for details.

Validation:
- Authored parser and three homing unit tests pass.
- All four affected flat/VR weapon-audit rows pass; their TODO annotations are removed.
- Both mode steering scenarios, turning-missile save/lock restoration, and off-axis laser velocity/shooter-filter save regression pass.
- All six proximity-grenade deployment/save scenarios pass.
- All 23 mission-load scenarios and 63 fast SDK tests pass; warning-denied checks pass for dark, gameplay, desktop and debug runtime.
- Independent agent and Codex CLI review completed; the agent's save-velocity finding was fixed and reproduced in the runtime test.

Both modes visibly hit and kill the fixture hybrid. Visible impact particles expire, but the explosion root and two child entities persist after 26 seconds: secondary-effect entity cleanup and full damage/stim parity remain documented audit gaps. Before this change the same firing path crashes, so no before-flight animation exists.

![Both modes in flight](https://gist.githubusercontent.com/tommy-xr/682c33b25f01ba3101050cfa6432067c/raw/homing-flight.png)
![Both modes steering and impacting, slowed 3x](https://gist.githubusercontent.com/tommy-xr/682c33b25f01ba3101050cfa6432067c/raw/homing-impact.gif)
