### PR TITLE
feat(mfd): mark shoulder weapons on inventory icons

### DIFF
--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -27,3 +27,32 @@ Retail behavior below is confirmed by the [System Shock 2 manual, PDF page 5](ht
 Two different guns; gun plus psi amp; swapped hands; one support grip; no weapon; dropping/swapping a weapon between drawing and clicking its control. Research active, chemical-paused and completed after the item is gone. Inspect a hypo without consumption, a gun without firing, and an ordinary object without research data. Use the same rendered/hit-test rectangles in flat and VR, and retain press-edge protection when opening or switching panels.
 
 A weapon-pinned ammo display remains a separate optional grip-editor placement mode. The psi amp keeps its authored forearm and needs its own mount; glove-mounted wrist plates deliberately skip it.
+
+## Shoulder assignments in the inventory
+
+The first MFD increment marks the existing backpack weapon icon with L or R.
+The idle item-name line explains `L / R: shoulder recall`; hovering an assigned
+weapon prefixes its name with `Left shoulder:` or `Right shoulder:`. These are
+shoulder recall assignments, independent of controller handedness.
+
+The assignment list comes from the same live backpack-membership query used by
+shoulder retrieval. There are no duplicate weapon slots or extra grab targets.
+The normal item click/grab behavior stays on the original icon, including under
+the badge. A cursor lift hides both icon and badge; recall/world removal hides
+the badge when the item leaves the backpack. Returning an assigned weapon to
+the backpack restores its mark. Reassigning a shoulder marks its new weapon.
+
+Layout is emitted once in the shared interface canvas for flat and VR. This
+increment makes existing assignments visible; editing assignments from the MFD
+is a follow-up interaction, alongside the retail utility controls above.
+
+### Next: replace the single-arm equipment column
+
+`invback.png` bakes one arm into the narrow equipment column. A proposed next
+increment overlays that column with two stacked, explicitly named LEFT HAND /
+RIGHT HAND panels and each held item icon. A support hand reads SUPPORTING
+rather than duplicating ownership. Keep armor and implant areas intact. This
+separates what is held from the shoulder recall marks on backpack items, and
+can reuse shared canvas overlays without changing the retail texture. Read the
+equipment layout and current slot behavior before adding controls; the first
+pass should prioritize readable state over new actions.

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -248,6 +248,9 @@ pub struct FlatUiHost {
     /// from [`Self::pointed_item`] / the world object the player is aiming at
     /// (see [`Self::set_name_strip`]). `None` draws an empty frame.
     name_strip: Option<String>,
+    /// Live backpack recall assignments, left/right. These decorate the
+    /// existing item icons; they never create another inventory owner.
+    shoulder_weapons: [Option<EntityId>; 2],
     /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
@@ -289,6 +292,7 @@ impl FlatUiHost {
             readouts: None,
             sticky_panel: false,
             name_strip: None,
+            shoulder_weapons: [None; 2],
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
@@ -386,6 +390,40 @@ impl FlatUiHost {
     /// Set the mini-frame's name line (already resolved to a display name).
     pub fn set_name_strip(&mut self, name: Option<String>) {
         self.name_strip = name;
+    }
+
+    pub(crate) fn set_shoulder_weapons(&mut self, weapons: [Option<EntityId>; 2]) {
+        self.shoulder_weapons = weapons;
+    }
+
+    /// Badge geometry comes from the same cached item rects as inventory
+    /// drawing and hit testing. A lifted item hides its badge with its icon.
+    fn shoulder_badges(&self) -> Vec<(EntityId, Rect, &'static str, &'static str)> {
+        let (Some(strip), Some(rect)) = (self.strip.as_ref(), self.strip_rect()) else {
+            return Vec::new();
+        };
+        strip
+            .components
+            .iter()
+            .filter_map(|component| {
+                let entity = component_entity(component)?;
+                if Some(entity) == self.held_entity() {
+                    return None;
+                }
+                let side = self
+                    .shoulder_weapons
+                    .iter()
+                    .position(|item| *item == Some(entity))?;
+                let slot = component.canvas_rect(rect);
+                let badge = Rect::new(slot.x + slot.w - 23.0, slot.y + slot.h - 13.0, 22.0, 12.0);
+                let (letter, label) = if side == 0 {
+                    ("L", "Left shoulder")
+                } else {
+                    ("R", "Right shoulder")
+                };
+                Some((entity, badge, letter, label))
+            })
+            .collect()
     }
 
     /// The mini-frame's current name line, for `GET /v1/ui`.
@@ -1022,6 +1060,16 @@ impl FlatUiHost {
             // Hide the item riding the cursor from the strip grid (it is drawn
             // as the cursor instead).
             draw_components(&mut canvas, &strip.components, rect, self.held_entity());
+            for (_, badge, letter, _) in self.shoulder_badges() {
+                canvas.image(badge, "frame.pcx");
+                canvas.text_native(
+                    badge,
+                    letter,
+                    NAME_STRIP_FONT,
+                    HAlign::Center,
+                    VAlign::Middle,
+                );
+            }
             // The mini-frame sits in the inventory bar, so it is up exactly
             // while the bar is. Placement is decided here, once, in canvas
             // pixels - both presentations map this rect (AGENTS.md 3).
@@ -1029,6 +1077,14 @@ impl FlatUiHost {
             canvas.image(frame, "frame.pcx");
             if let Some(name) = self.name_strip.as_deref() {
                 canvas.text_native_fit(text, name, NAME_STRIP_FONT, HAlign::Left, VAlign::Middle);
+            } else if self.shoulder_weapons.iter().any(Option::is_some) {
+                canvas.text_native_fit(
+                    text,
+                    "L / R: shoulder recall",
+                    NAME_STRIP_FONT,
+                    HAlign::Left,
+                    VAlign::Middle,
+                );
             }
         }
         if let Some(rect) = panel_rect {
@@ -1128,7 +1184,20 @@ impl FlatUiHost {
         match (self.strip.as_ref(), self.strip_rect()) {
             // Hide the item on the cursor: it left the grid for the drag.
             (Some(strip), Some(rect)) => {
-                self.elements_for(world, &strip.components, rect, self.held_entity())
+                let mut elements =
+                    self.elements_for(world, &strip.components, rect, self.held_entity());
+                elements.extend(self.shoulder_badges().into_iter().map(
+                    |(entity, r, letter, label)| crate::game_scene::DebugUiElement {
+                        kind: "text".to_owned(),
+                        texture: None,
+                        text: Some(letter.to_owned()),
+                        label: Some(label.to_owned()),
+                        entity_id: Some(entity.inner() as i32),
+                        rect: [r.x, r.y, r.w, r.h],
+                        screen_rect: self.to_screen_rect(r),
+                    },
+                ));
+                elements
             }
             _ => Vec::new(),
         }
@@ -2072,6 +2141,49 @@ mod tests {
             &[strip_item(wrench, 0)],
         );
         (world, host, wrench, inventory)
+    }
+
+    #[test]
+    fn shoulder_badges_follow_items_without_becoming_duplicate_grab_targets() {
+        let (mut world, mut host, left, _) = drag_world();
+        let right = world.add_entity(());
+        host.strip
+            .as_mut()
+            .unwrap()
+            .components
+            .push(strip_item(right, 2));
+        host.set_shoulder_weapons([Some(left), Some(right)]);
+        let badges = host.shoulder_badges();
+        assert_eq!(badges.len(), 2);
+        for (entity, rect, letter, label) in &badges {
+            assert_eq!(host.strip_item_at(rect.center()), Some(*entity));
+            assert_eq!(
+                (*letter, *label),
+                if *entity == left {
+                    ("L", "Left shoulder")
+                } else {
+                    ("R", "Right shoulder")
+                }
+            );
+        }
+        let elements = host.strip_debug_elements(&world);
+        assert_eq!(elements.iter().filter(|e| e.kind == "button").count(), 2);
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| e.label.as_deref() == Some("Left shoulder"))
+                .count(),
+            1
+        );
+        // Cursor lifts keep backpack membership, but must not leave an orphan
+        // badge where the hidden inventory icon used to be.
+        host.cursor_item = Some(make_cursor_item(&world, left));
+        assert_eq!(host.shoulder_badges().len(), 1);
+        host.cursor_item = None;
+        host.set_shoulder_weapons([None, Some(right)]);
+        assert_eq!(host.shoulder_badges()[0].0, right);
+        host.set_strip(None);
+        assert!(host.shoulder_badges().is_empty());
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4713,11 +4713,29 @@ impl MissionCore {
         // `resolve_item_name`, so an object is never called two things at once.
         // Unlike the brackets this readout is not gated on `P$HUDSelect`: a
         // door gets no brackets but does get named here.
+        let shoulder_weapons = self
+            .flat_ui
+            .strip_entity()
+            .map(|inventory| super::shoulder_backpack::weapons(&self.world, inventory))
+            .unwrap_or([None; 2]);
+        self.flat_ui.set_shoulder_weapons(shoulder_weapons);
         let name_strip = self.flat_ui.strip_entity().and_then(|_| {
             self.flat_ui
                 .pointed_item()
                 .or_else(|| self.name_strip_world_pick(game_options))
-                .and_then(|entity| crate::hud::resolve_item_name(asset_cache, &self.world, entity))
+                .and_then(|entity| {
+                    let name = crate::hud::resolve_item_name(asset_cache, &self.world, entity)?;
+                    Some(
+                        match shoulder_weapons
+                            .iter()
+                            .position(|item| *item == Some(entity))
+                        {
+                            Some(0) => format!("Left shoulder: {name}"),
+                            Some(1) => format!("Right shoulder: {name}"),
+                            _ => name,
+                        },
+                    )
+                })
         });
         self.flat_ui.set_name_strip(name_strip);
 

--- a/tools/shock2-sdk/test/vr-shoulder-weapon-recall.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-shoulder-weapon-recall.e2e.test.ts
@@ -42,6 +42,21 @@ test("large weapons refuse thigh storage and recall independently from either sh
   await game.input.set("left_hand.squeeze", 0);
   await game.step({ frames: 8 });
   assert.deepEqual(await remembered(game), [pistol.id, shotgun.id]);
+  // The interface decorates the original inventory items, not duplicate slots.
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 8 });
+  const assignedUi = await game.ui.state();
+  for (const [entity, label] of [[pistol.id, "Left shoulder"], [shotgun.id, "Right shoulder"]] as const) {
+    const elements = assignedUi.strip!.elements.filter(e => e.entity_id === entity);
+    assert.equal(elements.filter(e => e.kind === "button").length, 1);
+    const badge = elements.find(e => e.label === label)!;
+    assert.ok(badge, `${label} marks the original item`);
+    await aimVrHandAtCanvas(game, assignedUi.panel_pose!, [badge.rect[0] + badge.rect[2] / 2, badge.rect[1] + badge.rect[3] / 2], { hand: "right", squeeze: 0 });
+    await game.step({ frames: 2 });
+    assert.ok((await game.ui.state()).name_strip!.startsWith(`${label}:`));
+  }
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 5 });
   // Cross-hand recall is based on the shoulder reached, not controller handedness.
   await reach(game, "left", 1);
   await game.input.set("left_hand.squeeze", 1);
@@ -52,6 +67,7 @@ test("large weapons refuse thigh storage and recall independently from either sh
   // Returning via the ordinary MFD preserves the shoulder assignment.
   await game.input.trigger("ToggleUseMode");
   await game.step({ frames: 5 });
+  assert.equal((await game.ui.state()).strip!.elements.some(e => e.label === "Right shoulder"), false, "recalled weapon has no inventory badge");
   const panel = (await game.ui.state()).panel_pose!;
   await aimVrHandAtCanvas(game, panel, [320, 60], { hand: "left", squeeze: 1 });
   await game.step({ frames: 5 });
@@ -59,6 +75,7 @@ test("large weapons refuse thigh storage and recall independently from either sh
   await game.step({ frames: 8 });
   assert.equal((await game.info()).player.wielded_entity_id, null);
   assert.deepEqual(await remembered(game), [pistol.id, shotgun.id]);
+  assert.ok((await game.ui.state()).strip!.elements.some(e => e.label === "Right shoulder" && e.entity_id === shotgun.id), "ordinary backpack return restores the badge");
   await game.input.trigger("ToggleUseMode");
   await game.step({ frames: 5 });
   await reach(game, "left", 1);
@@ -84,6 +101,12 @@ test("large weapons refuse thigh storage and recall independently from either sh
   await game.step({ frames: 8 });
   assert.deepEqual(await remembered(game), [null, pistol.id]);
   assert.equal((await game.player.inventory()).items.find(i => i.entity_id === shotgun.id)?.location, "inventory");
+  await game.input.trigger("ToggleUseMode");
+  await game.step({ frames: 8 });
+  const reassigned = (await game.ui.state()).strip!.elements.filter(e => e.label === "Left shoulder" || e.label === "Right shoulder");
+  assert.equal(reassigned.length, 1);
+  assert.equal(reassigned[0].entity_id, pistol.id);
+  assert.equal(reassigned[0].label, "Right shoulder");
 });
 
 test("shoulder weapon survives save/load and mission transition in the real backpack", { skip: !enabled, timeout: 240_000 }, async () => {


### PR DESCRIPTION
Weapons assigned to shoulder recall now carry an L/R badge on their existing backpack icon. Hovering prefixes the item name with Left shoulder or Right shoulder; the idle name strip explains the badge meaning. The assignments come from the same live inventory-membership query used by shoulder retrieval.

This starts a new MFD stack from main, independent of the weapon-haptics PR. Badges add no inventory copies or click/grab targets. Cursor lifts hide icon and badge together; recall, backpack return and reassignment update the display. Layout is shared by flat and VR.

Validation: 46 UI host tests, both shoulder lifecycle/save-load integration tests, TypeScript compilation, formatting and diff checks passed. Integration assertions cover hover names, one original item target, badge removal/restoration and reassignment. Correctness and duplication reviews found no actionable issues; independent GPT-5.6-sol visual review confirmed readable, unclipped badges and matching flat/VR placement. Headset validation remains deferred. User-authored pose edits are excluded.

The follow-on design note proposes replacing the baked single-arm equipment column with a left/right hand overview; that layout is not implemented here.

![Shoulder badges before and after](https://gist.githubusercontent.com/tommy-xr/8f192da058d1537836c2230c16db9903/raw/astra-mfd-shoulders-before-after.png)

![Flat and VR shoulder hover cycle](https://gist.githubusercontent.com/tommy-xr/8f192da058d1537836c2230c16db9903/raw/astra-mfd-shoulders-hover.gif)

Inventory-panel crops; loop cycles discrete idle and hover checkpoints. Both final shoulder assignments were verified through real pickup/storage and save/load. Baseline has the same inventory icons, with only its right assignment validated. No headset validation.

[Download the self-contained gallery and open locally](https://gist.githubusercontent.com/tommy-xr/8f192da058d1537836c2230c16db9903/raw/astra-mfd-shoulders-gallery.html).
