### PR TITLE
feat(mfd): show held items on both arms and align VR borders

### DIFF
--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -54,9 +54,24 @@ texture is shipped. The original strip scales uniformly by about 0.945 to fit
 both arms within the existing canvas width; inventory drop coordinates map
 back into the original grid. Flat and VR use the same layout.
 
-The new arm is decorative for this increment: clicking it does not equip or
-throw a cursor-held item. Armor, implant and inventory controls retain their
-existing behavior. A follow-up can place explicitly named LEFT HAND / RIGHT
-HAND item readouts over the two arms, with SUPPORTING for a support grip rather
-than duplicate ownership. Those readouts describe held items independently of
-the shoulder recall marks on backpack items.
+### Held-item readouts
+
+Both arms now carry LEFT / RIGHT labels and a fitted icon for the item that
+hand owns, or EMPTY. The paperdoll faces the viewer: RIGHT is left of the torso
+and LEFT is right of it. Hover names include the hand and full item name;
+missing icons fall back to ITEM. The flat viewmodel maps to RIGHT through the
+interaction's physical handedness, even though its internal storage uses the
+left slot.
+
+The empty caption uses an explicit compact font size so it fits without an
+ellipsis. Adjacent background crops share a depth plane in VR; only overlapping
+resolved elements advance toward the viewer to preserve painter order. This
+avoids introducing a perspective seam between pieces of the same border.
+
+The arms are read-only: clicking them does not equip, use, or throw an item.
+Armor, implant and inventory controls retain their existing behavior. These
+readouts describe held items independently of shoulder recall assignments.
+Opening the cyber interface currently releases a support grip for pointing,
+so the freed hand reads EMPTY and a two-handed weapon appears only once. If
+that interaction policy changes, add an explicit SUPPORTING state rather than
+representing the support hand as another owner.

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -257,6 +257,9 @@ pub struct FlatUiHost {
     /// Live backpack recall assignments, left/right. These decorate the
     /// existing item icons; they never create another inventory owner.
     shoulder_weapons: [Option<EntityId>; 2],
+    /// Read-only snapshots in physical left/right order. A support hand owns
+    /// no item; flat wielding is mapped to its visible right hand by the caller.
+    hand_items: [Option<CursorItem>; 2],
     /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
@@ -299,6 +302,7 @@ impl FlatUiHost {
             sticky_panel: false,
             name_strip: None,
             shoulder_weapons: [None; 2],
+            hand_items: [None, None],
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
@@ -403,6 +407,39 @@ impl FlatUiHost {
 
     pub(crate) fn set_shoulder_weapons(&mut self, weapons: [Option<EntityId>; 2]) {
         self.shoulder_weapons = weapons;
+    }
+
+    pub(crate) fn set_hand_items(
+        &mut self,
+        world: &World,
+        asset_cache: &mut AssetCache,
+        items: [Option<EntityId>; 2],
+    ) {
+        self.hand_items = items.map(|entity| {
+            let entity = entity.filter(|entity| {
+                world
+                    .borrow::<EntitiesView>()
+                    .is_ok_and(|entities| entities.is_alive(*entity))
+            })?;
+            let mut item = make_cursor_item(world, entity);
+            item.label = crate::hud::resolve_item_name(asset_cache, world, entity).or(item.label);
+            Some(item)
+        });
+    }
+
+    pub(crate) fn pointed_hand_name(&self) -> Option<String> {
+        if self.cursor_item.is_some() {
+            return None;
+        }
+        let pointer = self.cursor_canvas?;
+        let rects = hand_readout_rects(self.strip_rect()?);
+        let slot = rects.iter().position(|rect| rect.contains(pointer))?;
+        let side = ["Left hand", "Right hand"][slot];
+        let name = self.hand_items[slot]
+            .as_ref()
+            .map(|item| item.label.as_deref().unwrap_or("Held item"))
+            .unwrap_or("Empty");
+        Some(format!("{side}: {name}"))
     }
 
     /// Badge geometry comes from the same cached item rects as inventory
@@ -544,6 +581,11 @@ impl FlatUiHost {
     /// a recycled `EntityId`. The destruction effect pipeline calls this before
     /// deleting the world entity.
     pub fn on_entity_destroyed(&mut self, entity: EntityId) {
+        for item in &mut self.hand_items {
+            if item.as_ref().is_some_and(|item| item.entity == entity) {
+                *item = None;
+            }
+        }
         if self.active_panel == Some(entity) {
             self.close();
         }
@@ -845,9 +887,9 @@ impl FlatUiHost {
             .and_then(|s| s.size_px)
             .map(strip_canvas_rect);
         let over_strip = strip_rect.map(|r| r.contains(canvas_pos)).unwrap_or(false);
-        if strip_rect.is_some_and(|r| mirrored_arm_rect(r).contains(canvas_pos)) {
-            // Decorative equipment chrome is not bare world. Until it has
-            // equipment controls, a click must not throw a cursor-held item.
+        if strip_rect.is_some_and(|r| hand_readout_rects(r).iter().any(|r| r.contains(canvas_pos)))
+        {
+            // Hand readouts never equip, use or throw an item.
             self.hover_close = false;
             return (Vec::new(), Vec::new());
         }
@@ -1107,6 +1149,44 @@ impl FlatUiHost {
                     VAlign::Middle,
                 );
             }
+            for (slot, arm) in hand_readout_rects(rect).into_iter().enumerate() {
+                let title = Rect::new(arm.x + 1.0, arm.y + 16.0, arm.w - 2.0, 12.0);
+                canvas.image(title, "frame.pcx");
+                canvas.text_native_fit(
+                    title,
+                    ["LEFT", "RIGHT"][slot],
+                    NAME_STRIP_FONT,
+                    HAlign::Center,
+                    VAlign::Middle,
+                );
+                let content = Rect::new(arm.x + 3.0, arm.y + 30.0, arm.w - 6.0, arm.h - 34.0);
+                match self.hand_items[slot].as_ref() {
+                    Some(item) => match item.icon.as_deref() {
+                        Some(icon) => {
+                            canvas.fitted_object_icon(content, icon);
+                        }
+                        None => {
+                            canvas.text_native_fit(
+                                content,
+                                "ITEM",
+                                NAME_STRIP_FONT,
+                                HAlign::Center,
+                                VAlign::Middle,
+                            );
+                        }
+                    },
+                    None => {
+                        canvas.text(
+                            Rect::new(arm.x + 1.0, content.y, arm.w - 2.0, content.h),
+                            "EMPTY",
+                            NAME_STRIP_FONT,
+                            8.0,
+                            HAlign::Center,
+                            VAlign::Middle,
+                        );
+                    }
+                }
+            }
             // The mini-frame sits in the inventory bar, so it is up exactly
             // while the bar is. Placement is decided here, once, in canvas
             // pixels - both presentations map this rect (AGENTS.md 3).
@@ -1234,6 +1314,24 @@ impl FlatUiHost {
                         screen_rect: self.to_screen_rect(r),
                     },
                 ));
+                elements.extend(hand_readout_rects(rect).into_iter().enumerate().map(
+                    |(slot, r)| {
+                        let item = self.hand_items[slot].as_ref();
+                        crate::game_scene::DebugUiElement {
+                            kind: "readout".to_owned(),
+                            texture: item.and_then(|item| item.icon.clone()),
+                            text: Some(
+                                item.map(|item| item.label.as_deref().unwrap_or("Held item"))
+                                    .unwrap_or("Empty")
+                                    .to_owned(),
+                            ),
+                            label: Some(["Left hand", "Right hand"][slot].to_owned()),
+                            entity_id: item.map(|item| item.entity.inner() as i32),
+                            rect: [r.x, r.y, r.w, r.h],
+                            screen_rect: self.to_screen_rect(r),
+                        }
+                    },
+                ));
                 elements
             }
             _ => Vec::new(),
@@ -1353,6 +1451,20 @@ fn mirrored_arm_rect(strip: Rect) -> Rect {
         EXTRA_ARM_WIDTH * STRIP_SCALE,
         strip.h,
     )
+}
+
+/// The paperdoll faces the viewer: its right arm is on the viewer's left.
+/// These same rectangles draw, describe and consume input for the readouts.
+fn hand_readout_rects(strip: Rect) -> [Rect; 2] {
+    [
+        mirrored_arm_rect(strip),
+        Rect::new(
+            strip.x + strip.w * 527.0 / 636.0,
+            strip.y,
+            strip.w * EXTRA_ARM_WIDTH / 636.0,
+            strip.h,
+        ),
+    ]
 }
 
 /// A `GUIHover` for `to`, in panel-local normalized coordinates - the same
@@ -1828,7 +1940,7 @@ mod tests {
         let frame = canvas
             .elements()
             .iter()
-            .find(|e| matches!(e, crate::ui::UiElement::Image { texture, .. } if texture == "frame.pcx"))
+            .find(|e| matches!(e, crate::ui::UiElement::Image { texture, .. } if texture == "frame.pcx" && e.rect().y == 0.0))
             .expect("the inventory bar should draw the mini-frame");
         assert_eq!(
             frame.rect(),
@@ -1871,7 +1983,7 @@ mod tests {
             !canvas
                 .elements()
                 .iter()
-                .any(|e| matches!(e, crate::ui::UiElement::Text { .. })),
+                .any(|e| matches!(e, crate::ui::UiElement::Text { .. }) && e.rect().y == 0.0),
             "an empty readout draws no text"
         );
 
@@ -1886,7 +1998,9 @@ mod tests {
                     font,
                     fit_to_rect,
                     ..
-                } => Some((text.clone(), font.clone(), *fit_to_rect, e.rect())),
+                } if text == "Laser Rapier" => {
+                    Some((text.clone(), font.clone(), *fit_to_rect, e.rect()))
+                }
                 _ => None,
             })
             .expect("the readout should draw its name");
@@ -2321,6 +2435,54 @@ mod tests {
     }
 
     #[test]
+    fn hand_readouts_name_physical_sides_and_do_not_take_ownership() {
+        let (world, mut host, item, _) = drag_world();
+        host.hand_items[1] = Some(make_cursor_item(&world, item));
+        let [left, right] = hand_readout_rects(host.strip_rect().unwrap());
+        assert!(right.x < left.x, "paperdoll faces the viewer");
+        host.cursor_canvas = Some(right.center());
+        assert_eq!(
+            host.pointed_hand_name().as_deref(),
+            Some("Right hand: Wrench")
+        );
+        host.cursor_canvas = Some(left.center());
+        assert_eq!(
+            host.pointed_hand_name().as_deref(),
+            Some("Left hand: Empty")
+        );
+        let readouts: Vec<_> = host
+            .strip_debug_elements(&world)
+            .into_iter()
+            .filter(|e| e.kind == "readout")
+            .collect();
+        assert_eq!(readouts.len(), 2);
+        assert_eq!(readouts[0].entity_id, None);
+        assert_eq!(readouts[1].entity_id, Some(item.inner() as i32));
+        for rect in [left, right] {
+            assert_eq!(host.strip_cell_at(rect.center(), &world), None);
+            assert!(press_edge(&mut host, &world, (rect.center().x, rect.center().y)).is_empty());
+        }
+        host.on_entity_destroyed(item);
+        host.cursor_canvas = Some(right.center());
+        assert_eq!(
+            host.pointed_hand_name().as_deref(),
+            Some("Right hand: Empty")
+        );
+    }
+
+    #[test]
+    fn hand_readouts_preserve_the_cursor_item_on_both_sides() {
+        let (world, mut host, item, _) = drag_world();
+        host.cursor_item = Some(make_cursor_item(&world, item));
+        for rect in hand_readout_rects(host.strip_rect().unwrap()) {
+            let point = rect.center();
+            assert!(press_edge(&mut host, &world, (point.x, point.y)).is_empty());
+            assert_eq!(host.held_entity(), Some(item));
+            assert_eq!(host.pointed_hand_name(), None);
+        }
+    }
+
+    #[test]
     fn compact_inventory_fits_item_icons_inside_their_cells() {
         let (_world, mut host, _, _) = drag_world();
         if let GuiComponentRenderInfo::Image { kind, .. } =
@@ -2582,7 +2744,11 @@ mod tests {
             &[strip_item(wrench, 0)],
         );
 
-        assert!(host.strip_debug_elements(&world).is_empty());
+        assert!(
+            host.strip_debug_elements(&world)
+                .iter()
+                .all(|e| e.entity_id.is_none())
+        );
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4719,23 +4719,36 @@ impl MissionCore {
             .map(|inventory| super::shoulder_backpack::weapons(&self.world, inventory))
             .unwrap_or([None; 2]);
         self.flat_ui.set_shoulder_weapons(shoulder_weapons);
+        // Resolve physical ownership through the interaction boundary: flat's
+        // internal left slot represents the visibly right-handed viewmodel.
+        let held = self.interaction.held_entities();
+        let mut hand_items = [None; 2];
+        for entity in [held.0, held.1].into_iter().flatten() {
+            if let Some(hand) = self.interaction.holding_hand(entity) {
+                hand_items[crate::vr_config::hand_slot(hand)] = Some(entity);
+            }
+        }
+        self.flat_ui
+            .set_hand_items(&self.world, asset_cache, hand_items);
         let name_strip = self.flat_ui.strip_entity().and_then(|_| {
-            self.flat_ui
-                .pointed_item()
-                .or_else(|| self.name_strip_world_pick(game_options))
-                .and_then(|entity| {
-                    let name = crate::hud::resolve_item_name(asset_cache, &self.world, entity)?;
-                    Some(
-                        match shoulder_weapons
-                            .iter()
-                            .position(|item| *item == Some(entity))
-                        {
-                            Some(0) => format!("Left shoulder: {name}"),
-                            Some(1) => format!("Right shoulder: {name}"),
-                            _ => name,
-                        },
-                    )
-                })
+            self.flat_ui.pointed_hand_name().or_else(|| {
+                self.flat_ui
+                    .pointed_item()
+                    .or_else(|| self.name_strip_world_pick(game_options))
+                    .and_then(|entity| {
+                        let name = crate::hud::resolve_item_name(asset_cache, &self.world, entity)?;
+                        Some(
+                            match shoulder_weapons
+                                .iter()
+                                .position(|item| *item == Some(entity))
+                            {
+                                Some(0) => format!("Left shoulder: {name}"),
+                                Some(1) => format!("Right shoulder: {name}"),
+                                _ => name,
+                            },
+                        )
+                    })
+            })
         });
         self.flat_ui.set_name_strip(name_strip);
 

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -940,19 +940,42 @@ where
     ) -> Vec<SceneObject> {
         let placed = self.layout_with_pointer(asset_cache, pointer);
         let mut objects = Vec::with_capacity(placed.len());
-        for (index, element) in placed.iter().enumerate() {
+        let layers = overlap_layers(placed.iter().map(|element| element.rect));
+        for (element, layer) in placed.iter().zip(layers) {
             let alpha = force_alpha.unwrap_or(element.alpha);
             let mut object = present_world(asset_cache, element, alpha, self.size);
-            // Panel-local +Z faces the viewer, so later (higher-layer)
-            // elements step toward them to sort in front of the backdrop.
+            // Only overlapping art needs separation. Stepping every element
+            // forward gave adjacent backdrop crops different perspective
+            // scales in VR, breaking borders that join exactly on screen.
             object.set_transform(
                 root_transform
-                    * Matrix4::from_translation(vec3(0.0, 0.0, component_z_step * index as f32)),
+                    * Matrix4::from_translation(vec3(0.0, 0.0, component_z_step * layer as f32)),
             );
             objects.push(object);
         }
         objects
     }
+}
+
+/// Preserve painter order where rectangles overlap, keeping adjoining pieces
+/// on the same plane. Input rectangles are the shared, fully resolved layout.
+fn overlap_layers(rects: impl IntoIterator<Item = Rect>) -> Vec<usize> {
+    let mut previous: Vec<(Rect, usize)> = Vec::new();
+    for rect in rects {
+        let layer = previous
+            .iter()
+            .filter(|(other, _)| {
+                rect.x < other.x + other.w
+                    && other.x < rect.x + rect.w
+                    && rect.y < other.y + other.h
+                    && other.y < rect.y + rect.h
+            })
+            .map(|(_, layer)| layer + 1)
+            .max()
+            .unwrap_or(0);
+        previous.push((rect, layer));
+    }
+    previous.into_iter().map(|(_, layer)| layer).collect()
 }
 
 impl UiCanvas<()> {
@@ -1243,6 +1266,19 @@ fn world_element_transform(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn adjacent_background_pieces_share_depth_but_overlays_keep_painter_order() {
+        let layers = overlap_layers([
+            Rect::new(0.0, 0.0, 100.0, 20.0),
+            Rect::new(100.0, 0.0, 20.0, 5.0),
+            Rect::new(100.0, 5.0, 20.0, 15.0),
+            Rect::new(10.0, 5.0, 20.0, 10.0),
+            Rect::new(12.0, 6.0, 5.0, 5.0),
+            Rect::new(105.0, 6.0, 5.0, 5.0),
+        ]);
+        assert_eq!(layers, [0, 0, 0, 1, 2, 1]);
+    }
 
     #[test]
     fn cropped_art_keeps_its_destination_rect_and_authored_texel_bounds() {


### PR DESCRIPTION
The inventory paperdoll now shows what each physical hand holds. Its RIGHT arm is on the viewer’s left and LEFT arm is on the viewer’s right, with fitted item icons, complete EMPTY captions, and full hand-prefixed names on hover. Flat wielding correctly appears on RIGHT despite its internal left storage slot.

The arms are read-only: clicking does not equip, consume, or throw anything. Shoulder recall badges and Left shoulder / Right shoulder name prefixes remain separate. Opening the cyber interface releases the support grip for pointing, so a two-handed weapon appears only in its owning hand.

Also fixes the slight VR seam between adjacent background crops: shared UI depth ordering separates overlapping elements while keeping adjoining pieces coplanar. This changes depth assignment for world-space canvases; screen-space placement is unchanged.

Stacked on #1466. No game assets added.

Validation:
- 51 inventory UI host tests and 222 UI tests pass, including ownership readouts, inert clicks, destroyed items, and adjacent/overlapping depth ordering.
- Both shoulder recall and save/load/mission-transition SDK scenarios pass.
- Runtime capture assertions verify pistol + psi amp ownership, empty/drop states, full-name hover, inert clicks, and flat physical handedness.
- Debug runtime builds; independent code and duplication reviews passed. Claude review remains unavailable from the earlier exhausted-credit condition.
- Flat and VR rendered evidence below; headset validation deferred as requested.

![Hand readouts before and after](https://gist.githubusercontent.com/tommy-xr/caaa546e6a79658ad0465b794276e3b2/raw/astra-mfd-hands-before-after.png)

![Hand readouts, empty states and hover cycle](https://gist.githubusercontent.com/tommy-xr/caaa546e6a79658ad0465b794276e3b2/raw/astra-mfd-hands-cycle.gif)

Matching VR pickup sequence: right pistol, left psi amp, then left release. RIGHT appears left of the facing torso. Runtime assertions verify exact ownership, full-name hover and inert clicks. Flat independently confirms wielded pistol maps to RIGHT; its baseline was empty. Loop shows discrete checkpoints. Full EMPTY and aligned frontal borders verified; no headset validation.

[Download the self-contained gallery and open locally](https://gist.githubusercontent.com/tommy-xr/caaa546e6a79658ad0465b794276e3b2/raw/astra-mfd-hands-gallery.html).
