### PR TITLE
fix(weapons): apply authored weapon skill accuracy

### DIFF
--- a/projects/weapon-feel-workstream.md
+++ b/projects/weapon-feel-workstream.md
@@ -59,7 +59,8 @@ headset comfort.
   not a claim about original System Shock 2. Preserve the original Agility,
   Still Hand and aiming-implant behavior when establishing parity; tune how
   Strength combines with it after that baseline is measurable.
-- Weapon skill governs authored inaccuracy. Preserve Sharpshooter's original
+- Weapon skill governs authored inaccuracy, but shipped `SKILLPARAM` sets that
+  inaccuracy to zero. Strength does not enter this calculation. Preserve Sharpshooter's original
   ranged-damage benefit; an accuracy bonus is not part of the accepted baseline.
 - Begin failed-fire feedback with a brief message above the firing glove, e.g.
   `Requires Standard Weapons 6 · You have 4`. Do not force a vertical grip.
@@ -526,3 +527,66 @@ per shell. See the [pellet audit](weapon-projectile-audit.md#shotgun-pellet-coun
 for source records, mode differences, flat/VR tests and matched near/far media.
 Gun accuracy/stat hooks and Strength-based VR spring recoil remain subsequent
 increments, separate from this projectile-authored spread.
+
+
+### Authored weapon accuracy and the stat comparison
+
+The layer above #1468 wires `CalcRandAngle` into the shared player projectile
+launch: `SKILLPARAM.inaccuracy * max(6 - effective weapon skill, 0)`. One random
+heading/pitch offset is sampled per shell, before the independent pellet spread.
+The effective skill comes from the same trained/factory skill helper as weapon
+eligibility. A zero angle preserves both launch transform and RNG state.
+
+**The shipped parameter is zero.** At fixed aim, pistol shots at Standard 1/3/6
+and Strength 1/6 therefore have no random weapon aim error. The AR requires
+Standard 6: lower-skill attempts are refusals, not samples of a wider pattern.
+At Standard 6 it also has zero weapon aim error. This does not claim that the
+original game has no recoil: angular kick, its recovery, Agility/Still Hand and
+aiming-implant hooks remain a separate implementation slice.
+
+For a measurable nonzero test, a private gamesys fixture changes only the first
+`u16` in `SKILLPARAM` from 0 to 128 (0.703125° per missing skill level). Its pistol
+bounds per axis are ±3.515625° at Standard 1, ±2.109375° at Standard 3, and 0° at
+Standard 6. Strength 1 and 6 use the same bounds; their sampled points need not
+match because they are separate random draws. Before this layer even this
+nonzero fixture shoots straight, proving the missing launch hook.
+
+Source evidence: `darkengine/src/shock/shkplgun.cpp:627–645` (`CalcRandAngle`)
+and `shkproj.cpp:483,495–514` (global error precedes individual pellet error).
+`shkparam.cpp` labels inaccuracy outdated, consistent with the shipped zero.
+Sharpshooter is a launch-time stimulus/damage multiplier at `shkplgun.cpp:766`,
+not an accuracy bonus. Strength-based recoil remains the intentional VR
+augmentation already accepted above; this layer does not invent a Strength
+accuracy multiplier or implement the separate pending skill/trait damage work.
+
+The durable scenario is `tools/shock2-sdk/test/weapon-accuracy.e2e.test.ts`.
+It uses MedSci1, where stats start low enough to establish the requested values,
+a fixed 12m corridor wall, and an excluded setup shot that removes intervening
+glass. Each eligible weapon/stat group fires 8 measured shots; stock and custom
+fixtures are separate test cases. The custom cases require
+`SHOCK2_ACCURACY_FIXTURE=/path/to/private/nonzero-data-install`; otherwise they
+are explicitly skipped. Unit tests exercise nonzero bounds, Strength and
+Sharpshooter independence, zero-RNG behavior and one shared error before pellets
+on every run. Existing shotgun, contact-damage and stasis scenarios guard the
+stock launch paths in flat and VR.
+
+The private fixture used for evaluation is `/tmp/weapon-accuracy-fixture` on the
+capture machine. It is an APFS copy-on-write clone of `sshock2.kpf` with only
+`data/shock2.gam` overridden; other install files are symlinked. The original
+install is unchanged and game assets are not checked in. To reproduce on another
+machine, clone a personal install, replace that packed field with little-endian
+128, and supply the resulting install root to the environment variable above.
+
+
+Measured plots and [raw capture data](https://gist.github.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b)
+use six shots per illustrated group (the automated scenarios use eight). The
+animated plots reveal recorded impacts sequentially; they are data animations,
+not recordings of gameplay timing. Coincident impacts are not visually jittered.
+
+![Stock accuracy comparison](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/stock-comparison.png)
+
+![Synthetic nonzero accuracy comparison](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/synthetic-comparison.png)
+
+[AR eligibility/results](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/ar-results.png) and
+[matched runtime screenshots](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/runtime-comparison.png)
+complete the evaluation.

--- a/projects/weapon-projectile-audit.md
+++ b/projects/weapon-projectile-audit.md
@@ -230,3 +230,16 @@ This layer does not implement gun-wide accuracy, Sharpshooter/stat modifiers,
 recoil, or change the separate AI projectile launch path. Remaining impact and
 explosion lifecycles, burst cadence and accuracy/stat parity precede the planned
 Strength-based VR spring recoil augmentation.
+
+
+## Weapon accuracy follow-up
+
+The layer after pellet spread applies authored skill-dependent weapon error
+once per shell, then independent projectile spread. Stock `SKILLPARAM` authors
+zero, so fixed-aim pistol/AR comparisons must stay centered across eligible
+skills and Strength values. A labelled nonzero-data fixture verifies narrower
+pistol bounds at higher Standard Weapons skill. AR attempts below Standard 6
+remain refused. Strength and Sharpshooter are not accuracy multipliers.
+See the [accuracy evaluation](weapon-feel-workstream.md#authored-weapon-accuracy-and-the-stat-comparison)
+for source evidence, test setup and the distinction from pending recoil and
+skill/trait damage work.

--- a/shock2vr/src/mission/projectile_spray.rs
+++ b/shock2vr/src/mission/projectile_spray.rs
@@ -47,36 +47,39 @@ pub(crate) fn expand(spray: PropProjectile, launch: Effect, rng: &mut impl Rng) 
     }
     Effect::Multiple(
         (0..spray.count)
-            .map(|_| {
-                let mut pellet = launch.clone();
-                if let Effect::CreateEntity { root_transform, .. } = &mut pellet {
-                    if spray.spread != 0 {
-                        let forward = root_transform
-                            .transform_vector(vec3(0.0, 0.0, 1.0))
-                            .normalize();
-                        // Dark independently perturbs global heading and pitch by
-                        // uniform integer angles, not a uniform disk/cone. Gun roll
-                        // does not rotate this square angular distribution.
-                        let angle = i32::from(spray.spread);
-                        let radians = std::f32::consts::TAU / 65536.0;
-                        let heading = forward.x.atan2(forward.z)
-                            + rng.gen_range(-angle..=angle) as f32 * radians;
-                        let pitch = forward.y.clamp(-1.0, 1.0).asin()
-                            + rng.gen_range(-angle..=angle) as f32 * radians;
-                        let direction = vec3(
-                            heading.sin() * pitch.cos(),
-                            pitch.sin(),
-                            heading.cos() * pitch.cos(),
-                        );
-                        let origin = root_transform.transform_point(point3(0.0, 0.0, 0.0));
-                        *root_transform = Matrix4::from_translation(origin.to_vec())
-                            * Matrix4::from(get_rotation_from_forward_vector(direction));
-                    }
-                }
-                pellet
-            })
+            .map(|_| deviate(launch.clone(), spray.spread, rng))
             .collect(),
     )
+}
+
+/// Apply a single global heading/pitch error before any per-pellet spray.
+/// Dark uses the same randomization routine for weapon error and pellet spread.
+/// Zero error must not consume RNG or alter the resolved launch transform.
+pub(crate) fn deviate(mut launch: Effect, spread: u16, rng: &mut impl Rng) -> Effect {
+    if spread == 0 {
+        return launch;
+    }
+    if let Effect::CreateEntity { root_transform, .. } = &mut launch {
+        let forward = root_transform
+            .transform_vector(vec3(0.0, 0.0, 1.0))
+            .normalize();
+        // Independent global heading/pitch angles, not a circular cone; gun
+        // roll does not rotate the distribution.
+        let angle = i32::from(spread);
+        let radians = std::f32::consts::TAU / 65536.0;
+        let heading = forward.x.atan2(forward.z) + rng.gen_range(-angle..=angle) as f32 * radians;
+        let pitch =
+            forward.y.clamp(-1.0, 1.0).asin() + rng.gen_range(-angle..=angle) as f32 * radians;
+        let direction = vec3(
+            heading.sin() * pitch.cos(),
+            pitch.sin(),
+            heading.cos() * pitch.cos(),
+        );
+        let origin = root_transform.transform_point(point3(0.0, 0.0, 0.0));
+        *root_transform = Matrix4::from_translation(origin.to_vec())
+            * Matrix4::from(get_rotation_from_forward_vector(direction));
+    }
+    launch
 }
 
 #[cfg(test)]
@@ -97,6 +100,46 @@ mod tests {
                 projectile_raycast_origin: Some(point3(1.0, 3.0, 4.0)),
                 ..Default::default()
             },
+        }
+    }
+
+    #[test]
+    fn weapon_error_is_sampled_once_before_pellets_and_zero_preserves_rng() {
+        let mut rng = StdRng::seed_from_u64(81);
+        let unchanged = deviate(launch(), 0, &mut rng);
+        assert!(matches!(unchanged, Effect::CreateEntity { .. }));
+        let mut untouched_rng = StdRng::seed_from_u64(81);
+        assert_eq!(rng.r#gen::<u32>(), untouched_rng.r#gen::<u32>());
+        let aimed = deviate(launch(), 640, &mut rng);
+        let Effect::CreateEntity {
+            root_transform: expected,
+            ..
+        } = &aimed
+        else {
+            panic!("launch")
+        };
+        assert_ne!(
+            expected.transform_vector(vec3(0.0, 0.0, 1.0)),
+            vec3(0.0, 0.0, 1.0)
+        );
+        let expected = *expected;
+        let pellets = Effect::flatten(vec![expand(
+            PropProjectile {
+                count: 6,
+                spread: 0,
+            },
+            aimed,
+            &mut rng,
+        )]);
+        assert_eq!(pellets.len(), 6);
+        for pellet in pellets {
+            let Effect::CreateEntity { root_transform, .. } = pellet else {
+                panic!("pellet")
+            };
+            assert_eq!(
+                root_transform, expected,
+                "one common shell error, then independent pellet spread"
+            );
         }
     }
 

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -316,7 +316,8 @@ impl PlayerStats {
     /// Per-shot deviation from the aim direction for a weapon fired at
     /// `skill_level`, in degrees: the gamesys inaccuracy angle
     /// (`SkillParams::inaccuracy_degrees`) scaled by how far the skill falls
-    /// short of [`SKILL_CAP`]. A maxed skill shoots dead straight.
+    /// short of [`SKILL_CAP`]. A maxed skill adds no weapon aim error; authored
+    /// pellet spread and recoil are separate. Stock gamesys inaccuracy is zero.
     pub fn shot_deviation_degrees(inaccuracy_degrees: f32, skill_level: i32) -> f32 {
         inaccuracy_degrees * (SKILL_CAP - skill_level).max(0) as f32
     }

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -174,6 +174,22 @@ fn weapon_skill_level(world: &World, entity_id: EntityId) -> i32 {
     crate::scripts::script_util::player_skill_level(world, skill)
 }
 
+/// Dark CalcRandAngle: authored error per missing weapon-skill level. Stock
+/// SKILLPARAM sets this to zero. Strength and Sharpshooter do not enter this
+/// calculation (Sharpshooter is a stimulus multiplier in the original).
+fn weapon_inaccuracy(world: &World, entity_id: EntityId) -> u16 {
+    let per_level = world
+        .borrow::<UniqueView<GlobalSkillParams>>()
+        .ok()
+        .and_then(|params| params.0.as_ref().map(|p| p.inaccuracy_degrees))
+        .unwrap_or(0.0);
+    let degrees = crate::player_stats::PlayerStats::shot_deviation_degrees(
+        per_level,
+        weapon_skill_level(world, entity_id),
+    );
+    (degrees * (65536.0 / 360.0)) as u16
+}
+
 /// The chance, 0..1, that the shot about to be fired breaks the gun. Zero at
 /// or above the reliability's break threshold: a gun in good condition cannot
 /// break at all. Below the threshold the authored min/max percentages are
@@ -774,11 +790,13 @@ pub(super) fn create_projectile(
         .ok()
         .and_then(|sprays| sprays.0.get(&projectile_template_id).copied())
         .unwrap_or_default();
-    crate::mission::projectile_spray::expand(
-        spray,
+    let mut rng = rand::thread_rng();
+    let launch = crate::mission::projectile_spray::deviate(
         create_projectile_launch(world, entity_id, projectile_template_id, modifiers),
-        &mut rand::thread_rng(),
-    )
+        weapon_inaccuracy(world, entity_id),
+        &mut rng,
+    );
+    crate::mission::projectile_spray::expand(spray, launch, &mut rng)
 }
 
 fn create_projectile_launch(
@@ -851,6 +869,56 @@ fn create_projectile_launch(
 #[cfg(test)]
 mod tests {
     use cgmath::Rotation;
+
+    #[test]
+    fn authored_accuracy_uses_weapon_skill_not_strength_or_sharpshooter() {
+        use crate::{mission::mission_core::GlobalSkillParams, quest_info::QuestInfo};
+        use shipyard::UniqueViewMut;
+        let mut world = World::new();
+        let gun = world.add_entity(PropWeaponType(0));
+        world.add_unique(QuestInfo::new());
+        world.add_unique(GlobalSkillParams(Some(dark::gamesys::SkillParams {
+            inaccuracy_degrees: 0.703125, // 128 Dark angle units; synthetic fixture
+            weapon_break_factor: 0.0,
+            research_factor: 0.0,
+            damage_modifier: 0.0,
+            organ_damage: 0.0,
+        })));
+        for strength in [1, 6] {
+            for (skill, expected) in [(1, 640), (3, 384), (6, 0)] {
+                {
+                    let mut quests = world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    let stats = quests.player_stats_mut();
+                    stats.strength = strength;
+                    stats.skills.standard_weapons = skill;
+                }
+                assert_eq!(weapon_inaccuracy(&world, gun), expected);
+                world
+                    .borrow::<UniqueViewMut<QuestInfo>>()
+                    .unwrap()
+                    .player_stats_mut()
+                    .add_os_trait(5);
+                assert_eq!(weapon_inaccuracy(&world, gun), expected);
+            }
+        }
+        // The stock record explicitly disables random weapon aim error, even
+        // at minimum skill. This must not invent a cone for the shipping game.
+        world
+            .borrow::<UniqueViewMut<GlobalSkillParams>>()
+            .unwrap()
+            .0
+            .as_mut()
+            .unwrap()
+            .inaccuracy_degrees = 0.0;
+        world
+            .borrow::<UniqueViewMut<QuestInfo>>()
+            .unwrap()
+            .player_stats_mut()
+            .skills
+            .standard_weapons = 1;
+        assert_eq!(weapon_inaccuracy(&world, gun), 0);
+    }
+
     #[test]
     fn flash_cone_points_out_of_held_and_world_barrels() {
         for (name, axis) in [

--- a/tools/shock2-sdk/test/weapon-accuracy.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-accuracy.e2e.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GameServer } from "../src/index.js";
+import { ammoOf, fireOnce } from "./helpers/weapon.js";
+
+const enabled = process.env.SHOCK2_E2E === "1";
+// Optional private data fixture: only SKILLPARAM's first u16 is changed from
+// stock0 to128 (0.703125 degrees per missing skill). Never modify shipped assets.
+const fixtureRoot = process.env.SHOCK2_ACCURACY_FIXTURE;
+for (const synthetic of [false, true])
+  for (const strength of [1, 6]) {
+    test(
+      `${synthetic ? "synthetic nonzero data" : "stock data"} accuracy at Strength ${strength}`,
+      {
+        skip: !enabled || (synthetic && !fixtureRoot),
+        timeout: 240_000,
+      },
+      async () => {
+        const originalRoot = process.env.DARK_ASSET_PATH;
+        try {
+          if (synthetic) process.env.DARK_ASSET_PATH = fixtureRoot;
+          await using game = await GameServer.launch({
+            mission: "medsci1.mis",
+          });
+          await game.step({ frames: 5 });
+          await game.player.setStats({ strength });
+          await game.player.teleport({ x: -34.96759, y: -4.7559557, z: 20.9 });
+          await game.input.set("head.look", [-90, 0]);
+          await game.step({ frames: 3 });
+          await game.player.spawnItem("Pistol");
+          await game.player.spawnItem("Assault Rifle");
+          // The first ray breaks a glass pane in this corridor. Exclude that
+          // setup shot so every measured bullet reaches the same 12m wall.
+          await game.player.setStats({ skills: { standard_weapons: 1 } });
+          await game.input.trigger("EquipPistol");
+          await game.step({ frames: 3 });
+          await fireOnce(game);
+          await game.step({ frames: 20 });
+          for (const skill of [1, 3, 6]) {
+            const stats = await game.player.setStats({
+              skills: { standard_weapons: skill },
+            });
+            assert.equal(stats.strength, strength);
+            assert.equal(stats.skills.standard_weapons, skill);
+            for (const weapon of ["pistol", "ar"]) {
+              await game.input.trigger(
+                weapon === "pistol" ? "EquipPistol" : "EquipAssaultRifle",
+              );
+              await game.step({ frames: 3 });
+              const id = (await game.info()).player.wielded_entity_id;
+              assert.ok(id);
+              const positions: number[][] = [];
+              const refused = weapon === "ar" && skill < 6;
+              for (let shot = 0; shot < (refused ? 1 : 8); shot++) {
+                if (ammoOf(await game.entities.detail(id)) < 3) {
+                  await game.player.spawnItem(-31);
+                  await game.input.trigger("Reload");
+                  await game.step({ frames: 180 });
+                }
+                const ammo = ammoOf(await game.entities.detail(id));
+                const prior = new Set(
+                  (await game.entities.byTemplate(-3544)).map((e) => e.id),
+                );
+                await fireOnce(game);
+                await game.step({ frames: 20 });
+                const hits = (await game.entities.byTemplate(-3544)).filter(
+                  (e) => !prior.has(e.id),
+                );
+                const spent: number =
+                  ammo - ammoOf(await game.entities.detail(id));
+                if (refused) {
+                  assert.equal(
+                    spent,
+                    0,
+                    "under-skilled AR attempts are refusals, not accuracy samples",
+                  );
+                  assert.equal(hits.length, 0);
+                  assert.ok(
+                    (await game.entities.detail(id)).properties.some(
+                      (p) => p.name === "WeaponSkillNotice",
+                    ),
+                    "the AR must report its unmet skill requirement",
+                  );
+                } else {
+                  assert.equal(spent, 1);
+                  assert.equal(
+                    hits.length,
+                    1,
+                    "one actual bullet must reach the test wall",
+                  );
+                  assert.ok(
+                    Math.abs(hits[0]!.position[2] - 32.9) < 0.02,
+                    "the wall must receive the shot",
+                  );
+                  positions.push(hits[0]!.position);
+                }
+              }
+              if (refused) continue;
+              const width =
+                Math.max(...positions.map((p) => p[0]!)) -
+                Math.min(...positions.map((p) => p[0]!));
+              const height =
+                Math.max(...positions.map((p) => p[1]!)) -
+                Math.min(...positions.map((p) => p[1]!));
+              if (!synthetic || skill === 6) {
+                assert.ok(
+                  width < 0.002 && height < 0.002,
+                  "stock/max-skill shots add no random aim error",
+                );
+              } else {
+                assert.ok(
+                  width > 0.01 && height > 0.01,
+                  "nonzero data must produce independent two-axis spread",
+                );
+                const bound =
+                  2 *
+                    12.1 *
+                    Math.tan((0.703125 * (6 - skill) * Math.PI) / 180) +
+                  0.02;
+                assert.ok(
+                  width <= bound && height <= bound,
+                  "skill controls the authored angular bounds",
+                );
+              }
+            }
+          }
+        } finally {
+          if (originalRoot === undefined) delete process.env.DARK_ASSET_PATH;
+          else process.env.DARK_ASSET_PATH = originalRoot;
+        }
+      },
+    );
+  }


### PR DESCRIPTION
Player shots now apply the authored weapon-skill aim error once per shell, before independent shotgun pellet spread. The calculation reuses the existing effective-skill and deviation helpers, and flat/VR launches share the same heading/pitch randomization. Zero error preserves both the launch transform and RNG state.

The shipped gamesys explicitly sets this inaccuracy parameter to zero. Consequently, fixed-aim pistol shots stay centered at Standard Weapons 1/3/6 and Strength 1/6. The AR requires Standard 6; lower-skill attempts are refusals, not wider patterns. Strength does not enter the accuracy formula, and Sharpshooter affects damage rather than accuracy. This does not claim the original game has no recoil: recoil and its stat hooks remain a separate workstream.

A clearly labelled private data fixture changes only SKILLPARAM.inaccuracy to 128 Dark angle units (0.703125 degrees per missing skill level). It verifies pistol bounds of ±3.515625 degrees at skill 1,±2.109375 at skill 3, and zero at skill 6. Both Strength values obey the same bounds. Before this change the fixture still fires straight, exposing the missing hook. Original game assets remain unchanged and are not included in the PR.

Stacked above #1468. Source evidence and reproduction details are in `projects/weapon-feel-workstream.md`, under "Authored weapon accuracy and the stat comparison".

Validation:

- Four actual-shot matrices pass: stock/synthetic data × Strength 1/6, with pistol and AR at Standard 1/3/6, eight shots per eligible group and explicit under-skilled AR refusals.
- Both synthetic matrix tests fail against the parent, then pass with the hook wired.
- Seventeen existing shotgun/contact-damage/stasis runtime tests pass, including flat/VR shotgun firing.
- 1,628 gameplay library tests pass (2 ignored), plus 63 fast SDK tests.
- Warning-denied checks pass for gameplay, desktop and debug runtimes (Dark dependency included).
- Independent code and duplication reviews found no actionable issues.


Measured impact plots use six shots per illustrated group. Animated plots reveal
recorded points sequentially; they do not depict gameplay timing. Coincident
impacts are not jittered. Recoil is excluded from this fixed-aim measurement.

![Stock accuracy](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/stock-comparison.png)

![Synthetic nonzero accuracy](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/synthetic-comparison.gif)

![Synthetic comparison still](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/synthetic-comparison.png)

![AR eligibility and results](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/ar-results.png)

![Matched actual runtime screenshots](https://gist.githubusercontent.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b/raw/runtime-comparison.png)

[Raw data and SVG plots](https://gist.github.com/tommy-xr/8adecab028e128f1e6490a24fd241c0b)


CI note: the first two Linux jobs failed before compilation during `apt-get
update`, due to a Chrome package-repository `Hash Sum mismatch`. The standalone
job was retried and hit the same repository checksum error; GitHub would not
rerun the matrix job while its workflow was
still active. Local build/test results above are green.
