### PR TITLE
feat(weapons): add timed stasis freezing and save/load

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -151,8 +151,11 @@ impl AnimatedModel {
     }
 
     fn to_animated_scene_objects(&self, player: &AnimationPlayer) -> Vec<SceneObject> {
-        let pose = player.get_transforms(&self.skeleton);
-        let palette = build_palette(&pose, &self.skeleton, self.bind.as_deref());
+        self.to_posed_scene_objects(&player.get_transforms(&self.skeleton))
+    }
+
+    fn to_posed_scene_objects(&self, pose: &[Matrix4<f32>; 40]) -> Vec<SceneObject> {
+        let palette = build_palette(pose, &self.skeleton, self.bind.as_deref());
 
         self.scene_objects
             .iter()
@@ -475,6 +478,15 @@ impl Model {
                 animated_model.to_animated_scene_objects(player)
             }
             InnerModel::Static(static_model) => static_model.to_scene_objects().clone(),
+        }
+    }
+
+    /// Render a saved model-space pose using the same palette construction as
+    /// live animation (including inverse bind transforms for remaster models).
+    pub fn to_posed_scene_objects(&self, pose: &[Matrix4<f32>; 40]) -> Vec<SceneObject> {
+        match &self.inner {
+            InnerModel::Animated(model) => model.to_posed_scene_objects(pose),
+            InnerModel::Static(model) => model.to_scene_objects().clone(),
         }
     }
 

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -868,8 +868,10 @@ pub enum ReceptronEffect {
     /// Add radiation exposure scaled by `multiplier`. The player authors this
     /// response to the Radiation stimulus with a multiplier of 1.
     Radiate { multiplier: f32 },
+    /// Freeze an AI for the incoming intensity times this duration multiplier.
+    Freeze { duration_multiplier: i32 },
     /// An effect the game does not implement yet (EnvSound, add_metaprop,
-    /// Freeze, Stun, toxin, ...).
+    /// Stun, toxin, ...).
     Unhandled(String),
 }
 
@@ -906,7 +908,8 @@ impl ReceptronOptions {
         let name = String::from_utf8_lossy(&name_bytes[..name_end]).into_owned();
         let _target = read_i32(reader);
         let _agent = read_i32(reader);
-        let param_56 = read_single(reader);
+        let param_56_bits = read_u32(reader);
+        let param_56 = f32::from_bits(param_56_bits);
         let _param_60 = read_i32(reader);
         let param_64 = read_single(reader);
         let param_68 = read_i32(reader);
@@ -918,6 +921,9 @@ impl ReceptronOptions {
             },
             "Amplify" => ReceptronEffect::Amplify { factor: param_56 },
             "Abort" => ReceptronEffect::Abort,
+            "Freeze" => ReceptronEffect::Freeze {
+                duration_multiplier: param_56_bits as i32,
+            },
             "radiate" => ReceptronEffect::Radiate {
                 multiplier: param_56,
             },
@@ -2703,6 +2709,19 @@ mod tests {
         bytes.extend_from_slice(&p68.to_le_bytes());
         bytes.resize(88, 0);
         bytes
+    }
+
+    #[test]
+    fn freeze_reaction_reads_integer_duration_multiplier() {
+        let mut payload = vec![0u8; 88];
+        payload[16..22].copy_from_slice(b"Freeze");
+        payload[56..60].copy_from_slice(&1i32.to_le_bytes());
+        assert_eq!(
+            read_receptron(payload).effect,
+            ReceptronEffect::Freeze {
+                duration_multiplier: 1
+            }
+        );
     }
 
     fn read_receptron(payload: Vec<u8>) -> ReceptronOptions {

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -451,9 +451,8 @@ Matched single-shot captures and SDK regressions against OG-Pipe show:
 Standard Bullet authors Standard Impact at 4; the fixture hit crosses a limb
 with the existing 0.75 multiplier. Laser Shot authors Energy Stim at 2, received
 at x1 by the hybrid. Stasis Shot authors Stasis at 8; its receiver authors
-`Freeze` and `add_metaprop`, not damage. **Stasis freezing is still unimplemented:**
-this layer removes its erroneous HP loss. Implement those reactions, their
-expiry/reapplication behavior and current-build saves in the next increment.
+`Freeze` and `add_metaprop`, not damage. This layer removes its erroneous HP loss. The next layer below implements
+native timed freezing; the companion `FreezeFX` reaction remains a follow-up.
 
 All three new firing tests fail against the parent and pass after the fix;
 1,622 gameplay library tests pass (2 ignored), as do warning-denied runtime
@@ -465,3 +464,54 @@ retains its limb identity. Do not count that existing failed scenario as green.
 [Matched PNG](https://gist.githubusercontent.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3/raw/comparison.png)
 and [capture gallery](https://gist.github.com/tommy-xr/0f0374285dddac7fab90c2b24983e8d3)
 provide flat-runtime evidence. Quest particle validation remains with the user.
+
+
+### Timed stasis: freeze, expiry and current-build saves
+
+Stacked above #1463, native `Freeze` now stops AI updates, animation advancement
+and horizontal root motion. Normal Stasis Shot (-1352) delivers intensity 8
+through Stasis (-1486); the hybrid's Stasis Vulnerability (-3446) multiplies by
+1, giving **eight seconds**. Big Stasis Shot (-3868) creates Stasis Explosion
+(-3869), whose radius source reaches the same reaction through the existing
+falloff/terrain-exposure path. Fully blocked blasts do not refresh or clear a
+previous freeze. Stasis itself still causes no HP loss.
+
+Duration units were checked against the shipped 25th Anniversary executable,
+not inferred from the older source. `SystemShock2Remastered.exe` registers the
+Freeze callback at VA `0x1403755ee`; callback `0x140472b40` multiplies the integer
+reaction parameter by intensity and truncates to whole seconds. AI::Freeze
+(`0x1403465d0`, multiplication at `0x1403465ed`) converts those seconds to
+milliseconds. The older `darkengine/src/frezreac.cpp` describes milliseconds at
+the callback boundary and therefore cannot supply the shipped unit convention.
+`darkengine/src/ai/aifreeze.cpp` establishes replacement semantics: a new hit
+replaces the remaining interval, even when shorter, rather than adding time or
+taking the maximum. Negative authored durations remain indefinite.
+
+`BaseMonster` owns the remaining simulation-time interval and captured
+model-space pose under script-state key `shock2vr.ai_stasis`. Saving and loading
+preserves both; the shared palette builder uses that pose for rendering and
+hitboxes while frozen. Gravity and external contact resolution remain active.
+Death releases the freeze immediately. Animation bookkeeping already queued at
+impact is delivered in order, while attack flags are suppressed; this avoids
+stranding a one-shot animation or replaying an old completion into a new
+behavior after thaw. Existing native AI behavior initialization on load remains
+unchanged; this is not a general AI behavior-state serialization feature.
+
+Verification lives in `tools/shock2-sdk/test/timed-stasis.e2e.test.ts`: actual
+normal/area shots, reapplication, timed expiry, death, and a real `earth.mis`
+save/load preserving remaining duration and joint pose. Parser/resolver tests
+cover integer parameters, amplification and immunity, and the script unit test
+covers shorter replacement and expiry. Matched runtime captures show a hybrid
+continuing to attack before this layer, frozen for eight seconds after it, then
+resuming movement:
+
+![Timed stasis before/after](https://gist.githubusercontent.com/tommy-xr/322f260c0635fb88b579e61937c87e71/raw/stasis-comparison.gif)
+
+![Frozen pose](https://gist.githubusercontent.com/tommy-xr/322f260c0635fb88b579e61937c87e71/raw/stasis-frozen.png)
+
+Remaining companion gap: the authored `add_metaprop` reaction adds Frozen
+(-4183), which carries `FreezeFX` and `AI_BcstSe`. Its visual/broadcast behavior
+is not implemented by this native freeze layer; a queued AI bookkeeping message
+can still emit a vocalization while frozen. Radius falloff and physical blast
+impulses also retain the existing engine behavior pending broader parity work.
+Quest particle validation for #1460 remains with the user.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3648,6 +3648,17 @@ impl MissionCore {
             })
             .unwrap_or_default();
 
+        // A frozen AI keeps its physical body and gravity, but cannot coast
+        // on the previous animation's horizontal root-motion velocity.
+        for entity in self.id_to_physics.keys() {
+            if self.script_world.stasis(*entity, &self.world).is_some() {
+                if let Some(velocity) = self.physics.get_velocity(*entity) {
+                    self.physics
+                        .set_velocity(*entity, vec3(0.0, velocity.y, 0.0));
+                }
+            }
+        }
+
         // Skip physics while time is frozen (the debug runtime's paused state
         // calls update with zero dt): the Rapier pipeline advances by a fixed
         // internal dt per call regardless of elapsed time, so stepping it here
@@ -5370,6 +5381,13 @@ impl MissionCore {
         }
 
         for (id, player) in self.id_to_animation_player.iter_mut() {
+            if let Some(stasis) = self.script_world.stasis(*id, &self.world) {
+                if let Some(pose) = stasis.pose() {
+                    self.world
+                        .add_component(*id, RuntimePropJointTransforms(*pose));
+                }
+                continue;
+            }
             // self.id_to_animation_player.entry(*id).and_modify(|player| {
             //     *player = AnimationPlayer::update(player, time.elapsed);
             // });
@@ -5675,7 +5693,17 @@ impl MissionCore {
                 stim_template_id,
                 felt_intensity,
             );
-            // Explosions only ever deal damage: dispatch a Damage message only
+            if let Some(duration_seconds) = crate::mission::stim_response::resolve_stim_freeze(
+                &receptrons,
+                stim_template_id,
+                felt_intensity,
+            ) {
+                self.script_world.dispatch(Message {
+                    to: entity_id,
+                    payload: MessagePayload::Freeze { duration_seconds },
+                });
+            }
+            // Dispatch a Damage message only
             // for a positive result. A zero amount (fully shielded) would still
             // read as "took damage" and aggro AI; a negative one (a heal
             // receptron) has no meaning through the damage path.
@@ -11147,7 +11175,13 @@ impl MissionCore {
             rendered_model_count += 1;
 
             let scene_objs = {
-                if let Some(player) = self.id_to_animation_player.get(entity_id) {
+                if let Some(pose) = self
+                    .script_world
+                    .stasis(*entity_id, &self.world)
+                    .and_then(|s| s.pose())
+                {
+                    objs.to_posed_scene_objects(pose)
+                } else if let Some(player) = self.id_to_animation_player.get(entity_id) {
                     objs.to_animated_scene_objects(player)
                 } else {
                     objs.to_scene_objects().clone()
@@ -13422,6 +13456,13 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                             awareness.last_known_pos.y,
                             awareness.last_known_pos.z
                         ),
+                    });
+                }
+
+                if let Some(stasis) = self.script_world.stasis(id, &self.world) {
+                    properties.push(DebugPropertyInfo {
+                        name: "StasisRemaining".to_owned(),
+                        value: format!("{:.6}", stasis.remaining_seconds),
                     });
                 }
 

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -97,6 +97,59 @@ pub fn contact_stim_damage_scaled(
         .sum()
 }
 
+/// Resolve the last applicable freeze response. As in AISetFrozen, a new
+/// stimulus replaces the previous timer rather than adding to it.
+pub fn contact_stim_freeze(
+    world: &World,
+    emitter_template: i32,
+    victim: EntityId,
+    intensity_scale: f32,
+) -> Option<f32> {
+    let sources = world.borrow::<UniqueView<GlobalContactStims>>().ok()?;
+    let stims = sources.0.get(&emitter_template)?;
+    let receptrons = victim_receptrons(world, victim);
+    stims
+        .iter()
+        .filter_map(|(stim, intensity)| {
+            resolve_stim_freeze(&receptrons, *stim, *intensity * intensity_scale)
+        })
+        .last()
+}
+
+pub fn resolve_stim_freeze(
+    receptrons: &[(i32, ReceptronOptions)],
+    stim_template_id: i32,
+    intensity: f32,
+) -> Option<f32> {
+    // No delivered stimulus (for example a fully occluded blast) must not
+    // replace an existing timer. An authored zero duration with a positive
+    // stimulus still resolves to Some(0), allowing an explicit thaw.
+    if intensity <= 0.0 {
+        return None;
+    }
+    let mut amplify = 1.0;
+    let mut duration = None;
+    for (_, options) in receptrons
+        .iter()
+        .filter(|(stim, _)| *stim == stim_template_id)
+    {
+        match options.effect {
+            ReceptronEffect::Abort => return None,
+            ReceptronEffect::Amplify { factor } => amplify *= factor,
+            ReceptronEffect::Freeze {
+                duration_multiplier,
+            } => {
+                if duration.is_none_or(|(order, _)| options.order >= order) {
+                    duration = Some((options.order, duration_multiplier));
+                }
+            }
+            _ => {}
+        }
+    }
+    let seconds = duration?.1 as f32 * intensity * amplify;
+    seconds.is_finite().then_some(seconds.trunc())
+}
+
 fn victim_receptrons(world: &World, victim: EntityId) -> Vec<(i32, ReceptronOptions)> {
     let Ok(v_links) = world.borrow::<View<Links>>() else {
         return Vec::new();
@@ -162,7 +215,7 @@ pub fn resolve_stim_damage(
                     flat_damage += multiplier;
                 }
             }
-            ReceptronEffect::Radiate { .. } => {}
+            ReceptronEffect::Radiate { .. } | ReceptronEffect::Freeze { .. } => {}
             ReceptronEffect::Unhandled(_) => {}
         }
     }
@@ -194,7 +247,9 @@ pub fn resolve_stim_radiation(
                 has_radiate = true;
                 multiplier += factor;
             }
-            ReceptronEffect::Damage { .. } | ReceptronEffect::Unhandled(_) => {}
+            ReceptronEffect::Damage { .. }
+            | ReceptronEffect::Freeze { .. }
+            | ReceptronEffect::Unhandled(_) => {}
         }
     }
 
@@ -221,6 +276,30 @@ mod tests {
                 use_intensity: true,
             },
         )
+    }
+
+    #[test]
+    fn freeze_response_uses_amplification_immunity_and_whole_seconds() {
+        let freeze = |order, duration_multiplier| {
+            receptron(
+                order,
+                ReceptronEffect::Freeze {
+                    duration_multiplier,
+                },
+            )
+        };
+        let mut responses = vec![(EMP, freeze(82, 1))];
+        assert_eq!(resolve_stim_freeze(&responses, EMP, 8.0), Some(8.0));
+        assert_eq!(resolve_stim_freeze(&responses, EMP, 0.0), None);
+        assert_eq!(
+            resolve_stim_freeze(&[(EMP, freeze(82, 0))], EMP, 8.0),
+            Some(0.0)
+        );
+        assert_eq!(resolve_stim_freeze(&responses, HIGH_EXPLOSIVE, 8.0), None);
+        responses.push((EMP, receptron(90, ReceptronEffect::Amplify { factor: 0.7 })));
+        assert_eq!(resolve_stim_freeze(&responses, EMP, 8.0), Some(5.0));
+        responses.push((EMP, receptron(99, ReceptronEffect::Abort)));
+        assert_eq!(resolve_stim_freeze(&responses, EMP, 8.0), None);
     }
 
     #[test]

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -11,15 +11,53 @@ use super::{
 
 pub struct BaseMonster {
     ai: Box<dyn Script>,
+    stasis: Option<super::stasis::StasisState>,
 }
 impl BaseMonster {
     pub fn new() -> BaseMonster {
         BaseMonster {
             ai: Box::new(NoopScript {}),
+            stasis: None,
         }
     }
 }
 impl Script for BaseMonster {
+    fn stasis(&self) -> Option<&super::stasis::StasisState> {
+        self.stasis.as_ref()
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some("shock2vr.ai_stasis")
+    }
+    fn save_state(&self) -> Result<super::ScriptState, super::ScriptStateError> {
+        super::ScriptState::encode(1, &self.stasis, "shock2vr.ai_stasis")
+    }
+    fn restore_state(
+        &mut self,
+        state: &super::ScriptState,
+        _context: &super::ScriptRestoreContext<'_>,
+    ) -> Result<(), super::ScriptStateError> {
+        self.stasis = state.decode(1, "shock2vr.ai_stasis")?;
+        // Reject malformed state through the same typed decoder error path.
+        if self.stasis.as_ref().is_some_and(|state| !state.valid()) {
+            return Err(super::ScriptStateError::InvalidPayload {
+                script_key: "shock2vr.ai_stasis".to_owned(),
+                message: "invalid stasis state".to_owned(),
+            });
+        }
+        Ok(())
+    }
+    fn initialize_after_hydration(
+        &mut self,
+        entity: EntityId,
+        world: &World,
+        _hydrated: bool,
+    ) -> Effect {
+        // Only stasis is hydrated; the native AI must still be constructed.
+        // initialize() deliberately leaves the restored freeze state intact.
+        self.initialize(entity, world)
+    }
+
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
         let v_ai = world.borrow::<View<PropAI>>().unwrap();
         let v_prop_sig_resp = world.borrow::<View<PropAISignalResponse>>().unwrap();
@@ -77,6 +115,14 @@ impl Script for BaseMonster {
         physics: &PhysicsWorld,
         time: &Time,
     ) -> Effect {
+        if super::ai::ai_util::is_killed(entity_id, world) {
+            self.stasis = None;
+        } else if let Some(stasis) = self.stasis.as_mut() {
+            if stasis.tick(time.elapsed.as_secs_f32()) {
+                return Effect::NoEffect;
+            }
+            self.stasis = None;
+        }
         self.ai.update(entity_id, world, physics, time)
     }
 
@@ -87,6 +133,153 @@ impl Script for BaseMonster {
         physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
+        if let MessagePayload::Freeze { duration_seconds } = msg {
+            if world.borrow::<View<PropAI>>().unwrap().contains(entity_id)
+                && !super::ai::ai_util::is_killed(entity_id, world)
+                && duration_seconds.is_finite()
+            {
+                if let Some(stasis) = self.stasis.as_mut() {
+                    stasis.remaining_seconds = *duration_seconds;
+                } else if *duration_seconds != 0.0 {
+                    self.stasis = Some(super::stasis::StasisState::capture(
+                        world,
+                        entity_id,
+                        *duration_seconds,
+                    ));
+                }
+            }
+            return Effect::NoEffect;
+        }
+        if matches!(msg, MessagePayload::Slay) || super::ai::ai_util::is_killed(entity_id, world) {
+            self.stasis = None;
+        }
+        // Preserve animation bookkeeping in message order even while paused.
+        // Dropping a queued completion strands PlayOnce actions; delaying it
+        // can apply an old completion to a newer scripted behavior. Animation
+        // advancement remains paused centrally, and attack flags are suppressed.
+        if self.stasis.is_some() && matches!(msg, MessagePayload::AnimationFlagTriggered { .. }) {
+            return Effect::NoEffect;
+        }
         self.ai.handle_message(entity_id, world, physics, msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scripts::{MessagePayload, ScriptRestoreContext};
+    use dark::properties::PropHitPoints;
+    use std::{cell::Cell, collections::HashMap, rc::Rc, time::Duration};
+
+    struct Counter(Rc<Cell<u32>>);
+    impl Script for Counter {
+        fn update(&mut self, _: EntityId, _: &World, _: &PhysicsWorld, _: &Time) -> Effect {
+            self.0.set(self.0.get() + 1);
+            Effect::NoEffect
+        }
+        fn handle_message(
+            &mut self,
+            _: EntityId,
+            _: &World,
+            _: &PhysicsWorld,
+            _: &MessagePayload,
+        ) -> Effect {
+            self.0.set(self.0.get() + 1);
+            Effect::NoEffect
+        }
+    }
+
+    #[test]
+    fn stasis_pauses_ai_refreshes_expires_and_preserves_remaining_time() {
+        let mut world = World::new();
+        let entity =
+            world.add_entity((PropAI("Melee".to_owned()), PropHitPoints { hit_points: 12 }));
+        let count = Rc::new(Cell::new(0));
+        let mut script = BaseMonster {
+            ai: Box::new(Counter(count.clone())),
+            stasis: None,
+        };
+        let physics = PhysicsWorld::new();
+        script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::Freeze {
+                duration_seconds: 8.0,
+            },
+        );
+        script.update(
+            entity,
+            &world,
+            &physics,
+            &Time {
+                elapsed: Duration::from_secs(3),
+                total: Duration::from_secs(3),
+            },
+        );
+        assert_eq!(count.get(), 0);
+        assert_eq!(script.stasis().unwrap().remaining_seconds, 5.0);
+        // A shorter replacement is intentionally shorter, never max/add.
+        script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::Freeze {
+                duration_seconds: 2.0,
+            },
+        );
+        assert_eq!(script.stasis().unwrap().remaining_seconds, 2.0);
+        script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::AnimationCompleted,
+        );
+        assert_eq!(count.get(), 1);
+        script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::Damage {
+                amount: 1.0,
+                impact: None,
+            },
+        );
+        assert_eq!(count.get(), 2);
+        let saved = script.save_state().unwrap();
+        let remap = HashMap::new();
+        script.stasis = None;
+        script
+            .restore_state(
+                &saved,
+                &ScriptRestoreContext {
+                    entity_id_map: &remap,
+                },
+            )
+            .unwrap();
+        assert_eq!(script.stasis().unwrap().remaining_seconds, 2.0);
+        script.update(
+            entity,
+            &world,
+            &physics,
+            &Time {
+                elapsed: Duration::from_secs(2),
+                total: Duration::from_secs(5),
+            },
+        );
+        assert!(script.stasis().is_none());
+        assert_eq!(count.get(), 3, "bookkeeping is retained and AI resumes");
+        script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::Freeze {
+                duration_seconds: 8.0,
+            },
+        );
+        world.add_component(entity, PropHitPoints { hit_points: 0 });
+        script.update(entity, &world, &physics, &Time::default());
+        assert!(script.stasis().is_none());
+        assert_eq!(count.get(), 4, "death update must not wait for expiry");
     }
 }

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -5,7 +5,7 @@ use shipyard::{EntityId, Get, View, World};
 use crate::{
     mission::entity_creator::CreateEntityOptions,
     physics::PhysicsWorld,
-    scripts::script_util::{choose_impact_spang, projectile_contact_damage},
+    scripts::script_util::{choose_impact_spang, projectile_contact_effects},
     util::{get_position_from_transform, get_rotation_from_forward_vector},
 };
 
@@ -70,7 +70,7 @@ impl Script for InternalCollisionType {
                 } else {
                     Effect::DestroyEntity { entity_id }
                 };
-                let damage_effect = projectile_contact_damage(
+                let damage_effect = projectile_contact_effects(
                     world,
                     entity_id,
                     *with,

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -14,7 +14,7 @@ use crate::{
     runtime_props::{
         RuntimePropPlayerFiredProjectile, RuntimePropProjectileRayOrigin, RuntimePropTransform,
     },
-    scripts::script_util::{choose_impact_spang, play_impact_sound, projectile_contact_damage},
+    scripts::script_util::{choose_impact_spang, play_impact_sound, projectile_contact_effects},
     time::Time,
     util::{get_position_from_transform, get_rotation_from_forward_vector},
 };
@@ -101,7 +101,7 @@ impl Script for InternalFastProjectileScript {
             };
 
             let mut effects = vec![
-                projectile_contact_damage(world, entity_id, hit_entity_id, {
+                projectile_contact_effects(world, entity_id, hit_entity_id, {
                     let travel = hit_point - start_point;
                     (travel.magnitude2() > 1.0e-12).then(|| crate::scripts::DamageImpact {
                         direction: travel.normalize(),

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -3,6 +3,7 @@ pub mod effect;
 pub(crate) mod proximity_grenade;
 pub mod speech_registry;
 pub mod speech_util;
+pub mod stasis;
 
 mod apparition;
 mod auto_install_soft;
@@ -243,6 +244,10 @@ pub enum MessagePayload {
     },
     SensorEndIntersect {
         with: EntityId,
+    },
+    /// Native AI freeze reaction; negative duration is indefinite.
+    Freeze {
+        duration_seconds: f32,
     },
     Collided {
         with: EntityId,
@@ -582,6 +587,11 @@ pub trait Script {
         _msg: &MessagePayload,
     ) -> Effect {
         Effect::NoEffect
+    }
+
+    /// Read-only view of native AI stasis, shared by animation/physics gates.
+    fn stasis(&self) -> Option<&stasis::StasisState> {
+        None
     }
 
     /// Stable opt-in identity for private runtime state. Entity properties and
@@ -1382,6 +1392,15 @@ impl ScriptWorld {
         }
 
         Ok(())
+    }
+
+    pub fn stasis(&self, entity: EntityId, world: &World) -> Option<&stasis::StasisState> {
+        let stasis = self
+            .entity_to_scripts
+            .get(&entity)?
+            .iter()
+            .find_map(|s| s.script.stasis())?;
+        (!crate::scripts::ai::ai_util::is_killed(entity, world)).then_some(stasis)
     }
 
     pub fn update(&mut self, world: &World, physics: &PhysicsWorld, time: &Time) -> Vec<Effect> {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -39,10 +39,10 @@ pub(crate) fn entity_class_template_id(world: &World, entity: EntityId) -> Optio
         })
 }
 
-/// Resolve a projectile's contact damage against the owning receiver, then
-/// send through the struck hitbox so limb scaling and ragdoll metadata survive.
+/// Resolve contact damage and freeze against the owning receiver. Damage goes
+/// through the struck hitbox so limb scaling and ragdoll metadata survive.
 /// Non-damage stims and immune receivers do not emit a zero-damage AI alert.
-pub(crate) fn projectile_contact_damage(
+pub(crate) fn projectile_contact_effects(
     world: &World,
     projectile: EntityId,
     struck: EntityId,
@@ -58,14 +58,33 @@ pub(crate) fn projectile_contact_damage(
         receiver,
         crate::runtime_props::RuntimePropShotModifiers::of(world, projectile).stim,
     );
-    if amount <= 0.0 {
-        return Effect::NoEffect;
-    }
-    Effect::Send {
-        msg: Message {
-            to: struck,
-            payload: MessagePayload::Damage { amount, impact },
-        },
+    let damage = if amount > 0.0 {
+        Effect::Send {
+            msg: Message {
+                to: struck,
+                payload: MessagePayload::Damage { amount, impact },
+            },
+        }
+    } else {
+        Effect::NoEffect
+    };
+    if let Some(duration_seconds) = crate::mission::stim_response::contact_stim_freeze(
+        world,
+        template,
+        receiver,
+        crate::runtime_props::RuntimePropShotModifiers::of(world, projectile).stim,
+    ) {
+        Effect::combine(vec![
+            damage,
+            Effect::Send {
+                msg: Message {
+                    to: receiver,
+                    payload: MessagePayload::Freeze { duration_seconds },
+                },
+            },
+        ])
+    } else {
+        damage
     }
 }
 
@@ -1830,7 +1849,7 @@ mod projectile_contact_tests {
             bone: None,
         };
         let Effect::Send { msg } =
-            projectile_contact_damage(&world, projectile, limb, Some(impact))
+            projectile_contact_effects(&world, projectile, limb, Some(impact))
         else {
             panic!("authored contact damage must reach the struck limb");
         };
@@ -1858,7 +1877,7 @@ mod projectile_contact_tests {
         let projectile = world.add_entity(PropTemplateId { template_id: -1352 });
         let immune = world.add_entity(());
         assert!(matches!(
-            projectile_contact_damage(&world, projectile, immune, None),
+            projectile_contact_effects(&world, projectile, immune, None),
             Effect::NoEffect
         ));
         let victim = world.add_entity(Links {
@@ -1867,13 +1886,16 @@ mod projectile_contact_tests {
                 to_entity_id: None,
                 link: Link::Receptron(ReceptronOptions {
                     order: 82,
-                    effect: ReceptronEffect::Unhandled("Freeze".to_owned()),
+                    effect: ReceptronEffect::Freeze {
+                        duration_multiplier: 1,
+                    },
                 }),
             }],
         });
         assert!(matches!(
-            projectile_contact_damage(&world, projectile, victim, None),
-            Effect::NoEffect
+            Effect::flatten(vec![projectile_contact_effects(&world, projectile, victim, None)]).as_slice(),
+            [Effect::Send { msg: Message { to, payload: MessagePayload::Freeze { duration_seconds } } }]
+                if *to == victim && *duration_seconds == 8.0
         ));
     }
 }

--- a/shock2vr/src/scripts/stasis.rs
+++ b/shock2vr/src/scripts/stasis.rs
@@ -1,0 +1,41 @@
+//! Saved native AI freeze state. The timer belongs to BaseMonster, and the
+//! captured model-space pose keeps animation and hitboxes identical on load.
+use crate::runtime_props::RuntimePropJointTransforms;
+use cgmath::Matrix4;
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, View, World};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct StasisState {
+    pub remaining_seconds: f32,
+    pose: Option<Vec<Matrix4<f32>>>,
+}
+impl StasisState {
+    pub fn capture(world: &World, entity: EntityId, seconds: f32) -> Self {
+        let pose = world
+            .borrow::<View<RuntimePropJointTransforms>>()
+            .unwrap()
+            .get(entity)
+            .ok()
+            .map(|p| p.0.to_vec());
+        Self {
+            remaining_seconds: seconds,
+            pose,
+        }
+    }
+    pub fn pose(&self) -> Option<&[Matrix4<f32>; 40]> {
+        self.pose.as_deref()?.try_into().ok()
+    }
+    pub fn valid(&self) -> bool {
+        self.remaining_seconds.is_finite() && self.pose.as_ref().is_none_or(|pose| pose.len() == 40)
+    }
+    /// Negative authored durations are indefinite. A finite timer expires at
+    /// the boundary, not one frame later.
+    pub fn tick(&mut self, seconds: f32) -> bool {
+        if self.remaining_seconds < 0.0 {
+            return true;
+        }
+        self.remaining_seconds = (self.remaining_seconds - seconds).max(0.0);
+        self.remaining_seconds > 0.0
+    }
+}

--- a/tools/shock2-sdk/test/timed-stasis.e2e.test.ts
+++ b/tools/shock2-sdk/test/timed-stasis.e2e.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { cycleToWeapon, fireOnce } from "./helpers/weapon.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+
+async function remaining(
+  game: GameServer,
+  id: number,
+): Promise<number | undefined> {
+  const value = (await game.entities.detail(id)).properties.find(
+    (p) => p.name === "StasisRemaining",
+  )?.value;
+  return value === undefined ? undefined : Number(value);
+}
+
+for (const scenario of ["refresh", "save", "area", "death"] as const) {
+  test(
+    `actual stasis shot: ${scenario}`,
+    { skip: !enabled, timeout: 240_000 },
+    async () => {
+      await using game = await GameServer.launch({
+        mission: scenario === "save" ? "earth.mis" : "debug_weapons",
+      });
+      await game.step({ frames: 10 });
+      if (scenario === "save") {
+        await game.player.setStats({
+          skills: { energy_weapons: 6, heavy_weapons: 6, exotic_weapons: 6 },
+        });
+        await game.player.spawnItem(-25);
+        await game.input.trigger("EquipStasisFieldGenerator");
+        await game.step({ frames: 10 });
+      } else {
+        await cycleToWeapon(game, (e) => e.template_id === -25);
+      }
+      if (scenario === "area") {
+        await game.input.trigger("CycleGunSetting");
+        await game.step({ frames: 2 });
+      }
+      await game.input.trigger("EjectClip");
+      await game.step({ frames: 2 });
+      await game.player.spawnItem(-41);
+      await game.input.trigger("Reload");
+      await game.step({ frames: 180 });
+      await game.input.set("head.look", [0, 0]);
+      await game.input.trigger("SpawnDebugMonster");
+      await game.step({ frames: 2 });
+      let [target] = await game.entities.byTemplate(-397);
+      assert.ok(target);
+      await game.player.aimAt(target, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      await game.step({ frames: 1 });
+      await fireOnce(game);
+      for (
+        let i = 0;
+        i < 30 && (await remaining(game, target.id)) === undefined;
+        i++
+      ) {
+        await game.step({ frames: 2 });
+      }
+      const duration = await remaining(game, target.id);
+      assert.ok(
+        duration !== undefined && duration > 0 && duration <= 8,
+        "a real projectile must freeze the target",
+      );
+      if (scenario !== "area")
+        assert.ok(duration > 7.8, "normal stasis lasts eight seconds");
+      assert.equal(
+        Number(
+          (await game.entities.detail(target.id)).properties.find(
+            (p) => p.name === "HitPoints",
+          )?.value,
+        ),
+        12,
+      );
+
+      if (scenario === "death") {
+        await game.entities.sendMessage(target.id, {
+          type: "Damage",
+          amount: 100,
+        });
+        await game.step({ frames: 2 });
+        assert.equal(
+          await remaining(game, target.id),
+          undefined,
+          "death must release stasis immediately",
+        );
+        return;
+      }
+      await game.step({ frames: 60 });
+      const frozen = await game.entities.animation(target.id);
+      assert.ok(frozen);
+      await game.step({ frames: 120 });
+      const held = await game.entities.animation(target.id);
+      assert.ok(held);
+      // Gravity/contact resolution may translate the body; joint offsets must
+      // retain the same pose rather than advancing animation.
+      const poseError = (joints: number[][]) =>
+        Math.max(
+          ...joints.flatMap((joint, i) =>
+            joint.map((v, axis) =>
+              Math.abs(
+                v -
+                  joints[0]![axis]! -
+                  (frozen.joints[i]![axis]! - frozen.joints[0]![axis]!),
+              ),
+            ),
+          ),
+        );
+      assert.ok(
+        poseError(held.joints) < 0.0001,
+        "the frozen pose and hitboxes must not advance",
+      );
+
+      if (scenario === "refresh") {
+        await game.player.aimAt(target.id, {
+          hitbox: "torso",
+          visibility: "required",
+        });
+        await fireOnce(game);
+        await game.step({ frames: 12 });
+        const refreshed = await remaining(game, target.id);
+        assert.ok(
+          refreshed !== undefined && refreshed > 7.5 && refreshed <= 8,
+          "reapplication replaces the remaining duration",
+        );
+      }
+      if (scenario === "save") {
+        const before = await remaining(game, target.id);
+        const slot = `timed_stasis_${Date.now()}`;
+        assert.equal((await game.save(slot)).success, true);
+        assert.equal((await game.load(slot)).success, true);
+        [target] = await game.entities.byTemplate(-397);
+        assert.ok(target, "discover the restored target by stable template");
+        const restored = await remaining(game, target.id);
+        assert.ok(
+          restored !== undefined &&
+            before !== undefined &&
+            Math.abs(restored - before) < 0.05,
+          "load preserves remaining duration",
+        );
+        await game.step({ frames: 2 });
+        const pose = await game.entities.animation(target.id);
+        assert.ok(pose);
+        assert.ok(
+          poseError(pose.joints) < 0.0001,
+          "load preserves the frozen pose",
+        );
+      }
+      const left = await remaining(game, target.id);
+      assert.ok(left !== undefined && left > 0);
+      await game.step({ frames: Math.max(1, Math.floor(left * 60) - 2) });
+      assert.ok(
+        (await remaining(game, target.id)) !== undefined,
+        "stasis remains until its deadline",
+      );
+      await game.step({ frames: 4 });
+      assert.equal(
+        await remaining(game, target.id),
+        undefined,
+        "stasis expires at the deadline",
+      );
+      const thawed = await game.entities.animation(target.id);
+      await game.step({ frames: 30 });
+      assert.notDeepEqual(
+        (await game.entities.animation(target.id))?.joints,
+        thawed?.joints,
+        "animation resumes after expiry",
+      );
+    },
+  );
+}


### PR DESCRIPTION
Stasis shots now freeze vulnerable enemies instead of leaving them moving and attacking. Normal shots freeze for eight seconds; area shots use the existing radius exposure and falloff. Repeated hits replace the remaining interval, expiry resumes AI and animation, and death releases the freeze immediately.

Save/load preserves the remaining simulation time and captured pose through native script state. Rendering and hitboxes share that saved pose; gravity and external contacts remain active. The duration convention was checked against the shipped 25th Anniversary executable: whole seconds at the Freeze callback, converted to milliseconds by AI::Freeze. Fully occluded blasts cannot clear an existing freeze.

Stacked on #1463. Implementation and source evidence are documented in `projects/weapon-feel-workstream.md`. The companion Frozen metaproperty/FreezeFX visual and broadcast behavior remains a follow-up; native AI behavior serialization and radius impulse parity are outside this layer.

Validation:

- 170 Dark and 1,624 gameplay library tests pass (2 ignored); focused contact/freeze regression tests pass after review fixes.
- Warning-denied checks pass for Dark, gameplay, desktop and debug runtimes.
- 63 fast SDK tests pass.
- All 30 targeted SDK scenarios pass: all 23 mission loads, three contact-damage regressions, and four actual-shot stasis cases covering normal refresh/expiry, area mode, death, and a real earth.mis save/load retaining timer and pose. The four stasis cases were also rerun successfully on the final code.
- Matched deterministic before/after captures show eight seconds of frozen pose followed by resumed movement.

![Before and after timed stasis](https://gist.githubusercontent.com/tommy-xr/322f260c0635fb88b579e61937c87e71/raw/stasis-comparison.gif)

![Frozen pose](https://gist.githubusercontent.com/tommy-xr/322f260c0635fb88b579e61937c87e71/raw/stasis-frozen.png)

![Movement resumes after expiry](https://gist.githubusercontent.com/tommy-xr/322f260c0635fb88b579e61937c87e71/raw/stasis-resumed.png)
