### PR TITLE
fix(weapons): use authored projectile contact damage

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -421,3 +421,47 @@ be captured. The existing simulated-VR gallery demonstrates the enabled shared
 render path, but does not verify the corrected APK on a headset. Keep this layer
 in draft until it is installed, projectile orbs are visibly checked and device
 captures are embedded. No device performance claim is made.
+
+
+## Authored projectile contact damage
+
+`fix/projectile-contact-stims` replaces ray damage 6 and physical impact damage
+1 with the existing contact-stimulus resolver used by melee. Projectile sources
+select the stimulus/intensity; the receiving object's inherited receptrons select
+damage, amplification or immunity. Launch modifiers scale source intensity
+before response evaluation, matching `shkproj.cpp::ShockMakeProjectile`'s source
+scale property, so flat damage responses remain flat. The existing resolver's
+reaction ordering and supported-effect set are retained; this is not full
+act/react parity.
+
+Hitbox contacts read the parent creature's receptrons, then send the result
+through the original hitbox to preserve limb scaling and ragdoll impact data.
+Terminal physical impacts now latch once for damage, spang and sound, avoiding
+duplicate application when capsule/limb or adjacent faces queue contacts before
+destruction. Non-damage and immune contacts emit no Damage message.
+
+Matched single-shot captures and SDK regressions against OG-Pipe show:
+
+| Weapon | Previous HP | Authored HP |
+| --- | --- | --- |
+| Pistol | 12 -> 7 | 12 -> 9 |
+| Laser pistol | 12 -> 11 | 12 -> 10 |
+| Stasis | 12 -> 11 | 12 -> 12 |
+
+Standard Bullet authors Standard Impact at 4; the fixture hit crosses a limb
+with the existing 0.75 multiplier. Laser Shot authors Energy Stim at 2, received
+at x1 by the hybrid. Stasis Shot authors Stasis at 8; its receiver authors
+`Freeze` and `add_metaprop`, not damage. **Stasis freezing is still unimplemented:**
+this layer removes its erroneous HP loss. Implement those reactions, their
+expiry/reapplication behavior and current-build saves in the next increment.
+
+All three new firing tests fail against the parent and pass after the fix;
+1,622 gameplay library tests pass (2 ignored), as do warning-denied runtime
+checks. Thirteen additional projectile/owner/homing/proximity/ranged scenarios
+pass. `ranged-hitbox.e2e.test.ts` still fails to land its centred shot on both the
+parent and this layer; the new pistol scenario independently confirms a real hit
+retains its limb identity. Do not count that existing failed scenario as green.
+
+[Matched PNG](https://gist.githubusercontent.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3/raw/comparison.png)
+and [capture gallery](https://gist.github.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3)
+provide flat-runtime evidence. Quest particle validation remains with the user.

--- a/projects/weapon-projectile-audit.md
+++ b/projects/weapon-projectile-audit.md
@@ -170,3 +170,21 @@ mask 3), hit it, and remove the rocket and its flight riders. Visible impact
 particles expire, but three secondary effect entities persist after 26 seconds;
 cleanup remains open. See [the workstream](weapon-feel-workstream.md#annelid-homing)
 for source references and intentional VR adaptations.
+
+
+## Contact damage followup
+
+Fast rays and physical projectiles now resolve authored contact stimulus damage
+through the receiving object's receptrons, replacing fixed 6/1 damage. The shared
+source multiplier applies before responses, and hitbox forwarding retains limb
+scaling. Immune or non-damage contacts emit no Damage message. Physical terminal
+contacts are handled once even when multiple collision messages are queued.
+
+Pistol, laser and stasis actual-shot regressions fail on the parent and pass on
+this layer. Stasis no longer removes an erroneous hit point; **Freeze and
+add_metaprop reactions remain pending**, including duration, reapplication and
+save/load. This is the next item before pellet spread. Full act/react ordering,
+remaining non-damage reactions, special-effect entity cleanup and complete
+weapon/target damage-matrix verification remain open. See the workstream's
+[contact damage section](weapon-feel-workstream.md#authored-projectile-contact-damage)
+for observed values, source evidence and the known baseline test failure.

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -69,6 +69,17 @@ impl GlobalContactStims {
 /// emitter carries are summed; a victim with no receptron for a stim simply
 /// feels nothing from it.
 pub fn contact_stim_damage(world: &World, emitter_template: i32, victim: EntityId) -> f32 {
+    contact_stim_damage_scaled(world, emitter_template, victim, 1.0)
+}
+
+/// Launch modifiers scale source intensity before the receiver's response,
+/// matching Dark's source-scale property. Flat damage responses stay flat.
+pub fn contact_stim_damage_scaled(
+    world: &World,
+    emitter_template: i32,
+    victim: EntityId,
+    intensity_scale: f32,
+) -> f32 {
     let Ok(contact_stims) = world.borrow::<UniqueView<GlobalContactStims>>() else {
         return 0.0;
     };
@@ -80,7 +91,7 @@ pub fn contact_stim_damage(world: &World, emitter_template: i32, victim: EntityI
     stims
         .iter()
         .filter_map(|(stim_template_id, intensity)| {
-            resolve_stim_damage(&receptrons, *stim_template_id, *intensity)
+            resolve_stim_damage(&receptrons, *stim_template_id, *intensity * intensity_scale)
         })
         .filter(|damage| *damage > 0.0)
         .sum()
@@ -419,6 +430,35 @@ mod tests {
         );
 
         assert_eq!(contact_stim_damage(&world, LEAD_PIPE, victim), 0.0);
+    }
+
+    #[test]
+    fn launch_scale_precedes_responses_and_does_not_scale_flat_damage() {
+        let (world, victim) = world_with_victim(
+            GlobalContactStims(HashMap::from([(LEAD_PIPE, vec![(WEAPON_BASH, 10.0)])])),
+            vec![
+                (WEAPON_BASH, damage(1, 2.0)),
+                (
+                    WEAPON_BASH,
+                    receptron(2, ReceptronEffect::Amplify { factor: 0.5 }),
+                ),
+                (
+                    WEAPON_BASH,
+                    receptron(
+                        3,
+                        ReceptronEffect::Damage {
+                            multiplier: 7.0,
+                            use_intensity: false,
+                        },
+                    ),
+                ),
+            ],
+        );
+        assert_eq!(
+            contact_stim_damage_scaled(&world, LEAD_PIPE, victim, 1.5),
+            22.0
+        );
+        assert_eq!(contact_stim_damage(&world, LEAD_PIPE, victim), 17.0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -5,23 +5,23 @@ use shipyard::{EntityId, Get, View, World};
 use crate::{
     mission::entity_creator::CreateEntityOptions,
     physics::PhysicsWorld,
-    scripts::script_util::choose_impact_spang,
+    scripts::script_util::{choose_impact_spang, projectile_contact_damage},
     util::{get_position_from_transform, get_rotation_from_forward_vector},
 };
 
-use super::{Effect, Message, MessagePayload, Script, script_util::play_impact_sound};
+use super::{Effect, MessagePayload, Script, script_util::play_impact_sound};
 
 // Script to handle collision type
 pub struct InternalCollisionType {
     collision_flags: CollisionType,
-    spang_spawned: bool,
+    impact_handled: bool,
 }
 
 impl InternalCollisionType {
     pub fn new() -> InternalCollisionType {
         InternalCollisionType {
             collision_flags: CollisionType::empty(),
-            spang_spawned: false,
+            impact_handled: false,
         }
     }
 }
@@ -45,7 +45,7 @@ impl Script for InternalCollisionType {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with, .. } => {
+            MessagePayload::Collided { with, contact } => {
                 // Only impact-payload entities (projectiles / fragile props
                 // flagged to slay or destroy themselves on contact) deal
                 // collision damage. A plain BOUNCE creature must not: any two
@@ -56,32 +56,30 @@ impl Script for InternalCollisionType {
                 let is_impact = self
                     .collision_flags
                     .intersects(CollisionType::SLAY_ON_IMPACT | CollisionType::DESTROY_ON_IMPACT);
-                if !is_impact {
+                if !is_impact || self.impact_handled {
                     return Effect::NoEffect;
                 }
 
+                // A capsule and limb (or two world faces) can enqueue contact
+                // messages before destruction is applied. One projectile has
+                // one terminal impact, including damage, sound and spang.
+                self.impact_handled = true;
                 let initial_effect = if self.collision_flags.contains(CollisionType::SLAY_ON_IMPACT)
                 {
                     Effect::SlayEntity { entity_id }
                 } else {
                     Effect::DestroyEntity { entity_id }
                 };
-                let damage_effect = Effect::Send {
-                    msg: Message {
-                        to: *with,
-                        // TODO: Resolve damage from the projectile's authored
-                        // data - shared follow-up with the fast (raycast)
-                        // projectile path's hardcoded 6.0 in
-                        // internal_fast_projectile.rs.
-                        payload: MessagePayload::Damage {
-                            amount: crate::runtime_props::RuntimePropShotModifiers::of(
-                                world, entity_id,
-                            )
-                            .stim,
-                            impact: None,
-                        },
-                    },
-                };
+                let damage_effect = projectile_contact_damage(
+                    world,
+                    entity_id,
+                    *with,
+                    contact.map(|contact| crate::scripts::DamageImpact {
+                        direction: contact.normal,
+                        point: contact.point,
+                        bone: None,
+                    }),
+                );
                 let mut effects = vec![initial_effect, damage_effect];
 
                 let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
@@ -95,10 +93,7 @@ impl Script for InternalCollisionType {
                 // colliders at once (a corner, a creature capsule + its
                 // hitbox proxy) queues multiple Collided messages before the
                 // slay/destroy effect lands.
-                if !self.spang_spawned
-                    && let Some(template_id) = choose_impact_spang(world, entity_id, *with)
-                {
-                    self.spang_spawned = true;
+                if let Some(template_id) = choose_impact_spang(world, entity_id, *with) {
                     // The physics collision event carries no contact normal,
                     // and spang orientation is minor cosmetics, so
                     // approximate the impact facing with the reversed
@@ -143,5 +138,38 @@ impl Script for InternalCollisionType {
             }
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_terminal_impact_is_handled_once_even_before_destruction_is_applied() {
+        let mut world = World::new();
+        let projectile = world.add_entity(PropCollisionType {
+            collision_type: CollisionType::DESTROY_ON_IMPACT | CollisionType::NO_COLLISION_SOUND,
+        });
+        world.add_component(
+            projectile,
+            crate::runtime_props::RuntimePropTransform(Matrix4::identity()),
+        );
+        let victim = world.add_entity(());
+        let physics = PhysicsWorld::new();
+        let mut script = InternalCollisionType::new();
+        script.initialize(projectile, &world);
+        let message = MessagePayload::Collided {
+            with: victim,
+            contact: None,
+        };
+        assert!(matches!(
+            script.handle_message(projectile, &world, &physics, &message),
+            Effect::Multiple(_)
+        ));
+        assert!(matches!(
+            script.handle_message(projectile, &world, &physics, &message),
+            Effect::NoEffect
+        ));
     }
 }

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -12,13 +12,9 @@ use crate::{
     mission::entity_creator::CreateEntityOptions,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::{
-        RuntimePropPlayerFiredProjectile, RuntimePropProjectileRayOrigin, RuntimePropShotModifiers,
-        RuntimePropTransform,
+        RuntimePropPlayerFiredProjectile, RuntimePropProjectileRayOrigin, RuntimePropTransform,
     },
-    scripts::{
-        Message,
-        script_util::{choose_impact_spang, play_impact_sound},
-    },
+    scripts::script_util::{choose_impact_spang, play_impact_sound, projectile_contact_damage},
     time::Time,
     util::{get_position_from_transform, get_rotation_from_forward_vector},
 };
@@ -105,30 +101,14 @@ impl Script for InternalFastProjectileScript {
             };
 
             let mut effects = vec![
-                Effect::Send {
-                    msg: Message {
-                        to: hit_entity_id,
-                        // TODO: Properly calculate damage
-                        payload: MessagePayload::Damage {
-                            amount: 6.0 * RuntimePropShotModifiers::of(world, entity_id).stim,
-                            // The shot's travel direction + hit point seed the
-                            // victim's death-ragdoll reaction. Bone is filled
-                            // in by the hitbox script when a hitbox was struck.
-                            impact: {
-                                let travel = hit_point - start_point;
-                                if travel.magnitude2() > 1.0e-12 {
-                                    Some(crate::scripts::DamageImpact {
-                                        direction: travel.normalize(),
-                                        point: hit_point.to_vec(),
-                                        bone: None,
-                                    })
-                                } else {
-                                    None
-                                }
-                            },
-                        },
-                    },
-                },
+                projectile_contact_damage(world, entity_id, hit_entity_id, {
+                    let travel = hit_point - start_point;
+                    (travel.magnitude2() > 1.0e-12).then(|| crate::scripts::DamageImpact {
+                        direction: travel.normalize(),
+                        point: hit_point.to_vec(),
+                        bone: None,
+                    })
+                }),
                 Effect::DrawDebugLines {
                     lines: vec![(start_point, hit_point, color)],
                 },

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -39,6 +39,36 @@ pub(crate) fn entity_class_template_id(world: &World, entity: EntityId) -> Optio
         })
 }
 
+/// Resolve a projectile's contact damage against the owning receiver, then
+/// send through the struck hitbox so limb scaling and ragdoll metadata survive.
+/// Non-damage stims and immune receivers do not emit a zero-damage AI alert.
+pub(crate) fn projectile_contact_damage(
+    world: &World,
+    projectile: EntityId,
+    struck: EntityId,
+    impact: Option<super::DamageImpact>,
+) -> Effect {
+    let Some(template) = entity_class_template_id(world, projectile) else {
+        return Effect::NoEffect;
+    };
+    let receiver = resolve_proxy_entity(world, struck);
+    let amount = crate::mission::stim_response::contact_stim_damage_scaled(
+        world,
+        template,
+        receiver,
+        crate::runtime_props::RuntimePropShotModifiers::of(world, projectile).stim,
+    );
+    if amount <= 0.0 {
+        return Effect::NoEffect;
+    }
+    Effect::Send {
+        msg: Message {
+            to: struck,
+            payload: MessagePayload::Damage { amount, impact },
+        },
+    }
+}
+
 /// Base gamesys templates for the three nanite pile sizes (Small/Medium/Big
 /// Nanite Pile). Deliberately narrower than their shared ultimate ancestor
 /// `Nanites` (-85): that ancestor also roots `FakeNanites` (-1271), a
@@ -1755,5 +1785,95 @@ mod tests {
             inherits: true,
         });
         assert!(!is_always_collected(&world, disc));
+    }
+}
+
+#[cfg(test)]
+mod projectile_contact_tests {
+    use super::*;
+    use crate::{
+        mission::stim_response::GlobalContactStims,
+        runtime_props::{RuntimePropProxyEntity, RuntimePropShotModifiers},
+        scripts::DamageImpact,
+    };
+    use cgmath::vec3;
+    use dark::properties::{ReceptronEffect, ReceptronOptions};
+
+    #[test]
+    fn contact_damage_resolves_parent_receptrons_then_forwards_through_the_limb() {
+        let mut world = World::new();
+        world.add_unique(GlobalContactStims(HashMap::from([(-362, vec![(-3, 2.0)])])));
+        let victim = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: -3,
+                to_entity_id: None,
+                link: Link::Receptron(ReceptronOptions {
+                    order: 1,
+                    effect: ReceptronEffect::Damage {
+                        multiplier: 3.0,
+                        use_intensity: true,
+                    },
+                }),
+            }],
+        });
+        let limb = world.add_entity(RuntimePropProxyEntity(victim));
+        let projectile = world.add_entity((
+            PropTemplateId { template_id: -362 },
+            RuntimePropShotModifiers {
+                stim: 1.5,
+                ..Default::default()
+            },
+        ));
+        let impact = DamageImpact {
+            direction: vec3(1.0, 0.0, 0.0),
+            point: vec3(2.0, 3.0, 4.0),
+            bone: None,
+        };
+        let Effect::Send { msg } =
+            projectile_contact_damage(&world, projectile, limb, Some(impact))
+        else {
+            panic!("authored contact damage must reach the struck limb");
+        };
+        assert_eq!(msg.to, limb);
+        let MessagePayload::Damage {
+            amount,
+            impact: Some(result),
+        } = msg.payload
+        else {
+            panic!("missing impact")
+        };
+        assert_eq!(amount, 9.0); // 2 * 1.5 * 3; the hitbox applies limb scaling later.
+        assert_eq!(result.bone, None);
+        assert_eq!(result.point, impact.point);
+        assert_eq!(result.direction, impact.direction);
+    }
+
+    #[test]
+    fn non_damage_and_immune_contacts_do_not_send_damage_messages() {
+        let mut world = World::new();
+        world.add_unique(GlobalContactStims(HashMap::from([(
+            -1352,
+            vec![(-1486, 8.0)],
+        )])));
+        let projectile = world.add_entity(PropTemplateId { template_id: -1352 });
+        let immune = world.add_entity(());
+        assert!(matches!(
+            projectile_contact_damage(&world, projectile, immune, None),
+            Effect::NoEffect
+        ));
+        let victim = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: -1486,
+                to_entity_id: None,
+                link: Link::Receptron(ReceptronOptions {
+                    order: 82,
+                    effect: ReceptronEffect::Unhandled("Freeze".to_owned()),
+                }),
+            }],
+        });
+        assert!(matches!(
+            projectile_contact_damage(&world, projectile, victim, None),
+            Effect::NoEffect
+        ));
     }
 }

--- a/tools/shock2-sdk/test/projectile-contact-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/projectile-contact-damage.e2e.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { cycleToWeapon } from "./helpers/weapon.js";
+
+// Shipped sources: Standard Bullet -> Standard Impact @4; Laser Shot ->
+// Energy Stim @2; Stasis Shot -> Stasis @8. The hybrid responds x1 to the
+// first two. This pistol aim crosses a limb (x0.75); the physical laser hits
+// the capsule. Stasis authors Freeze/add_metaprop, not damage.
+for (const { name, weapon, projectile, expectedHp } of [
+  { name: "pistol", weapon: -17, projectile: -362, expectedHp: 9 },
+  { name: "laser", weapon: -22, projectile: -2474, expectedHp: 10 },
+  { name: "stasis", weapon: -25, projectile: -1352, expectedHp: 12 },
+]) {
+  test(
+    `${name} contact uses the hybrid's authored damage response`,
+    {
+      skip: process.env.SHOCK2_E2E !== "1",
+      timeout: 180_000,
+    },
+    async () => {
+      await using game = await GameServer.launch({ mission: "debug_weapons" });
+      await game.step({ frames: 10 });
+      await cycleToWeapon(game, (entity) => entity.template_id === weapon, {
+        settleFrames: 10,
+      });
+      if (name === "stasis") {
+        await game.input.trigger("EjectClip");
+        await game.step({ frames: 2 });
+        await game.player.spawnItem(-41);
+        await game.input.trigger("Reload");
+        await game.step({ frames: 180 });
+        assert.equal((await game.info()).player.reloading, false);
+      }
+      await game.input.set("head.look", [0, 0]);
+      await game.input.trigger("SpawnDebugMonster");
+      await game.step({ frames: 2 });
+      const [target] = await game.entities.byTemplate(-397);
+      assert.ok(target);
+      await game.player.aimAt(target, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      await game.step({ frames: 1 });
+      const before = await game.entities.detail(target.id);
+      assert.equal(
+        Number(before.properties.find((p) => p.name === "HitPoints")?.value),
+        12,
+      );
+      const sequence = Math.max(
+        0,
+        ...(await game.messages.recent()).messages.map((m) => m.sequence),
+      );
+      await game.input.set("right_hand.trigger", 1);
+      await game.step({ frames: 1 });
+      await game.input.set("right_hand.trigger", 0);
+      let nearTarget = false;
+      let impactFrame: number | undefined;
+      for (let i = 0; i < 24; i++) {
+        const shots = await game.entities.byTemplate(projectile);
+        if (nearTarget && shots.length === 0) impactFrame ??= i * 2;
+        for (const shot of shots) {
+          const distance = Math.hypot(
+            ...shot.position.map(
+              (value, axis) => value - before.position[axis]!,
+            ),
+          );
+          nearTarget ||= distance < 1.5;
+        }
+        await game.step({ frames: 2 });
+      }
+      const after = await game.entities.detail(target.id);
+      const hp = Number(
+        after.properties.find((p) => p.name === "HitPoints")?.value,
+      );
+      assert.equal(
+        hp,
+        expectedHp,
+        `${name} must resolve its source through the target receptron`,
+      );
+      const messages = (await game.messages.recent()).messages.filter(
+        (m) => m.sequence > sequence,
+      );
+      const damage = messages.filter(
+        (m) => m.to.entity_id === target.id && m.payload === "Damage",
+      );
+      if (name === "stasis") {
+        assert.ok(nearTarget, "a real stasis projectile must reach the target");
+        assert.equal(
+          (await game.entities.byTemplate(projectile)).length,
+          0,
+          "the shot impacts well before reaching the backstop",
+        );
+        // Collision messages are intentionally omitted from the trace. The
+        // live shot reaches the hybrid and disappears within 0.2s, far short
+        // of the backstop at x=-12 or its authored lifetime.
+        assert.ok(
+          impactFrame !== undefined && impactFrame < 12,
+          "the observed projectile must impact at the nearby target",
+        );
+        assert.equal(
+          damage.length,
+          0,
+          "a non-damage contact must not send even a zero-damage AI alert",
+        );
+      } else {
+        assert.equal(
+          damage.length,
+          1,
+          "one shot produces exactly one damage message to the target",
+        );
+        if (name === "pistol")
+          assert.ok(
+            damage[0]!.impact?.bone != null,
+            "the hit must retain its limb identity",
+          );
+      }
+    },
+  );
+}


### PR DESCRIPTION
Ray projectiles dealt a fixed 6 damage and physical projectiles dealt 1, so weapon/ammo effectiveness was ignored and even stasis removed HP. Both paths now resolve the projectile's authored contact stimuli through the target's receptrons using the existing melee damage resolver.

Launch modifiers scale source intensity before response evaluation. Hitbox contacts resolve the parent receiver and then forward damage through the struck limb, preserving limb scaling and ragdoll metadata. A terminal physical impact is handled once, avoiding duplicate damage/sounds/spangs from queued capsule/limb contacts. Immune and non-damage contacts send no Damage message.

Matched actual shots against the hybrid:

| Weapon | Before | After |
| --- | --- | --- |
| Pistol | 12 -> 7 HP | 12 -> 9 HP |
| Laser pistol | 12 -> 11 HP | 12 -> 10 HP |
| Stasis | 12 -> 11 HP | 12 -> 12 HP |

**Stasis freezing remains pending.** Its authored Freeze/add_metaprop responses are the next increment; this layer removes the incorrect HP damage. Existing act/react ordering, unsupported non-damage reactions and remaining effect cleanup are not claimed complete. Source values, intentional boundaries and remaining work are documented in both weapon project files.

Validation: three new actual-shot SDK tests fail on the parent and pass here; the pistol test retains its limb identity and the stasis test observes a real shot reaching and disappearing at the target. All 1,622 gameplay library tests pass (2 ignored), warning-denied dark/gameplay/desktop/debug checks pass, and thirteen additional projectile/owner/homing/proximity/ranged scenarios pass. The older ranged-hitbox scenario fails its centred-shot assertion on both parent and current builds; it is documented as a baseline failure, not counted as passing. Independent code and duplication reviews found no blocking issues.

Stacked on #1460. These captures are from the flat debug runtime; the user's Quest particle verification remains pending separately.

![Matched single-shot HP results](https://gist.githubusercontent.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3/raw/comparison.png)
![Pistol before and after](https://gist.githubusercontent.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3/raw/pistol-comparison.gif)
![Laser before and after](https://gist.githubusercontent.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3/raw/laser-comparison.gif)
![Stasis before and after; freezing pending](https://gist.githubusercontent.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3/raw/stasis-comparison.gif)
