### PR TITLE
fix(vr): restore particle rendering on Quest

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -403,3 +403,21 @@ The next separate layer addresses Quest's explicit `render_particles: false`
 override. It explains the missing particle orbs despite smaller mesh effects
 (the user's four-dot EMP observation); headset before/after verification remains
 required before calling that presentation gap fixed.
+
+
+## Quest particle rendering
+
+Since the initial runtime commit, Quest's `GameOptions` explicitly disabled all
+particle rendering while the
+shared default and debug runtime enabled it. The Quest layer removes that
+override and uses the shared default. This affects particle effects throughout
+the level, including EMP, stasis and fusion projectile riders; it is not a
+replacement orb or a weapon-specific approximation. The user's four-dot EMP
+observation is consistent with mesh effects remaining visible while particles
+are suppressed; identifying those exact dots still needs a matched device capture.
+
+The attached Quest disconnected before a usable before/after comparison could
+be captured. The existing simulated-VR gallery demonstrates the enabled shared
+render path, but does not verify the corrected APK on a headset. Keep this layer
+in draft until it is installed, projectile orbs are visibly checked and device
+captures are embedded. No device performance claim is made.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -547,7 +547,6 @@ fn main() {
     let mission = quest_config::configured_mission();
     let game_init_started = Instant::now();
     let options: GameOptions = GameOptions {
-        render_particles: false,
         mission: mission.clone(),
         experimental_features,
         debug_skeletons: false,


### PR DESCRIPTION
Quest has disabled all particle rendering since the initial runtime commit. Remove its `render_particles: false` override so it uses the same enabled default as desktop and the debug runtime. This restores the particle submission path used by EMP, stasis, fusion and other level effects.

The user's four-dot EMP projectile with no orb is consistent with mesh geometry drawing while its particle riders are suppressed. Identifying the exact dots and confirming the corrected orb on the headset still requires a matched device capture.

Stacked on #1459. **Draft: device verification pending.** The Quest disconnected from ADB before a usable before/after capture could be obtained. The release APK built and signed successfully from `38793d2f`. No headset or performance verification is claimed.

The following existing simulated-VR captures show the shared enabled renderer only; they are not before/after Quest evidence:

![Projectile gallery, simulated VR](https://gist.githubusercontent.com/tommy-xr/682c33b25f01ba3101050cfa6432067c/raw/gallery.png)

Before marking ready: install the corrected release APK, capture matched Quest PNG/GIF evidence for EMP and the other requested projectiles, and inspect the actual orbs. Tracking details are in `projects/weapon-feel-workstream.md`.
