### PR TITLE
feat(mfd): inspect carried items without using them

### DIFF
--- a/dark/src/importers/strings_importer.rs
+++ b/dark/src/importers/strings_importer.rs
@@ -116,6 +116,22 @@ pub fn resolve_symbolic_name(sym_name: &str, strings: &HashMap<String, String>) 
     lookup(strings, &sym_name.replace(' ', "_"))
 }
 
+/// Ordinary items reuse their ObjName key in OBJLOOKS unless ObjLookS
+/// overrides it. A short display name is never a description fallback.
+pub fn resolve_object_description(
+    look: Option<&str>,
+    name: Option<&str>,
+    sym_name: Option<&str>,
+    strings: &HashMap<String, String>,
+) -> Option<String> {
+    look.map(|raw| resolve_localized_property_string(raw, strings))
+        .filter(|text| !text.trim().is_empty())
+        .or_else(|| name.and_then(|raw| lookup(strings, split_object_string(raw).0)))
+        .filter(|text| !text.trim().is_empty())
+        .or_else(|| sym_name.and_then(|name| resolve_symbolic_name(name, strings)))
+        .filter(|text| !text.trim().is_empty())
+}
+
 /// Resolve a gun fire-setting string (`P$Sett1`/`P$SHead2`/...) against its
 /// `SETT*`/`SHEAD*` table.
 ///
@@ -139,6 +155,51 @@ pub static STRINGS_IMPORTER: Lazy<AssetImporter<Vec<String>, HashMap<String, Str
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn empty_description_entries_allow_symbolic_fallback() {
+        let blank = std::collections::HashMap::from([
+            ("empty".into(), " ".into()),
+            ("symbol".into(), "Description".into()),
+        ]);
+        assert_eq!(
+            super::resolve_object_description(None, Some("empty"), Some("symbol"), &blank)
+                .as_deref(),
+            Some("Description")
+        );
+        assert_eq!(
+            super::resolve_object_description(None, Some("empty"), None, &blank),
+            None
+        );
+    }
+    #[test]
+    fn description_uses_name_key_but_not_name_fallback() {
+        let strings =
+            std::collections::HashMap::from([("med_patch".into(), "Medical description".into())]);
+        assert_eq!(
+            super::resolve_object_description(
+                None,
+                Some("Med_Patch: \"A medical hypo\""),
+                None,
+                &strings
+            )
+            .as_deref(),
+            Some("Medical description")
+        );
+        assert_eq!(
+            super::resolve_object_description(None, Some("missing: \"A name\""), None, &strings),
+            None
+        );
+        assert_eq!(
+            super::resolve_object_description(
+                Some("custom: \"An override\""),
+                Some("Med_Patch"),
+                None,
+                &strings
+            )
+            .as_deref(),
+            Some("An override")
+        );
+    }
     use std::collections::HashMap;
 
     use super::{parse_strings, resolve_gun_setting_string, resolve_localized_property_string};

--- a/projects/astra-vr-mfd-controls.md
+++ b/projects/astra-vr-mfd-controls.md
@@ -24,6 +24,21 @@ Retail behavior below is confirmed by the [System Shock 2 manual, PDF page 5](ht
 
 ## Review cases
 
+### Item information control
+
+The `?` utility enters a selection mode that consumes click/grab edges before
+inventory use, wield, drop or Frob. Select an inventory item, cursor item, or
+held-item arm readout to open its localized description in the right MFD.
+`?` again cancels selection; CLOSE dismisses the reader. Long descriptions
+have previous/next pages. Closing the cyber interface resets inspection.
+Ordinary items use their object-name key in OBJLOOKS; an authored look-string
+override takes priority. Missing entries show an explicit fallback, never the
+short item name masquerading as a description.
+
+Utility buttons occupy a dedicated row below the reserved right MFD slot and
+above the ammo readout. Their drawing, input and debug rectangles are shared
+in canvas pixels; these are new layout rectangles, not guessed BIN indices.
+
 Two different guns; gun plus psi amp; swapped hands; one support grip; no weapon; dropping/swapping a weapon between drawing and clicking its control. Research active, chemical-paused and completed after the item is gone. Inspect a hypo without consumption, a gun without firing, and an ordinary object without research data. Use the same rendered/hit-test rectangles in flat and VR, and retain press-edge protection when opening or switching panels.
 
 A weapon-pinned ammo display remains a separate optional grip-editor placement mode. The psi amp keeps its authored forearm and needs its own mount; glove-mounted wrist plates deliberately skip it.

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -260,6 +260,7 @@ pub struct FlatUiHost {
     /// Read-only snapshots in physical left/right order. A support hand owns
     /// no item; flat wielding is mapped to its visible right hand by the caller.
     hand_items: [Option<CursorItem>; 2],
+    pub(crate) utilities: super::mfd_utilities::MfdUtilities,
     /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
@@ -303,6 +304,7 @@ impl FlatUiHost {
             name_strip: None,
             shoulder_weapons: [None; 2],
             hand_items: [None, None],
+            utilities: Default::default(),
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
@@ -624,6 +626,7 @@ impl FlatUiHost {
     /// entity, whose `GuiScript` already emits `SetUI` every frame - the
     /// strip just stashes and re-anchors it.
     pub fn set_strip(&mut self, entity: Option<EntityId>) {
+        self.utilities = Default::default();
         // The readout belongs to the bar: leaving use mode must not leave a
         // stale name behind for `/v1/ui` (the mission's per-frame update runs
         // before the effect that unbinds the strip).
@@ -872,6 +875,9 @@ impl FlatUiHost {
         // bare-view click: throw a held item, else close the panel. In VR the
         // canvas is the panel, so an off-panel press belongs to the world hand.
         let Some(canvas_pos) = canvas_pos else {
+            if self.utilities.is_inspecting() {
+                return (Vec::new(), Vec::new());
+            }
             if pressed_edge && pointer.bare_view == BareViewPress::Exit {
                 if let Some(held) = self.cursor_item.take() {
                     return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
@@ -887,6 +893,23 @@ impl FlatUiHost {
             .and_then(|s| s.size_px)
             .map(strip_canvas_rect);
         let over_strip = strip_rect.map(|r| r.contains(canvas_pos)).unwrap_or(false);
+        if let Some(rect) = strip_rect {
+            let hand_item = hand_readout_rects(rect)
+                .iter()
+                .position(|r| r.contains(canvas_pos))
+                .and_then(|slot| self.hand_items[slot].as_ref().map(|item| item.entity));
+            let candidate = self
+                .held_entity()
+                .or(hand_item)
+                .or_else(|| self.strip_item_at(canvas_pos));
+            if self
+                .utilities
+                .update(canvas_pos, pressed_edge || grab_edge, candidate)
+            {
+                self.hover_close = false;
+                return (Vec::new(), Vec::new());
+            }
+        }
         if strip_rect.is_some_and(|r| hand_readout_rects(r).iter().any(|r| r.contains(canvas_pos)))
         {
             // Hand readouts never equip, use or throw an item.
@@ -1114,6 +1137,7 @@ impl FlatUiHost {
             readouts::emit_use_mode(&mut canvas, readouts);
         }
         if let (Some(strip), Some(rect)) = (self.strip.as_ref(), strip_rect) {
+            self.utilities.draw(&mut canvas);
             // Reverse only the source U interval: the mirrored paperdoll is
             // background art, never mirrored text, item icons, or input.
             let arm = mirrored_arm_rect(rect);
@@ -1303,6 +1327,16 @@ impl FlatUiHost {
             (Some(strip), Some(rect)) => {
                 let mut elements =
                     self.elements_for(world, &strip.components, rect, self.held_entity());
+                elements.extend(
+                    self.utilities
+                        .debug_elements()
+                        .into_iter()
+                        .map(|mut element| {
+                            let [x, y, w, h] = element.rect;
+                            element.screen_rect = self.to_screen_rect(Rect::new(x, y, w, h));
+                            element
+                        }),
+                );
                 elements.extend(self.shoulder_badges().into_iter().map(
                     |(entity, r, letter, label)| crate::game_scene::DebugUiElement {
                         kind: "text".to_owned(),
@@ -2360,7 +2394,13 @@ mod tests {
             );
         }
         let elements = host.strip_debug_elements(&world);
-        assert_eq!(elements.iter().filter(|e| e.kind == "button").count(), 2);
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|e| e.kind == "button" && e.entity_id.is_some())
+                .count(),
+            2
+        );
         assert_eq!(
             elements
                 .iter()
@@ -2432,6 +2472,30 @@ mod tests {
             None,
             "the decorative arm is not another backpack cell"
         );
+    }
+
+    #[test]
+    fn inspect_click_does_not_lift_wield_or_frob_an_inventory_item() {
+        let (world, mut host, item, _) = drag_world();
+        assert!(press_edge(&mut host, &world, (468.0, 395.0)).is_empty());
+        assert!(host.utilities.is_inspecting());
+        let point = host
+            .strip_debug_elements(&world)
+            .into_iter()
+            .find(|e| e.entity_id == Some(item.inner() as i32))
+            .unwrap()
+            .rect;
+        assert!(
+            press_edge(
+                &mut host,
+                &world,
+                (point[0] + point[2] / 2.0, point[1] + point[3] / 2.0)
+            )
+            .is_empty()
+        );
+        assert!(!host.utilities.is_inspecting());
+        assert_eq!(host.held_entity(), None);
+        assert!(world.borrow::<EntitiesView>().unwrap().is_alive(item));
     }
 
     #[test]

--- a/shock2vr/src/mission/mfd_utilities.rs
+++ b/shock2vr/src/mission/mfd_utilities.rs
@@ -1,0 +1,265 @@
+//! Read-only cyber-interface utility panels. Input and art share canvas rects.
+
+use cgmath::Vector2;
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{EntitiesView, EntityId, Get, View, World};
+
+use crate::{
+    scripts::gui::wrap_text,
+    ui::{HAlign, Rect, UiCanvas, VAlign},
+};
+
+const PANEL: Rect = Rect::new(450.0, 124.0, 188.0, 248.0);
+const FONT: &str = "mainfont.fon";
+const PAGE_LINES: usize = 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Control {
+    Inspect,
+    Close,
+    Previous,
+    Next,
+}
+
+#[derive(Default)]
+pub(crate) struct MfdUtilities {
+    inspecting: bool,
+    selected: Option<EntityId>,
+    title: String,
+    lines: Vec<String>,
+    page: usize,
+}
+
+impl MfdUtilities {
+    pub(crate) fn is_inspecting(&self) -> bool {
+        self.inspecting
+    }
+    fn controls(&self) -> Vec<(Control, Rect, &'static str)> {
+        // Dedicated utility row below the reserved right MFD slot, clear of
+        // the bottom ammo readout. New utilities fill the row incrementally.
+        let mut controls = vec![(Control::Inspect, Rect::new(450.0, 382.0, 36.0, 26.0), "?")];
+        if self.inspecting || self.selected.is_some() {
+            controls.push((Control::Close, Rect::new(570.0, 346.0, 60.0, 20.0), "CLOSE"));
+            if self.page > 0 {
+                controls.push((Control::Previous, Rect::new(458.0, 346.0, 28.0, 20.0), "<"));
+            }
+            if (self.page + 1) * PAGE_LINES < self.lines.len() {
+                controls.push((Control::Next, Rect::new(490.0, 346.0, 28.0, 20.0), ">"));
+            }
+        }
+        controls
+    }
+
+    /// Returns whether this pointer belongs to utilities. Inspect mode owns
+    /// selection edges everywhere, so a rejected selection cannot use an item.
+    pub(crate) fn update(
+        &mut self,
+        point: Vector2<f32>,
+        pressed: bool,
+        candidate: Option<EntityId>,
+    ) -> bool {
+        if let Some((control, _, _)) = self
+            .controls()
+            .into_iter()
+            .find(|(_, rect, _)| rect.contains(point))
+        {
+            if pressed {
+                match control {
+                    Control::Inspect => {
+                        if self.inspecting {
+                            *self = Self::default();
+                        } else {
+                            self.inspecting = true;
+                            self.selected = None;
+                            self.set_content("Item information".into(), "Select an inventory or held item to inspect. Select ? again to cancel.".into());
+                        }
+                    }
+                    Control::Close => *self = Self::default(),
+                    Control::Previous => self.page = self.page.saturating_sub(1),
+                    Control::Next => self.page += 1,
+                }
+            }
+            return true;
+        }
+        if self.inspecting {
+            if pressed && let Some(entity) = candidate {
+                self.selected = Some(entity);
+                self.inspecting = false;
+                self.page = 0;
+            }
+            return true;
+        }
+        self.selected.is_some() && PANEL.contains(point)
+    }
+
+    fn set_content(&mut self, title: String, body: String) {
+        let lines = wrap_text(&body, 23);
+        if self.title != title || self.lines != lines {
+            self.title = title;
+            self.lines = lines;
+            self.page = self
+                .page
+                .min(self.lines.len().saturating_sub(1) / PAGE_LINES);
+        }
+    }
+
+    pub(crate) fn refresh(&mut self, world: &World, assets: &mut AssetCache) {
+        let Some(entity) = self.selected else {
+            return;
+        };
+        if !world
+            .borrow::<EntitiesView>()
+            .is_ok_and(|entities| entities.is_alive(entity))
+        {
+            *self = Self::default();
+            return;
+        }
+        let title = crate::hud::resolve_item_name(assets, world, entity)
+            .unwrap_or_else(|| "Item information".into());
+        let strings = assets.get(&dark::importers::STRINGS_IMPORTER, "objlooks.str");
+        self.set_content(title, item_description(world, entity, &strings));
+    }
+
+    pub(crate) fn draw(&self, canvas: &mut UiCanvas) {
+        if self.inspecting || self.selected.is_some() {
+            canvas.image(PANEL, "IFBTN00.PCX");
+            canvas.text_native_fit(
+                Rect::new(458.0, 130.0, 172.0, 16.0),
+                &self.title,
+                FONT,
+                HAlign::Left,
+                VAlign::Middle,
+            );
+            for (rect, line) in self.visible_lines() {
+                canvas.text_native_fit(rect, line, FONT, HAlign::Left, VAlign::Middle);
+            }
+        }
+        for (_, rect, label) in self.controls() {
+            canvas.image(rect, "IFBTN00.PCX");
+            canvas.text_native_fit(rect, label, FONT, HAlign::Center, VAlign::Middle);
+        }
+    }
+
+    fn visible_lines(&self) -> impl Iterator<Item = (Rect, &String)> {
+        self.lines
+            .iter()
+            .skip(self.page * PAGE_LINES)
+            .take(PAGE_LINES)
+            .enumerate()
+            .map(|(i, line)| (Rect::new(460.0, 152.0 + i as f32 * 11.0, 168.0, 11.0), line))
+    }
+
+    pub(crate) fn debug_elements(&self) -> Vec<crate::game_scene::DebugUiElement> {
+        self.controls()
+            .into_iter()
+            .map(|(control, r, label)| crate::game_scene::DebugUiElement {
+                kind: "button".into(),
+                texture: Some("IFBTN00.PCX".into()),
+                text: Some(label.into()),
+                label: Some(
+                    match control {
+                        Control::Inspect => "inspect",
+                        Control::Close => "utility_close",
+                        Control::Previous => "utility_previous",
+                        Control::Next => "utility_next",
+                    }
+                    .into(),
+                ),
+                entity_id: None,
+                rect: [r.x, r.y, r.w, r.h],
+                screen_rect: [r.x, r.y, r.w, r.h],
+            })
+            .chain(self.visible_lines().map(|(rect, line)| {
+                let r = [rect.x, rect.y, rect.w, rect.h];
+                crate::game_scene::DebugUiElement {
+                    kind: "text".into(),
+                    texture: None,
+                    text: Some(line.clone()),
+                    label: Some("utility_text".into()),
+                    entity_id: self.selected.map(|e| e.inner() as i32),
+                    rect: r,
+                    screen_rect: r,
+                }
+            }))
+            .collect()
+    }
+}
+
+fn item_description(
+    world: &World,
+    entity: EntityId,
+    strings: &std::collections::HashMap<String, String>,
+) -> String {
+    use dark::properties::{PropObjLookString, PropObjName, PropSymName};
+    let (looks, names, symbols) = world
+        .borrow::<(
+            View<PropObjLookString>,
+            View<PropObjName>,
+            View<PropSymName>,
+        )>()
+        .unwrap();
+    dark::importers::resolve_object_description(
+        looks.get(entity).ok().map(|p| p.0.as_str()),
+        names.get(entity).ok().map(|p| p.0.as_str()),
+        symbols.get(entity).ok().map(|p| p.0.as_str()),
+        strings,
+    )
+    .unwrap_or_else(|| "No description available.".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::vec2;
+
+    #[test]
+    fn pages_cover_every_line_and_clamp_when_content_shrinks() {
+        let mut ui = MfdUtilities::default();
+        ui.update(vec2(468.0, 395.0), true, None);
+        ui.set_content(
+            "Long description".into(),
+            (0..40).map(|i| format!("Line {i}\n")).collect(),
+        );
+        let all = ui.lines.clone();
+        let mut seen = Vec::new();
+        loop {
+            seen.extend(ui.visible_lines().map(|(_, line)| line.clone()));
+            let Some((_, rect, _)) = ui
+                .controls()
+                .into_iter()
+                .find(|(control, _, _)| *control == Control::Next)
+            else {
+                break;
+            };
+            ui.update(rect.center(), true, None);
+        }
+        assert_eq!(seen, all);
+        assert!(ui.page > 0);
+        ui.set_content("Short".into(), "Only one line".into());
+        assert_eq!(ui.page, 0);
+        assert_eq!(ui.visible_lines().count(), 1);
+    }
+
+    #[test]
+    fn inspection_selects_without_mutating_an_item_and_cancels_cleanly() {
+        let mut world = World::new();
+        let hypo = world.add_entity(dark::properties::PropObjLookString(
+            "hypo: \"Restores health.\"".into(),
+        ));
+        let mut ui = MfdUtilities::default();
+        assert!(ui.update(vec2(468.0, 395.0), true, None));
+        assert!(ui.inspecting);
+        assert!(ui.update(vec2(10.0, 40.0), false, Some(hypo)));
+        assert_eq!(ui.selected, None);
+        assert!(ui.update(vec2(10.0, 40.0), true, Some(hypo)));
+        assert_eq!(ui.selected, Some(hypo));
+        assert_eq!(
+            item_description(&world, hypo, &Default::default()),
+            "Restores health."
+        );
+        assert!(world.borrow::<EntitiesView>().unwrap().is_alive(hypo));
+        assert!(ui.update(vec2(600.0, 355.0), true, None));
+        assert_eq!(ui.selected, None);
+        assert!(!ui.inspecting);
+    }
+}

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4081,6 +4081,12 @@ impl MissionCore {
             input_context.left_hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD,
             input_context.right_hand.trigger_value > crate::ui::VR_TRIGGER_THRESHOLD,
         ];
+        if self.flat_ui.utilities.is_inspecting() {
+            // Selection owns both triggers even off-panel. Upgrade an ongoing
+            // pull to safe and retain that decision until physical release,
+            // so cancelling inspection cannot consume a held hypo mid-pull.
+            self.vr_trigger_safe_latch = [Some(true); 2];
+        }
         let mut trigger_safe = latch_trigger_safe(
             &mut self.vr_trigger_safe_latch,
             pressed,
@@ -4719,6 +4725,7 @@ impl MissionCore {
             .map(|inventory| super::shoulder_backpack::weapons(&self.world, inventory))
             .unwrap_or([None; 2]);
         self.flat_ui.set_shoulder_weapons(shoulder_weapons);
+        self.flat_ui.utilities.refresh(&self.world, asset_cache);
         // Resolve physical ownership through the interaction boundary: flat's
         // internal left slot represents the visibly right-handed viewmodel.
         let held = self.interaction.held_entities();

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -6,6 +6,7 @@ mod body_inventory;
 pub mod entity_populator;
 pub mod flat_ui_host;
 mod holsters;
+mod mfd_utilities;
 pub mod mission_core;
 pub mod pathfinding_debug;
 pub mod pathfinding_test;

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -87,7 +87,7 @@ pub enum MediaGuiMsg {
 /// Greedy word-wrap that honors explicit `\n` paragraph breaks. A single word
 /// longer than `max_chars` stays on its own (over-long) line rather than being
 /// split mid-token, so codes like "45100" are never broken.
-pub(super) fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
+pub(crate) fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
     let mut lines = Vec::new();
     for paragraph in text.split('\n') {
         if paragraph.trim().is_empty() {

--- a/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
+++ b/tools/shock2-sdk/test/mfd-utilities.e2e.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { aimVrHandAt, aimVrHandAtCanvas } from "./helpers/vr-hand.js";
+
+for (const vr of [false, true]) {
+  test(`MFD item information is read-only and cancellable (${vr ? "VR" : "flat"})`, {
+    skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
+  }, async () => {
+    await using game = await GameServer.launch({mission: "debug_interactions", debugFlags: vr ? ["--vr"] : []});
+    await game.step({frames: 30});
+    const hypo = await game.player.spawnItem(-52);
+    await game.input.trigger("ToggleUseMode");
+    await game.step({frames: 5});
+    const output = process.env.ASTRA_MFD_CAPTURE;
+    const capture = async (name: string) => {
+      if (!output) return;
+      await mkdir(output, {recursive: true});
+      const path = `${output}/${vr ? "vr" : "flat"}-${name}`;
+      await game.screenshot(`${path}.png`, 1600);
+      await writeFile(`${path}.json`, JSON.stringify({ui: await game.ui.state(), inventory: await game.player.inventory(), info: await game.info()}, null, 2));
+    };
+    const elements = async () => (await game.ui.state()).strip!.elements;
+    const control = async (label: string) => {
+      const element = (await elements()).find(e => e.label === label);
+      assert.ok(element, `${label} exists`);
+      return element;
+    };
+    // Reuse the common VR canvas aim; flat screen_rect follows the existing loot tests.
+    const click = async (element: UiElement) => {
+      if (vr) {
+        const ui = await game.ui.state();
+        const [x,y,w,h] = element.rect;
+        await aimVrHandAtCanvas(game, ui.panel_pose!, [x+w/2,y+h/2], {hand:"right",squeeze:0});
+        await game.input.set("right_hand.trigger",1);
+      } else {
+        const [x,y,w,h] = element.screen_rect;
+        await game.input.set("pointer.position",[x+w/2,y+h/2]);
+        await game.step({frames:2});
+        await game.input.set("pointer.pressed",1);
+      }
+      await game.step({frames:2});
+      await game.input.set(vr ? "right_hand.trigger" : "pointer.pressed",0);
+      await game.step({frames:2});
+    };
+    const before = await game.player.inventory();
+    const cursor = (await game.ui.state()).cursor;
+    await capture("idle");
+    await click(await control("inspect"));
+    await capture("select");
+    await click(await control("inspect"));
+    assert.equal((await elements()).some(e => e.label === "utility_close"),false,"second ? cancels selection");
+    await click(await control("inspect"));
+    const item = (await elements()).find(e => e.entity_id === hypo.entity_id && e.kind === "button");
+    assert.ok(item);
+    await click(item);
+    const text = (await elements()).filter(e => e.label === "utility_text");
+    assert.ok(text.length > 0);
+    assert.doesNotMatch(text.map(e=>e.text).join(" "), /No description available/i, "authored hypo description resolves");
+    assert.ok(text.every(e => e.entity_id === hypo.entity_id),"description belongs to selected hypo");
+    await capture("description");
+    const next = (await elements()).find(e => e.label === "utility_next");
+    assert.ok(next, "medical hypo description exercises pagination");
+    if (next) {
+      const first = text.map(e=>e.text);
+      await click(next);
+      assert.notDeepEqual((await elements()).filter(e=>e.label === "utility_text").map(e=>e.text),first);
+      await capture("page-2");
+      await click(await control("utility_previous"));
+      assert.deepEqual((await elements()).filter(e=>e.label === "utility_text").map(e=>e.text),first);
+    }
+    await click(await control("utility_close"));
+    assert.equal((await elements()).some(e=>e.label === "utility_close"),false);
+    assert.deepEqual(await game.player.inventory(),before,"inspection does not consume or move hypo");
+    assert.deepEqual((await game.ui.state()).cursor,cursor,"inspection leaves cursor item unchanged");
+    await capture("closed");
+  });
+}
+
+
+test("VR inspection reserves an off-panel held hypo trigger through cancel until release", {
+  skip: process.env.SHOCK2_E2E !== "1", timeout: 180_000,
+}, async () => {
+  await using game = await GameServer.launch({mission:"debug_interactions",debugFlags:["--vr"]});
+  await game.step({frames:30});
+  const hypo = (await game.entities.list()).entities.find(e=>e.template_id === -52);
+  assert.ok(hypo);
+  await aimVrHandAt(game,hypo.position,.2,1,0,{hand:"right"});
+  assert.equal((await game.info()).player.right_hand_entity_id,hypo.id);
+  await game.input.set("right_hand.position",[.8,1,-.2]);
+  await game.input.set("right_hand.rotation",[0,0,0,1]);
+  await game.input.set("head.rotation",[0,0,0,1]);
+  await game.input.trigger("ToggleUseMode");
+  await game.step({frames:5});
+  const stack = (await game.entities.detail(hypo.id)).properties.find(p=>p.name === "StackCount");
+  assert.ok(stack);
+  const health = (await game.info()).player.hit_points;
+  const inspect = (await game.ui.state()).strip!.elements.find(e=>e.label === "inspect")!;
+  const [x,y,w,h] = inspect.rect;
+  await aimVrHandAtCanvas(game,(await game.ui.state()).panel_pose!,[x+w/2,y+h/2],{hand:"left",squeeze:0});
+  await game.input.set("left_hand.trigger",1);
+  await game.step({frames:2});
+  await game.input.set("left_hand.trigger",0);
+  await game.step({frames:2});
+  assert.ok((await game.ui.state()).strip!.elements.some(e=>e.label === "utility_close"));
+  // The holding hand points outside every panel. Its trigger must still be reserved.
+  await game.input.set("right_hand.rotation",[0,1,0,0]);
+  await game.input.set("right_hand.trigger",1);
+  await game.step({frames:5});
+  assert.equal((await game.info()).player.right_hand_entity_id,hypo.id);
+  assert.equal((await game.info()).player.hit_points,health);
+  assert.deepEqual((await game.entities.detail(hypo.id)).properties.find(p=>p.name === "StackCount"),stack,"held hypo properties/stack remain unchanged");
+  // Closing the interface cancels inspection while the held trigger remains down.
+  await game.input.trigger("ToggleUseMode");
+  await game.step({frames:5});
+  assert.equal((await game.info()).player.right_hand_entity_id,hypo.id);
+  assert.equal((await game.info()).player.hit_points,health);
+  assert.deepEqual((await game.entities.detail(hypo.id)).properties.find(p=>p.name === "StackCount"),stack);
+  await game.input.set("right_hand.trigger",0);
+  await game.step({frames:3});
+  assert.equal((await game.info()).player.right_hand_entity_id,hypo.id,"releasing reserved trigger does not consume hypo");
+});


### PR DESCRIPTION
Adds a `?` control to the cyber interface. Select it, then an inventory, cursor-carried or held item to read its localized description in the right MFD. The selection click/grab is read-only: no Frob, wield, movement or consumption. Select `?` again to cancel, or CLOSE to dismiss; descriptions paginate.

Description lookup uses an explicit look-string override, then the object-name key in OBJLOOKS, then a symbolic-name key. Empty entries use a clear fallback. Inspection also latches both VR triggers safe off-panel, retaining safety through cancellation until release so a held hypo cannot be consumed accidentally.

Stacked on #1469. This establishes a shared reading panel and utility row for the following Research, Map, Access Cards and Character PRs.

Validation: 249 mission tests, 2 description resolver tests, 9 trigger safety tests, and flat/VR SDK inspection scenarios. Authored hypo description and page roundtrip verified, with inventory/cursor unchanged. Independent code/duplication and visual review; review findings for off-panel triggers and empty description entries fixed. Headset validation deferred. Claude review remains unavailable from the earlier credit condition.

![Item information in flat and VR](https://gist.githubusercontent.com/tommy-xr/942345bcb701b506fc104f60f2cf5180/raw/astra-mfd-item-info.png)

![Select, inspect, page and close](https://gist.githubusercontent.com/tommy-xr/942345bcb701b506fc104f60f2cf5180/raw/astra-mfd-item-info.gif)

New inspection panel, captured with the actual medical-hypo description. Both presentations pass selection cancellation, required pagination and page-back checks; the hypo inventory and cursor remain unchanged. Loop shows discrete checkpoints. Full screenshots in the gallery include the selected inventory icon/name; no headset validation.

[Download the self-contained gallery and open locally](https://gist.githubusercontent.com/tommy-xr/942345bcb701b506fc104f60f2cf5180/raw/astra-mfd-item-info-gallery.html).
