### PR TITLE
feat(vr): route gun recoil to primary and support hands

### DIFF
--- a/projects/astra-vr-thigh-holsters.md
+++ b/projects/astra-vr-thigh-holsters.md
@@ -128,21 +128,27 @@ Gameplay emits `Effect::HandHaptic { hand, pulse }`, with hardware-independent
 amplitude and duration. Only the central effect handler updates the transient
 per-hand output state. The Quest runtime consumes that state once and performs
 the OpenXR call; pause/loading discard unconsumed output. Same-frame requests
-resolve to the strongest pulse, then longest duration for equal strength.
+resolve to the strongest pulse, then longest duration for equal strength. An
+active pulse also blocks weaker later requests until its duration expires;
+equal-strength shots can retrigger immediately. Suppressed cues are discarded.
+The shared `HapticMixer` takes a monotonic timestamp supplied just before
+OpenXR submission, so a slow gameplay update cannot expire a fresh vibration.
 The request counters remain available to headless assertions.
 
-Next increments can translate semantic weapon events into named pulse profiles:
+Successful shots now emit `WeaponRecoil`, resolved centrally to the primary VR
+hand (0.75 / 45 ms) and an actively attached support hand (0.30 / 30 ms). Each
+burst round cues independently. Dry fire, a broken gun, and a rejected trigger
+emit no recoil. Flat and unheld weapons produce no controller output. These
+initial generic profiles still need headset tuning; weapon-specific profiles
+can follow.
 
-- Successful shot: short firing-hand recoil; a weaker optional support-hand
-  pulse, with weapon-specific strength/duration. Do not cue a dry fire as a shot.
+Next increments can translate additional semantic events into named profiles:
+
 - Melee enemy hit: contact pulse in the primary hand and, when attached, the
   support hand. Use real impact/damage events, not overlap every physics frame.
 - Melee wall block: a distinct, lighter profile, with per-contact cooldown so
   resting a weapon against a surface never produces continuous buzzing.
 - Inventory refusal: distinguish it from the light shoulder-ready tick.
 
-Before multiple sources ship, add arbitration over the lifetime of an active
-pulse as well as within a frame, so a weaker later ready tick cannot interrupt a
-strong impact. Keep profiles and cooldown policy in shared gameplay, leaving
-only haptic submission in platform runtimes. These weapon cues are planned;
-this increment emits shoulder-ready feedback only.
+Keep profiles and cooldown policy in shared gameplay, leaving only haptic
+submission in platform runtimes. Headset validation is deferred.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -607,6 +607,8 @@ fn main() {
     let mut requested_display_refresh_rate = None;
     let mut ready_reported = false;
     let mut session_focused = false;
+    let haptic_clock = Instant::now();
+    let mut haptic_mixer = shock2vr::haptics::HapticMixer::default();
     // Consecutive rejected frame submissions, and consecutive frames whose
     // views were not tracked. Both are logged once at the start of a burst and
     // once on recovery (with the length), so a long outage is still visible in
@@ -1053,6 +1055,7 @@ fn main() {
         game.update(&time_context, &input_context, &mut action_state);
         let pulses = game.take_haptics();
         if session_focused {
+            let pulses = haptic_mixer.select(haptic_clock.elapsed(), pulses);
             for (hand, action) in [&left_haptic, &right_haptic].into_iter().enumerate() {
                 if let Some(request) = pulses[hand] {
                     let pulse = xr::HapticVibration::new()

--- a/shock2vr/src/haptics.rs
+++ b/shock2vr/src/haptics.rs
@@ -12,6 +12,15 @@ pub const SHOULDER_READY: HapticPulse = HapticPulse {
     duration_ms: 60,
 };
 
+pub const GUN_RECOIL: HapticPulse = HapticPulse {
+    amplitude: 0.75,
+    duration_ms: 45,
+};
+pub const GUN_SUPPORT: HapticPulse = HapticPulse {
+    amplitude: 0.3,
+    duration_ms: 30,
+};
+
 #[derive(Default, Unique, serde::Serialize)]
 pub struct HapticFeedback {
     pub pending: [Option<HapticPulse>; 2],
@@ -29,6 +38,7 @@ impl HapticFeedback {
             amplitude: pulse.amplitude.min(1.0),
             duration_ms: pulse.duration_ms,
         };
+        self.sequence[hand] += 1;
         // Same-frame effects resolve deterministically: the stronger pulse
         // wins, then the longer one. A ready tick cannot overwrite an impact.
         if self.pending[hand].is_none_or(|current| {
@@ -37,7 +47,35 @@ impl HapticFeedback {
         }) {
             self.pending[hand] = Some(pulse);
         }
-        self.sequence[hand] += 1;
+    }
+}
+
+/// Pure output arbitration. The runtime supplies a monotonic timestamp at
+/// submission, after gameplay update, so slow frames cannot age a fresh pulse.
+#[derive(Default)]
+pub struct HapticMixer {
+    active: [Option<(f32, std::time::Duration)>; 2],
+}
+
+impl HapticMixer {
+    pub fn select(
+        &mut self,
+        now: std::time::Duration,
+        requests: [Option<HapticPulse>; 2],
+    ) -> [Option<HapticPulse>; 2] {
+        std::array::from_fn(|hand| {
+            let pulse = requests[hand]?;
+            if self.active[hand]
+                .is_some_and(|(amplitude, until)| now < until && amplitude > pulse.amplitude)
+            {
+                return None;
+            }
+            self.active[hand] = Some((
+                pulse.amplitude,
+                now.saturating_add(std::time::Duration::from_millis(pulse.duration_ms.into())),
+            ));
+            Some(pulse)
+        })
     }
 }
 
@@ -52,6 +90,41 @@ pub fn take(world: &World) -> [Option<HapticPulse>; 2] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn submitted_recoil_survives_weaker_later_requests_without_delaying_them() {
+        use std::time::Duration;
+        let mut mixer = HapticMixer::default();
+        // A slow 100 ms update has just completed; the pulse starts NOW.
+        let at = |ms| Duration::from_millis(ms);
+        assert_eq!(
+            mixer.select(at(100), [None, Some(GUN_RECOIL)]),
+            [None, Some(GUN_RECOIL)]
+        );
+        assert_eq!(
+            mixer.select(at(116), [Some(SHOULDER_READY), Some(SHOULDER_READY)]),
+            [Some(SHOULDER_READY), None]
+        );
+        // Equal-strength shots retrigger; later weaker requests cannot truncate them.
+        assert_eq!(
+            mixer.select(at(120), [None, Some(GUN_RECOIL)])[1],
+            Some(GUN_RECOIL)
+        );
+        assert_eq!(mixer.select(at(150), [None, Some(SHOULDER_READY)])[1], None);
+        assert_eq!(
+            mixer.select(at(165), [None; 2]),
+            [None; 2],
+            "no delayed tick"
+        );
+        assert_eq!(
+            mixer.select(at(165), [None, Some(SHOULDER_READY)])[1],
+            Some(SHOULDER_READY)
+        );
+        assert_eq!(
+            mixer.select(at(166), [None, Some(GUN_RECOIL)])[1],
+            Some(GUN_RECOIL)
+        );
+    }
 
     #[test]
     fn output_is_consumed_once_and_absent_worlds_are_silent() {

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -166,6 +166,12 @@ pub trait PlayerInteraction {
     /// right, matching the right-hand trigger it fires with.
     fn holding_hand(&self, entity_id: EntityId) -> Option<Handedness>;
 
+    /// Primary and actively attached support hand for controller feedback.
+    /// Flatscreen and unheld weapons produce no controller output.
+    fn haptic_hands(&self, _entity_id: EntityId) -> [Option<Handedness>; 2] {
+        [None; 2]
+    }
+
     /// Tracked palm on the firing side of a held weapon's muzzle offset.
     fn held_launch_origin(&self, _entity_id: EntityId) -> Option<Point3<f32>> {
         None
@@ -1439,6 +1445,22 @@ impl PlayerInteraction for VrInteraction {
         Some(Point3::new(point.x, point.y, point.z))
     }
 
+    fn haptic_hands(&self, entity_id: EntityId) -> [Option<Handedness>; 2] {
+        let primary = self.holding_hand(entity_id);
+        let support = self
+            .support
+            .as_ref()
+            .filter(|s| s.active && s.entity == entity_id && primary.is_some())
+            .map(|s| {
+                if s.primary == 0 {
+                    Handedness::Right
+                } else {
+                    Handedness::Left
+                }
+            });
+        [primary, support]
+    }
+
     fn holding_hand(&self, entity_id: EntityId) -> Option<Handedness> {
         if self.left_hand.is_holding(entity_id) {
             Some(Handedness::Left)
@@ -1688,6 +1710,30 @@ mod tests {
             (start.z - 0.1).abs() < 0.001,
             "must start at the palm, not the offset model: {start:?}"
         );
+    }
+
+    #[test]
+    fn recoil_routes_only_to_the_owner_and_active_support_hand() {
+        let (world, entity, physics, mut interaction, mut input) = wrench_support_fixture();
+        assert_eq!(
+            interaction.haptic_hands(entity),
+            [Some(Handedness::Right), None]
+        );
+        interaction.update_support(&context(&world, &physics, &input));
+        input.left_hand.squeeze_value = 1.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert_eq!(
+            interaction.haptic_hands(entity),
+            [Some(Handedness::Right), Some(Handedness::Left)]
+        );
+        input.left_hand.squeeze_value = 0.0;
+        interaction.update_support(&context(&world, &physics, &input));
+        assert_eq!(
+            interaction.haptic_hands(entity),
+            [Some(Handedness::Right), None]
+        );
+        assert_eq!(interaction.haptic_hands(EntityId::dead()), [None; 2]);
+        assert_eq!(FlatInteraction::new().haptic_hands(entity), [None; 2]);
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8760,6 +8760,17 @@ impl MissionCore {
                     }
                     drop(quests);
                 }
+                Effect::WeaponRecoil { entity_id } => {
+                    let hands = self.interaction.haptic_hands(entity_id);
+                    for (hand, pulse) in hands
+                        .into_iter()
+                        .zip([crate::haptics::GUN_RECOIL, crate::haptics::GUN_SUPPORT])
+                    {
+                        if let Some(hand) = hand {
+                            effects.push_back(Effect::HandHaptic { hand, pulse });
+                        }
+                    }
+                }
                 Effect::HandHaptic { hand, pulse } => {
                     self.world
                         .borrow::<UniqueViewMut<crate::haptics::HapticFeedback>>()

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -685,6 +685,9 @@ pub enum Effect {
     },
     /// One-shot controller feedback. Gameplay describes it; only the runtime
     /// talks to hardware. Transient output is never serialized into saves.
+    WeaponRecoil {
+        entity_id: EntityId,
+    },
     HandHaptic {
         hand: crate::Handedness,
         pulse: crate::haptics::HapticPulse,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -588,6 +588,9 @@ fn fire_one_shot(world: &World, entity_id: EntityId, setting: &GunSettingDesc) -
 
     // Consume the setting's per-shot cost when the weapon tracks ammo.
     let mut effects = vec![sound_effect, muzzle_flash_effect, projectile_effect];
+    if is_gunshot {
+        effects.push(Effect::WeaponRecoil { entity_id });
+    }
     if maybe_ammo.is_some() {
         effects.push(Effect::AdjustAmmo {
             entity_id,
@@ -1321,6 +1324,38 @@ mod tests {
         assert!(matches!(
             fire_one_shot(&world, gun, &GunSettingDesc::default()),
             ShotOutcome::Fired(_)
+        ));
+    }
+
+    #[test]
+    fn recoil_is_a_successful_shot_effect_not_a_trigger_effect() {
+        let (mut world, gun) = gun_world(None);
+        let ShotOutcome::Fired(Effect::Multiple(effects)) =
+            fire_one_shot(&world, gun, &GunSettingDesc::default())
+        else {
+            panic!("loaded gun must fire");
+        };
+        assert_eq!(
+            effects
+                .iter()
+                .filter(|effect| matches!(effect,
+            Effect::WeaponRecoil { entity_id } if *entity_id == gun))
+                .count(),
+            1
+        );
+        world.add_component(
+            gun,
+            dark::properties::PropGunState {
+                ammo: 0,
+                condition: 100.0,
+                setting: 0,
+                modification: 0,
+                silence_value: 0.0,
+            },
+        );
+        assert!(matches!(
+            fire_one_shot(&world, gun, &GunSettingDesc::default()),
+            ShotOutcome::Empty
         ));
     }
 

--- a/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-gun-support.e2e.test.ts
@@ -21,7 +21,8 @@ for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
       const other = primary === "left" ? "right" : "left";
       const owner = primary === "left" ? "wielded_entity_id" : "right_hand_entity_id";
       const empty = primary === "left" ? "right_hand_entity_id" : "wielded_entity_id";
-      await game.input.set(`${primary}_hand.position`,[0,1,-.5]);
+      // Keep support acquisition clear of the enlarged body-inventory regions.
+      await game.input.set(`${primary}_hand.position`,[0,1,-1.2]);
       await game.input.set(`${primary}_hand.rotation`,[0,0,0,1]);
       await game.input.set(`${other}_hand.squeeze`,0);
       await game.step({frames:30});
@@ -53,9 +54,12 @@ for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
       }
       const ammo = ammoOf(await game.entities.detail(weapon.id));
       assert.ok(ammo > 0);
+      const pulses = async () => (await game.info()).player.hand_feedback!.haptics!;
+      const beforePulses = (await pulses()).sequence;
       await game.input.set(`${other}_hand.trigger`,1);
       await game.step({frames:2});
       assert.equal(ammoOf(await game.entities.detail(weapon.id)),ammo,"support trigger cannot fire");
+      assert.deepEqual((await pulses()).sequence, beforePulses);
       assert.equal((await grip()).support!.visual_trigger,1,"reserved support input remains available to finger animation");
       assert.equal((await game.info()).player[empty],null);
       // Pistol/shotgun rounds are fast raycast projectiles, not Rapier bodies.
@@ -63,6 +67,8 @@ for (const [model, template] of [["atek_h",-17],["sg_h",-19]] as const) {
       await game.input.set(`${primary}_hand.trigger`,1);
       await game.step({frames:1});
       assert.equal(ammoOf(await game.entities.detail(weapon.id)),ammo-1,"primary trigger fires while supported");
+      const feedback = await pulses();
+      assert.deepEqual(feedback.sequence, beforePulses.map(n => n + 1));
       const fired = await grip();
       assert.equal(fired.visual_trigger,1);
       assert.deepEqual(fired.finger_curls,fired.grip!.trigger_curls ?? fired.grip!.curls);

--- a/tools/shock2-sdk/test/vr-weapon-haptics.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-weapon-haptics.e2e.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+import { ammoOf, cycleToWeapon } from "./helpers/weapon.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+for (const hand of ["left", "right"] as const) {
+  test(`${hand} pistol cues each burst round and stays silent when empty`, { skip: !enabled, timeout: 180_000 }, async () => {
+    await using game = await GameServer.launch({ mission: "debug_weapons", debugFlags: ["--vr"] });
+    await game.step({ frames: 30 });
+    const gun = await cycleToWeapon(game, e => e.template_id === -17);
+    await aimVrHandAt(game, gun.position, 0.2, 1, 0, { hand });
+    await game.input.set(`${hand}_hand.position`, [hand === "left" ? -0.5 : 0.5, 1, -0.6]);
+    await game.input.set(`${hand}_hand.rotation`, [0, 0, 0, 1]);
+    await game.step({ frames: 10 });
+    await game.input.trigger("CycleGunSetting");
+    await game.step({ frames: 2 });
+    const rounds = async () => ammoOf(await game.entities.detail(gun.id));
+    const feedback = async () => (await game.info()).player.hand_feedback!.haptics!;
+    const start = (await feedback()).sequence;
+    const loaded = await rounds();
+    assert.equal(loaded, 12);
+    for (let burst = 0; burst < 4; burst++) {
+      await game.input.set(`${hand}_hand.trigger`, 1);
+      await game.step({ frames: 1 });
+      assert.equal((await feedback()).pending[hand === "left" ? 0 : 1]!.amplitude, 0.75);
+      await game.input.set(`${hand}_hand.trigger`, 0);
+      await game.step({ frames: 60 });
+      assert.equal(await rounds(), loaded - 3 * (burst + 1));
+    }
+    const expected = [...start];
+    expected[hand === "left" ? 0 : 1] += loaded;
+    assert.deepEqual((await feedback()).sequence, expected);
+    await game.input.set(`${hand}_hand.trigger`, 1);
+    await game.step({ frames: 1 });
+    assert.equal(await rounds(), 0);
+    assert.deepEqual((await feedback()).sequence, expected, "dry fire produces no recoil");
+    assert.deepEqual((await feedback()).pending, [null, null]);
+  });
+}
+
+test("dual wielding sends recoil to the gun that fired", { skip: !enabled, timeout: 180_000 }, async () => {
+  await using game = await GameServer.launch({ mission: "debug_interactions", debugFlags: ["--vr"] });
+  await game.step({ frames: 30 });
+  const entities = (await game.entities.list()).entities;
+  const pistol = entities.find(e => e.template_id === -17)!;
+  const shotgun = entities.find(e => e.template_id === -19)!;
+  await aimVrHandAt(game, pistol.position, 0.2, 1, 0, { hand: "left" });
+  await game.step({ frames: 5 });
+  await aimVrHandAt(game, shotgun.position, 0.2, 1, 0, { hand: "right" });
+  await game.step({ frames: 5 });
+  for (const hand of ["left", "right"] as const) {
+    await game.input.set(`${hand}_hand.position`, [hand === "left" ? -0.6 : 0.6, 1, -0.6]);
+    await game.input.set(`${hand}_hand.rotation`, [0, 0, 0, 1]);
+  }
+  await game.step({ frames: 10 });
+  const player = (await game.info()).player;
+  assert.equal(player.wielded_entity_id, pistol.id);
+  assert.equal(player.right_hand_entity_id, shotgun.id);
+  const before = player.hand_feedback!.haptics!.sequence;
+  const ammo = [ammoOf(await game.entities.detail(pistol.id)), ammoOf(await game.entities.detail(shotgun.id))];
+  await game.input.set("left_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  assert.deepEqual((await game.info()).player.hand_feedback!.haptics!.sequence, [before[0] + 1, before[1]]);
+  assert.equal(ammoOf(await game.entities.detail(pistol.id)), ammo[0] - 1);
+  assert.equal(ammoOf(await game.entities.detail(shotgun.id)), ammo[1]);
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  assert.deepEqual((await game.info()).player.hand_feedback!.haptics!.sequence, before.map(n => n + 1));
+  assert.equal(ammoOf(await game.entities.detail(shotgun.id)), ammo[1] - 1);
+});


### PR DESCRIPTION
Successful gunshots now return a recoil effect that resolves to the weapon’s current primary VR hand and any actively attached support hand. Burst rounds cue individually; empty/broken guns, rejected triggers, flat presentation, and unheld weapons produce no recoil output.

Primary recoil uses 0.75 amplitude for 45 ms; support uses 0.30 for 30 ms. These are initial generic profiles pending headset tuning. A shared pure mixer protects a stronger active pulse from weaker later requests, using a monotonic timestamp supplied immediately before OpenXR submission. Suppressed requests are discarded; equal-strength shots retrigger immediately.

This starts a new stack from main after the body-inventory stack merged. Melee impact and wall-contact feedback are the next increment.

Validation:
- Rust library suite: 1,644 passed, 2 ignored; final timing regression covered by deterministic mixer tests.
- Seven headless gun scenarios passed: pistol/shotgun supported fire in either hand, left/right burst and dry fire, and dual wielding. Four shoulder/body-contact regression scenarios also passed.
- TypeScript compilation, Rust formatting, and Android release `cargo apk check -p shock2quest` passed.
- The support fixture now acquires its support grip away from the enlarged body-inventory regions.
- Correctness review caught and resolved frame-start timing that could expire protection during a slow update; follow-up review is clean. Duplication review found no actionable reuse. Claude review remained unavailable; Codex review was used.

No visual rendering change: evidence is hand-specific pulse counts paired with ammo/ownership assertions and deterministic mixer tests. Physical vibration and comfort remain unverified; headset testing is deferred at the user’s request. Local authored pose JSON edits are excluded.
