### PR TITLE
fix(weapons): honor authored shotgun pellet count and spread

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -33,6 +33,7 @@ mod prop_phys_attr;
 mod prop_phys_initial_velocity;
 mod prop_phys_type;
 mod prop_player_gun;
+mod prop_projectile;
 mod prop_psi;
 mod prop_quest_bit;
 mod prop_render_type;
@@ -81,6 +82,7 @@ pub use prop_phys_attr::*;
 pub use prop_phys_initial_velocity::*;
 pub use prop_phys_type::*;
 pub use prop_player_gun::*;
+pub use prop_projectile::*;
 pub use prop_psi::*;
 pub use prop_quest_bit::*;
 pub use prop_render_type::*;
@@ -1532,6 +1534,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         ),
         define_prop("P$KeyDst", KeyCard::read, PropKeyDst, accumulator::latest),
         define_prop("P$KeySrc", KeyCard::read, PropKeySrc, accumulator::latest),
+        define_prop(
+            "P$Projectil",
+            PropProjectile::read,
+            identity,
+            accumulator::latest,
+        ),
         define_prop(
             "P$BaseGunDe",
             PropBaseGunDesc::read,

--- a/dark/src/properties/prop_projectile.rs
+++ b/dark/src/properties/prop_projectile.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+use std::io;
+
+use crate::ss2_common::{read_i32, read_u16};
+
+/// P$Projectil: packed sProjectile, distinct from the weapon's Projectile link
+/// and BaseGunDesc.spray. One shell launches `count` independently aimed pellets.
+#[derive(Debug, Clone, Copy, Component, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PropProjectile {
+    pub count: i32,
+    /// Unsigned Dark angle units (65536 units = one turn).
+    pub spread: u16,
+}
+
+impl Default for PropProjectile {
+    fn default() -> Self {
+        Self {
+            count: 1,
+            spread: 0,
+        }
+    }
+}
+
+impl PropProjectile {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        Self {
+            count: read_i32(reader),
+            spread: read_u16(reader),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parses_both_shipped_pellet_records_without_padding() {
+        let mut bytes = io::Cursor::new([6, 0, 0, 0, 0, 4]);
+        assert_eq!(
+            PropProjectile::read(&mut bytes, 6),
+            PropProjectile {
+                count: 6,
+                spread: 1024
+            }
+        );
+        assert_eq!(bytes.position(), 6);
+    }
+}

--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -515,3 +515,14 @@ is not implemented by this native freeze layer; a queued AI bookkeeping message
 can still emit a vocalization while frozen. Radius falloff and physical blast
 impulses also retain the existing engine behavior pending broader parity work.
 Quest particle validation for #1460 remains with the user.
+
+
+### Shotgun pellet generation
+
+The next layer above #1465 parses `P$Projectil` and emits the authored six
+pellets for both shotgun modes, each with independent ±5.625° heading/pitch
+spread. Slugs remain single projectiles; ammo costs and shot presentation remain
+per shell. See the [pellet audit](weapon-projectile-audit.md#shotgun-pellet-count-and-spread-follow-up)
+for source records, mode differences, flat/VR tests and matched near/far media.
+Gun accuracy/stat hooks and Strength-based VR spring recoil remain subsequent
+increments, separate from this projectile-authored spread.

--- a/projects/weapon-projectile-audit.md
+++ b/projects/weapon-projectile-audit.md
@@ -48,7 +48,7 @@ Separate paths: Wrench (-928), Crystal Shard (-28), Electro Shock (-24), PsiSwor
 ## Confirmed source discrepancies
 
 - Fast rays use fixed 6 damage; physical collisions use fixed 1 damage. Authored pistol contact intensity is 4, assault rifle 10, slug 8/16, laser 2/12; target receptrons and ammo type must determine resulting damage.
-- Shotgun pellets carry unparsed `P$Projectil`. Dark `shkproj.cpp:495–514` gets pellet count/spread from the projectile archetype, not BaseGunDesc.spray (shotgun setting spray is zero). Do not implement shotgun spread from the misleading gun field.
+- Shotgun pellet count/spread comes from `P$Projectil`, now parsed and applied in the pellet follow-up below. Dark `shkproj.cpp:495–514` reads the projectile archetype, not BaseGunDesc.spray (shotgun setting spray is zero).
 - Stasis is an authored non-damage contact stimulus, requiring separate behavior; fixed collision damage is not an acceptable substitute.
 - Annelid homing remains unparsed; exotic secondary spawns need effect/lifecycle verification.
 
@@ -181,10 +181,52 @@ scaling. Immune or non-damage contacts emit no Damage message. Physical terminal
 contacts are handled once even when multiple collision messages are queued.
 
 Pistol, laser and stasis actual-shot regressions fail on the parent and pass on
-this layer. Stasis no longer removes an erroneous hit point; **Freeze and
-add_metaprop reactions remain pending**, including duration, reapplication and
-save/load. This is the next item before pellet spread. Full act/react ordering,
+this layer. Stasis no longer removes an erroneous hit point. #1465 implements
+native Freeze, duration/reapplication, expiry and save/load; the companion
+add_metaprop/FreezeFX behavior remains pending. Full act/react ordering,
 remaining non-damage reactions, special-effect entity cleanup and complete
 weapon/target damage-matrix verification remain open. See the workstream's
 [contact damage section](weapon-feel-workstream.md#authored-projectile-contact-damage)
 for observed values, source evidence and the known baseline test failure.
+
+
+## Shotgun pellet count and spread follow-up
+
+Both pellet archetypes carry the same packed six-byte `P$Projectil` record:
+`06 00 00 00 00 04` (`i32 count = 6`, `u16 spread = 1024`). Dark angle units
+encode one turn in 65536 units, so each pellet receives independently sampled
+heading and pitch offsets in **[-5.625°, +5.625°]**. This is a square angular
+distribution, not a uniform circular cone. The global heading/pitch axes match
+`darkengine/src/shock/shkproj.cpp:303–314,495–514`; gun roll does not rotate that
+distribution. `engfeat/projbase.h` defines the two packed fields.
+
+| Setting | Projectile | Pellets | Spread per axis | Ammo cost | Contact source |
+| --- | --- | ---: | ---: | ---: | --- |
+| Normal | Pellet Projectile (-524) | 6 | ±5.625° | 1 | High Explosive (-376), intensity 1 each |
+| Triple | Double Pellet (-3423) | 6 | ±5.625° | 3 | High Explosive (-376), intensity 2 each |
+| Normal | Rifled Slug (-516) | 1 | 0° | 1 | Existing authored source |
+| Triple | Double Slug (-3422) | 1 | 0° | 3 | Existing authored source |
+
+The player weapon path expands only the launch effect. Each pellet retains its
+owner filtering, shot modifiers and flat eye/VR muzzle origin, and independently
+resolves contact damage and impact effects. Ammo, sound, muzzle flash, casing and
+wear remain once per shell. The launch descriptor cache uses the existing
+property hydrator for inherited values and mission overrides.
+
+`tools/shock2-sdk/test/shotgun-pellets.e2e.test.ts` fires both settings and both
+ammo types in flat and VR, verifies six pellet impacts versus one slug impact,
+checks bounded two-axis spread, and checks unchanged cost and firing-sound
+count. Two close-range cases verify six separate creature hitbox contacts and
+lethal aggregate damage against a 12HP hybrid (Human Vulnerability receives
+High Explosive at x4 before the existing limb multiplier). Matched captures at
+4m and 11.5m show one impact before the fix and six after it. Exact random
+patterns vary between shots; deterministic stepping does not seed gameplay RNG.
+
+![Shotgun pellet comparison](https://gist.githubusercontent.com/tommy-xr/47770507a648941ea8a6f2a5736b5e8a/raw/near-0-comparison.gif)
+
+![Near/far, both settings](https://gist.githubusercontent.com/tommy-xr/47770507a648941ea8a6f2a5736b5e8a/raw/all-comparisons.png)
+
+This layer does not implement gun-wide accuracy, Sharpshooter/stat modifiers,
+recoil, or change the separate AI projectile launch path. Remaining impact and
+explosion lifecycles, burst cadence and accuracy/stat parity precede the planned
+Strength-based VR spring recoil augmentation.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2347,6 +2347,11 @@ impl MissionCore {
         let template_class_tags = create_template_class_tag_map(&entity_info_rc);
         world.add_unique(GlobalTemplateClassTags(template_class_tags));
         world.add_unique(
+            crate::mission::projectile_spray::GlobalProjectileSprays::from_entity_info(
+                &entity_info_rc,
+            ),
+        );
+        world.add_unique(
             crate::mission::reload::GlobalProjectileClips::from_entity_info(&entity_info_rc),
         );
         world.add_unique(

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -11,6 +11,7 @@ pub mod mission_core;
 pub mod pathfinding_debug;
 pub mod pathfinding_test;
 pub mod player_footsteps;
+pub(crate) mod projectile_spray;
 pub(crate) mod reload;
 mod research_overview;
 mod shoulder_backpack;

--- a/shock2vr/src/mission/projectile_spray.rs
+++ b/shock2vr/src/mission/projectile_spray.rs
@@ -1,0 +1,186 @@
+//! Shkproj.cpp's per-projectile spray, independent of gun accuracy and recoil.
+use std::collections::{HashMap, HashSet};
+
+use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Transform, point3, vec3};
+use dark::{
+    properties::{Link, PropProjectile},
+    ss2_entity_info::SystemShock2EntityInfo,
+};
+use rand::Rng;
+use shipyard::Unique;
+
+use crate::{
+    scripts::{Effect, script_util::hydrate_template_component},
+    util::get_rotation_from_forward_vector,
+};
+
+#[derive(Unique, Default)]
+pub(crate) struct GlobalProjectileSprays(pub HashMap<i32, PropProjectile>);
+
+impl GlobalProjectileSprays {
+    pub fn from_entity_info(info: &SystemShock2EntityInfo) -> Self {
+        // Only hydrate archetypes a gun can launch, including inherited links.
+        // The existing hydrator resolves mission overrides and property donors.
+        let projectiles: HashSet<_> = info
+            .template_to_links
+            .values()
+            .flat_map(|links| &links.to_links)
+            .filter(|link| matches!(link.link, Link::Projectile(_)))
+            .map(|link| link.to_template_id)
+            .collect();
+        Self(
+            projectiles
+                .into_iter()
+                .filter_map(|id| {
+                    hydrate_template_component::<PropProjectile>(id, info).map(|prop| (id, prop))
+                })
+                .collect(),
+        )
+    }
+}
+
+/// Expand just the launch effect: ammo, sound, flash, casing and wear remain
+/// once per shell. Each pellet retains its owner, damage modifiers and origins.
+pub(crate) fn expand(spray: PropProjectile, launch: Effect, rng: &mut impl Rng) -> Effect {
+    if spray == PropProjectile::default() {
+        return launch;
+    }
+    Effect::Multiple(
+        (0..spray.count)
+            .map(|_| {
+                let mut pellet = launch.clone();
+                if let Effect::CreateEntity { root_transform, .. } = &mut pellet {
+                    if spray.spread != 0 {
+                        let forward = root_transform
+                            .transform_vector(vec3(0.0, 0.0, 1.0))
+                            .normalize();
+                        // Dark independently perturbs global heading and pitch by
+                        // uniform integer angles, not a uniform disk/cone. Gun roll
+                        // does not rotate this square angular distribution.
+                        let angle = i32::from(spray.spread);
+                        let radians = std::f32::consts::TAU / 65536.0;
+                        let heading = forward.x.atan2(forward.z)
+                            + rng.gen_range(-angle..=angle) as f32 * radians;
+                        let pitch = forward.y.clamp(-1.0, 1.0).asin()
+                            + rng.gen_range(-angle..=angle) as f32 * radians;
+                        let direction = vec3(
+                            heading.sin() * pitch.cos(),
+                            pitch.sin(),
+                            heading.cos() * pitch.cos(),
+                        );
+                        let origin = root_transform.transform_point(point3(0.0, 0.0, 0.0));
+                        *root_transform = Matrix4::from_translation(origin.to_vec())
+                            * Matrix4::from(get_rotation_from_forward_vector(direction));
+                    }
+                }
+                pellet
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mission::entity_creator::CreateEntityOptions;
+    use cgmath::{Deg, Quaternion, Rotation3};
+    use rand::{SeedableRng, rngs::StdRng};
+
+    fn launch() -> Effect {
+        Effect::CreateEntity {
+            template_id: -524,
+            position: point3(0.0, 0.0, 0.0),
+            orientation: Quaternion::from_angle_y(Deg(90.0)),
+            root_transform: Matrix4::from_translation(vec3(2.0, 3.0, 4.0)),
+            options: CreateEntityOptions {
+                player_fired_projectile: true,
+                projectile_raycast_origin: Some(point3(1.0, 3.0, 4.0)),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn six_pellets_preserve_origins_and_have_independent_bounded_angles() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let effects = Effect::flatten(vec![expand(
+            PropProjectile {
+                count: 6,
+                spread: 1024,
+            },
+            launch(),
+            &mut rng,
+        )]);
+        assert_eq!(effects.len(), 6);
+        let mut directions = Vec::new();
+        for effect in effects {
+            let Effect::CreateEntity {
+                root_transform,
+                options,
+                template_id,
+                ..
+            } = effect
+            else {
+                panic!("launch")
+            };
+            assert_eq!(template_id, -524);
+            assert!(options.player_fired_projectile);
+            assert_eq!(
+                options.projectile_raycast_origin,
+                Some(point3(1.0, 3.0, 4.0))
+            );
+            assert_eq!(
+                root_transform.transform_point(point3(0.0, 0.0, 0.0)),
+                point3(2.0, 3.0, 4.0)
+            );
+            let direction = root_transform.transform_vector(vec3(0.0, 0.0, 1.0));
+            assert!((direction.magnitude() - 1.0).abs() < 0.00001);
+            assert!(direction.x.atan2(direction.z).abs() <= 5.625_f32.to_radians());
+            assert!(direction.y.asin().abs() <= 5.625_f32.to_radians());
+            assert!(
+                !directions.contains(&direction),
+                "each pellet samples independently"
+            );
+            directions.push(direction);
+        }
+        let next = expand(
+            PropProjectile {
+                count: 6,
+                spread: 1024,
+            },
+            launch(),
+            &mut rng,
+        );
+        assert_ne!(
+            format!("{next:?}"),
+            format!(
+                "{:?}",
+                expand(
+                    PropProjectile {
+                        count: 6,
+                        spread: 1024
+                    },
+                    launch(),
+                    &mut StdRng::seed_from_u64(42)
+                )
+            ),
+            "successive shells must not repeat the same pattern"
+        );
+    }
+
+    #[test]
+    fn slug_without_projectile_property_stays_a_single_straight_launch() {
+        let effect = expand(
+            PropProjectile::default(),
+            launch(),
+            &mut StdRng::seed_from_u64(42),
+        );
+        let Effect::CreateEntity { root_transform, .. } = effect else {
+            panic!("single launch")
+        };
+        assert_eq!(
+            root_transform.transform_vector(vec3(0.0, 0.0, 1.0)),
+            vec3(0.0, 0.0, 1.0)
+        );
+    }
+}

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -769,6 +769,24 @@ pub(super) fn create_projectile(
     _options: &ProjectileOptions,
     modifiers: RuntimePropShotModifiers,
 ) -> Effect {
+    let spray = world
+        .borrow::<UniqueView<crate::mission::projectile_spray::GlobalProjectileSprays>>()
+        .ok()
+        .and_then(|sprays| sprays.0.get(&projectile_template_id).copied())
+        .unwrap_or_default();
+    crate::mission::projectile_spray::expand(
+        spray,
+        create_projectile_launch(world, entity_id, projectile_template_id, modifiers),
+        &mut rand::thread_rng(),
+    )
+}
+
+fn create_projectile_launch(
+    world: &World,
+    entity_id: EntityId,
+    projectile_template_id: i32,
+    modifiers: RuntimePropShotModifiers,
+) -> Effect {
     // Flatscreen camera-origin aim: if the weapon carries a flat fire ray, spawn
     // the projectile just ahead of the camera travelling straight along the
     // crosshair, ignoring the offset/rotated barrel transform. This makes both

--- a/tools/shock2-sdk/test/shotgun-pellets.e2e.test.ts
+++ b/tools/shock2-sdk/test/shotgun-pellets.e2e.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { ammoOf, cycleToWeapon } from "./helpers/weapon.js";
+import { tagValue } from "./helpers/audio.js";
+import { aimVrHandAt, quatFromTo } from "./helpers/vr-hand.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+for (const vr of [false, true])
+  for (const setting of [0, 1])
+    for (const pellets of [false, true]) {
+      test(
+        `${vr ? "VR" : "flat"} shotgun setting ${setting}: ${pellets ? "six pellets" : "one slug"}`,
+        { skip: !enabled, timeout: 180_000 },
+        async () => {
+          await using game = await GameServer.launch({
+            mission: "debug_weapons",
+            debugFlags: vr ? ["--vr"] : [],
+          });
+          await game.step({ frames: 5 });
+          const gun = await cycleToWeapon(game, (e) => e.template_id === -19, {
+            settleFrames: vr ? 90 : 5,
+          });
+          if (vr) {
+            await aimVrHandAt(game, gun.position, 0.45, 1, 0);
+            await game.step({ frames: 8 });
+            assert.equal(
+              (await game.info()).player.right_hand_entity_id,
+              gun.id,
+            );
+            await game.input.set("right_hand.position", [0, 1, -2]);
+            await game.input.set(
+              "right_hand.rotation",
+              quatFromTo([0, 0, -1], [-1, 0, 0]),
+            );
+            await game.step({ frames: 3 });
+          } else {
+            await game.input.set("head.look", [0, 0]);
+          }
+          if (setting) {
+            await game.input.trigger("CycleGunSetting");
+            await game.step({ frames: 2 });
+          }
+          await game.input.trigger("EjectClip");
+          await game.step({ frames: 2 });
+          if (pellets) {
+            await game.input.trigger("CycleAmmo");
+            await game.step({ frames: 2 });
+          }
+          await game.player.spawnItem(pellets ? -42 : -43);
+          await game.input.trigger("Reload");
+          await game.step({ frames: 180 });
+          const beforeAmmo = ammoOf(await game.entities.detail(gun.id));
+          const sequence =
+            (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+          const priorHits = new Set(
+            (await game.entities.byTemplate(-3544)).map((e) => e.id),
+          );
+          await game.input.set("right_hand.trigger", 1);
+          await game.step({ frames: 1 });
+          await game.input.set("right_hand.trigger", 0);
+          let hits = (await game.entities.byTemplate(-3544)).filter(
+            (e) => !priorHits.has(e.id),
+          );
+          for (let frame = 0; frame < 4 && hits.length === 0; frame++) {
+            await game.step({ frames: 1 });
+            hits = (await game.entities.byTemplate(-3544)).filter(
+              (e) => !priorHits.has(e.id),
+            );
+          }
+          assert.equal(
+            hits.length,
+            pellets ? 6 : 1,
+            "one real wall impact per authored projectile",
+          );
+          assert.equal(
+            beforeAmmo - ammoOf(await game.entities.detail(gun.id)),
+            setting ? 3 : 1,
+            "cost is per shell, not per pellet",
+          );
+          const sounds = (await game.audio.recent()).sounds.filter(
+            (s) => s.sequence > sequence && tagValue(s, "event") === "shoot",
+          );
+          assert.equal(sounds.length, 1, "one firing sound per shell");
+          if (pellets) {
+            const width =
+              Math.max(...hits.map((e) => e.position[2])) -
+              Math.min(...hits.map((e) => e.position[2]));
+            const height =
+              Math.max(...hits.map((e) => e.position[1])) -
+              Math.min(...hits.map((e) => e.position[1]));
+            assert.ok(
+              width > 0.05 && height > 0.05,
+              "independent pitch and heading spread reaches the wall",
+            );
+            assert.ok(
+              width < 3 && height < 3,
+              "pattern remains bounded at the far wall",
+            );
+          }
+        },
+      );
+    }
+
+for (const setting of [0, 1]) {
+  test(
+    `shotgun setting ${setting}: each pellet applies authored contact damage`,
+    { skip: !enabled, timeout: 180_000 },
+    async () => {
+      await using game = await GameServer.launch({ mission: "debug_weapons" });
+      await game.step({ frames: 5 });
+      await cycleToWeapon(game, (e) => e.template_id === -19);
+      if (setting) {
+        await game.input.trigger("CycleGunSetting");
+        await game.step({ frames: 2 });
+      }
+      await game.input.trigger("EjectClip");
+      await game.step({ frames: 2 });
+      await game.input.trigger("CycleAmmo");
+      await game.step({ frames: 2 });
+      await game.player.spawnItem(-42);
+      await game.input.trigger("Reload");
+      await game.step({ frames: 180 });
+      await game.input.set("head.look", [0, 0]);
+      await game.input.trigger("SpawnDebugMonster");
+      await game.step({ frames: 2 });
+      const [target] = await game.entities.byTemplate(-397);
+      assert.ok(target);
+      // Close enough that all six rays land on creature hitboxes despite spread.
+      // Keep the eye outside the capsule and aim toward the torso.
+      await game.player.teleport({
+        x: target.position[0] + 1.1,
+        y: 0,
+        z: target.position[2],
+      });
+      await game.player.aimAt(target, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      await game.step({ frames: 1 });
+      const seq = Math.max(
+        0,
+        ...(await game.messages.recent()).messages.map((m) => m.sequence),
+      );
+      await game.input.set("right_hand.trigger", 1);
+      await game.step({ frames: 1 });
+      await game.input.set("right_hand.trigger", 0);
+      await game.step({ frames: 2 });
+      const damage = (await game.messages.recent()).messages.filter(
+        (m) =>
+          m.sequence > seq &&
+          m.to.entity_id === target.id &&
+          m.payload === "Damage",
+      );
+      assert.equal(
+        damage.length,
+        6,
+        "six separate pellet contacts reach the target",
+      );
+      const hp = Number(
+        (await game.entities.detail(target.id)).properties.find(
+          (p) => p.name === "HitPoints",
+        )?.value,
+      );
+      // Human Vulnerability responds x4 to High Explosive. Even with the
+      // existing limb multiplier, six normal pellets kill this 12HP hybrid;
+      // one pre-fix projectile does not. Alternate pellets author intensity2.
+      assert.equal(hp, 0, "six authored contacts are lethal to the hybrid");
+    },
+  );
+}


### PR DESCRIPTION
Shotgun pellet shells previously fired one straight projectile. They now launch the six pellets authored by `P$Projectil`, each with independent heading/pitch spread of ±5.625°, in both flat and VR. Slugs remain single projectiles. Each pellet resolves its own contact damage and impact effects; ammo, sound, flash, casing and weapon wear remain once per shell.

Both modes author six pellets. Normal costs one round and uses contact intensity 1; triple costs three rounds and uses intensity 2. The packed six-byte property and global heading/pitch distribution match `projbase.h` and `shkproj.cpp` in the original Dark Engine source. Existing property hydration preserves inheritance and mission overrides. Gun-wide accuracy/stat modifiers and VR recoil remain separate increments.

Stacked above #1465. Source records, mode differences and remaining scope are documented in `projects/weapon-projectile-audit.md`.

Validation:

- Ten actual-shot SDK scenarios pass: both modes and both ammo types in flat/VR, plus six-contact damage cases against a hybrid.
- All 23 mission loads and seven existing contact/stasis runtime regressions pass.
- Both flat pellet-count cases fail on the parent with one impact instead of six, then pass with this change.
- 171 Dark and 1,626 gameplay library tests pass (2 ignored); 63 fast SDK tests pass.
- Warning-denied checks pass for Dark, gameplay, desktop and debug runtimes.
- Matched captures verify one→six impacts at 4m and 11.5m in both modes, preserving ammo costs. Exact random patterns vary between shots.

![Shotgun before/after](https://gist.githubusercontent.com/tommy-xr/47770507a648941ea8a6f2a5736b5e8a/raw/near-0-comparison.gif)

![Shotgun still](https://gist.githubusercontent.com/tommy-xr/47770507a648941ea8a6f2a5736b5e8a/raw/near-0-comparison.png)

![Both modes, near and far](https://gist.githubusercontent.com/tommy-xr/47770507a648941ea8a6f2a5736b5e8a/raw/all-comparisons.png)
